### PR TITLE
feat(antigravity): show subagent calls and results

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -2121,6 +2121,62 @@ describe("buildThreadFeed", () => {
 });
 
 describe("quiet timeline: nested agents", () => {
+  it.each(["cancelled", "failed", "interrupted"] as const)(
+    "replaces Antigravity progress with %s without a timeline bypass flag",
+    (status) => {
+      const thread = makeThread({
+        id: ThreadId.make("antigravity-agents"),
+        projectId: ProjectId.make("project-1"),
+        title: "Antigravity subagents",
+        activities: [
+          ...["trajectory:4", "trajectory:5"].map((taskId, index) =>
+            makeActivity({
+              id: EventId.make(`progress-${index}`),
+              kind: "task.progress",
+              summary: "Antigravity subagent",
+              createdAt: `2026-04-01T00:00:0${index + 1}.000Z`,
+              payload: {
+                taskId,
+                taskType: "subagent",
+                agentKind: "agent",
+                title: "Antigravity subagent",
+                detail: "Antigravity subagent",
+                status: "running",
+              },
+            }),
+          ),
+          makeActivity({
+            id: EventId.make("agent-stopped"),
+            kind: "task.updated",
+            summary: `Task ${status}`,
+            createdAt: "2026-04-01T00:00:03.000Z",
+            payload: {
+              taskId: "trajectory:4",
+              taskType: "subagent",
+              agentKind: "agent",
+              title: "Antigravity subagent",
+              status,
+              error: "Antigravity process stopped.",
+            },
+          }),
+        ],
+      });
+      const rows = buildThreadFeed(thread).flatMap((entry) =>
+        entry.type === "activity-group" ? entry.activities : [],
+      );
+      expect(rows).toHaveLength(2);
+      expect(rows[0]).toMatchObject({
+        lifecycleStatus: status === "failed" ? "failed" : "stopped",
+        detail: "Antigravity process stopped.",
+        workEntry: { taskId: "trajectory:4", toolTitle: "Antigravity subagent" },
+      });
+      expect(rows[1]).toMatchObject({
+        lifecycleStatus: "inProgress",
+        workEntry: { taskId: "trajectory:5" },
+      });
+    },
+  );
+
   it("keeps a nested agent's terminal row but hides its background work", () => {
     const thread = makeThread({
       id: ThreadId.make("thread-nested"),

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -2121,6 +2121,48 @@ describe("buildThreadFeed", () => {
 });
 
 describe("quiet timeline: nested agents", () => {
+  it.each(["task.updated", "task.progress"] as const)(
+    "does not mark an ordinary task complete when it resumes through %s",
+    (resumeKind) => {
+      const thread = makeThread({
+        id: ThreadId.make("resumed-agent"),
+        projectId: ProjectId.make("project-1"),
+        title: "Resumed agent",
+        activities: (
+          [
+            ["task.progress", "running", "Review"],
+            ["task.updated", "idle", "Task idle"],
+            [resumeKind, "running", "Review resumed"],
+          ] as const
+        ).map(([kind, status, summary], index) =>
+          makeActivity({
+            id: EventId.make(`resumed-${index}`),
+            kind,
+            summary,
+            createdAt: `2026-04-01T00:00:0${index + 1}.000Z`,
+            payload: {
+              taskId: "agent-1",
+              agentKind: "agent",
+              title: "Reviewer",
+              status,
+              detail: summary,
+            },
+          }),
+        ),
+      });
+      const rows = buildThreadFeed(thread).flatMap((entry) =>
+        entry.type === "activity-group" ? entry.activities : [],
+      );
+      expect(rows).toMatchObject([
+        {
+          lifecycleStatus: "inProgress",
+          summary: "Reviewer",
+          workEntry: { label: resumeKind === "task.progress" ? "Review resumed" : "Review" },
+        },
+      ]);
+    },
+  );
+
   it.each(["cancelled", "failed", "interrupted"] as const)(
     "replaces Antigravity progress with %s without a timeline bypass flag",
     (status) => {

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -323,7 +323,6 @@ function resolvePendingUserInputAnswer(
 
 /** Some providers settle agents through task.updated instead of task.completed. */
 const MOBILE_TERMINAL_UPDATE_STATUSES: ReadonlySet<string> = new Set([
-  "idle",
   "completed",
   "failed",
   "cancelled",
@@ -338,7 +337,11 @@ function isTerminalTaskUpdate(activity: OrchestrationThreadActivity): boolean {
     activity.payload && typeof activity.payload === "object"
       ? (activity.payload as Record<string, unknown>)
       : null;
-  return typeof payload?.status === "string" && MOBILE_TERMINAL_UPDATE_STATUSES.has(payload.status);
+  return (
+    typeof payload?.status === "string" &&
+    (MOBILE_TERMINAL_UPDATE_STATUSES.has(payload.status) ||
+      (payload.timelineBypass === true && payload.status === "idle"))
+  );
 }
 
 /**
@@ -1095,7 +1098,6 @@ function extractWorkLogToolLifecycleStatus(
   const status = payload?.status;
   if (status === "pending" || status === "running" || status === "waiting") return "inProgress";
   if (status === "cancelled" || status === "interrupted") return "stopped";
-  if (status === "idle") return "completed";
   if (
     status === "inProgress" ||
     status === "completed" ||

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -321,8 +321,7 @@ function resolvePendingUserInputAnswer(
   return selectedOptionValues[0] ?? null;
 }
 
-/** Codex children settle via task.updated (idle/failed/interrupted), never
- * task.completed — these rows are mobile's only terminal signal for them. */
+/** Some providers settle agents through task.updated instead of task.completed. */
 const MOBILE_TERMINAL_UPDATE_STATUSES: ReadonlySet<string> = new Set([
   "idle",
   "completed",
@@ -331,7 +330,7 @@ const MOBILE_TERMINAL_UPDATE_STATUSES: ReadonlySet<string> = new Set([
   "interrupted",
 ]);
 
-function isTerminalBypassUpdate(activity: OrchestrationThreadActivity): boolean {
+function isTerminalTaskUpdate(activity: OrchestrationThreadActivity): boolean {
   if (activity.kind !== "task.updated") {
     return false;
   }
@@ -339,11 +338,7 @@ function isTerminalBypassUpdate(activity: OrchestrationThreadActivity): boolean 
     activity.payload && typeof activity.payload === "object"
       ? (activity.payload as Record<string, unknown>)
       : null;
-  return (
-    payload?.timelineBypass === true &&
-    typeof payload.status === "string" &&
-    MOBILE_TERMINAL_UPDATE_STATUSES.has(payload.status)
-  );
+  return typeof payload?.status === "string" && MOBILE_TERMINAL_UPDATE_STATUSES.has(payload.status);
 }
 
 /**
@@ -351,8 +346,7 @@ function isTerminalBypassUpdate(activity: OrchestrationThreadActivity): boolean 
  * activity lives in the Agents sheet, not the work log. Terminal rows are
  * kept — with no Agents surface on mobile they are the terminal signal
  * (a surface that hides rows must keep its own terminal signal). That means
- * task.completed (Claude) AND terminal bypassed task.updated (Codex, whose
- * children never emit task.completed — review finding).
+ * task.completed and terminal task.updated, including Antigravity cancellation.
  */
 function isAgentInternalActivity(activity: OrchestrationThreadActivity): boolean {
   const payload =
@@ -362,7 +356,7 @@ function isAgentInternalActivity(activity: OrchestrationThreadActivity): boolean
   if (!payload) {
     return false;
   }
-  const isTerminalTaskRow = activity.kind === "task.completed" || isTerminalBypassUpdate(activity);
+  const isTerminalTaskRow = activity.kind === "task.completed" || isTerminalTaskUpdate(activity);
   if (payload.timelineBypass === true && !isTerminalTaskRow) {
     return true;
   }
@@ -387,8 +381,7 @@ function deriveWorkLogEntries(
     if (activity.tone !== "error" && isWorktreeSetupActivity(activity.kind)) continue;
     if (activity.kind === "tool.started") continue;
     if (activity.kind === "task.started") continue;
-    // Terminal bypassed updates pass: Codex children's only terminal signal.
-    if (activity.kind === "task.updated" && !isTerminalBypassUpdate(activity)) continue;
+    if (activity.kind === "task.updated" && !isTerminalTaskUpdate(activity)) continue;
     if (activity.kind === "tool.progress") continue;
     if (activity.kind === "context-window.updated") continue;
     if (activity.summary === "Checkpoint captured") continue;
@@ -432,9 +425,7 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   const changedFiles = extractChangedFiles(payload);
   const title = extractToolTitle(payload);
   const toolPresentation = extractToolActivityPresentation(payload);
-  // task.updated included: terminal bypassed updates (Codex children's only
-  // terminal signal) must carry task identity so they collapse per child
-  // instead of stacking anonymous "Task idle" rows.
+  // Terminal task updates carry identity so they replace each child's progress row.
   const isTaskActivity =
     activity.kind === "task.progress" ||
     activity.kind === "task.completed" ||
@@ -497,6 +488,9 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
         data,
       });
     if (detail && !repeatsCommand) entry.detail = detail;
+  }
+  if (isTaskActivity && typeof payload?.error === "string" && payload.error.trim()) {
+    entry.detail = payload.error;
   }
   if (viewedImagePath) {
     entry.viewedImagePath = viewedImagePath;
@@ -1099,6 +1093,9 @@ function extractWorkLogToolLifecycleStatus(
   payload: Record<string, unknown> | null,
 ): WorkLogToolLifecycleStatus | undefined {
   const status = payload?.status;
+  if (status === "pending" || status === "running" || status === "waiting") return "inProgress";
+  if (status === "cancelled" || status === "interrupted") return "stopped";
+  if (status === "idle") return "completed";
   if (
     status === "inProgress" ||
     status === "completed" ||

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -26,6 +26,7 @@ import { ServerConfig } from "../../config.ts";
 import { ANTIGRAVITY_SIGN_IN_REQUIRED_MESSAGE } from "../antigravityAuthSupport.ts";
 import type { AcpSessionRuntimeEvent } from "../acp/AcpSessionRuntime.ts";
 import { makeAntigravityAcpRuntime } from "../acp/AntigravityAcpSupport.ts";
+import { parseSessionUpdateEvent } from "../acp/AcpRuntimeModel.ts";
 import { makeAntigravityAdapter, type AntigravityAdapterOptions } from "./AntigravityAdapter.ts";
 
 const instanceId = ProviderInstanceId.make("antigravity-test");
@@ -48,6 +49,19 @@ interface NativePrompt {
 }
 
 type Runtime = Effect.Success<ReturnType<AntigravityAdapterOptions["makeRuntime"]>>;
+
+function nativeToolUpdate(
+  update: Extract<
+    AcpSchema.SessionNotification["update"],
+    { sessionUpdate: "tool_call" | "tool_call_update" }
+  >,
+) {
+  const event = parseSessionUpdateEvent({ sessionId: nativeSessionId, update }).events.find(
+    (event) => event._tag === "ToolCallUpdated",
+  );
+  if (!event) throw new Error("Expected a native tool update");
+  return event;
+}
 
 const makeHarness = Effect.fn("makeAntigravityAdapterHarness")(function* (options?: {
   readonly enabled?: boolean;
@@ -733,6 +747,215 @@ it.layer(layer)("AntigravityAdapter", (it) => {
       expect(ended.payload.status).toBe("completed");
     }),
   );
+
+  it.effect(
+    "shows concurrent native subagent calls and their results without inventing metadata",
+    () =>
+      Effect.gen(function* () {
+        const h = yield* makeHarness();
+        yield* h.adapter.startSession({
+          threadId,
+          cwd: process.cwd(),
+          runtimeMode: "approval-required",
+        });
+        const sending = yield* h.adapter
+          .sendTurn({ threadId, input: "Review with subagents" })
+          .pipe(Effect.forkChild);
+        const prompt = yield* h.nextPrompt;
+        for (const id of ["trajectory:4", "trajectory:5"]) {
+          yield* h.emitNative(
+            nativeToolUpdate({
+              sessionUpdate: "tool_call",
+              toolCallId: id,
+              title: "Running start_subagent",
+              kind: "other",
+              status: "in_progress",
+              rawInput: {},
+            }),
+          );
+          const running = yield* h.waitForEvent((event) => event.type === "task.progress");
+          expect(running.payload).toEqual({
+            taskId: id,
+            taskType: "subagent",
+            toolUseId: id,
+            title: "Antigravity subagent",
+            description: "Antigravity subagent",
+            status: "running",
+          });
+          yield* h.emitNative(
+            nativeToolUpdate({
+              sessionUpdate: "tool_call_update",
+              toolCallId: id,
+              status: "in_progress",
+            }),
+          );
+        }
+        for (const [id, status, result] of [
+          ["trajectory:4", "completed", "No defects found."],
+          ["trajectory:5", "failed", "Subagent exceeded its limit."],
+        ] as const) {
+          yield* h.emitNative(
+            nativeToolUpdate({
+              sessionUpdate: "tool_call_update",
+              toolCallId: id,
+              status,
+              rawOutput: result,
+            }),
+          );
+          const completed = yield* h.waitForEvent((event) => event.type === "task.completed");
+          expect(completed.payload).toEqual({
+            taskId: id,
+            taskType: "subagent",
+            toolUseId: id,
+            title: "Antigravity subagent",
+            status,
+            summary: result,
+          });
+        }
+        yield* Deferred.succeed(prompt.result, { stopReason: "end_turn" });
+        const turn = yield* Fiber.join(sending);
+        yield* h.waitForEvent((event) => event.type === "turn.completed");
+        expect(
+          h.seen
+            .filter((event) => event.type.startsWith("task."))
+            .every((event) => event.turnId === turn.turnId),
+        ).toBe(true);
+        expect(h.seen.filter((event) => event.type.startsWith("item."))).toHaveLength(0);
+        expect(h.seen.filter((event) => event.type === "task.progress")).toHaveLength(2);
+      }),
+  );
+
+  it.effect("waits for a replayed subagent's final status and result", () =>
+    Effect.gen(function* () {
+      const h = yield* makeHarness();
+      yield* h.adapter.startSession({
+        threadId,
+        cwd: process.cwd(),
+        runtimeMode: "approval-required",
+      });
+      // ACP history announces a completed tool first, even when its result failed.
+      yield* h.emitNative(
+        nativeToolUpdate({
+          sessionUpdate: "tool_call",
+          toolCallId: "replayed:4",
+          title: "Running start_subagent",
+          kind: "other",
+          status: "completed",
+          rawInput: "{}",
+        }),
+      );
+      yield* h.emitNative(
+        nativeToolUpdate({
+          sessionUpdate: "tool_call_update",
+          toolCallId: "replayed:4",
+          status: "failed",
+          rawOutput: "Review failed.",
+        }),
+      );
+      const completed = yield* h.waitForEvent((event) => event.type === "task.completed");
+      expect(completed.payload).toEqual({
+        taskId: "replayed:4",
+        taskType: "subagent",
+        toolUseId: "replayed:4",
+        title: "Antigravity subagent",
+        status: "failed",
+        summary: "Review failed.",
+      });
+      expect(h.seen.filter((event) => event.type.startsWith("task."))).toHaveLength(1);
+    }),
+  );
+
+  it.effect("shows pending subagents and closes a denied invocation", () =>
+    Effect.gen(function* () {
+      const h = yield* makeHarness();
+      yield* h.adapter.startSession({
+        threadId,
+        cwd: process.cwd(),
+        runtimeMode: "approval-required",
+      });
+      yield* h.emitNative(
+        nativeToolUpdate({
+          sessionUpdate: "tool_call",
+          toolCallId: "permission-1",
+          title: "Run start_subagent?",
+          kind: "other",
+          status: "pending",
+          rawInput: {},
+        }),
+      );
+      const pending = yield* h.waitForEvent((event) => event.type === "task.progress");
+      expect(pending.payload.status).toBe("pending");
+      yield* h.emitNative(
+        nativeToolUpdate({
+          sessionUpdate: "tool_call_update",
+          toolCallId: "permission-1",
+          status: "failed",
+        }),
+      );
+      const completed = yield* h.waitForEvent((event) => event.type === "task.completed");
+      expect(completed.payload.status).toBe("failed");
+    }),
+  );
+
+  for (const stop of ["cancel", "steer", "disconnect", "end_turn"] as const) {
+    it.effect(`settles open subagent calls on ${stop}`, () =>
+      Effect.gen(function* () {
+        const h = yield* makeHarness();
+        yield* h.adapter.startSession({
+          threadId,
+          cwd: process.cwd(),
+          runtimeMode: "approval-required",
+        });
+        const sending = yield* h.adapter
+          .sendTurn({ threadId, input: "Start a subagent" })
+          .pipe(Effect.forkChild);
+        const prompt = yield* h.nextPrompt;
+        yield* h.emitNative(
+          nativeToolUpdate({
+            sessionUpdate: "tool_call",
+            toolCallId: "trajectory:4",
+            title: "Running start_subagent",
+            kind: "other",
+            status: "in_progress",
+            rawInput: {},
+          }),
+        );
+        yield* h.waitForEvent((event) => event.type === "task.progress");
+        if (stop === "disconnect") {
+          yield* h.emitNative({
+            _tag: "ConnectionTerminated",
+            error: new AcpErrors.AcpTransportError({ detail: "Process exited.", cause: undefined }),
+          });
+        } else if (stop === "cancel") {
+          yield* h.adapter.interruptTurn(threadId);
+        } else if (stop === "steer") {
+          const steering = yield* h.adapter
+            .sendTurn({ threadId, input: "Change direction" })
+            .pipe(Effect.forkChild);
+          const replacement = yield* h.nextPrompt;
+          yield* Deferred.succeed(replacement.result, { stopReason: "end_turn" });
+          yield* Fiber.join(steering);
+        } else {
+          yield* Deferred.succeed(prompt.result, { stopReason: "end_turn" });
+        }
+        const settled = yield* h.waitForEvent((event) => event.type === "task.updated");
+        expect(settled.payload).toMatchObject({
+          taskId: "trajectory:4",
+          title: "Antigravity subagent",
+          taskType: "subagent",
+          status:
+            stop === "disconnect"
+              ? "failed"
+              : stop === "cancel" || stop === "steer"
+                ? "cancelled"
+                : "interrupted",
+        });
+        if (stop === "disconnect")
+          yield* h.waitForEvent((event) => event.type === "session.exited");
+        else yield* Fiber.join(sending);
+      }),
+    );
+  }
 
   it.effect("retires a prompt cancelled before native dispatch", () =>
     Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -26,7 +26,11 @@ import { ServerConfig } from "../../config.ts";
 import { ANTIGRAVITY_SIGN_IN_REQUIRED_MESSAGE } from "../antigravityAuthSupport.ts";
 import type { AcpSessionRuntimeEvent } from "../acp/AcpSessionRuntime.ts";
 import { makeAntigravityAcpRuntime } from "../acp/AntigravityAcpSupport.ts";
-import { parseSessionUpdateEvent } from "../acp/AcpRuntimeModel.ts";
+import {
+  mergeToolCallState,
+  parseSessionUpdateEvent,
+  type AcpToolCallState,
+} from "../acp/AcpRuntimeModel.ts";
 import { makeAntigravityAdapter, type AntigravityAdapterOptions } from "./AntigravityAdapter.ts";
 
 const instanceId = ProviderInstanceId.make("antigravity-test");
@@ -55,12 +59,13 @@ function nativeToolUpdate(
     AcpSchema.SessionNotification["update"],
     { sessionUpdate: "tool_call" | "tool_call_update" }
   >,
+  previous?: AcpToolCallState,
 ) {
   const event = parseSessionUpdateEvent({ sessionId: nativeSessionId, update }).events.find(
     (event) => event._tag === "ToolCallUpdated",
   );
   if (!event) throw new Error("Expected a native tool update");
-  return event;
+  return { ...event, toolCall: mergeToolCallState(previous, event.toolCall) };
 }
 
 const makeHarness = Effect.fn("makeAntigravityAdapterHarness")(function* (options?: {
@@ -900,6 +905,135 @@ it.layer(layer)("AntigravityAdapter", (it) => {
       yield* Fiber.join(sending);
       yield* h.waitForEvent((event) => event.type === "turn.completed");
       expect(h.seen.filter((event) => event.type === "task.updated")).toHaveLength(0);
+    }),
+  );
+
+  for (const settlement of ["cancelled", "interrupted", "completed"] as const) {
+    it.effect(`does not reopen a ${settlement} subagent on late merged updates`, () =>
+      Effect.gen(function* () {
+        const h = yield* makeHarness();
+        yield* h.adapter.startSession({
+          threadId,
+          cwd: process.cwd(),
+          runtimeMode: "approval-required",
+        });
+        const first = yield* h.adapter
+          .sendTurn({ threadId, input: "Start review" })
+          .pipe(Effect.forkChild);
+        const firstPrompt = yield* h.nextPrompt;
+        const started = nativeToolUpdate({
+          sessionUpdate: "tool_call",
+          toolCallId: "old:4",
+          title: "Running start_subagent",
+          kind: "other",
+          status: "in_progress",
+          rawInput: {},
+        });
+        yield* h.emitNative(started);
+        yield* h.waitForEvent((event) => event.type === "task.progress");
+        if (settlement === "cancelled") {
+          yield* h.adapter.interruptTurn(threadId);
+        } else {
+          if (settlement === "completed") {
+            yield* h.emitNative(
+              nativeToolUpdate(
+                {
+                  sessionUpdate: "tool_call_update",
+                  toolCallId: "old:4",
+                  status: "completed",
+                  rawOutput: "Original result.",
+                },
+                started.toolCall,
+              ),
+            );
+          }
+          yield* Deferred.succeed(firstPrompt.result, { stopReason: "end_turn" });
+        }
+        yield* Fiber.join(first);
+        yield* h.waitForEvent((event) => event.type === "turn.completed");
+        const second = yield* h.adapter
+          .sendTurn({ threadId, input: "Next review" })
+          .pipe(Effect.forkChild);
+        const secondPrompt = yield* h.nextPrompt;
+        for (const status of ["in_progress", "completed"] as const) {
+          yield* h.emitNative(
+            nativeToolUpdate(
+              {
+                sessionUpdate: "tool_call_update",
+                toolCallId: "old:4",
+                status,
+                rawOutput: "Late result.",
+              },
+              started.toolCall,
+            ),
+          );
+        }
+        yield* h.emitNative(
+          nativeToolUpdate({
+            sessionUpdate: "tool_call",
+            toolCallId: "new:4",
+            title: "Running start_subagent",
+            kind: "other",
+            status: "completed",
+            rawOutput: "New result.",
+          }),
+        );
+        const completed = yield* h.waitForEvent((event) => event.type === "task.completed");
+        expect(completed.payload.taskId).toBe("new:4");
+        yield* Deferred.succeed(secondPrompt.result, { stopReason: "end_turn" });
+        yield* Fiber.join(second);
+        yield* h.waitForEvent((event) => event.type === "turn.completed");
+        expect(h.seen.filter((event) => event.type === "task.progress")).toHaveLength(1);
+        expect(
+          h.seen.filter(
+            (event) => event.type === "task.completed" && event.payload.taskId === "old:4",
+          ),
+        ).toHaveLength(settlement === "completed" ? 1 : 0);
+      }),
+    );
+  }
+
+  it.effect("keeps MCP identity when later updates omit metadata", () =>
+    Effect.gen(function* () {
+      const h = yield* makeHarness();
+      yield* h.adapter.startSession({
+        threadId,
+        cwd: process.cwd(),
+        runtimeMode: "approval-required",
+      });
+      const sending = yield* h.adapter
+        .sendTurn({ threadId, input: "Run an MCP tool" })
+        .pipe(Effect.forkChild);
+      const prompt = yield* h.nextPrompt;
+      const started = nativeToolUpdate({
+        sessionUpdate: "tool_call",
+        toolCallId: "mcp-4",
+        title: "Running start_subagent",
+        kind: "other",
+        status: "in_progress",
+        rawInput: { arguments: {} },
+        _meta: { is_mcp_tool_call: true },
+      });
+      yield* h.emitNative(started);
+      for (const status of ["in_progress", "completed"] as const) {
+        yield* h.emitNative(
+          nativeToolUpdate(
+            {
+              sessionUpdate: "tool_call_update",
+              toolCallId: "mcp-4",
+              status,
+              rawOutput: "MCP output.",
+            },
+            started.toolCall,
+          ),
+        );
+      }
+      yield* Deferred.succeed(prompt.result, { stopReason: "end_turn" });
+      yield* Fiber.join(sending);
+      yield* h.waitForEvent((event) => event.type === "turn.completed");
+      expect(h.seen.filter((event) => event.type.startsWith("task."))).toHaveLength(0);
+      expect(h.seen.filter((event) => event.type === "item.updated")).toHaveLength(2);
+      expect(h.seen.filter((event) => event.type === "item.completed")).toHaveLength(1);
     }),
   );
 

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -865,6 +865,44 @@ it.layer(layer)("AntigravityAdapter", (it) => {
     }),
   );
 
+  it.effect("completes a live subagent delivered in one tool call", () =>
+    Effect.gen(function* () {
+      const h = yield* makeHarness();
+      yield* h.adapter.startSession({
+        threadId,
+        cwd: process.cwd(),
+        runtimeMode: "approval-required",
+      });
+      const sending = yield* h.adapter
+        .sendTurn({ threadId, input: "Review with subagents" })
+        .pipe(Effect.forkChild);
+      const prompt = yield* h.nextPrompt;
+      for (const [id, rawOutput] of [
+        ["live:4", "Review complete."],
+        ["live:5", undefined],
+      ] as const) {
+        yield* h.emitNative(
+          nativeToolUpdate({
+            sessionUpdate: "tool_call",
+            toolCallId: id,
+            title: "Running start_subagent",
+            kind: "other",
+            status: "completed",
+            rawInput: {},
+            ...(rawOutput ? { rawOutput } : {}),
+          }),
+        );
+        const completed = yield* h.waitForEvent((event) => event.type === "task.completed");
+        expect(completed.payload).toMatchObject({ taskId: id, status: "completed" });
+        expect(completed.payload.summary).toBe(rawOutput);
+      }
+      yield* Deferred.succeed(prompt.result, { stopReason: "end_turn" });
+      yield* Fiber.join(sending);
+      yield* h.waitForEvent((event) => event.type === "turn.completed");
+      expect(h.seen.filter((event) => event.type === "task.updated")).toHaveLength(0);
+    }),
+  );
+
   it.effect("shows pending subagents and closes a denied invocation", () =>
     Effect.gen(function* () {
       const h = yield* makeHarness();

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -607,7 +607,10 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
               const turnId = subagent?.turnId ?? context.activeTurnId;
               const linkage = subagentLinkage(toolCall.toolCallId);
               // Replay starts claim completion before the result says whether the call failed.
-              if (isAntigravitySubagentReplayStart(event.rawPayload)) {
+              if (
+                context.activeTurnId === undefined &&
+                isAntigravitySubagentReplayStart(event.rawPayload)
+              ) {
                 context.subagents.set(toolCall.toolCallId, { turnId, status: undefined });
                 return;
               }

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -1,5 +1,4 @@
 import {
-  ANTIGRAVITY_DEFAULT_MODEL,
   ApprovalRequestId,
   EventId,
   ProviderDriverKind,
@@ -13,6 +12,7 @@ import {
   type ProviderSession,
   type ProviderSetupError,
   type ProviderUserInputAnswers,
+  type RuntimeTaskStatus,
   type ThreadId,
   type TurnCompletedPayload,
 } from "@t3tools/contracts";
@@ -71,8 +71,11 @@ import {
 } from "../acp/AntigravityAcpSupport.ts";
 import {
   antigravityApprovalOptions,
+  antigravitySubagentResult,
   extractAntigravityUserInputQuestion,
   isAntigravityOpenCommand,
+  isAntigravitySubagentReplayStart,
+  isAntigravitySubagentToolCall,
   isAntigravityUserInputRequest,
   makeAntigravityUserInputResponse,
   normalizeAntigravityToolCall,
@@ -161,6 +164,20 @@ interface OpenCommand {
   readonly promoted: boolean;
 }
 
+interface OpenSubagent {
+  readonly turnId: TurnId | undefined;
+  readonly status: "pending" | "running" | undefined;
+}
+
+function subagentLinkage(toolCallId: string) {
+  return {
+    taskId: RuntimeTaskId.make(toolCallId),
+    taskType: "subagent",
+    toolUseId: toolCallId,
+    title: "Antigravity subagent",
+  };
+}
+
 interface TurnIntent {
   readonly turnId: TurnId;
   readonly generation: number;
@@ -179,6 +196,7 @@ interface SessionContext {
   readonly approvals: Map<ApprovalRequestId, PendingApproval>;
   readonly questions: Map<ApprovalRequestId, PendingQuestion>;
   readonly commands: Map<string, OpenCommand>;
+  readonly subagents: Map<string, OpenSubagent>;
   readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
   session: ProviderSession;
   activeTurnId: TurnId | undefined;
@@ -365,6 +383,31 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
       }),
     );
 
+  const finishSubagents = (
+    context: SessionContext,
+    status: Extract<RuntimeTaskStatus, "cancelled" | "failed" | "interrupted">,
+    error?: string,
+  ) =>
+    context.commandLock.withPermit(
+      Effect.gen(function* () {
+        for (const [id, subagent] of context.subagents) {
+          yield* emit({
+            type: "task.updated",
+            ...(yield* stamp),
+            provider: PROVIDER,
+            threadId: context.threadId,
+            turnId: subagent.turnId,
+            payload: {
+              ...subagentLinkage(id),
+              status,
+              ...(error ? { error } : {}),
+            },
+          });
+        }
+        context.subagents.clear();
+      }),
+    );
+
   const stopContext = (context: SessionContext) =>
     context.stopLock
       .withPermit(
@@ -380,6 +423,11 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
           context.closed = true;
           if (sessions.get(context.threadId) === context) sessions.delete(context.threadId);
           yield* finishBackgroundCommands(context);
+          yield* finishSubagents(
+            context,
+            context.disconnected ? "failed" : "cancelled",
+            context.disconnected ? "Antigravity process stopped." : undefined,
+          );
           yield* emit({
             type: "session.exited",
             ...(yield* stamp),
@@ -554,6 +602,46 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
         yield* context.commandLock.withPermit(
           Effect.gen(function* () {
             const toolCall = normalizeAntigravityToolCall(event.toolCall);
+            const subagent = context.subagents.get(toolCall.toolCallId);
+            if (subagent || isAntigravitySubagentToolCall(toolCall, event.rawPayload)) {
+              const turnId = subagent?.turnId ?? context.activeTurnId;
+              const linkage = subagentLinkage(toolCall.toolCallId);
+              // Replay starts claim completion before the result says whether the call failed.
+              if (isAntigravitySubagentReplayStart(event.rawPayload)) {
+                context.subagents.set(toolCall.toolCallId, { turnId, status: undefined });
+                return;
+              }
+              if (toolCall.status === "completed" || toolCall.status === "failed") {
+                const summary = antigravitySubagentResult(toolCall);
+                yield* emit({
+                  type: "task.completed",
+                  ...(yield* stamp),
+                  provider: PROVIDER,
+                  threadId: context.threadId,
+                  turnId,
+                  payload: {
+                    ...linkage,
+                    status: toolCall.status,
+                    ...(summary ? { summary } : {}),
+                  },
+                });
+                context.subagents.delete(toolCall.toolCallId);
+              } else {
+                const status = toolCall.status === "pending" ? "pending" : "running";
+                if (subagent?.status !== status) {
+                  yield* emit({
+                    type: "task.progress",
+                    ...(yield* stamp),
+                    provider: PROVIDER,
+                    threadId: context.threadId,
+                    turnId,
+                    payload: { ...linkage, description: linkage.title, status },
+                  });
+                }
+                context.subagents.set(toolCall.toolCallId, { turnId, status });
+              }
+              return;
+            }
             const existing = context.commands.get(toolCall.toolCallId);
             yield* emit(
               makeAcpToolCallEvent({
@@ -739,6 +827,7 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
                 approvals: new Map(),
                 questions: new Map(),
                 commands: new Map(),
+                subagents: new Map(),
                 turns: [],
                 session,
                 activeTurnId: undefined,
@@ -860,6 +949,18 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
         if (turn.settled || context.stopped || context.generation !== turn.generation) return;
         turn.settled = true;
         yield* promoteBackgroundCommands(context);
+        yield* finishSubagents(
+          context,
+          payload.state === "cancelled"
+            ? "cancelled"
+            : payload.state === "failed"
+              ? "failed"
+              : "interrupted",
+          payload.errorMessage ??
+            (payload.state === "completed"
+              ? "Antigravity ended the turn before reporting a subagent result."
+              : undefined),
+        );
         context.activeTurnId = undefined;
         context.promptFiber = undefined;
         context.session = {
@@ -917,6 +1018,7 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
             yield* cancelRequests(context);
             yield* context.runtime.cancel;
             yield* Fiber.await(context.promptFiber);
+            yield* finishSubagents(context, "cancelled");
           }
           yield* applyAntigravityAcpModelSelection({
             runtime: context.runtime,

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -72,10 +72,10 @@ import {
 import {
   antigravityApprovalOptions,
   antigravitySubagentResult,
+  classifyAntigravitySubagentToolCall,
   extractAntigravityUserInputQuestion,
   isAntigravityOpenCommand,
   isAntigravitySubagentReplayStart,
-  isAntigravitySubagentToolCall,
   isAntigravityUserInputRequest,
   makeAntigravityUserInputResponse,
   normalizeAntigravityToolCall,
@@ -196,7 +196,8 @@ interface SessionContext {
   readonly approvals: Map<ApprovalRequestId, PendingApproval>;
   readonly questions: Map<ApprovalRequestId, PendingQuestion>;
   readonly commands: Map<string, OpenCommand>;
-  readonly subagents: Map<string, OpenSubagent>;
+  /** Keep only IDs after settlement or MCP exclusion so merged late updates cannot change identity. */
+  readonly subagents: Map<string, OpenSubagent | "finished" | "mcp">;
   readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
   session: ProviderSession;
   activeTurnId: TurnId | undefined;
@@ -391,6 +392,7 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
     context.commandLock.withPermit(
       Effect.gen(function* () {
         for (const [id, subagent] of context.subagents) {
+          if (subagent === "finished" || subagent === "mcp") continue;
           yield* emit({
             type: "task.updated",
             ...(yield* stamp),
@@ -403,8 +405,8 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
               ...(error ? { error } : {}),
             },
           });
+          context.subagents.set(id, "finished");
         }
-        context.subagents.clear();
       }),
     );
 
@@ -428,6 +430,7 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
             context.disconnected ? "failed" : "cancelled",
             context.disconnected ? "Antigravity process stopped." : undefined,
           );
+          context.subagents.clear();
           yield* emit({
             type: "session.exited",
             ...(yield* stamp),
@@ -602,8 +605,13 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
         yield* context.commandLock.withPermit(
           Effect.gen(function* () {
             const toolCall = normalizeAntigravityToolCall(event.toolCall);
-            const subagent = context.subagents.get(toolCall.toolCallId);
-            if (subagent || isAntigravitySubagentToolCall(toolCall, event.rawPayload)) {
+            const tracked = context.subagents.get(toolCall.toolCallId);
+            if (tracked === "finished") return;
+            const kind = classifyAntigravitySubagentToolCall(toolCall, event.rawPayload);
+            const isMcp = tracked === "mcp" || kind === "mcp";
+            if (isMcp) context.subagents.set(toolCall.toolCallId, "mcp");
+            const subagent = tracked === "mcp" ? undefined : tracked;
+            if (!isMcp && (subagent || kind === "subagent")) {
               const turnId = subagent?.turnId ?? context.activeTurnId;
               const linkage = subagentLinkage(toolCall.toolCallId);
               // Replay starts claim completion before the result says whether the call failed.
@@ -628,7 +636,7 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
                     ...(summary ? { summary } : {}),
                   },
                 });
-                context.subagents.delete(toolCall.toolCallId);
+                context.subagents.set(toolCall.toolCallId, "finished");
               } else {
                 const status = toolCall.status === "pending" ? "pending" : "running";
                 if (subagent?.status !== status) {

--- a/apps/server/src/provider/acp/AntigravityProtocol.test.ts
+++ b/apps/server/src/provider/acp/AntigravityProtocol.test.ts
@@ -51,6 +51,11 @@ describe("native Antigravity subagent tools", () => {
   it("recognizes history starts and bounds the native result", () => {
     expect(
       isAntigravitySubagentReplayStart({
+        update: { sessionUpdate: "tool_call", status: "completed", rawOutput: "Done." },
+      }),
+    ).toBe(false);
+    expect(
+      isAntigravitySubagentReplayStart({
         update: { sessionUpdate: "tool_call", status: "completed" },
       }),
     ).toBe(true);

--- a/apps/server/src/provider/acp/AntigravityProtocol.test.ts
+++ b/apps/server/src/provider/acp/AntigravityProtocol.test.ts
@@ -8,7 +8,7 @@ import {
   antigravityApprovalOptions,
   antigravitySubagentResult,
   isAntigravitySubagentReplayStart,
-  isAntigravitySubagentToolCall,
+  classifyAntigravitySubagentToolCall,
   isAntigravityUserInputRequest,
   makeAntigravityUserInputResponse,
   normalizeAntigravitySessionUpdate,
@@ -24,13 +24,13 @@ describe("native Antigravity subagent tools", () => {
   it("recognizes only native invocation titles and excludes MCP tools", () => {
     const toolCall = { toolCallId: "trajectory:4", kind: "other", data: {} };
     for (const title of ["Running start_subagent", "Run start_subagent?"]) {
-      expect(isAntigravitySubagentToolCall({ ...toolCall, title }, {})).toBe(true);
+      expect(classifyAntigravitySubagentToolCall({ ...toolCall, title }, {})).toBe("subagent");
       expect(
-        isAntigravitySubagentToolCall(
+        classifyAntigravitySubagentToolCall(
           { ...toolCall, title },
           { update: { _meta: { is_mcp_tool_call: true } } },
         ),
-      ).toBe(false);
+      ).toBe("mcp");
     }
     for (const title of [
       "Running subagent",
@@ -38,14 +38,14 @@ describe("native Antigravity subagent tools", () => {
       "Run command",
       "Running manage_task",
     ]) {
-      expect(isAntigravitySubagentToolCall({ ...toolCall, title }, {})).toBe(false);
+      expect(classifyAntigravitySubagentToolCall({ ...toolCall, title }, {})).toBeUndefined();
     }
     expect(
-      isAntigravitySubagentToolCall(
+      classifyAntigravitySubagentToolCall(
         { ...toolCall, title: "Running start_subagent", kind: "execute" },
         {},
       ),
-    ).toBe(false);
+    ).toBeUndefined();
   });
 
   it("recognizes history starts and bounds the native result", () => {

--- a/apps/server/src/provider/acp/AntigravityProtocol.test.ts
+++ b/apps/server/src/provider/acp/AntigravityProtocol.test.ts
@@ -6,6 +6,9 @@ import {
   extractAntigravityUserInputQuestion,
   isAntigravityOpenCommand,
   antigravityApprovalOptions,
+  antigravitySubagentResult,
+  isAntigravitySubagentReplayStart,
+  isAntigravitySubagentToolCall,
   isAntigravityUserInputRequest,
   makeAntigravityUserInputResponse,
   normalizeAntigravitySessionUpdate,
@@ -16,6 +19,63 @@ import {
 import { mergeToolCallState, parseSessionUpdateEvent } from "./AcpRuntimeModel.ts";
 
 const isSessionNotification = Schema.is(EffectAcpSchema.SessionNotification);
+
+describe("native Antigravity subagent tools", () => {
+  it("recognizes only native invocation titles and excludes MCP tools", () => {
+    const toolCall = { toolCallId: "trajectory:4", kind: "other", data: {} };
+    for (const title of ["Running start_subagent", "Run start_subagent?"]) {
+      expect(isAntigravitySubagentToolCall({ ...toolCall, title }, {})).toBe(true);
+      expect(
+        isAntigravitySubagentToolCall(
+          { ...toolCall, title },
+          { update: { _meta: { is_mcp_tool_call: true } } },
+        ),
+      ).toBe(false);
+    }
+    for (const title of [
+      "Running subagent",
+      "start_subagent",
+      "Run command",
+      "Running manage_task",
+    ]) {
+      expect(isAntigravitySubagentToolCall({ ...toolCall, title }, {})).toBe(false);
+    }
+    expect(
+      isAntigravitySubagentToolCall(
+        { ...toolCall, title: "Running start_subagent", kind: "execute" },
+        {},
+      ),
+    ).toBe(false);
+  });
+
+  it("recognizes history starts and bounds the native result", () => {
+    expect(
+      isAntigravitySubagentReplayStart({
+        update: { sessionUpdate: "tool_call", status: "completed" },
+      }),
+    ).toBe(true);
+    expect(
+      isAntigravitySubagentReplayStart({
+        update: { sessionUpdate: "tool_call_update", status: "completed" },
+      }),
+    ).toBe(false);
+    expect(
+      antigravitySubagentResult({
+        toolCallId: "trajectory:4",
+        data: { rawOutput: "  Finished review.  " },
+      }),
+    ).toBe("Finished review.");
+    const result = antigravitySubagentResult({
+      toolCallId: "trajectory:4",
+      data: { rawOutput: `${"x".repeat(16_000)}The result.` },
+    });
+    expect(result?.length).toBeLessThan(8_100);
+    expect(result?.endsWith("The result.")).toBe(true);
+    expect(
+      antigravitySubagentResult({ toolCallId: "trajectory:4", data: { rawOutput: {} } }),
+    ).toBeUndefined();
+  });
+});
 
 const questionRequest = {
   sessionId: "session-1",

--- a/apps/server/src/provider/acp/AntigravityProtocol.ts
+++ b/apps/server/src/provider/acp/AntigravityProtocol.ts
@@ -349,3 +349,32 @@ export function normalizeAntigravityToolCall(toolCall: AcpToolCallState): AcpToo
 export function isAntigravityOpenCommand(toolCall: AcpToolCallState): boolean {
   return toolCall.kind === "execute" && toolCall.status === "inProgress";
 }
+
+/** ACP 1.1.1 exposes subagent invocations as ordinary tools, without child IDs or models. */
+export function isAntigravitySubagentToolCall(
+  toolCall: AcpToolCallState,
+  rawPayload: unknown,
+): boolean {
+  const update = Predicate.isObject(rawPayload) ? rawPayload.update : undefined;
+  const meta = Predicate.isObject(update) ? update._meta : undefined;
+  if (Predicate.isObject(meta) && meta.is_mcp_tool_call === true) return false;
+  return (
+    (toolCall.kind === undefined || toolCall.kind === "other") &&
+    (toolCall.title === "Running start_subagent" || toolCall.title === "Run start_subagent?")
+  );
+}
+
+/** History sends a completed start before the separate result and its final status. */
+export function isAntigravitySubagentReplayStart(rawPayload: unknown): boolean {
+  const update = Predicate.isObject(rawPayload) ? rawPayload.update : undefined;
+  return (
+    Predicate.isObject(update) &&
+    update.sessionUpdate === "tool_call" &&
+    update.status === "completed"
+  );
+}
+
+export function antigravitySubagentResult(toolCall: AcpToolCallState): string | undefined {
+  const output = toolCall.data.rawOutput;
+  return typeof output === "string" && output.trim() ? boundText(output.trim()) : undefined;
+}

--- a/apps/server/src/provider/acp/AntigravityProtocol.ts
+++ b/apps/server/src/provider/acp/AntigravityProtocol.ts
@@ -351,17 +351,18 @@ export function isAntigravityOpenCommand(toolCall: AcpToolCallState): boolean {
 }
 
 /** ACP 1.1.1 exposes subagent invocations as ordinary tools, without child IDs or models. */
-export function isAntigravitySubagentToolCall(
+export function classifyAntigravitySubagentToolCall(
   toolCall: AcpToolCallState,
   rawPayload: unknown,
-): boolean {
+): "subagent" | "mcp" | undefined {
+  if (
+    (toolCall.kind !== undefined && toolCall.kind !== "other") ||
+    (toolCall.title !== "Running start_subagent" && toolCall.title !== "Run start_subagent?")
+  )
+    return undefined;
   const update = Predicate.isObject(rawPayload) ? rawPayload.update : undefined;
   const meta = Predicate.isObject(update) ? update._meta : undefined;
-  if (Predicate.isObject(meta) && meta.is_mcp_tool_call === true) return false;
-  return (
-    (toolCall.kind === undefined || toolCall.kind === "other") &&
-    (toolCall.title === "Running start_subagent" || toolCall.title === "Run start_subagent?")
-  );
+  return Predicate.isObject(meta) && meta.is_mcp_tool_call === true ? "mcp" : "subagent";
 }
 
 /** History sends a completed start before the separate result and its final status. */

--- a/apps/server/src/provider/acp/AntigravityProtocol.ts
+++ b/apps/server/src/provider/acp/AntigravityProtocol.ts
@@ -370,7 +370,8 @@ export function isAntigravitySubagentReplayStart(rawPayload: unknown): boolean {
   return (
     Predicate.isObject(update) &&
     update.sessionUpdate === "tool_call" &&
-    update.status === "completed"
+    update.status === "completed" &&
+    (update.rawOutput === undefined || update.rawOutput === null)
   );
 }
 

--- a/docs/user/providers-antigravity.md
+++ b/docs/user/providers-antigravity.md
@@ -138,6 +138,17 @@ T3 Code keeps thread history and file diffs. Antigravity does not support conver
 so reverting a thread or editing and resubmitting an earlier turn is unavailable. Send a
 follow-up message or start a new thread instead.
 
+### Subagents
+
+Antigravity subagent calls appear in **Agents** on web and desktop, and in the work log on
+mobile. Each call shows its status and the result or error returned by Antigravity. Calls
+that run at the same time have separate entries.
+
+The official ACP agent does not report subagent names, models, token usage, or parent links.
+Entries use the name **Antigravity subagent**. Child tool calls cannot be assigned to an entry
+because ACP does not include their owning subagent. These entries track each invocation,
+not a separate thread you can open or control.
+
 ## Accounts and removal
 
 Each Antigravity provider instance has its own Google sign-in on its environment. Use


### PR DESCRIPTION
Antigravity subagent calls appeared as generic tools, so the Agents panel stayed empty. Mobile could miss their cancelled or interrupted state.

Map the official ACP `start_subagent` calls to existing task events. Web and desktop use the Agents panel. Mobile uses its existing task rows. Concurrent calls stay separate, results and errors remain visible, and cancellation or process exit clears active calls. Replayed calls wait for their final result before reporting success.

ACP does not expose child names, models, usage, or parent links. The UI shows only the invocation status and result. No new wire contract or agent controls.

Verified 193 focused tests for this PR and 350 focused tests with the other Antigravity changes. Server and mobile typechecks, targeted lint, and formatting pass. An isolated browser check covers two concurrent calls, success, failure, late updates, and an MCP name collision. A real Google subagent turn has not been run.

## Client check

These images and the video use native-format ACP 1.1.1 events from a local fixture, not a live Google subagent session.

| Before | After, running |
| --- | --- |
| ![Generic tool call](https://files.tslop.org/2026/09/antigravity-subagents-before-8342f330.png) | ![Two calls in Agents](https://files.tslop.org/2026/09/antigravity-subagents-after-running-9d552c3d.png) |

![Completed and failed results](https://files.tslop.org/2026/09/antigravity-subagents-after-completed-eef6a262.png)

[Status change video](https://files.tslop.org/2026/09/antigravity-subagent-statuses-5a70c6b3.mp4)

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mobile work-log rules for which `task.updated` events are terminal changed (notably `idle` is only terminal with `timelineBypass`), and the Antigravity adapter now owns subagent lifecycle emission—incorrect classification could mis-route MCP tools or drop terminal rows.
> 
> **Overview**
> Antigravity **ACP `start_subagent` tool calls** are no longer surfaced as generic tool items. The adapter **classifies** native invocations (and excludes MCP-flagged tools), emits **`task.progress` / `task.completed`** with per-call linkage, and **tracks open subagents** in session state so late merged updates cannot reopen settled calls. **Open subagents are settled** via **`task.updated`** when a turn ends, the user cancels or steers, or the process disconnects or stops.
> 
> **Mobile work-log derivation** is updated so terminal **`task.updated`** rows (`completed`, `failed`, `cancelled`, `interrupted`) can replace progress **without requiring `timelineBypass`**, task **errors** show as row detail, and provider status strings map to **in-progress** vs **stopped** lifecycle. Resuming agents through ordinary **`task.progress` / `task.updated`** no longer marks them complete incorrectly.
> 
> User docs add a **Subagents** section describing Agents / work-log behavior and ACP metadata limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faf37732d2b16d6e29ee0224cf85917d242357e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show Antigravity subagent calls and results as task events across platforms
> - Adds native `start_subagent` classification and tracking in `AntigravityAdapter`, emitting `task.progress` for pending/running states and `task.completed` for finished states with bounded result summaries
> - Settles open subagents on turn end, context shutdown, and model-change prompt cancellation by emitting terminal `task.updated` events with appropriate statuses (`interrupted`, `cancelled`, or `failed`)
> - Broadens mobile work-log terminal recognition in `MOBILE_TERMINAL_UPDATE_STATUSES` to include `completed`, `failed`, `cancelled`, and `interrupted` `task.updated` rows, not only timeline-bypassed ones; idle remains terminal only via `timelineBypass`
> - Adds lifecycle status mappings (`pending`/`running`/`waiting` → `inProgress`, `cancelled`/`interrupted` → `stopped`) and task error extraction in `extractWorkLogToolLifecycleStatus` and `toDerivedWorkLogEntry`
> - Behavioral Change: mobile `deriveWorkLogEntries` now emits terminal rows for `task.updated` events from providers that do not set `timelineBypass`; late updates for already-settled subagents in `ToolCallUpdated` are silently ignored
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized faf3773.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

