### PR TITLE
fix(web): keep right panel controls clickable

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1844,8 +1844,7 @@ function ChatViewContent(props: ChatViewProps) {
     panelAnimationDurationMs,
   );
   const rightPanelPresent = rightPanelPresence.present;
-  const rightPanelControlsInPanel =
-    rightPanelPresent && (!shouldUseRightPanelSheet || rightPanelOpen);
+  const rightPanelControlsInPanel = rightPanelPresent && rightPanelOpen;
   const renderedRightPanelSurface = rightPanelPresence.value?.activeSurface ?? null;
   const renderedRightPanelSurfaces = rightPanelPresence.value?.surfaces ?? [];
   const previewMiniPlayerVisible = shouldRenderPreviewMiniPlayer(
@@ -7411,6 +7410,15 @@ function ChatViewContent(props: ChatViewProps) {
       <div className="pointer-events-auto flex h-full items-center">{panelToggleControls}</div>
     </div>
   );
+  const inlineRightPanelControls = (
+    <div className="mr-px flex h-full items-center gap-1 [-webkit-app-region:no-drag]">
+      <RightPanelMaximizeControl
+        maximized={rightPanelMaximized}
+        onToggle={toggleRightPanelMaximized}
+      />
+      {panelToggleControls}
+    </div>
+  );
   const rightPanelContent = activeThreadRef ? (
     renderedRightPanelSurface?.kind === "preview" ? (
       <Suspense fallback={null}>
@@ -7571,7 +7579,7 @@ function ChatViewContent(props: ChatViewProps) {
           reserveNativeControls={reserveTitleBarControlInset && !inlineRightPanelOwnsTitleBar}
           className="relative bg-background"
         >
-          {!shouldUseRightPanelSheet || !rightPanelControlsInPanel ? panelLayoutControls : null}
+          {!rightPanelControlsInPanel ? panelLayoutControls : null}
           <ChatHeader
             {...(!supportsPullRequests || activeProjectRepository === null
               ? {}
@@ -7999,6 +8007,7 @@ function ChatViewContent(props: ChatViewProps) {
           mode="inline"
           open={rightPanelOpen}
           maximized={rightPanelMaximized}
+          layoutControls={rightPanelOpen ? inlineRightPanelControls : null}
           surfaces={renderedRightPanelSurfaces}
           environmentId={activeThreadRef.environmentId}
           activeSurfaceId={renderedRightPanelSurface?.id ?? null}

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -990,7 +990,10 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
           // controls a few pixels higher and the cluster jumps on open.
           props.mode === "inline" && !props.layoutControls ? "pr-28" : "pr-3",
           ownsDesktopTitleBar && "drag-region",
-          ownsDesktopTitleBar && "wco:pr-[calc(var(--workspace-native-controls-inset)+6rem)]",
+          ownsDesktopTitleBar &&
+            (props.layoutControls
+              ? "wco:pr-[var(--workspace-native-controls-inset)]"
+              : "wco:pr-[calc(var(--workspace-native-controls-inset)+6rem)]"),
           props.mode === "inline" && props.maximized && COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,
         )}
         data-right-panel-tabbar


### PR DESCRIPTION
The Electron drag region around scrollable right-panel tabs intercepted the header controls, and maximizing the panel hid its restore control with the collapsed chat column. This moves the open-panel controls into the tab bar's no-drag area while keeping the closed-state controls in the chat header, so maximize, restore, terminal, and panel toggles remain reachable. Web typecheck, targeted lint, formatting, and real-app interaction checks pass; the existing component tests are blocked before collection by the repository's current vite-plus/test config error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI layout and pointer-event behavior only in the chat workspace header and right panel tab bar; no auth, data, or API changes.
> 
> **Overview**
> Moves **maximize/restore and panel toggle controls** into the inline right panel tab bar when that panel is open, instead of leaving them in the fixed chat header where Electron’s tab-bar **drag region** could swallow clicks.
> 
> `rightPanelControlsInPanel` now requires the panel to be **present and open**, so the header shows `panelLayoutControls` only while the inline panel is closed; open inline panels receive `layoutControls` on `RightPanelTabs` inside a `[-webkit-app-region:no-drag]` cluster. `RightPanelTabs` tightens title-bar padding when those controls are embedded so window chrome spacing stays correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3ceeab84754098021f3ae152c7718bfe327e885. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix right panel controls rendering in 'ChatViewContent' and 'RightPanelTabs'
> - `ChatViewContent` passes an inline control cluster (maximize and toggle controls) to `RightPanelTabs` only while the right panel is open
> - The workspace header renders its panel layout controls only when the panel is closed or not present
> - Risk: `RightPanelTabs` changes tab-bar padding for inline desktop mode when layout controls are present, replacing the `native-controls` inset plus six rem with just the `native-controls` inset
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3ceeab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

![right panel controls remain reachable through maximize, restore, terminal, and panel toggles](https://uploads-production-47e4.up.railway.app/files/3ae53b7a-cf17-4575-86e4-6b9a08c39590/right-panel-controls.gif)

Implemented by gpt-5.6-sol in T3 Code through the Codex harness.