### PR TITLE
chore: forward issue/PR/discussion events to Cursor hygiene

### DIFF
--- a/.github/workflows/cursor-hygiene-webhook.yml
+++ b/.github/workflows/cursor-hygiene-webhook.yml
@@ -32,7 +32,7 @@ jobs:
             echo "Missing CURSOR_T3CODE_WEBHOOK_URL or CURSOR_T3CODE_WEBHOOK_AUTH — skipping."
             exit 0
           fi
-          curl -fsS -X POST "$URL" \
+          curl -fsS --max-time 60 -X POST "$URL" \
             -H "Authorization: $AUTH" \
             -H "Content-Type: application/json" \
             -H "X-GitHub-Event: ${{ github.event_name }}" \

--- a/.github/workflows/cursor-hygiene-webhook.yml
+++ b/.github/workflows/cursor-hygiene-webhook.yml
@@ -1,8 +1,10 @@
 name: Forward to Cursor hygiene
 
 on:
+  push:
+    branches: [main]
   pull_request:
-    types: [opened, closed, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
   issues:
     types: [opened, closed, reopened]
   discussion:

--- a/.github/workflows/cursor-hygiene-webhook.yml
+++ b/.github/workflows/cursor-hygiene-webhook.yml
@@ -1,0 +1,38 @@
+name: Forward to Cursor hygiene
+
+on:
+  pull_request:
+    types: [opened, closed, reopened, ready_for_review]
+  issues:
+    types: [opened, closed, reopened]
+  discussion:
+    types: [created, closed, reopened]
+  issue_comment:
+    types: [created]
+  discussion_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  forward:
+    name: POST to Cursor
+    runs-on: ubuntu-24.04
+    steps:
+      - name: POST to Cursor
+        env:
+          URL: ${{ secrets.CURSOR_T3CODE_WEBHOOK_URL }}
+          AUTH: ${{ secrets.CURSOR_T3CODE_WEBHOOK_AUTH }}
+        run: |
+          set -euo pipefail
+          if [ -z "${URL:-}" ] || [ -z "${AUTH:-}" ]; then
+            echo "Missing CURSOR_T3CODE_WEBHOOK_URL or CURSOR_T3CODE_WEBHOOK_AUTH — skipping."
+            exit 0
+          fi
+          curl -fsS -X POST "$URL" \
+            -H "Authorization: $AUTH" \
+            -H "Content-Type: application/json" \
+            -H "X-GitHub-Event: ${{ github.event_name }}" \
+            -H "X-GitHub-Delivery: ${{ github.run_id }}-${{ github.run_attempt }}" \
+            --data-binary @"${{ github.event_path }}"


### PR DESCRIPTION
GitHub's native repository webhooks cannot send the `Authorization: Bearer ...` header that Cursor's automation endpoint requires. A direct repository webhook therefore receives HTTP 401, and the hygiene automation never sees the event.

This adds a GitHub Actions workflow that forwards selected pull request, issue, discussion, issue comment, and discussion comment events to Cursor. The job posts the original GitHub event payload and reads the endpoint and full authorization value from Actions secrets. If either secret is absent, it logs a message and skips the request without failing unrelated repository activity.

After merge, add these Actions secrets:

- `CURSOR_T3CODE_WEBHOOK_URL`: the Cursor automation webhook URL
- `CURSOR_T3CODE_WEBHOOK_AUTH`: the full `Authorization` header value, including `Bearer`

Do not put either secret in the repository.

Validation: `git diff --check` and manual review of the staged workflow against the requested event list and request headers.

Built with GPT-5 Codex in the Codex app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only outbound forwarding with read-only permissions; no application or auth logic changes, and missing secrets fail open without blocking merges.
> 
> **Overview**
> Adds a **GitHub Actions** workflow (`cursor-hygiene-webhook.yml`) so repo activity can reach Cursor’s hygiene automation with a proper `Authorization` header—something native GitHub webhooks can’t send.
> 
> The workflow runs on **pushes to `main`**, selected **PR**, **issue**, **discussion**, and **comment** events. A single job POSTs the raw event JSON from `github.event_path`, sets `X-GitHub-Event` and `X-GitHub-Delivery`, and uses Actions secrets `CURSOR_T3CODE_WEBHOOK_URL` and `CURSOR_T3CODE_WEBHOOK_AUTH` (full header value, including `Bearer`). If either secret is missing, it **logs and exits 0** so other CI isn’t blocked. Job permissions are limited to `contents: read`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c7a614dd132a07ac84fdf817623f1f20fa224cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `cursor-hygiene-webhook` workflow to forward issue, PR, and discussion events
> - Adds a GitHub Actions workflow that triggers on pushes to `main`, selected pull request, issue, and discussion lifecycle events, and creation of issue/discussion comments.
> - A `forward` job on `ubuntu-24.04` with contents-read permission POSTs the GitHub event payload from `github.event_path` to a Cursor webhook URL, including authorization, event name, and a delivery header built from the workflow run ID and attempt.
> - The job exits successfully with a skip message when either the webhook URL or authorization secret is absent; a failing or timed-out curl (60s max) fails the step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c7a614.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->