### PR TITLE
fix(antigravity): finish failed callback cleanup before retry

### DIFF
--- a/apps/server/src/provider/AntigravityAuth.test.ts
+++ b/apps/server/src/provider/AntigravityAuth.test.ts
@@ -57,6 +57,7 @@ const makeHarness = Effect.fn("makeAuthTestHarness")(function* (
     readonly authorizationUrls?: ReadonlyArray<string>;
     readonly supportsLogout?: boolean;
     readonly beforeInitialize?: Effect.Effect<void>;
+    readonly beforeProcessClose?: Effect.Effect<void>;
     readonly forwardCallback?: Effect.Effect<void, ProviderSetupError>;
   } = {},
 ) {
@@ -77,6 +78,7 @@ const makeHarness = Effect.fn("makeAuthTestHarness")(function* (
         events.push("process-open");
         yield* Effect.addFinalizer(() =>
           Effect.gen(function* () {
+            yield* options.beforeProcessClose ?? Effect.void;
             events.push("process-close");
             yield* Deferred.succeed(closed, undefined);
           }),
@@ -305,6 +307,42 @@ it.layer(NodeServices.layer)("AntigravityAuth", (it) => {
       const failed = yield* phase(harness.auth, "failed");
       assert.include(failed.message ?? "", "Could not deliver");
       assert.isTrue(harness.events.includes("process-close"));
+    }),
+  );
+
+  it.effect("finishes failed callback cleanup before allowing an immediate retry", () =>
+    Effect.gen(function* () {
+      const processCloseGate = yield* Deferred.make<void>();
+      const completionReturned = yield* Deferred.make<void>();
+      const harness = yield* makeHarness({
+        beforeProcessClose: Deferred.await(processCloseGate),
+        forwardCallback: Effect.fail(
+          new ProviderSetupError({
+            instanceId,
+            operation: "complete",
+            detail: "loopback refused",
+          }),
+        ),
+      });
+      const first = yield* harness.auth.controller.start(owner);
+      yield* phase(harness.auth, "waiting");
+
+      const completion = yield* harness.auth.controller
+        .complete(owner, { flowId: first.flowId!, callbackUrl })
+        .pipe(
+          Effect.exit,
+          Effect.tap(() => Deferred.succeed(completionReturned, undefined)),
+          Effect.forkScoped,
+        );
+      yield* phase(harness.auth, "failed");
+      const returnedBeforeCleanup = yield* Deferred.poll(completionReturned);
+      yield* Deferred.succeed(processCloseGate, undefined);
+      assert.isTrue(Option.isNone(returnedBeforeCleanup));
+      assert.isTrue(Exit.isFailure(yield* Fiber.join(completion)));
+      const retry = yield* harness.auth.controller.start(owner);
+      assert.notEqual(retry.flowId, first.flowId);
+      yield* phase(harness.auth, "waiting");
+      yield* harness.auth.controller.cancel(owner, retry.flowId!);
     }),
   );
 

--- a/apps/server/src/provider/AntigravityAuth.test.ts
+++ b/apps/server/src/provider/AntigravityAuth.test.ts
@@ -313,9 +313,12 @@ it.layer(NodeServices.layer)("AntigravityAuth", (it) => {
   it.effect("finishes failed callback cleanup before allowing an immediate retry", () =>
     Effect.gen(function* () {
       const processCloseGate = yield* Deferred.make<void>();
+      const processCloseStarted = yield* Deferred.make<void>();
       const completionReturned = yield* Deferred.make<void>();
       const harness = yield* makeHarness({
-        beforeProcessClose: Deferred.await(processCloseGate),
+        beforeProcessClose: Deferred.succeed(processCloseStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(processCloseGate)),
+        ),
         forwardCallback: Effect.fail(
           new ProviderSetupError({
             instanceId,
@@ -335,6 +338,7 @@ it.layer(NodeServices.layer)("AntigravityAuth", (it) => {
           Effect.forkScoped,
         );
       yield* phase(harness.auth, "failed");
+      yield* Deferred.await(processCloseStarted);
       const returnedBeforeCleanup = yield* Deferred.poll(completionReturned);
       yield* Deferred.succeed(processCloseGate, undefined);
       assert.isTrue(Option.isNone(returnedBeforeCleanup));

--- a/apps/server/src/provider/AntigravityAuth.ts
+++ b/apps/server/src/provider/AntigravityAuth.ts
@@ -291,35 +291,39 @@ export const makeAntigravityAuth = Effect.fn("makeAntigravityAuth")(function* <
       Effect.flatMap((result) => finishFlow(flow, result)),
     );
 
-  const stopFlow = (flow: AuthFlow, phase: "cancelled" | "failed", message: string) =>
-    Effect.uninterruptible(
+  const stopFlow = Effect.fn("AntigravityAuth.stopFlow")(function* (
+    flow: AuthFlow,
+    phase: "cancelled" | "failed",
+    message: string,
+    options: { readonly interruptForwarding?: boolean } = {},
+  ) {
+    const detached = yield* lock.withPermits(1)(
       Effect.gen(function* () {
-        const detached = yield* lock.withPermits(1)(
-          Effect.gen(function* () {
-            if (activeFlow !== flow) return false;
-            activeFlow = undefined;
-            operation = "cancel";
-            flow.pending = undefined;
-            yield* publishFlow(flow, {
-              ...flow.state,
-              phase,
-              authorizationUrl: null,
-              expiresAt: null,
-              message,
-            });
-            return true;
-          }),
-        );
-        if (!detached) return;
-        if (flow.forwarding) yield* Fiber.interrupt(flow.forwarding);
-        if (flow.fiber) yield* Fiber.interrupt(flow.fiber);
-        yield* lock.withPermits(1)(
-          Effect.sync(() => {
-            if (operation === "cancel") operation = "idle";
-          }),
-        );
+        if (activeFlow !== flow) return false;
+        activeFlow = undefined;
+        operation = "cancel";
+        flow.pending = undefined;
+        yield* publishFlow(flow, {
+          ...flow.state,
+          phase,
+          authorizationUrl: null,
+          expiresAt: null,
+          message,
+        });
+        return true;
       }),
     );
+    if (!detached) return;
+    if ((options.interruptForwarding ?? true) && flow.forwarding) {
+      yield* Fiber.interrupt(flow.forwarding);
+    }
+    if (flow.fiber) yield* Fiber.interrupt(flow.fiber);
+    yield* lock.withPermits(1)(
+      Effect.sync(() => {
+        if (operation === "cancel") operation = "idle";
+      }),
+    );
+  }, Effect.uninterruptible);
 
   const requireFlow = (ownerSessionId: string, flowId: string, name: string) =>
     Effect.gen(function* () {
@@ -411,11 +415,10 @@ export const makeAntigravityAuth = Effect.fn("makeAntigravityAuth")(function* <
             options.forwardCallback?.(callback) ??
             forwardAntigravityCallback(options.instanceId, callback)
           ).pipe(
-            // stopFlow interrupts this fiber, so it runs from a sibling fiber.
             Effect.tapError(() =>
-              stopFlow(flow, "failed", FORWARDING_FAILED_MESSAGE).pipe(
-                Effect.forkIn(instanceScope),
-              ),
+              stopFlow(flow, "failed", FORWARDING_FAILED_MESSAGE, {
+                interruptForwarding: false,
+              }),
             ),
             Effect.interruptible,
             Effect.forkIn(instanceScope),


### PR DESCRIPTION
## What Changed

A failed callback delivery could let `complete()` return before the Antigravity process closed, so an immediate retry could fail with `Antigravity setup is already in progress.`

- Make the callback forwarding fiber await `stopFlow()` when callback delivery fails.
- Skip interrupting the forwarding fiber while that same fiber runs cleanup.
- Add a regression test for an immediate sign-in retry after callback failure.

```mermaid
sequenceDiagram
    participant Client
    participant Auth as AntigravityAuth
    participant Agent as Antigravity process

    Client->>Auth: complete(callbackUrl)
    Auth->>Agent: Forward callback
    Agent-->>Auth: Delivery fails
    Auth->>Auth: stopFlow()
    Auth->>Agent: Interrupt and close
    Agent-->>Auth: Process closed
    Auth->>Auth: operation = idle
    Auth-->>Client: Return setup error
    Client->>Auth: start()
    Auth-->>Client: Start new flow
```

## Why

Before this change, the forwarding error handler forked `stopFlow()`. That let `complete()` return while the Antigravity process was still closing. An immediate retry could observe `operation === "cancel"` and fail with `Antigravity setup is already in progress.`

Cleanup still belongs to the provider instance, so it survives a requester disconnect. `complete()` now waits until cleanup closes the process and restores the idle state.

This is a follow-up to #9348 and its [sign-in retry review thread](https://github.com/pingdotgg/t3code/pull/9348#discussion_r3922406921).

## Test Plan

- [x] Apply only the regression test to `upstream/main`; the new test fails while the other 18 tests pass.
- [x] Run `vp test run apps/server/src/provider/AntigravityAuth.test.ts`; all 19 tests pass.
- [x] Run targeted `vp lint` and `vp fmt --check` on both changed files.
- [x] Run `vp run --filter t3 typecheck`.
- [x] Run `npx --yes fallow@3.22.0 audit --base upstream/main --format json --quiet --explain`; Fallow returns `verdict: pass` with no introduced findings.
- [x] Complete the Fallow graph review round-trip; Fallow accepts the live graph anchor with no stale or rejected anchors.
- [x] Inspect the only consumer outside the diff; the exported `makeAntigravityAuth` signature remains unchanged.

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why.
- [x] This PR does not change the UI, motion, or interaction design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth flow lifecycle and fiber interruption timing on callback failure; incorrect cleanup ordering could still block retries or leave processes running.
> 
> **Overview**
> Fixes a race where **`complete()`** could return after callback forwarding failed while the Antigravity process was still shutting down, so an immediate **`start()`** could hit *"Antigravity setup is already in progress."*
> 
> **`stopFlow`** is now an uninterruptible Effect that still detaches the flow under the lock, then interrupts fibers and sets **`operation`** back to **`idle`** only after cleanup finishes. When forwarding fails, the error handler **awaits** **`stopFlow`** in the same fiber (with **`interruptForwarding: false`**) instead of forking cleanup to a sibling fiber, so **`complete()`** does not resolve until process close and idle state are restored.
> 
> Adds test harness hook **`beforeProcessClose`** and a regression test that blocks process shutdown to assert **`complete()`** stays pending until cleanup completes and a retry can start a new flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61b7d5ca581b0f0d5b1046e686e4b6c0043a836c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AntigravityAuth` to finish failed callback cleanup before retry
> - When callback forwarding fails, the error handler now calls `stopFlow` directly in the forwarding effect's error path with `interruptForwarding: false`, so cleanup and owned-process shutdown finish before the completion effect returns with the error.
> - `stopFlow` is reworked as a named uninterruptible Effect; flow detachment and state publication happen under the lock, while child-fiber interruption happens after. The new `interruptForwarding` option (default `true`) lets callers avoid interrupting the forwarding fiber that is currently running cleanup; existing callers keep current behavior.
> - Adds a regression test in [AntigravityAuth.test.ts](https://github.com/pingdotgg/t3code/pull/9519/files#diff-ae8c7e4eacbcc409292a467800efffe678d6e307b70c34811f32c49b5ac3c861) and a `process-close` hook to the test harness to verify failed callback completion waits for cleanup and that a subsequent sign-in starts a new flow.
> - Risk: `stopFlow` now runs cleanup without interrupting the forwarding fiber when called from the error path; callers relying on the forwarding fiber being interrupted during cleanup should pass `interruptForwarding: true` explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61b7d5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when completing authentication callbacks after a failure.
  * Ensured required cleanup finishes before an immediate retry is allowed.
  * Prevented failed completion handling from interrupting related authentication processing.
  * Reduced the risk of authentication flows becoming inconsistent during callback failures and rapid retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Implemented with GPT-5.6 Sol via Codex in T3 Code.