### PR TITLE
fix(server): keep events during thread subscription startup

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -7304,7 +7304,6 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
           projectionSnapshotQuery: {
             getThreadDetailSnapshot: () =>
               Effect.gen(function* () {
-                yield* Effect.sleep("25 millis");
                 yield* PubSub.publish(liveEvents, messageEvent);
                 return Option.some({ snapshotSequence: 1, thread });
               }),
@@ -7317,14 +7316,19 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         withWsRpcClient(wsUrl, (client) =>
           client[ORCHESTRATION_WS_METHODS.subscribeThread]({
             threadId: defaultThreadId,
-          }).pipe(Stream.take(2), Stream.runCollect),
+            requestCompletionMarker: true,
+          }).pipe(
+            Stream.takeUntil((item) => item.kind === "synchronized"),
+            Stream.runCollect,
+          ),
         ),
-      ).pipe(Effect.timeout("2 seconds"));
+      );
 
       assert.equal(items[0]?.kind, "snapshot");
       assert.equal(items[1]?.kind, "event");
       assert.equal(items[1]?.kind === "event" ? items[1].event.sequence : null, 2);
-    }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
+      assert.equal(items[2]?.kind, "synchronized");
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
   it.effect("coalesces buffered live tool updates to the latest state", () =>

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1549,7 +1549,9 @@ const makeWsRpcLayer = (
               // Attach live delivery before reading either replay or snapshot state.
               // Otherwise an event published while the snapshot is loading is lost.
               const liveBuffer = yield* makeThreadLiveEventCoalescer();
-              yield* Effect.forkScoped(liveStream.pipe(Stream.runForEach(liveBuffer.offer)));
+              yield* Effect.forkScoped(liveStream.pipe(Stream.runForEach(liveBuffer.offer)), {
+                startImmediately: true,
+              });
               const bufferedLiveStream = liveBuffer.stream;
 
               // When the client already loaded the snapshot over HTTP it passes


### PR DESCRIPTION
A thread can lose its first live events while the initial snapshot or replay starts. A missed assistant-text event can leave an empty reply until the client reloads, even though the server saved the text.

Start the thread's live consumer immediately before reading state, as the shell subscription already does.

The existing snapshot test now publishes without a delay and waits for the synchronization marker. It fails before the fix and passes after it. Eleven focused subscription/coalescer tests and the server typecheck pass. Targeted lint reports only existing unused-parameter warnings in the test file.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time orchestration WebSocket delivery during subscription startup; incorrect behavior could still drop or reorder early thread events for clients.
> 
> **Overview**
> Fixes a race where **thread WebSocket subscriptions** could drop the first live events while the initial snapshot or replay was still loading—matching behavior **`subscribeShell` already had** via `startImmediately: true` on the scoped fork that feeds the live event coalescer.
> 
> The integration test no longer relies on a publish delay or `TestClock.withLive`; it publishes as soon as the snapshot hook runs, enables **`requestCompletionMarker`**, and reads until a **`synchronized`** frame so snapshot, event, and completion are all asserted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4642cf765d0198db8352328300cbe847d4228f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Start live-event consumer immediately in `ws.subscribeThread` subscription handler
> - The scoped fork that consumes the live thread-event stream now starts immediately, so live delivery is attached before the handler proceeds with snapshot or catch-up processing. This prevents events from being missed between the fork and snapshot/replay.
> - Updates the subscription test in [server.test.ts](https://github.com/pingdotgg/t3code/pull/9521/files#diff-311d34bc81e1c9cdae991c24771a5c0b8f02084dc94251982be7466403965b9f) to request a synchronization marker, collect items up to that marker, and assert the sequence contains snapshot, event, and synchronized items.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4642cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->