### PR TITLE
chore: drop comment events from Cursor hygiene forwarder

### DIFF
--- a/.github/workflows/cursor-hygiene-webhook.yml
+++ b/.github/workflows/cursor-hygiene-webhook.yml
@@ -9,10 +9,6 @@ on:
     types: [opened, closed, reopened]
   discussion:
     types: [created, closed, reopened]
-  issue_comment:
-    types: [created]
-  discussion_comment:
-    types: [created]
 
 permissions:
   contents: read


### PR DESCRIPTION
Removes issue_comment and discussion_comment triggers — they were only bot noise (Macroscope/Codex). Issues, discussions, same-repo PR open/ready, and push-to-main stay.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow trigger-only change; reduces webhook noise with no app or security impact.
> 
> **Overview**
> Stops the **Forward to Cursor hygiene** workflow from running on new issue and discussion comments.
> 
> **`issue_comment`** and **`discussion_comment`** (`created`) are removed from `on:`; pushes to `main`, PR open/reopen/ready-for-review, and issue/discussion lifecycle events are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e09d12d96642128662fbaf944b11750e5b7d9020. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `issue_comment` and `discussion_comment` triggers from Cursor hygiene workflow
> The workflow at [.github/workflows/cursor-hygiene-webhook.yml](https://github.com/pingdotgg/t3code/pull/9527/files#diff-d56b827eac376ce5d018274b2c167e286c144fa25280aff00f79e3870903b34c) no longer fires when a new issue or discussion comment is created. Other triggers for the workflow remain unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e09d12d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->