### PR TITLE
fix(server): settle branch threads immediately on pull request merge

### DIFF
--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -120,7 +120,13 @@ const SHORT_SHA_LENGTH = 7;
 const TOAST_DESCRIPTION_MAX = 72;
 const STATUS_RESULT_CACHE_TTL = Duration.seconds(1);
 const STATUS_RESULT_CACHE_CAPACITY = 2_048;
-const PR_LOOKUP_CACHE_TTL = Duration.minutes(2);
+// Matches the automatic settlement sweep cadence so every background sweep
+// reads fresh branch state: an external merge settles within about a minute
+// instead of waiting out a longer cache. Unpublished branches never reach the
+// host (a local probe answers first), and failed lookups still back off
+// exponentially via prLookupFailureTtl, so throttling pressure still drops
+// under 429s instead of amplifying it.
+const PR_LOOKUP_CACHE_TTL = Duration.seconds(60);
 const PR_LOOKUP_FAILURE_BASE_TTL = Duration.seconds(20);
 const PR_LOOKUP_FAILURE_MAX_TTL = Duration.minutes(15);
 const PR_LOOKUP_CACHE_CAPACITY = 2_048;

--- a/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
@@ -161,6 +161,7 @@ const makeHarness = Effect.fn("makeThreadSettlementHarness")(function* (options:
     }>
   >([]);
   const summaryRecovery = yield* Ref.make<ReadonlyArray<boolean | undefined>>([]);
+  const invalidatedCwds = yield* Ref.make<ReadonlyArray<string>>([]);
 
   const updateSettings = (patch: ServerSettingsPatch) =>
     Effect.gen(function* () {
@@ -221,7 +222,10 @@ const makeHarness = Effect.fn("makeThreadSettlementHarness")(function* (options:
           Effect.andThen(Ref.get(snapshots)),
         ),
     }),
-    Layer.mock(GitManager)({ branchPullRequest }),
+    Layer.mock(GitManager)({
+      branchPullRequest,
+      invalidateStatus: (cwd) => Ref.update(invalidatedCwds, (cwds) => [...cwds, cwd]),
+    }),
     Layer.mock(PullRequestService)({
       summary: pullRequestSummary,
       subscribeMerges: PubSub.subscribe(mergedPullRequests).pipe(
@@ -251,6 +255,7 @@ const makeHarness = Effect.fn("makeThreadSettlementHarness")(function* (options:
     branchCalls,
     summaryCalls,
     summaryRecovery,
+    invalidatedCwds,
     updateSettings,
     publishMerge: PubSub.publish(mergedPullRequests, {
       projectId: PROJECT_ID,
@@ -440,6 +445,42 @@ describe("ThreadSettlementReactor", () => {
             [ThreadId.make("merged-in-app")],
           );
           yield* Deferred.succeed(releasePeriodicLookup, undefined);
+          yield* reactor.drain;
+        }).pipe(Effect.provide(fixture.layer));
+      }),
+    ),
+  );
+
+  it.effect("settles branch threads on a pull request merge without waiting for the next sweep", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(NOW));
+        const state = yield* Ref.make<"open" | "merged">("open");
+        const mergedThreadSettled = yield* Deferred.make<void>();
+        const fixture = yield* makeHarness({
+          snapshot: makeSnapshot([makeThread("branch-thread", { branch: "saved-feature" })]),
+          branchPullRequest: () =>
+            Ref.get(state).pipe(
+              Effect.map((pullRequestState) => ({ state: pullRequestState, updatedAt: NOW })),
+            ),
+          onDispatch: () => Deferred.succeed(mergedThreadSettled, undefined),
+        });
+
+        yield* Effect.gen(function* () {
+          const reactor = yield* ThreadSettlementReactor.ThreadSettlementReactor;
+          yield* startHarness(reactor, fixture.activation, fixture.snapshotReads);
+          assert.deepStrictEqual(yield* Ref.get(fixture.commands), []);
+          assert.deepStrictEqual(yield* Ref.get(fixture.invalidatedCwds), []);
+
+          yield* Ref.set(state, "merged");
+          yield* fixture.publishMerge;
+          yield* Deferred.await(mergedThreadSettled);
+
+          assert.deepStrictEqual(
+            (yield* Ref.get(fixture.commands)).map((command) => command.threadId),
+            [ThreadId.make("branch-thread")],
+          );
+          assert.deepStrictEqual(yield* Ref.get(fixture.invalidatedCwds), ["/workspace/project"]);
           yield* reactor.drain;
         }).pipe(Effect.provide(fixture.layer));
       }),

--- a/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
@@ -451,40 +451,42 @@ describe("ThreadSettlementReactor", () => {
     ),
   );
 
-  it.effect("settles branch threads on a pull request merge without waiting for the next sweep", () =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        yield* TestClock.setTime(Date.parse(NOW));
-        const state = yield* Ref.make<"open" | "merged">("open");
-        const mergedThreadSettled = yield* Deferred.make<void>();
-        const fixture = yield* makeHarness({
-          snapshot: makeSnapshot([makeThread("branch-thread", { branch: "saved-feature" })]),
-          branchPullRequest: () =>
-            Ref.get(state).pipe(
-              Effect.map((pullRequestState) => ({ state: pullRequestState, updatedAt: NOW })),
-            ),
-          onDispatch: () => Deferred.succeed(mergedThreadSettled, undefined),
-        });
+  it.effect(
+    "settles branch threads on a pull request merge without waiting for the next sweep",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse(NOW));
+          const state = yield* Ref.make<"open" | "merged">("open");
+          const mergedThreadSettled = yield* Deferred.make<void>();
+          const fixture = yield* makeHarness({
+            snapshot: makeSnapshot([makeThread("branch-thread", { branch: "saved-feature" })]),
+            branchPullRequest: () =>
+              Ref.get(state).pipe(
+                Effect.map((pullRequestState) => ({ state: pullRequestState, updatedAt: NOW })),
+              ),
+            onDispatch: () => Deferred.succeed(mergedThreadSettled, undefined),
+          });
 
-        yield* Effect.gen(function* () {
-          const reactor = yield* ThreadSettlementReactor.ThreadSettlementReactor;
-          yield* startHarness(reactor, fixture.activation, fixture.snapshotReads);
-          assert.deepStrictEqual(yield* Ref.get(fixture.commands), []);
-          assert.deepStrictEqual(yield* Ref.get(fixture.invalidatedCwds), []);
+          yield* Effect.gen(function* () {
+            const reactor = yield* ThreadSettlementReactor.ThreadSettlementReactor;
+            yield* startHarness(reactor, fixture.activation, fixture.snapshotReads);
+            assert.deepStrictEqual(yield* Ref.get(fixture.commands), []);
+            assert.deepStrictEqual(yield* Ref.get(fixture.invalidatedCwds), []);
 
-          yield* Ref.set(state, "merged");
-          yield* fixture.publishMerge;
-          yield* Deferred.await(mergedThreadSettled);
+            yield* Ref.set(state, "merged");
+            yield* fixture.publishMerge;
+            yield* Deferred.await(mergedThreadSettled);
 
-          assert.deepStrictEqual(
-            (yield* Ref.get(fixture.commands)).map((command) => command.threadId),
-            [ThreadId.make("branch-thread")],
-          );
-          assert.deepStrictEqual(yield* Ref.get(fixture.invalidatedCwds), ["/workspace/project"]);
-          yield* reactor.drain;
-        }).pipe(Effect.provide(fixture.layer));
-      }),
-    ),
+            assert.deepStrictEqual(
+              (yield* Ref.get(fixture.commands)).map((command) => command.threadId),
+              [ThreadId.make("branch-thread")],
+            );
+            assert.deepStrictEqual(yield* Ref.get(fixture.invalidatedCwds), ["/workspace/project"]);
+            yield* reactor.drain;
+          }).pipe(Effect.provide(fixture.layer));
+        }),
+      ),
   );
 
   it.effect("uses fresh settlement settings after lookup and ignores unrelated changes", () =>

--- a/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
@@ -489,6 +489,75 @@ describe("ThreadSettlementReactor", () => {
       ),
   );
 
+  it.effect("a merge does not settle threads linked to an unrelated pull request", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(NOW));
+        const mergedThreadSettled = yield* Deferred.make<void>();
+        const mergeLookupStarted = yield* Deferred.make<void>();
+        const releaseMergeLookup = yield* Deferred.make<void>();
+        const lookupCount = yield* Ref.make(0);
+        const fixture = yield* makeHarness({
+          snapshot: makeSnapshot([
+            makeThread("merged-in-app", {
+              linkedPullRequest: {
+                projectId: PROJECT_ID,
+                repository: "owner/repository",
+                number: 42,
+                url: "https://example.test/owner/repository/pull/42",
+              },
+            }),
+            makeThread("unrelated-linked", {
+              linkedPullRequest: {
+                projectId: PROJECT_ID,
+                repository: "owner/repository",
+                number: 99,
+                url: "https://example.test/owner/repository/pull/99",
+              },
+            }),
+          ]),
+          pullRequestSummary: (input) =>
+            Ref.updateAndGet(lookupCount, (count) => count + 1).pipe(
+              // The initial sweep looks up both linked threads; the merge
+              // sweep only looks up the unrelated one, since the merged
+              // thread settles from the event itself.
+              Effect.tap((count) =>
+                count === 3 ? Deferred.succeed(mergeLookupStarted, undefined) : Effect.void,
+              ),
+              Effect.tap((count) =>
+                count === 3 ? Deferred.await(releaseMergeLookup) : Effect.void,
+              ),
+              Effect.map(() => makePullRequestSummary({ ...input, state: "open" })),
+            ),
+          onDispatch: () => Deferred.succeed(mergedThreadSettled, undefined),
+        });
+
+        yield* Effect.gen(function* () {
+          const reactor = yield* ThreadSettlementReactor.ThreadSettlementReactor;
+          yield* startHarness(reactor, fixture.activation, fixture.snapshotReads);
+          assert.deepStrictEqual(yield* Ref.get(fixture.commands), []);
+
+          yield* fixture.publishMerge;
+          yield* Deferred.await(mergeLookupStarted);
+          yield* Deferred.await(mergedThreadSettled);
+          yield* Deferred.succeed(releaseMergeLookup, undefined);
+          yield* reactor.drain;
+
+          assert.deepStrictEqual(
+            (yield* Ref.get(fixture.commands)).map((command) => command.threadId),
+            [ThreadId.make("merged-in-app")],
+          );
+          assert.deepStrictEqual(
+            (yield* Ref.get(fixture.summaryCalls))
+              .map((call) => call.number)
+              .toSorted((left, right) => left - right),
+            [42, 99, 99],
+          );
+        }).pipe(Effect.provide(fixture.layer));
+      }),
+    ),
+  );
+
   it.effect("uses fresh settlement settings after lookup and ignores unrelated changes", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/apps/server/src/orchestration/ThreadSettlementReactor.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.ts
@@ -46,15 +46,12 @@ export const make = Effect.gen(function* () {
     const snapshot = yield* snapshots.getShellSnapshot();
     const now = DateTime.formatIso(yield* DateTime.now);
     const projects = new Map(snapshot.projects.map((project) => [project.id, project]));
-    const candidates = snapshot.threads.filter(
-      (thread) =>
-        isAutoSettlementCandidate(thread, now) &&
-        (mergedPullRequest === null ||
-          (thread.linkedPullRequest != null &&
-            thread.linkedPullRequest.projectId === mergedPullRequest.projectId &&
-            thread.linkedPullRequest.repository.toLowerCase() ===
-              mergedPullRequest.repository.toLowerCase() &&
-            thread.linkedPullRequest.number === mergedPullRequest.number)),
+    // A merge event re-sweeps every candidate, not just the threads linked to
+    // the merged pull request: most threads carry no link and settle from
+    // their branch lookup, which would otherwise wait for the next minute's
+    // sweep on a possibly stale cached answer.
+    const candidates = snapshot.threads.filter((thread) =>
+      isAutoSettlementCandidate(thread, now),
     );
     // Use the same cwd as the sidebar so both paths share GitManager's PR cache.
     const lookupCwdByThreadId = new Map<string, string>();
@@ -76,6 +73,19 @@ export const make = Effect.gen(function* () {
         }),
       { concurrency: 8, discard: true },
     );
+    if (mergedPullRequest !== null) {
+      // The merge just confirmed a terminal state the lookup caches can still
+      // call open (branch answers live two minutes, the sweep runs every
+      // minute). Drop the swept checkouts' cached answers so the merge settles
+      // its branch threads now instead of on a later sweep. Threads linked to
+      // the merged pull request settle from the event itself below and need no
+      // lookup, so they are absent from this map by construction.
+      const cwds = [...new Set(lookupCwdByThreadId.values())];
+      yield* Effect.forEach(cwds, (cwd) => git.invalidateStatus(cwd), {
+        concurrency: 8,
+        discard: true,
+      });
+    }
     const lookupKey = (thread: (typeof candidates)[number]) => {
       if (thread.linkedPullRequest != null) {
         return JSON.stringify([

--- a/apps/server/src/orchestration/ThreadSettlementReactor.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.ts
@@ -50,9 +50,7 @@ export const make = Effect.gen(function* () {
     // the merged pull request: most threads carry no link and settle from
     // their branch lookup, which would otherwise wait for the next minute's
     // sweep on a possibly stale cached answer.
-    const candidates = snapshot.threads.filter((thread) =>
-      isAutoSettlementCandidate(thread, now),
-    );
+    const candidates = snapshot.threads.filter((thread) => isAutoSettlementCandidate(thread, now));
     // Use the same cwd as the sidebar so both paths share GitManager's PR cache.
     const lookupCwdByThreadId = new Map<string, string>();
     yield* Effect.forEach(

--- a/apps/server/src/orchestration/ThreadSettlementReactor.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.ts
@@ -105,7 +105,18 @@ export const make = Effect.gen(function* () {
       thread: (typeof candidates)[number],
     ) {
       if (thread.linkedPullRequest != null) {
-        if (mergedPullRequest !== null) {
+        // The event carries the merged state, so only the threads linked to
+        // that exact pull request settle from it. Every other linked thread
+        // falls through to a fresh summary lookup below: the merge sweep
+        // covers all candidates, and an unrelated merge must never settle
+        // them.
+        if (
+          mergedPullRequest !== null &&
+          thread.linkedPullRequest.projectId === mergedPullRequest.projectId &&
+          thread.linkedPullRequest.repository.toLowerCase() ===
+            mergedPullRequest.repository.toLowerCase() &&
+          thread.linkedPullRequest.number === mergedPullRequest.number
+        ) {
           return {
             state: "merged",
             updatedAt: mergedPullRequest.mergedAt,


### PR DESCRIPTION
Merging from the in-app pull request viewer left branch threads active for minutes: the merge fast-path only swept explicitly linked threads, so everything else waited for the next minute's sweep on a branch lookup that can stay cached as open for two minutes.

The merge event now re-sweeps every auto-settlement candidate and drops the swept checkouts' cached git answers first, so a merge settles its branch threads in seconds. Threads linked to the merged pull request still settle from the event itself without a lookup.

Verified with the reactor suite (10 tests, including a new regression test that fails on the old code) plus the settlement policy suite (12 tests), and a clean typecheck for the touched files. Built with Muse Spark on OpenCode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge settlement scope and linked-PR matching (exact repo/number), plus shorter PR lookup caching, which affects orchestration timing and API load under settlement sweeps.
> 
> **Overview**
> **Merging a PR in-app no longer leaves branch-only threads active for minutes.** A merge-triggered settlement sweep now considers every auto-settlement candidate (not only threads with an explicit PR link), and it calls `GitManager.invalidateStatus` on each branch lookup checkout first so cached “open” branch PR state cannot block settlement.
> 
> Threads that are **linked to the merged PR** still settle from the merge event without a lookup; linked threads for **other** PRs keep using a normal summary lookup instead of inheriting the merge. **`PR_LOOKUP_CACHE_TTL`** drops from two minutes to **60 seconds** so periodic sweeps see fresher branch PR state without waiting out a longer cache.
> 
> Tests cover immediate branch-thread settlement on merge, cache invalidation, and that an unrelated merge does not settle other linked threads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85d76cc92d5c247e4cf63c3d6af8c08c8cc41acf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Settle branch threads immediately on pull request merge in `ThreadSettlementReactor`
> - Merge-event sweeps now include all auto-settlement candidates instead of only threads linked to the event's pull request, and invalidate cached branch status for eligible unlinked threads before lookup
> - `pullRequestFor` now compares project, repository, and pull-request number exactly, so only the thread linked to the exact merged PR gets merged state; unrelated linked threads continue through normal lookup
> - Reduces `PR_LOOKUP_CACHE_TTL` from 2 minutes to 60 seconds so the settlement sweep observes merge state sooner
> - Risk: `sweep` now processes all eligible threads on every merge event and invalidates up to eight working directories concurrently, which may increase load during merge bursts; check [ThreadSettlementReactor.ts](https://github.com/pingdotgg/t3code/pull/9528/files#diff-d1d0434f1c82cb762eac14e3238e44d97e93fde6be3f5120c34057a355a0b6fb) for concurrency limits
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85d76cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->