### PR TITLE
fix(web): preserve composer focus during preview presses

### DIFF
--- a/apps/desktop/src/ipc/methods/preview.test.ts
+++ b/apps/desktop/src/ipc/methods/preview.test.ts
@@ -170,3 +170,42 @@ describe("preview IPC methods", () => {
     ).toThrow();
   });
 });
+
+describe("automationPressResult", () => {
+  effectIt.effect("returns an interrupted outcome for human control takeover", () =>
+    Effect.gen(function* () {
+      const error = new PreviewManager.PreviewAutomationControlInterruptedError({
+        operation: "press",
+        tabId: "tab-1",
+        webContentsId: 42,
+      });
+
+      expect(yield* PreviewIpc.automationPressResult(Effect.fail(error))).toEqual({
+        status: "interrupted",
+      });
+    }),
+  );
+
+  effectIt.effect("returns a completed outcome after a successful press", () =>
+    Effect.gen(function* () {
+      expect(yield* PreviewIpc.automationPressResult(Effect.succeed("restored"))).toEqual({
+        status: "completed",
+        focusDisposition: "restored",
+      });
+    }),
+  );
+
+  effectIt.effect("keeps unexpected failures as rejected effects", () =>
+    Effect.gen(function* () {
+      const error = new PreviewManager.PreviewWebContentsNotFoundError({
+        tabId: "tab-1",
+        webContentsId: 42,
+      });
+      const exit = yield* Effect.exit(PreviewIpc.automationPressResult(Effect.fail(error)));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isSuccess(exit)) return;
+      expect(Cause.squash(exit.cause)).toBe(error);
+    }),
+  );
+});

--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -4,6 +4,7 @@ import {
   DesktopPreviewAutomationClickInputSchema,
   DesktopPreviewAutomationEvaluateInputSchema,
   DesktopPreviewAutomationPressInputSchema,
+  DesktopPreviewAutomationPressResultSchema,
   DesktopPreviewAutomationScrollInputSchema,
   DesktopPreviewAutomationStatusSchema,
   DesktopPreviewAutomationTypeInputSchema,
@@ -23,6 +24,8 @@ import {
   DesktopPreviewCreateTabInputSchema,
   DesktopPreviewTabInputSchema,
   DesktopPreviewWebviewConfigSchema,
+  type DesktopPreviewAutomationPressFocusDisposition,
+  type DesktopPreviewAutomationPressResult,
   PreviewAnnotationSubmissionResultSchema,
   PreviewAutomationSnapshot,
   DEFAULT_BROWSER_PROFILE_ID,
@@ -420,12 +423,27 @@ export const automationType = DesktopIpc.makeIpcMethod({
 export const automationPress = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_AUTOMATION_PRESS_CHANNEL,
   payload: DesktopPreviewAutomationPressInputSchema,
-  result: Schema.Void,
+  result: DesktopPreviewAutomationPressResultSchema,
   handler: Effect.fn("desktop.ipc.preview.automationPress")(function* ({ tabId, input }) {
     const manager = yield* PreviewManager.PreviewManager;
-    yield* manager.automationPress(tabId, input);
+    return yield* automationPressResult(manager.automationPress(tabId, input));
   }),
 });
+
+export const automationPressResult = (
+  effect: Effect.Effect<
+    DesktopPreviewAutomationPressFocusDisposition,
+    PreviewManager.PreviewManagerError
+  >,
+): Effect.Effect<DesktopPreviewAutomationPressResult, PreviewManager.PreviewManagerError> =>
+  effect.pipe(
+    Effect.map((focusDisposition) => ({ status: "completed" as const, focusDisposition })),
+    Effect.catch((error: PreviewManager.PreviewManagerError) =>
+      PreviewManager.isPreviewAutomationControlInterruptedError(error)
+        ? Effect.succeed({ status: "interrupted" as const })
+        : Effect.fail(error),
+    ),
+  );
 
 export const automationScroll = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_AUTOMATION_SCROLL_CHANNEL,

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -3510,6 +3510,12 @@ describe("PreviewManager", () => {
       Effect.gen(function* () {
         let failKeyDown = false;
         let interruptPress = false;
+        let blockCleanup = false;
+        const cleanupStarted = Deferred.makeUnsafe<void>();
+        let releaseCleanup!: () => void;
+        const cleanupRelease = new Promise<void>((resolve) => {
+          releaseCleanup = resolve;
+        });
         let humanInput: ((_event: unknown, signal: unknown) => void) | undefined;
         const sendCommand = vi.fn(async (method: string, params?: Record<string, unknown>) => {
           if (
@@ -3533,6 +3539,10 @@ describe("PreviewManager", () => {
                     code: params["code"] ?? "Digit1",
                   },
             );
+          }
+          if (blockCleanup && method === "Input.dispatchKeyEvent" && params?.["type"] === "keyUp") {
+            Deferred.doneUnsafe(cleanupStarted, Effect.void);
+            await cleanupRelease;
           }
           return method === "Runtime.evaluate" ? { result: { value: { ok: true } } } : undefined;
         });
@@ -3728,6 +3738,35 @@ describe("PreviewManager", () => {
           webContentsId: 42,
         });
         expect(restoreFocus).toHaveBeenCalledTimes(3);
+
+        sendCommand.mockClear();
+        getFocusedWebContents.mockReset();
+        getFocusedWebContents.mockReturnValueOnce(previousFocused).mockReturnValue(focusedGuest);
+        interruptPress = false;
+        blockCleanup = true;
+        const cleanupPress = yield* manager
+          .automationPress("tab_input", { key: "~" })
+          .pipe(Effect.forkChild);
+        yield* Deferred.await(cleanupStarted);
+        const interruptCleanup = yield* Effect.forkChild(Fiber.interrupt(cleanupPress));
+        yield* Effect.yieldNow;
+        releaseCleanup();
+        yield* Fiber.join(interruptCleanup);
+
+        const cleanupExit = yield* Fiber.await(cleanupPress);
+        expect(Exit.isFailure(cleanupExit)).toBe(true);
+        expect(sendCommand).toHaveBeenCalledWith("Input.dispatchKeyEvent", {
+          type: "keyUp",
+          key: "~",
+          code: "Backquote",
+          modifiers: 0,
+          windowsVirtualKeyCode: 192,
+          location: 0,
+          isKeypad: false,
+        });
+        expect(sendCommand).toHaveBeenCalledWith("Emulation.setFocusEmulationEnabled", {
+          enabled: false,
+        });
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -3642,6 +3642,16 @@ describe("PreviewManager", () => {
 
         sendCommand.mockClear();
         getFocusedWebContents.mockReset();
+        getFocusedWebContents.mockReturnValueOnce(previousFocused).mockReturnValue(previousFocused);
+        const restoreCallsBeforeAlreadyFocusedPress = restoreFocus.mock.calls.length;
+        // The host may have moved DOM focus while the app renderer stayed
+        // focused. Mark the native disposition as restored without calling
+        // focus again so the host can restore its DOM focus.
+        expect(yield* manager.automationPress("tab_input", { key: "=" })).toBe("restored");
+        expect(restoreFocus).toHaveBeenCalledTimes(restoreCallsBeforeAlreadyFocusedPress);
+
+        sendCommand.mockClear();
+        getFocusedWebContents.mockReset();
         getFocusedWebContents.mockReturnValueOnce(previousFocused).mockReturnValue(focusedGuest);
         failKeyDown = true;
         const failedPress = yield* Effect.exit(manager.automationPress("tab_input", { key: "y" }));

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -116,6 +116,7 @@ const {
   createFromPath,
   fromId,
   getFocusedWebContents,
+  getFocusedWindow,
   mkdir,
   showItemInFolder,
   webviewSend,
@@ -126,6 +127,9 @@ const {
   createFromPath: vi.fn((): { readonly isEmpty: () => boolean } => ({ isEmpty: () => false })),
   fromId: vi.fn<(_id?: number) => Electron.WebContents | null>((_id?: number) => null),
   getFocusedWebContents: vi.fn(() => null),
+  getFocusedWindow: vi.fn<() => Electron.BrowserWindow | null>(
+    () => ({}) as Electron.BrowserWindow,
+  ),
   mkdir: vi.fn((_path: string) => undefined),
   showItemInFolder: vi.fn(),
   webviewSend: vi.fn(),
@@ -134,7 +138,7 @@ const {
 }));
 
 vi.mock("electron", () => ({
-  BrowserWindow: browserWindowConstructor,
+  BrowserWindow: Object.assign(browserWindowConstructor, { getFocusedWindow }),
   clipboard: {
     writeImage,
   },
@@ -466,6 +470,8 @@ describe("PreviewManager", () => {
     fromId.mockClear();
     getFocusedWebContents.mockReset();
     getFocusedWebContents.mockReturnValue(null);
+    getFocusedWindow.mockReset();
+    getFocusedWindow.mockReturnValue({} as Electron.BrowserWindow);
     mkdir.mockClear();
     writeFile.mockClear();
     showItemInFolder.mockClear();
@@ -3503,6 +3509,7 @@ describe("PreviewManager", () => {
     withManager((manager) =>
       Effect.gen(function* () {
         let failKeyDown = false;
+        let interruptPress = false;
         let humanInput: ((_event: unknown, signal: unknown) => void) | undefined;
         const sendCommand = vi.fn(async (method: string, params?: Record<string, unknown>) => {
           if (
@@ -3518,22 +3525,26 @@ describe("PreviewManager", () => {
           ) {
             humanInput?.(
               {},
-              {
-                kind: "key",
-                key: params["key"],
-                code: params["code"] ?? "Digit1",
-              },
+              interruptPress
+                ? { kind: "pointer", x: 400, y: 300, button: 0 }
+                : {
+                    kind: "key",
+                    key: params["key"],
+                    code: params["code"] ?? "Digit1",
+                  },
             );
           }
           return method === "Runtime.evaluate" ? { result: { value: { ok: true } } } : undefined;
         });
         const restoreFocus = vi.fn();
         const focus = vi.fn();
-        getFocusedWebContents.mockReturnValue({
+        const previousFocused = {
           id: 7,
           isDestroyed: () => false,
           focus: restoreFocus,
-        } as never);
+        } as never;
+        const focusedGuest = { id: 42, isDestroyed: () => false } as never;
+        getFocusedWebContents.mockReturnValueOnce(previousFocused).mockReturnValue(focusedGuest);
         fromId.mockReturnValue({
           id: 42,
           isDestroyed: () => false,
@@ -3571,7 +3582,7 @@ describe("PreviewManager", () => {
         yield* manager.registerWebview("tab_input", 42);
         yield* manager.automationType("tab_input", { text: "hello", clear: true });
         yield* manager.automationType("tab_input", { text: "", clear: true });
-        yield* manager.automationPress("tab_input", { key: "x" });
+        expect(yield* manager.automationPress("tab_input", { key: "x" })).toBe("restored");
 
         const calls = sendCommand.mock.calls;
         const methods = calls.map(([method]) => method);
@@ -3630,6 +3641,8 @@ describe("PreviewManager", () => {
         expect(sendCommand).toHaveBeenCalledWith("Input.setIgnoreInputEvents", { ignore: false });
 
         sendCommand.mockClear();
+        getFocusedWebContents.mockReset();
+        getFocusedWebContents.mockReturnValueOnce(previousFocused).mockReturnValue(focusedGuest);
         failKeyDown = true;
         const failedPress = yield* Effect.exit(manager.automationPress("tab_input", { key: "y" }));
 
@@ -3655,6 +3668,8 @@ describe("PreviewManager", () => {
         ).toHaveLength(1);
 
         sendCommand.mockClear();
+        getFocusedWebContents.mockReset();
+        getFocusedWebContents.mockReturnValueOnce(previousFocused).mockReturnValue(focusedGuest);
         failKeyDown = false;
         yield* manager.automationPress("tab_input", { key: "!" });
         expect(sendCommand).toHaveBeenCalledWith("Input.dispatchKeyEvent", {
@@ -3667,6 +3682,40 @@ describe("PreviewManager", () => {
           isKeypad: false,
           text: "!",
           unmodifiedText: "!",
+        });
+        expect(restoreFocus).toHaveBeenCalledTimes(3);
+
+        sendCommand.mockClear();
+        getFocusedWebContents.mockReset();
+        getFocusedWebContents
+          .mockReturnValueOnce({ id: 7, isDestroyed: () => false, focus: restoreFocus } as never)
+          .mockReturnValueOnce(null);
+        getFocusedWindow.mockReturnValue(null);
+        expect(yield* manager.automationPress("tab_input", { key: "?" })).toBe("preserved");
+        expect(restoreFocus).toHaveBeenCalledTimes(3);
+
+        getFocusedWebContents.mockReset();
+        getFocusedWebContents
+          .mockReturnValueOnce({ id: 7, isDestroyed: () => false, focus: restoreFocus } as never)
+          .mockReturnValueOnce({ id: 43, isDestroyed: () => false } as never);
+        getFocusedWindow.mockReturnValue({} as Electron.BrowserWindow);
+        expect(yield* manager.automationPress("tab_input", { key: "/" })).toBe("preserved");
+        expect(restoreFocus).toHaveBeenCalledTimes(3);
+
+        sendCommand.mockClear();
+        getFocusedWebContents.mockReset();
+        getFocusedWebContents.mockReturnValueOnce(previousFocused).mockReturnValue(focusedGuest);
+        interruptPress = true;
+        const interruptedPress = yield* Effect.exit(
+          manager.automationPress("tab_input", { key: "=" }),
+        );
+        expect(Exit.isFailure(interruptedPress)).toBe(true);
+        if (Exit.isSuccess(interruptedPress)) return;
+        expect(Option.getOrThrow(Cause.findErrorOption(interruptedPress.cause))).toMatchObject({
+          _tag: "PreviewAutomationControlInterruptedError",
+          operation: "press",
+          tabId: "tab_input",
+          webContentsId: 42,
         });
         expect(restoreFocus).toHaveBeenCalledTimes(3);
       }),

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -3943,7 +3943,10 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       isPreviewAutomationControlInterruptedError(
         Option.getOrNull(Cause.findErrorOption(pressExit.cause)),
       );
-    yield* releaseInput(!interrupted);
+    // Input cleanup must finish even when the action fiber is interrupted while
+    // a CDP cleanup command is in flight. Otherwise Chromium can retain a held
+    // key or focus emulation state after the preview loses control.
+    yield* Effect.uninterruptible(releaseInput(!interrupted));
     if (pressExit._tag === "Failure") return yield* Effect.failCause(pressExit.cause);
     return focusDisposition;
   });

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -9,6 +9,7 @@ import { DESKTOP_PREVIEW_RECORDING_CAPTURE_TRIGGER } from "@t3tools/contracts";
 import type {
   DesktopPreviewAnnotationTheme,
   DesktopPreviewAutomationStatus,
+  DesktopPreviewAutomationPressFocusDisposition,
   DesktopPreviewColorScheme,
   DesktopPreviewFavicon,
   DesktopPreviewPointerEvent,
@@ -3866,41 +3867,76 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       { operation: "automationPress.getFocusedWebContents", tabId, webContentsId: wc.id },
       () => webContents.getFocusedWebContents(),
     );
+    let focusDisposition: DesktopPreviewAutomationPressFocusDisposition = "preserved";
     let keyDownAttempted = false;
-    const releaseInput = Effect.gen(function* () {
-      if (keyDownAttempted) {
-        yield* sendCleanup("Input.dispatchKeyEvent", keySequence.keyUp).pipe(Effect.ignore);
-      }
-      yield* sendCleanup("Emulation.setFocusEmulationEnabled", { enabled: false }).pipe(
-        Effect.ignore,
-      );
-      if (previouslyFocused && previouslyFocused.id !== wc.id && !previouslyFocused.isDestroyed()) {
-        yield* attempt(
+    const releaseInput = (restoreFocus: boolean) =>
+      Effect.gen(function* () {
+        if (keyDownAttempted) {
+          yield* sendCleanup("Input.dispatchKeyEvent", keySequence.keyUp).pipe(Effect.ignore);
+        }
+        yield* sendCleanup("Emulation.setFocusEmulationEnabled", { enabled: false }).pipe(
+          Effect.ignore,
+        );
+        const focusedWebContents = yield* attempt(
           {
-            operation: "automationPress.restoreFocusedWebContents",
+            operation: "automationPress.getCurrentFocusedWebContents",
             tabId,
-            webContentsId: previouslyFocused.id,
+            webContentsId: wc.id,
           },
-          () => previouslyFocused.focus(),
-        ).pipe(Effect.ignore);
-      }
-    });
+          () => webContents.getFocusedWebContents(),
+        ).pipe(Effect.orElseSucceed(() => null));
+        const focusedWindow = yield* attempt(
+          { operation: "automationPress.getFocusedWindow", tabId, webContentsId: wc.id },
+          () => BrowserWindow.getFocusedWindow(),
+        ).pipe(Effect.orElseSucceed(() => null));
+        const automationOwnsFocus = focusedWindow !== null && focusedWebContents?.id === wc.id;
+        if (
+          restoreFocus &&
+          automationOwnsFocus &&
+          previouslyFocused &&
+          previouslyFocused.id !== wc.id &&
+          !previouslyFocused.isDestroyed()
+        ) {
+          const restored = yield* attempt(
+            {
+              operation: "automationPress.restoreFocusedWebContents",
+              tabId,
+              webContentsId: previouslyFocused.id,
+            },
+            () => previouslyFocused.focus(),
+          ).pipe(
+            Effect.as(true),
+            Effect.orElseSucceed(() => false),
+          );
+          if (restored) focusDisposition = "restored";
+        }
+      });
 
     // Focus the guest WebContents itself, not its containing BrowserWindow. This
     // activates native keyboard behavior for hidden/background previews without
     // changing which thread is mounted in the UI. Restore the previous renderer
     // after dispatch so automation never leaves the app's input focus behind.
-    yield* Effect.gen(function* () {
-      yield* attempt(
-        { operation: "automationPress.focusWebContents", tabId, webContentsId: wc.id },
-        () => wc.focus(),
+    const pressExit = yield* Effect.exit(
+      Effect.gen(function* () {
+        yield* attempt(
+          { operation: "automationPress.focusWebContents", tabId, webContentsId: wc.id },
+          () => wc.focus(),
+        );
+        yield* send("Page.bringToFront");
+        yield* send("Emulation.setFocusEmulationEnabled", { enabled: true });
+        yield* expectAgentInput(tabId, keySequence.signal);
+        keyDownAttempted = true;
+        yield* send("Input.dispatchKeyEvent", keySequence.keyDown);
+      }),
+    );
+    const interrupted =
+      pressExit._tag === "Failure" &&
+      isPreviewAutomationControlInterruptedError(
+        Option.getOrNull(Cause.findErrorOption(pressExit.cause)),
       );
-      yield* send("Page.bringToFront");
-      yield* send("Emulation.setFocusEmulationEnabled", { enabled: true });
-      yield* expectAgentInput(tabId, keySequence.signal);
-      keyDownAttempted = true;
-      yield* send("Input.dispatchKeyEvent", keySequence.keyDown);
-    }).pipe(Effect.ensuring(releaseInput));
+    yield* releaseInput(!interrupted);
+    if (pressExit._tag === "Failure") return yield* Effect.failCause(pressExit.cause);
+    return focusDisposition;
   });
 
   const automationPress = Effect.fn("PreviewManager.automationPress")(function* (
@@ -3908,7 +3944,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     input: PreviewAutomationPressInput,
   ) {
     const wc = yield* requireWebContents(tabId);
-    yield* withControlSession(tabId, wc, "press", (send, sendCleanup) =>
+    return yield* withControlSession(tabId, wc, "press", (send, sendCleanup) =>
       performAutomationPress(tabId, wc, input, send, sendCleanup),
     );
   });
@@ -4558,7 +4594,7 @@ export class PreviewManager extends Context.Service<
     readonly automationPress: (
       tabId: string,
       input: PreviewAutomationPressInput,
-    ) => Effect.Effect<void, PreviewManagerError>;
+    ) => Effect.Effect<DesktopPreviewAutomationPressFocusDisposition, PreviewManagerError>;
     readonly automationScroll: (
       tabId: string,
       input: PreviewAutomationScrollInput,

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -3890,13 +3890,22 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           () => BrowserWindow.getFocusedWindow(),
         ).pipe(Effect.orElseSucceed(() => null));
         const automationOwnsFocus = focusedWindow !== null && focusedWebContents?.id === wc.id;
+        const previousRendererOwnsFocus =
+          focusedWindow !== null && focusedWebContents?.id === previouslyFocused?.id;
         if (
           restoreFocus &&
-          automationOwnsFocus &&
           previouslyFocused &&
           previouslyFocused.id !== wc.id &&
-          !previouslyFocused.isDestroyed()
+          !previouslyFocused.isDestroyed() &&
+          (automationOwnsFocus || previousRendererOwnsFocus)
         ) {
+          if (previousRendererOwnsFocus) {
+            // Native focus is already where it needs to be. Report the same
+            // disposition as an explicit restore so the host can restore its
+            // DOM focus without needlessly refocusing the renderer.
+            focusDisposition = "restored";
+            return;
+          }
           const restored = yield* attempt(
             {
               operation: "automationPress.restoreFocusedWebContents",

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -8,6 +8,7 @@ import {
   type EnvironmentId,
   type PreviewAutomationNavigateInput,
   type PreviewAutomationOpenInput,
+  type DesktopPreviewAutomationPressResult,
   type PreviewAutomationResizeInput,
   type PreviewAutomationResizeResult,
   type PreviewAutomationSetColorSchemeInput,
@@ -54,6 +55,7 @@ import { useAtomCommand } from "~/state/use-atom-command";
 import { previewBridge } from "./previewBridge";
 import {
   PreviewAutomationOperationError,
+  PreviewAutomationControlInterruptedHostError,
   PreviewAutomationOverlayTimeoutError,
   PreviewAutomationRecordingNotActiveError,
   PreviewAutomationTargetUnavailableError,
@@ -653,13 +655,29 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             );
           }
           case "press": {
-            return await withPreviewAutomationFocus(async () => {
-              const ready = await requireReadyTab();
-              return await ready.bridge.automation.press(
-                ready.runtimeTabId,
-                request.input as Parameters<typeof ready.bridge.automation.press>[1],
-              );
-            });
+            const pressResult = await withPreviewAutomationFocus(
+              async (): Promise<DesktopPreviewAutomationPressResult> => {
+                const ready = await requireReadyTab();
+                return await ready.bridge.automation.press(
+                  ready.runtimeTabId,
+                  request.input as Parameters<typeof ready.bridge.automation.press>[1],
+                );
+              },
+              {
+                shouldRestoreFocus: (result) =>
+                  result.status === "completed" && result.focusDisposition === "restored",
+              },
+            );
+            if (pressResult.status === "interrupted") {
+              throw new PreviewAutomationControlInterruptedHostError({
+                requestId: request.requestId,
+                operation: request.operation,
+                environmentId,
+                threadId: request.threadId,
+                tabId,
+              });
+            }
+            return undefined;
           }
           case "scroll": {
             const ready = await requireReadyTab();

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -45,6 +45,7 @@ import { browserDefaultOpenViewport, resolveBrowserDefaults } from "~/browser/br
 import { runBrowserViewportMutation } from "~/browser/browserViewportActions";
 import { previewRuntimeTabId } from "~/browser/previewRuntimeTabId";
 import { isElectron } from "~/env";
+import { withPreviewAutomationFocus } from "~/lib/previewAutomationFocus";
 import { useEnvironments } from "~/state/environments";
 import { previewEnvironment } from "~/state/preview";
 import { useAtomQueryRunner } from "~/state/use-atom-query-runner";
@@ -652,11 +653,13 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             );
           }
           case "press": {
-            const ready = await requireReadyTab();
-            return await ready.bridge.automation.press(
-              ready.runtimeTabId,
-              request.input as Parameters<typeof ready.bridge.automation.press>[1],
-            );
+            return await withPreviewAutomationFocus(async () => {
+              const ready = await requireReadyTab();
+              return await ready.bridge.automation.press(
+                ready.runtimeTabId,
+                request.input as Parameters<typeof ready.bridge.automation.press>[1],
+              );
+            });
           }
           case "scroll": {
             const ready = await requireReadyTab();

--- a/apps/web/src/components/preview/previewAutomationErrors.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.ts
@@ -113,6 +113,25 @@ export class PreviewAutomationRecordingNotActiveError extends Schema.TaggedError
   }
 }
 
+export class PreviewAutomationControlInterruptedHostError extends Schema.TaggedErrorClass<PreviewAutomationControlInterruptedHostError>()(
+  "PreviewAutomationControlInterruptedHostError",
+  {
+    requestId: TrimmedNonEmptyString,
+    operation: PreviewAutomationOperation,
+    environmentId: EnvironmentId,
+    threadId: ThreadId,
+    tabId: Schema.NullOr(PreviewTabId),
+  },
+) {
+  get responseTag() {
+    return "PreviewAutomationControlInterruptedError" as const;
+  }
+
+  override get message(): string {
+    return `Preview automation ${this.operation} request ${this.requestId} was interrupted by human input on environment ${this.environmentId} thread ${this.threadId}.`;
+  }
+}
+
 export class PreviewAutomationTargetNotEditableHostError extends Schema.TaggedErrorClass<PreviewAutomationTargetNotEditableHostError>()(
   "PreviewAutomationTargetNotEditableHostError",
   {
@@ -211,6 +230,7 @@ export const PreviewAutomationHostError = Schema.Union([
   PreviewAutomationViewportTimeoutError,
   PreviewAutomationTargetUnavailableError,
   PreviewAutomationRecordingNotActiveError,
+  PreviewAutomationControlInterruptedHostError,
   PreviewAutomationTargetNotEditableHostError,
   PreviewAutomationOperationError,
 ]);

--- a/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
+++ b/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
@@ -10,6 +10,7 @@ import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
+  PreviewAutomationControlInterruptedHostError,
   PreviewAutomationRecordingNotActiveError,
   PreviewAutomationTargetUnavailableError,
   PreviewAutomationViewportTimeoutError,
@@ -265,6 +266,29 @@ describe("previewAutomationRequestConsumer", () => {
     ).toMatchObject({
       _tag: "PreviewAutomationExecutionError",
       detail: { tabId: null },
+    });
+  });
+
+  it("serializes interrupted desktop presses as the typed interruption response", () => {
+    const error = new PreviewAutomationControlInterruptedHostError({
+      requestId: "request-press",
+      operation: "press",
+      environmentId,
+      threadId,
+      tabId,
+    });
+
+    expect(
+      serializePreviewAutomationError(error, {
+        requestId: "request-press",
+        operation: "press",
+        environmentId,
+        threadId,
+        tabId,
+      }),
+    ).toMatchObject({
+      _tag: "PreviewAutomationControlInterruptedError",
+      detail: { operation: "press", tabId: "tab-1" },
     });
   });
 

--- a/apps/web/src/lib/previewAutomationFocus.test.ts
+++ b/apps/web/src/lib/previewAutomationFocus.test.ts
@@ -18,16 +18,50 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-const setupDocument = (activeElement: MockHTMLElement | null) => {
+const setupDocument = (activeElement: MockHTMLElement | null, initiallyFocused = true) => {
   const body = new MockHTMLElement();
   const documentElement = new MockHTMLElement();
+  let focused = initiallyFocused;
+  const listeners = new Map<string, Set<(event: Event) => void>>();
+  const windowListeners = new Map<string, Set<() => void>>();
   vi.stubGlobal("HTMLElement", MockHTMLElement);
   vi.stubGlobal("document", {
     activeElement,
     body,
     documentElement,
+    hasFocus: () => focused,
+    addEventListener: (type: string, listener: (event: Event) => void) => {
+      const typeListeners = listeners.get(type) ?? new Set();
+      typeListeners.add(listener);
+      listeners.set(type, typeListeners);
+    },
+    removeEventListener: (type: string, listener: (event: Event) => void) => {
+      listeners.get(type)?.delete(listener);
+    },
   });
-  return { body, documentElement };
+  vi.stubGlobal("window", {
+    addEventListener: (type: string, listener: () => void) => {
+      const typeListeners = windowListeners.get(type) ?? new Set();
+      typeListeners.add(listener);
+      windowListeners.set(type, typeListeners);
+    },
+    removeEventListener: (type: string, listener: () => void) => {
+      windowListeners.get(type)?.delete(listener);
+    },
+  });
+  return {
+    body,
+    documentElement,
+    setFocused: (value: boolean) => (focused = value),
+    dispatch: (type: string, target: MockHTMLElement, isTrusted = true) => {
+      for (const listener of listeners.get(type) ?? []) {
+        listener({ target, isTrusted } as unknown as Event);
+      }
+    },
+    dispatchWindow: (type: string) => {
+      for (const listener of windowListeners.get(type) ?? []) listener();
+    },
+  };
 };
 
 describe("withPreviewAutomationFocus", () => {
@@ -60,6 +94,99 @@ describe("withPreviewAutomationFocus", () => {
     expect(composer.focus).toHaveBeenCalledWith({ preventScroll: true });
   });
 
+  it("does not mask the operation rejection when restoration fails", async () => {
+    const composer = new MockHTMLElement();
+    const { body } = setupDocument(composer);
+    const error = new Error("press failed");
+    composer.focus.mockImplementation(() => {
+      throw new Error("focus failed");
+    });
+
+    await expect(
+      withPreviewAutomationFocus(async () => {
+        setActiveElement(body);
+        throw error;
+      }),
+    ).rejects.toBe(error);
+  });
+
+  it("does not mask the operation result when restoration fails", async () => {
+    const composer = new MockHTMLElement();
+    const { body } = setupDocument(composer);
+    composer.focus.mockImplementation(() => {
+      throw new Error("focus failed");
+    });
+
+    await expect(
+      withPreviewAutomationFocus(async () => {
+        setActiveElement(body);
+        return "pressed";
+      }),
+    ).resolves.toBe("pressed");
+  });
+
+  it("skips restoration for an interrupted automation result", async () => {
+    const composer = new MockHTMLElement();
+    const hostButton = new MockHTMLElement();
+    setupDocument(composer);
+
+    const result = await withPreviewAutomationFocus<{ status: "completed" | "interrupted" }>(
+      async () => {
+        setActiveElement(hostButton);
+        return { status: "interrupted" as const };
+      },
+      { shouldRestoreFocus: (value) => value.status === "completed" },
+    );
+
+    expect(result).toEqual({ status: "interrupted" });
+    expect(composer.focus).not.toHaveBeenCalled();
+    expect(globalThis.document.activeElement).toBe(hostButton);
+  });
+
+  it("skips restoration when native automation preserves focus", async () => {
+    const composer = new MockHTMLElement();
+    const hostButton = new MockHTMLElement();
+    setupDocument(composer);
+
+    const result = await withPreviewAutomationFocus<{
+      readonly status: "completed";
+      readonly focusDisposition: "preserved" | "restored";
+    }>(
+      async () => {
+        setActiveElement(hostButton);
+        return { status: "completed" as const, focusDisposition: "preserved" as const };
+      },
+      {
+        shouldRestoreFocus: (value) =>
+          value.status === "completed" && value.focusDisposition === "restored",
+      },
+    );
+
+    expect(result).toEqual({ status: "completed", focusDisposition: "preserved" });
+    expect(composer.focus).not.toHaveBeenCalled();
+    expect(globalThis.document.activeElement).toBe(hostButton);
+  });
+
+  it("restores connected focus when native automation reports restoration", async () => {
+    const composer = new MockHTMLElement();
+    const hostButton = new MockHTMLElement();
+    setupDocument(composer);
+
+    await withPreviewAutomationFocus(
+      async () => {
+        setActiveElement(hostButton);
+        return { status: "completed" as const, focusDisposition: "restored" as const };
+      },
+      {
+        shouldRestoreFocus: (value) =>
+          value.status === "completed" && value.focusDisposition === "restored",
+      },
+    );
+
+    expect(composer.focus).toHaveBeenCalledWith({ preventScroll: true });
+    expect(globalThis.document.activeElement).toBe(composer);
+  });
+
   it("does not restore a detached prior element", async () => {
     const composer = new MockHTMLElement();
     const { body } = setupDocument(composer);
@@ -72,16 +199,215 @@ describe("withPreviewAutomationFocus", () => {
     expect(composer.focus).not.toHaveBeenCalled();
   });
 
-  it("restores focus when automation moves it to another connected element", async () => {
+  it("restores focus when automation moves to a connected host button", async () => {
     const composer = new MockHTMLElement();
-    const previewControl = new MockHTMLElement();
-    setupDocument(composer);
+    const hostButton = new MockHTMLElement();
+    const { dispatch, dispatchWindow } = setupDocument(composer);
 
     await withPreviewAutomationFocus(async () => {
-      setActiveElement(previewControl);
+      dispatchWindow("blur");
+      dispatchWindow("focus");
+      setActiveElement(hostButton);
+      dispatch("focusin", hostButton);
     });
 
     expect(composer.focus).toHaveBeenCalledWith({ preventScroll: true });
     expect(globalThis.document.activeElement).toBe(composer);
+  });
+
+  it("preserves pointer focus into the same connected host button", async () => {
+    const composer = new MockHTMLElement();
+    const hostButton = new MockHTMLElement();
+    const { dispatch } = setupDocument(composer);
+
+    await withPreviewAutomationFocus(async () => {
+      dispatch("pointerdown", hostButton);
+      setActiveElement(hostButton);
+      dispatch("focusin", hostButton);
+    });
+
+    expect(composer.focus).not.toHaveBeenCalled();
+    expect(globalThis.document.activeElement).toBe(hostButton);
+  });
+
+  it("preserves keyboard focus into the same connected host button", async () => {
+    const composer = new MockHTMLElement();
+    const hostButton = new MockHTMLElement();
+    const { dispatch } = setupDocument(composer);
+
+    await withPreviewAutomationFocus(async () => {
+      dispatch("keydown", composer);
+      setActiveElement(hostButton);
+      dispatch("focusin", hostButton);
+    });
+
+    expect(composer.focus).not.toHaveBeenCalled();
+    expect(globalThis.document.activeElement).toBe(hostButton);
+  });
+
+  it("preserves pointer focus into the preview", async () => {
+    const composer = new MockHTMLElement();
+    const previewElement = new MockHTMLElement();
+    const { dispatch } = setupDocument(composer);
+
+    await withPreviewAutomationFocus(async () => {
+      dispatch("pointerdown", previewElement);
+      setActiveElement(previewElement);
+      dispatch("focusin", previewElement);
+    });
+
+    expect(composer.focus).not.toHaveBeenCalled();
+    expect(globalThis.document.activeElement).toBe(previewElement);
+  });
+
+  it("preserves trusted programmatic-like focus without a native window transfer", async () => {
+    const composer = new MockHTMLElement();
+    const previewElement = new MockHTMLElement();
+    const { dispatch } = setupDocument(composer);
+
+    await withPreviewAutomationFocus(async () => {
+      setActiveElement(previewElement);
+      // Chromium emits trusted focusin for HTMLElement.focus(), just like a
+      // native focus transition without an accompanying pointer or key event.
+      dispatch("focusin", previewElement);
+    });
+
+    expect(composer.focus).not.toHaveBeenCalled();
+    expect(globalThis.document.activeElement).toBe(previewElement);
+  });
+
+  it("ignores synthetic pointer and keyboard input as user intent", async () => {
+    const composer = new MockHTMLElement();
+    const hostButton = new MockHTMLElement();
+    const { dispatch, dispatchWindow } = setupDocument(composer);
+
+    await withPreviewAutomationFocus(async () => {
+      dispatch("pointerdown", hostButton, false);
+      dispatch("keydown", composer, false);
+      dispatchWindow("blur");
+      dispatchWindow("focus");
+      setActiveElement(hostButton);
+      dispatch("focusin", hostButton);
+    });
+
+    expect(composer.focus).toHaveBeenCalledWith({ preventScroll: true });
+    expect(globalThis.document.activeElement).toBe(composer);
+  });
+
+  it("expires user intent when a pointer does not focus its target", async () => {
+    const composer = new MockHTMLElement();
+    const nonFocusableTarget = new MockHTMLElement();
+    const hostButton = new MockHTMLElement();
+    const { dispatch, dispatchWindow } = setupDocument(composer);
+
+    await withPreviewAutomationFocus(async () => {
+      dispatch("pointerdown", nonFocusableTarget);
+      await Promise.resolve();
+      dispatchWindow("blur");
+      dispatchWindow("focus");
+      setActiveElement(hostButton);
+    });
+
+    expect(composer.focus).toHaveBeenCalledWith({ preventScroll: true });
+    expect(globalThis.document.activeElement).toBe(composer);
+  });
+
+  it("does not replace newer user focus while automation is pending", async () => {
+    const composer = new MockHTMLElement();
+    const { body, dispatch } = setupDocument(composer);
+    const newerControl = new MockHTMLElement();
+    let finishOperation!: () => void;
+    let operationStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      operationStarted = resolve;
+    });
+
+    const pending = withPreviewAutomationFocus(async () => {
+      setActiveElement(body);
+      operationStarted();
+      await new Promise<void>((resolve) => {
+        finishOperation = resolve;
+      });
+    });
+
+    await started;
+    dispatch("focusin", newerControl, false);
+    setActiveElement(newerControl);
+    finishOperation();
+    await pending;
+
+    expect(composer.focus).not.toHaveBeenCalled();
+    expect(globalThis.document.activeElement).toBe(newerControl);
+  });
+
+  it("skips restoration when the document is not focused at the start", async () => {
+    const composer = new MockHTMLElement();
+    const { body } = setupDocument(composer, false);
+
+    await withPreviewAutomationFocus(async () => {
+      setActiveElement(body);
+    });
+
+    expect(composer.focus).not.toHaveBeenCalled();
+  });
+
+  it("skips restoration when the document is not focused at completion", async () => {
+    const composer = new MockHTMLElement();
+    const { body, setFocused } = setupDocument(composer);
+
+    await withPreviewAutomationFocus(async () => {
+      setActiveElement(body);
+      setFocused(false);
+    });
+
+    expect(composer.focus).not.toHaveBeenCalled();
+  });
+
+  it("does not let an older thread restore over a newer transaction", async () => {
+    const firstComposer = new MockHTMLElement();
+    const { body } = setupDocument(firstComposer);
+    let firstStarted!: () => void;
+    let finishFirst!: () => void;
+    let secondStarted!: () => void;
+    let finishSecond!: () => void;
+    const firstHasFocus = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    const firstDone = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+    const secondDone = new Promise<void>((resolve) => {
+      finishSecond = resolve;
+    });
+    const secondHasFocus = new Promise<void>((resolve) => {
+      secondStarted = resolve;
+    });
+
+    const first = withPreviewAutomationFocus(async () => {
+      setActiveElement(body);
+      firstStarted();
+      await firstDone;
+    });
+
+    await firstHasFocus;
+    const second = withPreviewAutomationFocus(async () => {
+      setActiveElement(body);
+      secondStarted();
+      await secondDone;
+    });
+
+    finishFirst();
+    await first;
+
+    expect(firstComposer.focus).toHaveBeenCalledWith({ preventScroll: true });
+    expect(globalThis.document.activeElement).toBe(firstComposer);
+
+    await secondHasFocus;
+    expect(globalThis.document.activeElement).toBe(body);
+    finishSecond();
+    await second;
+
+    expect(firstComposer.focus).toHaveBeenCalledTimes(2);
+    expect(globalThis.document.activeElement).toBe(firstComposer);
   });
 });

--- a/apps/web/src/lib/previewAutomationFocus.test.ts
+++ b/apps/web/src/lib/previewAutomationFocus.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { withPreviewAutomationFocus } from "./previewAutomationFocus";
+
+class MockHTMLElement {
+  isConnected = true;
+  readonly focus = vi.fn((_options?: FocusOptions) => {
+    setActiveElement(this);
+  });
+}
+
+const setActiveElement = (activeElement: MockHTMLElement | null): void => {
+  (globalThis.document as unknown as { activeElement: MockHTMLElement | null }).activeElement =
+    activeElement;
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const setupDocument = (activeElement: MockHTMLElement | null) => {
+  const body = new MockHTMLElement();
+  const documentElement = new MockHTMLElement();
+  vi.stubGlobal("HTMLElement", MockHTMLElement);
+  vi.stubGlobal("document", {
+    activeElement,
+    body,
+    documentElement,
+  });
+  return { body, documentElement };
+};
+
+describe("withPreviewAutomationFocus", () => {
+  it("restores connected focus when automation leaves no meaningful active element", async () => {
+    const composer = new MockHTMLElement();
+    const { body } = setupDocument(composer);
+
+    const result = await withPreviewAutomationFocus(async () => {
+      setActiveElement(body);
+      return "pressed";
+    });
+
+    expect(result).toBe("pressed");
+    expect(composer.focus).toHaveBeenCalledWith({ preventScroll: true });
+    expect(globalThis.document.activeElement).toBe(composer);
+  });
+
+  it("restores focus on failure without replacing the original rejection", async () => {
+    const composer = new MockHTMLElement();
+    const { body } = setupDocument(composer);
+    const error = new Error("press failed");
+
+    await expect(
+      withPreviewAutomationFocus(async () => {
+        setActiveElement(body);
+        throw error;
+      }),
+    ).rejects.toBe(error);
+
+    expect(composer.focus).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it("does not restore a detached prior element", async () => {
+    const composer = new MockHTMLElement();
+    const { body } = setupDocument(composer);
+
+    await withPreviewAutomationFocus(async () => {
+      composer.isConnected = false;
+      setActiveElement(body);
+    });
+
+    expect(composer.focus).not.toHaveBeenCalled();
+  });
+
+  it("restores focus when automation moves it to another connected element", async () => {
+    const composer = new MockHTMLElement();
+    const previewControl = new MockHTMLElement();
+    setupDocument(composer);
+
+    await withPreviewAutomationFocus(async () => {
+      setActiveElement(previewControl);
+    });
+
+    expect(composer.focus).toHaveBeenCalledWith({ preventScroll: true });
+    expect(globalThis.document.activeElement).toBe(composer);
+  });
+});

--- a/apps/web/src/lib/previewAutomationFocus.ts
+++ b/apps/web/src/lib/previewAutomationFocus.ts
@@ -1,0 +1,33 @@
+const getMeaningfulActiveElement = (): HTMLElement | null => {
+  if (typeof document === "undefined" || typeof HTMLElement === "undefined") return null;
+
+  const activeElement = document.activeElement;
+  if (
+    !(activeElement instanceof HTMLElement) ||
+    !activeElement.isConnected ||
+    activeElement === document.body ||
+    activeElement === document.documentElement
+  ) {
+    return null;
+  }
+  return activeElement;
+};
+
+/**
+ * Keeps preview automation from changing focus in the shared renderer.
+ */
+export async function withPreviewAutomationFocus<T>(operation: () => Promise<T>): Promise<T> {
+  const previouslyFocused = getMeaningfulActiveElement();
+
+  try {
+    return await operation();
+  } finally {
+    if (previouslyFocused?.isConnected) {
+      try {
+        previouslyFocused.focus({ preventScroll: true });
+      } catch {
+        // Focus restoration is best effort; never mask the automation result.
+      }
+    }
+  }
+}

--- a/apps/web/src/lib/previewAutomationFocus.ts
+++ b/apps/web/src/lib/previewAutomationFocus.ts
@@ -13,21 +13,170 @@ const getMeaningfulActiveElement = (): HTMLElement | null => {
   return activeElement;
 };
 
+const isDocumentFocused = (): boolean =>
+  typeof document !== "undefined" && typeof document.hasFocus === "function" && document.hasFocus();
+
+type FocusIntent = {
+  userFocusedElement: HTMLElement | null;
+  pendingFocus: boolean;
+  pendingFocusVersion: number;
+  automationFocusedElement: HTMLElement | null;
+  windowBlurred: boolean;
+  windowRefocused: boolean;
+};
+
+const trackFocusIntent = (intent: FocusIntent): (() => void) | null => {
+  if (typeof document === "undefined") return null;
+
+  const onPointerDown = (event: Event): void => {
+    if (!event.isTrusted) return;
+    intent.pendingFocus = true;
+    intent.userFocusedElement = event.target instanceof HTMLElement ? event.target : null;
+    const version = ++intent.pendingFocusVersion;
+    queueMicrotask(() => {
+      if (intent.pendingFocusVersion !== version || !intent.pendingFocus) return;
+      intent.pendingFocus = false;
+      intent.userFocusedElement = null;
+    });
+  };
+  const onKeyDown = (event: Event): void => {
+    if (!event.isTrusted) return;
+    intent.pendingFocus = true;
+    intent.userFocusedElement = null;
+    const version = ++intent.pendingFocusVersion;
+    queueMicrotask(() => {
+      if (intent.pendingFocusVersion !== version || !intent.pendingFocus) return;
+      intent.pendingFocus = false;
+    });
+  };
+  const onFocusIn = (event: Event): void => {
+    const focusedElement = event.target instanceof HTMLElement ? event.target : null;
+    const nativeFocus = intent.windowBlurred && intent.windowRefocused;
+    intent.pendingFocusVersion += 1;
+    intent.userFocusedElement = intent.pendingFocus || !nativeFocus ? focusedElement : null;
+    intent.automationFocusedElement = nativeFocus ? focusedElement : null;
+    intent.pendingFocus = false;
+    intent.windowBlurred = false;
+    intent.windowRefocused = false;
+  };
+  const onWindowBlur = (): void => {
+    intent.windowBlurred = true;
+    intent.windowRefocused = false;
+    intent.userFocusedElement = null;
+  };
+  const onWindowFocus = (): void => {
+    if (intent.windowBlurred) intent.windowRefocused = true;
+  };
+
+  document.addEventListener("pointerdown", onPointerDown, true);
+  document.addEventListener("keydown", onKeyDown, true);
+  document.addEventListener("focusin", onFocusIn, true);
+  if (typeof window !== "undefined") {
+    window.addEventListener("blur", onWindowBlur);
+    window.addEventListener("focus", onWindowFocus);
+  }
+  return () => {
+    document.removeEventListener("pointerdown", onPointerDown, true);
+    document.removeEventListener("keydown", onKeyDown, true);
+    document.removeEventListener("focusin", onFocusIn, true);
+    if (typeof window !== "undefined") {
+      window.removeEventListener("blur", onWindowBlur);
+      window.removeEventListener("focus", onWindowFocus);
+    }
+  };
+};
+
+let nextFocusTransactionId = 0;
+let latestFocusTransactionId = 0;
+let focusTransactionTail = Promise.resolve();
+
+const acquireFocusTransaction = async (): Promise<() => void> => {
+  const predecessor = focusTransactionTail;
+  let release!: () => void;
+  focusTransactionTail = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await predecessor;
+  return release;
+};
+
 /**
  * Keeps preview automation from changing focus in the shared renderer.
  */
-export async function withPreviewAutomationFocus<T>(operation: () => Promise<T>): Promise<T> {
-  const previouslyFocused = getMeaningfulActiveElement();
+export async function withPreviewAutomationFocus<T>(
+  operation: () => Promise<T>,
+  options?: { readonly shouldRestoreFocus?: (result: T) => boolean },
+): Promise<T> {
+  const releaseFocusTransaction = await acquireFocusTransaction();
 
   try {
-    return await operation();
-  } finally {
-    if (previouslyFocused?.isConnected) {
+    const transactionId = ++nextFocusTransactionId;
+    latestFocusTransactionId = transactionId;
+    const wasDocumentFocused = isDocumentFocused();
+    const previouslyFocused = getMeaningfulActiveElement();
+    const focusIntent: FocusIntent = {
+      userFocusedElement: null,
+      pendingFocus: false,
+      pendingFocusVersion: 0,
+      automationFocusedElement: null,
+      windowBlurred: false,
+      windowRefocused: false,
+    };
+    const stopTrackingFocusIntent = trackFocusIntent(focusIntent);
+
+    let operationCompleted = false;
+    let operationResult!: T;
+    try {
+      operationResult = await operation();
+      operationCompleted = true;
+      return operationResult;
+    } finally {
       try {
-        previouslyFocused.focus({ preventScroll: true });
+        stopTrackingFocusIntent?.();
       } catch {
-        // Focus restoration is best effort; never mask the automation result.
+        // Listener cleanup is best effort; never mask the automation result.
+      }
+      try {
+        // A connected active element may represent either automation or a user
+        // interaction (including one into the preview). Pointer/keyboard focus
+        // events provide the ownership signal available here. Chromium reports
+        // programmatic HTMLElement.focus() as trusted focusin too, so an active
+        // document focusin without the native window transfer is treated as
+        // user-owned; native focus without that transfer remains ambiguous.
+        let resultAllowsRestore = true;
+        if (operationCompleted && options?.shouldRestoreFocus) {
+          try {
+            resultAllowsRestore = options.shouldRestoreFocus(operationResult);
+          } catch {
+            // A result predicate is advisory; never mask the automation result.
+          }
+        }
+        const activeElement = getMeaningfulActiveElement();
+        const nativeRestorationConfirmed =
+          options?.shouldRestoreFocus !== undefined && resultAllowsRestore;
+        const shouldRestoreFocus =
+          resultAllowsRestore &&
+          transactionId === latestFocusTransactionId &&
+          wasDocumentFocused &&
+          isDocumentFocused() &&
+          previouslyFocused?.isConnected &&
+          (!activeElement ||
+            ((nativeRestorationConfirmed ||
+              activeElement === focusIntent.automationFocusedElement ||
+              (focusIntent.windowBlurred && focusIntent.windowRefocused)) &&
+              activeElement !== focusIntent.userFocusedElement));
+        if (shouldRestoreFocus) {
+          try {
+            previouslyFocused.focus({ preventScroll: true });
+          } catch {
+            // Focus restoration is best effort; never mask the automation result.
+          }
+        }
+      } catch {
+        // Focus state inspection is best effort; never mask the automation result.
       }
     }
+  } finally {
+    releaseFocusTransaction();
   }
 }

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1037,6 +1037,25 @@ export const DesktopPreviewAutomationPressInputSchema = Schema.Struct({
   input: PreviewAutomationPressInput,
 });
 
+export const DesktopPreviewAutomationPressFocusDisposition = Schema.Literals([
+  "restored",
+  "preserved",
+]);
+export type DesktopPreviewAutomationPressFocusDisposition =
+  typeof DesktopPreviewAutomationPressFocusDisposition.Type;
+
+export const DesktopPreviewAutomationPressResultSchema = Schema.Union([
+  Schema.Struct({
+    status: Schema.Literal("completed"),
+    focusDisposition: DesktopPreviewAutomationPressFocusDisposition,
+  }),
+  Schema.Struct({
+    status: Schema.Literal("interrupted"),
+  }),
+]);
+export type DesktopPreviewAutomationPressResult =
+  typeof DesktopPreviewAutomationPressResultSchema.Type;
+
 export const DesktopPreviewAutomationScrollInputSchema = Schema.Struct({
   tabId: DesktopPreviewTabIdSchema,
   input: PreviewAutomationScrollInput,
@@ -1235,7 +1254,10 @@ export interface DesktopPreviewBridge {
     snapshot: (tabId: string) => Promise<PreviewAutomationSnapshot>;
     click: (tabId: string, input: PreviewAutomationClickInput) => Promise<void>;
     type: (tabId: string, input: PreviewAutomationTypeInput) => Promise<void>;
-    press: (tabId: string, input: PreviewAutomationPressInput) => Promise<void>;
+    press: (
+      tabId: string,
+      input: PreviewAutomationPressInput,
+    ) => Promise<DesktopPreviewAutomationPressResult>;
     scroll: (tabId: string, input: PreviewAutomationScrollInput) => Promise<void>;
     evaluate: (tabId: string, input: PreviewAutomationEvaluateInput) => Promise<unknown>;
     waitFor: (tabId: string, input: PreviewAutomationWaitForInput) => Promise<void>;


### PR DESCRIPTION
## Problem

`preview_press` temporarily focuses the preview guest WebContents so Electron can deliver native keyboard input. Restoring the outer renderer afterward did not restore its active DOM element, interrupting users typing in either the current thread or another thread.

## Fix

Capture the renderer's meaningful active element around `preview_press` and restore it after success or failure while that element remains connected.

Restoration is best-effort, avoids scrolling, skips detached elements, and remains scoped to the press path that transfers native focus.

## Testing

- `./node_modules/.bin/vp test run apps/web/src/lib/previewAutomationFocus.test.ts` — 4 tests passed
- `./node_modules/.bin/vp lint --report-unused-disable-directives apps/web/src/lib/previewAutomationFocus.ts apps/web/src/lib/previewAutomationFocus.test.ts`
- `./node_modules/.bin/vp fmt apps/web/src/lib/previewAutomationFocus.ts apps/web/src/lib/previewAutomationFocus.test.ts --check`
- `./node_modules/.bin/vp run -F @t3tools/web typecheck`
- `git diff --check`
- Integrated Electron pass: reproduced the unfixed branch moving focus from `composer-editor` to a host button and dropping the next keystroke; verified the fixed branch keeps `composer-editor` focused and accepts the next keystroke
- Captured direct, unedited 1440×900/30fps before and after recordings

Fixes #5792

Implemented with GPT-5.6 Luna and reviewed with GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes native focus/keyboard cleanup and IPC contract for `press`, with nuanced restore vs preserve behavior; mistakes could leave stuck keys or steal composer focus, but scope is limited to preview automation press.
> 
> **Overview**
> **Preview automation `press` now reports whether native focus was restored or preserved, and surfaces human takeover as an explicit interrupted outcome instead of a silent `void`.**
> 
> Contracts add `DesktopPreviewAutomationPressResult` (`completed` with `restored` / `preserved`, or `interrupted`). Desktop `PreviewManager.automationPress` returns that disposition: cleanup runs **uninterruptibly** (key-up and focus emulation off even on fiber interrupt), native restore is skipped when the app is unfocused or focus moved elsewhere, and human control during press still fails with `PreviewAutomationControlInterruptedError` without restoring renderer focus. IPC maps that error to `{ status: "interrupted" }` via `automationPressResult`.
> 
> On web, `preview_press` runs inside new `withPreviewAutomationFocus`, which serializes focus transactions, tracks trusted user focus intent, and restores the prior DOM element only when the desktop result says `focusDisposition === "restored"`. Interrupted presses throw `PreviewAutomationControlInterruptedHostError` and serialize to `PreviewAutomationControlInterruptedError` for automation clients.
> 
> **Breaking:** `DesktopPreviewBridge.automation.press` and the preview IPC handler return `DesktopPreviewAutomationPressResult` instead of `void`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2935896a47c9cc90fd3d3d37ec93c57a0dcc661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve composer focus during preview automation presses
> - Desktop `performAutomationPress` now inspects the focused `WebContents` and `BrowserWindow` during cleanup and restores the prior renderer only when automation still owns focus or the prior renderer already has it; human-control takeover completes cleanup before re-emitting the interruption.
> - Adds `withPreviewAutomationFocus` in [previewAutomationFocus.ts](https://github.com/pingdotgg/t3code/pull/9530/files#diff-5635846b7a6ed2e52c3b2b3ac8ea7e1e9bb7a0ac43bbc745c675038c3efb5e3e) to serialize concurrent focus transactions, track trusted user focus vs synthetic input via `trackFocusIntent`, and restore the prior host element only when the document stays focused and no newer transaction supersedes it.
> - Changes the desktop press IPC contract from `Promise<void>` to `Promise<DesktopPreviewAutomationPressResult>` in [ipc.ts](https://github.com/pingdotgg/t3code/pull/9530/files#diff-b3653a8424fd66e30684757f240a41b389e093822f7c4139866bcae9e917a38a), returning either a completed result with `focusDisposition` or an interrupted status; the web host converts interrupted results into the new `PreviewAutomationControlInterruptedHostError`.
> - Behavioral Change: `DesktopPreviewBridge.automation.press` and `PreviewManager.automationPress` now return a typed `DesktopPreviewAutomationPressFocusDisposition` or `DesktopPreviewAutomationPressResult` instead of `void`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d293589.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->