### PR TITLE
ci: delete superseded pending-approval runs on fork PRs

### DIFF
--- a/.github/workflows/pr-superseded-runs.yml
+++ b/.github/workflows/pr-superseded-runs.yml
@@ -1,0 +1,61 @@
+name: PR Superseded Runs
+
+# Fork PRs need maintainer approval before `pull_request` workflows may run.
+# Until then every push leaves one jobless run per workflow parked in
+# "action required", and `concurrency` never reaches them because they never
+# start. When the PR closes GitHub flips every parked run to failure and emails
+# the author once per run. This deletes the parked runs for commits that a
+# newer push has already replaced, so only the current head keeps its runs.
+#
+# `pull_request_target` runs without approval and never checks out PR code.
+
+on:
+  pull_request_target:
+    types: [synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  delete:
+    name: Delete superseded pending runs
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: write
+    concurrency:
+      group: pr-superseded-runs-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Delete pending runs for replaced commits
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: pr.head.ref,
+              event: "pull_request",
+              status: "action_required",
+              per_page: 100,
+            });
+
+            const superseded = runs.filter(
+              (run) => run.head_repository?.id === pr.head.repo.id && run.head_sha !== pr.head.sha,
+            );
+
+            for (const run of superseded) {
+              await github.rest.actions.deleteWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+              });
+              core.info(`Deleted ${run.name} run ${run.id} for ${run.head_sha.slice(0, 7)}`);
+            }
+
+            core.info(
+              `PR #${pr.number}: deleted ${superseded.length} pending run(s) superseded by ${pr.head.sha.slice(0, 7)}`,
+            );


### PR DESCRIPTION
## What Changed

Adds `.github/workflows/pr-superseded-runs.yml`, a `pull_request_target` workflow that runs on `synchronize` for fork PRs only. It lists the repo's `pull_request` runs for the PR's head branch that are parked in `action_required`, keeps the ones for the current head commit, and deletes the rest. It never checks out PR code and needs only `actions: write`.

## Why

Fixes #9529.

Fork PRs need maintainer approval before `pull_request` workflows may run. Until then every push leaves one jobless run per workflow parked in "action required". The existing `concurrency` groups never reach them because a run that never started cannot be cancelled by a newer one, so they pile up (PR #7434 accumulated 68 across 17 commits). When the PR closes, GitHub flips every parked run to `failure` within seconds and emails the author once per run with "No jobs were run".

Cleaning up on `closed` cannot win that race, so this cleans up on each push instead. After a push, only the current head's runs stay pending, so a close produces one email per workflow instead of one per workflow per commit. The current head's runs still flip on close; that part is GitHub's behavior and not addressable from the repo.

Delete rather than cancel: the API reports these runs as `status: completed`, `conclusion: action_required`, so the cancel endpoint would reject them. Delete is the endpoint GitHub itself uses when it purges runs awaiting approval after 30 days, and nothing is lost because these runs never executed a job.

Verified against open PR #6191 by dry-running the same list-and-filter logic with `gh api`: 17 runs for the four replaced commits selected, 5 runs for the current head kept. The delete call itself needs repository write access, so it could only be exercised once merged.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (n/a)
- [ ] I included a video for animation/interaction changes (n/a)

Written with Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only automation using pull_request_target with no PR checkout; writes only via GitHub Actions API to delete superseded pending runs on fork PRs.
> 
> **Overview**
> Adds a **`pull_request_target`** workflow that runs on every fork PR **`synchronize`** event to trim stale workflow runs stuck in **`action_required`** (waiting for maintainer approval).
> 
> On each push it lists **`pull_request`** runs for the PR head branch in **`action_required`**, keeps runs for the **current head SHA**, and **deletes** runs tied to older commits on the same fork head repo. It is **fork-only**, uses **`actions/github-script`** (no checkout of PR code), and scopes job permissions to **`actions: write`** with per-PR **concurrency** so cleanup does not pile up.
> 
> This reduces how many parked runs flip to failure and email the author when the PR closes—addressing the pile-up that **`concurrency`** cannot cancel because those runs never start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9335fb46985de8fe90c120948be5f95e03b3dbc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CI workflow to delete superseded pending runs on fork PRs
> - Adds [pr-superseded-runs.yml](https://github.com/pingdotgg/t3code/pull/9531/files#diff-4172bab62919fe406cad25aab19268385aa5ac098c7d7f1942303caec3ddeb0f) triggered by `pull_request_target` synchronization events to remove stale `action_required` runs on fork pull requests.
> - Uses `actions/github-script` to find runs matching the source branch, `pull_request` event, and `action_required` status. It deletes runs from the same fork repository with an older head SHA.
> - Execution is serialized per pull request using `concurrency`, canceling older cleanup jobs.
> - Behavioral Change: Grants `actions: write` and `contents: read` permissions to the workflow to delete runs via the Actions API.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9335fb4. 1 file reviewed, 2 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->