### PR TITLE
feat(usage): read Cursor and Grok plan quota from their TUIs

### DIFF
--- a/apps/server/src/provider/Drivers/CursorDriver.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.ts
@@ -14,6 +14,7 @@
 import { CursorSettings, ProviderDriverKind } from "@t3tools/contracts";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
@@ -22,6 +23,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 
 import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
 import { ServerConfig } from "../../config.ts";
+import * as PtyAdapter from "../../terminal/PtyAdapter.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { makeCursorTextGeneration } from "../../textGeneration/CursorTextGeneration.ts";
 import { ProviderDriverError } from "../Errors.ts";
@@ -88,6 +90,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
     Effect.gen(function* () {
       const crypto = yield* Crypto.Crypto;
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const { cwd } = yield* ServerConfig;
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const httpClient = yield* HttpClient.HttpClient;
@@ -118,12 +121,17 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
       });
       const textGeneration = yield* makeCursorTextGeneration(effectiveConfig, processEnv);
 
-      const checkProvider = checkCursorProviderStatus(effectiveConfig, processEnv).pipe(
+      // The usage probe drives the CLI's TUI, so it needs a PTY. The adapter
+      // is optional here: without it the probe reports limits unavailable.
+      const ptyAdapter = Option.getOrUndefined(yield* Effect.serviceOption(PtyAdapter.PtyAdapter));
+      const checkProvider = checkCursorProviderStatus(effectiveConfig, processEnv, cwd).pipe(
         Effect.map(stampIdentity),
         Effect.provideService(Crypto.Crypto, crypto),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
         Effect.provideService(FileSystem.FileSystem, fileSystem),
         Effect.provideService(Path.Path, path),
+        (effect) =>
+          ptyAdapter ? Effect.provideService(effect, PtyAdapter.PtyAdapter, ptyAdapter) : effect,
       );
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);

--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -1,6 +1,7 @@
 import { GrokSettings, ProviderDriverKind } from "@t3tools/contracts";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
@@ -9,6 +10,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 
 import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
 import { ServerConfig } from "../../config.ts";
+import * as PtyAdapter from "../../terminal/PtyAdapter.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { makeGrokTextGeneration } from "../../textGeneration/GrokTextGeneration.ts";
 import { ProviderDriverError } from "../Errors.ts";
@@ -100,10 +102,15 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
       });
       const textGeneration = yield* makeGrokTextGeneration(effectiveConfig, processEnv);
 
+      // The usage probe drives the CLI's TUI, so it needs a PTY. The adapter
+      // is optional here: without it the probe reports limits unavailable.
+      const ptyAdapter = Option.getOrUndefined(yield* Effect.serviceOption(PtyAdapter.PtyAdapter));
       const checkProvider = checkGrokProviderStatus(effectiveConfig, processEnv, cwd).pipe(
         Effect.map(stampIdentity),
         Effect.provideService(Crypto.Crypto, crypto),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        (effect) =>
+          ptyAdapter ? Effect.provideService(effect, PtyAdapter.PtyAdapter, ptyAdapter) : effect,
       );
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -7,6 +7,7 @@ import type {
   ServerProviderAuth,
   ServerProviderModel,
   ServerProviderState,
+  ServerProviderUsageLimits,
 } from "@t3tools/contracts";
 import type * as EffectAcpSchema from "effect-acp/schema";
 import { causeErrorTag } from "@t3tools/shared/observability";
@@ -45,6 +46,7 @@ import {
   type ProviderMaintenanceCapabilities,
 } from "../providerMaintenance.ts";
 import * as AcpSessionRuntime from "../acp/AcpSessionRuntime.ts";
+import { probeCursorUsageLimits } from "../cursorUsageProbe.ts";
 import { CursorListAvailableModelsResponse } from "../acp/CursorAcpExtension.ts";
 
 const decodeCursorListAvailableModelsResponse = Schema.decodeUnknownEffect(
@@ -628,6 +630,7 @@ export function buildCursorProviderSnapshot(input: {
   readonly parsed: CursorAboutResult;
   readonly discoveredModels?: ReadonlyArray<ServerProviderModel>;
   readonly discoveryWarning?: string;
+  readonly usageLimits?: ServerProviderUsageLimits;
 }): ServerProviderDraft {
   const message = joinProviderMessages(input.parsed.message, input.discoveryWarning);
   return buildServerProvider({
@@ -645,6 +648,7 @@ export function buildCursorProviderSnapshot(input: {
       status:
         input.discoveryWarning && input.parsed.status === "ready" ? "warning" : input.parsed.status,
       auth: input.parsed.auth,
+      ...(input.usageLimits ? { usageLimits: input.usageLimits } : {}),
       ...(message ? { message } : {}),
     },
   });
@@ -987,6 +991,7 @@ const runCursorAboutCommand = (cursorSettings: CursorSettings, environment?: Nod
 export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(function* (
   cursorSettings: CursorSettings,
   environment?: NodeJS.ProcessEnv,
+  cwd = process.cwd(),
 ): Effect.fn.Return<
   ServerProviderDraft,
   never,
@@ -1101,6 +1106,19 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       discoveredModels = discoveryExit.value;
     }
   }
+  // The `/usage` panel is the only place Cursor reports its plan quota, so
+  // this drives the TUI in a PTY. An unauthenticated account has no panel.
+  const usageLimits =
+    parsed.auth.status === "unauthenticated"
+      ? undefined
+      : yield* probeCursorUsageLimits({
+          binaryPath: cursorSettings.binaryPath,
+          ...(cursorSettings.apiEndpoint ? { apiEndpoint: cursorSettings.apiEndpoint } : {}),
+          cwd,
+          checkedAt,
+          ...(environment ? { environment } : {}),
+        }).pipe(Effect.map((result) => result.usageLimits));
+
   return buildCursorProviderSnapshot({
     checkedAt,
     cursorSettings,
@@ -1110,6 +1128,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       () => [] as const,
     ),
     ...(discoveryWarning ? { discoveryWarning } : {}),
+    ...(usageLimits ? { usageLimits } : {}),
   });
 });
 

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -39,6 +39,8 @@ import {
 } from "../acp/GrokAcpSupport.ts";
 import { sessionModelStateFromInitialize } from "../acp/AcpRuntimeModel.ts";
 import { discoverGrokSkills } from "../Drivers/GrokSkills.ts";
+import { probeGrokUsageLimits } from "../grokTuiUsageProbe.ts";
+import { makeUnavailableUsageLimits } from "../providerUsageLimits.ts";
 
 const GROK_PRESENTATION = {
   displayName: "Grok",
@@ -493,6 +495,18 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     });
   }
 
+  // The weekly limit only exists in the TUI's `/usage` panel, and only on a
+  // signed-in account; an API-key session has no plan quota to report.
+  const usageLimits =
+    auth.type === "api_key"
+      ? makeUnavailableUsageLimits({ checkedAt, reason: "unsupported" })
+      : yield* probeGrokUsageLimits({
+          binaryPath: grokSettings.binaryPath || "grok",
+          cwd: cwd ?? process.cwd(),
+          checkedAt,
+          environment,
+        }).pipe(Effect.map((result) => result.usageLimits));
+
   return buildServerProvider({
     presentation: GROK_PRESENTATION,
     enabled: grokSettings.enabled,
@@ -505,6 +519,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
       // A failed metadata probe degrades the model picker, it does not make chats fail.
       status: acpFailed ? "warning" : "ready",
       auth,
+      usageLimits,
       ...(acpFailed
         ? {
             message:

--- a/apps/server/src/provider/cursorUsageProbe.test.ts
+++ b/apps/server/src/provider/cursorUsageProbe.test.ts
@@ -1,0 +1,555 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+
+import * as PtyAdapter from "../terminal/PtyAdapter.ts";
+
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+
+import {
+  parseCursorUsageLimitsOutput,
+  probeCursorUsageLimits,
+  type ProbeClock,
+} from "./cursorUsageProbe.ts";
+
+/**
+ * Binary resolution is platform-dependent, so pin the platform rather than
+ * letting assertions depend on whichever OS the suite happens to run on.
+ */
+const probeCursorUsageLimitsOnLinux = (
+  input: Parameters<typeof probeCursorUsageLimits>[0],
+  ptyAdapter: PtyAdapter.PtyAdapter["Service"],
+  clock?: ProbeClock,
+) =>
+  probeCursorUsageLimits(input, clock).pipe(
+    Effect.provideService(HostProcessPlatform, "linux"),
+    Effect.provideService(PtyAdapter.PtyAdapter, ptyAdapter),
+  );
+
+class MockPtyChild implements PtyAdapter.PtyProcess {
+  public readonly writes: string[] = [];
+  public killed = false;
+  public onWrite: ((data: string) => void) | undefined;
+  private readonly dataListeners = new Set<(data: string) => void>();
+  private readonly exitListeners = new Set<(event: PtyAdapter.PtyExitEvent) => void>();
+
+  public get pid(): number {
+    return 12345;
+  }
+
+  public write(data: string): void {
+    this.writes.push(data);
+    this.onWrite?.(data);
+  }
+
+  public kill(): void {
+    this.killed = true;
+  }
+
+  public resize(): void {
+    // no-op
+  }
+
+  public onData(listener: (data: string) => void): () => void {
+    this.dataListeners.add(listener);
+    return () => this.dataListeners.delete(listener);
+  }
+
+  public onExit(listener: (event: PtyAdapter.PtyExitEvent) => void): () => void {
+    this.exitListeners.add(listener);
+    return () => this.exitListeners.delete(listener);
+  }
+
+  public emitData(data: string): void {
+    for (const listener of this.dataListeners) listener(data);
+  }
+}
+
+function createFakeClock(): ProbeClock & { advance(ms: number): void } {
+  const timers: Array<{ id: number; ms: number; fn: () => void; cancelled: boolean }> = [];
+  let nextId = 1;
+  const setTimeout = ((fn: () => void, ms?: number) => {
+    const id = nextId++;
+    timers.push({ id, ms: ms ?? 0, fn, cancelled: false });
+    return id as unknown as ReturnType<typeof globalThis.setTimeout>;
+  }) as typeof globalThis.setTimeout;
+  const clearTimeout = ((id: ReturnType<typeof globalThis.setTimeout>) => {
+    const timer = timers.find((entry) => entry.id === (id as unknown as number));
+    if (timer) timer.cancelled = true;
+  }) as typeof globalThis.clearTimeout;
+
+  return {
+    setTimeout,
+    clearTimeout,
+    advance(ms) {
+      const due = timers.filter((entry) => !entry.cancelled);
+      for (const timer of due) {
+        if (timer.cancelled) continue;
+        timer.ms -= ms;
+        if (timer.ms <= 0) {
+          timer.cancelled = true;
+          timer.fn();
+        }
+      }
+    },
+  };
+}
+
+const COMPOSER_READY = `
+  Cursor Agent
+  v2026.08.11-e8db854
+  Tip: Use /debug to instrument and debug complex problems.
+  → Plan, search, build anything
+`;
+
+const SAMPLE_OUTPUT = `
+ Usage • Free                                                                         Resets 7 Aug
+ Monthly plan and on-demand usage
+
+ Category        Current             Usage
+ Included        23% used            ░░░░░░░░░░
+   Auto          10% used            ░░░░░░░░░░
+   API           13% used            ░░░░░░░░░░
+ On-Demand       Disabled            ----------
+
+ On-demand usage is off
+
+ View in dashboard: cursor.com/dashboard?tab=usage
+
+ Esc to close
+`;
+
+describe("cursorUsageProbe", () => {
+  it("ignores Auto/API percents that are not from the /usage panel", () => {
+    const parsed = parseCursorUsageLimitsOutput({
+      checkedAt: "2026-07-25T12:00:00.000Z",
+      output: "Auto  10% used\nAPI  13% used\n",
+    });
+
+    expect(parsed.unavailable).toBeDefined();
+  });
+
+  it("parses Auto and API percents plus the reset date", () => {
+    const parsed = parseCursorUsageLimitsOutput({
+      checkedAt: "2026-07-25T12:00:00.000Z",
+      output: SAMPLE_OUTPUT,
+    });
+
+    expect(parsed.unavailable).toBeUndefined();
+    expect(parsed.windows).toEqual([
+      {
+        id: "monthly_1_auto",
+        kind: "monthly",
+        label: "Auto",
+        usedPercent: 10,
+        windowDurationMins: 30 * 24 * 60,
+        resetsAt: "2026-08-07T00:00:00.000Z",
+      },
+      {
+        id: "monthly_2_api",
+        kind: "monthly",
+        label: "API",
+        usedPercent: 13,
+        windowDurationMins: 30 * 24 * 60,
+        resetsAt: "2026-08-07T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("parses Cursor Pro /usage with a Sept reset and a zero API bar", () => {
+    const parsed = parseCursorUsageLimitsOutput({
+      checkedAt: "2026-08-16T12:00:00.000Z",
+      output: `
+ Usage • Pro                                                                                                                               Resets 16 Sept
+ Monthly plan and on-demand usage
+
+ Category        Current             Usage
+ Included        2% used             ██░░░░░░░░
+   Auto          2% used             ███░░░░░░░
+   API           0% used             ░░░░░░░░░░
+`,
+    });
+
+    expect(parsed.windows).toEqual([
+      {
+        id: "monthly_1_auto",
+        kind: "monthly",
+        label: "Auto",
+        usedPercent: 2,
+        windowDurationMins: 30 * 24 * 60,
+        resetsAt: "2026-09-16T00:00:00.000Z",
+      },
+      {
+        id: "monthly_2_api",
+        kind: "monthly",
+        label: "API",
+        usedPercent: 0,
+        windowDurationMins: 30 * 24 * 60,
+        resetsAt: "2026-09-16T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("parses OSC-8 hyperlink frames without dropping Auto, API, or the reset", () => {
+    const osc = String.fromCharCode(27);
+    const parsed = parseCursorUsageLimitsOutput({
+      checkedAt: "2026-08-16T12:00:00.000Z",
+      output: [
+        `${osc}]8;id=1;https://github.com/example/pull/1${osc}\\#1${osc}]8;;${osc}\\`,
+        `${osc}[36mLoading usage data...${osc}[m`,
+        `${osc}[1mUsage${osc}[m • Pro${osc}[91CResets 16 Sept`,
+        " Included        6% used",
+        `${osc}[2m  Auto${osc}[22m${osc}[10C7% used`,
+        `${osc}[2m  API${osc}[22m${osc}[11C0% used`,
+        `${osc}]8;id=2;https://cursor.com/dashboard?tab=usage${osc}\\cursor.com${osc}]8;;${osc}\\`,
+        "Esc to close",
+      ].join("\n"),
+    });
+
+    expect(
+      parsed.windows.map((window) => [window.label, window.usedPercent, window.resetsAt]),
+    ).toEqual([
+      ["Auto", 7, "2026-09-16T00:00:00.000Z"],
+      ["API", 0, "2026-09-16T00:00:00.000Z"],
+    ]);
+  });
+
+  it("reads a reset glued to the plan name after Ink cursor addressing", () => {
+    const parsed = parseCursorUsageLimitsOutput({
+      checkedAt: "2026-08-16T12:00:00.000Z",
+      output: "Usage • ProResets 16 Sept\nAuto  8% used\nAPI  0% used",
+    });
+
+    expect(parsed.windows[0]?.resetsAt).toBe("2026-09-16T00:00:00.000Z");
+    expect(parsed.windows.map((window) => window.label)).toEqual(["Auto", "API"]);
+  });
+
+  it("parses the compact colon layout Ink uses on a narrow PTY", () => {
+    const parsed = parseCursorUsageLimitsOutput({
+      checkedAt: "2026-08-16T12:00:00.000Z",
+      output:
+        "Usage • Pro  Resets Sep 16\nIncluded: 2% used\nAuto: 2% used\nAPI: 0% used\nOn-Demand: Disabled",
+    });
+
+    expect(parsed.windows.map((window) => [window.label, window.usedPercent])).toEqual([
+      ["Auto", 2],
+      ["API", 0],
+    ]);
+    expect(parsed.windows[0]?.resetsAt).toBe("2026-09-16T00:00:00.000Z");
+  });
+
+  it("ignores the Included total when Auto and API are missing", () => {
+    const parsed = parseCursorUsageLimitsOutput({
+      checkedAt: "2026-07-25T12:00:00.000Z",
+      output: "Usage • Free   Resets 7 Aug\nIncluded  23% used  ░░░",
+    });
+
+    expect(parsed.unavailable).toBeDefined();
+    expect(parsed.windows).toEqual([]);
+  });
+
+  it("returns unavailable when no percent rows are present", () => {
+    expect(
+      parseCursorUsageLimitsOutput({
+        checkedAt: "2026-07-25T12:00:00.000Z",
+        output: "Esc to close",
+      }),
+    ).toEqual({
+      checkedAt: "2026-07-25T12:00:00.000Z",
+      windows: [],
+      unavailable: {
+        reason: "probeFailed",
+        message: "Could not read usage limits for this Cursor account.",
+      },
+    });
+  });
+
+  it("rolls the reset year forward when a year-less reset wraps into next year", () => {
+    const parsed = parseCursorUsageLimitsOutput({
+      checkedAt: "2026-12-30T12:00:00.000Z",
+      output: "Usage • Free   Resets 3 Jan\nAuto  90% used  ░░░",
+    });
+
+    expect(parsed.windows[0]?.resetsAt).toBe("2027-01-03T00:00:00.000Z");
+  });
+
+  it("does not roll a stale same-year reset forward", () => {
+    const parsed = parseCursorUsageLimitsOutput({
+      checkedAt: "2026-07-20T12:00:00.000Z",
+      output: "Usage • Free   Resets 10 Jul\nAuto  90% used  ░░░",
+    });
+
+    expect(parsed.windows[0]?.resetsAt).toBe("2026-07-10T00:00:00.000Z");
+  });
+
+  it.effect("writes /usage after the composer is ready, not during the splash", () =>
+    Effect.gen(function* () {
+      const child = new MockPtyChild();
+      const clock = createFakeClock();
+      child.onWrite = (data) => {
+        if (data === "/usage\r") {
+          child.emitData(SAMPLE_OUTPUT);
+        }
+      };
+      const ptyAdapter: PtyAdapter.PtyAdapter["Service"] = {
+        spawn: () => Effect.succeed(child),
+      };
+      const resultFiber = yield* Effect.forkChild(
+        probeCursorUsageLimitsOnLinux(
+          { binaryPath: "cursor-agent", cwd: "/tmp", checkedAt: "2026-07-25T12:00:00.000Z" },
+          ptyAdapter,
+          clock,
+        ),
+        { startImmediately: true },
+      );
+
+      expect(child.writes).toEqual([]);
+      child.emitData(COMPOSER_READY);
+      expect(child.writes).toEqual([]);
+      clock.advance(799);
+      expect(child.writes).toEqual([]);
+      clock.advance(1);
+
+      const result = yield* Fiber.join(resultFiber);
+      expect(
+        result.usageLimits.windows.map((window) => [window.label, window.usedPercent]),
+      ).toEqual([
+        ["Auto", 10],
+        ["API", 13],
+      ]);
+      expect(child.writes).toEqual(["/usage\r"]);
+      expect(child.killed).toBe(true);
+    }),
+  );
+
+  it.effect("accepts /usage from the slash palette instead of leaving it highlighted", () =>
+    Effect.gen(function* () {
+      const child = new MockPtyChild();
+      const clock = createFakeClock();
+      child.onWrite = (data) => {
+        if (data === "/usage\r") {
+          child.emitData("→ /usage  Show plan and on-demand usage\n");
+        }
+        if (data === "\r") {
+          child.emitData(SAMPLE_OUTPUT);
+        }
+      };
+      const ptyAdapter: PtyAdapter.PtyAdapter["Service"] = {
+        spawn: () => Effect.succeed(child),
+      };
+      const resultFiber = yield* Effect.forkChild(
+        probeCursorUsageLimitsOnLinux(
+          { binaryPath: "cursor-agent", cwd: "/tmp", checkedAt: "2026-07-25T12:00:00.000Z" },
+          ptyAdapter,
+          clock,
+        ),
+        { startImmediately: true },
+      );
+
+      child.emitData(COMPOSER_READY);
+      clock.advance(800);
+
+      const result = yield* Fiber.join(resultFiber);
+      expect(child.writes).toEqual(["/usage\r", "\r"]);
+      expect(
+        result.usageLimits.windows.map((window) => [window.label, window.usedPercent]),
+      ).toEqual([
+        ["Auto", 10],
+        ["API", 13],
+      ]);
+      expect(result.usageLimits.windows[0]?.resetsAt).toBe("2026-08-07T00:00:00.000Z");
+    }),
+  );
+
+  it.effect("treats the wide-PTY Run a command placeholder as composer-ready", () =>
+    Effect.gen(function* () {
+      const child = new MockPtyChild();
+      const clock = createFakeClock();
+      child.onWrite = (data) => {
+        if (data === "/usage\r") {
+          child.emitData(SAMPLE_OUTPUT);
+        }
+      };
+      const ptyAdapter: PtyAdapter.PtyAdapter["Service"] = {
+        spawn: () => Effect.succeed(child),
+      };
+      const resultFiber = yield* Effect.forkChild(
+        probeCursorUsageLimitsOnLinux(
+          { binaryPath: "cursor-agent", cwd: "/tmp", checkedAt: "2026-07-25T12:00:00.000Z" },
+          ptyAdapter,
+          clock,
+        ),
+        { startImmediately: true },
+      );
+
+      child.emitData("Cursor Agent\n→ Run a command — e.g., dir\n");
+      expect(child.writes).toEqual([]);
+      clock.advance(800);
+
+      const result = yield* Fiber.join(resultFiber);
+      expect(result.usageLimits.unavailable).toBeUndefined();
+      expect(child.writes).toEqual(["/usage\r"]);
+    }),
+  );
+
+  it.effect("passes -e <apiEndpoint> when a custom API endpoint is configured", () =>
+    Effect.gen(function* () {
+      const child = new MockPtyChild();
+      let spawnInput: PtyAdapter.PtySpawnInput | undefined;
+      const ptyAdapter: PtyAdapter.PtyAdapter["Service"] = {
+        spawn: (input) => {
+          spawnInput = input;
+          return Effect.succeed(child);
+        },
+      };
+
+      yield* Effect.forkChild(
+        probeCursorUsageLimitsOnLinux(
+          {
+            binaryPath: "cursor-agent",
+            apiEndpoint: "https://example.com",
+            cwd: "/tmp",
+            checkedAt: "2026-07-25T12:00:00.000Z",
+          },
+          ptyAdapter,
+        ),
+        { startImmediately: true },
+      );
+
+      expect(spawnInput?.args).toEqual(["--trust", "-e", "https://example.com"]);
+    }),
+  );
+
+  it.effect("settles Auto and API even when no reset line arrives", () =>
+    Effect.gen(function* () {
+      const child = new MockPtyChild();
+      const clock = createFakeClock();
+      const ptyAdapter: PtyAdapter.PtyAdapter["Service"] = {
+        spawn: () => Effect.succeed(child),
+      };
+      const resultFiber = yield* Effect.forkChild(
+        probeCursorUsageLimitsOnLinux(
+          { binaryPath: "cursor-agent", cwd: "/tmp", checkedAt: "2026-07-25T12:00:00.000Z" },
+          ptyAdapter,
+          clock,
+        ),
+        { startImmediately: true },
+      );
+
+      child.emitData("Usage • Pro\nAuto  10% used\nAPI  13% used\n");
+
+      const result = yield* Fiber.join(resultFiber);
+      expect(result.usageLimits).not.toHaveProperty("unavailable");
+      expect(result.usageLimits.windows.map((window) => window.label)).toEqual(["Auto", "API"]);
+      expect(result.usageLimits.windows[0]?.resetsAt).toBeUndefined();
+      expect(child.killed).toBe(true);
+    }),
+  );
+
+  it.effect("does not finish on Included+Resets until Auto and API arrive", () =>
+    Effect.gen(function* () {
+      const child = new MockPtyChild();
+      const clock = createFakeClock();
+      const ptyAdapter: PtyAdapter.PtyAdapter["Service"] = {
+        spawn: () => Effect.succeed(child),
+      };
+      const resultFiber = yield* Effect.forkChild(
+        probeCursorUsageLimitsOnLinux(
+          { binaryPath: "cursor-agent", cwd: "/tmp", checkedAt: "2026-08-16T12:00:00.000Z" },
+          ptyAdapter,
+          clock,
+        ),
+        { startImmediately: true },
+      );
+
+      child.emitData("Usage • Pro  Resets 16 Sept\nIncluded  2% used\n");
+      expect(child.killed).toBe(false);
+      child.emitData("  Auto  2% used\n  API  0% used\n");
+
+      const result = yield* Fiber.join(resultFiber);
+      expect(
+        result.usageLimits.windows.map((window) => [window.label, window.usedPercent]),
+      ).toEqual([
+        ["Auto", 2],
+        ["API", 0],
+      ]);
+      expect(result.usageLimits.windows[0]?.resetsAt).toBe("2026-09-16T00:00:00.000Z");
+      expect(child.killed).toBe(true);
+    }),
+  );
+
+  it.effect("retries /usage after the slash palette misses during boot", () =>
+    Effect.gen(function* () {
+      const child = new MockPtyChild();
+      const clock = createFakeClock();
+      child.onWrite = (data) => {
+        if (
+          data === "/usage\r" &&
+          child.writes.filter((write) => write === "/usage\r").length >= 2
+        ) {
+          child.emitData(SAMPLE_OUTPUT);
+        }
+      };
+      const ptyAdapter: PtyAdapter.PtyAdapter["Service"] = {
+        spawn: () => Effect.succeed(child),
+      };
+      const resultFiber = yield* Effect.forkChild(
+        probeCursorUsageLimitsOnLinux(
+          { binaryPath: "cursor-agent", cwd: "/tmp", checkedAt: "2026-07-25T12:00:00.000Z" },
+          ptyAdapter,
+          clock,
+        ),
+        { startImmediately: true },
+      );
+
+      child.emitData(COMPOSER_READY);
+      expect(child.writes).toEqual([]);
+      clock.advance(800);
+      expect(child.writes).toEqual(["/usage\r"]);
+      child.emitData("     No matches\n");
+      clock.advance(1_499);
+      expect(child.writes).toEqual(["/usage\r"]);
+      clock.advance(1);
+
+      const result = yield* Fiber.join(resultFiber);
+      expect(child.writes).toEqual(["/usage\r", "\x1b", "/usage\r"]);
+      expect(result.usageLimits.unavailable).toBeUndefined();
+      expect(child.killed).toBe(true);
+    }),
+  );
+
+  it.effect("retries /usage on a timer even when the TUI emits nothing after the first send", () =>
+    Effect.gen(function* () {
+      const child = new MockPtyChild();
+      const clock = createFakeClock();
+      child.onWrite = (data) => {
+        if (
+          data === "/usage\r" &&
+          child.writes.filter((write) => write === "/usage\r").length >= 2
+        ) {
+          child.emitData(SAMPLE_OUTPUT);
+        }
+      };
+      const ptyAdapter: PtyAdapter.PtyAdapter["Service"] = {
+        spawn: () => Effect.succeed(child),
+      };
+      const resultFiber = yield* Effect.forkChild(
+        probeCursorUsageLimitsOnLinux(
+          { binaryPath: "cursor-agent", cwd: "/tmp", checkedAt: "2026-07-25T12:00:00.000Z" },
+          ptyAdapter,
+          clock,
+        ),
+        { startImmediately: true },
+      );
+
+      child.emitData(COMPOSER_READY);
+      clock.advance(800);
+      expect(child.writes).toEqual(["/usage\r"]);
+      clock.advance(1_500);
+
+      const result = yield* Fiber.join(resultFiber);
+      expect(child.writes).toEqual(["/usage\r", "\x1b", "/usage\r"]);
+      expect(result.usageLimits.unavailable).toBeUndefined();
+    }),
+  );
+});

--- a/apps/server/src/provider/cursorUsageProbe.ts
+++ b/apps/server/src/provider/cursorUsageProbe.ts
@@ -1,0 +1,327 @@
+import type { ServerProviderUsageLimits } from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import * as PtyAdapter from "../terminal/PtyAdapter.ts";
+import {
+  collectPtyProbeOutput,
+  defaultProbeClock,
+  type ProbeClock,
+  resolvePtyProbeCommand,
+  rollResetYearForward,
+  stripAnsi,
+} from "./ptyProbeSupport.ts";
+import {
+  clampPercent,
+  makeUnavailableUsageLimits,
+  makeUsageLimits,
+} from "./providerUsageLimits.ts";
+
+export type { ProbeClock } from "./ptyProbeSupport.ts";
+
+const CURSOR_USAGE_PROBE_TIMEOUT_MS = 25_000;
+/**
+ * `/usage` is a slash command that is only registered after the TUI finishes
+ * booting and the dashboard client is up. Typing it during the splash screen
+ * opens the command palette with "No matches" and never paints the usage
+ * pager. Wait for the composer, give the dashboard a beat to register the
+ * command, then confirm the highlighted `/usage` match with Enter. A second
+ * Escape retry is only for a palette miss — confirming a hit with Enter is
+ * what actually opens Auto/API.
+ *
+ * Retries are scheduled from the send itself: if `/usage` is swallowed with
+ * no further paint, waiting for the next `onData` would sit until timeout.
+ */
+const CURSOR_USAGE_COMMAND_READY_DELAY_MS = 800;
+const CURSOR_USAGE_COMMAND_RETRY_MS = 1_500;
+const CURSOR_USAGE_COMMAND_MAX_ATTEMPTS = 4;
+/** Cursor's `/usage` window resets on a monthly cadence, not a fixed weekly one. */
+const CURSOR_MONTHLY_WINDOW_DURATION_MINS = 30 * 24 * 60;
+const CURSOR_USAGE_ROW_LABELS = ["Auto", "API"] as const;
+
+function isCursorUsageRowLabel(value: string): value is (typeof CURSOR_USAGE_ROW_LABELS)[number] {
+  return (CURSOR_USAGE_ROW_LABELS as readonly string[]).includes(value);
+}
+
+export interface CursorUsageProbeResult {
+  readonly usageLimits: ServerProviderUsageLimits;
+  readonly rawOutput: string;
+}
+
+export interface CursorUsageProbeInput {
+  readonly binaryPath: string;
+  readonly apiEndpoint?: string;
+  readonly cwd: string;
+  readonly checkedAt: string;
+  readonly environment?: NodeJS.ProcessEnv;
+}
+
+function parsePercent(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function inferYearForCursorReset(checkedAt: string): number {
+  // checkedAt is always an ISO timestamp from DateTime.now in production.
+  const fromChecked = Number.parseInt(checkedAt.slice(0, 4), 10);
+  return Number.isFinite(fromChecked) && fromChecked >= 2000 ? fromChecked : 2000;
+}
+
+/**
+ * Cursor's `/usage` panel reports resets as "D Mon" (e.g. "7 Aug") with no
+ * year or time-of-day. Reorder to a "Mon D, YYYY" string DateTime can parse,
+ * assuming UTC since the panel gives no timezone.
+ */
+function parseCursorResetsAtIso(checkedAt: string, resetText: string): string | undefined {
+  const trimmed = resetText.trim().replace(/\s+/g, " ");
+  const match = trimmed.match(
+    /^(?:(\d{1,2})\s+([A-Za-z]{3,9})|([A-Za-z]{3,9})\s+(\d{1,2}))(?:\s+((?:19|20)\d{2}))?$/,
+  );
+  if (!match) return undefined;
+  const day = match[1] ?? match[4];
+  const month = match[2] ?? match[3];
+  const explicitYear = match[5];
+  if (!day || !month) return undefined;
+  const hasExplicitYear = Boolean(explicitYear);
+  const year = explicitYear ?? String(inferYearForCursorReset(checkedAt));
+  // `/usage` writes "Sept"; DateTime wants a 3-letter English month.
+  const canonical = `${month.slice(0, 3)} ${day}, ${year}`;
+  const dt = DateTime.makeZoned(canonical, { timeZone: "UTC", adjustForTimeZone: true });
+  return Option.isSome(dt)
+    ? DateTime.formatIso(rollResetYearForward(dt.value, checkedAt, hasExplicitYear))
+    : undefined;
+}
+
+function parseCursorUsageRows(cleaned: string): ReadonlyArray<{
+  readonly label: (typeof CURSOR_USAGE_ROW_LABELS)[number];
+  readonly usedPercent: number;
+}> {
+  const rows = new Map<(typeof CURSOR_USAGE_ROW_LABELS)[number], number>();
+  // Ink may emit `Auto  2% used` or the compact `Auto: 2% used`, and
+  // cursor addressing often leaves no line start in front of the label.
+  const pattern = /\b(Auto|API)\s*:?\s*(\d{1,3}(?:\.\d+)?)\s*%/gi;
+  for (const match of cleaned.matchAll(pattern)) {
+    const label = match[1];
+    const usedPercent = parsePercent(match[2]);
+    if (!label || !isCursorUsageRowLabel(label) || usedPercent === undefined || rows.has(label)) {
+      continue;
+    }
+    rows.set(label, usedPercent);
+  }
+  return CURSOR_USAGE_ROW_LABELS.flatMap((label) => {
+    const usedPercent = rows.get(label);
+    return usedPercent === undefined ? [] : [{ label, usedPercent }];
+  });
+}
+
+export function parseCursorUsageLimitsOutput(input: {
+  readonly output: string;
+  readonly checkedAt: string;
+}): ServerProviderUsageLimits {
+  const cleaned = stripAnsi(input.output);
+  const hasUsagePanel = /(?:^|\n)\s*Usage\s*[•·]/i.test(cleaned);
+  const rows = parseCursorUsageRows(cleaned);
+  // Ink right-aligns the reset with CUF (`ESC [ n C`), so after stripping
+  // ANSI the header is often `Usage • ProResets 16 Sept` with no word break.
+  const resetMatch = cleaned.match(
+    /Resets\s+(?:(\d{1,2}\s+[A-Za-z]{3,9})|([A-Za-z]{3,9}\s+\d{1,2}))(?:\s+((?:19|20)\d{2}))?\b/,
+  );
+  const resetText = [resetMatch?.[1] ?? resetMatch?.[2], resetMatch?.[3]].filter(Boolean).join(" ");
+  const resetsAt = resetText ? parseCursorResetsAtIso(input.checkedAt, resetText) : undefined;
+
+  if (hasUsagePanel && rows.length > 0) {
+    return makeUsageLimits({
+      checkedAt: input.checkedAt,
+      windows: rows.map((row) => ({
+        // Sorted by id inside the kind; Auto is the plan allowance and belongs first.
+        id: row.label === "Auto" ? "monthly_1_auto" : "monthly_2_api",
+        kind: "monthly" as const,
+        label: row.label,
+        usedPercent: clampPercent(row.usedPercent),
+        windowDurationMins: CURSOR_MONTHLY_WINDOW_DURATION_MINS,
+        ...(resetsAt ? { resetsAt } : {}),
+      })),
+    });
+  }
+
+  return makeUnavailableUsageLimits({
+    checkedAt: input.checkedAt,
+    reason: "probeFailed",
+    message: "Could not read usage limits for this Cursor account.",
+  });
+}
+
+function isCursorUsageTableComplete(parsed: ServerProviderUsageLimits): boolean {
+  const labels = new Set(parsed.windows.map((window) => window.label));
+  return labels.has("Auto") && labels.has("API");
+}
+
+function isCursorComposerReady(output: string): boolean {
+  const cleaned = stripAnsi(output);
+  // Wide PTYs (this probe is 120 cols) use "Run a command — e.g., dir" on
+  // Windows instead of the empty-chat "Plan, search, build anything" copy.
+  return (
+    /Plan, search, build anything/i.test(cleaned) ||
+    /Add a follow-up/i.test(cleaned) ||
+    /Run a command/i.test(cleaned) ||
+    /Tip: Use \/debug/i.test(cleaned)
+  );
+}
+
+function isCursorUsagePaletteReady(output: string): boolean {
+  const cleaned = stripAnsi(output);
+  return /Show plan and on-demand usage/i.test(cleaned);
+}
+
+function runCursorUsageProbeLoop(
+  child: PtyAdapter.PtyProcess,
+  input: CursorUsageProbeInput,
+  clock: ProbeClock,
+  signal: AbortSignal,
+): Promise<CursorUsageProbeResult> {
+  let usageAttempts = 0;
+  let acceptedUsage = false;
+  let readyTimer: ReturnType<typeof setTimeout> | undefined;
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const clearTimer = (timer: ReturnType<typeof setTimeout> | undefined) => {
+    if (timer === undefined) {
+      return undefined;
+    }
+    clock.clearTimeout(timer);
+    return undefined;
+  };
+
+  const clearSendTimers = () => {
+    readyTimer = clearTimer(readyTimer);
+    retryTimer = clearTimer(retryTimer);
+  };
+
+  const sendUsage = () => {
+    if (usageAttempts >= CURSOR_USAGE_COMMAND_MAX_ATTEMPTS) {
+      return;
+    }
+    if (usageAttempts > 0) {
+      child.write("\x1b");
+    }
+    usageAttempts += 1;
+    acceptedUsage = false;
+    child.write("/usage\r");
+    retryTimer = clearTimer(retryTimer);
+    if (usageAttempts < CURSOR_USAGE_COMMAND_MAX_ATTEMPTS) {
+      retryTimer = clock.setTimeout(() => {
+        retryTimer = undefined;
+        sendUsage();
+      }, CURSOR_USAGE_COMMAND_RETRY_MS);
+    }
+  };
+
+  const acceptUsage = () => {
+    if (acceptedUsage) {
+      return;
+    }
+    acceptedUsage = true;
+    retryTimer = clearTimer(retryTimer);
+    child.write("\r");
+  };
+
+  return collectPtyProbeOutput({
+    child,
+    clock,
+    timeoutMs: CURSOR_USAGE_PROBE_TIMEOUT_MS,
+    signal,
+    decideAfterOutput: (rawOutput) => {
+      const parsed = parseCursorUsageLimitsOutput({
+        output: rawOutput,
+        checkedAt: input.checkedAt,
+      });
+      const loading = /Loading usage data/i.test(stripAnsi(rawOutput));
+      if (parsed.unavailable === undefined && isCursorUsageTableComplete(parsed)) {
+        clearSendTimers();
+        return "finish";
+      }
+      if (loading) {
+        clearSendTimers();
+        return "continue";
+      }
+
+      if (usageAttempts > 0 && isCursorUsagePaletteReady(rawOutput)) {
+        acceptUsage();
+        return "continue";
+      }
+
+      if (usageAttempts === 0 && readyTimer === undefined && isCursorComposerReady(rawOutput)) {
+        readyTimer = clock.setTimeout(() => {
+          readyTimer = undefined;
+          sendUsage();
+        }, CURSOR_USAGE_COMMAND_READY_DELAY_MS);
+      }
+
+      return "continue";
+    },
+  }).then((rawOutput) => {
+    clearSendTimers();
+    return {
+      usageLimits: parseCursorUsageLimitsOutput({
+        output: rawOutput,
+        checkedAt: input.checkedAt,
+      }),
+      rawOutput,
+    };
+  });
+}
+
+export function probeCursorUsageLimits(
+  input: CursorUsageProbeInput,
+  clock: ProbeClock = defaultProbeClock,
+): Effect.Effect<CursorUsageProbeResult> {
+  return Effect.gen(function* () {
+    const ptyAdapter = Option.getOrUndefined(yield* Effect.serviceOption(PtyAdapter.PtyAdapter));
+    if (!ptyAdapter) {
+      return {
+        usageLimits: makeUnavailableUsageLimits({
+          checkedAt: input.checkedAt,
+          reason: "probeFailed",
+          message: "Usage limits are unavailable in this runtime.",
+        }),
+        rawOutput: "",
+      };
+    }
+
+    const environment: NodeJS.ProcessEnv = {
+      ...(input.environment ?? process.env),
+      FORCE_COLOR: "1",
+    };
+    delete environment.CI;
+    const command = yield* resolvePtyProbeCommand(
+      input.binaryPath,
+      ["--trust", ...(input.apiEndpoint ? ["-e", input.apiEndpoint] : [])],
+      environment,
+    );
+    const child = yield* ptyAdapter
+      .spawn({
+        shell: command.shell,
+        args: command.args,
+        cwd: input.cwd,
+        cols: 120,
+        rows: 40,
+        env: environment,
+      })
+      .pipe(Effect.orElseSucceed(() => null as PtyAdapter.PtyProcess | null));
+
+    if (!child) {
+      return {
+        usageLimits: makeUnavailableUsageLimits({
+          checkedAt: input.checkedAt,
+          reason: "probeFailed",
+          message: "Failed to spawn Cursor process for usage probe.",
+        }),
+        rawOutput: "",
+      };
+    }
+
+    return yield* Effect.promise((signal) => runCursorUsageProbeLoop(child, input, clock, signal));
+  });
+}

--- a/apps/server/src/provider/grokTuiUsageProbe.test.ts
+++ b/apps/server/src/provider/grokTuiUsageProbe.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+
+import * as PtyAdapter from "../terminal/PtyAdapter.ts";
+
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+
+import {
+  parseGrokUsageLimitsOutput,
+  probeGrokUsageLimits,
+  type ProbeClock,
+} from "./grokTuiUsageProbe.ts";
+
+/**
+ * Binary resolution is platform-dependent, so pin the platform rather than
+ * letting assertions depend on whichever OS the suite happens to run on.
+ */
+const probeGrokUsageLimitsOnLinux = (
+  input: Parameters<typeof probeGrokUsageLimits>[0],
+  ptyAdapter: PtyAdapter.PtyAdapter["Service"],
+  clock?: ProbeClock,
+) =>
+  probeGrokUsageLimits(input, clock).pipe(
+    Effect.provideService(HostProcessPlatform, "linux"),
+    Effect.provideService(PtyAdapter.PtyAdapter, ptyAdapter),
+  );
+
+class MockPtyChild implements PtyAdapter.PtyProcess {
+  public readonly writes: string[] = [];
+  public killed = false;
+  public onWrite: ((data: string) => void) | undefined;
+  private readonly dataListeners = new Set<(data: string) => void>();
+  private readonly exitListeners = new Set<(event: PtyAdapter.PtyExitEvent) => void>();
+
+  public get pid(): number {
+    return 12345;
+  }
+
+  public write(data: string): void {
+    this.writes.push(data);
+    this.onWrite?.(data);
+  }
+
+  public kill(): void {
+    this.killed = true;
+  }
+
+  public resize(): void {
+    // no-op
+  }
+
+  public onData(listener: (data: string) => void): () => void {
+    this.dataListeners.add(listener);
+    return () => this.dataListeners.delete(listener);
+  }
+
+  public onExit(listener: (event: PtyAdapter.PtyExitEvent) => void): () => void {
+    this.exitListeners.add(listener);
+    return () => this.exitListeners.delete(listener);
+  }
+
+  public emitData(data: string): void {
+    for (const listener of this.dataListeners) listener(data);
+  }
+}
+
+function createFakeClock(): ProbeClock & { advance(ms: number): void } {
+  const timers: Array<{ id: number; ms: number; fn: () => void; cancelled: boolean }> = [];
+  let nextId = 1;
+  const setTimeout = ((fn: () => void, ms?: number) => {
+    const id = nextId++;
+    timers.push({ id, ms: ms ?? 0, fn, cancelled: false });
+    return id as unknown as ReturnType<typeof globalThis.setTimeout>;
+  }) as typeof globalThis.setTimeout;
+  const clearTimeout = ((id: ReturnType<typeof globalThis.setTimeout>) => {
+    const timer = timers.find((entry) => entry.id === (id as unknown as number));
+    if (timer) timer.cancelled = true;
+  }) as typeof globalThis.clearTimeout;
+
+  return {
+    setTimeout,
+    clearTimeout,
+    advance(ms) {
+      for (const timer of timers) {
+        if (timer.cancelled) continue;
+        timer.ms -= ms;
+        if (timer.ms <= 0) {
+          timer.cancelled = true;
+          timer.fn();
+        }
+      }
+    },
+  };
+}
+
+describe("grokTuiUsageProbe", () => {
+  it("parses weekly limit and next reset from Grok /usage show output", () => {
+    const checkedAt = "2026-07-07T12:00:00.000Z";
+    const parsed = parseGrokUsageLimitsOutput({
+      checkedAt,
+      output: `
+        Usage
+        Show    Manage
+        Weekly limit: 32%
+        Next reset: July 11, 02:10 PT
+      `,
+    });
+
+    expect(parsed.unavailable).toBeUndefined();
+    expect(parsed.windows).toHaveLength(1);
+    expect(parsed.windows[0]).toMatchObject({
+      id: "weekly",
+      kind: "weekly",
+      label: "Weekly",
+      usedPercent: 32,
+      windowDurationMins: 7 * 24 * 60,
+    });
+    expect(parsed.windows[0]?.resetsAt).toBeDefined();
+  });
+
+  it("returns unavailable when weekly limit text is absent", () => {
+    expect(
+      parseGrokUsageLimitsOutput({
+        checkedAt: "2026-07-07T12:00:00.000Z",
+        output: "Show    Manage",
+      }),
+    ).toEqual({
+      checkedAt: "2026-07-07T12:00:00.000Z",
+      windows: [],
+      unavailable: {
+        reason: "probeFailed",
+        message: "Could not read usage limits for this Grok account.",
+      },
+    });
+  });
+
+  it("uses the Pacific standard-time offset in winter", () => {
+    const parsed = parseGrokUsageLimitsOutput({
+      checkedAt: "2026-01-07T12:00:00.000Z",
+      output: "Weekly limit: 32%\nNext reset: January 11, 02:10 PST",
+    });
+
+    expect(parsed.windows[0]?.resetsAt).toBe("2026-01-11T10:10:00.000Z");
+  });
+
+  it("rolls the reset year forward when a year-less reset wraps into next year", () => {
+    const parsed = parseGrokUsageLimitsOutput({
+      checkedAt: "2026-12-30T12:00:00.000Z",
+      output: "Weekly limit: 90%\nNext reset: January 3, 09:00 PT",
+    });
+
+    expect(parsed.windows[0]?.resetsAt).toBe("2027-01-03T17:00:00.000Z");
+  });
+
+  it("does not roll stale same-year or explicitly dated resets forward", () => {
+    const staleYearless = parseGrokUsageLimitsOutput({
+      checkedAt: "2026-07-20T12:00:00.000Z",
+      output: "Weekly limit: 90%\nNext reset: July 10, 09:00 PT",
+    });
+    const explicitYear = parseGrokUsageLimitsOutput({
+      checkedAt: "2026-12-30T12:00:00.000Z",
+      output: "Weekly limit: 90%\nNext reset: January 3, 2026, 09:00 PT",
+    });
+
+    expect(staleYearless.windows[0]?.resetsAt).toBe("2026-07-10T16:00:00.000Z");
+    expect(explicitYear.windows[0]?.resetsAt).toBe("2026-01-03T17:00:00.000Z");
+  });
+
+  it.effect("captures synchronous output using the default probe clock", () =>
+    Effect.gen(function* () {
+      const child = new MockPtyChild();
+      child.onWrite = () => {
+        child.emitData("Weekly limit: 32%\nNext reset: July 11, 02:10 PT\n");
+      };
+      const ptyAdapter: PtyAdapter.PtyAdapter["Service"] = {
+        spawn: () => Effect.succeed(child),
+      };
+
+      const result = yield* probeGrokUsageLimitsOnLinux(
+        { binaryPath: "grok", cwd: "/tmp", checkedAt: "2026-07-07T12:00:00.000Z" },
+        ptyAdapter,
+      );
+
+      expect(result.usageLimits.windows[0]?.resetsAt).toBe("2026-07-11T09:10:00.000Z");
+      expect(child.writes).toEqual(["/usage\r"]);
+      expect(child.killed).toBe(true);
+    }),
+  );
+
+  it.effect("settles after utilization output when no reset line arrives", () =>
+    Effect.gen(function* () {
+      const child = new MockPtyChild();
+      const clock = createFakeClock();
+      const ptyAdapter: PtyAdapter.PtyAdapter["Service"] = {
+        spawn: () => Effect.succeed(child),
+      };
+      const resultFiber = yield* Effect.forkChild(
+        probeGrokUsageLimitsOnLinux(
+          { binaryPath: "grok", cwd: "/tmp", checkedAt: "2026-07-07T12:00:00.000Z" },
+          ptyAdapter,
+          clock,
+        ),
+        { startImmediately: true },
+      );
+
+      child.emitData("Weekly limit: 32%\n");
+      clock.advance(199);
+      expect(child.killed).toBe(false);
+      clock.advance(1);
+
+      const result = yield* Fiber.join(resultFiber);
+      expect(result.usageLimits).not.toHaveProperty("unavailable");
+      expect(result.usageLimits.windows[0]?.resetsAt).toBeUndefined();
+      expect(child.killed).toBe(true);
+    }),
+  );
+
+  it.effect("opens usage in the TUI and waits briefly for the reset line", () =>
+    Effect.gen(function* () {
+      const child = new MockPtyChild();
+      const clock = createFakeClock();
+      let spawnInput: PtyAdapter.PtySpawnInput | undefined;
+      const ptyAdapter: PtyAdapter.PtyAdapter["Service"] = {
+        spawn: (input) => {
+          spawnInput = input;
+          return Effect.succeed(child);
+        },
+      };
+      const resultFiber = yield* Effect.forkChild(
+        probeGrokUsageLimitsOnLinux(
+          { binaryPath: "grok", cwd: "/tmp", checkedAt: "2026-07-07T12:00:00.000Z" },
+          ptyAdapter,
+          clock,
+        ),
+        { startImmediately: true },
+      );
+
+      expect(spawnInput?.args).toEqual([]);
+      expect(child.writes).toEqual(["/usage\r"]);
+      child.emitData("Weekly limit: 32%\n");
+      expect(child.killed).toBe(false);
+      child.emitData("Next reset: July 11, 02:10 PT\n");
+
+      const result = yield* Fiber.join(resultFiber);
+      expect(result.usageLimits.windows[0]?.resetsAt).toBe("2026-07-11T09:10:00.000Z");
+      expect(child.killed).toBe(true);
+    }),
+  );
+
+  it.effect("re-issues /usage when the TUI drops the first write", () =>
+    Effect.gen(function* () {
+      const child = new MockPtyChild();
+      const clock = createFakeClock();
+      const ptyAdapter: PtyAdapter.PtyAdapter["Service"] = {
+        spawn: () => Effect.succeed(child),
+      };
+      const resultFiber = yield* Effect.forkChild(
+        probeGrokUsageLimitsOnLinux(
+          { binaryPath: "grok", cwd: "/tmp", checkedAt: "2026-07-07T12:00:00.000Z" },
+          ptyAdapter,
+          clock,
+        ),
+        { startImmediately: true },
+      );
+
+      // The TUI is still booting, so the first `/usage` produces no output.
+      expect(child.writes).toEqual(["/usage\r"]);
+
+      clock.advance(750);
+
+      // The command is re-issued, and only ever as `/usage`. The retry count is
+      // capped so a genuinely unresponsive TUI still falls through to the probe
+      // timeout instead of writing forever.
+      expect(child.writes.length).toBeGreaterThan(1);
+      expect(child.writes.length).toBeLessThanOrEqual(4);
+      expect([...new Set(child.writes)]).toEqual(["/usage\r"]);
+
+      // The retry lands once the TUI is accepting input.
+      child.emitData("Weekly limit: 32%\n");
+      child.emitData("Next reset: July 11, 02:10 PT\n");
+
+      const result = yield* Fiber.join(resultFiber);
+      expect(result.usageLimits).not.toHaveProperty("unavailable");
+      expect(result.usageLimits.windows[0]?.resetsAt).toBe("2026-07-11T09:10:00.000Z");
+    }),
+  );
+});

--- a/apps/server/src/provider/grokTuiUsageProbe.ts
+++ b/apps/server/src/provider/grokTuiUsageProbe.ts
@@ -1,0 +1,193 @@
+import type { ServerProviderUsageLimits } from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import * as PtyAdapter from "../terminal/PtyAdapter.ts";
+import {
+  collectPtyProbeOutput,
+  defaultProbeClock,
+  type ProbeClock,
+  resolvePtyProbeCommand,
+  rollResetYearForward,
+  stripAnsi,
+} from "./ptyProbeSupport.ts";
+import {
+  clampPercent,
+  makeUnavailableUsageLimits,
+  makeUsageLimits,
+} from "./providerUsageLimits.ts";
+
+export type { ProbeClock } from "./ptyProbeSupport.ts";
+
+const GROK_USAGE_PROBE_TIMEOUT_MS = 10_000;
+const GROK_USAGE_OUTPUT_SETTLE_MS = 200;
+/**
+ * The Grok TUI drops input written before it finishes booting, so `/usage` is
+ * re-issued a few times rather than waiting out the full probe timeout on a
+ * single dropped keystroke.
+ */
+const GROK_USAGE_COMMAND_RESEND_MS = 750;
+const GROK_USAGE_COMMAND_MAX_RESENDS = 3;
+
+export interface GrokUsageProbeResult {
+  readonly usageLimits: ServerProviderUsageLimits;
+  readonly rawOutput: string;
+}
+
+export interface GrokUsageProbeInput {
+  readonly binaryPath: string;
+  readonly cwd: string;
+  readonly checkedAt: string;
+  readonly environment?: NodeJS.ProcessEnv;
+}
+
+function parsePercent(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function inferYearForGrokReset(checkedAt: string): number {
+  // checkedAt is always an ISO timestamp from DateTime.now in production.
+  const fromChecked = Number.parseInt(checkedAt.slice(0, 4), 10);
+  return Number.isFinite(fromChecked) && fromChecked >= 2000 ? fromChecked : 2000;
+}
+
+function parseGrokNextResetIso(checkedAt: string, resetLine: string): string | undefined {
+  const trimmed = resetLine.trim().replace(/\s+/g, " ");
+  if (!trimmed) return undefined;
+
+  const hasExplicitYear = /\b20\d{2}\b/.test(trimmed);
+  const withYear = hasExplicitYear ? trimmed : `${trimmed}, ${inferYearForGrokReset(checkedAt)}`;
+  const pacificTime = /\b(?:pt|pdt|pst)\b/i.test(withYear)
+    ? withYear.replace(/\b(?:pt|pdt|pst)\b/i, "")
+    : withYear;
+  const dt = DateTime.makeZoned(pacificTime, {
+    timeZone: "America/Los_Angeles",
+    adjustForTimeZone: true,
+  });
+  return Option.isSome(dt)
+    ? DateTime.formatIso(rollResetYearForward(dt.value, checkedAt, hasExplicitYear))
+    : undefined;
+}
+
+export function parseGrokUsageLimitsOutput(input: {
+  readonly output: string;
+  readonly checkedAt: string;
+}): ServerProviderUsageLimits {
+  const cleaned = stripAnsi(input.output);
+  const weeklyMatch = cleaned.match(/weekly\s*limit\s*:\s*(\d{1,3}(?:\.\d+)?)\s*%/i);
+  const usedPercent = parsePercent(weeklyMatch?.[1]);
+  const resetMatch = cleaned.match(/next\s*reset\s*:\s*([^\n\r]+)/i);
+  const resetsAt = resetMatch?.[1]
+    ? parseGrokNextResetIso(input.checkedAt, resetMatch[1])
+    : undefined;
+
+  if (usedPercent !== undefined) {
+    return makeUsageLimits({
+      checkedAt: input.checkedAt,
+      windows: [
+        {
+          id: "weekly",
+          kind: "weekly",
+          label: "Weekly",
+          usedPercent: clampPercent(usedPercent),
+          windowDurationMins: 7 * 24 * 60,
+          ...(resetsAt ? { resetsAt } : {}),
+        },
+      ],
+    });
+  }
+
+  return makeUnavailableUsageLimits({
+    checkedAt: input.checkedAt,
+    reason: "probeFailed",
+    message: "Could not read usage limits for this Grok account.",
+  });
+}
+
+function runGrokUsageProbeLoop(
+  child: PtyAdapter.PtyProcess,
+  input: GrokUsageProbeInput,
+  clock: ProbeClock,
+  signal: AbortSignal,
+): Promise<GrokUsageProbeResult> {
+  return collectPtyProbeOutput({
+    child,
+    clock,
+    timeoutMs: GROK_USAGE_PROBE_TIMEOUT_MS,
+    signal,
+    onStart: () => child.write("/usage\r"),
+    resend: {
+      send: () => child.write("/usage\r"),
+      everyMs: GROK_USAGE_COMMAND_RESEND_MS,
+      maxAttempts: GROK_USAGE_COMMAND_MAX_RESENDS,
+    },
+    decideAfterOutput: (rawOutput) => {
+      const parsed = parseGrokUsageLimitsOutput({
+        output: rawOutput,
+        checkedAt: input.checkedAt,
+      });
+      if (parsed.unavailable === undefined && parsed.windows.every((window) => window.resetsAt)) {
+        return "finish";
+      }
+      return parsed.unavailable === undefined
+        ? { settleAfterMs: GROK_USAGE_OUTPUT_SETTLE_MS }
+        : "continue";
+    },
+  }).then((rawOutput) => {
+    return {
+      usageLimits: parseGrokUsageLimitsOutput({
+        output: rawOutput,
+        checkedAt: input.checkedAt,
+      }),
+      rawOutput,
+    };
+  });
+}
+
+export function probeGrokUsageLimits(
+  input: GrokUsageProbeInput,
+  clock: ProbeClock = defaultProbeClock,
+): Effect.Effect<GrokUsageProbeResult> {
+  return Effect.gen(function* () {
+    const ptyAdapter = Option.getOrUndefined(yield* Effect.serviceOption(PtyAdapter.PtyAdapter));
+    if (!ptyAdapter) {
+      return {
+        usageLimits: makeUnavailableUsageLimits({
+          checkedAt: input.checkedAt,
+          reason: "probeFailed",
+          message: "Usage limits unavailable for this Grok instance in the current runtime.",
+        }),
+        rawOutput: "",
+      };
+    }
+
+    const environment = input.environment ?? process.env;
+    const command = yield* resolvePtyProbeCommand(input.binaryPath, [], environment);
+    const child = yield* ptyAdapter
+      .spawn({
+        shell: command.shell,
+        args: command.args,
+        cwd: input.cwd,
+        cols: 120,
+        rows: 40,
+        env: environment,
+      })
+      .pipe(Effect.orElseSucceed(() => null as PtyAdapter.PtyProcess | null));
+
+    if (!child) {
+      return {
+        usageLimits: makeUnavailableUsageLimits({
+          checkedAt: input.checkedAt,
+          reason: "probeFailed",
+          message: "Failed to spawn Grok process for usage probe.",
+        }),
+        rawOutput: "",
+      };
+    }
+
+    return yield* Effect.promise((signal) => runGrokUsageProbeLoop(child, input, clock, signal));
+  });
+}

--- a/apps/server/src/provider/ptyProbeSupport.ts
+++ b/apps/server/src/provider/ptyProbeSupport.ts
@@ -1,0 +1,256 @@
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { SpawnExecutableResolution } from "@t3tools/shared/shell";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import type * as PtyAdapter from "../terminal/PtyAdapter.ts";
+
+/** Extensions cmd.exe must interpret; they are not directly executable images. */
+const WINDOWS_INTERPRETED_EXTENSIONS = [".cmd", ".bat"];
+
+/**
+ * Resolves a provider binary into something a PTY can actually launch.
+ *
+ * On Windows these CLIs install as `name.cmd` shims sitting next to an
+ * extensionless shell script, and `PATH` lookup finds the latter. node-pty
+ * spawns the target file directly instead of going through a shell, so handing
+ * it the bare `claude` / `cursor` / `grok` path fails outright — which is why
+ * every PTY-backed provider reported "Failed to spawn ... for usage probe" on
+ * Windows while Codex (whose usage comes from an app-server RPC, not a PTY)
+ * worked fine. `.cmd` shims are only executable through the command
+ * interpreter, so route those via ComSpec.
+ *
+ * Deliberately does not reuse `resolveSpawnCommand`: that helper escapes the
+ * executable for `ChildProcess` with `shell: true`, where the command is a
+ * single string. node-pty instead takes an argv array and quotes each element
+ * itself, so a pre-escaped path arrives double-quoted and cmd.exe rejects it
+ * with "is not recognized as an internal or external command".
+ */
+export const resolvePtyProbeCommand = Effect.fn("resolvePtyProbeCommand")(function* (
+  binaryPath: string,
+  args: ReadonlyArray<string>,
+  env: NodeJS.ProcessEnv,
+) {
+  const platform = yield* HostProcessPlatform;
+  if (platform !== "win32") {
+    return { shell: binaryPath, args: [...args] };
+  }
+
+  const resolveExecutable = yield* SpawnExecutableResolution;
+  const resolved = resolveExecutable(binaryPath, platform, env) ?? binaryPath;
+  const lowerCased = resolved.toLowerCase();
+  if (!WINDOWS_INTERPRETED_EXTENSIONS.some((extension) => lowerCased.endsWith(extension))) {
+    return { shell: resolved, args: [...args] };
+  }
+
+  const comSpec = env.ComSpec ?? env.COMSPEC ?? "cmd.exe";
+  return { shell: comSpec, args: ["/c", resolved, ...args] };
+});
+
+/**
+ * Matches common CSI / OSC ANSI escape sequences emitted by interactive CLI
+ * output. Shared by every PTY-backed usage probe.
+ *
+ * OSC bodies must not span ESC. A greedy `[^\x07]*` until the last `ESC \`
+ * in the stream swallows later Ink frames — Cursor's `/usage` panel is
+ * bookended by OSC-8 hyperlinks, which is how Auto/API rows disappeared
+ * after a successful scrape.
+ */
+const ESCAPE_CHAR = String.fromCharCode(27);
+const BEL_CHAR = String.fromCharCode(7);
+const ANSI_PATTERN = new RegExp(
+  `${ESCAPE_CHAR}(?:\\[[0-?]*[ -/]*[@-~]|\\][^${BEL_CHAR}${ESCAPE_CHAR}]*(?:${BEL_CHAR}|${ESCAPE_CHAR}\\\\))`,
+  "g",
+);
+
+export function stripAnsi(value: string): string {
+  return value.replaceAll(ANSI_PATTERN, "");
+}
+
+export interface ProbeClock {
+  readonly setTimeout: typeof setTimeout;
+  readonly clearTimeout: typeof clearTimeout;
+}
+
+export const defaultProbeClock: ProbeClock = { setTimeout, clearTimeout };
+
+/** Best-effort kill during probe cleanup; the process may have already exited. */
+function killPtyProcessQuietly(child: PtyAdapter.PtyProcess): void {
+  try {
+    child.kill();
+  } catch {
+    // Ignore kill failures during cleanup.
+  }
+}
+
+export type PtyProbeOutputDecision = "continue" | "finish" | { readonly settleAfterMs: number };
+
+export function collectPtyProbeOutput(input: {
+  readonly child: PtyAdapter.PtyProcess;
+  readonly clock: ProbeClock;
+  readonly timeoutMs: number;
+  readonly onStart?: () => void;
+  /**
+   * When the surrounding Effect is interrupted, abort the probe immediately
+   * instead of waiting out `timeoutMs` with an orphaned child process.
+   */
+  readonly signal?: AbortSignal;
+  /**
+   * Re-issues the probe command on a timer until the probe settles.
+   *
+   * Interactive CLIs routinely drop input written before they finish painting
+   * the first frame and installing their key handlers. With a single write at
+   * spawn time a dropped command is indistinguishable from "no usage data": the
+   * probe waits out the full timeout and reports limits unavailable even for a
+   * healthy, authenticated account. Slash commands like `/usage` just reopen a
+   * panel, so re-issuing them is idempotent and safe.
+   */
+  readonly resend?: {
+    readonly send: () => void;
+    readonly everyMs: number;
+    readonly maxAttempts: number;
+  };
+  readonly decideAfterOutput?: (rawOutput: string) => PtyProbeOutputDecision;
+}): Promise<string> {
+  return new Promise((resolve) => {
+    let rawOutput = "";
+    let settled = false;
+    let exited = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let settleTimer: ReturnType<typeof setTimeout> | undefined;
+    let resendTimer: ReturnType<typeof setTimeout> | undefined;
+    let resendAttempts = 0;
+    let offData: () => void = () => {};
+    let offExit: () => void = () => {};
+    let offAbort: () => void = () => {};
+
+    const clearSettleTimer = () => {
+      if (settleTimer) {
+        input.clock.clearTimeout(settleTimer);
+        settleTimer = undefined;
+      }
+    };
+
+    const clearResendTimer = () => {
+      if (resendTimer) {
+        input.clock.clearTimeout(resendTimer);
+        resendTimer = undefined;
+      }
+    };
+
+    const scheduleResend = () => {
+      const resend = input.resend;
+      if (!resend || resendAttempts >= resend.maxAttempts) return;
+      resendTimer = input.clock.setTimeout(() => {
+        resendTimer = undefined;
+        if (settled) return;
+        resendAttempts += 1;
+        try {
+          resend.send();
+        } catch {
+          // A closed PTY surfaces on the exit listener; nothing to do here.
+        }
+        scheduleResend();
+      }, resend.everyMs);
+    };
+
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      if (timeout) {
+        input.clock.clearTimeout(timeout);
+      }
+      clearSettleTimer();
+      clearResendTimer();
+      offAbort();
+      offData();
+      offExit();
+      // A probe whose binary is missing exits the instant it spawns, so this
+      // path runs constantly for uninstalled providers. Never kill a PTY that
+      // already exited — see `killPtyProcessQuietly`.
+      if (!exited) {
+        killPtyProcessQuietly(input.child);
+      }
+      resolve(rawOutput);
+    };
+
+    // Subscribe to exit before data/start so an already-exited child (the
+    // adapter replays the last exit event) finishes immediately instead of
+    // waiting out the probe timeout.
+    offExit = input.child.onExit(() => {
+      exited = true;
+      finish();
+    });
+    offData = input.child.onData((data) => {
+      if (settled) return;
+      rawOutput += data;
+      const decision = input.decideAfterOutput?.(rawOutput) ?? "continue";
+      if (decision === "finish") {
+        finish();
+      } else if (decision === "continue") {
+        clearSettleTimer();
+      } else {
+        clearSettleTimer();
+        settleTimer = input.clock.setTimeout(finish, decision.settleAfterMs);
+      }
+    });
+    timeout = input.clock.setTimeout(finish, input.timeoutMs);
+
+    if (input.signal) {
+      const onAbort = () => finish();
+      if (input.signal.aborted) {
+        finish();
+        return;
+      }
+      input.signal.addEventListener("abort", onAbort, { once: true });
+      offAbort = () => input.signal?.removeEventListener("abort", onAbort);
+    }
+
+    if (settled) {
+      return;
+    }
+
+    try {
+      input.onStart?.();
+    } catch {
+      finish();
+      return;
+    }
+
+    scheduleResend();
+  });
+}
+
+/**
+ * Usage-probe output often reports a reset date without a year (e.g. "Jan 3,
+ * 9:00am"). Callers assume the reset falls in the same year as `checkedAt`,
+ * which is wrong when the probe runs near year-end for a reset that rolls
+ * into January (e.g. checked Dec 30, reset Jan 3 of the *following* year).
+ * Roll the year forward only for the December-to-January boundary. Other past
+ * yearless timestamps may be stale output and must not be moved a year ahead.
+ * No-ops when the source text already had an explicit year.
+ */
+export function rollResetYearForward<A extends DateTime.DateTime>(
+  resetDateTime: A,
+  checkedAt: string,
+  hadExplicitYear: boolean,
+): A {
+  if (hadExplicitYear) {
+    return resetDateTime;
+  }
+  const checked = DateTime.make(checkedAt);
+  if (Option.isNone(checked)) {
+    return resetDateTime;
+  }
+  const checkedParts = DateTime.toPartsUtc(checked.value);
+  const resetParts = DateTime.toParts(resetDateTime);
+  if (
+    checkedParts.month !== 12 ||
+    resetParts.month !== 1 ||
+    resetParts.year !== checkedParts.year
+  ) {
+    return resetDateTime;
+  }
+  return DateTime.add(resetDateTime, { years: 1 });
+}


### PR DESCRIPTION
Reference port of the Cursor and Grok usage probes from #1732 onto the model that landed in #9507. Kept as a draft: the data source is the interactive `/usage` TUI driven in a PTY, which is fragile by nature (copy changes in either CLI break the parse) and adds a 10–25s PTY session to every status check. It lives here so the work is preserved against `main` and can land the day either CLI exposes quota over ACP or a JSON command — at which point the parser swaps and the wiring stays.

## What changed

- `cursorUsageProbe.ts`, `grokTuiUsageProbe.ts`, `ptyProbeSupport.ts` and their tests, from #1732, retargeted onto `ServerProviderUsageLimits`: stable window ids (`monthly_1_auto` / `monthly_2_api`, `weekly`), typed `unavailable.reason`, no `source` enum.
- `CursorProvider` and `GrokProvider` call the probe from their own `checkProvider` and return `usageLimits` on the snapshot — the one-driver-change shape #9507 was built for. A Grok API-key session reports `unsupported`.
- `PtyAdapter` is threaded into both drivers as an optional service; without it the probe reports limits unavailable rather than failing the provider.

Nothing central changes. OpenCode, the Claude PTY probe, and the terminal-adapter changes from #1732 are not carried (superseded, replaced by the SDK read, and out of scope respectively).

## Verification

- 73 tests across the two probe suites and the Cursor/Grok provider suites, typecheck clean with the repo's Effect diagnostics.
- Not exercised against real CLIs on this pass; #1732's fixtures were captured from real output at the time.

Authored by @Aditya190803 in #1732; ported by Claude Fable 5 via Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add PTY-backed usage probes for Cursor and Grok providers
> - Adds PTY-backed usage probes to parse monthly plan limits from the Cursor TUI and weekly limits from the Grok TUI.
> - Introduces shared utilities in [ptyProbeSupport.ts](https://github.com/pingdotgg/t3code/pull/9532/files#diff-8d9e7f6dd01932fef4272be0bf777b3795bcf566b1c46d427440ee9da48c6308) for ANSI stripping, Windows command resolution, bounded retries, and process cleanup.
> - Driver status checks in [CursorDriver.ts](https://github.com/pingdotgg/t3code/pull/9532/files#diff-0b170344a3fe14a0680129b8c4a48317ca4a65346ddb307888262f6b3956b3ee) and [GrokDriver.ts](https://github.com/pingdotgg/t3code/pull/9532/files#diff-0b86a3e67f98dbf93f42e8168829458b1cdde63a0486e43e2bebcdaaf32f64e8) pass the server working directory and optional `PtyAdapter` to the new probes.
> - Risk: Status checks spawn external processes via `probeCursorUsageLimits` and `probeGrokUsageLimits`; if PTY output hangs past the configured timeout or cleanup logic fails, it could leave orphaned child processes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e37dd9d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->