### PR TITLE
feat(web): open HTML files in the browser from the files context menu

### DIFF
--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -12,6 +12,7 @@ import { Button } from "~/components/ui/button";
 import { InputGroup, InputGroupInput } from "~/components/ui/input-group";
 import { toastManager } from "~/components/ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
+import { isBrowserPreviewFile } from "~/browser/openFileInPreview";
 import { useComposerHandleContext } from "~/composerHandleContext";
 import { writeTextToClipboard } from "~/hooks/useCopyToClipboard";
 import { useTheme } from "~/hooks/useTheme";
@@ -37,6 +38,8 @@ interface FileBrowserPanelProps {
   onOpenFile: (relativePath: string) => void;
   onRefreshSelectedFile?: () => void;
   workspaceMutationId: string | null;
+  /** Present when the runtime can open a workspace file in the integrated browser. */
+  onOpenInBrowser?: ((relativePath: string) => void) | undefined;
 }
 
 function treePath(entry: ProjectEntry): string {
@@ -101,6 +104,7 @@ export default function FileBrowserPanel({
   onOpenFile,
   onRefreshSelectedFile,
   workspaceMutationId,
+  onOpenInBrowser,
 }: FileBrowserPanelProps) {
   const { resolvedTheme } = useTheme();
   const composerRef = useComposerHandleContext();
@@ -144,6 +148,10 @@ export default function FileBrowserPanel({
     }
     const relativePath = item.path.replace(/\/$/, "");
     const mention = serializeComposerFileLink(relativePath);
+    const canOpenInBrowser =
+      onOpenInBrowser !== undefined &&
+      entryKindsRef.current.get(relativePath) === "file" &&
+      isBrowserPreviewFile(relativePath);
     const pointer = contextMenuPointerRef.current;
     const pointerIsFresh = pointer !== null && performance.now() - pointer.at < 1000;
     const anchorRect = context.anchorElement.getBoundingClientRect();
@@ -153,11 +161,18 @@ export default function FileBrowserPanel({
     try {
       const clicked = await api.contextMenu.show(
         [
+          ...(canOpenInBrowser
+            ? [{ id: "open-in-browser" as const, label: "Open in browser" }]
+            : []),
           { id: "copy-mention", label: "Copy mention" },
           { id: "add-to-chat", label: "Add to chat" },
         ],
         position,
       );
+      if (clicked === "open-in-browser") {
+        onOpenInBrowser?.(relativePath);
+        return;
+      }
       if (clicked === "copy-mention") {
         try {
           await writeTextToClipboard(mention);

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -36,7 +36,7 @@ import { DIFF_SURFACE_THEME_UNSAFE_CSS, resolveDiffThemeName } from "~/lib/diffR
 import { PREFERRED_HIGHLIGHTER } from "~/lib/syntaxHighlighting";
 import { cn } from "~/lib/utils";
 import { isPreviewSupportedInRuntime } from "~/previewStateStore";
-import { isAbsolutePath, resolvePathLinkTarget } from "~/terminal-links";
+import { isAbsolutePath, resolveWorkspaceFilePath } from "~/terminal-links";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { Toggle } from "~/components/ui/toggle";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
@@ -1066,7 +1066,7 @@ export default function FilePreviewPanel({
     isPreviewSupportedInRuntime() &&
     isBrowserPreviewFile(relativePath);
   const absolutePath =
-    relativePath && attachment === undefined ? resolvePathLinkTarget(relativePath, cwd) : null;
+    relativePath && attachment === undefined ? resolveWorkspaceFilePath(relativePath, cwd) : null;
   const onFilePostRender = useFileLineReveal(relativePath, revealLine, revealRequestId);
   useWorkspaceMutationRefresh({
     enabled:
@@ -1099,30 +1099,35 @@ export default function FilePreviewPanel({
     });
   };
 
-  const handleOpenInBrowser = useCallback(() => {
-    if (!absolutePath || !environmentHttpBaseUrl) return;
-    void (async () => {
-      const result = await openFileInPreview({
-        threadRef,
-        filePath: absolutePath,
-        workspaceRoot: cwd,
-        httpBaseUrl: environmentHttpBaseUrl,
-        createAssetUrl,
-        openPreview,
-      });
-      if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
-        return;
-      }
-      const error = squashAtomCommandFailure(result);
-      toastManager.add(
-        stackedThreadToast({
-          type: "error",
-          title: "Unable to open file in browser",
-          description: error instanceof Error ? error.message : "An error occurred.",
-        }),
-      );
-    })();
-  }, [absolutePath, createAssetUrl, cwd, environmentHttpBaseUrl, openPreview, threadRef]);
+  const handleOpenInBrowser = useCallback(
+    (filePath: string) => {
+      if (!environmentHttpBaseUrl) return;
+      void (async () => {
+        const result = await openFileInPreview({
+          threadRef,
+          // Tree and preview-header paths are workspace-relative; resolve them
+          // against the workspace root without terminal-link `~/` expansion.
+          filePath: resolveWorkspaceFilePath(filePath, cwd),
+          workspaceRoot: cwd,
+          httpBaseUrl: environmentHttpBaseUrl,
+          createAssetUrl,
+          openPreview,
+        });
+        if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
+          return;
+        }
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Unable to open file in browser",
+            description: error instanceof Error ? error.message : "An error occurred.",
+          }),
+        );
+      })();
+    },
+    [createAssetUrl, cwd, environmentHttpBaseUrl, openPreview, threadRef],
+  );
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
@@ -1205,7 +1210,7 @@ export default function FilePreviewPanel({
                   <Toggle
                     className="shrink-0"
                     pressed={false}
-                    onPressedChange={handleOpenInBrowser}
+                    onPressedChange={() => handleOpenInBrowser(relativePath)}
                     aria-label="Open file in preview browser"
                     variant="ghost"
                     size="sm"
@@ -1368,6 +1373,11 @@ export default function FilePreviewPanel({
               {...(relativePath && !isMedia && !isPdf
                 ? { onRefreshSelectedFile: file.refresh }
                 : {})}
+              onOpenInBrowser={
+                isPreviewSupportedInRuntime() && environmentHttpBaseUrl
+                  ? (browserPath) => handleOpenInBrowser(browserPath)
+                  : undefined
+              }
             />
           </aside>
         ) : null}

--- a/apps/web/src/terminal-links.ts
+++ b/apps/web/src/terminal-links.ts
@@ -264,3 +264,14 @@ export function resolvePathLinkTarget(rawPath: string, cwd: string): string {
 
   return formatFilePathPosition({ ...position, path: resolvedPath });
 }
+
+/**
+ * Resolves a workspace-relative file path against the workspace root. Unlike
+ * terminal links, a leading `~/` is a literal folder name inside the
+ * workspace, not the user's home directory.
+ */
+export function resolveWorkspaceFilePath(rawPath: string, cwd: string): string {
+  if (isAbsolutePath(rawPath)) return rawPath;
+  const separator: "/" | "\\" = isWindowsPathStyle(cwd) ? "\\" : "/";
+  return joinPath(cwd, rawPath, separator);
+}


### PR DESCRIPTION
## Problem

Right-clicking an HTML file in the files panel only offers "Copy mention" and "Add to chat". Opening the file drops you into the code view, and the only way to see it rendered is to first open the file and then find the small globe button in the preview header. Nothing in the tree menu hints a browser view exists.

## Fix

- Add **"Open in browser"** to the files tree context menu for previewable files (`.html`/`.htm`/`.pdf`), shown as the first item.
- The item only renders when the runtime can actually do it: `isPreviewSupportedInRuntime()` (integrated browser present) plus an environment HTTP base URL. On web and mobile it simply doesn't appear, matching the existing header button.
- `FilePreviewPanel.handleOpenInBrowser` now takes the file path and resolves it against `cwd`, so the header globe button and the new menu item share one code path (including its error toast).

## Test plan

- [x] `tsgo --noEmit`, `vp lint`, `FilePreviewPanel` unit tests (8/8)
- [x] Desktop: right-click `index.html` in files → menu shows "Open in browser" → opens the file in the browser surface
- [x] Menu item is absent in runtimes without the integrated browser (web client)
- [ ] Manual pass on desktop: confirm menu item on a `.pdf` too

## Screenshots

![Before: files tree context menu on an HTML file](https://gist.githubusercontent.com/mrmg/f4f4966c0a9dbf90fd188aa6ac190463/raw/ca49f6ad1153312cfccf4956773ef577a4953548/1-before-menu.svg)

![After: "Open in browser" as the first menu item](https://gist.githubusercontent.com/mrmg/f4f4966c0a9dbf90fd188aa6ac190463/raw/ea75dea0fdbf64d07171f3eba20ef24bc0d925ac/2-after-menu.svg)

![Result: the file rendered in the integrated browser surface](https://gist.githubusercontent.com/mrmg/f4f4966c0a9dbf90fd188aa6ac190463/raw/4e19ece95c584e79bc3dbc472d7911a01c8796a8/3-after-opened-in-browser.svg)

Made with GLM-5.3-Flash in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only file explorer and preview wiring with a small, well-scoped path helper; no auth or persistence changes.
> 
> **Overview**
> Adds **Open in browser** as the first item on the file tree right-click menu for workspace files that support integrated preview (e.g. HTML/HTM/PDF), when the runtime has an integrated browser and an environment HTTP base URL.
> 
> The tree wires this through a new optional `onOpenInBrowser` prop from `FilePreviewPanel`, which reuses the same `openFileInPreview` flow and error toast as the preview header globe button. `handleOpenInBrowser` now takes a workspace-relative path instead of relying on a pre-resolved absolute path.
> 
> Path resolution for the file panel switches from terminal-link `resolvePathLinkTarget` to new `resolveWorkspaceFilePath`, so a leading `~/` inside the workspace is treated as a literal folder name, not home-directory expansion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 041fff61614d3399b46f67bf6d84906c9865fe03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add "Open in browser" action to `FileBrowserPanel` context menu
> - Adds an optional `onOpenInBrowser` callback to `FileBrowserPanelProps` that displays an "Open in browser" context menu item for eligible files
> - `FilePreviewPanel` provides this callback when the runtime supports browser preview and an environment HTTP base URL is available
> - Introduces `resolveWorkspaceFilePath` in [terminal-links.ts](https://github.com/pingdotgg/t3code/pull/9533/files#diff-5f57eb38e8e99e705308a736729815ef1ec005cf2f20cca912a9f7abcf28c110) to resolve relative paths against the workspace root
> - Behavioral Change: `FilePreviewPanel` resolves browser-opening and preview file paths using `resolveWorkspaceFilePath`, which treats a leading `~/` segment as a literal directory rather than expanding it to the user's home directory
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 041fff6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
