### PR TITLE
fix(server): include SQLite conditions in persistence errors

### DIFF
--- a/apps/server/src/persistence/Errors.test.ts
+++ b/apps/server/src/persistence/Errors.test.ts
@@ -25,19 +25,38 @@ it("keeps SQL operation context without a tautological detail", () => {
   assert.equal(error.message, "SQL error in AuthSessionRepository.list:query");
 });
 
-it("carries the driver failure into the mapped SQL error message", () => {
-  const cause = new Error("SQLITE_BUSY: database is locked");
+it("names the SQLite condition by its normalized result code", () => {
+  const cause = Object.assign(new Error("UNIQUE constraint failed: orders.customer_email"), {
+    errcode: 1555,
+    errstr: "constraint failed",
+  });
   const error = toPersistenceSqlError("OrchestrationCommandReceiptRepository.upsert:query")(cause);
 
-  assert.equal(
-    error.message,
-    "SQL error in OrchestrationCommandReceiptRepository.upsert:query: SQLITE_BUSY: database is locked",
-  );
+  assert.equal(error.detail, "SQLITE(1555) constraint failed");
   assert.equal(error.cause, cause);
 });
 
-it("omits a detail when the cause carries no message of its own", () => {
-  const error = toPersistenceSqlError("AuthSessionRepository.list:query")("unhelpful");
+it("reads the condition through a wrapping driver error", () => {
+  const driver = Object.assign(new Error("locked"), { errcode: 5, errstr: "database is locked" });
+  const error = toPersistenceSqlError("AuthSessionRepository.list:query")(
+    new Error("Failed to prepare statement", { cause: driver }),
+  );
+
+  assert.equal(error.detail, "SQLITE(5) database is locked");
+});
+
+it("keeps the driver's own prose out of the message", () => {
+  const cause = Object.assign(new Error("UNIQUE constraint failed: orders.customer_email"), {
+    errcode: 1555,
+    errstr: "constraint failed",
+  });
+  const error = toPersistenceSqlError("AuthSessionRepository.create:query")(cause);
+
+  assert.ok(!error.message.includes("customer_email"));
+});
+
+it("omits a detail for a cause it cannot categorize", () => {
+  const error = toPersistenceSqlError("AuthSessionRepository.list:query")(new Error("unhelpful"));
 
   assert.equal(error.detail, undefined);
   assert.equal(error.message, "SQL error in AuthSessionRepository.list:query");

--- a/apps/server/src/persistence/Errors.test.ts
+++ b/apps/server/src/persistence/Errors.test.ts
@@ -2,7 +2,7 @@ import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
-import { PersistenceDecodeError, PersistenceSqlError } from "./Errors.ts";
+import { PersistenceDecodeError, PersistenceSqlError, toPersistenceSqlError } from "./Errors.ts";
 
 const decodeRuntimePayload = Schema.decodeUnknownEffect(
   Schema.Struct({
@@ -24,6 +24,37 @@ it("keeps SQL operation context without a tautological detail", () => {
   assert.equal(error.cause, cause);
   assert.equal(error.message, "SQL error in AuthSessionRepository.list:query");
 });
+
+it("carries the driver failure into the mapped SQL error message", () => {
+  const cause = new Error("SQLITE_BUSY: database is locked");
+  const error = toPersistenceSqlError("OrchestrationCommandReceiptRepository.upsert:query")(cause);
+
+  assert.equal(
+    error.message,
+    "SQL error in OrchestrationCommandReceiptRepository.upsert:query: SQLITE_BUSY: database is locked",
+  );
+  assert.equal(error.cause, cause);
+});
+
+it("omits a detail when the cause carries no message of its own", () => {
+  const error = toPersistenceSqlError("AuthSessionRepository.list:query")("unhelpful");
+
+  assert.equal(error.detail, undefined);
+  assert.equal(error.message, "SQL error in AuthSessionRepository.list:query");
+});
+
+it.effect("summarizes a schema cause by issue tag instead of by rejected value", () =>
+  Effect.gen(function* () {
+    const rejectedPayload = "sql-mapper-secret-sentinel";
+    const cause = yield* Effect.flip(
+      decodeRuntimePayload({ runtimePayload: { attempt: rejectedPayload } }),
+    );
+    const error = toPersistenceSqlError("ProviderSessionRuntimeRepository.list:query")(cause);
+
+    assert.ok(error.detail !== undefined);
+    assert.ok(!error.message.includes(rejectedPayload));
+  }),
+);
 
 it.effect("maps schema errors without copying rejected payloads into diagnostics", () =>
   Effect.gen(function* () {

--- a/apps/server/src/persistence/Errors.test.ts
+++ b/apps/server/src/persistence/Errors.test.ts
@@ -1,6 +1,9 @@
 import { assert, it } from "@effect/vitest";
+import * as NodeSqliteClient from "@t3tools/shared/nodeSqliteClient";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import { classifySqliteError, SqlError } from "effect/unstable/sql/SqlError";
 
 import { PersistenceDecodeError, PersistenceSqlError, toPersistenceSqlError } from "./Errors.ts";
 
@@ -25,16 +28,23 @@ it("keeps SQL operation context without a tautological detail", () => {
   assert.equal(error.message, "SQL error in AuthSessionRepository.list:query");
 });
 
-it("names the SQLite condition by its normalized result code", () => {
-  const cause = Object.assign(new Error("UNIQUE constraint failed: orders.customer_email"), {
-    errcode: 1555,
-    errstr: "constraint failed",
-  });
-  const error = toPersistenceSqlError("OrchestrationCommandReceiptRepository.upsert:query")(cause);
+it.effect("names a real SQLite condition without copying query data", () =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const payload = "sql-private-sentinel";
+    yield* sql`CREATE TABLE error_test (private_column TEXT PRIMARY KEY)`;
+    yield* sql`INSERT INTO error_test VALUES (${payload})`;
+    const cause = yield* Effect.flip(sql`INSERT INTO error_test VALUES (${payload})`);
+    const error = toPersistenceSqlError("OrchestrationCommandReceiptRepository.upsert:query")(
+      cause,
+    );
 
-  assert.equal(error.detail, "SQLITE(1555) constraint failed");
-  assert.equal(error.cause, cause);
-});
+    assert.equal(error.detail, "SQLITE(1555) constraint failed");
+    assert.equal(error.cause, cause);
+    assert.notInclude(error.message, payload);
+    assert.notInclude(error.message, "private_column");
+  }).pipe(Effect.provide(NodeSqliteClient.layerMemory())),
+);
 
 it("reads the condition through a wrapping driver error", () => {
   const driver = Object.assign(new Error("locked"), { errcode: 5, errstr: "database is locked" });
@@ -45,18 +55,29 @@ it("reads the condition through a wrapping driver error", () => {
   assert.equal(error.detail, "SQLITE(5) database is locked");
 });
 
-it("keeps the driver's own prose out of the message", () => {
-  const cause = Object.assign(new Error("UNIQUE constraint failed: orders.customer_email"), {
-    errcode: 1555,
-    errstr: "constraint failed",
-  });
-  const error = toPersistenceSqlError("AuthSessionRepository.create:query")(cause);
+it.each([{ errno: 1555, code: "SQLITE_CONSTRAINT_PRIMARYKEY" }, { errno: 1 }])(
+  "names Bun SQLite condition $errno through the SQL error wrapper",
+  (condition) => {
+    const driver = Object.assign(new Error("bun-sql-private-sentinel"), {
+      name: "SQLiteError",
+      ...condition,
+    });
+    const cause = new SqlError({ reason: classifySqliteError(driver) });
+    const error = toPersistenceSqlError("AuthSessionRepository.create:query")(cause);
 
-  assert.ok(!error.message.includes("customer_email"));
-});
+    assert.equal(
+      error.message,
+      `SQL error in AuthSessionRepository.create:query: SQLITE(${condition.errno})`,
+    );
+    assert.equal(error.cause, cause);
+  },
+);
 
-it("omits a detail for a cause it cannot categorize", () => {
-  const error = toPersistenceSqlError("AuthSessionRepository.list:query")(new Error("unhelpful"));
+it.each([
+  new Error("unhelpful"),
+  Object.assign(new Error("file not found"), { errno: -2, code: "ENOENT" }),
+])("omits a detail for a cause it cannot categorize (%#)", (cause) => {
+  const error = toPersistenceSqlError("AuthSessionRepository.list:query")(cause);
 
   assert.equal(error.detail, undefined);
   assert.equal(error.message, "SQL error in AuthSessionRepository.list:query");

--- a/apps/server/src/persistence/Errors.ts
+++ b/apps/server/src/persistence/Errors.ts
@@ -74,16 +74,31 @@ const isPersistenceDecodeError = Schema.is(PersistenceDecodeError);
 
 // Kept for orchestration/projection call sites, which are being revamped separately.
 /**
+ * SQLite names its condition through a fixed result-code table, so the code and
+ * its canonical string are bounded and carry no query data. The driver message
+ * is not bounded: a constraint failure spells out the table and column it hit.
+ * Only the normalized pair is carried here; `cause` keeps everything else.
+ */
+function sqliteCondition(cause: unknown): string | undefined {
+  let value: unknown = cause;
+  for (let depth = 0; depth < 4 && typeof value === "object" && value !== null; depth += 1) {
+    const { errcode, errstr } = value as { errcode?: unknown; errstr?: unknown };
+    if (typeof errcode === "number" && typeof errstr === "string") {
+      return `SQLITE(${errcode}) ${errstr}`;
+    }
+    value = (value as { cause?: unknown }).cause;
+  }
+  return undefined;
+}
+
+/**
  * A rejected payload must never reach diagnostics, so a schema failure
- * contributes only its issue tags. A driver error names the SQLite condition
- * and at most the constraint it violated, never a bound value, so its own
- * message is safe to carry and is the part that makes an occurrence
- * diagnosable at all.
+ * contributes only its issue tags, and a driver failure only its normalized
+ * condition. Anything the mapper cannot categorize leaves the detail unset.
  */
 function describeSqlCause(cause: unknown): string | undefined {
   if (Schema.isSchemaError(cause)) return summarizeSchemaIssue(cause.issue);
-  if (cause instanceof Error && cause.message.length > 0) return cause.message;
-  return undefined;
+  return sqliteCondition(cause);
 }
 
 export function toPersistenceSqlError(operation: string) {

--- a/apps/server/src/persistence/Errors.ts
+++ b/apps/server/src/persistence/Errors.ts
@@ -73,13 +73,30 @@ const isPersistenceSqlError = Schema.is(PersistenceSqlError);
 const isPersistenceDecodeError = Schema.is(PersistenceDecodeError);
 
 // Kept for orchestration/projection call sites, which are being revamped separately.
+/**
+ * A rejected payload must never reach diagnostics, so a schema failure
+ * contributes only its issue tags. A driver error names the SQLite condition
+ * and at most the constraint it violated, never a bound value, so its own
+ * message is safe to carry and is the part that makes an occurrence
+ * diagnosable at all.
+ */
+function describeSqlCause(cause: unknown): string | undefined {
+  if (Schema.isSchemaError(cause)) return summarizeSchemaIssue(cause.issue);
+  if (cause instanceof Error && cause.message.length > 0) return cause.message;
+  return undefined;
+}
+
 export function toPersistenceSqlError(operation: string) {
-  return (cause: unknown): PersistenceSqlError =>
-    new PersistenceSqlError({
+  return (cause: unknown): PersistenceSqlError => {
+    // Restating the operation as the detail only doubled it in the message and
+    // buried the cause; `message` already reads well without a detail.
+    const detail = describeSqlCause(cause);
+    return new PersistenceSqlError({
       operation,
-      detail: `Failed to execute ${operation}`,
+      ...(detail === undefined ? {} : { detail }),
       cause,
     });
+  };
 }
 
 // Kept for orchestration/projection call sites, which are being revamped separately.

--- a/apps/server/src/persistence/Errors.ts
+++ b/apps/server/src/persistence/Errors.ts
@@ -1,3 +1,4 @@
+import * as Predicate from "effect/Predicate";
 import * as Schema from "effect/Schema";
 import * as SchemaIssue from "effect/SchemaIssue";
 
@@ -72,21 +73,31 @@ export class PersistenceDecodeError extends Schema.TaggedErrorClass<PersistenceD
 const isPersistenceSqlError = Schema.is(PersistenceSqlError);
 const isPersistenceDecodeError = Schema.is(PersistenceDecodeError);
 
-// Kept for orchestration/projection call sites, which are being revamped separately.
 /**
- * SQLite names its condition through a fixed result-code table, so the code and
- * its canonical string are bounded and carry no query data. The driver message
- * is not bounded: a constraint failure spells out the table and column it hit.
- * Only the normalized pair is carried here; `cause` keeps everything else.
+ * Read a SQLite condition through SQL error wrappers.
+ * Use Node's fixed description or Bun's numeric code, never the driver message.
  */
 function sqliteCondition(cause: unknown): string | undefined {
-  let value: unknown = cause;
-  for (let depth = 0; depth < 4 && typeof value === "object" && value !== null; depth += 1) {
-    const { errcode, errstr } = value as { errcode?: unknown; errstr?: unknown };
-    if (typeof errcode === "number" && typeof errstr === "string") {
-      return `SQLITE(${errcode}) ${errstr}`;
+  let value = cause;
+  for (let depth = 0; depth < 4 && Predicate.isObject(value); depth += 1) {
+    if (
+      "errcode" in value &&
+      typeof value.errcode === "number" &&
+      "errstr" in value &&
+      typeof value.errstr === "string"
+    ) {
+      return `SQLITE(${value.errcode}) ${value.errstr}`;
     }
-    value = (value as { cause?: unknown }).cause;
+    if (
+      "name" in value &&
+      value.name === "SQLiteError" &&
+      "errno" in value &&
+      typeof value.errno === "number" &&
+      Number.isInteger(value.errno)
+    ) {
+      return `SQLITE(${value.errno})`;
+    }
+    value = "cause" in value ? value.cause : undefined;
   }
   return undefined;
 }
@@ -101,10 +112,9 @@ function describeSqlCause(cause: unknown): string | undefined {
   return sqliteCondition(cause);
 }
 
+// Kept for orchestration/projection call sites, which are being revamped separately.
 export function toPersistenceSqlError(operation: string) {
   return (cause: unknown): PersistenceSqlError => {
-    // Restating the operation as the detail only doubled it in the message and
-    // buried the cause; `message` already reads well without a detail.
     const detail = describeSqlCause(cause);
     return new PersistenceSqlError({
       operation,


### PR DESCRIPTION
Persistence SQL errors repeat the operation name and hide the cause.

Include Node's fixed SQLite description, Bun's numeric error code, or schema issue tags without copying driver messages or rejected values. This improves diagnosis. It does not fix the database failure reported in [issue #4818](https://github.com/pingdotgg/t3code/issues/4818).

Continues @Sy-D's [#4837](https://github.com/pingdotgg/t3code/pull/4837). The original commits and co-author credit are preserved. This adds the missing Bun handling and tests through the SQL client.

Verified with 14 focused tests, server typecheck, changed-file lint and formatting, and real in-memory Node and Bun failures.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostics-only change in the persistence error mapper; behavior for uncategorized errors matches omitting detail, with no query or auth logic changes.
> 
> **Overview**
> **`toPersistenceSqlError`** no longer sets a tautological `detail` (`Failed to execute …`). It now derives optional **`detail`** from the cause: normalized **SQLite** conditions (Node `errcode`/`errstr` or Bun `SQLiteError` errno, walking a short `cause` chain), or **schema issue tags** when the failure is a `SchemaError`. Driver text, query values, and rejected payloads stay out of **`message`**/`detail`.
> 
> Tests cover in-memory constraint failures, wrapped Node driver errors, Bun errors behind **`SqlError`**, uncategorizable causes (no detail), and schema mapping without leaking sentinels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 577b098346a171c27d14ded55c6512c1c40428db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include SQLite conditions in `toPersistenceSqlError` persistence diagnostics
> - Adds `sqliteCondition` helper in [Errors.ts](https://github.com/pingdotgg/t3code/pull/9536/files#diff-a49007546447945afb00362617c4fe342b8a0113ab70f400117cb1fe2c48ed61) that traverses the cause chain (up to four wrappers) and recognizes Node SQLite errors by numeric `errcode`+`errstr` and Bun `SQLiteError` by integer `errno`; driver messages are not read for classification
> - Adds `describeSqlCause` helper that routes schema causes to the existing issue-tag summarizer and all other causes to the SQLite condition extractor, returning `undefined` when neither applies
> - `toPersistenceSqlError` now derives detail from these helpers and no longer assigns a fixed failed-operation detail to every cause; operation and original cause remain attached
> - Risk: `toPersistenceSqlError` no longer emits detail for uncategorized causes — callers that relied on the previous fixed detail string will see `PersistenceSqlError` with no detail for non-SQLite, non-schema errors
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 577b098.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->