### PR TITLE
ci: add on-demand Windows test workflow

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -1,0 +1,81 @@
+# On-demand Windows test lane. Manual only: nothing in the suite passes on
+# Windows yet, so this exists to give contributors (and agents) a cloud Windows
+# box to iterate against. Once the suite is green here, fold it into ci.yml.
+#
+#   gh workflow run windows-tests.yml --ref <branch> -f package=packages/shared
+#   gh workflow run windows-tests.yml --ref <branch> -f package=apps/server \
+#     -f files="src/process/externalLauncher.test.ts src/cli/theme.test.ts"
+#   gh run watch && gh run view --log-failed
+name: Windows Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: "Workspace directory to test, e.g. apps/server or packages/shared. Empty runs every package except apps/server."
+        type: string
+        default: ""
+      files:
+        description: "Space-separated test files relative to the package directory. Empty runs the package's whole suite. Requires package."
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test (${{ inputs.package || 'all non-server' }})
+    runs-on: blacksmith-8vcpu-windows-2025
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            /*
+            !/.repos/
+          sparse-checkout-cone-mode: false
+
+      # setup-vp's own cache restores a Linux-shaped store on Windows, which is
+      # slower than no cache (see #7975). Cache pnpm's Windows store directly.
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: package.json
+          cache: false
+          run-install: false
+
+      - name: Resolve package cache path
+        id: package_cache_path
+        shell: pwsh
+        run: '"path=$(vp pm cache dir)" >> $env:GITHUB_OUTPUT'
+
+      - name: Cache packages
+        uses: actions/cache@v6
+        with:
+          path: ${{ steps.package_cache_path.outputs.path }}
+          key: windows-tests-packages-v1-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install
+        run: vp install
+
+      - name: Ensure Electron runtime is installed
+        if: inputs.package == '' || inputs.package == 'apps/desktop'
+        run: vp run --filter @t3tools/desktop ensure:electron
+
+      # `vp run ... test -- <files>` does not forward positional args to vitest,
+      # so file-scoped runs call `vp test run` inside the package instead.
+      - name: Test
+        shell: pwsh
+        run: |
+          $package = '${{ inputs.package }}'
+          $files = '${{ inputs.files }}'
+          if ($package -eq '') {
+            vp run --parallel --concurrency-limit 4 --filter '!t3' --filter '!@t3tools/monorepo' test
+          } elseif ($files -eq '') {
+            vp run --filter "./$package" test
+          } else {
+            Set-Location $package
+            vp test run $files.Split(' ')
+          }

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Ensure Electron runtime is installed
         if: inputs.package == '' || inputs.package == 'apps/desktop'
-        run: vp run --filter @t3tools/desktop ensure:electron
+        run: vp run --filter "@t3tools/desktop" ensure:electron
 
       # `vp run ... test -- <files>` does not forward positional args to vitest,
       # so file-scoped runs call `vp test run` inside the package instead.

--- a/apps/desktop/scripts/ensure-electron-runtime.mjs
+++ b/apps/desktop/scripts/ensure-electron-runtime.mjs
@@ -2,6 +2,7 @@ import * as NodeFS from "node:fs";
 import * as NodeModule from "node:module";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
+import * as NodeURL from "node:url";
 import * as NodeChildProcess from "node:child_process";
 
 const require = NodeModule.createRequire(import.meta.url);
@@ -176,7 +177,8 @@ export function ensureElectronRuntime() {
   return electronPath;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// `file://${argv[1]}` never matches on Windows (drive letters need `file:///C:/`).
+if (process.argv[1] && NodeURL.pathToFileURL(process.argv[1]).href === import.meta.url) {
   const electronPath = ensureElectronRuntime();
   process.stdout.write(`${electronPath}\n`);
 }

--- a/docs/internals/ci.md
+++ b/docs/internals/ci.md
@@ -22,6 +22,14 @@ and pushes to `main`:
 - **Release Smoke**: exercises release-only workflow steps through `scripts/release-smoke.ts`, so
   release breakage surfaces on PRs rather than at tag time.
 
+[`.github/workflows/windows-tests.yml`](../../.github/workflows/windows-tests.yml) is a manual
+Windows lane (`workflow_dispatch` only) on a Blacksmith Windows 2025 runner. The suite does not
+pass on Windows yet, so it is not a required check; it exists so the work to get there can be
+iterated against a real Windows box without one on hand. Dispatch it with `gh workflow run
+windows-tests.yml --ref <branch>`, optionally with `-f package=<dir>` to run one workspace package
+and `-f files="<paths>"` to run specific test files inside it. Once it is green, fold it into
+`ci.yml`.
+
 `.github/workflows/release.yml` builds macOS (`arm64` and `x64`), Linux (`x64`), and Windows (`x64`)
 desktop artifacts from a single `v*.*.*` tag and publishes one GitHub release. It auto-enables
 signing only when platform credentials are present. macOS passkey builds additionally require


### PR DESCRIPTION
The test suite has never run on Windows, and there is no Windows CI, so a Windows contributor has no way to see what is broken and we have no way to fix it without a Windows box. A static audit found ~55 test files with real Windows breakage, concentrated in a handful of repeated patterns (posix `PATH` delimiter under an injected platform, host `Path.Path` vs `/`-joined expectations, ungated `fs.symlink`, `#!/bin/sh` fake CLIs, mode-bit negative tests).

This adds a `workflow_dispatch`-only lane on a Blacksmith Windows 2025 runner. It is not a required check and never runs on its own; it exists so the fixes can be iterated against a real Windows runner:

```
gh workflow run windows-tests.yml --ref <branch> -f package=packages/shared
gh workflow run windows-tests.yml --ref <branch> -f package=apps/server -f files="src/cli/theme.test.ts"
```

Also fixes the main-module guard in `apps/desktop/scripts/ensure-electron-runtime.mjs`: it compared `import.meta.url` to `` `file://${argv[1]}` ``, which never matches a Windows path (`file:///C:/...`), so the CI Electron install step was silently a no-op there. Uses the same `pathToFileURL` form as `verify-preload-bundle.mjs`.

Follow-up PRs will fix the suite in small chunks; once it is green here the lane can move into `ci.yml`.

Model: Claude Fable 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and standalone-script changes only; no production runtime or auth/data paths affected.
> 
> **Overview**
> Adds a **manual-only** GitHub Actions workflow (`windows-tests.yml`) that runs the monorepo test suite on a Blacksmith Windows 2025 runner so Windows failures can be debugged without a local machine. Dispatch supports an optional `package` workspace path and `files` list for scoped runs; default mode runs all packages except `apps/server`. Dependency install disables setup-vp’s Linux-shaped cache and instead caches the Windows pnpm store keyed on `pnpm-lock.yaml`, and the desktop Electron runtime is ensured when running the full lane or `apps/desktop`.
> 
> Fixes the **direct-run guard** in `ensure-electron-runtime.mjs` by comparing `import.meta.url` to `pathToFileURL(process.argv[1])` instead of `` `file://${argv[1]}` ``, which never matched on Windows and made the CI `ensure:electron` step a no-op when invoked as a script.
> 
> `docs/internals/ci.md` documents the lane as non-required until the suite is green, with intent to fold it into `ci.yml` later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6201303c440ade0f8095a21950e3da64a15137d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add on-demand Windows test workflow and fix `ensure-electron-runtime` Windows path guard
> - Adds a manual-only GitHub Actions workflow in [windows-tests.yml](https://github.com/pingdotgg/t3code/pull/9538/files#diff-6d9f7f34f7ffa41013ceb3a36a1674d0b565decb958ca9e5c97f3013bac441ee) that runs tests on a Blacksmith Windows 2025 runner, with optional `workspace-package` and `test-file` inputs.
> - Fixes [ensure-electron-runtime.mjs](https://github.com/pingdotgg/t3code/pull/9538/files#diff-ffa12623c197ac91a2f9d1fa734698e3ae5f97ed3b4f614ff78be20aef1e3952) to recognize direct execution under Windows drive-letter path syntax, so the Electron runtime setup runs and prints its path on Windows.
> - Documents the new workflow and its non-required status in [ci.md](https://github.com/pingdotgg/t3code/pull/9538/files#diff-d88698dc5909f010b1462a8ad36a3f429f191b627825e2acac8214ba2ec254b3).
> - Risk: the workflow uses a read-only contents permission and a 45-minute timeout; when `workspace-package` is empty, the `test-file` input is ignored because the all-packages branch takes precedence.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b620130. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->