### PR TITLE
fix(web): restore composer controls as space becomes available

### DIFF
--- a/apps/web/src/components/composerFooterLayout.test.ts
+++ b/apps/web/src/components/composerFooterLayout.test.ts
@@ -333,6 +333,33 @@ describe("resolveRestingComposerControlsLayout hysteresis", () => {
     ).toEqual({ hiddenCount: 0, visible: true });
   });
 
+  it("restores the blocks that fit when the full cluster has no slack", () => {
+    const partlyRestored = resolveRestingComposerControlsLayout({
+      ...base,
+      hostWidth: 357,
+      previous: { hiddenCount: 2, visible: true },
+    });
+    expect(partlyRestored).toEqual({ hiddenCount: 1, visible: true });
+    expect(
+      resolveRestingComposerControlsLayout({ ...base, hostWidth: 357, previous: partlyRestored }),
+    ).toEqual(partlyRestored);
+    expect(
+      resolveRestingComposerControlsLayout({ ...base, hostWidth: 358, previous: partlyRestored }),
+    ).toEqual({ hiddenCount: 0, visible: true });
+  });
+
+  it("requires slack before partially restoring a cluster", () => {
+    // One inline block, the picker, and overflow need 149 + 60 + 24 + 8 = 241px.
+    const previous = { hiddenCount: 2, visible: true };
+    expect(resolveRestingComposerControlsLayout({ ...base, hostWidth: 241, previous })).toEqual(
+      previous,
+    );
+    expect(resolveRestingComposerControlsLayout({ ...base, hostWidth: 242, previous })).toEqual({
+      hiddenCount: 1,
+      visible: true,
+    });
+  });
+
   it("still resolves from scratch when there is no previous layout", () => {
     expect(resolveRestingComposerControlsLayout({ ...base, hostWidth: 357 })).toEqual({
       hiddenCount: 0,

--- a/apps/web/src/components/composerFooterLayout.ts
+++ b/apps/web/src/components/composerFooterLayout.ts
@@ -134,9 +134,13 @@ export function resolveRestingComposerControlsLayout(
   // composer re-measures on every render, so without that margin a host
   // sitting exactly on a threshold flips a block in and out until React
   // gives up with "Maximum update depth exceeded".
-  if (previous && hiddenCount < previous.hiddenCount) {
-    if (restingComposerControlsWidth(input, hiddenCount) > hostWidth - RESTING_CONTROLS_SLACK_PX) {
-      hiddenCount = Math.min(previous.hiddenCount, blockWidths.length);
+  if (previous) {
+    const previousHiddenCount = Math.min(previous.hiddenCount, blockWidths.length);
+    while (
+      hiddenCount < previousHiddenCount &&
+      restingComposerControlsWidth(input, hiddenCount) > hostWidth - RESTING_CONTROLS_SLACK_PX
+    ) {
+      hiddenCount += 1;
     }
   }
   const minimumWidth = restingComposerControlsWidth(input, hiddenCount, input.minimumFixedWidth);


### PR DESCRIPTION
The one-pixel margin added in [#9482](https://github.com/pingdotgg/t3code/pull/9482) can keep every previously overflowed control hidden when only the last control still needs more room. For example, with two blocks hidden, a 357px host can restore the traits block even though restoring both blocks has not earned the extra pixel of slack.

Try the intermediate layouts before retaining the previous hidden count. This preserves the anti-oscillation margin while restoring each control that fits.

Verification:

- 31 composer layout tests pass, including partial restoration, exact-threshold retention, and restoration after earning one pixel of slack.
- Web typecheck and targeted lint pass.
- Integrated browser verification and before/after evidence have not been performed.

This changes the resting composer in web and desktop, including mobile-width web layouts. Native mobile, providers, and wire contracts are unchanged.

Implemented with Codex through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized layout hysteresis logic for the resting composer footer with added regression tests; no auth, data, or API changes.
> 
> **Overview**
> Fixes resting composer footer controls staying fully overflowed when only the last block still needs the 1px anti-oscillation slack.
> 
> **`resolveRestingComposerControlsLayout`** no longer snaps back to the previous `hiddenCount` in one step when shrinking the overflow menu. It now walks `hiddenCount` upward until the layout fits within `hostWidth - RESTING_CONTROLS_SLACK_PX` or matches the prior hidden count, so controls that fit (e.g. one of two blocks at 357px) come back inline while the rest stay in overflow until there is slack.
> 
> New hysteresis tests cover partial restoration, exact-threshold retention, and stability across re-layout passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4268800cb893e232484f21865c4a63e74f2ffb52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `resolveRestingComposerControlsLayout` to restore composer controls one block at a time
> - Replaces the single-step hysteresis fallback with a loop that advances the hidden count one block at a time until the candidate layout fits with the configured slack.
> - Previously, when controls were hidden and the fully restored candidate lacked slack, the resolver reverted to the previous hidden count. Now it retains the greatest number of restored blocks that fit.
> - Adds tests for partial multi-block restoration, stability at the same width, and the one-pixel slack boundary at the minimum threshold.
> - Risk: `resolveRestingComposerControlsLayout` in [composerFooterLayout.ts](https://github.com/pingdotgg/t3code/pull/9539/files#diff-f2c45cfa4b4b1e011f20b2464141c82ddc1b7023b5d2707e33b4ab4504c747f8) changes restoration behavior; layouts that relied on all-or-nothing restoration may now show partially restored controls.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4268800.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->