### PR TITLE
fix(web): measure collapsed model labels at their visible width

### DIFF
--- a/apps/web/src/components/chat/restingComposerControlsMeasurement.test.ts
+++ b/apps/web/src/components/chat/restingComposerControlsMeasurement.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  resolveRestingComposerControlsLayout,
+  resolveRestingComposerControlsNaturalWidth,
+} from "../composerFooterLayout";
+import { measureRestingComposerControls } from "./restingComposerControlsMeasurement";
+
+function measurePicker(input: { clientWidth: number; flexGrow: string; maxWidth?: string }) {
+  const label = { clientWidth: input.clientWidth, scrollWidth: 160 };
+  const picker = {
+    getBoundingClientRect: () => ({ width: 52 }),
+    querySelector: () => label,
+  };
+  const controls = {
+    querySelector: (selector: string) => {
+      if (selector === "[data-chat-provider-model-picker]") return picker;
+      if (selector === "[data-resting-controls-overflow]") {
+        return { getBoundingClientRect: () => ({ width: 24 }) };
+      }
+      return null;
+    },
+    querySelectorAll: () => [{ getBoundingClientRect: () => ({ width: 140 }) }],
+  };
+  vi.stubGlobal("getComputedStyle", (element: unknown) => {
+    if (element === label) return { flexGrow: input.flexGrow };
+    if (element === picker) return { minWidth: "52px", maxWidth: input.maxWidth ?? "none" };
+    return { columnGap: "4px" };
+  });
+  return measureRestingComposerControls(controls as unknown as HTMLElement)!;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("measureRestingComposerControls", () => {
+  it("keeps controls inline when the model label is deliberately collapsed", () => {
+    const measurement = measurePicker({ clientWidth: 0, flexGrow: "0" });
+
+    expect(measurement.naturalFixedWidth).toBe(52);
+    expect(resolveRestingComposerControlsNaturalWidth(measurement)).toBe(196);
+    expect(resolveRestingComposerControlsLayout({ ...measurement, hostWidth: 200 })).toEqual({
+      hiddenCount: 0,
+      visible: true,
+    });
+  });
+
+  it("recovers truncated text while the model label is flexible", () => {
+    const measurement = measurePicker({ clientWidth: 20, flexGrow: "1" });
+
+    expect(measurement.naturalFixedWidth).toBe(192);
+    expect(resolveRestingComposerControlsLayout({ ...measurement, hostWidth: 200 })).toEqual({
+      hiddenCount: 1,
+      visible: true,
+    });
+  });
+
+  it("recovers flexible text squeezed to zero instead of mistaking it for collapsed text", () => {
+    const measurement = measurePicker({ clientWidth: 0, flexGrow: "1" });
+
+    expect(measurement.naturalFixedWidth).toBe(212);
+    expect(resolveRestingComposerControlsLayout({ ...measurement, hostWidth: 200 })).toEqual({
+      hiddenCount: 1,
+      visible: true,
+    });
+  });
+
+  it("still caps recovered text at the model picker's maximum width", () => {
+    expect(
+      measurePicker({ clientWidth: 0, flexGrow: "1", maxWidth: "180px" }).naturalFixedWidth,
+    ).toBe(180);
+  });
+});

--- a/apps/web/src/components/chat/restingComposerControlsMeasurement.ts
+++ b/apps/web/src/components/chat/restingComposerControlsMeasurement.ts
@@ -24,7 +24,11 @@ function providerModelPickerNaturalWidth(picker: HTMLElement): number {
   if (renderedWidth === 0) return 0;
   const style = getComputedStyle(picker);
   const label = picker.querySelector<HTMLElement>('[data-chat-provider-model-picker-label="true"]');
-  const hiddenLabelWidth = label ? Math.max(0, label.scrollWidth - label.clientWidth) : 0;
+  // Narrow composers deliberately collapse the label with w-0 and flex-none.
+  // A flexible label squeezed to zero still needs its natural width recovered.
+  const labelIsCollapsed = label?.clientWidth === 0 && getComputedStyle(label).flexGrow === "0";
+  const hiddenLabelWidth =
+    label && !labelIsCollapsed ? Math.max(0, label.scrollWidth - label.clientWidth) : 0;
   const maxWidth = Number.parseFloat(style.maxWidth);
   const naturalWidth = Math.min(
     renderedWidth + hiddenLabelWidth,


### PR DESCRIPTION
At narrow composer widths, the model label deliberately collapses to zero width with `flex-none`. Measurement still adds the label's `scrollWidth`, reserving space for text that will not be shown and moving other controls into overflow too early.

Do not recover the text width of a deliberately collapsed label. Keep recovering the natural width of flexible labels, even when they have been squeezed to zero, and retain the picker's maximum-width cap.

Verification:

- Four new measurement tests pass. With a collapsed label, a 52px picker and 140px mode block fit a 200px host with the 4px gap, instead of overflowing.
- All 35 measurement and composer layout tests pass together.
- Web typecheck and targeted lint pass.
- Integrated browser verification and before/after evidence have not been performed.

Stacked on [#9539](https://github.com/pingdotgg/t3code/pull/9539). This changes shared web/desktop rendering, not native mobile or provider behavior.

Implemented with Codex through T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `providerModelPickerNaturalWidth` to measure collapsed model labels at visible width
> - `providerModelPickerNaturalWidth` now treats a label as intentionally collapsed only when both its client width and computed flex growth are zero. Zero-width labels with flexible growth now recover their scroll-width overflow for natural-width calculations.
> - Previously every zero-width model label was treated as collapsed, so flexible labels squeezed to zero contributed no width even though their text was still present.
> - Adds a test suite covering collapsed labels, flexible truncated labels, flexible zero-width labels, and the existing 180-pixel picker maximum-width cap.
> - Risk: labels that are zero-width with non-zero flex growth now contribute recovered text width to picker sizing, which may change layout in narrow composer widths where labels were previously ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8309a40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized DOM measurement logic for composer footer layout; behavior change only affects when controls move to overflow at narrow widths.
> 
> **Overview**
> Fixes **resting composer control measurement** so narrow layouts no longer reserve space for model label text that is intentionally hidden.
> 
> `providerModelPickerNaturalWidth` now treats a label with **zero width and `flex-grow: 0`** as deliberately collapsed and **does not** add `scrollWidth − clientWidth` to the picker’s natural width. Flexible labels (`flex-grow` not `0`) still get truncated text recovered when squeezed, including when `clientWidth` is 0, and the picker **`max-width`** cap is unchanged.
> 
> Adds **four unit tests** for collapsed vs flexible labels, overflow layout at a 200px host, and the max-width ceiling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8309a40d3aa36566409fcbfba2909a88fc11fe42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->