### PR TITLE
fix(web): close composer menus when their controls hide

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -87,6 +87,7 @@ import {
 } from "../../promptStashStore";
 import { ComposerStashBadge } from "./ComposerStashBadge";
 import { ComposerStashMenu } from "./ComposerStashMenu";
+import { useComposerMenuState } from "./useComposerMenuState";
 import {
   ComposerTasksBadge,
   ComposerTasksContent,
@@ -908,10 +909,12 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
   interactionMode: ProviderInteractionMode;
   runtimeMode: RuntimeMode;
   size?: "sm" | "xs";
+  hidden?: boolean;
   onToggleInteractionMode: () => void;
   onRuntimeModeChange: (mode: RuntimeMode) => void;
 }) {
   const size = props.size ?? "sm";
+  const [open, setOpen] = useComposerMenuState(props.hidden);
   const runtimeModeOption = runtimeModeConfig[props.runtimeMode];
   const RuntimeModeIcon = runtimeModeOption.icon;
   const interactionModeTooltip =
@@ -969,6 +972,8 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
 
       <Tooltip>
         <Select
+          open={open}
+          onOpenChange={setOpen}
           value={props.runtimeMode}
           onValueChange={(value) => props.onRuntimeModeChange(value!)}
         >
@@ -2070,10 +2075,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     isComposerOwned: true,
   } satisfies Parameters<typeof renderProviderTraitsPicker>[0];
   const providerTraitsPicker = renderProviderTraitsPicker(providerTraitsPickerInput);
-  const restingProviderTraitsPicker = renderProviderTraitsPicker({
-    ...providerTraitsPickerInput,
-    size: "xs",
-  });
   const {
     controlsRef: restingComposerControlsRef,
     hiddenBlockCount: restingControlsHiddenBlockCount,
@@ -3558,6 +3559,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // to see or change the model without expanding the composer.
   const composerControlsInStrip = isComposerResting || isComposerCollapsedMobile;
   const composerControlsVisibleInStrip = composerControlsInStrip && restingControlsVisible;
+  const composerControlsHidden = composerControlsInStrip && !restingControlsVisible;
+  if (composerControlsHidden && isComposerModelPickerOpen) {
+    setIsComposerModelPickerOpen(false);
+  }
   useLayoutEffect(() => {
     onRestingControlsVisibilityChange(composerControlsVisibleInStrip);
   }, [composerControlsVisibleInStrip, onRestingControlsVisibilityChange]);
@@ -3728,6 +3733,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
 
   const restingHiddenBlockCount = composerControlsInStrip ? restingControlsHiddenBlockCount : 0;
   const composerControlsCompact = !composerControlsInStrip && isComposerFooterCompact;
+  const restingProviderTraitsPicker = renderProviderTraitsPicker({
+    ...providerTraitsPickerInput,
+    size: "xs",
+    hidden: composerControlsHidden || restingHiddenBlockCount > 1,
+  });
   const restingBlockDefs = [
     ...(providerTraitsPicker
       ? [
@@ -3750,6 +3760,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           interactionMode={interactionMode}
           runtimeMode={runtimeMode}
           size={composerControlsInStrip ? "xs" : "sm"}
+          hidden={composerControlsHidden || restingHiddenBlockCount > 0}
           onToggleInteractionMode={toggleInteractionMode}
           onRuntimeModeChange={handleRuntimeModeChange}
         />
@@ -3868,7 +3879,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                 interactionMode={interactionMode}
                 runtimeMode={runtimeMode}
                 size="xs"
-                hidden={hiddenRestingBlockIds.length === 0}
+                hidden={composerControlsHidden || hiddenRestingBlockIds.length === 0}
                 showInteractionModeToggle={
                   planModeUiEnabled && hiddenRestingBlockIds.includes("mode")
                 }
@@ -4418,6 +4429,18 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   // Imperative handle
   // ------------------------------------------------------------------
+  const openModelPicker = useCallback(() => {
+    if (composerControlsHidden) {
+      if (composerBlurFrameRef.current !== null) {
+        window.cancelAnimationFrame(composerBlurFrameRef.current);
+        composerBlurFrameRef.current = null;
+      }
+      setIsComposerScrollCollapsed(false);
+      setIsComposerFocused(true);
+    }
+    setIsComposerModelPickerOpen(true);
+  }, [composerControlsHidden]);
+
   useImperativeHandle(
     composerRef,
     () => ({
@@ -4441,11 +4464,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           "cursor",
           { ensureLeadingBoundary: true, citationCommentAnchor: sourceAnchor },
         ),
-      openModelPicker: () => {
-        setIsComposerModelPickerOpen(true);
-      },
+      openModelPicker,
       toggleModelPicker: () => {
-        setIsComposerModelPickerOpen((open) => !open);
+        if (isComposerModelPickerOpen) {
+          setIsComposerModelPickerOpen(false);
+        } else {
+          openModelPicker();
+        }
       },
       compactContext: compactThreadContext,
       isModelPickerOpen: () => isComposerModelPickerOpen,
@@ -4558,6 +4583,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       projectSelectionRequired,
       applyPromptReplacement,
       isComposerModelPickerOpen,
+      openModelPicker,
       readComposerSnapshot,
       selectedModel,
       selectedModelOptionsForDispatch,

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
@@ -1,5 +1,5 @@
 import { ProviderInteractionMode, RuntimeMode } from "@t3tools/contracts";
-import { memo, type ReactNode, useState } from "react";
+import { memo, type ReactNode } from "react";
 import { EllipsisIcon } from "lucide-react";
 import {
   Menu,
@@ -11,6 +11,7 @@ import {
 } from "../ui/menu";
 import { ComposerControl, ComposerControlIcon } from "./ComposerControl";
 import { composerFloatingLayerProps } from "./composerEventScope";
+import { useComposerMenuState } from "./useComposerMenuState";
 
 export const CompactComposerControlsMenu = memo(function CompactComposerControlsMenu(props: {
   interactionMode: ProviderInteractionMode;
@@ -28,19 +29,10 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
   onRuntimeModeChange: (mode: RuntimeMode) => void;
 }) {
   const size = props.size ?? "sm";
-  const [open, setOpen] = useState(false);
-  const hidden = props.hidden ?? false;
-  // Base UI does not report a close it did not initiate, so clear the state
-  // when the trigger hides or the menu would reopen by itself when the
-  // trigger returns.
-  const [wasHidden, setWasHidden] = useState(hidden);
-  if (hidden !== wasHidden) {
-    setWasHidden(hidden);
-    if (hidden) setOpen(false);
-  }
+  const [open, setOpen] = useComposerMenuState(props.hidden);
 
   return (
-    <Menu open={open && !hidden} onOpenChange={setOpen}>
+    <Menu open={open} onOpenChange={setOpen}>
       <MenuTrigger
         render={
           <ComposerControl

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -15,7 +15,7 @@ import {
   isClaudeUltrathinkPrompt,
   normalizeModelSlug,
 } from "@t3tools/shared/model";
-import { memo, useCallback, useState } from "react";
+import { memo, useCallback } from "react";
 import type { VariantProps } from "class-variance-authority";
 import { ZapIcon } from "lucide-react";
 import { buttonVariants } from "../ui/button";
@@ -39,6 +39,7 @@ import {
   type ComposerControlSize,
 } from "./ComposerControl";
 import { composerFloatingLayerProps } from "./composerEventScope";
+import { useComposerMenuState } from "./useComposerMenuState";
 
 type ProviderOptions = ReadonlyArray<ProviderOptionSelection>;
 
@@ -549,12 +550,14 @@ export const TraitsPicker = memo(function TraitsPicker({
   triggerClassName,
   isComposerOwned,
   size = "sm",
+  hidden = false,
   ...persistence
 }: TraitsMenuContentProps &
   TraitsPersistence & {
     size?: ComposerControlSize;
+    hidden?: boolean;
   }) {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useComposerMenuState(hidden);
   const { descriptors, primarySelectDescriptor, ultrathinkPromptControlled } =
     getTraitsSectionVisibility({
       provider,

--- a/apps/web/src/components/chat/composerProviderState.tsx
+++ b/apps/web/src/components/chat/composerProviderState.tsx
@@ -53,6 +53,7 @@ type TraitsRenderInput = {
   onPromptChange: (prompt: string) => void;
   planModeEnabled: boolean;
   size?: ComposerControlSize;
+  hidden?: boolean;
   triggerVariant?: VariantProps<typeof buttonVariants>["variant"];
   triggerClassName?: string;
   isComposerOwned?: boolean;
@@ -131,6 +132,7 @@ function renderTraitsControl(
     onPromptChange,
     planModeEnabled,
     size,
+    hidden,
     triggerVariant,
     triggerClassName,
     isComposerOwned,
@@ -162,6 +164,7 @@ function renderTraitsControl(
       onPromptChange={onPromptChange}
       planModeEnabled={planModeEnabled}
       {...(size !== undefined ? { size } : {})}
+      {...(hidden !== undefined ? { hidden } : {})}
       {...(triggerVariant !== undefined ? { triggerVariant } : {})}
       {...(triggerClassName !== undefined ? { triggerClassName } : {})}
       {...(isComposerOwned ? { isComposerOwned } : {})}

--- a/apps/web/src/components/chat/useComposerMenuState.test.tsx
+++ b/apps/web/src/components/chat/useComposerMenuState.test.tsx
@@ -1,0 +1,90 @@
+import { act, StrictMode, useLayoutEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { useComposerMenuState } from "./useComposerMenuState";
+
+let root: Root;
+let setOpen: ReturnType<typeof useComposerMenuState>[1];
+let committedOpen: boolean[];
+let closePopup = vi.fn<() => void>();
+
+function MenuStateProbe({ hidden }: { hidden: boolean }) {
+  const [open, updateOpen] = useComposerMenuState(hidden);
+  useLayoutEffect(() => {
+    setOpen = updateOpen;
+    committedOpen.push(open);
+    if (open) return closePopup;
+  }, [open, updateOpen]);
+  return null;
+}
+
+async function renderMenu(hidden: boolean) {
+  await act(() => {
+    root.render(
+      <StrictMode>
+        <MenuStateProbe hidden={hidden} />
+      </StrictMode>,
+    );
+  });
+}
+
+beforeEach(() => {
+  // The probe renders no host nodes, but ReactDOM still needs an event target.
+  const document = {
+    nodeType: 9,
+    addEventListener() {},
+    removeEventListener() {},
+  };
+  const container = {
+    nodeType: 1,
+    tagName: "DIV",
+    namespaceURI: "http://www.w3.org/1999/xhtml",
+    ownerDocument: document,
+    addEventListener() {},
+    removeEventListener() {},
+  };
+  vi.stubGlobal("document", document);
+  vi.stubGlobal("window", { document, HTMLIFrameElement: EventTarget });
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  committedOpen = [];
+  closePopup = vi.fn();
+  root = createRoot(container as unknown as HTMLElement);
+});
+
+afterEach(async () => {
+  await act(() => root.unmount());
+  vi.unstubAllGlobals();
+});
+
+describe("useComposerMenuState", () => {
+  it("closes an open popup when its trigger hides and does not reopen when it returns", async () => {
+    await renderMenu(false);
+    await act(() => setOpen(true));
+    expect(committedOpen.at(-1)).toBe(true);
+
+    await renderMenu(true);
+    expect(committedOpen.at(-1)).toBe(false);
+    expect(closePopup).toHaveBeenCalledTimes(1);
+
+    const afterClose = committedOpen.length;
+    await renderMenu(false);
+    expect(committedOpen).toHaveLength(afterClose);
+    expect(committedOpen.at(-1)).toBe(false);
+
+    await act(() => setOpen(true));
+    expect(committedOpen.at(-1)).toBe(true);
+    await act(() => setOpen(false));
+    expect(committedOpen.at(-1)).toBe(false);
+    expect(closePopup).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not commit an open popup requested while its trigger is hidden", async () => {
+    await renderMenu(true);
+    await act(() => setOpen(true));
+    await renderMenu(false);
+
+    expect(committedOpen.every((open) => !open)).toBe(true);
+    expect(closePopup).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/chat/useComposerMenuState.ts
+++ b/apps/web/src/components/chat/useComposerMenuState.ts
@@ -1,0 +1,12 @@
+import { useState } from "react";
+
+/** Clear portaled menus when their measured, still-mounted triggers hide. */
+export function useComposerMenuState(hidden = false) {
+  const [open, setOpen] = useState(false);
+  // Base UI does not notify us when we close it by changing its open prop.
+  // Reset the stored state too, so revealing the trigger cannot reopen it.
+  if (hidden && open) {
+    setOpen(false);
+  }
+  return [open && !hidden, setOpen] as const;
+}


### PR DESCRIPTION
The resting composer keeps hidden controls mounted for measurement, but their portaled menus live outside the hidden wrapper. Runtime and traits menus can outlive the move into overflow; model and overflow menus can outlive the whole control cluster becoming hidden.

Close the menus and clear their stored open state when their triggers hide, without unmounting the measured controls. Revealing the controls does not reopen an old menu. Model-picker commands reveal the composer when the shortcut would otherwise target a hidden trigger.

Verification:

- React lifecycle tests cover open, hide, reveal, reopen, and attempted opening while hidden, under Strict Mode.
- All 145 focused tests across composer layout, measurement, menu state, toolbar layout, traits, provider state, and composer event scope pass.
- Web typecheck passes. Targeted lint reports no errors and the same 34 existing ChatComposer warnings as the base.
- Integrated resize/focus verification, before/after screenshots, and an interaction recording have not been performed.

Stacked on [#9540](https://github.com/pingdotgg/t3code/pull/9540). Covers web/desktop composer controls and the model-picker command entry points, including mobile-width web layouts. Native mobile, provider adapters, and connection protocols are unchanged.

Implemented with Codex through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only composer menu and focus behavior with targeted tests; no auth, data, or API changes.
> 
> **Overview**
> Fixes **orphaned portaled menus** when the resting/collapsed composer keeps control triggers mounted but visually hidden for layout measurement.
> 
> Introduces **`useComposerMenuState`**, shared by the runtime mode select, traits picker, and compact overflow menu. When a trigger is marked `hidden`, open menus close and internal open state resets so controls do not **reopen stale menus** when they become visible again. Opening while hidden is not committed to the effective open state.
> 
> **`ChatComposer`** threads a `composerControlsHidden` flag (strip visible but measured controls not shown) into those pickers and closes the model picker if it was open when the cluster hides. **`openModelPicker`** / **`toggleModelPicker`** now expand and focus the composer when the shortcut would target a hidden trigger, then open the picker.
> 
> Adds **Strict Mode lifecycle tests** for hide, reveal, reopen, and open-while-hidden behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b150cbbffb426840dc8ac7736514e3d174b09443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix composer menus staying open when their controls hide
> - Adds shared hook `useComposerMenuState` in [useComposerMenuState.ts](https://github.com/pingdotgg/t3code/pull/9541/files#diff-f8980c48d6e8eedb18cb30261c0cd36dcbcd598272fc1ffbf9e32de5a17731db) that reports menus closed while hidden, clears stored open state, and does not auto-reopen on visibility return
> - Adopts the hook across `ComposerFooterModeControls`, `CompactComposerControlsMenu`, and `TraitsPicker`, replacing local menu state and hidden-transition bookkeeping
> - `ChatComposer` now resets an open model picker at render time when relocated controls hide, and opening/toggling the picker while controls are hidden cancels pending blur, expands the composer, restores focus, then opens the picker
> - Adds unit tests in [useComposerMenuState.test.tsx](https://github.com/pingdotgg/t3code/pull/9541/files#diff-1b6e9f0ffca2042941df9a87b4b5f5288ad0298d638584544738a801720fce6f) covering popup close on hide, no open while hidden, and explicit reopen/close behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b150cbb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->