### PR TITLE
fix(mobile): keep store screenshots free of system banners and show dictation

### DIFF
--- a/apps/mobile/src/features/voice-input/useVoiceInputController.ts
+++ b/apps/mobile/src/features/voice-input/useVoiceInputController.ts
@@ -14,6 +14,7 @@ import { useSharedValue } from "react-native-reanimated";
 
 import type { ComposerEditorSelection } from "../../components/ComposerEditor";
 import { getLocalVoiceTranscriber } from "../../native/voiceTranscription";
+import { getNativeShowcaseScene } from "../showcase/nativeShowcaseScene";
 import {
   VoiceInputController,
   VOICE_RECORDING_LIMIT_SECONDS,
@@ -203,7 +204,9 @@ export function useVoiceInputController(input: {
   const cancel = useCallback(() => controller.cancel(), [controller]);
 
   return {
-    isAvailable: getLocalVoiceTranscriber() !== null,
+    // Store screenshots show the dictation button even on simulators, whose
+    // on-device transcription is unavailable.
+    isAvailable: getLocalVoiceTranscriber() !== null || getNativeShowcaseScene() !== null,
     state,
     audioLevels,
     elapsedSeconds,

--- a/scripts/mobile-showcase.ts
+++ b/scripts/mobile-showcase.ts
@@ -806,6 +806,47 @@ async function ensureIosSimulator(device: ShowcaseIosDevice): Promise<{
   };
 }
 
+async function iosSimulatorDataPath(udid: string): Promise<string> {
+  const parsed = JSON.parse(await commandOutput("xcrun", ["simctl", "list", "devices", "-j"])) as {
+    readonly devices: Readonly<
+      Record<string, ReadonlyArray<SimctlDevice & { readonly dataPath: string }>>
+    >;
+  };
+  const dataPath = Object.values(parsed.devices)
+    .flat()
+    .find((device) => device.udid === udid)?.dataPath;
+  if (!dataPath) throw new Error(`Could not resolve the data path of iOS simulator ${udid}.`);
+  return dataPath;
+}
+
+// generativeexperiencesd posts a "Ready for Apple Intelligence" follow-up
+// banner on an eligible device's first boot, and CoreFollowUp re-surfaces it
+// on every boot until the user dismisses it. Stamping the readiness marker
+// before boot makes the daemon skip the post, and dropping the CoreFollowUp
+// store clears a banner that a previous boot already queued. Runs while the
+// device is shut down so the files are read fresh on the next boot.
+async function suppressIosSystemFollowUps(udid: string): Promise<void> {
+  const dataPath = await iosSimulatorDataPath(udid);
+  const preferences = NodePath.join(dataPath, "Library/Preferences");
+  await NodeFSP.mkdir(preferences, { recursive: true });
+  await NodeFSP.writeFile(
+    NodePath.join(preferences, "com.apple.generativeexperiences.corefollowup.plist"),
+    `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+\t<key>DateOfLastAppleIntelligenceReadinessCFU</key>
+\t<date>2020-01-01T00:00:00Z</date>
+</dict>
+</plist>
+`,
+  );
+  await NodeFSP.rm(NodePath.join(dataPath, "Library/CoreFollowUp"), {
+    recursive: true,
+    force: true,
+  });
+}
+
 async function normalizeIosSimulator(appearance: ShowcaseAppearance, udid: string): Promise<void> {
   await runCommand("xcrun", ["simctl", "ui", udid, "appearance", appearance]);
   await runCommand("xcrun", [
@@ -922,6 +963,7 @@ async function captureIos(
     // confirmations, keyboards) without erasing the developer's simulator.
     await runCommand("xcrun", ["simctl", "shutdown", simulator.udid]);
   }
+  await suppressIosSystemFollowUps(simulator.udid);
   await runCommand("xcrun", ["simctl", "boot", simulator.udid]);
   await runCommand("xcrun", ["simctl", "bootstatus", simulator.udid, "-b"]);
   if (capture.device.orientation === "landscape") {


### PR DESCRIPTION
Store screenshots captured by `screenshots:mobile` came out with a "Ready for Apple Intelligence" banner over the status bar, and the composer never showed the dictation button.

The banner is a CoreFollowUp item that `generativeexperiencesd` posts on an eligible iOS 26 simulator's first boot; `followupd` re-surfaces it on every later boot until someone dismisses it. The daemon skips the post when `DateOfLastAppleIntelligenceReadinessCFU` is already set in `com.apple.generativeexperiences.corefollowup`, so the runner now writes that marker and drops the `CoreFollowUp` store while the device is shut down, right before booting it. That prevents a fresh simulator from ever posting the banner and clears one an existing simulator already queued. Verified on both cases: the daemon logs `should NOT post Readiness CFU` and the items table stays empty across reboots.

The dictation button is gated on on-device transcription, which simulators never have. The composer now reports it available whenever the app was launched by the showcase runner with a scene, so captures show the real composer.

| Before |
| --- |
| ![Capture with the Apple Intelligence banner covering the top of the thread and no mic button in the composer](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/08bb380e9eb818e1/before-apple-intelligence-banner.png) |

Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to showcase automation and a showcase-only `isAvailable` override; normal app voice behavior on real devices is unchanged.
> 
> **Overview**
> **Store screenshot capture** is adjusted so iOS simulators boot clean and the composer matches production chrome in showcase runs.
> 
> The mobile showcase runner now **suppresses the “Ready for Apple Intelligence” system banner** before each iOS boot: while the simulator is shut down it writes `DateOfLastAppleIntelligenceReadinessCFU` into `com.apple.generativeexperiences.corefollowup` and removes `Library/CoreFollowUp`, so `generativeexperiencesd` skips posting and any queued follow-up is cleared.
> 
> **Voice input availability** in `useVoiceInputController` now treats dictation as available when a native showcase scene is active (`getNativeShowcaseScene() !== null`), not only when on-device transcription exists—so simulator captures show the dictation button even though simulators lack local transcription.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97985fb37e3f6d754a919b0008e6286867c0372c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix iOS showcase screenshots to hide system banners and enable dictation in showcase scenes
> - Updates `useVoiceInputController` to report voice input as available when a native showcase scene is active, even on devices without an on-device transcriber.
> - Adds `suppressIosSystemFollowUps` in [mobile-showcase.ts](https://github.com/pingdotgg/t3code/pull/9548/files#diff-4c6db0a1db2f6a714f8822c0a8a8fab41c97ba88c4a49fb52c21332ac758133c) which sets the Apple Intelligence readiness preference and removes the CoreFollowUp store on a shut-down simulator before boot.
> - Adds `iosSimulatorDataPath` helper to resolve a simulator's filesystem data path from its UDID, failing explicitly when not found.
> - Inserts the follow-up suppression step into `captureIos` after shutdown and before boot so captured store screenshots are free of system banners.
> - Risk: `suppressIosSystemFollowUps` deletes the simulator's CoreFollowUp store recursively; if the preferences directory path resolution in `iosSimulatorDataPath` returns the wrong path, it could operate on unintended simulator data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97985fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->