### PR TITLE
fix(web): simplify expanded tool details

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -3172,6 +3172,8 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
                     : "truncate",
                   headingClass,
                 )}
+                onClick={expanded ? stopRowToggle : undefined}
+                onPointerDown={expanded ? stopRowToggle : undefined}
               >
                 {previewText}
               </span>

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -3068,18 +3068,6 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
       : workEntryIconName(workEntry);
   const previewText = displayLabel ?? workEntryDisplayLabel(workEntry, workspaceRoot);
   const viewedImagePath = workEntryViewedImagePath(workEntry);
-  const canExpand =
-    (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) ||
-    Boolean(
-      workEntryRawCommand(workEntry) ||
-      workEntry.command?.trim() ||
-      workEntry.detail?.trim() ||
-      workEntry.changedFiles?.length ||
-      viewedImagePath,
-    );
-  const expandedBody = expanded
-    ? buildToolCallExpandedBody(workEntry, workspaceRoot, previewText, viewedImagePath)
-    : null;
   const viewedImage =
     viewedImagePath && threadRef
       ? resolveViewedImageAsset(viewedImagePath, {
@@ -3087,6 +3075,24 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
           workspaceRoot,
         })
       : null;
+  const commandMatchesVisibleLabel = workEntry.command?.trim() === previewText.trim();
+  const canExpand =
+    (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) ||
+    Boolean(
+      (!commandMatchesVisibleLabel &&
+        (workEntryRawCommand(workEntry) || workEntry.command?.trim())) ||
+      workEntry.detail?.trim() ||
+      workEntry.changedFiles?.length ||
+      viewedImage,
+    );
+  const expandedBody = expanded
+    ? buildToolCallExpandedBody(
+        workEntry,
+        workspaceRoot,
+        previewText,
+        viewedImage ? viewedImagePath : null,
+      )
+    : null;
   const showDestructiveRowStyle =
     showFailedIndicator &&
     (workEntrySignalsSevereFailure(workEntry) || !workLogEntryIsToolLike(workEntry));
@@ -3158,7 +3164,17 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
         <div className="flex min-w-0 flex-1 items-center gap-1.5">
           <div className="min-w-0 flex-1 overflow-hidden">
             <p className="flex min-w-0 w-full items-baseline gap-1.5 text-sm leading-relaxed">
-              <span className={cn("min-w-0 flex-1 truncate", headingClass)}>{previewText}</span>
+              <span
+                className={cn(
+                  "min-w-0 flex-1",
+                  expanded || (commandMatchesVisibleLabel && !canExpand)
+                    ? "whitespace-pre-wrap break-words select-text"
+                    : "truncate",
+                  headingClass,
+                )}
+              >
+                {previewText}
+              </span>
             </p>
           </div>
           {showFailedIndicator && hasSpecialToolIcon ? (

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -2841,27 +2841,47 @@ function workEntryRawCommand(
 function buildToolCallExpandedBody(
   workEntry: TimelineWorkEntry,
   workspaceRoot: string | undefined,
+  visibleLabel: string,
+  viewedImagePath: string | null,
 ): string | null {
   const blocks: string[] = [];
+  const seen = new Set<string>();
+  const addBlock = (value: string | null | undefined) => {
+    const text = value?.trim();
+    if (!text || seen.has(text)) return;
+    seen.add(text);
+    blocks.push(text);
+  };
   if (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) {
-    blocks.push(`MCP call\n${JSON.stringify(workEntry.toolData, null, 2)}`);
+    addBlock(`MCP call\n${JSON.stringify(workEntry.toolData, null, 2)}`);
   }
+  const command = workEntry.command?.trim();
   const raw = workEntryRawCommand(workEntry);
-  if (raw?.trim()) {
-    blocks.push(raw.trim());
-  } else if (workEntry.command?.trim()) {
-    blocks.push(workEntry.command.trim());
+  if (command === visibleLabel.trim()) {
+    seen.add(command);
+  } else {
+    addBlock(raw ?? command);
   }
-  if (workEntry.detail?.trim()) {
-    blocks.push(workEntry.detail.trim());
+  const detail = workEntry.detail?.trim();
+  if (detail !== viewedImagePath?.trim()) {
+    addBlock(detail);
   }
-  const changedFiles = workEntry.changedFiles ?? [];
+  const viewedImagePaths = new Set(
+    viewedImagePath
+      ? [viewedImagePath.trim(), formatWorkspaceRelativePath(viewedImagePath, workspaceRoot)]
+      : [],
+  );
+  const changedFiles = (workEntry.changedFiles ?? []).flatMap((filePath) => {
+    const formattedPath = formatWorkspaceRelativePath(filePath, workspaceRoot);
+    return viewedImagePaths.has(filePath) ||
+      viewedImagePaths.has(formattedPath) ||
+      filePath.trim() === detail ||
+      formattedPath === detail
+      ? []
+      : [formattedPath];
+  });
   if (changedFiles.length > 0) {
-    blocks.push(
-      changedFiles
-        .map((filePath) => formatWorkspaceRelativePath(filePath, workspaceRoot))
-        .join("\n"),
-    );
+    addBlock([...new Set(changedFiles)].join("\n"));
   }
   return blocks.length > 0 ? blocks.join("\n\n") : null;
 }
@@ -3047,8 +3067,6 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
       ? "circle-alert"
       : workEntryIconName(workEntry);
   const previewText = displayLabel ?? workEntryDisplayLabel(workEntry, workspaceRoot);
-  const displayText =
-    !toolPresentation && expanded && workEntry.command?.trim() ? "Command" : previewText;
   const viewedImagePath = workEntryViewedImagePath(workEntry);
   const canExpand =
     (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) ||
@@ -3059,7 +3077,9 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
       workEntry.changedFiles?.length ||
       viewedImagePath,
     );
-  const expandedBody = expanded ? buildToolCallExpandedBody(workEntry, workspaceRoot) : null;
+  const expandedBody = expanded
+    ? buildToolCallExpandedBody(workEntry, workspaceRoot, previewText, viewedImagePath)
+    : null;
   const viewedImage =
     viewedImagePath && threadRef
       ? resolveViewedImageAsset(viewedImagePath, {
@@ -3138,7 +3158,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
         <div className="flex min-w-0 flex-1 items-center gap-1.5">
           <div className="min-w-0 flex-1 overflow-hidden">
             <p className="flex min-w-0 w-full items-baseline gap-1.5 text-sm leading-relaxed">
-              <span className={cn("min-w-0 flex-1 truncate", headingClass)}>{displayText}</span>
+              <span className={cn("min-w-0 flex-1 truncate", headingClass)}>{previewText}</span>
             </p>
           </div>
           {showFailedIndicator && hasSpecialToolIcon ? (
@@ -3179,7 +3199,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
       ) : null}
       {expanded && canExpand && expandedBody ? (
         <div
-          className="mt-1 ms-7 cursor-default border-s border-border/45 ps-3 pt-0.5"
+          className="mt-1 ms-7 cursor-default rounded-md bg-muted/40 px-3 py-2"
           onClick={stopRowToggle}
           onPointerDown={stopRowToggle}
         >


### PR DESCRIPTION
Expanded command and tool rows no longer repeat the visible command, shell wrapper, image path, or duplicate changed files. Expanded details now use a rounded muted inset instead of the left rail while preserving unique output, file lists, MCP payloads, and image actions. Verified with web typecheck, formatting, targeted lint, and real-app interaction checks in light and dark themes; the focused existing Vitest suite is currently blocked by `TypeError: Cannot read properties of undefined (reading config)` before tests run.

![Expanded image tool before](https://uploads-production-47e4.up.railway.app/files/020a33e0-08aa-44fb-9edd-f8e7cbe1ae40/78460500-c2d2-4e35-bdf6-a7a12014b63e-e8634b67-0e3f-44e6-9e82-390b3651a23c.png)

![Expanded image tool after with one path and preview](https://uploads-production-47e4.up.railway.app/files/efeb3ec4-a72f-4392-93c1-13fba23c518c/t3-expanded-image-after.png)

![Expanded command and file change before](https://uploads-production-47e4.up.railway.app/files/3e4c6a70-9c8f-49e6-81e5-b8df74a3734d/t3-expanded-tools-before.png)

![Expanded command and file change after without repeated details or left rail](https://uploads-production-47e4.up.railway.app/files/850c6db8-b33d-457b-8528-9fd5000a1faf/t3-expanded-tools-after.png)

Built by `gpt-5.6-sol` in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only presentation logic in chat timeline work rows; no auth, API, or data-path changes.
> 
> **Overview**
> **Expanded tool/command rows** in the chat timeline show less duplicate information and a cleaner layout when opened.
> 
> `buildToolCallExpandedBody` now builds blocks through a deduplicating helper: it skips the command when it already matches the row’s visible label, skips `detail` when it’s the same as the viewed image path, and drops changed-file paths that repeat the image path or that detail. MCP payloads and unique output still appear.
> 
> **`PlainWorkEntryRow`** always shows the normal preview label (no swapping to “Command” on expand). Rows that only duplicate the visible command are no longer expandable. When expanded—or when the label is the full command with nothing else to show—the title can wrap and be selected; the detail panel uses a **rounded muted inset** instead of the previous left-border rail.
> 
> **Note:** When a distinct raw command exists, expanded body prefers `raw ?? command` (including an empty raw string) rather than always falling back to the trimmed command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36d44a49d114231bd2331f3a8b43d7d23938c1e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate content and label display in expanded chat tool details
> - `chat.buildToolCallExpandedBody` trims and deduplicates expanded blocks: it suppresses command content that matches the visible label, omits detail and changed-file entries for the viewed image or duplicate detail text, and formats changed-file paths as workspace-relative. A whitespace-only raw command no longer triggers the regular command fallback.
> - `chat.PlainWorkEntryRow` now renders the preview label in both collapsed and expanded states instead of swapping in a generic command label, and expanded labels wrap and are selectable. Click and pointer-down events on the label or expanded body no longer toggle the row.
> - Expansion eligibility excludes commands matching the visible label and requires a resolved viewed-image asset, not just a path.
> - Risk: rows that previously expanded solely because of an unresolved viewed-image path will no longer be expandable; callers relying on the old generic command label in expanded view will see the preview label instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36d44a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->