### PR TITLE
fix(antigravity): hand the Google sign-in URL to T3 through a browser preload

### DIFF
--- a/apps/server/src/provider/AntigravityInstallation.test.ts
+++ b/apps/server/src/provider/AntigravityInstallation.test.ts
@@ -312,7 +312,7 @@ it.layer(NodeServices.layer)("Antigravity installation", (it) => {
           const profile = command.options.env?.GEMINI_HOME;
           if (!profile) return yield* Effect.die("Expected a disposable validation profile.");
           profiles.add(profile);
-          const helper = command.args[0] === "-e";
+          const helper = command.args[0]?.startsWith("https://") === true;
           const output = yield* Queue.unbounded<Uint8Array>();
           const exited = yield* Deferred.make<ChildProcessSpawner.ExitCode>();
           const terminate = Deferred.succeed(exited, ChildProcessSpawner.ExitCode(0)).pipe(

--- a/apps/server/src/provider/Drivers/AntigravityDriver.ts
+++ b/apps/server/src/provider/Drivers/AntigravityDriver.ts
@@ -28,6 +28,7 @@ import {
   isAntigravitySignInRequiredError,
   prepareAntigravityProfile,
   resolveAntigravityProfileDirectory,
+  serveAntigravityAuthorizationUrlSink,
   type AntigravityAuthConfig,
 } from "../antigravityAuthSupport.ts";
 import {
@@ -151,6 +152,9 @@ export const AntigravityDriver: ProviderDriver<AntigravitySettings, AntigravityD
           Effect.provideService(Path.Path, path),
           Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
         );
+        const authorizationUrlSink = input.onAuthorizationUrl
+          ? yield* serveAntigravityAuthorizationUrlSink(input.onAuthorizationUrl)
+          : undefined;
         const runtime = yield* makeAntigravityAcpRuntime({
           ...input,
           authMethod: auth.authMethod,
@@ -161,6 +165,7 @@ export const AntigravityDriver: ProviderDriver<AntigravitySettings, AntigravityD
             cwd: input.cwd,
             baseEnv: processEnvironment,
             auth,
+            ...(authorizationUrlSink ? { authorizationUrlSink } : {}),
           }),
         }).pipe(Effect.provideService(Crypto.Crypto, crypto));
         return {

--- a/apps/server/src/provider/antigravityAuthSupport.test.ts
+++ b/apps/server/src/provider/antigravityAuthSupport.test.ts
@@ -5,6 +5,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { ProviderInstanceId } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { describe, expect, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
@@ -32,6 +33,7 @@ import {
   parseAntigravityAuthorizationUrl,
   prepareAntigravityProfile,
   resolveAntigravityProfileDirectory,
+  serveAntigravityAuthorizationUrlSink,
 } from "./antigravityAuthSupport.ts";
 
 const authorizationUrl =
@@ -51,7 +53,37 @@ describe("Antigravity process environment", () => {
     acpDirectory: "/t3/userdata/providers/antigravity/profile/antigravity-acp",
     tokenPath: "/t3/userdata/providers/antigravity/profile/antigravity-acp/acp_token.json",
     browserCommand: "managed-browser-helper",
+    browserHelperPath: "/runtime/node",
+    browserPreloadPath:
+      "/t3/userdata/providers/antigravity/profile/antigravity-acp/t3-browser-preload.cjs",
   };
+
+  it("routes only the sign-in launch through the browser preload and sink", () => {
+    const signIn = buildAntigravityAcpSpawnInput({
+      installation: { executablePath: "/release/acp", harnessPath: "/release/harness" },
+      profile,
+      cwd: "/project",
+      baseEnv: { NODE_OPTIONS: "--max-old-space-size=4096", T3_ANTIGRAVITY_AUTH_SINK: "stale" },
+      authorizationUrlSink: "http://127.0.0.1:41234/token",
+    });
+    expect(signIn.env).toMatchObject({
+      BROWSER: "/runtime/node",
+      NODE_OPTIONS: `--max-old-space-size=4096 --require "${profile.browserPreloadPath}"`,
+      T3_ANTIGRAVITY_AUTH_SINK: "http://127.0.0.1:41234/token",
+    });
+
+    const session = buildAntigravityAcpSpawnInput({
+      installation: { executablePath: "/release/acp", harnessPath: "/release/harness" },
+      profile,
+      cwd: "/project",
+      baseEnv: { NODE_OPTIONS: "--max-old-space-size=4096", T3_ANTIGRAVITY_AUTH_SINK: "stale" },
+    });
+    expect(session.env).toMatchObject({
+      BROWSER: profile.browserCommand,
+      NODE_OPTIONS: "--max-old-space-size=4096",
+    });
+    expect(session.env).not.toHaveProperty("T3_ANTIGRAVITY_AUTH_SINK");
+  });
 
   it("isolates the profile and harness after merging overrides without changing the base environment", () => {
     const baseEnv = {
@@ -590,7 +622,47 @@ it.layer(NodeServices.layer)("Antigravity profile preparation", (it) => {
       }).pipe(Effect.result);
 
       expect(Result.isFailure(result)).toBe(true);
-      expect(yield* fs.exists(profileDirectory)).toBe(false);
+      expect(
+        yield* fs.exists(path.join(profileDirectory, "antigravity-acp", "settings.json")),
+      ).toBe(false);
+    }),
+  );
+
+  it.effect("delivers the sign-in URL from the browser preload to the sink", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const temporaryDirectory = yield* fs.makeTempDirectoryScoped();
+      const profile = yield* prepareAntigravityProfile({ profileDirectory: temporaryDirectory });
+      const received = yield* Deferred.make<string>();
+      const sink = yield* serveAntigravityAuthorizationUrlSink((url) =>
+        Deferred.succeed(received, url).pipe(Effect.asVoid),
+      );
+      const spawn = buildAntigravityAcpSpawnInput({
+        installation: { executablePath: "unused", harnessPath: "unused" },
+        profile,
+        cwd: temporaryDirectory,
+        authorizationUrlSink: sink,
+      });
+      const env = spawn.env ?? {};
+      const child = yield* Effect.acquireRelease(
+        Effect.sync(() =>
+          NodeChildProcess.spawn(env.BROWSER ?? "", [authorizationUrl], {
+            cwd: temporaryDirectory,
+            env,
+            stdio: "ignore",
+          }),
+        ),
+        (process) => Effect.sync(() => void process.kill()),
+      );
+      const exitCode = yield* Effect.promise(
+        () =>
+          new Promise<number | null>((resolve, reject) => {
+            child.once("error", reject);
+            child.once("exit", resolve);
+          }),
+      );
+      expect(exitCode).toBe(0);
+      expect(yield* Deferred.await(received)).toBe(authorizationUrl);
     }),
   );
 

--- a/apps/server/src/provider/antigravityAuthSupport.ts
+++ b/apps/server/src/provider/antigravityAuthSupport.ts
@@ -1,4 +1,6 @@
 import * as NodeCrypto from "node:crypto";
+// @effect-diagnostics-next-line nodeBuiltinImport:off - node:http hosts the one-shot loopback sink with no routing, logging, or middleware.
+import * as NodeHttp from "node:http";
 // @effect-diagnostics-next-line nodeBuiltinImport:off - resolveAntigravityProfileDirectory is a pure sync helper, so it cannot use the Path service.
 import * as NodePath from "node:path";
 
@@ -9,6 +11,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import type * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
+import type * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
@@ -20,6 +23,7 @@ import type { AcpSpawnInput } from "./acp/AcpSessionRuntime.ts";
 export const ANTIGRAVITY_AUTH_STDOUT_PREFIX =
   "Open the following link to authenticate the ACP server: ";
 export const ANTIGRAVITY_AUTH_BROWSER_MARKER = "__T3_ANTIGRAVITY_AUTH_URL__";
+export const ANTIGRAVITY_AUTH_SINK_ENV = "T3_ANTIGRAVITY_AUTH_SINK";
 export const ANTIGRAVITY_SIGN_IN_REQUIRED_MESSAGE =
   "Sign in to Antigravity in Settings before you continue.";
 
@@ -52,6 +56,39 @@ const browserHelperSource =
   `process.stderr.on("error",()=>process.exit(0)).write(` +
   `"${ANTIGRAVITY_AUTH_BROWSER_MARKER}"+JSON.stringify(process.argv[1])+"\\n",` +
   `()=>process.exit(0))`;
+// The agent's Python 3.10 webbrowser runs BROWSER as one executable with the
+// URL as its only argument, and its stdout copy of the URL sits in a block
+// buffer until the process exits. Sign-in therefore points BROWSER at the T3
+// runtime and preloads this file through NODE_OPTIONS. Node resolves its entry
+// argument as a path before preloads run, so the URL arrives as
+// <cwd>/https:/host/path and is rebuilt here. The entry then fails to load,
+// which the handler ignores until delivery has finished.
+const browserPreloadSource = String.raw`"use strict";
+const argument = process.argv[1];
+const cwd = process.cwd();
+const trimmed =
+  typeof argument === "string" && argument.startsWith(cwd) ? argument.slice(cwd.length) : "";
+const url = trimmed
+  .replace(/^[\\/]+/, "")
+  .replaceAll("\\", "/")
+  .replace(/^https:\/(?!\/)/, "https://");
+if (url.startsWith("https://")) {
+  process.on("uncaughtException", () => {});
+  const done = () => process.exit(0);
+  const sink = process.env.${ANTIGRAVITY_AUTH_SINK_ENV};
+  if (sink) {
+    fetch(sink, { method: "POST", headers: { "content-type": "text/plain" }, body: url }).then(
+      done,
+      done,
+    );
+  } else {
+    process.stderr
+      .on("error", done)
+      .write("${ANTIGRAVITY_AUTH_BROWSER_MARKER}" + JSON.stringify(url) + "\n", done);
+  }
+}
+`;
+const browserPreloadFileName = "t3-browser-preload.cjs";
 const browserPreflightUrl = "https://example.invalid/t3-antigravity-browser-preflight";
 
 const removedEnvironmentKeys = new Set([
@@ -72,6 +109,7 @@ const removedEnvironmentKeys = new Set([
   "BROWSER",
   "PYTHONUNBUFFERED",
   "ELECTRON_RUN_AS_NODE",
+  ANTIGRAVITY_AUTH_SINK_ENV,
 ]);
 
 export interface AntigravityProfile {
@@ -80,6 +118,10 @@ export interface AntigravityProfile {
   readonly acpDirectory: string;
   readonly tokenPath: string;
   readonly browserCommand: string;
+  /** T3 runtime that sign-in launches instead of a browser. */
+  readonly browserHelperPath: string;
+  /** Preload that hands the sign-in URL to T3. Lives inside `acpDirectory`. */
+  readonly browserPreloadPath: string;
 }
 
 /**
@@ -189,16 +231,37 @@ function quoteBrowserArgument(value: string): string {
   return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
+/**
+ * Sign-in launches route the browser through the preload, and only they carry
+ * NODE_OPTIONS so turn subprocesses never inherit it. Other launches keep a
+ * BROWSER value Python cannot run, so no browser opens.
+ */
 function antigravityEnvironment(
   profile: AntigravityProfile,
   baseEnv: NodeJS.ProcessEnv,
   auth: AntigravityAuthConfig,
+  signIn?: { readonly authorizationUrlSink?: string },
 ) {
   const environment: NodeJS.ProcessEnv = {};
   for (const [key, value] of Object.entries(baseEnv)) {
     // Windows treats environment keys as case-insensitive. Remove aliases too.
     if (!removedEnvironmentKeys.has(key.toUpperCase())) environment[key] = value;
   }
+  const browser = signIn
+    ? {
+        BROWSER: profile.browserHelperPath,
+        // Node reads backslashes inside quoted NODE_OPTIONS values as escapes.
+        NODE_OPTIONS: [
+          environment.NODE_OPTIONS,
+          `--require "${profile.browserPreloadPath.replaceAll("\\", "/")}"`,
+        ]
+          .filter((value) => value)
+          .join(" "),
+        ...(signIn.authorizationUrlSink
+          ? { [ANTIGRAVITY_AUTH_SINK_ENV]: signIn.authorizationUrlSink }
+          : {}),
+      }
+    : { BROWSER: profile.browserCommand };
   // Only the configured method's credential reaches the agent. The agent
   // prefers GOOGLE_API_KEY over the GCP pair for Agent Platform, so the pair
   // goes through settings.json instead of the environment.
@@ -213,7 +276,7 @@ function antigravityEnvironment(
     ...credential,
     GEMINI_HOME: profile.geminiHome,
     AGY_ACP_FORCE_FILE_STORAGE: "1",
-    BROWSER: profile.browserCommand,
+    ...browser,
     PYTHONUNBUFFERED: "1",
     ELECTRON_RUN_AS_NODE: "1",
   };
@@ -251,17 +314,50 @@ export const prepareAntigravityProfile = Effect.fn("prepareAntigravityProfile")(
 
   const geminiHome = path.resolve(input.profileDirectory);
   const acpDirectory = path.join(geminiHome, "antigravity-acp");
+  const browserPreloadPath = path.join(acpDirectory, browserPreloadFileName);
+  if (browserPreloadPath.includes('"')) {
+    return yield* authSupportError(
+      "The Antigravity profile path cannot be used to suppress browser launches.",
+    );
+  }
   const profile: AntigravityProfile = {
     platform,
     geminiHome,
     acpDirectory,
     tokenPath: path.join(acpDirectory, "acp_token.json"),
     browserCommand,
+    browserHelperPath: helperExecutable,
+    browserPreloadPath,
   };
-  const environment = antigravityEnvironment(profile, input.baseEnv ?? process.env, auth);
+  for (const directory of [geminiHome, acpDirectory]) {
+    yield* fs
+      .makeDirectory(directory, { recursive: true, mode: 0o700 })
+      .pipe(
+        Effect.mapError(() =>
+          authSupportError("The Antigravity profile directory could not be created."),
+        ),
+      );
+    if (platform !== "win32") {
+      yield* fs
+        .chmod(directory, 0o700)
+        .pipe(
+          Effect.mapError(() =>
+            authSupportError("The Antigravity profile directory permissions could not be set."),
+          ),
+        );
+    }
+  }
+  yield* fs
+    .writeFileString(browserPreloadPath, browserPreloadSource)
+    .pipe(
+      Effect.mapError(() =>
+        authSupportError("The Antigravity browser preload could not be written."),
+      ),
+    );
+  const environment = antigravityEnvironment(profile, input.baseEnv ?? process.env, auth, {});
   yield* Effect.gen(function* () {
     const child = yield* spawner.spawn(
-      ChildProcess.make(helperExecutable, ["-e", browserHelperSource, "--", browserPreflightUrl], {
+      ChildProcess.make(helperExecutable, [browserPreflightUrl], {
         env: environment,
         extendEnv: false,
         shell: false,
@@ -298,24 +394,6 @@ export const prepareAntigravityProfile = Effect.fn("prepareAntigravityProfile")(
     ),
   );
 
-  for (const directory of [geminiHome, acpDirectory]) {
-    yield* fs
-      .makeDirectory(directory, { recursive: true, mode: 0o700 })
-      .pipe(
-        Effect.mapError(() =>
-          authSupportError("The Antigravity profile directory could not be created."),
-        ),
-      );
-    if (platform !== "win32") {
-      yield* fs
-        .chmod(directory, 0o700)
-        .pipe(
-          Effect.mapError(() =>
-            authSupportError("The Antigravity profile directory permissions could not be set."),
-          ),
-        );
-    }
-  }
   // Rewriting on every launch keeps a method, project, or location edit in
   // Settings effective. The agent also records auth.type here after a
   // sign-in, which matches the value written below.
@@ -339,6 +417,8 @@ export function buildAntigravityAcpSpawnInput(input: {
   readonly cwd: string;
   readonly baseEnv?: NodeJS.ProcessEnv;
   readonly auth?: AntigravityAuthConfig;
+  /** Present only for the sign-in launch. See `serveAntigravityAuthorizationUrlSink`. */
+  readonly authorizationUrlSink?: string;
 }): AcpSpawnInput {
   return {
     command: input.installation.executablePath,
@@ -349,6 +429,9 @@ export function buildAntigravityAcpSpawnInput(input: {
         input.profile,
         input.baseEnv ?? process.env,
         input.auth ?? ANTIGRAVITY_PERSONAL_AUTH,
+        input.authorizationUrlSink
+          ? { authorizationUrlSink: input.authorizationUrlSink }
+          : undefined,
       ),
       ANTIGRAVITY_HARNESS_PATH: input.installation.harnessPath,
     },
@@ -499,3 +582,60 @@ export function makeAntigravityStderrHandler(
     yield* Effect.forEach(lines, handleLine, { discard: true });
   });
 }
+
+/**
+ * Serves the loopback endpoint the browser preload posts the sign-in URL to.
+ * The agent's own stdout copy of the URL never leaves its buffer until exit,
+ * so this is how sign-in learns the URL. Lives for the sign-in scope.
+ */
+export const serveAntigravityAuthorizationUrlSink = Effect.fn(
+  "serveAntigravityAuthorizationUrlSink",
+)(function* (
+  onAuthorizationUrl: (url: string) => Effect.Effect<void, AcpErrors.AcpError>,
+): Effect.fn.Return<string, AcpErrors.AcpError, Scope.Scope> {
+  const token = NodeCrypto.randomBytes(16).toString("hex");
+  const runFork = Effect.runForkWith(yield* Effect.context<never>());
+  const server = NodeHttp.createServer((request, response) => {
+    if (request.method !== "POST" || request.url !== `/${token}`) {
+      response.statusCode = 404;
+      response.end();
+      request.resume();
+      return;
+    }
+    const chunks: Buffer[] = [];
+    let bytes = 0;
+    request.on("data", (chunk: Buffer) => {
+      bytes += chunk.byteLength;
+      if (bytes > maxAuthorizationUrlLength) {
+        response.statusCode = 413;
+        response.end();
+        request.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    request.on("end", () => {
+      response.statusCode = 204;
+      response.end();
+      runFork(onAuthorizationUrl(Buffer.concat(chunks).toString("utf8")).pipe(Effect.ignore));
+    });
+  });
+  yield* Effect.acquireRelease(
+    Effect.callback<void, AcpErrors.AcpError>((resume) => {
+      server.once("error", () =>
+        resume(authSupportError("The Antigravity sign-in listener could not start.")),
+      );
+      server.listen(0, "127.0.0.1", () => resume(Effect.void));
+    }),
+    () =>
+      Effect.sync(() => {
+        server.closeAllConnections();
+        server.close();
+      }),
+  );
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    return yield* authSupportError("The Antigravity sign-in listener could not start.");
+  }
+  return `http://127.0.0.1:${address.port}/${token}`;
+});


### PR DESCRIPTION
On Windows, Antigravity Google sign-in stays on its starting state and never shows the link. #9425 started reading the browser-helper marker from stderr, but the helper never runs: the agent's Python 3.10 `webbrowser` runs the whole `BROWSER` value as one executable with the URL as its only argument, so the quoted `node -e ... -- %s` command cannot start. Python then logs "Could not open a browser automatically", and the agent's own stdout copy of the URL sits in a block-buffered `print()` that only flushes at exit. T3 has no path to the URL, and the flow expires.

Reproduced against the packaged agent (`agy_acp_server.exe`, PyInstaller Python 3.10.4) on Windows 11 with the installed nightly `0.0.39-nightly.20260903`. Reports in #9405 (closed by #9425) say sign-in still fails on the current nightly, which matches.

## Fix

- Sign-in launches set `BROWSER` to the bare T3 runtime executable, which Python can run, and add `NODE_OPTIONS=--require <profile>/antigravity-acp/t3-browser-preload.cjs`. Node resolves the URL argument as a path before preloads run, so the preload rebuilds the URL from `<cwd>/https:/host/path`, posts it to a per-sign-in loopback sink (`T3_ANTIGRAVITY_AUTH_SINK`, random token, 127.0.0.1, 204 only for `POST /<token>`), and exits 0. With no sink it writes the existing stderr marker, which the preflight check uses.
- Only the sign-in launch carries `NODE_OPTIONS`, the runtime `BROWSER`, and the sink, so turn subprocesses never inherit them. Other launches keep the unrunnable `BROWSER` value so no browser opens.
- The preload is written before the preflight helper runs, and the preflight now spawns the helper the way Python does: one executable, one URL argument.
- Existing stdout and stderr URL paths stay as fallbacks; #9425's same-URL dedup handles duplicate delivery.

Verified end to end on Windows with the real packaged agent: the sink receives the URL about 100 ms after `authenticate`, no browser window opens, and a rebuilt server bundle in the installed nightly completes sign-in.

## Tests

- New: only the sign-in launch is routed through the preload and sink; the sign-in URL reaches the sink from a real spawn of the preload; the profile is not created when the helper cannot start.
- Focused server suites (`antigravityAuthSupport`, `AntigravityAuth`, `AntigravityAcpSupport`, `AntigravityProvider`): 97 passed.
- Server typecheck, targeted lint, and format check pass.

Built with Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth sign-in, loopback HTTP, and subprocess environment wiring; scope is limited to Antigravity personal/business browser auth with existing URL validation and sign-in-only env isolation.
> 
> **Overview**
> Fixes Antigravity OAuth on Windows (and similar hosts) where Python 3.10’s `webbrowser` runs `BROWSER` as a **single executable** with the URL as its only argument, so the old quoted `node -e` helper never runs and the auth link stays stuck in block-buffered agent stdout.
> 
> **Sign-in-only path:** When `onAuthorizationUrl` is set, the driver starts `serveAntigravityAuthorizationUrlSink` and passes its URL into `buildAntigravityAcpSpawnInput`. That launch sets `BROWSER` to the bare T3 runtime, adds `NODE_OPTIONS=--require <profile>/t3-browser-preload.cjs`, and `T3_ANTIGRAVITY_AUTH_SINK`. The preload rebuilds the URL from Node’s path-mangled argv, POSTs it to the one-shot `127.0.0.1` listener (random token, size cap), then exits 0. Normal ACP sessions keep the non-runnable `BROWSER` string and **no** preload/sink so subprocesses do not inherit sign-in env.
> 
> **Profile prep:** Writes `t3-browser-preload.cjs` before verification; browser preflight now spawns the runtime with a URL argument (matching Python), not `-e` inline script. `AntigravityProfile` gains `browserHelperPath` and `browserPreloadPath`. Stdout/stderr URL parsing remains as fallbacks.
> 
> Tests cover env split (sign-in vs session), end-to-end preload→sink delivery, and updated installation validation mocks for URL-as-first-arg.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35d2ecc886ca0218a747a1af540aeac96f707bf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route Google sign-in URL to T3 via browser preload and loopback sink in Antigravity
> - Sign-in ACP launches now set `BROWSER` to the profile's runtime executable and append a generated CommonJS preload to `NODE_OPTIONS`; ordinary ACP launches keep the configured browser command
> - The preload reconstructs an HTTPS URL from the Node entry argument and POSTs it to a loopback sink (or falls back to the existing stdout marker when no sink is set), then exits
> - `serveAntigravityAuthorizationUrlSink` starts a scoped loopback HTTP server on an ephemeral port with a tokenized POST path; invalid routes return 404 and oversized bodies return 413
> - `prepareAntigravityProfile` writes the preload file into the ACP profile and rejects profile paths containing a double quote to avoid preload-path injection
> - `AntigravityDriver.create` starts a loopback sink when the runtime input supplies an auth-URL callback and passes the sink endpoint into the ACP spawn config
> - Behavioral Change: `antigravityEnvironment` now strips the auth-sink env var from inherited environment keys; only explicitly supplied sign-in launches receive it. Profiles with quoted preload paths now fail preparation with an auth-support error
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35d2ecc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->