### PR TITLE
fix(server): reveal normalized paths in File Explorer

### DIFF
--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -206,7 +206,9 @@ it.effect("reveals a file in File Explorer through PowerShell on Windows", () =>
       const launcher = yield* ExternalLauncher.ExternalLauncher;
       yield* launcher.launchEditor({
         editor: "file-manager",
-        cwd: "C:\\workspace with spaces\\media\\author's clip.mp4",
+        // Web file links normalize separators even when the server runs on
+        // Windows. Explorer's `/select` switch requires Windows separators.
+        cwd: "C:/workspace with spaces/media/author's clip.mp4",
         reveal: true,
       });
       return yield* launcher.resolveFileManagerRevealKind();
@@ -261,8 +263,12 @@ it.skipIf(process.platform !== "win32")(
       const outputPath = NodePath.join(tempDir, "argv.txt");
       NodeFS.writeFileSync(recorderPath, `@echo off\r\n>"${outputPath}" echo(%*\r\n`);
 
-      const target = "C:\\workspace with spaces\\media\\author's clip.mp4";
-      const source = ExternalLauncher.buildFileExplorerRevealPowerShellSource(recorderPath, target);
+      const target = "C:/workspace with spaces/media/author's clip.mp4";
+      const explorerTarget = target.replaceAll("/", "\\");
+      const source = ExternalLauncher.buildFileExplorerRevealPowerShellSource(
+        recorderPath,
+        explorerTarget,
+      );
       const powerShellPath = `${process.env.SYSTEMROOT ?? "C:\\Windows"}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
       NodeChildProcess.execFileSync(
         powerShellPath,
@@ -290,7 +296,7 @@ it.skipIf(process.platform !== "win32")(
       }
       await sleep(200);
       const recorded = NodeFS.readFileSync(outputPath, "utf8").trim();
-      assert.equal(recorded, `/select,"${target}"`);
+      assert.equal(recorded, `/select,"${explorerTarget}"`);
     } finally {
       NodeFS.rmSync(tempDir, { recursive: true, force: true });
     }

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -609,6 +609,10 @@ function fileExplorerRevealLaunch(
   };
 }
 
+function normalizeWindowsFileManagerPath(target: string): string {
+  return target.replaceAll("/", "\\");
+}
+
 const resolveFileManagerRevealLaunch = Effect.fn("resolveFileManagerRevealLaunch")(function* (
   target: string,
   platform: NodeJS.Platform,
@@ -626,7 +630,11 @@ const resolveFileManagerRevealLaunch = Effect.fn("resolveFileManagerRevealLaunch
   }
 
   if (platform === "win32") {
-    return fileExplorerRevealLaunch(target, target, resolvePowerShellPath(env));
+    return fileExplorerRevealLaunch(
+      target,
+      normalizeWindowsFileManagerPath(target),
+      resolvePowerShellPath(env),
+    );
   }
 
   if (


### PR DESCRIPTION
## What Changed

Normalize slash-separated Windows file paths before passing them to File Explorer's `/select` switch. The launcher keeps the original target for reporting while sending Explorer a native backslash path.

The Windows launcher regression test now starts from the same forward-slash path shape produced by web file links and verifies the PowerShell process chain receives a valid Explorer selection argument.

## Why

Chat file chips resolve Windows paths as `C:/...`. File Explorer interprets forward slashes inside `/select` as switches and silently ignores the requested selection, even though the detached launcher reports success.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No visual UI changes
- [x] No animation or motion changes

Verification:
- `vp test run apps/server/src/process/externalLauncher.test.ts` (22 passed)
- `vp lint --report-unused-disable-directives apps/server/src/process/externalLauncher.ts apps/server/src/process/externalLauncher.test.ts`
- `vp run --filter t3 typecheck`
- `vp fmt --check apps/server/src/process/externalLauncher.ts apps/server/src/process/externalLauncher.test.ts`

Implemented with GPT-5.6 Sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to Windows file reveal argument formatting with targeted tests; no auth, data, or API surface changes.
> 
> **Overview**
> **Windows file-manager reveal** now converts forward-slash paths (e.g. from chat file links as `C:/...`) to backslashes before building Explorer’s `/select` PowerShell argument. The **reported `target` stays unchanged**; only the path passed to `explorer.exe` is normalized.
> 
> Tests were updated to **drive reveal with `C:/...` paths** and assert the encoded PowerShell command and smoke-test recorder see **`C:\...`** in `/select,"<path>"`, matching the web-link path shape on Windows hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ccda10854b652be609985fccbc50addf62e7daa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `resolveFileManagerRevealLaunch` to normalize Windows paths for Explorer
> Windows File Explorer requires backslash-separated paths, but web file links supply forward slashes. The new `normalizeWindowsFileManagerPath` utility in [externalLauncher.ts](https://github.com/pingdotgg/t3code/pull/9551/files#diff-157ca66b5181820e0a628ef443d244577cda2329dd1d88fe5f2aff441da05e56) converts the target before passing it to the Explorer reveal builder, while the launch record preserves the original path. Tests in [externalLauncher.test.ts](https://github.com/pingdotgg/t3code/pull/9551/files#diff-f9009ae89a140555a41340a33170f91688ae528ad831d3e5f016056b18fa8024) now exercise forward-slash input and assert backslash output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ccda10.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->