### PR TITLE
fix(antigravity): preserve discovered workspace skills across session updates

### DIFF
--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -204,11 +204,17 @@ export function useComposerCommandMenu({
     readonly key: string;
     readonly timeout: ReturnType<typeof setTimeout>;
   } | null>(null);
+  const workspaceRefreshMissingRetryKeyRef = useRef<string | null>(null);
   const [workspaceRefreshRetryVersion, setWorkspaceRefreshRetryVersion] = useState(0);
+  const hasPendingWorkspaceSkillDiscovery = Boolean(
+    selectedProviderStatus &&
+    hasPendingProviderWorkspaceSkillDiscovery(selectedProviderStatus, projectCwd),
+  );
   const hasCompleteWorkspaceSnapshotRef = useRef(hasCompleteWorkspaceSnapshot);
   useEffect(() => {
     hasCompleteWorkspaceSnapshotRef.current = hasCompleteWorkspaceSnapshot;
     workspaceRefreshAttemptKeyRef.current = null;
+    workspaceRefreshMissingRetryKeyRef.current = null;
     if (hasCompleteWorkspaceSnapshot && workspaceRefreshRetryTimerRef.current !== null) {
       clearTimeout(workspaceRefreshRetryTimerRef.current.timeout);
       workspaceRefreshRetryTimerRef.current = null;
@@ -216,6 +222,9 @@ export function useComposerCommandMenu({
   }, [hasCompleteWorkspaceSnapshot]);
   useEffect(() => {
     const key = workspaceRefreshKey;
+    if (workspaceRefreshMissingRetryKeyRef.current !== key) {
+      workspaceRefreshMissingRetryKeyRef.current = null;
+    }
     return () => {
       if (workspaceRefreshRetryTimerRef.current?.key === key) {
         clearTimeout(workspaceRefreshRetryTimerRef.current.timeout);
@@ -235,12 +244,11 @@ export function useComposerCommandMenu({
     const key = workspaceRefreshKey;
     if (hasCompleteWorkspaceSnapshot) return;
     const attemptKey = `${key}:${workspaceRefreshRetryVersion}`;
-    if (workspaceRefreshAttemptKeyRef.current === attemptKey) return;
-    workspaceRefreshAttemptKeyRef.current = attemptKey;
     const retryLater = () => {
       if (
         workspaceRefreshAttemptKeyRef.current !== attemptKey ||
-        hasCompleteWorkspaceSnapshotRef.current
+        hasCompleteWorkspaceSnapshotRef.current ||
+        workspaceRefreshRetryTimerRef.current !== null
       ) {
         return;
       }
@@ -256,30 +264,61 @@ export function useComposerCommandMenu({
       }, WORKSPACE_SNAPSHOT_RETRY_COOLDOWN_MS);
       workspaceRefreshRetryTimerRef.current = { key, timeout };
     };
+    const retryMissingSnapshotOnce = (canRetry: boolean) => {
+      if (
+        !canRetry ||
+        workspaceRefreshAttemptKeyRef.current !== attemptKey ||
+        workspaceRefreshMissingRetryKeyRef.current === key
+      ) {
+        return;
+      }
+      workspaceRefreshMissingRetryKeyRef.current = key;
+      retryLater();
+    };
+    const retryAfterFailedRefresh = () => {
+      if (hasPendingWorkspaceSkillDiscovery) {
+        retryLater();
+        return;
+      }
+      retryMissingSnapshotOnce(selectedProviderStatus?.status !== "error");
+    };
+    if (workspaceRefreshAttemptKeyRef.current === attemptKey) {
+      if (hasPendingWorkspaceSkillDiscovery) retryLater();
+      return;
+    }
+    workspaceRefreshAttemptKeyRef.current = attemptKey;
     void refreshProviders({
       environmentId,
       input: { instanceId: selectedProviderInstanceId, cwd: projectCwd },
-    }).then(
-      (result) => {
-        const discoveryPending =
-          result._tag === "Success" &&
-          result.value.providers.some(
-            (provider) =>
-              provider.instanceId === selectedProviderInstanceId &&
-              hasPendingProviderWorkspaceSkillDiscovery(provider, projectCwd),
-          );
-        if (discoveryPending && workspaceRefreshAttemptKeyRef.current === attemptKey) {
-          retryLater();
-        }
-      },
-      () => undefined,
-    );
+    }).then((result) => {
+      if (result._tag !== "Success") {
+        retryAfterFailedRefresh();
+        return;
+      }
+      const refreshedProvider = result.value.providers.find(
+        (provider) => provider.instanceId === selectedProviderInstanceId,
+      );
+      if (
+        refreshedProvider &&
+        hasPendingProviderWorkspaceSkillDiscovery(refreshedProvider, projectCwd)
+      ) {
+        retryLater();
+        return;
+      }
+      retryMissingSnapshotOnce(
+        refreshedProvider?.status !== "error" &&
+          (!refreshedProvider ||
+            !hasCompleteProviderWorkspaceSnapshot(refreshedProvider, projectCwd)),
+      );
+    }, retryAfterFailedRefresh);
   }, [
     environmentId,
     hasCompleteWorkspaceSnapshot,
+    hasPendingWorkspaceSkillDiscovery,
     projectCwd,
     refreshProviders,
     selectedProviderInstanceId,
+    selectedProviderStatus,
     workspaceRefreshKey,
     workspaceRefreshRetryVersion,
   ]);

--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -14,6 +14,7 @@ import {
   dedupeProviderSkillsByName,
   getProviderSkillsForSlashMenu,
   hasCompleteProviderWorkspaceSnapshot,
+  hasPendingProviderWorkspaceSkillDiscovery,
   isProviderSkillUserInvocable,
   resolveProviderSkillsForCwd,
 } from "@t3tools/client-runtime/providerSkills";
@@ -198,22 +199,30 @@ export function useComposerCommandMenu({
     selectedProviderStatus &&
     hasCompleteProviderWorkspaceSnapshot(selectedProviderStatus, projectCwd),
   );
-  const workspaceRefreshKeyRef = useRef<string | null>(null);
-  const workspaceRefreshRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const workspaceRefreshAttemptKeyRef = useRef<string | null>(null);
+  const workspaceRefreshRetryTimerRef = useRef<{
+    readonly key: string;
+    readonly timeout: ReturnType<typeof setTimeout>;
+  } | null>(null);
   const [workspaceRefreshRetryVersion, setWorkspaceRefreshRetryVersion] = useState(0);
   const hasCompleteWorkspaceSnapshotRef = useRef(hasCompleteWorkspaceSnapshot);
   useEffect(() => {
     hasCompleteWorkspaceSnapshotRef.current = hasCompleteWorkspaceSnapshot;
+    workspaceRefreshAttemptKeyRef.current = null;
+    if (hasCompleteWorkspaceSnapshot && workspaceRefreshRetryTimerRef.current !== null) {
+      clearTimeout(workspaceRefreshRetryTimerRef.current.timeout);
+      workspaceRefreshRetryTimerRef.current = null;
+    }
   }, [hasCompleteWorkspaceSnapshot]);
   useEffect(() => {
-    workspaceRefreshKeyRef.current = null;
+    const key = workspaceRefreshKey;
     return () => {
-      if (workspaceRefreshRetryTimerRef.current !== null) {
-        clearTimeout(workspaceRefreshRetryTimerRef.current);
+      if (workspaceRefreshRetryTimerRef.current?.key === key) {
+        clearTimeout(workspaceRefreshRetryTimerRef.current.timeout);
         workspaceRefreshRetryTimerRef.current = null;
       }
     };
-  }, [hasCompleteWorkspaceSnapshot, workspaceRefreshKey]);
+  }, [workspaceRefreshKey]);
   useEffect(() => {
     if (
       !environmentId ||
@@ -224,42 +233,48 @@ export function useComposerCommandMenu({
       return;
     }
     const key = workspaceRefreshKey;
-    if (hasCompleteWorkspaceSnapshot) {
-      workspaceRefreshKeyRef.current = key;
-      return;
-    }
-    if (workspaceRefreshKeyRef.current === key) return;
-    workspaceRefreshKeyRef.current = key;
+    if (hasCompleteWorkspaceSnapshot) return;
+    const attemptKey = `${key}:${workspaceRefreshRetryVersion}`;
+    if (workspaceRefreshAttemptKeyRef.current === attemptKey) return;
+    workspaceRefreshAttemptKeyRef.current = attemptKey;
     const retryLater = () => {
-      if (workspaceRefreshKeyRef.current !== key || hasCompleteWorkspaceSnapshotRef.current) {
+      if (
+        workspaceRefreshAttemptKeyRef.current !== attemptKey ||
+        hasCompleteWorkspaceSnapshotRef.current
+      ) {
         return;
       }
-      workspaceRefreshRetryTimerRef.current = setTimeout(() => {
+      const timeout = setTimeout(() => {
         workspaceRefreshRetryTimerRef.current = null;
-        if (workspaceRefreshKeyRef.current !== key || hasCompleteWorkspaceSnapshotRef.current) {
+        if (
+          workspaceRefreshAttemptKeyRef.current !== attemptKey ||
+          hasCompleteWorkspaceSnapshotRef.current
+        ) {
           return;
         }
-        workspaceRefreshKeyRef.current = null;
         setWorkspaceRefreshRetryVersion((version) => version + 1);
       }, WORKSPACE_SNAPSHOT_RETRY_COOLDOWN_MS);
+      workspaceRefreshRetryTimerRef.current = { key, timeout };
     };
     void refreshProviders({
       environmentId,
       input: { instanceId: selectedProviderInstanceId, cwd: projectCwd },
-    }).then((result) => {
-      const refreshCompleted =
-        result._tag === "Success" &&
-        result.value.providers.some(
-          (provider) =>
-            provider.instanceId === selectedProviderInstanceId &&
-            hasCompleteProviderWorkspaceSnapshot(provider, projectCwd),
-        );
-      if (!refreshCompleted && workspaceRefreshKeyRef.current === key) {
-        retryLater();
-      }
-    }, retryLater);
+    }).then(
+      (result) => {
+        const discoveryPending =
+          result._tag === "Success" &&
+          result.value.providers.some(
+            (provider) =>
+              provider.instanceId === selectedProviderInstanceId &&
+              hasPendingProviderWorkspaceSkillDiscovery(provider, projectCwd),
+          );
+        if (discoveryPending && workspaceRefreshAttemptKeyRef.current === attemptKey) {
+          retryLater();
+        }
+      },
+      () => undefined,
+    );
   }, [
-    draftMessage,
     environmentId,
     hasCompleteWorkspaceSnapshot,
     projectCwd,

--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -190,39 +190,58 @@ export function useComposerCommandMenu({
     reportFailure: false,
   });
   const selectedProviderInstanceId = selectedProviderStatus?.instanceId;
+  const workspaceRefreshKey =
+    environmentId && projectCwd && selectedProviderInstanceId
+      ? `${environmentId}:${selectedProviderInstanceId}:${projectCwd}`
+      : null;
   const hasCompleteWorkspaceSnapshot = Boolean(
     selectedProviderStatus &&
     hasCompleteProviderWorkspaceSnapshot(selectedProviderStatus, projectCwd),
   );
   const workspaceRefreshKeyRef = useRef<string | null>(null);
-  const workspaceRefreshRetryRef = useRef<{ key: string; notBefore: number } | null>(null);
-  const hadCompleteWorkspaceSnapshotRef = useRef(false);
+  const workspaceRefreshRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [workspaceRefreshRetryVersion, setWorkspaceRefreshRetryVersion] = useState(0);
+  const hasCompleteWorkspaceSnapshotRef = useRef(hasCompleteWorkspaceSnapshot);
   useEffect(() => {
-    if (hadCompleteWorkspaceSnapshotRef.current && !hasCompleteWorkspaceSnapshot) {
-      workspaceRefreshKeyRef.current = null;
-      workspaceRefreshRetryRef.current = null;
-    }
-    hadCompleteWorkspaceSnapshotRef.current = hasCompleteWorkspaceSnapshot;
+    hasCompleteWorkspaceSnapshotRef.current = hasCompleteWorkspaceSnapshot;
   }, [hasCompleteWorkspaceSnapshot]);
   useEffect(() => {
-    if (!environmentId || !projectCwd || !selectedProviderInstanceId) return;
-    const key = `${environmentId}:${selectedProviderInstanceId}:${projectCwd}`;
-    if (workspaceRefreshKeyRef.current === key) return;
-    if (hasCompleteWorkspaceSnapshot) {
-      workspaceRefreshKeyRef.current = key;
-      workspaceRefreshRetryRef.current = null;
+    workspaceRefreshKeyRef.current = null;
+    return () => {
+      if (workspaceRefreshRetryTimerRef.current !== null) {
+        clearTimeout(workspaceRefreshRetryTimerRef.current);
+        workspaceRefreshRetryTimerRef.current = null;
+      }
+    };
+  }, [hasCompleteWorkspaceSnapshot, workspaceRefreshKey]);
+  useEffect(() => {
+    if (
+      !environmentId ||
+      !projectCwd ||
+      !selectedProviderInstanceId ||
+      workspaceRefreshKey === null
+    ) {
       return;
     }
-    const retry = workspaceRefreshRetryRef.current;
-    if (retry?.key === key && Date.now() < retry.notBefore) return;
+    const key = workspaceRefreshKey;
+    if (hasCompleteWorkspaceSnapshot) {
+      workspaceRefreshKeyRef.current = key;
+      return;
+    }
+    if (workspaceRefreshKeyRef.current === key) return;
     workspaceRefreshKeyRef.current = key;
     const retryLater = () => {
-      if (workspaceRefreshKeyRef.current !== key) return;
-      workspaceRefreshKeyRef.current = null;
-      workspaceRefreshRetryRef.current = {
-        key,
-        notBefore: Date.now() + WORKSPACE_SNAPSHOT_RETRY_COOLDOWN_MS,
-      };
+      if (workspaceRefreshKeyRef.current !== key || hasCompleteWorkspaceSnapshotRef.current) {
+        return;
+      }
+      workspaceRefreshRetryTimerRef.current = setTimeout(() => {
+        workspaceRefreshRetryTimerRef.current = null;
+        if (workspaceRefreshKeyRef.current !== key || hasCompleteWorkspaceSnapshotRef.current) {
+          return;
+        }
+        workspaceRefreshKeyRef.current = null;
+        setWorkspaceRefreshRetryVersion((version) => version + 1);
+      }, WORKSPACE_SNAPSHOT_RETRY_COOLDOWN_MS);
     };
     void refreshProviders({
       environmentId,
@@ -246,6 +265,8 @@ export function useComposerCommandMenu({
     projectCwd,
     refreshProviders,
     selectedProviderInstanceId,
+    workspaceRefreshKey,
+    workspaceRefreshRetryVersion,
   ]);
 
   const trigger = useMemo(() => {

--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -13,6 +13,7 @@ import {
 import {
   dedupeProviderSkillsByName,
   getProviderSkillsForSlashMenu,
+  hasCompleteProviderWorkspaceSnapshot,
   isProviderSkillUserInvocable,
   resolveProviderSkillsForCwd,
 } from "@t3tools/client-runtime/providerSkills";
@@ -189,25 +190,25 @@ export function useComposerCommandMenu({
     reportFailure: false,
   });
   const selectedProviderInstanceId = selectedProviderStatus?.instanceId;
-  const hasWorkspaceSnapshot = Boolean(
-    projectCwd &&
-    selectedProviderStatus?.workspaceSnapshots?.some((snapshot) => snapshot.cwd === projectCwd),
+  const hasCompleteWorkspaceSnapshot = Boolean(
+    selectedProviderStatus &&
+    hasCompleteProviderWorkspaceSnapshot(selectedProviderStatus, projectCwd),
   );
   const workspaceRefreshKeyRef = useRef<string | null>(null);
   const workspaceRefreshRetryRef = useRef<{ key: string; notBefore: number } | null>(null);
-  const hadWorkspaceSnapshotRef = useRef(false);
+  const hadCompleteWorkspaceSnapshotRef = useRef(false);
   useEffect(() => {
-    if (hadWorkspaceSnapshotRef.current && !hasWorkspaceSnapshot) {
+    if (hadCompleteWorkspaceSnapshotRef.current && !hasCompleteWorkspaceSnapshot) {
       workspaceRefreshKeyRef.current = null;
       workspaceRefreshRetryRef.current = null;
     }
-    hadWorkspaceSnapshotRef.current = hasWorkspaceSnapshot;
-  }, [hasWorkspaceSnapshot]);
+    hadCompleteWorkspaceSnapshotRef.current = hasCompleteWorkspaceSnapshot;
+  }, [hasCompleteWorkspaceSnapshot]);
   useEffect(() => {
     if (!environmentId || !projectCwd || !selectedProviderInstanceId) return;
     const key = `${environmentId}:${selectedProviderInstanceId}:${projectCwd}`;
     if (workspaceRefreshKeyRef.current === key) return;
-    if (hasWorkspaceSnapshot) {
+    if (hasCompleteWorkspaceSnapshot) {
       workspaceRefreshKeyRef.current = key;
       workspaceRefreshRetryRef.current = null;
       return;
@@ -227,19 +228,21 @@ export function useComposerCommandMenu({
       environmentId,
       input: { instanceId: selectedProviderInstanceId, cwd: projectCwd },
     }).then((result) => {
-      const refreshed =
+      const refreshCompleted =
         result._tag === "Success" &&
-        result.value.providers
-          .find((provider) => provider.instanceId === selectedProviderInstanceId)
-          ?.workspaceSnapshots?.some((snapshot) => snapshot.cwd === projectCwd);
-      if (!refreshed && workspaceRefreshKeyRef.current === key) {
+        result.value.providers.some(
+          (provider) =>
+            provider.instanceId === selectedProviderInstanceId &&
+            hasCompleteProviderWorkspaceSnapshot(provider, projectCwd),
+        );
+      if (!refreshCompleted && workspaceRefreshKeyRef.current === key) {
         retryLater();
       }
     }, retryLater);
   }, [
     draftMessage,
     environmentId,
-    hasWorkspaceSnapshot,
+    hasCompleteWorkspaceSnapshot,
     projectCwd,
     refreshProviders,
     selectedProviderInstanceId,

--- a/apps/server/src/provider/Layers/AntigravityProvider.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.test.ts
@@ -426,6 +426,14 @@ it.layer(testLayer)("Antigravity provider snapshots", (it) => {
       Effect.gen(function* () {
         const harness = yield* makeHarness();
         yield* harness.initialize;
+        yield* harness.provider.snapshotForCwd("/workspace", [
+          {
+            name: "deploy",
+            description: "Ship it",
+            path: "/workspace/.agent/skills/deploy",
+            enabled: true,
+          },
+        ]);
         yield* harness.provider.onSessionStarted(started, "/workspace");
         yield* harness.provider.onAvailableCommands(commands, "/workspace");
         yield* Ref.set(
@@ -521,6 +529,14 @@ it.layer(testLayer)("Antigravity provider snapshots", (it) => {
           },
         ];
         for (const { error, installed } of failures) {
+          yield* harness.provider.snapshotForCwd("/workspace", [
+            {
+              name: "deploy",
+              description: "Ship it",
+              path: "/workspace/.agent/skills/deploy",
+              enabled: true,
+            },
+          ]);
           yield* harness.provider.onSessionStarted(started, "/workspace");
           yield* harness.provider.onAvailableCommands(commands, "/workspace");
           yield* Ref.set(harness.probe, Effect.fail(error));
@@ -624,6 +640,10 @@ it.layer(testLayer)("Antigravity provider snapshots", (it) => {
           ];
           yield* harness.provider.onSessionStarted(started, "/workspace");
           yield* harness.provider.onAvailableCommands(commands, "/workspace");
+          const beforeDiscovery = yield* harness.provider.snapshot.getSnapshot;
+          expect(
+            beforeDiscovery.workspaceSnapshots?.find((entry) => entry.cwd === "/workspace"),
+          ).toBeUndefined();
           const discovered = yield* harness.provider.snapshotForCwd("/workspace", skills);
           expect(discovered.skills).toEqual(skills);
           const snapshot = yield* harness.provider.snapshot.getSnapshot;
@@ -638,6 +658,41 @@ it.layer(testLayer)("Antigravity provider snapshots", (it) => {
           ).toEqual(skills);
         }),
       ),
+  );
+
+  it.effect("does not retain empty skill discoveries as workspace snapshots", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const harness = yield* makeHarness();
+        yield* harness.initialize;
+        const emptySnapshot = yield* harness.provider.snapshotForCwd("/empty", []);
+        expect(emptySnapshot.skills).toEqual([]);
+        expect(
+          emptySnapshot.workspaceSnapshots?.find((entry) => entry.cwd === "/empty"),
+        ).toBeUndefined();
+        yield* harness.provider.onAvailableCommands(commands, "/empty");
+        const afterCommands = yield* harness.provider.snapshot.getSnapshot;
+        expect(
+          afterCommands.workspaceSnapshots?.find((entry) => entry.cwd === "/empty"),
+        ).toBeUndefined();
+
+        const skills = [
+          {
+            name: "deploy",
+            description: "Ship it",
+            path: "/workspace/.agent/skills/deploy",
+            enabled: true,
+          },
+        ];
+        yield* harness.provider.snapshotForCwd("/workspace", skills);
+        yield* harness.provider.onAvailableCommands(commands, "/workspace");
+        yield* harness.provider.snapshotForCwd("/workspace", []);
+        const existing = yield* harness.provider.snapshot.getSnapshot;
+        expect(
+          existing.workspaceSnapshots?.find((entry) => entry.cwd === "/workspace"),
+        ).toMatchObject({ slashCommands: commands, skills: [] });
+      }),
+    ),
   );
 
   it.effect("does not register empty workspace snapshots on session start before discovery", () =>
@@ -660,8 +715,16 @@ it.layer(testLayer)("Antigravity provider snapshots", (it) => {
         const harness = yield* makeHarness();
         yield* harness.initialize;
         yield* harness.provider.onSessionStarted(started);
+        yield* harness.provider.onAvailableCommands(commands);
         for (let index = 0; index < 35; index++) {
-          yield* harness.provider.onAvailableCommands(commands, `/workspace-${index}`);
+          yield* harness.provider.snapshotForCwd(`/workspace-${index}`, [
+            {
+              name: "deploy",
+              description: "Ship it",
+              path: `/workspace-${index}/.agent/skills/deploy`,
+              enabled: true,
+            },
+          ]);
         }
         const snapshot = yield* harness.provider.snapshotForCwd("/workspace-34");
         expect(snapshot.workspaceSnapshots).toHaveLength(32);

--- a/apps/server/src/provider/Layers/AntigravityProvider.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.test.ts
@@ -607,6 +607,53 @@ it.layer(testLayer)("Antigravity provider snapshots", (it) => {
     ),
   );
 
+  it.effect(
+    "does not let premature session startup or command updates hide later discovered skills",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const harness = yield* makeHarness();
+          yield* harness.initialize;
+          const skills = [
+            {
+              name: "deploy",
+              description: "Ship it",
+              path: "/workspace/.agent/skills/deploy",
+              enabled: true,
+            },
+          ];
+          yield* harness.provider.onSessionStarted(started, "/workspace");
+          yield* harness.provider.onAvailableCommands(commands, "/workspace");
+          const discovered = yield* harness.provider.snapshotForCwd("/workspace", skills);
+          expect(discovered.skills).toEqual(skills);
+          const snapshot = yield* harness.provider.snapshot.getSnapshot;
+          expect(
+            snapshot.workspaceSnapshots?.find((entry) => entry.cwd === "/workspace")?.skills,
+          ).toEqual(skills);
+          expect((yield* harness.provider.snapshotForCwd("/workspace")).skills).toEqual(skills);
+          yield* harness.provider.onAvailableCommands(commands, "/workspace");
+          const afterCommands = yield* harness.provider.snapshot.getSnapshot;
+          expect(
+            afterCommands.workspaceSnapshots?.find((entry) => entry.cwd === "/workspace")?.skills,
+          ).toEqual(skills);
+        }),
+      ),
+  );
+
+  it.effect("does not register empty workspace snapshots on session start before discovery", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const harness = yield* makeHarness();
+        yield* harness.initialize;
+        yield* harness.provider.onSessionStarted(started, "/unscanned");
+        const snapshot = yield* harness.provider.snapshot.getSnapshot;
+        expect(
+          snapshot.workspaceSnapshots?.find((entry) => entry.cwd === "/unscanned"),
+        ).toBeUndefined();
+      }),
+    ),
+  );
+
   it.effect("bounds workspace metadata without starting sessions for workspace lookup", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/AntigravityProvider.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.test.ts
@@ -643,13 +643,24 @@ it.layer(testLayer)("Antigravity provider snapshots", (it) => {
           const beforeDiscovery = yield* harness.provider.snapshot.getSnapshot;
           expect(
             beforeDiscovery.workspaceSnapshots?.find((entry) => entry.cwd === "/workspace"),
-          ).toBeUndefined();
+          ).toMatchObject({
+            slashCommands: commands,
+            skills: [],
+            skillsDiscoveryPending: true,
+          });
+          const otherCommands = [{ name: "review", description: "Review changes" }];
+          yield* harness.provider.onAvailableCommands(otherCommands, "/other-workspace");
+          const afterOtherWorkspace = yield* harness.provider.snapshot.getSnapshot;
+          expect(
+            afterOtherWorkspace.workspaceSnapshots?.find((entry) => entry.cwd === "/workspace")
+              ?.slashCommands,
+          ).toEqual(commands);
           const discovered = yield* harness.provider.snapshotForCwd("/workspace", skills);
           expect(discovered.skills).toEqual(skills);
           const snapshot = yield* harness.provider.snapshot.getSnapshot;
           expect(
-            snapshot.workspaceSnapshots?.find((entry) => entry.cwd === "/workspace")?.skills,
-          ).toEqual(skills);
+            snapshot.workspaceSnapshots?.find((entry) => entry.cwd === "/workspace"),
+          ).toMatchObject({ skills, skillsDiscoveryPending: false });
           expect((yield* harness.provider.snapshotForCwd("/workspace")).skills).toEqual(skills);
           yield* harness.provider.onAvailableCommands(commands, "/workspace");
           const afterCommands = yield* harness.provider.snapshot.getSnapshot;
@@ -660,7 +671,7 @@ it.layer(testLayer)("Antigravity provider snapshots", (it) => {
       ),
   );
 
-  it.effect("does not retain empty skill discoveries as workspace snapshots", () =>
+  it.effect("keeps empty skill discoveries retryable while preserving workspace commands", () =>
     Effect.scoped(
       Effect.gen(function* () {
         const harness = yield* makeHarness();
@@ -674,7 +685,11 @@ it.layer(testLayer)("Antigravity provider snapshots", (it) => {
         const afterCommands = yield* harness.provider.snapshot.getSnapshot;
         expect(
           afterCommands.workspaceSnapshots?.find((entry) => entry.cwd === "/empty"),
-        ).toBeUndefined();
+        ).toMatchObject({
+          slashCommands: commands,
+          skills: [],
+          skillsDiscoveryPending: true,
+        });
 
         const skills = [
           {
@@ -690,7 +705,11 @@ it.layer(testLayer)("Antigravity provider snapshots", (it) => {
         const existing = yield* harness.provider.snapshot.getSnapshot;
         expect(
           existing.workspaceSnapshots?.find((entry) => entry.cwd === "/workspace"),
-        ).toMatchObject({ slashCommands: commands, skills: [] });
+        ).toMatchObject({
+          slashCommands: commands,
+          skills: [],
+          skillsDiscoveryPending: true,
+        });
       }),
     ),
   );

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -269,6 +269,8 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
       const { message: _previousMessage, ...draft } = state.draft;
       const workspaces = draft.workspaceSnapshots ?? [];
       const workspace = cwd ? workspaces.find((entry) => entry.cwd === cwd) : undefined;
+      const shouldIncludeWorkspace =
+        cwd !== undefined && (workspace !== undefined || discoveredSkills.has(cwd));
       return {
         authRevision: state.authRevision + 1,
         draft: {
@@ -284,7 +286,7 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
           checkedAt: updatedAt,
           models: buildAntigravityModelsFromSession(started.sessionSetupResult),
           supportsTextGeneration,
-          ...(cwd
+          ...(shouldIncludeWorkspace
             ? {
                 workspaceSnapshots: [
                   ...workspaces.filter((entry) => entry.cwd !== cwd),
@@ -292,7 +294,7 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
                     cwd,
                     checkedAt: updatedAt,
                     slashCommands: workspace?.slashCommands ?? draft.slashCommands,
-                    skills: workspace?.skills ?? discoveredSkills.get(cwd) ?? [],
+                    skills: discoveredSkills.get(cwd) ?? workspace?.skills ?? [],
                   },
                 ].slice(-MAX_WORKSPACE_SNAPSHOTS),
               }
@@ -320,6 +322,9 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
     const updatedAt = DateTime.formatIso(yield* DateTime.now);
     yield* SubscriptionRef.update(metadata, (state) => {
       if (state.draft.auth.status === "unauthenticated") return state;
+      const existing = cwd
+        ? state.draft.workspaceSnapshots?.find((entry) => entry.cwd === cwd)
+        : undefined;
       return {
         ...state,
         draft: {
@@ -333,10 +338,7 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
                     cwd,
                     checkedAt: updatedAt,
                     slashCommands,
-                    skills:
-                      state.draft.workspaceSnapshots?.find((entry) => entry.cwd === cwd)?.skills ??
-                      discoveredSkills.get(cwd) ??
-                      [],
+                    skills: discoveredSkills.get(cwd) ?? existing?.skills ?? [],
                   },
                 ].slice(-MAX_WORKSPACE_SNAPSHOTS),
               }
@@ -374,10 +376,36 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
     cwd: string,
     skills?: ServerProvider["skills"],
   ) {
-    if (skills) discoveredSkills.set(cwd, skills);
+    if (skills) {
+      discoveredSkills.set(cwd, skills);
+      const updatedAt = DateTime.formatIso(yield* DateTime.now);
+      yield* SubscriptionRef.update(metadata, (state) => {
+        const existing = state.draft.workspaceSnapshots ?? [];
+        const match = existing.find((entry) => entry.cwd === cwd);
+        return {
+          ...state,
+          draft: {
+            ...state.draft,
+            workspaceSnapshots: match
+              ? existing.map((entry) =>
+                  entry.cwd === cwd ? { ...entry, skills, checkedAt: updatedAt } : entry,
+                )
+              : [
+                  ...existing,
+                  {
+                    cwd,
+                    checkedAt: updatedAt,
+                    slashCommands: state.draft.slashCommands,
+                    skills,
+                  },
+                ].slice(-MAX_WORKSPACE_SNAPSHOTS),
+          },
+        };
+      });
+    }
     const snapshot = yield* getSnapshot;
     const workspace = snapshot.workspaceSnapshots?.find((entry) => entry.cwd === cwd);
-    const resolvedSkills = skills ?? workspace?.skills ?? discoveredSkills.get(cwd) ?? [];
+    const resolvedSkills = skills ?? discoveredSkills.get(cwd) ?? workspace?.skills ?? [];
     return workspace
       ? { ...snapshot, slashCommands: workspace.slashCommands, skills: resolvedSkills }
       : { ...snapshot, skills: resolvedSkills };

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -325,12 +325,14 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
       const existing = cwd
         ? state.draft.workspaceSnapshots?.find((entry) => entry.cwd === cwd)
         : undefined;
+      const shouldIncludeWorkspace =
+        cwd !== undefined && (existing !== undefined || discoveredSkills.has(cwd));
       return {
         ...state,
         draft: {
           ...state.draft,
           slashCommands,
-          ...(cwd
+          ...(shouldIncludeWorkspace
             ? {
                 workspaceSnapshots: [
                   ...(state.draft.workspaceSnapshots ?? []).filter((entry) => entry.cwd !== cwd),
@@ -376,12 +378,17 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
     cwd: string,
     skills?: ServerProvider["skills"],
   ) {
-    if (skills) {
-      discoveredSkills.set(cwd, skills);
+    if (skills !== undefined) {
+      if (skills.length > 0) {
+        discoveredSkills.set(cwd, skills);
+      } else {
+        discoveredSkills.delete(cwd);
+      }
       const updatedAt = DateTime.formatIso(yield* DateTime.now);
       yield* SubscriptionRef.update(metadata, (state) => {
         const existing = state.draft.workspaceSnapshots ?? [];
         const match = existing.find((entry) => entry.cwd === cwd);
+        if (match === undefined && skills.length === 0) return state;
         return {
           ...state,
           draft: {

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -295,6 +295,7 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
                     checkedAt: updatedAt,
                     slashCommands: workspace?.slashCommands ?? draft.slashCommands,
                     skills: discoveredSkills.get(cwd) ?? workspace?.skills ?? [],
+                    skillsDiscoveryPending: !discoveredSkills.has(cwd),
                   },
                 ].slice(-MAX_WORKSPACE_SNAPSHOTS),
               }
@@ -325,14 +326,12 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
       const existing = cwd
         ? state.draft.workspaceSnapshots?.find((entry) => entry.cwd === cwd)
         : undefined;
-      const shouldIncludeWorkspace =
-        cwd !== undefined && (existing !== undefined || discoveredSkills.has(cwd));
       return {
         ...state,
         draft: {
           ...state.draft,
           slashCommands,
-          ...(shouldIncludeWorkspace
+          ...(cwd
             ? {
                 workspaceSnapshots: [
                   ...(state.draft.workspaceSnapshots ?? []).filter((entry) => entry.cwd !== cwd),
@@ -341,6 +340,7 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
                     checkedAt: updatedAt,
                     slashCommands,
                     skills: discoveredSkills.get(cwd) ?? existing?.skills ?? [],
+                    skillsDiscoveryPending: !discoveredSkills.has(cwd),
                   },
                 ].slice(-MAX_WORKSPACE_SNAPSHOTS),
               }
@@ -395,7 +395,14 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
             ...state.draft,
             workspaceSnapshots: match
               ? existing.map((entry) =>
-                  entry.cwd === cwd ? { ...entry, skills, checkedAt: updatedAt } : entry,
+                  entry.cwd === cwd
+                    ? {
+                        ...entry,
+                        skills,
+                        skillsDiscoveryPending: skills.length === 0,
+                        checkedAt: updatedAt,
+                      }
+                    : entry,
                 )
               : [
                   ...existing,
@@ -404,6 +411,7 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
                     checkedAt: updatedAt,
                     slashCommands: state.draft.slashCommands,
                     skills,
+                    skillsDiscoveryPending: false,
                   },
                 ].slice(-MAX_WORKSPACE_SNAPSHOTS),
           },

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1168,7 +1168,17 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           const emptyScopedProvider = {
             ...machineProvider,
             checkedAt: "2026-06-10T00:00:30.000Z",
-            workspaceSnapshots: [],
+            slashCommands: [{ name: "project" }],
+            skills: [],
+            workspaceSnapshots: [
+              {
+                cwd: "/workspace",
+                checkedAt: "2026-06-10T00:00:30.000Z",
+                slashCommands: [{ name: "project" }],
+                skills: [],
+                skillsDiscoveryPending: true,
+              },
+            ],
           } as const satisfies ServerProvider;
           const snapshotCalls = yield* Ref.make(0);
           const snapshotResult = yield* Ref.make<Effect.Effect<ServerProvider>>(
@@ -1255,7 +1265,10 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             assert.strictEqual((yield* registry.getProviders)[0]?.workspaceSnapshots, undefined);
             yield* Ref.set(snapshotResult, Effect.succeed(emptyScopedProvider));
             yield* registry.refreshWorkspaceSnapshot({ instanceId, cwd: "/workspace" });
-            assert.strictEqual((yield* registry.getProviders)[0]?.workspaceSnapshots, undefined);
+            assert.deepStrictEqual(
+              (yield* registry.getProviders)[0]?.workspaceSnapshots?.[0],
+              emptyScopedProvider.workspaceSnapshots[0],
+            );
             assert.strictEqual(yield* Ref.get(snapshotCalls), 2);
             yield* Ref.set(
               snapshotResult,

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1170,15 +1170,6 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             checkedAt: "2026-06-10T00:00:30.000Z",
             slashCommands: [{ name: "project" }],
             skills: [],
-            workspaceSnapshots: [
-              {
-                cwd: "/workspace",
-                checkedAt: "2026-06-10T00:00:30.000Z",
-                slashCommands: [{ name: "project" }],
-                skills: [],
-                skillsDiscoveryPending: true,
-              },
-            ],
           } as const satisfies ServerProvider;
           const snapshotCalls = yield* Ref.make(0);
           const snapshotResult = yield* Ref.make<Effect.Effect<ServerProvider>>(
@@ -1265,10 +1256,13 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             assert.strictEqual((yield* registry.getProviders)[0]?.workspaceSnapshots, undefined);
             yield* Ref.set(snapshotResult, Effect.succeed(emptyScopedProvider));
             yield* registry.refreshWorkspaceSnapshot({ instanceId, cwd: "/workspace" });
-            assert.deepStrictEqual(
-              (yield* registry.getProviders)[0]?.workspaceSnapshots?.[0],
-              emptyScopedProvider.workspaceSnapshots[0],
-            );
+            assert.deepStrictEqual((yield* registry.getProviders)[0]?.workspaceSnapshots?.[0], {
+              cwd: "/workspace",
+              checkedAt: emptyScopedProvider.checkedAt,
+              slashCommands: emptyScopedProvider.slashCommands,
+              skills: [],
+              skillsDiscoveryPending: true,
+            });
             assert.strictEqual(yield* Ref.get(snapshotCalls), 2);
             yield* registry.refreshWorkspaceSnapshot({ instanceId, cwd: "/workspace" });
             assert.strictEqual(yield* Ref.get(snapshotCalls), 2);

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1270,6 +1270,9 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               emptyScopedProvider.workspaceSnapshots[0],
             );
             assert.strictEqual(yield* Ref.get(snapshotCalls), 2);
+            yield* registry.refreshWorkspaceSnapshot({ instanceId, cwd: "/workspace" });
+            assert.strictEqual(yield* Ref.get(snapshotCalls), 2);
+            yield* TestClock.adjust("1 minute");
             yield* Ref.set(
               snapshotResult,
               Deferred.succeed(probeStarted, undefined).pipe(

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1136,7 +1136,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         }),
       );
 
-      it.effect("deduplicates cwd probes and clears snapshots when an instance rebuilds", () =>
+      it.effect("retries incomplete cwd probes and clears rebuilt snapshots", () =>
         Effect.gen(function* () {
           const driver = ProviderDriverKind.make("codex");
           const instanceId = ProviderInstanceId.make("codex");
@@ -1165,8 +1165,15 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             installed: false,
             slashCommands: [],
           } as const satisfies ServerProvider;
+          const emptyScopedProvider = {
+            ...machineProvider,
+            checkedAt: "2026-06-10T00:00:30.000Z",
+            workspaceSnapshots: [],
+          } as const satisfies ServerProvider;
           const snapshotCalls = yield* Ref.make(0);
-          const returnPendingSnapshot = yield* Ref.make(true);
+          const snapshotResult = yield* Ref.make<Effect.Effect<ServerProvider>>(
+            Effect.succeed(pendingScopedProvider),
+          );
           const probeStarted = yield* Deferred.make<void>();
           const releaseProbe = yield* Deferred.make<void>();
           const makeInstance = (
@@ -1196,13 +1203,10 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             textGeneration: {} as ProviderInstance["textGeneration"],
           });
           const firstInstance = makeInstance(machineProvider, () =>
-            Effect.gen(function* () {
-              yield* Ref.update(snapshotCalls, (count) => count + 1);
-              if (yield* Ref.get(returnPendingSnapshot)) return pendingScopedProvider;
-              yield* Deferred.succeed(probeStarted, undefined);
-              yield* Deferred.await(releaseProbe);
-              return scopedProvider;
-            }),
+            Ref.update(snapshotCalls, (count) => count + 1).pipe(
+              Effect.andThen(Ref.get(snapshotResult)),
+              Effect.flatten,
+            ),
           );
           const rebuiltProvider = {
             ...machineProvider,
@@ -1249,7 +1253,17 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             const registry = yield* ProviderRegistry.ProviderRegistry;
             yield* registry.refreshWorkspaceSnapshot({ instanceId, cwd: "/workspace" });
             assert.strictEqual((yield* registry.getProviders)[0]?.workspaceSnapshots, undefined);
-            yield* Ref.set(returnPendingSnapshot, false);
+            yield* Ref.set(snapshotResult, Effect.succeed(emptyScopedProvider));
+            yield* registry.refreshWorkspaceSnapshot({ instanceId, cwd: "/workspace" });
+            assert.strictEqual((yield* registry.getProviders)[0]?.workspaceSnapshots, undefined);
+            assert.strictEqual(yield* Ref.get(snapshotCalls), 2);
+            yield* Ref.set(
+              snapshotResult,
+              Deferred.succeed(probeStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(releaseProbe)),
+                Effect.as(scopedProvider),
+              ),
+            );
             const workspaceUpdate = yield* registry.streamChanges.pipe(
               Stream.runHead,
               Effect.forkChild,
@@ -1263,7 +1277,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               .refreshWorkspaceSnapshot({ instanceId, cwd: "/workspace" })
               .pipe(Effect.forkChild);
             yield* Effect.yieldNow;
-            assert.strictEqual(yield* Ref.get(snapshotCalls), 2);
+            assert.strictEqual(yield* Ref.get(snapshotCalls), 3);
             yield* Deferred.succeed(releaseProbe, undefined);
             yield* Fiber.join(firstRefresh);
             yield* Fiber.join(duplicateRefresh);
@@ -1276,7 +1290,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               scopedProvider.skills,
             );
             yield* registry.refreshWorkspaceSnapshot({ instanceId, cwd: "/workspace" });
-            assert.strictEqual(yield* Ref.get(snapshotCalls), 2);
+            assert.strictEqual(yield* Ref.get(snapshotCalls), 3);
 
             yield* Ref.set(instancesRef, [rebuiltInstance]);
             yield* PubSub.publish(registryChanges, undefined);

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -110,22 +110,29 @@ const shouldCacheWorkspaceSnapshot = (snapshot: ServerProvider, cwd: string): bo
   (snapshot.workspaceSnapshots === undefined ||
     snapshot.workspaceSnapshots.some((entry) => entry.cwd === cwd));
 
+const getWorkspaceSkillsDiscoveryPending = (
+  snapshot: ServerProvider,
+  cwd: string,
+): boolean | undefined => {
+  const workspaceSnapshot = snapshot.workspaceSnapshots?.find((entry) => entry.cwd === cwd);
+  if (workspaceSnapshot?.skillsDiscoveryPending !== undefined) {
+    return workspaceSnapshot.skillsDiscoveryPending;
+  }
+  return workspaceSnapshot === undefined && snapshot.skills.length === 0 ? true : undefined;
+};
+
 export function upsertProviderWorkspaceSnapshot(
   provider: ServerProvider,
   cwd: string,
   scopedSnapshot: ServerProvider,
 ): ServerProvider {
-  const scopedWorkspaceSnapshot = scopedSnapshot.workspaceSnapshots?.find(
-    (snapshot) => snapshot.cwd === cwd,
-  );
+  const skillsDiscoveryPending = getWorkspaceSkillsDiscoveryPending(scopedSnapshot, cwd);
   const workspaceSnapshot = {
     cwd,
     checkedAt: scopedSnapshot.checkedAt,
     slashCommands: scopedSnapshot.slashCommands,
     skills: scopedSnapshot.skills,
-    ...(scopedWorkspaceSnapshot?.skillsDiscoveryPending !== undefined
-      ? { skillsDiscoveryPending: scopedWorkspaceSnapshot.skillsDiscoveryPending }
-      : {}),
+    ...(skillsDiscoveryPending !== undefined ? { skillsDiscoveryPending } : {}),
   } satisfies NonNullable<ServerProvider["workspaceSnapshots"]>[number];
   return {
     ...provider,
@@ -839,13 +846,12 @@ export const ProviderRegistryLive = Layer.effect(
               }
               const currentInstance = yield* instanceRegistry.getInstance(input.instanceId);
               if (currentInstance !== instance) return yield* Ref.get(providersRef);
-              const workspaceSnapshot = scopedSnapshot.workspaceSnapshots?.find(
-                (snapshot) => snapshot.cwd === input.cwd,
+              const skillsDiscoveryPending = getWorkspaceSkillsDiscoveryPending(
+                scopedSnapshot,
+                input.cwd,
               );
               const scannedAt =
-                workspaceSnapshot?.skillsDiscoveryPending === true
-                  ? yield* Clock.currentTimeMillis
-                  : undefined;
+                skillsDiscoveryPending === true ? yield* Clock.currentTimeMillis : undefined;
               yield* Ref.update(workspaceEmptyScanTimesRef, (scans) =>
                 updateWorkspaceEmptyScanTime(scans, instance, input.cwd, scannedAt),
               );

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -80,6 +80,11 @@ const hasModelCapabilities = (model: ServerProvider["models"][number]): boolean 
 
 const MAX_WORKSPACE_SNAPSHOTS_PER_PROVIDER = 16;
 
+const shouldCacheWorkspaceSnapshot = (snapshot: ServerProvider, cwd: string): boolean =>
+  snapshot.status !== "error" &&
+  (snapshot.workspaceSnapshots === undefined ||
+    snapshot.workspaceSnapshots.some((entry) => entry.cwd === cwd));
+
 export function upsertProviderWorkspaceSnapshot(
   provider: ServerProvider,
   cwd: string,
@@ -781,7 +786,7 @@ export const ProviderRegistryLive = Layer.effect(
       if (!claimed) return yield* Ref.get(providersRef);
       return yield* instance.snapshotForCwd(input.cwd).pipe(
         Effect.flatMap((scopedSnapshot) =>
-          scopedSnapshot.status === "error"
+          !shouldCacheWorkspaceSnapshot(scopedSnapshot, input.cwd)
             ? Ref.get(providersRef)
             : instanceRegistry.getInstance(input.instanceId).pipe(
                 Effect.flatMap((currentInstance) => {

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -808,7 +808,9 @@ export const ProviderRegistryLive = Layer.effect(
         return providers;
       }
       const instance = yield* instanceRegistry.getInstance(input.instanceId);
-      if (!instance?.snapshotForCwd) return providers;
+      if (!instance) return providers;
+      const snapshotForCwd = instance.snapshotForCwd;
+      if (!snapshotForCwd) return providers;
       const claimed = yield* Ref.modify(workspaceRefreshesRef, (refreshes) => {
         const current = refreshes.get(instance);
         if (current?.has(input.cwd)) return [false, refreshes] as const;
@@ -829,7 +831,7 @@ export const ProviderRegistryLive = Layer.effect(
         ) {
           return yield* Ref.get(providersRef);
         }
-        return yield* instance.snapshotForCwd(input.cwd).pipe(
+        return yield* snapshotForCwd(input.cwd).pipe(
           Effect.flatMap((scopedSnapshot) =>
             Effect.gen(function* () {
               if (!shouldCacheWorkspaceSnapshot(scopedSnapshot, input.cwd)) {

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -30,6 +30,7 @@ import {
   type ServerProviderUpdateState,
 } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
+import * as Clock from "effect/Clock";
 import * as Effect from "effect/Effect";
 import * as Equal from "effect/Equal";
 import * as FileSystem from "effect/FileSystem";
@@ -79,6 +80,24 @@ const hasModelCapabilities = (model: ServerProvider["models"][number]): boolean 
   (model.capabilities?.optionDescriptors?.length ?? 0) > 0;
 
 const MAX_WORKSPACE_SNAPSHOTS_PER_PROVIDER = 16;
+const EMPTY_WORKSPACE_SKILL_DISCOVERY_RETRY_MS = 60_000;
+
+type WorkspaceEmptyScanTimes = ReadonlyMap<ProviderInstance, ReadonlyMap<string, number>>;
+
+const updateWorkspaceEmptyScanTime = (
+  scans: WorkspaceEmptyScanTimes,
+  instance: ProviderInstance,
+  cwd: string,
+  scannedAt: number | undefined,
+): WorkspaceEmptyScanTimes => {
+  const nextScans = new Map(scans);
+  const instanceScans = new Map(nextScans.get(instance));
+  if (scannedAt === undefined) instanceScans.delete(cwd);
+  else instanceScans.set(cwd, scannedAt);
+  if (instanceScans.size > 0) nextScans.set(instance, instanceScans);
+  else nextScans.delete(instance);
+  return nextScans;
+};
 
 const hasCompleteWorkspaceSnapshot = (provider: ServerProvider, cwd: string): boolean =>
   provider.workspaceSnapshots?.some(
@@ -335,6 +354,7 @@ export const ProviderRegistryLive = Layer.effect(
     const workspaceRefreshesRef = yield* Ref.make<
       ReadonlyMap<ProviderInstance, ReadonlySet<string>>
     >(new Map());
+    const workspaceEmptyScanTimesRef = yield* Ref.make<WorkspaceEmptyScanTimes>(new Map());
     const maintenanceActionStatesRef = yield* Ref.make<
       ReadonlyMap<ProviderInstanceId, { readonly update?: ServerProviderUpdateState | undefined }>
     >(new Map());
@@ -670,6 +690,11 @@ export const ProviderRegistryLive = Layer.effect(
           nextSubs.set(instanceId, instance);
         }
         yield* Ref.set(liveSubsRef, nextSubs);
+        const activeInstances = new Set(nextSubs.values());
+        yield* Ref.update(
+          workspaceEmptyScanTimesRef,
+          (scans) => new Map([...scans].filter(([instance]) => activeInstances.has(instance))),
+        );
 
         // Drop aggregator state for instances that have disappeared —
         // otherwise the UI would keep rendering ghosts.
@@ -792,32 +817,56 @@ export const ProviderRegistryLive = Layer.effect(
         return [true, next] as const;
       });
       if (!claimed) return yield* Ref.get(providersRef);
-      return yield* instance.snapshotForCwd(input.cwd).pipe(
-        Effect.flatMap((scopedSnapshot) =>
-          !shouldCacheWorkspaceSnapshot(scopedSnapshot, input.cwd)
-            ? Ref.get(providersRef)
-            : instanceRegistry.getInstance(input.instanceId).pipe(
-                Effect.flatMap((currentInstance) => {
-                  if (currentInstance !== instance) return Ref.get(providersRef);
-                  return Ref.modify(providersRef, (currentProviders) => {
-                    const nextProviders = currentProviders.map((candidate) =>
-                      candidate.instanceId === input.instanceId &&
-                      !hasCompleteWorkspaceSnapshot(candidate, input.cwd)
-                        ? upsertProviderWorkspaceSnapshot(candidate, input.cwd, scopedSnapshot)
-                        : candidate,
-                    );
-                    return [[currentProviders, nextProviders] as const, nextProviders];
-                  }).pipe(
-                    Effect.tap(([previousProviders, nextProviders]) =>
-                      haveProvidersChanged(previousProviders, nextProviders)
-                        ? PubSub.publish(changesPubSub, nextProviders)
-                        : Effect.void,
-                    ),
-                    Effect.map(([, nextProviders]) => nextProviders),
-                  );
-                }),
-              ),
-        ),
+      return yield* Effect.gen(function* () {
+        const now = yield* Clock.currentTimeMillis;
+        const lastEmptyScan = (yield* Ref.get(workspaceEmptyScanTimesRef))
+          .get(instance)
+          ?.get(input.cwd);
+        if (
+          lastEmptyScan !== undefined &&
+          now >= lastEmptyScan &&
+          now - lastEmptyScan < EMPTY_WORKSPACE_SKILL_DISCOVERY_RETRY_MS
+        ) {
+          return yield* Ref.get(providersRef);
+        }
+        return yield* instance.snapshotForCwd(input.cwd).pipe(
+          Effect.flatMap((scopedSnapshot) =>
+            Effect.gen(function* () {
+              if (!shouldCacheWorkspaceSnapshot(scopedSnapshot, input.cwd)) {
+                return yield* Ref.get(providersRef);
+              }
+              const currentInstance = yield* instanceRegistry.getInstance(input.instanceId);
+              if (currentInstance !== instance) return yield* Ref.get(providersRef);
+              const workspaceSnapshot = scopedSnapshot.workspaceSnapshots?.find(
+                (snapshot) => snapshot.cwd === input.cwd,
+              );
+              const scannedAt =
+                workspaceSnapshot?.skillsDiscoveryPending === true
+                  ? yield* Clock.currentTimeMillis
+                  : undefined;
+              yield* Ref.update(workspaceEmptyScanTimesRef, (scans) =>
+                updateWorkspaceEmptyScanTime(scans, instance, input.cwd, scannedAt),
+              );
+              return yield* Ref.modify(providersRef, (currentProviders) => {
+                const nextProviders = currentProviders.map((candidate) =>
+                  candidate.instanceId === input.instanceId &&
+                  !hasCompleteWorkspaceSnapshot(candidate, input.cwd)
+                    ? upsertProviderWorkspaceSnapshot(candidate, input.cwd, scopedSnapshot)
+                    : candidate,
+                );
+                return [[currentProviders, nextProviders] as const, nextProviders];
+              }).pipe(
+                Effect.tap(([previousProviders, nextProviders]) =>
+                  haveProvidersChanged(previousProviders, nextProviders)
+                    ? PubSub.publish(changesPubSub, nextProviders)
+                    : Effect.void,
+                ),
+                Effect.map(([, nextProviders]) => nextProviders),
+              );
+            }),
+          ),
+        );
+      }).pipe(
         Effect.ensuring(
           Ref.update(workspaceRefreshesRef, (refreshes) => {
             const next = new Map(refreshes);

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -80,6 +80,12 @@ const hasModelCapabilities = (model: ServerProvider["models"][number]): boolean 
 
 const MAX_WORKSPACE_SNAPSHOTS_PER_PROVIDER = 16;
 
+const hasCompleteWorkspaceSnapshot = (provider: ServerProvider, cwd: string): boolean =>
+  provider.workspaceSnapshots?.some(
+    (snapshot) => snapshot.cwd === cwd && snapshot.skillsDiscoveryPending !== true,
+  ) ?? false;
+
+/** Drivers without an explicit workspace list return cwd-scoped fields at the snapshot root. */
 const shouldCacheWorkspaceSnapshot = (snapshot: ServerProvider, cwd: string): boolean =>
   snapshot.status !== "error" &&
   (snapshot.workspaceSnapshots === undefined ||
@@ -90,11 +96,17 @@ export function upsertProviderWorkspaceSnapshot(
   cwd: string,
   scopedSnapshot: ServerProvider,
 ): ServerProvider {
+  const scopedWorkspaceSnapshot = scopedSnapshot.workspaceSnapshots?.find(
+    (snapshot) => snapshot.cwd === cwd,
+  );
   const workspaceSnapshot = {
     cwd,
     checkedAt: scopedSnapshot.checkedAt,
     slashCommands: scopedSnapshot.slashCommands,
     skills: scopedSnapshot.skills,
+    ...(scopedWorkspaceSnapshot?.skillsDiscoveryPending !== undefined
+      ? { skillsDiscoveryPending: scopedWorkspaceSnapshot.skillsDiscoveryPending }
+      : {}),
   } satisfies NonNullable<ServerProvider["workspaceSnapshots"]>[number];
   return {
     ...provider,
@@ -767,11 +779,7 @@ export const ProviderRegistryLive = Layer.effect(
     }) {
       const providers = yield* Ref.get(providersRef);
       const provider = providers.find((candidate) => candidate.instanceId === input.instanceId);
-      if (
-        !provider ||
-        !provider.enabled ||
-        provider.workspaceSnapshots?.some((s) => s.cwd === input.cwd)
-      ) {
+      if (!provider || !provider.enabled || hasCompleteWorkspaceSnapshot(provider, input.cwd)) {
         return providers;
       }
       const instance = yield* instanceRegistry.getInstance(input.instanceId);
@@ -794,7 +802,7 @@ export const ProviderRegistryLive = Layer.effect(
                   return Ref.modify(providersRef, (currentProviders) => {
                     const nextProviders = currentProviders.map((candidate) =>
                       candidate.instanceId === input.instanceId &&
-                      !candidate.workspaceSnapshots?.some((s) => s.cwd === input.cwd)
+                      !hasCompleteWorkspaceSnapshot(candidate, input.cwd)
                         ? upsertProviderWorkspaceSnapshot(candidate, input.cwd, scopedSnapshot)
                         : candidate,
                     );

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -797,6 +797,7 @@ import {
   formatProviderSkillDisplayName,
   getProviderSlashCommandsForSlashMenu,
   getProviderSkillsForSlashMenu,
+  hasCompleteProviderWorkspaceSnapshot,
   resolveProviderSkillsForCwd,
   resolveProviderSlashCommandsForCwd,
 } from "@t3tools/client-runtime/providerSkills";
@@ -1625,26 +1626,22 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   });
   const workspaceRefreshKeyRef = useRef<string | null>(null);
   const workspaceRefreshRetryRef = useRef<{ key: string; notBefore: number } | null>(null);
-  const hadWorkspaceSnapshotRef = useRef(false);
+  const hasCompleteWorkspaceSnapshot = Boolean(
+    selectedProviderStatus && hasCompleteProviderWorkspaceSnapshot(selectedProviderStatus, gitCwd),
+  );
+  const hadCompleteWorkspaceSnapshotRef = useRef(false);
   useEffect(() => {
-    const hasWorkspaceSnapshot = Boolean(
-      gitCwd &&
-      selectedProviderStatus?.workspaceSnapshots?.some((snapshot) => snapshot.cwd === gitCwd),
-    );
-    if (hadWorkspaceSnapshotRef.current && !hasWorkspaceSnapshot) {
+    if (hadCompleteWorkspaceSnapshotRef.current && !hasCompleteWorkspaceSnapshot) {
       workspaceRefreshKeyRef.current = null;
       workspaceRefreshRetryRef.current = null;
     }
-    hadWorkspaceSnapshotRef.current = hasWorkspaceSnapshot;
-  }, [gitCwd, selectedProviderStatus]);
+    hadCompleteWorkspaceSnapshotRef.current = hasCompleteWorkspaceSnapshot;
+  }, [hasCompleteWorkspaceSnapshot]);
   useEffect(() => {
     if (!gitCwd || !selectedProviderEntry) return;
     const key = `${environmentId}:${selectedProviderEntry.instanceId}:${gitCwd}`;
-    const hasWorkspaceSnapshot = selectedProviderStatus?.workspaceSnapshots?.some(
-      (snapshot) => snapshot.cwd === gitCwd,
-    );
     if (workspaceRefreshKeyRef.current === key) return;
-    if (hasWorkspaceSnapshot) {
+    if (hasCompleteWorkspaceSnapshot) {
       workspaceRefreshKeyRef.current = key;
       workspaceRefreshRetryRef.current = null;
       return;
@@ -1664,16 +1661,25 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       environmentId,
       input: { instanceId: selectedProviderEntry.instanceId, cwd: gitCwd },
     }).then((result) => {
-      const hasWorkspaceSnapshot =
+      const refreshCompleted =
         result._tag === "Success" &&
-        result.value.providers
-          .find((provider) => provider.instanceId === selectedProviderEntry.instanceId)
-          ?.workspaceSnapshots?.some((snapshot) => snapshot.cwd === gitCwd);
-      if (!hasWorkspaceSnapshot && workspaceRefreshKeyRef.current === key) {
+        result.value.providers.some(
+          (provider) =>
+            provider.instanceId === selectedProviderEntry.instanceId &&
+            hasCompleteProviderWorkspaceSnapshot(provider, gitCwd),
+        );
+      if (!refreshCompleted && workspaceRefreshKeyRef.current === key) {
         retryLater();
       }
     }, retryLater);
-  }, [environmentId, gitCwd, prompt, refreshProviders, selectedProviderEntry]);
+  }, [
+    environmentId,
+    gitCwd,
+    hasCompleteWorkspaceSnapshot,
+    prompt,
+    refreshProviders,
+    selectedProviderEntry,
+  ]);
   const selectedProviderModels = useMemo<ReadonlyArray<ServerProvider["models"][number]>>(
     () => selectedProviderEntry?.models ?? [],
     [selectedProviderEntry],

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -798,6 +798,7 @@ import {
   getProviderSlashCommandsForSlashMenu,
   getProviderSkillsForSlashMenu,
   hasCompleteProviderWorkspaceSnapshot,
+  hasPendingProviderWorkspaceSkillDiscovery,
   resolveProviderSkillsForCwd,
   resolveProviderSlashCommandsForCwd,
 } from "@t3tools/client-runtime/providerSkills";
@@ -1628,8 +1629,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     gitCwd && selectedProviderEntry
       ? `${environmentId}:${selectedProviderEntry.instanceId}:${gitCwd}`
       : null;
-  const workspaceRefreshKeyRef = useRef<string | null>(null);
-  const workspaceRefreshRetryTimerRef = useRef<number | null>(null);
+  const workspaceRefreshAttemptKeyRef = useRef<string | null>(null);
+  const workspaceRefreshRetryTimerRef = useRef<{
+    readonly key: string;
+    readonly timeout: number;
+  } | null>(null);
   const [workspaceRefreshRetryVersion, setWorkspaceRefreshRetryVersion] = useState(0);
   const hasCompleteWorkspaceSnapshot = Boolean(
     selectedProviderStatus && hasCompleteProviderWorkspaceSnapshot(selectedProviderStatus, gitCwd),
@@ -1637,58 +1641,69 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const hasCompleteWorkspaceSnapshotRef = useRef(hasCompleteWorkspaceSnapshot);
   useEffect(() => {
     hasCompleteWorkspaceSnapshotRef.current = hasCompleteWorkspaceSnapshot;
+    workspaceRefreshAttemptKeyRef.current = null;
+    if (hasCompleteWorkspaceSnapshot && workspaceRefreshRetryTimerRef.current !== null) {
+      window.clearTimeout(workspaceRefreshRetryTimerRef.current.timeout);
+      workspaceRefreshRetryTimerRef.current = null;
+    }
   }, [hasCompleteWorkspaceSnapshot]);
   useEffect(() => {
-    workspaceRefreshKeyRef.current = null;
+    const key = workspaceRefreshKey;
     return () => {
-      if (workspaceRefreshRetryTimerRef.current !== null) {
-        window.clearTimeout(workspaceRefreshRetryTimerRef.current);
+      if (workspaceRefreshRetryTimerRef.current?.key === key) {
+        window.clearTimeout(workspaceRefreshRetryTimerRef.current.timeout);
         workspaceRefreshRetryTimerRef.current = null;
       }
     };
-  }, [hasCompleteWorkspaceSnapshot, workspaceRefreshKey]);
+  }, [workspaceRefreshKey]);
   useEffect(() => {
     if (!gitCwd || !selectedProviderEntry || workspaceRefreshKey === null) return;
     const key = workspaceRefreshKey;
-    if (hasCompleteWorkspaceSnapshot) {
-      workspaceRefreshKeyRef.current = key;
-      return;
-    }
-    if (workspaceRefreshKeyRef.current === key) return;
-    workspaceRefreshKeyRef.current = key;
+    if (hasCompleteWorkspaceSnapshot) return;
+    const attemptKey = `${key}:${workspaceRefreshRetryVersion}`;
+    if (workspaceRefreshAttemptKeyRef.current === attemptKey) return;
+    workspaceRefreshAttemptKeyRef.current = attemptKey;
     const retryLater = () => {
-      if (workspaceRefreshKeyRef.current !== key || hasCompleteWorkspaceSnapshotRef.current) {
+      if (
+        workspaceRefreshAttemptKeyRef.current !== attemptKey ||
+        hasCompleteWorkspaceSnapshotRef.current
+      ) {
         return;
       }
-      workspaceRefreshRetryTimerRef.current = window.setTimeout(() => {
+      const timeout = window.setTimeout(() => {
         workspaceRefreshRetryTimerRef.current = null;
-        if (workspaceRefreshKeyRef.current !== key || hasCompleteWorkspaceSnapshotRef.current) {
+        if (
+          workspaceRefreshAttemptKeyRef.current !== attemptKey ||
+          hasCompleteWorkspaceSnapshotRef.current
+        ) {
           return;
         }
-        workspaceRefreshKeyRef.current = null;
         setWorkspaceRefreshRetryVersion((version) => version + 1);
       }, WORKSPACE_SNAPSHOT_RETRY_COOLDOWN_MS);
+      workspaceRefreshRetryTimerRef.current = { key, timeout };
     };
     void refreshProviders({
       environmentId,
       input: { instanceId: selectedProviderEntry.instanceId, cwd: gitCwd },
-    }).then((result) => {
-      const refreshCompleted =
-        result._tag === "Success" &&
-        result.value.providers.some(
-          (provider) =>
-            provider.instanceId === selectedProviderEntry.instanceId &&
-            hasCompleteProviderWorkspaceSnapshot(provider, gitCwd),
-        );
-      if (!refreshCompleted && workspaceRefreshKeyRef.current === key) {
-        retryLater();
-      }
-    }, retryLater);
+    }).then(
+      (result) => {
+        const discoveryPending =
+          result._tag === "Success" &&
+          result.value.providers.some(
+            (provider) =>
+              provider.instanceId === selectedProviderEntry.instanceId &&
+              hasPendingProviderWorkspaceSkillDiscovery(provider, gitCwd),
+          );
+        if (discoveryPending && workspaceRefreshAttemptKeyRef.current === attemptKey) {
+          retryLater();
+        }
+      },
+      () => undefined,
+    );
   }, [
     environmentId,
     gitCwd,
     hasCompleteWorkspaceSnapshot,
-    prompt,
     refreshProviders,
     selectedProviderEntry,
     workspaceRefreshKey,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1624,38 +1624,50 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const refreshProviders = useAtomCommand(serverEnvironment.refreshProviders, {
     reportFailure: false,
   });
+  const workspaceRefreshKey =
+    gitCwd && selectedProviderEntry
+      ? `${environmentId}:${selectedProviderEntry.instanceId}:${gitCwd}`
+      : null;
   const workspaceRefreshKeyRef = useRef<string | null>(null);
-  const workspaceRefreshRetryRef = useRef<{ key: string; notBefore: number } | null>(null);
+  const workspaceRefreshRetryTimerRef = useRef<number | null>(null);
+  const [workspaceRefreshRetryVersion, setWorkspaceRefreshRetryVersion] = useState(0);
   const hasCompleteWorkspaceSnapshot = Boolean(
     selectedProviderStatus && hasCompleteProviderWorkspaceSnapshot(selectedProviderStatus, gitCwd),
   );
-  const hadCompleteWorkspaceSnapshotRef = useRef(false);
+  const hasCompleteWorkspaceSnapshotRef = useRef(hasCompleteWorkspaceSnapshot);
   useEffect(() => {
-    if (hadCompleteWorkspaceSnapshotRef.current && !hasCompleteWorkspaceSnapshot) {
-      workspaceRefreshKeyRef.current = null;
-      workspaceRefreshRetryRef.current = null;
-    }
-    hadCompleteWorkspaceSnapshotRef.current = hasCompleteWorkspaceSnapshot;
+    hasCompleteWorkspaceSnapshotRef.current = hasCompleteWorkspaceSnapshot;
   }, [hasCompleteWorkspaceSnapshot]);
   useEffect(() => {
-    if (!gitCwd || !selectedProviderEntry) return;
-    const key = `${environmentId}:${selectedProviderEntry.instanceId}:${gitCwd}`;
-    if (workspaceRefreshKeyRef.current === key) return;
+    workspaceRefreshKeyRef.current = null;
+    return () => {
+      if (workspaceRefreshRetryTimerRef.current !== null) {
+        window.clearTimeout(workspaceRefreshRetryTimerRef.current);
+        workspaceRefreshRetryTimerRef.current = null;
+      }
+    };
+  }, [hasCompleteWorkspaceSnapshot, workspaceRefreshKey]);
+  useEffect(() => {
+    if (!gitCwd || !selectedProviderEntry || workspaceRefreshKey === null) return;
+    const key = workspaceRefreshKey;
     if (hasCompleteWorkspaceSnapshot) {
       workspaceRefreshKeyRef.current = key;
-      workspaceRefreshRetryRef.current = null;
       return;
     }
-    const retry = workspaceRefreshRetryRef.current;
-    if (retry?.key === key && Date.now() < retry.notBefore) return;
+    if (workspaceRefreshKeyRef.current === key) return;
     workspaceRefreshKeyRef.current = key;
     const retryLater = () => {
-      if (workspaceRefreshKeyRef.current !== key) return;
-      workspaceRefreshKeyRef.current = null;
-      workspaceRefreshRetryRef.current = {
-        key,
-        notBefore: Date.now() + WORKSPACE_SNAPSHOT_RETRY_COOLDOWN_MS,
-      };
+      if (workspaceRefreshKeyRef.current !== key || hasCompleteWorkspaceSnapshotRef.current) {
+        return;
+      }
+      workspaceRefreshRetryTimerRef.current = window.setTimeout(() => {
+        workspaceRefreshRetryTimerRef.current = null;
+        if (workspaceRefreshKeyRef.current !== key || hasCompleteWorkspaceSnapshotRef.current) {
+          return;
+        }
+        workspaceRefreshKeyRef.current = null;
+        setWorkspaceRefreshRetryVersion((version) => version + 1);
+      }, WORKSPACE_SNAPSHOT_RETRY_COOLDOWN_MS);
     };
     void refreshProviders({
       environmentId,
@@ -1679,6 +1691,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     prompt,
     refreshProviders,
     selectedProviderEntry,
+    workspaceRefreshKey,
+    workspaceRefreshRetryVersion,
   ]);
   const selectedProviderModels = useMemo<ReadonlyArray<ServerProvider["models"][number]>>(
     () => selectedProviderEntry?.models ?? [],

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1634,14 +1634,20 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     readonly key: string;
     readonly timeout: number;
   } | null>(null);
+  const workspaceRefreshMissingRetryKeyRef = useRef<string | null>(null);
   const [workspaceRefreshRetryVersion, setWorkspaceRefreshRetryVersion] = useState(0);
   const hasCompleteWorkspaceSnapshot = Boolean(
     selectedProviderStatus && hasCompleteProviderWorkspaceSnapshot(selectedProviderStatus, gitCwd),
+  );
+  const hasPendingWorkspaceSkillDiscovery = Boolean(
+    selectedProviderStatus &&
+    hasPendingProviderWorkspaceSkillDiscovery(selectedProviderStatus, gitCwd),
   );
   const hasCompleteWorkspaceSnapshotRef = useRef(hasCompleteWorkspaceSnapshot);
   useEffect(() => {
     hasCompleteWorkspaceSnapshotRef.current = hasCompleteWorkspaceSnapshot;
     workspaceRefreshAttemptKeyRef.current = null;
+    workspaceRefreshMissingRetryKeyRef.current = null;
     if (hasCompleteWorkspaceSnapshot && workspaceRefreshRetryTimerRef.current !== null) {
       window.clearTimeout(workspaceRefreshRetryTimerRef.current.timeout);
       workspaceRefreshRetryTimerRef.current = null;
@@ -1649,6 +1655,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   }, [hasCompleteWorkspaceSnapshot]);
   useEffect(() => {
     const key = workspaceRefreshKey;
+    if (workspaceRefreshMissingRetryKeyRef.current !== key) {
+      workspaceRefreshMissingRetryKeyRef.current = null;
+    }
     return () => {
       if (workspaceRefreshRetryTimerRef.current?.key === key) {
         window.clearTimeout(workspaceRefreshRetryTimerRef.current.timeout);
@@ -1661,12 +1670,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     const key = workspaceRefreshKey;
     if (hasCompleteWorkspaceSnapshot) return;
     const attemptKey = `${key}:${workspaceRefreshRetryVersion}`;
-    if (workspaceRefreshAttemptKeyRef.current === attemptKey) return;
-    workspaceRefreshAttemptKeyRef.current = attemptKey;
     const retryLater = () => {
       if (
         workspaceRefreshAttemptKeyRef.current !== attemptKey ||
-        hasCompleteWorkspaceSnapshotRef.current
+        hasCompleteWorkspaceSnapshotRef.current ||
+        workspaceRefreshRetryTimerRef.current !== null
       ) {
         return;
       }
@@ -1682,29 +1690,59 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       }, WORKSPACE_SNAPSHOT_RETRY_COOLDOWN_MS);
       workspaceRefreshRetryTimerRef.current = { key, timeout };
     };
+    const retryMissingSnapshotOnce = (canRetry: boolean) => {
+      if (
+        !canRetry ||
+        workspaceRefreshAttemptKeyRef.current !== attemptKey ||
+        workspaceRefreshMissingRetryKeyRef.current === key
+      ) {
+        return;
+      }
+      workspaceRefreshMissingRetryKeyRef.current = key;
+      retryLater();
+    };
+    const retryAfterFailedRefresh = () => {
+      if (hasPendingWorkspaceSkillDiscovery) {
+        retryLater();
+        return;
+      }
+      retryMissingSnapshotOnce(selectedProviderStatus?.status !== "error");
+    };
+    if (workspaceRefreshAttemptKeyRef.current === attemptKey) {
+      if (hasPendingWorkspaceSkillDiscovery) retryLater();
+      return;
+    }
+    workspaceRefreshAttemptKeyRef.current = attemptKey;
     void refreshProviders({
       environmentId,
       input: { instanceId: selectedProviderEntry.instanceId, cwd: gitCwd },
-    }).then(
-      (result) => {
-        const discoveryPending =
-          result._tag === "Success" &&
-          result.value.providers.some(
-            (provider) =>
-              provider.instanceId === selectedProviderEntry.instanceId &&
-              hasPendingProviderWorkspaceSkillDiscovery(provider, gitCwd),
-          );
-        if (discoveryPending && workspaceRefreshAttemptKeyRef.current === attemptKey) {
-          retryLater();
-        }
-      },
-      () => undefined,
-    );
+    }).then((result) => {
+      if (result._tag !== "Success") {
+        retryAfterFailedRefresh();
+        return;
+      }
+      const refreshedProvider = result.value.providers.find(
+        (provider) => provider.instanceId === selectedProviderEntry.instanceId,
+      );
+      if (
+        refreshedProvider &&
+        hasPendingProviderWorkspaceSkillDiscovery(refreshedProvider, gitCwd)
+      ) {
+        retryLater();
+        return;
+      }
+      retryMissingSnapshotOnce(
+        refreshedProvider?.status !== "error" &&
+          (!refreshedProvider || !hasCompleteProviderWorkspaceSnapshot(refreshedProvider, gitCwd)),
+      );
+    }, retryAfterFailedRefresh);
   }, [
     environmentId,
     gitCwd,
     hasCompleteWorkspaceSnapshot,
+    hasPendingWorkspaceSkillDiscovery,
     refreshProviders,
+    selectedProviderStatus,
     selectedProviderEntry,
     workspaceRefreshKey,
     workspaceRefreshRetryVersion,

--- a/packages/client-runtime/src/providerSkills.test.ts
+++ b/packages/client-runtime/src/providerSkills.test.ts
@@ -7,6 +7,7 @@ import {
   getProviderSlashCommandsForSlashMenu,
   getProviderSkillsForSlashMenu,
   hasCompleteProviderWorkspaceSnapshot,
+  hasPendingProviderWorkspaceSkillDiscovery,
   resolveProviderSkillsForCwd,
   resolveProviderSlashCommandsForCwd,
   resolveProviderSkillSourceKind,
@@ -253,6 +254,16 @@ describe("workspace provider snapshots", () => {
       false,
     );
     expect(hasCompleteProviderWorkspaceSnapshot(provider, "/workspace/project-b")).toBe(false);
+    expect(hasPendingProviderWorkspaceSkillDiscovery(pendingProvider, "/workspace/project-a")).toBe(
+      true,
+    );
+    expect(hasPendingProviderWorkspaceSkillDiscovery(provider, "/workspace/project-b")).toBe(false);
+    expect(
+      hasPendingProviderWorkspaceSkillDiscovery(
+        { ...pendingProvider, status: "error" },
+        "/workspace/project-a",
+      ),
+    ).toBe(false);
   });
 
   it("uses the cwd snapshot after a provider session has populated it", () => {

--- a/packages/client-runtime/src/providerSkills.test.ts
+++ b/packages/client-runtime/src/providerSkills.test.ts
@@ -6,6 +6,7 @@ import {
   formatProviderSkillDisplayName,
   getProviderSlashCommandsForSlashMenu,
   getProviderSkillsForSlashMenu,
+  hasCompleteProviderWorkspaceSnapshot,
   resolveProviderSkillsForCwd,
   resolveProviderSlashCommandsForCwd,
   resolveProviderSkillSourceKind,
@@ -238,6 +239,22 @@ describe("resolveProviderSkillSourceKind", () => {
 });
 
 describe("workspace provider snapshots", () => {
+  it("keeps pending workspace snapshots retryable", () => {
+    const pendingProvider = {
+      ...provider,
+      workspaceSnapshots: provider.workspaceSnapshots.map((snapshot) => ({
+        ...snapshot,
+        skillsDiscoveryPending: true,
+      })),
+    } satisfies ServerProvider;
+
+    expect(hasCompleteProviderWorkspaceSnapshot(provider, "/workspace/project-a")).toBe(true);
+    expect(hasCompleteProviderWorkspaceSnapshot(pendingProvider, "/workspace/project-a")).toBe(
+      false,
+    );
+    expect(hasCompleteProviderWorkspaceSnapshot(provider, "/workspace/project-b")).toBe(false);
+  });
+
   it("uses the cwd snapshot after a provider session has populated it", () => {
     expect(resolveProviderSkillsForCwd(provider, "/workspace/project-a")).toEqual([
       { name: "project", path: "/workspace/project-a/SKILL.md", enabled: true },

--- a/packages/client-runtime/src/providerSkills.ts
+++ b/packages/client-runtime/src/providerSkills.ts
@@ -119,6 +119,16 @@ export function hasCompleteProviderWorkspaceSnapshot(
   return snapshot !== undefined && snapshot.skillsDiscoveryPending !== true;
 }
 
+export function hasPendingProviderWorkspaceSkillDiscovery(
+  provider: ServerProvider,
+  cwd: string | null | undefined,
+): boolean {
+  return (
+    provider.status !== "error" &&
+    resolveProviderWorkspaceSnapshot(provider, cwd)?.skillsDiscoveryPending === true
+  );
+}
+
 export function resolveProviderSkillsForCwd(
   provider: ServerProvider,
   cwd: string | null | undefined,

--- a/packages/client-runtime/src/providerSkills.ts
+++ b/packages/client-runtime/src/providerSkills.ts
@@ -111,6 +111,14 @@ function resolveProviderWorkspaceSnapshot(
   return provider.workspaceSnapshots?.find((snapshot) => snapshot.cwd === cwd);
 }
 
+export function hasCompleteProviderWorkspaceSnapshot(
+  provider: ServerProvider,
+  cwd: string | null | undefined,
+): boolean {
+  const snapshot = resolveProviderWorkspaceSnapshot(provider, cwd);
+  return snapshot !== undefined && snapshot.skillsDiscoveryPending !== true;
+}
+
 export function resolveProviderSkillsForCwd(
   provider: ServerProvider,
   cwd: string | null | undefined,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -120,6 +120,8 @@ export const ServerProviderWorkspaceSnapshot = Schema.Struct({
   checkedAt: IsoDateTime,
   slashCommands: Schema.Array(ServerProviderSlashCommand),
   skills: Schema.Array(ServerProviderSkill),
+  /** Scoped commands are known, but workspace skills should be discovered again. */
+  skillsDiscoveryPending: Schema.optional(Schema.Boolean),
 });
 export type ServerProviderWorkspaceSnapshot = typeof ServerProviderWorkspaceSnapshot.Type;
 


### PR DESCRIPTION
## What changed

- Antigravity now keeps a command snapshot for each workspace before skill discovery finishes.
- Workspace snapshots expose `skillsDiscoveryPending` while their skill list is incomplete.
- The provider registry retries pending discovery results. A complete result replaces the pending snapshot, while an empty result remains pending so a later refresh can detect newly added skills.
- Regression tests cover command updates across multiple workspaces, empty discovery results, refresh retries, and replacement with a complete snapshot.

## Why

Command updates can arrive before Antigravity discovers workspace skills. Suppressing those snapshots loses workspace-specific commands, but treating them as complete prevents later skill discovery. The explicit pending state preserves both behaviors without changing providers that already return complete, cwd-scoped snapshots.

## Flow

```mermaid
flowchart LR
  A[Session or command update] --> B[Store cwd-scoped commands]
  B --> C{Skills discovered?}
  C -- No --> D[Mark discovery pending]
  D --> E[Registry scans the workspace]
  E --> F{Skills found?}
  F -- Yes --> G[Replace with complete snapshot]
  F -- No --> H[Keep pending and retry later]
  C -- Yes --> G
```

## Verification

- `pnpm exec vp test run apps/server/src/provider/Layers/ProviderRegistry.test.ts apps/server/src/provider/Layers/AntigravityProvider.test.ts packages/client-runtime/src/providerSkills.test.ts` (80 passed)
- Targeted format and lint checks passed
- Contracts and server typechecks passed
- Fallow accepted all three changed contract signals with no rejected or stale judgments

## UI changes

N/A

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A)
- [x] I included a video for animation/interaction changes (N/A)

---

Built with GPT-5.6 via Codex in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve workspace skills across session updates in `useComposerCommandMenu`
> - Replaces the one-shot snapshot refresh guard in [use-composer-command-menu.ts](https://github.com/pingdotgg/t3code/pull/9552/files#diff-765bb6c8049500163389336a7a5e0c83873e041f5b14c72e5f5804359e6492d9) with keyed attempt tracking, cooldown timers, and retry logic.
> - Retries pending skill discovery after a cooldown and retries missing snapshots at most once per workspace key.
> - Stops all retries on provider errors or once a complete snapshot is found.
> - Updates Antigravity provider tests to verify skill preservation during pending discovery and prevention of empty workspace snapshots.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33b3b7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace skills discovered during scanning are now saved and retained.
  - Incomplete skill discoveries remain marked for retry while preserving known workspace commands.
  - Workspace scans no longer overwrite data for a different directory.
  - Skill discoveries are prioritized across session and command updates.
  - Empty discoveries update existing workspace entries without creating unnecessary new entries.
  - Workspace snapshots refresh when skill discovery is still pending.
  - Web and mobile command menus now wait for complete workspace snapshots before finishing refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider workspace snapshot lifecycle and client refresh retries; behavior is covered by new server and client-runtime tests but affects slash/skill menus and Antigravity timing.
> 
> **Overview**
> Fixes a race where Antigravity **slash commands** could arrive before **workspace skills** were discovered, which either hid commands or froze an incomplete skill list as “done.”
> 
> Workspace snapshots now carry an optional **`skillsDiscoveryPending`** flag. **Antigravity** keeps cwd-scoped commands while discovery is incomplete, prefers newly discovered skills over stored ones, and avoids creating empty workspace entries on session start. **`ProviderRegistry.refreshWorkspaceSnapshot`** keeps retrying until discovery is complete, treats empty skill scans as still pending (with a **60s** throttle per instance/cwd), and only caches snapshots when appropriate.
> 
> **Web** and **mobile** composers use **`hasCompleteProviderWorkspaceSnapshot`** / **`hasPendingProviderWorkspaceSkillDiscovery`** so provider refresh retries until the snapshot is complete, including when discovery is still pending after a successful refresh.
> 
> **Note:** A workspace row no longer appears immediately after session start for an unscanned cwd until commands or discovery populate it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33b3b7a2e8c15000242a56a1e1115c1e16aa8994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->