### PR TITLE
fix(web): keep the last message visible when the resting composer expands

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4987,17 +4987,12 @@ function ChatViewContent(props: ChatViewProps) {
   // The composer reports its resting flag from a layout effect, which runs
   // before this component's own layout effects and before any resize
   // observation, so every measurement below sees the flag for its layout.
-  // A flag change with no height change still recomputes the reservation.
-  const onComposerRestingChange = useCallback(
-    (resting: boolean) => {
-      if (composerRestingRef.current === resting) return;
-      composerRestingRef.current = resting;
-      if (composerOverlayHeightRef.current > 0) {
-        publishComposerOverlayHeight(composerOverlayHeightRef.current);
-      }
-    },
-    [publishComposerOverlayHeight],
-  );
+  // Only the flag is stored here: the stored height still belongs to the
+  // previous layout, and the composer publishes the new layout's height
+  // itself once it has measured it.
+  const onComposerRestingChange = useCallback((resting: boolean) => {
+    composerRestingRef.current = resting;
+  }, []);
   // A held reservation belongs to the previous thread's draft. Rebuild it from
   // this thread's overlay so a tall draft elsewhere does not pad this one.
   useLayoutEffect(() => {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4984,13 +4984,17 @@ function ChatViewContent(props: ChatViewProps) {
       currentClearance === nextHeight ? currentClearance : nextHeight,
     );
   }, []);
-  // The composer reports the destination geometry of each resting transition
-  // together with the state it belongs to, so the reservation never pairs a
-  // resting flag with the other layout's height.
-  const publishComposerOverlayGeometry = useCallback(
-    (height: number, resting: boolean) => {
+  // The composer reports its resting flag from a layout effect, which runs
+  // before this component's own layout effects and before any resize
+  // observation, so every measurement below sees the flag for its layout.
+  // A flag change with no height change still recomputes the reservation.
+  const onComposerRestingChange = useCallback(
+    (resting: boolean) => {
+      if (composerRestingRef.current === resting) return;
       composerRestingRef.current = resting;
-      publishComposerOverlayHeight(height);
+      if (composerOverlayHeightRef.current > 0) {
+        publishComposerOverlayHeight(composerOverlayHeightRef.current);
+      }
     },
     [publishComposerOverlayHeight],
   );
@@ -7955,7 +7959,8 @@ function ChatViewContent(props: ChatViewProps) {
                             onRestingControlsVisibilityChange={setRestingComposerControlsVisible}
                             getTimelineScrollableNode={getTimelineScrollableNode}
                             isTimelineAtLogicalEnd={isTimelineAtLogicalEnd}
-                            onComposerOverlayGeometryChange={publishComposerOverlayGeometry}
+                            onComposerOverlayHeightChange={publishComposerOverlayHeight}
+                            onRestingChange={onComposerRestingChange}
                             promptRef={promptRef}
                             composerImagesRef={composerImagesRef}
                             composerFilesRef={composerFilesRef}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -298,6 +298,7 @@ import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
 import { MessagesTimeline } from "./chat/MessagesTimeline";
 import type { AssistantCitationRequest } from "./chat/AssistantCitationSource";
 import { resolveTimelineIsAtEnd } from "./chat/MessagesTimeline.logic";
+import { resolveComposerTimelineInset } from "./composerFooterLayout";
 import { ChatHeader } from "./chat/ChatHeader";
 import { PanelLayoutControls, RightPanelMaximizeControl } from "./chat/PanelLayoutControls";
 import { expandedImageKey, type ExpandedImagePreview } from "./chat/ExpandedImagePreview";
@@ -1628,6 +1629,12 @@ function ChatViewContent(props: ChatViewProps) {
   const [composerOverlayElement, setComposerOverlayElement] = useState<HTMLDivElement | null>(null);
   const [composerOverlayHeight, setComposerOverlayHeight] = useState(0);
   const composerOverlayHeightRef = useRef(0);
+  // Space the timeline keeps clear above its end. Tracks the overlay while the
+  // composer is expanded and holds that height while it rests, so the resting
+  // composer never exposes rows that its expansion will cover.
+  const [composerTimelineInset, setComposerTimelineInset] = useState(0);
+  const composerTimelineInsetRef = useRef(0);
+  const composerRestingRef = useRef(false);
   const [scrollToEndClearance, setScrollToEndClearance] = useState(0);
   const isAtEndRef = useRef(true);
   const isTimelineAtLogicalEnd = useCallback(() => isAtEndRef.current, []);
@@ -4459,11 +4466,11 @@ function ChatViewContent(props: ChatViewProps) {
       return getAnchoredTurnMetrics({
         state,
         anchorIndex,
-        composerOverlayHeight,
+        composerOverlayHeight: composerTimelineInset,
         anchorOffset: CHAT_TIMELINE_ANCHOR_OFFSET,
       });
     },
-    [composerOverlayHeight],
+    [composerTimelineInset],
   );
   const timelineRealContentOverflowsViewport = useCallback(
     (list?: LegendListRef | null) => {
@@ -4488,11 +4495,11 @@ function ChatViewContent(props: ChatViewProps) {
       const realContentBottom = lastRowTop + Math.max(1, lastRowHeight);
       const visibleScrollLength = Math.max(
         0,
-        (state.scrollLength ?? 0) - composerOverlayHeight - CHAT_TIMELINE_ANCHOR_OFFSET,
+        (state.scrollLength ?? 0) - composerTimelineInset - CHAT_TIMELINE_ANCHOR_OFFSET,
       );
       return realContentBottom > visibleScrollLength;
     },
-    [composerOverlayHeight],
+    [composerTimelineInset],
   );
   const pageScrollControllerRef = useRef<ReturnType<typeof createPageScrollController> | null>(
     null,
@@ -4964,10 +4971,36 @@ function ChatViewContent(props: ChatViewProps) {
       composerOverlayHeightRef.current = nextHeight;
       setComposerOverlayHeight(nextHeight);
     }
+    const nextInset = resolveComposerTimelineInset({
+      currentInset: composerTimelineInsetRef.current,
+      overlayHeight: nextHeight,
+      isResting: composerRestingRef.current,
+    });
+    if (composerTimelineInsetRef.current !== nextInset) {
+      composerTimelineInsetRef.current = nextInset;
+      setComposerTimelineInset(nextInset);
+    }
     setScrollToEndClearance((currentClearance) =>
       currentClearance === nextHeight ? currentClearance : nextHeight,
     );
   }, []);
+  // The composer reports the destination geometry of each resting transition
+  // together with the state it belongs to, so the reservation never pairs a
+  // resting flag with the other layout's height.
+  const publishComposerOverlayGeometry = useCallback(
+    (height: number, resting: boolean) => {
+      composerRestingRef.current = resting;
+      publishComposerOverlayHeight(height);
+    },
+    [publishComposerOverlayHeight],
+  );
+  // A held reservation belongs to the previous thread's draft. Rebuild it from
+  // this thread's overlay so a tall draft elsewhere does not pad this one.
+  useLayoutEffect(() => {
+    if (!composerOverlayElement) return;
+    composerTimelineInsetRef.current = 0;
+    publishComposerOverlayHeight(composerOverlayElement.getBoundingClientRect().height);
+  }, [activeThreadKey, composerOverlayElement, publishComposerOverlayHeight]);
 
   useLayoutEffect(() => {
     if (!composerOverlayElement) return;
@@ -7775,7 +7808,7 @@ function ChatViewContent(props: ChatViewProps) {
                 }
                 anchorMessageId={timelineAnchorMessageId}
                 onAnchorReady={onTimelineAnchorReady}
-                contentInsetEndAdjustment={composerOverlayHeight}
+                contentInsetEndAdjustment={composerTimelineInset}
                 liveFollowEnabled={timelineLiveFollowEnabled}
                 onIsAtEndChange={onIsAtEndChange}
                 onManualNavigation={cancelTimelineLiveFollowForUserNavigation}
@@ -7922,7 +7955,7 @@ function ChatViewContent(props: ChatViewProps) {
                             onRestingControlsVisibilityChange={setRestingComposerControlsVisible}
                             getTimelineScrollableNode={getTimelineScrollableNode}
                             isTimelineAtLogicalEnd={isTimelineAtLogicalEnd}
-                            onComposerOverlayHeightChange={publishComposerOverlayHeight}
+                            onComposerOverlayGeometryChange={publishComposerOverlayGeometry}
                             promptRef={promptRef}
                             composerImagesRef={composerImagesRef}
                             composerFilesRef={composerFilesRef}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -251,12 +251,14 @@ const COMPOSER_RESTING_CONTROLS_ARRIVAL_DRIFT_PX = 4;
 
 function useComposerRestingTransition(
   isCollapsed: boolean,
+  isResting: boolean,
   restingControlsRef: React.RefObject<HTMLDivElement | null>,
   onOverlayHeightChange: (height: number) => void,
 ) {
   const elementRef = useRef<HTMLDivElement>(null);
   const isCollapsedRef = useRef(isCollapsed);
   const previousCollapsedRef = useRef(isCollapsed);
+  const previousRestingRef = useRef(isResting);
   const previousHeightRef = useRef<number | null>(null);
   const previousContentOffsetsRef = useRef<{
     promptFromTop: number | null;
@@ -610,6 +612,18 @@ function useComposerRestingTransition(
       }
     };
   }, [isCollapsed, transitionToCurrentGeometry]);
+
+  // The resting flag can change while the collapsed layout stays the same,
+  // for example when an unfocused thread crosses the phone breakpoint. The
+  // chat view pairs overlay heights with that flag, so republish the natural
+  // height for the new flag. A transition in flight publishes its own.
+  useLayoutEffect(() => {
+    if (previousRestingRef.current === isResting) return;
+    previousRestingRef.current = isResting;
+    if (animationRef.current) return;
+    const overlay = elementRef.current?.closest<HTMLElement>('[data-chat-composer-overlay="true"]');
+    if (overlay) onOverlayHeightChange(overlay.getBoundingClientRect().height);
+  }, [isResting, onOverlayHeightChange]);
 
   useLayoutEffect(() => {
     const element = elementRef.current;
@@ -3647,6 +3661,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     ) : null;
   const composerMainSurfaceRef = useComposerRestingTransition(
     composerControlsInStrip,
+    isComposerResting,
     restingComposerControlsRef,
     onComposerOverlayHeightChange,
   );

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -251,11 +251,13 @@ const COMPOSER_RESTING_CONTROLS_ARRIVAL_DRIFT_PX = 4;
 
 function useComposerRestingTransition(
   isCollapsed: boolean,
+  isResting: boolean,
   restingControlsRef: React.RefObject<HTMLDivElement | null>,
-  onOverlayHeightChange: (height: number) => void,
+  onOverlayGeometryChange: (height: number, resting: boolean) => void,
 ) {
   const elementRef = useRef<HTMLDivElement>(null);
   const isCollapsedRef = useRef(isCollapsed);
+  const isRestingRef = useRef(isResting);
   const previousCollapsedRef = useRef(isCollapsed);
   const previousHeightRef = useRef<number | null>(null);
   const previousContentOffsetsRef = useRef<{
@@ -301,6 +303,7 @@ function useComposerRestingTransition(
   }, [clearOverlayPin]);
 
   isCollapsedRef.current = isCollapsed;
+  isRestingRef.current = isResting;
 
   const transitionToCurrentGeometry = useCallback(
     (stateChanged: boolean) => {
@@ -309,6 +312,7 @@ function useComposerRestingTransition(
       if (!element || !surface) return;
 
       const nextIsCollapsed = isCollapsedRef.current;
+      const nextIsResting = isRestingRef.current;
 
       const visibleTransitionElement = (selector: string) =>
         Array.from(element.querySelectorAll<HTMLElement>(selector)).find(
@@ -355,6 +359,16 @@ function useComposerRestingTransition(
 
       const nextRect = element.getBoundingClientRect();
       const nextHeight = nextRect.height;
+      // The chat view resize-observes the overlay to place the timeline
+      // inset, the scroll-to-end pill, and the mini player. Publishing the
+      // destination geometry here, paired with the resting state it belongs
+      // to, turns that feedback into one update instead of a ChatView
+      // re-render on every animation frame.
+      const overlay = element.closest<HTMLElement>('[data-chat-composer-overlay="true"]');
+      const overlayHeight = overlay?.getBoundingClientRect().height ?? null;
+      if (overlayHeight !== null) {
+        onOverlayGeometryChange(overlayHeight, nextIsResting);
+      }
       const nextPromptRect = prompt?.getBoundingClientRect() ?? null;
       const nextPromptTop = nextPromptRect?.top ?? null;
       const nextActionTop = action?.getBoundingClientRect().top ?? null;
@@ -385,18 +399,13 @@ function useComposerRestingTransition(
         element.style.overflow = "clip";
         surface.style.height = "100%";
 
-        // The chat view resize-observes the overlay to place the timeline
-        // inset, the scroll-to-end pill, and the mini player. Pinning the
-        // overlay at the destination height turns that feedback into one
-        // update instead of a ChatView re-render on every animation frame;
-        // bottom alignment keeps the animating surface glued to the overlay's
-        // stable bottom edge. The pin lasts only for the tween so later
-        // attachment, thread, font, and viewport changes remain natural.
-        const overlay = element.closest<HTMLElement>('[data-chat-composer-overlay="true"]');
-        let pinnedOverlayHeight: number | null = null;
-        if (overlay) {
-          pinnedOverlayHeight = overlay.getBoundingClientRect().height;
-          overlay.style.height = `${String(pinnedOverlayHeight)}px`;
+        // Pinning the overlay at the destination height keeps the resize
+        // observer quiet for the tween; bottom alignment keeps the animating
+        // surface glued to the overlay's stable bottom edge. The pin lasts
+        // only for the tween so later attachment, thread, font, and viewport
+        // changes remain natural.
+        if (overlay && overlayHeight !== null) {
+          overlay.style.height = `${String(overlayHeight)}px`;
           overlay.style.display = "flex";
           overlay.style.flexDirection = "column";
           overlay.style.justifyContent = "flex-end";
@@ -430,11 +439,6 @@ function useComposerRestingTransition(
         );
         animationRef.current = animation;
         animationTargetHeightRef.current = nextHeight;
-        // Publish the destination overlay geometry in the same layout pass;
-        // ResizeObserver remains the fallback for non-transition changes.
-        if (pinnedOverlayHeight !== null) {
-          onOverlayHeightChange(pinnedOverlayHeight);
-        }
 
         const animatedRect = element.getBoundingClientRect();
         const previousPromptTop =
@@ -591,7 +595,7 @@ function useComposerRestingTransition(
         actionFromBottom: nextActionTop === null ? null : nextRect.bottom - nextActionTop,
       };
     },
-    [clearTransitionStyles, onOverlayHeightChange, restingControlsRef],
+    [clearTransitionStyles, onOverlayGeometryChange, restingControlsRef],
   );
 
   useLayoutEffect(() => {
@@ -1231,7 +1235,12 @@ export interface ChatComposerProps {
   onRestingControlsVisibilityChange: (visible: boolean) => void;
   getTimelineScrollableNode: () => HTMLElement | null;
   isTimelineAtLogicalEnd: () => boolean;
-  onComposerOverlayHeightChange: (height: number) => void;
+  /**
+   * Overlay height at the destination of a resting transition, with whether
+   * the composer is resting there. Both land in one update so the chat view
+   * never pairs a resting flag with the other layout's height.
+   */
+  onComposerOverlayGeometryChange: (height: number, resting: boolean) => void;
 
   // Refs the parent needs kept in sync
   promptRef: React.RefObject<string>;
@@ -1335,7 +1344,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     onRestingControlsVisibilityChange,
     getTimelineScrollableNode,
     isTimelineAtLogicalEnd,
-    onComposerOverlayHeightChange,
+    onComposerOverlayGeometryChange,
     promptRef,
     composerRef,
     composerImagesRef,
@@ -3639,8 +3648,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     ) : null;
   const composerMainSurfaceRef = useComposerRestingTransition(
     composerControlsInStrip,
+    isComposerResting,
     restingComposerControlsRef,
-    onComposerOverlayHeightChange,
+    onComposerOverlayGeometryChange,
   );
   const canTrackComposerScrollGesture =
     routeKind === "server" && activeThreadId !== null && !isMobileViewport;

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -251,13 +251,11 @@ const COMPOSER_RESTING_CONTROLS_ARRIVAL_DRIFT_PX = 4;
 
 function useComposerRestingTransition(
   isCollapsed: boolean,
-  isResting: boolean,
   restingControlsRef: React.RefObject<HTMLDivElement | null>,
-  onOverlayGeometryChange: (height: number, resting: boolean) => void,
+  onOverlayHeightChange: (height: number) => void,
 ) {
   const elementRef = useRef<HTMLDivElement>(null);
   const isCollapsedRef = useRef(isCollapsed);
-  const isRestingRef = useRef(isResting);
   const previousCollapsedRef = useRef(isCollapsed);
   const previousHeightRef = useRef<number | null>(null);
   const previousContentOffsetsRef = useRef<{
@@ -311,7 +309,6 @@ function useComposerRestingTransition(
       if (!element || !surface) return;
 
       const nextIsCollapsed = isCollapsedRef.current;
-      const nextIsResting = isRestingRef.current;
 
       const visibleTransitionElement = (selector: string) =>
         Array.from(element.querySelectorAll<HTMLElement>(selector)).find(
@@ -360,13 +357,12 @@ function useComposerRestingTransition(
       const nextHeight = nextRect.height;
       // The chat view resize-observes the overlay to place the timeline
       // inset, the scroll-to-end pill, and the mini player. Publishing the
-      // destination geometry here, paired with the resting state it belongs
-      // to, turns that feedback into one update instead of a ChatView
-      // re-render on every animation frame.
+      // destination height here turns that feedback into one update instead
+      // of a ChatView re-render on every animation frame.
       const overlay = element.closest<HTMLElement>('[data-chat-composer-overlay="true"]');
       const overlayHeight = overlay?.getBoundingClientRect().height ?? null;
       if (overlayHeight !== null) {
-        onOverlayGeometryChange(overlayHeight, nextIsResting);
+        onOverlayHeightChange(overlayHeight);
       }
       const nextPromptRect = prompt?.getBoundingClientRect() ?? null;
       const nextPromptTop = nextPromptRect?.top ?? null;
@@ -594,15 +590,10 @@ function useComposerRestingTransition(
         actionFromBottom: nextActionTop === null ? null : nextRect.bottom - nextActionTop,
       };
     },
-    [clearTransitionStyles, onOverlayGeometryChange, restingControlsRef],
+    [clearTransitionStyles, onOverlayHeightChange, restingControlsRef],
   );
 
-  // The resting flag can change without the collapsed layout changing, for
-  // example when an unfocused thread crosses the phone breakpoint. Republish
-  // the geometry then too, so the chat view's next measurement is paired
-  // with the right state. Only a collapsed-layout change animates.
   useLayoutEffect(() => {
-    isRestingRef.current = isResting;
     const requestId = transitionLayoutRequestRef.current + 1;
     transitionLayoutRequestRef.current = requestId;
     const stateChanged = previousCollapsedRef.current !== isCollapsed;
@@ -618,7 +609,7 @@ function useComposerRestingTransition(
         transitionLayoutRequestRef.current += 1;
       }
     };
-  }, [isCollapsed, isResting, transitionToCurrentGeometry]);
+  }, [isCollapsed, transitionToCurrentGeometry]);
 
   useLayoutEffect(() => {
     const element = elementRef.current;
@@ -1239,12 +1230,12 @@ export interface ChatComposerProps {
   onRestingControlsVisibilityChange: (visible: boolean) => void;
   getTimelineScrollableNode: () => HTMLElement | null;
   isTimelineAtLogicalEnd: () => boolean;
+  onComposerOverlayHeightChange: (height: number) => void;
   /**
-   * Overlay height at the destination of a resting transition, with whether
-   * the composer is resting there. Both land in one update so the chat view
-   * never pairs a resting flag with the other layout's height.
+   * Whether the desktop resting layout is active. Reported from a layout
+   * effect, so it is current before the chat view measures the overlay.
    */
-  onComposerOverlayGeometryChange: (height: number, resting: boolean) => void;
+  onRestingChange: (resting: boolean) => void;
 
   // Refs the parent needs kept in sync
   promptRef: React.RefObject<string>;
@@ -1348,7 +1339,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     onRestingControlsVisibilityChange,
     getTimelineScrollableNode,
     isTimelineAtLogicalEnd,
-    onComposerOverlayGeometryChange,
+    onComposerOverlayHeightChange,
+    onRestingChange,
     promptRef,
     composerRef,
     composerImagesRef,
@@ -3597,6 +3589,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   useLayoutEffect(() => {
     onRestingControlsVisibilityChange(composerControlsVisibleInStrip);
   }, [composerControlsVisibleInStrip, onRestingControlsVisibilityChange]);
+  useLayoutEffect(() => {
+    onRestingChange(isComposerResting);
+  }, [isComposerResting, onRestingChange]);
   const restingImagePreviewCounts = getRestingComposerImagePreviewCounts(
     standaloneComposerImages.length,
   );
@@ -3652,9 +3647,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     ) : null;
   const composerMainSurfaceRef = useComposerRestingTransition(
     composerControlsInStrip,
-    isComposerResting,
     restingComposerControlsRef,
-    onComposerOverlayGeometryChange,
+    onComposerOverlayHeightChange,
   );
   const canTrackComposerScrollGesture =
     routeKind === "server" && activeThreadId !== null && !isMobileViewport;

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -303,7 +303,6 @@ function useComposerRestingTransition(
   }, [clearOverlayPin]);
 
   isCollapsedRef.current = isCollapsed;
-  isRestingRef.current = isResting;
 
   const transitionToCurrentGeometry = useCallback(
     (stateChanged: boolean) => {
@@ -598,7 +597,12 @@ function useComposerRestingTransition(
     [clearTransitionStyles, onOverlayGeometryChange, restingControlsRef],
   );
 
+  // The resting flag can change without the collapsed layout changing, for
+  // example when an unfocused thread crosses the phone breakpoint. Republish
+  // the geometry then too, so the chat view's next measurement is paired
+  // with the right state. Only a collapsed-layout change animates.
   useLayoutEffect(() => {
+    isRestingRef.current = isResting;
     const requestId = transitionLayoutRequestRef.current + 1;
     transitionLayoutRequestRef.current = requestId;
     const stateChanged = previousCollapsedRef.current !== isCollapsed;
@@ -614,7 +618,7 @@ function useComposerRestingTransition(
         transitionLayoutRequestRef.current += 1;
       }
     };
-  }, [isCollapsed, transitionToCurrentGeometry]);
+  }, [isCollapsed, isResting, transitionToCurrentGeometry]);
 
   useLayoutEffect(() => {
     const element = elementRef.current;

--- a/apps/web/src/components/composerFooterLayout.test.ts
+++ b/apps/web/src/components/composerFooterLayout.test.ts
@@ -4,7 +4,9 @@ import { resolveContextStripLabelsCompact } from "./BranchToolbar.logic";
 import {
   COMPOSER_FOOTER_COMPACT_BREAKPOINT_PX,
   COMPOSER_FOOTER_WIDE_ACTIONS_COMPACT_BREAKPOINT_PX,
+  COMPOSER_RESTING_EXPANSION_MIN_PX,
   getRestingComposerImagePreviewCounts,
+  resolveComposerTimelineInset,
   resolveRestingComposerControlsLayout,
   resolveRestingComposerControlsNaturalWidth,
   shouldAnimateComposerRestingTransition,
@@ -71,6 +73,26 @@ describe("shouldUseCompactComposerPrimaryActions", () => {
         hasWideActions: true,
       }),
     ).toBe(false);
+  });
+});
+
+describe("resolveComposerTimelineInset", () => {
+  it("follows the expanded overlay height", () => {
+    expect(
+      resolveComposerTimelineInset({ currentInset: 160, overlayHeight: 140, isResting: false }),
+    ).toBe(140);
+  });
+
+  it("keeps a larger expanded reservation while resting", () => {
+    expect(
+      resolveComposerTimelineInset({ currentInset: 200, overlayHeight: 60, isResting: true }),
+    ).toBe(200);
+  });
+
+  it("reserves the empty expansion when no larger height is known", () => {
+    expect(
+      resolveComposerTimelineInset({ currentInset: 0, overlayHeight: 60, isResting: true }),
+    ).toBe(60 + COMPOSER_RESTING_EXPANSION_MIN_PX);
   });
 });
 

--- a/apps/web/src/components/composerFooterLayout.ts
+++ b/apps/web/src/components/composerFooterLayout.ts
@@ -48,6 +48,36 @@ export function shouldUseRestingComposerLayout(input: {
   return input.isExistingThread && !input.isMobileViewport && collapsed && !input.hasExpandedChrome;
 }
 
+/**
+ * How much taller the empty expanded composer is than its resting row on
+ * desktop widths, from the layout classes in ChatComposer: the body loses
+ * 8px of top padding, the prompt clamps from min-h-17.5 (70px) to 32px, and
+ * the 48px footer leaves flow.
+ */
+export const COMPOSER_RESTING_EXPANSION_MIN_PX = 94;
+
+/**
+ * The space the timeline reserves at its end for the composer overlay.
+ *
+ * The overlay is measured live, but a resting composer is much shorter than
+ * an expanded one. Reserving only the resting height lets a scroll to the end
+ * land flush against the short composer, and the expansion that follows then
+ * covers the last rows because the timeline never moves for footer growth.
+ * While resting, the reservation keeps the last expanded height, or at least
+ * the resting height plus the empty expansion, so expanding again changes
+ * nothing above the composer. An expanded measurement is authoritative and
+ * may shrink it.
+ */
+export function resolveComposerTimelineInset(input: {
+  currentInset: number;
+  overlayHeight: number;
+  isResting: boolean;
+}): number {
+  return input.isResting
+    ? Math.max(input.currentInset, input.overlayHeight + COMPOSER_RESTING_EXPANSION_MIN_PX)
+    : input.overlayHeight;
+}
+
 export function shouldAnimateComposerRestingTransition(input: {
   hasCompletedInitialLayout: boolean;
   stateChanged: boolean;

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -55,8 +55,9 @@ On web and desktop, an existing thread settles its composer into a single-line r
 the composer loses focus. At wider sizes, scrolling the conversation also rests a focused composer,
 except when scrolling toward the end while already there. When the thread-context strip has room,
 the model and mode controls stay available beside the thread context; otherwise they return when the
-composer is focused. Focus the composer or start typing to expand it again. New-thread layouts keep
-the full composer. **Settings → General → Collapse composer** chooses which triggers rest it:
+composer is focused. Focus the composer or start typing to expand it again. The conversation keeps
+the expanded composer's space clear above its last message while the composer rests, so expanding it
+again never covers what you scrolled to. New-thread layouts keep the full composer. **Settings → General → Collapse composer** chooses which triggers rest it:
 **On unfocus**, **On scroll**, both, or neither. With neither selected the composer stays expanded.
 
 At phone-sized web or desktop window widths, existing threads animate between their compact and


### PR DESCRIPTION
When the composer was at rest and I scrolled a long thread to the bottom, the page was slightly shorter than it is with the composer expanded. Reaching the end expands the composer, and the expansion covered the last message.

The cause: the timeline reserves space at its end equal to the live composer overlay height. A resting composer is about 94px shorter, so the scroll range shrank with it. The timeline deliberately does not move for footer growth, so the expansion had nothing to push against and covered the last rows.

The fix keeps the reserved space constant. While the composer rests, the timeline holds the expanded height (or the resting height plus the empty-composer delta when no expanded height is known yet). The visible composer still shrinks. Only the reserved space above it stays the same, so expanding again changes nothing behind it. The composer reports its overlay height together with the resting state so the two never get paired with the wrong layout, and switching threads rebuilds the reservation from that thread's overlay.

The scroll-to-end pill and the preview mini player still track the live overlay height. Mobile and the collapse-off settings are unchanged.

![Scroll to the end with the composer at rest, then it expands without covering the last message](https://files.tslop.org/2026/09/composer-collapse-scroll-ea37c562.gif)

[📹 screen recording](https://files.tslop.org/2026/09/composer-collapse-scroll-68c81781.mov)

Created with Claude Fable 5.1 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized chat scroll and composer layout behavior; scroll-to-end pill and mini player still use live overlay height.
> 
> **Overview**
> Fixes a scroll bug where the **resting composer** was shorter than the expanded one, so the timeline reserved too little space at the bottom and **expanding after scrolling to the end covered the last message**.
> 
> **ChatView** now drives timeline end padding, anchor metrics, and overflow checks from a **`composerTimelineInset`** instead of the live overlay height. While the composer is expanded, the inset matches the measured overlay; while it rests, it stays at the last expanded reservation (or resting height plus a **94px** minimum expansion allowance via new **`resolveComposerTimelineInset`** in `composerFooterLayout.ts`). Switching threads resets and remeasures that reservation so another thread’s tall draft does not leak padding.
> 
> **ChatComposer** reports **`onRestingChange`** from a layout effect (before the parent measures) and republishes overlay height when resting changes without a collapse transition; resting transition code publishes destination overlay height earlier in the layout pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 166dc412873e59e5e4a69d5828b36a200bb01e0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep last message visible when resting composer expands in `ChatViewContent`
> - The chat timeline now reserves resolved expanded-composer space at its end, using the larger known reservation or the minimum expansion allowance while the composer rests; when expanded, the current overlay height becomes authoritative
> - Adds a resting-state ref and callback passed into `ChatComposer`, and a layout effect that rebuilds the reservation when the active thread or overlay element changes in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/9553/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)
> - End anchoring and overflow calculations in `MessagesTimeline` now use the resolved timeline inset instead of the raw overlay height
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 166dc41.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->