### PR TITLE
fix(web): stabilize right panel transitions

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1865,8 +1865,7 @@ function ChatViewContent(props: ChatViewProps) {
     panelAnimationDurationMs,
   );
   const rightPanelPresent = rightPanelPresence.present;
-  const rightPanelControlsInPanel =
-    shouldUseRightPanelSheet && rightPanelPresent && rightPanelOpen;
+  const rightPanelControlsInPanel = shouldUseRightPanelSheet && rightPanelPresent && rightPanelOpen;
   const renderedRightPanelSurface = rightPanelPresence.value?.activeSurface ?? null;
   const renderedRightPanelSurfaces = rightPanelPresence.value?.surfaces ?? [];
   const previewMiniPlayerVisible = shouldRenderPreviewMiniPlayer(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1865,7 +1865,8 @@ function ChatViewContent(props: ChatViewProps) {
     panelAnimationDurationMs,
   );
   const rightPanelPresent = rightPanelPresence.present;
-  const rightPanelControlsInPanel = rightPanelPresent && rightPanelOpen;
+  const rightPanelControlsInPanel =
+    shouldUseRightPanelSheet && rightPanelPresent && rightPanelOpen;
   const renderedRightPanelSurface = rightPanelPresence.value?.activeSurface ?? null;
   const renderedRightPanelSurfaces = rightPanelPresence.value?.surfaces ?? [];
   const previewMiniPlayerVisible = shouldRenderPreviewMiniPlayer(
@@ -7450,15 +7451,6 @@ function ChatViewContent(props: ChatViewProps) {
       <div className="pointer-events-auto flex h-full items-center">{panelToggleControls}</div>
     </div>
   );
-  const inlineRightPanelControls = (
-    <div className="mr-px flex h-full items-center gap-1 [-webkit-app-region:no-drag]">
-      <RightPanelMaximizeControl
-        maximized={rightPanelMaximized}
-        onToggle={toggleRightPanelMaximized}
-      />
-      {panelToggleControls}
-    </div>
-  );
   const rightPanelContent = activeThreadRef ? (
     renderedRightPanelSurface?.kind === "preview" ? (
       <Suspense fallback={null}>
@@ -7605,6 +7597,7 @@ function ChatViewContent(props: ChatViewProps) {
 
   return (
     <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
+      {!rightPanelControlsInPanel ? panelLayoutControls : null}
       <div
         className={cn(
           "flex min-h-0 min-w-0 flex-col overflow-x-hidden",
@@ -7619,7 +7612,6 @@ function ChatViewContent(props: ChatViewProps) {
           reserveNativeControls={reserveTitleBarControlInset && !inlineRightPanelOwnsTitleBar}
           className="relative bg-background"
         >
-          {!rightPanelControlsInPanel ? panelLayoutControls : null}
           <ChatHeader
             {...(!supportsPullRequests || activeProjectRepository === null
               ? {}
@@ -8047,7 +8039,6 @@ function ChatViewContent(props: ChatViewProps) {
           mode="inline"
           open={rightPanelOpen}
           maximized={rightPanelMaximized}
-          layoutControls={rightPanelOpen ? inlineRightPanelControls : null}
           surfaces={renderedRightPanelSurfaces}
           environmentId={activeThreadRef.environmentId}
           activeSurfaceId={renderedRightPanelSurface?.id ?? null}

--- a/apps/web/src/components/preview/PreviewPanelShell.tsx
+++ b/apps/web/src/components/preview/PreviewPanelShell.tsx
@@ -68,10 +68,11 @@ export function PreviewPanelShell(props: {
   const isInline = props.mode === "inline";
   const collapsible = isInline && props.open !== undefined;
   const open = props.open ?? true;
+  const maximized = props.maximized ?? false;
   const hostRef = useRef<HTMLDivElement | null>(null);
   // Only inline non-maximized mode applies `width`/`maxWidth`; skip the
   // container measurement (and its re-renders) everywhere else.
-  const maxWidth = useClampedMaxWidth(hostRef, isInline && !props.maximized);
+  const maxWidth = useClampedMaxWidth(hostRef, isInline && !maximized);
   const { width, handlers } = useResizableWidth({
     storageKey: props.widthStorageKey ?? PREVIEW_PANEL_WIDTH_STORAGE_KEY,
     defaultWidth: props.defaultWidth ?? PREVIEW_PANEL_DEFAULT_WIDTH,
@@ -79,33 +80,50 @@ export function PreviewPanelShell(props: {
     maxWidth,
     edge: "left",
   });
-  const previousLayoutRef = useRef({ open, width });
+  // Derive suppression before the layout commits so the browser never creates
+  // a width transition for resize or maximize changes.
+  const [layoutTransition, setLayoutTransition] = useState(() => ({
+    open,
+    width,
+    maximized,
+    suppressed: false,
+  }));
+  if (
+    layoutTransition.open !== open ||
+    layoutTransition.width !== width ||
+    layoutTransition.maximized !== maximized
+  ) {
+    setLayoutTransition({
+      open,
+      width,
+      maximized,
+      suppressed:
+        collapsible &&
+        layoutTransition.open === open &&
+        (layoutTransition.width !== width || layoutTransition.maximized !== maximized),
+    });
+  }
+  const suppressWidthTransition = layoutTransition.suppressed;
   useLayoutEffect(() => {
-    const previous = previousLayoutRef.current;
-    previousLayoutRef.current = { open, width };
-    if (!collapsible || previous.open !== open || previous.width === width) return;
-    const host = hostRef.current;
-    if (!host?.closest("[data-panel-animations=true]")) return;
-    host.style.setProperty("transition-duration", "0ms");
+    if (!suppressWidthTransition) return;
     let restoreFrame = 0;
     const paintFrame = window.requestAnimationFrame(() => {
       restoreFrame = window.requestAnimationFrame(() => {
-        host.style.removeProperty("transition-duration");
+        setLayoutTransition((current) => ({ ...current, suppressed: false }));
       });
     });
     return () => {
       window.cancelAnimationFrame(paintFrame);
       window.cancelAnimationFrame(restoreFrame);
-      host.style.removeProperty("transition-duration");
     };
-  }, [collapsible, open, width]);
+  }, [suppressWidthTransition]);
   return (
     <div
       ref={hostRef}
       className={cn(
         "relative flex h-full min-h-0 min-w-0 max-w-full flex-col self-stretch bg-background",
         isInline
-          ? props.maximized
+          ? maximized
             ? "flex-1 border-l border-border"
             : "shrink-0 border-l border-border"
           : "w-full",
@@ -116,17 +134,20 @@ export function PreviewPanelShell(props: {
       )}
       style={
         isInline
-          ? { width: props.maximized ? "100%" : collapsible && !open ? "0px" : `${width}px` }
+          ? {
+              width: maximized ? "100%" : collapsible && !open ? "0px" : `${width}px`,
+              transitionDuration: suppressWidthTransition ? "0ms" : undefined,
+            }
           : undefined
       }
       data-preview-panel-mode={props.mode}
-      data-preview-panel-maximized={props.maximized ? "true" : "false"}
+      data-preview-panel-maximized={maximized ? "true" : "false"}
     >
-      {isInline && !props.maximized ? <RightPanelResizeHandle handlers={handlers} /> : null}
+      {isInline && !maximized ? <RightPanelResizeHandle handlers={handlers} /> : null}
       <div className={cn("h-full min-h-0 w-full", collapsible && "overflow-clip")}>
         <div
           className="flex h-full min-h-0 min-w-0 flex-col"
-          style={collapsible && !props.maximized ? { width: `calc(${width}px - 1px)` } : undefined}
+          style={collapsible && !maximized ? { width: `calc(${width}px - 1px)` } : undefined}
         >
           {useDragRegion ? <div className="electron-drag-region h-0 w-full" aria-hidden /> : null}
           {props.children}


### PR DESCRIPTION
The right panel animates from full width back to its stored width when panel animations are enabled, squeezing the chat column during restore. Its layout controls also switch DOM ownership on open, which makes them slide in with the panel.

This suppresses the width transition for resize and maximize state changes while preserving the configured open and close behavior. Inline layouts now keep one viewport-fixed control cluster mounted above the clipped chat column, so the controls remain stationary and clickable while the panel opens, closes, maximizes, and restores.

### Before

![Panel controls moving in from the right during the opening animation](https://uploads-production-47e4.up.railway.app/files/6eb2ac19-43bf-4ab6-8f46-9a553eb45eb3/before-panel-controls.gif)

### After

![Panel controls staying fixed while the right panel opens underneath them](https://uploads-production-47e4.up.railway.app/files/717a7deb-e61c-4811-a677-c3e355a34b99/after-panel-controls.gif)

Validation:

- scoped lint passes with existing warnings
- web typecheck passes
- verified the exact open, close, maximize, and restore interactions at the maximum 400ms panel animation duration
- sampled the opening transition at 0, 67, 133, 200, 267, 333, and 400ms; the control cluster remains at x=1175 throughout

Model: `gpt-5.6-sol`
Harness: T3 Code Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and CSS transition behavior in the chat right panel; no auth, data, or API changes.
> 
> **Overview**
> Fixes janky right-panel UX when animations are on: restoring from maximize no longer animates width back to the stored size (which squeezed the chat), and inline maximize/layout controls no longer ride in with the panel during open/close.
> 
> **Layout controls** stay in a viewport-fixed cluster above the workspace (only when not using the sheet layout), instead of being passed into `RightPanelTabs` as `layoutControls`. `rightPanelControlsInPanel` now also requires `shouldUseRightPanelSheet`, so inline desktop keeps one stationary control bar.
> 
> **`PreviewPanelShell`** tracks open/width/maximized and temporarily sets `transitionDuration: 0ms` when width or maximize changes while open stays the same, so resize and maximize toggles skip the width transition while normal open/close animations still run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82aa5767adcbc907383dcb20a1109466b76671f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stabilize right panel transitions in `PreviewPanelShell` and `ChatViewContent`
> - Moves general panel layout controls outside the workspace header for non-sheet layouts and removes the separate inline right-panel control group in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/9554/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
> - Replaces the ref-based transition effect in [PreviewPanelShell.tsx](https://github.com/pingdotgg/t3code/pull/9554/files#diff-2bc30e0009261fedf96201eed47a807896930a736b4d944b9393ec09c4a72396) with render-tracked layout state. Width or maximize changes while the panel is open set an inline zero-duration transition, cleared after two animation frames.
> - Behavioral Change: Maximized inline panels in `PreviewPanelShell` use full width, disable the max-width hook, and no longer render a resize handle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82aa576.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->