### PR TITLE
test(web): fix flaky startup and Tailwind tests

### DIFF
--- a/apps/web/src/bootstrap.test.ts
+++ b/apps/web/src/bootstrap.test.ts
@@ -30,9 +30,6 @@ describe("app startup failures", () => {
 
   beforeEach(() => {
     vi.resetModules();
-    vi.doMock("./main", () => {
-      throw new Error("@vitejs/plugin-react can't detect preamble. Something is wrong.");
-    });
     bootShell = new BootElement("div");
     vi.stubGlobal("document", {
       getElementById: () => bootShell,
@@ -51,12 +48,16 @@ describe("app startup failures", () => {
   });
 
   afterEach(() => {
+    vi.doUnmock("./main");
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
   it("replaces the splash when an app import throws before main can run", async () => {
+    vi.doMock("./main", () => {
+      throw new Error("@vitejs/plugin-react can't detect preamble. Something is wrong.");
+    });
     const reload = vi.fn();
     vi.stubGlobal("window", { location: { reload } });
 

--- a/apps/web/src/bundledDev.test.ts
+++ b/apps/web/src/bundledDev.test.ts
@@ -147,7 +147,8 @@ it("hot updates Tailwind classes when a source file changes in bundled dev", asy
     );
     const logger = createLogger("silent");
     logger.error = (message) => events.emit("error", new Error(message));
-    const built = NodeEvents.EventEmitter.once(events, "built");
+    const connected = NodeEvents.EventEmitter.once(events, "connected");
+    const ready = NodeEvents.EventEmitter.once(events, "ready");
     server = await createServer({
       configFile: false,
       root,
@@ -168,19 +169,18 @@ it("hot updates Tailwind classes when a source file changes in bundled dev", asy
           transform(code, id) {
             if (id.endsWith("/style.css")) css = code;
           },
-          generateBundle() {
-            events.emit("built");
+          async generateBundle() {
+            // Keep the build pending until the socket can receive Vite's ready message.
+            await connected;
           },
         },
       ],
       server: { host: "127.0.0.1", port: 0 },
     });
     await server.listen();
-    await built;
     const address = server.httpServer?.address();
     if (!address || typeof address === "string") throw new Error("Vite did not bind a port");
 
-    const connected = NodeEvents.EventEmitter.once(events, "connected");
     server.ws.on("vite:client-connected", () => events.emit("connected"));
     socket = new WebSocket(
       `ws://127.0.0.1:${address.port}/?token=${server.config.webSocketToken}`,
@@ -197,16 +197,21 @@ it("hot updates Tailwind classes when a source file changes in bundled dev", asy
     });
     socket.addEventListener("message", ({ data }) => {
       const message: unknown = JSON.parse(String(data));
-      if (
-        message !== null &&
-        typeof message === "object" &&
-        "type" in message &&
-        message.type === "bundled-dev-update"
-      ) {
-        events.emit("updated");
+      if (message !== null && typeof message === "object" && "type" in message) {
+        // generateBundle runs before Vite stores the files for HTTP requests.
+        if (
+          message.type === "full-reload" &&
+          "ifFallback" in message &&
+          message.ifFallback === true
+        ) {
+          events.emit("ready");
+        } else if (message.type === "bundled-dev-update") {
+          events.emit("updated");
+        }
       }
     });
     await connected;
+    await ready;
     const entry = await fetch(`http://127.0.0.1:${address.port}/assets/index.js`);
     expect(entry.headers.get("content-type")).toContain("javascript");
     await entry.text();


### PR DESCRIPTION
Two web tests failed on unrelated changes to main.

- Wait for Vite's ready message before fetching the Tailwind test bundle. The build hook runs before Vite can serve its output.
- Register one main-module mock per startup test. Queued mocks can resolve out of order.

Both files passed 50 consecutive runs, with 350 test executions. Focused tests, web typecheck, lint, and formatting also pass after rebasing onto main. No retries or longer timeouts were added.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code paths; risk is limited to CI signal quality.
> 
> **Overview**
> Stabilizes two web integration tests that were failing intermittently on unrelated `main` changes.
> 
> **Bootstrap startup tests:** The shared `beforeEach` no longer mocks `./main` with a synchronous throw. That mock is registered only in the test that asserts preamble/import failures, and `afterEach` calls `vi.doUnmock("./main")` so Vitest’s queued mocks cannot leak into the async startup rejection case.
> 
> **Tailwind HMR test:** Instead of treating `generateBundle` as “built,” the test waits for the HMR client to connect and for Vite’s `full-reload` message with `ifFallback: true` before fetching `/assets/index.js`. The observe plugin’s `generateBundle` stays pending until the socket is connected, matching the real ordering where bundle generation finishes before assets are served over HTTP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20355791d60f59cef2699544c7510b92e337e3b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky `bootstrap` startup and `bundledDev` Tailwind tests
> - Removes the default throwing `./main` mock from the `beforeEach` hook so it no longer affects every test in the startup-failure suite; the throwing import is moved into the single test that verifies the pre-main error path.
> - Adds `./main` mock cleanup in the `afterEach` hook to prevent mock reuse across tests.
> - Reworks the bundled-dev test synchronization: delays `generateBundle` completion until the WebSocket connects, treats Vite's fallback `full-reload` as the readiness signal, and waits for it before requesting the generated entry; source changes are still validated through the `bundled-dev-update` message.
> - Risk: test-only changes; no runtime behavior affected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2035579.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->