### PR TITLE
fix(web): keep codex restart responses continuous

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1326,6 +1326,111 @@ describe("deriveMessagesTimelineRows", () => {
     ]);
   });
 
+  it("keeps a promptless restart in one active visual response", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "user-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:00Z",
+          message: {
+            id: "user-1" as never,
+            role: "user",
+            text: "keep going",
+            turnId: null,
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-01T00:00:00Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "old-work-entry",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:05Z",
+          entry: {
+            id: "old-work",
+            createdAt: "2026-01-01T00:00:05Z",
+            turnId: "turn-before-restart" as never,
+            label: "Searched files",
+            command: "rg restart",
+            tone: "tool" as const,
+            toolLifecycleStatus: "completed" as const,
+          },
+        },
+        {
+          id: "old-stale-work-entry",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:06Z",
+          entry: {
+            id: "old-stale-work",
+            createdAt: "2026-01-01T00:00:06Z",
+            turnId: "turn-before-restart" as never,
+            label: "Running stale command",
+            command: "rg stale",
+            tone: "tool" as const,
+            toolLifecycleStatus: "inProgress" as const,
+          },
+        },
+        {
+          id: "old-commentary-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:08Z",
+          message: {
+            id: "old-commentary" as never,
+            role: "assistant",
+            text: "the server restarted, continuing here.",
+            turnId: "turn-before-restart" as never,
+            createdAt: "2026-01-01T00:00:08Z",
+            updatedAt: "2026-01-01T00:00:08Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "new-work-entry",
+          kind: "work",
+          createdAt: "2026-01-01T00:01:05Z",
+          entry: {
+            id: "new-work",
+            createdAt: "2026-01-01T00:01:05Z",
+            turnId: "turn-after-restart" as never,
+            label: "Running tests",
+            command: "vp test run",
+            tone: "tool" as const,
+            toolLifecycleStatus: "inProgress" as const,
+          },
+        },
+      ],
+      latestTurn: {
+        turnId: "turn-after-restart" as never,
+        state: "running",
+        startedAt: "2026-01-01T00:01:00Z",
+        completedAt: null,
+      },
+      isWorking: true,
+      activeTurnStartedAt: "2026-01-01T00:01:00Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.some((row) => row.kind === "turn-fold")).toBe(false);
+    expect(rows.filter((row) => row.id === "working-indicator-row")).toHaveLength(1);
+    expect(rows.findIndex((row) => row.id === "working-indicator-row")).toBeLessThan(
+      rows.findIndex((row) => row.id === "old-work-entry"),
+    );
+    expect(rows.find((row) => row.id === "working-indicator-row")).toMatchObject({
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    expect(rows.find((row) => row.id === "old-commentary-entry")).toMatchObject({
+      showAssistantMeta: false,
+      showAssistantCopyButton: false,
+      assistantCopyStreaming: true,
+    });
+    expect(rows.filter((row) => row.kind === "work-live" && row.active)).toEqual([
+      expect.objectContaining({ entry: expect.objectContaining({ id: "new-work" }) }),
+    ]);
+    expect(rows.some((row) => row.kind === "thinking")).toBe(false);
+  });
+
   it("keeps an actually running tool in the shared activity row", () => {
     const rows = deriveMessagesTimelineRows({
       timelineEntries: [

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -512,6 +512,37 @@ function timelineEntryTurnId(entry: TimelineEntry): TurnId | null {
   return entry.kind === "work" ? (entry.entry.turnId ?? null) : null;
 }
 
+/**
+ * A promptless provider restart replaces the native turn without adding a
+ * user message. Keep every provider turn since the latest user message in one
+ * visual response until the replacement turn settles. A steer has its own
+ * user message, so it naturally starts a new visual response.
+ */
+function deriveActiveVisualResponseTurnIds(input: {
+  timelineEntries: ReadonlyArray<TimelineEntry>;
+  unsettledTurnId: TurnId | null;
+  isWorking: boolean;
+}): ReadonlySet<TurnId> {
+  const turnIds = new Set<TurnId>();
+  if (input.unsettledTurnId === null) {
+    return turnIds;
+  }
+
+  turnIds.add(input.unsettledTurnId);
+  if (!input.isWorking) {
+    return turnIds;
+  }
+
+  const latestUserMessageIndex = lastUserMessageIndex(input.timelineEntries);
+  for (let index = latestUserMessageIndex + 1; index < input.timelineEntries.length; index += 1) {
+    const turnId = timelineEntryTurnId(input.timelineEntries[index]!);
+    if (turnId !== null) {
+      turnIds.add(turnId);
+    }
+  }
+  return turnIds;
+}
+
 function workEntryIsActiveTurnActivity(entry: WorkLogEntry): boolean {
   return (
     entry.toolLifecycleStatus === "inProgress" ||
@@ -529,7 +560,7 @@ function deriveTurnFolds(input: {
   timelineEntries: ReadonlyArray<TimelineEntry>;
   terminalAssistantMessageIds: ReadonlySet<string>;
   latestTurn: TimelineLatestTurn | null;
-  unsettledTurnId: TurnId | null;
+  unfoldedTurnIds: ReadonlySet<TurnId>;
 }): ReadonlyMap<string, TurnFold> {
   interface TurnGroup {
     entries: Array<TimelineEntry>;
@@ -587,7 +618,7 @@ function deriveTurnFolds(input: {
 
   const foldsByAnchorEntryId = new Map<string, TurnFold>();
   for (const [turnId, group] of groupsByTurnId) {
-    if (turnId === input.unsettledTurnId) {
+    if (input.unfoldedTurnIds.has(turnId)) {
       continue;
     }
     if (group.hasStreamingMessage) {
@@ -769,11 +800,16 @@ export function deriveMessagesTimelineRows(input: {
     input.latestTurn ?? null,
     input.runningTurnId ?? null,
   );
+  const activeVisualResponseTurnIds = deriveActiveVisualResponseTurnIds({
+    timelineEntries: input.timelineEntries,
+    unsettledTurnId,
+    isWorking: input.isWorking,
+  });
   const foldsByAnchorEntryId = deriveTurnFolds({
     timelineEntries: input.timelineEntries,
     terminalAssistantMessageIds,
     latestTurn: input.latestTurn ?? null,
-    unsettledTurnId,
+    unfoldedTurnIds: activeVisualResponseTurnIds,
   });
   const collapsedEntryIds = new Set<string>();
   for (const fold of foldsByAnchorEntryId.values()) {
@@ -787,15 +823,7 @@ export function deriveMessagesTimelineRows(input: {
   let activeTurnHeaderIndex = input.timelineEntries.length;
   if (input.isWorking) {
     const latestUserMessageIndex = lastUserMessageIndex(input.timelineEntries);
-    const firstOwnedAfterUser =
-      unsettledTurnId === null
-        ? -1
-        : input.timelineEntries.findIndex(
-            (entry, index) =>
-              index > latestUserMessageIndex && timelineEntryTurnId(entry) === unsettledTurnId,
-          );
-    activeTurnHeaderIndex =
-      firstOwnedAfterUser >= 0 ? firstOwnedAfterUser : latestUserMessageIndex + 1;
+    activeTurnHeaderIndex = latestUserMessageIndex + 1;
   }
   const entryBelongsToActiveTurn = (entry: TimelineEntry, index: number) =>
     input.isWorking &&
@@ -862,10 +890,17 @@ export function deriveMessagesTimelineRows(input: {
     activeWorkRow !== null || latestToolFailed ? activeToolEntries.map((entry) => entry.id) : [],
   );
   const appendWorkingRow = () => {
+    const latestUserMessage = input.timelineEntries[lastUserMessageIndex(input.timelineEntries)];
+    const visualResponseStartedAt =
+      activeVisualResponseTurnIds.size > 1 &&
+      latestUserMessage?.kind === "message" &&
+      latestUserMessage.message.role === "user"
+        ? latestUserMessage.message.createdAt
+        : input.activeTurnStartedAt;
     nextRows.push({
       kind: "working",
       id: "working-indicator-row",
-      createdAt: input.activeTurnStartedAt,
+      createdAt: visualResponseStartedAt,
     });
   };
   let hasActivityRow = false;
@@ -1081,10 +1116,11 @@ export function deriveMessagesTimelineRows(input: {
       continue;
     }
 
-    const assistantTurnStillInProgress =
+    const assistantResponseStillInProgress =
       timelineEntry.message.role === "assistant" &&
-      unsettledTurnId !== null &&
-      timelineEntry.message.turnId === unsettledTurnId;
+      timelineEntry.message.turnId !== null &&
+      timelineEntry.message.turnId !== undefined &&
+      activeVisualResponseTurnIds.has(timelineEntry.message.turnId);
 
     const durationStart =
       durationStartByMessageId.get(timelineEntry.message.id) ?? timelineEntry.message.createdAt;
@@ -1095,7 +1131,7 @@ export function deriveMessagesTimelineRows(input: {
     const showAssistantMeta =
       timelineEntry.message.role === "assistant" &&
       terminalAssistantMessageIds.has(timelineEntry.message.id) &&
-      !assistantTurnStillInProgress;
+      !assistantResponseStillInProgress;
 
     nextRows.push({
       kind: "message",
@@ -1105,7 +1141,7 @@ export function deriveMessagesTimelineRows(input: {
       durationStart,
       showAssistantMeta,
       showAssistantCopyButton: showAssistantMeta,
-      assistantCopyStreaming: timelineEntry.message.streaming || assistantTurnStillInProgress,
+      assistantCopyStreaming: timelineEntry.message.streaming || assistantResponseStillInProgress,
       assistantTurnDiffSummary:
         timelineEntry.message.role === "assistant"
           ? input.turnDiffSummaryByAssistantMessageId.get(timelineEntry.message.id)


### PR DESCRIPTION
> [!NOTE]
> Written by `gpt-5.6-sol` on behalf of Maria

Promptless Codex restart continuations currently split one visible response into two timers and fold the pre-restart work while the replacement turn is still running. This groups consecutive provider turns after the same user message into one active visual response while keeping live tool state scoped to the actual running turn. Verified with the focused timeline suite, web typecheck and lint, plus the same simulated restart fixture in dark and light desktop layouts.

Before:

![](https://uploads-production-47e4.up.railway.app/files/87ce2712-6d41-4bdc-8880-d4f1d46699c1/t3code-codex-restart-before.png)

After:

![](https://uploads-production-47e4.up.railway.app/files/71982445-53b9-423e-98d1-4259d320e512/t3code-codex-restart-after.png)

Implemented by `gpt-5.6-sol` through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to chat timeline presentation logic in `MessagesTimeline.logic.ts` with unit test coverage; no auth, persistence, or API changes.
> 
> **Overview**
> **Promptless Codex restarts** no longer split one user-facing reply into separate working timers or fold pre-restart activity while the replacement turn is still running.
> 
> Timeline derivation now builds an **active visual response** set: all provider turn IDs after the latest user message (plus the unsettled turn) stay unfolded and treated as one in-progress assistant response until work settles. Turn folding skips every ID in that set instead of only the single unsettled turn. The working row’s `createdAt` anchors to the user message when multiple turns share that visual response, and assistant meta/copy/streaming flags follow the broader set so pre-restart commentary stays “live” until the continuation finishes. **Live tool activity** still keys off the actual unsettled turn so only the post-restart in-progress tool drives the shared activity row.
> 
> A regression test covers the restart fixture (no turn-fold, single working indicator, stale pre-restart tools not live, new turn’s tool active).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c475673abe43a3bf20fa67fe8fa6d4bc7215b8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test for promptless codex restart rendering in `MessagesTimeline`
> Adds a test case to `deriveMessagesTimelineRows` in [MessagesTimeline.logic.test.ts](https://github.com/pingdotgg/t3code/pull/9560/files#diff-e1bf628eaf9220069a00bdd08d5e22144ed7c8bb723b4cafa3ffb550083c2a72) that verifies a promptless provider restart stays as one active visual response. The scenario covers a user message, work and commentary from one provider turn, then replacement work from a second turn without a new user message. Assertions confirm no turn-fold row, one working indicator before the earlier work, the user-message timestamp, provisional commentary, only the replacement work active, and no thinking row.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c47567.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->