### PR TITLE
fix(web): make settings sidebar sub-section buttons full width

### DIFF
--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -353,7 +353,7 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
                             <SidebarMenuSubButton
                               render={<button type="button" />}
                               size="sm"
-                              className="text-sidebar-muted-foreground/65"
+                              className="w-full text-sidebar-muted-foreground/65"
                               onClick={() => handlePageSectionClick(item.to, section.targetId)}
                             >
                               <span className="ms-0.5">{section.label}</span>


### PR DESCRIPTION
The sub-section links under the active settings page (Organization, Behavior, About, …) rendered as content-sized `<button>`s, so only the text itself was clickable and the hover state was a small pill hugging the label. This stretches them to the full row width, matching the section buttons above them and the \"Show more\" sub-buttons in the thread sidebar.

One-line change: add `w-full` to the `SidebarMenuSubButton` in `SettingsSidebarNav`.

## Evidence

Hovering \"Confirmations\" under Settings → General. Measured hit areas went from 52–123px (content width) to 190px (full row) for every sub-section button.

| Before | After |
| --- | --- |
| ![Before: hover highlight hugs the Confirmations label](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/c58e7d19a31322d3/settings-subbar-before.png) | ![After: hover highlight spans the full sidebar row](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/111aae020d367a09/settings-subbar-after.png) |

## Verification

- `vp fmt --check` and `apps/web` typecheck pass.
- Web only: the mobile app has its own settings navigation and does not use this component.

Made with Claude Fable 5 in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class on a settings nav button; UI hit-target/hover only, no auth, data, or routing logic.
> 
> **Overview**
> Settings sidebar **in-page section links** (e.g. Organization, Confirmations under General) now use **`w-full`** on `SidebarMenuSubButton`, so the clickable area and hover highlight span the full row instead of hugging the label.
> 
> This matches parent section buttons and thread sidebar sub-actions like “Show more.” **Web-only** styling; no navigation or scroll/hash behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42f8b3f233a18524bb664da0862134412e1114ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make settings sidebar sub-section buttons full width
> Updates the submenu button styling in [SettingsSidebarNav.tsx](https://github.com/pingdotgg/t3code/pull/9562/files#diff-0c64e545aee60962b27c61f412d1b564c5896199b9538212702b7da60246d134) so each section button spans the full available submenu width, providing a full-width clickable row.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42f8b3f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->