### PR TITLE
fix(web): render settings sidebar immediately

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -1,8 +1,6 @@
 import { useAtomValue } from "@effect/atom-react";
 import * as Schema from "effect/Schema";
 import {
-  lazy,
-  Suspense,
   useEffect,
   useState,
   useSyncExternalStore,
@@ -20,6 +18,7 @@ import { useEnvironmentIdentificationMode, useLegacySidebarEnabled } from "../ho
 import { usePanelAnimationSettings } from "../panelAnimations";
 import LegacyThreadSidebar from "./LegacySidebar";
 import ThreadSidebar from "./Sidebar";
+import { SettingsSidebarNav } from "./settings/SettingsSidebarNav";
 import { SidebarChromeHeader } from "./sidebar/SidebarChrome";
 import {
   resolveSidebarStageFocusRingOffsetClass,
@@ -44,14 +43,6 @@ import {
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 
 const MACOS_TRAFFIC_LIGHTS_LEFT_INSET = "90px";
-
-// The settings nav (and the Clerk profile surfaces behind it) only renders on
-// settings routes; lazy-loading it keeps that subtree out of the startup chunk.
-const SettingsSidebarNav = lazy(() =>
-  import("./settings/SettingsSidebarNav").then((module) => ({
-    default: module.SettingsSidebarNav,
-  })),
-);
 
 function subscribeToViewportWidth(onChange: () => void): () => void {
   window.addEventListener("resize", onChange);
@@ -247,9 +238,7 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
         {isOnSettings ? (
           <>
             <SidebarChromeHeader isElectron={isElectron} />
-            <Suspense fallback={null}>
-              <SettingsSidebarNav pathname={pathname} />
-            </Suspense>
+            <SettingsSidebarNav pathname={pathname} />
           </>
         ) : legacySidebarEnabled ? (
           <LegacyThreadSidebar />

--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -1,4 +1,6 @@
 import {
+  lazy,
+  Suspense,
   useCallback,
   useEffect,
   useMemo,
@@ -36,7 +38,6 @@ import {
   SidebarMenuSubItem,
   useSidebar,
 } from "../ui/sidebar";
-import { T3ConnectSidebarAvatar, T3ConnectSidebarSignIn } from "../clerk/T3ConnectSidebarSignIn";
 import { SidebarUtilityMenu } from "../sidebar/SidebarChrome";
 import { scrollToSettingsTarget } from "./settingsLayout";
 import {
@@ -46,6 +47,17 @@ import {
   type SettingsSearchItem,
 } from "./settingsSearch";
 import { useAvailableSettingsSearchItems } from "./useAvailableSettingsSearchItems";
+
+const T3ConnectSidebarSignIn = lazy(() =>
+  import("../clerk/T3ConnectSidebarSignIn").then((module) => ({
+    default: module.T3ConnectSidebarSignIn,
+  })),
+);
+const T3ConnectSidebarAvatar = lazy(() =>
+  import("../clerk/T3ConnectSidebarSignIn").then((module) => ({
+    default: module.T3ConnectSidebarAvatar,
+  })),
+);
 
 const SETTINGS_SECTION_ICONS: Readonly<
   Record<SettingsPath, ComponentType<{ className?: string }>>
@@ -370,12 +382,16 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
         </SidebarGroup>
       </SidebarContent>
       <SidebarFooter className="p-[var(--sidebar-content-inset)]">
-        <T3ConnectSidebarSignIn />
+        <Suspense fallback={null}>
+          <T3ConnectSidebarSignIn />
+        </Suspense>
         <div className="flex items-center gap-1">
           <div className="min-w-0 flex-1">
             <SidebarUtilityMenu />
           </div>
-          <T3ConnectSidebarAvatar />
+          <Suspense fallback={null}>
+            <T3ConnectSidebarAvatar />
+          </Suspense>
         </div>
       </SidebarFooter>
     </>


### PR DESCRIPTION
The settings sidebar replaced the thread sidebar before its separately lazy-loaded navigation chunk arrived, leaving it blank for 562.5 ms in the reproduced cold open. This renders the core settings navigation synchronously while keeping optional Clerk profile controls split, eliminating the blank interval with 0 ms measured after the change. Verified with focused lint, web typecheck, production build, and a cold first-open browser pass.

![Settings sidebar rendered with search, sections, and back control](https://uploads-production-47e4.up.railway.app/files/20f4a855-06b4-480a-9c6f-4c150747f615/t3-settings-sidebar-after.png)

Implemented with `gpt-5.6-sol` in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bundle and render-timing change only; no auth or routing logic changes beyond when Clerk footer widgets load.
> 
> **Overview**
> Fixes a **blank settings sidebar** on cold navigation to settings by loading the settings nav **synchronously** instead of behind `React.lazy` in `AppSidebarLayout`.
> 
> **Lazy loading moves** to the footer-only Clerk pieces (`T3ConnectSidebarSignIn`, `T3ConnectSidebarAvatar`) inside `SettingsSidebarNav`, wrapped in `Suspense` with a null fallback, so search, section links, and back chrome appear immediately while auth UI still splits into a separate chunk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 745d80da3479f4dc8ff2ebfd03ec87bc6d37ac88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render `SettingsSidebarNav` statically in `AppSidebarLayout` and lazy-load Clerk footer components
> - Removes the dynamic import and outer `Suspense` boundary for `SettingsSidebarNav` in [AppSidebarLayout.tsx](https://github.com/pingdotgg/t3code/pull/9563/files#diff-b580a936d60a70bebcccf38ac9a82ca5f4440c99445dbccb0c176ebe5dc1d301), so the settings sidebar renders without waiting on a code-split chunk.
> - Moves the lazy split to the Clerk sign-in and avatar elements inside [SettingsSidebarNav.tsx](https://github.com/pingdotgg/t3code/pull/9563/files#diff-0c64e545aee60962b27c61f412d1b564c5896199b9538212702b7da60246d134), wrapping each in its own `Suspense` with a null fallback so the sidebar is usable while those load.
> - Behavioral Change: `T3ConnectSidebarSignIn` and `T3ConnectSidebarAvatar` now render nothing until their lazy imports resolve instead of blocking the initial sidebar paint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 745d80d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->