### PR TITLE
test(server): pin git config for fixtures and compare native realpaths

### DIFF
--- a/apps/server/src/project/RepositoryIdentityResolver.test.ts
+++ b/apps/server/src/project/RepositoryIdentityResolver.test.ts
@@ -1,3 +1,5 @@
+// @effect-diagnostics nodeBuiltinImport:off - realpathSync.native resolves Windows 8.3 short names, which the Effect realPath does not.
+import * as NodeFS from "node:fs";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { expect, it } from "@effect/vitest";
 import * as Duration from "effect/Duration";
@@ -131,9 +133,11 @@ it.layer(NodeServices.layer)("RepositoryIdentityResolverLive", (it) => {
 
       const resolver = yield* RepositoryIdentityResolver.RepositoryIdentityResolver;
       const identity = yield* resolver.resolve(cwd);
+      // Native realpath, since git reports the long form of a directory the
+      // temp dir may name by its 8.3 short form on Windows.
       const resolvedIdentityRoot =
-        identity?.rootPath === undefined ? "" : yield* fileSystem.realPath(identity.rootPath);
-      const resolvedCwd = yield* fileSystem.realPath(cwd);
+        identity?.rootPath === undefined ? "" : NodeFS.realpathSync.native(identity.rootPath);
+      const resolvedCwd = NodeFS.realpathSync.native(cwd);
 
       expect(identity).not.toBeNull();
       expect(identity?.canonicalKey).toBe("github.com/t3tools/t3code");
@@ -161,8 +165,8 @@ it.layer(NodeServices.layer)("RepositoryIdentityResolverLive", (it) => {
       const resolver = yield* RepositoryIdentityResolver.RepositoryIdentityResolver;
       const identity = yield* resolver.resolve(nestedWorkspace);
       const resolvedIdentityRoot =
-        identity?.rootPath === undefined ? "" : yield* fileSystem.realPath(identity.rootPath);
-      const resolvedRepoRoot = yield* fileSystem.realPath(repoRoot);
+        identity?.rootPath === undefined ? "" : NodeFS.realpathSync.native(identity.rootPath);
+      const resolvedRepoRoot = NodeFS.realpathSync.native(repoRoot);
 
       expect(identity).not.toBeNull();
       expect(identity?.canonicalKey).toBe("github.com/t3tools/t3code");

--- a/apps/server/src/testUtils/gitConfig.setup.ts
+++ b/apps/server/src/testUtils/gitConfig.setup.ts
@@ -1,0 +1,21 @@
+// Pins git behaviour for every repository the suite creates, ahead of the
+// host's ~/.gitconfig. Git for Windows installs with core.autocrlf=true,
+// which checks committed LF files out as CRLF and breaks every byte-exact
+// content assertion; a signing key or a non-default init branch on the
+// developer's machine breaks fixtures the same way. Set as environment so
+// each git child the driver spawns sees it without touching the fixtures.
+const entries: ReadonlyArray<readonly [key: string, value: string]> = [
+  ["core.autocrlf", "false"],
+  ["core.filemode", "false"],
+  ["core.longpaths", "true"],
+  ["commit.gpgsign", "false"],
+  ["tag.gpgsign", "false"],
+  ["init.defaultBranch", "main"],
+];
+
+const existing = Number(process.env.GIT_CONFIG_COUNT ?? "0");
+process.env.GIT_CONFIG_COUNT = String(existing + entries.length);
+entries.forEach(([key, value], index) => {
+  process.env[`GIT_CONFIG_KEY_${existing + index}`] = key;
+  process.env[`GIT_CONFIG_VALUE_${existing + index}`] = value;
+});

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -1,4 +1,7 @@
+// @effect-diagnostics nodeBuiltinImport:off - realpathSync.native resolves Windows 8.3 short names, which the Effect realPath does not.
+import * as NodeFS from "node:fs";
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { assert, it, describe } from "@effect/vitest";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
@@ -570,7 +573,6 @@ it.effect("backs off failed upstream refreshes across linked worktrees", () =>
       const driver = yield* makeGitVcsDriverCore().pipe(
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, failingFetchSpawner),
       );
-      const fileSystem = yield* FileSystem.FileSystem;
       const cwd = yield* makeTmpDir();
       const remote = yield* makeTmpDir("git-vcs-driver-remote-");
       const worktreesRoot = yield* makeTmpDir("git-vcs-driver-worktrees-");
@@ -606,9 +608,11 @@ it.effect("backs off failed upstream refreshes across linked worktrees", () =>
         "rev-parse",
         "--git-common-dir",
       ])).stdout.trim();
+      // Native realpath, since git reports the long form of a directory the
+      // temp dir may name by its 8.3 short form on Windows.
       assert.equal(
-        yield* fileSystem.realPath(pathService.resolve(cwd, rootCommonDir)),
-        yield* fileSystem.realPath(pathService.resolve(worktreePath, linkedCommonDir)),
+        NodeFS.realpathSync.native(pathService.resolve(cwd, rootCommonDir)),
+        NodeFS.realpathSync.native(pathService.resolve(worktreePath, linkedCommonDir)),
       );
       yield* Ref.set(fetchAttempts, 0);
 
@@ -1376,31 +1380,33 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
   });
 
   describe("worktree operations", () => {
-    it.effect("preserves newline characters in worktree paths when listing refs", () =>
-      Effect.gen(function* () {
-        const cwd = yield* makeTmpDir();
-        yield* initRepoWithCommit(cwd);
-        const worktreesRoot = yield* makeTmpDir("git-vcs-driver-worktrees-");
-        const fileSystem = yield* FileSystem.FileSystem;
-        const pathService = yield* Path.Path;
-        const worktreePath = pathService.join(worktreesRoot, "linked\nworktree");
-        const driver = yield* GitVcsDriver.GitVcsDriver;
+    // NTFS rejects a newline in a file name, so there is nothing to preserve there.
+    it.effect.skipIf(HostProcessPlatform.defaultValue() === "win32")(
+      "preserves newline characters in worktree paths when listing refs",
+      () =>
+        Effect.gen(function* () {
+          const cwd = yield* makeTmpDir();
+          yield* initRepoWithCommit(cwd);
+          const worktreesRoot = yield* makeTmpDir("git-vcs-driver-worktrees-");
+          const pathService = yield* Path.Path;
+          const worktreePath = pathService.join(worktreesRoot, "linked\nworktree");
+          const driver = yield* GitVcsDriver.GitVcsDriver;
 
-        yield* git(cwd, ["worktree", "add", "-b", "feature/newline-path", worktreePath]);
+          yield* git(cwd, ["worktree", "add", "-b", "feature/newline-path", worktreePath]);
 
-        const refs = yield* driver.listRefs({ cwd, refresh: true });
-        const listedPath = refs.refs.find(
-          (ref) => ref.name === "feature/newline-path",
-        )?.worktreePath;
+          const refs = yield* driver.listRefs({ cwd, refresh: true });
+          const listedPath = refs.refs.find(
+            (ref) => ref.name === "feature/newline-path",
+          )?.worktreePath;
 
-        if (typeof listedPath !== "string") {
-          return assert.fail("expected the linked branch to include its worktree path");
-        }
-        assert.equal(
-          yield* fileSystem.realPath(listedPath),
-          yield* fileSystem.realPath(worktreePath),
-        );
-      }),
+          if (typeof listedPath !== "string") {
+            return assert.fail("expected the linked branch to include its worktree path");
+          }
+          assert.equal(
+            NodeFS.realpathSync.native(listedPath),
+            NodeFS.realpathSync.native(worktreePath),
+          );
+        }),
     );
 
     it.effect("checks out submodules in a new worktree", () =>

--- a/apps/server/vite.config.ts
+++ b/apps/server/vite.config.ts
@@ -78,6 +78,7 @@ export default mergeConfig(
       // The server suite exercises sqlite, git, temp worktrees, and orchestration
       // runtimes heavily. Running files in parallel introduces load-sensitive flakes.
       fileParallelism: false,
+      setupFiles: ["./src/testUtils/gitConfig.setup.ts"],
       // Server integration tests exercise sqlite, git, and orchestration together.
       // Under package-wide runs they can exceed the default budget on loaded CI hosts.
       hookTimeout: 120_000,


### PR DESCRIPTION
Git for Windows installs with core.autocrlf=true, so every repository the
suite creates checked committed LF files out as CRLF and byte-exact content
assertions in GitManager, CheckpointReactor, and the orchestration engine
integration test compared 'v2\r\n' against 'v2\n'. A vitest setup file
now pins autocrlf, filemode, longpaths, gpgsign, and the default branch
through GIT_CONFIG_* so every git child the driver spawns sees them, ahead
of whatever the host's ~/.gitconfig says.

Two tests compared an Effect realPath of os.tmpdir() against git's own
report of the same directory; on GitHub's Windows runners the temp dir is
spelled with its 8.3 short name (RUNNER~1) and only realpathSync.native
expands it. The newline-in-worktree-path test is skipped on Windows, where
NTFS rejects the name outright.

Part of the Windows test-suite stack rooted at [#9564](https://github.com/pingdotgg/t3code/pull/9564); the manual Windows lane comes from [#9538](https://github.com/pingdotgg/t3code/pull/9538).

Model: Claude Fable 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin Git config for test fixtures and switch path comparisons to native `realpath`
> - Adds [gitConfig.setup.ts](https://github.com/pingdotgg/t3code/pull/9570/files#diff-4b0cd6b441fcf19ae253655106a55d6e16c9a57683e608d1ae4487116ddba386) to inject fixed Git defaults (no autocrlf, no signing, no filemode, longpaths, `main` branch) into the test environment, and loads it via [vite.config.ts](https://github.com/pingdotgg/t3code/pull/9570/files#diff-0624f97be2b48ce1dcbd7427ae167f8521013f9f45650746dbaedce5f34458a2) before server tests run
> - Replaces Effect FileSystem `realpath` calls with Node's native `realpath` in `RepositoryIdentityResolver` and `GitVcsDriverCore` tests so path comparisons match platform behavior, including Windows short-name canonicalization
> - Skips the newline-path worktree listing test on `win32` because NTFS disallows newline characters in file names
> - Behavioral Change: Git subprocesses spawned by server tests now inherit the pinned config entries; path equality assertions use native realpath rather than Effect's implementation
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11da79b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes (Vitest setup, assertions, and one conditional skip); no production Git or VCS behavior is modified.
> 
> **Overview**
> Hardens the **server test suite on Windows and mixed host Git configs** without changing production code.
> 
> A new Vitest setup file injects fixed Git settings (`core.autocrlf=false`, no GPG signing, `init.defaultBranch=main`, etc.) through `GIT_CONFIG_*` so every `git` child process in tests ignores the developer’s `~/.gitconfig` and Git for Windows defaults that were breaking byte-exact content checks.
> 
> Path equality assertions in `RepositoryIdentityResolver` and `GitVcsDriverCore` tests now use **`NodeFS.realpathSync.native`** instead of Effect’s `realPath`, so comparisons match Git’s long paths when temp dirs appear as 8.3 short names on Windows runners. The worktree test that uses a newline in a path is **skipped on `win32`** because NTFS cannot create that name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11da79bf1749dd38c5d89072ca3db3b5a684400f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

