### PR TITLE
test: resolve the Windows temp directory to its long name

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,3 +1,4 @@
+import "vite-plus/test/config";
 import { defineConfig } from "vite-plus";
 
 import { loadRepoEnv } from "../../scripts/lib/public-config.ts";
@@ -87,5 +88,6 @@ export default defineConfig({
     // The Windows lane runs workspace suites concurrently; filesystem-heavy
     // desktop integration tests can exceed Vitest's 5 second default there.
     testTimeout: 15_000,
+    setupFiles: ["../../packages/shared/src/testing/longTempDir.ts"],
   },
 });

--- a/apps/server/src/bootstrap.test.ts
+++ b/apps/server/src/bootstrap.test.ts
@@ -55,6 +55,8 @@ vi.mock("node:fs", async (importOriginal) => {
   };
 });
 
+const windowsHost = HostProcessPlatform.defaultValue() === "win32";
+const nullDevice = windowsHost ? "\\\\.\\NUL" : "/dev/null";
 const TestEnvelopeSchema = Schema.Struct({ mode: Schema.String });
 const encodeTestEnvelopeSchema = Schema.encodeEffect(Schema.fromJsonString(TestEnvelopeSchema));
 
@@ -146,7 +148,7 @@ it.layer(NodeServices.layer)("readBootstrapEnvelope", (it) => {
 
   it.effect("returns none when the fd is unavailable", () =>
     Effect.gen(function* () {
-      const fd = NodeFS.openSync("/dev/null", "r");
+      const fd = NodeFS.openSync(nullDevice, "r");
       NodeFS.closeSync(fd);
 
       const payload = yield* readBootstrapEnvelope(TestEnvelopeSchema, fd, { timeoutMs: 100 });
@@ -157,7 +159,7 @@ it.layer(NodeServices.layer)("readBootstrapEnvelope", (it) => {
   it.effect("preserves fd and cause when stat fails for a non-availability reason", () =>
     Effect.gen(function* () {
       const fd = yield* Effect.acquireRelease(
-        Effect.sync(() => NodeFS.openSync("/dev/null", "r")),
+        Effect.sync(() => NodeFS.openSync(nullDevice, "r")),
         (fd) => Effect.sync(() => NodeFS.closeSync(fd)),
       );
 
@@ -201,40 +203,43 @@ it.layer(NodeServices.layer)("readBootstrapEnvelope", (it) => {
     }),
   );
 
-  it.effect("returns none when the bootstrap read times out before any value arrives", () =>
-    Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem;
-      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-bootstrap-" });
-      const fifoPath = NodePath.join(tempDir, "bootstrap.pipe");
+  // Needs a FIFO, which mkfifo creates; Windows has neither.
+  it.effect.skipIf(windowsHost)(
+    "returns none when the bootstrap read times out before any value arrives",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-bootstrap-" });
+        const fifoPath = NodePath.join(tempDir, "bootstrap.pipe");
 
-      yield* Effect.sync(() => NodeChildProcess.execFileSync("mkfifo", [fifoPath]));
+        yield* Effect.sync(() => NodeChildProcess.execFileSync("mkfifo", [fifoPath]));
 
-      const _writer = yield* Effect.acquireRelease(
-        Effect.sync(() =>
-          NodeChildProcess.spawn("sh", ["-c", 'exec 3>"$1"; sleep 60', "sh", fifoPath], {
-            stdio: ["ignore", "ignore", "ignore"],
-          }),
-        ),
-        (writer) =>
-          Effect.sync(() => {
-            writer.kill("SIGKILL");
-          }),
-      );
+        const _writer = yield* Effect.acquireRelease(
+          Effect.sync(() =>
+            NodeChildProcess.spawn("sh", ["-c", 'exec 3>"$1"; sleep 60', "sh", fifoPath], {
+              stdio: ["ignore", "ignore", "ignore"],
+            }),
+          ),
+          (writer) =>
+            Effect.sync(() => {
+              writer.kill("SIGKILL");
+            }),
+        );
 
-      const fd = yield* Effect.acquireRelease(
-        Effect.sync(() => NodeFS.openSync(fifoPath, "r")),
-        (fd) => Effect.sync(() => NodeFS.closeSync(fd)),
-      );
+        const fd = yield* Effect.acquireRelease(
+          Effect.sync(() => NodeFS.openSync(fifoPath, "r")),
+          (fd) => Effect.sync(() => NodeFS.closeSync(fd)),
+        );
 
-      const fiber = yield* readBootstrapEnvelope(TestEnvelopeSchema, fd, {
-        timeoutMs: 100,
-      }).pipe(Effect.forkScoped);
+        const fiber = yield* readBootstrapEnvelope(TestEnvelopeSchema, fd, {
+          timeoutMs: 100,
+        }).pipe(Effect.forkScoped);
 
-      yield* Effect.yieldNow;
-      yield* TestClock.adjust(Duration.millis(100));
+        yield* Effect.yieldNow;
+        yield* TestClock.adjust(Duration.millis(100));
 
-      const payload = yield* Fiber.join(fiber);
-      assertNone(payload);
-    }).pipe(Effect.provide(TestClock.layer())),
+        const payload = yield* Fiber.join(fiber);
+        assertNone(payload);
+      }).pipe(Effect.provide(TestClock.layer())),
   );
 });

--- a/apps/server/vite.config.ts
+++ b/apps/server/vite.config.ts
@@ -78,6 +78,7 @@ export default mergeConfig(
       // The server suite exercises sqlite, git, temp worktrees, and orchestration
       // runtimes heavily. Running files in parallel introduces load-sensitive flakes.
       fileParallelism: false,
+      // Appended to the root setup, which mergeConfig concatenates.
       setupFiles: ["./src/testUtils/gitConfig.setup.ts"],
       // Server integration tests exercise sqlite, git, and orchestration together.
       // Under package-wide runs they can exceed the default budget on loaded CI hosts.

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -80,6 +80,7 @@ const unitTestProject = {
     // run, those async tests can exceed Vitest's default 5s budget.
     hookTimeout: 15_000,
     testTimeout: 15_000,
+    setupFiles: ["../../packages/shared/src/testing/longTempDir.ts"],
   },
 } satisfies TestProjectInlineConfiguration;
 

--- a/packages/client-runtime/vite.config.ts
+++ b/packages/client-runtime/vite.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
+    setupFiles: ["../shared/src/testing/longTempDir.ts"],
   },
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -223,6 +223,10 @@
       "types": "./src/hostProcess.ts",
       "import": "./src/hostProcess.ts"
     },
+    "./testing/longTempDir": {
+      "types": "./src/testing/longTempDir.ts",
+      "import": "./src/testing/longTempDir.ts"
+    },
     "./testing/symlinks": {
       "types": "./src/testing/symlinks.ts",
       "import": "./src/testing/symlinks.ts"

--- a/packages/shared/src/testing/longTempDir.ts
+++ b/packages/shared/src/testing/longTempDir.ts
@@ -1,0 +1,19 @@
+// @effect-diagnostics nodeBuiltinImport:off - runs once at test setup, outside any Effect runtime.
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import { HostProcessPlatform } from "../hostProcess.ts";
+
+// GitHub's Windows runners hand out the temp directory by its 8.3 short name
+// (C:\Users\RUNNER~1\...). Anything that canonicalises a path, such as git or
+// realpath, reports the long form, so equality checks between a temp path and
+// its canonical form fail. Node reads TEMP/TMP on every os.tmpdir() call, so
+// pointing them at the long form fixes every temp directory the suite makes.
+if (HostProcessPlatform.defaultValue() === "win32") {
+  try {
+    const longForm = NodeFS.realpathSync.native(NodeOS.tmpdir());
+    process.env.TEMP = longForm;
+    process.env.TMP = longForm;
+  } catch {
+    // Leave the host's value alone if it cannot be resolved.
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,11 @@ export default defineConfig({
     ],
     hookTimeout: 60_000,
     testTimeout: 60_000,
+    setupFiles: [
+      NodeURL.fileURLToPath(
+        new URL("./packages/shared/src/testing/longTempDir.ts", import.meta.url),
+      ),
+    ],
   },
   staged: {
     // Formatter only for now — no lint or typecheck on commit.


### PR DESCRIPTION
GitHub's Windows runners set TEMP to the 8.3 short form
(C:\Users\RUNNER~1\...), and every path that goes through git or realpath
comes back in the long form, so equality checks between a temp directory and
its canonical form fail. A shared setup file, run by every package's vitest
config, points TEMP/TMP at the long form once so os.tmpdir() and everything
built on it agree with the canonical spelling.

bootstrap.test opens the platform null device instead of /dev/null and skips
the FIFO case, since Windows has neither.

Part of the Windows test-suite stack rooted at [#9564](https://github.com/pingdotgg/t3code/pull/9564); the manual Windows lane comes from [#9538](https://github.com/pingdotgg/t3code/pull/9538).

Model: Claude Fable 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve Windows temp directory to long name in test setup
> - Adds [longTempDir.ts](https://github.com/pingdotgg/t3code/pull/9573/files#diff-9f11225c87968c5b3c1e7d62db9cd4fb9df489c517208e7c5889d4f7ff6f9c36), which on win32 resolves the canonical long form of the temp directory and assigns it to `TEMP` and `TMP`; non-Windows hosts and resolution failures are left unchanged
> - Wires this setup module into the root, desktop, web, and client-runtime Vite test configs via an absolute path or package subpath export in [package.json](https://github.com/pingdotgg/t3code/pull/9573/files#diff-3752b1e4e3e2032593e21e9268ec0379680a59e4e7b8517d0d5492a71530d3e8)
> - Updates [bootstrap.test.ts](https://github.com/pingdotgg/t3code/pull/9573/files#diff-0ce606ba1b9ab11f436ea374b47d8760acc9ca02c427343b8690bdc8c52a2175) to select the platform-specific null device (`NUL` vs `/dev/null`) and skips the FIFO timeout test on Windows
> - Behavioral Change: Windows test runs now see long-form `TEMP`/`TMP` paths; if resolution fails the environment is untouched
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5032af7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only environment and platform-guard changes; production runtime behavior is unchanged aside from optional Vitest setup on Windows.
> 
> **Overview**
> Adds shared Vitest setup **`longTempDir.ts`** that on **win32** rewrites **`TEMP`** and **`TMP`** to the canonical long path from **`realpathSync`**, so **`os.tmpdir()`** matches git/realpath spelling on GitHub Windows runners (8.3 short names). The module is exported from **`@t3tools/shared`** and registered in the root, desktop, web, and client-runtime Vite test configs (server inherits it via **`mergeConfig`** with its existing git setup).
> 
> **`bootstrap.test.ts`** uses **`NUL`** vs **`/dev/null`** for null-device FD tests and **`skipIf(windowsHost)`** on the FIFO timeout case because Windows lacks **`mkfifo`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5032af7a8437942c058182d017f5884641e5f8c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

