### PR TITLE
fix(web): align the sidebar wordmark by baseline

### DIFF
--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -86,19 +86,21 @@ function SidebarBrand({ onBackdrop }: { onBackdrop: boolean }) {
     <Link
       aria-label="Go to threads"
       className={cn(
-        "relative z-10 ml-[var(--workspace-titlebar-content-left)] hidden h-7 w-fit min-w-0 shrink-0 items-center gap-1 overflow-hidden rounded-md outline-hidden ring-ring focus-visible:ring-2 md:flex",
+        "relative z-10 ml-[var(--workspace-titlebar-content-left)] hidden h-7 w-fit min-w-0 shrink-0 items-center overflow-hidden rounded-md outline-hidden ring-ring focus-visible:ring-2 md:flex",
         onBackdrop ? "text-white" : "text-foreground",
       )}
       to="/"
     >
-      <T3Wordmark aria-label="T3" className="h-2.5 w-auto shrink-0" />
-      <span
-        className={cn(
-          "truncate text-sm font-medium tracking-tight",
-          onBackdrop ? "text-white/70" : "text-muted-foreground",
-        )}
-      >
-        Code
+      <span className="inline-flex min-w-0 items-baseline gap-1">
+        <T3Wordmark aria-label="T3" className="h-2.5 w-auto shrink-0" />
+        <span
+          className={cn(
+            "truncate text-sm font-medium tracking-tight",
+            onBackdrop ? "text-white/70" : "text-muted-foreground",
+          )}
+        >
+          Code
+        </span>
       </span>
     </Link>
   );


### PR DESCRIPTION
The sidebar header aligned the T3 SVG and "Code" by their boxes, so font ascent and descent differences made the label shift across platforms. This wraps them in a baseline-aligned group while keeping the group centered in the existing hit target, replacing the platform-specific pixel nudges that have been added and reverted. Verified with `vp lint apps/web/src/components/sidebar/SidebarChrome.tsx --deny-warnings`, `vp run --filter=@t3tools/web typecheck`, and the live web app in light and dark at 1280×800 and 800×600; the mark and label share a measured baseline with system UI, Segoe-style, Arial, monospace, and custom-font fallbacks.

before

![before: the T3 mark sits below the Code label with Arial interface text](https://uploads-production-47e4.up.railway.app/files/12924fbd-28c2-445d-99c0-098235602a5c/t3code-header-before.png)

after

![after: the T3 mark and Code label share a baseline with Arial interface text](https://uploads-production-47e4.up.railway.app/files/95bf5c5f-72b5-47e6-b77b-93cec5186d12/t3code-header-after.png)

Built with `gpt-5.6-sol` through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only sidebar header markup and Tailwind classes; no routing, auth, or data changes.
> 
> **Overview**
> **Sidebar brand alignment** — In `SidebarBrand`, the T3 wordmark and “Code” label are no longer direct flex siblings on the home link. They sit inside an `inline-flex items-baseline gap-1` wrapper so the SVG and text align on a shared baseline instead of by box centering, which had caused cross-platform vertical drift.
> 
> The outer `Link` keeps the same hit target and layout (`items-center`, no `gap-1` on the link itself); only the inner grouping and baseline alignment behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d7455cce4315db22416c25d1cc7382f6437d408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align sidebar wordmark and "Code" label by baseline in `SidebarBrand`
> Moves the horizontal gap from the outer link to a new inline-flex wrapper around the T3 wordmark and the "Code" label in [SidebarChrome.tsx](https://github.com/pingdotgg/t3code/pull/9578/files#diff-cbdc7d544762cec67fb7c23f9e66e80e1ca2158f0d100a878363a7ae01f77c11). The wrapper aligns its children on their baselines and sets a minimum width. The wordmark and label keep their existing sizing, truncation, color, and typography classes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d7455c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->