### PR TITLE
fix(antigravity): keep subagent batches active after launch

### DIFF
--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -761,81 +761,70 @@ it.layer(layer)("AntigravityAdapter", (it) => {
     }),
   );
 
-  it.effect(
-    "shows concurrent native subagent calls and their results without inventing metadata",
-    () =>
-      Effect.gen(function* () {
-        const h = yield* makeHarness();
-        yield* h.adapter.startSession({
-          threadId,
-          cwd: process.cwd(),
-          runtimeMode: "approval-required",
-        });
-        const sending = yield* h.adapter
-          .sendTurn({ threadId, input: "Review with subagents" })
-          .pipe(Effect.forkChild);
-        const prompt = yield* h.nextPrompt;
-        for (const id of ["trajectory:4", "trajectory:5"]) {
-          yield* h.emitNative(
-            nativeToolUpdate({
-              sessionUpdate: "tool_call",
-              toolCallId: id,
-              title: "Running start_subagent",
-              kind: "other",
-              status: "in_progress",
-              rawInput: {},
-            }),
-          );
-          const running = yield* h.waitForEvent((event) => event.type === "task.progress");
-          expect(running.payload).toEqual({
-            taskId: id,
-            taskType: "subagent",
-            toolUseId: id,
-            title: "Antigravity subagent",
-            description: "Antigravity subagent",
-            status: "running",
-          });
-          yield* h.emitNative(
-            nativeToolUpdate({
-              sessionUpdate: "tool_call_update",
-              toolCallId: id,
-              status: "in_progress",
-            }),
-          );
-        }
-        for (const [id, status, result] of [
-          ["trajectory:4", "completed", "No defects found."],
-          ["trajectory:5", "failed", "Subagent exceeded its limit."],
-        ] as const) {
-          yield* h.emitNative(
-            nativeToolUpdate({
-              sessionUpdate: "tool_call_update",
-              toolCallId: id,
-              status,
-              rawOutput: result,
-            }),
-          );
-          const completed = yield* h.waitForEvent((event) => event.type === "task.completed");
-          expect(completed.payload).toEqual({
-            taskId: id,
-            taskType: "subagent",
-            toolUseId: id,
-            title: "Antigravity subagent",
-            status,
-            summary: result,
-          });
-        }
-        yield* Deferred.succeed(prompt.result, { stopReason: "end_turn" });
-        const turn = yield* Fiber.join(sending);
-        yield* h.waitForEvent((event) => event.type === "turn.completed");
-        expect(
-          h.seen
-            .filter((event) => event.type.startsWith("task."))
-            .every((event) => event.turnId === turn.turnId),
-        ).toBe(true);
-        expect(h.seen.filter((event) => event.type.startsWith("item."))).toHaveLength(0);
-        expect(h.seen.filter((event) => event.type === "task.progress")).toHaveLength(2);
-      }),
+  it.effect("keeps a launched batch active while child tools continue", () =>
+    Effect.gen(function* () {
+      const h = yield* makeHarness();
+      yield* h.adapter.startSession({ threadId, cwd: process.cwd(), runtimeMode: "full-access" });
+      const sending = yield* h.adapter
+        .sendTurn({ threadId, input: "Run two readers in one batch" })
+        .pipe(Effect.forkChild);
+      const prompt = yield* h.nextPrompt;
+      // ACP 1.1.1 capture: one launch call covers both children and returns
+      // only its description before either child finishes.
+      const started = nativeToolUpdate({
+        sessionUpdate: "tool_call",
+        toolCallId: `${nativeSessionId}:2`,
+        title: "Running start_subagent",
+        kind: "other",
+        status: "in_progress",
+        rawInput: {},
+      });
+      yield* h.emitNative(started);
+      yield* h.waitForEvent((event) => event.type === "task.progress");
+      yield* h.emitNative(
+        nativeToolUpdate(
+          {
+            sessionUpdate: "tool_call_update",
+            toolCallId: started.toolCall.toolCallId,
+            status: "completed",
+            rawOutput: "Launch subagents",
+          },
+          started.toolCall,
+        ),
+      );
+      const launched = yield* h.waitForEvent((event) => event.type === "task.progress");
+      expect(launched.payload).toMatchObject({
+        taskId: started.toolCall.toolCallId,
+        title: "Antigravity subagent batch",
+        description: "Launch subagents",
+        status: "running",
+      });
+      for (const child of ["alpha", "beta"]) {
+        yield* h.emitNative(
+          nativeToolUpdate({
+            sessionUpdate: "tool_call",
+            toolCallId: `${child}:1`,
+            title: "Read file",
+            kind: "read",
+            status: "completed",
+            rawOutput: "File contents",
+          }),
+        );
+      }
+      yield* h.drainEvents;
+      expect(h.seen.filter((event) => event.type === "task.completed")).toHaveLength(0);
+      expect(h.seen.filter((event) => event.type === "task.updated")).toHaveLength(0);
+      yield* Deferred.succeed(prompt.result, { stopReason: "end_turn" });
+      yield* Fiber.join(sending);
+      yield* h.waitForEvent((event) => event.type === "turn.completed");
+      expect(h.seen.filter((event) => event.type === "task.completed")).toHaveLength(0);
+      expect(h.seen.find((event) => event.type === "task.updated")?.payload).toMatchObject({
+        taskId: started.toolCall.toolCallId,
+        status: "idle",
+        description: "Turn ended. Individual agent status is unavailable.",
+        timelineBypass: true,
+      });
+    }),
   );
 
   it.effect("waits for a replayed subagent's final status and result", () =>
@@ -870,7 +859,7 @@ it.layer(layer)("AntigravityAdapter", (it) => {
         taskId: "replayed:4",
         taskType: "subagent",
         toolUseId: "replayed:4",
-        title: "Antigravity subagent",
+        title: "Antigravity subagent batch",
         status: "failed",
         summary: "Review failed.",
       });
@@ -878,128 +867,93 @@ it.layer(layer)("AntigravityAdapter", (it) => {
     }),
   );
 
-  it.effect("completes a live subagent delivered in one tool call", () =>
+  it.effect("keeps one-message launches active and ignores late updates after settlement", () =>
     Effect.gen(function* () {
       const h = yield* makeHarness();
-      yield* h.adapter.startSession({
-        threadId,
-        cwd: process.cwd(),
-        runtimeMode: "approval-required",
-      });
-      const sending = yield* h.adapter
-        .sendTurn({ threadId, input: "Review with subagents" })
+      yield* h.adapter.startSession({ threadId, cwd: process.cwd(), runtimeMode: "full-access" });
+      const first = yield* h.adapter
+        .sendTurn({ threadId, input: "Start readers" })
         .pipe(Effect.forkChild);
-      const prompt = yield* h.nextPrompt;
-      for (const [id, rawOutput] of [
-        ["live:4", "Review complete."],
-        ["live:5", undefined],
-      ] as const) {
-        yield* h.emitNative(
-          nativeToolUpdate({
-            sessionUpdate: "tool_call",
-            toolCallId: id,
-            title: "Running start_subagent",
-            kind: "other",
-            status: "completed",
-            rawInput: {},
-            ...(rawOutput ? { rawOutput } : {}),
-          }),
-        );
-        const completed = yield* h.waitForEvent((event) => event.type === "task.completed");
-        expect(completed.payload).toMatchObject({ taskId: id, status: "completed" });
-        expect(completed.payload.summary).toBe(rawOutput);
-      }
-      yield* Deferred.succeed(prompt.result, { stopReason: "end_turn" });
-      yield* Fiber.join(sending);
-      yield* h.waitForEvent((event) => event.type === "turn.completed");
-      expect(h.seen.filter((event) => event.type === "task.updated")).toHaveLength(0);
-    }),
-  );
-
-  for (const settlement of ["cancelled", "interrupted", "completed"] as const) {
-    it.effect(`does not reopen a ${settlement} subagent on late merged updates`, () =>
-      Effect.gen(function* () {
-        const h = yield* makeHarness();
-        yield* h.adapter.startSession({
-          threadId,
-          cwd: process.cwd(),
-          runtimeMode: "approval-required",
-        });
-        const first = yield* h.adapter
-          .sendTurn({ threadId, input: "Start review" })
-          .pipe(Effect.forkChild);
-        const firstPrompt = yield* h.nextPrompt;
-        const started = nativeToolUpdate({
+      const firstPrompt = yield* h.nextPrompt;
+      const launches = ["Launch readers", undefined].map((rawOutput, index) =>
+        nativeToolUpdate({
           sessionUpdate: "tool_call",
-          toolCallId: "old:4",
+          toolCallId: `old:${index}`,
           title: "Running start_subagent",
           kind: "other",
-          status: "in_progress",
+          status: "completed",
           rawInput: {},
-        });
-        yield* h.emitNative(started);
-        yield* h.waitForEvent((event) => event.type === "task.progress");
-        if (settlement === "cancelled") {
-          yield* h.adapter.interruptTurn(threadId);
-        } else {
-          if (settlement === "completed") {
-            yield* h.emitNative(
-              nativeToolUpdate(
-                {
-                  sessionUpdate: "tool_call_update",
-                  toolCallId: "old:4",
-                  status: "completed",
-                  rawOutput: "Original result.",
-                },
-                started.toolCall,
-              ),
-            );
-          }
-          yield* Deferred.succeed(firstPrompt.result, { stopReason: "end_turn" });
-        }
-        yield* Fiber.join(first);
-        yield* h.waitForEvent((event) => event.type === "turn.completed");
-        const second = yield* h.adapter
-          .sendTurn({ threadId, input: "Next review" })
-          .pipe(Effect.forkChild);
-        const secondPrompt = yield* h.nextPrompt;
-        for (const status of ["in_progress", "completed"] as const) {
+          ...(rawOutput ? { rawOutput } : {}),
+        }),
+      );
+      for (const launch of launches) yield* h.emitNative(launch);
+      yield* h.drainEvents;
+      expect(h.seen.filter((event) => event.type === "task.progress")).toHaveLength(2);
+      expect(h.seen.filter((event) => event.type === "task.completed")).toHaveLength(0);
+      yield* Deferred.succeed(firstPrompt.result, { stopReason: "end_turn" });
+      yield* Fiber.join(first);
+      yield* h.waitForEvent((event) => event.type === "turn.completed");
+      const second = yield* h.adapter
+        .sendTurn({ threadId, input: "Next task" })
+        .pipe(Effect.forkChild);
+      const secondPrompt = yield* h.nextPrompt;
+      for (const launch of launches) {
+        for (const status of ["in_progress", "completed", "failed"] as const) {
           yield* h.emitNative(
             nativeToolUpdate(
               {
                 sessionUpdate: "tool_call_update",
-                toolCallId: "old:4",
+                toolCallId: launch.toolCall.toolCallId,
                 status,
-                rawOutput: "Late result.",
+                rawOutput: "Late update",
               },
-              started.toolCall,
+              launch.toolCall,
             ),
           );
         }
-        yield* h.emitNative(
-          nativeToolUpdate({
-            sessionUpdate: "tool_call",
-            toolCallId: "new:4",
-            title: "Running start_subagent",
-            kind: "other",
+      }
+      yield* h.drainEvents;
+      expect(h.seen.filter((event) => event.type === "task.progress")).toHaveLength(2);
+      expect(h.seen.filter((event) => event.type === "task.updated")).toHaveLength(2);
+      expect(h.seen.filter((event) => event.type === "task.completed")).toHaveLength(0);
+      yield* Deferred.succeed(secondPrompt.result, { stopReason: "end_turn" });
+      yield* Fiber.join(second);
+    }),
+  );
+
+  it.effect("does not report a historical launch as running or completed work", () =>
+    Effect.gen(function* () {
+      const h = yield* makeHarness();
+      yield* h.adapter.startSession({ threadId, cwd: process.cwd(), runtimeMode: "full-access" });
+      const launch = nativeToolUpdate({
+        sessionUpdate: "tool_call",
+        toolCallId: "history:2",
+        title: "Running start_subagent",
+        kind: "other",
+        status: "completed",
+        rawInput: {},
+      });
+      yield* h.emitNative(launch);
+      yield* h.emitNative(
+        nativeToolUpdate(
+          {
+            sessionUpdate: "tool_call_update",
+            toolCallId: launch.toolCall.toolCallId,
             status: "completed",
-            rawOutput: "New result.",
-          }),
-        );
-        const completed = yield* h.waitForEvent((event) => event.type === "task.completed");
-        expect(completed.payload.taskId).toBe("new:4");
-        yield* Deferred.succeed(secondPrompt.result, { stopReason: "end_turn" });
-        yield* Fiber.join(second);
-        yield* h.waitForEvent((event) => event.type === "turn.completed");
-        expect(h.seen.filter((event) => event.type === "task.progress")).toHaveLength(1);
-        expect(
-          h.seen.filter(
-            (event) => event.type === "task.completed" && event.payload.taskId === "old:4",
-          ),
-        ).toHaveLength(settlement === "completed" ? 1 : 0);
-      }),
-    );
-  }
+            rawOutput: "Launch readers",
+          },
+          launch.toolCall,
+        ),
+      );
+      yield* h.drainEvents;
+      expect(h.seen.filter((event) => event.type.startsWith("task."))).toMatchObject([
+        {
+          type: "task.updated",
+          payload: { status: "idle", timelineBypass: true },
+        },
+      ]);
+    }),
+  );
 
   it.effect("keeps MCP identity when later updates omit metadata", () =>
     Effect.gen(function* () {
@@ -1101,6 +1055,15 @@ it.layer(layer)("AntigravityAdapter", (it) => {
           }),
         );
         yield* h.waitForEvent((event) => event.type === "task.progress");
+        yield* h.emitNative(
+          nativeToolUpdate({
+            sessionUpdate: "tool_call_update",
+            toolCallId: "trajectory:4",
+            status: "completed",
+            rawOutput: "Launch subagents",
+          }),
+        );
+        yield* h.waitForEvent((event) => event.type === "task.progress");
         if (stop === "disconnect") {
           yield* h.emitNative({
             _tag: "ConnectionTerminated",
@@ -1121,14 +1084,14 @@ it.layer(layer)("AntigravityAdapter", (it) => {
         const settled = yield* h.waitForEvent((event) => event.type === "task.updated");
         expect(settled.payload).toMatchObject({
           taskId: "trajectory:4",
-          title: "Antigravity subagent",
+          title: "Antigravity subagent batch",
           taskType: "subagent",
           status:
             stop === "disconnect"
               ? "failed"
               : stop === "cancel" || stop === "steer"
                 ? "cancelled"
-                : "interrupted",
+                : "idle",
         });
         if (stop === "disconnect")
           yield* h.waitForEvent((event) => event.type === "session.exited");

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -71,7 +71,7 @@ import {
 } from "../acp/AntigravityAcpSupport.ts";
 import {
   antigravityApprovalOptions,
-  antigravitySubagentResult,
+  antigravitySubagentOutput,
   classifyAntigravitySubagentToolCall,
   extractAntigravityUserInputQuestion,
   isAntigravityOpenCommand,
@@ -170,6 +170,7 @@ interface OpenCommand {
 interface OpenSubagent {
   readonly turnId: TurnId | undefined;
   readonly status: "pending" | "running" | undefined;
+  readonly description?: string;
 }
 
 function subagentLinkage(toolCallId: string) {
@@ -177,7 +178,7 @@ function subagentLinkage(toolCallId: string) {
     taskId: RuntimeTaskId.make(toolCallId),
     taskType: "subagent",
     toolUseId: toolCallId,
-    title: "Antigravity subagent",
+    title: "Antigravity subagent batch",
   };
 }
 
@@ -389,7 +390,7 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
 
   const finishSubagents = (
     context: SessionContext,
-    status: Extract<RuntimeTaskStatus, "cancelled" | "failed" | "interrupted">,
+    status: Extract<RuntimeTaskStatus, "cancelled" | "failed" | "idle">,
     error?: string,
   ) =>
     context.commandLock.withPermit(
@@ -405,6 +406,12 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
             payload: {
               ...subagentLinkage(id),
               status,
+              ...(status === "idle"
+                ? {
+                    description: "Turn ended. Individual agent status is unavailable.",
+                    timelineBypass: true,
+                  }
+                : {}),
               ...(error ? { error } : {}),
             },
           });
@@ -628,8 +635,8 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
                 context.subagents.set(toolCall.toolCallId, { turnId, status: undefined });
                 return;
               }
-              if (toolCall.status === "completed" || toolCall.status === "failed") {
-                const summary = antigravitySubagentResult(toolCall);
+              if (toolCall.status === "failed") {
+                const summary = antigravitySubagentOutput(toolCall);
                 yield* emit({
                   type: "task.completed",
                   ...(yield* stamp),
@@ -643,19 +650,38 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
                   },
                 });
                 context.subagents.set(toolCall.toolCallId, "finished");
+              } else if (context.activeTurnId === undefined && toolCall.status === "completed") {
+                yield* emit({
+                  type: "task.updated",
+                  ...(yield* stamp),
+                  provider: PROVIDER,
+                  threadId: context.threadId,
+                  turnId,
+                  payload: {
+                    ...linkage,
+                    status: "idle",
+                    description: "Individual agent status is unavailable for this earlier batch.",
+                    timelineBypass: true,
+                  },
+                });
+                context.subagents.set(toolCall.toolCallId, "finished");
               } else {
+                // start_subagent returns after launching a batch. Its output is
+                // the launch description, not a child result or completion.
                 const status = toolCall.status === "pending" ? "pending" : "running";
-                if (subagent?.status !== status) {
+                const description =
+                  antigravitySubagentOutput(toolCall) ?? subagent?.description ?? linkage.title;
+                if (subagent?.status !== status || subagent?.description !== description) {
                   yield* emit({
                     type: "task.progress",
                     ...(yield* stamp),
                     provider: PROVIDER,
                     threadId: context.threadId,
                     turnId,
-                    payload: { ...linkage, description: linkage.title, status },
+                    payload: { ...linkage, description, summary: description, status },
                   });
                 }
-                context.subagents.set(toolCall.toolCallId, { turnId, status });
+                context.subagents.set(toolCall.toolCallId, { turnId, status, description });
               }
               return;
             }
@@ -972,11 +998,8 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
             ? "cancelled"
             : payload.state === "failed"
               ? "failed"
-              : "interrupted",
-          payload.errorMessage ??
-            (payload.state === "completed"
-              ? "Antigravity ended the turn before reporting a subagent result."
-              : undefined),
+              : "idle",
+          payload.errorMessage,
         );
         context.activeTurnId = undefined;
         context.promptFiber = undefined;

--- a/apps/server/src/provider/acp/AntigravityProtocol.test.ts
+++ b/apps/server/src/provider/acp/AntigravityProtocol.test.ts
@@ -6,7 +6,7 @@ import {
   extractAntigravityUserInputQuestion,
   isAntigravityOpenCommand,
   antigravityApprovalOptions,
-  antigravitySubagentResult,
+  antigravitySubagentOutput,
   isAntigravitySubagentReplayStart,
   classifyAntigravitySubagentToolCall,
   isAntigravityUserInputRequest,
@@ -48,7 +48,7 @@ describe("native Antigravity subagent tools", () => {
     ).toBeUndefined();
   });
 
-  it("recognizes history starts and bounds the native result", () => {
+  it("recognizes history starts and bounds the launch output", () => {
     expect(
       isAntigravitySubagentReplayStart({
         update: { sessionUpdate: "tool_call", status: "completed", rawOutput: "Done." },
@@ -65,19 +65,19 @@ describe("native Antigravity subagent tools", () => {
       }),
     ).toBe(false);
     expect(
-      antigravitySubagentResult({
+      antigravitySubagentOutput({
         toolCallId: "trajectory:4",
         data: { rawOutput: "  Finished review.  " },
       }),
     ).toBe("Finished review.");
-    const result = antigravitySubagentResult({
+    const result = antigravitySubagentOutput({
       toolCallId: "trajectory:4",
       data: { rawOutput: `${"x".repeat(16_000)}The result.` },
     });
     expect(result?.length).toBeLessThan(8_100);
     expect(result?.endsWith("The result.")).toBe(true);
     expect(
-      antigravitySubagentResult({ toolCallId: "trajectory:4", data: { rawOutput: {} } }),
+      antigravitySubagentOutput({ toolCallId: "trajectory:4", data: { rawOutput: {} } }),
     ).toBeUndefined();
   });
 });

--- a/apps/server/src/provider/acp/AntigravityProtocol.ts
+++ b/apps/server/src/provider/acp/AntigravityProtocol.ts
@@ -376,7 +376,7 @@ export function isAntigravitySubagentReplayStart(rawPayload: unknown): boolean {
   );
 }
 
-export function antigravitySubagentResult(toolCall: AcpToolCallState): string | undefined {
+export function antigravitySubagentOutput(toolCall: AcpToolCallState): string | undefined {
   const output = toolCall.data.rawOutput;
   return typeof output === "string" && output.trim() ? boundText(output.trim()) : undefined;
 }

--- a/docs/user/providers-antigravity.md
+++ b/docs/user/providers-antigravity.md
@@ -141,14 +141,15 @@ follow-up message or start a new thread instead.
 
 ### Subagents
 
-Antigravity subagent calls appear in **Agents** on web and desktop, and in the work log on
-mobile. Each call shows its status and the result or error returned by Antigravity. Calls
-that run at the same time have separate entries.
+Subagent launches appear as **Antigravity subagent batch** in **Agents** on web and desktop,
+and in the work log on mobile. One launch can start several agents. The batch stays active
+after launch while the parent turn runs. When that turn ends, the entry becomes idle and
+states that individual agent status is unavailable. Launch errors remain visible.
 
-The official ACP agent does not report subagent names, models, token usage, or parent links.
-Entries use the name **Antigravity subagent**. Child tool calls cannot be assigned to an entry
-because ACP does not include their owning subagent. These entries track each invocation,
-not a separate thread you can open or control.
+The official ACP agent does not send individual child status, names, models, token usage,
+or reply ownership. T3 Code cannot show separate child entries or separate child replies
+from the parent conversation. The launch description is not a child result. Batch entries
+cannot be opened or controlled as separate threads.
 
 ## Accounts and removal
 

--- a/packages/client-runtime/src/state/subagentRuntime.test.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.test.ts
@@ -66,6 +66,34 @@ function fold(rows: ReadonlyArray<OrchestrationThreadActivity>) {
 }
 
 describe("foldSubagentActivities", () => {
+  it("shows the batch status limit after its parent turn ends without claiming a result", () => {
+    const running = activity("task.progress", {
+      taskId: "batch-1",
+      taskType: "subagent",
+      title: "Antigravity subagent batch",
+      status: "running",
+      summary: "Launch readers",
+    });
+    const agents = fold([
+      running,
+      activity("task.updated", {
+        taskId: "batch-1",
+        taskType: "subagent",
+        status: "idle",
+        detail: "Turn ended. Individual agent status is unavailable.",
+        timelineBypass: true,
+      }),
+    ]);
+    expect(agents).toHaveLength(1);
+    expect(agents[0]).toMatchObject({
+      title: "Antigravity subagent batch",
+      status: "idle",
+      progress: "Turn ended. Individual agent status is unavailable.",
+      result: null,
+      error: null,
+    });
+  });
+
   it("builds an agent from start → progress → completion", () => {
     const agents = fold([
       activity("task.started", {

--- a/packages/client-runtime/src/state/subagentRuntime.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.ts
@@ -546,6 +546,8 @@ export function foldSubagentActivities(
         if (!agents.has(taskId) && isBackgroundTaskActivity(payload)) break;
         const agent = getOrCreate(agents, taskId, payload, at);
         fillMetadata(agent, payload);
+        const detail = asString(payload.detail);
+        if (detail) agent.progress = bounded(detail);
         // A task first seen via task.updated (start row aged out) has run at
         // least once — zero activations would misreport "run 0" and let a
         // later start row treat it as never-started (review finding).


### PR DESCRIPTION
Antigravity marked subagents done as soon as `start_subagent` returned, even while the children were still running. One call can launch several children, and its output is a launch description.

Show each launch as an **Antigravity subagent batch**. Keep it active for the parent turn, then mark it idle with an explanation that individual agent status is unavailable. Preserve launch failures, cancellation, disconnect handling, and history replay. The shared client fold now displays that status explanation.

Google's current ACP stream omits individual child status, names, and reply ownership. This fixes the false completion and batch label. It cannot provide separate child entries or separate their replies from the parent conversation. The provider docs describe these limits.

Validation:

- 195 focused tests passed across the adapter, protocol, shared subagent state, and mobile work log.
- Server and shared-client typechecks, targeted lint, and formatting passed.
- An isolated run through the official ACP binary launched two agents. The launch returned in 3 ms. The updated adapter kept the batch running through three later child tool completions, then marked it idle when the parent turn ended. It emitted no subagent completion event.
- Browser replay verification confirmed the batch lifecycle. It exposed remaining summary labels, fixed in [#9616](https://github.com/pingdotgg/t3code/pull/9616), which includes before/after screenshots.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Antigravity subagent event semantics (running vs completed vs idle) that drive Agents UI and work log; behavior is heavily tested but affects user-visible task state.
> 
> **Overview**
> Fixes Antigravity treating **`start_subagent`** as finished when the launch tool returns, even though one launch can start several agents and its output is only a launch description—not child results.
> 
> **Antigravity adapter** now models each launch as **Antigravity subagent batch**: it stays **running** through launch completion and sibling child tool activity, emits **`task.progress`** with the launch description, and only emits **`task.completed`** on real **failed** launches (including replayed history). Normal turn end settles open batches to **`idle`** via **`task.updated`** with an explanation and **`timelineBypass`**, instead of **`interrupted`** or a fake completion. Historical launches without an active turn get a similar idle update; late updates after settlement are ignored. **`antigravitySubagentResult`** is renamed to **`antigravitySubagentOutput`**.
> 
> **Shared client** **`foldSubagentActivities`** applies **`detail`** from **`task.updated`** to agent **progress**, so the idle message shows in Agents / work log. **User docs** describe batch behavior and ACP limits (no per-child status or separate entries).
> 
> Tests were rewritten/added across the adapter, protocol, and subagent fold to match this lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b0562068326b46f9a1a4ee08d7abdd8003b9ccd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep Antigravity subagent launches active as idle batches after turn end
> - Active native `start-subagent` calls are now treated as batch launches that stay running during the parent turn instead of being reported as completed child results. Failed launches still complete with bounded output.
> - When a parent turn ends normally, `finishSubagents` in [AntigravityAdapter.ts](https://github.com/pingdotgg/t3code/pull/9579/files#diff-8fcca741cbe472382864eb090a2a7340c13c15e8d8a28f1589523fa05b7f6205) settles unfinished batch tasks as `idle` rather than `interrupted`, adds an "individual agent status unavailable" message, and marks the update for timeline bypass. Cancelled and failed settlements retain their statuses.
> - The turn settlement handler no longer synthesizes a missing-result error for normally completed turns with unfinished subagent work; only provider-supplied turn errors are forwarded.
> - `foldSubagentActivities` in [subagentRuntime.ts](https://github.com/pingdotgg/t3code/pull/9579/files#diff-b28278fe62e259afab164f07d2e56800ca49f60942f6b12da5f748e9415c8259) now reads a non-empty `detail` field from `task.updated` activities and stores it as bounded progress text.
> - Behavioral Change: `subagentLinkage` task titles changed from the individual-subagent label to the batch label; normal turn-end status changed from `interrupted` to `idle`; completed historical launches now emit `task.updated` (idle) instead of `task.completed`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b05620.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
