### PR TITLE
fix(server): load OpenCode workspace skills via SDK to avoid 64KB CLI pipe truncation

### DIFF
--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -149,6 +149,14 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
         Effect.provideService(OpenCodeServerOwner.OpenCodeServerOwner, serverOwner),
         Effect.provideService(OpenCodeRuntime, openCodeRuntime),
       );
+      // NOTE: the local branch intentionally uses the shared SDK server
+      // instead of `opencode debug skill` (loadSkillsFromCli). The CLI writes
+      // its full JSON inventory to stdout, but the Bun-compiled binary does
+      // not flush more than one 64KB pipe buffer to a non-TTY stdout, so the
+      // piped output arrives truncated and unparseable — which degrades to an
+      // empty skill list and poisons the workspace snapshot the `$` picker
+      // reads. The SDK `app.skills` endpoint honors the per-request directory
+      // and returns complete results regardless of size.
       const loadSkillsForCwd = (cwd: string) =>
         effectiveConfig.serverUrl.trim().length > 0
           ? Effect.scoped(
@@ -172,11 +180,17 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
                 return yield* openCodeRuntime.loadOpenCodeSkills(client);
               }),
             )
-          : openCodeRuntime.loadSkillsFromCli({
-              binaryPath: effectiveConfig.binaryPath,
-              cwd,
-              environment: processEnv,
-            });
+          : serverOwner.withServer((server) =>
+              openCodeRuntime.loadOpenCodeSkills(
+                openCodeRuntime.createOpenCodeSdkClient({
+                  baseUrl: server.url,
+                  directory: cwd,
+                  ...(server.serverPassword !== undefined
+                    ? { serverPassword: server.serverPassword }
+                    : {}),
+                }),
+              ),
+            );
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<OpenCodeSettings>>(


### PR DESCRIPTION
## What changed

`snapshotForCwd` for the OpenCode driver now loads per-workspace skills through the shared SDK server (`serverOwner.withServer` + `loadOpenCodeSkills` with per-request `directory: cwd`) instead of shelling out to `opencode debug skill` (`loadSkillsFromCli`).

One file: `apps/server/src/provider/Drivers/OpenCodeDriver.ts` (+19/-5).

## Why

The Bun-compiled `opencode` binary does not flush more than one 64KB pipe buffer to a non-TTY stdout. With a realistic skill library the CLI emits ~750KB of JSON (47 skills here), but a piped child process delivers exactly 65536 bytes and the truncated JSON fails to parse:

- file redirect: 754586 bytes, 47 skills, valid JSON
- pipe: 65536 bytes, `JSONDecodeError: Unterminated string ... (char 64013)`

`parseSkillsCliOutput` degrades that to a successful empty list, so `snapshotForCwd` published a **ready** snapshot with `skills: []`. The composer prefers the workspace snapshot over the machine snapshot (`resolveProviderSkillsForCwd`), so the `$` picker permanently showed `No skills found` even though `~/.t3/caches/opencode.json` correctly listed 43+ skills (populated via the SDK path in `checkOpenCodeProviderStatus`).

I verified the SDK `app.skills` endpoint honors the per-request directory: same server returned 47 skills (incl. repo-local `test-t3-app`) for the repo cwd and 43 (globals only) for an empty dir.

Related: #7807 (pipe truncation root cause), #2736 (OpenCode skills missing in composer).

## Test evidence

- `vp test run` on `OpenCodeProvider.test.ts`, `opencodeRuntime.inventory.test.ts`, `opencodeRuntime.cliParsers.test.ts`: 3 files, 35 tests, all pass
- `vp run --filter t3 typecheck`: 0 errors
- `vp lint`: nothing on the changed file
- Live: dev server from this branch, fresh draft thread, `$` picker now lists all skills (before: `No skills found`)

## Before / after

- Before: `$` in any OpenCode thread shows `No skills found. Try / to browse provider commands.` despite skills existing on disk and in the provider cache.
- After: `$` lists the full workspace skill inventory (global `~/.agents/skills` plus repo-local `.agents/skills`), e.g. `test-t3-app` appears when the thread cwd is this repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how per-cwd skill inventory is loaded for local OpenCode instances; behavior should improve but depends on the shared server and SDK `app.skills` path instead of the CLI.
> 
> **Overview**
> **Per-workspace OpenCode skills** in `snapshotForCwd` no longer use `loadSkillsFromCli` (`opencode debug skill`) when no remote `serverUrl` is configured. That path now reuses the shared local OpenCode server via `serverOwner.withServer` and fetches skills through the SDK (`loadOpenCodeSkills` with `directory: cwd`), matching the behavior already used when `serverUrl` is set.
> 
> This fixes workspace snapshots that were **ready** but carried `skills: []` because piped CLI JSON was truncated at ~64KB and parsing fell back to an empty list—so the composer `$` picker showed no skills even when the machine cache had them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c981dc970e3613cf6d0adb8965f8901ea6910e58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `OpenCodeDriver.create` local skill loading to avoid 64KB CLI pipe truncation
> - Updates local OpenCode skill discovery in `OpenCodeDriver.create` to use the OpenCode SDK client instead of the CLI command, avoiding a 64KB pipe truncation issue with large skill lists
> - Passes the configured working directory per request and conditionally forwards the server password to authenticate with the shared SDK server
> - Risk: local skill loading now requires a reachable shared SDK server when no explicit server URL is configured
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c981dc9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->