### PR TITLE
fix(web): bound disconnected send toasts

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1335,6 +1335,8 @@ function chatActionErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "An error occurred.";
 }
 
+const ENVIRONMENT_UNAVAILABLE_SEND_TOAST_TRAIL_SIZE = 3;
+
 /**
  * Drops the send-time anchored end space. That space is what holds a sent
  * message near the top while its turn streams, and it keeps LegendList's
@@ -1641,6 +1643,7 @@ function ChatViewContent(props: ChatViewProps) {
   const attachmentPreviewHandoffByMessageIdRef = useRef<Record<string, string[]>>({});
   const attachmentPreviewPromotionInFlightByMessageIdRef = useRef<Record<string, true>>({});
   const sendInFlightRef = useRef(false);
+  const environmentUnavailableSendToastSlotRef = useRef(0);
   const feedbackUploadsInFlightRef = useRef(new Set<string>());
   const terminalUiOpenByThreadRef = useRef<Record<string, boolean>>({});
 
@@ -6073,13 +6076,17 @@ function ChatViewContent(props: ChatViewProps) {
       return;
     }
     if (activeEnvironmentUnavailable) {
-      toastManager.add(
-        stackedThreadToast({
+      const toastSlot = environmentUnavailableSendToastSlotRef.current;
+      environmentUnavailableSendToastSlotRef.current =
+        (toastSlot + 1) % ENVIRONMENT_UNAVAILABLE_SEND_TOAST_TRAIL_SIZE;
+      toastManager.add({
+        ...stackedThreadToast({
           type: "warning",
           title: "Not connected: message not sent",
           description: "Reconnecting to the environment. Try again once it is connected.",
         }),
-      );
+        id: `chat-send-environment-unavailable:${toastSlot}`,
+      });
       return;
     }
     if (activePendingProgress) {


### PR DESCRIPTION
> [!NOTE]
> Written by `gpt-5.6-sol` on behalf of Maria

Repeated sends while an environment is unavailable used unique Base UI toast IDs, so hidden toast state and DOM nodes accumulated even though only three cards were visible. This reuses a three-slot ID ring, preserving the existing three-card trail while bounding retained toast state. Web typecheck, targeted lint and formatting passed; a 150-toast benchmark reduced retained roots from 150 to 3, added DOM nodes from 2,400 to 48, and settling time from 4.55 s to 166.7 ms.

![](https://uploads-production-47e4.up.railway.app/files/2649c789-6403-4444-8a79-905ed393fcf5/toasts-before-after.gif)

![](https://uploads-production-47e4.up.railway.app/files/6f3a633d-bab3-488f-a5ed-948b332cc9ff/toasts-before-after.mp4)

Implemented with `gpt-5.6-sol` in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX feedback change when sends are blocked for a disconnected environment; no auth, data, or send-path logic beyond toast identity reuse.
>
> **Overview**
> Repeated send attempts while the environment is disconnected no longer create a new toast identity every time. **ChatView** now assigns the “Not connected: message not sent” warning through a **three-slot ID ring** (`chat-send-environment-unavailable:0`–`2`), matching the visible stacked trail while capping retained toast state and DOM.
>
> The toast payload is unchanged; only the `toastManager.add` call gains an explicit rotating `id` and a ref that advances the slot on each blocked send.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5364e33d02ba567975ba07a5103ed697cc9e4259. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
