### PR TITLE
fix(mobile): surface dynamic tool approvals

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -263,6 +263,29 @@ describe("pending user input answers", () => {
 });
 
 describe("pending approvals", () => {
+  it("surfaces dynamic tool requests from servers that did not stamp requestKind", () => {
+    const activity = makeActivity({
+      id: EventId.make("approval-dynamic-tool"),
+      kind: "approval.requested",
+      summary: "Approval requested",
+      createdAt: "2026-08-24T00:00:00.000Z",
+      payload: {
+        requestId: "req-dynamic-tool",
+        requestType: "dynamic_tool_call",
+        detail: "Search the web",
+      },
+    });
+
+    expect(derivePendingApprovals([activity])).toEqual([
+      {
+        requestId: "req-dynamic-tool",
+        requestKind: "command",
+        createdAt: "2026-08-24T00:00:00.000Z",
+        detail: "Search the web",
+      },
+    ]);
+  });
+
   it("keeps app access approvals and persistence choices from remote environments", () => {
     const options = [
       { decision: "decline", label: "Decline" },

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -189,6 +189,7 @@ function requestKindFromRequestType(requestType: unknown): PendingApproval["requ
   switch (requestType) {
     case "command_execution_approval":
     case "exec_command_approval":
+    case "dynamic_tool_call":
       return "command";
     case "file_read_approval":
       return "file-read";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.approval.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.approval.test.ts
@@ -31,6 +31,34 @@ describe("runtimeEventToActivities approval details", () => {
     expect((activity?.payload as Record<string, unknown> | undefined)?.detail).toBe(detail);
   });
 
+  it("stamps dynamic tool requests as actionable command approvals", () => {
+    const event = {
+      type: "request.opened",
+      eventId: EventId.make("evt-dynamic-tool"),
+      provider: ProviderDriverKind.make("claudeAgent"),
+      createdAt: "2026-07-18T00:00:00.000Z",
+      threadId: ThreadId.make("thread-1"),
+      requestId: RuntimeRequestId.make("approval-dynamic-tool"),
+      payload: {
+        requestType: "dynamic_tool_call",
+        detail: "Search the web",
+      },
+    } satisfies ProviderRuntimeEvent;
+
+    const [activity] = runtimeEventToActivities(event);
+
+    expect(activity).toMatchObject({
+      kind: "approval.requested",
+      summary: "Command approval requested",
+      payload: {
+        requestId: "approval-dynamic-tool",
+        requestKind: "command",
+        requestType: "dynamic_tool_call",
+        detail: "Search the web",
+      },
+    });
+  });
+
   it("keeps app details and approval options available to remote clients", () => {
     const options = [
       { decision: "decline", label: "Decline" },

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -340,6 +340,7 @@ function requestKindFromCanonicalRequestType(
   switch (requestType) {
     case "command_execution_approval":
     case "exec_command_approval":
+    case "dynamic_tool_call":
       return "command";
     case "file_read_approval":
       return "file-read";


### PR DESCRIPTION
## What Changed

- Classify canonical `dynamic_tool_call` approval requests as `command` when the server projects provider runtime events, so persisted approval activities carry an actionable `requestKind`.
- Add the same `dynamic_tool_call` fallback to mobile approval derivation for older servers and already-persisted activities that do not carry `requestKind`.
- Add focused regression coverage for both the server projection and the mobile fallback.

## Why

Providers can emit approval-required tools as `dynamic_tool_call` (Claude Agent already does this today). Web already treated that request type as an actionable command approval, but mobile did not. At the same time, orchestration did not stamp a `requestKind` for these events, so the phone could receive an `approval.requested` activity and silently drop it instead of rendering the existing approval card.

The fix is intentionally two-sided: new server projections are self-describing, while mobile remains compatible with older servers and historical snapshots.

## Verification

- `vp test run apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.approval.test.ts apps/mobile/src/lib/threadActivity.test.ts` — 84 passed
- Existing Claude adapter regression confirms Agent-tool approvals emit `dynamic_tool_call`
- Server and mobile typechecks passed
- Targeted lint, formatting, and `git diff --check` passed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Built and verified with GPT-5.6 Sol through the T3 Code harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow classification change for one approval request type, with server and mobile regression tests; no auth or data-model changes.
> 
> **Overview**
> **Dynamic tool approval requests** (`requestType: dynamic_tool_call`) are now treated like **command approvals** on both server ingestion and mobile pending-approval derivation, so they show up in the approval UI instead of being dropped when `requestKind` is missing.
> 
> On the **server**, `requestKindFromCanonicalRequestType` maps `dynamic_tool_call` to `command`, so new `approval.requested` activities are persisted with an actionable `requestKind` and the usual “Command approval requested” summary.
> 
> On **mobile**, the same mapping is applied in `requestKindFromRequestType` when activities only carry `requestType` (older servers or historical snapshots). Regression tests cover both paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a6d1253929356d1c0954e27d3b83886cc029f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dynamic tool approvals surfacing as command approvals on mobile and server
> - Adds `dynamic_tool_call` to the command request-kind cases in both `requestKindFromRequestType` (mobile) and `requestKindFromCanonicalRequestType` (server).
> - Dynamic tool requests are now classified as command approvals so they appear in pending approvals and are ingested as actionable `approval.requested` activities.
> - Adds regression tests on both sides covering the new classification and persisted activity fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a6d125.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->