### PR TITLE
fix(web): group image views like other tool calls

### DIFF
--- a/apps/server/src/provider/CodexDeveloperInstructions.ts
+++ b/apps/server/src/provider/CodexDeveloperInstructions.ts
@@ -1,5 +1,5 @@
 import type { ProviderInteractionMode } from "@t3tools/contracts";
-import { T3_CODE_INLINE_IMAGE_INSTRUCTIONS } from "./InlineImageInstructions.ts";
+import { buildRuntimeInstructions } from "./RuntimeInstructions.ts";
 
 const T3_CODE_BROWSER_TOOL_INSTRUCTIONS = `
 
@@ -176,11 +176,6 @@ export interface CodexRuntimeInfo {
   readonly reasoningEffort: string;
 }
 
-// Values come from trusted config, but keep the block single-line regardless.
-function toSingleLine(value: string): string {
-  return value.replaceAll(/\s+/g, " ").trim();
-}
-
 export function buildCodexDeveloperInstructions(
   interactionMode: ProviderInteractionMode,
   runtime: CodexRuntimeInfo,
@@ -197,5 +192,5 @@ export function buildCodexDeveloperInstructions(
       : codexDefaultModeDeveloperInstructions(browserToolsAvailable);
   return `${base}
 
-<runtime_info>In case you're asked: you are running in T3 Code through the Codex harness, as ${toSingleLine(runtime.model)} with ${toSingleLine(runtime.reasoningEffort)} reasoning effort. No need to mention this otherwise. ${T3_CODE_INLINE_IMAGE_INSTRUCTIONS}</runtime_info>`;
+${buildRuntimeInstructions({ harness: "Codex", ...runtime })}`;
 }

--- a/apps/server/src/provider/CodexDeveloperInstructions.ts
+++ b/apps/server/src/provider/CodexDeveloperInstructions.ts
@@ -197,7 +197,5 @@ export function buildCodexDeveloperInstructions(
       : codexDefaultModeDeveloperInstructions(browserToolsAvailable);
   return `${base}
 
-<response_format>${T3_CODE_INLINE_IMAGE_INSTRUCTIONS}</response_format>
-
-<runtime_info>In case you're asked: you are running in T3 Code through the Codex harness, as ${toSingleLine(runtime.model)} with ${toSingleLine(runtime.reasoningEffort)} reasoning effort. No need to mention this otherwise.</runtime_info>`;
+<runtime_info>In case you're asked: you are running in T3 Code through the Codex harness, as ${toSingleLine(runtime.model)} with ${toSingleLine(runtime.reasoningEffort)} reasoning effort. No need to mention this otherwise. ${T3_CODE_INLINE_IMAGE_INSTRUCTIONS}</runtime_info>`;
 }

--- a/apps/server/src/provider/CodexDeveloperInstructions.ts
+++ b/apps/server/src/provider/CodexDeveloperInstructions.ts
@@ -1,4 +1,5 @@
 import type { ProviderInteractionMode } from "@t3tools/contracts";
+import { T3_CODE_INLINE_IMAGE_INSTRUCTIONS } from "./InlineImageInstructions.ts";
 
 const T3_CODE_BROWSER_TOOL_INSTRUCTIONS = `
 
@@ -195,6 +196,8 @@ export function buildCodexDeveloperInstructions(
       ? codexPlanModeDeveloperInstructions(browserToolsAvailable)
       : codexDefaultModeDeveloperInstructions(browserToolsAvailable);
   return `${base}
+
+<response_format>${T3_CODE_INLINE_IMAGE_INSTRUCTIONS}</response_format>
 
 <runtime_info>In case you're asked: you are running in T3 Code through the Codex harness, as ${toSingleLine(runtime.model)} with ${toSingleLine(runtime.reasoningEffort)} reasoning effort. No need to mention this otherwise.</runtime_info>`;
 }

--- a/apps/server/src/provider/InlineImageInstructions.ts
+++ b/apps/server/src/provider/InlineImageInstructions.ts
@@ -1,0 +1,7 @@
+/**
+ * Shared across every adapter that can extend its provider's system prompt.
+ * Chat renders markdown images from workspace-relative and absolute paths, so
+ * the final response is the right place for a screenshot, not a tool row.
+ */
+export const T3_CODE_INLINE_IMAGE_INSTRUCTIONS =
+  "When an image helps the user judge the result (a screenshot, a rendered diff, a generated asset), embed it in your final response as markdown with the file path, for example `![Settings page after the change](/absolute/path/to/screenshot.png)`. T3 Code renders it inline in the chat.";

--- a/apps/server/src/provider/InlineImageInstructions.ts
+++ b/apps/server/src/provider/InlineImageInstructions.ts
@@ -1,7 +1,8 @@
 /**
- * Shared across every adapter that can extend its provider's system prompt.
- * Chat renders markdown images from workspace-relative and absolute paths, so
- * the final response is the right place for a screenshot, not a tool row.
+ * Appended to the system prompt by every adapter whose provider accepts one
+ * (Codex, Claude, OpenCode). ACP agents expose no such input. Chat renders
+ * markdown images from workspace-relative and absolute paths, so the final
+ * response is the right place for a screenshot, not a tool row.
  */
 export const T3_CODE_INLINE_IMAGE_INSTRUCTIONS =
   "When an image helps the user judge the result (a screenshot, a rendered diff, a generated asset), embed it in your final response as markdown with the file path, for example `![Settings page after the change](/absolute/path/to/screenshot.png)`. T3 Code renders it inline in the chat.";

--- a/apps/server/src/provider/InlineImageInstructions.ts
+++ b/apps/server/src/provider/InlineImageInstructions.ts
@@ -1,8 +1,3 @@
-/**
- * Appended to the system prompt by every adapter whose provider accepts one
- * (Codex, Claude, OpenCode). ACP agents expose no such input. Chat renders
- * markdown images from workspace-relative and absolute paths, so the final
- * response is the right place for a screenshot, not a tool row.
- */
+/** Shared by providers that accept system instructions. */
 export const T3_CODE_INLINE_IMAGE_INSTRUCTIONS =
-  "When an image helps the user judge the result (a screenshot, a rendered diff, a generated asset), embed it in your final response as markdown with the file path, for example `![Settings page after the change](/absolute/path/to/screenshot.png)`. T3 Code renders it inline in the chat.";
+  "You can embed images in your response using Markdown with absolute file paths.";

--- a/apps/server/src/provider/InlineImageInstructions.ts
+++ b/apps/server/src/provider/InlineImageInstructions.ts
@@ -1,3 +1,3 @@
 /** Shared by providers that accept system instructions. */
 export const T3_CODE_INLINE_IMAGE_INSTRUCTIONS =
-  "You can embed images in your response using Markdown with absolute file paths.";
+  "You can embed images and videos in your response using Markdown with absolute file paths.";

--- a/apps/server/src/provider/InlineImageInstructions.ts
+++ b/apps/server/src/provider/InlineImageInstructions.ts
@@ -1,3 +1,0 @@
-/** Shared by providers that accept system instructions. */
-export const T3_CODE_INLINE_IMAGE_INSTRUCTIONS =
-  "You can embed images and videos in your response using Markdown with absolute file paths.";

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -49,6 +49,7 @@ const decodeRequestLog = Schema.decodeEffect(
 
 interface NativePrompt {
   readonly index: number;
+  readonly content: ReadonlyArray<AcpSchema.ContentBlock>;
   readonly result: Deferred.Deferred<AcpSchema.PromptResponse, AcpErrors.AcpError>;
 }
 
@@ -179,12 +180,13 @@ const makeHarness = Effect.fn("makeAntigravityAdapterHarness")(function* (option
       }),
     getEvents: () => Stream.fromQueue(runtimeEvents),
     drainEvents,
-    prompt: (_payload, promptOptions) =>
+    prompt: (payload, promptOptions) =>
       Effect.gen(function* () {
         yield* Deferred.succeed(dispatchStarted, undefined);
         if (options?.holdDispatch) yield* Deferred.await(dispatchRelease);
         const prompt: NativePrompt = {
           index: ++promptIndex,
+          content: payload.prompt,
           result: yield* Deferred.make<AcpSchema.PromptResponse, AcpErrors.AcpError>(),
         };
         active = prompt;
@@ -597,7 +599,11 @@ it.layer(layer)("AntigravityAdapter", (it) => {
       const first = yield* h.adapter
         .sendTurn({ threadId, input: "First prompt" })
         .pipe(Effect.forkChild);
-      yield* h.nextPrompt;
+      const initialPrompt = yield* h.nextPrompt;
+      expect(initialPrompt.content).toEqual([
+        { type: "text", text: "First prompt" },
+        { type: "text", text: expect.stringContaining(`Antigravity harness, as ${nativeDefault}`) },
+      ]);
       const marker = h.calls.length;
       const second = yield* h.adapter
         .sendTurn({
@@ -615,6 +621,13 @@ it.layer(layer)("AntigravityAdapter", (it) => {
       });
       yield* Deferred.succeed(h.cancelRelease, undefined);
       const replacement = yield* h.nextPrompt;
+      expect(replacement.content).toEqual([
+        { type: "text", text: "Steer the turn" },
+        {
+          type: "text",
+          text: expect.stringContaining(`Antigravity harness, as ${nativeAlternative}`),
+        },
+      ]);
       expect(h.calls.slice(marker)).toEqual([
         "cancel:1",
         "drained:1",

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -36,6 +36,7 @@ import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
 import { ServerConfig } from "../../config.ts";
+import { buildRuntimeInstructions } from "../RuntimeInstructions.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import type { AntigravityAuth } from "../AntigravityAuth.ts";
 import {
@@ -1075,7 +1076,18 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
           };
           const dispatched = yield* Deferred.make<void>();
           const fiber = yield* context.runtime
-            .prompt({ prompt }, { dispatched })
+            .prompt(
+              {
+                prompt: [
+                  ...prompt,
+                  {
+                    type: "text",
+                    text: buildRuntimeInstructions({ harness: "Antigravity", model }),
+                  },
+                ],
+              },
+              { dispatched },
+            )
             .pipe(Effect.forkIn(context.scope));
           context.promptFiber = fiber;
           // Fiber.join can skip a scope-close waiter when the child is interrupted.

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -385,6 +385,12 @@ describe("ClaudeAdapterLive", () => {
 
       const createInput = harness.getLastCreateQueryInput();
       assert.deepEqual(createInput?.options.settingSources, ["user", "project", "local"]);
+      assert.deepEqual(createInput?.options.systemPrompt, {
+        type: "preset",
+        preset: "claude_code",
+        append:
+          "<runtime_info>In case you're asked: you are running in T3 Code through the Claude Code harness. No need to mention this otherwise. You can embed images and videos in your response using Markdown with absolute file paths.</runtime_info>",
+      });
       assert.equal(createInput?.options.permissionMode, "bypassPermissions");
       assert.equal(createInput?.options.allowDangerouslySkipPermissions, true);
     }).pipe(

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -83,7 +83,7 @@ import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
 import { planClaudeSkillDispatch } from "../Drivers/ClaudeSkillDispatch.ts";
 import { discoverClaudeSkills } from "../Drivers/ClaudeSkills.ts";
-import { T3_CODE_INLINE_IMAGE_INSTRUCTIONS } from "../InlineImageInstructions.ts";
+import { buildRuntimeInstructions } from "../RuntimeInstructions.ts";
 import {
   BUNDLED_CLAUDE_MODEL_CATALOG,
   type ClaudeModelCatalog,
@@ -4374,7 +4374,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         systemPrompt: {
           type: "preset",
           preset: "claude_code",
-          append: T3_CODE_INLINE_IMAGE_INSTRUCTIONS,
+          // Model and effort can change after this session-level prompt is set.
+          append: buildRuntimeInstructions({ harness: "Claude Code" }),
         },
         settingSources: [...CLAUDE_SETTING_SOURCES],
         // `ultracode` is a Claude Code setting, not an API effort level. It is

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -83,6 +83,7 @@ import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
 import { planClaudeSkillDispatch } from "../Drivers/ClaudeSkillDispatch.ts";
 import { discoverClaudeSkills } from "../Drivers/ClaudeSkills.ts";
+import { T3_CODE_INLINE_IMAGE_INSTRUCTIONS } from "../InlineImageInstructions.ts";
 import {
   BUNDLED_CLAUDE_MODEL_CATALOG,
   type ClaudeModelCatalog,
@@ -4370,7 +4371,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...(input.cwd ? { cwd: input.cwd } : {}),
         ...(apiModelId ? { model: apiModelId } : {}),
         pathToClaudeCodeExecutable: claudeBinaryPath,
-        systemPrompt: { type: "preset", preset: "claude_code" },
+        systemPrompt: {
+          type: "preset",
+          preset: "claude_code",
+          append: T3_CODE_INLINE_IMAGE_INSTRUCTIONS,
+        },
         settingSources: [...CLAUDE_SETTING_SOURCES],
         // `ultracode` is a Claude Code setting, not an API effort level. It is
         // normalized to `xhigh` above and paired with `settings.ultracode`.

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -465,13 +465,13 @@ describe("buildCodexDeveloperInstructions", () => {
     NodeAssert.match(instructions, /as gpt-5\.3-codex with high reasoning effort/);
   });
 
-  it("tells the agent to embed result images as markdown in both modes", () => {
+  it("describes Markdown image support in the runtime context in both modes", () => {
     for (const mode of ["default", "plan"] as const) {
       const instructions = buildCodexDeveloperInstructions(mode, {
         model: "gpt-5.3-codex",
         reasoningEffort: "high",
       });
-      NodeAssert.match(instructions, /<response_format>.*!\[.*\]\(.*\).*<\/response_format>/);
+      NodeAssert.match(instructions, /<runtime_info>.*embed images.*Markdown.*<\/runtime_info>/);
     }
   });
 

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -465,13 +465,16 @@ describe("buildCodexDeveloperInstructions", () => {
     NodeAssert.match(instructions, /as gpt-5\.3-codex with high reasoning effort/);
   });
 
-  it("describes Markdown image support in the runtime context in both modes", () => {
+  it("describes Markdown media support in the runtime context in both modes", () => {
     for (const mode of ["default", "plan"] as const) {
       const instructions = buildCodexDeveloperInstructions(mode, {
         model: "gpt-5.3-codex",
         reasoningEffort: "high",
       });
-      NodeAssert.match(instructions, /<runtime_info>.*embed images.*Markdown.*<\/runtime_info>/);
+      NodeAssert.match(
+        instructions,
+        /<runtime_info>.*embed images and videos.*Markdown.*<\/runtime_info>/,
+      );
     }
   });
 

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -465,6 +465,16 @@ describe("buildCodexDeveloperInstructions", () => {
     NodeAssert.match(instructions, /as gpt-5\.3-codex with high reasoning effort/);
   });
 
+  it("tells the agent to embed result images as markdown in both modes", () => {
+    for (const mode of ["default", "plan"] as const) {
+      const instructions = buildCodexDeveloperInstructions(mode, {
+        model: "gpt-5.3-codex",
+        reasoningEffort: "high",
+      });
+      NodeAssert.match(instructions, /<response_format>.*!\[.*\]\(.*\).*<\/response_format>/);
+    }
+  });
+
   it("includes runtime info alongside plan mode instructions", () => {
     const instructions = buildCodexDeveloperInstructions("plan", {
       model: "gpt-5.3-codex",

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -284,6 +284,18 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
         input: "please $review this",
         attachments: [],
       });
+      const snapshot = yield* adapter.readThread(threadId);
+      assert.deepStrictEqual(
+        snapshot.turns.map((turn) => turn.items),
+        [
+          [
+            {
+              prompt: [{ type: "text", text: "please /review this" }],
+              result: { stopReason: "end_turn" },
+            },
+          ],
+        ],
+      );
       yield* adapter.stopSession(threadId);
 
       const requests = yield* Effect.promise(() => readJsonLines(requestLogPath));

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -26,6 +26,7 @@ import {
 } from "@t3tools/contracts";
 
 import { ServerConfig } from "../../config.ts";
+import { buildRuntimeInstructions } from "../RuntimeInstructions.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import type { CursorAdapterShape } from "../Services/CursorAdapter.ts";
 import { makeCursorAdapter } from "./CursorAdapter.ts";
@@ -291,7 +292,12 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
         promptRequests.map(
           (request) => (request.params as Record<string, unknown> | undefined)?.prompt,
         ),
-        [[{ type: "text", text: "please /review this" }]],
+        [
+          [
+            { type: "text", text: "please /review this" },
+            { type: "text", text: buildRuntimeInstructions({ harness: "Cursor" }) },
+          ],
+        ],
       );
     }),
   );

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -42,6 +42,7 @@ import type * as EffectAcpSchema from "effect-acp/schema";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
+import { buildRuntimeInstructions } from "../RuntimeInstructions.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import {
   ProviderAdapterProcessError,
@@ -1043,6 +1044,11 @@ export function makeCursorAdapter(
             });
           }
 
+          // ACP has no system-message field; keep runtime context separate from the user's text.
+          promptParts.push({
+            type: "text",
+            text: buildRuntimeInstructions({ harness: "Cursor", model: resolvedModel }),
+          });
           const result = yield* ctx.acp
             .prompt({
               prompt: promptParts,

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -1045,13 +1045,15 @@ export function makeCursorAdapter(
           }
 
           // ACP has no system-message field; keep runtime context separate from the user's text.
-          promptParts.push({
-            type: "text",
-            text: buildRuntimeInstructions({ harness: "Cursor", model: resolvedModel }),
-          });
           const result = yield* ctx.acp
             .prompt({
-              prompt: promptParts,
+              prompt: [
+                ...promptParts,
+                {
+                  type: "text",
+                  text: buildRuntimeInstructions({ harness: "Cursor", model: resolvedModel }),
+                },
+              ],
             })
             .pipe(
               Effect.mapError((error) =>

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -213,7 +213,7 @@ it("requires a settlement to match the live Grok turn", () => {
 });
 
 it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
-  it.effect("sends runtime context with the current model without changing user text", () =>
+  it.effect("sends runtime context with the current model without changing saved prompts", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-runtime-context");
       const tempDir = yield* Effect.promise(() =>
@@ -240,6 +240,24 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
           options: [{ id: "reasoningEffort", value: "low" }],
         },
       });
+      const snapshot = yield* adapter.readThread(threadId);
+      assert.deepEqual(
+        snapshot.turns.map((turn) => turn.items),
+        [
+          [
+            {
+              prompt: [{ type: "text", text: "First prompt" }],
+              result: { stopReason: "end_turn" },
+            },
+          ],
+          [
+            {
+              prompt: [{ type: "text", text: "Second prompt" }],
+              result: { stopReason: "end_turn" },
+            },
+          ],
+        ],
+      );
       yield* adapter.stopSession(threadId);
       const requests = yield* Effect.promise(() => readJsonLines(requestLogPath));
       const prompts = requests

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -213,6 +213,50 @@ it("requires a settlement to match the live Grok turn", () => {
 });
 
 it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
+  it.effect("sends runtime context with the current model without changing user text", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-runtime-context");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-runtime-context-")),
+      );
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({ T3_ACP_REQUEST_LOG_PATH: requestLogPath }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      yield* adapter.startSession({
+        threadId,
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("grok"), model: "grok-mock-alt" },
+      });
+      yield* adapter.sendTurn({ threadId, input: "First prompt" });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "Second prompt",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("grok"),
+          model: "grok-4.6",
+          options: [{ id: "reasoningEffort", value: "low" }],
+        },
+      });
+      yield* adapter.stopSession(threadId);
+      const requests = yield* Effect.promise(() => readJsonLines(requestLogPath));
+      const prompts = requests
+        .filter((request) => request.method === "session/prompt")
+        .map(
+          (request) => (request.params as { prompt: Array<{ type: string; text: string }> }).prompt,
+        );
+      assert.equal(prompts.length, 2);
+      assert.deepEqual(prompts[0]?.[0], { type: "text", text: "First prompt" });
+      assert.include(prompts[0]?.[1]?.text, "Grok harness, as grok-mock-alt");
+      assert.deepEqual(prompts[1]?.[0], { type: "text", text: "Second prompt" });
+      assert.include(prompts[1]?.[1]?.text, "Grok harness, as grok-4.6");
+      assert.include(prompts[1]?.[1]?.text, "with low reasoning effort");
+      assert.include(prompts[1]?.[1]?.text, "embed images and videos");
+    }),
+  );
+
   it.effect("starts a session and maps mock ACP prompt flow to runtime events", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-mock-thread");

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -1584,13 +1584,10 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               const displayModel = currentModelId
                 ? resolveGrokAcpBaseModelId(currentModelId)
                 : undefined;
-              promptParts.push({
-                type: "text",
-                text: buildRuntimeInstructions({
-                  harness: "Grok",
-                  model: displayModel,
-                  reasoningEffort: normalizeGrokReasoningEffort(requestedTurnReasoningEffort),
-                }),
+              const runtimeInstructions = buildRuntimeInstructions({
+                harness: "Grok",
+                model: displayModel,
+                reasoningEffort: normalizeGrokReasoningEffort(requestedTurnReasoningEffort),
               });
               for (let yieldAttempt = 0; yieldAttempt < 8; yieldAttempt += 1) {
                 yield* Effect.yieldNow;
@@ -1647,6 +1644,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 acpSessionId: ctx.acpSessionId,
                 displayModel,
                 promptParts,
+                runtimeInstructions,
                 turnId,
                 promptEpoch,
                 promptLifecycle: ctx.promptLifecycle,
@@ -1703,7 +1701,15 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               }
               const dispatched = yield* Deferred.make<void>();
               const fiber = yield* liveCtx.acp
-                .prompt({ prompt: prepared.promptParts }, { dispatched })
+                .prompt(
+                  {
+                    prompt: [
+                      ...prepared.promptParts,
+                      { type: "text", text: prepared.runtimeInstructions },
+                    ],
+                  },
+                  { dispatched },
+                )
                 .pipe(Effect.forkChild({ startImmediately: true }));
               // Hold the lifecycle permit until the runtime has registered this
               // prompt's RPC fiber, so a later steer's session/cancel targets

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -40,6 +40,7 @@ import type * as EffectAcpSchema from "effect-acp/schema";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
+import { buildRuntimeInstructions } from "../RuntimeInstructions.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import {
   ProviderAdapterProcessError,
@@ -1583,6 +1584,14 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               const displayModel = currentModelId
                 ? resolveGrokAcpBaseModelId(currentModelId)
                 : undefined;
+              promptParts.push({
+                type: "text",
+                text: buildRuntimeInstructions({
+                  harness: "Grok",
+                  model: displayModel,
+                  reasoningEffort: normalizeGrokReasoningEffort(requestedTurnReasoningEffort),
+                }),
+              });
               for (let yieldAttempt = 0; yieldAttempt < 8; yieldAttempt += 1) {
                 yield* Effect.yieldNow;
               }

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -27,6 +27,7 @@ import {
 import { createModelSelection } from "@t3tools/shared/model";
 import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
+import { T3_CODE_INLINE_IMAGE_INSTRUCTIONS } from "../InlineImageInstructions.ts";
 import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory.ts";
 import type { OpenCodeAdapterShape } from "../Services/OpenCodeAdapter.ts";
 import {
@@ -4958,6 +4959,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         },
         agent: "github-copilot",
         variant: "high",
+        system: T3_CODE_INLINE_IMAGE_INSTRUCTIONS,
         parts: [{ type: "text", text: "Fix it" }],
       });
     }).pipe(Effect.provide(adapterLayer));
@@ -5005,6 +5007,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
           providerID: "anthropic",
           modelID: "claude-sonnet-4-5",
         },
+        system: T3_CODE_INLINE_IMAGE_INSTRUCTIONS,
         parts: [{ type: "text", text: "Fix it" }],
       });
     }).pipe(Effect.provide(adapterLayer));

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -27,7 +27,7 @@ import {
 import { createModelSelection } from "@t3tools/shared/model";
 import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
-import { T3_CODE_INLINE_IMAGE_INSTRUCTIONS } from "../InlineImageInstructions.ts";
+import { buildRuntimeInstructions } from "../RuntimeInstructions.ts";
 import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory.ts";
 import type { OpenCodeAdapterShape } from "../Services/OpenCodeAdapter.ts";
 import {
@@ -4959,7 +4959,10 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         },
         agent: "github-copilot",
         variant: "high",
-        system: T3_CODE_INLINE_IMAGE_INSTRUCTIONS,
+        system: buildRuntimeInstructions({
+          harness: "OpenCode",
+          model: "anthropic/claude-sonnet-4-5",
+        }),
         parts: [{ type: "text", text: "Fix it" }],
       });
     }).pipe(Effect.provide(adapterLayer));
@@ -5007,7 +5010,10 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
           providerID: "anthropic",
           modelID: "claude-sonnet-4-5",
         },
-        system: T3_CODE_INLINE_IMAGE_INSTRUCTIONS,
+        system: buildRuntimeInstructions({
+          harness: "OpenCode",
+          model: "anthropic/claude-sonnet-4-5",
+        }),
         parts: [{ type: "text", text: "Fix it" }],
       });
     }).pipe(Effect.provide(adapterLayer));

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -41,6 +41,7 @@ import {
   ProviderAdapterSessionNotFoundError,
   ProviderAdapterValidationError,
 } from "../Errors.ts";
+import { T3_CODE_INLINE_IMAGE_INSTRUCTIONS } from "../InlineImageInstructions.ts";
 import { type OpenCodeAdapterShape } from "../Services/OpenCodeAdapter.ts";
 import {
   buildOpenCodePermissionRules,
@@ -2856,6 +2857,8 @@ export function makeOpenCodeAdapter(
                 model: parsedModel,
                 ...(context.activeAgent ? { agent: context.activeAgent } : {}),
                 ...(context.activeVariant ? { variant: context.activeVariant } : {}),
+                // OpenCode appends this after its own agent/provider prompts.
+                system: T3_CODE_INLINE_IMAGE_INSTRUCTIONS,
                 parts: [...(text ? [{ type: "text" as const, text }] : []), ...fileParts],
               },
               { signal },

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -41,7 +41,7 @@ import {
   ProviderAdapterSessionNotFoundError,
   ProviderAdapterValidationError,
 } from "../Errors.ts";
-import { T3_CODE_INLINE_IMAGE_INSTRUCTIONS } from "../InlineImageInstructions.ts";
+import { buildRuntimeInstructions } from "../RuntimeInstructions.ts";
 import { type OpenCodeAdapterShape } from "../Services/OpenCodeAdapter.ts";
 import {
   buildOpenCodePermissionRules,
@@ -2858,7 +2858,10 @@ export function makeOpenCodeAdapter(
                 ...(context.activeAgent ? { agent: context.activeAgent } : {}),
                 ...(context.activeVariant ? { variant: context.activeVariant } : {}),
                 // OpenCode appends this after its own agent/provider prompts.
-                system: T3_CODE_INLINE_IMAGE_INSTRUCTIONS,
+                system: buildRuntimeInstructions({
+                  harness: "OpenCode",
+                  model: `${parsedModel.providerID}/${parsedModel.modelID}`,
+                }),
                 parts: [...(text ? [{ type: "text" as const, text }] : []), ...fileParts],
               },
               { signal },

--- a/apps/server/src/provider/RuntimeInstructions.test.ts
+++ b/apps/server/src/provider/RuntimeInstructions.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test";
+import { buildRuntimeInstructions } from "./RuntimeInstructions.ts";
+
+describe("buildRuntimeInstructions", () => {
+  it.each(["Codex", "Claude Code", "Cursor", "Grok", "OpenCode", "Antigravity"])(
+    "identifies the %s harness and describes media embedding",
+    (harness) => {
+      const instructions = buildRuntimeInstructions({ harness });
+      expect(instructions).toContain(`running in T3 Code through the ${harness} harness.`);
+      expect(instructions).toContain("embed images and videos");
+      expect(instructions).toContain("Markdown with absolute file paths");
+      expect(instructions).not.toContain("undefined");
+    },
+  );
+
+  it("keeps known model and effort metadata on one line", () => {
+    expect(
+      buildRuntimeInstructions({
+        harness: "Codex",
+        model: "  custom\nmodel  ",
+        reasoningEffort: " high\n",
+      }),
+    ).toContain("through the Codex harness, as custom model with high reasoning effort.");
+  });
+
+  it.each([undefined, "", "auto", "default"])("omits unresolved model %s", (model) => {
+    const instructions = buildRuntimeInstructions({ harness: "Cursor", model });
+    expect(instructions).toContain("through the Cursor harness.");
+    expect(instructions).not.toContain("reasoning effort");
+  });
+});

--- a/apps/server/src/provider/RuntimeInstructions.ts
+++ b/apps/server/src/provider/RuntimeInstructions.ts
@@ -1,0 +1,17 @@
+/** Shared runtime context; omit model and effort when the harness manages them dynamically. */
+export function buildRuntimeInstructions(runtime: {
+  readonly harness: string;
+  readonly model?: string | undefined;
+  readonly reasoningEffort?: string | undefined;
+}): string {
+  const harness = toSingleLine(runtime.harness);
+  const model = toSingleLine(runtime.model ?? "");
+  const effort = toSingleLine(runtime.reasoningEffort ?? "");
+  const modelInfo = model && model !== "auto" && model !== "default" ? `, as ${model}` : "";
+  const effortInfo = effort ? ` with ${effort} reasoning effort` : "";
+  return `<runtime_info>In case you're asked: you are running in T3 Code through the ${harness} harness${modelInfo}${effortInfo}. No need to mention this otherwise. You can embed images and videos in your response using Markdown with absolute file paths.</runtime_info>`;
+}
+
+function toSingleLine(value: string): string {
+  return value.replaceAll(/\s+/g, " ").trim();
+}

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -12,7 +12,6 @@ import {
   shouldPreserveAssistantLineBreaks,
   type MessagesTimelineRow,
   workEntryDisplayLabel,
-  workEntryIsVisibleInGroup,
 } from "./MessagesTimeline.logic";
 
 describe("expanded tool group scrolling", () => {
@@ -472,22 +471,6 @@ describe("resolveAssistantMessageCopyState", () => {
   });
 });
 
-describe("workEntryIsVisibleInGroup", () => {
-  it("keeps an in-progress image preview row visible outside a group", () => {
-    const entry = {
-      id: "work-image",
-      createdAt: "2026-01-01T00:00:04Z",
-      turnId: "turn-1" as never,
-      label: "Image view",
-      detail: "screenshots/result.png",
-      itemType: "image_view" as const,
-      tone: "tool" as const,
-      toolLifecycleStatus: "inProgress" as const,
-    };
-    expect(workEntryIsVisibleInGroup(entry, false)).toBe(true);
-  });
-});
-
 describe("deriveMessagesTimelineRows", () => {
   it("keeps context compaction visible outside folded work", () => {
     const rows = deriveMessagesTimelineRows({
@@ -881,125 +864,6 @@ describe("deriveMessagesTimelineRows", () => {
       showAssistantMeta: false,
       showAssistantCopyButton: false,
     });
-  });
-
-  it("keeps an image preview row visible after the turn settles", () => {
-    const timelineEntries = [
-      {
-        id: "work-command-entry",
-        kind: "work" as const,
-        createdAt: "2026-01-01T00:00:02Z",
-        entry: {
-          id: "work-command",
-          createdAt: "2026-01-01T00:00:02Z",
-          turnId: "turn-1" as never,
-          label: "Ran command",
-          tone: "tool" as const,
-        },
-      },
-      {
-        id: "work-image-entry",
-        kind: "work" as const,
-        createdAt: "2026-01-01T00:00:04Z",
-        entry: {
-          id: "work-image",
-          createdAt: "2026-01-01T00:00:04Z",
-          turnId: "turn-1" as never,
-          label: "Image view",
-          detail: "screenshots/result.png",
-          itemType: "image_view" as const,
-          tone: "tool" as const,
-        },
-      },
-      {
-        id: "assistant-final-entry",
-        kind: "message" as const,
-        createdAt: "2026-01-01T00:00:06Z",
-        message: {
-          id: "assistant-final" as never,
-          role: "assistant" as const,
-          text: "Here is the screenshot.",
-          turnId: "turn-1" as never,
-          createdAt: "2026-01-01T00:00:06Z",
-          updatedAt: "2026-01-01T00:00:07Z",
-          streaming: false,
-        },
-      },
-    ];
-
-    const rows = deriveMessagesTimelineRows({
-      timelineEntries,
-      isWorking: false,
-      activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
-    });
-
-    // The command row folds, the image row stays as its own visible row rather
-    // than collapsing into a tool group summary.
-    expect(rows.map((row) => row.id)).toEqual([
-      "turn-fold:turn-1",
-      "work-image-entry",
-      "assistant-final-entry",
-    ]);
-    expect(rows.find((row) => row.id === "work-image-entry")?.kind).toBe("work");
-  });
-
-  it("keeps a trailing image preview row visible while the turn is still working", () => {
-    const rows = deriveMessagesTimelineRows({
-      timelineEntries: [
-        {
-          id: "user-entry",
-          kind: "message" as const,
-          createdAt: "2026-01-01T00:00:00Z",
-          message: {
-            id: "user-1" as never,
-            role: "user" as const,
-            text: "show me the result",
-            turnId: null,
-            createdAt: "2026-01-01T00:00:00Z",
-            updatedAt: "2026-01-01T00:00:00Z",
-            streaming: false,
-          },
-        },
-        {
-          id: "work-command-entry",
-          kind: "work" as const,
-          createdAt: "2026-01-01T00:00:02Z",
-          entry: {
-            id: "work-command",
-            createdAt: "2026-01-01T00:00:02Z",
-            turnId: "turn-1" as never,
-            label: "Ran command",
-            tone: "tool" as const,
-          },
-        },
-        {
-          id: "work-image-entry",
-          kind: "work" as const,
-          createdAt: "2026-01-01T00:00:04Z",
-          entry: {
-            id: "work-image",
-            createdAt: "2026-01-01T00:00:04Z",
-            turnId: "turn-1" as never,
-            label: "Image view",
-            detail: "screenshots/result.png",
-            itemType: "image_view" as const,
-            tone: "tool" as const,
-          },
-        },
-      ],
-      isWorking: true,
-      activeTurnStartedAt: "2026-01-01T00:00:01Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
-    });
-
-    // The live activity row must not swallow the image: it renders only a
-    // label, which would hide the image until the turn settles.
-    const imageRow = rows.find((row) => row.id === "work-image-entry");
-    expect(imageRow?.kind).toBe("work");
-    expect(rows.some((row) => row.kind === "work-live")).toBe(false);
   });
 
   it("folds all assistant messages before the terminal message", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -9,7 +9,6 @@ import {
   summarizeToolGroup,
   toolGroupAction,
   toolGroupSummaryKind,
-  workEntryViewedImagePath,
   type ToolGroupSummaryKind,
 } from "@t3tools/client-runtime/work-log/presentation";
 export {
@@ -90,15 +89,6 @@ export function liveWorkEntryLabel(
   return workEntryDisplayLabel(entry, workspaceRoot);
 }
 
-/**
- * Rows that preview an image the agent viewed or produced. They stay out of
- * tool groups and out of the settled-turn fold: the image is the answer the
- * user asked for, not tool noise to hide behind "Worked for ...".
- */
-function workEntryRendersImagePreview(entry: WorkLogEntry): boolean {
-  return workEntryViewedImagePath(entry) !== null;
-}
-
 export function workEntryIsVisibleInGroup(
   entry: WorkLogEntry,
   expandedToolGroupEntry = false,
@@ -107,9 +97,6 @@ export function workEntryIsVisibleInGroup(
     (expandedToolGroupEntry &&
       (entry.toolLifecycleStatus === "inProgress" ||
         entry.sourceActivityKind === "task.progress")) ||
-    // An image row stands alone outside any group, so the neutral filter
-    // would leave an empty gap while its tool is still in progress.
-    workEntryRendersImagePreview(entry) ||
     !workEntryIndicatesToolNeutralStatus(entry)
   );
 }
@@ -645,9 +632,6 @@ function deriveTurnFolds(input: {
       ) {
         continue;
       }
-      if (entry.kind === "work" && workEntryRendersImagePreview(entry.entry)) {
-        continue;
-      }
       hiddenEntryIds.add(entry.id);
     }
     if (hiddenEntryIds.size === 0) {
@@ -842,8 +826,7 @@ export function deriveMessagesTimelineRows(input: {
       entry.kind !== "work" ||
       entry.entry.agentSpawn !== undefined ||
       entry.entry.sourceActivityKind === "context-compaction" ||
-      entry.entry.tone === "error" ||
-      workEntryRendersImagePreview(entry.entry)
+      entry.entry.tone === "error"
     ) {
       break;
     }
@@ -966,11 +949,7 @@ export function deriveMessagesTimelineRows(input: {
     }
 
     if (timelineEntry.kind === "work") {
-      if (
-        timelineEntry.entry.agentSpawn !== undefined ||
-        timelineEntry.entry.tone === "error" ||
-        workEntryRendersImagePreview(timelineEntry.entry)
-      ) {
+      if (timelineEntry.entry.agentSpawn !== undefined || timelineEntry.entry.tone === "error") {
         nextRows.push({
           kind: "work",
           id: timelineEntry.id,
@@ -990,7 +969,6 @@ export function deriveMessagesTimelineRows(input: {
           nextEntry.entry.agentSpawn !== undefined ||
           nextEntry.entry.sourceActivityKind === "context-compaction" ||
           nextEntry.entry.tone === "error" ||
-          workEntryRendersImagePreview(nextEntry.entry) ||
           activeWorkEntryIds.has(nextEntry.id) ||
           collapsedEntryIds.has(nextEntry.id) ||
           foldsByAnchorEntryId.has(nextEntry.id)

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -24,6 +24,18 @@ adapter in a child scope. Adapter implementations live beside them in
 [`ProviderAdapter.ts`][adapter]. Read the driver plus its adapter to see how a specific agent's
 transport, config, and event shapes are mapped.
 
+## Runtime context
+
+Every adapter uses `apps/server/src/provider/RuntimeInstructions.ts` to identify T3 Code and
+the harness, and describe Markdown image/video embeds. Codex includes it in developer
+instructions; Claude appends it to its system preset; OpenCode sends it in each prompt's
+`system` field. Cursor, Grok, and Antigravity append a separate text block to ACP prompts,
+which have no system-message field. This does not change the stored user message.
+
+Per-turn context includes the current model when known. Codex includes reasoning effort;
+Grok includes it when explicitly selected for the turn. Claude's session-level context omits model and effort because they can
+change during a session. OpenCode variants are not assumed to be reasoning-effort levels.
+
 ## Codex async questions
 
 Codex 0.153 exposes `request_user_input_async` through `item/started` and `item/completed`


### PR DESCRIPTION
Image views were forced out of tool groups and settled-turn folds by [#9126](https://github.com/pingdotgg/t3code/pull/9126). After [#9460](https://github.com/pingdotgg/t3code/pull/9460) hid their previews until expansion, bare image paths still split otherwise ordinary tool groups.

Remove that grouping exception. Image views group and fold like other reads, including in the live activity row. Expanding a tool row still uses the existing image-preview renderer.

All six providers now share a concise `<runtime_info>` block identifying T3 Code and their harness, ending with: "You can embed images and videos in your response using Markdown with absolute file paths."

Codex receives it in developer instructions, Claude in its system-preset append, and OpenCode in each prompt's `system` field. Cursor, Grok, and Antigravity receive a separate ACP text block after the user content, without changing the stored message. Per-turn context includes the model when known. Claude omits model/effort from its session-level prompt to avoid stale values; OpenCode variants are not assumed to be reasoning effort.

### Before

Base `2675e3c70`, the PR merge base. The same copied thread, expanded turn, scroll anchor, dark theme, and 1280 × 1000 viewport are used in both captures.

![Before: image-view paths split the surrounding tool groups](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/95fc03914c8036ef/before-clean.png)

### After

Captured at `73c468825`; the later prompt-only revision does not change the UI.

![After: image views join surrounding tool groups as file reads](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/76b90e325c93097f/after-clean.png)

### Verification

- On `fcffb6e6f`, all 307 focused tests pass across the shared runtime instructions, Codex session runtime, and Claude, OpenCode, Cursor, Grok, and Antigravity adapters. Grok and Cursor tests verify runtime context stays out of saved prompts. Server typecheck, targeted lint, and diff checks pass. CI, Cursor Bugbot, and Macroscope correctness and Effect conventions checks pass on this revision; both review threads are resolved.
- At `73c468825`, 294 focused tests passed across `CodexSessionRuntime.test.ts`, `OpenCodeAdapter.test.ts`, `MessagesTimeline.logic.test.ts`, `MessagesTimeline.test.tsx`, and `ChatMarkdown.test.tsx`.
- Preview deployments are label-gated and skipped. Mobile native static analysis is skipped because no native files changed; the native-change detection job passes. PR-size definition sync is inapplicable to this event, and Codesmith is not enabled.
- Macroscope approvability is neutral and requests human review for changes to default behavior. No human approval is recorded. This PR remains unmerged pending explicit authorization.
- Browser verification covers the shared web/desktop timeline. Mobile is unchanged; its Markdown renderer already supports these image paths. No wire-contract or connection-mode changes. Existing user documentation describes Markdown media and remote path resolution.
- Removed the old standalone-image assertions. No replacement grouping regression guards were added, as requested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default chat timeline layout and per-turn agent instructions across every harness; mistakes could mislead models or alter how tool activity is shown, though behavior is covered by adapter and timeline tests.
> 
> **Overview**
> **Image views in the chat timeline** no longer bypass tool grouping or settled-turn folding. The special-case logic that kept image-preview work rows standalone is removed, so image views behave like other tool reads in groups, folds, and the live activity strip; expanded rows still use the existing image preview renderer.
> 
> **All six provider adapters** now share `buildRuntimeInstructions` for a consistent `<runtime_info>` block (T3 Code + harness, optional model/reasoning effort, Markdown image/video embed hint). Codex folds it into developer instructions; Claude appends it to the `claude_code` system preset; OpenCode sends it on each prompt’s `system` field. Cursor, Grok, and Antigravity append an extra ACP text block after user content **without** changing stored thread prompts. Provider docs describe this wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcffb6e6febb222e37b9c8d7cd875278c7cc29e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Group image views like other tool calls and add shared provider runtime context
> - Removes special-case image-preview handling in the message timeline so image work entries follow the same grouping, folding, and active-work logic as other tool calls.
> - Adds a shared `buildRuntimeInstructions` formatter in [RuntimeInstructions.ts](https://github.com/pingdotgg/t3code/pull/9597/files#diff-ab39a8adc23c40c03a204272cbf9ed0793337f786db3f827112ed65b83592843) that emits a runtime-info block with harness identity, optional model/reasoning-effort metadata, and Markdown media-embedding instructions using absolute file paths.
> - Integrates the shared runtime context into all six provider adapters (Codex, Antigravity, Claude, Cursor, Grok, OpenCode) so each turn sends current harness/model context alongside the user prompt, without storing it in thread history.
> - Documents the runtime-instruction contract and per-adapter prompt channels in [providers.md](https://github.com/pingdotgg/t3code/pull/9597/files#diff-3d909027abc31a863f0c0e5ecef5aa50ac285620ad827db723eb0a4ac46d3f85).
> - Behavioral Change: settled-turn folding can now hide image-preview entries that were previously kept as standalone rows; image-preview entries are also eligible for active-tool grouping in [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/9597/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcffb6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Implemented with Claude Fable 5.1 via Claude Code in T3 Code. Preparation resumed and verified with vega-alpha via the Codex harness in T3 Code.
