### PR TITLE
feat(web): show usage limits and reset credits in provider settings

### DIFF
--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -362,6 +362,12 @@ interface ProviderInstanceCardProps {
    */
   readonly headerAction?: ReactNode | undefined;
   readonly setup?: ReactNode;
+  /**
+   * Subscription quota windows and banked reset credits the live provider
+   * reports. Only editor mode renders it; omitted when the driver cannot
+   * report limits.
+   */
+  readonly usageLimits?: ReactNode;
   readonly hiddenModels: ReadonlyArray<string>;
   readonly favoriteModels: ReadonlyArray<string>;
   readonly modelOrder: ReadonlyArray<string>;
@@ -404,6 +410,7 @@ export function ProviderInstanceCard({
   onDelete,
   headerAction,
   setup,
+  usageLimits,
   hiddenModels,
   favoriteModels,
   modelOrder,
@@ -802,6 +809,12 @@ export function ProviderInstanceCard({
       {setup ? (
         <SettingsSection title="Setup">
           <div className="px-3 py-3 sm:px-4">{setup}</div>
+        </SettingsSection>
+      ) : null}
+
+      {usageLimits ? (
+        <SettingsSection title="Usage limits">
+          <div className="flex flex-col gap-3 px-3 py-3 sm:px-4">{usageLimits}</div>
         </SettingsSection>
       ) : null}
 

--- a/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
@@ -286,6 +286,74 @@ describe("EnvironmentProviderSettings routing", () => {
     expect(visitElements(panel, isAddProviderButton)).not.toBeNull();
   });
 
+  it("shows the live provider's usage limits and reset credits in the editor", () => {
+    const live: ServerProvider = {
+      ...provider(),
+      usageLimits: {
+        checkedAt: "2026-07-24T12:00:00.000Z",
+        windows: [
+          {
+            id: "primary",
+            kind: "session",
+            label: "5h",
+            usedPercent: 40,
+            resetsAt: "2026-07-24T15:00:00.000Z",
+          },
+        ],
+        resetCredits: { availableCount: 2, nextExpiresAt: "2026-08-01T00:00:00.000Z" },
+      },
+    };
+    atoms.providers = [live];
+
+    let panel = renderPanel();
+    let editor = visitElements(
+      panel,
+      (element) => element.props.instanceId === codexId && element.props.mode === "editor",
+    );
+    const block = editor?.props.usageLimits as ReactElement<Record<string, unknown>> | null;
+    expect(block).not.toBeNull();
+    expect(block?.props.provider).toBe(live);
+    expect(block?.props.environmentId).toBe(environmentId);
+    expect(block?.props.readOnly).toBe(false);
+
+    panel = renderPanel({ readOnly: true });
+    editor = visitElements(
+      panel,
+      (element) => element.props.instanceId === codexId && element.props.mode === "editor",
+    );
+    expect(
+      (editor?.props.usageLimits as ReactElement<Record<string, unknown>> | null)?.props.readOnly,
+    ).toBe(true);
+  });
+
+  it("omits the usage-limits block when the provider reports none or cannot have any", () => {
+    atoms.providers = [provider()];
+    let panel = renderPanel();
+    let editor = visitElements(
+      panel,
+      (element) => element.props.instanceId === codexId && element.props.mode === "editor",
+    );
+    expect(editor).not.toBeNull();
+    expect(editor?.props.usageLimits).toBeNull();
+
+    atoms.providers = [
+      {
+        ...provider(),
+        usageLimits: {
+          checkedAt: "2026-07-24T12:00:00.000Z",
+          windows: [],
+          unavailable: { reason: "unsupported" },
+        },
+      },
+    ];
+    panel = renderPanel();
+    editor = visitElements(
+      panel,
+      (element) => element.props.instanceId === codexId && element.props.mode === "editor",
+    );
+    expect(editor?.props.usageLimits).toBeNull();
+  });
+
   it("keeps Advanced visible when search targets the provider health interval", () => {
     let panel = renderPanel();
     expect(visitElements(panel, (element) => element.props.title === "Advanced")).not.toBeNull();

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -66,6 +66,7 @@ import {
 import { ScrollArea } from "../ui/scroll-area";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { stackedThreadToast, toastManager } from "../ui/toast";
+import { ProviderUsageLimitsBlock } from "../usage/UsageLimits";
 import { AddProviderInstanceDialog } from "./AddProviderInstanceDialog";
 import { ProviderInstanceCard } from "./ProviderInstanceCard";
 import { ProviderSetupSection, readAntigravityAuthMethod } from "./ProviderSetupSection";
@@ -847,6 +848,18 @@ export function EnvironmentProviderSettings({
               enabled={resolveProviderInstanceEnabled(row.instance)}
               readOnly={readOnly}
               onEnable={() => updateProviderInstance(row, { ...row.instance, enabled: true })}
+            />
+          ) : null
+        }
+        usageLimits={
+          mode === "editor" &&
+          liveProvider?.usageLimits &&
+          liveProvider.usageLimits.unavailable?.reason !== "unsupported" ? (
+            <ProviderUsageLimitsBlock
+              provider={liveProvider}
+              environmentId={environmentId}
+              now={Date.now()}
+              readOnly={readOnly}
             />
           ) : null
         }

--- a/apps/web/src/components/usage/UsageLimits.tsx
+++ b/apps/web/src/components/usage/UsageLimits.tsx
@@ -257,27 +257,27 @@ function AccountHeading({
   );
 }
 
-function ProviderLimits({
+/**
+ * The windows and banked reset credits one provider reports, without the
+ * account heading. Shared by the Usage → Limits page and the provider's
+ * editor in Settings → Providers so both surfaces read and act the same.
+ */
+export function ProviderUsageLimitsBlock({
   provider,
   environmentId,
   now,
+  readOnly = false,
 }: {
   readonly provider: ServerProvider;
   readonly environmentId: EnvironmentId;
   readonly now: number;
+  readonly readOnly?: boolean | undefined;
 }) {
   const limits = provider.usageLimits;
   if (!limits) return null;
   const notice = limitsNotice(limits);
   return (
-    <section className="flex flex-col gap-3">
-      <AccountHeading
-        driver={provider.driver}
-        label={providerLimitsLabel(provider, (driver) => getDriverOption(driver)?.label)}
-        plan={provider.auth.label}
-        email={provider.auth.email}
-        accentColor={provider.accentColor}
-      />
+    <>
       {notice ? (
         <span className="text-xs text-muted-foreground">{notice}</span>
       ) : (
@@ -289,8 +289,33 @@ function ProviderLimits({
           instanceId={provider.instanceId}
           credits={limits.resetCredits}
           now={now}
+          readOnly={readOnly}
         />
       ) : null}
+    </>
+  );
+}
+
+function ProviderLimits({
+  provider,
+  environmentId,
+  now,
+}: {
+  readonly provider: ServerProvider;
+  readonly environmentId: EnvironmentId;
+  readonly now: number;
+}) {
+  if (!provider.usageLimits) return null;
+  return (
+    <section className="flex flex-col gap-3">
+      <AccountHeading
+        driver={provider.driver}
+        label={providerLimitsLabel(provider, (driver) => getDriverOption(driver)?.label)}
+        plan={provider.auth.label}
+        email={provider.auth.email}
+        accentColor={provider.accentColor}
+      />
+      <ProviderUsageLimitsBlock provider={provider} environmentId={environmentId} now={now} />
     </section>
   );
 }
@@ -311,11 +336,13 @@ function ResetCredits({
   instanceId,
   credits,
   now,
+  readOnly = false,
 }: {
   readonly environmentId: EnvironmentId;
   readonly instanceId: ProviderInstanceId;
   readonly credits: ServerProviderResetCredits;
   readonly now: number;
+  readonly readOnly?: boolean | undefined;
 }) {
   const consume = useAtomCommand(serverEnvironment.consumeResetCredit, { reportFailure: false });
   const [confirming, setConfirming] = useState(false);
@@ -354,7 +381,12 @@ function ResetCredits({
     <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
       <span className="tabular-nums">{summary}</span>
       {credits.availableCount > 0 ? (
-        <Button size="xs" variant="outline" disabled={busy} onClick={() => setConfirming(true)}>
+        <Button
+          size="xs"
+          variant="outline"
+          disabled={busy || readOnly}
+          onClick={() => setConfirming(true)}
+        >
           {busy ? "Using credit…" : "Use a reset credit"}
         </Button>
       ) : null}


### PR DESCRIPTION
## Summary

The Usage → Limits page already renders each provider's subscription quota windows and banked reset credits (Codex `account/rateLimits/read` + `provider.consumeResetCredit`). The provider editor in Settings → Providers said nothing about them, so checking your Codex limits or redeeming a banked reset meant leaving Settings.

This reuses the existing block in the provider editor as a **Usage limits** section.

## Changes

- `UsageLimits.tsx`: extract `ProviderUsageLimitsBlock` (windows + reset credits) from `ProviderLimits`; add a `readOnly` gate on the redeem button. The Usage page renders exactly what it did before.
- `ProviderInstanceCard.tsx`: optional `usageLimits` slot, rendered as a "Usage limits" section after Setup (editor mode only).
- `ProviderSettingsPanel.tsx`: pass the block when the live provider reports `usageLimits`. Skipped when `unavailable.reason === "unsupported"` (API-key accounts) so Settings stays quiet; probe failures still surface. Redeem follows the panel's `readOnly`.
- Tests: two regression cases in `ProviderSettingsPanel.environment.test.tsx`.

No server or contract changes. Works with a plain `codex login` (ChatGPT) account; nothing here depends on CLIProxyAPI sources.

## Before / After

_Before:_ Settings → Providers → Codex shows Display name / Runtime / Environment / Models only.

_After:_ a "Usage limits" section between Setup and Runtime with the 5h / weekly bars, pace glyph, reset countdown, and (when banked) "N reset credits banked · next expires in … [Use a reset credit]" behind the existing confirm dialog.

(Screenshots to follow.)

## Verification

- `pnpm --filter @t3tools/web typecheck`
- `vp test run --project unit` on `components/settings` + `components/usage`: 28/28
- Manually verified in the dev app against a real Codex account.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Web-only UI reuse of existing `consumeResetCredit` flow; redeem is gated by the same read-only permissions as other provider settings.
> 
> **Overview**
> **Settings → Providers** now shows the same subscription quota windows and banked reset credits as **Usage → Limits**, so users can check Codex-style limits or redeem credits without leaving the provider editor.
> 
> `ProviderUsageLimitsBlock` is extracted from the Usage page layout (windows, notices, reset credits) and passed into `ProviderInstanceCard` as a new **Usage limits** section between Setup and Runtime. The panel only renders it in editor mode when the live provider reports `usageLimits`, and skips drivers marked `unavailable.reason === "unsupported"`. **Use a reset credit** respects the settings panel’s `readOnly` flag (disabled when the session can’t operate).
> 
> The Usage → Limits page still uses the shared block inside `ProviderLimits` with the account heading unchanged. Two environment tests cover presence, read-only wiring, and omission when limits are missing or unsupported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c9dc16e4f1e49410584410c93454ba8856b94b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add usage limits and reset credits to provider settings cards
> - Extracts `ProviderUsageLimitsBlock` from `ProviderLimits` in [UsageLimits.tsx](https://github.com/pingdotgg/t3code/pull/9598/files#diff-2764f260dc4f879cad990f9601cd2a8d41a4af19eea6398254e9bbf00bdad23a) so limit windows, notices, and reset credits render as a standalone block without the account heading
> - Passes a new optional `usageLimits` ReactNode prop to `ProviderInstanceCard` in [ProviderInstanceCard.tsx](https://github.com/pingdotgg/t3code/pull/9598/files#diff-abfacda8242e42a51ed23d2b21b91d4822ff52c2dfb6650be36af9d8c82302e9), rendered as a "Usage limits" section between setup and runtime
> - `EnvironmentProviderSettings` in [ProviderSettingsPanel.tsx](https://github.com/pingdotgg/t3code/pull/9598/files#diff-f12e4babdd78afe45c2a0146ab2c0ef5a097d301ebed3350f53de81fc57349d3) supplies the block only to editor-mode cards with a live provider whose limits are not marked unsupported; list-mode cards and unsupported providers get no content
> - `ResetCredits` gains an optional `readOnly` prop that disables the redemption button alongside the existing busy state
> - Adds tests covering both the presence and omission of usage limits across providers
> - Risk: `ProviderLimits` wrapper in [UsageLimits.tsx](https://github.com/pingdotgg/t3code/pull/9598/files#diff-2764f260dc4f879cad990f9601cd2a8d41a4af19eea6398254e9bbf00bdad23a) now checks for absent usage limits before rendering; any caller relying on the section always rendering even with no limits data will see it omitted
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5c9dc16. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->