### PR TITLE
fix(web): snooze menu no longer overlaps thread details

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1122,7 +1122,8 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     [onSnooze, threadRef],
   );
   // While the snooze popover is open the pointer leaves the row, which
-  // would fade the hover actions out from under the open menu; pin them.
+  // would fade the hover actions out from under the open menu. Pin them and
+  // suppress the row tooltip so its portal cannot overlap the popover.
   const [snoozeMenuOpenRaw, setSnoozeMenuOpen] = useState(false);
   // Snooze is offered only where it can succeed: capability-gated and never
   // on blocked-on-you work or queued turns (the server rejects both).
@@ -1445,7 +1446,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
         sortable?.isDragging && "z-20 opacity-80",
       )}
     >
-      <Tooltip>
+      <Tooltip disabled={snoozeMenuOpen}>
         <TooltipTrigger
           render={
             <div


### PR DESCRIPTION
Opening the snooze menu from a hovered sidebar card left the thread details tooltip visible above it. The tooltip has a higher global layer than popovers, so the two cards obscured each other.

The thread card now disables its details tooltip while its snooze menu is open. This keeps the existing layer order intact for other tooltips and lets the details card return normally after the menu closes.

Tests: web typecheck, targeted lint, formatting check, and manual browser verification.

| Before | After |
| --- | --- |
| <img width="471" alt="Thread details tooltip overlapping the open snooze menu" src="https://github.com/user-attachments/assets/a30db525-7f11-4ba4-adb5-24ed3df6dea8" /> | <img width="471" alt="Snooze menu open without the thread details tooltip" src="https://github.com/user-attachments/assets/c6c07744-a6f3-4868-87fa-b9e32563f307" /> |

---
Built by GPT-5.6 Sol in T3 Code through the Codex harness.
