### PR TITLE
fix(web): name imported browser profiles clearly

### DIFF
--- a/apps/web/src/components/settings/BrowserImportWizard.tsx
+++ b/apps/web/src/components/settings/BrowserImportWizard.tsx
@@ -26,6 +26,7 @@ import {
   outcomeToStep,
   refreshedSourceProfileDirectory,
   refreshedSourceStep,
+  resolveSourceProfile,
   resolveWizardTarget,
   type ImportOutcome,
   type WizardTarget,
@@ -51,6 +52,7 @@ interface BrowserImportWizardProps {
    */
   readonly onImport: (input: {
     readonly sourceProfileDirectory: string;
+    readonly sourceProfileName: string;
     readonly target: WizardTarget;
   }) => Promise<ImportOutcome>;
   /** Re-checks the source's availability after the user quits the browser. */
@@ -94,6 +96,11 @@ export function BrowserImportWizard({
 
   const runImport = () => {
     if (importInFlight.current) return;
+    const sourceProfile = resolveSourceProfile(sourceProfileDirectory, source);
+    if (sourceProfile === undefined) {
+      setStep({ step: "blocked", reason: "unknownSourceProfile" });
+      return;
+    }
     const chosen = resolveWizardTarget(target, newProfileId.current, targetProfiles);
     if (chosen === undefined) {
       setTargetError("That profile is no longer available. Choose where to import these cookies.");
@@ -103,7 +110,11 @@ export function BrowserImportWizard({
     setTargetError(undefined);
     importInFlight.current = true;
     setStep({ step: "importing" });
-    void onImport({ sourceProfileDirectory, target: chosen })
+    void onImport({
+      sourceProfileDirectory,
+      sourceProfileName: sourceProfile.name,
+      target: chosen,
+    })
       .then((outcome) => setStep(outcomeToStep(outcome)))
       .catch(() => setStep({ step: "blocked", reason: "readFailed" }))
       .finally(() => {

--- a/apps/web/src/components/settings/IntegrationsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/IntegrationsSettings.logic.test.ts
@@ -111,6 +111,19 @@ describe("importedBrowserProfileName", () => {
       `${"C".repeat(30)} ${"W".repeat(15)} 2`,
     );
   });
+
+  it("does not split an astral character at the profile name limit", () => {
+    const sourceName = `${"C".repeat(47)}🚀`;
+    expect(importedBrowserProfileName(sourceName, "Work", new Set())).toBe("C".repeat(47));
+  });
+
+  it("does not split an astral character while reserving suffix space", () => {
+    const sourceName = `${"C".repeat(45)}🚀`;
+    const unsuffixedName = `${sourceName}`;
+    expect(importedBrowserProfileName(sourceName, "Work", new Set([unsuffixedName]))).toBe(
+      `${"C".repeat(45)} 2`,
+    );
+  });
 });
 
 // Mirrors `BrowserImportFailedError.message`, which IPC flattens to a string

--- a/apps/web/src/components/settings/IntegrationsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/IntegrationsSettings.logic.test.ts
@@ -4,6 +4,7 @@ import type { EnvironmentId } from "@t3tools/contracts";
 import {
   browserProfileRemovalAvailable,
   clearBrowserProfileData,
+  importedBrowserProfileName,
   importFailureReason,
 } from "./IntegrationsSettings";
 
@@ -74,6 +75,41 @@ describe("browserProfileRemovalAvailable", () => {
     expect(browserProfileRemovalAvailable(true, true, 0)).toBe(false);
     expect(browserProfileRemovalAvailable(true, false, 1)).toBe(false);
     expect(browserProfileRemovalAvailable(false, true, 1)).toBe(false);
+  });
+});
+
+describe("importedBrowserProfileName", () => {
+  it("uses the browser and selected source profile names when no name is taken", () => {
+    expect(importedBrowserProfileName("Chrome", "Work", new Set())).toBe("Chrome Work");
+  });
+
+  it("avoids names held by the resolved built-ins and user profiles", () => {
+    expect(
+      importedBrowserProfileName(
+        "Chrome",
+        "Work",
+        new Set(["Default", "Incognito", "Chrome Work"]),
+      ),
+    ).toBe("Chrome Work 2");
+  });
+
+  it("adds the next numeric suffix when prior imported names collide", () => {
+    expect(
+      importedBrowserProfileName("Chrome", "Work", new Set(["Chrome Work", "Chrome Work 2"])),
+    ).toBe("Chrome Work 3");
+  });
+
+  it("truncates an unsuffixed name at the browser profile name limit", () => {
+    expect(importedBrowserProfileName("C".repeat(30), "W".repeat(30), new Set())).toBe(
+      `${"C".repeat(30)} ${"W".repeat(17)}`,
+    );
+  });
+
+  it("reserves room for the numeric suffix when a long imported name collides", () => {
+    const fullName = `${"C".repeat(30)} ${"W".repeat(17)}`;
+    expect(importedBrowserProfileName("C".repeat(30), "W".repeat(30), new Set([fullName]))).toBe(
+      `${"C".repeat(30)} ${"W".repeat(15)} 2`,
+    );
   });
 });
 

--- a/apps/web/src/components/settings/IntegrationsSettings.tsx
+++ b/apps/web/src/components/settings/IntegrationsSettings.tsx
@@ -168,6 +168,23 @@ export const importFailureReason = (cause: unknown): BrowserImportFailureReason 
   );
 };
 
+export function importedBrowserProfileName(
+  sourceName: string,
+  sourceProfileName: string,
+  takenNames: ReadonlySet<string>,
+): string {
+  const baseName = `${sourceName} ${sourceProfileName}`;
+  const unsuffixedName = baseName.slice(0, BROWSER_PROFILE_NAME_MAX_LENGTH).trimEnd();
+  if (!takenNames.has(unsuffixedName)) return unsuffixedName;
+
+  for (let index = 2; ; index += 1) {
+    const suffix = ` ${index}`;
+    const stem = baseName.slice(0, BROWSER_PROFILE_NAME_MAX_LENGTH - suffix.length).trimEnd();
+    const name = `${stem}${suffix}`;
+    if (!takenNames.has(name)) return name;
+  }
+}
+
 const viewportSelectValue = (viewport: PreviewViewportSetting): string => {
   if (viewport._tag === "fill") return FILL_VALUE;
   if (
@@ -813,7 +830,11 @@ function BrowserProfilesSetting({ disabled }: { readonly disabled: boolean }) {
   const runWizardImport = async (
     source: BrowserImportSource,
     environmentId: EnvironmentId,
-    input: { readonly sourceProfileDirectory: string; readonly target: WizardTarget },
+    input: {
+      readonly sourceProfileDirectory: string;
+      readonly sourceProfileName: string;
+      readonly target: WizardTarget;
+    },
   ): Promise<ImportOutcome> => {
     if (!previewBridge) return { kind: "blocked", reason: "sessionUnavailable" };
     if (!settingsHydrated) return { kind: "blocked", reason: "sessionUnavailable" };
@@ -863,8 +884,7 @@ function BrowserProfilesSetting({ disabled }: { readonly disabled: boolean }) {
               const taken = new Set(
                 resolveBrowserProfiles(current.browserProfiles).map((profile) => profile.name),
               );
-              let name = source.name;
-              for (let index = 2; taken.has(name); index += 1) name = `${source.name} ${index}`;
+              const name = importedBrowserProfileName(source.name, input.sourceProfileName, taken);
               return {
                 ...current,
                 browserProfiles: [
@@ -875,7 +895,8 @@ function BrowserProfilesSetting({ disabled }: { readonly disabled: boolean }) {
             });
             targetName =
               persisted.browserProfiles.find((profile) => profile.id === input.target.profileId)
-                ?.name ?? source.name;
+                ?.name ??
+              importedBrowserProfileName(source.name, input.sourceProfileName, new Set());
           } catch (cause) {
             // This target id belongs only to the attempted new profile. Clear
             // its partition so a failed registration cannot strand imported

--- a/apps/web/src/components/settings/IntegrationsSettings.tsx
+++ b/apps/web/src/components/settings/IntegrationsSettings.tsx
@@ -168,18 +168,30 @@ export const importFailureReason = (cause: unknown): BrowserImportFailureReason 
   );
 };
 
+function truncateBrowserProfileName(name: string, maxLength: number): string {
+  const truncated = name.slice(0, maxLength);
+  const lastCodeUnit = truncated.charCodeAt(truncated.length - 1);
+  return lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff ? truncated.slice(0, -1) : truncated;
+}
+
 export function importedBrowserProfileName(
   sourceName: string,
   sourceProfileName: string,
   takenNames: ReadonlySet<string>,
 ): string {
   const baseName = `${sourceName} ${sourceProfileName}`;
-  const unsuffixedName = baseName.slice(0, BROWSER_PROFILE_NAME_MAX_LENGTH).trimEnd();
+  const unsuffixedName = truncateBrowserProfileName(
+    baseName,
+    BROWSER_PROFILE_NAME_MAX_LENGTH,
+  ).trimEnd();
   if (!takenNames.has(unsuffixedName)) return unsuffixedName;
 
   for (let index = 2; ; index += 1) {
     const suffix = ` ${index}`;
-    const stem = baseName.slice(0, BROWSER_PROFILE_NAME_MAX_LENGTH - suffix.length).trimEnd();
+    const stem = truncateBrowserProfileName(
+      baseName,
+      BROWSER_PROFILE_NAME_MAX_LENGTH - suffix.length,
+    ).trimEnd();
     const name = `${stem}${suffix}`;
     if (!takenNames.has(name)) return name;
   }

--- a/apps/web/src/components/settings/browserImportWizard.logic.test.ts
+++ b/apps/web/src/components/settings/browserImportWizard.logic.test.ts
@@ -10,6 +10,7 @@ import {
   outcomeToStep,
   refreshedSourceProfileDirectory,
   refreshedSourceStep,
+  resolveSourceProfile,
   resolveWizardTarget,
 } from "./browserImportWizard.logic";
 
@@ -149,6 +150,26 @@ describe("refreshedSourceProfileDirectory", () => {
   it("falls back only when the old profile vanished and clears an empty result", () => {
     expect(refreshedSourceProfileDirectory("Removed", refreshed)).toBe("Default");
     expect(refreshedSourceProfileDirectory("Removed", source({ profiles: [] }))).toBe("");
+  });
+});
+
+describe("resolveSourceProfile", () => {
+  const refreshed = source({
+    profiles: [
+      { directory: "Default", name: "Personal" },
+      { directory: "Profile 2", name: "Work" },
+    ],
+  });
+
+  it("resolves the selected non-first source profile from the current source", () => {
+    expect(resolveSourceProfile("Profile 2", refreshed)).toEqual({
+      directory: "Profile 2",
+      name: "Work",
+    });
+  });
+
+  it("does not reuse a profile name after the selected directory vanishes", () => {
+    expect(resolveSourceProfile("Removed", refreshed)).toBeUndefined();
   });
 });
 

--- a/apps/web/src/components/settings/browserImportWizard.logic.ts
+++ b/apps/web/src/components/settings/browserImportWizard.logic.ts
@@ -122,6 +122,13 @@ export function refreshedSourceProfileDirectory(
   return source.profiles[0]?.directory ?? "";
 }
 
+export function resolveSourceProfile(
+  sourceProfileDirectory: string,
+  source: BrowserImportSource,
+): BrowserImportSource["profiles"][number] | undefined {
+  return source.profiles.find((profile) => profile.directory === sourceProfileDirectory);
+}
+
 /**
  * Whether retrying could clear a failure. The keychain prompt can be approved
  * on a second try, a missing key appears once the user signs in to the


### PR DESCRIPTION
Imported browser profiles were named only after the browser, so importing multiple source profiles produced ambiguous names.

New profiles now use both labels, such as `Chrome Work`. The allocator keeps names within the 48-character limit and adds numeric suffixes for collisions. The wizard resolves the selected profile against its current source metadata before importing, while existing target profiles and rollback behavior stay unchanged.

Verification:

- `vp test run apps/web/src/components/settings/browserImportWizard.logic.test.ts apps/web/src/components/settings/IntegrationsSettings.logic.test.ts` (37 tests passed)
- `vp run --filter @t3tools/web typecheck`
- Targeted lint, formatting, and `git diff --check`

No layout or motion changed, so screenshots and video are not applicable.

Built by GPT-5.6 Sol through Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings-only naming and wizard validation changes; import rollback and existing-target behavior are unchanged.
> 
> **Overview**
> Imported **new** browser profiles are now named **`{browser} {source profile}`** (e.g. `Chrome Work`) instead of only the browser name, so multiple imports from the same browser stay distinguishable.
> 
> **`importedBrowserProfileName`** centralizes naming: it respects **`BROWSER_PROFILE_NAME_MAX_LENGTH`**, adds **` 2`**, **` 3`**, … when names collide, and truncates without splitting astral Unicode. **`runWizardImport`** uses it when registering a profile after a successful import.
> 
> The import wizard now **`resolveSourceProfile`** on the selected directory before starting import. If that profile disappeared from the refreshed source list, the flow **blocks** with **`unknownSourceProfile`** (no silent fallback to another profile’s name). **`onImport`** gains **`sourceProfileName`** so the parent can name the new profile correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 001f2f43a7e2f188d04ad056a5e56d7338786fe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Name imported browser profiles from source browser and source profile
> - New `importedBrowserProfileName` util combines the source browser name with the selected source profile name, adds an incrementing numeric suffix on collisions, and truncates to the configured max length
> - New `truncateBrowserProfileName` util avoids splitting astral (UTF-16 surrogate) characters when truncating
> - New `resolveSourceProfile` util looks up the source profile whose directory matches the selected directory; `BrowserImportWizard.runImport` blocks with an unknown-source-profile state when the directory is absent after refresh
> - `BrowserProfilesSetting.runWizardImport` receives the resolved source profile name and uses the naming util for newly created and fallback-looked-up persistent profiles
> - Risk: `BrowserImportWizard.runImport` now blocks the import action when the selected source profile directory is no longer present; reviewers should check the blocked-state transition in [browserImportWizard.logic.ts](https://github.com/pingdotgg/t3code/pull/9603/files#diff-c2813e87019a4dcff5d7f1e09a5d1d694702e291873e57bda505f2ae7f1d1916)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 001f2f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->