### PR TITLE
fix(web): widen provider settings

### DIFF
--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -195,7 +195,7 @@ interface ProviderSettingsTarget {
 
 export function ProviderSettingsPanel(target: ProviderSettingsTarget) {
   return (
-    <SettingsPageContainer width="wide" className="gap-8">
+    <SettingsPageContainer width="expanded" className="gap-8">
       <ProviderSettingsPanelContent
         key={`${target.environmentId ?? ""}:${target.instanceId ?? ""}`}
         {...target}


### PR DESCRIPTION
The Providers editor is constrained to the same content width as simpler Settings pages, leaving model names and capabilities less room to lay out at desktop widths.

Use the existing expanded workspace width only for Settings → Providers. Other Settings pages and the responsive single-column layout remain unchanged.

## UI change

<img width="1440" height="1000" alt="Settings Providers with expanded content width" src="https://github.com/user-attachments/assets/8200d9e9-d5ba-4cf0-a859-8d400bbf7010" />

## Verification

- `vp fmt --check apps/web/src/components/settings/ProviderSettingsPanel.tsx`
- `vp lint apps/web/src/components/settings/ProviderSettingsPanel.tsx`
- Browser-verified the provider and model layout at 1440×1000
- Browser-verified the existing single-column fallback at a narrow viewport

Built with GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single prop change to layout width with no behavior, auth, or data handling impact.
> 
> **Overview**
> **Settings → Providers** now uses the **`expanded`** page width instead of **`wide`**, giving the provider list and model editor more horizontal room on desktop ( **`max-w-6xl`** vs **`max-w-5xl`** ).
> 
> Other settings pages keep their existing widths; only **`ProviderSettingsPanel`** is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c2b35380896d8f01332ce5bee288c0e7133df82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
