### PR TITLE
fix: preserve tool icons on failed calls

### DIFF
--- a/apps/mobile/src/features/threads/thread-work-log.tsx
+++ b/apps/mobile/src/features/threads/thread-work-log.tsx
@@ -76,14 +76,13 @@ type WorkContentIcon = AppSymbolName | "browser" | "t3-code";
 function WorkLogIcon(props: {
   readonly icon: WorkContentIcon;
   readonly color: ColorValue;
+  readonly colorClassName?: string;
   readonly highlighted?: boolean;
 }) {
+  const colorClassName = props.highlighted ? "accent-foreground" : props.colorClassName;
   if (props.icon === "t3-code") {
     return (
-      <T3Wordmark
-        height={10}
-        {...(props.highlighted ? { colorClassName: "accent-foreground" } : { color: props.color })}
-      />
+      <T3Wordmark height={10} {...(colorClassName ? { colorClassName } : { color: props.color })} />
     );
   }
   return (
@@ -91,9 +90,7 @@ function WorkLogIcon(props: {
       name={props.icon === "browser" ? { ios: "globe", android: "public" } : props.icon}
       size={14}
       weight="medium"
-      {...(props.highlighted
-        ? { tintColorClassName: "accent-foreground" }
-        : { tintColor: props.color })}
+      {...(colorClassName ? { tintColorClassName: colorClassName } : { tintColor: props.color })}
       type="monochrome"
     />
   );
@@ -707,11 +704,7 @@ const ThreadWorkLogRow = memo(function ThreadWorkLogRow(
   const iconIsDestructive = row.icon === "alert" || row.icon === "warning";
   const failed = row.status === "failure";
   const toolIcon = row.workEntry.toolIcon ?? row.workEntry.toolSource?.icon;
-  const hasSpecialToolIcon =
-    toolPresentation !== null || row.workEntry.toolSurface !== undefined || toolIcon !== undefined;
-  const icon =
-    toolPresentation?.icon ??
-    (failed && !hasSpecialToolIcon ? "xmark" : workRowSymbolName(row.icon));
+  const icon = toolPresentation?.icon ?? workRowSymbolName(row.icon);
 
   return (
     <Animated.View
@@ -750,18 +743,25 @@ const ThreadWorkLogRow = memo(function ThreadWorkLogRow(
           ) : (
             <>
               <View className="h-6 w-6 shrink-0 items-center justify-center">
-                {failed && !hasSpecialToolIcon ? (
-                  <WorkLogIcon
-                    icon={icon}
-                    color={iconIsDestructive ? "#e11d48" : props.iconSubtleColor}
-                  />
-                ) : (
+                {toolIcon ? (
                   <ToolActivityIconView
                     environmentId={props.environmentId}
                     icon={toolIcon}
                     fallback={icon}
                     fallbackColor={props.iconSubtleColor}
                     themeAppearance={props.themeAppearance}
+                  />
+                ) : (
+                  <WorkLogIcon
+                    icon={icon}
+                    color={props.iconSubtleColor}
+                    colorClassName={
+                      iconIsDestructive
+                        ? "accent-adaptive-rose-600-400"
+                        : failed
+                          ? "accent-danger-foreground/70"
+                          : undefined
+                    }
                   />
                 )}
               </View>
@@ -783,7 +783,7 @@ const ThreadWorkLogRow = memo(function ThreadWorkLogRow(
                 Copied
               </Text>
             ) : null}
-            {failed && hasSpecialToolIcon ? (
+            {failed && toolIcon !== undefined ? (
               <View
                 className="h-4 w-4 items-center justify-center"
                 accessibilityElementsHidden
@@ -792,7 +792,7 @@ const ThreadWorkLogRow = memo(function ThreadWorkLogRow(
                 <SymbolView
                   name="xmark"
                   size={11}
-                  tintColorClassName="accent-adaptive-rose-600-400"
+                  tintColorClassName="accent-danger-foreground/70"
                   type="monochrome"
                 />
               </View>

--- a/apps/mobile/src/features/threads/thread-work-log.tsx
+++ b/apps/mobile/src/features/threads/thread-work-log.tsx
@@ -759,7 +759,7 @@ const ThreadWorkLogRow = memo(function ThreadWorkLogRow(
                       iconIsDestructive
                         ? "accent-adaptive-rose-600-400"
                         : failed
-                          ? "accent-danger-foreground/70"
+                          ? "accent-danger-foreground/40"
                           : undefined
                     }
                   />
@@ -792,7 +792,7 @@ const ThreadWorkLogRow = memo(function ThreadWorkLogRow(
                 <SymbolView
                   name="xmark"
                   size={11}
-                  tintColorClassName="accent-danger-foreground/70"
+                  tintColorClassName="accent-danger-foreground/40"
                   type="monochrome"
                 />
               </View>

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1471,7 +1471,7 @@ describe("MessagesTimeline", () => {
     );
 
     expect(markup).toContain('aria-label="Received 1 update and used 1 tool, tool call failed"');
-    // Ordinary tool failures render muted, not red.
+    // Ordinary tool failures do not use destructive row styling.
     expect(markup).not.toContain("text-destructive");
   });
 

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1892,7 +1892,7 @@ function ActivityShimmerOverlay({ children }: { children: ReactNode }) {
   );
 }
 
-const failedToolIconClassName = "text-error/70";
+const failedToolIconClassName = "text-error/40 dark:text-[#fca5a5]/40";
 
 /** Image icons and the gradient computer-use mark cannot take a currentColor
  *  tint, so failed rows using them get a trailing x instead. */

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1892,7 +1892,7 @@ function ActivityShimmerOverlay({ children }: { children: ReactNode }) {
   );
 }
 
-const failedToolIconClassName = "text-error/40 dark:text-[#fca5a5]/40";
+const failedToolIconClassName = "text-tool-error-icon/40";
 
 /** Image icons and the gradient computer-use mark cannot take a currentColor
  *  tint, so failed rows using them get a trailing x instead. */

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1892,6 +1892,17 @@ function ActivityShimmerOverlay({ children }: { children: ReactNode }) {
   );
 }
 
+const failedToolIconClassName = "text-error/70";
+
+/** Image icons and the gradient computer-use mark cannot take a currentColor
+ *  tint, so failed rows using them get a trailing x instead. */
+function toolIconAcceptsTint(
+  iconName: WorkEntryIconName,
+  toolIcon: ToolActivityIcon | undefined,
+): boolean {
+  return toolIcon === undefined && iconName !== "computer";
+}
+
 function LiveActivityRow({
   label,
   iconName,
@@ -1940,37 +1951,41 @@ function LiveActivityContent({
   announceFailure?: boolean;
   highlighted?: boolean;
 }) {
-  const isSpecialToolIcon =
-    iconName === "browser" || iconName === "computer" || iconName === "t3-code";
-  const resolvedIconName = failed && !isSpecialToolIcon ? "circle-alert" : iconName;
+  const showTrailingFailureMark =
+    failed && iconName !== undefined && !toolIconAcceptsTint(iconName, toolIcon);
 
   return (
     <span
       className={cn(
         "flex min-h-6 min-w-0 items-center gap-1.5 py-0.5",
-        resolvedIconName ? "px-0.5" : "px-1",
+        iconName ? "px-0.5" : "px-1",
         highlighted ? "text-foreground" : "text-secondary-label",
       )}
     >
-      {resolvedIconName ? (
+      {iconName ? (
         <span
           className={cn(
             "flex size-6 shrink-0 items-center justify-center",
-            highlighted ? "text-foreground" : "text-icon-muted",
+            highlighted ? "text-foreground" : failed ? failedToolIconClassName : "text-icon-muted",
           )}
           role={announceFailure ? "img" : undefined}
           aria-label={announceFailure ? "Tool call failed" : undefined}
         >
           <ToolActivityIconView
-            icon={failed && !isSpecialToolIcon ? undefined : toolIcon}
-            fallbackName={resolvedIconName}
+            icon={toolIcon}
+            fallbackName={iconName}
             className="block size-4 shrink-0 stroke-[1.8]"
             muted={!highlighted}
           />
         </span>
       ) : null}
       <span className="min-w-0 flex-1 truncate">{label}</span>
-      {failed && isSpecialToolIcon ? <XIcon aria-hidden className="size-3 shrink-0" /> : null}
+      {showTrailingFailureMark ? (
+        <XIcon
+          aria-hidden
+          className={cn("size-3 shrink-0", !highlighted && failedToolIconClassName)}
+        />
+      ) : null}
     </span>
   );
 }
@@ -3105,12 +3120,15 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
   const iconConfig = workToneIcon(workEntry.tone);
   const showWarningIndicator = workEntry.sourceActivityKind === "runtime.warning";
   const showFailedIndicator = workEntryDisplayIndicatesToolFailure(workEntry);
-  const toolPresentation = resolveWorkEntryToolPresentation(workEntry);
-  const hasSpecialToolIcon = toolPresentation !== null || workEntry.toolSurface !== undefined;
+  const showDestructiveRowStyle =
+    showFailedIndicator &&
+    (workEntrySignalsSevereFailure(workEntry) || !workLogEntryIsToolLike(workEntry));
   const entryIconName =
-    showWarningIndicator || (showFailedIndicator && !hasSpecialToolIcon)
-      ? "circle-alert"
-      : workEntryIconName(workEntry);
+    showWarningIndicator || showDestructiveRowStyle ? "circle-alert" : workEntryIconName(workEntry);
+  const entryToolIcon =
+    showWarningIndicator || showDestructiveRowStyle
+      ? undefined
+      : (workEntry.toolIcon ?? workEntry.toolSource?.icon);
   const previewText = displayLabel ?? workEntryDisplayLabel(workEntry, workspaceRoot);
   const viewedImagePath = workEntryViewedImagePath(workEntry);
   const viewedImage =
@@ -3138,20 +3156,18 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
         viewedImage ? viewedImagePath : null,
       )
     : null;
-  const showDestructiveRowStyle =
-    showFailedIndicator &&
-    (workEntrySignalsSevereFailure(workEntry) || !workLogEntryIsToolLike(workEntry));
-  // Ordinary tool failures stay muted; only runtime errors and warnings get
-  // color. The red treatment is reserved for severe failures.
+  // Reserve destructive row styling for severe failures, not routine tool errors.
   const iconWrapperClass = cn(
     "flex size-6 shrink-0 items-center justify-center",
     showWarningIndicator
       ? "text-warning"
       : showDestructiveRowStyle
         ? "text-destructive"
-        : workEntry.tone === "tool" || showFailedIndicator
-          ? "text-icon-muted"
-          : iconConfig.className,
+        : showFailedIndicator
+          ? failedToolIconClassName
+          : workEntry.tone === "tool"
+            ? "text-icon-muted"
+            : iconConfig.className,
   );
   const headingClass = showWarningIndicator
     ? "font-medium text-warning"
@@ -3196,11 +3212,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
           aria-label={showFailedIndicator ? "Tool call failed" : undefined}
         >
           <ToolActivityIconView
-            icon={
-              showWarningIndicator || (showFailedIndicator && !hasSpecialToolIcon)
-                ? undefined
-                : (workEntry.toolIcon ?? workEntry.toolSource?.icon)
-            }
+            icon={entryToolIcon}
             fallbackName={entryIconName}
             className="block size-4 shrink-0 stroke-[1.8]"
             muted
@@ -3224,8 +3236,10 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
               </span>
             </p>
           </div>
-          {showFailedIndicator && hasSpecialToolIcon ? (
-            <XIcon aria-hidden className="size-3 shrink-0 text-icon-muted" />
+          {showFailedIndicator &&
+          !showDestructiveRowStyle &&
+          !toolIconAcceptsTint(entryIconName, entryToolIcon) ? (
+            <XIcon aria-hidden className={cn("size-3 shrink-0", failedToolIconClassName)} />
           ) : null}
           <span
             className={cn(

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -154,6 +154,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   --color-warning: var(--warning);
   --color-warning-surface: var(--warning-surface);
   --color-error-foreground: var(--error-foreground);
+  --color-tool-error-icon: var(--tool-error-icon);
   --color-error: var(--error);
   --color-error-surface: var(--error-surface);
   --color-update-foreground: var(--update-foreground);
@@ -948,6 +949,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   --accent-foreground: var(--color-zinc-900);
   --error: var(--color-red-500);
   --error-foreground: var(--color-red-700);
+  --tool-error-icon: var(--error);
   --error-surface: color-mix(in srgb, var(--error) 8%, transparent);
   --destructive: var(--error);
   --border: var(--color-zinc-200);
@@ -1002,6 +1004,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     --accent-foreground: var(--color-neutral-100);
     --error: color-mix(in srgb, var(--color-red-500) 90%, var(--color-white));
     --error-foreground: var(--color-red-400);
+    --tool-error-icon: #fca5a5;
     --error-surface: color-mix(in srgb, var(--error) 16%, transparent);
     --border: --alpha(var(--color-white) / 6%);
     --input: --alpha(var(--color-white) / 8%);
@@ -1114,6 +1117,7 @@ html[data-theme-id]:not([data-theme-id=""]) {
   --message-action-hover: var(--app-theme-message-action-hover);
   --error: var(--app-theme-error);
   --error-foreground: var(--app-theme-error-foreground);
+  --tool-error-icon: var(--error-foreground);
   --error-surface: var(--app-theme-error-surface);
   --destructive: var(--error);
   --destructive-foreground: var(--error-foreground);

--- a/docs/user/tool-activity.md
+++ b/docs/user/tool-activity.md
@@ -13,6 +13,10 @@ The latest live activity stays in the present tense while the turn continues, su
 Expanded rows follow the call's own state, such as "Clicked" after success.
 When a call has not reported a state yet, the label stays in the present tense.
 Failed, declined, and stopped calls say what happened without implying success.
+Failed calls keep their tool icon with a muted red tint, so a failed command still
+looks like a command. App logos and other multicolor icons keep their artwork and
+show a small muted red failure mark beside the row. Expand the call to inspect its
+output. Runtime errors and warnings keep their stronger styling.
 Preview browser actions use a globe icon. Other T3 tools keep the T3 mark.
 Group summaries count browser actions separately, such as "Used browser 18 times" or
 "Ran 4 commands and used browser 15 times". Browser-only groups also use a globe icon.


### PR DESCRIPTION
Failed tool calls replaced their tool icon with a generic alert or cross, making it harder to tell what the agent tried to do.

Keep the tool's normal icon with a subtle red tint in web, desktop, and mobile. Default dark web uses the same pale rose as mobile, both at 40% opacity. A dedicated theme token lets custom palettes use their error color. Image-based icons keep their artwork and use a small muted-red failure mark. Runtime errors and warnings retain their stronger treatment, and failure labels remain available to screen readers.

## Verification

- 118 focused timeline and mobile activity tests passed.
- Web and mobile typechecks, targeted lint, formatting, and diff checks. Lint reports existing warnings in unchanged code.
- Isolated web client checked in light and dark appearances, including successful calls, failed commands, file reads/edits, browser/computer calls, and expanding command output.
- Verified the default light/dark colors after the theme-token change and checked that Ocean dark uses its own error-foreground color.
- Android development client verified on a Pixel 9 emulator against the same isolated backend.
- Browser captures cover the shared web/desktop renderer, not the Electron shell. iOS was not run on this Linux host.
- Configuration-only CI exceptions: native static analysis has no matching native changes; EAS, web, and macOS previews require opt-in deployment labels; macOS preview cleanup does not apply to a push; label-definition syncing excludes this PR event; Codesmith autofix is inactive. CodeRabbit reports automatic reviews disabled, and the marketing deployment is unaffected.

## Before and after

Actual original base and approved implementation, with the same disposable fixtures, viewport, and expansion state on each client. No real conversations or credentials appear in these captures.

### Web / desktop shared renderer, light

| Before | After |
| --- | --- |
| ![Before: Web / desktop shared renderer, light appearance](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/7e85619e2229345e/pair-web-light-before.png) | ![After: subtle failed-tool icons, Web / desktop shared renderer, light appearance](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d1d6d9e94e51d236/token-web-light-after.png) |

### Web / desktop shared renderer, dark

| Before | After |
| --- | --- |
| ![Before: Web / desktop shared renderer, dark appearance](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/092ee67170244976/pair-web-dark-before.png) | ![After: subtle failed-tool icons, Web / desktop shared renderer, dark appearance](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/24b0083ec4da1287/token-web-dark-after.png) |

### Android, light

| Before | After |
| --- | --- |
| ![Before: Android, light appearance](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/a49517812c9b5f39/pair-mobile-light-before.png) | ![After: subtle failed-tool icons, Android, light appearance](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/7cb9a859aa12e611/pair-mobile-light-after.png) |

### Android, dark

| Before | After |
| --- | --- |
| ![Before: Android, dark appearance](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/8a959f3de533691f/pair-mobile-dark-before.png) | ![After: subtle failed-tool icons, Android, dark appearance](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/a09d76cb68b4c145/pair-mobile-dark-after.png) |

Initial edits by Claude through Claude Code. Completed by vega-alpha through Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve tool icons on failed calls across mobile and web timelines
> - Failed tool calls now keep their original tool or command icon instead of being replaced by an xmark or circle-alert, applying a muted red `tool-error` tint to tintable icons.
> - Rows with non-tintable tool artwork or the computer icon get a trailing muted failure X instead of replacing the icon.
> - Severe failures and non-tool-like failures continue to use destructive `circle-alert` styling.
> - Adds a shared `tool-error-icon` theme token in [index.css](https://github.com/pingdotgg/t3code/pull/9606/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) with default, dark, and app-theme values.
> - Updates [tool-activity.md](https://github.com/pingdotgg/t3code/pull/9606/files#diff-5ea6b41330e70fafc5b57ca858ef4ce643327e008ac0d16960465b4d8ecb62ba) to document the new failure rendering behavior.
> - Risk: `ThreadWorkLogRow` and `PlainWorkEntryRow` changed their failure-icon selection logic; any out-of-tree callers relying on the old xmark replacement for failed rows will no longer see it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0304343.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->