### PR TITLE
fix(server): settle inactive threads with open PRs

### DIFF
--- a/apps/server/src/orchestration/ThreadSettlementPolicy.test.ts
+++ b/apps/server/src/orchestration/ThreadSettlementPolicy.test.ts
@@ -95,8 +95,8 @@ describe("resolveAutoSettlementAt", () => {
     expect(decide(makeThread({ latestUserMessageAt: "2026-08-25T12:00:00.000Z" }))).toBe(false);
   });
 
-  it("keeps open pull requests active", () => {
-    expect(decide(makeThread(), { state: "open", updatedAt: NOW })).toBe(false);
+  it("settles inactive threads with open pull requests", () => {
+    expect(decide(makeThread(), { state: "open", updatedAt: NOW })).toBe(true);
   });
 
   it("settles closed requests and honors the merge setting", () => {

--- a/apps/server/src/orchestration/ThreadSettlementPolicy.ts
+++ b/apps/server/src/orchestration/ThreadSettlementPolicy.ts
@@ -81,7 +81,6 @@ export function resolveAutoSettlementAt(input: {
     if (pullRequestSettles(thread, pullRequest, input.autoSettleOnMerge)) {
       return activityAt ?? thread.createdAt;
     }
-    if (pullRequest.state === "open") return null;
   }
   if (input.autoSettleAfterDays === null || activityAt === null) return null;
   return Date.parse(activityAt) < Date.parse(input.now) - input.autoSettleAfterDays * DAY_MS

--- a/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
@@ -408,6 +408,7 @@ describe("ThreadSettlementReactor", () => {
         const fixture = yield* makeHarness({
           snapshot: makeSnapshot([
             makeThread("merged-in-app", {
+              latestUserMessageAt: "2026-08-27T00:00:00.000Z",
               linkedPullRequest: {
                 projectId: PROJECT_ID,
                 repository: "owner/repository",
@@ -415,7 +416,10 @@ describe("ThreadSettlementReactor", () => {
                 url: "https://example.test/owner/repository/pull/42",
               },
             }),
-            makeThread("slow-periodic-lookup", { branch: "another-feature" }),
+            makeThread("slow-periodic-lookup", {
+              branch: "another-feature",
+              latestUserMessageAt: "2026-08-27T00:00:00.000Z",
+            }),
           ]),
           branchPullRequest: () =>
             Ref.updateAndGet(branchLookupCount, (count) => count + 1).pipe(
@@ -460,7 +464,12 @@ describe("ThreadSettlementReactor", () => {
           const state = yield* Ref.make<"open" | "merged">("open");
           const mergedThreadSettled = yield* Deferred.make<void>();
           const fixture = yield* makeHarness({
-            snapshot: makeSnapshot([makeThread("branch-thread", { branch: "saved-feature" })]),
+            snapshot: makeSnapshot([
+              makeThread("branch-thread", {
+                branch: "saved-feature",
+                latestUserMessageAt: "2026-08-27T00:00:00.000Z",
+              }),
+            ]),
             branchPullRequest: () =>
               Ref.get(state).pipe(
                 Effect.map((pullRequestState) => ({ state: pullRequestState, updatedAt: NOW })),
@@ -500,6 +509,7 @@ describe("ThreadSettlementReactor", () => {
         const fixture = yield* makeHarness({
           snapshot: makeSnapshot([
             makeThread("merged-in-app", {
+              latestUserMessageAt: "2026-08-27T00:00:00.000Z",
               linkedPullRequest: {
                 projectId: PROJECT_ID,
                 repository: "owner/repository",
@@ -508,6 +518,7 @@ describe("ThreadSettlementReactor", () => {
               },
             }),
             makeThread("unrelated-linked", {
+              latestUserMessageAt: "2026-08-27T00:00:00.000Z",
               linkedPullRequest: {
                 projectId: PROJECT_ID,
                 repository: "owner/repository",
@@ -683,7 +694,10 @@ describe("ThreadSettlementReactor", () => {
         const fixture = yield* makeHarness({
           snapshot: makeSnapshot(
             [
-              makeThread("missing-own-project", { linkedPullRequest }),
+              makeThread("missing-own-project", {
+                latestUserMessageAt: "2026-08-27T00:00:00.000Z",
+                linkedPullRequest,
+              }),
               makeThread("missing-branch-project", { branch: "saved-feature" }),
             ],
             [makeProject(LINKED_PROJECT_ID, "/workspace/linked")],

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -13,10 +13,10 @@ request merges if **Auto-settle merged threads** is enabled.
 Each server stores its own copy of the automatic settlement settings and checks them even when no
 web, desktop, or mobile client is connected. By default, it settles threads after three days without
 activity and when their pull request merges. An eligible idle thread also settles when its pull
-request closes. An open pull request blocks inactivity settlement. Active work, pending input, and
-live background work keep the thread active. T3 Code settles from a closed or merged pull request
-only when its timestamp is not older than the user's latest activity. If that timestamp is not
-available, the inactivity rule still applies. A manual un-settle also keeps the thread active.
+request closes. An open pull request does not block inactivity settlement. Active work, pending
+input, and live background work keep the thread active. T3 Code settles from a closed or merged
+pull request only when its timestamp is not older than the user's latest activity. If that timestamp
+is not available, the inactivity rule still applies. A manual un-settle also keeps the thread active.
 
 **Settled** lists threads by when their work finished, newest first. A thread you settle yourself
 sorts by the moment you settled it. A thread that settled on its own sorts by its last message or


### PR DESCRIPTION
## Problem

After #8600 made pull request state authoritative on the server, every open pull request bypassed inactivity settlement. Long-quiet threads therefore stayed active indefinitely despite the configured threshold.

## Fix

Let the existing inactivity policy run when a pull request is open. Closed and merged pull requests still settle immediately under their existing rules, and active work, pending input, snooze, and manual overrides remain unchanged.

Reactor fixtures that test merge behavior now use recent thread activity so they stay focused on merge events.

Closes #9600

## Verification

- `vp test run apps/server/src/orchestration/ThreadSettlementPolicy.test.ts apps/server/src/orchestration/ThreadSettlementReactor.test.ts` (23 passed)
- `vp run --filter t3 typecheck`
- Targeted lint and formatting passed
- `git diff --check`
- Direct policy repro now returns the thread activity timestamp for an inactive thread with an open pull request

Generated with GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes server-side thread lifecycle behavior for a common case (open PR + idle thread), which may move threads to Settled sooner than users expect, though it aligns with documented inactivity rules.
> 
> **Overview**
> **Open pull requests no longer prevent auto-settlement by inactivity.** `resolveAutoSettlementAt` drops the branch that returned `null` whenever a linked PR was still open, so idle threads can settle after `autoSettleAfterDays` even with an open PR. Closed/merged PR settlement, merge settings, and candidate guards (pending work, snooze, live sessions, etc.) are unchanged.
> 
> Tests now expect inactive threads with open PRs to settle, and reactor fixtures use recent `latestUserMessageAt` on merge-focused threads so initial sweeps do not settle them for inactivity before merge logic runs. User docs state that an open PR does **not** block inactivity settlement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed977dc5240ce9027dee2184941d2153ddb8bff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `resolveAutoSettlementAt` to settle inactive threads with open PRs
> Removes the special case in [ThreadSettlementPolicy.ts](https://github.com/pingdotgg/t3code/pull/9610/files#diff-1a7b1b5c03173a900198d178092ff4a33f844a21a2fa2486c7cd3df14821c106) that blocked all settlement while a thread had an open pull request. Open PRs now fall through to the inactivity-duration check, so eligible inactive threads can be auto-settled regardless of PR state. Updates reactor tests with recent user-activity timestamps and revises the [thread-sidebar docs](https://github.com/pingdotgg/t3code/pull/9610/files#diff-7bdc679f37b354bbc78160b5dc7435fb0d2d5a7d72c6a7015a8b682032a7150a) to match.
> - Behavioral Change: threads with open PRs are now eligible for inactivity-based settlement; previously `resolveAutoSettlementAt` always returned `null` for this state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed977dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->