### PR TITLE
fix(server): keep Claude messaging sessions alive

### DIFF
--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -5,6 +5,7 @@ import {
   TurnId,
   ProviderDriverKind,
   ProviderInstanceId,
+  type ProviderSession,
 } from "@t3tools/contracts";
 import * as Clock from "effect/Clock";
 import * as DateTime from "effect/DateTime";
@@ -147,6 +148,7 @@ describe("ProviderSessionReaper", () => {
 
   async function createHarness(input: {
     readonly readModel: ReturnType<typeof makeReadModel>;
+    readonly activeSessions?: ReadonlyArray<ProviderSession>;
     readonly stopSessionImplementation?: (input: {
       readonly threadId: ThreadId;
     }) => ReturnType<ProviderServiceShape["stopSession"]>;
@@ -169,7 +171,7 @@ describe("ProviderSessionReaper", () => {
       respondToRequest: () => unsupported(),
       respondToUserInput: () => unsupported(),
       stopSession,
-      listSessions: () => Effect.succeed([]),
+      listSessions: () => Effect.succeed(input.activeSessions ?? []),
       getCapabilities: () => Effect.succeed({ sessionModelSwitch: "in-session" }),
       assertConversationRollbackSupported: () => unsupported(),
       getInstanceInfo: (instanceId) => {
@@ -247,7 +249,7 @@ describe("ProviderSessionReaper", () => {
           session: {
             threadId,
             status: "ready",
-            providerName: "claudeAgent",
+            providerName: "codex",
             runtimeMode: "full-access",
             activeTurnId: null,
             lastError: null,
@@ -263,9 +265,9 @@ describe("ProviderSessionReaper", () => {
     await runtime!.runPromise(
       repository.upsert({
         threadId,
-        providerName: "claudeAgent",
+        providerName: "codex",
         providerInstanceId: null,
-        adapterKey: "claudeAgent",
+        adapterKey: "codex",
         runtimeMode: "full-access",
         status: "running",
         lastSeenAt: "2026-04-14T00:00:00.000Z",
@@ -283,6 +285,66 @@ describe("ProviderSessionReaper", () => {
     expect(harness.stopSession.mock.calls[0]?.[0]).toEqual({ threadId });
     expect(harness.stoppedThreadIds.has(threadId)).toBe(true);
   });
+
+  it.each(["ready", "error"] as const)(
+    "keeps stale %s Claude sessions alive for cross-session messaging",
+    async (status) => {
+      const threadId = ThreadId.make(`thread-reaper-claude-messaging-${status}`);
+      const now = "2026-01-01T00:00:00.000Z";
+      const harness = await createHarness({
+        activeSessions: [
+          {
+            threadId,
+            provider: ProviderDriverKind.make("claudeAgent"),
+            status: "ready",
+            runtimeMode: "full-access",
+            createdAt: now,
+            updatedAt: now,
+          },
+        ],
+        readModel: makeReadModel([
+          {
+            id: threadId,
+            session: {
+              threadId,
+              status,
+              providerName: "claudeAgent",
+              runtimeMode: "full-access",
+              activeTurnId: null,
+              lastError: null,
+              updatedAt: now,
+            },
+          },
+        ]),
+      });
+      const repository = await runtime!.runPromise(
+        Effect.service(ProviderSessionRuntime.ProviderSessionRuntimeRepository),
+      );
+
+      await runtime!.runPromise(
+        repository.upsert({
+          threadId,
+          providerName: "claudeAgent",
+          providerInstanceId: null,
+          adapterKey: "claudeAgent",
+          runtimeMode: "full-access",
+          status: "running",
+          lastSeenAt: "2026-04-14T00:00:00.000Z",
+          resumeCursor: {
+            opaque: "resume-claude-messaging",
+          },
+          runtimePayload: null,
+        }),
+      );
+
+      await startReaper();
+      await runtime!.runPromise(drainFibers);
+
+      expect(harness.stopSession).not.toHaveBeenCalled();
+      const remaining = await runtime!.runPromise(repository.getByThreadId({ threadId }));
+      expect(Option.isSome(remaining)).toBe(true);
+    },
+  );
 
   it("skips stale sessions when the thread still has an active turn", async () => {
     const threadId = ThreadId.make("thread-reaper-active-turn");
@@ -484,7 +546,7 @@ describe("ProviderSessionReaper", () => {
           id: failedThreadId,
           session: {
             threadId: failedThreadId,
-            status: "ready",
+            status: "error",
             providerName: "claudeAgent",
             runtimeMode: "full-access",
             activeTurnId: null,
@@ -570,7 +632,7 @@ describe("ProviderSessionReaper", () => {
           id: defectThreadId,
           session: {
             threadId: defectThreadId,
-            status: "ready",
+            status: "error",
             providerName: "claudeAgent",
             runtimeMode: "full-access",
             activeTurnId: null,

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.ts
@@ -36,6 +36,11 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
 
     const sweep = Effect.gen(function* () {
       const bindings = yield* directory.listBindings();
+      const liveClaudeThreadIds = new Set(
+        (yield* providerService.listSessions())
+          .filter((session) => session.provider === "claudeAgent")
+          .map((session) => session.threadId),
+      );
       const now = yield* Clock.currentTimeMillis;
       let reapedCount = 0;
 
@@ -79,6 +84,17 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
           yield* Effect.logDebug("provider.session.reaper.skipped-background-work", {
             threadId: binding.threadId,
             backgroundLiveness: thread.backgroundLiveness,
+            idleDurationMs,
+          });
+          continue;
+        }
+
+        // Claude's process is also its cross-session messaging endpoint, so
+        // a live idle session must remain addressable by its peers.
+        if (binding.provider === "claudeAgent" && liveClaudeThreadIds.has(binding.threadId)) {
+          yield* Effect.logDebug("provider.session.reaper.skipped-messaging-endpoint", {
+            threadId: binding.threadId,
+            provider: binding.provider,
             idleDurationMs,
           });
           continue;


### PR DESCRIPTION
## What Changed

Keep live Claude sessions out of the inactivity reaper so their cross-session messaging endpoint remains addressable. Other providers and Claude bindings without a live adapter session keep the existing cleanup behavior.

## Why

Claude's process owns its roster entry and messaging socket. Reaping an idle thread removes it from `ListAgents`, makes `SendMessage` fail, and resuming cannot restore the same endpoint identity.

Fixes #9586.

## Verification

- Reproduced the failure with a focused reaper test before the fix
- `vp test run apps/server/src/provider/Layers/ProviderSessionReaper.test.ts` (9 passed)
- Targeted format and lint passed
- `vp run --filter t3 typecheck` passed
- `git diff --check` passed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

Implemented with `gpt-5.6-sol` in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session lifecycle for Claude only and adds a listSessions dependency each sweep; wrong skip logic could leave zombie sessions or fail to reap when messaging is gone.
> 
> **Overview**
> The inactivity **ProviderSessionReaper** no longer stops idle **Claude** bindings when `listSessions()` still reports a live `claudeAgent` session for that thread, so cross-session messaging can keep using the same process endpoint. Other providers and Claude bindings without a live adapter session still follow the existing stale-session cleanup.
> 
> Tests mock `activeSessions` on the harness, assert stale **codex** sessions are still reaped, and add cases for idle **ready** / **error** Claude threads that must not call `stopSession`. Multi-session failure/defect scenarios use **error** thread status on the Claude side so those bindings are not exempted by the new skip rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ab694fbfd451087d1eee8a1dab1492f03057ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ProviderSessionReaper` to keep live Claude messaging sessions alive
> The reaper previously stopped stale persisted Claude bindings even when a live session was still active. The sweep in `makeProviderSessionReaper` now calls `providerService.listSessions`, builds a set of active Claude thread IDs, and skips stopping any Claude binding whose thread ID is in that set.
>
> Tests in [ProviderSessionReaper.test.ts](https://github.com/pingdotgg/t3code/pull/9612/files#diff-9c064659a893430d8c3796d891064feb010d88e0f11222f98b078f4f71c8d6e1) are updated: the generic stale-session test switched to the Codex provider, and new parameterized tests verify that live idle Claude sessions in `ready` and `error` states are retained.
>
> Risk: non-Claude providers are unaffected; only Claude bindings with a matching live thread ID are exempted from reaping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3ab694.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->