### PR TITLE
fix(web): keep command palette above composer menus

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -758,7 +758,7 @@ function ComposerCommandMenuLayer(props: { anchor: HTMLElement | null; children:
 
   return createPortal(
     <div
-      className="pointer-events-auto fixed z-[70]"
+      className="pointer-events-auto fixed z-40"
       data-composer-drawer-layer="true"
       style={{
         bottom: position.bottom,


### PR DESCRIPTION
Opening the global command palette while the composer slash-command menu was open left both portals visible. The composer drawer used layer 70 while the standard dialog used layer 50, so the slash menu covered the palette.

One-line change: lower the shared composer drawer to layer 40. It stays above the right-panel sheet at layer 35, while standard dialogs render above it. No menu-state coordination is needed.

Closes #9555

## Verification

- Reproduced in an isolated web app with `/`, then `Cmd+K`.
- Before: the overlap hit-test returned `composer-drawer` (`70` over `50`).
- After: the overlap hit-test returns `command-palette` (`50` over `40`).
- Web typecheck, targeted formatting, and diff checks pass.
- Targeted lint completes with pre-existing `ChatComposer.tsx` warnings only.
- React Doctor's changed-line scan reports no issues.
- Browser console reports no errors.

## Before / after

Same isolated draft and viewport. Before was captured at `caab2fd`; after uses head `02df0b8`.

| Before | After |
| --- | --- |
| ![Slash-command menu covering the command palette](https://github.com/user-attachments/assets/ddb41792-954c-43c0-b924-d05a3942ad67) | ![Command palette above the slash-command menu](https://github.com/user-attachments/assets/dbf1d6fd-8bfc-43e4-ac7c-a9839f2ad83a) |

Implemented with `gpt-5.6-sol` in T3 Code through the Codex harness.
