### PR TITLE
fix: show idle subagent batches without completion marks

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -2256,9 +2256,13 @@ describe("quiet timeline: nested agents", () => {
     },
   );
 
-  it.each(["cancelled", "failed", "interrupted"] as const)(
-    "replaces Antigravity progress with %s without a timeline bypass flag",
+  it.each(["cancelled", "failed", "interrupted", "idle"] as const)(
+    "replaces Antigravity batch progress with %s",
     (status) => {
+      const detail =
+        status === "idle"
+          ? "Turn ended. Individual agent status is unavailable."
+          : "Antigravity process stopped.";
       const thread = makeThread({
         id: ThreadId.make("antigravity-agents"),
         projectId: ProjectId.make("project-1"),
@@ -2268,14 +2272,14 @@ describe("quiet timeline: nested agents", () => {
             makeActivity({
               id: EventId.make(`progress-${index}`),
               kind: "task.progress",
-              summary: "Antigravity subagent",
+              summary: "Antigravity subagent batch",
               createdAt: `2026-04-01T00:00:0${index + 1}.000Z`,
               payload: {
                 taskId,
-                taskType: "subagent",
+                taskType: "subagent_batch",
                 agentKind: "agent",
-                title: "Antigravity subagent",
-                detail: "Antigravity subagent",
+                title: "Antigravity subagent batch",
+                detail: "Antigravity subagent batch",
                 status: "running",
               },
             }),
@@ -2287,11 +2291,11 @@ describe("quiet timeline: nested agents", () => {
             createdAt: "2026-04-01T00:00:03.000Z",
             payload: {
               taskId: "trajectory:4",
-              taskType: "subagent",
+              taskType: "subagent_batch",
               agentKind: "agent",
-              title: "Antigravity subagent",
+              title: "Antigravity subagent batch",
               status,
-              error: "Antigravity process stopped.",
+              ...(status === "idle" ? { detail, timelineBypass: true } : { error: detail }),
             },
           }),
         ],
@@ -2302,8 +2306,8 @@ describe("quiet timeline: nested agents", () => {
       expect(rows).toHaveLength(2);
       expect(rows[0]).toMatchObject({
         lifecycleStatus: status === "failed" ? "failed" : "stopped",
-        detail: "Antigravity process stopped.",
-        workEntry: { taskId: "trajectory:4", toolTitle: "Antigravity subagent" },
+        detail,
+        workEntry: { taskId: "trajectory:4", toolTitle: "Antigravity subagent batch" },
       });
       expect(rows[1]).toMatchObject({
         lifecycleStatus: "inProgress",

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -449,6 +449,7 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   const taskDetailAsLabel =
     isTaskActivity &&
     !taskSummary &&
+    !title &&
     typeof payload?.detail === "string" &&
     payload.detail.length > 0
       ? payload.detail
@@ -499,7 +500,7 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
         toolName: data?.toolName,
         data,
       });
-    if (detail && !repeatsCommand) entry.detail = detail;
+    if (detail && detail !== title && !repeatsCommand) entry.detail = detail;
   }
   if (isTaskActivity && typeof payload?.error === "string" && payload.error.trim()) {
     entry.detail = payload.error;
@@ -1110,6 +1111,9 @@ function extractWorkLogToolLifecycleStatus(
   payload: Record<string, unknown> | null,
 ): WorkLogToolLifecycleStatus | undefined {
   const status = payload?.status;
+  // The parent turn ended, so batch tracking is inactive. The detail explains
+  // that child status is unavailable; do not retain the earlier running marker.
+  if (status === "idle" && payload?.taskType === "subagent_batch") return "stopped";
   if (status === "pending" || status === "running" || status === "waiting") return "inProgress";
   if (status === "cancelled" || status === "interrupted") return "stopped";
   if (

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -796,6 +796,7 @@ it.layer(layer)("AntigravityAdapter", (it) => {
       expect(launched.payload).toMatchObject({
         taskId: started.toolCall.toolCallId,
         title: "Antigravity subagent batch",
+        taskType: "subagent_batch",
         description: "Launch subagents",
         status: "running",
       });
@@ -857,7 +858,7 @@ it.layer(layer)("AntigravityAdapter", (it) => {
       const completed = yield* h.waitForEvent((event) => event.type === "task.completed");
       expect(completed.payload).toEqual({
         taskId: "replayed:4",
-        taskType: "subagent",
+        taskType: "subagent_batch",
         toolUseId: "replayed:4",
         title: "Antigravity subagent batch",
         status: "failed",
@@ -1085,7 +1086,7 @@ it.layer(layer)("AntigravityAdapter", (it) => {
         expect(settled.payload).toMatchObject({
           taskId: "trajectory:4",
           title: "Antigravity subagent batch",
-          taskType: "subagent",
+          taskType: "subagent_batch",
           status:
             stop === "disconnect"
               ? "failed"

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -176,7 +176,7 @@ interface OpenSubagent {
 function subagentLinkage(toolCallId: string) {
   return {
     taskId: RuntimeTaskId.make(toolCallId),
-    taskType: "subagent",
+    taskType: "subagent_batch",
     toolUseId: toolCallId,
     title: "Antigravity subagent batch",
   };

--- a/apps/web/src/components/AgentsPanel.tsx
+++ b/apps/web/src/components/AgentsPanel.tsx
@@ -140,6 +140,8 @@ function agentActivityText(agent: RuntimeSubagent): string | null {
 /** Flat, non-interactive agent status line. No unfold. */
 function AgentRow({ agent }: { agent: RuntimeSubagent }) {
   const visuals = STATUS_VISUALS[agent.status];
+  const statusLabel =
+    agent.kind === "subagent_batch" && agent.status === "idle" ? "Idle" : visuals.label;
   const activity = agentActivityText(agent);
   const modelLabel = formatSubagentModelLabel(agent.model, agent.effort);
   const role =
@@ -180,12 +182,12 @@ function AgentRow({ agent }: { agent: RuntimeSubagent }) {
           agent.status === "failed" ? "text-destructive-foreground" : "text-muted-foreground",
         )}
       >
-        {activity ?? visuals.label}
+        {activity ?? statusLabel}
       </span>
       <span className="col-start-2 col-end-4 row-start-3 truncate font-mono text-[.7rem] tabular-nums text-muted-foreground/70">
         {metadata.join(" · ")}
       </span>
-      <span className="sr-only">{visuals.label}</span>
+      <span className="sr-only">{statusLabel}</span>
     </div>
   );
 }

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -167,6 +167,7 @@ import {
   formatInlineTerminalContextLabel,
   textContainsInlineTerminalContextLabels,
 } from "./userMessageTerminalContexts";
+import { deriveAgentSpawnSummary } from "./agentSpawnSummary";
 import { SkillInlineText } from "./SkillInlineText";
 import { formatWorkspaceRelativePath } from "../../filePathDisplay";
 import {
@@ -2993,22 +2994,12 @@ const AgentSpawnCtaRow = memo(function AgentSpawnCtaRow(props: { workEntry: Time
     Math.max(memberIds.size - (spawn.workflowId ? 1 : 0), 0),
   );
 
-  const running = agents.filter(
-    (agent) => agent.status === "running" || agent.status === "pending",
-  ).length;
-  const waiting = agents.filter((agent) => agent.status === "waiting").length;
-  const failed = agents.filter((agent) => agent.status === "failed").length;
-  // The coordinator's own status is authoritative for workflows: dynamic
-  // spawns mean the member list can be momentarily all-settled while the
-  // run is still mid-flight (the "completed" lie from live testing). A
-  // workflow is live until the coordinator itself reaches a terminal state.
-  const coordinatorStatus = workflowGroup?.workflow.status;
-  const coordinatorSettled =
-    coordinatorStatus === "completed" ||
-    coordinatorStatus === "failed" ||
-    coordinatorStatus === "cancelled" ||
-    coordinatorStatus === "interrupted";
-  const live = workflowGroup !== undefined ? !coordinatorSettled : running + waiting > 0;
+  const summary = deriveAgentSpawnSummary({
+    agents,
+    agentCount,
+    coordinatorStatus: workflowGroup?.workflow.status,
+  });
+  const { live, lead } = summary;
   // Same rule as the panel footer: providers may aggregate member usage into
   // the coordinator, so count the coordinator only when no members exist.
   const totalTokens = agents.reduce(
@@ -3020,22 +3011,14 @@ const AgentSpawnCtaRow = memo(function AgentSpawnCtaRow(props: { workEntry: Time
   const workflowName =
     workflowGroup?.workflow.workflowName ?? workflowGroup?.workflow.title ?? null;
 
-  // One steady in-flight presentation (monitoring-pill rule): waiting and
-  // stalled agents read as working; only settled states differentiate.
-  const working = running + waiting;
-  const dotClass = live ? "bg-info" : failed > 0 ? "bg-destructive" : "bg-success";
-  const lead = live
-    ? `Kicked off ${agentCount} subagent${agentCount === 1 ? "" : "s"}`
-    : `Ran ${agentCount} subagent${agentCount === 1 ? "" : "s"}`;
-  const status = live
-    ? livePhase
-      ? `${livePhase.title} · ${livePhase.activeCount} working`
-      : working > 0
-        ? `${working} working`
-        : "working"
-    : failed > 0
-      ? `${failed} failed`
-      : "✓ completed";
+  const dotClass = {
+    working: "bg-info",
+    failed: "bg-destructive",
+    completed: "bg-success",
+    inactive: "bg-muted-foreground/50",
+  }[summary.tone];
+  const status =
+    live && livePhase ? `${livePhase.title} · ${livePhase.activeCount} working` : summary.status;
 
   return (
     <button

--- a/apps/web/src/components/chat/agentSpawnSummary.test.ts
+++ b/apps/web/src/components/chat/agentSpawnSummary.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { RuntimeSubagent } from "@t3tools/client-runtime/state/subagentRuntime";
+import { deriveAgentSpawnSummary } from "./agentSpawnSummary";
+
+const batch = (status: RuntimeSubagent["status"]) => ({ kind: "subagent_batch" as const, status });
+const agent = (status: RuntimeSubagent["status"]) => ({ kind: "subagent" as const, status });
+
+describe("deriveAgentSpawnSummary", () => {
+  it("counts a native batch without claiming the number of children", () => {
+    expect(deriveAgentSpawnSummary({ agents: [batch("running")], agentCount: 1 })).toEqual({
+      live: true,
+      lead: "Launched 1 subagent batch",
+      status: "1 working",
+      tone: "working",
+    });
+    expect(deriveAgentSpawnSummary({ agents: [batch("idle")], agentCount: 1 })).toEqual({
+      live: false,
+      lead: "Launched 1 subagent batch",
+      status: "1 idle",
+      tone: "inactive",
+    });
+  });
+
+  it("keeps individual agents and batches separate in a mixed group", () => {
+    expect(
+      deriveAgentSpawnSummary({
+        agents: [agent("running"), batch("running"), batch("idle")],
+        agentCount: 3,
+      }).lead,
+    ).toBe("Launched 1 subagent and 2 batches");
+  });
+
+  it.each([
+    ["idle", "1 idle", "inactive"],
+    ["cancelled", "1 stopped", "inactive"],
+    ["interrupted", "1 stopped", "inactive"],
+    ["failed", "1 failed", "failed"],
+    ["completed", "✓ completed", "completed"],
+  ] as const)("reports %s accurately alongside a completed agent", (state, status, tone) => {
+    expect(
+      deriveAgentSpawnSummary({ agents: [agent("completed"), agent(state)], agentCount: 2 }),
+    ).toMatchObject({ live: false, status, tone });
+  });
+
+  it("does not claim completion when the roster is missing a member", () => {
+    expect(deriveAgentSpawnSummary({ agents: [agent("completed")], agentCount: 2 })).toMatchObject({
+      status: "Status unavailable",
+      tone: "inactive",
+    });
+  });
+
+  it("keeps a workflow active between child launches", () => {
+    expect(
+      deriveAgentSpawnSummary({
+        agents: [agent("completed")],
+        agentCount: 1,
+        coordinatorStatus: "running",
+      }),
+    ).toMatchObject({ live: true, status: "working", tone: "working" });
+  });
+
+  it.each([
+    ["failed", "Workflow failed", "failed"],
+    ["cancelled", "Workflow stopped", "inactive"],
+  ] as const)(
+    "preserves a %s workflow outcome when its children completed",
+    (coordinatorStatus, status, tone) => {
+      expect(
+        deriveAgentSpawnSummary({ agents: [agent("completed")], agentCount: 1, coordinatorStatus }),
+      ).toMatchObject({ live: false, status, tone });
+    },
+  );
+});

--- a/apps/web/src/components/chat/agentSpawnSummary.ts
+++ b/apps/web/src/components/chat/agentSpawnSummary.ts
@@ -1,0 +1,64 @@
+import {
+  isActiveSubagentStatus,
+  isTerminalSubagentStatus,
+  type RuntimeSubagent,
+} from "@t3tools/client-runtime/state/subagentRuntime";
+
+/** Summarize observed states without treating idle or missing agents as completed. */
+export function deriveAgentSpawnSummary({
+  agents,
+  agentCount,
+  coordinatorStatus,
+}: {
+  agents: ReadonlyArray<Pick<RuntimeSubagent, "kind" | "status">>;
+  agentCount: number;
+  coordinatorStatus?: RuntimeSubagent["status"] | undefined;
+}) {
+  const working = agents.filter((agent) => isActiveSubagentStatus(agent.status)).length;
+  const failed = agents.filter((agent) => agent.status === "failed").length;
+  const idle = agents.filter((agent) => agent.status === "idle").length;
+  const stopped = agents.filter(
+    (agent) => agent.status === "cancelled" || agent.status === "interrupted",
+  ).length;
+  const batches = agents.filter((agent) => agent.kind === "subagent_batch").length;
+  const individuals = agentCount - batches;
+  // Workflow coordinators can keep running between dynamic member launches.
+  const live =
+    coordinatorStatus !== undefined ? !isTerminalSubagentStatus(coordinatorStatus) : working > 0;
+  const subjects = [
+    individuals > 0 ? `${individuals} subagent${individuals === 1 ? "" : "s"}` : null,
+    batches > 0
+      ? `${batches} ${individuals > 0 ? "" : "subagent "}batch${batches === 1 ? "" : "es"}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(" and ");
+  const lead = `${batches > 0 ? "Launched" : live ? "Kicked off" : "Ran"} ${subjects || "subagents"}`;
+
+  const status = live
+    ? working > 0
+      ? `${working} working`
+      : "working"
+    : coordinatorStatus === "failed"
+      ? "Workflow failed"
+      : coordinatorStatus === "cancelled" || coordinatorStatus === "interrupted"
+        ? "Workflow stopped"
+        : failed > 0
+          ? `${failed} failed`
+          : stopped > 0
+            ? `${stopped} stopped`
+            : idle > 0
+              ? `${idle} idle`
+              : coordinatorStatus !== "completed" &&
+                  (agents.length === 0 || agents.length < agentCount)
+                ? "Status unavailable"
+                : "✓ completed";
+  const tone = live
+    ? "working"
+    : failed > 0 || coordinatorStatus === "failed"
+      ? "failed"
+      : status === "✓ completed"
+        ? "completed"
+        : "inactive";
+  return { live, lead, status, tone };
+}

--- a/docs/user/providers-antigravity.md
+++ b/docs/user/providers-antigravity.md
@@ -145,6 +145,8 @@ Subagent launches appear as **Antigravity subagent batch** in **Agents** on web 
 and in the work log on mobile. One launch can start several agents. The batch stays active
 after launch while the parent turn runs. When that turn ends, the entry becomes idle and
 states that individual agent status is unavailable. Launch errors remain visible.
+The conversation summary counts launches as batches and shows idle or stopped batches
+without a completion checkmark.
 
 The official ACP agent does not send individual child status, names, models, token usage,
 or reply ownership. T3 Code cannot show separate child entries or separate child replies

--- a/packages/client-runtime/src/state/subagentRuntime.test.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.test.ts
@@ -69,7 +69,7 @@ describe("foldSubagentActivities", () => {
   it("shows the batch status limit after its parent turn ends without claiming a result", () => {
     const running = activity("task.progress", {
       taskId: "batch-1",
-      taskType: "subagent",
+      taskType: "subagent_batch",
       title: "Antigravity subagent batch",
       status: "running",
       summary: "Launch readers",
@@ -78,7 +78,7 @@ describe("foldSubagentActivities", () => {
       running,
       activity("task.updated", {
         taskId: "batch-1",
-        taskType: "subagent",
+        taskType: "subagent_batch",
         status: "idle",
         detail: "Turn ended. Individual agent status is unavailable.",
         timelineBypass: true,
@@ -87,11 +87,22 @@ describe("foldSubagentActivities", () => {
     expect(agents).toHaveLength(1);
     expect(agents[0]).toMatchObject({
       title: "Antigravity subagent batch",
+      kind: "subagent_batch",
       status: "idle",
       progress: "Turn ended. Individual agent status is unavailable.",
       result: null,
       error: null,
     });
+  });
+
+  it("learns batch identity from a later update and retains it on sparse updates", () => {
+    const agents = fold([
+      activity("task.progress", { taskId: "batch-1", taskType: "subagent", status: "running" }),
+      activity("task.updated", { taskId: "batch-1", taskType: "subagent_batch", status: "idle" }),
+      activity("task.updated", { taskId: "batch-1", status: "idle" }),
+    ]);
+    expect(agents).toHaveLength(1);
+    expect(agents[0]).toMatchObject({ kind: "subagent_batch", status: "idle" });
   });
 
   it("builds an agent from start → progress → completion", () => {

--- a/packages/client-runtime/src/state/subagentRuntime.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.ts
@@ -58,7 +58,7 @@ export interface SubagentRunHandles {
 
 export interface RuntimeSubagent {
   readonly id: string;
-  readonly kind: "subagent" | "workflow" | "workflow_agent";
+  readonly kind: "subagent" | "subagent_batch" | "workflow" | "workflow_agent";
   readonly title: string;
   readonly role: string | null;
   readonly model: string | null;
@@ -259,6 +259,9 @@ function kindFromPayload(
   payload: Record<string, unknown>,
   agentId: string,
 ): RuntimeSubagent["kind"] {
+  if (payload.taskType === "subagent_batch") {
+    return "subagent_batch";
+  }
   if (asString(payload.taskType) === "local_workflow") {
     return "workflow";
   }
@@ -314,6 +317,7 @@ function getOrCreate(
 
 /** Metadata fill from any payload: never downgrades known values to null. */
 function fillMetadata(agent: MutableAgent, payload: Record<string, unknown>): void {
+  if (payload.taskType === "subagent_batch") agent.kind = "subagent_batch";
   const title = asString(payload.title);
   if (title) agent.title = title;
   const role = asString(payload.role);


### PR DESCRIPTION
An idle Antigravity batch showed its status correctly in Agents, but the conversation summary still called it one subagent and displayed a green completion checkmark. Browser verification of [#9579](https://github.com/pingdotgg/t3code/pull/9579) exposed the mismatch.

Mark native launches as batches through the existing task type. Count batches separately from individual agents, and show idle, stopped, or unavailable status without claiming completion. Keep workflow coordinator status authoritative. On mobile, clear the batch's running marker and retain the explanation that child status is unavailable.

Validation: 171 focused tests passed. Web, mobile, and shared-client typechecks passed. Targeted lint and formatting passed. Browser screenshots below use isolated replay fixtures generated from recorded ACP traffic through the adapter and activity conversion code. No live user state was changed.

Before: the parent turn ended, Agents says status is unavailable, but the conversation says completed.

![Idle batch incorrectly marked completed](https://files.tslop.org/2026/09/browser-ended-4f4847f3.png)

After launch: one batch remains active.

![One subagent batch working](https://files.tslop.org/2026/09/browser-final-active-bf708b68.png)

After the parent turn ends: one idle batch, with no completion checkmark.

![One idle batch with child status unavailable](https://files.tslop.org/2026/09/browser-final-idle-c5047ed9.png)

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and task-type labeling across clients and the Antigravity adapter; no auth or data-path changes, with broad test coverage.
> 
> **Overview**
> Antigravity multi-agent launches are now tagged as **`subagent_batch`** end-to-end (adapter events, runtime folding, tests) instead of generic subagents, so UI can treat them as batches with an **`idle`** state when the parent turn ends.
> 
> The chat **agent spawn** pill uses new **`deriveAgentSpawnSummary`** logic: it counts batches separately from individual agents, keeps workflows live via coordinator status, and shows **idle**, **stopped**, or **status unavailable** with muted styling—**not** a green completion checkmark when child status is unknown. **Agents** panel labels idle batches as **Idle**; **mobile** work log maps idle batches to **stopped** and avoids duplicate title/detail text.
> 
> Provider docs note that conversation summaries reflect batch launches and idle batches without implying success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a94d5bc56e13d9fc8f4566c61083f6105b97ec86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show idle subagent batches without completion marks in quiet timeline
> Expands the terminal-status parameterized test in [threadActivity.test.ts](https://github.com/pingdotgg/t3code/pull/9616/files#diff-8fc154ca47cb1e024c4e1f266b22114cd6071c6cdac94118a62011bf81c3ccd2) to cover idle Antigravity subagent batches. The fixture now uses batch-specific display text and supplies the turn-ended detail plus the timeline bypass marker for idle, while retaining the process-stopped error for other statuses. Asserts the batch title and status-specific detail so idle batch updates replace batch progress without exposing a separate timeline row.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a94d5bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->