### PR TITLE
perf(shared): skip duplicate PATH entries and per-probe tracing

### DIFF
--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -407,14 +407,27 @@ effectIt.layer(NodeServices.layer)("resolveCommandPath", (it) => {
   it.effect("visits a repeated PATH directory only once", () =>
     Effect.gen(function* () {
       const probed = yield* recordProbes({
-        PATH: "C:\\bin;C:\\other;C:\\BIN;C:\\bin",
+        PATH: "C:\\bin;C:\\other;C:\\bin;C:\\other",
         PATHEXT: ".COM;.EXE",
       });
 
-      // Two distinct directories, two extensions. The repeats of C:\bin, one of
-      // them differing only in case, cost nothing.
+      // Two distinct directories, two extensions. The repeats cost nothing.
       expect(probed).toHaveLength(4);
       expect(new Set(probed).size).toBe(probed.length);
+    }),
+  );
+
+  it.effect("still visits a PATH entry that differs only in case", () =>
+    Effect.gen(function* () {
+      const probed = yield* recordProbes({
+        PATH: "C:\\bin;C:\\BIN",
+        PATHEXT: ".COM;.EXE",
+      });
+
+      // Deliberately not folded together. Windows 10+ can mark a directory
+      // case-sensitive, so the two spellings are not provably one directory and
+      // skipping the second could hide a command that is really there.
+      expect(probed).toHaveLength(4);
     }),
   );
 

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -2,11 +2,13 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it as effectIt } from "@effect/vitest";
 import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
   extractPathFromShellOutput,
   CommandAvailability,
+  CommandResolutionCache,
   type CommandAvailabilityChecker,
   isCommandAvailable,
   listLoginShellCandidates,
@@ -373,6 +375,60 @@ effectIt.layer(NodeServices.layer)("resolveCommandPath", (it) => {
       }).pipe(Effect.provideService(HostProcessPlatform, "win32"), Effect.result);
 
       expect(result._tag).toBe("Failure");
+    }),
+  );
+
+  // Records every path the scan stats, without ever reporting a match, so the
+  // walk runs to exhaustion and the probe set can be inspected. Assertions
+  // below count probes rather than naming paths: `Path` is the host's, so the
+  // separator differs between a Windows and a Linux CI runner.
+  const recordProbes = (env: NodeJS.ProcessEnv) =>
+    Effect.gen(function* () {
+      const probed: Array<string> = [];
+      const result = yield* resolveCommandPath("definitely-not-installed", { env }).pipe(
+        Effect.provideService(HostProcessPlatform, "win32"),
+        Effect.provideService(CommandResolutionCache, new Map()),
+        Effect.provide(
+          FileSystem.layerNoop({
+            stat: (filePath) =>
+              Effect.sync(() => {
+                probed.push(filePath);
+                return { type: "Directory" } as FileSystem.File.Info;
+              }),
+          }),
+        ),
+        Effect.result,
+      );
+
+      expect(result._tag).toBe("Failure");
+      return probed;
+    });
+
+  it.effect("visits a repeated PATH directory only once", () =>
+    Effect.gen(function* () {
+      const probed = yield* recordProbes({
+        PATH: "C:\\bin;C:\\other;C:\\BIN;C:\\bin",
+        PATHEXT: ".COM;.EXE",
+      });
+
+      // Two distinct directories, two extensions. The repeats of C:\bin, one of
+      // them differing only in case, cost nothing.
+      expect(probed).toHaveLength(4);
+      expect(new Set(probed).size).toBe(probed.length);
+    }),
+  );
+
+  it.effect("probes one spelling per PATHEXT entry", () =>
+    Effect.gen(function* () {
+      const probed = yield* recordProbes({
+        PATH: "C:\\bin",
+        PATHEXT: ".COM;.EXE;.BAT;.CMD",
+      });
+
+      // Four extensions, not eight: Windows matches file names
+      // case-insensitively, so the lowercase spellings are the same question.
+      expect(probed).toHaveLength(4);
+      expect(probed.filter((filePath) => /\.(COM|EXE|BAT|CMD)$/.test(filePath))).toHaveLength(4);
     }),
   );
 });

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -3,6 +3,8 @@ import { it as effectIt } from "@effect/vitest";
 import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as TestClock from "effect/testing/TestClock";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
@@ -411,8 +413,8 @@ effectIt.layer(NodeServices.layer)("resolveCommandPath", (it) => {
         PATHEXT: ".COM;.EXE",
       });
 
-      // Two distinct directories, two extensions. The repeats cost nothing.
-      expect(probed).toHaveLength(4);
+      // Two directories, two extensions, upper and lowercase spellings.
+      expect(probed).toHaveLength(8);
       expect(new Set(probed).size).toBe(probed.length);
     }),
   );
@@ -427,21 +429,71 @@ effectIt.layer(NodeServices.layer)("resolveCommandPath", (it) => {
       // Deliberately not folded together. Windows 10+ can mark a directory
       // case-sensitive, so the two spellings are not provably one directory and
       // skipping the second could hide a command that is really there.
-      expect(probed).toHaveLength(4);
+      expect(probed).toHaveLength(8);
     }),
   );
 
-  it.effect("probes one spelling per PATHEXT entry", () =>
+  it.effect.each(["audit-command", "audit-command.CMD"])(
+    "resolves lowercase executable files for %s in a case-sensitive Windows PATH directory",
+    (command) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* fs.makeTempDirectoryScoped({ prefix: "t3-case-sensitive-path-" });
+        const executable = path.join(cwd, "audit-command.cmd");
+        yield* fs.writeFileString(executable, "@echo off\n");
+
+        const resolved = yield* resolveCommandPath(command, {
+          env: { PATH: cwd, PATHEXT: ".CMD" },
+        }).pipe(
+          Effect.provideService(HostProcessPlatform, "win32"),
+          Effect.provideService(CommandResolutionCache, new Map()),
+          Effect.provideService(FileSystem.FileSystem, {
+            ...fs,
+            // Keep this case-sensitive fixture portable to case-insensitive hosts.
+            stat: (filePath) =>
+              fs.stat(filePath === executable ? filePath : path.join(cwd, "missing")),
+          }),
+        );
+
+        expect(resolved).toBe(executable);
+      }),
+  );
+
+  it.effect("keeps cached misses until expiry while allowing explicit paths", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const cwd = yield* fs.makeTempDirectoryScoped({ prefix: "t3-path-cache-" });
+      const executable = path.join(cwd, "appeared.CMD");
+      const options = { env: { PATH: `${cwd};${cwd}`, PATHEXT: ".CMD" } };
+
+      expect((yield* resolveCommandPath("appeared", options).pipe(Effect.result))._tag).toBe(
+        "Failure",
+      );
+      yield* fs.writeFileString(executable, "@echo off\n");
+      expect((yield* resolveCommandPath("appeared", options).pipe(Effect.result))._tag).toBe(
+        "Failure",
+      );
+      expect(yield* resolveCommandPath(executable, options)).toBe(executable);
+      yield* TestClock.adjust("30 seconds");
+      expect(yield* resolveCommandPath("appeared", options)).toBe(executable);
+    }).pipe(
+      Effect.provideService(HostProcessPlatform, "win32"),
+      Effect.provideService(CommandResolutionCache, new Map()),
+    ),
+  );
+
+  it.effect("keeps upper and lowercase PATHEXT candidates", () =>
     Effect.gen(function* () {
       const probed = yield* recordProbes({
         PATH: "C:\\bin",
         PATHEXT: ".COM;.EXE;.BAT;.CMD",
       });
 
-      // Four extensions, not eight: Windows matches file names
-      // case-insensitively, so the lowercase spellings are the same question.
-      expect(probed).toHaveLength(4);
+      expect(probed).toHaveLength(8);
       expect(probed.filter((filePath) => /\.(COM|EXE|BAT|CMD)$/.test(filePath))).toHaveLength(4);
+      expect(probed.filter((filePath) => /\.(com|exe|bat|cmd)$/.test(filePath))).toHaveLength(4);
     }),
   );
 });

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -479,18 +479,19 @@ function resolveCommandCandidates(
 
   if (extension.length > 0 && windowsPathExtensions.includes(normalizedExtension)) {
     const commandWithoutExtension = command.slice(0, -extension.length);
-    return Array.from(new Set([command, `${commandWithoutExtension}${normalizedExtension}`]));
+    return Array.from(
+      new Set([
+        command,
+        `${commandWithoutExtension}${normalizedExtension}`,
+        `${commandWithoutExtension}${normalizedExtension.toLowerCase()}`,
+      ]),
+    );
   }
 
-  // Windows resolves file names case-insensitively, so probing `code.EXE` and
-  // `code.exe` costs two syscalls to ask the filesystem one question. Both
-  // consumers of the resolved path re-normalize the extension themselves -
-  // `isExecutableFile` uppercases it before the PATHEXT check, and
-  // `resolveSpawnCommand` lowercases it before the .cmd/.bat check - so the
-  // uppercase spelling alone is enough.
   const candidates: string[] = [];
   for (const candidateExtension of windowsPathExtensions) {
     candidates.push(`${command}${candidateExtension}`);
+    candidates.push(`${command}${candidateExtension.toLowerCase()}`);
   }
   return Array.from(new Set(candidates));
 }
@@ -543,11 +544,7 @@ function cacheCommandResolution(
   });
 }
 
-// Untraced on purpose. This runs once per (PATH directory x candidate name),
-// which is tens of thousands of spans for a single editor-discovery pass -
-// enough to dominate both the scan and the local trace file it writes to. The
-// enclosing `shell.resolveCommandPathForPlatform` span already reports every
-// lookup and its outcome.
+// Trace each command lookup, not every candidate file it probes.
 const isExecutableFile = Effect.fnUntraced(function* (
   filePath: string,
   platform: NodeJS.Platform,
@@ -609,19 +606,7 @@ const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlat
     return cached.resolvedPath;
   }
 
-  // A Windows PATH routinely names the same directory more than once: the user
-  // and machine values overlap, and `resolveKnownWindowsCliDirs` appends
-  // entries that are frequently already present. Visiting a directory twice
-  // inside one walk cannot produce a different answer, so drop the repeats
-  // before spending syscalls on them.
-  //
-  // Entries are compared verbatim rather than through
-  // `normalizePathEntryForComparison`. That helper case-folds on Windows, which
-  // is right when it picks which spelling of an entry to keep, but skipping a
-  // probe is a stronger claim: Windows 10+ can mark a directory case-sensitive
-  // (`fsutil file setCaseSensitiveInfo`), so `C:\Tools` and `C:\tools` are not
-  // provably the same directory. Exact matching still drops 15 of the 75
-  // entries on my PATH, and it cannot hide a command that exists.
+  // Keep case variants: Windows can make PATH directories case-sensitive.
   const pathEntries: string[] = [];
   const seenPathEntries = new Set<string>();
   for (const entry of pathValue.split(pathDelimiterForPlatform(platform))) {

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -479,19 +479,18 @@ function resolveCommandCandidates(
 
   if (extension.length > 0 && windowsPathExtensions.includes(normalizedExtension)) {
     const commandWithoutExtension = command.slice(0, -extension.length);
-    return Array.from(
-      new Set([
-        command,
-        `${commandWithoutExtension}${normalizedExtension}`,
-        `${commandWithoutExtension}${normalizedExtension.toLowerCase()}`,
-      ]),
-    );
+    return Array.from(new Set([command, `${commandWithoutExtension}${normalizedExtension}`]));
   }
 
+  // Windows resolves file names case-insensitively, so probing `code.EXE` and
+  // `code.exe` costs two syscalls to ask the filesystem one question. Both
+  // consumers of the resolved path re-normalize the extension themselves -
+  // `isExecutableFile` uppercases it before the PATHEXT check, and
+  // `resolveSpawnCommand` lowercases it before the .cmd/.bat check - so the
+  // uppercase spelling alone is enough.
   const candidates: string[] = [];
   for (const candidateExtension of windowsPathExtensions) {
     candidates.push(`${command}${candidateExtension}`);
-    candidates.push(`${command}${candidateExtension.toLowerCase()}`);
   }
   return Array.from(new Set(candidates));
 }
@@ -544,7 +543,12 @@ function cacheCommandResolution(
   });
 }
 
-const isExecutableFile = Effect.fn("shell.isExecutableFile")(function* (
+// Untraced on purpose. This runs once per (PATH directory x candidate name),
+// which is tens of thousands of spans for a single editor-discovery pass -
+// enough to dominate both the scan and the local trace file it writes to. The
+// enclosing `shell.resolveCommandPathForPlatform` span already reports every
+// lookup and its outcome.
+const isExecutableFile = Effect.fnUntraced(function* (
   filePath: string,
   platform: NodeJS.Platform,
   windowsPathExtensions: ReadonlyArray<string>,
@@ -605,12 +609,23 @@ const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlat
     return cached.resolvedPath;
   }
 
+  // A Windows PATH routinely names the same directory more than once: the user
+  // and machine values overlap, and `resolveKnownWindowsCliDirs` appends
+  // entries that are frequently already present. Visiting a directory twice
+  // inside one walk cannot produce a different answer, so drop the repeats
+  // before spending syscalls on them. `mergePathValues` above already
+  // de-duplicates this way; the scan simply never did.
   const pathEntries: string[] = [];
+  const seenPathEntries = new Set<string>();
   for (const entry of pathValue.split(pathDelimiterForPlatform(platform))) {
     const pathEntry = stripWrappingQuotes(entry.trim());
-    if (pathEntry.length > 0) {
-      pathEntries.push(pathEntry);
-    }
+    if (pathEntry.length === 0) continue;
+
+    const normalizedPathEntry = normalizePathEntryForComparison(pathEntry, platform);
+    if (seenPathEntries.has(normalizedPathEntry)) continue;
+
+    seenPathEntries.add(normalizedPathEntry);
+    pathEntries.push(pathEntry);
   }
 
   for (const pathEntry of pathEntries) {

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -613,18 +613,22 @@ const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlat
   // and machine values overlap, and `resolveKnownWindowsCliDirs` appends
   // entries that are frequently already present. Visiting a directory twice
   // inside one walk cannot produce a different answer, so drop the repeats
-  // before spending syscalls on them. `mergePathValues` above already
-  // de-duplicates this way; the scan simply never did.
+  // before spending syscalls on them.
+  //
+  // Entries are compared verbatim rather than through
+  // `normalizePathEntryForComparison`. That helper case-folds on Windows, which
+  // is right when it picks which spelling of an entry to keep, but skipping a
+  // probe is a stronger claim: Windows 10+ can mark a directory case-sensitive
+  // (`fsutil file setCaseSensitiveInfo`), so `C:\Tools` and `C:\tools` are not
+  // provably the same directory. Exact matching still drops 15 of the 75
+  // entries on my PATH, and it cannot hide a command that exists.
   const pathEntries: string[] = [];
   const seenPathEntries = new Set<string>();
   for (const entry of pathValue.split(pathDelimiterForPlatform(platform))) {
     const pathEntry = stripWrappingQuotes(entry.trim());
-    if (pathEntry.length === 0) continue;
+    if (pathEntry.length === 0 || seenPathEntries.has(pathEntry)) continue;
 
-    const normalizedPathEntry = normalizePathEntryForComparison(pathEntry, platform);
-    if (seenPathEntries.has(normalizedPathEntry)) continue;
-
-    seenPathEntries.add(normalizedPathEntry);
+    seenPathEntries.add(pathEntry);
     pathEntries.push(pathEntry);
   }
 


### PR DESCRIPTION
Repeated PATH directories make command discovery probe the same files again. Each probe also creates a trace span. On slow Windows installations, this work contributes to editor discovery timing out and showing no editors in [#4697](https://github.com/pingdotgg/t3code/issues/4697).

Skip exact duplicate PATH entries within a lookup and trace the enclosing command lookup instead of every candidate file. Keep case-distinct directories and all existing upper/lowercase PATHEXT candidates. The original version removed lowercase candidates, but two real-file regressions showed that this misses lowercase executable files in case-sensitive directories; that change has been removed.

Verification on main [2d5464af](https://github.com/pingdotgg/t3code/commit/2d5464afb):

- The production resolver performs 16 probes for two repeated directories and two PATHEXT extensions on main, versus 8 with this change. Case-distinct directory spellings are still visited separately.
- Real-file controls preserve lowercase `.cmd` resolution, explicit-path lookup, and the existing 30-second negative-cache expiry. The original uppercase-only patch fails both lowercase-file controls; the revised patch passes.
- `vp test run packages/shared/src/shell.test.ts apps/server/src/process/externalLauncher.test.ts --maxWorkers=2`: 57 tests pass, 1 skips. The server integration resolves this worktree's edited shared package. Targeted lint/format plus shared and server typechecks pass.

This is a bounded reduction in redundant work, not a guarantee that every Windows machine finishes discovery within five seconds. The timeout and its empty-editor fallback remain unchanged. The author's original Windows timings included the removed uppercase-only optimization and are not measurements of this revised head. A current native Windows end-to-end timing is still missing; do not close the full editor-discovery report based on these Linux fixtures.

Screenshots do not establish filesystem probe counts; the before/after evidence is the focused production-resolver tests. All executed current-head CI and configured review checks pass; preview jobs skip. The root reviewer read both changed files and the resolver/cache call paths, checked the case-sensitive and cache-expiry controls, and found no unresolved review threads. This is a bounded reduction of duplicate work, with no timeout, cache policy or supported executable changes. The broader Windows report remains open.

Original implementation and Windows investigation by Niklas Westman. Compatibility fixes and updated verification by GPT 6 Astra via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Windows command discovery used for spawn and editor detection; behavior changes are narrow (dedupe + tracing) but incorrect PATH/case handling could miss binaries or regress discovery timeouts.
> 
> **Overview**
> Windows command resolution (`resolveCommandPath`) now **skips exact duplicate PATH segments** within a single lookup so repeated directories are not re-scanned, while **case-distinct PATH spellings** (e.g. `C:\bin` vs `C:\BIN`) are still visited separately for case-sensitive directories.
> 
> **Tracing** moves from per-file `isExecutableFile` spans to untraced probes, cutting span noise during large PATH walks. **PATHEXT behavior is unchanged**: upper- and lowercase extension candidates are still tried.
> 
> New **`shell.test.ts` coverage** records probe counts via a noop filesystem, asserts dedupe vs case-split PATH, lowercase `.cmd` resolution in case-sensitive dirs, 30s negative-cache expiry with `TestClock`, and mixed-case PATHEXT probes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faa22fc2ea78525218f8ecb0cfb61e3bea83d486. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip duplicate PATH entries in `resolveCommandPathForPlatform` and untrace `isExecutableFile` probes
> - Windows command resolution now tracks exact PATH-entry strings and skips empty or repeated entries with the same spelling, while retaining entries that differ only by case.
> - `isExecutableFile` file probes use the untraced effect wrapper so individual candidate stats no longer generate tracing spans; the surrounding lookup stays traced.
> - Adds test coverage for duplicate PATH deduplication, case-distinct PATH entries, lowercase executable resolution, negative-cache expiry, and upper/lowercase PATHEXT probing in [shell.test.ts](https://github.com/pingdotgg/t3code/pull/9618/files#diff-024b87c2c05ce19f7366c156ab261b505a48c5dcc47f564611041c74af49c9f4).
> - Risk: `resolveCommandPathForPlatform` deduplication is string-exact only; PATH entries that differ only by case on a case-insensitive filesystem will still be scanned twice, which is intended but may surprise reviewers expecting case-insensitive deduplication.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized faa22fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->