### PR TITLE
fix(web): match provider settings layout for disconnected devices

### DIFF
--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -38,6 +38,7 @@ import { Button } from "../ui/button";
 import { ScrollArea } from "../ui/scroll-area";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { toastManager } from "../ui/toast";
+import { ExpandableText } from "./ExpandableText";
 import { ResourceTelemetryDiagnostics } from "./ResourceTelemetryDiagnostics";
 import { SettingsPageContainer, SettingsSection, useRelativeTimeTick } from "./settingsLayout";
 import { useAtomCommand } from "../../state/use-atom-command";
@@ -159,43 +160,6 @@ function StatsGrid({ children }: { children: ReactNode }) {
 
 function EmptyRows({ label }: { label: string }) {
   return <div className="px-4 py-4 text-xs text-muted-foreground sm:px-5">{label}</div>;
-}
-
-function ExpandableText({
-  text,
-  className,
-  collapsedClassName = "line-clamp-3",
-  expandLabel = "Show full error",
-}: {
-  text: string;
-  className?: string;
-  collapsedClassName?: string;
-  expandLabel?: string;
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const canExpand = text.length > 180 || text.includes("\n");
-
-  return (
-    <div className={cn("min-w-0", className)}>
-      <div
-        className={cn(
-          "whitespace-pre-wrap break-words",
-          !expanded && canExpand ? collapsedClassName : null,
-        )}
-      >
-        {text}
-      </div>
-      {canExpand ? (
-        <button
-          type="button"
-          className="cursor-pointer mt-1 text-[11px] font-medium text-foreground/70 underline-offset-2 hover:text-foreground hover:underline"
-          onClick={() => setExpanded((value) => !value)}
-        >
-          {expanded ? "Show less" : expandLabel}
-        </button>
-      ) : null}
-    </div>
-  );
 }
 
 function DiagnosticsTable({

--- a/apps/web/src/components/settings/ExpandableText.tsx
+++ b/apps/web/src/components/settings/ExpandableText.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Long error text clamped to a few lines with a toggle to reveal the rest.
+ * Short single-line text renders as-is without the toggle.
+ */
+export function ExpandableText({
+  text,
+  className,
+  collapsedClassName = "line-clamp-3",
+  expandLabel = "Show full error",
+}: {
+  text: string;
+  className?: string;
+  collapsedClassName?: string;
+  expandLabel?: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const canExpand = text.length > 180 || text.includes("\n");
+
+  return (
+    <div className={cn("min-w-0", className)}>
+      <div
+        className={cn(
+          "whitespace-pre-wrap break-words",
+          !expanded && canExpand ? collapsedClassName : null,
+        )}
+      >
+        {text}
+      </div>
+      {canExpand ? (
+        <button
+          type="button"
+          className="cursor-pointer mt-1 text-[11px] font-medium text-foreground/70 underline-offset-2 hover:text-foreground hover:underline"
+          onClick={() => setExpanded((value) => !value)}
+        >
+          {expanded ? "Show less" : expandLabel}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -543,9 +543,27 @@ export function ProviderInstanceCard({
     </span>
   );
 
-  const titleTailNode = headerAction ? (
-    <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">{headerAction}</span>
-  ) : null;
+  // The editor header always reserves this slot, whether it holds the reset
+  // button, the delete button, or nothing, so the version badge sits at the
+  // same offset in every editor.
+  const titleTailNode = (
+    <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">
+      {headerAction ??
+        (onDelete ? (
+          <Button
+            type="button"
+            size="icon-micro"
+            variant="ghost-muted"
+            disabled={readOnly}
+            className="[--control-icon-color:currentColor] hover:text-destructive"
+            onClick={onDelete}
+            aria-label={`Delete instance ${instanceId}`}
+          >
+            <Trash2Icon className="size-3" />
+          </Button>
+        ) : null)}
+    </span>
+  );
 
   const versionCodeNode = versionLabel ? (
     <code className="text-xs text-muted-foreground">{versionLabel}</code>
@@ -607,7 +625,11 @@ export function ProviderInstanceCard({
                   {instanceId}
                 </code>
               ) : null}
-              {versionCodeNode}
+              {versionLabel ? (
+                <code className="max-w-24 shrink-0 truncate text-xs text-muted-foreground">
+                  {versionLabel}
+                </code>
+              ) : null}
               {versionAdvisory ? (
                 <span role="img" aria-label="Update available" className="inline-flex shrink-0">
                   <ArrowUpCircleIcon className="size-3.5 text-muted-foreground" />
@@ -742,19 +764,6 @@ export function ProviderInstanceCard({
           </Popover>
         ) : null}
         {titleTailNode}
-        {onDelete ? (
-          <Button
-            type="button"
-            size="icon-micro"
-            variant="ghost-muted"
-            disabled={readOnly}
-            className="[--control-icon-color:currentColor] hover:text-destructive"
-            onClick={onDelete}
-            aria-label={`Delete instance ${instanceId}`}
-          >
-            <Trash2Icon className="size-3" />
-          </Button>
-        ) : null}
       </span>
     </div>
   );

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -543,27 +543,9 @@ export function ProviderInstanceCard({
     </span>
   );
 
-  // The editor header always reserves this slot, whether it holds the reset
-  // button, the delete button, or nothing, so the version badge sits at the
-  // same offset in every editor.
-  const titleTailNode = (
-    <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">
-      {headerAction ??
-        (onDelete ? (
-          <Button
-            type="button"
-            size="icon-micro"
-            variant="ghost-muted"
-            disabled={readOnly}
-            className="[--control-icon-color:currentColor] hover:text-destructive"
-            onClick={onDelete}
-            aria-label={`Delete instance ${instanceId}`}
-          >
-            <Trash2Icon className="size-3" />
-          </Button>
-        ) : null)}
-    </span>
-  );
+  const titleTailNode = headerAction ? (
+    <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">{headerAction}</span>
+  ) : null;
 
   const versionCodeNode = versionLabel ? (
     <code className="text-xs text-muted-foreground">{versionLabel}</code>
@@ -764,6 +746,19 @@ export function ProviderInstanceCard({
           </Popover>
         ) : null}
         {titleTailNode}
+        {onDelete ? (
+          <Button
+            type="button"
+            size="icon-micro"
+            variant="ghost-muted"
+            disabled={readOnly}
+            className="[--control-icon-color:currentColor] hover:text-destructive"
+            onClick={onDelete}
+            aria-label={`Delete instance ${instanceId}`}
+          >
+            <Trash2Icon className="size-3" />
+          </Button>
+        ) : null}
       </span>
     </div>
   );

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -168,8 +168,7 @@ function providerEnvironmentDetail(environment: EnvironmentPresentation): string
   return environment.displayUrl ?? "Remote device";
 }
 
-const providerCardClassName =
-  "overflow-hidden rounded-xl border border-border/60 bg-card/40 shadow-xs/5";
+const providerCardClassName = "rounded-xl border border-border/60 bg-card/40 shadow-xs/5";
 // Shared by the editor grid and the placeholder states so switching devices
 // never changes the card's footprint.
 const providerCardHeightClassName = "lg:h-[min(44rem,calc(100dvh-11rem))] lg:min-h-[32rem]";
@@ -194,7 +193,13 @@ function ProviderSettingsPlaceholder({
   return (
     <SettingsSection {...searchableSetting("providers")} variant="plain">
       {deviceTabs}
-      <div className={cn(providerCardClassName, providerCardHeightClassName, "flex")}>
+      <div
+        className={cn(
+          providerCardClassName,
+          providerCardHeightClassName,
+          "flex overflow-x-hidden overflow-y-auto",
+        )}
+      >
         <Empty className="min-h-88">
           <EmptyMedia variant="icon">{icon}</EmptyMedia>
           <EmptyHeader>
@@ -244,6 +249,7 @@ function EnvironmentUnavailablePlaceholder({
     >
       {error ? (
         <ExpandableText
+          key={environment.environmentId}
           text={error}
           className="w-full text-left font-mono text-xs leading-relaxed text-muted-foreground"
         />
@@ -1028,7 +1034,7 @@ export function EnvironmentProviderSettings({
       >
         {deviceTabs}
         {readOnly ? (
-          <div className={providerCardClassName}>
+          <div className={cn(providerCardClassName, "overflow-hidden")}>
             <SettingsRow
               title="Limited permissions"
               description={`This session can view ${environmentLabel}'s providers but can't change their settings.`}
@@ -1039,7 +1045,7 @@ export function EnvironmentProviderSettings({
           className={cn(
             providerCardClassName,
             providerCardHeightClassName,
-            "lg:grid lg:grid-cols-[17rem_minmax(0,1fr)]",
+            "overflow-hidden lg:grid lg:grid-cols-[17rem_minmax(0,1fr)]",
           )}
         >
           <div className="border-b border-border/60 bg-muted/10 lg:flex lg:min-h-0 lg:flex-col lg:border-r lg:border-b-0">

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -57,6 +57,14 @@ import {
 } from "../ProviderUpdateLaunchNotification.logic";
 import { Button } from "../ui/button";
 import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "../ui/empty";
+import {
   NumberField,
   NumberFieldDecrement,
   NumberFieldGroup,
@@ -160,7 +168,47 @@ function providerEnvironmentDetail(environment: EnvironmentPresentation): string
   return environment.displayUrl ?? "Remote device";
 }
 
-function EnvironmentUnavailableRow({
+const providerCardClassName =
+  "overflow-hidden rounded-xl border border-border/60 bg-card/40 shadow-xs/5";
+// Shared by the editor grid and the placeholder states so switching devices
+// never changes the card's footprint.
+const providerCardHeightClassName = "lg:h-[min(44rem,calc(100dvh-11rem))] lg:min-h-[32rem]";
+
+/**
+ * Same chrome as the provider editor (section heading, floating device tabs,
+ * tall card) for states that cannot render provider settings yet.
+ */
+function ProviderSettingsPlaceholder({
+  deviceTabs,
+  icon,
+  title,
+  description,
+  children,
+}: {
+  readonly deviceTabs?: ReactNode;
+  readonly icon: ReactNode;
+  readonly title: string;
+  readonly description: string;
+  readonly children?: ReactNode;
+}) {
+  return (
+    <SettingsSection {...searchableSetting("providers")} variant="plain">
+      {deviceTabs}
+      <div className={cn(providerCardClassName, providerCardHeightClassName, "flex")}>
+        <Empty className="min-h-88">
+          <EmptyMedia variant="icon">{icon}</EmptyMedia>
+          <EmptyHeader>
+            <EmptyTitle>{title}</EmptyTitle>
+            <EmptyDescription>{description}</EmptyDescription>
+          </EmptyHeader>
+          {children ? <EmptyContent className="max-w-xl">{children}</EmptyContent> : null}
+        </Empty>
+      </div>
+    </SettingsSection>
+  );
+}
+
+function EnvironmentUnavailablePlaceholder({
   environment,
   access,
   deviceTabs,
@@ -186,17 +234,21 @@ function EnvironmentUnavailableRow({
   // No spinner: this state can persist indefinitely for a wedged device, and a
   // continuously repainting animation would run the whole time.
   return (
-    <SettingsSection {...searchableSetting("providers")}>
-      {deviceTabs}
-      <SettingsRow title={title} description={description}>
-        {error ? (
-          <ExpandableText
-            text={error}
-            className="mb-2 max-w-xl font-mono text-xs leading-relaxed text-muted-foreground"
-          />
-        ) : null}
-      </SettingsRow>
-    </SettingsSection>
+    <ProviderSettingsPlaceholder
+      deviceTabs={deviceTabs}
+      icon={
+        <EnvironmentMachineIcon kind={resolveEnvironmentMachineKind(environment.serverConfig)} />
+      }
+      title={title}
+      description={description}
+    >
+      {error ? (
+        <ExpandableText
+          text={error}
+          className="w-full text-left font-mono text-xs leading-relaxed text-muted-foreground"
+        />
+      ) : null}
+    </ProviderSettingsPlaceholder>
   );
 }
 
@@ -313,25 +365,23 @@ function ProviderSettingsPanelContent(target: ProviderSettingsTarget) {
   return (
     <>
       {targetEnvironmentMissing ? (
-        <SettingsSection {...searchableSetting("providers")}>
-          {deviceTabs}
-          <SettingsRow
-            title="Device unavailable"
-            description="Reconnect this device to set up its provider, or select another device."
-          />
-        </SettingsSection>
+        <ProviderSettingsPlaceholder
+          deviceTabs={deviceTabs}
+          icon={<EnvironmentMachineIcon kind={resolveEnvironmentMachineKind(null)} />}
+          title="Device unavailable"
+          description="Reconnect this device to set up its provider, or select another device."
+        />
       ) : null}
       {options.length === 0 && !targetEnvironmentMissing ? (
-        <SettingsSection {...searchableSetting("providers")}>
-          <SettingsRow
-            title={isReady ? "No connected devices" : "Loading devices"}
-            description={
-              isReady
-                ? "Connect an execution environment before configuring providers."
-                : "Reading connected execution environments."
-            }
-          />
-        </SettingsSection>
+        <ProviderSettingsPlaceholder
+          icon={<EnvironmentMachineIcon kind={resolveEnvironmentMachineKind(null)} />}
+          title={isReady ? "No connected devices" : "Loading devices"}
+          description={
+            isReady
+              ? "Connect an execution environment before configuring providers."
+              : "Reading connected execution environments."
+          }
+        />
       ) : null}
 
       {selectedEnvironment ? (
@@ -461,7 +511,7 @@ function AccessGatedProviderSettings({
   });
   if (access.kind !== "editable" && access.kind !== "read-only") {
     return (
-      <EnvironmentUnavailableRow
+      <EnvironmentUnavailablePlaceholder
         environment={environment}
         access={access}
         deviceTabs={deviceTabs}
@@ -978,14 +1028,20 @@ export function EnvironmentProviderSettings({
       >
         {deviceTabs}
         {readOnly ? (
-          <div className="overflow-hidden rounded-xl border border-border/60 bg-card/40 shadow-xs/5">
+          <div className={providerCardClassName}>
             <SettingsRow
               title="Limited permissions"
               description={`This session can view ${environmentLabel}'s providers but can't change their settings.`}
             />
           </div>
         ) : null}
-        <div className="overflow-hidden rounded-xl border border-border/60 bg-card/40 shadow-xs/5 lg:grid lg:h-[min(44rem,calc(100dvh-11rem))] lg:min-h-[32rem] lg:grid-cols-[17rem_minmax(0,1fr)]">
+        <div
+          className={cn(
+            providerCardClassName,
+            providerCardHeightClassName,
+            "lg:grid lg:grid-cols-[17rem_minmax(0,1fr)]",
+          )}
+        >
           <div className="border-b border-border/60 bg-muted/10 lg:flex lg:min-h-0 lg:flex-col lg:border-r lg:border-b-0">
             <ScrollArea scrollFade chainVerticalScroll className="lg:min-h-0 lg:flex-1">
               <div className="divide-y divide-border/50">

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue } from "@effect/atom-react";
-import { connectionStatusText } from "@t3tools/client-runtime/connection";
+import { connectionStatusTitle } from "@t3tools/client-runtime/connection";
 import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
 import {
   isAtomCommandInterrupted,
@@ -67,6 +67,7 @@ import { ScrollArea } from "../ui/scroll-area";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import { AddProviderInstanceDialog } from "./AddProviderInstanceDialog";
+import { ExpandableText } from "./ExpandableText";
 import { ProviderInstanceCard } from "./ProviderInstanceCard";
 import { UsageProviderSettings } from "./UsageProviderSettings";
 import { ProviderSetupSection, readAntigravityAuthMethod } from "./ProviderSetupSection";
@@ -174,17 +175,27 @@ function EnvironmentUnavailableRow({
     : access.kind === "error"
       ? "Could not connect to this device"
       : "Provider settings are unavailable";
+  // Keep the description to a short status; the raw failure can be a
+  // multi-paragraph CLI dump, so it goes below, clamped and expandable.
   const description = isLoading
     ? access.reason === "permissions"
       ? "Checking what this session is allowed to change."
       : `Waiting for ${environment.label}'s configuration.`
-    : connectionStatusText(environment.connection);
+    : connectionStatusTitle(environment.connection);
+  const error = isLoading ? null : environment.connection.error;
   // No spinner: this state can persist indefinitely for a wedged device, and a
   // continuously repainting animation would run the whole time.
   return (
     <SettingsSection {...searchableSetting("providers")}>
       {deviceTabs}
-      <SettingsRow title={title} description={description} />
+      <SettingsRow title={title} description={description}>
+        {error ? (
+          <ExpandableText
+            text={error}
+            className="mb-2 max-w-xl font-mono text-xs leading-relaxed text-muted-foreground"
+          />
+        ) : null}
+      </SettingsRow>
     </SettingsSection>
   );
 }
@@ -260,7 +271,7 @@ function ProviderSettingsPanelContent(target: ProviderSettingsTarget) {
             const machine = resolveEnvironmentMachineKind(environment.serverConfig);
             const selected = environment.environmentId === effectiveEnvironmentId;
             const detail = providerEnvironmentDetail(environment);
-            const statusText = connectionStatusText(environment.connection);
+            const statusText = connectionStatusTitle(environment.connection);
             return (
               <Tooltip key={environment.environmentId}>
                 <TooltipTrigger


### PR DESCRIPTION
> [!NOTE]
> 🤖 **Fable 5.1 on behalf of Oliver**

## Problem

Selecting a disconnected environment in Settings → Providers looks nothing like the connected view. The tabs get wrapped inside a short grouped card, the raw connection failure is dumped in full as the row description (a multi-paragraph npm log for a failed SSH install), and the same wall of text repeats in the device tab tooltip.

Two smaller alignment issues in the same screen: the editor header's version badge shifts right or left depending on whether a reset or delete button is present, and a long version label such as `2026-08-18 RC01` wraps in the list row and squeezes the provider name down to `Antigra...`.

## Fix

- All "can't render settings" states (disconnected, loading, device missing, no devices) now share one placeholder that uses the same plain section, floating device tabs, and full-height card as the editor, with a centered empty state.
- The placeholder shows the short connection status and moves the raw reason into a clamped monospace block with a "Show full error" toggle. The tab tooltip and screen-reader label use the short status too. The expandable text helper moved out of Diagnostics settings so both panels share it.
- The editor header always reserves its trailing slot, holding the reset button, the delete button, or nothing, so the version badge sits at a fixed offset.
- List rows truncate long version labels instead of wrapping them.

## UI changes

### Before


<img width="1440" height="1080" alt="before" src="https://github.com/user-attachments/assets/f1d65268-4213-47a5-864d-5067e8bf5918" />
<img width="299" height="115" alt="SCR-20260904-idvs" src="https://github.com/user-attachments/assets/8f092715-cc18-447b-93ae-7dce59165136" />

https://github.com/user-attachments/assets/28d1019a-f7eb-4af4-8ce2-1fb8f91e6984


### After

<img width="1043" height="845" alt="image" src="https://github.com/user-attachments/assets/2696038f-4a96-4284-bf25-1836f4a80ce8" />
<img width="304" height="95" alt="SCR-20260904-iduk" src="https://github.com/user-attachments/assets/ceae7af2-acfd-4f34-bdab-733e277c12b3" />

## Verification

- `vp test run` on the provider panel and instance card tests (11 passed)
- `tsc --noEmit` for apps/web, `vp lint` and `vp format` on the touched files
- Reproduced in a dev client by pairing a second local server, then stopping it; confirmed the placeholder card height matches the editor grid

Written by Fable 5.1 (Claude) via Claude Code, running inside T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Match provider settings layout for disconnected devices using shared placeholder card
> - Extracts `ExpandableText` from `DiagnosticsSettings` into a shared component that collapses text over 180 chars or with newlines
> - Adds `ProviderSettingsPlaceholder` with icon-based empty state and fixed-height card chrome; reuses it for unavailable, missing-target, and no-connected-device states across `ProviderSettingsPanel`, `AccessGatedProviderSettings`, and `EnvironmentUnavailablePlaceholder`
> - Device tabs and unavailable states now show `connectionStatusTitle` instead of raw status text; connection errors render as expandable monospace text inside the placeholder card
> - `ProviderInstanceCard` renders non-empty `versionLabel` directly with truncation and max width; empty labels produce no version element
> - `EnvironmentProviderSettings` wraps the provider list/editor in a shared bordered card with responsive height and a two-column grid on large screens
> - Risk: `EnvironmentUnavailablePlaceholder` replaces `EnvironmentUnavailableRow` — any out-of-tree references to the old component name will break
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b9e34c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->