### PR TITLE
fix(web): mute sidebar branch name to match worktree icon

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1608,7 +1608,9 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
               {thread.branch ? (
                 <>
                   <ThreadWorktreeIndicator thread={thread} />
-                  <span className="min-w-0 flex-1 truncate whitespace-nowrap">{thread.branch}</span>
+                  <span className="min-w-0 flex-1 truncate whitespace-nowrap text-muted-foreground/40">
+                    {thread.branch}
+                  </span>
                 </>
               ) : (
                 <span className="flex-1" />


### PR DESCRIPTION
The sidebar branch name rendered in text-secondary-label, noticeably brighter than the worktree folder icon next to it. It now uses text-muted-foreground/40, the exact class on the icon, so the row reads as deprioritized metadata.

Verified in a local dev server against real data: computed color of the branch span matches the icon color, with before/after dark-mode screenshots below.

Built with Muse Spark on behalf of Maria.

![](https://uploads-production-47e4.up.railway.app/files/ec2acc60-ad02-4924-a7a7-221403337fcf/before-clip.png)
![](https://uploads-production-47e4.up.railway.app/files/7ad4e7f9-4bc2-4c61-a7f3-142e5de7af10/after-clip2.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on sidebar thread row text; no logic, data, or API impact.
> 
> **Overview**
> **Sidebar card rows:** the git branch label on the metadata row is styled as deprioritized metadata so it matches the adjacent worktree folder icon.
> 
> The branch name span now uses `text-muted-foreground/40` instead of inheriting the parent row’s `text-secondary-label`, which had made the text noticeably brighter than `ThreadWorktreeIndicator`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7240909f322b860c9ef414de095290f420cd7ce9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mute sidebar branch name label in `SidebarThreadRow`
> Changes the branch label span in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/9622/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) to use `text-muted-foreground/40`, matching the muted appearance of the adjacent worktree icon. Layout, flex, truncation, and whitespace behavior remain unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7240909.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->