### PR TITLE
fix(web,mobile): fold context compaction under settled turn folds

### DIFF
--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -1375,9 +1375,6 @@ function deriveThreadFeedTurnFolds(
       pendingUserBoundary = entry.message.createdAt;
       continue;
     }
-    if (entry.type === "activity-group" && isContextCompactionActivityGroup(entry)) {
-      continue;
-    }
     const turnId =
       entry.type === "message" && entry.message.role === "assistant"
         ? entry.message.turnId
@@ -1421,6 +1418,16 @@ function deriveThreadFeedTurnFolds(
         .map((entry) => entry.id),
     );
     if (hiddenEntryIds.size === 0) {
+      continue;
+    }
+    // A lone compaction row stays visible on its own; it only folds away as
+    // part of a turn that already folds other work.
+    const hidesNonCompactionWork = entries.some(
+      (entry) =>
+        hiddenEntryIds.has(entry.id) &&
+        !(entry.type === "activity-group" && isContextCompactionActivityGroup(entry)),
+    );
+    if (!hidesNonCompactionWork) {
       continue;
     }
 

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -619,22 +619,30 @@ function deriveTurnFolds(input: {
       if (entry.id === group.terminalEntry?.id) {
         continue;
       }
-      if (index > terminalEntryIndex) {
+      const isCompaction =
+        entry.kind === "work" && entry.entry.sourceActivityKind === "context-compaction";
+      if (!isCompaction && index > terminalEntryIndex) {
         continue;
       }
       // Agent-spawn CTA rows never fold: workflows outlive their launching
       // turn (dynamic spawns, background execution), and folding the CTA
       // when the turn settles makes a still-running fleet invisible.
-      if (
-        entry.kind === "work" &&
-        (entry.entry.agentSpawn !== undefined ||
-          entry.entry.sourceActivityKind === "context-compaction")
-      ) {
+      if (entry.kind === "work" && entry.entry.agentSpawn !== undefined) {
         continue;
       }
       hiddenEntryIds.add(entry.id);
     }
     if (hiddenEntryIds.size === 0) {
+      continue;
+    }
+    // A lone compaction row stays visible on its own; it only folds away as
+    // part of a turn that already folds other work.
+    const hidesNonCompactionWork = group.entries.some(
+      (entry) =>
+        hiddenEntryIds.has(entry.id) &&
+        !(entry.kind === "work" && entry.entry.sourceActivityKind === "context-compaction"),
+    );
+    if (!hidesNonCompactionWork) {
       continue;
     }
 


### PR DESCRIPTION
> [!NOTE]
> Written by `muse-spark-1.3-contributor-free` on behalf of Maria

A settled "Worked for ..." fold left its "Compacted context ..." row visible underneath. Compaction rows now fold with the rest of their turn on web and mobile, and reappear when the fold is expanded. A lone compaction with no other folded work stays visible as before.

Verified with the timeline unit suites on both clients plus typecheck, and with before/after renders of the real timeline component on the same fixture.

Before — compaction leaks out below the collapsed fold:

![before: compacted context row visible below collapsed worked-for fold](https://uploads-production-47e4.up.railway.app/files/521d6538-c37f-4e14-8730-9220cda14d2a/fold-before.png)

After — the fold hides the compaction row:

![after: collapsed worked-for fold with compaction hidden](https://uploads-production-47e4.up.railway.app/files/5e32825a-0253-4337-9a7b-ac833d72257e/fold-after.png)

Made with opencode/muse-spark-1.3-contributor-free.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only timeline folding logic in shared patterns on web and mobile; no auth, data, or API changes.
> 
> **Overview**
> Fixes **“Compacted context …”** rows staying visible below a collapsed **“Worked for …”** turn fold on web and mobile.
> 
> **Context compaction** is no longer exempt from turn-fold hiding (mobile stops skipping compaction groups when building turn groups; web stops treating compaction like agent-spawn rows that never fold). Compaction entries can be included in `hiddenEntryIds` and collapse with the rest of the turn when the fold is collapsed, and show again when expanded.
> 
> A turn fold is only created when it would hide **non-compaction** work (`hidesNonCompactionWork`). If the only hidden entries would be compaction, **no fold is emitted** so a lone compaction row stays visible, matching prior behavior for compaction-only turns.
> 
> On web, post-terminal folding rules still skip trailing work after the terminal assistant message, except compaction rows, which may still fold with the turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14fd2133367aea86c98643ff7f0a81a8dade67a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fold context-compaction entries under settled turn folds in web and mobile
> - Removes the early exclusion of context-compaction activity from turn fold calculations in `deriveThreadFeedTurnFolds` (mobile) and `deriveTurnFolds` (web), so compaction rows can fold alongside other hidden work in the same turn
> - Adds a post-filter guard in both derivations: a fold is suppressed when every hidden entry is context-compaction only, keeping that compaction row visible
> - Agent-spawn work entries remain excluded from folds on web
> - Behavioral Change: a context-compaction row after a terminal assistant message can now be folded with other work in the same turn; a turn whose only hidden candidate is compaction produces no fold and leaves the row visible
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14fd213.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->