### PR TITLE
fix(web): keep the slash menu above the composer when vertical space is short

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -758,7 +758,7 @@ function ComposerCommandMenuLayer(props: { anchor: HTMLElement | null; children:
 
   return createPortal(
     <div
-      className="pointer-events-auto fixed z-40"
+      className="pointer-events-auto fixed z-40 flex flex-col"
       data-composer-drawer-layer="true"
       style={{
         bottom: position.bottom,

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -91,11 +91,11 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu(props: {
     >
       <ComposerBanner.Surface
         ref={listRef}
-        className="w-full overflow-hidden pb-(--chat-composer-attachment-overlap) **:data-[slot=scroll-area-scrollbar]:data-[orientation=vertical]:my-4"
+        className="flex min-h-0 w-full flex-col overflow-hidden pb-(--chat-composer-attachment-overlap) **:data-[slot=scroll-area-scrollbar]:data-[orientation=vertical]:my-4"
         data-composer-command-drawer="true"
       >
         {props.items.length > 0 ? (
-          <CommandList className="max-h-72 scroll-pb-6">
+          <CommandList className="max-h-72 min-h-0 scroll-pb-6">
             <CommandGroup>
               {props.items.map((item) => (
                 <ComposerCommandMenuItem


### PR DESCRIPTION
The composer's command menu layer is bottom-anchored with a `maxHeight` derived from the space above the composer, but nothing made the content respect that cap: the list carries its own fixed max height, so when the bottom terminal pane pushes the composer high enough, the menu's content exceeds the layer and the excess sticks out below the anchor line into the prompt box. That is the clipped bottom edge in the report, and it shows with `/` and one or two letters because those are the queries whose lists are still tall enough to overflow.

The layer is now a flex column and the menu surface and list shrink with it (`min-h-0` chain), so a short viewport scrolls the list inside the drawer instead of overflowing the composer. The `$` skill and `@` file menus render through the same layer and get the same behavior.

### Before
<img width="2000" height="1360" alt="image" src="https://github.com/user-attachments/assets/648ff00b-b5e6-469a-b65a-f9d21fb4b949" />

### After
<img width="2000" height="1360" alt="image" src="https://github.com/user-attachments/assets/6dc4bc6f-05bb-408a-8b50-a51a080232b1" />


Fixes #9556.

Implemented with Claude Code (Claude Fable 5).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout changes in the composer command menu portal; no logic or API changes.
> 
> **Overview**
> When the terminal pane leaves little room above the composer, the **slash / @ / $ command drawer** could still grow past its bottom-anchored `maxHeight` and clip into the prompt because the list kept a fixed `max-h-72` without shrinking with the portal layer.
> 
> The fix threads a **flex column + `min-h-0`** through `ComposerCommandMenuLayer`, the command menu surface, and `CommandList`, so the drawer respects the computed height and **scrolls inside the menu** instead of overflowing the composer. Stash and other menus that use the same layer get the same behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 853bbe921569486b66722bb86c166fb7cc6254de. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix slash command menu positioning when vertical space is short
> Adds vertical flex layout to the `ComposerCommandMenuLayer` portal wrapper and sets zero minimum height on the `ComposerCommandMenu` banner and command list. This lets the menu shrink below its content-based minimum height in constrained layouts while keeping existing max-height and scroll behavior.
> - Risk: none identified — positioning, portal placement, and event cleanup are unchanged
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68576eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->