### PR TITLE
fix(antigravity): clean Windows runtime temp files

### DIFF
--- a/apps/server/src/provider/AntigravityInstallation.ts
+++ b/apps/server/src/provider/AntigravityInstallation.ts
@@ -485,6 +485,9 @@ export const makeAntigravityInstallation = Effect.fn("AntigravityInstallation.ma
           }),
           cwd: profileDirectory,
           childProcessSpawner: spawner,
+          fileSystem: fs,
+          path,
+          platform,
           clientInfo: { name: "t3-code", version: "0.0.0" },
         });
         const initialized = yield* runtime.initialize();

--- a/apps/server/src/provider/Drivers/AntigravityDriver.ts
+++ b/apps/server/src/provider/Drivers/AntigravityDriver.ts
@@ -117,7 +117,10 @@ export const AntigravityDriver: ProviderDriver<AntigravitySettings, AntigravityD
         );
 
       const makeRuntime = Effect.fn("AntigravityDriver.makeRuntime")(function* (
-        input: Omit<AntigravityAcpRuntimeInput, "spawn" | "childProcessSpawner">,
+        input: Omit<
+          AntigravityAcpRuntimeInput,
+          "spawn" | "childProcessSpawner" | "fileSystem" | "path" | "platform"
+        >,
       ): Effect.fn.Return<
         AcpSessionRuntime["Service"],
         AcpError | ProviderSetupError,
@@ -155,6 +158,9 @@ export const AntigravityDriver: ProviderDriver<AntigravitySettings, AntigravityD
           ...input,
           authMethod: auth.authMethod,
           childProcessSpawner: spawner,
+          fileSystem,
+          path,
+          platform: profile.platform,
           spawn: buildAntigravityAcpSpawnInput({
             installation: executable,
             profile,

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -1,5 +1,6 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { expect, it } from "@effect/vitest";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import {
   AntigravitySettings,
   ApprovalRequestId,
@@ -309,6 +310,7 @@ it.layer(layer)("AntigravityAdapter", (it) => {
         const fileSystem = yield* FileSystem.FileSystem;
         const path = yield* Path.Path;
         const crypto = yield* Crypto.Crypto;
+        const platform = yield* HostProcessPlatform;
         const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
         const cwd = yield* fileSystem.makeTempDirectoryScoped({
           prefix: "t3-antigravity-transport-",
@@ -328,6 +330,9 @@ it.layer(layer)("AntigravityAdapter", (it) => {
             makeAntigravityAcpRuntime({
               ...input,
               childProcessSpawner,
+              fileSystem,
+              path,
+              platform,
               spawn: {
                 command: process.execPath,
                 args: [mockAgentPath],

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -126,7 +126,10 @@ function mapAntigravityError(threadId: ThreadId, method: string, cause: EffectAc
 export interface AntigravityAdapterOptions {
   readonly instanceId: ProviderInstanceId;
   readonly makeRuntime: (
-    input: Omit<AntigravityAcpRuntimeInput, "spawn" | "childProcessSpawner" | "onAuthorizationUrl">,
+    input: Omit<
+      AntigravityAcpRuntimeInput,
+      "spawn" | "childProcessSpawner" | "fileSystem" | "onAuthorizationUrl" | "path" | "platform"
+    >,
   ) => Effect.Effect<Runtime, EffectAcpErrors.AcpError | ProviderSetupError, Scope.Scope>;
   readonly withProcess: AntigravityAuth["withProcess"];
   readonly onSessionStarted?: (

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.test.ts
@@ -26,8 +26,12 @@ import {
   makeAntigravityAcpRuntime,
 } from "./AntigravityAcpSupport.ts";
 
+const runtimeTempDirectoryMarkerName = ".t3-antigravity-runtime-owner";
+const runtimeTempDirectoryMarkerContents = (directory: string, ownerProcessId: number) =>
+  `${JSON.stringify({ schemaVersion: 1, ownerProcessId, directory })}\n`;
+
 it.layer(NodeServices.layer)("makeAntigravityAcpRuntime", (it) => {
-  it.effect("reclaims an orphan and removes the current extraction when interrupted", () =>
+  it.effect("reclaims only owned orphans and removes the current extraction when interrupted", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -40,12 +44,37 @@ it.layer(NodeServices.layer)("makeAntigravityAcpRuntime", (it) => {
       yield* Effect.addFinalizer(() =>
         fileSystem.remove(orphan, { recursive: true, force: true }).pipe(Effect.ignore),
       );
+      yield* fileSystem.writeFileString(
+        path.join(orphan, runtimeTempDirectoryMarkerName),
+        runtimeTempDirectoryMarkerContents(path.basename(orphan), 2147483647),
+      );
       yield* fileSystem.makeDirectory(path.join(orphan, "_MEIorphan"));
+      const unowned = yield* fileSystem.makeTempDirectory({
+        prefix: "t3-antigravity-runtime-2147483647-",
+      });
+      yield* Effect.addFinalizer(() =>
+        fileSystem.remove(unowned, { recursive: true, force: true }).pipe(Effect.ignore),
+      );
+      yield* fileSystem.writeFileString(path.join(unowned, "keep"), "unowned");
+      const mismatched = yield* fileSystem.makeTempDirectory({
+        prefix: "t3-antigravity-runtime-2147483647-",
+      });
+      yield* Effect.addFinalizer(() =>
+        fileSystem.remove(mismatched, { recursive: true, force: true }).pipe(Effect.ignore),
+      );
+      yield* fileSystem.writeFileString(
+        path.join(mismatched, runtimeTempDirectoryMarkerName),
+        runtimeTempDirectoryMarkerContents(path.basename(mismatched), 2147483646),
+      );
       const active = yield* fileSystem.makeTempDirectory({
         prefix: `t3-antigravity-runtime-${process.pid}-`,
       });
       yield* Effect.addFinalizer(() =>
         fileSystem.remove(active, { recursive: true, force: true }).pipe(Effect.ignore),
+      );
+      yield* fileSystem.writeFileString(
+        path.join(active, runtimeTempDirectoryMarkerName),
+        runtimeTempDirectoryMarkerContents(path.basename(active), process.pid),
       );
       yield* fileSystem.makeDirectory(path.join(active, "_MEIactive"));
       let runtimeTempDirectory: string | undefined;
@@ -103,10 +132,20 @@ it.layer(NodeServices.layer)("makeAntigravityAcpRuntime", (it) => {
       const fiber = yield* runtime.pipe(Effect.forkChild);
       yield* Deferred.await(runtimeReady);
       expect(yield* fileSystem.exists(orphan)).toBe(false);
+      expect(yield* fileSystem.exists(unowned)).toBe(true);
+      expect(yield* fileSystem.exists(mismatched)).toBe(true);
       expect(yield* fileSystem.exists(active)).toBe(true);
+      if (!runtimeTempDirectory) {
+        return yield* Effect.die("Runtime process was not observed.");
+      }
+      expect(
+        yield* fileSystem.readFileString(
+          path.join(runtimeTempDirectory, runtimeTempDirectoryMarkerName),
+        ),
+      ).toBe(runtimeTempDirectoryMarkerContents(path.basename(runtimeTempDirectory), process.pid));
       yield* Fiber.interrupt(fiber);
 
-      if (!runtimeTempDirectory || !child) {
+      if (!child) {
         return yield* Effect.die("Runtime process was not observed.");
       }
       expect(path.basename(runtimeTempDirectory)).toMatch(/^t3-antigravity-runtime-/u);

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.test.ts
@@ -77,6 +77,19 @@ it.layer(NodeServices.layer)("makeAntigravityAcpRuntime", (it) => {
         runtimeTempDirectoryMarkerContents(path.basename(active), process.pid),
       );
       yield* fileSystem.makeDirectory(path.join(active, "_MEIactive"));
+      const runtimeFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        makeTempDirectory: (options) =>
+          fileSystem
+            .exists(orphan)
+            .pipe(
+              Effect.flatMap((exists) =>
+                exists
+                  ? Effect.die("Owned orphans must be reclaimed before temp allocation.")
+                  : fileSystem.makeTempDirectory(options),
+              ),
+            ),
+      });
       let runtimeTempDirectory: string | undefined;
       let child: ChildProcessSpawner.ChildProcessHandle | undefined;
       const observedSpawner = ChildProcessSpawner.make((command) =>
@@ -107,7 +120,7 @@ it.layer(NodeServices.layer)("makeAntigravityAcpRuntime", (it) => {
         Effect.gen(function* () {
           yield* makeAntigravityAcpRuntime({
             childProcessSpawner: observedSpawner,
-            fileSystem,
+            fileSystem: runtimeFileSystem,
             path,
             platform: "win32",
             spawn: {

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.test.ts
@@ -7,9 +7,13 @@ import {
   type ChatAttachment,
   type RuntimeMode,
 } from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Fiber from "effect/Fiber";
 import * as Path from "effect/Path";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
@@ -19,7 +23,98 @@ import {
   antigravityPermissionMode,
   applyAntigravityAcpModelSelection,
   buildAntigravityPrompt,
+  makeAntigravityAcpRuntime,
 } from "./AntigravityAcpSupport.ts";
+
+it.layer(NodeServices.layer)("makeAntigravityAcpRuntime", (it) => {
+  it.effect("reclaims an orphan and removes the current extraction when interrupted", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const crypto = yield* Crypto.Crypto;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const runtimeReady = yield* Deferred.make<void>();
+      const orphan = yield* fileSystem.makeTempDirectory({
+        prefix: "t3-antigravity-runtime-2147483647-",
+      });
+      yield* Effect.addFinalizer(() =>
+        fileSystem.remove(orphan, { recursive: true, force: true }).pipe(Effect.ignore),
+      );
+      yield* fileSystem.makeDirectory(path.join(orphan, "_MEIorphan"));
+      const active = yield* fileSystem.makeTempDirectory({
+        prefix: `t3-antigravity-runtime-${process.pid}-`,
+      });
+      yield* Effect.addFinalizer(() =>
+        fileSystem.remove(active, { recursive: true, force: true }).pipe(Effect.ignore),
+      );
+      yield* fileSystem.makeDirectory(path.join(active, "_MEIactive"));
+      let runtimeTempDirectory: string | undefined;
+      let child: ChildProcessSpawner.ChildProcessHandle | undefined;
+      const observedSpawner = ChildProcessSpawner.make((command) =>
+        Effect.gen(function* () {
+          if (command._tag !== "StandardCommand") {
+            return yield* Effect.die("Unexpected process pipeline.");
+          }
+          const environment = command.options.env ?? {};
+          runtimeTempDirectory = environment.TEMP;
+          if (!runtimeTempDirectory) {
+            return yield* Effect.die("Missing isolated runtime temp directory.");
+          }
+          expect(environment.TMP).toBe(runtimeTempDirectory);
+          expect(environment.CUSTOM_SETTING).toBe("kept");
+          expect(
+            Object.keys(environment)
+              .filter((key) => key.toUpperCase() === "TEMP" || key.toUpperCase() === "TMP")
+              .sort(),
+          ).toEqual(["TEMP", "TMP"]);
+          const extraction = path.join(runtimeTempDirectory, "_MEIfixture");
+          yield* fileSystem.makeDirectory(extraction);
+          yield* fileSystem.writeFileString(path.join(extraction, "payload"), "fixture");
+          child = yield* spawner.spawn(command);
+          return child;
+        }),
+      );
+      const runtime = Effect.scoped(
+        Effect.gen(function* () {
+          yield* makeAntigravityAcpRuntime({
+            childProcessSpawner: observedSpawner,
+            fileSystem,
+            path,
+            platform: "win32",
+            spawn: {
+              command: process.execPath,
+              args: ["-e", "setInterval(() => {}, 1000)"],
+              cwd: process.cwd(),
+              env: {
+                ...process.env,
+                temp: "ambient-lowercase-temp",
+                TMP: "ambient-uppercase-tmp",
+                CUSTOM_SETTING: "kept",
+              },
+              extendEnv: false,
+            },
+            cwd: process.cwd(),
+            clientInfo: { name: "t3-code-test", version: "0.0.0" },
+          }).pipe(Effect.provideService(Crypto.Crypto, crypto));
+          yield* Deferred.succeed(runtimeReady, undefined);
+          return yield* Effect.never;
+        }),
+      );
+      const fiber = yield* runtime.pipe(Effect.forkChild);
+      yield* Deferred.await(runtimeReady);
+      expect(yield* fileSystem.exists(orphan)).toBe(false);
+      expect(yield* fileSystem.exists(active)).toBe(true);
+      yield* Fiber.interrupt(fiber);
+
+      if (!runtimeTempDirectory || !child) {
+        return yield* Effect.die("Runtime process was not observed.");
+      }
+      expect(path.basename(runtimeTempDirectory)).toMatch(/^t3-antigravity-runtime-/u);
+      expect(yield* fileSystem.exists(runtimeTempDirectory)).toBe(false);
+      expect(yield* child.isRunning).toBe(false);
+    }),
+  );
+});
 
 const modelConfig = {
   id: "model",

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.test.ts
@@ -13,6 +13,8 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Fiber from "effect/Fiber";
 import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
+import * as TestClock from "effect/testing/TestClock";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
@@ -31,6 +33,85 @@ const runtimeTempDirectoryMarkerContents = (directory: string, ownerProcessId: n
   `${JSON.stringify({ schemaVersion: 1, ownerProcessId, directory })}\n`;
 
 it.layer(NodeServices.layer)("makeAntigravityAcpRuntime", (it) => {
+  it.effect(
+    "preserves ownership after exhausted cleanup retries so a later sweep can recover",
+    () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const crypto = yield* Crypto.Crypto;
+        const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+        const orphan = yield* Effect.acquireRelease(
+          fileSystem.makeTempDirectory({ prefix: "t3-antigravity-runtime-2147483647-" }),
+          (directory) =>
+            fileSystem.remove(directory, { recursive: true, force: true }).pipe(Effect.orDie),
+        );
+        const marker = path.join(orphan, runtimeTempDirectoryMarkerName);
+        const markerContents = runtimeTempDirectoryMarkerContents(
+          path.basename(orphan),
+          2147483647,
+        );
+        yield* fileSystem.writeFileString(marker, markerContents);
+        const payload = path.join(orphan, "_MEIlocked");
+        yield* fileSystem.makeDirectory(payload);
+        yield* fileSystem.writeFileString(path.join(payload, "payload"), "locked fixture");
+        const attempts = yield* Effect.forEach([0, 1, 2, 3, 4, 5], () => Deferred.make<void>());
+        const lockedError = PlatformError.systemError({
+          _tag: "PermissionDenied",
+          module: "FileSystem",
+          method: "remove",
+          description: "EPERM: extraction is in use",
+        });
+        let locked = true;
+        let failures = 0;
+        const runtimeFileSystem = FileSystem.FileSystem.of({
+          ...fileSystem,
+          readDirectory: (directory) =>
+            directory === path.dirname(orphan)
+              ? Effect.succeed([path.basename(orphan)])
+              : fileSystem.readDirectory(directory),
+          remove: (directory, options) =>
+            Effect.gen(function* () {
+              if (locked && (directory === orphan || directory === payload)) {
+                // Whole-directory removal can unlink the marker before a locked sibling fails.
+                if (directory === orphan && options?.recursive) {
+                  yield* fileSystem.remove(marker, { force: true });
+                }
+                yield* Deferred.succeed(attempts[failures++]!, undefined);
+                return yield* lockedError;
+              }
+              return yield* fileSystem.remove(directory, options);
+            }),
+          // Stop after the sweep, before allocating or launching an unrelated runtime.
+          makeTempDirectory: () => Effect.fail(lockedError),
+        });
+        const sweep = makeAntigravityAcpRuntime({
+          childProcessSpawner,
+          fileSystem: runtimeFileSystem,
+          path,
+          platform: "win32",
+          spawn: { command: process.execPath, args: [], cwd: process.cwd() },
+          cwd: process.cwd(),
+          clientInfo: { name: "t3-code-test", version: "0.0.0" },
+        }).pipe(Effect.provideService(Crypto.Crypto, crypto), Effect.scoped, Effect.exit);
+        const firstSweep = yield* sweep.pipe(Effect.forkChild);
+        for (const [index, attempt] of attempts.entries()) {
+          yield* Deferred.await(attempt);
+          if (index < attempts.length - 1) {
+            yield* TestClock.adjust(`${100 * 2 ** index} millis`);
+          }
+        }
+        yield* Fiber.join(firstSweep);
+        expect(failures).toBe(6);
+        expect(yield* fileSystem.exists(payload)).toBe(true);
+        expect(yield* fileSystem.readFileString(marker)).toBe(markerContents);
+
+        locked = false;
+        yield* sweep;
+        expect(yield* fileSystem.exists(orphan)).toBe(false);
+      }),
+  );
+
   it.effect("reclaims only owned orphans and removes the current extraction when interrupted", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.ts
@@ -1,3 +1,5 @@
+import * as NodeOS from "node:os";
+
 import {
   ANTIGRAVITY_DEFAULT_MODEL,
   type AntigravityAuthMethod,
@@ -92,8 +94,7 @@ const removeRuntimeTempDirectory = Effect.fn("removeRuntimeTempDirectory")(funct
 
 /** Recovers hard-exit residue without touching directories owned by another live T3 server. */
 const reclaimOrphanedRuntimeTempDirectories = Effect.fn("reclaimOrphanedRuntimeTempDirectories")(
-  function* (fileSystem: FileSystem.FileSystem, path: Path.Path, directory: string) {
-    const parent = path.dirname(directory);
+  function* (fileSystem: FileSystem.FileSystem, path: Path.Path, parent: string) {
     const entries = yield* fileSystem.readDirectory(parent).pipe(Effect.orElseSucceed(() => []));
     for (const entry of entries) {
       const owner = runtimeTempDirectoryOwner.exec(entry)?.[1];
@@ -126,6 +127,7 @@ const makeWindowsRuntimeTempDirectory = Effect.fn("makeWindowsRuntimeTempDirecto
   fileSystem: FileSystem.FileSystem,
   path: Path.Path,
 ) {
+  yield* reclaimOrphanedRuntimeTempDirectories(fileSystem, path, NodeOS.tmpdir());
   const directory = yield* fileSystem
     .makeTempDirectory({ prefix: `${runtimeTempDirectoryPrefix}${process.pid}-` })
     .pipe(
@@ -152,7 +154,6 @@ const makeWindowsRuntimeTempDirectory = Effect.fn("makeWindowsRuntimeTempDirecto
           }),
       ),
     );
-  yield* reclaimOrphanedRuntimeTempDirectories(fileSystem, path, directory);
   return directory;
 });
 

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.ts
@@ -56,7 +56,12 @@ export interface AntigravityAcpRuntimeInput extends Omit<
 
 const windowsTempEnvironmentKeys = new Set(["TEMP", "TMP"]);
 const runtimeTempDirectoryPrefix = "t3-antigravity-runtime-";
-const runtimeTempDirectoryOwner = /^t3-antigravity-runtime-(\d+)-/u;
+const runtimeTempDirectoryOwner = /^t3-antigravity-runtime-(\d+)-.+$/u;
+const runtimeTempDirectoryMarkerName = ".t3-antigravity-runtime-owner";
+
+function runtimeTempDirectoryMarkerContents(directory: string, ownerProcessId: number): string {
+  return `${JSON.stringify({ schemaVersion: 1, ownerProcessId, directory })}\n`;
+}
 
 function withWindowsRuntimeTempDirectory(
   spawn: AcpSessionRuntime.AcpSpawnInput,
@@ -94,8 +99,24 @@ const reclaimOrphanedRuntimeTempDirectories = Effect.fn("reclaimOrphanedRuntimeT
       const owner = runtimeTempDirectoryOwner.exec(entry)?.[1];
       if (!owner) continue;
       const ownerProcessId = Number(owner);
-      if (!Number.isSafeInteger(ownerProcessId) || isProcessAlive(ownerProcessId)) continue;
-      yield* removeRuntimeTempDirectory(fileSystem, path.join(parent, entry));
+      if (
+        !Number.isSafeInteger(ownerProcessId) ||
+        ownerProcessId <= 0 ||
+        isProcessAlive(ownerProcessId)
+      ) {
+        continue;
+      }
+      const candidate = path.join(parent, entry);
+      const markerMatches = yield* fileSystem
+        .readFileString(path.join(candidate, runtimeTempDirectoryMarkerName))
+        .pipe(
+          Effect.map(
+            (contents) => contents === runtimeTempDirectoryMarkerContents(entry, ownerProcessId),
+          ),
+          Effect.orElseSucceed(() => false),
+        );
+      if (!markerMatches) continue;
+      yield* removeRuntimeTempDirectory(fileSystem, candidate);
     }
   },
 );
@@ -117,6 +138,20 @@ const makeWindowsRuntimeTempDirectory = Effect.fn("makeWindowsRuntimeTempDirecto
       ),
     );
   yield* Effect.addFinalizer(() => removeRuntimeTempDirectory(fileSystem, directory));
+  yield* fileSystem
+    .writeFileString(
+      path.join(directory, runtimeTempDirectoryMarkerName),
+      runtimeTempDirectoryMarkerContents(path.basename(directory), process.pid),
+    )
+    .pipe(
+      Effect.mapError(
+        (cause) =>
+          new EffectAcpErrors.AcpTransportError({
+            detail: "Could not mark the isolated Antigravity runtime temp directory.",
+            cause,
+          }),
+      ),
+    );
   yield* reclaimOrphanedRuntimeTempDirectories(fileSystem, path, directory);
   return directory;
 });

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.ts
@@ -11,6 +11,7 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
+import * as Schedule from "effect/Schedule";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
@@ -18,6 +19,7 @@ import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { isProcessAlive } from "../../serverRuntimeState.ts";
 import {
   makeAntigravityStderrHandler,
   makeAntigravityStdoutTransform,
@@ -36,6 +38,9 @@ export interface AntigravityAcpRuntimeInput extends Omit<
   | "transformStdout"
 > {
   readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
+  readonly fileSystem: FileSystem.FileSystem;
+  readonly path: Path.Path;
+  readonly platform: NodeJS.Platform;
   readonly onAuthorizationUrl?: (url: string) => Effect.Effect<void, EffectAcpErrors.AcpError>;
   /**
    * Advertise `fs.readTextFile` and `fs.writeTextFile`. The agent then routes
@@ -49,6 +54,73 @@ export interface AntigravityAcpRuntimeInput extends Omit<
   readonly authMethod?: AntigravityAuthMethod;
 }
 
+const windowsTempEnvironmentKeys = new Set(["TEMP", "TMP"]);
+const runtimeTempDirectoryPrefix = "t3-antigravity-runtime-";
+const runtimeTempDirectoryOwner = /^t3-antigravity-runtime-(\d+)-/u;
+
+function withWindowsRuntimeTempDirectory(
+  spawn: AcpSessionRuntime.AcpSpawnInput,
+  directory: string,
+): AcpSessionRuntime.AcpSpawnInput {
+  const environment = Object.fromEntries(
+    Object.entries(spawn.env ?? {}).filter(
+      ([key]) => !windowsTempEnvironmentKeys.has(key.toUpperCase()),
+    ),
+  );
+  return {
+    ...spawn,
+    env: { ...environment, TEMP: directory, TMP: directory },
+  };
+}
+
+const removeRuntimeTempDirectory = Effect.fn("removeRuntimeTempDirectory")(function* (
+  fileSystem: FileSystem.FileSystem,
+  directory: string,
+) {
+  yield* fileSystem.remove(directory, { recursive: true, force: true }).pipe(
+    Effect.retry({ times: 5, schedule: Schedule.exponential("100 millis") }),
+    Effect.catch((cause) =>
+      Effect.logWarning("antigravity runtime temp cleanup failed", { directory, cause }),
+    ),
+  );
+});
+
+/** Recovers hard-exit residue without touching directories owned by another live T3 server. */
+const reclaimOrphanedRuntimeTempDirectories = Effect.fn("reclaimOrphanedRuntimeTempDirectories")(
+  function* (fileSystem: FileSystem.FileSystem, path: Path.Path, directory: string) {
+    const parent = path.dirname(directory);
+    const entries = yield* fileSystem.readDirectory(parent).pipe(Effect.orElseSucceed(() => []));
+    for (const entry of entries) {
+      const owner = runtimeTempDirectoryOwner.exec(entry)?.[1];
+      if (!owner) continue;
+      const ownerProcessId = Number(owner);
+      if (!Number.isSafeInteger(ownerProcessId) || isProcessAlive(ownerProcessId)) continue;
+      yield* removeRuntimeTempDirectory(fileSystem, path.join(parent, entry));
+    }
+  },
+);
+
+/** Contains PyInstaller extraction residue inside a directory owned by this runtime scope. */
+const makeWindowsRuntimeTempDirectory = Effect.fn("makeWindowsRuntimeTempDirectory")(function* (
+  fileSystem: FileSystem.FileSystem,
+  path: Path.Path,
+) {
+  const directory = yield* fileSystem
+    .makeTempDirectory({ prefix: `${runtimeTempDirectoryPrefix}${process.pid}-` })
+    .pipe(
+      Effect.mapError(
+        (cause) =>
+          new EffectAcpErrors.AcpTransportError({
+            detail: "Could not create an isolated Antigravity runtime temp directory.",
+            cause,
+          }),
+      ),
+    );
+  yield* Effect.addFinalizer(() => removeRuntimeTempDirectory(fileSystem, directory));
+  yield* reclaimOrphanedRuntimeTempDirectories(fileSystem, path, directory);
+  return directory;
+});
+
 /** Normal launches reject browser login; only the auth flow supplies `onAuthorizationUrl`. */
 export const makeAntigravityAcpRuntime = Effect.fn("makeAntigravityAcpRuntime")(function* (
   input: AntigravityAcpRuntimeInput,
@@ -57,30 +129,42 @@ export const makeAntigravityAcpRuntime = Effect.fn("makeAntigravityAcpRuntime")(
   EffectAcpErrors.AcpError,
   Crypto.Crypto | Scope.Scope
 > {
+  const {
+    authMethod,
+    childProcessSpawner,
+    clientFileSystem,
+    fileSystem,
+    onAuthorizationUrl,
+    path,
+    platform,
+    ...runtimeInput
+  } = input;
+  const runtimeTempDirectory =
+    platform === "win32" ? yield* makeWindowsRuntimeTempDirectory(fileSystem, path) : undefined;
+  const spawn = runtimeTempDirectory
+    ? withWindowsRuntimeTempDirectory(runtimeInput.spawn, runtimeTempDirectory)
+    : runtimeInput.spawn;
   const context = yield* Layer.build(
     AcpSessionRuntime.layer({
-      ...input,
-      authMethodId: input.authMethod ?? "oauth-personal",
+      ...runtimeInput,
+      spawn,
+      authMethodId: authMethod ?? "oauth-personal",
       resumeMethod: "resume",
       cancelBehavior: "wait-for-prompt",
       clientCapabilities: {
         fs: {
-          readTextFile: input.clientFileSystem === true,
-          writeTextFile: input.clientFileSystem === true,
+          readTextFile: clientFileSystem === true,
+          writeTextFile: clientFileSystem === true,
         },
         terminal: false,
       },
       transformStdout: makeAntigravityStdoutTransform(
-        input.onAuthorizationUrl ? { onAuthorizationUrl: input.onAuthorizationUrl } : {},
+        onAuthorizationUrl ? { onAuthorizationUrl } : {},
       ),
-      onStderr: makeAntigravityStderrHandler(
-        input.onAuthorizationUrl ? { onAuthorizationUrl: input.onAuthorizationUrl } : {},
-      ),
+      onStderr: makeAntigravityStderrHandler(onAuthorizationUrl ? { onAuthorizationUrl } : {}),
       transformSessionUpdate: normalizeAntigravitySessionUpdate,
     }).pipe(
-      Layer.provide(
-        Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, input.childProcessSpawner),
-      ),
+      Layer.provide(Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner)),
     ),
   );
   return yield* Effect.service(AcpSessionRuntime.AcpSessionRuntime).pipe(Effect.provide(context));

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.ts
@@ -82,9 +82,20 @@ function withWindowsRuntimeTempDirectory(
 
 const removeRuntimeTempDirectory = Effect.fn("removeRuntimeTempDirectory")(function* (
   fileSystem: FileSystem.FileSystem,
+  path: Path.Path,
   directory: string,
 ) {
-  yield* fileSystem.remove(directory, { recursive: true, force: true }).pipe(
+  yield* Effect.gen(function* () {
+    const entries = yield* fileSystem
+      .readDirectory(directory)
+      .pipe(Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed([])));
+    // Keep proof of ownership if a locked payload survives all cleanup retries.
+    for (const entry of entries) {
+      if (entry === runtimeTempDirectoryMarkerName) continue;
+      yield* fileSystem.remove(path.join(directory, entry), { recursive: true, force: true });
+    }
+    yield* fileSystem.remove(directory, { recursive: true, force: true });
+  }).pipe(
     Effect.retry({ times: 5, schedule: Schedule.exponential("100 millis") }),
     Effect.catch((cause) =>
       Effect.logWarning("antigravity runtime temp cleanup failed", { directory, cause }),
@@ -117,7 +128,7 @@ const reclaimOrphanedRuntimeTempDirectories = Effect.fn("reclaimOrphanedRuntimeT
           Effect.orElseSucceed(() => false),
         );
       if (!markerMatches) continue;
-      yield* removeRuntimeTempDirectory(fileSystem, candidate);
+      yield* removeRuntimeTempDirectory(fileSystem, path, candidate);
     }
   },
 );
@@ -139,7 +150,7 @@ const makeWindowsRuntimeTempDirectory = Effect.fn("makeWindowsRuntimeTempDirecto
           }),
       ),
     );
-  yield* Effect.addFinalizer(() => removeRuntimeTempDirectory(fileSystem, directory));
+  yield* Effect.addFinalizer(() => removeRuntimeTempDirectory(fileSystem, path, directory));
   yield* fileSystem
     .writeFileString(
       path.join(directory, runtimeTempDirectoryMarkerName),


### PR DESCRIPTION
## What Changed

On Windows, run each Antigravity ACP process with an isolated runtime temp directory and remove that directory when the runtime shuts down.

Before allocating a new runtime directory, cleanup reclaims directories left by terminated T3 server processes after verifying an ownership marker that binds the directory name and owner PID. Cleanup retries transient filesystem failures, while unmarked directories, mismatched markers, and directories belonging to active T3 processes are preserved. The ownership marker is removed only after payload cleanup succeeds, preserving recovery after failed deletion.

Focused tests cover environment isolation, normal interruption cleanup, ownership-marker validation, pre-allocation orphan recovery, and protection of active runtime directories.

## Why

The packaged Antigravity runtime uses PyInstaller, which extracts files into `_MEI*` directories. When these directories are created directly in the system temp folder and not removed, repeated launches can consume hundreds of gigabytes.

Giving each runtime an owned temp directory allows T3 to clean up its files without touching unrelated temporary data.

## Testing

- `vp test run src/provider/acp/AntigravityAcpSupport.test.ts` — 33 tests passed
- `vp run --filter t3 typecheck`
- Targeted lint and formatting checks for all six changed files; rerun for the two updated files
- Earlier revision: manually launched and stopped the Windows desktop app twice; confirmed each launch's runtime temp directory was removed after shutdown
- New regression test verifies marker preservation after exhausted cleanup retries and recovery by a later sweep; failed before the fix and passes afterward
- Additional Windows test: all nine runtime folders from three refreshes were removed. Dev-runner shutdown left one marked folder; restart automatically reclaimed it.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes
- [x] No animation or interaction changes

Originally implemented with GPT-5.6 Sol in Codex Desktop.
Reviewed and updated with GPT-6 Astra via Codex in T3 Code.

Fixes #9650

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add scoped Windows runtime temp directory lifecycle to `makeAntigravityAcpRuntime`
> - On Windows, each Antigravity ACP runtime now allocates a marked, process-specific temp directory and rewrites both `TEMP` and `TMP` in the spawn environment to point there; non-Windows launches are unchanged.
> - Startup reclaims stale directories via `reclaimOrphanedRuntimeTempDirectories`, removing only marked dirs whose recorded owner PID is dead; invalid, mismatched, unowned, and live-owner dirs are left untouched.
> - Scope cleanup via `removeRuntimeTempDirectory` retries six times with exponential backoff, preserves the ownership marker while contents are locked, and logs a warning on final failure instead of propagating it.
> - The `AntigravityAcpRuntimeInput` interface now requires `filesystem`, `path`, and `platform` services; callers like `makeAntigravityInstallation` and `AntigravityDriver.makeRuntime` supply these instead of passing spawn/process fields.
> - Behavioral Change: Windows ACP spawn inputs now ignore any caller-provided `TEMP`/`TMP` (all case variants) and use the runtime-owned directory; cleanup failures are suppressed after logging.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2cab15.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
