### PR TITLE
fix(server): respawn Claude sessions after re-login on expired credentials

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -5626,4 +5626,115 @@ describe("ClaudeAdapterLive", () => {
       Effect.provide(harness.layer),
     );
   });
+
+  it.effect(
+    "stops the session after an authentication failure so the next turn resumes fresh",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+
+        const sessionExitedFiber = yield* adapter.streamEvents.pipe(
+          Stream.takeUntil((event) => event.type === "session.exited"),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+
+        const session = yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+        yield* adapter.sendTurn({
+          threadId: session.threadId,
+          input: "hello",
+          attachments: [],
+        });
+
+        // Exact shape from the field report: the CLI stamps the assistant
+        // snapshot with `error: "authentication_failed"` and "Not logged in"
+        // content, then finishes the turn with an is_error result.
+        harness.query.emit({
+          type: "assistant",
+          session_id: "sdk-session-1",
+          uuid: "assistant-auth-1",
+          parent_tool_use_id: null,
+          error: "authentication_failed",
+          message: {
+            id: "assistant-auth-message-1",
+            content: [{ type: "text", text: "Not logged in · Please run /login" }],
+          },
+        } as unknown as SDKMessage);
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: true,
+          errors: [],
+          session_id: "sdk-session-1",
+          uuid: "result-auth-1",
+        } as unknown as SDKMessage);
+
+        yield* Fiber.join(sessionExitedFiber);
+
+        // The stale-credentialed process must be gone so the next sendTurn goes
+        // through resume-thread recovery with a fresh process. close() runs
+        // twice by design: once from the auth-failure path, once from the
+        // regular stopSessionInternal teardown.
+        const hasSession = yield* adapter.hasSession(session.threadId);
+        assert.equal(hasSession, false);
+        assert.equal(harness.query.closeCalls > 0, true);
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
+  it.effect("keeps the session alive when a failed result is not an authentication failure", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-1",
+        uuid: "assistant-fail-1",
+        parent_tool_use_id: null,
+        message: {
+          id: "assistant-fail-message-1",
+          content: [{ type: "text", text: "Something went wrong" }],
+        },
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["rate limit exceeded"],
+        session_id: "sdk-session-1",
+        uuid: "result-fail-1",
+      } as unknown as SDKMessage);
+
+      // Give the stream a beat to settle: a session that was wrongly torn
+      // down would emit session.exited before this completes.
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      const hasSession = yield* adapter.hasSession(session.threadId);
+      assert.equal(hasSession, true);
+      assert.equal(harness.query.closeCalls, 0);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
 });

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -43,7 +43,11 @@ import {
   SYNTHETIC_CLAUDE_STANDARD_MODEL,
   SYNTHETIC_CLAUDE_THINKING_MODEL,
 } from "../ClaudeModelCatalog.testFixtures.ts";
-import { ProviderAdapterProcessError, ProviderAdapterValidationError } from "../Errors.ts";
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+} from "../Errors.ts";
 import type { ClaudeAdapterShape } from "../Services/ClaudeAdapter.ts";
 import type { ClaudeScopedLimitNames } from "./claudeUsageLimits.ts";
 import { makeClaudeAdapter, type ClaudeAdapterLiveOptions } from "./ClaudeAdapter.ts";
@@ -5683,6 +5687,18 @@ describe("ClaudeAdapterLive", () => {
         const hasSession = yield* adapter.hasSession(session.threadId);
         assert.equal(hasSession, false);
         assert.equal(harness.query.closeCalls > 0, true);
+
+        // No prompt may be accepted onto the dying runtime: a follow-up turn
+        // after the teardown must fail (session no longer routable) rather than
+        // enqueue onto the closed query.
+        const followUp = yield* adapter
+          .sendTurn({
+            threadId: session.threadId,
+            input: "hello again",
+            attachments: [],
+          })
+          .pipe(Effect.flip);
+        assert.instanceOf(followUp, ProviderAdapterSessionNotFoundError);
       }).pipe(
         Effect.provideService(Random.Random, makeDeterministicRandomService()),
         Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -188,10 +188,12 @@ function toSessionPermissionUpdates(
   toolName: string,
   suggestions: ReadonlyArray<PermissionUpdate> | undefined,
 ): Array<PermissionUpdate> {
-  const sessionScoped = (suggestions ?? []).map((suggestion): PermissionUpdate => ({
-    ...suggestion,
-    destination: "session",
-  }));
+  const sessionScoped = (suggestions ?? []).map(
+    (suggestion): PermissionUpdate => ({
+      ...suggestion,
+      destination: "session",
+    }),
+  );
   if (sessionScoped.length > 0) {
     return sessionScoped;
   }
@@ -325,6 +327,13 @@ interface ClaudeSessionContext {
   lastAssistantUuid: string | undefined;
   lastThreadStartedId: string | undefined;
   stopped: boolean;
+  /**
+   * Set when the CLI reports an authentication failure (expired credentials).
+   * The session process holds stale OAuth credentials it can never refresh, so
+   * the turn's result tears the session down instead of leaving a permanently
+   * logged-out process in place.
+   */
+  authenticationFailed: boolean;
 }
 
 interface ClaudeQueryRuntime extends AsyncIterable<SDKMessage> {
@@ -462,6 +471,25 @@ function isInterruptedResult(result: SDKResultMessage): boolean {
     (errors.includes("request was aborted") ||
       errors.includes("interrupted by user") ||
       errors.includes("aborted"))
+  );
+}
+
+/**
+ * The Claude CLI loads OAuth credentials once per process, so an expired
+ * session poisons every subsequent turn with the same "Not logged in" failure
+ * until the process is replaced. Recognizing these results lets the adapter
+ * tear the session down (see `handleResultMessage`); the next turn then
+ * resumes through `ProviderService`'s recovery path, which spawns a fresh
+ * process that picks up credentials refreshed in the meantime.
+ */
+function isClaudeAuthenticationErrorText(text: string): boolean {
+  const normalized = text.toLowerCase();
+  return (
+    normalized.includes("authentication_failed") ||
+    normalized.includes("failed to authenticate") ||
+    normalized.includes("oauth session expired") ||
+    normalized.includes("not logged in") ||
+    normalized.includes("please run /login")
   );
 }
 
@@ -2931,6 +2959,15 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
+    // The CLI stamps auth failures on the assistant snapshot itself
+    // (`error: "authentication_failed"` with "Not logged in" content). Record
+    // it here; the turn's result then tears the session down so the next turn
+    // resumes with a fresh process that reads the refreshed credentials.
+    const assistantError = (message as { error?: unknown }).error;
+    if (typeof assistantError === "string" && isClaudeAuthenticationErrorText(assistantError)) {
+      context.authenticationFailed = true;
+    }
+
     // Subagent-owned assistant snapshots (parent_tool_use_id set) are the
     // subagent's own conversation, not the parent's. Emitting them created
     // interleaved "Agent N done"-adjacent leak messages and spawned synthetic
@@ -3069,6 +3106,37 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     yield* completeTurn(context, status, errorMessage, message);
+
+    // The CLI loads OAuth credentials once per process. An auth failure means
+    // this process can never recover, and leaving it in place makes every
+    // later turn reply "Not logged in" even after the user logs in again.
+    // Closing the query ends the stream, so handleStreamExit tears the session
+    // down; the next turn then goes through the normal resume-thread recovery,
+    // which spawns a fresh process with current credentials. Interrupted and
+    // cancelled turns are left alone: the flag may be stale relative to a
+    // user-initiated stop.
+    const authenticationFailed =
+      context.authenticationFailed ||
+      (message.is_error === true &&
+        (isClaudeAuthenticationErrorText(resultErrorsText(message)) ||
+          isClaudeAuthenticationErrorText(errorMessage ?? "")));
+    if (authenticationFailed && status !== "interrupted" && status !== "cancelled") {
+      yield* Effect.logInfo("claude.session.stopping-after-auth-failure", {
+        threadId: context.session.threadId,
+        turnStatus: status,
+        detectedFrom: context.authenticationFailed ? "assistant-snapshot" : "result",
+      });
+      yield* Effect.try({
+        try: () => context.query.close(),
+        catch: (cause) =>
+          new ProviderAdapterProcessError({
+            provider: PROVIDER,
+            threadId: context.session.threadId,
+            detail: "Failed to close Claude runtime query after authentication failure.",
+            cause,
+          }),
+      });
+    }
   });
 
   /**
@@ -4499,6 +4567,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         lastAssistantUuid: resumeState?.resumeSessionAt,
         lastThreadStartedId: undefined,
         stopped: false,
+        authenticationFailed: false,
       };
       yield* Ref.set(contextRef, context);
       sessions.set(threadId, context);

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -3136,6 +3136,19 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
             cause,
           }),
       });
+
+      // The stream teardown (handleStreamExit -> stopSessionInternal) runs
+      // asynchronously after close(), so until it completes the context is
+      // still in `sessions` with `stopped` unset. Mark the session closed now
+      // so sendTurn rejects (via requireSession) instead of enqueueing a
+      // prompt onto the dying runtime.
+      const closedAt = yield* nowIso;
+      context.session = {
+        ...context.session,
+        status: "closed",
+        activeTurnId: undefined,
+        updatedAt: closedAt,
+      };
     }
   });
 
@@ -4858,7 +4871,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
   const hasSession: ClaudeAdapterShape["hasSession"] = (threadId) =>
     Effect.sync(() => {
       const context = sessions.get(threadId);
-      return context !== undefined && !context.stopped;
+      // A stopped or already-closed context is not a routable session. The
+      // closed check matters because an auth-failure teardown marks the
+      // session closed (see handleResultMessage) before the async stream exit
+      // removes the context, so a recovery must be able to replace it in that
+      // window instead of treating the dying process as active.
+      return context !== undefined && !context.stopped && context.session.status !== "closed";
     });
 
   const stopSessions = Effect.fn("stopSessions")(function* (


### PR DESCRIPTION
Closes #9607

## Problem

T3 keeps one long-lived Claude CLI process per thread, and that process loads
OAuth credentials **once at startup**. When a thread's OAuth session expires,
the adapter's process reports `authentication_failed` ("Not logged in") on
every subsequent turn. Because the adapter never treated that as a reason to
end the session, the same poisoned process stayed in place even **after the
user logged in again** via the CLI — until the idle-session reaper eventually
reclaimed it (up to 30 minutes) or the thread was stopped.

## Fix

The adapter now recognizes authentication failures and releases the stale
process so the thread can recover as soon as the user re-logs-in:

- In `handleAssistantMessage`, the CLI's `error: "authentication_failed"`
  stamp on the assistant snapshot flags the session (`context.authenticationFailed`).
- In `handleResultMessage`, once the turn completes, an auth failure
  (from the snapshot flag or the result's error text) closes the runtime
  query. That ends the stream and drives the existing
  `handleStreamExit -> stopSessionInternal` teardown, which removes the session.
- The next `sendTurn` on that thread then hits the **existing** resume-thread
  recovery path in `ProviderService` (the adapter reports `hasSession() == false`
  and the session is resumed from its persisted `resumeCursor`), spawning a
  fresh Claude process that reads the refreshed credentials.

No new recovery machinery is introduced — the fix is purely about detecting the
failure and letting the existing lifecycle respawn. User-aborted/interrupted and
cancelled turns are deliberately left alone.

This complements (and does not duplicate) #9612, which only exempts *live*
Claude sessions from the idle reaper.

## Verification

- New `ClaudeAdapter` test: an auth-failure turn closes the query and leaves
  `hasSession() == false` (so the next turn resumes fresh).
- New `ClaudeAdapter` test: a distinct non-auth failure (rate limit) keeps the
  session alive.
- `ClaudeAdapter.test.ts`: 82/82 pass.
- Server typecheck (`tsgo --noEmit`): clean for the edited files.

Done with Claude (Sonnet) in Cline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Claude session lifecycle and `hasSession` semantics during async teardown; misclassification could close healthy sessions or leave stale processes, but scope is limited to auth-error detection and existing resume recovery.
> 
> **Overview**
> Fixes threads that stay stuck on **"Not logged in"** after re-login because the long-lived Claude CLI process only loads OAuth once and never picks up refreshed credentials.
> 
> **`ClaudeAdapter`** now treats CLI auth failures as fatal for the session process: assistant snapshots with `error: "authentication_failed"` set a context flag, and when the turn’s result finishes (unless interrupted/cancelled), matching error text triggers **`query.close()`**, logs `claude.session.stopping-after-auth-failure`, and immediately marks the session **`closed`** so **`hasSession`** is false and follow-up **`sendTurn`** calls fail with **`ProviderAdapterSessionNotFoundError`** instead of enqueueing on a dying runtime. The next successful turn is expected to go through the existing resume-thread path and spawn a fresh process.
> 
> Non-auth failures (e.g. rate limits) are unchanged—the session stays open and **`close()`** is not called.
> 
> **Tests** cover auth-failure teardown plus a negative case where other errors keep the session alive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 862fdc9664314196f103c38c8090c3a058b1b3f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ClaudeAdapter` to tear down sessions on authentication failure
> - Adds `isClaudeAuthenticationErrorText` to classify known auth failure strings, such as `authentication_failed` and `/login`.
> - `handleAssistantMessage` sets `ClaudeSessionContext.authenticationFailed` when an assistant snapshot's `error` matches the detector.
> - `handleResultMessage` closes the Claude query and marks the session closed on auth failure, unless the turn was interrupted or cancelled. Non-auth failures leave the session open.
> - `hasSession` now returns `false` for sessions marked closed, so follow-up `sendTurn` calls fail with `ProviderAdapterSessionNotFoundError` during teardown.
> - Risk: `hasSession` now requires `sessionStatus` to not be `closed`; if status is not updated correctly during teardown, follow-up turns will be rejected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 862fdc9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->