### PR TITLE
feat(web): add provider usage pill

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -41,6 +41,7 @@ import {
   useSidebarVisibility,
 } from "./ui/sidebar";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
+import { ProviderUsageBootstrap } from "./ProviderUsageBootstrap";
 
 const MACOS_TRAFFIC_LIGHTS_LEFT_INSET = "90px";
 
@@ -249,6 +250,7 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
       </Sidebar>
       {children}
       <SidebarControl />
+      <ProviderUsageBootstrap />
     </SidebarProvider>
   );
 }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -7724,6 +7724,10 @@ function ChatViewContent(props: ChatViewProps) {
             availableEditors={availableEditors}
             rightPanelOpen={rightPanelOpen}
             gitCwd={gitCwd}
+            providers={providerStatuses}
+            activeProviderInstanceId={
+              activeThread.session?.providerInstanceId ?? activeProviderInstanceId
+            }
             onNewThreadInProject={handleNewThreadInActiveProject}
             onRunProjectScript={runProjectScript}
             onAddProjectScript={saveProjectScript}

--- a/apps/web/src/components/ProviderUsageBootstrap.tsx
+++ b/apps/web/src/components/ProviderUsageBootstrap.tsx
@@ -1,25 +1,32 @@
+import { useParams } from "@tanstack/react-router";
 import { useCallback, useEffect } from "react";
 
 import { useActiveEnvironmentId } from "../state/entities";
 import { serverEnvironment } from "../state/server";
 import { useAtomCommand } from "../state/use-atom-command";
+import { resolveThreadRouteRef } from "../threadRoutes";
 
 const USAGE_REFRESH_INTERVAL_MS = 60_000;
 
 /** Requests a fresh provider snapshot when the app connects to an environment. */
 export function ProviderUsageBootstrap() {
   const activeEnvironmentId = useActiveEnvironmentId();
+  const routeThreadRef = useParams({
+    strict: false,
+    select: (params) => resolveThreadRouteRef(params),
+  });
+  const refreshEnvironmentId = routeThreadRef?.environmentId ?? activeEnvironmentId;
   const refreshProviders = useAtomCommand(serverEnvironment.refreshProviders, {
     reportFailure: false,
   });
 
   const refresh = useCallback(() => {
-    if (activeEnvironmentId === null) return;
-    void refreshProviders({ environmentId: activeEnvironmentId, input: {} });
-  }, [activeEnvironmentId, refreshProviders]);
+    if (refreshEnvironmentId === null) return;
+    void refreshProviders({ environmentId: refreshEnvironmentId, input: {} });
+  }, [refreshEnvironmentId, refreshProviders]);
 
   useEffect(() => {
-    if (activeEnvironmentId === null) {
+    if (refreshEnvironmentId === null) {
       return;
     }
 
@@ -31,7 +38,7 @@ export function ProviderUsageBootstrap() {
       window.clearInterval(intervalId);
       window.removeEventListener("focus", refresh);
     };
-  }, [activeEnvironmentId, refresh]);
+  }, [refresh, refreshEnvironmentId]);
 
   return null;
 }

--- a/apps/web/src/components/ProviderUsageBootstrap.tsx
+++ b/apps/web/src/components/ProviderUsageBootstrap.tsx
@@ -1,0 +1,37 @@
+import { useCallback, useEffect } from "react";
+
+import { useActiveEnvironmentId } from "../state/entities";
+import { serverEnvironment } from "../state/server";
+import { useAtomCommand } from "../state/use-atom-command";
+
+const USAGE_REFRESH_INTERVAL_MS = 60_000;
+
+/** Requests a fresh provider snapshot when the app connects to an environment. */
+export function ProviderUsageBootstrap() {
+  const activeEnvironmentId = useActiveEnvironmentId();
+  const refreshProviders = useAtomCommand(serverEnvironment.refreshProviders, {
+    reportFailure: false,
+  });
+
+  const refresh = useCallback(() => {
+    if (activeEnvironmentId === null) return;
+    void refreshProviders({ environmentId: activeEnvironmentId, input: {} });
+  }, [activeEnvironmentId, refreshProviders]);
+
+  useEffect(() => {
+    if (activeEnvironmentId === null) {
+      return;
+    }
+
+    refresh();
+    const intervalId = window.setInterval(refresh, USAGE_REFRESH_INTERVAL_MS);
+    window.addEventListener("focus", refresh);
+
+    return () => {
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", refresh);
+    };
+  }, [activeEnvironmentId, refresh]);
+
+  return null;
+}

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -2,7 +2,9 @@ import {
   type EnvironmentId,
   type EditorId,
   type ProjectScript,
+  type ProviderInstanceId,
   type ResolvedKeybindingsConfig,
+  type ServerProvider,
   type ThreadId,
 } from "@t3tools/contracts";
 import { scopeThreadRef } from "@t3tools/client-runtime/environment";
@@ -45,6 +47,7 @@ import {
   WorkspaceBreadcrumbSeparator,
 } from "../WorkspaceBreadcrumb";
 import { cn } from "~/lib/utils";
+import { ProviderUsagePill } from "./ProviderUsagePill";
 
 interface ChatHeaderProps {
   activeThreadEnvironmentId: EnvironmentId;
@@ -64,6 +67,8 @@ interface ChatHeaderProps {
   availableEditors: ReadonlyArray<EditorId>;
   rightPanelOpen: boolean;
   gitCwd: string | null;
+  providers: readonly ServerProvider[];
+  activeProviderInstanceId: ProviderInstanceId | null;
   readonly onOpenPullRequest?: ((number: number) => void) | undefined;
   onNewThreadInProject: () => void;
   onRunProjectScript: (script: ProjectScript) => void;
@@ -135,6 +140,8 @@ export const ChatHeader = memo(function ChatHeader({
   availableEditors,
   rightPanelOpen,
   gitCwd,
+  providers,
+  activeProviderInstanceId,
   onOpenPullRequest,
   onNewThreadInProject,
   onRunProjectScript,
@@ -402,6 +409,10 @@ export const ChatHeader = memo(function ChatHeader({
           "[[data-panel-animations=true]_&]:motion-safe:transition-[padding-right] [[data-panel-animations=true]_&]:motion-safe:[transition-duration:var(--panel-animation-duration)] [[data-panel-animations=true]_&]:motion-safe:ease-out",
         )}
       >
+        <ProviderUsagePill
+          providers={providers}
+          activeProviderInstanceId={activeProviderInstanceId}
+        />
         {activeProjectScripts && (
           <ProjectScriptsControl
             scripts={activeProjectScripts}

--- a/apps/web/src/components/chat/ProviderUsagePill.logic.test.ts
+++ b/apps/web/src/components/chat/ProviderUsagePill.logic.test.ts
@@ -1,0 +1,106 @@
+import {
+  ProviderDriverKind,
+  ProviderInstanceId,
+  type ServerProvider,
+  type ServerProviderUsageWindow,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  highestUsageWindow,
+  providersWithReportedUsage,
+  selectCollapsedUsageProvider,
+} from "./ProviderUsagePill.logic";
+
+const checkedAt = "2026-09-04T08:00:00.000Z";
+
+function usageWindow(id: string, usedPercent: number): ServerProviderUsageWindow {
+  return {
+    id,
+    kind: id === "weekly" ? "weekly" : "session",
+    label: id === "weekly" ? "Weekly" : "Five hour",
+    usedPercent,
+  };
+}
+
+function provider(
+  instanceId: string,
+  driver: string,
+  windows: readonly ServerProviderUsageWindow[] | null,
+  options: {
+    readonly unavailable?: "unsupported" | "probeFailed";
+    readonly enabled?: boolean;
+  } = {},
+): ServerProvider {
+  return {
+    instanceId: ProviderInstanceId.make(instanceId),
+    driver: ProviderDriverKind.make(driver),
+    displayName: instanceId,
+    enabled: options.enabled ?? true,
+    installed: true,
+    version: "1.0.0",
+    status: "ready",
+    auth: { status: "authenticated" },
+    checkedAt,
+    models: [],
+    slashCommands: [],
+    skills: [],
+    ...(windows === null
+      ? {}
+      : {
+          usageLimits: {
+            checkedAt,
+            windows: [...windows],
+            ...(options.unavailable ? { unavailable: { reason: options.unavailable } } : {}),
+          },
+        }),
+  };
+}
+
+describe("provider usage pill selection", () => {
+  it("shows only usable providers with live reported windows", () => {
+    const codex = provider("codex", "codex", [usageWindow("five_hour", 42)]);
+    const unsupported = provider("claudeAgent", "claudeAgent", [], {
+      unavailable: "unsupported",
+    });
+    const failed = provider("grok", "grok", [usageWindow("weekly", 73)], {
+      unavailable: "probeFailed",
+    });
+    const noLimits = provider("cursor", "cursor", null);
+    const disabled = provider("opencode", "opencode", [usageWindow("weekly", 90)], {
+      enabled: false,
+    });
+
+    expect(providersWithReportedUsage([codex, unsupported, failed, noLimits, disabled])).toEqual([
+      codex,
+    ]);
+  });
+
+  it("uses the active session provider even when another provider is fuller", () => {
+    const codex = provider("codex", "codex", [
+      usageWindow("five_hour", 18),
+      usageWindow("weekly", 31),
+    ]);
+    const claude = provider("claudeAgent", "claudeAgent", [usageWindow("weekly", 82)]);
+    const providers = providersWithReportedUsage([codex, claude]);
+
+    expect(
+      selectCollapsedUsageProvider(providers, ProviderInstanceId.make("codex"))?.instanceId,
+    ).toBe("codex");
+    expect(highestUsageWindow(providers[0]!).usedPercent).toBe(31);
+  });
+
+  it("falls back to the provider with the highest current usage", () => {
+    const codex = provider("codex", "codex", [usageWindow("weekly", 42)]);
+    const claude = provider("claudeAgent", "claudeAgent", [usageWindow("five_hour", 67)]);
+    const providers = providersWithReportedUsage([codex, claude]);
+
+    expect(
+      selectCollapsedUsageProvider(providers, ProviderInstanceId.make("grok"))?.instanceId,
+    ).toBe("claudeAgent");
+  });
+
+  it("renders nothing when no provider reports usage", () => {
+    expect(selectCollapsedUsageProvider(providersWithReportedUsage([]), null)).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/ProviderUsagePill.logic.ts
+++ b/apps/web/src/components/chat/ProviderUsagePill.logic.ts
@@ -1,0 +1,58 @@
+import {
+  isProviderAvailable,
+  type ProviderInstanceId,
+  type ServerProvider,
+  type ServerProviderUsageLimits,
+  type ServerProviderUsageWindow,
+} from "@t3tools/contracts";
+
+export type ProviderWithReportedUsage = ServerProvider & {
+  readonly usageLimits: ServerProviderUsageLimits;
+};
+
+/**
+ * Only surface providers that are usable and currently report at least one
+ * quota window. An unsupported or failed probe stays out of the title bar.
+ */
+export function providersWithReportedUsage(
+  providers: readonly ServerProvider[],
+): readonly ProviderWithReportedUsage[] {
+  return providers.filter(
+    (provider): provider is ProviderWithReportedUsage =>
+      provider.enabled &&
+      provider.installed &&
+      isProviderAvailable(provider) &&
+      provider.usageLimits !== undefined &&
+      provider.usageLimits.unavailable === undefined &&
+      provider.usageLimits.windows.length > 0,
+  );
+}
+
+export function highestUsageWindow(provider: ProviderWithReportedUsage): ServerProviderUsageWindow {
+  return provider.usageLimits.windows.reduce((highest, window) =>
+    window.usedPercent > highest.usedPercent ? window : highest,
+  );
+}
+
+/**
+ * Prefer the provider bound to the current session. When it cannot report
+ * usage, show the provider whose most constrained window is currently fullest.
+ */
+export function selectCollapsedUsageProvider(
+  providers: readonly ProviderWithReportedUsage[],
+  activeProviderInstanceId: ProviderInstanceId | null,
+): ProviderWithReportedUsage | null {
+  const activeProvider = providers.find(
+    (provider) => provider.instanceId === activeProviderInstanceId,
+  );
+  if (activeProvider) return activeProvider;
+
+  return (
+    providers.reduce<ProviderWithReportedUsage | null>((highest, provider) => {
+      if (highest === null) return provider;
+      return highestUsageWindow(provider).usedPercent > highestUsageWindow(highest).usedPercent
+        ? provider
+        : highest;
+    }, null) ?? null
+  );
+}

--- a/apps/web/src/components/chat/ProviderUsagePill.tsx
+++ b/apps/web/src/components/chat/ProviderUsagePill.tsx
@@ -1,0 +1,238 @@
+import type {
+  ProviderInstanceId,
+  ServerProvider,
+  ServerProviderUsageWindow,
+} from "@t3tools/contracts";
+import { useMemo, useState } from "react";
+
+import { formatResetsIn } from "@t3tools/shared/usageLimits";
+import { cn } from "~/lib/utils";
+import { formatRelativeTimeLabel } from "~/timestampFormat";
+import { getDriverOption } from "../settings/providerDriverMeta";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+import { ProviderInstanceIcon } from "./ProviderInstanceIcon";
+import {
+  highestUsageWindow,
+  providersWithReportedUsage,
+  selectCollapsedUsageProvider,
+  type ProviderWithReportedUsage,
+} from "./ProviderUsagePill.logic";
+
+function providerLabel(provider: ServerProvider): string {
+  return (
+    provider.displayName?.trim() ||
+    getDriverOption(provider.driver)?.label ||
+    String(provider.driver)
+  );
+}
+
+function roundedUsage(usedPercent: number): number {
+  return Math.round(Math.max(0, Math.min(100, usedPercent)));
+}
+
+function windowColor(provider: ServerProvider): string {
+  return provider.accentColor ?? "var(--foreground)";
+}
+
+function UsageWindowRow({
+  provider,
+  window,
+  now,
+}: {
+  readonly provider: ProviderWithReportedUsage;
+  readonly window: ServerProviderUsageWindow;
+  readonly now: number;
+}) {
+  const used = roundedUsage(window.usedPercent);
+  const resetsIn = formatResetsIn(window, now);
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-baseline justify-between gap-3 text-xs">
+        <span className="min-w-0 truncate text-muted-foreground">{window.label}</span>
+        <span className="shrink-0 font-medium text-foreground tabular-nums">{used}% used</span>
+      </div>
+      <div
+        role="progressbar"
+        aria-label={`${window.label}: ${used}% used`}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={used}
+        className="h-1.5 overflow-hidden rounded-full bg-muted/70"
+      >
+        <div
+          className="h-full rounded-full transition-[width] duration-300 ease-out motion-reduce:transition-none"
+          style={{ width: `${used}%`, backgroundColor: windowColor(provider) }}
+        />
+      </div>
+      {resetsIn ? (
+        <span className="self-end text-[11px] leading-none text-secondary-label tabular-nums">
+          {resetsIn}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function ProviderTab({
+  provider,
+  selected,
+  onSelect,
+}: {
+  readonly provider: ProviderWithReportedUsage;
+  readonly selected: boolean;
+  readonly onSelect: () => void;
+}) {
+  const label = providerLabel(provider);
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={selected}
+      aria-label={`${label} usage`}
+      onClick={onSelect}
+      className={cn(
+        "relative flex h-8 min-w-0 flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-md px-2 text-xs font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+        selected
+          ? "bg-background text-foreground shadow-xs ring-1 ring-border/70"
+          : "text-muted-foreground hover:bg-background/60 hover:text-foreground",
+      )}
+    >
+      <ProviderInstanceIcon
+        driverKind={provider.driver}
+        displayName={label}
+        className="size-4"
+        iconClassName="size-3.5"
+      />
+      <span className="truncate">{label}</span>
+    </button>
+  );
+}
+
+export function ProviderUsagePill({
+  providers,
+  activeProviderInstanceId,
+}: {
+  readonly providers: readonly ServerProvider[];
+  readonly activeProviderInstanceId: ProviderInstanceId | null;
+}) {
+  const usageProviders = useMemo(() => providersWithReportedUsage(providers), [providers]);
+  const collapsedProvider = useMemo(
+    () => selectCollapsedUsageProvider(usageProviders, activeProviderInstanceId),
+    [activeProviderInstanceId, usageProviders],
+  );
+  const [selectedInstanceId, setSelectedInstanceId] = useState<ProviderInstanceId | null>(
+    collapsedProvider?.instanceId ?? null,
+  );
+  const [now, setNow] = useState(() => Date.now());
+
+  if (collapsedProvider === null) return null;
+
+  const selectedProvider =
+    usageProviders.find((provider) => provider.instanceId === selectedInstanceId) ??
+    collapsedProvider;
+  const label = providerLabel(collapsedProvider);
+  const collapsedUsage = roundedUsage(highestUsageWindow(collapsedProvider).usedPercent);
+  const selectedLabel = providerLabel(selectedProvider);
+  const updated = formatRelativeTimeLabel(selectedProvider.usageLimits.checkedAt);
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <button
+            type="button"
+            aria-label={`${label} usage: ${collapsedUsage}% used`}
+            onClick={() => {
+              setSelectedInstanceId(collapsedProvider.instanceId);
+              setNow(Date.now());
+            }}
+            className="group/usage-pill relative flex h-7 shrink-0 cursor-pointer items-center gap-1.5 overflow-hidden rounded-full border border-border/70 bg-secondary/80 px-2.5 text-xs font-medium text-foreground shadow-xs outline-none transition-[background-color,border-color,box-shadow,scale] [-webkit-app-region:no-drag] hover:border-border hover:bg-secondary active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-ring data-pressed:bg-accent"
+          >
+            <ProviderInstanceIcon
+              driverKind={collapsedProvider.driver}
+              displayName={label}
+              className="size-4"
+              iconClassName="size-3.5 text-foreground/80"
+            />
+            <span className="hidden max-w-20 truncate text-muted-foreground sm:inline">
+              {label}
+            </span>
+            <span className="tabular-nums">{collapsedUsage}%</span>
+            <span
+              aria-hidden
+              className="absolute inset-x-2 bottom-0 h-px origin-left rounded-full bg-foreground/45"
+              style={{ transform: `scaleX(${collapsedUsage / 100})` }}
+            />
+          </button>
+        }
+      />
+      <PopoverPopup
+        side="bottom"
+        align="center"
+        sideOffset={6}
+        className="w-[min(22rem,calc(100vw-1rem))] max-w-none"
+        viewportClassName="p-0"
+      >
+        <div className="flex flex-col">
+          {usageProviders.length > 1 ? (
+            <div
+              role="tablist"
+              aria-label="Provider usage"
+              className="flex gap-1 border-b border-border/70 bg-muted/30 p-1.5"
+            >
+              {usageProviders.map((provider) => (
+                <ProviderTab
+                  key={provider.instanceId}
+                  provider={provider}
+                  selected={provider.instanceId === selectedProvider.instanceId}
+                  onSelect={() => setSelectedInstanceId(provider.instanceId)}
+                />
+              ))}
+            </div>
+          ) : null}
+
+          <div
+            role="tabpanel"
+            aria-label={`${selectedLabel} usage limits`}
+            className="flex flex-col gap-4 p-4"
+          >
+            <div className="flex min-w-0 items-center gap-2.5">
+              <ProviderInstanceIcon
+                driverKind={selectedProvider.driver}
+                displayName={selectedLabel}
+                accentColor={selectedProvider.accentColor}
+                showBadge={Boolean(selectedProvider.accentColor)}
+                indicatorBackground="var(--popover)"
+                className="size-5"
+                iconClassName="size-4.5"
+              />
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-medium text-foreground">{selectedLabel}</div>
+                {selectedProvider.auth.label ? (
+                  <div className="truncate text-[11px] text-secondary-label">
+                    {selectedProvider.auth.label}
+                  </div>
+                ) : null}
+              </div>
+              {updated ? (
+                <span className="shrink-0 text-[11px] text-secondary-label">Updated {updated}</span>
+              ) : null}
+            </div>
+
+            <div className="flex flex-col gap-3.5">
+              {selectedProvider.usageLimits.windows.map((window) => (
+                <UsageWindowRow
+                  key={window.id}
+                  provider={selectedProvider}
+                  window={window}
+                  now={now}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </PopoverPopup>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/chat/ProviderUsagePill.tsx
+++ b/apps/web/src/components/chat/ProviderUsagePill.tsx
@@ -3,7 +3,7 @@ import type {
   ServerProvider,
   ServerProviderUsageWindow,
 } from "@t3tools/contracts";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { formatResetsIn } from "@t3tools/shared/usageLimits";
 import { cn } from "~/lib/utils";
@@ -17,6 +17,8 @@ import {
   selectCollapsedUsageProvider,
   type ProviderWithReportedUsage,
 } from "./ProviderUsagePill.logic";
+
+const RESET_LABEL_REFRESH_INTERVAL_MS = 60_000;
 
 function providerLabel(provider: ServerProvider): string {
   return (
@@ -124,7 +126,18 @@ export function ProviderUsagePill({
   const [selectedInstanceId, setSelectedInstanceId] = useState<ProviderInstanceId | null>(
     collapsedProvider?.instanceId ?? null,
   );
+  const [open, setOpen] = useState(false);
   const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!open) return;
+
+    const intervalId = window.setInterval(
+      () => setNow(Date.now()),
+      RESET_LABEL_REFRESH_INTERVAL_MS,
+    );
+    return () => window.clearInterval(intervalId);
+  }, [open]);
 
   if (collapsedProvider === null) return null;
 
@@ -137,16 +150,21 @@ export function ProviderUsagePill({
   const updated = formatRelativeTimeLabel(selectedProvider.usageLimits.checkedAt);
 
   return (
-    <Popover>
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (nextOpen) {
+          setSelectedInstanceId(collapsedProvider.instanceId);
+          setNow(Date.now());
+        }
+      }}
+    >
       <PopoverTrigger
         render={
           <button
             type="button"
             aria-label={`${label} usage: ${collapsedUsage}% used`}
-            onClick={() => {
-              setSelectedInstanceId(collapsedProvider.instanceId);
-              setNow(Date.now());
-            }}
             className="group/usage-pill relative flex h-7 shrink-0 cursor-pointer items-center gap-1.5 overflow-hidden rounded-full border border-border/70 bg-secondary/80 px-2.5 text-xs font-medium text-foreground shadow-xs outline-none transition-[background-color,border-color,box-shadow,scale] [-webkit-app-region:no-drag] hover:border-border hover:bg-secondary active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-ring data-pressed:bg-accent"
           >
             <ProviderInstanceIcon

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -18,6 +18,14 @@ provider health-check interval and update live while a turn runs. API-key accoun
 subscription windows and say so; that includes a Claude Code that reaches Anthropic through a proxy
 via `ANTHROPIC_AUTH_TOKEN`, since the CLI then treats itself as an API-key client.
 
+The thread title bar shows a compact limits pill beside the project actions as soon as a connected
+provider reports usage. The pill follows the provider running that thread, and its percentage is
+the provider's fullest reported window. Select the pill to inspect every window and switch between
+other connected providers that report limits. If the thread's provider does not report subscription
+limits, the pill falls back to the connected provider with the fullest window; providers without
+reported windows stay hidden. Snapshots refresh on connection, every minute while the app is open,
+and when the app regains focus.
+
 If you pool accounts behind a CLIProxyAPI hub, open **Settings → Providers → Usage providers**
 and choose **Add hub**. Select the device that should connect to the hub; its accounts appear on
 the Limits view. Remove hubs from the same settings section. Each limits row shows its provider


### PR DESCRIPTION
## Summary
- Add a compact provider usage pill beside the thread project actions.
- Show the active session provider when it reports usage, otherwise fall back to the fullest reported provider.
- Render provider-reported usage windows and reset times without hardcoded periods; hide unsupported or unavailable providers.
- Refresh provider snapshots on connection, every 60 seconds, and when the app regains focus.

## Verification
- pnpm --filter @t3tools/web run typecheck
- vp test run src/components/chat/ProviderUsagePill.logic.test.ts --project unit (4 tests)
- vp lint on the changed web files
- Desktop development smoke-tested with an isolated T3 profile.

<img width="568" height="292" alt="image" src="https://github.com/user-attachments/assets/58ed5a31-e425-499c-bd84-bb3491622fba" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only surfacing of existing provider usage data with periodic refresh; no auth, billing, or server contract changes beyond reusing `refreshProviders`.
> 
> **Overview**
> Adds a **compact provider usage pill** in the thread title bar (via `ChatHeader`) so users can see subscription quota at a glance without opening Limits.
> 
> **`ProviderUsagePill`** shows the active thread’s provider when it reports usage windows; otherwise it picks the connected provider with the **fullest** reported window. Providers without usable limits (disabled, unsupported probes, empty windows) stay hidden. The collapsed control shows icon, optional name, and max-window **%**; opening the popover lists all quota windows with progress bars, reset timing, and tabs when multiple providers report usage.
> 
> **`ProviderUsageBootstrap`** (mounted in `AppSidebarLayout`) keeps snapshots fresh by calling `serverEnvironment.refreshProviders` on environment connect, every **60s**, and when the window regains focus. `ChatView` passes existing `providerStatuses` and session `activeProviderInstanceId` into the header.
> 
> Selection and filtering live in **`ProviderUsagePill.logic`** with unit tests; user docs in `docs/user/usage.md` describe the pill behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01e0def3dc7f97c0de69c439b63ae8d297729546. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add provider usage pill to chat header in web app
> - Adds `ProviderUsagePill` to [ChatHeader.tsx](https://github.com/pingdotgg/t3code/pull/9629/files#diff-124f699b87245f05f11a8bf7ef3d0b17dbe34657c443a51e23125ce90e0fcf0c), showing the fullest usage window for the active session provider (or highest-usage fallback) with a popover for per-window percentages, progress bars, and reset labels.
> - Adds `ProviderUsageBootstrap` in [AppSidebarLayout.tsx](https://github.com/pingdotgg/t3code/pull/9629/files#diff-b580a936d60a70bebcccf38ac9a82ca5f4440c99445dbccb0c176ebe5dc1d301) to call `refreshProviders` on mount, every 60 seconds, and on window focus, scoped to the current thread route or active environment.
> - Implements selection logic in [ProviderUsagePill.logic.ts](https://github.com/pingdotgg/t3code/pull/9629/files#diff-f12ef16f83057b953d9c3e89098dcabe1eb65411e81955ad8f56d5ec4ee4658c) that filters to enabled, installed, available providers with reportable usage windows, prefers the active session provider, and falls back to the provider with the highest used percentage.
> - Adds test coverage for filtering, active-provider preference, highest-usage fallback, and empty-provider cases, and documents the feature in [usage.md](https://github.com/pingdotgg/t3code/pull/9629/files#diff-d73591feaa8c26e8f16b7467464af0044ee0a9c288ef17901538a61715440e62).
> - Behavioral Change: providers without reported usage windows are excluded from the pill; the pill renders nothing when no provider reports usage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01e0def.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->