### PR TITLE
fix(source-control): support custom CLI paths

### DIFF
--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -868,6 +868,11 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
 
       const next = yield* serverSettings.updateSettings({
+        sourceControlProviders: {
+          github: { binaryPath: "  /opt/homebrew/bin/gh  " },
+          gitlab: { binaryPath: "  /opt/homebrew/bin/glab  " },
+          azureDevOps: { binaryPath: "  /opt/homebrew/bin/az  " },
+        },
         providers: {
           codex: {
             binaryPath: "  /opt/homebrew/bin/codex  ",
@@ -908,6 +913,11 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         serverPassword: "secret-password",
         customModels: [],
       });
+      assert.deepEqual(next.sourceControlProviders, {
+        github: { binaryPath: "/opt/homebrew/bin/gh" },
+        gitlab: { binaryPath: "/opt/homebrew/bin/glab" },
+        azureDevOps: { binaryPath: "/opt/homebrew/bin/az" },
+      });
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
@@ -936,6 +946,11 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
 
       const next = yield* serverSettings.updateSettings({
+        sourceControlProviders: {
+          github: { binaryPath: "   " },
+          gitlab: { binaryPath: "" },
+          azureDevOps: { binaryPath: "   " },
+        },
         providers: {
           codex: {
             binaryPath: "   ",
@@ -948,6 +963,11 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
       assert.equal(next.providers.codex.binaryPath, "codex");
       assert.equal(next.providers.claudeAgent.binaryPath, "claude");
+      assert.deepEqual(next.sourceControlProviders, {
+        github: { binaryPath: "gh" },
+        gitlab: { binaryPath: "glab" },
+        azureDevOps: { binaryPath: "az" },
+      });
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 

--- a/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
@@ -63,6 +63,48 @@ describe("AzureDevOpsCli.layer", () => {
     ),
   );
 
+  it.effect("reports the configured Azure CLI path when spawning fails", () =>
+    Effect.gen(function* () {
+      const binaryPath = "/opt/tools/az";
+      mockRun.mockReturnValueOnce(
+        Effect.fail(
+          new VcsProcessSpawnError({
+            operation: "AzureDevOpsCli.execute",
+            command: binaryPath,
+            cwd: "/repo",
+            argumentCount: 1,
+            cause: PlatformError.systemError({
+              _tag: "NotFound",
+              module: "ChildProcess",
+              method: "spawn",
+              pathOrDescriptor: binaryPath,
+            }),
+          }),
+        ),
+      );
+      const az = yield* AzureDevOpsCli.AzureDevOpsCli;
+      const error = yield* az.execute({ cwd: "/repo", args: ["--version"] }).pipe(Effect.flip);
+
+      assert.equal(error._tag, "AzureDevOpsCliUnavailableError");
+      assert.strictEqual(error.command, binaryPath);
+      assert.match(error.message, /`\/opt\/tools\/az`/);
+    }).pipe(
+      Effect.provide(
+        AzureDevOpsCli.layer.pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              Layer.mock(VcsProcess.VcsProcess)({ run: mockRun }),
+              ServerSettings.layerTest({
+                sourceControlProviders: { azureDevOps: { binaryPath: "/opt/tools/az" } },
+              }),
+              NodeServices.layer,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
   it.effect("parses pull request view output", () =>
     Effect.gen(function* () {
       mockRun.mockReturnValueOnce(

--- a/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
@@ -9,6 +9,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 import { VcsProcessExitError, VcsProcessSpawnError } from "@t3tools/contracts";
 
 import * as VcsProcess from "../vcs/VcsProcess.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import * as AzureDevOpsCli from "./AzureDevOpsCli.ts";
 
 const processOutput = (stdout: string): VcsProcess.VcsProcessOutput => ({
@@ -26,6 +27,7 @@ const supportLayer = Layer.mergeAll(
     run: mockRun,
   }),
   NodeServices.layer,
+  ServerSettings.layerTest(),
 );
 const layer = Layer.mergeAll(AzureDevOpsCli.layer.pipe(Layer.provide(supportLayer)), supportLayer);
 
@@ -34,6 +36,33 @@ afterEach(() => {
 });
 
 describe("AzureDevOpsCli.layer", () => {
+  it.effect("uses the configured Azure CLI path", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(Effect.succeed(processOutput("")));
+      const az = yield* AzureDevOpsCli.AzureDevOpsCli;
+
+      yield* az.execute({ cwd: "/repo", args: ["--version"] });
+
+      expect(mockRun).toHaveBeenCalledWith(
+        expect.objectContaining({ command: "/opt/tools/az", args: ["--version"] }),
+      );
+    }).pipe(
+      Effect.provide(
+        AzureDevOpsCli.layer.pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              Layer.mock(VcsProcess.VcsProcess)({ run: mockRun }),
+              ServerSettings.layerTest({
+                sourceControlProviders: { azureDevOps: { binaryPath: "/opt/tools/az" } },
+              }),
+              NodeServices.layer,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
   it.effect("parses pull request view output", () =>
     Effect.gen(function* () {
       mockRun.mockReturnValueOnce(

--- a/apps/server/src/sourceControl/AzureDevOpsCli.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.ts
@@ -12,6 +12,7 @@ import {
 } from "@t3tools/contracts";
 
 import * as VcsProcess from "../vcs/VcsProcess.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import {
   decodeAzureDevOpsPullRequestJson,
   decodeAzureDevOpsPullRequestListJson,
@@ -354,30 +355,34 @@ function decodeAzureDevOpsJson<S extends Schema.Top>(
 
 export const make = Effect.gen(function* () {
   const process = yield* VcsProcess.VcsProcess;
+  const settings = yield* ServerSettings.ServerSettingsService;
 
   const execute: AzureDevOpsCli["Service"]["execute"] = (input) =>
-    process
-      .run({
-        operation: "AzureDevOpsCli.execute",
-        command: "az",
-        args: input.args,
-        cwd: input.cwd,
-        timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-        ...(input.maxOutputBytes === undefined ? {} : { maxOutputBytes: input.maxOutputBytes }),
-      })
-      .pipe(
-        Effect.mapError((error) =>
-          AzureDevOpsCommandFailedError.fromVcsError(
-            {
-              operation: "execute",
-              command: "az",
-              cwd: input.cwd,
-              argumentCount: input.args.length,
-            },
-            error,
-          ),
+    settings.getSettings.pipe(
+      Effect.map((current) => current.sourceControlProviders.azureDevOps.binaryPath),
+      Effect.orElseSucceed(() => "az"),
+      Effect.flatMap((binaryPath) =>
+        process.run({
+          operation: "AzureDevOpsCli.execute",
+          command: binaryPath,
+          args: input.args,
+          cwd: input.cwd,
+          timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          ...(input.maxOutputBytes === undefined ? {} : { maxOutputBytes: input.maxOutputBytes }),
+        }),
+      ),
+      Effect.mapError((error) =>
+        AzureDevOpsCommandFailedError.fromVcsError(
+          {
+            operation: "execute",
+            command: "az",
+            cwd: input.cwd,
+            argumentCount: input.args.length,
+          },
+          error,
         ),
-      );
+      ),
+    );
 
   const executeJson = (input: Parameters<AzureDevOpsCli["Service"]["execute"]>[0]) =>
     execute({

--- a/apps/server/src/sourceControl/AzureDevOpsCli.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.ts
@@ -24,7 +24,7 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 
 const azureDevOpsCommandErrorFields = {
   operation: Schema.Literal("execute"),
-  command: Schema.Literal("az"),
+  command: Schema.String,
   cwd: Schema.String,
   argumentCount: NonNegativeInt,
   cause: Schema.Defect(),
@@ -35,7 +35,7 @@ export class AzureDevOpsCliUnavailableError extends Schema.TaggedErrorClass<Azur
   azureDevOpsCommandErrorFields,
 ) {
   get detail(): string {
-    return "Azure CLI (`az`) with the Azure DevOps extension is required but not available on PATH.";
+    return `Azure CLI executable \`${this.command}\` with the Azure DevOps extension is required but not available.`;
   }
 
   override get message(): string {
@@ -97,7 +97,7 @@ export class AzureDevOpsCommandFailedError extends Schema.TaggedErrorClass<Azure
   static fromVcsError(
     context: {
       readonly operation: "execute";
-      readonly command: "az";
+      readonly command: string;
       readonly cwd: string;
       readonly argumentCount: number;
     },
@@ -362,25 +362,28 @@ export const make = Effect.gen(function* () {
       Effect.map((current) => current.sourceControlProviders.azureDevOps.binaryPath),
       Effect.orElseSucceed(() => "az"),
       Effect.flatMap((binaryPath) =>
-        process.run({
-          operation: "AzureDevOpsCli.execute",
-          command: binaryPath,
-          args: input.args,
-          cwd: input.cwd,
-          timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-          ...(input.maxOutputBytes === undefined ? {} : { maxOutputBytes: input.maxOutputBytes }),
-        }),
-      ),
-      Effect.mapError((error) =>
-        AzureDevOpsCommandFailedError.fromVcsError(
-          {
-            operation: "execute",
-            command: "az",
+        process
+          .run({
+            operation: "AzureDevOpsCli.execute",
+            command: binaryPath,
+            args: input.args,
             cwd: input.cwd,
-            argumentCount: input.args.length,
-          },
-          error,
-        ),
+            timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+            ...(input.maxOutputBytes === undefined ? {} : { maxOutputBytes: input.maxOutputBytes }),
+          })
+          .pipe(
+            Effect.mapError((error) =>
+              AzureDevOpsCommandFailedError.fromVcsError(
+                {
+                  operation: "execute",
+                  command: binaryPath,
+                  cwd: input.cwd,
+                  argumentCount: input.args.length,
+                },
+                error,
+              ),
+            ),
+          ),
       ),
     );
 

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -61,6 +61,46 @@ describe("GitHubCli.layer", () => {
     ),
   );
 
+  it.effect("reports the configured GitHub CLI path when spawning fails", () =>
+    Effect.gen(function* () {
+      const binaryPath = "/opt/tools/gh";
+      mockRun.mockReturnValueOnce(
+        Effect.fail(
+          new VcsProcessSpawnError({
+            operation: "GitHubCli.execute",
+            command: binaryPath,
+            cwd: "/repo",
+            cause: PlatformError.systemError({
+              _tag: "NotFound",
+              module: "ChildProcess",
+              method: "spawn",
+              pathOrDescriptor: binaryPath,
+            }),
+          }),
+        ),
+      );
+      const gh = yield* GitHubCli.GitHubCli;
+      const error = yield* gh.execute({ cwd: "/repo", args: ["--version"] }).pipe(Effect.flip);
+
+      assert.equal(error._tag, "GitHubCliUnavailableError");
+      assert.strictEqual(error.command, binaryPath);
+      assert.match(error.message, /`\/opt\/tools\/gh`/);
+    }).pipe(
+      Effect.provide(
+        GitHubCli.layer.pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              Layer.mock(VcsProcess.VcsProcess)({ run: mockRun }),
+              ServerSettings.layerTest({
+                sourceControlProviders: { github: { binaryPath: "/opt/tools/gh" } },
+              }),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
   it("does not classify a missing cwd as an unavailable gh executable", () => {
     const context = { command: "gh", cwd: "/repo" } as const;
     const missingCwd = new VcsProcessSpawnError({

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -6,6 +6,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 import { VcsProcessExitError, VcsProcessSpawnError } from "@t3tools/contracts";
 
 import * as VcsProcess from "../vcs/VcsProcess.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import * as GitHubCli from "./GitHubCli.ts";
 
 const processOutput = (stdout: string): VcsProcess.VcsProcessOutput => ({
@@ -20,9 +21,12 @@ const mockRun = vi.fn<VcsProcess.VcsProcess["Service"]["run"]>();
 
 const layer = GitHubCli.layer.pipe(
   Layer.provide(
-    Layer.mock(VcsProcess.VcsProcess)({
-      run: mockRun,
-    }),
+    Layer.mergeAll(
+      Layer.mock(VcsProcess.VcsProcess)({
+        run: mockRun,
+      }),
+      ServerSettings.layerTest(),
+    ),
   ),
 );
 
@@ -31,6 +35,32 @@ afterEach(() => {
 });
 
 describe("GitHubCli.layer", () => {
+  it.effect("uses the configured GitHub CLI path", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(Effect.succeed(processOutput("")));
+      const gh = yield* GitHubCli.GitHubCli;
+
+      yield* gh.execute({ cwd: "/repo", args: ["--version"] });
+
+      expect(mockRun).toHaveBeenCalledWith(
+        expect.objectContaining({ command: "/opt/tools/gh", args: ["--version"] }),
+      );
+    }).pipe(
+      Effect.provide(
+        GitHubCli.layer.pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              Layer.mock(VcsProcess.VcsProcess)({ run: mockRun }),
+              ServerSettings.layerTest({
+                sourceControlProviders: { github: { binaryPath: "/opt/tools/gh" } },
+              }),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
   it("does not classify a missing cwd as an unavailable gh executable", () => {
     const context = { command: "gh", cwd: "/repo" } as const;
     const missingCwd = new VcsProcessSpawnError({

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -24,7 +24,7 @@ import {
 const DEFAULT_TIMEOUT_MS = 30_000;
 
 const gitHubCliFailureFields = {
-  command: Schema.Literal("gh"),
+  command: Schema.String,
   cwd: Schema.String,
   cause: Schema.Defect(),
 } as const;
@@ -34,7 +34,7 @@ export class GitHubCliUnavailableError extends Schema.TaggedErrorClass<GitHubCli
   gitHubCliFailureFields,
 ) {
   get detail(): string {
-    return "GitHub CLI (`gh`) is required but not available on PATH.";
+    return `GitHub CLI executable \`${this.command}\` is required but not available.`;
   }
 
   override get message(): string {
@@ -169,7 +169,7 @@ export const isGitHubCliError = Schema.is(GitHubCliError);
 
 export function fromVcsError(
   context: {
-    readonly command: "gh";
+    readonly command: string;
     readonly cwd: string;
   },
   error: VcsError,
@@ -346,17 +346,22 @@ export const make = Effect.gen(function* () {
       Effect.map((current) => current.sourceControlProviders.github.binaryPath),
       Effect.orElseSucceed(() => "gh"),
       Effect.flatMap((binaryPath) =>
-        process.run({
-          operation: "GitHubCli.execute",
-          command: binaryPath,
-          args: input.args,
-          cwd: input.cwd,
-          timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-          ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
-          ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
-        }),
+        process
+          .run({
+            operation: "GitHubCli.execute",
+            command: binaryPath,
+            args: input.args,
+            cwd: input.cwd,
+            timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+            ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
+            ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
+          })
+          .pipe(
+            Effect.mapError((error) =>
+              fromVcsError({ command: binaryPath, cwd: input.cwd }, error),
+            ),
+          ),
       ),
-      Effect.mapError((error) => fromVcsError({ command: "gh", cwd: input.cwd }, error)),
     );
 
   return GitHubCli.of({

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -14,6 +14,7 @@ import {
 } from "@t3tools/contracts";
 
 import * as VcsProcess from "../vcs/VcsProcess.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import {
   decodeGitHubPullRequestJson,
   decodeGitHubPullRequestListJson,
@@ -338,19 +339,25 @@ function deriveRepositoryCloneUrlsFromCreateOutput(
 
 export const make = Effect.gen(function* () {
   const process = yield* VcsProcess.VcsProcess;
+  const settings = yield* ServerSettings.ServerSettingsService;
 
   const execute: GitHubCli["Service"]["execute"] = (input) =>
-    process
-      .run({
-        operation: "GitHubCli.execute",
-        command: "gh",
-        args: input.args,
-        cwd: input.cwd,
-        timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-        ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
-        ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
-      })
-      .pipe(Effect.mapError((error) => fromVcsError({ command: "gh", cwd: input.cwd }, error)));
+    settings.getSettings.pipe(
+      Effect.map((current) => current.sourceControlProviders.github.binaryPath),
+      Effect.orElseSucceed(() => "gh"),
+      Effect.flatMap((binaryPath) =>
+        process.run({
+          operation: "GitHubCli.execute",
+          command: binaryPath,
+          args: input.args,
+          cwd: input.cwd,
+          timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
+          ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
+        }),
+      ),
+      Effect.mapError((error) => fromVcsError({ command: "gh", cwd: input.cwd }, error)),
+    );
 
   return GitHubCli.of({
     execute,

--- a/apps/server/src/sourceControl/GitLabCli.test.ts
+++ b/apps/server/src/sourceControl/GitLabCli.test.ts
@@ -3,7 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
-import { VcsProcessExitError } from "@t3tools/contracts";
+import { VcsProcessExitError, VcsProcessSpawnError } from "@t3tools/contracts";
 
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 import * as ServerSettings from "../serverSettings.ts";
@@ -47,6 +47,41 @@ it.effect("uses the configured GitLab CLI path", () =>
     expect(mockedRun).toHaveBeenCalledWith(
       expect.objectContaining({ command: "/opt/tools/glab", args: ["--version"] }),
     );
+  }).pipe(
+    Effect.provide(
+      GitLabCli.layer.pipe(
+        Layer.provide(
+          Layer.mergeAll(
+            Layer.mock(VcsProcess.VcsProcess)({ run: mockedRun }),
+            ServerSettings.layerTest({
+              sourceControlProviders: { gitlab: { binaryPath: "/opt/tools/glab" } },
+            }),
+          ),
+        ),
+      ),
+    ),
+  ),
+);
+
+it.effect("reports the configured GitLab CLI path when spawning fails", () =>
+  Effect.gen(function* () {
+    const binaryPath = "/opt/tools/glab";
+    mockedRun.mockReturnValueOnce(
+      Effect.fail(
+        new VcsProcessSpawnError({
+          operation: "GitLabCli.execute",
+          command: binaryPath,
+          cwd: "/repo",
+          cause: new Error("not found"),
+        }),
+      ),
+    );
+    const glab = yield* GitLabCli.GitLabCli;
+    const error = yield* glab.execute({ cwd: "/repo", args: ["--version"] }).pipe(Effect.flip);
+
+    assert.equal(error._tag, "GitLabCliUnavailableError");
+    assert.strictEqual(error.command, binaryPath);
+    assert.match(error.message, /`\/opt\/tools\/glab`/);
   }).pipe(
     Effect.provide(
       GitLabCli.layer.pipe(

--- a/apps/server/src/sourceControl/GitLabCli.test.ts
+++ b/apps/server/src/sourceControl/GitLabCli.test.ts
@@ -6,15 +6,19 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 import { VcsProcessExitError } from "@t3tools/contracts";
 
 import * as VcsProcess from "../vcs/VcsProcess.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import * as GitLabCli from "./GitLabCli.ts";
 
 const mockedRun = vi.fn<VcsProcess.VcsProcess["Service"]["run"]>();
 const layer = it.layer(
   GitLabCli.layer.pipe(
     Layer.provide(
-      Layer.mock(VcsProcess.VcsProcess)({
-        run: mockedRun,
-      }),
+      Layer.mergeAll(
+        Layer.mock(VcsProcess.VcsProcess)({
+          run: mockedRun,
+        }),
+        ServerSettings.layerTest(),
+      ),
     ),
   ),
 );
@@ -32,6 +36,32 @@ function processOutput(stdout: string): VcsProcess.VcsProcessOutput {
 afterEach(() => {
   mockedRun.mockReset();
 });
+
+it.effect("uses the configured GitLab CLI path", () =>
+  Effect.gen(function* () {
+    mockedRun.mockReturnValueOnce(Effect.succeed(processOutput("")));
+    const glab = yield* GitLabCli.GitLabCli;
+
+    yield* glab.execute({ cwd: "/repo", args: ["--version"] });
+
+    expect(mockedRun).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "/opt/tools/glab", args: ["--version"] }),
+    );
+  }).pipe(
+    Effect.provide(
+      GitLabCli.layer.pipe(
+        Layer.provide(
+          Layer.mergeAll(
+            Layer.mock(VcsProcess.VcsProcess)({ run: mockedRun }),
+            ServerSettings.layerTest({
+              sourceControlProviders: { gitlab: { binaryPath: "/opt/tools/glab" } },
+            }),
+          ),
+        ),
+      ),
+    ),
+  ),
+);
 
 layer("GitLabCli.layer", (it) => {
   it.effect("parses merge request view output", () =>

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -25,7 +25,7 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 
 const gitLabCliExecutionErrorContext = {
   operation: Schema.Literal("execute"),
-  command: Schema.Literal("glab"),
+  command: Schema.String,
   cwd: Schema.String,
   cause: Schema.Defect(),
 };
@@ -41,7 +41,7 @@ export class GitLabCliUnavailableError extends Schema.TaggedErrorClass<GitLabCli
   gitLabCliExecutionErrorContext,
 ) {
   get detail(): string {
-    return "GitLab CLI (`glab`) is required but not available on PATH.";
+    return `GitLab CLI executable \`${this.command}\` is required but not available.`;
   }
 
   override get message(): string {
@@ -93,7 +93,7 @@ export class GitLabMergeRequestNotFoundError extends Schema.TaggedErrorClass<Git
   static fromVcsError(
     context: {
       readonly operation: "execute";
-      readonly command: "glab";
+      readonly command: string;
       readonly cwd: string;
       readonly reference: string;
     },
@@ -129,7 +129,7 @@ export class GitLabCliCommandError extends Schema.TaggedErrorClass<GitLabCliComm
   static fromVcsError(
     context: {
       readonly operation: "execute";
-      readonly command: "glab";
+      readonly command: string;
       readonly cwd: string;
     },
     error: VcsError,
@@ -414,31 +414,29 @@ export const make = Effect.gen(function* () {
 
   const run = (
     input: Parameters<GitLabCli["Service"]["execute"]>[0],
-    mapError: (error: VcsError) => GitLabCliError,
+    mapError: (command: string, error: VcsError) => GitLabCliError,
   ) =>
     settings.getSettings.pipe(
       Effect.map((current) => current.sourceControlProviders.gitlab.binaryPath),
       Effect.orElseSucceed(() => "glab"),
       Effect.flatMap((binaryPath) =>
-        process.run({
-          operation: "GitLabCli.execute",
-          command: binaryPath,
-          args: input.args,
-          cwd: input.cwd,
-          timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-          ...(input.stdin === undefined ? {} : { stdin: input.stdin }),
-          ...(input.maxOutputBytes === undefined ? {} : { maxOutputBytes: input.maxOutputBytes }),
-        }),
+        process
+          .run({
+            operation: "GitLabCli.execute",
+            command: binaryPath,
+            args: input.args,
+            cwd: input.cwd,
+            timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+            ...(input.stdin === undefined ? {} : { stdin: input.stdin }),
+            ...(input.maxOutputBytes === undefined ? {} : { maxOutputBytes: input.maxOutputBytes }),
+          })
+          .pipe(Effect.mapError((error) => mapError(binaryPath, error))),
       ),
-      Effect.mapError(mapError),
     );
 
   const execute: GitLabCli["Service"]["execute"] = (input) =>
-    run(input, (error) =>
-      GitLabCliCommandError.fromVcsError(
-        { operation: "execute", command: "glab", cwd: input.cwd },
-        error,
-      ),
+    run(input, (command, error) =>
+      GitLabCliCommandError.fromVcsError({ operation: "execute", command, cwd: input.cwd }, error),
     );
 
   const executeMergeRequest = (input: {
@@ -446,11 +444,11 @@ export const make = Effect.gen(function* () {
     readonly reference: string;
     readonly args: ReadonlyArray<string>;
   }) =>
-    run(input, (error) =>
+    run(input, (command, error) =>
       GitLabMergeRequestNotFoundError.fromVcsError(
         {
           operation: "execute",
-          command: "glab",
+          command,
           cwd: input.cwd,
           reference: input.reference,
         },

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -14,6 +14,7 @@ import {
 } from "@t3tools/contracts";
 
 import * as VcsProcess from "../vcs/VcsProcess.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import {
   decodeGitLabMergeRequestJson,
   decodeGitLabMergeRequestListJson,
@@ -409,22 +410,28 @@ function parseRepositoryPath(repository: string): {
 
 export const make = Effect.gen(function* () {
   const process = yield* VcsProcess.VcsProcess;
+  const settings = yield* ServerSettings.ServerSettingsService;
 
   const run = (
     input: Parameters<GitLabCli["Service"]["execute"]>[0],
     mapError: (error: VcsError) => GitLabCliError,
   ) =>
-    process
-      .run({
-        operation: "GitLabCli.execute",
-        command: "glab",
-        args: input.args,
-        cwd: input.cwd,
-        timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-        ...(input.stdin === undefined ? {} : { stdin: input.stdin }),
-        ...(input.maxOutputBytes === undefined ? {} : { maxOutputBytes: input.maxOutputBytes }),
-      })
-      .pipe(Effect.mapError(mapError));
+    settings.getSettings.pipe(
+      Effect.map((current) => current.sourceControlProviders.gitlab.binaryPath),
+      Effect.orElseSucceed(() => "glab"),
+      Effect.flatMap((binaryPath) =>
+        process.run({
+          operation: "GitLabCli.execute",
+          command: binaryPath,
+          args: input.args,
+          cwd: input.cwd,
+          timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          ...(input.stdin === undefined ? {} : { stdin: input.stdin }),
+          ...(input.maxOutputBytes === undefined ? {} : { maxOutputBytes: input.maxOutputBytes }),
+        }),
+      ),
+      Effect.mapError(mapError),
+    );
 
   const execute: GitLabCli["Service"]["execute"] = (input) =>
     run(input, (error) =>

--- a/apps/server/src/sourceControl/SourceControlDiscovery.test.ts
+++ b/apps/server/src/sourceControl/SourceControlDiscovery.test.ts
@@ -7,6 +7,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 import { VcsProcessSpawnError } from "@t3tools/contracts";
 
 import * as ServerConfig from "../config.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 import * as AzureDevOpsCli from "./AzureDevOpsCli.ts";
@@ -32,6 +33,7 @@ const sourceControlProviderRegistryTestLayer = (input: {
         Layer.mock(GitLabCli.GitLabCli)({}),
         Layer.mock(VcsDriverRegistry.VcsDriverRegistry)({}),
         Layer.mock(VcsProcess.VcsProcess)(input.process),
+        ServerSettings.layerTest(),
       ),
     ),
   );

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
@@ -8,6 +8,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 import { VcsRepositoryDetectionError } from "@t3tools/contracts";
 
 import * as ServerConfig from "../config.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import type * as VcsDriver from "../vcs/VcsDriver.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
 import * as VcsProcess from "../vcs/VcsProcess.ts";
@@ -40,6 +41,7 @@ function makeRegistry(input: {
   }>;
   readonly process?: Partial<VcsProcess.VcsProcess["Service"]>;
   readonly resolve?: VcsDriverRegistry.VcsDriverRegistry["Service"]["resolve"];
+  readonly githubBinaryPath?: string;
 }) {
   const driver = {
     listRemotes: () =>
@@ -89,9 +91,25 @@ function makeRegistry(input: {
         registryLayer,
         processLayer,
         Layer.mock(AzureDevOpsCli.AzureDevOpsCli)({}),
-        Layer.mock(BitbucketApi.BitbucketApi)({}),
+        Layer.mock(BitbucketApi.BitbucketApi)({
+          probeAuth: Effect.succeed({
+            status: "unknown",
+            account: Option.none(),
+            host: Option.none(),
+            detail: Option.none(),
+          }),
+        }),
         Layer.mock(GitHubCli.GitHubCli)({}),
         Layer.mock(GitLabCli.GitLabCli)({}),
+        ServerSettings.layerTest(
+          input.githubBinaryPath === undefined
+            ? {}
+            : {
+                sourceControlProviders: {
+                  github: { binaryPath: input.githubBinaryPath },
+                },
+              },
+        ),
         ServerConfig.layerTest(process.cwd(), {
           prefix: "t3-source-control-registry-test-",
         }).pipe(Layer.provide(NodeServices.layer)),
@@ -99,6 +117,32 @@ function makeRegistry(input: {
     ),
   );
 }
+
+it.effect("discovers GitHub with the configured CLI path", () =>
+  Effect.gen(function* () {
+    const calls: Array<Parameters<VcsProcess.VcsProcess["Service"]["run"]>[0]> = [];
+    const registry = yield* makeRegistry({
+      remotes: [],
+      githubBinaryPath: "/opt/tools/gh",
+      process: {
+        run: (input) => {
+          calls.push(input);
+          return Effect.succeed(processOutput(""));
+        },
+      },
+    });
+
+    yield* registry.discover;
+
+    assert.equal(
+      calls.some(
+        (call) =>
+          call.operation === "source-control.discovery.probe" && call.command === "/opt/tools/gh",
+      ),
+      true,
+    );
+  }),
+);
 
 it.effect("routes GitHub remotes to the GitHub provider", () =>
   Effect.gen(function* () {

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
@@ -5,10 +5,12 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import {
+  sourceControlProviderBinaryPath,
   SourceControlProviderError,
   type SourceControlProviderDiscoveryItem,
+  type SourceControlProviderKind,
+  type ServerSettings,
 } from "@t3tools/contracts";
-import type { SourceControlProviderKind } from "@t3tools/contracts";
 import { detectSourceControlProviderFromRemoteUrl } from "@t3tools/shared/sourceControl";
 
 import * as AzureDevOpsSourceControlProvider from "./AzureDevOpsSourceControlProvider.ts";
@@ -22,6 +24,7 @@ import {
   type SourceControlProviderDiscoverySpec,
 } from "./SourceControlProviderDiscovery.ts";
 import { ServerConfig } from "../config.ts";
+import { ServerSettingsService } from "../serverSettings.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 
@@ -194,9 +197,25 @@ function bindProviderContext(
   });
 }
 
+function configureDiscoverySpecs(
+  specs: ReadonlyArray<SourceControlProviderDiscoverySpec>,
+  settings: ServerSettings,
+): ReadonlyArray<SourceControlProviderDiscoverySpec> {
+  return specs.map((spec) => {
+    if (spec.type !== "cli") return spec;
+    return {
+      ...spec,
+      executable:
+        sourceControlProviderBinaryPath(settings.sourceControlProviders, spec.kind) ??
+        spec.executable,
+    };
+  });
+}
+
 export const makeWithProviders = Effect.fn("makeSourceControlProviderRegistryWithProviders")(
   function* (registrations: ReadonlyArray<SourceControlProviderRegistration>) {
     const config = yield* ServerConfig;
+    const settingsService = yield* ServerSettingsService;
     const process = yield* VcsProcess.VcsProcess;
     const vcsRegistry = yield* VcsDriverRegistry.VcsDriverRegistry;
     const providers = new Map<
@@ -204,6 +223,10 @@ export const makeWithProviders = Effect.fn("makeSourceControlProviderRegistryWit
       SourceControlProvider.SourceControlProvider["Service"]
     >(registrations.map((registration) => [registration.kind, registration.provider]));
     const discoverySpecs = registrations.map((registration) => registration.discovery);
+    const configuredDiscoverySpecs = settingsService.getSettings.pipe(
+      Effect.map((settings) => configureDiscoverySpecs(discoverySpecs, settings)),
+      Effect.orElseSucceed(() => discoverySpecs),
+    );
 
     const get: SourceControlProviderRegistry["Service"]["get"] = (kind) =>
       Effect.succeed(providers.get(kind) ?? unsupportedProvider(kind));
@@ -236,12 +259,8 @@ export const makeWithProviders = Effect.fn("makeSourceControlProviderRegistryWit
         );
         const context = selectProviderContext(remotes.remotes);
 
-        return yield* refineUnknownRemoteProvider({
-          specs: discoverySpecs,
-          process,
-          cwd,
-          context,
-        });
+        const specs = yield* configuredDiscoverySpecs;
+        return yield* refineUnknownRemoteProvider({ specs, process, cwd, context });
       },
     );
 
@@ -254,15 +273,21 @@ export const makeWithProviders = Effect.fn("makeSourceControlProviderRegistryWit
       timeToLive: (exit) => (Exit.isSuccess(exit) ? PROVIDER_DETECTION_CACHE_TTL : Duration.zero),
     });
 
-    const resolveHandle: SourceControlProviderRegistry["Service"]["resolveHandle"] = (input) =>
-      (input.context === undefined
-        ? Cache.get(providerContextCache, input.cwd)
-        : refineUnknownRemoteProvider({
-            specs: discoverySpecs,
-            process,
-            cwd: input.cwd,
-            context: input.context,
-          })
+    const resolveHandle: SourceControlProviderRegistry["Service"]["resolveHandle"] = (input) => {
+      const providedContext = input.context;
+      return (
+        providedContext === undefined
+          ? Cache.get(providerContextCache, input.cwd)
+          : configuredDiscoverySpecs.pipe(
+              Effect.flatMap((specs) =>
+                refineUnknownRemoteProvider({
+                  specs,
+                  process,
+                  cwd: input.cwd,
+                  context: providedContext,
+                }),
+              ),
+            )
       ).pipe(
         Effect.map((context) => {
           const kind = context?.provider.kind ?? "unknown";
@@ -273,20 +298,25 @@ export const makeWithProviders = Effect.fn("makeSourceControlProviderRegistryWit
           } satisfies SourceControlProviderHandle;
         }),
       );
+    };
 
     return SourceControlProviderRegistry.of({
       get,
       resolveHandle,
       resolve: (input) => resolveHandle(input).pipe(Effect.map((handle) => handle.provider)),
-      discover: Effect.all(
-        discoverySpecs.map((spec) =>
-          probeSourceControlProvider({
-            spec,
-            process,
-            cwd: config.cwd,
-          }),
+      discover: configuredDiscoverySpecs.pipe(
+        Effect.flatMap((specs) =>
+          Effect.all(
+            specs.map((spec) =>
+              probeSourceControlProvider({
+                spec,
+                process,
+                cwd: config.cwd,
+              }),
+            ),
+            { concurrency: "unbounded" },
+          ),
         ),
-        { concurrency: "unbounded" },
       ),
     });
   },

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -2,14 +2,16 @@ import { ChevronDownIcon, GitPullRequestIcon, RefreshCwIcon } from "lucide-react
 import * as Duration from "effect/Duration";
 import * as Option from "effect/Option";
 import { useEffect, useState, type ReactNode } from "react";
-import type {
-  BackgroundActivitySettings,
-  SourceControlProviderKind,
-  SourceControlDiscoveryResult,
-  SourceControlProviderAuth,
-  SourceControlProviderDiscoveryItem,
-  VcsDriverKind,
-  VcsDiscoveryItem,
+import {
+  sourceControlProviderBinaryPath,
+  type BackgroundActivitySettings,
+  type ServerSettingsPatch,
+  type SourceControlProviderKind,
+  type SourceControlDiscoveryResult,
+  type SourceControlProviderAuth,
+  type SourceControlProviderDiscoveryItem,
+  type VcsDriverKind,
+  type VcsDiscoveryItem,
 } from "@t3tools/contracts";
 import {
   getBackgroundActivityBaseProfile,
@@ -35,6 +37,7 @@ import {
   EmptyTitle,
 } from "../ui/empty";
 import { Skeleton } from "../ui/skeleton";
+import { DraftInput } from "../ui/draft-input";
 import {
   NumberField,
   NumberFieldDecrement,
@@ -421,6 +424,52 @@ function GitFetchIntervalSettings() {
   );
 }
 
+function sourceControlProviderBinaryPathPatch(
+  kind: SourceControlProviderKind,
+  binaryPath: string,
+): ServerSettingsPatch {
+  switch (kind) {
+    case "github":
+      return { sourceControlProviders: { github: { binaryPath } } };
+    case "gitlab":
+      return { sourceControlProviders: { gitlab: { binaryPath } } };
+    case "azure-devops":
+      return { sourceControlProviders: { azureDevOps: { binaryPath } } };
+    default:
+      return {};
+  }
+}
+
+function SourceControlProviderBinaryPathSettings(props: {
+  readonly kind: SourceControlProviderKind;
+}) {
+  const settings = usePrimarySettings();
+  const updateSettings = useUpdatePrimarySettings();
+  const binaryPath = sourceControlProviderBinaryPath(settings.sourceControlProviders, props.kind);
+
+  if (binaryPath === undefined) return null;
+
+  return (
+    <div className="grid gap-2">
+      <label className="text-xs font-medium text-foreground" htmlFor={`${props.kind}-binary-path`}>
+        CLI executable
+      </label>
+      <DraftInput
+        id={`${props.kind}-binary-path`}
+        value={binaryPath}
+        onCommit={(next) => updateSettings(sourceControlProviderBinaryPathPatch(props.kind, next))}
+        autoComplete="off"
+        spellCheck={false}
+        className="font-mono"
+      />
+      <p className="text-xs leading-relaxed text-muted-foreground">
+        Command name or absolute path used for discovery and source control operations. Rescan after
+        changing it.
+      </p>
+    </div>
+  );
+}
+
 function SourceControlSectionSkeleton({
   title,
   headerAction,
@@ -573,7 +622,11 @@ export function SourceControlSettingsPanel() {
               headerAction={hasVersionControlSystems ? null : scanButton}
             >
               {result.sourceControlProviders.map((item) => (
-                <DiscoveryItemRow key={`provider:${item.kind}`} item={item} />
+                <DiscoveryItemRow key={`provider:${item.kind}`} item={item}>
+                  {isPrimaryEnvironment && item.executable ? (
+                    <SourceControlProviderBinaryPathSettings kind={item.kind} />
+                  ) : undefined}
+                </DiscoveryItemRow>
               ))}
             </SettingsSection>
           ) : null}

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -92,6 +92,8 @@ The **Source Control settings** page shows you exactly what's connected:
 - 👤 Which account is signed in (when available)
 
 Run a quick **Rescan** after setting up a new machine or changing credentials.
+If a CLI is installed outside the server's `PATH`, expand its provider row and set **CLI
+executable** to the command name or absolute path, then rescan.
 
 ## Getting Started
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -25,6 +25,7 @@ import {
   ProviderInstanceId,
   type ProviderDriverKind,
 } from "./providerInstance.ts";
+import type { SourceControlProviderKind } from "./sourceControl.ts";
 
 // ── Client Settings (local-only) ───────────────────────────────
 
@@ -771,6 +772,34 @@ export const SourceControlWritingStyleSettings = Schema.Struct({
 });
 export type SourceControlWritingStyleSettings = typeof SourceControlWritingStyleSettings.Type;
 
+const makeSourceControlProviderSettings = (fallback: string) =>
+  Schema.Struct({
+    binaryPath: makeBinaryPathSetting(fallback),
+  }).pipe(Schema.withDecodingDefault(Effect.succeed({})));
+
+export const SourceControlProvidersSettings = Schema.Struct({
+  github: makeSourceControlProviderSettings("gh"),
+  gitlab: makeSourceControlProviderSettings("glab"),
+  azureDevOps: makeSourceControlProviderSettings("az"),
+}).pipe(Schema.withDecodingDefault(Effect.succeed({})));
+export type SourceControlProvidersSettings = typeof SourceControlProvidersSettings.Type;
+
+export function sourceControlProviderBinaryPath(
+  settings: SourceControlProvidersSettings,
+  kind: SourceControlProviderKind,
+): string | undefined {
+  switch (kind) {
+    case "github":
+      return settings.github.binaryPath;
+    case "gitlab":
+      return settings.gitlab.binaryPath;
+    case "azure-devops":
+      return settings.azureDevOps.binaryPath;
+    default:
+      return undefined;
+  }
+}
+
 export const DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL = Duration.seconds(30);
 export const DEFAULT_PROVIDER_HEALTH_REFRESH_INTERVAL = Duration.minutes(5);
 
@@ -898,6 +927,7 @@ export const ServerSettings = Schema.Struct({
   sourceControlWritingStyle: SourceControlWritingStyleSettings.pipe(
     Schema.withDecodingDefault(Effect.succeed({})),
   ),
+  sourceControlProviders: SourceControlProvidersSettings,
   sourceControlWriterModelSelection: Schema.NullOr(ModelSelection).pipe(
     Schema.withDecodingDefault(Effect.succeed(null)),
   ),
@@ -1111,6 +1141,15 @@ export const ServerSettingsPatch = Schema.Struct({
       mode: Schema.optionalKey(SourceControlWritingStyleMode),
       customInstructions: Schema.optionalKey(TrimmedString),
       followChangeRequestTemplates: Schema.optionalKey(Schema.Boolean),
+    }),
+  ),
+  sourceControlProviders: Schema.optionalKey(
+    Schema.Struct({
+      github: Schema.optionalKey(Schema.Struct({ binaryPath: Schema.optionalKey(TrimmedString) })),
+      gitlab: Schema.optionalKey(Schema.Struct({ binaryPath: Schema.optionalKey(TrimmedString) })),
+      azureDevOps: Schema.optionalKey(
+        Schema.Struct({ binaryPath: Schema.optionalKey(TrimmedString) }),
+      ),
     }),
   ),
   sourceControlWriterModelSelection: Schema.optionalKey(Schema.NullOr(ModelSelection)),


### PR DESCRIPTION
Source-control integrations currently spawn `gh`, `glab`, and `az` by command name. When these tools are installed through a version manager or outside the server's inherited PATH, T3 Code reports them as unavailable and cannot run source-control operations.

This adds server-scoped binary path settings for GitHub, GitLab, and Azure DevOps. The configured executable is used consistently for discovery, authentication checks, remote refinement, and provider operations. The Source Control settings page exposes the path in each CLI provider row, while preserving `gh`, `glab`, and `az` as defaults.

Related to #7618.

## Verification

- 83 focused server tests pass
- Contracts, server, and web typechecks pass
- Modified-file lint passes

## Screenshots

### Before

![Source Control Providers before custom CLI paths](https://github.com/user-attachments/assets/ebd8b172-b3f4-48a5-9814-36f15dbbb12a)

### After

![Source Control Providers after custom CLI paths](https://github.com/user-attachments/assets/6b6b8228-e914-4444-8168-8c003fce2b4e)

Assisted by GPT-5.6 Sol via the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add custom CLI path configuration for source-control providers
> - Adds settings schema, resolver, and UI control for configuring custom executable paths for GitHub, GitLab, and Azure DevOps providers.
> - Updates the CLI factories (`AzureDevOpsCli.make`, `GitHubCli.make`, `GitLabCli.make`) to read the configured path from server settings and pass it to `VcsProcess.run`.
> - Error schemas and mappers for all three providers are updated to retain and report the configured executable used for the failed invocation.
> - Risk: `SourceControlProviderRegistry.makeWithProviders` uses the configured executable during discovery; settings-read failures fall back to the default discovery specifications.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db14ad9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Source-control discovery and all CLI operations now depend on server settings at runtime; settings read failures fall back to default command names, which could mask misconfiguration on constrained deployments.
> 
> **Overview**
> Adds **server-scoped `sourceControlProviders.*.binaryPath` settings** (defaults `gh`, `glab`, `az`) so GitHub, GitLab, and Azure DevOps integrations can run CLIs installed outside the server’s `PATH`.
> 
> **GitHubCli**, **GitLabCli**, and **AzureDevOpsCli** now resolve the executable from `ServerSettingsService` on each run and pass that path into process spawn and error context (unavailable messages cite the configured path, not only “on PATH”). **SourceControlProviderRegistry** applies the same paths to CLI discovery probes and remote refinement via `configureDiscoverySpecs`.
> 
> The **Source Control** settings UI adds a **CLI executable** field on each CLI provider row (primary environment only), with trim-on-save and blank → default behavior covered in server settings tests. User docs note setting the path and rescanning when needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db14ad9389f7b4fc120836069a636681178b94e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->