### PR TITLE
feat(web): format GitHub repository links

### DIFF
--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -241,6 +241,22 @@ describe("ChatMarkdown file option chips", () => {
   });
 });
 
+describe("ChatMarkdown GitHub repository links", () => {
+  it("shows the repository name with a GitHub icon instead of a favicon URL", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        cwd="/tmp/project"
+        text="https://github.com/pingdotgg/t3code"
+        messageLinkStyle
+      />,
+    );
+
+    expect(html).toContain("pingdotgg/t3code");
+    expect(html).toContain("<svg");
+    expect(html).not.toContain("google.com/s2/favicons");
+  });
+});
+
 const ARTIFACT_TEMPLATE_DIRECTIVE =
   '::artifact-template{skill_name="artifact-template-hello-world" skill_directory="/Users/test/.codex/skills/artifact-template-hello-world" display_name="Hello World" artifact_kind="document"}';
 

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -174,6 +174,8 @@ import {
   BrowserPreviewUnavailableError,
 } from "../browser/openFileInPreview";
 import { resolveLinkTarget } from "../browser/browserLinkTarget";
+import { parseGitHubRepositoryLink } from "../githubRepositoryLink";
+import { GitHubIcon } from "./Icons";
 
 interface ChatMarkdownProps {
   text: string;
@@ -185,6 +187,8 @@ interface ChatMarkdownProps {
   isStreaming?: boolean;
   skills?: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
   className?: string;
+  /** Use the contrasting link treatment for markdown rendered inside a user message. */
+  messageLinkStyle?: boolean;
   /** Treat single newlines as hard breaks — chat-style user input. */
   lineBreaks?: boolean;
   /** Parse sanitized raw HTML instead of displaying its source text. */
@@ -1579,6 +1583,15 @@ function MarkdownExternalLinkContent({
   );
 }
 
+function MarkdownGitHubRepositoryLinkContent({ nameWithOwner }: { nameWithOwner: string }) {
+  return (
+    <span className="inline-flex min-w-0 max-w-full items-center gap-[0.35em] align-middle">
+      <GitHubIcon aria-hidden="true" className="size-[1em] shrink-0" />
+      <span className="min-w-0 truncate">{nameWithOwner}</span>
+    </span>
+  );
+}
+
 const MarkdownFileLink = memo(function MarkdownFileLink({
   href,
   targetPath,
@@ -1961,6 +1974,7 @@ function ChatMarkdown({
   isStreaming = false,
   skills = EMPTY_MARKDOWN_SKILLS,
   className,
+  messageLinkStyle = false,
   lineBreaks = false,
   parseRawHtml = true,
   onUseArtifactTemplate,
@@ -2432,6 +2446,7 @@ function ChatMarkdown({
           : null;
         if (!fileLinkMeta) {
           const faviconHost = resolveExternalWebLinkHost(href);
+          const githubRepository = href ? parseGitHubRepositoryLink(href) : null;
           const pullRequestAutolink = String(
             (props as Record<string, unknown>)["data-pull-request-autolink"] ?? "",
           );
@@ -2442,6 +2457,8 @@ function ChatMarkdown({
                 ? plainHastText(node)
                 : undefined;
           const isPullRequestAutolink = pullRequestCopy !== undefined;
+          const isGitHubRepositoryLink =
+            githubRepository !== null && hastHasText(node) && !isPullRequestAutolink;
           const isSameDocumentLink = href?.startsWith("#") ?? false;
           const onClick = props.onClick;
           const canOpenInPreview = Boolean(threadRef) && isPreviewSupportedInRuntime();
@@ -2449,7 +2466,14 @@ function ChatMarkdown({
           const link = (
             <a
               {...props}
-              className={cn(props.className, pullRequestAutolink === "commit" && "font-mono")}
+              className={cn(
+                props.className,
+                pullRequestAutolink === "commit" && "font-mono",
+                isGitHubRepositoryLink && "chat-markdown-github-repository-link",
+                isGitHubRepositoryLink &&
+                  messageLinkStyle &&
+                  "chat-markdown-github-repository-message-link",
+              )}
               data-markdown-copy={pullRequestCopy}
               href={href}
               target={isSameDocumentLink ? undefined : "_blank"}
@@ -2563,7 +2587,11 @@ function ChatMarkdown({
                 });
               }}
             >
-              {faviconHost && hastHasText(node) && !isPullRequestAutolink ? (
+              {isGitHubRepositoryLink && githubRepository ? (
+                <MarkdownGitHubRepositoryLinkContent
+                  nameWithOwner={githubRepository.nameWithOwner}
+                />
+              ) : faviconHost && hastHasText(node) && !isPullRequestAutolink ? (
                 <MarkdownExternalLinkContent host={faviconHost} plainText={plainHastText(node)}>
                   {linkChildren}
                 </MarkdownExternalLinkContent>
@@ -2743,6 +2771,7 @@ function ChatMarkdown({
     imageBaseDir,
     isStreaming,
     linkTargetPreference,
+    messageLinkStyle,
     markdownFileLinkMetaByHref,
     onTaskListChange,
     onUseArtifactTemplate,

--- a/apps/web/src/components/ComposerPromptEditor.test.ts
+++ b/apps/web/src/components/ComposerPromptEditor.test.ts
@@ -52,6 +52,8 @@ function createCitationEditor(text = "") {
   registerComposerInlineTokenPaste(editor, {
     createMentionNode: (path) => $createTextNode(`<mention:${path}>`),
     createCitationNode: $createComposerCitationNode,
+    createGitHubRepositoryNode: (_href, nameWithOwner) =>
+      $createTextNode(`<github:${nameWithOwner}>`),
     getExpandedAbsoluteOffsetForPoint: (_node, offset) => offset,
   });
   return editor;
@@ -113,6 +115,8 @@ describe("registerComposerInlineTokenPaste", () => {
     registerComposerInlineTokenPaste(editor, {
       createMentionNode: (path) => $createTextNode(`<mention:${path}>`),
       createCitationNode: $createComposerCitationNode,
+      createGitHubRepositoryNode: (_href, nameWithOwner) =>
+        $createTextNode(`<github:${nameWithOwner}>`),
       getExpandedAbsoluteOffsetForPoint: () => 0,
     });
     editor.registerCommand(PASTE_COMMAND, plainTextFallback, COMMAND_PRIORITY_EDITOR);
@@ -159,6 +163,8 @@ describe("registerComposerInlineTokenPaste", () => {
     registerComposerInlineTokenPaste(editor, {
       createMentionNode: (path) => $createTextNode(`<mention:${path}>`),
       createCitationNode: $createComposerCitationNode,
+      createGitHubRepositoryNode: (_href, nameWithOwner) =>
+        $createTextNode(`<github:${nameWithOwner}>`),
       getExpandedAbsoluteOffsetForPoint: () => 0,
     });
     editor.registerCommand(PASTE_COMMAND, plainTextFallback, COMMAND_PRIORITY_EDITOR);
@@ -194,6 +200,8 @@ describe("registerComposerInlineTokenPaste", () => {
     registerComposerInlineTokenPaste(editor, {
       createMentionNode: (path) => $createTextNode(`<mention:${path}>`),
       createCitationNode: $createComposerCitationNode,
+      createGitHubRepositoryNode: (_href, nameWithOwner) =>
+        $createTextNode(`<github:${nameWithOwner}>`),
       getExpandedAbsoluteOffsetForPoint: () => 0,
     });
     editor.registerCommand(PASTE_COMMAND, plainTextFallback, COMMAND_PRIORITY_EDITOR);
@@ -212,6 +220,38 @@ describe("registerComposerInlineTokenPaste", () => {
     expect(event.defaultPrevented).toBe(true);
     expect(editor.getEditorState().read(() => $getRoot().getTextContent())).toBe(
       "<mention:@scope/pkg/sub> ",
+    );
+  });
+
+  it("pastes a GitHub repository link as a display token while preserving its URL", () => {
+    vi.stubGlobal("ClipboardEvent", TestClipboardEvent);
+    const editor = createEditor();
+    const githubUrl = "https://github.com/pingdotgg/t3code";
+    const createGitHubRepositoryNode = vi.fn((href: string, nameWithOwner: string) =>
+      $createTextNode(`<github:${href}:${nameWithOwner}>`),
+    );
+
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        $getRoot().append(paragraph);
+        paragraph.selectEnd();
+      },
+      { discrete: true },
+    );
+    registerComposerInlineTokenPaste(editor, {
+      createMentionNode: (path) => $createTextNode(`<mention:${path}>`),
+      createCitationNode: $createComposerCitationNode,
+      createGitHubRepositoryNode,
+      getExpandedAbsoluteOffsetForPoint: () => 0,
+    });
+
+    const event = pasteText(editor, githubUrl);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(createGitHubRepositoryNode).toHaveBeenCalledWith(githubUrl, "pingdotgg/t3code");
+    expect(editor.getEditorState().read(() => $getRoot().getTextContent())).toBe(
+      `<github:${githubUrl}:pingdotgg/t3code> `,
     );
   });
 

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -78,12 +78,14 @@ import {
   COMPOSER_INLINE_CHIP_DECORATOR_CLASS_NAME,
   COMPOSER_INLINE_CHIP_ICON_CLASS_NAME,
   COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME,
+  COMPOSER_INLINE_LINK_DECORATOR_CLASS_NAME,
   COMPOSER_INLINE_SKILL_CHIP_CLASS_NAME,
   SKILL_CHIP_ICON_SVG,
 } from "./composerInlineChip";
 import { FILE_TAG_CHIP_CLASS_NAME, FileTagChipContent } from "./chat/FileTagChip";
 import { ComposerPendingTerminalContextChip } from "./chat/ComposerPendingTerminalContexts";
 import { getTimelinePageScrollKey } from "./chat/pageScrollController";
+import { GitHubIcon } from "./Icons";
 import { formatProviderSkillDisplayName } from "@t3tools/client-runtime/providerSkills";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 import { registerComposerInlineTokenPaste } from "./composerInlineTokenPaste";
@@ -118,6 +120,16 @@ type SerializedComposerMentionNode = Spread<
   {
     path: string;
     type: "composer-mention";
+    version: 1;
+  },
+  SerializedLexicalNode
+>;
+
+type SerializedComposerGitHubRepositoryNode = Spread<
+  {
+    href: string;
+    nameWithOwner: string;
+    type: "composer-github-repository";
     version: 1;
   },
   SerializedLexicalNode
@@ -226,6 +238,91 @@ class ComposerMentionNode extends DecoratorNode<React.ReactElement> {
 
 function $createComposerMentionNode(path: string): ComposerMentionNode {
   return $applyNodeReplacement(new ComposerMentionNode(path));
+}
+
+function ComposerGitHubRepositoryDecorator(props: { nameWithOwner: string }) {
+  return (
+    <span
+      className="inline-flex max-w-full items-baseline gap-[0.33em] leading-[inherit] text-primary"
+      contentEditable={false}
+      spellCheck={false}
+      data-composer-github-repository-chip="true"
+    >
+      <span aria-hidden="true" className={COMPOSER_INLINE_CHIP_ICON_CLASS_NAME}>
+        <GitHubIcon className="size-full" />
+      </span>
+      <span className="block self-baseline truncate leading-[inherit] select-none">
+        {props.nameWithOwner}
+      </span>
+    </span>
+  );
+}
+
+class ComposerGitHubRepositoryNode extends DecoratorNode<React.ReactElement> {
+  __href: string;
+  __nameWithOwner: string;
+
+  static override getType(): string {
+    return "composer-github-repository";
+  }
+
+  static override clone(node: ComposerGitHubRepositoryNode): ComposerGitHubRepositoryNode {
+    return new ComposerGitHubRepositoryNode(node.__href, node.__nameWithOwner, node.__key);
+  }
+
+  static override importJSON(
+    serializedNode: SerializedComposerGitHubRepositoryNode,
+  ): ComposerGitHubRepositoryNode {
+    return $createComposerGitHubRepositoryNode(
+      serializedNode.href,
+      serializedNode.nameWithOwner,
+    ).updateFromJSON(serializedNode);
+  }
+
+  constructor(href: string, nameWithOwner: string, key?: NodeKey) {
+    super(key);
+    this.__href = href;
+    this.__nameWithOwner = nameWithOwner;
+  }
+
+  override exportJSON(): SerializedComposerGitHubRepositoryNode {
+    return {
+      ...super.exportJSON(),
+      href: this.__href,
+      nameWithOwner: this.__nameWithOwner,
+      type: "composer-github-repository",
+      version: 1,
+    };
+  }
+
+  override createDOM(): HTMLElement {
+    const dom = document.createElement("span");
+    dom.className = COMPOSER_INLINE_LINK_DECORATOR_CLASS_NAME;
+    return dom;
+  }
+
+  override updateDOM(): false {
+    return false;
+  }
+
+  override getTextContent(): string {
+    return this.__href;
+  }
+
+  override isInline(): true {
+    return true;
+  }
+
+  override decorate(): React.ReactElement {
+    return <ComposerGitHubRepositoryDecorator nameWithOwner={this.__nameWithOwner} />;
+  }
+}
+
+function $createComposerGitHubRepositoryNode(
+  href: string,
+  nameWithOwner: string,
+): ComposerGitHubRepositoryNode {
+  return $applyNodeReplacement(new ComposerGitHubRepositoryNode(href, nameWithOwner));
 }
 
 function resolveSkillDescription(
@@ -441,6 +538,7 @@ function $createComposerTerminalContextNode(
 
 type ComposerInlineTokenNode =
   | ComposerMentionNode
+  | ComposerGitHubRepositoryNode
   | ComposerSkillNode
   | ComposerCitationNode
   | ComposerTerminalContextNode;
@@ -448,6 +546,7 @@ type ComposerInlineTokenNode =
 function isComposerInlineTokenNode(candidate: unknown): candidate is ComposerInlineTokenNode {
   return (
     candidate instanceof ComposerMentionNode ||
+    candidate instanceof ComposerGitHubRepositoryNode ||
     candidate instanceof ComposerSkillNode ||
     candidate instanceof ComposerCitationNode ||
     candidate instanceof ComposerTerminalContextNode
@@ -852,6 +951,10 @@ function $setComposerEditorPrompt(
     }
     if (segment.type === "mention") {
       paragraph.append($createComposerMentionNode(segment.path));
+      continue;
+    }
+    if (segment.type === "github-repository") {
+      paragraph.append($createComposerGitHubRepositoryNode(segment.href, segment.nameWithOwner));
       continue;
     }
     if (segment.type === "skill") {
@@ -1281,6 +1384,7 @@ function ComposerInlineTokenPastePlugin() {
       registerComposerInlineTokenPaste(editor, {
         createMentionNode: $createComposerMentionNode,
         createCitationNode: $createComposerCitationNode,
+        createGitHubRepositoryNode: $createComposerGitHubRepositoryNode,
         getExpandedAbsoluteOffsetForPoint,
       }),
     [editor],
@@ -1985,6 +2089,7 @@ export function ComposerPromptEditor({
       editable: true,
       nodes: [
         ComposerMentionNode,
+        ComposerGitHubRepositoryNode,
         ComposerSkillNode,
         ComposerCitationNode,
         ComposerTerminalContextNode,

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -2357,6 +2357,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
             threadRef={ctx.threadRef ?? undefined}
             skills={props.skills}
             className="text-message-foreground"
+            messageLinkStyle
             lineBreaks
             parseRawHtml={false}
           />
@@ -2380,6 +2381,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
                   threadRef={ctx.threadRef ?? undefined}
                   skills={props.skills}
                   className="text-message-foreground"
+                  messageLinkStyle
                   lineBreaks
                   parseRawHtml={false}
                 />
@@ -2469,6 +2471,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
           threadRef={ctx.threadRef ?? undefined}
           skills={props.skills}
           className="text-message-foreground"
+          messageLinkStyle
           lineBreaks
           parseRawHtml={false}
         />,
@@ -2495,6 +2498,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
       threadRef={ctx.threadRef ?? undefined}
       skills={props.skills}
       className="text-message-foreground"
+      messageLinkStyle
       lineBreaks
       parseRawHtml={false}
     />
@@ -2531,6 +2535,7 @@ function UserMessageReviewCommentCard({ comment }: { comment: ReviewCommentConte
           threadRef={ctx.threadRef ?? undefined}
           skills={ctx.skills}
           className="text-message-foreground"
+          messageLinkStyle
         />
       )}
       {renderablePatch?.kind === "files" &&

--- a/apps/web/src/components/composerInlineChip.ts
+++ b/apps/web/src/components/composerInlineChip.ts
@@ -6,12 +6,16 @@ const INLINE_CHIP_GEOMETRY_CLASS_NAME =
 
 const INLINE_CHIP_CLASS_NAME = `${INLINE_CHIP_GEOMETRY_CLASS_NAME} border border-border/70 bg-accent/40 text-foreground`;
 
+const COMPOSER_INLINE_CHIP_SELECTION_CLASS_NAME =
+  "data-[composer-chip-selected]:after:pointer-events-none data-[composer-chip-selected]:after:absolute data-[composer-chip-selected]:after:inset-0 data-[composer-chip-selected]:after:rounded-[6px] data-[composer-chip-selected]:after:bg-[Highlight] data-[composer-chip-selected]:after:opacity-30 data-[composer-chip-selected]:after:content-['']";
+
 export const CHAT_INLINE_CHIP_CLASS_NAME = `${INLINE_CHIP_CLASS_NAME} text-[12px]`;
 
 export const COMPOSER_INLINE_CHIP_CLASS_NAME = `${INLINE_CHIP_CLASS_NAME} text-[0.86em] select-none`;
 
-export const COMPOSER_INLINE_CHIP_DECORATOR_CLASS_NAME =
-  "relative inline-flex align-[-0.125em] leading-none data-[composer-chip-selected]:after:pointer-events-none data-[composer-chip-selected]:after:absolute data-[composer-chip-selected]:after:inset-0 data-[composer-chip-selected]:after:rounded-[6px] data-[composer-chip-selected]:after:bg-[Highlight] data-[composer-chip-selected]:after:opacity-30 data-[composer-chip-selected]:after:content-['']";
+export const COMPOSER_INLINE_CHIP_DECORATOR_CLASS_NAME = `relative inline-flex align-[-0.125em] leading-none ${COMPOSER_INLINE_CHIP_SELECTION_CLASS_NAME}`;
+
+export const COMPOSER_INLINE_LINK_DECORATOR_CLASS_NAME = `relative inline-flex align-baseline ${COMPOSER_INLINE_CHIP_SELECTION_CLASS_NAME}`;
 
 export const COMPOSER_INLINE_CHIP_ICON_CLASS_NAME =
   "block size-[1.17em] shrink-0 self-center opacity-85 [&>svg]:block";

--- a/apps/web/src/components/composerInlineTokenPaste.ts
+++ b/apps/web/src/components/composerInlineTokenPaste.ts
@@ -16,6 +16,7 @@ import { collectComposerPromptInlineTokens } from "../composer-editor-mentions";
 interface ComposerInlineTokenPasteOptions {
   createMentionNode: (path: string) => LexicalNode;
   createCitationNode: (citation: AssistantCitation, source: string) => LexicalNode;
+  createGitHubRepositoryNode: (href: string, nameWithOwner: string) => LexicalNode;
   getExpandedAbsoluteOffsetForPoint: (node: LexicalNode, pointOffset: number) => number;
 }
 
@@ -36,11 +37,14 @@ export function registerComposerInlineTokenPaste(
       if (text.length === 0) {
         return false;
       }
-      // Token grammar requires trailing whitespace; a virtual newline lets a
-      // mention at the very end of the pasted text still parse.
+      // Token grammar requires trailing whitespace; a virtual newline lets an
+      // inline token at the very end of the pasted text still parse.
       const tokens = collectComposerPromptInlineTokens(`${text}\n`).filter(
         (token) =>
-          (token.type === "mention" || token.type === "citation") && token.end <= text.length,
+          (token.type === "mention" ||
+            token.type === "citation" ||
+            token.type === "github-repository") &&
+          token.end <= text.length,
       );
       if (tokens.length === 0) {
         return false;
@@ -67,7 +71,10 @@ export function registerComposerInlineTokenPaste(
         }
       };
       const firstToken = tokens[0];
-      if (firstToken?.type === "mention" && firstToken.start === 0) {
+      if (
+        (firstToken?.type === "mention" || firstToken?.type === "github-repository") &&
+        firstToken.start === 0
+      ) {
         const startPoint = selection.isBackward() ? selection.focus : selection.anchor;
         const insertionOffset = options.getExpandedAbsoluteOffsetForPoint(
           startPoint.getNode(),
@@ -91,16 +98,18 @@ export function registerComposerInlineTokenPaste(
         nodes.push(
           token.type === "citation"
             ? options.createCitationNode(token.citation, token.source)
-            : options.createMentionNode(token.value),
+            : token.type === "github-repository"
+              ? options.createGitHubRepositoryNode(token.href, token.nameWithOwner)
+              : options.createMentionNode(token.value),
         );
         cursor = token.end;
       }
       if (cursor < text.length) {
         appendText(text.slice(cursor));
-      } else if (tokens.at(-1)?.type === "mention") {
-        // Keep the serialized prompt valid: mention tokens need trailing
-        // whitespace, so a paste ending in a mention gets the same
-        // trailing space the autocomplete inserts.
+      } else if (tokens.at(-1)?.type === "mention" || tokens.at(-1)?.type === "github-repository") {
+        // Keep the serialized prompt valid: inline tokens need trailing
+        // whitespace, so a paste ending in one gets the same trailing space
+        // the autocomplete inserts.
         nodes.push($createTextNode(" "));
       }
       selection.insertNodes(nodes);

--- a/apps/web/src/composer-editor-mentions.test.ts
+++ b/apps/web/src/composer-editor-mentions.test.ts
@@ -85,6 +85,26 @@ describe("splitPromptIntoComposerSegments", () => {
     ).toEqual([{ type: "text", text: "Read [the docs](https://example.com/docs) first" }]);
   });
 
+  it("splits completed GitHub repository links into display segments", () => {
+    expect(
+      splitPromptIntoComposerSegments("Review https://github.com/pingdotgg/t3code please"),
+    ).toEqual([
+      { type: "text", text: "Review " },
+      {
+        type: "github-repository",
+        href: "https://github.com/pingdotgg/t3code",
+        nameWithOwner: "pingdotgg/t3code",
+        source: "https://github.com/pingdotgg/t3code",
+      },
+      { type: "text", text: " please" },
+    ]);
+  });
+
+  it("leaves GitHub links to issues and files as normal text", () => {
+    const prompt = "Read https://github.com/pingdotgg/t3code/issues/1 please";
+    expect(splitPromptIntoComposerSegments(prompt)).toEqual([{ type: "text", text: prompt }]);
+  });
+
   it("keeps multiple assistant citations atomic next to punctuation and Unicode", () => {
     const source = serializeAssistantCitation(citation);
     const otherCitation = {

--- a/apps/web/src/composer-editor-mentions.ts
+++ b/apps/web/src/composer-editor-mentions.ts
@@ -8,6 +8,7 @@ import {
   collectComposerInlineTokens,
   type ComposerInlineToken,
 } from "@t3tools/shared/composerInlineTokens";
+import { collectGitHubRepositoryLinkMatches } from "./githubRepositoryLink";
 
 export type ComposerPromptSegment =
   | {
@@ -26,6 +27,12 @@ export type ComposerPromptSegment =
   | {
       type: "citation";
       citation: AssistantCitation;
+      source: string;
+    }
+  | {
+      type: "github-repository";
+      href: string;
+      nameWithOwner: string;
       source: string;
     }
   | {
@@ -132,9 +139,13 @@ function forEachMentionMatch(
 }
 
 export function collectComposerPromptInlineTokens(text: string) {
-  const tokens = collectComposerInlineTokens(text);
+  const githubRepositories = collectGitHubRepositoryLinkMatches(text).map((match) => ({
+    ...match,
+    type: "github-repository" as const,
+  }));
+  const tokens = [...collectComposerInlineTokens(text), ...githubRepositories];
   const citations = collectAssistantCitations(text);
-  if (citations.length === 0) return tokens;
+  if (citations.length === 0) return tokens.sort((left, right) => left.start - right.start);
 
   // An unfinished @ mention can otherwise consume the start of a citation's label.
   return [
@@ -169,6 +180,13 @@ function splitPromptTextIntoComposerSegments(text: string): ComposerPromptSegmen
       segments.push({
         type: "mention",
         path: match.value,
+        source: match.source,
+      });
+    } else if (match.type === "github-repository") {
+      segments.push({
+        type: "github-repository",
+        href: match.href,
+        nameWithOwner: match.nameWithOwner,
         source: match.source,
       });
     } else {

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -72,7 +72,11 @@ export function expandCollapsedComposerCursor(text: string, cursorInput: number)
   let expandedCursor = 0;
 
   for (const segment of segments) {
-    if (segment.type === "mention" || segment.type === "citation") {
+    if (
+      segment.type === "mention" ||
+      segment.type === "citation" ||
+      segment.type === "github-repository"
+    ) {
       const expandedLength = segment.source.length;
       if (remaining <= 1) {
         return expandedCursor + (remaining === 0 ? 0 : expandedLength);
@@ -149,7 +153,11 @@ export function collapseExpandedComposerCursor(text: string, cursorInput: number
   let collapsedCursor = 0;
 
   for (const segment of segments) {
-    if (segment.type === "mention" || segment.type === "citation") {
+    if (
+      segment.type === "mention" ||
+      segment.type === "citation" ||
+      segment.type === "github-repository"
+    ) {
       const expandedLength = segment.source.length;
       if (remaining === 0) {
         return collapsedCursor;

--- a/apps/web/src/githubRepositoryLink.test.ts
+++ b/apps/web/src/githubRepositoryLink.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  collectGitHubRepositoryLinkMatches,
+  parseGitHubRepositoryLink,
+} from "./githubRepositoryLink";
+
+describe("parseGitHubRepositoryLink", () => {
+  it("recognizes canonical repository URLs", () => {
+    expect(parseGitHubRepositoryLink("https://github.com/pingdotgg/t3code/")).toEqual({
+      href: "https://github.com/pingdotgg/t3code/",
+      nameWithOwner: "pingdotgg/t3code",
+    });
+    expect(parseGitHubRepositoryLink("https://www.github.com/pingdotgg/t3code.git")).toEqual({
+      href: "https://www.github.com/pingdotgg/t3code.git",
+      nameWithOwner: "pingdotgg/t3code",
+    });
+  });
+
+  it.each([
+    "https://github.com/pingdotgg/t3code/issues/1",
+    "https://example.com/pingdotgg/t3code",
+    "https://github.com/pingdotgg/t3code with spaces",
+  ])("rejects non-repository URLs: %s", (href) => {
+    expect(parseGitHubRepositoryLink(href)).toBeNull();
+  });
+});
+
+describe("collectGitHubRepositoryLinkMatches", () => {
+  it("collects complete repository links and excludes sentence punctuation", () => {
+    const text = "Review https://github.com/pingdotgg/t3code?tab=readme, then continue.";
+
+    expect(collectGitHubRepositoryLinkMatches(text)).toEqual([
+      {
+        href: "https://github.com/pingdotgg/t3code?tab=readme",
+        nameWithOwner: "pingdotgg/t3code",
+        source: "https://github.com/pingdotgg/t3code?tab=readme",
+        start: 7,
+        end: 53,
+      },
+    ]);
+  });
+
+  it("requires whitespace after a link before making it a composer token", () => {
+    expect(collectGitHubRepositoryLinkMatches("https://github.com/pingdotgg/t3code")).toEqual([]);
+  });
+});

--- a/apps/web/src/githubRepositoryLink.ts
+++ b/apps/web/src/githubRepositoryLink.ts
@@ -1,0 +1,101 @@
+export interface GitHubRepositoryLink {
+  readonly href: string;
+  readonly nameWithOwner: string;
+}
+
+export interface GitHubRepositoryLinkMatch extends GitHubRepositoryLink {
+  readonly source: string;
+  readonly start: number;
+  readonly end: number;
+}
+
+const GITHUB_REPOSITORY_HOSTNAMES = new Set(["github.com", "www.github.com"]);
+const GITHUB_OWNER_PATTERN = /^[A-Za-z0-9-]+$/u;
+const GITHUB_REPOSITORY_PATTERN = /^[A-Za-z0-9._-]+$/u;
+const GITHUB_REPOSITORY_URL_PATTERN = /(^|\s)(https?:\/\/(?:www\.)?github\.com\/\S+)(?=\s)/giu;
+const TRAILING_LINK_PUNCTUATION_PATTERN = /[.,!?;:)\]}]+$/u;
+
+function decodePathSegment(segment: string): string | null {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return null;
+  }
+}
+
+export function parseGitHubRepositoryLink(
+  href: string | null | undefined,
+): GitHubRepositoryLink | null {
+  if (!href) return null;
+
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+
+  if (
+    (url.protocol !== "http:" && url.protocol !== "https:") ||
+    !GITHUB_REPOSITORY_HOSTNAMES.has(url.hostname.toLowerCase()) ||
+    url.port.length > 0 ||
+    url.username.length > 0 ||
+    url.password.length > 0
+  ) {
+    return null;
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean).map(decodePathSegment);
+  if (segments.length !== 2 || segments.some((segment) => segment === null)) {
+    return null;
+  }
+
+  const owner = segments[0];
+  const repository = segments[1]?.replace(/\.git$/iu, "");
+  if (
+    !owner ||
+    !repository ||
+    owner === "." ||
+    owner === ".." ||
+    repository === "." ||
+    repository === ".." ||
+    repository.endsWith(".") ||
+    !GITHUB_OWNER_PATTERN.test(owner) ||
+    !GITHUB_REPOSITORY_PATTERN.test(repository)
+  ) {
+    return null;
+  }
+
+  return {
+    href,
+    nameWithOwner: `${owner}/${repository}`,
+  };
+}
+
+function trimTrailingLinkPunctuation(candidate: string): string {
+  return candidate.replace(TRAILING_LINK_PUNCTUATION_PATTERN, "");
+}
+
+export function collectGitHubRepositoryLinkMatches(
+  text: string,
+): ReadonlyArray<GitHubRepositoryLinkMatch> {
+  const matches: GitHubRepositoryLinkMatch[] = [];
+
+  for (const match of text.matchAll(GITHUB_REPOSITORY_URL_PATTERN)) {
+    const prefix = match[1] ?? "";
+    const candidate = match[2] ?? "";
+    const source = trimTrailingLinkPunctuation(candidate);
+    const parsed = parseGitHubRepositoryLink(source);
+    if (!parsed) continue;
+
+    const start = (match.index ?? 0) + prefix.length;
+    matches.push({
+      ...parsed,
+      source,
+      start,
+      end: start + source.length,
+    });
+  }
+
+  return matches;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1700,6 +1700,22 @@ code {
   text-decoration: none;
 }
 
+.chat-markdown a.chat-markdown-github-repository-link {
+  display: inline-flex;
+  max-width: 100%;
+  align-items: center;
+  vertical-align: middle;
+}
+
+.chat-markdown a.chat-markdown-github-repository-message-link,
+.chat-markdown a.chat-markdown-github-repository-message-link:hover,
+.chat-markdown a.chat-markdown-github-repository-message-link:focus-visible {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.15em;
+}
+
 .chat-markdown a:not(.chat-markdown-file-link):hover,
 .chat-markdown a:not(.chat-markdown-file-link):focus-visible {
   background-image: radial-gradient(circle, currentcolor 0.75px, transparent 1px);

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -8,6 +8,11 @@ On mobile, an empty composer shows an interrupt button while the agent is workin
 or an attachment replaces it with the send button. This applies to both compact and expanded
 composers.
 
+On web and desktop, a GitHub repository URL displays as a compact GitHub icon with its
+`owner/repository` name in the composer and after sending. T3 Code preserves the full URL when
+copying or sending the message. Links to issues, pull requests, files, and other repository pages
+keep their full text.
+
 You can attach images up to 10 MB. On servers that support file uploads, you can also
 attach videos, text files, PDFs, ZIP archives, and other files. Each file can be up to the limit advertised
 by the server, capped at 50 MB. Each message can contain up to eight attachments in total. Files


### PR DESCRIPTION
## What Changed

- Format root GitHub repository URLs as a compact GitHub icon and `owner/repository` label in the composer and sent user messages.
- Preserve the original URL when sending, copying, serializing, or reopening a draft.
- Leave issue, pull request, file, and other deeper GitHub URLs unchanged.

## Why

Raw repository URLs are visually noisy in conversation and inconsistent with the compact link treatment used by ChatGPT. This adds focused parsing and rendering for canonical repository-root links without changing link behavior or provider/server contracts.

Discussed in [Ideas discussion #9633](https://github.com/pingdotgg/t3code/discussions/9633).

## UI Changes

| Before | After |
| --- | --- |
| ![Raw GitHub repository URL before formatting](https://github.com/user-attachments/assets/146dfde0-3da0-46a2-87d3-cf93f7f6c67d) | ![Formatted GitHub repository link after formatting](https://github.com/user-attachments/assets/77805dda-931c-4105-9e19-ed3bd6e90f78) |

## Verification

- `vp test run --project unit ...`: 152 tests passed across 5 focused files
- Web typecheck passed
- Targeted lint completed without errors
- Formatting and `git diff --check` passed
- Verified in the running web client that the formatted link and adjacent text share the same baseline
- Updated the user-facing composer documentation

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] A video is not applicable because this change has no animation or interaction timing

Generated by GPT-5.6-Sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only markdown and composer rendering with strict URL parsing; no auth, API, or server contract changes.
> 
> **Overview**
> Adds focused handling for **canonical GitHub repository URLs** (`https://github.com/owner/repo` with no deeper path): they render as a **GitHub icon plus `owner/repo`** instead of a favicon and full URL, in both the **composer** and **sent user messages**.
> 
> A new `githubRepositoryLink` parser/matcher limits this to repo-root links (issues, PRs, and other paths stay plain). The composer gets a **`ComposerGitHubRepositoryNode`** inline token, segment splitting, paste support, and cursor mapping that still **serializes the full URL** for send/copy. **`ChatMarkdown`** gains optional **`messageLinkStyle`** for user-message link styling, and user timeline markdown enables it.
> 
> Composer chip styling is split so link-style decorators (GitHub repo) can share selection chrome without pill borders. User docs describe the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bb31caf7dc38808f1d156b14779fc89c3f4f261. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Format GitHub repository links as icon-and-owner/repo tokens in web chat and composer
> - Adds a GitHub repository URL parser and text matcher in [githubRepositoryLink.ts](https://github.com/pingdotgg/t3code/pull/9634/files#diff-2e0705a691f61f37dadd703de034d9be9733e5635aed4e06fa78d5cd999ed637) that accepts canonical `github.com` repository-root URLs and rejects issues, PRs, files, other hosts, ports, and credentials.
> - Updates [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/9634/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) to render qualifying repository links inline with a GitHub icon and truncated `nameWithOwner` label, plus a `messageLinkStyle` prop for user-message-specific styling.
> - Adds a `ComposerGitHubRepositoryNode` Lexical node, decorator, factory, and paste handler in [ComposerPromptEditor.tsx](https://github.com/pingdotgg/t3code/pull/9634/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4) so pasted or initial-prompt repository URLs become compact non-editable tokens while preserving the full href.
> - Updates prompt segment parsing in [composer-editor-mentions.ts](https://github.com/pingdotgg/t3code/pull/9634/files#diff-fe3b0266af75d6e06d8819ee307b1048dd163e07bfc6758027f84a441c92be3c) and cursor mapping in [composer-logic.ts](https://github.com/pingdotgg/t3code/pull/9634/files#diff-d8bf01d2c2c41e34161141355950c042b07686d185ea476beb91213ecf6466a6) to handle the new `github-repository` segment variant.
> - Behavioral Change: only repository-root URLs (e.g. `https://github.com/owner/repo`) are converted to display tokens; issue, pull-request, file, and other repository-page links remain plain text.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9bb31ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->