### PR TITLE
feat(web only): find in chat with mod+f

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -204,6 +204,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
       assert.equal(defaultsByCommand.get("themeEditor.toggle"), "mod+alt+shift+t");
       assert.equal(defaultsByCommand.get("filePicker.toggle"), "mod+p");
       assert.equal(defaultsByCommand.get("projectSearch.toggle"), "mod+shift+f");
+      assert.equal(defaultsByCommand.get("chat.find"), "mod+f");
       assert.equal(defaultsByCommand.get("sidebar.toggle"), "mod+b");
       assert.equal(defaultsByCommand.get("rightPanel.toggle"), "mod+alt+b");
       assert.isFalse(defaultsByCommand.has("rightPanel.toggleMaximized"));

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -49,6 +49,7 @@ import {
   LinkIcon,
   MessageSquareIcon,
   PaletteIcon,
+  SearchIcon,
   SettingsIcon,
   SquarePenIcon,
   TextSearchIcon,
@@ -149,6 +150,7 @@ import { EnvironmentMachineIcon } from "./EnvironmentMachineIcon";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { ProjectFilePicker } from "./files/ProjectFilePicker";
 import { ProjectContentSearchDialog } from "./search/ProjectContentSearchDialog";
+import { openChatFind } from "./chat/chatFindBus";
 import { toggleThemeEditorForTheme } from "./settings/themeEditorStore";
 import { searchSettings, SETTINGS_SECTION_LABELS } from "./settings/settingsSearch";
 import {
@@ -1654,6 +1656,20 @@ function OpenCommandPaletteDialog(props: {
       openOverlayMode("content");
     },
   });
+
+  if (activeThread != null) {
+    actionItems.push({
+      kind: "action",
+      value: "action:find-in-chat",
+      searchTerms: ["find in chat", "find in thread", "search chat", "search messages", "find"],
+      title: "Find in chat",
+      icon: <SearchIcon className={ITEM_ICON_CLASS} />,
+      shortcutCommand: "chat.find",
+      run: async () => {
+        openChatFind();
+      },
+    });
+  }
 
   actionItems.push({
     kind: "action",

--- a/apps/web/src/components/chat/ChatFindBar.logic.test.ts
+++ b/apps/web/src/components/chat/ChatFindBar.logic.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
+  buildChatFindPattern,
   countChatFindOccurrences,
   deriveChatFindMatches,
   resolveChatFindActiveIndex,
@@ -46,30 +47,64 @@ const rows: MessagesTimelineRow[] = [
   messageRow("assistant-2", "assistant", "Found the error; the ERROR was a typo. error fixed."),
 ];
 
+function find(query: string, options?: Parameters<typeof buildChatFindPattern>[1]) {
+  return deriveChatFindMatches(rows, buildChatFindPattern(query, options));
+}
+
+describe("buildChatFindPattern", () => {
+  it("returns null for an empty or whitespace query", () => {
+    expect(buildChatFindPattern("")).toBeNull();
+    expect(buildChatFindPattern("   ")).toBeNull();
+  });
+
+  it("escapes regex metacharacters", () => {
+    expect(countChatFindOccurrences("a.b a-b a.b", buildChatFindPattern("a.b")!)).toBe(2);
+    expect(countChatFindOccurrences("x(1) x(2)", buildChatFindPattern("(1)")!)).toBe(1);
+  });
+});
+
 describe("countChatFindOccurrences", () => {
-  it("counts case-insensitive, non-overlapping occurrences", () => {
-    expect(countChatFindOccurrences("Error error ERROR", "error")).toBe(3);
-    expect(countChatFindOccurrences("aaaa", "aa")).toBe(2);
-    expect(countChatFindOccurrences("nothing", "error")).toBe(0);
-    expect(countChatFindOccurrences("anything", "")).toBe(0);
+  it("counts case-insensitive, non-overlapping occurrences by default", () => {
+    expect(countChatFindOccurrences("Error error ERROR", buildChatFindPattern("error")!)).toBe(3);
+    expect(countChatFindOccurrences("aaaa", buildChatFindPattern("aa")!)).toBe(2);
+    expect(countChatFindOccurrences("nothing", buildChatFindPattern("error")!)).toBe(0);
+  });
+
+  it("honors case sensitivity", () => {
+    const pattern = buildChatFindPattern("Error", { caseSensitive: true, wholeWord: false })!;
+    expect(countChatFindOccurrences("Error error ERROR", pattern)).toBe(1);
+  });
+
+  it("honors whole word matching around punctuation and unicode letters", () => {
+    const pattern = buildChatFindPattern("error", { caseSensitive: false, wholeWord: true })!;
+    expect(countChatFindOccurrences("error errors (error) my_error Error.", pattern)).toBe(3);
+    expect(countChatFindOccurrences("erroré", pattern)).toBe(0);
+    const dotted = buildChatFindPattern("foo.", { caseSensitive: false, wholeWord: true })!;
+    expect(countChatFindOccurrences("foo. foo.bar", dotted)).toBe(1);
   });
 });
 
 describe("deriveChatFindMatches", () => {
-  it("returns nothing for an empty or whitespace query", () => {
-    expect(deriveChatFindMatches(rows, "")).toEqual([]);
-    expect(deriveChatFindMatches(rows, "   ")).toEqual([]);
+  it("returns nothing without a pattern", () => {
+    expect(deriveChatFindMatches(rows, null)).toEqual([]);
   });
 
   it("lists one match per occurrence in timeline order and skips non-message rows", () => {
-    expect(deriveChatFindMatches(rows, " error ")).toEqual([
+    expect(find(" error ")).toEqual([
       { rowId: "user-1", rowIndex: 0, occurrence: 0 },
       { rowId: "assistant-1", rowIndex: 2, occurrence: 0 },
       { rowId: "assistant-2", rowIndex: 4, occurrence: 0 },
       { rowId: "assistant-2", rowIndex: 4, occurrence: 1 },
       { rowId: "assistant-2", rowIndex: 4, occurrence: 2 },
     ]);
-    expect(deriveChatFindMatches(rows, "Worked for")).toEqual([]);
+    expect(find("Worked for")).toEqual([]);
+  });
+
+  it("applies the match options to every row", () => {
+    expect(find("ERROR", { caseSensitive: true, wholeWord: false })).toEqual([
+      { rowId: "assistant-2", rowIndex: 4, occurrence: 0 },
+    ]);
+    expect(find("Error", { caseSensitive: false, wholeWord: true })).toHaveLength(5);
   });
 });
 
@@ -85,18 +120,21 @@ describe("stepChatFindIndex", () => {
 });
 
 describe("resolveChatFindActiveIndex", () => {
-  const matches = deriveChatFindMatches(rows, "error");
+  const matches = find("error");
 
   it("follows the same occurrence when rows shift underneath it", () => {
     const previous = matches[3]!;
-    const shifted = deriveChatFindMatches([messageRow("user-0", "user", "hi"), ...rows], "error");
+    const shifted = deriveChatFindMatches(
+      [messageRow("user-0", "user", "hi"), ...rows],
+      buildChatFindPattern("error"),
+    );
     expect(resolveChatFindActiveIndex(shifted, 3, previous)).toBe(3);
     expect(shifted[3]).toEqual({ rowId: "assistant-2", rowIndex: 5, occurrence: 1 });
   });
 
   it("clamps when the previous occurrence is gone", () => {
     const previous = matches[4]!;
-    const fewer = deriveChatFindMatches(rows.slice(0, 3), "error");
+    const fewer = deriveChatFindMatches(rows.slice(0, 3), buildChatFindPattern("error"));
     expect(resolveChatFindActiveIndex(fewer, 4, previous)).toBe(1);
     expect(resolveChatFindActiveIndex([], 4, previous)).toBe(0);
     expect(resolveChatFindActiveIndex(matches, -2, null)).toBe(0);
@@ -104,7 +142,7 @@ describe("resolveChatFindActiveIndex", () => {
 });
 
 describe("resolveChatFindStartIndex", () => {
-  const matches = deriveChatFindMatches(rows, "error");
+  const matches = find("error");
 
   it("starts at the first match at or after the visible row", () => {
     expect(resolveChatFindStartIndex(matches, null)).toBe(0);

--- a/apps/web/src/components/chat/ChatFindBar.logic.test.ts
+++ b/apps/web/src/components/chat/ChatFindBar.logic.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  countChatFindOccurrences,
+  deriveChatFindMatches,
+  resolveChatFindActiveIndex,
+  resolveChatFindStartIndex,
+  stepChatFindIndex,
+} from "./ChatFindBar.logic";
+import type { MessagesTimelineRow } from "./MessagesTimeline.logic";
+
+function messageRow(id: string, role: "user" | "assistant", text: string): MessagesTimelineRow {
+  return {
+    kind: "message",
+    id,
+    createdAt: "2026-01-01T00:00:00Z",
+    message: {
+      id: id as never,
+      role,
+      text,
+      turnId: null,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      streaming: false,
+    },
+    durationStart: "2026-01-01T00:00:00Z",
+    showAssistantMeta: false,
+    showAssistantCopyButton: false,
+    assistantCopyStreaming: false,
+  };
+}
+
+const foldRow: MessagesTimelineRow = {
+  kind: "turn-fold",
+  id: "turn-fold:turn-1",
+  createdAt: "2026-01-01T00:00:00Z",
+  turnId: "turn-1" as never,
+  label: "Worked for 3s on error handling",
+  expanded: false,
+};
+
+const rows: MessagesTimelineRow[] = [
+  messageRow("user-1", "user", "Fix the Error in the parser"),
+  foldRow,
+  messageRow("assistant-1", "assistant", "No error here."),
+  messageRow("user-2", "user", "still broken"),
+  messageRow("assistant-2", "assistant", "Found the error; the ERROR was a typo. error fixed."),
+];
+
+describe("countChatFindOccurrences", () => {
+  it("counts case-insensitive, non-overlapping occurrences", () => {
+    expect(countChatFindOccurrences("Error error ERROR", "error")).toBe(3);
+    expect(countChatFindOccurrences("aaaa", "aa")).toBe(2);
+    expect(countChatFindOccurrences("nothing", "error")).toBe(0);
+    expect(countChatFindOccurrences("anything", "")).toBe(0);
+  });
+});
+
+describe("deriveChatFindMatches", () => {
+  it("returns nothing for an empty or whitespace query", () => {
+    expect(deriveChatFindMatches(rows, "")).toEqual([]);
+    expect(deriveChatFindMatches(rows, "   ")).toEqual([]);
+  });
+
+  it("lists one match per occurrence in timeline order and skips non-message rows", () => {
+    expect(deriveChatFindMatches(rows, " error ")).toEqual([
+      { rowId: "user-1", rowIndex: 0, occurrence: 0 },
+      { rowId: "assistant-1", rowIndex: 2, occurrence: 0 },
+      { rowId: "assistant-2", rowIndex: 4, occurrence: 0 },
+      { rowId: "assistant-2", rowIndex: 4, occurrence: 1 },
+      { rowId: "assistant-2", rowIndex: 4, occurrence: 2 },
+    ]);
+    expect(deriveChatFindMatches(rows, "Worked for")).toEqual([]);
+  });
+});
+
+describe("stepChatFindIndex", () => {
+  it("wraps in both directions and tolerates a single match", () => {
+    expect(stepChatFindIndex(0, 3, 1)).toBe(1);
+    expect(stepChatFindIndex(2, 3, 1)).toBe(0);
+    expect(stepChatFindIndex(0, 3, -1)).toBe(2);
+    expect(stepChatFindIndex(0, 1, 1)).toBe(0);
+    expect(stepChatFindIndex(0, 1, -1)).toBe(0);
+    expect(stepChatFindIndex(4, 0, 1)).toBe(0);
+  });
+});
+
+describe("resolveChatFindActiveIndex", () => {
+  const matches = deriveChatFindMatches(rows, "error");
+
+  it("follows the same occurrence when rows shift underneath it", () => {
+    const previous = matches[3]!;
+    const shifted = deriveChatFindMatches([messageRow("user-0", "user", "hi"), ...rows], "error");
+    expect(resolveChatFindActiveIndex(shifted, 3, previous)).toBe(3);
+    expect(shifted[3]).toEqual({ rowId: "assistant-2", rowIndex: 5, occurrence: 1 });
+  });
+
+  it("clamps when the previous occurrence is gone", () => {
+    const previous = matches[4]!;
+    const fewer = deriveChatFindMatches(rows.slice(0, 3), "error");
+    expect(resolveChatFindActiveIndex(fewer, 4, previous)).toBe(1);
+    expect(resolveChatFindActiveIndex([], 4, previous)).toBe(0);
+    expect(resolveChatFindActiveIndex(matches, -2, null)).toBe(0);
+  });
+});
+
+describe("resolveChatFindStartIndex", () => {
+  const matches = deriveChatFindMatches(rows, "error");
+
+  it("starts at the first match at or after the visible row", () => {
+    expect(resolveChatFindStartIndex(matches, null)).toBe(0);
+    expect(resolveChatFindStartIndex(matches, 0)).toBe(0);
+    expect(resolveChatFindStartIndex(matches, 1)).toBe(1);
+    expect(resolveChatFindStartIndex(matches, 3)).toBe(2);
+  });
+
+  it("falls back to the first match when nothing follows the visible row", () => {
+    expect(resolveChatFindStartIndex(matches, 10)).toBe(0);
+  });
+});

--- a/apps/web/src/components/chat/ChatFindBar.logic.ts
+++ b/apps/web/src/components/chat/ChatFindBar.logic.ts
@@ -16,34 +16,53 @@ export function chatFindSearchableText(row: MessagesTimelineRow): string | null 
   return typeof text === "string" && text.length > 0 ? text : null;
 }
 
-export function countChatFindOccurrences(text: string, query: string): number {
-  if (query.length === 0) return 0;
-  const haystack = text.toLowerCase();
-  const needle = query.toLowerCase();
+export interface ChatFindOptions {
+  readonly caseSensitive: boolean;
+  readonly wholeWord: boolean;
+}
+
+export const DEFAULT_CHAT_FIND_OPTIONS: ChatFindOptions = {
+  caseSensitive: false,
+  wholeWord: false,
+};
+
+const WORD_CHARACTER = String.raw`[\p{L}\p{N}_]`;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function buildChatFindPattern(
+  query: string,
+  options: ChatFindOptions = DEFAULT_CHAT_FIND_OPTIONS,
+): RegExp | null {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) return null;
+  const escaped = escapeRegExp(trimmed);
+  const source = options.wholeWord
+    ? `(?<!${WORD_CHARACTER})${escaped}(?!${WORD_CHARACTER})`
+    : escaped;
+  return new RegExp(source, options.caseSensitive ? "gu" : "giu");
+}
+
+export function countChatFindOccurrences(text: string, pattern: RegExp): number {
   let count = 0;
-  for (
-    let index = haystack.indexOf(needle);
-    index !== -1;
-    index = haystack.indexOf(needle, index + needle.length)
-  ) {
-    count += 1;
-  }
+  for (const _ of text.matchAll(pattern)) count += 1;
   return count;
 }
 
 export function deriveChatFindMatches(
   rows: ReadonlyArray<MessagesTimelineRow>,
-  query: string,
+  pattern: RegExp | null,
 ): ChatFindMatch[] {
-  const trimmed = query.trim();
-  if (trimmed.length === 0) return [];
+  if (pattern === null) return [];
   const matches: ChatFindMatch[] = [];
   for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
     const row = rows[rowIndex];
     if (!row) continue;
     const text = chatFindSearchableText(row);
     if (text === null) continue;
-    const count = countChatFindOccurrences(text, trimmed);
+    const count = countChatFindOccurrences(text, pattern);
     for (let occurrence = 0; occurrence < count; occurrence += 1) {
       matches.push({ rowId: row.id, rowIndex, occurrence });
     }

--- a/apps/web/src/components/chat/ChatFindBar.logic.ts
+++ b/apps/web/src/components/chat/ChatFindBar.logic.ts
@@ -1,0 +1,80 @@
+import type { MessagesTimelineRow } from "./MessagesTimeline.logic";
+
+export interface ChatFindMatch {
+  readonly rowId: string;
+  readonly rowIndex: number;
+  readonly occurrence: number;
+}
+
+export function chatFindMatchKey(match: ChatFindMatch): string {
+  return `${match.rowId}:${match.occurrence}`;
+}
+
+export function chatFindSearchableText(row: MessagesTimelineRow): string | null {
+  if (row.kind !== "message") return null;
+  const text = row.message.text;
+  return typeof text === "string" && text.length > 0 ? text : null;
+}
+
+export function countChatFindOccurrences(text: string, query: string): number {
+  if (query.length === 0) return 0;
+  const haystack = text.toLowerCase();
+  const needle = query.toLowerCase();
+  let count = 0;
+  for (
+    let index = haystack.indexOf(needle);
+    index !== -1;
+    index = haystack.indexOf(needle, index + needle.length)
+  ) {
+    count += 1;
+  }
+  return count;
+}
+
+export function deriveChatFindMatches(
+  rows: ReadonlyArray<MessagesTimelineRow>,
+  query: string,
+): ChatFindMatch[] {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) return [];
+  const matches: ChatFindMatch[] = [];
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
+    const row = rows[rowIndex];
+    if (!row) continue;
+    const text = chatFindSearchableText(row);
+    if (text === null) continue;
+    const count = countChatFindOccurrences(text, trimmed);
+    for (let occurrence = 0; occurrence < count; occurrence += 1) {
+      matches.push({ rowId: row.id, rowIndex, occurrence });
+    }
+  }
+  return matches;
+}
+
+export function resolveChatFindStartIndex(
+  matches: ReadonlyArray<ChatFindMatch>,
+  fromRowIndex: number | null,
+): number {
+  if (fromRowIndex === null) return 0;
+  const index = matches.findIndex((match) => match.rowIndex >= fromRowIndex);
+  return index === -1 ? 0 : index;
+}
+
+export function stepChatFindIndex(index: number, count: number, direction: 1 | -1): number {
+  if (count <= 0) return 0;
+  return (((index + direction) % count) + count) % count;
+}
+
+export function resolveChatFindActiveIndex(
+  matches: ReadonlyArray<ChatFindMatch>,
+  previousIndex: number,
+  previousMatch: ChatFindMatch | null,
+): number {
+  if (matches.length === 0) return 0;
+  if (previousMatch !== null) {
+    const key = chatFindMatchKey(previousMatch);
+    const sameIndex = matches.findIndex((match) => chatFindMatchKey(match) === key);
+    if (sameIndex !== -1) return sameIndex;
+  }
+  return Math.min(Math.max(previousIndex, 0), matches.length - 1);
+}

--- a/apps/web/src/components/chat/ChatFindBar.tsx
+++ b/apps/web/src/components/chat/ChatFindBar.tsx
@@ -18,11 +18,16 @@ import { isCommandPaletteOpen } from "../../commandPaletteBus";
 import { resolveShortcutCommand } from "../../keybindings";
 import { isTerminalFocused } from "../../lib/terminalFocus";
 import { Button } from "../ui/button";
+import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from "../ui/input-group";
+import { Toggle } from "../ui/toggle";
 import { primaryServerKeybindingsAtom } from "~/state/server";
 import { cn } from "~/lib/utils";
 import {
   type ChatFindMatch,
+  type ChatFindOptions,
+  buildChatFindPattern,
   chatFindMatchKey,
+  DEFAULT_CHAT_FIND_OPTIONS,
   deriveChatFindMatches,
   resolveChatFindActiveIndex,
   resolveChatFindStartIndex,
@@ -40,6 +45,14 @@ const EMPTY_MATCHES: ReadonlyArray<ChatFindMatch> = [];
 const REVEAL_VIEW_OFFSET = 96;
 const REVEAL_TOP_MARGIN = 24;
 const REVEAL_BOTTOM_FRACTION = 0.6;
+const MAX_PREFILL_LENGTH = 200;
+
+function readSelectionPrefill(): string | null {
+  const selection = window.getSelection()?.toString() ?? "";
+  const line = selection.split(/\r?\n/, 1)[0]?.trim() ?? "";
+  if (line.length === 0 || line.length > MAX_PREFILL_LENGTH) return null;
+  return line;
+}
 
 interface ChatFindBarProps {
   rows: ReadonlyArray<MessagesTimelineRow>;
@@ -50,7 +63,7 @@ interface ChatFindBarProps {
 
 interface ChatFindHighlightState {
   open: boolean;
-  query: string;
+  pattern: RegExp | null;
   matchRowIds: ReadonlySet<string>;
   activeMatch: ChatFindMatch | null;
 }
@@ -64,6 +77,7 @@ export const ChatFindBar = memo(function ChatFindBar({
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
+  const [options, setOptions] = useState<ChatFindOptions>(DEFAULT_CHAT_FIND_OPTIONS);
   const [activeIndex, setActiveIndex] = useState(0);
   const [focusToken, setFocusToken] = useState(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -76,15 +90,19 @@ export const ChatFindBar = memo(function ChatFindBar({
   const frameRef = useRef<number | null>(null);
   const highlightStateRef = useRef<ChatFindHighlightState>({
     open: false,
-    query: "",
+    pattern: null,
     matchRowIds: new Set(),
     activeMatch: null,
   });
 
   const trimmedQuery = query.trim();
+  const pattern = useMemo(
+    () => buildChatFindPattern(trimmedQuery, options),
+    [options, trimmedQuery],
+  );
   const matches = useMemo(
-    () => (open ? deriveChatFindMatches(rows, trimmedQuery) : EMPTY_MATCHES),
-    [open, rows, trimmedQuery],
+    () => (open && pattern !== null ? deriveChatFindMatches(rows, pattern) : EMPTY_MATCHES),
+    [open, pattern, rows],
   );
   const matchRowIds = useMemo(() => new Set(matches.map((match) => match.rowId)), [matches]);
   const activeMatch = matches[activeIndex] ?? null;
@@ -95,13 +113,13 @@ export const ChatFindBar = memo(function ChatFindBar({
     const scrollNode = list?.getScrollableNode();
     if (!list || !(scrollNode instanceof HTMLElement)) return;
     const state = highlightStateRef.current;
-    if (!state.open || state.query.length === 0) {
+    if (!state.open || state.pattern === null) {
       clearChatFindHighlights();
       return;
     }
     const activeRange = applyChatFindHighlights({
       scrollNode,
-      query: state.query,
+      pattern: state.pattern,
       matchRowIds: state.matchRowIds,
       active: state.activeMatch,
     });
@@ -139,7 +157,7 @@ export const ChatFindBar = memo(function ChatFindBar({
   }, [runHighlight]);
 
   useLayoutEffect(() => {
-    highlightStateRef.current = { open, query: trimmedQuery, matchRowIds, activeMatch };
+    highlightStateRef.current = { open, pattern, matchRowIds, activeMatch };
     activeMatchRef.current = activeMatch;
     openRef.current = open;
     queryRef.current = trimmedQuery;
@@ -225,14 +243,24 @@ export const ChatFindBar = memo(function ChatFindBar({
     };
   }, [listRef, open, scheduleHighlight]);
 
+  const restartFromQuery = useCallback((value: string) => {
+    setQuery(value);
+    setActiveIndex(0);
+    activeMatchRef.current = null;
+    revealFirstMatchRef.current = value.trim().length > 0;
+  }, []);
+
   const openBar = useCallback(() => {
-    if (!openRef.current && queryRef.current.length > 0) {
+    const prefill = readSelectionPrefill();
+    if (prefill !== null) {
+      restartFromQuery(prefill);
+    } else if (!openRef.current && queryRef.current.length > 0) {
       activeMatchRef.current = null;
       revealFirstMatchRef.current = true;
     }
     setOpen(true);
     setFocusToken((token) => token + 1);
-  }, []);
+  }, [restartFromQuery]);
 
   useEffect(() => {
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
@@ -276,11 +304,11 @@ export const ChatFindBar = memo(function ChatFindBar({
     [activeIndex, matches, reveal],
   );
 
-  const onQueryChange = useCallback((value: string) => {
-    setQuery(value);
+  const toggleOption = useCallback((key: keyof ChatFindOptions) => {
+    setOptions((current) => ({ ...current, [key]: !current[key] }));
     setActiveIndex(0);
     activeMatchRef.current = null;
-    revealFirstMatchRef.current = value.trim().length > 0;
+    revealFirstMatchRef.current = queryRef.current.length > 0;
   }, []);
 
   const onInputKeyDown = useCallback(
@@ -316,65 +344,91 @@ export const ChatFindBar = memo(function ChatFindBar({
       aria-label="Find in chat"
       data-chat-find-bar="true"
       className={cn(
-        "absolute right-4 z-30 flex items-center gap-0.5 rounded-[var(--control-radius)] border border-border bg-popover p-1 text-foreground shadow-md",
+        "absolute right-4 z-30 rounded-[var(--control-radius)] border border-border bg-popover p-0.5 shadow-md",
         topFadeEnabled ? "top-[var(--workspace-titlebar-scroll-fade-height)]" : "top-2",
       )}
     >
-      <SearchIcon className="ml-1.5 size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
-      <input
-        ref={inputRef}
-        type="text"
-        value={query}
-        onChange={(event) => onQueryChange(event.target.value)}
-        onKeyDown={onInputKeyDown}
-        placeholder="Find in chat"
-        aria-label="Find in chat"
-        autoComplete="off"
-        autoCorrect="off"
-        autoCapitalize="off"
-        spellCheck={false}
-        className="h-6 w-44 min-w-0 bg-transparent px-1.5 text-xs text-foreground outline-none placeholder:text-placeholder"
-      />
-      <span
-        className={cn(
-          "min-w-14 shrink-0 pr-1 text-right text-xs tabular-nums",
-          hasQuery && matches.length === 0
-            ? "text-destructive-foreground"
-            : "text-muted-foreground",
-        )}
-        aria-live="polite"
-      >
-        {countLabel}
-      </span>
-      <Button
-        variant="ghost-muted"
-        size="icon-xs"
-        aria-label="Previous match"
-        title="Previous match (Shift+Enter)"
-        disabled={matches.length === 0}
-        onClick={() => step(-1)}
-      >
-        <ChevronUpIcon />
-      </Button>
-      <Button
-        variant="ghost-muted"
-        size="icon-xs"
-        aria-label="Next match"
-        title="Next match (Enter)"
-        disabled={matches.length === 0}
-        onClick={() => step(1)}
-      >
-        <ChevronDownIcon />
-      </Button>
-      <Button
-        variant="ghost-muted"
-        size="icon-xs"
-        aria-label="Close find"
-        title="Close (Esc)"
-        onClick={close}
-      >
-        <XIcon />
-      </Button>
+      <InputGroup variant="ghost" className="h-7 w-[23rem]">
+        <InputGroupAddon>
+          <SearchIcon aria-hidden className="size-3.5" />
+        </InputGroupAddon>
+        <InputGroupInput
+          ref={inputRef}
+          type="search"
+          size="sm"
+          value={query}
+          onChange={(event) => restartFromQuery(event.currentTarget.value)}
+          onKeyDown={onInputKeyDown}
+          placeholder="Find in chat"
+          aria-label="Find in chat"
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
+        />
+        <InputGroupAddon align="inline-end" className="gap-0.5">
+          <Toggle
+            variant="ghost"
+            size="xs"
+            aria-label="Match case"
+            title="Match case"
+            pressed={options.caseSensitive}
+            onPressedChange={() => toggleOption("caseSensitive")}
+            className="font-mono text-xs text-muted-foreground data-pressed:text-foreground"
+          >
+            Aa
+          </Toggle>
+          <Toggle
+            variant="ghost"
+            size="xs"
+            aria-label="Match whole word"
+            title="Match whole word"
+            pressed={options.wholeWord}
+            onPressedChange={() => toggleOption("wholeWord")}
+            className="font-mono text-xs text-muted-foreground data-pressed:text-foreground"
+          >
+            <span className="underline decoration-2 underline-offset-2">ab</span>
+          </Toggle>
+          <InputGroupText
+            className={cn(
+              "min-w-14 justify-end text-xs tabular-nums",
+              hasQuery && matches.length === 0 && "text-destructive-foreground",
+            )}
+            aria-live="polite"
+          >
+            {countLabel}
+          </InputGroupText>
+          <Button
+            variant="ghost-muted"
+            size="icon-xs"
+            aria-label="Previous match"
+            title="Previous match (Shift+Enter)"
+            disabled={matches.length === 0}
+            onClick={() => step(-1)}
+          >
+            <ChevronUpIcon />
+          </Button>
+          <Button
+            variant="ghost-muted"
+            size="icon-xs"
+            aria-label="Next match"
+            title="Next match (Enter)"
+            disabled={matches.length === 0}
+            onClick={() => step(1)}
+          >
+            <ChevronDownIcon />
+          </Button>
+          <Button
+            variant="ghost-muted"
+            size="icon-xs"
+            aria-label="Close find"
+            title="Close (Esc)"
+            onClick={close}
+          >
+            <XIcon />
+          </Button>
+        </InputGroupAddon>
+      </InputGroup>
     </div>
   );
 });

--- a/apps/web/src/components/chat/ChatFindBar.tsx
+++ b/apps/web/src/components/chat/ChatFindBar.tsx
@@ -18,7 +18,8 @@ import { isCommandPaletteOpen } from "../../commandPaletteBus";
 import { resolveShortcutCommand } from "../../keybindings";
 import { isTerminalFocused } from "../../lib/terminalFocus";
 import { Button } from "../ui/button";
-import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from "../ui/input-group";
+import { Input } from "../ui/input";
+import { Separator } from "../ui/separator";
 import { Toggle } from "../ui/toggle";
 import { primaryServerKeybindingsAtom } from "~/state/server";
 import { cn } from "~/lib/utils";
@@ -344,91 +345,88 @@ export const ChatFindBar = memo(function ChatFindBar({
       aria-label="Find in chat"
       data-chat-find-bar="true"
       className={cn(
-        "absolute right-4 z-30 rounded-[var(--control-radius)] border border-border bg-popover p-0.5 shadow-md",
+        "absolute right-4 z-30 flex h-8 w-[24rem] max-w-[calc(100%-2rem)] items-center gap-0.5 rounded-lg border border-border/70 bg-popover/95 p-0.5 shadow-md/10 backdrop-blur",
         topFadeEnabled ? "top-[var(--workspace-titlebar-scroll-fade-height)]" : "top-2",
       )}
     >
-      <InputGroup variant="ghost" className="h-7 w-[23rem]">
-        <InputGroupAddon>
-          <SearchIcon aria-hidden className="size-3.5" />
-        </InputGroupAddon>
-        <InputGroupInput
-          ref={inputRef}
-          type="search"
-          size="sm"
-          value={query}
-          onChange={(event) => restartFromQuery(event.currentTarget.value)}
-          onKeyDown={onInputKeyDown}
-          placeholder="Find in chat"
-          aria-label="Find in chat"
-          autoComplete="off"
-          autoCorrect="off"
-          autoCapitalize="off"
-          spellCheck={false}
-        />
-        <InputGroupAddon align="inline-end" className="gap-0.5">
-          <Toggle
-            variant="ghost"
-            size="xs"
-            aria-label="Match case"
-            title="Match case"
-            pressed={options.caseSensitive}
-            onPressedChange={() => toggleOption("caseSensitive")}
-            className="font-mono text-xs text-muted-foreground data-pressed:text-foreground"
-          >
-            Aa
-          </Toggle>
-          <Toggle
-            variant="ghost"
-            size="xs"
-            aria-label="Match whole word"
-            title="Match whole word"
-            pressed={options.wholeWord}
-            onPressedChange={() => toggleOption("wholeWord")}
-            className="font-mono text-xs text-muted-foreground data-pressed:text-foreground"
-          >
-            <span className="underline decoration-2 underline-offset-2">ab</span>
-          </Toggle>
-          <InputGroupText
-            className={cn(
-              "min-w-14 justify-end text-xs tabular-nums",
-              hasQuery && matches.length === 0 && "text-destructive-foreground",
-            )}
-            aria-live="polite"
-          >
-            {countLabel}
-          </InputGroupText>
-          <Button
-            variant="ghost-muted"
-            size="icon-xs"
-            aria-label="Previous match"
-            title="Previous match (Shift+Enter)"
-            disabled={matches.length === 0}
-            onClick={() => step(-1)}
-          >
-            <ChevronUpIcon />
-          </Button>
-          <Button
-            variant="ghost-muted"
-            size="icon-xs"
-            aria-label="Next match"
-            title="Next match (Enter)"
-            disabled={matches.length === 0}
-            onClick={() => step(1)}
-          >
-            <ChevronDownIcon />
-          </Button>
-          <Button
-            variant="ghost-muted"
-            size="icon-xs"
-            aria-label="Close find"
-            title="Close (Esc)"
-            onClick={close}
-          >
-            <XIcon />
-          </Button>
-        </InputGroupAddon>
-      </InputGroup>
+      <SearchIcon aria-hidden className="ms-1.5 size-3.5 shrink-0 text-muted-foreground" />
+      <Input
+        ref={inputRef}
+        unstyled
+        type="search"
+        size="sm"
+        value={query}
+        onChange={(event) => restartFromQuery(event.currentTarget.value)}
+        onKeyDown={onInputKeyDown}
+        placeholder="Find in chat"
+        aria-label="Find in chat"
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        className="min-w-0 flex-1 text-sm [&_input]:px-1.5"
+      />
+      <span
+        className={cn(
+          "min-w-[4.75rem] shrink-0 whitespace-nowrap px-1.5 text-end text-xs tabular-nums text-muted-foreground",
+          hasQuery && matches.length === 0 && "text-destructive-foreground",
+        )}
+        aria-live="polite"
+      >
+        {countLabel}
+      </span>
+      <Separator orientation="vertical" className="mx-0.5 h-4 bg-border/70" />
+      <Toggle
+        variant="ghost"
+        size="xs"
+        aria-label="Match case"
+        title="Match case"
+        pressed={options.caseSensitive}
+        onPressedChange={() => toggleOption("caseSensitive")}
+        className="size-7 min-w-0 px-0 font-mono text-xs text-muted-foreground data-pressed:text-foreground sm:size-6"
+      >
+        Aa
+      </Toggle>
+      <Toggle
+        variant="ghost"
+        size="xs"
+        aria-label="Match whole word"
+        title="Match whole word"
+        pressed={options.wholeWord}
+        onPressedChange={() => toggleOption("wholeWord")}
+        className="size-7 min-w-0 px-0 font-mono text-xs text-muted-foreground data-pressed:text-foreground sm:size-6"
+      >
+        <span className="underline decoration-2 underline-offset-2">ab</span>
+      </Toggle>
+      <Button
+        variant="ghost-muted"
+        size="icon-xs"
+        aria-label="Previous match"
+        title="Previous match (Shift+Enter)"
+        disabled={matches.length === 0}
+        onClick={() => step(-1)}
+      >
+        <ChevronUpIcon />
+      </Button>
+      <Button
+        variant="ghost-muted"
+        size="icon-xs"
+        aria-label="Next match"
+        title="Next match (Enter)"
+        disabled={matches.length === 0}
+        onClick={() => step(1)}
+      >
+        <ChevronDownIcon />
+      </Button>
+      <Button
+        variant="ghost-muted"
+        size="icon-xs"
+        aria-label="Close find"
+        title="Close (Esc)"
+        onClick={close}
+      >
+        <XIcon />
+      </Button>
     </div>
   );
 });

--- a/apps/web/src/components/chat/ChatFindBar.tsx
+++ b/apps/web/src/components/chat/ChatFindBar.tsx
@@ -1,0 +1,380 @@
+"use client";
+
+import { useAtomValue } from "@effect/atom-react";
+import type { LegendListRef } from "@legendapp/list/react";
+import { ChevronDownIcon, ChevronUpIcon, SearchIcon, XIcon } from "lucide-react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type RefObject,
+} from "react";
+import { isCommandPaletteOpen } from "../../commandPaletteBus";
+import { resolveShortcutCommand } from "../../keybindings";
+import { isTerminalFocused } from "../../lib/terminalFocus";
+import { Button } from "../ui/button";
+import { primaryServerKeybindingsAtom } from "~/state/server";
+import { cn } from "~/lib/utils";
+import {
+  type ChatFindMatch,
+  chatFindMatchKey,
+  deriveChatFindMatches,
+  resolveChatFindActiveIndex,
+  resolveChatFindStartIndex,
+  stepChatFindIndex,
+} from "./ChatFindBar.logic";
+import {
+  applyChatFindHighlights,
+  clearChatFindHighlights,
+  findMountedChatRow,
+} from "./chatFindHighlight";
+import { onOpenChatFind } from "./chatFindBus";
+import type { MessagesTimelineRow } from "./MessagesTimeline.logic";
+
+const EMPTY_MATCHES: ReadonlyArray<ChatFindMatch> = [];
+const REVEAL_VIEW_OFFSET = 96;
+const REVEAL_TOP_MARGIN = 24;
+const REVEAL_BOTTOM_FRACTION = 0.6;
+
+interface ChatFindBarProps {
+  rows: ReadonlyArray<MessagesTimelineRow>;
+  listRef: RefObject<LegendListRef | null>;
+  topFadeEnabled: boolean;
+  onManualNavigation: () => void;
+}
+
+interface ChatFindHighlightState {
+  open: boolean;
+  query: string;
+  matchRowIds: ReadonlySet<string>;
+  activeMatch: ChatFindMatch | null;
+}
+
+export const ChatFindBar = memo(function ChatFindBar({
+  rows,
+  listRef,
+  topFadeEnabled,
+  onManualNavigation,
+}: ChatFindBarProps) {
+  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [focusToken, setFocusToken] = useState(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const openRef = useRef(false);
+  const queryRef = useRef("");
+  const activeMatchRef = useRef<ChatFindMatch | null>(null);
+  const revealKeyRef = useRef<string | null>(null);
+  const revealFirstMatchRef = useRef(false);
+  const scrollingRef = useRef(false);
+  const frameRef = useRef<number | null>(null);
+  const highlightStateRef = useRef<ChatFindHighlightState>({
+    open: false,
+    query: "",
+    matchRowIds: new Set(),
+    activeMatch: null,
+  });
+
+  const trimmedQuery = query.trim();
+  const matches = useMemo(
+    () => (open ? deriveChatFindMatches(rows, trimmedQuery) : EMPTY_MATCHES),
+    [open, rows, trimmedQuery],
+  );
+  const matchRowIds = useMemo(() => new Set(matches.map((match) => match.rowId)), [matches]);
+  const activeMatch = matches[activeIndex] ?? null;
+
+  const runHighlight = useCallback(() => {
+    frameRef.current = null;
+    const list = listRef.current;
+    const scrollNode = list?.getScrollableNode();
+    if (!list || !(scrollNode instanceof HTMLElement)) return;
+    const state = highlightStateRef.current;
+    if (!state.open || state.query.length === 0) {
+      clearChatFindHighlights();
+      return;
+    }
+    const activeRange = applyChatFindHighlights({
+      scrollNode,
+      query: state.query,
+      matchRowIds: state.matchRowIds,
+      active: state.activeMatch,
+    });
+    if (revealKeyRef.current === null || scrollingRef.current) return;
+    if (
+      state.activeMatch === null ||
+      revealKeyRef.current !== chatFindMatchKey(state.activeMatch)
+    ) {
+      revealKeyRef.current = null;
+      return;
+    }
+    if (activeRange === null) return;
+    const rect = activeRange.getBoundingClientRect();
+    if (rect.height <= 0) return;
+    revealKeyRef.current = null;
+    const scrollRect = scrollNode.getBoundingClientRect();
+    const inView =
+      rect.top >= scrollRect.top + REVEAL_TOP_MARGIN &&
+      rect.bottom <= scrollRect.top + scrollNode.clientHeight * REVEAL_BOTTOM_FRACTION;
+    if (inView) return;
+    const listState = list.getState();
+    const offset = Math.max(
+      0,
+      (listState.scroll ?? scrollNode.scrollTop) + rect.top - scrollRect.top - REVEAL_VIEW_OFFSET,
+    );
+    scrollingRef.current = true;
+    void list.scrollToOffset({ offset, animated: true }).finally(() => {
+      scrollingRef.current = false;
+    });
+  }, [listRef]);
+
+  const scheduleHighlight = useCallback(() => {
+    if (frameRef.current !== null) return;
+    frameRef.current = requestAnimationFrame(runHighlight);
+  }, [runHighlight]);
+
+  useLayoutEffect(() => {
+    highlightStateRef.current = { open, query: trimmedQuery, matchRowIds, activeMatch };
+    activeMatchRef.current = activeMatch;
+    openRef.current = open;
+    queryRef.current = trimmedQuery;
+    if (open) scheduleHighlight();
+  });
+
+  const reveal = useCallback(
+    (match: ChatFindMatch) => {
+      const list = listRef.current;
+      if (!list) return;
+      onManualNavigation();
+      revealKeyRef.current = chatFindMatchKey(match);
+      const scrollNode = list.getScrollableNode();
+      const mounted =
+        scrollNode instanceof HTMLElement && findMountedChatRow(scrollNode, match.rowId) !== null;
+      if (!mounted) {
+        scrollingRef.current = true;
+        void list
+          .scrollToIndex({
+            index: match.rowIndex,
+            animated: true,
+            viewOffset: REVEAL_VIEW_OFFSET,
+          })
+          .catch(() => {})
+          .finally(() => {
+            scrollingRef.current = false;
+            scheduleHighlight();
+          });
+      }
+      scheduleHighlight();
+    },
+    [listRef, onManualNavigation, scheduleHighlight],
+  );
+
+  useEffect(() => {
+    setActiveIndex((current) =>
+      resolveChatFindActiveIndex(matches, current, activeMatchRef.current),
+    );
+    if (!revealFirstMatchRef.current) return;
+    revealFirstMatchRef.current = false;
+    if (matches.length === 0) return;
+    const scrollNode = listRef.current?.getScrollableNode();
+    let fromRowIndex: number | null = null;
+    if (scrollNode instanceof HTMLElement) {
+      const top = scrollNode.getBoundingClientRect().top;
+      for (const element of scrollNode.querySelectorAll<HTMLElement>("[data-timeline-row-id]")) {
+        if (element.getBoundingClientRect().bottom <= top) continue;
+        const rowId = element.dataset.timelineRowId;
+        const rowIndex = rows.findIndex((row) => row.id === rowId);
+        if (rowIndex !== -1) fromRowIndex = rowIndex;
+        break;
+      }
+    }
+    const startIndex = resolveChatFindStartIndex(matches, fromRowIndex);
+    setActiveIndex(startIndex);
+    const match = matches[startIndex];
+    if (match) reveal(match);
+  }, [listRef, matches, reveal, rows]);
+
+  useEffect(() => {
+    if (!open) {
+      clearChatFindHighlights();
+      return;
+    }
+    const scrollNode = listRef.current?.getScrollableNode();
+    if (!(scrollNode instanceof HTMLElement)) return;
+    const observer = new MutationObserver(scheduleHighlight);
+    observer.observe(scrollNode, { childList: true, characterData: true, subtree: true });
+    const cancelReveal = () => {
+      revealKeyRef.current = null;
+    };
+    scrollNode.addEventListener("wheel", cancelReveal, { passive: true });
+    scrollNode.addEventListener("touchstart", cancelReveal, { passive: true });
+    return () => {
+      observer.disconnect();
+      scrollNode.removeEventListener("wheel", cancelReveal);
+      scrollNode.removeEventListener("touchstart", cancelReveal);
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current);
+        frameRef.current = null;
+      }
+      clearChatFindHighlights();
+    };
+  }, [listRef, open, scheduleHighlight]);
+
+  const openBar = useCallback(() => {
+    if (!openRef.current && queryRef.current.length > 0) {
+      activeMatchRef.current = null;
+      revealFirstMatchRef.current = true;
+    }
+    setOpen(true);
+    setFocusToken((token) => token + 1);
+  }, []);
+
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.defaultPrevented || isCommandPaletteOpen()) return;
+      const command = resolveShortcutCommand(event, keybindings, {
+        context: { terminalFocus: isTerminalFocused() },
+      });
+      if (command !== "chat.find") return;
+      event.preventDefault();
+      event.stopPropagation();
+      openBar();
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [keybindings, openBar]);
+
+  useEffect(() => onOpenChatFind(openBar), [openBar]);
+
+  useEffect(() => {
+    if (!open || focusToken === 0) return;
+    const input = inputRef.current;
+    if (!input) return;
+    input.focus();
+    input.select();
+  }, [focusToken, open]);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    revealKeyRef.current = null;
+    revealFirstMatchRef.current = false;
+  }, []);
+
+  const step = useCallback(
+    (direction: 1 | -1) => {
+      if (matches.length === 0) return;
+      const nextIndex = stepChatFindIndex(activeIndex, matches.length, direction);
+      setActiveIndex(nextIndex);
+      const match = matches[nextIndex];
+      if (match) reveal(match);
+    },
+    [activeIndex, matches, reveal],
+  );
+
+  const onQueryChange = useCallback((value: string) => {
+    setQuery(value);
+    setActiveIndex(0);
+    activeMatchRef.current = null;
+    revealFirstMatchRef.current = value.trim().length > 0;
+  }, []);
+
+  const onInputKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.nativeEvent.isComposing) return;
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        close();
+        return;
+      }
+      if (event.key === "Enter") {
+        event.preventDefault();
+        event.stopPropagation();
+        step(event.shiftKey ? -1 : 1);
+      }
+    },
+    [close, step],
+  );
+
+  if (!open) return null;
+
+  const hasQuery = trimmedQuery.length > 0;
+  const countLabel = !hasQuery
+    ? null
+    : matches.length === 0
+      ? "No matches"
+      : `${activeIndex + 1} of ${matches.length}`;
+
+  return (
+    <div
+      role="search"
+      aria-label="Find in chat"
+      data-chat-find-bar="true"
+      className={cn(
+        "absolute right-4 z-30 flex items-center gap-0.5 rounded-[var(--control-radius)] border border-border bg-popover p-1 text-foreground shadow-md",
+        topFadeEnabled ? "top-[var(--workspace-titlebar-scroll-fade-height)]" : "top-2",
+      )}
+    >
+      <SearchIcon className="ml-1.5 size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(event) => onQueryChange(event.target.value)}
+        onKeyDown={onInputKeyDown}
+        placeholder="Find in chat"
+        aria-label="Find in chat"
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        className="h-6 w-44 min-w-0 bg-transparent px-1.5 text-xs text-foreground outline-none placeholder:text-placeholder"
+      />
+      <span
+        className={cn(
+          "min-w-14 shrink-0 pr-1 text-right text-xs tabular-nums",
+          hasQuery && matches.length === 0
+            ? "text-destructive-foreground"
+            : "text-muted-foreground",
+        )}
+        aria-live="polite"
+      >
+        {countLabel}
+      </span>
+      <Button
+        variant="ghost-muted"
+        size="icon-xs"
+        aria-label="Previous match"
+        title="Previous match (Shift+Enter)"
+        disabled={matches.length === 0}
+        onClick={() => step(-1)}
+      >
+        <ChevronUpIcon />
+      </Button>
+      <Button
+        variant="ghost-muted"
+        size="icon-xs"
+        aria-label="Next match"
+        title="Next match (Enter)"
+        disabled={matches.length === 0}
+        onClick={() => step(1)}
+      >
+        <ChevronDownIcon />
+      </Button>
+      <Button
+        variant="ghost-muted"
+        size="icon-xs"
+        aria-label="Close find"
+        title="Close (Esc)"
+        onClick={close}
+      >
+        <XIcon />
+      </Button>
+    </div>
+  );
+});

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -113,6 +113,7 @@ import { CHAT_TIMELINE_ANCHOR_OFFSET } from "./timelineScrollAnchoring";
 import { MessageCopyButton } from "./MessageCopyButton";
 import { PierreEntryIcon } from "./PierreEntryIcon";
 import { AssistantSelectionToolbar } from "./AssistantSelectionToolbar";
+import { ChatFindBar } from "./ChatFindBar";
 import type { AssistantCitationSourceAnchor } from "~/lib/assistantTextSelection";
 import {
   AssistantCitationSource,
@@ -735,6 +736,12 @@ export const MessagesTimeline = memo(function MessagesTimeline({
               onCite={onCiteAssistantText}
             />
           ) : null}
+          <ChatFindBar
+            rows={rows}
+            listRef={listRef}
+            topFadeEnabled={topFadeEnabled}
+            onManualNavigation={onManualNavigation}
+          />
           <LegendList<MessagesTimelineRow>
             ref={listRef}
             data={rows}

--- a/apps/web/src/components/chat/chatFindBus.ts
+++ b/apps/web/src/components/chat/chatFindBus.ts
@@ -1,0 +1,14 @@
+"use client";
+
+const EVENT_NAME = "t3code:chat-find-open";
+
+export function openChatFind(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(EVENT_NAME));
+}
+
+export function onOpenChatFind(listener: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener(EVENT_NAME, listener);
+  return () => window.removeEventListener(EVENT_NAME, listener);
+}

--- a/apps/web/src/components/chat/chatFindHighlight.ts
+++ b/apps/web/src/components/chat/chatFindHighlight.ts
@@ -1,0 +1,79 @@
+import { readAssistantText } from "~/lib/assistantTextSelection";
+import type { ChatFindMatch } from "./ChatFindBar.logic";
+
+const FIND_HIGHLIGHT_NAME = "t3-chat-find";
+const FIND_ACTIVE_HIGHLIGHT_NAME = "t3-chat-find-active";
+
+export function supportsChatFindHighlight(): boolean {
+  return (
+    typeof Highlight !== "undefined" && typeof CSS !== "undefined" && CSS.highlights !== undefined
+  );
+}
+
+export function clearChatFindHighlights(): void {
+  if (!supportsChatFindHighlight()) return;
+  CSS.highlights.delete(FIND_HIGHLIGHT_NAME);
+  CSS.highlights.delete(FIND_ACTIVE_HIGHLIGHT_NAME);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function findChatRowTextRanges(root: HTMLElement, query: string): Range[] {
+  if (query.length === 0) return [];
+  const stream = readAssistantText(root);
+  const pattern = new RegExp(escapeRegExp(query), "gi");
+  const ranges: Range[] = [];
+  for (const match of stream.text.matchAll(pattern)) {
+    const start = match.index;
+    const end = start + match[0].length;
+    if (end <= start) continue;
+    const first = stream.chunks.find((chunk) => chunk.end > start);
+    const last = stream.chunks.findLast((chunk) => chunk.start < end);
+    if (first === undefined || last === undefined) continue;
+    const range = root.ownerDocument.createRange();
+    range.setStart(first.node, Math.max(0, start - first.start));
+    range.setEnd(last.node, Math.min(last.node.length, end - last.start));
+    if (!range.collapsed) ranges.push(range);
+  }
+  return ranges;
+}
+
+export function findMountedChatRow(scrollNode: HTMLElement, rowId: string): HTMLElement | null {
+  return scrollNode.querySelector<HTMLElement>(`[data-timeline-row-id="${CSS.escape(rowId)}"]`);
+}
+
+export function applyChatFindHighlights({
+  scrollNode,
+  query,
+  matchRowIds,
+  active,
+}: {
+  scrollNode: HTMLElement;
+  query: string;
+  matchRowIds: ReadonlySet<string>;
+  active: ChatFindMatch | null;
+}): Range | null {
+  if (!supportsChatFindHighlight()) return null;
+  const ranges: Range[] = [];
+  let activeRange: Range | null = null;
+  for (const element of scrollNode.querySelectorAll<HTMLElement>("[data-timeline-row-id]")) {
+    const rowId = element.dataset.timelineRowId;
+    if (!rowId || !matchRowIds.has(rowId)) continue;
+    const rowRanges = findChatRowTextRanges(element, query);
+    if (active !== null && rowId === active.rowId && rowRanges.length > 0) {
+      activeRange = rowRanges[Math.min(active.occurrence, rowRanges.length - 1)] ?? null;
+    }
+    for (const range of rowRanges) {
+      if (range !== activeRange) ranges.push(range);
+    }
+  }
+  CSS.highlights.set(FIND_HIGHLIGHT_NAME, new Highlight(...ranges));
+  if (activeRange) {
+    CSS.highlights.set(FIND_ACTIVE_HIGHLIGHT_NAME, new Highlight(activeRange));
+  } else {
+    CSS.highlights.delete(FIND_ACTIVE_HIGHLIGHT_NAME);
+  }
+  return activeRange;
+}

--- a/apps/web/src/components/chat/chatFindHighlight.ts
+++ b/apps/web/src/components/chat/chatFindHighlight.ts
@@ -16,14 +16,8 @@ export function clearChatFindHighlights(): void {
   CSS.highlights.delete(FIND_ACTIVE_HIGHLIGHT_NAME);
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-export function findChatRowTextRanges(root: HTMLElement, query: string): Range[] {
-  if (query.length === 0) return [];
+export function findChatRowTextRanges(root: HTMLElement, pattern: RegExp): Range[] {
   const stream = readAssistantText(root);
-  const pattern = new RegExp(escapeRegExp(query), "gi");
   const ranges: Range[] = [];
   for (const match of stream.text.matchAll(pattern)) {
     const start = match.index;
@@ -46,12 +40,12 @@ export function findMountedChatRow(scrollNode: HTMLElement, rowId: string): HTML
 
 export function applyChatFindHighlights({
   scrollNode,
-  query,
+  pattern,
   matchRowIds,
   active,
 }: {
   scrollNode: HTMLElement;
-  query: string;
+  pattern: RegExp;
   matchRowIds: ReadonlySet<string>;
   active: ChatFindMatch | null;
 }): Range | null {
@@ -61,7 +55,7 @@ export function applyChatFindHighlights({
   for (const element of scrollNode.querySelectorAll<HTMLElement>("[data-timeline-row-id]")) {
     const rowId = element.dataset.timelineRowId;
     if (!rowId || !matchRowIds.has(rowId)) continue;
-    const rowRanges = findChatRowTextRanges(element, query);
+    const rowRanges = findChatRowTextRanges(element, pattern);
     if (active !== null && rowId === active.rowId && rowRanges.length > 0) {
       activeRange = rowRanges[Math.min(active.occurrence, rowRanges.length - 1)] ?? null;
     }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -516,6 +516,13 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   ::highlight(t3-assistant-citation-comment) {
     background-color: color-mix(in oklab, var(--primary) 45%, transparent);
   }
+  ::highlight(t3-chat-find) {
+    background-color: color-mix(in oklab, var(--primary) 28%, transparent);
+  }
+  ::highlight(t3-chat-find-active) {
+    background-color: color-mix(in oklab, var(--primary) 60%, transparent);
+    color: var(--primary-foreground);
+  }
   :root {
     /* Keep the original T3 Code artwork palettes as the defaults. Built-in
        themes override them with their own pigments in the components layer. */

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -134,6 +134,11 @@ const DEFAULT_BINDINGS = compile([
     whenAst: whenNot(whenIdentifier("terminalFocus")),
   },
   {
+    shortcut: modShortcut("f"),
+    command: "chat.find",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
+  {
     shortcut: modShortcut("t", { altKey: true, shiftKey: true }),
     command: "themeEditor.toggle",
   },
@@ -644,6 +649,37 @@ describe("chat/editor shortcuts", () => {
         context: { terminalFocus: true },
       }),
       "projectSearch.toggle",
+    );
+  });
+
+  it("matches chat.find shortcut outside terminal focus without shift", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "f", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "chat.find",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "f", ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "Win32",
+        context: { terminalFocus: false },
+      }),
+      "chat.find",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "f", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: true },
+      }),
+      null,
+    );
+    assert.notStrictEqual(
+      resolveShortcutCommand(event({ key: "f", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "chat.find",
     );
   });
 

--- a/apps/web/src/lib/assistantTextSelection.ts
+++ b/apps/web/src/lib/assistantTextSelection.ts
@@ -128,7 +128,7 @@ export function findAssistantCitationText(
   return match ?? (quoteCount === 1 ? onlyQuote : null);
 }
 
-type TextChunk = { node: Text; start: number; end: number };
+export type TextChunk = { node: Text; start: number; end: number };
 
 /**
  * Uses DOM text order, with a line break between HTML blocks and at <br>.
@@ -137,7 +137,7 @@ type TextChunk = { node: Text; start: number; end: number };
  * reads, CSS-generated content, or soft-wrap line breaks enter the stream, so
  * reflow cannot move it.
  */
-function readAssistantText(root: HTMLElement) {
+export function readAssistantText(root: HTMLElement) {
   const parts: string[] = [];
   const chunks: TextChunk[] = [];
   let length = 0;

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -2186,6 +2186,7 @@ function PullRequestsColumn({
   listBody: ReactNode;
   scrollRef: RefObject<HTMLDivElement | null>;
 }) {
+  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const markerRef = useRef<HTMLDivElement | null>(null);
   const [condensed, setCondensed] = useState(false);
   useEffect(() => {
@@ -2212,9 +2213,11 @@ function PullRequestsColumn({
   // it focuses the in-flow bar and selects the query the way a find field would.
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.defaultPrevented) return;
-      if (event.key.toLowerCase() !== "f" || !(event.metaKey || event.ctrlKey)) return;
-      if (event.altKey || event.shiftKey) return;
+      if (event.defaultPrevented || isCommandPaletteOpen()) return;
+      const command = resolveShortcutCommand(event, keybindings, {
+        context: { terminalFocus: isTerminalFocused() },
+      });
+      if (command !== "chat.find") return;
       event.preventDefault();
       if (condensed) {
         setSearchOpen(true);
@@ -2227,7 +2230,7 @@ function PullRequestsColumn({
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [condensed]);
+  }, [condensed, keybindings]);
   useEffect(() => {
     if (condensed) return;
     // The fold-out is gone from the chrome; forgetting it open keeps the next condensing

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -40,6 +40,9 @@ Commands are IDs like `terminal.toggle`, `commandPalette.toggle`, `preview.refre
 `filePicker.toggle` opens file search for the active project and defaults to `mod+p`.
 `projectSearch.toggle` searches inside the active project's files and defaults to `mod+shift+f`.
 Repeating either shortcut closes that search, and switching shortcuts replaces the open search.
+`chat.find` opens a find bar over the open thread and defaults to `mod+f`. Type to highlight every
+message that contains the text, then press `Enter` or `Shift+Enter` to step between matches and
+`Escape` to close it. On the pull requests page the same shortcut focuses the list search instead.
 `themeEditor.toggle` opens or closes the floating theme editor and defaults to
 `mod+alt+shift+t`. Select a color label to spotlight the elements that use it; select the label
 again to clear the spotlight. The swatch and hex field keep that color selected while you edit it.

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -40,9 +40,11 @@ Commands are IDs like `terminal.toggle`, `commandPalette.toggle`, `preview.refre
 `filePicker.toggle` opens file search for the active project and defaults to `mod+p`.
 `projectSearch.toggle` searches inside the active project's files and defaults to `mod+shift+f`.
 Repeating either shortcut closes that search, and switching shortcuts replaces the open search.
-`chat.find` opens a find bar over the open thread and defaults to `mod+f`. Type to highlight every
-message that contains the text, then press `Enter` or `Shift+Enter` to step between matches and
-`Escape` to close it. On the pull requests page the same shortcut focuses the list search instead.
+`chat.find` opens a find bar over the open thread and defaults to `mod+f`. Any text selected when
+you press it becomes the search. Type to highlight every message that contains the text, then press
+`Enter` or `Shift+Enter` to step between matches and `Escape` to close it. The `Aa` and `ab` toggles
+match case and whole words only. On the pull requests page the same shortcut focuses the list
+search instead.
 `themeEditor.toggle` opens or closes the floating theme editor and defaults to
 `mod+alt+shift+t`. Select a color label to spotlight the elements that use it; select the label
 again to clear the spotlight. The swatch and hex field keep that color selected while you edit it.

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -70,6 +70,7 @@ export const STATIC_KEYBINDING_COMMANDS = [
   "commandPalette.toggle",
   "filePicker.toggle",
   "projectSearch.toggle",
+  "chat.find",
   "themeEditor.toggle",
   "composer.stash",
   "chat.new",

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -38,6 +38,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+k", command: "commandPalette.toggle", when: "!terminalFocus" },
   { key: "mod+p", command: "filePicker.toggle", when: "!terminalFocus" },
   { key: "mod+shift+f", command: "projectSearch.toggle", when: "!terminalFocus" },
+  { key: "mod+f", command: "chat.find", when: "!terminalFocus" },
   { key: "mod+alt+shift+t", command: "themeEditor.toggle" },
   { key: "mod+s", command: "composer.stash", when: "!terminalFocus" },
   { key: "mod+n", command: "chat.new", when: "!terminalFocus" },


### PR DESCRIPTION
## What Changed

Adds a find bar over the open thread.

- New `chat.find` keybinding command, default `mod+f` with `when: "!terminalFocus"`, plus a "Find in chat" command palette action.
- Matches are counted from the timeline's row model, so messages that the virtualized list has not mounted are still found.
- Matches in mounted rows are painted with the CSS Custom Highlight API. No markdown is rewritten and no DOM nodes are wrapped.
- Enter and Shift+Enter step through matches and scroll each one into view. Esc closes.
- `Aa` and `ab` toggles for match case and whole word. One shared pattern feeds both the counter and the highlighter, so counts and painted ranges always agree.
- Selected text becomes the query when the bar opens, as in browser find.
- The pull requests page now resolves the same `chat.find` command for its list search instead of matching Mod+F by hand.

Composed from the shared UI primitives: `InputGroup`, `InputGroupAddon`, `InputGroupInput`, and `InputGroupText` for the field, `Button` (`ghost-muted`, `icon-xs`) for the controls, `Toggle` (`ghost`, `xs`) for the options, and the shared keybinding registry via `resolveShortcutCommand` for the shortcut. No new surfaces or variants are introduced.

Supersedes #5562 with a smaller footprint, and picks up where #4599 left off. Resolves the request in discussion #6709 (formerly #1486).

## Why

Long threads have no way to search the conversation. The timeline is virtualized, so the browser's native find only sees mounted rows, and the desktop shell binds no find-in-page at all. Users asked for Codex-style Cmd+F in #1486 and have kept +1ing it since.

Searching the row model rather than the DOM is what makes off-screen matches work. Painting with the Highlight API avoids the code-block corruption that earlier attempts hit when they injected markup into markdown.

### Relation to orchestration V2 (#2829)

Earlier find PRs (#3539, #4599, #3779) were closed ahead of the orchestration V2 rewrite. This PR is web-only: it touches no orchestration, adapter, or provider code, and its single server change is one assertion in `keybindings.test.ts`. Replaying it on the current #2829 head applies cleanly apart from two adjacent-line conflicts in `CommandPalette.tsx` and `keybindings.test.ts`, so it should survive that merge with a trivial rebase.

## UI Changes

<img width="515" height="387" alt="image" src="https://github.com/user-attachments/assets/56090571-b5a6-4722-8e8a-abef37627ed6" />


https://github.com/user-attachments/assets/33f5045b-a490-4a59-8afe-19727b089c8d


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Made with Claude Fable 5.1 in Claude Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `chat.find` command bound to `mod+f` for web chat search
> - Registers `chat.find` in the static keybinding registry and maps it to `mod+f` (excluding terminal focus) in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/9638/files#diff-43f35e6edaf374f5ed53b0c61409d76e733a1b8e06098a0e8ded132d3b433f06).
> - Adds the `ChatFindBar` component and search logic in [ChatFindBar.logic.ts](https://github.com/pingdotgg/t3code/pull/9638/files#diff-846eedb7babc96f730778420971494628fe12c01ad6b8de4483de54feb8c11d0) to find, count, and navigate literal, case-sensitive, and whole-word matches across message rows.
> - Renders matches using the CSS Custom Highlight API in [chatFindHighlight.ts](https://github.com/pingdotgg/t3code/pull/9638/files#diff-4d84dcd4492891b42c5f0782e554145ac66403f4c1364c0262c569542c978272), and prefills the query from the current browser text selection when it is ≤200 characters.
> - Adds a "Find in chat" action to the command palette and updates [PullRequestsColumn](https://github.com/pingdotgg/t3code/pull/9638/files#diff-514a5b26d9687035b089d834742d874da174aa0a8a0c7c2fd47c61d11795afa5) to open its list search via the resolved `chat.find` shortcut rather than a hard-coded modifier check.
> - Behavioral Change: `mod+f` outside terminal focus now opens the chat find bar instead of being unhandled in web chat; the pull requests page honors the configured `chat.find` binding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e2338a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->