### PR TITLE
feat(server,contracts): add Claude advisor model setting

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -476,6 +476,130 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("passes the configured advisor model to Claude", () => {
+    const harness = makeHarness({ claudeConfig: { advisorModel: "opus" } });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const options = harness.getLastCreateQueryInput()?.options;
+      assert.deepEqual(options?.settings, { advisorModel: "opus" });
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("omits the advisor model when the setting is empty", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const options = harness.getLastCreateQueryInput()?.options;
+      assert.equal(options?.settings, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("completes the advisor item when the advisor result block arrives", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 7).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-1",
+        uuid: "stream-0",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "server_tool_use",
+            id: "srvtoolu-advisor-1",
+            name: "advisor",
+            input: {},
+          },
+        },
+      } as unknown as SDKMessage);
+
+      // The advisor result lands on its own block index and names the tool it
+      // closes, so completion cannot key off the stream index.
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-1",
+        uuid: "stream-1",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_start",
+          index: 1,
+          content_block: {
+            type: "advisor_tool_result",
+            tool_use_id: "srvtoolu-advisor-1",
+            content: {
+              type: "advisor_redacted_result",
+              encrypted_content: "opaque",
+            },
+          },
+        },
+      } as unknown as SDKMessage);
+
+      // No result message: the consult must close on its own result block. The
+      // end-of-turn sweep that completes abandoned tool items never runs here,
+      // so this fiber only joins if the advisor block did the work.
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const advisorStarted = runtimeEvents.find((event) => event.type === "item.started");
+      assert.equal(advisorStarted?.type, "item.started");
+      if (advisorStarted?.type === "item.started") {
+        assert.equal(String(advisorStarted.itemId), "srvtoolu-advisor-1");
+        assert.equal(advisorStarted.payload.title, "Advisor consult");
+        assert.equal(advisorStarted.payload.detail, undefined);
+      }
+
+      const advisorCompletions = runtimeEvents.filter(
+        (event) => event.type === "item.completed" && String(event.itemId) === "srvtoolu-advisor-1",
+      );
+      assert.equal(advisorCompletions.length, 1);
+      const advisorCompleted = advisorCompletions[0];
+      assert.equal(advisorCompleted?.type, "item.completed");
+      if (advisorCompleted?.type === "item.completed") {
+        assert.equal(advisorCompleted.payload.status, "completed");
+        assert.equal(advisorCompleted.payload.title, "Advisor consult");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("forwards claude effort levels into query options", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -1228,6 +1228,24 @@ function summarizeToolRequest(toolName: string, input: Record<string, unknown>):
   return `${toolName}: ${serialized.slice(0, 397)}...`;
 }
 
+/**
+ * The advisor is a server-side tool: Claude consults a second model mid-turn.
+ * It arrives as a `server_tool_use` block named `advisor` and its result comes
+ * back in the assistant stream, never as a `tool_result` user message.
+ */
+function isAdvisorToolName(toolName: string): boolean {
+  return toolName.toLowerCase() === "advisor";
+}
+
+/** The advisor result block, which closes the advisor tool item it names. */
+function isAdvisorResultBlock(block: unknown): block is { readonly tool_use_id?: unknown } {
+  return (
+    typeof block === "object" &&
+    block !== null &&
+    (block as { readonly type?: unknown }).type === "advisor_tool_result"
+  );
+}
+
 function titleForTool(itemType: CanonicalItemType): string {
   switch (itemType) {
     case "command_execution":
@@ -2471,11 +2489,14 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       // Drop only the subagent's narration (text/thinking); tool_use blocks
       // and their input_json_delta frames must flow so attributed tool items
       // keep their inputs (review finding: dropping deltas emptied inputs).
+      // The advisor result block flows for the same reason: it is what closes
+      // the subagent's advisor tool item.
       const dropStart =
         event.type === "content_block_start" &&
         event.content_block.type !== "tool_use" &&
         event.content_block.type !== "server_tool_use" &&
-        event.content_block.type !== "mcp_tool_use";
+        event.content_block.type !== "mcp_tool_use" &&
+        !isAdvisorResultBlock(event.content_block);
       const dropDelta =
         event.type === "content_block_delta" &&
         (event.delta.type === "text_delta" || event.delta.type === "thinking_delta");
@@ -2668,6 +2689,59 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         });
         return;
       }
+      // The advisor's result closes the tool block that started it. It never
+      // arrives as a `tool_result` user message, so without this the item
+      // spins until the turn's end-of-result sweep completes it.
+      if (isAdvisorResultBlock(block)) {
+        const advisorToolUseId =
+          typeof block.tool_use_id === "string" ? block.tool_use_id : undefined;
+        const advisorEntry = advisorToolUseId
+          ? Array.from(context.inFlightTools.entries()).find(
+              ([, inFlight]) => inFlight.itemId === advisorToolUseId,
+            )
+          : undefined;
+        if (!advisorEntry) {
+          return;
+        }
+        const [advisorIndex, advisorTool] = advisorEntry;
+        context.inFlightTools.delete(advisorIndex);
+        const advisorStamp = yield* makeEventStamp();
+        yield* offerRuntimeEvent({
+          type: "item.completed",
+          eventId: advisorStamp.eventId,
+          provider: PROVIDER,
+          createdAt: advisorStamp.createdAt,
+          threadId: context.session.threadId,
+          ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+          itemId: asRuntimeItemId(advisorTool.itemId),
+          payload: {
+            itemType: advisorTool.itemType,
+            status: "completed",
+            title: advisorTool.title,
+            ...(advisorTool.detail ? { detail: advisorTool.detail } : {}),
+            ...(advisorTool.agentId ? { agentId: advisorTool.agentId } : {}),
+            ...(advisorTool.parentToolUseId
+              ? { parentToolUseId: advisorTool.parentToolUseId }
+              : {}),
+            // The advisor's advice is returned encrypted, so there is no result
+            // text to carry: the item records that the consult happened.
+            data: {
+              toolName: advisorTool.toolName,
+              input: advisorTool.input,
+            },
+          },
+          providerRefs: nativeProviderRefs(context, {
+            providerItemId: advisorTool.itemId,
+          }),
+          raw: {
+            source: "claude.sdk.message",
+            method: "claude/stream_event/content_block_start",
+            payload: message,
+          },
+        });
+        return;
+      }
+
       if (
         block.type !== "tool_use" &&
         block.type !== "server_tool_use" &&
@@ -2683,7 +2757,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           : {};
       const itemType = classifyToolItemType(toolName, toolInput);
       const itemId = block.id;
-      const detail = summarizeToolRequest(toolName, toolInput);
+      // The advisor takes no arguments, so the generic input summary reads
+      // "advisor: {}". Its title carries the meaning instead.
+      const isAdvisor = isAdvisorToolName(toolName);
+      const detail = isAdvisor ? undefined : summarizeToolRequest(toolName, toolInput);
       const inputFingerprint =
         Object.keys(toolInput).length > 0 ? toolInputFingerprint(toolInput) : undefined;
 
@@ -2699,8 +2776,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         itemId,
         itemType,
         toolName,
-        title: titleForTool(itemType),
-        detail,
+        title: isAdvisor ? "Advisor consult" : titleForTool(itemType),
+        ...(detail ? { detail } : {}),
         input: toolInput,
         partialInputJson: "",
         ...(inputFingerprint ? { lastEmittedInputFingerprint: inputFingerprint } : {}),
@@ -4357,6 +4434,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...(claudeSettings.autoCompactWindow
           ? { autoCompactWindow: Number(claudeSettings.autoCompactWindow) }
           : {}),
+        // Settings key, not the `--advisor` flag: the flag aborts session start
+        // when the advisor cannot advise the thread model, while this path logs
+        // and runs the turn without an advisor.
+        ...(claudeSettings.advisorModel ? { advisorModel: claudeSettings.advisorModel } : {}),
       };
       const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
       // The attachments dir grant lets the agent Read/copy pasted images at

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -111,6 +111,7 @@ const makeClaudeConfig = (overrides: Partial<ClaudeSettings>): ClaudeSettings =>
   customModels: [],
   launchArgs: "",
   autoCompactWindow: "",
+  advisorModel: "",
   ...overrides,
 });
 

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -234,6 +234,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         customModels: ["claude-custom"],
         launchArgs: "",
         autoCompactWindow: "",
+        advisorModel: "",
       });
       assert.deepEqual(
         next.textGenerationModelSelection,
@@ -899,6 +900,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         customModels: [],
         launchArgs: "",
         autoCompactWindow: "",
+        advisorModel: "",
       });
       assert.deepEqual(next.providers.opencode, {
         // OpenCode is disabled by default; this update only touches paths.

--- a/apps/web/src/components/settings/ProviderSettingsForm.test.ts
+++ b/apps/web/src/components/settings/ProviderSettingsForm.test.ts
@@ -67,6 +67,7 @@ describe("ProviderSettingsForm helpers", () => {
     expect(deriveProviderSettingsFields(claude!).map((field) => field.key)).toEqual([
       "binaryPath",
       "homePath",
+      "advisorModel",
       "autoCompactWindow",
       "launchArgs",
     ]);

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -46,6 +46,26 @@ offers to compact the conversation before you continue. You can also select **Co
 from the context meter. On every client, you can enter `/compact` in the message composer, and
 Claude can show its own resume prompt when you continue an old session.
 
+## Let Claude Ask A Second Model For Advice
+
+Claude can consult a stronger model during a turn. The second model sees the work so far and gives
+guidance before Claude continues.
+
+In Settings, open your Claude provider and set **Advisor model** to `fable`, `opus`, or `sonnet`.
+Leave the field empty to keep the advisor setting from your Claude Code configuration.
+
+The advisor must be at least as capable as the model of the thread. For example, `sonnet` cannot
+advise an Opus thread. If the two models do not match, Claude Code runs the turn without an
+advisor.
+
+`fable` bills to usage credits. You must set up usage credits for your account before the advisor
+can use `fable`. Run `/model fable` in an interactive Claude Code session to review and enable it.
+Until you do this, T3 Code runs the turn without an advisor and shows no message.
+
+Each consult shows in the timeline as **Advisor consult**. The advice itself is encrypted, so the
+item shows that the consult happened and no text. The advisor model uses its own tokens, which are
+additional to the tokens of the thread model.
+
 ## Where Claude Skills Are Loaded
 
 T3 Code looks for Claude skills in the Claude config directory's `skills` folder and

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -50,6 +50,22 @@ describe("ClaudeSettings auto-compaction", () => {
   });
 });
 
+describe("ClaudeSettings advisor model", () => {
+  it("inherits Claude's own advisor setting when none is configured", () => {
+    expect(decodeClaudeSettings({}).advisorModel).toBe("");
+  });
+
+  it("keeps a configured advisor alias", () => {
+    expect(decodeClaudeSettings({ advisorModel: "opus" }).advisorModel).toBe("opus");
+  });
+
+  it("accepts an advisor model at the settings patch boundary", () => {
+    expect(
+      decodeServerSettingsPatch({ providers: { claudeAgent: { advisorModel: "fable" } } }),
+    ).toBeDefined();
+  });
+});
+
 describe("ClientSettings word wrap", () => {
   it("defaults word wrap on", () => {
     expect(decodeClientSettings({}).wordWrap).toBe(true);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -528,9 +528,21 @@ export const ClaudeSettings = makeProviderSettingsSchema(
         },
       }),
     ),
+    advisorModel: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Advisor model",
+        description:
+          "Let Claude consult a second model during a turn. Use fable, opus, or sonnet. The advisor must be at least as capable as the thread model. Leave empty to use Claude's own setting.",
+        providerSettingsForm: {
+          placeholder: "e.g. opus",
+          clearWhenEmpty: "omit",
+        },
+      }),
+    ),
   },
   {
-    order: ["binaryPath", "homePath", "autoCompactWindow", "launchArgs"],
+    order: ["binaryPath", "homePath", "advisorModel", "autoCompactWindow", "launchArgs"],
   },
 );
 export type ClaudeSettings = typeof ClaudeSettings.Type;
@@ -1050,6 +1062,7 @@ const ClaudeSettingsPatch = Schema.Struct({
   autoCompactWindow: Schema.optionalKey(
     TrimmedString.check(Schema.isPattern(CLAUDE_AUTO_COMPACT_WINDOW_PATTERN)),
   ),
+  advisorModel: Schema.optionalKey(TrimmedString),
 });
 
 const CursorSettingsPatch = Schema.Struct({


### PR DESCRIPTION
## Problem

Claude Code can consult a stronger model in the middle of a turn through its advisor tool. T3 Code had no way to turn this on.

It was also already broken when it did run. `CLAUDE_SETTING_SOURCES` includes `user`, so a developer with `advisorModel` in `~/.claude/settings.json` already got advisor consults inside T3 Code. The advisor is a **server-side** tool: the `server_tool_use` block opens the item, but the result arrives in the assistant stream as an `advisor_tool_result` block, never as a `tool_result` user message. `handleUserMessage` is the only path that completes a tool item, and it matches on `tool_result`, so nothing closed the item. The consult rendered as a generic "Tool call" and spun until the end-of-turn sweep swept it up — a lying spinner.

## Fix

- Adds an **Advisor model** field to the Claude provider settings, and passes it to the Agent SDK as the `advisorModel` settings key.
- Completes the advisor item when its own `advisor_tool_result` block arrives, matched by `tool_use_id` rather than block index (the result lands at a different index from the request).
- Titles the item "Advisor consult" instead of the generic tool-call label, and drops the input summary, which is always empty.

The settings key is deliberate, not the hidden `--advisor` CLI flag. The flag aborts session start when the advisor cannot advise the thread model; the settings path logs and runs the turn without an advisor, which is the behavior you want for a per-instance setting.

## Before / after

Claude provider settings, Runtime section:

| Before | After |
| --- | --- |
| <img width="480" src="https://github.com/schorke/t3code/releases/download/pr-assets-advisor-model/before-claude-provider-form.png"> | <img width="480" src="https://github.com/schorke/t3code/releases/download/pr-assets-advisor-model/after-claude-provider-form.png"> |

The field is derived from the contracts schema by `deriveProviderSettingsFields`, so web and desktop pick it up with no component change. Mobile has no provider config form, so there is nothing to add there.

## Tests

- `ClaudeAdapter.test.ts`: the advisor model reaches the SDK, is omitted when the field is empty, and the item completes on its result block. The completion test emits no `result` message on purpose, so the end-of-turn sweep cannot mask the bug. Stubbing the new branch out makes it hang and fail.
- `settings.test.ts`: default, round-trip, and server-patch decoding for the new field.
- `ProviderSettingsForm.test.ts`: field order.

## Not in this PR

- **Advisor token and cost attribution.** `usage.iterations` carries `advisor_message` entries and the final `modelUsage` gains a separate entry for the advisor model with its own `costUSD`, but `emitThreadTokenUsage` reads top-level usage only. Advisor spend stays invisible in the context meter. That is a separate change.
- **`/advisor` in the composer.** Claude's init message lists it, so it appears in the command menu and does nothing useful, because it is an interactive picker that mutates Claude's own `settings.json`. That is why this PR is a setting and not a chat command. T3 Code forwards every Claude built-in unfiltered, so `/model`, `/config`, and about forty others behave the same way. Filtering interactive-only commands is a separate concern.

Written by Claude Opus 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Claude stream event handling and session settings for a server-side tool path; mistakes could leave tool items stuck or mis-complete unrelated tools, but scope is narrow and heavily tested.
> 
> **Overview**
> Adds a configurable **Advisor model** on the Claude provider (contracts + settings UI field order) and forwards it to the Agent SDK as `advisorModel` when set, omitting it when empty so Claude Code’s own config can apply.
> 
> Fixes advisor **timeline** handling in `ClaudeAdapter`: the advisor is a server-side tool whose result arrives as an `advisor_tool_result` stream block (not a user `tool_result`). The adapter now completes the in-flight tool item when that block arrives (matched by `tool_use_id`), labels it **Advisor consult** without empty input detail, and keeps `advisor_tool_result` blocks from being dropped in subagent stream filtering.
> 
> Tests cover SDK option wiring, completion without an end-of-turn sweep, settings decode/patch, and provider form fields; user docs describe `fable` / `opus` / `sonnet` and capability rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef51c0de0086c320d52b70b1fb0df02862b84735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `advisorModel` setting to Claude provider and handle advisor tool lifecycle in `ClaudeAdapter`
> - Adds `advisorModel` as a trimmed-string field to `ClaudeSettings` and `ClaudeSettingsPatch` in [settings.ts](https://github.com/pingdotgg/t3code/pull/9640/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), with an empty default and a form-field position between `homePath` and `autoCompactWindow`.
> - `makeClaudeAdapter` in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/9640/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) now passes a non-empty `advisorModel` into Claude query settings, and handles advisor tool blocks: advisor tool starts use the title "Advisor consult" and omit the generic empty-input detail; advisor result blocks (type `advisor_tool_result`) from nested streams complete the in-flight advisor item by tool-use ID, emitting `item.completed` with no result text.
> - Adds user-facing documentation for the advisor feature in [providers-claude.md](https://github.com/pingdotgg/t3code/pull/9640/files#diff-f3b54bb573c78b526a8c1181ccd8146c7df38119b974038b08aff6f4e5a3819d).
> - Behavioral Change: completed advisor timeline items contain no advice text in their result detail; consumers that previously expected tool-result text for advisor consults will receive an empty result.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef51c0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->