### PR TITLE
fix(web): toggle a single stashed prompt with Cmd+S

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -3336,7 +3336,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     const images = [...composerImagesRef.current];
     const files = [...composerFilesRef.current];
     if (prompt.length === 0 && images.length === 0 && files.length === 0) {
-      setIsStashMenuOpen((open) => !open);
+      const entries = usePromptStashStore.getState().entries;
+      const entry = entries.length === 1 ? entries[0] : undefined;
+      if (entry && !entry.pendingImageCount) {
+        await restoreStashEntry(entry);
+      } else {
+        setIsStashMenuOpen((open) => !open);
+      }
       return;
     }
     const stashedFiles: PersistedComposerFileAttachment[] = [];
@@ -3523,6 +3529,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     finalizeStashEntryImages,
     promptRef,
     pulseStashBadge,
+    restoreStashEntry,
     stashEntryToQueue,
   ]);
 

--- a/apps/web/src/components/chat/ComposerStashMenu.tsx
+++ b/apps/web/src/components/chat/ComposerStashMenu.tsx
@@ -30,10 +30,10 @@ function stashEntrySnippet(entry: PromptStashEntry): string {
 }
 
 /**
- * Attached banner listing the stashed prompts. Keyboard-first: opened by ⌘S on an
- * empty composer, navigated with arrows, restored with Enter, dismissed
- * with Escape. The listener runs capture-phase on window so it wins over
- * the Lexical editor's handlers while the menu is open.
+ * Attached banner listing the stashed prompts. Opened by the stash badge or ⌘S
+ * when the empty composer cannot restore a single entry. Navigated with arrows,
+ * restored with Enter, dismissed with Escape. The listener runs capture-phase
+ * on window so it wins over the Lexical editor's handlers while the menu is open.
  */
 export const ComposerStashMenu = memo(function ComposerStashMenu(props: {
   entries: ReadonlyArray<PromptStashEntry>;

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -182,8 +182,10 @@ open the stack. Interacting with the attached banner or composer does not open t
 ## Prompt stash
 
 Use the default shortcut, `Cmd+S` on macOS or `Ctrl+S` on Windows and Linux, to stash the current
-prompt and its attachments after all file uploads finish. Restore the entry later from the stash
-menu. Stashes that contain files must be restored in the environment where those files were
+prompt and its attachments after all file uploads finish. When the composer is empty and the stash
+has one entry, press the shortcut again to restore it. The shortcut opens the stash menu if there
+are multiple entries or the entry's images are still saving. You can also open the menu from the
+stash badge. Stashes that contain files must be restored in the environment where those files were
 uploaded. Stashed files stay uploaded on the server for 24 hours. If you restore an entry after
 that, the file comes back with **Attach again** next to it. Attach the file again or remove it, then
 send.


### PR DESCRIPTION
Cmd+S opened the stash menu even when the composer was empty and only one prompt was stashed. It now restores that prompt directly, so repeated presses toggle between the draft and stash.

Multiple entries and images that are still saving open the menu. The stash badge still opens the menu.

Validation: 94 focused stash, shortcut, and attachment tests pass. Web typecheck and formatting pass. Targeted lint has no new warnings or errors. Browser checks were skipped at Theo's request.

Original implementation by Theo Browne. No code changes were needed during the takeover audit.

Audited with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized composer keyboard UX change reusing existing `restoreStashEntry`; no auth, data, or API surface changes.
> 
> **Overview**
> **Cmd+S on an empty composer** now restores the only stashed prompt when there is exactly one entry and its images are not still saving, instead of always opening the stash menu. That makes repeated **Cmd+S** toggle between stashing the current draft and pulling the lone entry back.
> 
> If the stash has **multiple entries**, or the single entry still has **`pendingImageCount`**, **Cmd+S** keeps the previous behavior and **toggles the stash menu**. The **stash badge** still opens the menu only.
> 
> Docs and **`ComposerStashMenu`** comments were updated to match this shortcut vs. menu split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db2d6bcfaa208ea9fb98e30a9ed553de35e00940. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore single stashed prompt with `Cmd+S` in `ChatComposer`
> - When the composer is empty, `Cmd+S` restores the sole stashed prompt if it has no pending images. Otherwise, the shortcut opens the stash menu.
> - Updates component comments in [ComposerStashMenu.tsx](https://github.com/pingdotgg/t3code/pull/9644/files#diff-2fcc66d7913594ea9e35be547ee395de158ea142ad58496a4f8089f6ca66ebff) and user docs in [composer.md](https://github.com/pingdotgg/t3code/pull/9644/files#diff-6c496fed927e1ba2296273bdfca78fd482921ebd76a32bb9d0c534f7bda35b63) to match.
> - Behavioral Change: `Cmd+S` with an empty composer no longer always opens the stash menu; it restores a single entry directly when possible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db2d6bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->