### PR TITLE
fix(web): resume Antigravity threads without repeated sign-in

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1,4 +1,5 @@
 import {
+  ANTIGRAVITY_DEFAULT_MODEL,
   CheckpointRef,
   EnvironmentId,
   MessageId,
@@ -793,14 +794,20 @@ describe("resolveComposerProviderSelection", () => {
     );
   });
 
-  it("blocks sends until Antigravity confirms authentication", () => {
+  it("lets Antigravity check saved credentials when resuming after a restart", () => {
     const provider = entry("antigravity", "google_work", {
+      status: "warning",
       auth: { status: "unknown" },
-      models: catalogModels,
+      models: [],
     }).snapshot;
 
-    expect(getAntigravitySendBlockReason(provider, "gemini-pro")).toBe(
-      "Sign in to Antigravity in provider settings before sending.",
+    expect(getAntigravitySendBlockReason(provider, "gemini-pro")).toBeNull();
+    expect(getAntigravitySendBlockReason(provider, ANTIGRAVITY_DEFAULT_MODEL)).toBeNull();
+    expect(
+      getAntigravitySendBlockReason({ ...provider, models: catalogModels }, "gemini-pro"),
+    ).toBeNull();
+    expect(getAntigravitySendBlockReason(provider, "")).toBe(
+      "Choose an Antigravity model before sending.",
     );
   });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -421,14 +421,17 @@ export function getAntigravitySendBlockReason(
   if (!provider.installed) {
     return "Install Antigravity in provider settings before sending.";
   }
-  if (provider.auth.status !== "authenticated") {
+  if (provider.auth.status === "unauthenticated") {
     return "Sign in to Antigravity in provider settings before sending.";
-  }
-  if (provider.models.length === 0) {
-    return "Refresh Antigravity models in provider settings before sending.";
   }
   const slug = model.trim();
   if (slug.length === 0) return "Choose an Antigravity model before sending.";
+  // A restart clears the account status and catalog. Session startup checks
+  // saved credentials and validates the model before sending the prompt.
+  if (provider.auth.status === "unknown") return null;
+  if (provider.models.length === 0) {
+    return "Refresh Antigravity models in provider settings before sending.";
+  }
   // A saved model that left the catalog is kept in the picker as unavailable
   // so the user sees what the thread used. The server rejects it at turn
   // start, so block here unless the provider is in an error state, where a

--- a/apps/web/src/components/chat/ProviderStatusBanner.test.tsx
+++ b/apps/web/src/components/chat/ProviderStatusBanner.test.tsx
@@ -28,6 +28,42 @@ function warningProvider(): ServerProvider {
 }
 
 describe("ProviderStatusBanner", () => {
+  it("waits for an Antigravity auth result before showing a sign-in warning", () => {
+    const status: ServerProvider = {
+      ...warningProvider(),
+      instanceId: ProviderInstanceId.make("google_work"),
+      driver: ProviderDriverKind.make("antigravity"),
+      auth: { status: "unknown" },
+      message: "Antigravity is installed. Google account access is not checked yet.",
+    };
+
+    expect(shouldShowProviderStatusBanner(status, null)).toBe(false);
+    expect(
+      shouldShowProviderStatusBanner(
+        {
+          ...status,
+          auth: { status: "unauthenticated" },
+          message: "Sign in with Google to use Antigravity.",
+        },
+        null,
+      ),
+    ).toBe(true);
+  });
+
+  it("shows Antigravity installation and startup failures before auth is checked", () => {
+    const status: ServerProvider = {
+      ...warningProvider(),
+      driver: ProviderDriverKind.make("antigravity"),
+      auth: { status: "unknown" },
+    };
+
+    expect(shouldShowProviderStatusBanner({ ...status, installed: false }, null)).toBe(true);
+    expect(shouldShowProviderStatusBanner({ ...status, status: "error" }, null)).toBe(true);
+    expect(
+      shouldShowProviderStatusBanner({ ...status, driver: ProviderDriverKind.make("codex") }, null),
+    ).toBe(true);
+  });
+
   it("stays hidden after its current warning is dismissed", () => {
     const status = warningProvider();
 

--- a/apps/web/src/components/chat/ProviderStatusBanner.tsx
+++ b/apps/web/src/components/chat/ProviderStatusBanner.tsx
@@ -7,9 +7,20 @@ import { formatProviderDriverKindLabel } from "../../providerModels";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
 export function getProviderStatusBannerKey(status: ServerProvider | null): string | null {
-  return !status || status.status === "ready" || status.status === "disabled"
-    ? null
-    : [status.instanceId, status.status, status.auth.status, status.message ?? ""].join("\u0000");
+  if (!status || status.status === "ready" || status.status === "disabled") return null;
+  // Antigravity checks saved credentials when a session starts. Its local
+  // health check leaves auth unknown after a restart, which is not a failure.
+  if (
+    status.driver === "antigravity" &&
+    status.installed &&
+    status.status === "warning" &&
+    status.auth.status === "unknown"
+  ) {
+    return null;
+  }
+  return [status.instanceId, status.status, status.auth.status, status.message ?? ""].join(
+    "\u0000",
+  );
 }
 
 export function shouldShowProviderStatusBanner(
@@ -59,7 +70,7 @@ export const ProviderStatusBanner = memo(function ProviderStatusBanner({
   onOpenProviderSetup?: (instanceId: ProviderInstanceId) => void;
   status: ServerProvider | null;
 }) {
-  if (!status || status.status === "ready" || status.status === "disabled") {
+  if (!status || getProviderStatusBannerKey(status) === null) {
     return null;
   }
 

--- a/docs/user/providers-antigravity.md
+++ b/docs/user/providers-antigravity.md
@@ -179,10 +179,14 @@ paid-plan tier or remaining subscription quota. See Google's [Antigravity plans]
 [personal Google sign-in guide][google-setup].
 
 After an environment restarts, Google sign-in can show as not checked until an authenticated
-session succeeds. To check account access and reload models, use **Refresh provider status**
-in web or desktop provider settings, or **Refresh models** in the mobile model picker. Refresh
-uses saved Google sign-in and does not open a login page. If sign-in is required, use the
-provider's setup controls. Automatic status checks verify the installation only.
+session succeeds. You can continue an existing thread. Antigravity checks saved Google sign-in
+when the session starts. An unchecked status does not require signing in again.
+
+To check account access and reload models on web or desktop, open **Settings** > **Providers**
+and select the circular arrow beside **Checked** at the top of the page. Its tooltip says
+**Refresh provider status**. On mobile, use **Refresh models** in the model picker.
+Refresh uses saved Google sign-in and does not open a login page. If sign-in is required,
+use the provider's setup controls. Automatic status checks verify the installation only.
 
 The packaged runtime can be slow to start, especially on Windows. Health checks, model refresh,
 and sign-out each allow up to 90 seconds before reporting a timeout.


### PR DESCRIPTION
After a server restart, reopening an Antigravity thread shows a provider warning and blocks sending because T3 treats unchecked authentication as signed out. Saved Google credentials are still present, and refreshing provider status restores access.

Allow session startup to check the saved login and selected model. Hide the warning for an installed Antigravity provider whose authentication has not been checked. Keep installation errors and confirmed sign-in failures visible. Clarify the refresh control in the user docs.

Validation: 136 focused web and Antigravity adapter tests pass, including native authentication, session resume, and missing-login handling. Web typecheck and targeted lint pass. On macOS, the adapter suite uses `TMPDIR=/private/tmp` to avoid an existing temporary-directory symlink mismatch.

Validation uses focused tests only at the maintainer's request. Browser testing and screenshots were not performed.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted Antigravity UX gating in the web client with expanded tests; confirmed unauthenticated and install errors remain blocked.
> 
> **Overview**
> After a server restart, Antigravity often reports **auth unknown** and an empty model catalog even when saved Google credentials are still valid. This PR stops treating that state like a sign-in failure so users can keep chatting on existing threads.
> 
> **Composer send gating** (`getAntigravitySendBlockReason`) now blocks only on confirmed `unauthenticated` auth, not on `unknown`. With auth still unchecked, sends are allowed when a model is selected (including after catalog reload); empty model and real sign-out/install/catalog rules are unchanged.
> 
> **Provider status banner** hides the warning for installed Antigravity in `warning` + `unknown` auth, while still showing install failures, errors, and confirmed unauthenticated states. Banner visibility is aligned with `getProviderStatusBannerKey`.
> 
> User docs clarify that unchecked sign-in after restart does not require re-login, that session startup validates saved credentials, and where **Refresh provider status** lives in Settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b557c84ddf3ba16ea24d3dfdac302532e2ce2036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Antigravity thread resume without repeated sign-in
> - Update `getAntigravitySendBlockReason` to only block explicitly unauthenticated providers, allowing sends for unknown auth states when a model is selected.
> - Suppress the warning banner in `ProviderStatusBanner` for installed Antigravity providers with unknown authentication.
> - Update `providers-antigravity.md` to document that existing threads can continue while authentication is unchecked.
> - Behavioral Change: `getAntigravitySendBlockReason` no longer blocks sends for installed providers with unknown authentication, relying on session startup to validate saved credentials.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b557c84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->