### PR TITLE
feat(server): add Pi Agent provider

### DIFF
--- a/apps/mobile/src/components/ProviderIcon.tsx
+++ b/apps/mobile/src/components/ProviderIcon.tsx
@@ -1,5 +1,5 @@
 import { Image } from "expo-image";
-import { Path, Svg } from "react-native-svg";
+import { Path, Rect, Svg } from "react-native-svg";
 import { useAppearancePreferences } from "../features/settings/appearance/AppearancePreferencesProvider";
 
 type ProviderIconProps = {
@@ -20,6 +20,20 @@ export function ProviderIcon(props: ProviderIconProps) {
         style={{ width: size, height: size }}
         contentFit="contain"
       />
+    );
+  }
+
+  if (props.provider?.trim().toLowerCase() === "piagent") {
+    return (
+      <Svg width={size} height={size} viewBox="0 0 800 800" fill="none">
+        <Rect width="800" height="800" rx="160" fill="#000" />
+        <Path
+          fill="#fff"
+          fillRule="evenodd"
+          d="M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29ZM282.65 282.65V400H400V282.65Z"
+        />
+        <Path fill="#fff" d="M517.36 400H634.72V634.72H517.36Z" />
+      </Svg>
     );
   }
 

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -880,7 +880,10 @@ export function NewTaskDraftScreen(props: {
     const selectedWorktreePath =
       draft.workspaceSelection?.worktreePath ?? flow.selectedWorktreePath;
     const startFromOrigin = draft.workspaceSelection?.startFromOrigin ?? flow.startFromOrigin;
-    const runtimeMode = draft.runtimeMode ?? flow.runtimeMode;
+    // The flow reconciles the draft mode against the selected provider's
+    // current capabilities. Dispatch that value even when the draft still
+    // contains the pre-switch mode.
+    const runtimeMode = flow.runtimeMode;
     const interactionMode = resolveProviderInteractionMode(
       selectedEnvironmentServerConfig?.providers.find(
         (provider) => provider.instanceId === modelSelection?.instanceId,

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -8,6 +8,7 @@ import type {
   RuntimeMode,
   ServerConfig as T3ServerConfig,
 } from "@t3tools/contracts";
+import { getProviderSupportedRuntimeModes } from "@t3tools/client-runtime/runtime-mode-options";
 import { StackActions, useFocusEffect, useNavigation } from "@react-navigation/native";
 import type { ReactNode } from "react";
 import {
@@ -335,6 +336,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       ) ?? null
     );
   }, [props.serverConfig, props.selectedThread.modelSelection.instanceId]);
+  const supportedRuntimeModes = getProviderSupportedRuntimeModes(selectedProviderStatus);
   const composerOwnerKey = scopedThreadKey(props.environmentId, props.selectedThread.id);
 
   const composerMenu = useComposerCommandMenu({
@@ -500,6 +502,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       onUpdateOptionSelections: (options) =>
         props.onUpdateModelSelection({ ...currentModelSelection, options }),
       runtimeMode: currentRuntimeMode,
+      supportedRuntimeModes,
       onUpdateRuntimeMode: props.onUpdateRuntimeMode,
     }),
     [
@@ -508,6 +511,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       props.onUpdateModelSelection,
       props.onUpdateRuntimeMode,
       providerOptionDescriptors,
+      supportedRuntimeModes,
       settingsOwnerId,
       threadProviderGroups,
     ],

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -7,7 +7,10 @@ import type {
   RuntimeMode,
   ServerProvider,
 } from "@t3tools/contracts";
-import { getProviderSupportedRuntimeModes } from "@t3tools/client-runtime/runtime-mode-options";
+import {
+  getProviderSupportedRuntimeModes,
+  reconcileRuntimeMode,
+} from "@t3tools/client-runtime/runtime-mode-options";
 import { useAtomValue } from "@effect/atom-react";
 import type { LegendListRenderItemProps } from "@legendapp/list/react-native";
 import { AnimatedLegendList } from "@legendapp/list/reanimated";
@@ -417,9 +420,27 @@ function ThreadSettingsSessionProvider(
     () => new Set(),
   );
   const [pendingModel, setPendingModel] = useState<ModelOption | null>(null);
+  // Model selection is staged in this sheet. Resolve runtime capabilities from
+  // that staged option so switching to a narrower provider immediately
+  // updates the Runtime submenu before Save applies the model.
+  // Always read the staged option back from the current provider snapshot:
+  // status refreshes can change capabilities while this sheet is open.
+  const latestPendingModel = useMemo(
+    () =>
+      pendingModel
+        ? props.providerGroups
+            .flatMap((group) => group.models)
+            .find((option) => option.key === pendingModel.key)
+        : undefined,
+    [pendingModel, props.providerGroups],
+  );
+  const stagedSupportedRuntimeModes = pendingModel
+    ? latestPendingModel?.supportedRuntimeModes
+    : props.supportedRuntimeModes;
+  const runtimeMode = reconcileRuntimeMode(props.runtimeMode, stagedSupportedRuntimeModes);
   const runtimeModeChoices = useMemo(
-    () => filterRuntimeModeChoices(props.supportedRuntimeModes),
-    [props.supportedRuntimeModes],
+    () => filterRuntimeModeChoices(stagedSupportedRuntimeModes),
+    [stagedSupportedRuntimeModes],
   );
 
   const isApplied = useCallback(
@@ -513,7 +534,7 @@ function ThreadSettingsSessionProvider(
       environmentId: props.environmentId,
       providerInstanceId: props.providerInstanceId,
       providerGroups: props.providerGroups,
-      runtimeMode: props.runtimeMode,
+      runtimeMode,
       runtimeModeChoices,
       onUpdateRuntimeMode: props.onUpdateRuntimeMode,
       displayedDescriptors,
@@ -548,7 +569,7 @@ function ThreadSettingsSessionProvider(
       providerFilter,
       props.onUpdateRuntimeMode,
       props.providerGroups,
-      props.runtimeMode,
+      runtimeMode,
       runtimeModeChoices,
       searchQuery,
       showLegacyToggle,

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -7,6 +7,7 @@ import type {
   RuntimeMode,
   ServerProvider,
 } from "@t3tools/contracts";
+import { getProviderSupportedRuntimeModes } from "@t3tools/client-runtime/runtime-mode-options";
 import { useAtomValue } from "@effect/atom-react";
 import type { LegendListRenderItemProps } from "@legendapp/list/react-native";
 import { AnimatedLegendList } from "@legendapp/list/reanimated";
@@ -68,7 +69,7 @@ import {
   NATIVE_MAIL_SEARCH_TOOLBAR_CONTENT_INSET,
   NATIVE_MAIL_SEARCH_TOOLBAR_SUPPORTED,
 } from "../layout/native-mail-search-toolbar";
-import { RUNTIME_MODE_CHOICES, selectableChoices } from "./thread-settings-options";
+import { filterRuntimeModeChoices, selectableChoices } from "./thread-settings-options";
 import {
   canCommitPendingModel,
   modelMatchesCatalogQuery,
@@ -329,6 +330,7 @@ type ThreadSettingsSessionProps = {
   readonly optionDescriptors: ReadonlyArray<ProviderOptionDescriptor>;
   readonly onUpdateOptionSelections: (selections: ReadonlyArray<ProviderOptionSelection>) => void;
   readonly runtimeMode: RuntimeMode;
+  readonly supportedRuntimeModes?: ReadonlyArray<RuntimeMode> | undefined;
   readonly onUpdateRuntimeMode: (mode: RuntimeMode) => void;
 };
 
@@ -378,6 +380,11 @@ type ThreadSettingsSessionValue = {
   readonly providerInstanceId?: ProviderInstanceId;
   readonly providerGroups: ReadonlyArray<ProviderGroup>;
   readonly runtimeMode: RuntimeMode;
+  readonly runtimeModeChoices: ReadonlyArray<{
+    readonly mode: RuntimeMode;
+    readonly label: string;
+    readonly description: string;
+  }>;
   readonly onUpdateRuntimeMode: (mode: RuntimeMode) => void;
   readonly displayedDescriptors: ReadonlyArray<ProviderOptionDescriptor>;
   readonly providerExpansionOverrides: ReadonlySet<string>;
@@ -410,6 +417,10 @@ function ThreadSettingsSessionProvider(
     () => new Set(),
   );
   const [pendingModel, setPendingModel] = useState<ModelOption | null>(null);
+  const runtimeModeChoices = useMemo(
+    () => filterRuntimeModeChoices(props.supportedRuntimeModes),
+    [props.supportedRuntimeModes],
+  );
 
   const isApplied = useCallback(
     (option: ModelOption) =>
@@ -503,6 +514,7 @@ function ThreadSettingsSessionProvider(
       providerInstanceId: props.providerInstanceId,
       providerGroups: props.providerGroups,
       runtimeMode: props.runtimeMode,
+      runtimeModeChoices,
       onUpdateRuntimeMode: props.onUpdateRuntimeMode,
       displayedDescriptors,
       providerExpansionOverrides,
@@ -537,6 +549,7 @@ function ThreadSettingsSessionProvider(
       props.onUpdateRuntimeMode,
       props.providerGroups,
       props.runtimeMode,
+      runtimeModeChoices,
       searchQuery,
       showLegacyToggle,
       toggleProvider,
@@ -766,7 +779,8 @@ function ThreadSettingsOptionsItem(props: {
             isLast
             label="Runtime"
             value={
-              RUNTIME_MODE_CHOICES.find((choice) => choice.mode === session.runtimeMode)?.label
+              session.runtimeModeChoices.find((choice) => choice.mode === session.runtimeMode)
+                ?.label
             }
             onPress={() => props.onOpenSubmenu({ kind: "runtime" })}
           />
@@ -940,7 +954,7 @@ function ThreadSettingsChoiceContent(props: {
   const submenuContent =
     props.submenu.kind === "runtime"
       ? {
-          rows: RUNTIME_MODE_CHOICES.map((choice) => ({
+          rows: session.runtimeModeChoices.map((choice) => ({
             id: choice.mode,
             label: choice.label,
             description: choice.description,
@@ -1350,6 +1364,7 @@ export function NewTaskThreadSettingsRouteScreen() {
       optionDescriptors={optionDescriptors}
       onUpdateOptionSelections={flow.setSelectedModelOptions}
       runtimeMode={flow.runtimeMode}
+      supportedRuntimeModes={getProviderSupportedRuntimeModes(flow.selectedProviderStatus)}
       onUpdateRuntimeMode={flow.setRuntimeMode}
     >
       <ThreadSettingsPickerNavigator onClose={() => navigation.goBack()} />

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -78,6 +78,10 @@ import {
 import { EnvironmentProject } from "@t3tools/client-runtime/state/shell";
 import { type VcsRef } from "@t3tools/client-runtime/state/vcs";
 import {
+  getProviderSupportedRuntimeModes,
+  reconcileRuntimeMode,
+} from "@t3tools/client-runtime/runtime-mode-options";
+import {
   buildHomeProjectScopes,
   sortHomeProjectScopes,
   type HomeProjectScope,
@@ -415,7 +419,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     draftStartFromOrigin ??
     selectedEnvironmentServerConfig?.settings.newWorktreesStartFromOrigin ??
     true;
-  const runtimeMode = selectedProjectDraft.runtimeMode ?? DEFAULT_RUNTIME_MODE;
+  const configuredRuntimeMode = selectedProjectDraft.runtimeMode ?? DEFAULT_RUNTIME_MODE;
 
   // Antigravity keeps unavailable selections so sign-out or a catalog change
   // cannot switch the user's model. Other providers retain their fallback
@@ -473,6 +477,16 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       ) ?? null,
     [selectedEnvironmentServerConfig, selectedModel?.instanceId],
   );
+  const runtimeMode = reconcileRuntimeMode(
+    configuredRuntimeMode,
+    getProviderSupportedRuntimeModes(selectedProviderStatus),
+  );
+  useEffect(() => {
+    if (selectedProjectDraftKey === null || runtimeMode === configuredRuntimeMode) {
+      return;
+    }
+    updateComposerDraftSettings(selectedProjectDraftKey, { runtimeMode });
+  }, [configuredRuntimeMode, runtimeMode, selectedProjectDraftKey]);
   const planModeEnabled =
     legacyPlanModeEnabled && selectedProviderStatus?.showInteractionModeToggle !== false;
   const interactionMode = planModeEnabled
@@ -493,15 +507,20 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       const provider = selectedEnvironmentServerConfig?.providers.find(
         (candidate) => candidate.instanceId === selection.instanceId,
       );
+      const runtimeMode = reconcileRuntimeMode(
+        configuredRuntimeMode,
+        getProviderSupportedRuntimeModes(provider),
+      );
       updateComposerDraftSettings(selectedProjectDraftKey, {
         modelSelection: selection,
+        ...(runtimeMode !== configuredRuntimeMode ? { runtimeMode } : {}),
         ...(provider?.showInteractionModeToggle === false
           ? { interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE }
           : {}),
       });
       setStickyComposerModelSelection(selection);
     },
-    [modelOptions, selectedEnvironmentServerConfig, selectedProjectDraftKey],
+    [configuredRuntimeMode, modelOptions, selectedEnvironmentServerConfig, selectedProjectDraftKey],
   );
   const setSelectedModelOptions = useCallback(
     (options: ReadonlyArray<ProviderOptionSelection> | undefined) => {
@@ -906,7 +925,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
         text,
         attachments: draft.attachments,
         modelSelection: draftModelSelection,
-        runtimeMode: draft.runtimeMode ?? DEFAULT_RUNTIME_MODE,
+        runtimeMode,
         interactionMode: resolvePendingTaskInteractionMode({
           preferenceLoaded: planModePreferenceLoaded,
           planModeEnabled: legacyPlanModeEnabled,
@@ -946,6 +965,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       selectedProjectDraftKey,
       legacyPlanModeEnabled,
       planModePreferenceLoaded,
+      runtimeMode,
       startFromOrigin,
       workspaceMode,
     ],

--- a/apps/mobile/src/features/threads/thread-settings-options.test.ts
+++ b/apps/mobile/src/features/threads/thread-settings-options.test.ts
@@ -43,4 +43,10 @@ describe("filterRuntimeModeChoices", () => {
       filterRuntimeModeChoices(["full-access", "approval-required"]).map((choice) => choice.mode),
     ).toEqual(["approval-required", "full-access"]);
   });
+
+  it("keeps the defensive fallback visible for an explicitly empty capability list", () => {
+    expect(filterRuntimeModeChoices([]).map((choice) => choice.mode)).toEqual([
+      "approval-required",
+    ]);
+  });
 });

--- a/apps/mobile/src/features/threads/thread-settings-options.test.ts
+++ b/apps/mobile/src/features/threads/thread-settings-options.test.ts
@@ -1,7 +1,7 @@
 import type { ProviderOptionDescriptor } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { selectableChoices } from "./thread-settings-options";
+import { filterRuntimeModeChoices, selectableChoices } from "./thread-settings-options";
 
 const effortDescriptor: Extract<ProviderOptionDescriptor, { type: "select" }> = {
   id: "effort",
@@ -25,5 +25,22 @@ describe("selectableChoices", () => {
       "medium",
       "high",
     ]);
+  });
+});
+
+describe("filterRuntimeModeChoices", () => {
+  it("keeps every runtime mode for providers without the optional capability", () => {
+    expect(filterRuntimeModeChoices(undefined).map((choice) => choice.mode)).toEqual([
+      "approval-required",
+      "auto-accept-edits",
+      "auto",
+      "full-access",
+    ]);
+  });
+
+  it("filters to explicitly supported modes while preserving product order", () => {
+    expect(
+      filterRuntimeModeChoices(["full-access", "approval-required"]).map((choice) => choice.mode),
+    ).toEqual(["approval-required", "full-access"]);
   });
 });

--- a/apps/mobile/src/features/threads/thread-settings-options.ts
+++ b/apps/mobile/src/features/threads/thread-settings-options.ts
@@ -1,4 +1,5 @@
 import type { ProviderOptionDescriptor, RuntimeMode } from "@t3tools/contracts";
+import { filterRuntimeModeOptions } from "@t3tools/client-runtime/runtime-mode-options";
 
 /**
  * Desktop-oriented effort keywords that don't belong in the phone picker.
@@ -35,6 +36,12 @@ export const RUNTIME_MODE_CHOICES: ReadonlyArray<{
     description: "Allow commands and edits without prompts.",
   },
 ];
+
+export function filterRuntimeModeChoices(
+  supportedRuntimeModes: ReadonlyArray<RuntimeMode> | undefined,
+) {
+  return filterRuntimeModeOptions(RUNTIME_MODE_CHOICES, supportedRuntimeModes);
+}
 
 export function selectableChoices(
   descriptor: Extract<ProviderOptionDescriptor, { type: "select" }>,

--- a/apps/mobile/src/features/threads/use-project-actions.ts
+++ b/apps/mobile/src/features/threads/use-project-actions.ts
@@ -1,6 +1,10 @@
 import { useCallback } from "react";
 
 import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import {
+  getProviderSupportedRuntimeModes,
+  reconcileRuntimeMode,
+} from "@t3tools/client-runtime/runtime-mode-options";
 import { EnvironmentProject } from "@t3tools/client-runtime/state/shell";
 import { mapAtomCommandResult } from "@t3tools/client-runtime/state/runtime";
 import {
@@ -127,6 +131,12 @@ export function useCreateProjectThread() {
       const provider = serverConfig?.providers.find(
         (candidate) => candidate.instanceId === input.modelSelection.instanceId,
       );
+      // Attachment preparation above can cross a provider snapshot refresh;
+      // resolve the mode from the live config immediately before dispatch.
+      const runtimeMode = reconcileRuntimeMode(
+        input.runtimeMode,
+        getProviderSupportedRuntimeModes(provider),
+      );
 
       const result = await startTurn({
         environmentId: input.project.environmentId,
@@ -141,7 +151,7 @@ export function useCreateProjectThread() {
           attachments: input.initialAttachments,
           uploadedAttachments: prepared.attachments,
           modelSelection: input.modelSelection,
-          runtimeMode: input.runtimeMode,
+          runtimeMode,
           interactionMode: resolveProviderInteractionMode(provider, input.interactionMode),
           workspaceMode: input.envMode,
           branch: input.branch,

--- a/apps/mobile/src/features/usage/usageProviders.test.ts
+++ b/apps/mobile/src/features/usage/usageProviders.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("../settings/appearance/AppearancePreferencesProvider", () => ({
+  useAppearancePreferences: () => ({ themeAppearance: "dark" }),
+}));
+
+import { PROVIDER_LABEL, PROVIDER_ORDER } from "./usageProviders";
+
+describe("mobile usage provider presentation", () => {
+  it("includes Pi in charts and model breakdowns", () => {
+    expect(PROVIDER_ORDER).toContain("pi");
+    expect(PROVIDER_LABEL.pi).toBe("Pi Agent");
+  });
+});

--- a/apps/mobile/src/features/usage/usageProviders.ts
+++ b/apps/mobile/src/features/usage/usageProviders.ts
@@ -5,17 +5,18 @@ import { useAppearancePreferences } from "../settings/appearance/AppearancePrefe
  * Series and table order. The chart stacks providers from the bottom in this
  * order, so it also fixes which band sits on top of the bars.
  */
-export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude", "grok"];
+export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude", "grok", "pi"];
 
 export const PROVIDER_LABEL: Record<UsageProviderKind, string> = {
   claude: "Claude Code",
   codex: "Codex",
   grok: "Grok Build",
+  pi: "Pi Agent",
 };
 
 /**
- * Claude's brand orange holds in both themes; Codex and Grok are neutrals and
- * must flip with the theme or their bars vanish against the matching background.
+ * Claude and Pi keep their series colours in both themes; Codex and Grok are
+ * neutrals and must flip or their bars vanish against the matching background.
  */
 export function useProviderColors(): Record<UsageProviderKind, string> {
   const { themeAppearance: scheme } = useAppearancePreferences();
@@ -23,5 +24,6 @@ export function useProviderColors(): Record<UsageProviderKind, string> {
     claude: "#d97757",
     codex: scheme === "dark" ? "#e6e6e6" : "#3c3c43",
     grok: scheme === "dark" ? "#a1a1aa" : "#52525b",
+    pi: "#8b9cf6",
   };
 }

--- a/apps/mobile/src/lib/modelOptions.test.ts
+++ b/apps/mobile/src/lib/modelOptions.test.ts
@@ -13,6 +13,57 @@ import {
 } from "./modelOptions";
 
 describe("mobile model options", () => {
+  it("carries provider runtime capabilities onto staged model options", () => {
+    const config = {
+      providers: [
+        {
+          instanceId: "piAgent",
+          driver: "piAgent",
+          displayName: "Pi Agent",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          supportedRuntimeModes: ["full-access"],
+          models: [
+            {
+              slug: "pi-model",
+              name: "Pi Model",
+              isCustom: false,
+              capabilities: null,
+            },
+          ],
+        },
+      ],
+    } as unknown as ServerConfig;
+
+    expect(buildModelOptions(config, null)[0]?.supportedRuntimeModes).toEqual(["full-access"]);
+  });
+
+  it("preserves an explicitly empty provider capability list", () => {
+    const config = {
+      providers: [
+        {
+          instanceId: "empty-runtime-modes",
+          driver: "custom",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          supportedRuntimeModes: [],
+          models: [
+            {
+              slug: "model",
+              name: "Model",
+              isCustom: false,
+              capabilities: null,
+            },
+          ],
+        },
+      ],
+    } as unknown as ServerConfig;
+
+    expect(buildModelOptions(config, null)[0]?.supportedRuntimeModes).toEqual([]);
+  });
+
   it("groups models by provider and flags legacy entries", () => {
     const config = {
       providers: [

--- a/apps/mobile/src/lib/modelOptions.ts
+++ b/apps/mobile/src/lib/modelOptions.ts
@@ -2,6 +2,7 @@ import type {
   ModelCapabilities,
   ModelSelection,
   ServerConfig as T3ServerConfig,
+  RuntimeMode,
 } from "@t3tools/contracts";
 import {
   buildExplicitProviderOptionSelectionsFromDescriptors,
@@ -19,6 +20,8 @@ export type ModelOption = {
   readonly isLegacy: boolean;
   readonly isUnavailable?: boolean;
   readonly capabilities: ModelCapabilities | null;
+  /** Provider-level runtime policies, carried for staged settings picks. */
+  readonly supportedRuntimeModes?: ReadonlyArray<RuntimeMode>;
   readonly selection: ModelSelection;
 };
 
@@ -176,6 +179,9 @@ export function buildModelOptions(
         isDefault: model.isDefault === true,
         isLegacy: model.isLegacy === true,
         capabilities: model.capabilities,
+        ...(provider.supportedRuntimeModes
+          ? { supportedRuntimeModes: provider.supportedRuntimeModes }
+          : {}),
         selection: normalizeSelectionOptions(
           {
             instanceId: provider.instanceId,
@@ -226,6 +232,9 @@ export function buildModelOptions(
           ? { isUnavailable: true }
           : {}),
         capabilities: model?.capabilities ?? null,
+        ...(provider?.supportedRuntimeModes
+          ? { supportedRuntimeModes: provider.supportedRuntimeModes }
+          : {}),
         selection: fallbackModelSelection,
       });
     }

--- a/apps/mobile/src/state/thread-outbox-model.ts
+++ b/apps/mobile/src/state/thread-outbox-model.ts
@@ -1,5 +1,9 @@
 import { isTransportConnectionErrorMessage } from "@t3tools/client-runtime/errors";
 import {
+  getProviderSupportedRuntimeModes,
+  reconcileRuntimeMode,
+} from "@t3tools/client-runtime/runtime-mode-options";
+import {
   clampFileAttachmentUploadBytes,
   fileAttachmentTooLargeMessage,
 } from "@t3tools/client-runtime/state/attachments";
@@ -95,7 +99,9 @@ export interface ThreadSettingsSnapshot {
 export function resolveQueuedThreadSettings(
   message: QueuedThreadMessage,
   thread: ThreadSettingsSnapshot,
-  providers: ReadonlyArray<Pick<ServerProvider, "instanceId" | "showInteractionModeToggle">> = [],
+  providers: ReadonlyArray<
+    Pick<ServerProvider, "instanceId" | "showInteractionModeToggle" | "supportedRuntimeModes">
+  > = [],
 ): ThreadSettingsSnapshot {
   const modelSelection = message.modelSelection ?? thread.modelSelection;
   const provider = providers.find(
@@ -103,7 +109,10 @@ export function resolveQueuedThreadSettings(
   );
   return {
     modelSelection,
-    runtimeMode: message.runtimeMode ?? thread.runtimeMode,
+    runtimeMode: reconcileRuntimeMode(
+      message.runtimeMode ?? thread.runtimeMode,
+      getProviderSupportedRuntimeModes(provider),
+    ),
     interactionMode: resolveProviderInteractionMode(
       provider,
       message.interactionMode ?? thread.interactionMode,

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -192,6 +192,36 @@ describe("thread outbox", () => {
     ).toBe("plan");
   });
 
+  it("reconciles a queued runtime mode against the provider snapshot at drain time", () => {
+    const modelSelection = {
+      instanceId: ProviderInstanceId.make("piAgent"),
+      model: "pi-model",
+    };
+    const message = {
+      ...queuedMessage({ messageId: "queued-runtime", createdAt: "2026-09-04T10:00:00.000Z" }),
+      modelSelection,
+      runtimeMode: "approval-required" as const,
+    } satisfies QueuedThreadMessage;
+
+    expect(
+      resolveQueuedThreadSettings(
+        message,
+        {
+          modelSelection,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+        },
+        [
+          {
+            instanceId: modelSelection.instanceId,
+            showInteractionModeToggle: true,
+            supportedRuntimeModes: ["full-access"],
+          },
+        ],
+      ),
+    ).toMatchObject({ runtimeMode: "full-access" });
+  });
+
   it("normalizes a legacy queued message that inherits unsupported plan mode", () => {
     const modelSelection = {
       instanceId: ProviderInstanceId.make("google-personal"),

--- a/apps/mobile/src/state/use-thread-composer-state.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.ts
@@ -6,6 +6,7 @@ import * as Cause from "effect/Cause";
 import {
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
+  DEFAULT_RUNTIME_MODE,
   MessageId,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   type EnvironmentId,
@@ -15,6 +16,10 @@ import {
   type ThreadId,
 } from "@t3tools/contracts";
 import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
+import {
+  getProviderSupportedRuntimeModes,
+  reconcileRuntimeMode,
+} from "@t3tools/client-runtime/runtime-mode-options";
 import {
   codexFeedbackMessage,
   parseCodexFeedbackCommand,
@@ -148,10 +153,27 @@ export function useThreadComposerState() {
   const selectedThreadQueueCount = selectedThreadQueuedMessages.length;
   const selectedThread = selectedThreadDetail ?? selectedThreadShell;
   const modelSelection = selectedDraft?.modelSelection ?? selectedThread?.modelSelection ?? null;
-  const runtimeMode = selectedDraft?.runtimeMode ?? selectedThread?.runtimeMode ?? null;
   const selectedProvider = selectedEnvironmentRuntime?.serverConfig?.providers.find(
     (provider) => provider.instanceId === modelSelection?.instanceId,
   );
+  const configuredRuntimeMode = selectedDraft?.runtimeMode ?? selectedThread?.runtimeMode ?? null;
+  const runtimeMode =
+    configuredRuntimeMode === null
+      ? null
+      : reconcileRuntimeMode(
+          configuredRuntimeMode,
+          getProviderSupportedRuntimeModes(selectedProvider),
+        );
+  useEffect(() => {
+    if (
+      selectedThreadKey === null ||
+      runtimeMode === null ||
+      runtimeMode === configuredRuntimeMode
+    ) {
+      return;
+    }
+    updateComposerDraftSettings(selectedThreadKey, { runtimeMode });
+  }, [configuredRuntimeMode, runtimeMode, selectedThreadKey]);
   const interactionMode = selectedThread
     ? resolveProviderInteractionMode(
         selectedProvider,
@@ -352,7 +374,7 @@ export function useThreadComposerState() {
       text,
       attachments,
       modelSelection,
-      runtimeMode: draft.runtimeMode ?? thread.runtimeMode,
+      runtimeMode: runtimeMode ?? thread.runtimeMode,
       interactionMode: resolveProviderInteractionMode(
         provider,
         draft.interactionMode ?? thread.interactionMode,
@@ -385,6 +407,7 @@ export function useThreadComposerState() {
     selectedEnvironmentRuntime?.serverConfig,
     selectedThreadDetail,
     selectedThreadShell,
+    runtimeMode,
     uploadThreadFeedback,
   ]);
 
@@ -527,14 +550,21 @@ export function useThreadComposerState() {
       const provider = selectedEnvironmentRuntime?.serverConfig?.providers.find(
         (candidate) => candidate.instanceId === value.instanceId,
       );
+      const nextRuntimeMode = reconcileRuntimeMode(
+        configuredRuntimeMode ?? DEFAULT_RUNTIME_MODE,
+        getProviderSupportedRuntimeModes(provider),
+      );
       updateComposerDraftSettings(selectedThreadKey, {
         modelSelection: value,
+        ...(nextRuntimeMode !== (configuredRuntimeMode ?? DEFAULT_RUNTIME_MODE)
+          ? { runtimeMode: nextRuntimeMode }
+          : {}),
         ...(provider?.showInteractionModeToggle === false
           ? { interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE }
           : {}),
       });
     },
-    [selectedEnvironmentRuntime?.serverConfig, selectedThreadKey],
+    [configuredRuntimeMode, selectedEnvironmentRuntime?.serverConfig, selectedThreadKey],
   );
 
   const onUpdateRuntimeMode = useCallback(

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2887,12 +2887,18 @@ describe("ProviderCommandReactor", () => {
     );
 
     await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+    await waitFor(() => harness.startSession.mock.calls.length === 3);
 
     expect(harness.stopSession.mock.calls.length).toBe(0);
     expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
       threadId: ThreadId.make("thread-1"),
       resumeCursor: { opaque: "resume-1" },
       runtimeMode: "approval-required",
+    });
+    expect(harness.startSession.mock.calls[2]?.[1]).toMatchObject({
+      threadId: ThreadId.make("thread-1"),
+      resumeCursor: { opaque: "resume-1" },
+      runtimeMode: "full-access",
     });
     expect(harness.sendTurn.mock.calls[1]?.[0]).toMatchObject({
       threadId: ThreadId.make("thread-1"),
@@ -2901,7 +2907,7 @@ describe("ProviderCommandReactor", () => {
     const readModel = await harness.readModel();
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
     expect(thread?.session?.threadId).toBe("thread-1");
-    expect(thread?.session?.runtimeMode).toBe("approval-required");
+    expect(thread?.session?.runtimeMode).toBe("full-access");
   });
 
   it("does not inject derived model options when restarting claude on runtime mode changes", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1670,8 +1670,6 @@ const make = Effect.gen(function* () {
               return normalizeRuntimeTurnState(event.payload.state) === "failed"
                 ? "error"
                 : "ready";
-            case "turn.aborted":
-              return "ready";
             case "session.started":
             case "thread.started":
               // Provider thread/session start notifications can arrive during an

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1670,6 +1670,8 @@ const make = Effect.gen(function* () {
               return normalizeRuntimeTurnState(event.payload.state) === "failed"
                 ? "error"
                 : "ready";
+            case "turn.aborted":
+              return "ready";
             case "session.started":
             case "thread.started":
               // Provider thread/session start notifications can arrive during an

--- a/apps/server/src/orchestration/decider.projectScripts.test.ts
+++ b/apps/server/src/orchestration/decider.projectScripts.test.ts
@@ -321,7 +321,7 @@ it.layer(NodeServices.layer)("decider project scripts", (it) => {
             { id: "fastMode", value: true },
           ]),
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-          runtimeMode: "approval-required",
+          runtimeMode: "full-access",
           createdAt: now,
         },
         readModel,
@@ -329,11 +329,12 @@ it.layer(NodeServices.layer)("decider project scripts", (it) => {
 
       expect(Array.isArray(result)).toBe(true);
       const events = Array.isArray(result) ? result : [result];
-      expect(events).toHaveLength(2);
-      expect(events[0]?.type).toBe("thread.message-sent");
-      const turnStartEvent = events[1];
+      expect(events).toHaveLength(3);
+      expect(events[0]?.type).toBe("thread.runtime-mode-set");
+      expect(events[1]?.type).toBe("thread.message-sent");
+      const turnStartEvent = events[2];
       expect(turnStartEvent?.type).toBe("thread.turn-start-requested");
-      expect(turnStartEvent?.causationEventId).toBe(events[0]?.eventId ?? null);
+      expect(turnStartEvent?.causationEventId).toBe(events[1]?.eventId ?? null);
       if (turnStartEvent?.type !== "thread.turn-start-requested") {
         return;
       }
@@ -344,7 +345,7 @@ it.layer(NodeServices.layer)("decider project scripts", (it) => {
           { id: "reasoningEffort", value: "high" },
           { id: "fastMode", value: true },
         ]),
-        runtimeMode: "approval-required",
+        runtimeMode: "full-access",
       });
     }),
   );

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -910,6 +910,25 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         threadId: command.threadId,
       });
+      // A start command carries the mode that was reconciled at the client
+      // dispatch boundary. Persist it through the existing runtime-mode
+      // command path before deciding the turn, so the provider reactor does
+      // not fall back to a stale mode from the thread snapshot.
+      if (command.runtimeMode !== targetThread.runtimeMode) {
+        return yield* decideCommandSequence({
+          readModel,
+          commands: [
+            {
+              type: "thread.runtime-mode.set",
+              commandId: command.commandId,
+              threadId: command.threadId,
+              runtimeMode: command.runtimeMode,
+              createdAt: command.createdAt,
+            },
+            command,
+          ],
+        });
+      }
       const sourceProposedPlan = command.sourceProposedPlan;
       const sourceThread = sourceProposedPlan
         ? yield* requireThread({
@@ -970,7 +989,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
             ? { modelSelection: command.modelSelection }
             : {}),
           ...(command.titleSeed !== undefined ? { titleSeed: command.titleSeed } : {}),
-          runtimeMode: targetThread.runtimeMode,
+          runtimeMode: command.runtimeMode,
           interactionMode: targetThread.interactionMode,
           ...(sourceProposedPlan !== undefined ? { sourceProposedPlan } : {}),
           createdAt: command.createdAt,

--- a/apps/server/src/provider/Drivers/PiAgentDriver.test.ts
+++ b/apps/server/src/provider/Drivers/PiAgentDriver.test.ts
@@ -1,0 +1,40 @@
+import { it } from "@effect/vitest";
+import { describe, expect } from "vite-plus/test";
+
+import { PiAgentDriver, resolvePiAgentSettingsPaths } from "./PiAgentDriver.ts";
+
+describe("PiAgentDriver", () => {
+  it("is an Early Access multi-instance driver with a disabled default", () => {
+    expect(PiAgentDriver.driverKind).toBe("piAgent");
+    expect(PiAgentDriver.metadata).toMatchObject({
+      displayName: "Pi Agent",
+      supportsMultipleInstances: true,
+    });
+    expect(PiAgentDriver.defaultConfig()).toMatchObject({
+      enabled: false,
+      binaryPath: "pi",
+      agentDir: "",
+      sessionDir: "",
+      customModels: [],
+    });
+  });
+
+  it("resolves relative profile directories from the stable server root", () => {
+    expect(
+      resolvePiAgentSettingsPaths(
+        {
+          enabled: true,
+          binaryPath: "pi",
+          agentDir: ".pi/profile",
+          sessionDir: ".pi/sessions",
+          customModels: [],
+        },
+        "/srv/t3code",
+        (path, ...paths) => [path, ...paths].join("/"),
+      ),
+    ).toMatchObject({
+      agentDir: "/srv/t3code/.pi/profile",
+      sessionDir: "/srv/t3code/.pi/sessions",
+    });
+  });
+});

--- a/apps/server/src/provider/Drivers/PiAgentDriver.ts
+++ b/apps/server/src/provider/Drivers/PiAgentDriver.ts
@@ -1,0 +1,231 @@
+/**
+ * Early Access Pi Agent driver.
+ *
+ * Pi is a user-managed executable and a profile can be configured more than
+ * once. Each instance owns its adapter, profile environment, RPC sessions,
+ * dynamic catalog, and continuation identity; no process or catalog state is
+ * shared with another instance.
+ */
+import { PiAgentSettings, ProviderDriverKind, TextGenerationError } from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
+import { ServerConfig } from "../../config.ts";
+import { expandHomePath } from "../../pathExpansion.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import { TextGeneration } from "../../textGeneration/TextGeneration.ts";
+import { ProviderDriverError } from "../Errors.ts";
+import {
+  checkPiAgentProviderStatus,
+  discoverPiAgentCatalog,
+  makePendingPiAgentProvider,
+  providerModelsFromPiCatalog,
+} from "../Layers/PiAgentProvider.ts";
+import { makePiAgentAdapter } from "../Layers/PiAgentAdapter.ts";
+import { makePiRpcClient } from "../pi/PiRpcClient.ts";
+import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import {
+  makeManualOnlyProviderMaintenanceCapabilities,
+  makeStaticProviderMaintenanceResolver,
+  resolveProviderMaintenanceCapabilitiesEffect,
+} from "../providerMaintenance.ts";
+import {
+  haveProviderSnapshotSettingsChanged,
+  makeProviderSnapshotSettingsSource,
+  type ProviderSnapshotSettings,
+} from "../providerUpdateSettings.ts";
+import { withInstanceIdentity } from "./instanceIdentity.ts";
+
+const DRIVER_KIND = ProviderDriverKind.make("piAgent");
+const decodePiAgentSettings = Schema.decodeSync(PiAgentSettings);
+const UPDATE = makeStaticProviderMaintenanceResolver(
+  makeManualOnlyProviderMaintenanceCapabilities({ provider: DRIVER_KIND, packageName: null }),
+);
+
+/** Keep instance-level profile paths stable across projects and Usage scans. */
+export function resolvePiAgentSettingsPaths(
+  config: PiAgentSettings,
+  serverRoot: string,
+  resolvePath: (path: string, ...paths: ReadonlyArray<string>) => string,
+): PiAgentSettings {
+  const resolveDirectory = (value: string) => {
+    const configured = value.trim();
+    return configured ? resolvePath(serverRoot, expandHomePath(configured)) : "";
+  };
+  return {
+    ...config,
+    agentDir: resolveDirectory(config.agentDir),
+    sessionDir: resolveDirectory(config.sessionDir),
+  };
+}
+
+export type PiAgentDriverEnv =
+  | BackgroundPolicy.BackgroundPolicy
+  | ChildProcessSpawner.ChildProcessSpawner
+  | Crypto.Crypto
+  | FileSystem.FileSystem
+  | Path.Path
+  | ServerConfig
+  | ServerSettingsService;
+
+const unsupportedTextGeneration = <Operation extends string>(operation: Operation) =>
+  Effect.fail(
+    new TextGenerationError({
+      operation,
+      detail: "Pi Agent does not support T3 Code structured text generation.",
+    }),
+  );
+
+function makeUnsupportedTextGeneration(): TextGeneration["Service"] {
+  return {
+    generateCommitMessage: () => unsupportedTextGeneration("generateCommitMessage"),
+    generatePrContent: () => unsupportedTextGeneration("generatePrContent"),
+    generateBranchName: () => unsupportedTextGeneration("generateBranchName"),
+    generateThreadTitle: () => unsupportedTextGeneration("generateThreadTitle"),
+  };
+}
+
+/** Services required by the Pi driver. */
+export const PiAgentDriver: ProviderDriver<PiAgentSettings, PiAgentDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "Pi Agent",
+    supportsMultipleInstances: true,
+  },
+  configSchema: PiAgentSettings,
+  defaultConfig: () => decodePiAgentSettings({}),
+  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const crypto = yield* Crypto.Crypto;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const serverConfig = yield* ServerConfig;
+      const serverSettings = yield* ServerSettingsService;
+      const processEnvironment = mergeProviderInstanceEnvironment(environment);
+      const effectiveConfig = resolvePiAgentSettingsPaths(
+        { ...config, enabled },
+        serverConfig.cwd,
+        path.resolve,
+      );
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const stampIdentity = withInstanceIdentity({
+        instanceId,
+        driverKind: DRIVER_KIND,
+        displayName,
+        accentColor,
+        continuationGroupKey: continuationIdentity.continuationKey,
+      });
+      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+        binaryPath: effectiveConfig.binaryPath,
+        env: processEnvironment,
+      });
+
+      const adapter = yield* makePiAgentAdapter(effectiveConfig, {
+        instanceId,
+        makeClient: (options) =>
+          makePiRpcClient({
+            ...options,
+            env: {
+              ...Object.fromEntries(
+                Object.entries(processEnvironment).filter(
+                  (entry): entry is [string, string] => entry[1] !== undefined,
+                ),
+              ),
+              ...options.env,
+            },
+          }).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner)),
+      }).pipe(
+        Effect.provideService(Crypto.Crypto, crypto),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.provideService(ServerConfig, serverConfig),
+      );
+
+      const checkProvider = checkPiAgentProviderStatus(
+        effectiveConfig,
+        serverConfig.cwd,
+        processEnvironment,
+      ).pipe(
+        Effect.map(stampIdentity),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      );
+      const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
+      const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<PiAgentSettings>>({
+        maintenanceCapabilities,
+        getSettings: snapshotSettings.getSettings,
+        streamSettings: snapshotSettings.streamSettings,
+        haveSettingsChanged: haveProviderSnapshotSettingsChanged,
+        initialSnapshot: (settings) =>
+          makePendingPiAgentProvider(settings.provider).pipe(Effect.map(stampIdentity)),
+        checkProvider,
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderDriverError({
+              driver: DRIVER_KIND,
+              instanceId,
+              detail: `Failed to build Pi Agent snapshot: ${cause.message ?? String(cause)}`,
+              cause,
+            }),
+        ),
+      );
+
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled,
+        snapshot,
+        snapshotForCwd: (cwd: string) =>
+          !effectiveConfig.enabled
+            ? snapshot.getSnapshot
+            : Effect.all([
+                snapshot.getSnapshot,
+                discoverPiAgentCatalog(effectiveConfig, cwd, processEnvironment).pipe(
+                  Effect.timeout("12 seconds"),
+                  Effect.scoped,
+                  Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+                ),
+              ]).pipe(
+                Effect.map(([machineSnapshot, catalog]) => ({
+                  ...machineSnapshot,
+                  models:
+                    catalog.models.length > 0
+                      ? providerModelsFromPiCatalog(catalog.models, effectiveConfig.customModels)
+                      : machineSnapshot.models,
+                  slashCommands: catalog.slashCommands,
+                  skills: catalog.skills,
+                })),
+                Effect.mapError(
+                  (cause) =>
+                    new ProviderDriverError({
+                      driver: DRIVER_KIND,
+                      instanceId,
+                      detail: `Failed to discover Pi Agent metadata for '${cwd}'`,
+                      cause,
+                    }),
+                ),
+              ),
+        adapter,
+        textGeneration: makeUnsupportedTextGeneration(),
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Drivers/PiSkillDispatch.test.ts
+++ b/apps/server/src/provider/Drivers/PiSkillDispatch.test.ts
@@ -2,7 +2,14 @@ import { describe, expect, it } from "vite-plus/test";
 
 import { planPiSkillDispatch } from "./PiSkillDispatch.ts";
 
-const SKILLS = new Set(["html-communicator", "review", "re-release-version"]);
+const SKILLS = new Set([
+  "html-communicator",
+  "review",
+  "re-release-version",
+  "review.v2",
+  "réviser",
+  "123-review",
+]);
 
 describe("planPiSkillDispatch", () => {
   it("leaves prompts without a discovered Pi skill unchanged", () => {
@@ -36,4 +43,65 @@ describe("planPiSkillDispatch", () => {
   it("ignores a dollar token glued to other text", () => {
     expect(planPiSkillDispatch("cost is 5$review", SKILLS)).toBeUndefined();
   });
+
+  it("supports dotted names with punctuation delimiters", () => {
+    expect(planPiSkillDispatch("please ($review.v2), thanks", SKILLS)).toEqual({
+      commandText: "/skill:review.v2 please ( ), thanks",
+      skillName: "review.v2",
+    });
+    expect(planPiSkillDispatch("please use $review.v2. now", SKILLS)).toEqual({
+      commandText: "/skill:review.v2 please use . now",
+      skillName: "review.v2",
+    });
+  });
+
+  it("does not accept a dotted extension on an otherwise known skill", () => {
+    expect(planPiSkillDispatch("keep $review.extra as prose", SKILLS)).toBeUndefined();
+    expect(planPiSkillDispatch("cost is 5$review.v2", SKILLS)).toBeUndefined();
+  });
+
+  it("keeps punctuation outside earlier inline skill commands", () => {
+    expect(planPiSkillDispatch("$review. then $html-communicator report", SKILLS)).toEqual({
+      commandText: "/skill:html-communicator /skill:review . then report",
+      skillName: "html-communicator",
+    });
+  });
+
+  it("dispatches discovered Unicode skill names", () => {
+    expect(planPiSkillDispatch("please use $réviser now", SKILLS)).toEqual({
+      commandText: "/skill:réviser please use now",
+      skillName: "réviser",
+    });
+  });
+
+  it("dispatches discovered skill names that begin with digits", () => {
+    expect(planPiSkillDispatch("please use $123-review now", SKILLS)).toEqual({
+      commandText: "/skill:123-review please use now",
+      skillName: "123-review",
+    });
+  });
+
+  it.each([":", "-", "_"])(
+    "trims terminal %s punctuation when it is not a skill name",
+    (suffix) => {
+      expect(planPiSkillDispatch(`$review${suffix} now`, new Set(["review"]))).toEqual({
+        commandText: `/skill:review ${suffix} now`,
+        skillName: "review",
+      });
+    },
+  );
+
+  it("keeps discovered names that end in punctuation-like characters", () => {
+    expect(planPiSkillDispatch("$review_ now", new Set(["review", "review_"]))).toEqual({
+      commandText: "/skill:review_ now",
+      skillName: "review_",
+    });
+  });
+
+  it.each(["e\u0301$review", "foo\u203f$review"])(
+    "does not treat combining marks or connector punctuation as mention boundaries in %s",
+    (prompt) => {
+      expect(planPiSkillDispatch(prompt, SKILLS)).toBeUndefined();
+    },
+  );
 });

--- a/apps/server/src/provider/Drivers/PiSkillDispatch.test.ts
+++ b/apps/server/src/provider/Drivers/PiSkillDispatch.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { planPiSkillDispatch } from "./PiSkillDispatch.ts";
+
+const SKILLS = new Set(["html-communicator", "review", "re-release-version"]);
+
+describe("planPiSkillDispatch", () => {
+  it("leaves prompts without a discovered Pi skill unchanged", () => {
+    expect(planPiSkillDispatch("fix the build", SKILLS)).toBeUndefined();
+    expect(planPiSkillDispatch("echo $HOME then $unknown", SKILLS)).toBeUndefined();
+  });
+
+  it("turns a leading composer skill mention into Pi's native command", () => {
+    expect(planPiSkillDispatch("$html-communicator create a report", SKILLS)).toEqual({
+      commandText: "/skill:html-communicator create a report",
+      skillName: "html-communicator",
+    });
+  });
+
+  it("keeps all prose when the selected skill appears mid-prompt", () => {
+    expect(planPiSkillDispatch("please $review focus on auth", SKILLS)).toEqual({
+      commandText: "/skill:review please focus on auth",
+      skillName: "review",
+    });
+  });
+
+  it("dispatches the last known skill and preserves earlier mentions as arguments", () => {
+    expect(
+      planPiSkillDispatch("$review the diff, then $html-communicator report it", SKILLS),
+    ).toEqual({
+      commandText: "/skill:html-communicator /skill:review the diff, then report it",
+      skillName: "html-communicator",
+    });
+  });
+
+  it("ignores a dollar token glued to other text", () => {
+    expect(planPiSkillDispatch("cost is 5$review", SKILLS)).toBeUndefined();
+  });
+});

--- a/apps/server/src/provider/Drivers/PiSkillDispatch.ts
+++ b/apps/server/src/provider/Drivers/PiSkillDispatch.ts
@@ -1,6 +1,22 @@
 /** Turn a T3 `$skill` mention into Pi's native `/skill:name` command. */
 
-const SKILL_MENTION_PATTERN = /(^|\s)\$([a-zA-Z][a-zA-Z0-9:_-]*)(?=\s|$)/g;
+// Keep word-like text and a second `$` from being treated as mention boundaries,
+// while allowing punctuation around a valid skill token. Dots are part of skill
+// names, but a terminal dot is also common sentence punctuation; the matcher
+// trims that punctuation below when it is not itself a discovered skill name.
+const SKILL_MENTION_PATTERN =
+  /(^|[^\p{L}\p{M}\p{N}\p{Pc}$])\$([\p{L}\p{N}][\p{L}\p{M}\p{N}\p{Pc}:.-]*)(?=$|[^\p{L}\p{M}\p{N}\p{Pc}$])/gu;
+
+function rewritePiSkillMention(
+  text: string,
+  mention: { readonly name: string; readonly start: number; readonly end: number },
+): string {
+  const trailing = text.slice(mention.end);
+  // A punctuation delimiter must stay prose, but a space keeps Pi from parsing
+  // it as part of the earlier inline `/skill:name` command.
+  const separator = trailing.length > 0 && !/^\s/u.test(trailing) ? " " : "";
+  return `${text.slice(0, mention.start)}/skill:${mention.name}${separator}${trailing}`;
+}
 
 export interface PiSkillDispatch {
   readonly commandText: string;
@@ -12,7 +28,11 @@ export function planPiSkillDispatch(
   skillNames: ReadonlySet<string>,
 ): PiSkillDispatch | undefined {
   const mentions = [...prompt.matchAll(SKILL_MENTION_PATTERN)].flatMap((match) => {
-    const name = match[2] ?? "";
+    const rawName = match[2] ?? "";
+    let name = rawName;
+    while (/[.:_-]$/u.test(name) && !skillNames.has(name)) {
+      name = name.slice(0, -1);
+    }
     if (!skillNames.has(name)) return [];
     const start = (match.index ?? 0) + (match[1]?.length ?? 0);
     return [{ name, start, end: start + name.length + 1 }];
@@ -23,7 +43,7 @@ export function planPiSkillDispatch(
   const leading = mentions
     .slice(0, -1)
     .reduceRight(
-      (text, mention) => `${text.slice(0, mention.start)}/skill:${text.slice(mention.start + 1)}`,
+      (text, mention) => rewritePiSkillMention(text, mention),
       prompt.slice(0, selected.start),
     )
     .trimEnd();

--- a/apps/server/src/provider/Drivers/PiSkillDispatch.ts
+++ b/apps/server/src/provider/Drivers/PiSkillDispatch.ts
@@ -1,0 +1,37 @@
+/** Turn a T3 `$skill` mention into Pi's native `/skill:name` command. */
+
+const SKILL_MENTION_PATTERN = /(^|\s)\$([a-zA-Z][a-zA-Z0-9:_-]*)(?=\s|$)/g;
+
+export interface PiSkillDispatch {
+  readonly commandText: string;
+  readonly skillName: string;
+}
+
+export function planPiSkillDispatch(
+  prompt: string,
+  skillNames: ReadonlySet<string>,
+): PiSkillDispatch | undefined {
+  const mentions = [...prompt.matchAll(SKILL_MENTION_PATTERN)].flatMap((match) => {
+    const name = match[2] ?? "";
+    if (!skillNames.has(name)) return [];
+    const start = (match.index ?? 0) + (match[1]?.length ?? 0);
+    return [{ name, start, end: start + name.length + 1 }];
+  });
+  const selected = mentions.at(-1);
+  if (!selected) return undefined;
+
+  const leading = mentions
+    .slice(0, -1)
+    .reduceRight(
+      (text, mention) => `${text.slice(0, mention.start)}/skill:${text.slice(mention.start + 1)}`,
+      prompt.slice(0, selected.start),
+    )
+    .trimEnd();
+  const trailing = prompt.slice(selected.end).trimStart();
+  const argumentsText = [leading, trailing].filter((part) => part.length > 0).join(" ");
+
+  return {
+    commandText: `/skill:${selected.name}${argumentsText ? ` ${argumentsText}` : ""}`,
+    skillName: selected.name,
+  };
+}

--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -1,6 +1,10 @@
 import { assert, it } from "@effect/vitest";
 
-import { applyPreferredCodexDefaultModel, mapCodexModelCapabilities } from "./CodexProvider.ts";
+import {
+  applyPreferredCodexDefaultModel,
+  mapCodexModelCapabilities,
+  toDisplayName,
+} from "./CodexProvider.ts";
 
 it("maps current Codex model capability fields", () => {
   const capabilities = mapCodexModelCapabilities({
@@ -143,4 +147,31 @@ it("ignores custom models that shadow a preferred slug", () => {
   ]);
 
   assert.deepStrictEqual(models.find((model) => model.isDefault)?.slug, "gpt-5.4");
+});
+
+it("re-attaches the effort suffix a backend strips from the display name", () => {
+  assert.strictEqual(
+    toDisplayName({ displayName: "Gemini 3.8 Flash", model: "gemini-3.8-flash-high" }),
+    "Gemini 3.8 Flash (High)",
+  );
+  assert.strictEqual(
+    toDisplayName({ displayName: "Gemini 3.8 Flash", model: "gemini-3.8-flash-medium" }),
+    "Gemini 3.8 Flash (Medium)",
+  );
+  assert.strictEqual(
+    toDisplayName({ displayName: "Gemini 3.8 Flash", model: "gemini-3.8-flash-low" }),
+    "Gemini 3.8 Flash (Low)",
+  );
+});
+
+it("leaves display names without an effort-baked slug alone", () => {
+  assert.strictEqual(
+    toDisplayName({ displayName: "GPT-5.6-Sol", model: "gpt-5.6-sol" }),
+    "GPT-5.6-Sol",
+  );
+  assert.strictEqual(toDisplayName({ displayName: "GPT Test", model: "gpt-test" }), "GPT Test");
+  assert.strictEqual(
+    toDisplayName({ displayName: "Gemini 3.8 Flash (High)", model: "gemini-3.8-flash-high" }),
+    "Gemini 3.8 Flash (High)",
+  );
 });

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -200,11 +200,27 @@ export function mapCodexModelCapabilities(
   });
 }
 
-const toDisplayName = (model: CodexSchema.V2ModelListResponse__Model): string => {
+/**
+ * Names a Codex-catalog model for the picker.
+ *
+ * Some backends bake the reasoning effort into the slug
+ * (`gemini-3.8-flash-high`) while advertising a bare display name
+ * (`Gemini 3.8 Flash`), so the picker reads "Flash" no matter which effort
+ * the turn actually runs at. The suffix is re-attached from the slug unless
+ * the display name already carries it, keeping the usage breakdown
+ * (`gemini-3.8-flash-high`) and the picker visibly the same model.
+ */
+export const toDisplayName = (
+  model: Pick<CodexSchema.V2ModelListResponse__Model, "displayName" | "model">,
+): string => {
   // Capitalize 'gpt' to 'GPT-' and capitalize any letter following a dash
-  return model.displayName
+  const base = model.displayName
     .replace(/^gpt/i, "GPT") // Handle start with 'gpt' or 'GPT'
     .replace(/-([a-z])/g, (_, c) => "-" + c.toUpperCase());
+  const effort = model.model.match(/-(high|medium|low)$/i)?.[1]?.toLowerCase();
+  if (effort === undefined) return base;
+  if (new RegExp(`\\(${effort}\\)\\s*$`, "i").test(base)) return base;
+  return `${base} (${effort[0]!.toUpperCase()}${effort.slice(1)})`;
 };
 
 function parseCodexModelListResponse(

--- a/apps/server/src/provider/Layers/PiAgentAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAgentAdapter.test.ts
@@ -787,6 +787,45 @@ it.effect("rejects Pi modes that RPC cannot enforce without a policy bridge", ()
   }).pipe(Effect.scoped, Effect.provide(testLayer)),
 );
 
+it.effect("rejects malformed model fields in Pi state without throwing", () =>
+  Effect.gen(function* () {
+    const fake = yield* makeFakeClient;
+    const client: PiRpcClient = {
+      ...fake.client,
+      request: (command) =>
+        command.type === "get_state"
+          ? Effect.succeed({
+              type: "response" as const,
+              command: "get_state" as const,
+              success: true as const,
+              data: {
+                sessionFile: "/tmp/pi/session.jsonl",
+                sessionId: "pi-session-1",
+                model: { provider: 1, id: "model-1" },
+              },
+            })
+          : fake.client.request(command),
+    };
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      { instanceId, makeClient: () => Effect.succeed(client) },
+    );
+
+    const error = yield* adapter
+      .startSession({
+        threadId,
+        provider: ProviderDriverKind.make("piAgent"),
+        providerInstanceId: instanceId,
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      })
+      .pipe(Effect.flip);
+
+    assert.equal(error._tag, "ProviderAdapterRequestError");
+    assert.match(error.message, /durable session file and id/i);
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
 it.effect("removes a session after the Pi RPC transport fails", () =>
   Effect.gen(function* () {
     const fake = yield* makeFakeClient;

--- a/apps/server/src/provider/Layers/PiAgentAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAgentAdapter.test.ts
@@ -533,6 +533,239 @@ it.effect("round-trips Pi extension dialogs and interrupts an active turn", () =
   }).pipe(Effect.scoped, Effect.provide(testLayer)),
 );
 
+it.effect("keeps an interrupted turn active until Pi settles it", () =>
+  Effect.gen(function* () {
+    const fake = yield* makeFakeClient;
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      { instanceId, makeClient: () => Effect.succeed(fake.client) },
+    );
+    const collected = yield* startEventCollector(adapter);
+    yield* adapter.startSession({
+      threadId,
+      provider: ProviderDriverKind.make("piAgent"),
+      providerInstanceId: instanceId,
+      cwd: process.cwd(),
+      runtimeMode: "full-access",
+    });
+
+    const interrupted = yield* adapter.sendTurn({ threadId, input: "Stop this" });
+    yield* adapter.interruptTurn(threadId, interrupted.turnId);
+
+    const replacementFiber = yield* adapter
+      .sendTurn({ threadId, input: "Retry this" })
+      .pipe(Effect.forkChild);
+    yield* Effect.yieldNow;
+    assert.deepEqual((yield* Ref.get(fake.commands)).slice(-2), [
+      { type: "clear_queue" },
+      { type: "abort" },
+    ]);
+
+    yield* fake.emit({ type: "agent_settled" });
+    const replacement = yield* Fiber.join(replacementFiber);
+    assert.notEqual(replacement.turnId, interrupted.turnId);
+    assert.deepEqual((yield* Ref.get(fake.commands)).at(-1), {
+      type: "prompt",
+      message: "Retry this",
+    });
+
+    const beforeReplacementSettled = yield* Ref.get(collected.events);
+    assert.isFalse(
+      beforeReplacementSettled.some(
+        (event) => event.type === "turn.completed" && event.turnId === replacement.turnId,
+      ),
+    );
+
+    yield* fake.emit({ type: "agent_start" });
+    yield* fake.emit({ type: "agent_end", messages: [], willRetry: false });
+    yield* fake.emit({ type: "agent_settled" });
+    yield* Effect.yieldNow;
+
+    const events = yield* Ref.get(collected.events);
+    assert.isTrue(
+      events.some((event) => event.type === "turn.aborted" && event.turnId === interrupted.turnId),
+    );
+    assert.isTrue(
+      events.some(
+        (event) => event.type === "turn.completed" && event.turnId === replacement.turnId,
+      ),
+    );
+    yield* Fiber.interrupt(collected.fiber);
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
+it.effect("does not resume a send after its context is stopped before Pi settles", () =>
+  Effect.gen(function* () {
+    const fake = yield* makeFakeClient;
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      { instanceId, makeClient: () => Effect.succeed(fake.client) },
+    );
+    yield* adapter.startSession({
+      threadId,
+      provider: ProviderDriverKind.make("piAgent"),
+      providerInstanceId: instanceId,
+      cwd: process.cwd(),
+      runtimeMode: "full-access",
+    });
+    const turn = yield* adapter.sendTurn({ threadId, input: "Stop and replace" });
+    yield* adapter.interruptTurn(threadId, turn.turnId);
+    const replacementFiber = yield* adapter
+      .sendTurn({ threadId, input: "Do not send this to the stopped context" })
+      .pipe(Effect.forkChild);
+    yield* Effect.yieldNow;
+
+    yield* adapter.stopSession(threadId);
+    const replacementExit = yield* Fiber.await(replacementFiber);
+    assert.isTrue(replacementExit._tag === "Failure");
+    assert.deepEqual((yield* Ref.get(fake.commands)).slice(-2), [
+      { type: "clear_queue" },
+      { type: "abort" },
+    ]);
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
+it.effect("cleans up a cancelled interrupt so later sends do not wait forever", () =>
+  Effect.gen(function* () {
+    const fake = yield* makeFakeClient;
+    const clearQueueEntered = yield* Deferred.make<void>();
+    const releaseClearQueue = yield* Deferred.make<void>();
+    const blockingClient: PiRpcClient = {
+      ...fake.client,
+      request: (command) =>
+        command.type === "clear_queue"
+          ? Deferred.succeed(clearQueueEntered, undefined).pipe(
+              Effect.andThen(Deferred.await(releaseClearQueue)),
+              Effect.andThen(fake.client.request(command)),
+            )
+          : fake.client.request(command),
+    };
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      { instanceId, makeClient: () => Effect.succeed(blockingClient) },
+    );
+    yield* adapter.startSession({
+      threadId,
+      provider: ProviderDriverKind.make("piAgent"),
+      providerInstanceId: instanceId,
+      cwd: process.cwd(),
+      runtimeMode: "full-access",
+    });
+    const turn = yield* adapter.sendTurn({ threadId, input: "Interrupt me" });
+    const interruptFiber = yield* adapter
+      .interruptTurn(threadId, turn.turnId)
+      .pipe(Effect.forkChild);
+    yield* Deferred.await(clearQueueEntered);
+    yield* Fiber.interrupt(interruptFiber);
+
+    const resumed = yield* adapter.sendTurn({ threadId, input: "Continue" });
+    assert.equal(resumed.turnId, turn.turnId);
+    assert.deepEqual((yield* Ref.get(fake.commands)).at(-1), {
+      type: "prompt",
+      message: "Continue",
+      streamingBehavior: "steer",
+    });
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
+it.effect("does not publish ready after the Pi startup watcher has failed", () =>
+  Effect.gen(function* () {
+    const fake = yield* makeFakeClient;
+    const stateRequestEntered = yield* Deferred.make<void>();
+    const releaseStateRequest = yield* Deferred.make<void>();
+    const client: PiRpcClient = {
+      ...fake.client,
+      request: (command) =>
+        command.type === "get_state"
+          ? Deferred.succeed(stateRequestEntered, undefined).pipe(
+              Effect.andThen(Deferred.await(releaseStateRequest)),
+              Effect.andThen(fake.client.request(command)),
+            )
+          : fake.client.request(command),
+    };
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      { instanceId, makeClient: () => Effect.succeed(client) },
+    );
+    const collected = yield* startEventCollector(adapter);
+    const exited = yield* Deferred.make<void>();
+    const watcher = yield* adapter.streamEvents.pipe(
+      Stream.filter(
+        (event) => event.type === "session.exited" && event.payload.exitKind === "error",
+      ),
+      Stream.take(1),
+      Stream.runDrain,
+      Effect.tap(() => Deferred.succeed(exited, undefined)),
+      Effect.forkChild,
+    );
+
+    const startFiber = yield* adapter
+      .startSession({
+        threadId,
+        provider: ProviderDriverKind.make("piAgent"),
+        providerInstanceId: instanceId,
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      })
+      .pipe(Effect.forkChild);
+    yield* Deferred.await(stateRequestEntered);
+    yield* fake.fail(
+      new PiRpcClientError({ operation: "process-exit", detail: "Pi exited during startup" }),
+    );
+    yield* Deferred.await(exited);
+    yield* Deferred.succeed(releaseStateRequest, undefined);
+
+    const startExit = yield* Fiber.await(startFiber);
+    assert.isTrue(startExit._tag === "Failure");
+    assert.isFalse(yield* adapter.hasSession(threadId));
+    const events = yield* Ref.get(collected.events);
+    assert.isFalse(events.some((event) => event.type === "session.started"));
+    assert.isFalse(
+      events.some(
+        (event) => event.type === "session.state.changed" && event.payload.state === "ready",
+      ),
+    );
+    yield* Fiber.interrupt(watcher);
+    yield* Fiber.interrupt(collected.fiber);
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
+it.effect("coalesces concurrent interrupts for one active Pi turn", () =>
+  Effect.gen(function* () {
+    const fake = yield* makeFakeClient;
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      { instanceId, makeClient: () => Effect.succeed(fake.client) },
+    );
+    const collected = yield* startEventCollector(adapter);
+    yield* adapter.startSession({
+      threadId,
+      provider: ProviderDriverKind.make("piAgent"),
+      providerInstanceId: instanceId,
+      cwd: process.cwd(),
+      runtimeMode: "full-access",
+    });
+    const turn = yield* adapter.sendTurn({ threadId, input: "Interrupt once" });
+    yield* Effect.all(
+      [adapter.interruptTurn(threadId, turn.turnId), adapter.interruptTurn(threadId, turn.turnId)],
+      { concurrency: "unbounded" },
+    );
+    assert.deepEqual((yield* Ref.get(fake.commands)).slice(-2), [
+      { type: "clear_queue" },
+      { type: "abort" },
+    ]);
+
+    yield* fake.emit({ type: "agent_settled" });
+    yield* Effect.yieldNow;
+    const events = yield* Ref.get(collected.events);
+    assert.lengthOf(
+      events.filter((event) => event.type === "turn.aborted" && event.turnId === turn.turnId),
+      1,
+    );
+    yield* Fiber.interrupt(collected.fiber);
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
 it.effect("rejects Pi modes that RPC cannot enforce without a policy bridge", () =>
   Effect.gen(function* () {
     const fake = yield* makeFakeClient;
@@ -637,5 +870,241 @@ it.effect("serializes concurrent starts for the same thread", () =>
     assert.equal(yield* Ref.get(factoryCalls), 2);
     assert.isTrue(yield* adapter.hasSession(threadId));
     assert.lengthOf(yield* adapter.listSessions(), 1);
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
+it.effect("reclaims stopped-session locks without splitting concurrent starts", () =>
+  Effect.gen(function* () {
+    const first = yield* makeFakeClient;
+    const second = yield* makeFakeClient;
+    const third = yield* makeFakeClient;
+    const secondFactoryEntered = yield* Deferred.make<void>();
+    const releaseSecondFactory = yield* Deferred.make<void>();
+    const factoryCalls = yield* Ref.make(0);
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      {
+        instanceId,
+        makeClient: () =>
+          Ref.updateAndGet(factoryCalls, (count) => count + 1).pipe(
+            Effect.flatMap((call) =>
+              call === 1
+                ? Effect.succeed(first.client)
+                : call === 2
+                  ? Deferred.succeed(secondFactoryEntered, undefined).pipe(
+                      Effect.andThen(Deferred.await(releaseSecondFactory)),
+                      Effect.as(second.client),
+                    )
+                  : Effect.succeed(third.client),
+            ),
+          ),
+      },
+    );
+    const start = () =>
+      adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("piAgent"),
+        providerInstanceId: instanceId,
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+
+    yield* start();
+    const replacement = yield* start().pipe(Effect.forkChild);
+    yield* Deferred.await(secondFactoryEntered);
+    const concurrent = yield* start().pipe(Effect.forkChild);
+    yield* Effect.yieldNow;
+    assert.equal(yield* Ref.get(factoryCalls), 2);
+
+    yield* Deferred.succeed(releaseSecondFactory, undefined);
+    yield* Fiber.join(replacement);
+    yield* Fiber.join(concurrent);
+    assert.equal(yield* Ref.get(factoryCalls), 3);
+    assert.isTrue(yield* adapter.hasSession(threadId));
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
+it.effect("cleans up an interrupted startup scope and reclaims its thread lock", () =>
+  Effect.gen(function* () {
+    const first = yield* makeFakeClient;
+    const second = yield* makeFakeClient;
+    const stateRequestEntered = yield* Deferred.make<void>();
+    const closeCalls = yield* Ref.make(0);
+    const factoryCalls = yield* Ref.make(0);
+    const firstClient: PiRpcClient = {
+      ...first.client,
+      request: (command) =>
+        command.type === "get_state"
+          ? Deferred.succeed(stateRequestEntered, undefined).pipe(Effect.andThen(Effect.never))
+          : first.client.request(command),
+      close: Ref.update(closeCalls, (count) => count + 1).pipe(Effect.andThen(first.client.close)),
+    };
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      {
+        instanceId,
+        makeClient: () =>
+          Ref.updateAndGet(factoryCalls, (count) => count + 1).pipe(
+            Effect.map((call) => (call === 1 ? firstClient : second.client)),
+          ),
+      },
+    );
+    const input = {
+      threadId,
+      provider: ProviderDriverKind.make("piAgent"),
+      providerInstanceId: instanceId,
+      cwd: process.cwd(),
+      runtimeMode: "full-access" as const,
+    };
+
+    const interrupted = yield* adapter.startSession(input).pipe(Effect.forkChild);
+    yield* Deferred.await(stateRequestEntered);
+    yield* Fiber.interrupt(interrupted);
+
+    assert.equal(yield* Ref.get(closeCalls), 1);
+    assert.equal(yield* Ref.get(factoryCalls), 1);
+    assert.isFalse(yield* adapter.hasSession(threadId));
+
+    yield* adapter.startSession(input);
+    assert.equal(yield* Ref.get(factoryCalls), 2);
+    assert.isTrue(yield* adapter.hasSession(threadId));
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
+it.effect("rejects sends while a Pi session is still connecting", () =>
+  Effect.gen(function* () {
+    const fake = yield* makeFakeClient;
+    const stateRequestEntered = yield* Deferred.make<void>();
+    const releaseStateRequest = yield* Deferred.make<void>();
+    const client: PiRpcClient = {
+      ...fake.client,
+      request: (command) =>
+        command.type === "get_state"
+          ? Deferred.succeed(stateRequestEntered, undefined).pipe(
+              Effect.andThen(Deferred.await(releaseStateRequest)),
+              Effect.andThen(fake.client.request(command)),
+            )
+          : fake.client.request(command),
+    };
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      { instanceId, makeClient: () => Effect.succeed(client) },
+    );
+    const input = {
+      threadId,
+      provider: ProviderDriverKind.make("piAgent"),
+      providerInstanceId: instanceId,
+      cwd: process.cwd(),
+      runtimeMode: "full-access" as const,
+    };
+    const startup = yield* adapter.startSession(input).pipe(Effect.forkChild);
+    yield* Deferred.await(stateRequestEntered);
+
+    const error = yield* adapter.sendTurn({ threadId, input: "Do not send yet" }).pipe(Effect.flip);
+    assert.equal(error._tag, "ProviderAdapterRequestError");
+    assert.isFalse((yield* Ref.get(fake.commands)).some((command) => command.type === "prompt"));
+
+    yield* Deferred.succeed(releaseStateRequest, undefined);
+    yield* Fiber.join(startup);
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
+it.effect("rejects sends until startup finishes configuring the model", () =>
+  Effect.gen(function* () {
+    const fake = yield* makeFakeClient;
+    const setModelEntered = yield* Deferred.make<void>();
+    const releaseSetModel = yield* Deferred.make<void>();
+    const client: PiRpcClient = {
+      ...fake.client,
+      request: (command) =>
+        command.type === "set_model"
+          ? Deferred.succeed(setModelEntered, undefined).pipe(
+              Effect.andThen(Deferred.await(releaseSetModel)),
+              Effect.andThen(fake.client.request(command)),
+            )
+          : fake.client.request(command),
+    };
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      { instanceId, makeClient: () => Effect.succeed(client) },
+    );
+    const startup = yield* adapter
+      .startSession({
+        threadId,
+        provider: ProviderDriverKind.make("piAgent"),
+        providerInstanceId: instanceId,
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: { instanceId, model: "anthropic/claude-opus" },
+      })
+      .pipe(Effect.forkChild);
+    yield* Deferred.await(setModelEntered);
+
+    const error = yield* adapter
+      .sendTurn({ threadId, input: "Do not send during startup" })
+      .pipe(Effect.flip);
+    assert.equal(error._tag, "ProviderAdapterRequestError");
+    assert.isFalse((yield* Ref.get(fake.commands)).some((command) => command.type === "prompt"));
+
+    yield* Deferred.succeed(releaseSetModel, undefined);
+    yield* Fiber.join(startup);
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
+it.effect("does not report a stale transport failure after a replacement starts", () =>
+  Effect.gen(function* () {
+    const first = yield* makeFakeClient;
+    const second = yield* makeFakeClient;
+    const factoryCalls = yield* Ref.make(0);
+    const secondFactoryEntered = yield* Deferred.make<void>();
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      {
+        instanceId,
+        makeClient: () =>
+          Ref.updateAndGet(factoryCalls, (count) => count + 1).pipe(
+            Effect.flatMap((call) =>
+              call === 1
+                ? Effect.succeed(first.client)
+                : Deferred.succeed(secondFactoryEntered, undefined).pipe(
+                    Effect.andThen(Effect.succeed(second.client)),
+                  ),
+            ),
+          ),
+      },
+    );
+    const collected = yield* startEventCollector(adapter);
+    const input = {
+      threadId,
+      provider: ProviderDriverKind.make("piAgent"),
+      providerInstanceId: instanceId,
+      cwd: process.cwd(),
+      runtimeMode: "full-access" as const,
+    };
+    yield* adapter.startSession(input);
+    const replacement = yield* adapter.startSession(input).pipe(Effect.forkChild);
+    yield* Deferred.await(secondFactoryEntered);
+    yield* Fiber.join(replacement);
+    yield* first.fail(
+      new PiRpcClientError({ operation: "process-exit", detail: "Old Pi session exited" }),
+    );
+    yield* Effect.yieldNow;
+
+    const events = yield* Ref.get(collected.events);
+    assert.isFalse(
+      events.some(
+        (event) =>
+          event.type === "runtime.error" && event.payload.message === "Old Pi session exited",
+      ),
+    );
+    assert.isFalse(
+      events.some(
+        (event) =>
+          event.type === "session.exited" &&
+          event.payload.exitKind === "error" &&
+          event.payload.reason === "Old Pi session exited",
+      ),
+    );
+    yield* Fiber.interrupt(collected.fiber);
   }).pipe(Effect.scoped, Effect.provide(testLayer)),
 );

--- a/apps/server/src/provider/Layers/PiAgentAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAgentAdapter.test.ts
@@ -1,0 +1,641 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { it } from "@effect/vitest";
+import {
+  ApprovalRequestId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+  type ProviderRuntimeEvent,
+} from "@t3tools/contracts";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
+import * as Queue from "effect/Queue";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
+import { assert } from "vite-plus/test";
+
+import { ServerConfig } from "../../config.ts";
+import { expandHomePath } from "../../pathExpansion.ts";
+import { makePiAgentAdapter } from "./PiAgentAdapter.ts";
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
+import { PiRpcClientError, type PiRpcClient, type PiRpcClientOptions } from "../pi/PiRpcClient.ts";
+import type { PiRpcCommand, PiRpcEnvelope, PiRpcResponse } from "../pi/PiRpcProtocol.ts";
+
+const threadId = ThreadId.make("thread-pi-test");
+const instanceId = ProviderInstanceId.make("pi-personal");
+
+interface FakeClient {
+  readonly client: PiRpcClient;
+  readonly commands: Ref.Ref<ReadonlyArray<PiRpcCommand>>;
+  readonly emit: (event: PiRpcEnvelope) => Effect.Effect<void>;
+  readonly fail: (error: PiRpcClientError) => Effect.Effect<void>;
+}
+
+const makeFakeClient = Effect.gen(function* () {
+  const events = yield* Queue.unbounded<PiRpcEnvelope>();
+  const commands = yield* Ref.make<ReadonlyArray<PiRpcCommand>>([]);
+  const closed = yield* Deferred.make<never, PiRpcClientError>();
+  const response = (command: PiRpcCommand): PiRpcResponse => {
+    const state = {
+      model: { provider: "anthropic", id: "claude-sonnet", name: "Claude Sonnet" },
+      thinkingLevel: "medium",
+      isStreaming: false,
+      isCompacting: false,
+      sessionFile: "/tmp/pi/session.jsonl",
+      sessionId: "pi-session-1",
+      messageCount: 0,
+      pendingMessageCount: 0,
+    };
+    return {
+      ...(command.id ? { id: command.id } : {}),
+      type: "response",
+      command: command.type,
+      success: true,
+      data:
+        command.type === "get_state"
+          ? state
+          : command.type === "get_entries"
+            ? { entries: [{ id: "entry-9" }] }
+            : {},
+    };
+  };
+  const record = (command: PiRpcCommand) =>
+    Ref.update(commands, (current) => [...current, command]);
+  const client: PiRpcClient = {
+    request: (command) => record(command).pipe(Effect.as(response(command))),
+    send: (command) => record(command),
+    events: Stream.merge(Stream.fromQueue(events), Stream.fromEffect(Deferred.await(closed))),
+    awaitFailure: Deferred.await(closed),
+    close: Queue.shutdown(events),
+  };
+  return {
+    client,
+    commands,
+    emit: (event: PiRpcEnvelope) =>
+      Queue.offer(events, event).pipe(Effect.andThen(Effect.yieldNow), Effect.asVoid),
+    fail: (error: PiRpcClientError) => Deferred.fail(closed, error).pipe(Effect.asVoid),
+  } satisfies FakeClient;
+});
+
+const testLayer = ServerConfig.layerTest(process.cwd(), {
+  prefix: "t3code-pi-adapter-test-",
+}).pipe(Layer.provideMerge(NodeServices.layer));
+
+const startEventCollector = (adapter: AwaitedAdapter) =>
+  Effect.gen(function* () {
+    const events = yield* Ref.make<ReadonlyArray<ProviderRuntimeEvent>>([]);
+    const fiber = yield* adapter.streamEvents.pipe(
+      Stream.runForEach((event) => Ref.update(events, (current) => [...current, event])),
+      Effect.forkChild,
+    );
+    yield* Effect.yieldNow;
+    return { events, fiber };
+  });
+
+type AwaitedAdapter = ProviderAdapterShape<ProviderAdapterError>;
+
+it.effect("resumes, streams a turn, and settles only on agent_settled", () =>
+  Effect.gen(function* () {
+    const fake = yield* makeFakeClient;
+    const spawnOptions = yield* Ref.make<PiRpcClientOptions | undefined>(undefined);
+    const adapter = yield* makePiAgentAdapter(
+      {
+        enabled: true,
+        binaryPath: "~/.local/bin/pi",
+        agentDir: "/tmp/pi-profile",
+        sessionDir: "/tmp/pi-sessions",
+      },
+      {
+        instanceId,
+        makeClient: (options) => Ref.set(spawnOptions, options).pipe(Effect.as(fake.client)),
+      },
+    );
+    const collected = yield* startEventCollector(adapter);
+
+    const session = yield* adapter.startSession({
+      threadId,
+      provider: ProviderDriverKind.make("piAgent"),
+      providerInstanceId: instanceId,
+      cwd: process.cwd(),
+      runtimeMode: "full-access",
+      resumeCursor: {
+        schemaVersion: 1,
+        sessionFile: "/tmp/pi/old-session.jsonl",
+        sessionId: "old-session",
+        lastEntryId: "entry-8",
+      },
+    });
+    assert.deepEqual(session.resumeCursor, {
+      schemaVersion: 1,
+      sessionFile: "/tmp/pi/session.jsonl",
+      sessionId: "pi-session-1",
+      lastEntryId: "entry-9",
+    });
+    assert.deepEqual((yield* Ref.get(spawnOptions))?.args, [
+      "--mode",
+      "rpc",
+      "--approve",
+      "--append-system-prompt",
+      "You are running inside T3 Code. For multi-step work that uses tools, communicate before acting: send a concise preamble explaining what you will do, then provide brief milestone updates before each substantial tool batch or after roughly a minute of quiet work. Keep updates concrete and avoid narrating trivial actions. For simple answers that need no tools, answer directly.",
+      "--session-dir",
+      "/tmp/pi-sessions",
+    ]);
+    assert.equal((yield* Ref.get(spawnOptions))?.binaryPath, expandHomePath("~/.local/bin/pi"));
+    assert.equal((yield* Ref.get(spawnOptions))?.env?.PI_CODING_AGENT_DIR, "/tmp/pi-profile");
+
+    const turn = yield* adapter.sendTurn({
+      threadId,
+      input: "Build it",
+      modelSelection: {
+        instanceId,
+        model: "anthropic/claude-opus",
+        options: [{ id: "reasoningEffort", value: "high" }],
+      },
+    });
+    yield* fake.emit({ type: "agent_start" });
+    const steered = yield* adapter.sendTurn({ threadId, input: "/extension-command" });
+    assert.equal(steered.turnId, turn.turnId);
+    yield* fake.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_start", contentIndex: 0 },
+    });
+    yield* fake.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "Hello" },
+    });
+    yield* fake.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_end", contentIndex: 0, content: "Hello" },
+    });
+    yield* fake.emit({
+      type: "tool_execution_start",
+      toolCallId: "tool-1",
+      toolName: "bash",
+      args: { command: "printf hi" },
+    });
+    yield* fake.emit({
+      type: "tool_execution_update",
+      toolCallId: "tool-1",
+      toolName: "bash",
+      args: { command: "printf hi" },
+      partialResult: { content: [{ type: "text", text: "h" }] },
+    });
+    yield* fake.emit({
+      type: "tool_execution_update",
+      toolCallId: "tool-1",
+      toolName: "bash",
+      args: { command: "printf hi" },
+      partialResult: { content: [{ type: "text", text: "hi" }] },
+    });
+    yield* fake.emit({
+      type: "tool_execution_end",
+      toolCallId: "tool-1",
+      toolName: "bash",
+      result: { content: [{ type: "text", text: "hi" }] },
+      isError: false,
+    });
+    yield* fake.emit({ type: "agent_end", willRetry: true });
+    yield* Effect.yieldNow;
+    assert.isFalse(
+      (yield* Ref.get(collected.events)).some((event) => event.type === "turn.completed"),
+    );
+    yield* fake.emit({ type: "agent_start" });
+    yield* fake.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_start", contentIndex: 0 },
+    });
+    yield* fake.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "Recovered" },
+    });
+    yield* fake.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_end", contentIndex: 0, content: "Recovered" },
+    });
+
+    const completed = yield* Deferred.make<void>();
+    const completionWatcher = yield* adapter.streamEvents.pipe(
+      Stream.filter((event) => event.type === "turn.completed" && event.turnId === turn.turnId),
+      Stream.take(1),
+      Stream.runDrain,
+      Effect.tap(() => Deferred.succeed(completed, undefined)),
+      Effect.forkChild,
+    );
+    yield* Effect.yieldNow;
+    yield* fake.emit({ type: "agent_settled" });
+    yield* Deferred.await(completed);
+    yield* Fiber.interrupt(completionWatcher);
+
+    const events = yield* Ref.get(collected.events);
+    assert.isTrue(events.some((event) => event.type === "turn.started"));
+    const assistantItemIds = events.flatMap((event) =>
+      event.type === "item.started" && event.payload.itemType === "assistant_message"
+        ? [event.itemId]
+        : [],
+    );
+    assert.lengthOf(assistantItemIds, 2);
+    assert.equal(new Set(assistantItemIds).size, 2);
+    assert.isTrue(
+      events.some(
+        (event) =>
+          event.type === "content.delta" &&
+          event.payload.streamKind === "assistant_text" &&
+          event.payload.delta === "Hello",
+      ),
+    );
+    assert.deepEqual(
+      events
+        .filter(
+          (event) =>
+            event.type === "content.delta" && event.payload.streamKind === "command_output",
+        )
+        .map((event) => (event.type === "content.delta" ? event.payload.delta : "")),
+      ["h", "i"],
+    );
+    assert.isTrue(
+      events.some(
+        (event) =>
+          event.type === "turn.completed" &&
+          event.turnId === turn.turnId &&
+          event.payload.state === "completed",
+      ),
+    );
+    assert.deepEqual(
+      (yield* Ref.get(fake.commands)).map((command) => command.type),
+      [
+        "switch_session",
+        "get_state",
+        "get_entries",
+        "set_model",
+        "set_thinking_level",
+        "prompt",
+        "prompt",
+      ],
+    );
+    assert.deepEqual((yield* Ref.get(fake.commands))[2], {
+      type: "get_entries",
+      since: "entry-8",
+    });
+    assert.deepEqual((yield* Ref.get(fake.commands)).at(-1), {
+      type: "prompt",
+      message: "/extension-command",
+      streamingBehavior: "steer",
+    });
+    yield* Fiber.interrupt(collected.fiber);
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
+it.effect("uses the final assistant stop reason when an agent run settles", () =>
+  Effect.gen(function* () {
+    const fake = yield* makeFakeClient;
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      { instanceId, makeClient: () => Effect.succeed(fake.client) },
+    );
+    const collected = yield* startEventCollector(adapter);
+    yield* adapter.startSession({
+      threadId,
+      provider: ProviderDriverKind.make("piAgent"),
+      providerInstanceId: instanceId,
+      cwd: process.cwd(),
+      runtimeMode: "full-access",
+    });
+
+    const retriedTurn = yield* adapter.sendTurn({ threadId, input: "Retry if needed" });
+    yield* fake.emit({
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          stopReason: "error",
+          errorMessage: "Temporary model failure",
+        },
+      ],
+      willRetry: true,
+    });
+    yield* fake.emit({ type: "agent_start" });
+    yield* fake.emit({
+      type: "agent_end",
+      messages: [{ role: "assistant", stopReason: "stop" }],
+      willRetry: false,
+    });
+    yield* fake.emit({ type: "agent_settled" });
+    yield* Effect.yieldNow;
+
+    const failedTurn = yield* adapter.sendTurn({ threadId, input: "Surface the failure" });
+    yield* fake.emit({
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          stopReason: "error",
+          errorMessage: "Model credentials expired",
+        },
+      ],
+      willRetry: false,
+    });
+    yield* fake.emit({ type: "agent_settled" });
+    yield* Effect.yieldNow;
+
+    const completions = (yield* Ref.get(collected.events)).filter(
+      (event) => event.type === "turn.completed",
+    );
+    assert.deepEqual(completions.find((event) => event.turnId === retriedTurn.turnId)?.payload, {
+      state: "completed",
+      stopReason: "stop",
+    });
+    assert.deepEqual(completions.find((event) => event.turnId === failedTurn.turnId)?.payload, {
+      state: "failed",
+      stopReason: "error",
+      errorMessage: "Model credentials expired",
+    });
+    yield* Fiber.interrupt(collected.fiber);
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
+it.effect("dispatches a composer $skill through Pi's native manual-skill command", () =>
+  Effect.gen(function* () {
+    const fake = yield* makeFakeClient;
+    const client: PiRpcClient = {
+      ...fake.client,
+      request: (command) =>
+        command.type === "get_commands"
+          ? fake.client.send(command).pipe(
+              Effect.as({
+                ...(command.id ? { id: command.id } : {}),
+                type: "response" as const,
+                command: command.type,
+                success: true,
+                data: {
+                  commands: [
+                    {
+                      name: "skill:html-communicator",
+                      source: "skill",
+                      sourceInfo: { path: "/tmp/skills/html-communicator/SKILL.md" },
+                    },
+                  ],
+                },
+              }),
+            )
+          : fake.client.request(command),
+    };
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      { instanceId, makeClient: () => Effect.succeed(client) },
+    );
+    yield* adapter.startSession({
+      threadId,
+      provider: ProviderDriverKind.make("piAgent"),
+      providerInstanceId: instanceId,
+      cwd: process.cwd(),
+      runtimeMode: "full-access",
+    });
+
+    yield* adapter.sendTurn({
+      threadId,
+      input: "Please $html-communicator create a short report",
+    });
+
+    assert.deepEqual((yield* Ref.get(fake.commands)).slice(-2), [
+      { type: "get_commands" },
+      {
+        type: "prompt",
+        message: "/skill:html-communicator Please create a short report",
+      },
+    ]);
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
+it.effect("clears a newly started turn when Pi rejects its prompt", () =>
+  Effect.gen(function* () {
+    const fake = yield* makeFakeClient;
+    const rejectingClient: PiRpcClient = {
+      ...fake.client,
+      request: (command) =>
+        command.type === "prompt"
+          ? fake.client.request(command).pipe(
+              Effect.andThen(
+                Effect.fail(
+                  new PiRpcClientError({
+                    operation: "request",
+                    detail: "Prompt was rejected",
+                  }),
+                ),
+              ),
+            )
+          : fake.client.request(command),
+    };
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      { instanceId, makeClient: () => Effect.succeed(rejectingClient) },
+    );
+    const collected = yield* startEventCollector(adapter);
+    yield* adapter.startSession({
+      threadId,
+      provider: ProviderDriverKind.make("piAgent"),
+      providerInstanceId: instanceId,
+      cwd: process.cwd(),
+      runtimeMode: "full-access",
+    });
+
+    const firstError = yield* adapter
+      .sendTurn({ threadId, input: "First rejected prompt" })
+      .pipe(Effect.flip);
+    const secondError = yield* adapter
+      .sendTurn({ threadId, input: "Second rejected prompt" })
+      .pipe(Effect.flip);
+    assert.equal(firstError._tag, "ProviderAdapterRequestError");
+    assert.equal(secondError._tag, "ProviderAdapterRequestError");
+    assert.deepEqual((yield* Ref.get(fake.commands)).slice(-2), [
+      { type: "prompt", message: "First rejected prompt" },
+      { type: "prompt", message: "Second rejected prompt" },
+    ]);
+    assert.deepEqual(
+      (yield* adapter.listSessions()).map(({ status, activeTurnId }) => ({
+        status,
+        activeTurnId,
+      })),
+      [{ status: "error", activeTurnId: undefined }],
+    );
+    assert.equal(
+      (yield* Ref.get(collected.events)).filter(
+        (event) => event.type === "turn.completed" && event.payload.state === "failed",
+      ).length,
+      2,
+    );
+    yield* Fiber.interrupt(collected.fiber);
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
+it.effect("round-trips Pi extension dialogs and interrupts an active turn", () =>
+  Effect.gen(function* () {
+    const fake = yield* makeFakeClient;
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      { instanceId, makeClient: () => Effect.succeed(fake.client) },
+    );
+    const collected = yield* startEventCollector(adapter);
+    yield* adapter.startSession({
+      threadId,
+      provider: ProviderDriverKind.make("piAgent"),
+      providerInstanceId: instanceId,
+      cwd: process.cwd(),
+      runtimeMode: "full-access",
+    });
+    yield* fake.emit({
+      type: "extension_ui_request",
+      id: "confirm-1",
+      method: "confirm",
+      title: "Proceed?",
+      message: "Run deployment",
+    });
+    yield* Effect.yieldNow;
+    yield* adapter.respondToRequest(threadId, ApprovalRequestId.make("confirm-1"), "accept");
+    yield* fake.emit({
+      type: "extension_ui_request",
+      id: "input-1",
+      method: "input",
+      title: "Branch name",
+      placeholder: "feat/name",
+    });
+    yield* Effect.yieldNow;
+    yield* adapter.respondToUserInput(threadId, ApprovalRequestId.make("input-1"), {
+      value: "feat/pi",
+    });
+    const turn = yield* adapter.sendTurn({ threadId, input: "Keep going" });
+    yield* adapter.interruptTurn(threadId, turn.turnId);
+    yield* fake.emit({ type: "agent_settled" });
+    yield* Effect.yieldNow;
+
+    const commands = yield* Ref.get(fake.commands);
+    assert.deepEqual(commands.slice(-5), [
+      { type: "extension_ui_response", id: "confirm-1", confirmed: true },
+      { type: "extension_ui_response", id: "input-1", value: "feat/pi" },
+      { type: "prompt", message: "Keep going" },
+      { type: "clear_queue" },
+      { type: "abort" },
+    ]);
+    const events = yield* Ref.get(collected.events);
+    assert.isTrue(events.some((event) => event.type === "request.opened"));
+    assert.isTrue(events.some((event) => event.type === "request.resolved"));
+    assert.isTrue(events.some((event) => event.type === "user-input.requested"));
+    assert.isTrue(events.some((event) => event.type === "user-input.resolved"));
+    assert.isTrue(
+      events.some((event) => event.type === "turn.aborted" && event.turnId === turn.turnId),
+    );
+    assert.isFalse(
+      events.some((event) => event.type === "turn.completed" && event.turnId === turn.turnId),
+    );
+    yield* Fiber.interrupt(collected.fiber);
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
+it.effect("rejects Pi modes that RPC cannot enforce without a policy bridge", () =>
+  Effect.gen(function* () {
+    const fake = yield* makeFakeClient;
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      { instanceId, makeClient: () => Effect.succeed(fake.client) },
+    );
+    const error = yield* adapter
+      .startSession({
+        threadId,
+        provider: ProviderDriverKind.make("piAgent"),
+        providerInstanceId: instanceId,
+        cwd: process.cwd(),
+        runtimeMode: "approval-required",
+      })
+      .pipe(Effect.flip);
+    assert.equal(error._tag, "ProviderAdapterValidationError");
+    assert.match(error.message, /full-access/i);
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
+it.effect("removes a session after the Pi RPC transport fails", () =>
+  Effect.gen(function* () {
+    const fake = yield* makeFakeClient;
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      { instanceId, makeClient: () => Effect.succeed(fake.client) },
+    );
+    const exited = yield* Deferred.make<void>();
+    const watcher = yield* adapter.streamEvents.pipe(
+      Stream.filter(
+        (event) => event.type === "session.exited" && event.payload.exitKind === "error",
+      ),
+      Stream.take(1),
+      Stream.runDrain,
+      Effect.tap(() => Deferred.succeed(exited, undefined)),
+      Effect.forkChild,
+    );
+    yield* Effect.yieldNow;
+
+    yield* adapter.startSession({
+      threadId,
+      provider: ProviderDriverKind.make("piAgent"),
+      providerInstanceId: instanceId,
+      cwd: process.cwd(),
+      runtimeMode: "full-access",
+    });
+    yield* fake.fail(
+      new PiRpcClientError({ operation: "process-exit", detail: "Pi exited unexpectedly" }),
+    );
+    yield* Deferred.await(exited);
+
+    assert.isFalse(yield* adapter.hasSession(threadId));
+    assert.deepEqual(yield* adapter.listSessions(), []);
+    yield* Fiber.interrupt(watcher);
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);
+
+it.effect("serializes concurrent starts for the same thread", () =>
+  Effect.gen(function* () {
+    const first = yield* makeFakeClient;
+    const second = yield* makeFakeClient;
+    const firstFactoryEntered = yield* Deferred.make<void>();
+    const releaseFirstFactory = yield* Deferred.make<void>();
+    const factoryCalls = yield* Ref.make(0);
+    const adapter = yield* makePiAgentAdapter(
+      { enabled: true, binaryPath: "pi", agentDir: "", sessionDir: "" },
+      {
+        instanceId,
+        makeClient: () =>
+          Ref.updateAndGet(factoryCalls, (count) => count + 1).pipe(
+            Effect.flatMap((call) =>
+              call === 1
+                ? Deferred.succeed(firstFactoryEntered, undefined).pipe(
+                    Effect.andThen(Deferred.await(releaseFirstFactory)),
+                    Effect.as(first.client),
+                  )
+                : Effect.succeed(second.client),
+            ),
+          ),
+      },
+    );
+    const start = () =>
+      adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("piAgent"),
+        providerInstanceId: instanceId,
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+
+    const firstStart = yield* start().pipe(Effect.forkChild);
+    yield* Deferred.await(firstFactoryEntered);
+    const secondStart = yield* start().pipe(Effect.forkChild);
+    yield* Effect.yieldNow;
+    const callsBeforeRelease = yield* Ref.get(factoryCalls);
+    yield* Effect.sync(() => assert.equal(callsBeforeRelease, 1)).pipe(
+      Effect.ensuring(Deferred.succeed(releaseFirstFactory, undefined)),
+    );
+    yield* Fiber.join(firstStart);
+    yield* Fiber.join(secondStart);
+    assert.equal(yield* Ref.get(factoryCalls), 2);
+    assert.isTrue(yield* adapter.hasSession(threadId));
+    assert.lengthOf(yield* adapter.listSessions(), 1);
+  }).pipe(Effect.scoped, Effect.provide(testLayer)),
+);

--- a/apps/server/src/provider/Layers/PiAgentAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAgentAdapter.ts
@@ -156,12 +156,23 @@ function readPiState(input: unknown): PiState | undefined {
   const value = input as Record<string, unknown>;
   if (typeof value.sessionFile !== "string" || !value.sessionFile.trim()) return undefined;
   if (typeof value.sessionId !== "string" || !value.sessionId.trim()) return undefined;
-  const model =
-    value.model && typeof value.model === "object"
-      ? (value.model as { readonly provider?: string; readonly id?: string })
-      : value.model === null
-        ? null
-        : undefined;
+  let model: PiState["model"];
+  if (value.model === null) {
+    model = null;
+  } else if (value.model !== undefined) {
+    if (typeof value.model !== "object") return undefined;
+    const candidate = value.model as Record<string, unknown>;
+    if (
+      (candidate.provider !== undefined && typeof candidate.provider !== "string") ||
+      (candidate.id !== undefined && typeof candidate.id !== "string")
+    ) {
+      return undefined;
+    }
+    model = {
+      ...(typeof candidate.provider === "string" ? { provider: candidate.provider } : {}),
+      ...(typeof candidate.id === "string" ? { id: candidate.id } : {}),
+    };
+  }
   return {
     sessionFile: value.sessionFile,
     sessionId: value.sessionId,

--- a/apps/server/src/provider/Layers/PiAgentAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAgentAdapter.ts
@@ -15,6 +15,7 @@ import {
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
@@ -116,6 +117,12 @@ interface PendingTurnOutcome {
   readonly errorMessage?: string;
 }
 
+interface ThreadLock {
+  readonly semaphore: Semaphore.Semaphore;
+  users: number;
+  reclaimable: boolean;
+}
+
 interface SessionContext {
   readonly threadId: ThreadId;
   readonly scope: Scope.Closeable;
@@ -129,9 +136,11 @@ interface SessionContext {
   session: ProviderSession;
   activeTurnId: TurnId | undefined;
   abortingTurnId: TurnId | undefined;
+  abortSettlement: Deferred.Deferred<void> | undefined;
   compactionItemId: RuntimeItemId | undefined;
   lastUsage: unknown;
   pendingTurnOutcome: PendingTurnOutcome | undefined;
+  startupFinished: boolean;
   stopped: boolean;
 }
 
@@ -250,7 +259,7 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
   const serverConfig = yield* ServerConfig;
   const ownerScope = yield* Effect.scope;
   const sessions = new Map<ThreadId, SessionContext>();
-  const threadLocks = yield* SynchronizedRef.make(new Map<ThreadId, Semaphore.Semaphore>());
+  const threadLocks = yield* SynchronizedRef.make(new Map<ThreadId, ThreadLock>());
   const events = yield* PubSub.unbounded<ProviderRuntimeEvent>();
   const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
   const randomId = crypto.randomUUIDv4.pipe(
@@ -278,11 +287,47 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
   const withThreadLock = <A, E, R>(threadId: ThreadId, task: Effect.Effect<A, E, R>) =>
     SynchronizedRef.modifyEffect(threadLocks, (current) => {
       const existing = current.get(threadId);
-      if (existing) return Effect.succeed([existing, current] as const);
+      if (existing) {
+        existing.users += 1;
+        return Effect.succeed([existing, current] as const);
+      }
       return Semaphore.make(1).pipe(
-        Effect.map((lock) => [lock, new Map(current).set(threadId, lock)] as const),
+        Effect.map((semaphore) => {
+          const lock: ThreadLock = { semaphore, users: 1, reclaimable: false };
+          return [lock, new Map(current).set(threadId, lock)] as const;
+        }),
       );
-    }).pipe(Effect.flatMap((lock) => lock.withPermit(task)));
+    }).pipe(
+      Effect.flatMap((lock) =>
+        lock.semaphore.withPermit(task).pipe(
+          Effect.ensuring(
+            SynchronizedRef.update(threadLocks, (current) => {
+              if (current.get(threadId) !== lock) return current;
+              lock.users -= 1;
+              if (lock.reclaimable && lock.users === 0) {
+                const next = new Map(current);
+                next.delete(threadId);
+                return next;
+              }
+              return current;
+            }),
+          ),
+        ),
+      ),
+    );
+
+  const retireThreadLock = (threadId: ThreadId) =>
+    SynchronizedRef.update(threadLocks, (current) => {
+      const lock = current.get(threadId);
+      if (!lock) return current;
+      lock.reclaimable = true;
+      if (lock.users === 0) {
+        const next = new Map(current);
+        next.delete(threadId);
+        return next;
+      }
+      return current;
+    });
 
   const isProviderAdapterError = (cause: unknown): cause is ProviderAdapterError =>
     typeof cause === "object" &&
@@ -309,9 +354,48 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
       : Effect.fail(new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }));
   };
 
-  const finishTurn = (context: SessionContext, outcome: PendingTurnOutcome) =>
+  const ensureCurrentContext = (context: SessionContext) =>
+    context.stopped || sessions.get(context.threadId) !== context
+      ? Effect.fail(
+          new ProviderAdapterSessionNotFoundError({
+            provider: PROVIDER,
+            threadId: context.threadId,
+          }),
+        )
+      : Effect.void;
+
+  const ensureReadyContext = (context: SessionContext) =>
     Effect.gen(function* () {
+      yield* ensureCurrentContext(context);
+      if (!context.startupFinished || context.session.status === "connecting") {
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "prompt",
+          detail: "Pi Agent session is still starting.",
+        });
+      }
+    });
+
+  const takeAbortSettlement = (context: SessionContext) => {
+    const settlement = context.abortSettlement;
+    context.abortSettlement = undefined;
+    return settlement;
+  };
+
+  const settleAbort = (context: SessionContext, settlement: Deferred.Deferred<void> | undefined) =>
+    settlement === undefined
+      ? Effect.void
+      : Effect.uninterruptible(
+          Effect.sync(() => {
+            if (context.abortSettlement === settlement) context.abortSettlement = undefined;
+          }).pipe(Effect.andThen(Deferred.succeed(settlement, undefined))),
+        ).pipe(Effect.asVoid);
+
+  const finishTurn = (context: SessionContext, outcome: PendingTurnOutcome) => {
+    let abortSettlement: Deferred.Deferred<void> | undefined;
+    return Effect.gen(function* () {
       const turnId = context.activeTurnId;
+      abortSettlement = context.abortSettlement;
       if (turnId === undefined || context.stopped) return;
       const { state } = outcome;
       context.activeTurnId = undefined;
@@ -344,10 +428,13 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
         },
       });
       context.lastUsage = undefined;
-    });
+    }).pipe(Effect.ensuring(Effect.suspend(() => settleAbort(context, abortSettlement))));
+  };
 
-  const abortTurn = (context: SessionContext, turnId: TurnId) =>
-    Effect.gen(function* () {
+  const abortTurn = (context: SessionContext, turnId: TurnId) => {
+    let abortSettlement: Deferred.Deferred<void> | undefined;
+    return Effect.gen(function* () {
+      abortSettlement = context.abortSettlement;
       if (context.activeTurnId !== turnId || context.stopped) return;
       context.activeTurnId = undefined;
       context.abortingTurnId = undefined;
@@ -371,7 +458,8 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
         turnId,
         payload: { reason: "Pi Agent turn interrupted" },
       });
-    });
+    }).pipe(Effect.ensuring(Effect.suspend(() => settleAbort(context, abortSettlement))));
+  };
 
   const emitToolOutput = (context: SessionContext, tool: ToolState, output: string) =>
     Effect.gen(function* () {
@@ -707,8 +795,13 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
 
   const stopContext = (context: SessionContext) =>
     Effect.gen(function* () {
-      if (context.stopped) return;
+      if (context.stopped) {
+        yield* settleAbort(context, takeAbortSettlement(context));
+        return;
+      }
       context.stopped = true;
+      yield* retireThreadLock(context.threadId);
+      yield* settleAbort(context, takeAbortSettlement(context));
       for (const [requestId] of context.dialogs) {
         yield* Effect.ignore(
           context.client.send({
@@ -733,8 +826,10 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
       });
     }).pipe(Effect.uninterruptible);
 
-  const startSession: Adapter["startSession"] = (input) =>
-    withThreadLock(
+  const startSession: Adapter["startSession"] = (input) => {
+    let startedContext: SessionContext | undefined;
+    let startedScope: Scope.Closeable | undefined;
+    return withThreadLock(
       input.threadId,
       Effect.gen(function* () {
         if (!settings.enabled) {
@@ -782,6 +877,7 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
         if (previous) yield* stopContext(previous);
         const cwd = path.resolve(input.cwd.trim());
         const sessionScope = yield* Scope.make("sequential");
+        startedScope = sessionScope;
         const env = {
           ...options?.environment,
           ...(settings.agentDir.trim()
@@ -840,52 +936,68 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
           },
           activeTurnId: undefined,
           abortingTurnId: undefined,
+          abortSettlement: undefined,
           compactionItemId: undefined,
           lastUsage: undefined,
           pendingTurnOutcome: undefined,
+          startupFinished: false,
           stopped: false,
         };
+        startedContext = context;
         sessions.set(input.threadId, context);
         context.eventFiber = yield* client.events.pipe(
           Stream.runForEach((event) => handleEvent(context, event)),
-          Effect.catch((cause) =>
-            Effect.gen(function* () {
-              if (context.stopped) return;
+          Effect.catch((cause) => {
+            const handleTransportFailure = Effect.gen(function* () {
+              if (context.stopped) {
+                yield* settleAbort(context, takeAbortSettlement(context));
+                return;
+              }
+              const shouldReportTransportFailure = sessions.get(context.threadId) === context;
               context.stopped = true;
-              if (sessions.get(context.threadId) === context) sessions.delete(context.threadId);
-              context.session = {
-                ...context.session,
-                status: "error",
-                lastError: cause.message,
-                updatedAt: yield* nowIso,
-              };
-              yield* emit({
-                type: "runtime.error",
-                ...(yield* stamp),
-                provider: PROVIDER,
-                providerInstanceId: instanceId,
-                threadId: input.threadId,
-                turnId: context.activeTurnId,
-                payload: { message: cause.message, class: "transport_error" },
-              });
-              yield* emit({
-                type: "session.exited",
-                ...(yield* stamp),
-                provider: PROVIDER,
-                providerInstanceId: instanceId,
-                threadId: input.threadId,
-                payload: {
-                  exitKind: "error",
-                  recoverable: true,
-                  reason: cause.message,
-                },
-              });
+              yield* retireThreadLock(context.threadId);
+              yield* settleAbort(context, takeAbortSettlement(context));
+              if (shouldReportTransportFailure) {
+                if (sessions.get(context.threadId) === context) sessions.delete(context.threadId);
+                context.session = {
+                  ...context.session,
+                  status: "error",
+                  lastError: cause.message,
+                  updatedAt: yield* nowIso,
+                };
+                yield* emit({
+                  type: "runtime.error",
+                  ...(yield* stamp),
+                  provider: PROVIDER,
+                  providerInstanceId: instanceId,
+                  threadId: input.threadId,
+                  turnId: context.activeTurnId,
+                  payload: { message: cause.message, class: "transport_error" },
+                });
+                yield* emit({
+                  type: "session.exited",
+                  ...(yield* stamp),
+                  provider: PROVIDER,
+                  providerInstanceId: instanceId,
+                  threadId: input.threadId,
+                  payload: {
+                    exitKind: "error",
+                    recoverable: true,
+                    reason: cause.message,
+                  },
+                });
+              }
               yield* Scope.close(context.scope, Exit.fail(cause)).pipe(
                 Effect.ignore,
                 Effect.forkIn(ownerScope),
               );
-            }),
-          ),
+            });
+            return (
+              context.startupFinished
+                ? withThreadLock(context.threadId, handleTransportFailure)
+                : handleTransportFailure
+            ).pipe(Effect.forkIn(ownerScope), Effect.asVoid);
+          }),
           Effect.forkIn(sessionScope),
         );
         return yield* Effect.gen(function* () {
@@ -929,6 +1041,7 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
           if (input.title?.trim()) {
             yield* client.request({ type: "set_session_name", name: input.title.trim() });
           }
+          yield* ensureCurrentContext(context);
           const session: ProviderSession = {
             ...context.session,
             status: "ready",
@@ -938,6 +1051,7 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
           };
           context.session = session;
           yield* applyModelSelection(context, input.modelSelection);
+          yield* ensureCurrentContext(context);
           yield* emit({
             type: "session.started",
             ...(yield* stamp),
@@ -946,6 +1060,7 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
             threadId: input.threadId,
             payload: { resume: cursor },
           });
+          yield* ensureCurrentContext(context);
           yield* emit({
             type: "session.state.changed",
             ...(yield* stamp),
@@ -954,6 +1069,7 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
             threadId: input.threadId,
             payload: { state: "ready", reason: "Pi Agent RPC session ready" },
           });
+          yield* ensureCurrentContext(context);
           yield* emit({
             type: "thread.started",
             ...(yield* stamp),
@@ -962,6 +1078,7 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
             threadId: input.threadId,
             payload: { providerThreadId: state.sessionId },
           });
+          context.startupFinished = true;
           return context.session;
         }).pipe(
           Effect.mapError((cause) =>
@@ -969,16 +1086,32 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
               ? cause
               : mapClientError(input.threadId, "session/start", cause),
           ),
-          Effect.tapError(() => stopContext(context)),
         );
       }),
+    ).pipe(
+      Effect.onExit((exit) =>
+        Exit.isSuccess(exit)
+          ? Effect.void
+          : Effect.uninterruptible(
+              Effect.gen(function* () {
+                yield* retireThreadLock(input.threadId);
+                if (startedContext) {
+                  yield* stopContext(startedContext);
+                } else if (startedScope) {
+                  yield* Scope.close(startedScope, Exit.void).pipe(Effect.ignore);
+                }
+              }),
+            ),
+      ),
     );
+  };
 
   const applyModelSelection = (
     context: SessionContext,
     selection: Parameters<Adapter["sendTurn"]>[0]["modelSelection"],
   ) =>
     Effect.gen(function* () {
+      yield* ensureCurrentContext(context);
       if (!selection) return;
       if (selection.instanceId !== instanceId) {
         return yield* new ProviderAdapterValidationError({
@@ -997,11 +1130,13 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
           });
         }
         yield* context.client.request({ type: "set_model", ...parsed });
+        yield* ensureCurrentContext(context);
         context.session = { ...context.session, model: selection.model };
       }
       const thinking = getModelSelectionStringOptionValue(selection, "reasoningEffort");
       if (thinking) {
         yield* context.client.request({ type: "set_thinking_level", level: thinking });
+        yield* ensureCurrentContext(context);
       }
     }).pipe(
       Effect.mapError((cause) =>
@@ -1049,6 +1184,16 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
   const sendTurn: Adapter["sendTurn"] = (input) =>
     Effect.gen(function* () {
       const context = yield* requireSession(input.threadId);
+      yield* ensureReadyContext(context);
+      if (context.abortingTurnId !== undefined && context.abortSettlement) {
+        yield* Deferred.await(context.abortSettlement);
+        if (context.stopped) {
+          return yield* new ProviderAdapterSessionNotFoundError({
+            provider: PROVIDER,
+            threadId: input.threadId,
+          });
+        }
+      }
       const message = input.input?.trim();
       if (!message) {
         return yield* new ProviderAdapterValidationError({
@@ -1060,6 +1205,11 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
       const images = yield* readImages(input);
       return yield* context.commandLock.withPermit(
         Effect.gen(function* () {
+          const abortSettlement = context.abortSettlement;
+          if (context.abortingTurnId !== undefined && abortSettlement) {
+            yield* Deferred.await(abortSettlement);
+          }
+          yield* ensureReadyContext(context);
           yield* applyModelSelection(context, input.modelSelection);
           const promptMessage = message.includes("$")
             ? yield* context.client.request({ type: "get_commands" }).pipe(
@@ -1071,6 +1221,7 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
                 }),
               )
             : message;
+          yield* ensureReadyContext(context);
           const steering = context.activeTurnId !== undefined;
           const turnId = context.activeTurnId ?? TurnId.make(yield* randomId);
           if (!steering) {
@@ -1122,6 +1273,7 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
                     }),
               ),
             );
+          yield* ensureReadyContext(context);
           return {
             threadId: input.threadId,
             turnId,
@@ -1138,21 +1290,38 @@ export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
   const interruptTurn: Adapter["interruptTurn"] = (threadId, turnId) =>
     Effect.gen(function* () {
       const context = yield* requireSession(threadId);
-      const activeTurnId = context.activeTurnId;
-      if (activeTurnId === undefined || (turnId !== undefined && activeTurnId !== turnId)) return;
-      context.abortingTurnId = activeTurnId;
       yield* context.commandLock.withPermit(
-        context.client.request({ type: "clear_queue" }).pipe(
-          Effect.andThen(context.client.request({ type: "abort" })),
-          Effect.mapError((cause) => mapClientError(threadId, "abort", cause)),
-          Effect.tapError(() =>
-            Effect.sync(() => {
-              if (context.abortingTurnId === activeTurnId) context.abortingTurnId = undefined;
-            }),
-          ),
-        ),
+        Effect.gen(function* () {
+          yield* ensureCurrentContext(context);
+          const activeTurnId = context.activeTurnId;
+          if (activeTurnId === undefined || (turnId !== undefined && activeTurnId !== turnId))
+            return;
+          if (context.abortingTurnId === activeTurnId && context.abortSettlement) return;
+
+          const abortSettlement = yield* Deferred.make<void>();
+          context.abortingTurnId = activeTurnId;
+          context.abortSettlement = abortSettlement;
+          yield* context.client.request({ type: "clear_queue" }).pipe(
+            Effect.andThen(context.client.request({ type: "abort" })),
+            Effect.mapError((cause) => mapClientError(threadId, "abort", cause)),
+            Effect.onExit((exit) =>
+              Exit.isSuccess(exit)
+                ? Effect.void
+                : Effect.uninterruptible(
+                    Effect.sync(() => {
+                      if (
+                        context.abortingTurnId === activeTurnId &&
+                        context.abortSettlement === abortSettlement
+                      ) {
+                        context.abortingTurnId = undefined;
+                        context.abortSettlement = undefined;
+                      }
+                    }).pipe(Effect.andThen(Deferred.succeed(abortSettlement, undefined))),
+                  ),
+            ),
+          );
+        }),
       );
-      yield* abortTurn(context, activeTurnId);
     });
 
   const respondToRequest: Adapter["respondToRequest"] = (threadId, requestId, decision) =>

--- a/apps/server/src/provider/Layers/PiAgentAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAgentAdapter.ts
@@ -1,0 +1,1291 @@
+import {
+  ApprovalRequestId,
+  EventId,
+  ProviderItemId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  RuntimeItemId,
+  RuntimeRequestId,
+  TurnId,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  type ProviderUserInputAnswers,
+  type ThreadId,
+} from "@t3tools/contracts";
+import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as PubSub from "effect/PubSub";
+import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import * as SynchronizedRef from "effect/SynchronizedRef";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+
+import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { ServerConfig } from "../../config.ts";
+import { expandHomePath } from "../../pathExpansion.ts";
+import { planPiSkillDispatch } from "../Drivers/PiSkillDispatch.ts";
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+  type ProviderAdapterError,
+} from "../Errors.ts";
+import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
+import {
+  makePiRpcClient,
+  type PiRpcClient,
+  type PiRpcClientError,
+  type PiRpcClientOptions,
+} from "../pi/PiRpcClient.ts";
+import {
+  PiResumeCursor,
+  cumulativeToolOutputDelta,
+  isPiRpcAgentEndEvent,
+  isPiRpcAgentSettledEvent,
+  isPiRpcAgentStartEvent,
+  isPiRpcCompactionEndEvent,
+  isPiRpcCompactionStartEvent,
+  isPiRpcExtensionUIRequest,
+  isPiRpcMessageUpdateEvent,
+  isPiRpcToolExecutionEndEvent,
+  isPiRpcToolExecutionStartEvent,
+  isPiRpcToolExecutionUpdateEvent,
+  type CumulativeToolOutputState,
+  type PiImageContent,
+  type PiRpcEnvelope,
+} from "../pi/PiRpcProtocol.ts";
+import { buildPiAgentSkills } from "./PiAgentProvider.ts";
+
+const PROVIDER = ProviderDriverKind.make("piAgent");
+const decodeResumeCursor = Schema.decodeUnknownOption(PiResumeCursor);
+const T3_PROGRESS_PROMPT =
+  "You are running inside T3 Code. For multi-step work that uses tools, communicate before acting: send a concise preamble explaining what you will do, then provide brief milestone updates before each substantial tool batch or after roughly a minute of quiet work. Keep updates concrete and avoid narrating trivial actions. For simple answers that need no tools, answer directly.";
+
+export interface PiAgentAdapterSettings {
+  readonly enabled: boolean;
+  readonly binaryPath: string;
+  readonly agentDir: string;
+  readonly sessionDir: string;
+}
+
+export interface PiAgentAdapterOptions {
+  readonly instanceId?: ProviderInstanceId;
+  readonly environment?: Record<string, string>;
+  readonly makeClient?: (
+    options: PiRpcClientOptions,
+  ) => Effect.Effect<PiRpcClient, PiRpcClientError, Scope.Scope>;
+}
+
+type Adapter = ProviderAdapterShape<ProviderAdapterError>;
+
+type PendingDialog =
+  | { readonly method: "confirm"; readonly title: string }
+  | { readonly method: "select"; readonly title: string }
+  | { readonly method: "input" | "editor"; readonly title: string };
+
+interface StreamItem {
+  readonly itemId: RuntimeItemId;
+  readonly itemType: "assistant_message" | "reasoning";
+}
+
+interface ToolState {
+  readonly itemId: RuntimeItemId;
+  readonly itemType:
+    | "command_execution"
+    | "file_change"
+    | "mcp_tool_call"
+    | "dynamic_tool_call"
+    | "web_search"
+    | "image_view";
+  output: CumulativeToolOutputState | undefined;
+}
+
+interface PendingTurnOutcome {
+  readonly state: "completed" | "cancelled" | "failed";
+  readonly stopReason?: string;
+  readonly errorMessage?: string;
+}
+
+interface SessionContext {
+  readonly threadId: ThreadId;
+  readonly scope: Scope.Closeable;
+  readonly client: PiRpcClient;
+  readonly commandLock: Semaphore.Semaphore;
+  readonly dialogs: Map<ApprovalRequestId, PendingDialog>;
+  readonly streamItems: Map<string, StreamItem>;
+  readonly tools: Map<string, ToolState>;
+  readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
+  eventFiber: Fiber.Fiber<void, unknown> | undefined;
+  session: ProviderSession;
+  activeTurnId: TurnId | undefined;
+  abortingTurnId: TurnId | undefined;
+  compactionItemId: RuntimeItemId | undefined;
+  lastUsage: unknown;
+  pendingTurnOutcome: PendingTurnOutcome | undefined;
+  stopped: boolean;
+}
+
+interface PiState {
+  readonly sessionFile: string;
+  readonly sessionId: string;
+  readonly model?: { readonly provider?: string; readonly id?: string } | null;
+  readonly thinkingLevel?: string;
+}
+
+function readPiState(input: unknown): PiState | undefined {
+  if (!input || typeof input !== "object") return undefined;
+  const value = input as Record<string, unknown>;
+  if (typeof value.sessionFile !== "string" || !value.sessionFile.trim()) return undefined;
+  if (typeof value.sessionId !== "string" || !value.sessionId.trim()) return undefined;
+  const model =
+    value.model && typeof value.model === "object"
+      ? (value.model as { readonly provider?: string; readonly id?: string })
+      : value.model === null
+        ? null
+        : undefined;
+  return {
+    sessionFile: value.sessionFile,
+    sessionId: value.sessionId,
+    ...(model !== undefined ? { model } : {}),
+    ...(typeof value.thinkingLevel === "string" ? { thinkingLevel: value.thinkingLevel } : {}),
+  };
+}
+
+function readLastEntryId(input: unknown): string | undefined {
+  if (!input || typeof input !== "object") return undefined;
+  const entries = (input as { readonly entries?: unknown }).entries;
+  if (!Array.isArray(entries)) return undefined;
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (!entry || typeof entry !== "object") continue;
+    const record = entry as { readonly entryId?: unknown; readonly id?: unknown };
+    const id = typeof record.entryId === "string" ? record.entryId : record.id;
+    if (typeof id === "string" && id.trim()) return id;
+  }
+  return undefined;
+}
+
+function modelSlug(state: PiState): string | undefined {
+  const provider = state.model?.provider?.trim();
+  const id = state.model?.id?.trim();
+  return provider && id ? `${provider}/${id}` : undefined;
+}
+
+function parseModelSlug(
+  slug: string,
+): { readonly provider: string; readonly modelId: string } | undefined {
+  const separator = slug.indexOf("/");
+  if (separator <= 0 || separator === slug.length - 1) return undefined;
+  return { provider: slug.slice(0, separator), modelId: slug.slice(separator + 1) };
+}
+
+function toolItemType(toolName: string): ToolState["itemType"] {
+  const normalized = toolName.toLowerCase();
+  if (normalized === "bash" || normalized.includes("shell") || normalized.includes("command")) {
+    return "command_execution";
+  }
+  if (normalized === "edit" || normalized === "write" || normalized.includes("patch")) {
+    return "file_change";
+  }
+  if (normalized.includes("mcp")) return "mcp_tool_call";
+  if (normalized.includes("web") && normalized.includes("search")) return "web_search";
+  if (normalized.includes("image") || normalized.includes("screenshot")) return "image_view";
+  return "dynamic_tool_call";
+}
+
+function toolOutput(content: ReadonlyArray<{ readonly text?: string }>): string {
+  return content.flatMap((part) => (part.text === undefined ? [] : [part.text])).join("");
+}
+
+function answerString(answers: ProviderUserInputAnswers): string | undefined {
+  const value = answers.value;
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    const first = value.find((entry): entry is string => typeof entry === "string");
+    return first;
+  }
+  return undefined;
+}
+
+function turnOutcomeFromMessages(messages: ReadonlyArray<unknown>): PendingTurnOutcome {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message || typeof message !== "object") continue;
+    const assistant = message as Record<string, unknown>;
+    if (assistant.role !== "assistant" || typeof assistant.stopReason !== "string") continue;
+    const stopReason = assistant.stopReason.trim();
+    if (!stopReason) break;
+    if (stopReason === "error") {
+      const errorMessage =
+        typeof assistant.errorMessage === "string" && assistant.errorMessage.trim()
+          ? assistant.errorMessage.trim()
+          : "Pi Agent model request failed.";
+      return { state: "failed", stopReason, errorMessage };
+    }
+    if (stopReason === "aborted") return { state: "cancelled", stopReason };
+    return { state: "completed", stopReason };
+  }
+  return { state: "completed" };
+}
+
+export const makePiAgentAdapter = Effect.fn("makePiAgentAdapter")(function* (
+  settings: PiAgentAdapterSettings,
+  options?: PiAgentAdapterOptions,
+) {
+  const instanceId = options?.instanceId ?? ProviderInstanceId.make("piAgent");
+  const crypto = yield* Crypto.Crypto;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const serverConfig = yield* ServerConfig;
+  const ownerScope = yield* Effect.scope;
+  const sessions = new Map<ThreadId, SessionContext>();
+  const threadLocks = yield* SynchronizedRef.make(new Map<ThreadId, Semaphore.Semaphore>());
+  const events = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+  const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+  const randomId = crypto.randomUUIDv4.pipe(
+    Effect.mapError(
+      (cause) =>
+        new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "crypto/randomUUIDv4",
+          detail: "Could not create a Pi Agent runtime identifier.",
+          cause,
+        }),
+    ),
+  );
+  const stamp = Effect.all({
+    eventId: Effect.map(randomId, EventId.make),
+    createdAt: nowIso,
+  });
+  const emit = (event: ProviderRuntimeEvent) => PubSub.publish(events, event).pipe(Effect.asVoid);
+  const clientFactory: NonNullable<PiAgentAdapterOptions["makeClient"]> =
+    options?.makeClient ??
+    ((input) =>
+      makePiRpcClient(input).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      ));
+  const withThreadLock = <A, E, R>(threadId: ThreadId, task: Effect.Effect<A, E, R>) =>
+    SynchronizedRef.modifyEffect(threadLocks, (current) => {
+      const existing = current.get(threadId);
+      if (existing) return Effect.succeed([existing, current] as const);
+      return Semaphore.make(1).pipe(
+        Effect.map((lock) => [lock, new Map(current).set(threadId, lock)] as const),
+      );
+    }).pipe(Effect.flatMap((lock) => lock.withPermit(task)));
+
+  const isProviderAdapterError = (cause: unknown): cause is ProviderAdapterError =>
+    typeof cause === "object" &&
+    cause !== null &&
+    "_tag" in cause &&
+    typeof cause._tag === "string" &&
+    cause._tag.startsWith("ProviderAdapter");
+
+  const mapClientError = (threadId: ThreadId, method: string, cause: unknown) =>
+    new ProviderAdapterRequestError({
+      provider: PROVIDER,
+      method,
+      detail:
+        cause instanceof Error && cause.message.trim() ? cause.message : `Pi rejected ${method}.`,
+      cause,
+    });
+
+  const requireSession = (
+    threadId: ThreadId,
+  ): Effect.Effect<SessionContext, ProviderAdapterSessionNotFoundError> => {
+    const context = sessions.get(threadId);
+    return context && !context.stopped
+      ? Effect.succeed(context)
+      : Effect.fail(new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }));
+  };
+
+  const finishTurn = (context: SessionContext, outcome: PendingTurnOutcome) =>
+    Effect.gen(function* () {
+      const turnId = context.activeTurnId;
+      if (turnId === undefined || context.stopped) return;
+      const { state } = outcome;
+      context.activeTurnId = undefined;
+      context.abortingTurnId = undefined;
+      context.pendingTurnOutcome = undefined;
+      context.streamItems.clear();
+      context.tools.clear();
+      const { lastError: _lastError, ...sessionWithoutLastError } = context.session;
+      context.session = {
+        ...sessionWithoutLastError,
+        status: state === "failed" ? "error" : "ready",
+        activeTurnId: undefined,
+        updatedAt: yield* nowIso,
+        ...(outcome.errorMessage ? { lastError: outcome.errorMessage } : {}),
+      };
+      const existing = context.turns.find((turn) => turn.id === turnId);
+      if (!existing) context.turns.push({ id: turnId, items: [] });
+      yield* emit({
+        type: "turn.completed",
+        ...(yield* stamp),
+        provider: PROVIDER,
+        providerInstanceId: instanceId,
+        threadId: context.threadId,
+        turnId,
+        payload: {
+          state,
+          ...(outcome.stopReason ? { stopReason: outcome.stopReason } : {}),
+          ...(context.lastUsage !== undefined ? { usage: context.lastUsage } : {}),
+          ...(outcome.errorMessage ? { errorMessage: outcome.errorMessage } : {}),
+        },
+      });
+      context.lastUsage = undefined;
+    });
+
+  const abortTurn = (context: SessionContext, turnId: TurnId) =>
+    Effect.gen(function* () {
+      if (context.activeTurnId !== turnId || context.stopped) return;
+      context.activeTurnId = undefined;
+      context.abortingTurnId = undefined;
+      context.pendingTurnOutcome = undefined;
+      context.lastUsage = undefined;
+      context.streamItems.clear();
+      context.tools.clear();
+      const { lastError: _lastError, ...sessionWithoutLastError } = context.session;
+      context.session = {
+        ...sessionWithoutLastError,
+        status: "ready",
+        activeTurnId: undefined,
+        updatedAt: yield* nowIso,
+      };
+      yield* emit({
+        type: "turn.aborted",
+        ...(yield* stamp),
+        provider: PROVIDER,
+        providerInstanceId: instanceId,
+        threadId: context.threadId,
+        turnId,
+        payload: { reason: "Pi Agent turn interrupted" },
+      });
+    });
+
+  const emitToolOutput = (context: SessionContext, tool: ToolState, output: string) =>
+    Effect.gen(function* () {
+      const update = cumulativeToolOutputDelta(tool.output, output);
+      tool.output = update.state;
+      if (!update.replaced && update.delta.length > 0) {
+        yield* emit({
+          type: "content.delta",
+          ...(yield* stamp),
+          provider: PROVIDER,
+          providerInstanceId: instanceId,
+          threadId: context.threadId,
+          turnId: context.activeTurnId,
+          itemId: tool.itemId,
+          payload: {
+            streamKind:
+              tool.itemType === "command_execution"
+                ? "command_output"
+                : tool.itemType === "file_change"
+                  ? "file_change_output"
+                  : "unknown",
+            delta: update.delta,
+          },
+        });
+      } else if (update.replaced) {
+        yield* emit({
+          type: "item.updated",
+          ...(yield* stamp),
+          provider: PROVIDER,
+          providerInstanceId: instanceId,
+          threadId: context.threadId,
+          turnId: context.activeTurnId,
+          itemId: tool.itemId,
+          payload: {
+            itemType: tool.itemType,
+            status: "inProgress",
+            data: { outputSnapshot: update.delta, replaced: true },
+          },
+        });
+      }
+    });
+
+  const handleDialog = (context: SessionContext, event: PiRpcEnvelope) =>
+    Effect.gen(function* () {
+      if (!isPiRpcExtensionUIRequest(event)) return;
+      if (
+        event.method === "notify" ||
+        event.method === "setStatus" ||
+        event.method === "setWidget" ||
+        event.method === "setTitle" ||
+        event.method === "set_editor_text"
+      ) {
+        return;
+      }
+      const title =
+        typeof event.title === "string" && event.title.trim() ? event.title : "Pi Agent";
+      const requestId = ApprovalRequestId.make(event.id);
+      const runtimeRequestId = RuntimeRequestId.make(event.id);
+      context.dialogs.set(requestId, { method: event.method, title });
+      if (event.method === "confirm") {
+        yield* emit({
+          type: "request.opened",
+          ...(yield* stamp),
+          provider: PROVIDER,
+          providerInstanceId: instanceId,
+          threadId: context.threadId,
+          turnId: context.activeTurnId,
+          requestId: runtimeRequestId,
+          payload: {
+            requestType: "dynamic_tool_call",
+            detail: event.message.trim() || title,
+            options: [
+              { decision: "accept", label: "Confirm" },
+              { decision: "decline", label: "Decline" },
+            ],
+            args: { title },
+          },
+        });
+        return;
+      }
+      yield* emit({
+        type: "user-input.requested",
+        ...(yield* stamp),
+        provider: PROVIDER,
+        providerInstanceId: instanceId,
+        threadId: context.threadId,
+        turnId: context.activeTurnId,
+        requestId: runtimeRequestId,
+        payload: {
+          questions: [
+            {
+              id: "value",
+              header: title,
+              question: title,
+              options:
+                event.method === "select"
+                  ? event.options.map((option) => ({
+                      label: option,
+                      description: "",
+                      value: option,
+                    }))
+                  : [],
+              allowCustomAnswer: event.method !== "select",
+            },
+          ],
+        },
+      });
+    });
+
+  const handleEvent = (context: SessionContext, event: PiRpcEnvelope) =>
+    Effect.gen(function* () {
+      if (context.stopped) return;
+      if (isPiRpcAgentStartEvent(event)) {
+        context.pendingTurnOutcome = undefined;
+        context.session = {
+          ...context.session,
+          status: "running",
+          updatedAt: yield* nowIso,
+        };
+        yield* emit({
+          type: "session.state.changed",
+          ...(yield* stamp),
+          provider: PROVIDER,
+          providerInstanceId: instanceId,
+          threadId: context.threadId,
+          turnId: context.activeTurnId,
+          payload: { state: "running", reason: "Pi is processing the turn" },
+        });
+        return;
+      }
+      if (isPiRpcMessageUpdateEvent(event)) {
+        context.lastUsage = event.usage ?? context.lastUsage;
+        const update = event.assistantMessageEvent;
+        const isReasoning = update.type.startsWith("thinking_");
+        const isAssistant = update.type.startsWith("text_");
+        if (!isReasoning && !isAssistant) return;
+        const key = `${isReasoning ? "reasoning" : "text"}:${update.contentIndex}`;
+        let item = context.streamItems.get(key);
+        if (update.type.endsWith("_start") && item === undefined) {
+          item = {
+            itemId: RuntimeItemId.make(`pi-${yield* randomId}`),
+            itemType: isReasoning ? "reasoning" : "assistant_message",
+          };
+          context.streamItems.set(key, item);
+          yield* emit({
+            type: "item.started",
+            ...(yield* stamp),
+            provider: PROVIDER,
+            providerInstanceId: instanceId,
+            threadId: context.threadId,
+            turnId: context.activeTurnId,
+            itemId: item.itemId,
+            payload: { itemType: item.itemType, status: "inProgress" },
+          });
+        }
+        if (update.type.endsWith("_delta") && update.delta !== undefined) {
+          item ??= {
+            itemId: RuntimeItemId.make(`pi-${yield* randomId}`),
+            itemType: isReasoning ? "reasoning" : "assistant_message",
+          };
+          context.streamItems.set(key, item);
+          yield* emit({
+            type: "content.delta",
+            ...(yield* stamp),
+            provider: PROVIDER,
+            providerInstanceId: instanceId,
+            threadId: context.threadId,
+            turnId: context.activeTurnId,
+            itemId: item.itemId,
+            payload: {
+              streamKind: isReasoning ? "reasoning_text" : "assistant_text",
+              delta: update.delta,
+              contentIndex: update.contentIndex,
+            },
+          });
+        }
+        if (update.type.endsWith("_end") && item !== undefined) {
+          yield* emit({
+            type: "item.completed",
+            ...(yield* stamp),
+            provider: PROVIDER,
+            providerInstanceId: instanceId,
+            threadId: context.threadId,
+            turnId: context.activeTurnId,
+            itemId: item.itemId,
+            payload: { itemType: item.itemType, status: "completed" },
+          });
+          context.streamItems.delete(key);
+        }
+        return;
+      }
+      if (isPiRpcToolExecutionStartEvent(event)) {
+        const itemType = toolItemType(event.toolName);
+        const tool: ToolState = {
+          itemId: RuntimeItemId.make(event.toolCallId),
+          itemType,
+          output: undefined,
+        };
+        context.tools.set(event.toolCallId, tool);
+        yield* emit({
+          type: "item.started",
+          ...(yield* stamp),
+          provider: PROVIDER,
+          providerInstanceId: instanceId,
+          threadId: context.threadId,
+          turnId: context.activeTurnId,
+          itemId: tool.itemId,
+          providerRefs: { providerItemId: ProviderItemId.make(event.toolCallId) },
+          payload: {
+            itemType,
+            status: "inProgress",
+            title: event.toolName,
+            data: { args: event.args },
+          },
+        });
+        return;
+      }
+      if (isPiRpcToolExecutionUpdateEvent(event)) {
+        const tool = context.tools.get(event.toolCallId);
+        if (tool) yield* emitToolOutput(context, tool, toolOutput(event.partialResult.content));
+        return;
+      }
+      if (isPiRpcToolExecutionEndEvent(event)) {
+        const tool = context.tools.get(event.toolCallId) ?? {
+          itemId: RuntimeItemId.make(event.toolCallId),
+          itemType: toolItemType(event.toolName),
+          output: undefined,
+        };
+        yield* emitToolOutput(context, tool, toolOutput(event.result.content));
+        yield* emit({
+          type: "item.completed",
+          ...(yield* stamp),
+          provider: PROVIDER,
+          providerInstanceId: instanceId,
+          threadId: context.threadId,
+          turnId: context.activeTurnId,
+          itemId: tool.itemId,
+          providerRefs: { providerItemId: ProviderItemId.make(event.toolCallId) },
+          payload: {
+            itemType: tool.itemType,
+            status: event.isError ? "failed" : "completed",
+            title: event.toolName,
+            data: { result: event.result.details },
+          },
+        });
+        context.tools.delete(event.toolCallId);
+        return;
+      }
+      if (isPiRpcCompactionStartEvent(event)) {
+        const itemId = RuntimeItemId.make(`pi-compaction-${yield* randomId}`);
+        context.compactionItemId = itemId;
+        yield* emit({
+          type: "item.started",
+          ...(yield* stamp),
+          provider: PROVIDER,
+          providerInstanceId: instanceId,
+          threadId: context.threadId,
+          turnId: context.activeTurnId,
+          itemId,
+          payload: {
+            itemType: "context_compaction",
+            status: "inProgress",
+            title: "Compacting context",
+            data: { reason: event.reason },
+          },
+        });
+        return;
+      }
+      if (isPiRpcCompactionEndEvent(event)) {
+        const itemId = context.compactionItemId;
+        if (itemId) {
+          yield* emit({
+            type: "item.completed",
+            ...(yield* stamp),
+            provider: PROVIDER,
+            providerInstanceId: instanceId,
+            threadId: context.threadId,
+            turnId: context.activeTurnId,
+            itemId,
+            payload: {
+              itemType: "context_compaction",
+              status: event.aborted || event.errorMessage ? "failed" : "completed",
+              title: "Context compacted",
+              data: { reason: event.reason, result: event.result, willRetry: event.willRetry },
+            },
+          });
+          context.compactionItemId = undefined;
+        }
+        if (!event.aborted && !event.errorMessage) {
+          yield* emit({
+            type: "thread.state.changed",
+            ...(yield* stamp),
+            provider: PROVIDER,
+            providerInstanceId: instanceId,
+            threadId: context.threadId,
+            payload: { state: "compacted", detail: event.result },
+          });
+        }
+        return;
+      }
+      if (isPiRpcExtensionUIRequest(event)) {
+        yield* handleDialog(context, event);
+        return;
+      }
+      // `agent_end` may precede an automatic retry or overflow compaction. Retain only
+      // the final run's outcome, then wait for Pi's authoritative settled boundary.
+      if (isPiRpcAgentEndEvent(event)) {
+        context.pendingTurnOutcome = event.willRetry
+          ? undefined
+          : turnOutcomeFromMessages(event.messages ?? []);
+        return;
+      }
+      if (isPiRpcAgentSettledEvent(event)) {
+        if (context.abortingTurnId !== undefined) {
+          yield* abortTurn(context, context.abortingTurnId);
+        } else {
+          const outcome = context.pendingTurnOutcome ?? { state: "completed" as const };
+          if (outcome.state === "failed" && outcome.errorMessage) {
+            yield* emit({
+              type: "runtime.error",
+              ...(yield* stamp),
+              provider: PROVIDER,
+              providerInstanceId: instanceId,
+              threadId: context.threadId,
+              turnId: context.activeTurnId,
+              payload: { message: outcome.errorMessage, class: "provider_error" },
+            });
+          }
+          yield* finishTurn(context, outcome);
+        }
+      }
+    });
+
+  const stopContext = (context: SessionContext) =>
+    Effect.gen(function* () {
+      if (context.stopped) return;
+      context.stopped = true;
+      for (const [requestId] of context.dialogs) {
+        yield* Effect.ignore(
+          context.client.send({
+            type: "extension_ui_response",
+            id: requestId,
+            cancelled: true,
+          }),
+        );
+      }
+      context.dialogs.clear();
+      if (context.eventFiber) yield* Fiber.interrupt(context.eventFiber);
+      yield* Effect.ignore(context.client.close);
+      yield* Scope.close(context.scope, Exit.void);
+      if (sessions.get(context.threadId) === context) sessions.delete(context.threadId);
+      yield* emit({
+        type: "session.exited",
+        ...(yield* stamp),
+        provider: PROVIDER,
+        providerInstanceId: instanceId,
+        threadId: context.threadId,
+        payload: { exitKind: "graceful" },
+      });
+    }).pipe(Effect.uninterruptible);
+
+  const startSession: Adapter["startSession"] = (input) =>
+    withThreadLock(
+      input.threadId,
+      Effect.gen(function* () {
+        if (!settings.enabled) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "startSession",
+            issue: "Enable Pi Agent in provider settings before starting a thread.",
+          });
+        }
+        if (
+          (input.provider !== undefined && input.provider !== PROVIDER) ||
+          (input.providerInstanceId !== undefined && input.providerInstanceId !== instanceId) ||
+          (input.modelSelection !== undefined && input.modelSelection.instanceId !== instanceId)
+        ) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "startSession",
+            issue: "The Pi Agent provider instance does not match the requested session.",
+          });
+        }
+        if (input.runtimeMode !== "full-access") {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "startSession",
+            issue:
+              "Pi Agent currently supports only full-access mode because RPC does not enforce T3 Code approval policies without a policy bridge.",
+          });
+        }
+        if (!input.cwd?.trim()) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "startSession",
+            issue: "The session requires a workspace directory.",
+          });
+        }
+        const resume = decodeResumeCursor(input.resumeCursor);
+        if (input.resumeCursor !== undefined && Option.isNone(resume)) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "startSession",
+            issue: "The saved Pi Agent session is invalid. Start a new thread.",
+          });
+        }
+        const previous = sessions.get(input.threadId);
+        if (previous) yield* stopContext(previous);
+        const cwd = path.resolve(input.cwd.trim());
+        const sessionScope = yield* Scope.make("sequential");
+        const env = {
+          ...options?.environment,
+          ...(settings.agentDir.trim()
+            ? {
+                PI_CODING_AGENT_DIR: path.resolve(cwd, expandHomePath(settings.agentDir.trim())),
+              }
+            : {}),
+        };
+        const args = [
+          "--mode",
+          "rpc",
+          "--approve",
+          "--append-system-prompt",
+          T3_PROGRESS_PROMPT,
+          ...(settings.sessionDir.trim()
+            ? ["--session-dir", path.resolve(cwd, expandHomePath(settings.sessionDir.trim()))]
+            : []),
+        ];
+        const client = yield* clientFactory({
+          binaryPath: expandHomePath(settings.binaryPath.trim() || "pi"),
+          args,
+          cwd,
+          ...(Object.keys(env).length > 0 ? { env } : {}),
+        }).pipe(
+          Effect.provideService(Scope.Scope, sessionScope),
+          Effect.mapError(
+            (cause) =>
+              new ProviderAdapterProcessError({
+                provider: PROVIDER,
+                threadId: input.threadId,
+                detail: "Could not start Pi Agent RPC.",
+                cause,
+              }),
+          ),
+        );
+        const createdAt = yield* nowIso;
+        const context: SessionContext = {
+          threadId: input.threadId,
+          scope: sessionScope,
+          client,
+          commandLock: yield* Semaphore.make(1),
+          dialogs: new Map(),
+          streamItems: new Map(),
+          tools: new Map(),
+          turns: [],
+          eventFiber: undefined,
+          session: {
+            provider: PROVIDER,
+            providerInstanceId: instanceId,
+            status: "connecting",
+            runtimeMode: "full-access",
+            cwd,
+            threadId: input.threadId,
+            createdAt,
+            updatedAt: createdAt,
+          },
+          activeTurnId: undefined,
+          abortingTurnId: undefined,
+          compactionItemId: undefined,
+          lastUsage: undefined,
+          pendingTurnOutcome: undefined,
+          stopped: false,
+        };
+        sessions.set(input.threadId, context);
+        context.eventFiber = yield* client.events.pipe(
+          Stream.runForEach((event) => handleEvent(context, event)),
+          Effect.catch((cause) =>
+            Effect.gen(function* () {
+              if (context.stopped) return;
+              context.stopped = true;
+              if (sessions.get(context.threadId) === context) sessions.delete(context.threadId);
+              context.session = {
+                ...context.session,
+                status: "error",
+                lastError: cause.message,
+                updatedAt: yield* nowIso,
+              };
+              yield* emit({
+                type: "runtime.error",
+                ...(yield* stamp),
+                provider: PROVIDER,
+                providerInstanceId: instanceId,
+                threadId: input.threadId,
+                turnId: context.activeTurnId,
+                payload: { message: cause.message, class: "transport_error" },
+              });
+              yield* emit({
+                type: "session.exited",
+                ...(yield* stamp),
+                provider: PROVIDER,
+                providerInstanceId: instanceId,
+                threadId: input.threadId,
+                payload: {
+                  exitKind: "error",
+                  recoverable: true,
+                  reason: cause.message,
+                },
+              });
+              yield* Scope.close(context.scope, Exit.fail(cause)).pipe(
+                Effect.ignore,
+                Effect.forkIn(ownerScope),
+              );
+            }),
+          ),
+          Effect.forkIn(sessionScope),
+        );
+        return yield* Effect.gen(function* () {
+          if (Option.isSome(resume)) {
+            const switched = yield* client.request({
+              type: "switch_session",
+              sessionPath: resume.value.sessionFile,
+            });
+            if (
+              switched.data &&
+              typeof switched.data === "object" &&
+              (switched.data as { readonly cancelled?: unknown }).cancelled === true
+            ) {
+              return yield* new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "switch_session",
+                detail: "Pi cancelled the saved session restore.",
+              });
+            }
+          }
+          const stateResponse = yield* client.request({ type: "get_state" });
+          const state = readPiState(stateResponse.data);
+          if (!state) {
+            return yield* new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "get_state",
+              detail: "Pi returned a state without a durable session file and id.",
+            });
+          }
+          const previousEntryId = Option.isSome(resume) ? resume.value.lastEntryId : undefined;
+          const entries = previousEntryId
+            ? yield* client.request({ type: "get_entries", since: previousEntryId })
+            : undefined;
+          const lastEntryId = readLastEntryId(entries?.data) ?? previousEntryId;
+          const cursor = PiResumeCursor.make({
+            schemaVersion: 1,
+            sessionFile: state.sessionFile,
+            sessionId: state.sessionId,
+            ...(lastEntryId ? { lastEntryId } : {}),
+          });
+          if (input.title?.trim()) {
+            yield* client.request({ type: "set_session_name", name: input.title.trim() });
+          }
+          const session: ProviderSession = {
+            ...context.session,
+            status: "ready",
+            ...(modelSlug(state) ? { model: modelSlug(state) } : {}),
+            resumeCursor: cursor,
+            updatedAt: yield* nowIso,
+          };
+          context.session = session;
+          yield* applyModelSelection(context, input.modelSelection);
+          yield* emit({
+            type: "session.started",
+            ...(yield* stamp),
+            provider: PROVIDER,
+            providerInstanceId: instanceId,
+            threadId: input.threadId,
+            payload: { resume: cursor },
+          });
+          yield* emit({
+            type: "session.state.changed",
+            ...(yield* stamp),
+            provider: PROVIDER,
+            providerInstanceId: instanceId,
+            threadId: input.threadId,
+            payload: { state: "ready", reason: "Pi Agent RPC session ready" },
+          });
+          yield* emit({
+            type: "thread.started",
+            ...(yield* stamp),
+            provider: PROVIDER,
+            providerInstanceId: instanceId,
+            threadId: input.threadId,
+            payload: { providerThreadId: state.sessionId },
+          });
+          return context.session;
+        }).pipe(
+          Effect.mapError((cause) =>
+            isProviderAdapterError(cause)
+              ? cause
+              : mapClientError(input.threadId, "session/start", cause),
+          ),
+          Effect.tapError(() => stopContext(context)),
+        );
+      }),
+    );
+
+  const applyModelSelection = (
+    context: SessionContext,
+    selection: Parameters<Adapter["sendTurn"]>[0]["modelSelection"],
+  ) =>
+    Effect.gen(function* () {
+      if (!selection) return;
+      if (selection.instanceId !== instanceId) {
+        return yield* new ProviderAdapterValidationError({
+          provider: PROVIDER,
+          operation: "sendTurn",
+          issue: "The selected model belongs to another provider instance.",
+        });
+      }
+      if (selection.model !== context.session.model) {
+        const parsed = parseModelSlug(selection.model);
+        if (!parsed) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "sendTurn",
+            issue: "Pi model identifiers must use the provider/model format.",
+          });
+        }
+        yield* context.client.request({ type: "set_model", ...parsed });
+        context.session = { ...context.session, model: selection.model };
+      }
+      const thinking = getModelSelectionStringOptionValue(selection, "reasoningEffort");
+      if (thinking) {
+        yield* context.client.request({ type: "set_thinking_level", level: thinking });
+      }
+    }).pipe(
+      Effect.mapError((cause) =>
+        cause._tag === "ProviderAdapterValidationError"
+          ? cause
+          : mapClientError(context.threadId, "model/configure", cause),
+      ),
+    );
+
+  const readImages = (input: Parameters<Adapter["sendTurn"]>[0]) =>
+    Effect.forEach(
+      (input.attachments ?? []).filter((attachment) => attachment.type === "image"),
+      (attachment) =>
+        Effect.gen(function* () {
+          const attachmentPath = resolveAttachmentPath({
+            attachmentsDir: serverConfig.attachmentsDir,
+            attachment,
+          });
+          if (!attachmentPath) {
+            return yield* new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "prompt",
+              detail: `Invalid attachment id '${attachment.id}'.`,
+            });
+          }
+          const bytes = yield* fileSystem.readFile(attachmentPath).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "prompt",
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+          return {
+            type: "image",
+            data: Buffer.from(bytes).toString("base64"),
+            mimeType: attachment.mimeType,
+          } satisfies PiImageContent;
+        }),
+    );
+
+  const sendTurn: Adapter["sendTurn"] = (input) =>
+    Effect.gen(function* () {
+      const context = yield* requireSession(input.threadId);
+      const message = input.input?.trim();
+      if (!message) {
+        return yield* new ProviderAdapterValidationError({
+          provider: PROVIDER,
+          operation: "sendTurn",
+          issue: "Pi Agent requires a non-empty prompt.",
+        });
+      }
+      const images = yield* readImages(input);
+      return yield* context.commandLock.withPermit(
+        Effect.gen(function* () {
+          yield* applyModelSelection(context, input.modelSelection);
+          const promptMessage = message.includes("$")
+            ? yield* context.client.request({ type: "get_commands" }).pipe(
+                Effect.map((response) => {
+                  const skillNames = new Set(
+                    buildPiAgentSkills(response.data).map((skill) => skill.name),
+                  );
+                  return planPiSkillDispatch(message, skillNames)?.commandText ?? message;
+                }),
+              )
+            : message;
+          const steering = context.activeTurnId !== undefined;
+          const turnId = context.activeTurnId ?? TurnId.make(yield* randomId);
+          if (!steering) {
+            context.activeTurnId = turnId;
+            context.pendingTurnOutcome = undefined;
+            context.session = {
+              ...context.session,
+              status: "running",
+              activeTurnId: turnId,
+              updatedAt: yield* nowIso,
+            };
+            yield* emit({
+              type: "turn.started",
+              ...(yield* stamp),
+              provider: PROVIDER,
+              providerInstanceId: instanceId,
+              threadId: input.threadId,
+              turnId,
+              payload: {
+                ...(context.session.model ? { model: context.session.model } : {}),
+                ...(getModelSelectionStringOptionValue(input.modelSelection, "reasoningEffort")
+                  ? {
+                      effort: getModelSelectionStringOptionValue(
+                        input.modelSelection,
+                        "reasoningEffort",
+                      ),
+                    }
+                  : {}),
+              },
+            });
+          }
+          yield* context.client
+            .request({
+              type: "prompt",
+              message: promptMessage,
+              ...(steering ? { streamingBehavior: "steer" as const } : {}),
+              ...(images.length > 0 ? { images } : {}),
+            })
+            .pipe(
+              Effect.tapError((cause) =>
+                steering
+                  ? Effect.void
+                  : finishTurn(context, {
+                      state: "failed",
+                      errorMessage:
+                        cause instanceof Error && cause.message.trim()
+                          ? cause.message
+                          : "Pi rejected the prompt.",
+                    }),
+              ),
+            );
+          return {
+            threadId: input.threadId,
+            turnId,
+            resumeCursor: context.session.resumeCursor,
+          };
+        }).pipe(
+          Effect.mapError((cause) =>
+            isProviderAdapterError(cause) ? cause : mapClientError(input.threadId, "prompt", cause),
+          ),
+        ),
+      );
+    });
+
+  const interruptTurn: Adapter["interruptTurn"] = (threadId, turnId) =>
+    Effect.gen(function* () {
+      const context = yield* requireSession(threadId);
+      const activeTurnId = context.activeTurnId;
+      if (activeTurnId === undefined || (turnId !== undefined && activeTurnId !== turnId)) return;
+      context.abortingTurnId = activeTurnId;
+      yield* context.commandLock.withPermit(
+        context.client.request({ type: "clear_queue" }).pipe(
+          Effect.andThen(context.client.request({ type: "abort" })),
+          Effect.mapError((cause) => mapClientError(threadId, "abort", cause)),
+          Effect.tapError(() =>
+            Effect.sync(() => {
+              if (context.abortingTurnId === activeTurnId) context.abortingTurnId = undefined;
+            }),
+          ),
+        ),
+      );
+      yield* abortTurn(context, activeTurnId);
+    });
+
+  const respondToRequest: Adapter["respondToRequest"] = (threadId, requestId, decision) =>
+    Effect.gen(function* () {
+      const context = yield* requireSession(threadId);
+      const pending = context.dialogs.get(requestId);
+      if (!pending || pending.method !== "confirm") {
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "extension_ui_response",
+          detail: "This Pi confirmation is no longer pending.",
+        });
+      }
+      yield* context.client
+        .send(
+          decision === "cancel"
+            ? { type: "extension_ui_response", id: requestId, cancelled: true }
+            : {
+                type: "extension_ui_response",
+                id: requestId,
+                confirmed:
+                  decision === "accept" ||
+                  decision === "acceptAlways" ||
+                  decision === "acceptForSession",
+              },
+        )
+        .pipe(Effect.mapError((cause) => mapClientError(threadId, "extension_ui_response", cause)));
+      context.dialogs.delete(requestId);
+      yield* emit({
+        type: "request.resolved",
+        ...(yield* stamp),
+        provider: PROVIDER,
+        providerInstanceId: instanceId,
+        threadId,
+        turnId: context.activeTurnId,
+        requestId: RuntimeRequestId.make(requestId),
+        payload: { requestType: "dynamic_tool_call", decision },
+      });
+    });
+
+  const respondToUserInput: Adapter["respondToUserInput"] = (threadId, requestId, answers) =>
+    Effect.gen(function* () {
+      const context = yield* requireSession(threadId);
+      const pending = context.dialogs.get(requestId);
+      if (!pending || pending.method === "confirm") {
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "extension_ui_response",
+          detail: "This Pi input request is no longer pending.",
+        });
+      }
+      const answer = answerString(answers);
+      yield* context.client
+        .send(
+          answer === undefined
+            ? { type: "extension_ui_response", id: requestId, cancelled: true }
+            : { type: "extension_ui_response", id: requestId, value: answer },
+        )
+        .pipe(Effect.mapError((cause) => mapClientError(threadId, "extension_ui_response", cause)));
+      context.dialogs.delete(requestId);
+      yield* emit({
+        type: "user-input.resolved",
+        ...(yield* stamp),
+        provider: PROVIDER,
+        providerInstanceId: instanceId,
+        threadId,
+        turnId: context.activeTurnId,
+        requestId: RuntimeRequestId.make(requestId),
+        payload: { answers },
+      });
+    });
+
+  const compactThread: NonNullable<Adapter["compactThread"]> = (threadId, modelSelection) =>
+    Effect.gen(function* () {
+      const context = yield* requireSession(threadId);
+      yield* context.commandLock.withPermit(
+        applyModelSelection(context, modelSelection).pipe(
+          Effect.andThen(context.client.request({ type: "compact" })),
+          Effect.asVoid,
+          Effect.mapError((cause) =>
+            isProviderAdapterError(cause) ? cause : mapClientError(threadId, "compact", cause),
+          ),
+        ),
+      );
+    });
+
+  const stopSession: Adapter["stopSession"] = (threadId) =>
+    requireSession(threadId).pipe(Effect.flatMap(stopContext));
+  const listSessions: Adapter["listSessions"] = () =>
+    Effect.sync(() => Array.from(sessions.values(), (context) => ({ ...context.session })));
+  const hasSession: Adapter["hasSession"] = (threadId) =>
+    Effect.sync(() => {
+      const context = sessions.get(threadId);
+      return context !== undefined && !context.stopped;
+    });
+  const readThread: Adapter["readThread"] = (threadId) =>
+    requireSession(threadId).pipe(Effect.map((context) => ({ threadId, turns: context.turns })));
+  const rollbackThread: Adapter["rollbackThread"] = (threadId, _numTurns) =>
+    requireSession(threadId).pipe(
+      Effect.flatMap(
+        () =>
+          new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "rollbackThread",
+            issue: "Pi Agent RPC does not support conversation rollback.",
+          }),
+      ),
+    );
+  const stopAll: Adapter["stopAll"] = () =>
+    Effect.forEach([...sessions.values()], stopContext, { discard: true });
+
+  yield* Effect.addFinalizer(() =>
+    stopAll().pipe(Effect.ignore, Effect.andThen(PubSub.shutdown(events))),
+  );
+
+  return {
+    provider: PROVIDER,
+    capabilities: {
+      sessionModelSwitch: "in-session",
+      supportsConversationRollback: false,
+    },
+    startSession,
+    sendTurn,
+    compactThread,
+    interruptTurn,
+    respondToRequest,
+    respondToUserInput,
+    stopSession,
+    listSessions,
+    hasSession,
+    readThread,
+    rollbackThread,
+    stopAll,
+    streamEvents: Stream.fromPubSub(events),
+  } satisfies Adapter;
+});

--- a/apps/server/src/provider/Layers/PiAgentProvider.test.ts
+++ b/apps/server/src/provider/Layers/PiAgentProvider.test.ts
@@ -6,7 +6,7 @@ import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { describe, expect } from "vite-plus/test";
 
-import type { PiRpcClient } from "../pi/PiRpcClient.ts";
+import { PiRpcClientError, type PiRpcClient } from "../pi/PiRpcClient.ts";
 import type { PiRpcCommand, PiRpcResponse } from "../pi/PiRpcProtocol.ts";
 import {
   buildPiAgentModels,
@@ -238,6 +238,35 @@ describe("Pi Agent provider", () => {
         },
       ]);
       expect(commands).toHaveLength(4);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("fails catalog discovery when an RPC request fails", () =>
+    Effect.gen(function* () {
+      const requestError = new PiRpcClientError({
+        operation: "process-exit",
+        detail: "Pi exited during catalog discovery.",
+      });
+      const client: PiRpcClient = {
+        request: () => Effect.fail(requestError),
+        send: () => Effect.void,
+        events: Stream.empty,
+        awaitFailure: Effect.never,
+        close: Effect.void,
+      };
+
+      const result = yield* Effect.exit(
+        discoverPiAgentCatalog(
+          settings,
+          "/tmp/project",
+          {},
+          {
+            makeClient: () => Effect.succeed(client),
+          },
+        ),
+      );
+
+      expect(result._tag).toBe("Failure");
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 

--- a/apps/server/src/provider/Layers/PiAgentProvider.test.ts
+++ b/apps/server/src/provider/Layers/PiAgentProvider.test.ts
@@ -1,0 +1,266 @@
+import { PiAgentSettings } from "@t3tools/contracts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+import { describe, expect } from "vite-plus/test";
+
+import type { PiRpcClient } from "../pi/PiRpcClient.ts";
+import type { PiRpcCommand, PiRpcResponse } from "../pi/PiRpcProtocol.ts";
+import {
+  buildPiAgentModels,
+  buildPiAgentSkills,
+  buildPiAgentSlashCommands,
+  checkPiAgentProviderStatus,
+  discoverPiAgentCatalog,
+  makePendingPiAgentProvider,
+} from "./PiAgentProvider.ts";
+
+const decodeSettings = Schema.decodeSync(PiAgentSettings);
+const settings = decodeSettings({
+  enabled: true,
+  agentDir: "~/.pi/work",
+  sessionDir: "~/.pi/sessions",
+});
+
+describe("Pi Agent provider", () => {
+  it("normalizes dynamic models and marks the active model", () => {
+    const models = buildPiAgentModels({
+      response: {
+        models: [
+          { provider: "anthropic", id: "claude-sonnet", name: "Claude Sonnet" },
+          { provider: "openai", id: "gpt-5", displayName: "GPT-5" },
+          { provider: "unknown", id: "unknown", name: "No configured model" },
+          { provider: "anthropic", id: "claude-sonnet", name: "Duplicate" },
+        ],
+      },
+      state: { model: { provider: "openai", id: "gpt-5" }, thinkingLevel: "high" },
+      thinkingLevels: ["low", "medium", "high"],
+    });
+
+    expect(models).toHaveLength(2);
+    expect(models[1]).toMatchObject({
+      slug: "openai/gpt-5",
+      name: "GPT-5",
+      isDefault: true,
+    });
+    expect(models[1]?.capabilities?.optionDescriptors?.[0]).toMatchObject({
+      id: "reasoningEffort",
+      currentValue: "high",
+    });
+  });
+
+  it("preserves each model's advertised thinking levels", () => {
+    const models = buildPiAgentModels({
+      response: {
+        models: [
+          {
+            provider: "cliproxyapi",
+            id: "gpt-5.6-sol",
+            name: "GPT 5.6 Sol",
+            reasoning: true,
+            thinkingLevelMap: {
+              off: null,
+              low: "low",
+              medium: "medium",
+              high: "high",
+              ultra: "ultra",
+            },
+          },
+          {
+            provider: "cliproxyapi",
+            id: "gpt-5.6-terra",
+            name: "GPT 5.6 Terra",
+            reasoning: true,
+            thinkingLevelMap: {
+              off: null,
+              low: "low",
+              medium: "medium",
+              high: "high",
+              ultra: "ultra",
+            },
+          },
+          {
+            provider: "cliproxyapi",
+            id: "gpt-5.6-luna",
+            name: "GPT 5.6 Luna",
+            reasoning: true,
+            thinkingLevelMap: {
+              off: null,
+              low: "low",
+              medium: "medium",
+              high: "high",
+              max: "max",
+              ultra: null,
+            },
+          },
+        ],
+      },
+      state: {
+        model: { provider: "cliproxyapi", id: "gpt-5.6-sol" },
+        thinkingLevel: "high",
+      },
+      thinkingLevels: ["low", "medium", "high", "ultra"],
+    });
+
+    const thinkingOptionIds = (model: (typeof models)[number] | undefined) =>
+      model?.capabilities?.optionDescriptors?.flatMap((descriptor) =>
+        descriptor.type === "select" && descriptor.id === "reasoningEffort"
+          ? [descriptor.options.map((option) => option.id)]
+          : [],
+      )[0];
+    expect(thinkingOptionIds(models[1])).toEqual(["low", "medium", "high", "ultra"]);
+    expect(thinkingOptionIds(models[2])).toEqual(["low", "medium", "high", "max"]);
+  });
+
+  it("normalizes and deduplicates Pi extension commands", () => {
+    expect(
+      buildPiAgentSlashCommands({
+        commands: [
+          { name: "deploy", description: "Deploy the app", input: { hint: "environment" } },
+          {
+            name: "skill:html-communicator",
+            description: "Create an HTML report",
+            source: "skill",
+            sourceInfo: {
+              path: "/home/user/.pi/agent/skills/html-communicator/SKILL.md",
+              scope: "user",
+            },
+          },
+          { name: "deploy", description: "duplicate" },
+          { command: "review", help: "Review changes" },
+        ],
+      }),
+    ).toEqual([
+      { name: "deploy", description: "Deploy the app", input: { hint: "environment" } },
+      { name: "review", description: "Review changes" },
+    ]);
+  });
+
+  it("publishes Pi manual skills separately from slash commands", () => {
+    expect(
+      buildPiAgentSkills({
+        commands: [
+          {
+            name: "skill:html-communicator",
+            description: "Create an HTML report",
+            source: "skill",
+            sourceInfo: {
+              path: "/home/user/.pi/agent/skills/html-communicator/SKILL.md",
+              scope: "user",
+            },
+          },
+          { name: "deploy", description: "Deploy the app", source: "extension" },
+          {
+            name: "skill:missing-path",
+            description: "Cannot be shown without its source path",
+            source: "skill",
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        name: "html-communicator",
+        description: "Create an HTML report",
+        shortDescription: "Create an HTML report",
+        path: "/home/user/.pi/agent/skills/html-communicator/SKILL.md",
+        scope: "user",
+        enabled: true,
+      },
+    ]);
+  });
+
+  it.effect("discovers models, commands, and paths through one short-lived RPC client", () =>
+    Effect.gen(function* () {
+      const commands: PiRpcCommand[] = [];
+      const response = (command: PiRpcCommand): PiRpcResponse => ({
+        ...(command.id ? { id: command.id } : {}),
+        type: "response",
+        command: command.type,
+        success: true,
+        data:
+          command.type === "get_state"
+            ? { model: { provider: "mock", id: "model-1" } }
+            : command.type === "get_available_models"
+              ? { models: [{ provider: "mock", id: "model-1", name: "Mock" }] }
+              : command.type === "get_available_thinking_levels"
+                ? { levels: ["medium", "high"] }
+                : {
+                    commands: [
+                      { name: "hello", description: "Say hello" },
+                      {
+                        name: "skill:report",
+                        description: "Write a report",
+                        source: "skill",
+                        sourceInfo: { path: "/tmp/skills/report/SKILL.md", scope: "project" },
+                      },
+                    ],
+                  },
+      });
+      const client: PiRpcClient = {
+        request: (command) =>
+          Effect.sync(() => commands.push(command)).pipe(Effect.map(() => response(command))),
+        send: () => Effect.void,
+        events: Stream.empty,
+        awaitFailure: Effect.never,
+        close: Effect.void,
+      };
+      const catalog = yield* discoverPiAgentCatalog(
+        settings,
+        "/tmp/project",
+        {},
+        {
+          makeClient: (options) => {
+            expect(options.binaryPath).toBe("pi");
+            expect(options.args).toEqual([
+              "--mode",
+              "rpc",
+              "--no-session",
+              "--session-dir",
+              expect.stringContaining("/.pi/sessions"),
+            ]);
+            expect(options.env?.PI_CODING_AGENT_DIR).toEqual(expect.stringContaining("/.pi/work"));
+            return Effect.succeed(client);
+          },
+        },
+      );
+      expect(catalog.models[0]?.slug).toBe("mock/model-1");
+      expect(catalog.slashCommands).toEqual([{ name: "hello", description: "Say hello" }]);
+      expect(catalog.skills).toEqual([
+        {
+          name: "report",
+          description: "Write a report",
+          shortDescription: "Write a report",
+          path: "/tmp/skills/report/SKILL.md",
+          scope: "project",
+          enabled: true,
+        },
+      ]);
+      expect(commands).toHaveLength(4);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("publishes the full-access-only and unsupported text-generation metadata", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* makePendingPiAgentProvider(decodeSettings({}));
+      expect(snapshot.showInteractionModeToggle).toBe(false);
+      expect(snapshot.supportedRuntimeModes).toEqual(["full-access"]);
+      expect(snapshot.supportsConversationRollback).toBe(false);
+      expect(snapshot.supportsTextGeneration).toBe(false);
+    }),
+  );
+
+  it.effect("does not probe a disabled user-managed binary", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* checkPiAgentProviderStatus(
+        decodeSettings({ enabled: false, binaryPath: "/does/not/exist" }),
+        "/tmp/project",
+        {},
+      );
+      expect(snapshot.status).toBe("disabled");
+      expect(snapshot.installed).toBe(false);
+      expect(snapshot.supportedRuntimeModes).toEqual(["full-access"]);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+});

--- a/apps/server/src/provider/Layers/PiAgentProvider.ts
+++ b/apps/server/src/provider/Layers/PiAgentProvider.ts
@@ -1,0 +1,595 @@
+/**
+ * Provider status and catalog discovery for the Pi coding agent.
+ *
+ * Pi is deliberately user-managed: T3 Code does not install, update, or
+ * authenticate its binary. The status check only runs the configured binary
+ * and a short-lived RPC process, then closes that process before publishing a
+ * snapshot. Model and slash-command metadata come from Pi's RPC inventory so
+ * a profile can expose its own providers and extensions.
+ *
+ * @module provider/Layers/PiAgentProvider
+ */
+import type {
+  ModelCapabilities,
+  PiAgentSettings,
+  ServerProviderModel,
+  ServerProviderSkill,
+  ServerProviderSlashCommand,
+} from "@t3tools/contracts";
+import { createModelCapabilities } from "@t3tools/shared/model";
+import * as Cause from "effect/Cause";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Option from "effect/Option";
+import * as Scope from "effect/Scope";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
+import { expandHomePath } from "../../pathExpansion.ts";
+import {
+  buildServerProvider,
+  isCommandMissingCause,
+  parseGenericCliVersion,
+  providerModelsFromSettings,
+  spawnAndCollect,
+  type ServerProviderDraft,
+} from "../providerSnapshot.ts";
+import {
+  makePiRpcClient,
+  PiRpcClientError,
+  type PiRpcRequestCommand,
+  type PiRpcClient,
+  type PiRpcClientOptions,
+} from "../pi/PiRpcClient.ts";
+import type { PiRpcResponse } from "../pi/PiRpcProtocol.ts";
+
+const PI_BINARY = "pi";
+const PI_RPC_TIMEOUT = "6 seconds";
+const PI_VERSION_TIMEOUT = "4 seconds";
+
+export const PI_AGENT_PRESENTATION = {
+  displayName: "Pi Agent",
+  badgeLabel: "Early Access",
+  // Pi RPC has no T3 plan-mode contract. Permission modes are advertised
+  // separately through `supportedRuntimeModes` below.
+  showInteractionModeToggle: false,
+} as const;
+
+const EMPTY_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
+  optionDescriptors: [],
+});
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function arrayFromResponse(data: unknown, keys: ReadonlyArray<string>): ReadonlyArray<unknown> {
+  if (Array.isArray(data)) return data;
+  if (!isRecord(data)) return [];
+  for (const key of keys) {
+    if (Array.isArray(data[key])) return data[key];
+  }
+  return [];
+}
+
+function responseData(response: PiRpcResponse | undefined): unknown {
+  return response?.success === true ? response.data : undefined;
+}
+
+function responseStringList(
+  response: PiRpcResponse | undefined,
+  keys: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  return arrayFromResponse(responseData(response), keys).flatMap((entry) => {
+    if (typeof entry === "string") {
+      const value = stringValue(entry);
+      return value ? [value] : [];
+    }
+    if (!isRecord(entry)) return [];
+    const value =
+      stringValue(entry.id) ??
+      stringValue(entry.value) ??
+      stringValue(entry.name) ??
+      stringValue(entry.level);
+    return value ? [value] : [];
+  });
+}
+
+function uniqueStrings(values: ReadonlyArray<string>): ReadonlyArray<string> {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    if (seen.has(value)) return false;
+    seen.add(value);
+    return true;
+  });
+}
+
+function thinkingCapabilities(
+  thinkingLevels: ReadonlyArray<string>,
+  currentThinkingLevel?: string,
+): ModelCapabilities {
+  const levels = uniqueStrings(thinkingLevels);
+  if (levels.length === 0) return EMPTY_MODEL_CAPABILITIES;
+  const defaultLevel =
+    currentThinkingLevel && levels.includes(currentThinkingLevel)
+      ? currentThinkingLevel
+      : levels.includes("medium")
+        ? "medium"
+        : levels[0];
+  return createModelCapabilities({
+    optionDescriptors: [
+      {
+        id: "reasoningEffort",
+        label: "Thinking",
+        type: "select",
+        options: levels.map((level) => ({
+          id: level,
+          label: level.charAt(0).toUpperCase() + level.slice(1),
+          ...(level === defaultLevel ? { isDefault: true } : {}),
+        })),
+        currentValue: defaultLevel,
+      },
+    ],
+  });
+}
+
+function modelSlug(model: UnknownRecord): string | undefined {
+  const provider = stringValue(model.provider) ?? stringValue(model.providerId);
+  const id =
+    stringValue(model.id) ??
+    stringValue(model.modelId) ??
+    stringValue(model.slug) ??
+    stringValue(model.name);
+  if (!id) return undefined;
+  return provider && !id.includes("/") ? `${provider}/${id}` : id;
+}
+
+function isUnknownPiModel(slug: string): boolean {
+  return slug.toLowerCase() === "unknown/unknown";
+}
+
+function modelName(model: UnknownRecord, slug: string): string {
+  return (
+    stringValue(model.name) ?? stringValue(model.displayName) ?? stringValue(model.label) ?? slug
+  );
+}
+
+function modelThinkingLevels(model: UnknownRecord): ReadonlyArray<string> {
+  if (!isRecord(model.thinkingLevelMap)) return [];
+  return uniqueStrings(
+    Object.values(model.thinkingLevelMap).flatMap((value) => {
+      const level = stringValue(value);
+      return level ? [level] : [];
+    }),
+  );
+}
+
+function currentModelSlug(state: unknown): string | undefined {
+  if (!isRecord(state)) return undefined;
+  const current = state.model;
+  if (typeof current === "string") return stringValue(current);
+  return isRecord(current) ? modelSlug(current) : undefined;
+}
+
+/**
+ * Convert Pi's intentionally loose model inventory into T3's model picker
+ * shape. Pi profiles commonly return `{ provider, id, name }`, but accepting
+ * `modelId`/`slug` keeps this hook compatible with older Pi builds and forks.
+ */
+export function buildPiAgentModels(input: {
+  readonly response: unknown;
+  readonly state?: unknown;
+  readonly thinkingLevels?: ReadonlyArray<string>;
+}): ReadonlyArray<ServerProviderModel> {
+  const currentThinkingLevel = isRecord(input.state)
+    ? stringValue(input.state.thinkingLevel)
+    : undefined;
+  const currentCapabilities = thinkingCapabilities(
+    input.thinkingLevels ?? [],
+    currentThinkingLevel,
+  );
+  const models = arrayFromResponse(input.response, ["models", "availableModels", "available"]);
+  const current = currentModelSlug(input.state);
+  const seen = new Set<string>();
+  const result: ServerProviderModel[] = [];
+
+  for (const entry of models) {
+    if (!isRecord(entry)) continue;
+    const slug = modelSlug(entry);
+    if (!slug || isUnknownPiModel(slug) || seen.has(slug)) continue;
+    seen.add(slug);
+    const advertisedThinkingLevels = modelThinkingLevels(entry);
+    const capabilities = thinkingCapabilities(
+      advertisedThinkingLevels.length > 0
+        ? advertisedThinkingLevels
+        : current === slug
+          ? (input.thinkingLevels ?? [])
+          : [],
+      current === slug ? currentThinkingLevel : undefined,
+    );
+    result.push({
+      slug,
+      name: modelName(entry, slug),
+      isCustom: false,
+      ...(current === slug ? { isDefault: true } : {}),
+      capabilities,
+    });
+  }
+
+  // A Pi version may expose the active model through get_state but not publish
+  // its inventory until a provider is authenticated. Keep that active model
+  // selectable instead of returning an empty picker.
+  if (result.length === 0 && isRecord(input.state) && isRecord(input.state.model)) {
+    const active = input.state.model;
+    const slug = modelSlug(active);
+    if (slug && !isUnknownPiModel(slug)) {
+      result.push({
+        slug,
+        name: modelName(active, slug),
+        isCustom: false,
+        isDefault: true,
+        capabilities: currentCapabilities,
+      });
+    }
+  }
+  return result;
+}
+
+function commandName(command: UnknownRecord): string | undefined {
+  return stringValue(command.name) ?? stringValue(command.id) ?? stringValue(command.command);
+}
+
+function isPiSkillCommand(command: UnknownRecord, name: string): boolean {
+  return command.source === "skill" && name.startsWith("skill:");
+}
+
+/** Convert Pi's manual skill commands into T3's shared skill-picker shape. */
+export function buildPiAgentSkills(response: unknown): ReadonlyArray<ServerProviderSkill> {
+  const commands = arrayFromResponse(response, ["commands", "availableCommands"]);
+  const seen = new Set<string>();
+  const result: ServerProviderSkill[] = [];
+  for (const entry of commands) {
+    if (!isRecord(entry)) continue;
+    const command = commandName(entry);
+    if (!command || !isPiSkillCommand(entry, command)) continue;
+    const name = stringValue(command.slice("skill:".length));
+    const sourceInfo = isRecord(entry.sourceInfo) ? entry.sourceInfo : undefined;
+    const skillPath = sourceInfo ? stringValue(sourceInfo.path) : undefined;
+    if (!name || !skillPath || seen.has(name)) continue;
+    seen.add(name);
+    const description = stringValue(entry.description) ?? stringValue(entry.help);
+    const scope = sourceInfo ? stringValue(sourceInfo.scope) : undefined;
+    result.push({
+      name,
+      path: skillPath,
+      enabled: true,
+      ...(description ? { description, shortDescription: description } : {}),
+      ...(scope ? { scope } : {}),
+    });
+  }
+  return result;
+}
+
+/** Convert Pi extension commands into the slash-command wire shape. */
+export function buildPiAgentSlashCommands(
+  response: unknown,
+): ReadonlyArray<ServerProviderSlashCommand> {
+  const commands = arrayFromResponse(response, ["commands", "availableCommands"]);
+  const seen = new Set<string>();
+  const result: ServerProviderSlashCommand[] = [];
+  for (const entry of commands) {
+    if (!isRecord(entry)) continue;
+    const name = commandName(entry);
+    if (!name || isPiSkillCommand(entry, name) || seen.has(name)) continue;
+    seen.add(name);
+    const description = stringValue(entry.description) ?? stringValue(entry.help);
+    const hint =
+      stringValue(entry.hint) ??
+      stringValue(entry.inputHint) ??
+      (isRecord(entry.input) ? stringValue(entry.input.hint) : undefined);
+    result.push({
+      name,
+      ...(description ? { description } : {}),
+      ...(hint ? { input: { hint } } : {}),
+    });
+  }
+  return result;
+}
+
+export function providerModelsFromPiCatalog(
+  models: ReadonlyArray<ServerProviderModel>,
+  customModels: ReadonlyArray<string>,
+): ReadonlyArray<ServerProviderModel> {
+  // The built-in entries already carry capabilities for the selected model;
+  // custom entries have no model-specific probe, so leave them conservative.
+  return providerModelsFromSettings(models, customModels, EMPTY_MODEL_CAPABILITIES);
+}
+
+export interface PiAgentCatalog {
+  readonly models: ReadonlyArray<ServerProviderModel>;
+  readonly slashCommands: ReadonlyArray<ServerProviderSlashCommand>;
+  readonly skills: ReadonlyArray<ServerProviderSkill>;
+  readonly thinkingLevels: ReadonlyArray<string>;
+  readonly state: unknown;
+}
+
+export interface PiAgentClientFactory {
+  readonly makeClient: (
+    options: PiRpcClientOptions,
+  ) => Effect.Effect<PiRpcClient, unknown, Scope.Scope>;
+}
+
+function rpcArgs(settings: PiAgentSettings, shortLived: boolean): ReadonlyArray<string> {
+  const sessionDir = expandHomePath(settings.sessionDir.trim());
+  return [
+    "--mode",
+    "rpc",
+    ...(shortLived ? ["--no-session"] : []),
+    ...(sessionDir ? ["--session-dir", sessionDir] : []),
+  ];
+}
+
+function rpcEnvironment(
+  settings: PiAgentSettings,
+  environment: NodeJS.ProcessEnv,
+): Record<string, string> {
+  const next: Record<string, string> = {};
+  for (const [key, value] of Object.entries(environment)) {
+    if (value !== undefined) next[key] = value;
+  }
+  const agentDir = expandHomePath(settings.agentDir.trim());
+  if (agentDir) next.PI_CODING_AGENT_DIR = agentDir;
+  return next;
+}
+
+const requestOptional = (client: PiRpcClient, command: PiRpcRequestCommand) =>
+  client.request(command).pipe(
+    Effect.timeoutOption(PI_RPC_TIMEOUT),
+    Effect.map(Option.getOrUndefined),
+    Effect.orElseSucceed(() => undefined),
+  );
+
+/**
+ * Probe one Pi profile's dynamic catalog. `factory` is injectable so the
+ * parser and driver can be tested without starting a real user binary.
+ */
+export const discoverPiAgentCatalog = Effect.fn("discoverPiAgentCatalog")(function* (
+  settings: PiAgentSettings,
+  cwd: string,
+  environment: NodeJS.ProcessEnv = process.env,
+  factory?: PiAgentClientFactory,
+): Effect.fn.Return<
+  PiAgentCatalog,
+  PiRpcClientError,
+  ChildProcessSpawner.ChildProcessSpawner | Scope.Scope
+> {
+  const clientOptions = {
+    binaryPath: expandHomePath(settings.binaryPath || PI_BINARY),
+    args: rpcArgs(settings, true),
+    cwd,
+    env: rpcEnvironment(settings, environment),
+  } satisfies PiRpcClientOptions;
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const client = yield* (
+    factory?.makeClient(clientOptions).pipe(
+      Effect.mapError(
+        (cause) =>
+          new PiRpcClientError({
+            operation: "spawn",
+            detail: "Could not start Pi Agent RPC for catalog discovery.",
+            cause,
+          }),
+      ),
+    ) ??
+      makePiRpcClient(clientOptions).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      )
+  );
+
+  const [stateResponse, modelsResponse, thinkingResponse, commandsResponse] = yield* Effect.all(
+    [
+      requestOptional(client, { type: "get_state" }),
+      requestOptional(client, { type: "get_available_models" }),
+      requestOptional(client, { type: "get_available_thinking_levels" }),
+      requestOptional(client, { type: "get_commands" }),
+    ],
+    { concurrency: "unbounded" },
+  );
+  const state = responseData(stateResponse);
+  const thinkingLevels = uniqueStrings(
+    responseStringList(thinkingResponse, ["levels", "thinkingLevels", "available"]),
+  );
+  return {
+    models: buildPiAgentModels({
+      response: responseData(modelsResponse),
+      state,
+      thinkingLevels,
+    }),
+    slashCommands: buildPiAgentSlashCommands(responseData(commandsResponse)),
+    skills: buildPiAgentSkills(responseData(commandsResponse)),
+    thinkingLevels,
+    state,
+  };
+});
+
+const runPiVersion = Effect.fn("runPiVersion")(function* (
+  settings: PiAgentSettings,
+  environment: NodeJS.ProcessEnv,
+) {
+  const binaryPath = expandHomePath(settings.binaryPath || PI_BINARY);
+  const spawnCommand = yield* resolveSpawnCommand(binaryPath, ["--version"], {
+    env: environment,
+    extendEnv: true,
+  });
+  return yield* spawnAndCollect(
+    binaryPath,
+    ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+      env: environment,
+      extendEnv: true,
+      shell: spawnCommand.shell,
+    }),
+  );
+});
+
+function piMissingBinary(cause: unknown): boolean {
+  if (isCommandMissingCause(cause)) return true;
+  if (!isRecord(cause)) return false;
+  return cause.code === "ENOENT" || /not found|enoent/i.test(String(cause.message ?? ""));
+}
+
+function buildPiAgentProvider(input: {
+  readonly settings: PiAgentSettings;
+  readonly checkedAt: string;
+  readonly models: ReadonlyArray<ServerProviderModel>;
+  readonly slashCommands?: ReadonlyArray<ServerProviderSlashCommand>;
+  readonly skills?: ReadonlyArray<ServerProviderSkill>;
+  readonly installed: boolean;
+  readonly version: string | null;
+  readonly status: "ready" | "warning" | "error";
+  readonly message?: string;
+}): ServerProviderDraft {
+  // `supportsTextGeneration` is intentionally explicit: generic Git/source
+  // control flows must not silently choose Pi for structured text generation.
+  return {
+    ...buildServerProvider({
+      presentation: PI_AGENT_PRESENTATION,
+      enabled: input.settings.enabled,
+      checkedAt: input.checkedAt,
+      models: input.models,
+      slashCommands: input.slashCommands ?? [],
+      skills: input.skills ?? [],
+      probe: {
+        installed: input.installed,
+        version: input.version,
+        status: input.status,
+        auth: { status: "unknown" },
+        ...(input.message ? { message: input.message } : {}),
+      },
+    }),
+    supportsTextGeneration: false,
+    supportsConversationRollback: false,
+    supportedRuntimeModes: ["full-access"],
+  };
+}
+
+export const makePendingPiAgentProvider = (
+  settings: PiAgentSettings,
+): Effect.Effect<ServerProviderDraft> =>
+  Effect.map(DateTime.now, (now) =>
+    buildPiAgentProvider({
+      settings,
+      checkedAt: DateTime.formatIso(now),
+      models: providerModelsFromSettings([], settings.customModels, EMPTY_MODEL_CAPABILITIES),
+      installed: false,
+      version: null,
+      status: "warning",
+      message: settings.enabled
+        ? "Checking Pi Agent availability..."
+        : "Pi Agent is disabled in T3 Code settings.",
+    }),
+  );
+
+export const checkPiAgentProviderStatus = Effect.fn("checkPiAgentProviderStatus")(function* (
+  settings: PiAgentSettings,
+  cwd: string,
+  environment: NodeJS.ProcessEnv = process.env,
+  factory?: PiAgentClientFactory,
+): Effect.fn.Return<ServerProviderDraft, never, ChildProcessSpawner.ChildProcessSpawner> {
+  const checkedAt = DateTime.formatIso(yield* DateTime.now);
+  const fallbackModels = providerModelsFromSettings(
+    [],
+    settings.customModels,
+    EMPTY_MODEL_CAPABILITIES,
+  );
+  if (!settings.enabled) {
+    return buildPiAgentProvider({
+      settings,
+      checkedAt,
+      models: fallbackModels,
+      installed: false,
+      version: null,
+      status: "warning",
+      message: "Pi Agent is disabled in T3 Code settings.",
+    });
+  }
+
+  const versionExit = yield* Effect.exit(
+    runPiVersion(settings, environment).pipe(Effect.timeout(PI_VERSION_TIMEOUT)),
+  );
+  if (Exit.isFailure(versionExit)) {
+    const cause = Cause.squash(versionExit.cause);
+    return buildPiAgentProvider({
+      settings,
+      checkedAt,
+      models: fallbackModels,
+      installed: !piMissingBinary(cause),
+      version: null,
+      status: "error",
+      message: piMissingBinary(cause)
+        ? `Pi Agent binary ('${settings.binaryPath || PI_BINARY}') was not found. Install Pi yourself or set Binary path in provider settings.`
+        : "Pi Agent binary was found but failed its version probe.",
+    });
+  }
+
+  const versionResult = versionExit.value;
+  const version = parseGenericCliVersion(`${versionResult.stdout}\n${versionResult.stderr}`);
+  if (versionResult.code !== 0) {
+    return buildPiAgentProvider({
+      settings,
+      checkedAt,
+      models: fallbackModels,
+      installed: true,
+      version,
+      status: "error",
+      message: "Pi Agent is installed but its version command failed.",
+    });
+  }
+
+  const catalogExit = yield* Effect.exit(
+    discoverPiAgentCatalog(settings, cwd, environment, factory).pipe(
+      Effect.timeout(PI_RPC_TIMEOUT),
+      Effect.scoped,
+    ),
+  );
+  if (Exit.isFailure(catalogExit)) {
+    return buildPiAgentProvider({
+      settings,
+      checkedAt,
+      models: fallbackModels,
+      installed: true,
+      version,
+      status: "warning",
+      message: "Pi Agent is installed, but dynamic model and command discovery failed.",
+    });
+  }
+
+  const models = providerModelsFromPiCatalog(catalogExit.value.models, settings.customModels);
+  const hasUsableCatalog = models.length > 0;
+
+  return buildPiAgentProvider({
+    settings,
+    checkedAt,
+    models,
+    slashCommands: catalogExit.value.slashCommands,
+    skills: catalogExit.value.skills,
+    installed: true,
+    version,
+    status: hasUsableCatalog ? "ready" : "warning",
+    ...(hasUsableCatalog
+      ? {}
+      : {
+          message:
+            "Pi Agent is installed, but no usable models were reported. Configure a model in Pi or add a custom model in provider settings.",
+        }),
+  });
+});

--- a/apps/server/src/provider/Layers/PiAgentProvider.ts
+++ b/apps/server/src/provider/Layers/PiAgentProvider.ts
@@ -353,11 +353,9 @@ function rpcEnvironment(
 }
 
 const requestOptional = (client: PiRpcClient, command: PiRpcRequestCommand) =>
-  client.request(command).pipe(
-    Effect.timeoutOption(PI_RPC_TIMEOUT),
-    Effect.map(Option.getOrUndefined),
-    Effect.orElseSucceed(() => undefined),
-  );
+  client
+    .request(command)
+    .pipe(Effect.timeoutOption(PI_RPC_TIMEOUT), Effect.map(Option.getOrUndefined));
 
 /**
  * Probe one Pi profile's dynamic catalog. `factory` is injectable so the

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -26,6 +26,7 @@ import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
 import { GrokDriver, type GrokDriverEnv } from "./Drivers/GrokDriver.ts";
 import { OpenCodeDriver, type OpenCodeDriverEnv } from "./Drivers/OpenCodeDriver.ts";
 import { AntigravityDriver, type AntigravityDriverEnv } from "./Drivers/AntigravityDriver.ts";
+import { PiAgentDriver, type PiAgentDriverEnv } from "./Drivers/PiAgentDriver.ts";
 import type { AnyProviderDriver } from "./ProviderDriver.ts";
 
 /**
@@ -39,7 +40,8 @@ export type BuiltInDriversEnv =
   | CursorDriverEnv
   | GrokDriverEnv
   | OpenCodeDriverEnv
-  | AntigravityDriverEnv;
+  | AntigravityDriverEnv
+  | PiAgentDriverEnv;
 
 /**
  * Ordered list of built-in drivers. Order matters only for tie-breaking in
@@ -53,4 +55,5 @@ export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv
   GrokDriver,
   OpenCodeDriver,
   AntigravityDriver,
+  PiAgentDriver,
 ];

--- a/apps/server/src/provider/pi/PiRpcClient.test.ts
+++ b/apps/server/src/provider/pi/PiRpcClient.test.ts
@@ -1,0 +1,88 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodePath from "node:path";
+import * as NodeURL from "node:url";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Stream from "effect/Stream";
+import { describe, expect } from "vite-plus/test";
+
+import { makePiRpcClient } from "./PiRpcClient.ts";
+import { isPiRpcAgentSettledEvent, isPiRpcExtensionUIRequest } from "./PiRpcProtocol.ts";
+
+const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
+const mockAgentPath = NodePath.join(__dirname, "testFixtures/pi-rpc-mock-agent.mjs");
+
+describe("PiRpcClient", () => {
+  it.effect("correlates responses while publishing interleaved events", () =>
+    Effect.gen(function* () {
+      const client = yield* makePiRpcClient({
+        binaryPath: "node",
+        args: [mockAgentPath],
+        cwd: process.cwd(),
+      });
+      const firstEvent = yield* client.events.pipe(
+        Stream.take(1),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      const state = yield* client.request({ type: "get_state" });
+
+      expect(state).toMatchObject({
+        command: "get_state",
+        success: true,
+        data: { sessionId: "mock-session" },
+      });
+      expect((yield* Fiber.join(firstEvent))._tag).toBe("Some");
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("round-trips extension dialogs and streams through agent settlement", () =>
+    Effect.gen(function* () {
+      const client = yield* makePiRpcClient({
+        binaryPath: "node",
+        args: [mockAgentPath],
+        cwd: process.cwd(),
+      });
+      const dialog = yield* Deferred.make<string>();
+      const settled = yield* Deferred.make<void>();
+      yield* client.events.pipe(
+        Stream.runForEach((event) => {
+          if (isPiRpcExtensionUIRequest(event) && event.method === "confirm") {
+            return Deferred.succeed(dialog, event.id);
+          }
+          if (isPiRpcAgentSettledEvent(event)) {
+            return Deferred.succeed(settled, undefined);
+          }
+          return Effect.void;
+        }),
+        Effect.forkChild,
+      );
+
+      expect(yield* client.request({ type: "prompt", message: "hello" })).toMatchObject({
+        command: "prompt",
+        success: true,
+      });
+      const dialogId = yield* Deferred.await(dialog);
+      yield* client.send({ type: "extension_ui_response", id: dialogId, confirmed: true });
+      yield* Deferred.await(settled);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("fails later operations after an unexpected child exit", () =>
+    Effect.gen(function* () {
+      const client = yield* makePiRpcClient({
+        binaryPath: "node",
+        args: [mockAgentPath],
+        cwd: process.cwd(),
+      });
+      yield* client.request({ type: "prompt", message: "exit" });
+      const failure = yield* client.awaitFailure.pipe(Effect.flip);
+      expect(failure).toMatchObject({ _tag: "PiRpcClientError", operation: "process-exit" });
+      expect(yield* client.request({ type: "abort" }).pipe(Effect.flip)).toBe(failure);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+});

--- a/apps/server/src/provider/pi/PiRpcClient.ts
+++ b/apps/server/src/provider/pi/PiRpcClient.ts
@@ -1,0 +1,305 @@
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Queue from "effect/Queue";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
+
+import {
+  encodePiRpcCommand,
+  isPiRpcResponse,
+  makePiJsonlDecoder,
+  type PiRpcCommand,
+  type PiRpcEnvelope,
+  type PiRpcResponse,
+} from "./PiRpcProtocol.ts";
+
+export class PiRpcClientError extends Schema.TaggedErrorClass<PiRpcClientError>()(
+  "PiRpcClientError",
+  {
+    operation: Schema.Literals(["spawn", "write", "protocol", "request", "process-exit", "closed"]),
+    detail: Schema.String,
+    exitCode: Schema.optionalKey(Schema.Number),
+    cause: Schema.optionalKey(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return `Pi RPC client ${this.operation} failed: ${this.detail}`;
+  }
+}
+const isPiRpcClientError = Schema.is(PiRpcClientError);
+
+export type PiRpcRequestCommand = Exclude<PiRpcCommand, { readonly type: "extension_ui_response" }>;
+
+export interface PiRpcClient {
+  readonly request: (
+    command: PiRpcRequestCommand,
+  ) => Effect.Effect<PiRpcResponse, PiRpcClientError>;
+  readonly send: (command: PiRpcCommand) => Effect.Effect<void, PiRpcClientError>;
+  readonly events: Stream.Stream<PiRpcEnvelope, PiRpcClientError>;
+  readonly awaitFailure: Effect.Effect<never, PiRpcClientError>;
+  readonly close: Effect.Effect<void>;
+}
+
+export interface PiRpcClientOptions {
+  readonly binaryPath: string;
+  readonly args: ReadonlyArray<string>;
+  readonly cwd: string;
+  readonly env?: Record<string, string>;
+  readonly maxLineBytes?: number;
+  readonly maxStderrChunkChars?: number;
+  readonly onStderr?: (chunk: string) => Effect.Effect<void>;
+}
+
+type PendingResponse = Deferred.Deferred<PiRpcResponse, PiRpcClientError>;
+
+export const makePiRpcClient = Effect.fn("makePiRpcClient")(function* (
+  options: PiRpcClientOptions,
+): Effect.fn.Return<
+  PiRpcClient,
+  PiRpcClientError,
+  ChildProcessSpawner.ChildProcessSpawner | Scope.Scope
+> {
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const scope = yield* Scope.Scope;
+  const spawnCommand = yield* resolveSpawnCommand(options.binaryPath, options.args, {
+    ...(options.env ? { env: options.env } : {}),
+    extendEnv: true,
+  });
+  const child = yield* spawner
+    .spawn(
+      ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+        cwd: options.cwd,
+        ...(options.env ? { env: options.env } : {}),
+        extendEnv: true,
+        shell: spawnCommand.shell,
+        stdin: { stream: "pipe", endOnDone: false },
+      }),
+    )
+    .pipe(
+      Effect.mapError(
+        (cause) =>
+          new PiRpcClientError({
+            operation: "spawn",
+            detail: `Could not start ${options.binaryPath}.`,
+            cause,
+          }),
+      ),
+    );
+
+  const eventQueue = yield* Queue.bounded<PiRpcEnvelope>(1_024);
+  const failure = yield* Deferred.make<never, PiRpcClientError>();
+  const failureRef = yield* Ref.make<Option.Option<PiRpcClientError>>(Option.none());
+  const pendingRef = yield* Ref.make(new Map<string, PendingResponse>());
+  const nextRequestIdRef = yield* Ref.make(1);
+  const stoppingRef = yield* Ref.make(false);
+  const writeLock = yield* Semaphore.make(1);
+  const textEncoder = new TextEncoder();
+
+  const failPending = Effect.fn("PiRpcClient.failPending")(function* (error: PiRpcClientError) {
+    const pending = yield* Ref.getAndSet(pendingRef, new Map());
+    yield* Effect.forEach(pending.values(), (deferred) => Deferred.fail(deferred, error), {
+      discard: true,
+    });
+  });
+
+  const recordFailure = Effect.fn("PiRpcClient.recordFailure")(function* (error: PiRpcClientError) {
+    const isFirst = yield* Ref.modify(failureRef, (current) =>
+      Option.isSome(current) ? ([false, current] as const) : ([true, Option.some(error)] as const),
+    );
+    if (!isFirst) return;
+    yield* failPending(error);
+    yield* Deferred.fail(failure, error);
+  });
+
+  const ensureConnected = Effect.fn("PiRpcClient.ensureConnected")(function* () {
+    const existing = yield* Ref.get(failureRef);
+    if (Option.isSome(existing)) {
+      return yield* existing.value;
+    }
+    if (yield* Ref.get(stoppingRef)) {
+      return yield* new PiRpcClientError({
+        operation: "closed",
+        detail: "The Pi RPC client is closed.",
+      });
+    }
+  });
+
+  const write = (command: PiRpcCommand): Effect.Effect<void, PiRpcClientError> =>
+    writeLock.withPermit(
+      ensureConnected().pipe(
+        Effect.andThen(
+          Stream.run(Stream.make(textEncoder.encode(encodePiRpcCommand(command))), child.stdin),
+        ),
+        Effect.mapError((cause) =>
+          isPiRpcClientError(cause)
+            ? cause
+            : new PiRpcClientError({
+                operation: "write",
+                detail: `Could not send ${command.type}.`,
+                cause,
+              }),
+        ),
+      ),
+    );
+
+  const handleMessage = Effect.fn("PiRpcClient.handleMessage")(function* (message: PiRpcEnvelope) {
+    if (!isPiRpcResponse(message) || message.id === undefined) {
+      yield* Queue.offer(eventQueue, message);
+      return;
+    }
+    const pending = yield* Ref.modify(pendingRef, (current) => {
+      const deferred = current.get(message.id!);
+      if (deferred === undefined) return [undefined, current] as const;
+      const next = new Map(current);
+      next.delete(message.id!);
+      return [deferred, next] as const;
+    });
+    if (pending === undefined) return;
+    if (!message.success) {
+      yield* Deferred.fail(
+        pending,
+        new PiRpcClientError({
+          operation: "request",
+          detail: message.error ?? `${message.command} was rejected by Pi.`,
+        }),
+      );
+      return;
+    }
+    yield* Deferred.succeed(pending, message);
+  });
+
+  const jsonl = makePiJsonlDecoder(
+    options.maxLineBytes === undefined ? undefined : { maxLineBytes: options.maxLineBytes },
+  );
+  yield* child.stdout.pipe(
+    Stream.runForEach((chunk) =>
+      Effect.try({
+        try: () => jsonl.push(chunk),
+        catch: (cause) =>
+          new PiRpcClientError({
+            operation: "protocol",
+            detail: "Pi emitted an invalid RPC record.",
+            cause,
+          }),
+      }).pipe(
+        Effect.flatMap((messages) => Effect.forEach(messages, handleMessage, { discard: true })),
+      ),
+    ),
+    Effect.flatMap(() =>
+      Effect.try({
+        try: () => jsonl.end(),
+        catch: (cause) =>
+          new PiRpcClientError({
+            operation: "protocol",
+            detail: "Pi ended with an invalid RPC record.",
+            cause,
+          }),
+      }),
+    ),
+    Effect.flatMap((messages) => Effect.forEach(messages, handleMessage, { discard: true })),
+    Effect.mapError((cause) =>
+      isPiRpcClientError(cause)
+        ? cause
+        : new PiRpcClientError({
+            operation: "protocol",
+            detail: "Could not read Pi RPC output.",
+            cause,
+          }),
+    ),
+    Effect.catch((error) => recordFailure(error)),
+    Effect.forkIn(scope),
+  );
+
+  const maxStderrChunkChars = options.maxStderrChunkChars ?? 4_096;
+  yield* child.stderr.pipe(
+    Stream.decodeText(),
+    Stream.runForEach((chunk) =>
+      options.onStderr ? options.onStderr(chunk.slice(-maxStderrChunkChars)) : Effect.void,
+    ),
+    Effect.ignore,
+    Effect.forkIn(scope),
+  );
+
+  yield* child.exitCode.pipe(
+    Effect.flatMap((exitCode) =>
+      Ref.get(stoppingRef).pipe(
+        Effect.flatMap((stopping) =>
+          stopping
+            ? Effect.void
+            : recordFailure(
+                new PiRpcClientError({
+                  operation: "process-exit",
+                  detail: `Pi exited with code ${Number(exitCode)}.`,
+                  exitCode: Number(exitCode),
+                }),
+              ),
+        ),
+      ),
+    ),
+    Effect.catch((cause) =>
+      recordFailure(
+        new PiRpcClientError({
+          operation: "process-exit",
+          detail: "Pi exited without a status code.",
+          cause,
+        }),
+      ),
+    ),
+    Effect.forkIn(scope),
+  );
+
+  const closeError = new PiRpcClientError({
+    operation: "closed",
+    detail: "The Pi RPC client was closed.",
+  });
+  const close = Ref.getAndSet(stoppingRef, true).pipe(
+    Effect.flatMap((wasStopping) =>
+      wasStopping
+        ? Effect.void
+        : failPending(closeError).pipe(
+            Effect.andThen(child.kill({ forceKillAfter: "1 second" }).pipe(Effect.ignore)),
+          ),
+    ),
+  );
+  yield* Scope.addFinalizer(scope, close);
+  yield* Scope.addFinalizer(scope, Queue.shutdown(eventQueue));
+
+  const request = Effect.fn("PiRpcClient.request")(function* (command: PiRpcRequestCommand) {
+    yield* ensureConnected();
+    const requestId = yield* Ref.getAndUpdate(nextRequestIdRef, (current) => current + 1);
+    const id = `t3-pi-${requestId}`;
+    const deferred = yield* Deferred.make<PiRpcResponse, PiRpcClientError>();
+    yield* Ref.update(pendingRef, (current) => {
+      const next = new Map(current);
+      next.set(id, deferred);
+      return next;
+    });
+    const correlated = { ...command, id } as PiRpcCommand;
+    return yield* write(correlated).pipe(
+      Effect.andThen(Deferred.await(deferred)),
+      Effect.ensuring(
+        Ref.update(pendingRef, (current) => {
+          if (current.get(id) !== deferred) return current;
+          const next = new Map(current);
+          next.delete(id);
+          return next;
+        }),
+      ),
+    );
+  });
+
+  return {
+    request,
+    send: write,
+    events: Stream.merge(Stream.fromQueue(eventQueue), Stream.fromEffect(Deferred.await(failure))),
+    awaitFailure: Deferred.await(failure),
+    close,
+  } satisfies PiRpcClient;
+});

--- a/apps/server/src/provider/pi/PiRpcProtocol.test.ts
+++ b/apps/server/src/provider/pi/PiRpcProtocol.test.ts
@@ -73,6 +73,11 @@ describe("Pi RPC protocol", () => {
     const first = cumulativeToolOutputDelta(undefined, "hel", 8);
     const second = cumulativeToolOutputDelta(first.state, "hello", 8);
     const oversizedAppend = cumulativeToolOutputDelta(second.state, `hello${"x".repeat(20)}`, 8);
+    const appendAfterTruncation = cumulativeToolOutputDelta(
+      oversizedAppend.state,
+      `hello${"x".repeat(20)}y`,
+      8,
+    );
     const replacement = cumulativeToolOutputDelta(second.state, "different output", 8);
 
     expect(first).toEqual({
@@ -88,6 +93,11 @@ describe("Pi RPC protocol", () => {
     expect(oversizedAppend).toEqual({
       delta: "xxxxxxxx",
       state: { length: 25, tail: "xxxxxxxx" },
+      replaced: true,
+    });
+    expect(appendAfterTruncation).toEqual({
+      delta: "xxxxxxxy",
+      state: { length: 26, tail: "xxxxxxxy" },
       replaced: true,
     });
     expect(replacement.replaced).toBe(true);

--- a/apps/server/src/provider/pi/PiRpcProtocol.test.ts
+++ b/apps/server/src/provider/pi/PiRpcProtocol.test.ts
@@ -1,0 +1,137 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodePath from "node:path";
+import * as NodeURL from "node:url";
+
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  PiResumeCursor,
+  cumulativeToolOutputDelta,
+  decodePiRpcMessage,
+  encodePiRpcCommand,
+  makePiJsonlDecoder,
+} from "./PiRpcProtocol.ts";
+
+const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
+
+describe("Pi RPC protocol", () => {
+  it("frames only on LF across split UTF-8 chunks and accepts CRLF", () => {
+    const decoder = makePiJsonlDecoder();
+    const encoded = new TextEncoder().encode(
+      `${JSON.stringify({ type: "message_update", assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "left\u2028middle\u2029right" } })}\r\n${JSON.stringify({ type: "agent_settled" })}\n`,
+    );
+
+    const messages = [
+      ...decoder.push(encoded.slice(0, 17)),
+      ...decoder.push(encoded.slice(17, 53)),
+      ...decoder.push(encoded.slice(53)),
+      ...decoder.end(),
+    ];
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({
+      type: "message_update",
+      assistantMessageEvent: { delta: "left\u2028middle\u2029right" },
+    });
+    expect(messages[1]).toEqual({ type: "agent_settled" });
+  });
+
+  it("decodes interleaved responses, lifecycle events, tools, and dialogs", () => {
+    const fixture = NodeFS.readFileSync(
+      NodePath.join(__dirname, "testFixtures/turn-lifecycle.jsonl"),
+    );
+    const decoder = makePiJsonlDecoder();
+    const messages = [
+      ...decoder.push(fixture.subarray(0, 97)),
+      ...decoder.push(fixture.subarray(97, 421)),
+      ...decoder.push(fixture.subarray(421)),
+      ...decoder.end(),
+    ];
+
+    expect(messages.map((message) => message.type)).toEqual([
+      "response",
+      "agent_start",
+      "message_update",
+      "message_update",
+      "tool_execution_start",
+      "tool_execution_update",
+      "tool_execution_update",
+      "extension_ui_request",
+      "tool_execution_end",
+      "agent_end",
+      "compaction_start",
+      "compaction_end",
+      "agent_start",
+      "agent_end",
+      "agent_settled",
+    ]);
+    expect(messages.filter((message) => message.type === "agent_settled")).toHaveLength(1);
+  });
+
+  it("bounds cumulative tool output while emitting only new suffixes when possible", () => {
+    const first = cumulativeToolOutputDelta(undefined, "hel", 8);
+    const second = cumulativeToolOutputDelta(first.state, "hello", 8);
+    const oversizedAppend = cumulativeToolOutputDelta(second.state, `hello${"x".repeat(20)}`, 8);
+    const replacement = cumulativeToolOutputDelta(second.state, "different output", 8);
+
+    expect(first).toEqual({
+      delta: "hel",
+      state: { length: 3, tail: "hel" },
+      replaced: false,
+    });
+    expect(second).toEqual({
+      delta: "lo",
+      state: { length: 5, tail: "hello" },
+      replaced: false,
+    });
+    expect(oversizedAppend).toEqual({
+      delta: "xxxxxxxx",
+      state: { length: 25, tail: "xxxxxxxx" },
+      replaced: true,
+    });
+    expect(replacement.replaced).toBe(true);
+    expect(replacement.state).toEqual({ length: 16, tail: "t output" });
+    expect(replacement.delta.length).toBeLessThanOrEqual(8);
+  });
+
+  it("validates dialog round-trips and a versioned durable resume cursor", () => {
+    expect(
+      decodePiRpcMessage({
+        type: "extension_ui_request",
+        id: "dialog-1",
+        method: "select",
+        title: "Choose",
+        options: ["A", "B"],
+      }),
+    ).toMatchObject({ method: "select", options: ["A", "B"] });
+    expect(
+      encodePiRpcCommand({
+        type: "extension_ui_response",
+        id: "dialog-1",
+        value: "B",
+      }),
+    ).toBe('{"type":"extension_ui_response","id":"dialog-1","value":"B"}\n');
+    expect(
+      PiResumeCursor.make({
+        schemaVersion: 1,
+        sessionFile: "/tmp/pi/session.jsonl",
+        sessionId: "session-1",
+        lastEntryId: "entry-9",
+      }),
+    ).toEqual({
+      schemaVersion: 1,
+      sessionFile: "/tmp/pi/session.jsonl",
+      sessionId: "session-1",
+      lastEntryId: "entry-9",
+    });
+  });
+
+  it("rejects malformed JSON and oversized unterminated records", () => {
+    const malformed = makePiJsonlDecoder();
+    expect(() => malformed.push(new TextEncoder().encode("{nope}\n"))).toThrow(/invalid JSON/i);
+
+    const oversized = makePiJsonlDecoder({ maxLineBytes: 8 });
+    expect(() => oversized.push(new TextEncoder().encode("123456789"))).toThrow(/exceeded 8/i);
+  });
+});

--- a/apps/server/src/provider/pi/PiRpcProtocol.ts
+++ b/apps/server/src/provider/pi/PiRpcProtocol.ts
@@ -1,0 +1,355 @@
+import * as Schema from "effect/Schema";
+
+const UnknownRecord = Schema.Record(Schema.String, Schema.Unknown);
+const OpenStruct = <const Fields extends Schema.Struct.Fields>(fields: Fields) =>
+  Schema.StructWithRest(Schema.Struct(fields), [UnknownRecord]);
+
+export class PiRpcProtocolError extends Schema.TaggedErrorClass<PiRpcProtocolError>()(
+  "PiRpcProtocolError",
+  {
+    operation: Schema.Literals(["frame", "parse-json", "decode-message"]),
+    detail: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Pi RPC ${this.operation} failed: ${this.detail}`;
+  }
+}
+
+export const PiRpcEnvelope = OpenStruct({ type: Schema.String.check(Schema.isNonEmpty()) });
+export type PiRpcEnvelope = typeof PiRpcEnvelope.Type;
+
+export const PiRpcResponse = OpenStruct({
+  id: Schema.optionalKey(Schema.String),
+  type: Schema.Literal("response"),
+  command: Schema.String,
+  success: Schema.Boolean,
+  data: Schema.optionalKey(Schema.Unknown),
+  error: Schema.optionalKey(Schema.String),
+});
+export type PiRpcResponse = typeof PiRpcResponse.Type;
+
+export const PiRpcAssistantMessageEvent = OpenStruct({
+  type: Schema.Literals([
+    "text_start",
+    "text_delta",
+    "text_end",
+    "thinking_start",
+    "thinking_delta",
+    "thinking_end",
+    "toolcall_start",
+    "toolcall_delta",
+    "toolcall_end",
+  ]),
+  contentIndex: Schema.Number,
+  delta: Schema.optionalKey(Schema.String),
+  content: Schema.optionalKey(Schema.String),
+  id: Schema.optionalKey(Schema.String),
+  toolName: Schema.optionalKey(Schema.String),
+  toolCall: Schema.optionalKey(Schema.Unknown),
+});
+export type PiRpcAssistantMessageEvent = typeof PiRpcAssistantMessageEvent.Type;
+
+export const PiRpcMessageUpdateEvent = OpenStruct({
+  type: Schema.Literal("message_update"),
+  usage: Schema.optionalKey(Schema.Unknown),
+  assistantMessageEvent: PiRpcAssistantMessageEvent,
+});
+export type PiRpcMessageUpdateEvent = typeof PiRpcMessageUpdateEvent.Type;
+
+const PiRpcToolContent = Schema.Array(
+  OpenStruct({
+    type: Schema.String,
+    text: Schema.optionalKey(Schema.String),
+  }),
+);
+
+const PiRpcToolResult = OpenStruct({
+  content: PiRpcToolContent,
+  details: Schema.optionalKey(Schema.Unknown),
+});
+
+export const PiRpcToolExecutionStartEvent = OpenStruct({
+  type: Schema.Literal("tool_execution_start"),
+  toolCallId: Schema.String.check(Schema.isNonEmpty()),
+  toolName: Schema.String.check(Schema.isNonEmpty()),
+  args: Schema.Unknown,
+});
+export type PiRpcToolExecutionStartEvent = typeof PiRpcToolExecutionStartEvent.Type;
+
+export const PiRpcToolExecutionUpdateEvent = OpenStruct({
+  type: Schema.Literal("tool_execution_update"),
+  toolCallId: Schema.String.check(Schema.isNonEmpty()),
+  toolName: Schema.String.check(Schema.isNonEmpty()),
+  args: Schema.Unknown,
+  partialResult: PiRpcToolResult,
+});
+export type PiRpcToolExecutionUpdateEvent = typeof PiRpcToolExecutionUpdateEvent.Type;
+
+export const PiRpcToolExecutionEndEvent = OpenStruct({
+  type: Schema.Literal("tool_execution_end"),
+  toolCallId: Schema.String.check(Schema.isNonEmpty()),
+  toolName: Schema.String.check(Schema.isNonEmpty()),
+  result: PiRpcToolResult,
+  isError: Schema.Boolean,
+});
+export type PiRpcToolExecutionEndEvent = typeof PiRpcToolExecutionEndEvent.Type;
+
+const PiRpcExtensionUIBase = {
+  type: Schema.Literal("extension_ui_request"),
+  id: Schema.String.check(Schema.isNonEmpty()),
+};
+
+export const PiRpcExtensionUIRequest = Schema.Union([
+  OpenStruct({
+    ...PiRpcExtensionUIBase,
+    method: Schema.Literal("select"),
+    title: Schema.String.check(Schema.isNonEmpty()),
+    options: Schema.Array(Schema.String),
+    timeout: Schema.optionalKey(Schema.Number),
+  }),
+  OpenStruct({
+    ...PiRpcExtensionUIBase,
+    method: Schema.Literal("confirm"),
+    title: Schema.String.check(Schema.isNonEmpty()),
+    message: Schema.String,
+    timeout: Schema.optionalKey(Schema.Number),
+  }),
+  OpenStruct({
+    ...PiRpcExtensionUIBase,
+    method: Schema.Literal("input"),
+    title: Schema.String.check(Schema.isNonEmpty()),
+    placeholder: Schema.optionalKey(Schema.String),
+    timeout: Schema.optionalKey(Schema.Number),
+  }),
+  OpenStruct({
+    ...PiRpcExtensionUIBase,
+    method: Schema.Literal("editor"),
+    title: Schema.String.check(Schema.isNonEmpty()),
+    prefill: Schema.optionalKey(Schema.String),
+  }),
+  OpenStruct({
+    ...PiRpcExtensionUIBase,
+    method: Schema.Literals(["notify", "setStatus", "setWidget", "setTitle", "set_editor_text"]),
+  }),
+]);
+export type PiRpcExtensionUIRequest = typeof PiRpcExtensionUIRequest.Type;
+
+export const PiRpcAgentSettledEvent = OpenStruct({ type: Schema.Literal("agent_settled") });
+export const PiRpcAgentStartEvent = OpenStruct({ type: Schema.Literal("agent_start") });
+export const PiRpcAgentEndEvent = OpenStruct({
+  type: Schema.Literal("agent_end"),
+  messages: Schema.optionalKey(Schema.Array(Schema.Unknown)),
+  willRetry: Schema.optionalKey(Schema.Boolean),
+});
+export const PiRpcCompactionStartEvent = OpenStruct({
+  type: Schema.Literal("compaction_start"),
+  reason: Schema.Literals(["manual", "threshold", "overflow"]),
+});
+export const PiRpcCompactionEndEvent = OpenStruct({
+  type: Schema.Literal("compaction_end"),
+  reason: Schema.Literals(["manual", "threshold", "overflow"]),
+  result: Schema.Unknown,
+  aborted: Schema.Boolean,
+  willRetry: Schema.Boolean,
+  errorMessage: Schema.optionalKey(Schema.String),
+});
+
+export const PiResumeCursor = Schema.Struct({
+  schemaVersion: Schema.Literal(1),
+  sessionFile: Schema.String.check(Schema.isNonEmpty()),
+  sessionId: Schema.String.check(Schema.isNonEmpty()),
+  lastEntryId: Schema.optionalKey(Schema.String.check(Schema.isNonEmpty())),
+});
+export type PiResumeCursor = typeof PiResumeCursor.Type;
+
+export type PiImageContent = {
+  readonly type: "image";
+  readonly data: string;
+  readonly mimeType: string;
+};
+
+export type PiRpcCommand =
+  | {
+      readonly id?: string;
+      readonly type: "prompt";
+      readonly message: string;
+      readonly images?: ReadonlyArray<PiImageContent>;
+      readonly streamingBehavior?: "steer" | "followUp";
+    }
+  | {
+      readonly id?: string;
+      readonly type: "steer" | "follow_up";
+      readonly message: string;
+      readonly images?: ReadonlyArray<PiImageContent>;
+    }
+  | {
+      readonly id?: string;
+      readonly type: "abort" | "clear_queue" | "get_state" | "get_available_models";
+    }
+  | {
+      readonly id?: string;
+      readonly type: "get_available_thinking_levels" | "get_commands" | "get_entries";
+      readonly since?: string;
+    }
+  | {
+      readonly id?: string;
+      readonly type: "set_model";
+      readonly provider: string;
+      readonly modelId: string;
+    }
+  | { readonly id?: string; readonly type: "set_thinking_level"; readonly level: string }
+  | { readonly id?: string; readonly type: "compact"; readonly customInstructions?: string }
+  | { readonly id?: string; readonly type: "switch_session"; readonly sessionPath: string }
+  | { readonly id?: string; readonly type: "set_session_name"; readonly name: string }
+  | { readonly type: "extension_ui_response"; readonly id: string; readonly value: string }
+  | { readonly type: "extension_ui_response"; readonly id: string; readonly confirmed: boolean }
+  | { readonly type: "extension_ui_response"; readonly id: string; readonly cancelled: true };
+
+const decodeEnvelope = Schema.decodeUnknownSync(PiRpcEnvelope);
+
+export function decodePiRpcMessage(input: unknown): PiRpcEnvelope {
+  try {
+    return decodeEnvelope(input);
+  } catch {
+    throw new PiRpcProtocolError({
+      operation: "decode-message",
+      detail: "message must be an object with a non-empty type",
+    });
+  }
+}
+
+export function encodePiRpcCommand(command: PiRpcCommand): string {
+  return `${JSON.stringify(command)}\n`;
+}
+
+export interface PiJsonlDecoder {
+  readonly push: (chunk: Uint8Array) => ReadonlyArray<PiRpcEnvelope>;
+  readonly end: () => ReadonlyArray<PiRpcEnvelope>;
+}
+
+export function makePiJsonlDecoder(options?: { readonly maxLineBytes?: number }): PiJsonlDecoder {
+  const maxLineBytes = options?.maxLineBytes ?? 4 * 1024 * 1024;
+  const textDecoder = new TextDecoder("utf-8", { fatal: true });
+  let segments: Uint8Array[] = [];
+  let bufferedBytes = 0;
+
+  const append = (segment: Uint8Array): void => {
+    if (segment.byteLength === 0) return;
+    bufferedBytes += segment.byteLength;
+    if (bufferedBytes > maxLineBytes) {
+      throw new PiRpcProtocolError({
+        operation: "frame",
+        detail: `record exceeded ${maxLineBytes} bytes`,
+      });
+    }
+    segments.push(segment.slice());
+  };
+
+  const consume = (): PiRpcEnvelope | undefined => {
+    if (bufferedBytes === 0) {
+      segments = [];
+      return undefined;
+    }
+    const record = new Uint8Array(bufferedBytes);
+    let offset = 0;
+    for (const segment of segments) {
+      record.set(segment, offset);
+      offset += segment.byteLength;
+    }
+    segments = [];
+    bufferedBytes = 0;
+    const end = record.at(-1) === 0x0d ? record.byteLength - 1 : record.byteLength;
+    let text: string;
+    try {
+      text = textDecoder.decode(record.subarray(0, end));
+    } catch {
+      throw new PiRpcProtocolError({
+        operation: "parse-json",
+        detail: "record was not valid UTF-8",
+      });
+    }
+    if (text.length === 0) return undefined;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      throw new PiRpcProtocolError({
+        operation: "parse-json",
+        detail: "record contained invalid JSON",
+      });
+    }
+    return decodePiRpcMessage(parsed);
+  };
+
+  return {
+    push: (chunk) => {
+      const messages: PiRpcEnvelope[] = [];
+      let start = 0;
+      for (let index = 0; index < chunk.byteLength; index += 1) {
+        if (chunk[index] !== 0x0a) continue;
+        append(chunk.subarray(start, index));
+        const message = consume();
+        if (message !== undefined) messages.push(message);
+        start = index + 1;
+      }
+      append(chunk.subarray(start));
+      return messages;
+    },
+    end: () => {
+      const message = consume();
+      return message === undefined ? [] : [message];
+    },
+  };
+}
+
+export interface CumulativeToolOutputState {
+  readonly length: number;
+  readonly tail: string;
+}
+
+export function cumulativeToolOutputDelta(
+  previous: CumulativeToolOutputState | undefined,
+  current: string,
+  maxRetainedChars = 64 * 1024,
+): {
+  readonly delta: string;
+  readonly state: CumulativeToolOutputState;
+  readonly replaced: boolean;
+} {
+  const tail = current.slice(-maxRetainedChars);
+  const state = { length: current.length, tail } satisfies CumulativeToolOutputState;
+  if (previous === undefined) {
+    return { delta: tail, state, replaced: current.length > maxRetainedChars };
+  }
+  const overlapStart = Math.max(0, previous.length - previous.tail.length);
+  const prefixStillMatches =
+    current.length >= previous.length &&
+    current.slice(overlapStart, previous.length) === previous.tail;
+  if (prefixStillMatches) {
+    const delta = current.slice(previous.length);
+    if (delta.length > maxRetainedChars) return { delta: tail, state, replaced: true };
+    return {
+      delta,
+      state,
+      replaced: false,
+    };
+  }
+  return {
+    delta: tail,
+    state,
+    replaced: true,
+  };
+}
+
+export const isPiRpcResponse = Schema.is(PiRpcResponse);
+export const isPiRpcMessageUpdateEvent = Schema.is(PiRpcMessageUpdateEvent);
+export const isPiRpcToolExecutionStartEvent = Schema.is(PiRpcToolExecutionStartEvent);
+export const isPiRpcToolExecutionUpdateEvent = Schema.is(PiRpcToolExecutionUpdateEvent);
+export const isPiRpcToolExecutionEndEvent = Schema.is(PiRpcToolExecutionEndEvent);
+export const isPiRpcExtensionUIRequest = Schema.is(PiRpcExtensionUIRequest);
+export const isPiRpcAgentSettledEvent = Schema.is(PiRpcAgentSettledEvent);
+export const isPiRpcAgentStartEvent = Schema.is(PiRpcAgentStartEvent);
+export const isPiRpcAgentEndEvent = Schema.is(PiRpcAgentEndEvent);
+export const isPiRpcCompactionStartEvent = Schema.is(PiRpcCompactionStartEvent);
+export const isPiRpcCompactionEndEvent = Schema.is(PiRpcCompactionEndEvent);

--- a/apps/server/src/provider/pi/PiRpcProtocol.ts
+++ b/apps/server/src/provider/pi/PiRpcProtocol.ts
@@ -328,6 +328,9 @@ export function cumulativeToolOutputDelta(
     current.slice(overlapStart, previous.length) === previous.tail;
   if (prefixStillMatches) {
     const delta = current.slice(previous.length);
+    if (current.length > previous.length && current.length > maxRetainedChars) {
+      return { delta: tail, state, replaced: true };
+    }
     if (delta.length > maxRetainedChars) return { delta: tail, state, replaced: true };
     return {
       delta,

--- a/apps/server/src/provider/pi/testFixtures/pi-rpc-mock-agent.mjs
+++ b/apps/server/src/provider/pi/testFixtures/pi-rpc-mock-agent.mjs
@@ -1,0 +1,89 @@
+import * as NodeStringDecoder from "node:string_decoder";
+
+const decoder = new NodeStringDecoder.StringDecoder("utf8");
+let buffer = "";
+
+function send(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+function handle(command) {
+  if (command.type === "get_state") {
+    send({ type: "queue_update", steering: [], followUp: [] });
+    send({
+      id: command.id,
+      type: "response",
+      command: command.type,
+      success: true,
+      data: {
+        model: { provider: "mock", id: "model-1" },
+        thinkingLevel: "medium",
+        isStreaming: false,
+        isCompacting: false,
+        steeringMode: "one-at-a-time",
+        followUpMode: "one-at-a-time",
+        sessionFile: "/tmp/pi/mock-session.jsonl",
+        sessionId: "mock-session",
+        autoCompactionEnabled: true,
+        messageCount: 0,
+        pendingMessageCount: 0,
+      },
+    });
+    return;
+  }
+
+  if (command.type === "prompt") {
+    send({ id: command.id, type: "response", command: "prompt", success: true });
+    if (command.message === "exit") {
+      process.exit(19);
+    }
+    send({ type: "agent_start" });
+    send({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "hello" },
+    });
+    send({
+      type: "extension_ui_request",
+      id: "dialog-1",
+      method: "confirm",
+      title: "Continue?",
+      message: "Finish the turn?",
+    });
+    return;
+  }
+
+  if (command.type === "extension_ui_response") {
+    send({ type: "agent_end", messages: [], willRetry: false });
+    send({ type: "agent_settled" });
+    return;
+  }
+
+  if (command.type === "abort") {
+    send({ id: command.id, type: "response", command: "abort", success: true });
+    return;
+  }
+
+  send({
+    id: command.id,
+    type: "response",
+    command: command.type,
+    success: false,
+    error: `Unsupported command: ${command.type}`,
+  });
+}
+
+process.stdin.on("data", (chunk) => {
+  buffer += decoder.write(chunk);
+  while (true) {
+    const newlineIndex = buffer.indexOf("\n");
+    if (newlineIndex < 0) break;
+    let line = buffer.slice(0, newlineIndex);
+    buffer = buffer.slice(newlineIndex + 1);
+    if (line.endsWith("\r")) line = line.slice(0, -1);
+    if (line.length > 0) handle(JSON.parse(line));
+  }
+});
+
+process.stdin.on("end", () => {
+  buffer += decoder.end();
+});

--- a/apps/server/src/provider/pi/testFixtures/pi-rpc-mock-agent.mjs
+++ b/apps/server/src/provider/pi/testFixtures/pi-rpc-mock-agent.mjs
@@ -3,8 +3,8 @@ import * as NodeStringDecoder from "node:string_decoder";
 const decoder = new NodeStringDecoder.StringDecoder("utf8");
 let buffer = "";
 
-function send(message) {
-  process.stdout.write(`${JSON.stringify(message)}\n`);
+function send(message, callback) {
+  process.stdout.write(`${JSON.stringify(message)}\n`, callback);
 }
 
 function handle(command) {
@@ -33,10 +33,13 @@ function handle(command) {
   }
 
   if (command.type === "prompt") {
-    send({ id: command.id, type: "response", command: "prompt", success: true });
     if (command.message === "exit") {
-      process.exit(19);
+      send({ id: command.id, type: "response", command: "prompt", success: true }, () => {
+        process.exit(19);
+      });
+      return;
     }
+    send({ id: command.id, type: "response", command: "prompt", success: true });
     send({ type: "agent_start" });
     send({
       type: "message_update",

--- a/apps/server/src/provider/pi/testFixtures/turn-lifecycle.jsonl
+++ b/apps/server/src/provider/pi/testFixtures/turn-lifecycle.jsonl
@@ -1,0 +1,15 @@
+{"id":"prompt-1","type":"response","command":"prompt","success":true}
+{"type":"agent_start"}
+{"type":"message_update","usage":{"input":10,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":11},"assistantMessageEvent":{"type":"thinking_delta","contentIndex":0,"delta":"Inspecting"}}
+{"type":"message_update","usage":{"input":10,"output":2,"cacheRead":0,"cacheWrite":0,"totalTokens":12},"assistantMessageEvent":{"type":"text_delta","contentIndex":1,"delta":"Hello"}}
+{"type":"tool_execution_start","toolCallId":"call-1","toolName":"bash","args":{"command":"printf hello"}}
+{"type":"tool_execution_update","toolCallId":"call-1","toolName":"bash","args":{"command":"printf hello"},"partialResult":{"content":[{"type":"text","text":"hel"}],"details":{}}}
+{"type":"tool_execution_update","toolCallId":"call-1","toolName":"bash","args":{"command":"printf hello"},"partialResult":{"content":[{"type":"text","text":"hello"}],"details":{}}}
+{"type":"extension_ui_request","id":"dialog-1","method":"confirm","title":"Continue?","message":"Run the next step?"}
+{"type":"tool_execution_end","toolCallId":"call-1","toolName":"bash","result":{"content":[{"type":"text","text":"hello"}],"details":{}},"isError":false}
+{"type":"agent_end","messages":[],"willRetry":true}
+{"type":"compaction_start","reason":"overflow"}
+{"type":"compaction_end","reason":"overflow","result":null,"aborted":false,"willRetry":true}
+{"type":"agent_start"}
+{"type":"agent_end","messages":[],"willRetry":false}
+{"type":"agent_settled"}

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -422,6 +422,26 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
+  it.effect("does not choose Pi Agent as a text generation fallback", () =>
+    Effect.gen(function* () {
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+
+      const next = yield* serverSettings.updateSettings({
+        providers: {
+          codex: { enabled: false },
+          claudeAgent: { enabled: false },
+          cursor: { enabled: false },
+          grok: { enabled: false },
+          opencode: { enabled: false },
+          antigravity: { enabled: false },
+          piAgent: { enabled: true },
+        },
+      });
+
+      assert.notEqual(next.textGenerationModelSelection.instanceId, "piAgent");
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
   it.effect(
     "preserves the source control writer selection when its provider instance is disabled",
     () =>
@@ -766,6 +786,33 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
+  it.effect("persists the opt-in Pi Agent enabled state", () =>
+    Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+
+      assert.isFalse((yield* serverSettings.getSettings).providers.piAgent.enabled);
+      yield* serverSettings.updateSettings({ providers: { piAgent: { enabled: true } } });
+      yield* serverSettings.updateSettings({ addProjectBaseDirectory: "~/Development" });
+
+      const raw = yield* fileSystem.readFileString(serverConfig.settingsPath);
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      assert.isTrue(JSON.parse(raw).providers.piAgent.enabled);
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect("restores Pi Agent enabled state from provider history", () =>
+    Effect.gen(function* () {
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      yield* recordProviderUsage("piAgent");
+
+      const settings = yield* serverSettings.getSettings;
+
+      assert.isTrue(settings.providers.piAgent.enabled);
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
   it.effect("keeps optional providers disabled after a new installation writes settings", () =>
     Effect.gen(function* () {
       const serverConfig = yield* ServerConfig.ServerConfig;
@@ -998,6 +1045,9 @@ it.layer(NodeServices.layer)("server settings", (it) => {
             enabled: false,
             serverUrl: "http://127.0.0.1:4096",
             serverPassword: "secret-password",
+          },
+          piAgent: {
+            enabled: false,
           },
         },
         backgroundActivity: {

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -259,6 +259,7 @@ const PersistedOptionalProviderSettings = Schema.Struct({
       cursor: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
       grok: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
       opencode: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
+      piAgent: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
     }),
   ),
 });
@@ -286,7 +287,8 @@ function restoreUsedProviders(
       instance.enabled === undefined &&
       (instance.driver === "cursor" ||
         instance.driver === "grok" ||
-        instance.driver === "opencode") &&
+        instance.driver === "opencode" ||
+        instance.driver === "piAgent") &&
       usedProviderInstances.has(instanceId)
         ? { ...instance, enabled: true }
         : instance,
@@ -309,6 +311,10 @@ function restoreUsedProviders(
         ...settings.providers.opencode,
         enabled: persisted.providers?.opencode?.enabled ?? usedProviders.has("opencode"),
       },
+      piAgent: {
+        ...settings.providers.piAgent,
+        enabled: persisted.providers?.piAgent?.enabled ?? usedProviders.has("piAgent"),
+      },
     },
     providerInstances,
   };
@@ -321,7 +327,11 @@ function resolveTextGenerationProvider(settings: ServerSettings): ServerSettings
 }
 
 function fallbackTextGenerationProvider(settings: ServerSettings): ServerSettings {
-  const fallbackEntry = Object.entries(settings.providers).find(([, provider]) => provider.enabled);
+  // Pi's RPC integration drives interactive agent sessions only. Keep the
+  // legacy provider fallback from selecting it for title/summary generation.
+  const fallbackEntry = Object.entries(settings.providers).find(
+    ([driver, provider]) => driver !== "piAgent" && provider.enabled,
+  );
   const fallback = fallbackEntry ? ProviderDriverKind.make(fallbackEntry[0]) : undefined;
   if (!fallback) {
     return settings;
@@ -356,6 +366,7 @@ const PERSISTED_SERVER_SETTINGS_DEFAULTS = {
     cursor: { ...DEFAULT_SERVER_SETTINGS.providers.cursor, enabled: undefined },
     grok: { ...DEFAULT_SERVER_SETTINGS.providers.grok, enabled: undefined },
     opencode: { ...DEFAULT_SERVER_SETTINGS.providers.opencode, enabled: undefined },
+    piAgent: { ...DEFAULT_SERVER_SETTINGS.providers.piAgent, enabled: undefined },
   },
 };
 
@@ -465,13 +476,13 @@ const make = Effect.gen(function* () {
         provider_name AS "providerName",
         provider_instance_id AS "providerInstanceId"
       FROM projection_thread_sessions
-      WHERE provider_name IN ('cursor', 'grok', 'opencode')
+      WHERE provider_name IN ('cursor', 'grok', 'opencode', 'piAgent')
       UNION
       SELECT DISTINCT
         provider_name AS "providerName",
         provider_instance_id AS "providerInstanceId"
       FROM provider_session_runtime
-      WHERE provider_name IN ('cursor', 'grok', 'opencode')
+      WHERE provider_name IN ('cursor', 'grok', 'opencode', 'piAgent')
     `.pipe(
       Effect.mapError(
         (cause) =>

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -7,7 +7,12 @@ import * as NodePath from "node:path";
 import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
-import { UsageDay, type UsageSummaryInput } from "@t3tools/contracts";
+import {
+  ProviderDriverKind,
+  ProviderInstanceId,
+  UsageDay,
+  type UsageSummaryInput,
+} from "@t3tools/contracts";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -35,6 +40,27 @@ function claudeLine(id: number, outputTokens: number): string {
   })}\n`;
 }
 
+function piLine(id: string, outputTokens: number): string {
+  return `${JSON.stringify({
+    type: "message",
+    id,
+    timestamp: "2026-08-01T11:00:00Z",
+    message: {
+      role: "assistant",
+      provider: "cliproxyapi",
+      model: "gpt-5.6-sol",
+      usage: {
+        input: 20,
+        output: outputTokens,
+        cacheRead: 30,
+        cacheWrite: 4,
+        reasoning: 3,
+        cost: { total: 0.25 },
+      },
+    },
+  })}\n`;
+}
+
 const WINDOW: UsageSummaryInput = {
   timeZone: "UTC",
   sinceDay: UsageDay.make("2026-07-31"),
@@ -49,14 +75,22 @@ const setup = Effect.gen(function* () {
     Effect.promise(() => NodeFSP.rm(home, { recursive: true, force: true })),
   );
   const transcriptDir = NodePath.join(home, "claude", "projects", "proj");
-  yield* Effect.promise(() => NodeFSP.mkdir(transcriptDir, { recursive: true }));
+  const piTranscriptDir = NodePath.join(home, "pi", "sessions", "project");
+  yield* Effect.promise(() =>
+    Promise.all([
+      NodeFSP.mkdir(transcriptDir, { recursive: true }),
+      NodeFSP.mkdir(piTranscriptDir, { recursive: true }),
+    ]),
+  );
   return {
     home,
     transcript: NodePath.join(transcriptDir, "session.jsonl"),
+    piTranscript: NodePath.join(piTranscriptDir, "pi-session.jsonl"),
     settings: {
       providers: {
         claudeAgent: { homePath: NodePath.join(home, "claude") },
         codex: { homePath: NodePath.join(home, "codex") },
+        piAgent: { agentDir: NodePath.join(home, "pi") },
       },
     },
   };
@@ -66,6 +100,7 @@ const serviceLayers = (input: {
   readonly prefix: string;
   readonly home: string;
   readonly settings: Parameters<typeof ServerSettings.layerTest>[0];
+  readonly piSessionDirEnv?: string;
   readonly onRatesFetch?: () => void;
   /** Defaults to an unparsable document so every scan retries the fetch. */
   readonly ratesDocument?: unknown;
@@ -87,7 +122,12 @@ const serviceLayers = (input: {
       ),
     ),
     Layer.provideMerge(
-      Layer.succeed(HostProcessEnvironment, { GROK_HOME: NodePath.join(input.home, "grok") }),
+      Layer.succeed(HostProcessEnvironment, {
+        GROK_HOME: NodePath.join(input.home, "grok"),
+        ...(input.piSessionDirEnv === undefined
+          ? {}
+          : { PI_CODING_AGENT_SESSION_DIR: input.piSessionDirEnv }),
+      }),
     ),
   );
 
@@ -96,6 +136,220 @@ function totalOutputTokens(summary: { buckets: readonly { totals: { outputTokens
 }
 
 describe("UsageService", () => {
+  it.live("includes Pi sessions from the configured agent directory", () =>
+    Effect.gen(function* () {
+      const { piTranscript, settings, home } = yield* setup;
+      yield* Effect.promise(() => NodeFSP.writeFile(piTranscript, piLine("pi-entry-1", 7)));
+
+      const service = yield* UsageService.make.pipe(
+        Effect.provide(serviceLayers({ prefix: "usage-service-pi-test", home, settings })),
+      );
+
+      const summary = yield* service.readSummary(WINDOW);
+      const piBucket = summary.buckets.find((bucket) => bucket.provider === "pi");
+      const piSource = summary.sources.find((source) => source.fingerprint.provider === "pi");
+
+      assert.deepStrictEqual(piBucket?.totals, {
+        uncachedInputTokens: 20,
+        cachedInputTokens: 30,
+        cacheCreationTokens: 4,
+        outputTokens: 7,
+        reasoningTokens: 3,
+      });
+      assert.strictEqual(piBucket?.model, "gpt-5.6-sol");
+      assert.strictEqual(piBucket?.costUsd, 0.25);
+      assert.strictEqual(piBucket?.costSource, "providerReported");
+      assert.strictEqual(piSource?.distinctSessions, 1);
+      assert.strictEqual(
+        piSource?.fingerprint.resolvedHomePath,
+        NodePath.join(home, "pi", "sessions"),
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("uses PI_CODING_AGENT_SESSION_DIR when sessionDir is not configured", () =>
+    Effect.gen(function* () {
+      const { settings, home } = yield* setup;
+      const envSessionDir = NodePath.join(home, "pi-env-sessions");
+      const envTranscript = NodePath.join(envSessionDir, "project", "pi-session.jsonl");
+      yield* Effect.promise(() =>
+        NodeFSP.mkdir(NodePath.dirname(envTranscript), { recursive: true }),
+      );
+      yield* Effect.promise(() => NodeFSP.writeFile(envTranscript, piLine("pi-env-entry", 11)));
+
+      const service = yield* UsageService.make.pipe(
+        Effect.provide(
+          serviceLayers({
+            prefix: "usage-service-pi-env-test",
+            home,
+            settings,
+            piSessionDirEnv: envSessionDir,
+          }),
+        ),
+      );
+
+      const summary = yield* service.readSummary(WINDOW);
+      const piBucket = summary.buckets.find((bucket) => bucket.provider === "pi");
+      const piSource = summary.sources.find((source) => source.fingerprint.provider === "pi");
+
+      assert.strictEqual(piBucket?.totals.outputTokens, 11);
+      assert.strictEqual(piSource?.fingerprint.resolvedHomePath, envSessionDir);
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("prefers configured Pi sessionDir over PI_CODING_AGENT_SESSION_DIR", () =>
+    Effect.gen(function* () {
+      const { settings, home } = yield* setup;
+      const configuredSessionDir = NodePath.join(home, "pi-configured-sessions");
+      const envSessionDir = NodePath.join(home, "pi-env-sessions");
+      const configuredTranscript = NodePath.join(configuredSessionDir, "project", "pi.jsonl");
+      const envTranscript = NodePath.join(envSessionDir, "project", "pi.jsonl");
+      yield* Effect.promise(() =>
+        Promise.all([
+          NodeFSP.mkdir(NodePath.dirname(configuredTranscript), { recursive: true }),
+          NodeFSP.mkdir(NodePath.dirname(envTranscript), { recursive: true }),
+        ]),
+      );
+      yield* Effect.promise(() =>
+        Promise.all([
+          NodeFSP.writeFile(configuredTranscript, piLine("pi-configured-entry", 13)),
+          NodeFSP.writeFile(envTranscript, piLine("pi-env-entry", 97)),
+        ]),
+      );
+
+      const configuredSettings = {
+        ...settings,
+        providers: {
+          ...settings.providers,
+          piAgent: { ...settings.providers.piAgent, sessionDir: configuredSessionDir },
+        },
+      };
+      const service = yield* UsageService.make.pipe(
+        Effect.provide(
+          serviceLayers({
+            prefix: "usage-service-pi-precedence-test",
+            home,
+            settings: configuredSettings,
+            piSessionDirEnv: envSessionDir,
+          }),
+        ),
+      );
+
+      const summary = yield* service.readSummary(WINDOW);
+      const piBucket = summary.buckets.find((bucket) => bucket.provider === "pi");
+      const piSource = summary.sources.find((source) => source.fingerprint.provider === "pi");
+
+      assert.strictEqual(piBucket?.totals.outputTokens, 13);
+      assert.strictEqual(piSource?.fingerprint.resolvedHomePath, configuredSessionDir);
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("includes sessions from enabled explicit Pi provider instances", () =>
+    Effect.gen(function* () {
+      const { settings, home } = yield* setup;
+      const instanceSessionDir = NodePath.join(home, "pi-instance-sessions");
+      const instanceTranscript = NodePath.join(instanceSessionDir, "project", "pi.jsonl");
+      yield* Effect.promise(() =>
+        NodeFSP.mkdir(NodePath.dirname(instanceTranscript), { recursive: true }),
+      );
+      yield* Effect.promise(() =>
+        NodeFSP.writeFile(instanceTranscript, piLine("pi-instance-entry", 17)),
+      );
+
+      const instanceId = ProviderInstanceId.make("pi-work");
+      const instanceSettings = {
+        ...settings,
+        providerInstances: {
+          [instanceId]: {
+            driver: ProviderDriverKind.make("piAgent"),
+            enabled: true,
+            config: { sessionDir: instanceSessionDir },
+          },
+        },
+      };
+      const service = yield* UsageService.make.pipe(
+        Effect.provide(
+          serviceLayers({
+            prefix: "usage-service-pi-instance-test",
+            home,
+            settings: instanceSettings,
+          }),
+        ),
+      );
+
+      const summary = yield* service.readSummary(WINDOW);
+      const piBucket = summary.buckets.find((bucket) => bucket.provider === "pi");
+      const piSource = summary.sources.find(
+        (source) => source.fingerprint.resolvedHomePath === instanceSessionDir,
+      );
+
+      assert.strictEqual(piBucket?.totals.outputTokens, 17);
+      assert.strictEqual(piSource?.fingerprint.resolvedHomePath, instanceSessionDir);
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("deduplicates Pi session directories shared by legacy and explicit instances", () =>
+    Effect.gen(function* () {
+      const { settings, home } = yield* setup;
+      const sharedSessionDir = NodePath.join(home, "pi-shared-sessions");
+      const instanceSessionDir = NodePath.join(home, "pi-instance-sessions");
+      const sharedTranscript = NodePath.join(sharedSessionDir, "project", "shared.jsonl");
+      const instanceTranscript = NodePath.join(instanceSessionDir, "project", "instance.jsonl");
+      yield* Effect.promise(() =>
+        Promise.all([
+          NodeFSP.mkdir(NodePath.dirname(sharedTranscript), { recursive: true }),
+          NodeFSP.mkdir(NodePath.dirname(instanceTranscript), { recursive: true }),
+        ]),
+      );
+      yield* Effect.promise(() =>
+        Promise.all([
+          NodeFSP.writeFile(sharedTranscript, piLine("pi-shared-entry", 5)),
+          NodeFSP.writeFile(instanceTranscript, piLine("pi-instance-entry", 7)),
+        ]),
+      );
+
+      const legacySettings = {
+        ...settings,
+        providers: {
+          ...settings.providers,
+          piAgent: { ...settings.providers.piAgent, sessionDir: sharedSessionDir },
+        },
+        providerInstances: {
+          [ProviderInstanceId.make("pi-shared")]: {
+            driver: ProviderDriverKind.make("piAgent"),
+            enabled: true,
+            config: { sessionDir: sharedSessionDir },
+          },
+          [ProviderInstanceId.make("pi-work")]: {
+            driver: ProviderDriverKind.make("piAgent"),
+            enabled: true,
+            config: { sessionDir: instanceSessionDir },
+          },
+        },
+      };
+      const service = yield* UsageService.make.pipe(
+        Effect.provide(
+          serviceLayers({
+            prefix: "usage-service-pi-instance-dedupe-test",
+            home,
+            settings: legacySettings,
+          }),
+        ),
+      );
+
+      const summary = yield* service.readSummary(WINDOW);
+      const piBucket = summary.buckets.find((bucket) => bucket.provider === "pi");
+      const piSources = summary.sources.filter((source) => source.fingerprint.provider === "pi");
+
+      assert.strictEqual(piBucket?.totals.outputTokens, 12);
+      assert.strictEqual(piSources.length, 2);
+      assert.deepStrictEqual(
+        new Set(piSources.map((source) => source.fingerprint.resolvedHomePath)),
+        new Set([sharedSessionDir, instanceSessionDir]),
+      );
+    }).pipe(Effect.scoped),
+  );
+
   it.live("counts appended usage on a rescan of a grown transcript", () =>
     Effect.gen(function* () {
       const { transcript, settings, home } = yield* setup;

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -1,9 +1,10 @@
 /**
  * UsageService - scans provider transcripts and returns priced usage buckets.
  *
- * The scan reads the provider CLIs' own session files (Claude Code, Codex, and
- * Grok Build) rather than T3 Code's orchestration projections, so usage covers
- * turns driven outside T3 Code too. This is the approach `ccusage` takes.
+ * The scan reads the provider CLIs' own session files (Claude Code, Codex,
+ * Grok Build, and Pi Agent) rather than T3 Code's orchestration projections,
+ * so usage covers turns driven outside T3 Code too. This is the approach
+ * `ccusage` takes.
  *
  * Transcripts are append-only, so parsed records are memoised per file by
  * `(size, mtime)`. A cold 30-day scan of ~1.4 GB lands around 2-3 seconds; warm
@@ -16,6 +17,7 @@ import * as NodeOS from "node:os";
 
 import {
   USAGE_CONTRACT_VERSION,
+  PiAgentSettings,
   type UsageProviderKind,
   type UsageSource,
   type UsagePricing,
@@ -94,6 +96,7 @@ const encodeRatesCache = Schema.encodeEffect(
 const ScanCacheJson = Schema.fromJsonString(Schema.Unknown as unknown as Schema.Codec<unknown>);
 const decodeScanCacheFile = Schema.decodeUnknownEffect(ScanCacheJson);
 const encodeScanCacheFile = Schema.encodeEffect(ScanCacheJson);
+const decodePiAgentSettings = Schema.decodeUnknownOption(PiAgentSettings);
 
 export class UsageService extends Context.Service<
   UsageService,
@@ -260,6 +263,38 @@ export const make = Effect.gen(function* () {
       grokHomeEnv.length > 0
         ? path.resolve(expandHomePath(grokHomeEnv))
         : path.join(NodeOS.homedir(), ".grok");
+    const resolvePiSessionDir = (
+      piSettings: PiAgentSettings,
+      environment: NodeJS.ProcessEnv,
+    ): string => {
+      const agentDirSetting = piSettings.agentDir.trim();
+      const agentDirEnv = environment["PI_CODING_AGENT_DIR"]?.trim() ?? "";
+      const agentDirOverride = agentDirSetting || agentDirEnv;
+      const agentDir =
+        agentDirOverride.length > 0
+          ? path.resolve(config.cwd, expandHomePath(agentDirOverride))
+          : path.join(NodeOS.homedir(), ".pi", "agent");
+      const sessionDirSetting = piSettings.sessionDir.trim();
+      const sessionDirEnv = environment["PI_CODING_AGENT_SESSION_DIR"]?.trim() ?? "";
+      const sessionDirOverride = sessionDirSetting || sessionDirEnv;
+      return sessionDirOverride.length > 0
+        ? path.resolve(config.cwd, expandHomePath(sessionDirOverride))
+        : path.join(agentDir, "sessions");
+    };
+
+    const piSessionDirs = new Set([
+      resolvePiSessionDir(settings.providers.piAgent, hostEnvironment),
+    ]);
+    for (const instance of Object.values(settings.providerInstances)) {
+      if (instance.driver !== "piAgent") continue;
+      const decoded = decodePiAgentSettings(instance.config ?? {});
+      if (Option.isNone(decoded)) continue;
+      const instanceEnvironment = { ...hostEnvironment };
+      for (const variable of instance.environment ?? []) {
+        instanceEnvironment[variable.name] = variable.value;
+      }
+      piSessionDirs.add(resolvePiSessionDir(decoded.value, instanceEnvironment));
+    }
 
     return [
       { provider: "claude" as const, dir: claudeDir },
@@ -269,6 +304,7 @@ export const make = Effect.gen(function* () {
         dir: path.join(grokHome, "sessions"),
         fileName: "updates.jsonl",
       },
+      ...[...piSessionDirs].map((dir) => ({ provider: "pi" as const, dir, fileName: undefined })),
     ];
   });
 

--- a/apps/server/src/usage/usagePricing.test.ts
+++ b/apps/server/src/usage/usagePricing.test.ts
@@ -61,4 +61,28 @@ describe("usage pricing", () => {
     expect(lookupRate(table, "provider-b/example-model")?.inputCostPerToken).toBe(3);
     expect(lookupRate(table, "example-model")).toBeNull();
   });
+
+  it("prices an effort-suffixed variant at the base model's rate", () => {
+    const table = parseRateTable({ "gemini-3.8-flash": rate(7.5e-7, 7.5e-8) });
+
+    expect(lookupRate(table, "gemini-3.8-flash-high")).toEqual(
+      lookupRate(table, "gemini-3.8-flash"),
+    );
+    expect(lookupRate(table, "gemini-3.8-flash-medium")).toEqual(
+      lookupRate(table, "gemini-3.8-flash"),
+    );
+    expect(lookupRate(table, "gemini-3.8-flash-low")).toEqual(
+      lookupRate(table, "gemini-3.8-flash"),
+    );
+    expect(lookupRate(table, "gemini/gemini-3.8-flash-high")).toEqual(
+      lookupRate(table, "gemini-3.8-flash"),
+    );
+  });
+
+  it("leaves an effort-suffixed variant unpriced when the base is unknown", () => {
+    const table = parseRateTable({ "some-other-model": rate(1) });
+
+    expect(lookupRate(table, "gemini-3.8-flash-high")).toBeNull();
+    expect(lookupRate(table, "gpt-5.6-sol")).toBeNull();
+  });
 });

--- a/apps/server/src/usage/usagePricing.ts
+++ b/apps/server/src/usage/usagePricing.ts
@@ -130,6 +130,21 @@ function stripVariantSuffix(key: string): string {
 }
 
 /**
+ * Drops a trailing effort suffix such as `-high`, `-medium`, or `-low`.
+ *
+ * Some drivers bake the reasoning effort into the model slug
+ * (`gemini-3.8-flash-high`) while LiteLLM only publishes the base model
+ * (`gemini-3.8-flash`). Effort changes how many tokens a turn burns, not the
+ * per-token rate, so pricing the variant at the base rate matches the
+ * base-tier policy above instead of reporting the variant as unpriced.
+ */
+const EFFORT_SUFFIX = /-(high|medium|low)$/;
+
+function stripEffortSuffix(key: string): string {
+  return key.replace(EFFORT_SUFFIX, "");
+}
+
+/**
  * Models we never price, regardless of the table.
  *
  * `<synthetic>` marks locally generated messages that were never billed. Bare
@@ -149,7 +164,17 @@ export function lookupRate(table: RateTable, model: string): ModelRate | null {
   const key = stripVariantSuffix(normalizeRateKey(model));
   const bareName = bareModelName(key);
   if (bareName.length === 0 || UNPRICEABLE_MODELS.has(bareName)) return null;
-  return table.get(key) ?? null;
+  const direct = table.get(key);
+  if (direct !== undefined) return direct;
+  // Effort-baked slugs fall back to the base model's rate (see
+  // `stripEffortSuffix`). The bare-name alias of the base is covered too, for
+  // provider-qualified variants whose base only exists as an alias.
+  const baseKey = stripEffortSuffix(key);
+  if (baseKey !== key) {
+    const base = table.get(baseKey) ?? table.get(bareModelName(baseKey));
+    if (base !== undefined) return base;
+  }
+  return null;
 }
 
 export interface PricedUsage {

--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -97,6 +97,34 @@ describe("scan cache round trip", () => {
     expect(restored.get("/codex.jsonl")).toEqual(original.get("/codex.jsonl"));
   });
 
+  it("restores Pi records unchanged", () => {
+    const original: ScanCache = new Map([
+      [
+        "/pi.jsonl",
+        {
+          size: 40,
+          mtimeMs: 300,
+          provider: "pi",
+          records: [
+            record({
+              provider: "pi",
+              model: "gpt-5.6-sol",
+              sessionId: "pi-session",
+              reportedCostUsd: 0.25,
+              dedupeKey: "pi:entry-1",
+            }),
+          ],
+          tailRecords: [],
+          position: position(),
+        },
+      ],
+    ]);
+
+    const restored = decodeScanCache(JSON.parse(JSON.stringify(encodeScanCache(original))));
+
+    expect(restored.get("/pi.jsonl")).toEqual(original.get("/pi.jsonl"));
+  });
+
   it("drops an entry whose persisted parse state is corrupt", () => {
     // Resuming with a bad reducer state would attach appended usage to the
     // wrong model or replay fork-copied history; that entry must cold parse.

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -219,7 +219,9 @@ export function decodeScanCache(document: unknown): ScanCache {
     if (typeof raw !== "object" || raw === null) continue;
     const entry = raw as Partial<SerializedFile>;
     if (typeof entry.s !== "number" || typeof entry.m !== "number") continue;
-    if (entry.p !== "claude" && entry.p !== "codex" && entry.p !== "grok") continue;
+    if (entry.p !== "claude" && entry.p !== "codex" && entry.p !== "grok" && entry.p !== "pi") {
+      continue;
+    }
     if (!isRecordArray(entry.r) || !isRecordArray(entry.t)) continue;
     // Position fields feed byte offsets and a Buffer allocation in the reader,
     // so anything outside their real ranges must reject the entry: a bogus

--- a/apps/server/src/usage/usageTranscriptReader.ts
+++ b/apps/server/src/usage/usageTranscriptReader.ts
@@ -26,6 +26,7 @@ import {
   parseClaudeLine,
   parseCodexLine,
   parseGrokLine,
+  parsePiLine,
   type CodexScanState,
   type UsageRecord,
 } from "./usageTranscripts.ts";
@@ -233,6 +234,11 @@ export async function readTranscriptRecords(
       if (!mightCarryUsage(line, provider)) return;
       if (provider === "grok") {
         for (const grokRecord of parseGrokLine(line)) out.push(grokRecord);
+        return;
+      }
+      if (provider === "pi") {
+        const record = parsePiLine(line, NodePath.basename(filePath, ".jsonl"));
+        if (record !== null) out.push(record);
         return;
       }
       const record = parseClaudeLine(line);

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -6,6 +6,7 @@ import {
   parseClaudeLine,
   parseCodexLine,
   parseGrokLine,
+  parsePiLine,
   totalTokens,
 } from "./usageTranscripts.ts";
 
@@ -249,6 +250,137 @@ describe("totalTokens", () => {
         reasoningTokens: 25,
       }),
     ).toBe(100);
+  });
+});
+
+describe("parsePiLine", () => {
+  const assistantLine = (overrides?: {
+    role?: string;
+    model?: string;
+    responseModel?: string;
+    timestamp?: string;
+    usage?: Record<string, unknown>;
+  }) =>
+    JSON.stringify({
+      type: "message",
+      id: "a7e96ec5",
+      timestamp: overrides?.timestamp ?? "2026-09-04T09:31:41.064Z",
+      message: {
+        role: overrides?.role ?? "assistant",
+        provider: "cliproxyapi",
+        model: overrides?.model ?? "gpt-5.6-sol",
+        responseModel: overrides?.responseModel,
+        usage: {
+          input: 2595,
+          output: 335,
+          cacheRead: 1024,
+          cacheWrite: 256,
+          reasoning: 73,
+          totalTokens: 4210,
+          cost: {
+            input: 0.01038,
+            output: 0.0067,
+            cacheRead: 0.0004096,
+            cacheWrite: 0.001024,
+            total: 0.0185136,
+          },
+          ...overrides?.usage,
+        },
+      },
+    });
+
+  it("extracts Pi's disjoint token totals and provider-reported cost", () => {
+    const record = parsePiLine(assistantLine(), "pi-session-1");
+
+    expect(record?.provider).toBe("pi");
+    expect(record?.model).toBe("gpt-5.6-sol");
+    expect(record?.sessionId).toBe("pi-session-1");
+    expect(record?.timestampMs).toBe(Date.parse("2026-09-04T09:31:41.064Z"));
+    expect(record?.totals).toEqual({
+      uncachedInputTokens: 2595,
+      cachedInputTokens: 1024,
+      cacheCreationTokens: 256,
+      outputTokens: 335,
+      reasoningTokens: 73,
+    });
+    expect(record?.reportedCostUsd).toBeCloseTo(0.0185136, 12);
+    expect(record?.dedupeKey).toBe("pi:a7e96ec5");
+  });
+
+  it("attributes usage to Pi's response model when it differs from the requested model", () => {
+    const record = parsePiLine(
+      assistantLine({ model: "requested-model", responseModel: "provider-model" }),
+      "pi-session-1",
+    );
+
+    expect(record?.model).toBe("provider-model");
+  });
+
+  it("counts Pi tool-result usage under the Tools/summaries bucket", () => {
+    const record = parsePiLine(
+      assistantLine({
+        role: "toolResult",
+        model: "requested-model",
+        responseModel: "provider-model",
+      }),
+      "pi-session-1",
+    );
+
+    expect(record?.model).toBe("Tools/summaries");
+    expect(record?.totals.outputTokens).toBe(335);
+  });
+
+  it.each(["compaction", "branch_summary"])("counts %s usage as Tools/summaries", (type) => {
+    const record = parsePiLine(
+      JSON.stringify({
+        type,
+        id: `${type}-1`,
+        timestamp: "2026-09-04T09:31:41.064Z",
+        usage: {
+          input: 12,
+          output: 8,
+          cacheRead: 4,
+          cacheWrite: 2,
+          reasoning: 3,
+          cost: { total: 0.25 },
+        },
+      }),
+      "pi-session-1",
+    );
+
+    expect(record).toMatchObject({
+      provider: "pi",
+      model: "Tools/summaries",
+      sessionId: "pi-session-1",
+      totals: {
+        uncachedInputTokens: 12,
+        cachedInputTokens: 4,
+        cacheCreationTokens: 2,
+        outputTokens: 8,
+        reasoningTokens: 3,
+      },
+      reportedCostUsd: 0.25,
+      dedupeKey: `pi:${type}-1`,
+    });
+  });
+
+  it("ignores non-assistant, malformed, model-less, and zero-token entries", () => {
+    expect(parsePiLine(assistantLine({ model: "" }), "session")).toBeNull();
+    expect(
+      parsePiLine(
+        assistantLine({
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            reasoning: 0,
+          },
+        }),
+        "session",
+      ),
+    ).toBeNull();
+    expect(parsePiLine("not json", "session")).toBeNull();
   });
 });
 

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -68,7 +68,7 @@ export function totalTokens(totals: UsageTokenTotals): number {
  * an order of magnitude.
  */
 export function mightCarryUsage(line: string, provider: UsageProviderKind): boolean {
-  if (provider === "claude") return line.includes('"usage"');
+  if (provider === "claude" || provider === "pi") return line.includes('"usage"');
   if (provider === "grok") return line.includes('"turn_completed"');
   return line.includes('"token_count"');
 }
@@ -82,6 +82,98 @@ export const GROK_COST_USD_TICKS_PER_DOLLAR = 10_000_000_000;
 export function grokCostTicksToUsd(ticks: unknown): number | null {
   if (typeof ticks !== "number" || !Number.isFinite(ticks) || ticks < 0) return null;
   return ticks / GROK_COST_USD_TICKS_PER_DOLLAR;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Pi Agent                                                                   */
+/* -------------------------------------------------------------------------- */
+
+const PI_AUXILIARY_USAGE_MODEL = "Tools/summaries";
+
+function parsePiUsageRecord(
+  record: Record<string, unknown>,
+  usage: unknown,
+  sessionId: string,
+  model: string,
+): UsageRecord | null {
+  if (typeof usage !== "object" || usage === null) return null;
+  const usageRecord = usage as Record<string, unknown>;
+  const timestampMs = parseTimestampMs(record["timestamp"]);
+  if (timestampMs === null) return null;
+
+  const outputTokens = int(usageRecord["output"]);
+  const totals: UsageTokenTotals = {
+    uncachedInputTokens: int(usageRecord["input"]),
+    cachedInputTokens: int(usageRecord["cacheRead"]),
+    cacheCreationTokens: int(usageRecord["cacheWrite"]),
+    outputTokens,
+    reasoningTokens: Math.min(outputTokens, int(usageRecord["reasoning"])),
+  };
+  if (totalTokens(totals) === 0) return null;
+
+  const cost = usageRecord["cost"];
+  const reportedCost =
+    typeof cost === "object" && cost !== null ? (cost as Record<string, unknown>)["total"] : null;
+  const entryId = typeof record["id"] === "string" ? record["id"] : null;
+
+  return {
+    provider: "pi",
+    timestampMs,
+    model,
+    sessionId,
+    totals,
+    reportedCostUsd:
+      typeof reportedCost === "number" && Number.isFinite(reportedCost) && reportedCost >= 0
+        ? reportedCost
+        : null,
+    // Pi preserves entry ids when a session tree is copied, so this also
+    // prevents copied history from being counted again in another file.
+    dedupeKey: entryId === null ? null : `pi:${entryId}`,
+  };
+}
+
+/**
+ * Parses one usage-bearing entry from a Pi session JSONL file.
+ *
+ * Pi reports uncached input, cache reads, cache writes, output, reasoning, and
+ * exact provider cost as disjoint fields. Assistant responses carry their
+ * response model; tool results and summary entries do not have reliable model
+ * attribution and therefore share Pi's `Tools/summaries` bucket.
+ */
+export function parsePiLine(line: string, sessionId: string): UsageRecord | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+
+  const record = parsed as Record<string, unknown>;
+  const type = record["type"];
+  if (type === "compaction" || type === "branch_summary") {
+    return parsePiUsageRecord(record, record["usage"], sessionId, PI_AUXILIARY_USAGE_MODEL);
+  }
+  if (type !== "message") return null;
+
+  const message = record["message"];
+  if (typeof message !== "object" || message === null) return null;
+  const messageRecord = message as Record<string, unknown>;
+  const role = messageRecord["role"];
+  if (role !== "assistant" && role !== "toolResult") return null;
+
+  if (role === "toolResult") {
+    return parsePiUsageRecord(record, messageRecord["usage"], sessionId, PI_AUXILIARY_USAGE_MODEL);
+  }
+
+  const responseModel =
+    typeof messageRecord["responseModel"] === "string" ? messageRecord["responseModel"].trim() : "";
+  const model =
+    responseModel ||
+    (typeof messageRecord["model"] === "string" ? messageRecord["model"].trim() : "");
+  if (model.length === 0) return null;
+
+  return parsePiUsageRecord(record, messageRecord["usage"], sessionId, model);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -28,6 +28,10 @@ import {
 import { type EnvironmentConnectionPresentation } from "@t3tools/client-runtime/connection";
 import { wasBootstrapThreadDeleted } from "@t3tools/client-runtime/errors";
 import { type CodexArtifactTemplate } from "@t3tools/client-runtime/codex-artifact-templates";
+import {
+  getProviderSupportedRuntimeModes,
+  reconcileRuntimeMode,
+} from "@t3tools/client-runtime/runtime-mode-options";
 import { effectiveSnoozed, threadWokeAt } from "@t3tools/client-runtime/state/thread-settled";
 import {
   codexFeedbackMessage,
@@ -1765,7 +1769,8 @@ function ChatViewContent(props: ChatViewProps) {
   // session.lastError. Bump a tick so the banner hides immediately. Mirrors
   // the branch mismatch banner.
   const [, setThreadErrorBannerDismissTick] = useState(0);
-  const runtimeMode = composerRuntimeMode ?? activeThread?.runtimeMode ?? DEFAULT_RUNTIME_MODE;
+  const configuredRuntimeMode =
+    composerRuntimeMode ?? activeThread?.runtimeMode ?? DEFAULT_RUNTIME_MODE;
   const isLocalDraftThread = !isServerThread && localDraftThread !== undefined;
   const canCheckoutPullRequestIntoThread = isLocalDraftThread;
   const activeThreadId = activeThread?.id ?? null;
@@ -2493,6 +2498,36 @@ function ChatViewContent(props: ChatViewProps) {
   const selectedProvider = selectedProviderEntry?.driverKind ?? requestedDriverKind;
   const activeProviderInstanceId = selectedProviderEntry?.instanceId ?? null;
   const activeProviderStatus = selectedProviderEntry?.snapshot ?? null;
+  const runtimeMode = reconcileRuntimeMode(
+    configuredRuntimeMode,
+    getProviderSupportedRuntimeModes(activeProviderStatus),
+  );
+  const resolveLatestRuntimeMode = useCallback(
+    (fallback: RuntimeMode, modelSelection: ModelSelection): RuntimeMode => {
+      const latestConfig = appAtomRegistry.get(environmentServerConfigsAtom).get(environmentId);
+      const latestProvider = latestConfig?.providers.find(
+        (provider) => provider.instanceId === modelSelection.instanceId,
+      );
+      return reconcileRuntimeMode(fallback, getProviderSupportedRuntimeModes(latestProvider));
+    },
+    [environmentId],
+  );
+  useEffect(() => {
+    if (runtimeMode === configuredRuntimeMode || !activeThread) return;
+    const threadRef = scopeThreadRef(activeThread.environmentId, activeThread.id);
+    setComposerDraftRuntimeMode(threadRef, runtimeMode);
+    if (isLocalDraftThread) {
+      setDraftThreadContext(composerDraftTarget, { runtimeMode });
+    }
+  }, [
+    activeThread,
+    composerDraftTarget,
+    configuredRuntimeMode,
+    isLocalDraftThread,
+    runtimeMode,
+    setComposerDraftRuntimeMode,
+    setDraftThreadContext,
+  ]);
   const { enabled: interactionModeEnabled, interactionMode } = resolveComposerInteractionMode({
     planModeEnabled: settings.planModeEnabled,
     provider: activeProviderStatus,
@@ -4380,13 +4415,24 @@ function ChatViewContent(props: ChatViewProps) {
         }
       }
 
-      if (input.runtimeMode !== serverThread.runtimeMode) {
+      // Metadata persistence above may await a command while provider status
+      // refreshes. Reconcile again at the runtime-mode command boundary.
+      const latestConfig = appAtomRegistry.get(environmentServerConfigsAtom).get(environmentId);
+      const latestModelSelection = input.modelSelection ?? serverThread.modelSelection;
+      const latestProvider = latestConfig?.providers.find(
+        (provider) => provider.instanceId === latestModelSelection.instanceId,
+      );
+      const resolvedRuntimeMode = reconcileRuntimeMode(
+        input.runtimeMode,
+        getProviderSupportedRuntimeModes(latestProvider),
+      );
+      if (resolvedRuntimeMode !== serverThread.runtimeMode) {
         result = mapAtomCommandResult(
           await setThreadRuntimeMode({
             environmentId,
             input: {
               threadId: input.threadId,
-              runtimeMode: input.runtimeMode,
+              runtimeMode: resolvedRuntimeMode,
               createdAt: input.createdAt,
             },
           }),
@@ -6606,6 +6652,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
 
     if (failure === null && isServerThread) {
+      const settingsRuntimeMode = resolveLatestRuntimeMode(runtimeMode, ctxSelectedModelSelection);
       const settingsResult = await persistThreadSettingsForNextTurn({
         threadId: threadIdForSend,
         createdAt: messageCreatedAt,
@@ -6613,7 +6660,7 @@ function ChatViewContent(props: ChatViewProps) {
         ...(localCheckoutBranchMismatch
           ? { branch: localCheckoutBranchMismatch.currentBranch }
           : {}),
-        runtimeMode,
+        runtimeMode: settingsRuntimeMode,
         interactionMode: sendInteractionMode,
       });
       if (settingsResult._tag === "Failure") {
@@ -6635,6 +6682,9 @@ function ChatViewContent(props: ChatViewProps) {
 
     let turnStartSucceeded = false;
     if (failure === null && turnAttachmentsResult._tag === "Success") {
+      // Uploads and settings persistence can outlive a provider snapshot;
+      // dispatch against the latest capability declaration.
+      const dispatchRuntimeMode = resolveLatestRuntimeMode(runtimeMode, ctxSelectedModelSelection);
       const bootstrap =
         isLocalDraftThread || baseBranchForWorktree
           ? {
@@ -6644,7 +6694,7 @@ function ChatViewContent(props: ChatViewProps) {
                       projectId: activeProject.id,
                       title,
                       modelSelection: threadCreateModelSelection,
-                      runtimeMode,
+                      runtimeMode: dispatchRuntimeMode,
                       interactionMode: sendInteractionMode,
                       branch: activeThreadBranch,
                       worktreePath: activeThread.worktreePath,
@@ -6684,7 +6734,7 @@ function ChatViewContent(props: ChatViewProps) {
           },
           modelSelection: ctxSelectedModelSelection,
           titleSeed: title,
-          runtimeMode,
+          runtimeMode: dispatchRuntimeMode,
           interactionMode: sendInteractionMode,
           ...(bootstrap ? { bootstrap } : {}),
           createdAt: messageCreatedAt,
@@ -7074,13 +7124,17 @@ function ChatViewContent(props: ChatViewProps) {
         ...(localCheckoutBranchMismatch
           ? { branch: localCheckoutBranchMismatch.currentBranch }
           : {}),
-        runtimeMode,
+        runtimeMode: resolveLatestRuntimeMode(runtimeMode, ctxSelectedModelSelection),
         interactionMode: nextInteractionMode,
       });
       let failure: AtomCommandResult<unknown, unknown> | null =
         settingsResult._tag === "Failure" ? settingsResult : null;
 
       if (failure === null) {
+        const dispatchRuntimeMode = resolveLatestRuntimeMode(
+          runtimeMode,
+          ctxSelectedModelSelection,
+        );
         // Keep the mode toggle and plan-follow-up banner in sync immediately
         // while the same-thread implementation turn is starting.
         setComposerDraftInteractionMode(
@@ -7100,7 +7154,7 @@ function ChatViewContent(props: ChatViewProps) {
             },
             modelSelection: ctxSelectedModelSelection,
             titleSeed: activeThread.title,
-            runtimeMode,
+            runtimeMode: dispatchRuntimeMode,
             interactionMode: nextInteractionMode,
             ...(nextInteractionMode === "default" && activeProposedPlan
               ? {
@@ -7145,6 +7199,7 @@ function ChatViewContent(props: ChatViewProps) {
       isServerThread,
       localCheckoutBranchMismatch,
       persistThreadSettingsForNextTurn,
+      resolveLatestRuntimeMode,
       resetLocalDispatch,
       runtimeMode,
       scrollToEnd,
@@ -7198,6 +7253,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
     const nextThreadTitle = truncate(buildPlanImplementationThreadTitle(planMarkdown));
     const nextThreadModelSelection: ModelSelection = ctxSelectedModelSelection;
+    const createRuntimeMode = resolveLatestRuntimeMode(runtimeMode, nextThreadModelSelection);
 
     sendInFlightRef.current = true;
     beginLocalDispatch({ preparingWorktree: false });
@@ -7213,7 +7269,7 @@ function ChatViewContent(props: ChatViewProps) {
         projectId: activeProject.id,
         title: nextThreadTitle,
         modelSelection: nextThreadModelSelection,
-        runtimeMode,
+        runtimeMode: createRuntimeMode,
         interactionMode: "default",
         branch: activeThreadBranch,
         worktreePath: activeThread.worktreePath,
@@ -7224,6 +7280,10 @@ function ChatViewContent(props: ChatViewProps) {
       createResult._tag === "Failure" ? createResult : null;
 
     if (failure === null) {
+      const dispatchRuntimeMode = resolveLatestRuntimeMode(
+        createRuntimeMode,
+        nextThreadModelSelection,
+      );
       const startResult = await startThreadTurn({
         environmentId,
         input: {
@@ -7236,7 +7296,7 @@ function ChatViewContent(props: ChatViewProps) {
           },
           modelSelection: ctxSelectedModelSelection,
           titleSeed: nextThreadTitle,
-          runtimeMode,
+          runtimeMode: dispatchRuntimeMode,
           interactionMode: "default",
           sourceProposedPlan: {
             threadId: activeThread.id,
@@ -7309,6 +7369,7 @@ function ChatViewContent(props: ChatViewProps) {
     isSendBusy,
     isServerThread,
     navigate,
+    resolveLatestRuntimeMode,
     resetLocalDispatch,
     runtimeMode,
     startThreadTurn,
@@ -7376,6 +7437,10 @@ function ChatViewContent(props: ChatViewProps) {
         instanceId,
         model: resolvedModel,
       };
+      const nextRuntimeMode = reconcileRuntimeMode(
+        runtimeMode,
+        getProviderSupportedRuntimeModes(entry),
+      );
       const modelChangeBlockReason = getStartedThreadModelChangeBlockReason({
         providers: providerStatuses,
         hasStartedSession: activeThread.session !== null,
@@ -7397,14 +7462,28 @@ function ChatViewContent(props: ChatViewProps) {
         nextModelSelection,
         { explicit: true },
       );
+      if (nextRuntimeMode !== runtimeMode) {
+        setComposerDraftRuntimeMode(
+          scopeThreadRef(activeThread.environmentId, activeThread.id),
+          nextRuntimeMode,
+        );
+        if (isLocalDraftThread) {
+          setDraftThreadContext(composerDraftTarget, { runtimeMode: nextRuntimeMode });
+        }
+      }
       setStickyComposerModelSelection(nextModelSelection);
       scheduleComposerFocus();
     },
     [
       activeThread,
+      composerDraftTarget,
+      isLocalDraftThread,
       lockedProvider,
+      runtimeMode,
       scheduleComposerFocus,
       setComposerDraftModelSelection,
+      setComposerDraftRuntimeMode,
+      setDraftThreadContext,
       setStickyComposerModelSelection,
       providerStatuses,
       settings,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -20,6 +20,10 @@ import {
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
 } from "@t3tools/contracts";
 import type { EnvironmentConnectionPresentation } from "@t3tools/client-runtime/connection";
+import {
+  filterRuntimeModeOptions,
+  getProviderSupportedRuntimeModes,
+} from "@t3tools/client-runtime/runtime-mode-options";
 import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
 import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model";
 import {
@@ -924,6 +928,7 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
   showInteractionModeToggle: boolean;
   interactionMode: ProviderInteractionMode;
   runtimeMode: RuntimeMode;
+  supportedRuntimeModes?: ReadonlyArray<RuntimeMode> | undefined;
   size?: "sm" | "xs";
   hidden?: boolean;
   onToggleInteractionMode: () => void;
@@ -933,6 +938,10 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
   const [open, setOpen] = useComposerMenuState(props.hidden);
   const runtimeModeOption = runtimeModeConfig[props.runtimeMode];
   const RuntimeModeIcon = runtimeModeOption.icon;
+  const runtimeModeChoices = filterRuntimeModeOptions(
+    runtimeModeOptions,
+    props.supportedRuntimeModes,
+  );
   const interactionModeTooltip =
     props.interactionMode === "plan"
       ? "Plan mode — click to return to normal build mode"
@@ -1006,7 +1015,7 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
             <SelectValue>{runtimeModeOption.label}</SelectValue>
           </TooltipTrigger>
           <SelectPopup alignItemWithTrigger={false} {...composerFloatingLayerProps}>
-            {runtimeModeOptions.map((mode) => {
+            {runtimeModeChoices.map((mode) => {
               const option = runtimeModeConfig[mode];
               const OptionIcon = option.icon;
               return (
@@ -3806,6 +3815,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           showInteractionModeToggle={planModeUiEnabled}
           interactionMode={interactionMode}
           runtimeMode={runtimeMode}
+          supportedRuntimeModes={getProviderSupportedRuntimeModes(selectedProviderStatus)}
           size={composerControlsInStrip ? "xs" : "sm"}
           hidden={composerControlsHidden || restingHiddenBlockCount > 0}
           onToggleInteractionMode={toggleInteractionMode}
@@ -3885,6 +3895,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         <CompactComposerControlsMenu
           interactionMode={interactionMode}
           runtimeMode={runtimeMode}
+          supportedRuntimeModes={getProviderSupportedRuntimeModes(selectedProviderStatus)}
           showInteractionModeToggle={planModeUiEnabled}
           traitsMenuContent={providerTraitsMenuContent}
           onToggleInteractionMode={toggleInteractionMode}
@@ -3925,6 +3936,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
               <CompactComposerControlsMenu
                 interactionMode={interactionMode}
                 runtimeMode={runtimeMode}
+                supportedRuntimeModes={getProviderSupportedRuntimeModes(selectedProviderStatus)}
                 size="xs"
                 hidden={composerControlsHidden || hiddenRestingBlockIds.length === 0}
                 showInteractionModeToggle={

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
@@ -1,4 +1,5 @@
 import { ProviderInteractionMode, RuntimeMode } from "@t3tools/contracts";
+import { filterRuntimeModeOptions } from "@t3tools/client-runtime/runtime-mode-options";
 import { memo, type ReactNode } from "react";
 import { EllipsisIcon } from "lucide-react";
 import {
@@ -13,9 +14,17 @@ import { ComposerControl, ComposerControlIcon } from "./ComposerControl";
 import { composerFloatingLayerProps } from "./composerEventScope";
 import { useComposerMenuState } from "./useComposerMenuState";
 
+const COMPACT_RUNTIME_MODE_CHOICES = [
+  { mode: "approval-required" as const, label: "Supervised" },
+  { mode: "auto-accept-edits" as const, label: "Auto-accept edits" },
+  { mode: "auto" as const, label: "Auto" },
+  { mode: "full-access" as const, label: "Full access" },
+];
+
 export const CompactComposerControlsMenu = memo(function CompactComposerControlsMenu(props: {
   interactionMode: ProviderInteractionMode;
   runtimeMode: RuntimeMode;
+  supportedRuntimeModes?: ReadonlyArray<RuntimeMode> | undefined;
   showInteractionModeToggle: boolean;
   traitsMenuContent?: ReactNode;
   size?: "sm" | "xs";
@@ -30,6 +39,10 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
 }) {
   const size = props.size ?? "sm";
   const [open, setOpen] = useComposerMenuState(props.hidden);
+  const runtimeModeChoices = filterRuntimeModeOptions(
+    COMPACT_RUNTIME_MODE_CHOICES,
+    props.supportedRuntimeModes,
+  );
 
   return (
     <Menu open={open} onOpenChange={setOpen}>
@@ -76,10 +89,11 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
             props.onRuntimeModeChange(value as RuntimeMode);
           }}
         >
-          <MenuRadioItem value="approval-required">Supervised</MenuRadioItem>
-          <MenuRadioItem value="auto-accept-edits">Auto-accept edits</MenuRadioItem>
-          <MenuRadioItem value="auto">Auto</MenuRadioItem>
-          <MenuRadioItem value="full-access">Full access</MenuRadioItem>
+          {runtimeModeChoices.map((choice) => (
+            <MenuRadioItem key={choice.mode} value={choice.mode}>
+              {choice.label}
+            </MenuRadioItem>
+          ))}
         </MenuRadioGroup>
       </MenuPopup>
     </Menu>

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -7,6 +7,7 @@ import {
   Icon,
   OpenAI,
   OpenCodeIcon,
+  PiAgentIcon,
 } from "../Icons";
 
 export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>> = {
@@ -16,6 +17,7 @@ export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>
   [ProviderDriverKind.make("cursor")]: CursorIcon,
   [ProviderDriverKind.make("grok")]: GrokIcon,
   [ProviderDriverKind.make("antigravity")]: AntigravityIcon,
+  [ProviderDriverKind.make("piAgent")]: PiAgentIcon,
 };
 
 export type ModelEsque = {

--- a/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
+++ b/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
@@ -14,7 +14,7 @@ import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hook
 import { cn } from "../../lib/utils";
 import { normalizeProviderAccentColor } from "../../providerInstances";
 import { Button } from "../ui/button";
-import { ACPRegistryIcon, Gemini, GithubCopilotIcon, PiAgentIcon, type Icon } from "../Icons";
+import { ACPRegistryIcon, Gemini, GithubCopilotIcon, type Icon } from "../Icons";
 import {
   Dialog,
   DialogDescription,
@@ -92,11 +92,6 @@ const COMING_SOON_DRIVER_OPTIONS: readonly ComingSoonDriverOption[] = [
     value: ProviderDriverKind.make("acpRegistry"),
     label: "ACP Registry",
     icon: ACPRegistryIcon,
-  },
-  {
-    value: ProviderDriverKind.make("piAgent"),
-    label: "Pi Agent",
-    icon: PiAgentIcon,
   },
 ];
 

--- a/apps/web/src/components/settings/ProviderSettingsForm.test.ts
+++ b/apps/web/src/components/settings/ProviderSettingsForm.test.ts
@@ -22,6 +22,16 @@ describe("ProviderSettingsForm helpers", () => {
     ]);
   });
 
+  it("registers Pi Agent as an early-access provider with its icon", () => {
+    const piAgent = DRIVER_OPTION_BY_VALUE[ProviderDriverKind.make("piAgent")];
+
+    expect(piAgent).toMatchObject({
+      label: "Pi Agent",
+      badgeLabel: "Early Access",
+    });
+    expect(piAgent?.icon).toBeDefined();
+  });
+
   it("sources labels and descriptions from schema annotations", () => {
     const opencode = DRIVER_OPTION_BY_VALUE[ProviderDriverKind.make("opencode")];
     expect(opencode).toBeDefined();

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -5,6 +5,7 @@ import {
   CursorSettings,
   GrokSettings,
   OpenCodeSettings,
+  PiSettings,
   ProviderDriverKind,
 } from "@t3tools/contracts";
 import type * as Schema from "effect/Schema";
@@ -16,6 +17,7 @@ import {
   type Icon,
   OpenAI,
   OpenCodeIcon,
+  PiAgentIcon,
 } from "../Icons";
 
 type ProviderSettingsSchema = {
@@ -75,6 +77,13 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     label: "OpenCode",
     icon: OpenCodeIcon,
     settingsSchema: OpenCodeSettings,
+  },
+  {
+    value: ProviderDriverKind.make("piAgent"),
+    label: "Pi Agent",
+    icon: PiAgentIcon,
+    badgeLabel: "Early Access",
+    settingsSchema: PiSettings,
   },
   {
     value: ProviderDriverKind.make("antigravity"),

--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -87,6 +87,7 @@ describe("buildDayColumns", () => {
       { provider: "codex", value: 10 },
       { provider: "claude", value: 20 },
       { provider: "grok", value: 0 },
+      { provider: "pi", value: 0 },
     ]);
   });
 
@@ -106,6 +107,15 @@ describe("providersWithUsage", () => {
         { provider: "claude", costUsd: 0, totalTokens: 200 },
       ]),
     ).toEqual(["claude"]);
+  });
+
+  it("includes Pi when its transcript usage is non-zero", () => {
+    expect(
+      providersWithUsage([
+        { provider: "codex", costUsd: 0, totalTokens: 0 },
+        { provider: "pi", costUsd: 0.25, totalTokens: 120_000 },
+      ]),
+    ).toEqual(["pi"]);
   });
 });
 

--- a/apps/web/src/components/usage/usageProviders.ts
+++ b/apps/web/src/components/usage/usageProviders.ts
@@ -1,6 +1,6 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
 
-import { ClaudeAI, GrokIcon, type Icon, OpenAI } from "../Icons";
+import { ClaudeAI, GrokIcon, type Icon, OpenAI, PiAgentIcon } from "../Icons";
 
 type UsageProviderPresentation = {
   readonly label: string;
@@ -29,6 +29,11 @@ export const PROVIDER_PRESENTATION = {
     // Contrast-aware neutral between the Codex series and muted chart chrome.
     color: "color-mix(in oklab, var(--contrast-foreground) 72%, var(--background))",
     mark: GrokIcon,
+  },
+  pi: {
+    label: "Pi Agent",
+    color: "#8b9cf6",
+    mark: PiAgentIcon,
   },
 } satisfies Record<UsageProviderKind, UsageProviderPresentation>;
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -67,6 +67,11 @@ export const PROVIDER_OPTIONS: Array<{
     available: true,
     pickerSidebarBadge: "new",
   },
+  {
+    value: ProviderDriverKind.make("piAgent"),
+    label: "Pi Agent",
+    available: true,
+  },
 ];
 
 export type WorkLogToolLifecycleStatus =

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -96,14 +96,24 @@ provider's CLI, or use T3 Code's managed setup for Antigravity.
 | Grok Build  | [Grok Build CLI](https://x.ai/cli)                                                                         | `grok`             | `grok login`                       |
 | OpenCode    | [OpenCode](https://opencode.ai)                                                                            | `opencode`         | `opencode auth login`              |
 | Antigravity | [Official ACP agent](https://github.com/agentclientprotocol/registry/blob/main/antigravity-acp/agent.json) | Managed by T3 Code | **Sign in with Google** in T3 Code |
+| Pi Agent    | [Pi coding agent](https://github.com/earendil-works/pi) (Early Access)                                     | `pi`               | Configure Pi on the server         |
 
-Codex and Claude are on by default. Cursor, Grok Build, OpenCode, and Antigravity are off by
-default. Turn them on in **Settings** > **Providers** when you want to use them.
+Codex and Claude are on by default. Cursor, Grok Build, OpenCode, Antigravity, and Pi Agent are
+off by default. Turn them on in **Settings** > **Providers** when you want to use them.
 
 For Antigravity, select the environment in provider settings, then install and sign in there.
 The runtime and credentials stay on that environment, even when you use a phone or remote
 browser. See [Antigravity setup](./providers-antigravity.md) for Google sign-in, remote callback
 steps, and supported hosts.
+
+Pi Agent is user-managed. Install it on the environment that runs T3 Code, then configure its
+binary, agent, and session paths in the provider instance:
+
+```bash
+npm install --global @earendil-works/pi-coding-agent
+```
+
+See [Pi Agent setup](./providers-pi-agent.md).
 
 Cursor is the one to watch: install Cursor CLI, which provides the `cursor-agent` binary that
 T3 Code looks for, but authenticate with `agent login`, not `cursor-agent login`.

--- a/docs/user/permission-modes.md
+++ b/docs/user/permission-modes.md
@@ -34,6 +34,10 @@ question the official agent sends in **Full access**. A remembered approval is a
 when the agent offers it for that action. Fixed-choice questions require one of the offered
 answers and do not accept custom text.
 
+Pi Agent is an Early Access exception: its RPC protocol currently supports Full Access only, so
+T3 Code only offers Full Access for Pi threads and rejects other modes. See
+[Pi Agent](./providers-pi-agent.md#permissions).
+
 ## Choosing a Mode
 
 Use **Full access** for work in a worktree or a sandbox you can throw away.

--- a/docs/user/providers-pi-agent.md
+++ b/docs/user/providers-pi-agent.md
@@ -1,0 +1,99 @@
+# Pi Agent (Early Access)
+
+Pi Agent is an Early Access provider for users who already have the Pi coding
+agent installed on the machine running T3 Code. T3 Code does not download,
+install, update, or sign in to Pi. The provider starts Pi in its RPC mode and
+reads the models, thinking levels, and slash commands that Pi reports.
+
+## Setup
+
+Open **Settings** → **Providers** on the environment where Pi is installed,
+choose **Add provider** → **Pi Agent**, and enable the instance. Leave
+**Binary path** as `pi` when the executable is on the server's `PATH`; set the
+absolute path when Pi is installed elsewhere.
+
+Each Pi instance can use its own profile and session directory:
+
+- **Agent directory** maps to `PI_CODING_AGENT_DIR` and keeps Pi configuration,
+  credentials, and extensions separate.
+- **Session directory** is passed to Pi as `--session-dir` and keeps session
+  files separate.
+
+Relative Agent and Session directory values are resolved from the T3 Code
+server directory, so the same instance keeps one profile and usage history
+when it is used from different projects. Absolute paths and `~` paths are also
+supported.
+
+Add another Pi Agent instance when you need different profiles or model
+catalogs. T3 Code gives every instance its own RPC process and remembers the
+instance with the thread that uses it.
+
+T3 Code launches your installed Pi executable rather than embedding Pi's SDK.
+Pi therefore continues to load its extensions, packages, skills, prompt
+templates, custom providers, credentials, and other profile configuration from
+the selected Agent directory. Full Access sessions also pass Pi's `--approve`
+flag so trusted project-local resources can load for that run.
+
+T3 Code only checks that the configured binary runs and asks Pi's RPC endpoint
+for metadata. If the status says that Pi was not found, install Pi on the
+server or correct **Binary path**, then refresh provider status.
+
+## Permissions
+
+Pi Agent currently supports **Full Access** only. Pi's RPC protocol does not
+provide a policy bridge for T3 Code to enforce read-only, approval-required, or
+auto-accept modes. T3 Code therefore offers only Full Access in its permission
+menus and rejects sessions requested with another mode. Review Pi's own
+configuration and extensions before starting a session.
+
+Pi can still display its native confirmation and input dialogs through T3 Code.
+Those dialogs are requests from Pi; they do not turn a restricted T3 Code mode
+into a supported Pi mode.
+
+Extensions that use Pi's RPC-native `select`, `confirm`, `input`, or `editor`
+requests appear as T3 questions or confirmations. Arbitrary terminal widgets
+built with `ctx.ui.custom` are TUI-only and cannot be transported through Pi's
+RPC protocol; an extension should provide its own non-TUI fallback for those.
+
+## Models and commands
+
+The model picker, `/` command menu, and `$` skill menu use Pi's live RPC
+inventory. Selecting a Pi skill from `$` sends Pi its native `/skill:name`
+command, so Pi loads the skill from the configured Agent directory rather than
+T3 Code copying or interpreting it. Changing providers, profiles, skills, or
+extensions outside T3 Code may change those lists. Refresh the provider status,
+or reconnect the environment, after such a change. Thinking levels are exposed
+as the model's **Thinking** option when Pi reports them.
+
+The **Usage** page reads Pi's session JSONL files from every configured Pi Agent
+instance, deduplicating instances that share a Session directory. If an
+instance has no override, T3 Code uses Pi's standard
+`PI_CODING_AGENT_SESSION_DIR` and Agent directory defaults. Token totals and
+costs come from Pi's own recorded usage, including provider-reported prices for
+custom models.
+
+Pi Agent does not currently provide T3 Code's structured text-generation
+operations for commit messages, pull-request text, branch names, or thread
+titles. Select another provider for those actions.
+
+## Sessions and troubleshooting
+
+Stopping a thread stops its Pi RPC session. Existing Pi session files remain in
+the configured session directory, so a later session can resume when Pi and
+the selected profile expose the same session. A provider instance being
+disabled stops new sessions but does not delete its profile or session files.
+
+If a session fails to start:
+
+1. Run the configured binary with `--version` on the T3 Code server.
+2. Confirm the Agent directory and Session directory are readable and belong
+   to the account running T3 Code.
+3. Confirm the binary supports `--mode rpc` and `--session-dir`.
+4. Refresh provider status after correcting the configuration.
+
+Pi Agent is Early Access. Its RPC inventory and event details can change with
+the Pi version; keep Pi updated according to its own documentation and report
+provider failures with the Pi version and T3 Code server logs.
+
+Pi Agent support is independent of the ACP Registry placeholder in T3 Code.
+Generic ACP Registry providers remain a separate future feature.

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -47,6 +47,10 @@
       "types": "./src/codexMarkdownDirectives.ts",
       "default": "./src/codexMarkdownDirectives.ts"
     },
+    "./runtime-mode-options": {
+      "types": "./src/runtimeModeOptions.ts",
+      "default": "./src/runtimeModeOptions.ts"
+    },
     "./errors": {
       "types": "./src/errors/index.ts",
       "default": "./src/errors/index.ts"

--- a/packages/client-runtime/src/runtimeModeOptions.test.ts
+++ b/packages/client-runtime/src/runtimeModeOptions.test.ts
@@ -42,5 +42,8 @@ describe("runtime mode options", () => {
 
   it("does not retain a wider mode when capabilities are explicitly empty", () => {
     expect(reconcileRuntimeMode("full-access", [])).toBe("approval-required");
+    expect(filterRuntimeModeOptions(options, []).map((option) => option.mode)).toEqual([
+      "approval-required",
+    ]);
   });
 });

--- a/packages/client-runtime/src/runtimeModeOptions.test.ts
+++ b/packages/client-runtime/src/runtimeModeOptions.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  filterRuntimeModeOptions,
+  getProviderSupportedRuntimeModes,
+} from "./runtimeModeOptions.ts";
+
+const options = [
+  { mode: "approval-required" as const, label: "Supervised" },
+  { mode: "auto-accept-edits" as const, label: "Auto-accept edits" },
+  { mode: "auto" as const, label: "Auto" },
+  { mode: "full-access" as const, label: "Full access" },
+];
+
+describe("runtime mode options", () => {
+  it("preserves all options when a provider omits its capability", () => {
+    expect(filterRuntimeModeOptions(options, undefined)).toBe(options);
+    expect(getProviderSupportedRuntimeModes({})).toBeUndefined();
+  });
+
+  it("keeps the product order for explicitly supported modes", () => {
+    expect(
+      filterRuntimeModeOptions(
+        ["approval-required", "auto", "full-access"],
+        ["full-access", "approval-required"],
+      ),
+    ).toEqual(["approval-required", "full-access"]);
+  });
+});

--- a/packages/client-runtime/src/runtimeModeOptions.test.ts
+++ b/packages/client-runtime/src/runtimeModeOptions.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   filterRuntimeModeOptions,
   getProviderSupportedRuntimeModes,
+  reconcileRuntimeMode,
 } from "./runtimeModeOptions.ts";
 
 const options = [
@@ -25,5 +26,21 @@ describe("runtime mode options", () => {
         ["full-access", "approval-required"],
       ),
     ).toEqual(["approval-required", "full-access"]);
+  });
+
+  it("reconciles an unsupported mode to the least permissive supported choice", () => {
+    expect(reconcileRuntimeMode("approval-required", ["full-access"])).toBe("full-access");
+    expect(reconcileRuntimeMode("full-access", ["auto", "approval-required"])).toBe(
+      "approval-required",
+    );
+  });
+
+  it("preserves modes for legacy and already-compatible capabilities", () => {
+    expect(reconcileRuntimeMode("approval-required", undefined)).toBe("approval-required");
+    expect(reconcileRuntimeMode("full-access", ["full-access"])).toBe("full-access");
+  });
+
+  it("does not retain a wider mode when capabilities are explicitly empty", () => {
+    expect(reconcileRuntimeMode("full-access", [])).toBe("approval-required");
   });
 });

--- a/packages/client-runtime/src/runtimeModeOptions.ts
+++ b/packages/client-runtime/src/runtimeModeOptions.ts
@@ -50,6 +50,11 @@ export function filterRuntimeModeOptions<T extends RuntimeMode | { readonly mode
   supportedRuntimeModes: ReadonlyArray<RuntimeMode> | undefined,
 ): ReadonlyArray<T> {
   if (supportedRuntimeModes === undefined) return options;
+  if (supportedRuntimeModes.length === 0) {
+    return options.filter(
+      (option) => (typeof option === "string" ? option : option.mode) === SAFEST_RUNTIME_MODE,
+    );
+  }
   const supported = new Set(supportedRuntimeModes);
   return options.filter((option) =>
     supported.has(typeof option === "string" ? option : option.mode),

--- a/packages/client-runtime/src/runtimeModeOptions.ts
+++ b/packages/client-runtime/src/runtimeModeOptions.ts
@@ -13,6 +13,37 @@ export function getProviderSupportedRuntimeModes(
   return provider?.supportedRuntimeModes;
 }
 
+const RUNTIME_MODE_ORDER: ReadonlyArray<RuntimeMode> = [
+  "approval-required",
+  "auto-accept-edits",
+  "auto",
+  "full-access",
+];
+const SAFEST_RUNTIME_MODE: RuntimeMode = "approval-required";
+
+/**
+ * Keep a staged/current mode valid for the selected provider. Missing
+ * capability metadata is intentionally treated as the full product menu for
+ * compatibility with older server snapshots.
+ */
+export function reconcileRuntimeMode(
+  runtimeMode: RuntimeMode,
+  supportedRuntimeModes: ReadonlyArray<RuntimeMode> | undefined,
+): RuntimeMode {
+  if (supportedRuntimeModes === undefined || supportedRuntimeModes.includes(runtimeMode)) {
+    return runtimeMode;
+  }
+
+  const supported = new Set(supportedRuntimeModes);
+  return (
+    RUNTIME_MODE_ORDER.find((mode) => supported.has(mode)) ??
+    // An explicit empty capability list cannot produce a provider-valid
+    // replacement. Use the least-permissive product mode rather than
+    // retaining a possibly wider selection or falling back to full access.
+    SAFEST_RUNTIME_MODE
+  );
+}
+
 /** Filter a runtime-mode menu while preserving its product-defined order. */
 export function filterRuntimeModeOptions<T extends RuntimeMode | { readonly mode: RuntimeMode }>(
   options: ReadonlyArray<T>,

--- a/packages/client-runtime/src/runtimeModeOptions.ts
+++ b/packages/client-runtime/src/runtimeModeOptions.ts
@@ -1,0 +1,26 @@
+import type { RuntimeMode, ServerProvider } from "@t3tools/contracts";
+
+export type ProviderRuntimeModeCapabilities = Pick<ServerProvider, "supportedRuntimeModes">;
+
+/**
+ * Read the provider capability without making older server snapshots opt in
+ * to a new restriction. An omitted field means the provider keeps the full
+ * product runtime-mode menu.
+ */
+export function getProviderSupportedRuntimeModes(
+  provider: ProviderRuntimeModeCapabilities | null | undefined,
+): ReadonlyArray<RuntimeMode> | undefined {
+  return provider?.supportedRuntimeModes;
+}
+
+/** Filter a runtime-mode menu while preserving its product-defined order. */
+export function filterRuntimeModeOptions<T extends RuntimeMode | { readonly mode: RuntimeMode }>(
+  options: ReadonlyArray<T>,
+  supportedRuntimeModes: ReadonlyArray<RuntimeMode> | undefined,
+): ReadonlyArray<T> {
+  if (supportedRuntimeModes === undefined) return options;
+  const supported = new Set(supportedRuntimeModes);
+  return options.filter((option) =>
+    supported.has(typeof option === "string" ? option : option.mode),
+  );
+}

--- a/packages/contracts/src/server.test.ts
+++ b/packages/contracts/src/server.test.ts
@@ -48,6 +48,22 @@ describe("ServerProvider", () => {
     expect(parsed.skills).toEqual([]);
     expect(parsed.versionAdvisory).toBeUndefined();
     expect(parsed.updateState).toBeUndefined();
+    expect(parsed.supportedRuntimeModes).toBeUndefined();
+  });
+
+  it("round-trips supported runtime modes while keeping the capability optional", () => {
+    const parsed = decodeServerProvider({
+      ...baseProviderSnapshot,
+      supportedRuntimeModes: ["full-access"],
+    });
+
+    expect(parsed.supportedRuntimeModes).toEqual(["full-access"]);
+    expect(
+      decodeServerProvider({
+        ...baseProviderSnapshot,
+        supportedRuntimeModes: ["full-access", "future-mode"],
+      }).supportedRuntimeModes,
+    ).toEqual(["full-access"]);
   });
 
   it("defaults one-click update support when decoding older advisory snapshots", () => {

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -23,6 +23,7 @@ import {
 } from "./keybindings.ts";
 import { EditorId, FileManagerRevealKind, RemoteOpenTarget } from "./editor.ts";
 import { ModelCapabilities } from "./model.ts";
+import { RuntimeMode } from "./orchestration.ts";
 import { ProviderDriverKind, ProviderInstanceId } from "./providerInstance.ts";
 import { ServerProviderUsageLimits, UsageLimitSourceSnapshots } from "./providerUsageLimits.ts";
 import { ServerSettings } from "./settings.ts";
@@ -200,6 +201,12 @@ export const ServerProvider = Schema.Struct({
   requiresNewThreadForModelChange: Schema.optional(Schema.Boolean),
   supportsConversationRollback: Schema.optional(Schema.Boolean),
   supportsTextGeneration: Schema.optional(Schema.Boolean),
+  /**
+   * Runtime policies this provider can enforce. Omitted by legacy providers
+   * and older snapshots; consumers interpret an absent value as the full
+   * current runtime-mode set for backward compatibility.
+   */
+  supportedRuntimeModes: Schema.optionalKey(ForwardCompatibleArray(RuntimeMode)),
   setup: Schema.optional(
     Schema.Struct({
       canAuthenticate: Schema.Boolean,

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -8,6 +8,7 @@ import {
   ClaudeSettings,
   DEFAULT_SERVER_SETTINGS,
   defaultEnabledForDriver,
+  PiSettings,
   resolveProviderInstanceEnabled,
   ServerSettings,
   ServerSettingsPatch,
@@ -20,6 +21,7 @@ const decodeServerSettings = Schema.decodeUnknownSync(ServerSettings);
 const decodeServerSettingsPatch = Schema.decodeUnknownSync(ServerSettingsPatch);
 const encodeServerSettings = Schema.encodeSync(ServerSettings);
 const decodeClaudeSettings = Schema.decodeUnknownSync(ClaudeSettings);
+const decodePiSettings = Schema.decodeUnknownSync(PiSettings);
 
 describe("ClaudeSettings auto-compaction", () => {
   it("uses Claude's default threshold when no override is configured", () => {
@@ -336,6 +338,48 @@ describe("ServerSettings.providerInstances (slice-2 invariant)", () => {
   });
 });
 
+describe("PiSettings", () => {
+  it("is opt-in and defaults its binary and directory overrides", () => {
+    expect(decodePiSettings({})).toEqual({
+      enabled: false,
+      binaryPath: "pi",
+      agentDir: "",
+      sessionDir: "",
+      customModels: [],
+    });
+    expect(DEFAULT_SERVER_SETTINGS.providers.piAgent).toEqual(decodePiSettings({}));
+  });
+
+  it("accepts and normalizes user-managed binary and directory settings", () => {
+    expect(
+      decodeServerSettingsPatch({
+        providers: {
+          piAgent: {
+            enabled: true,
+            binaryPath: "  /opt/pi  ",
+            agentDir: "  ~/.pi/work  ",
+            sessionDir: "  ~/.pi/sessions  ",
+          },
+        },
+      }),
+    ).toEqual({
+      providers: {
+        piAgent: {
+          enabled: true,
+          binaryPath: "/opt/pi",
+          agentDir: "~/.pi/work",
+          sessionDir: "~/.pi/sessions",
+        },
+      },
+    });
+  });
+  it("shows Pi's actual default session directory as the placeholder", () => {
+    const annotations = Schema.resolveAnnotationsKey(PiSettings.fields.sessionDir);
+
+    expect(annotations?.providerSettingsForm?.placeholder).toBe("~/.pi/agent/sessions");
+  });
+});
+
 describe("provider enabled defaults", () => {
   it("enables only the stable bindings by default", () => {
     const decoded = decodeServerSettings({});
@@ -344,12 +388,14 @@ describe("provider enabled defaults", () => {
     expect(decoded.providers.cursor.enabled).toBe(false);
     expect(decoded.providers.grok.enabled).toBe(false);
     expect(decoded.providers.opencode.enabled).toBe(false);
+    expect(decoded.providers.piAgent.enabled).toBe(false);
   });
 
   it("derives per-driver defaults from the settings schemas", () => {
     expect(defaultEnabledForDriver(ProviderDriverKind.make("codex"))).toBe(true);
     expect(defaultEnabledForDriver(ProviderDriverKind.make("cursor"))).toBe(false);
     expect(defaultEnabledForDriver(ProviderDriverKind.make("grok"))).toBe(false);
+    expect(defaultEnabledForDriver(ProviderDriverKind.make("piAgent"))).toBe(false);
     // Unknown fork drivers stay enabled; their own build decides otherwise.
     expect(defaultEnabledForDriver(ProviderDriverKind.make("ollama"))).toBe(true);
   });

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -733,6 +733,63 @@ export const OpenCodeSettings = makeProviderSettingsSchema(
 export type OpenCodeSettings = typeof OpenCodeSettings.Type;
 
 /**
+ * Pi Agent settings. Pi is opt-in because its RPC mode does not provide the
+ * same built-in runtime policy enforcement as the mature providers. The
+ * agent and session directories are optional overrides; an empty value lets
+ * Pi use its normal per-user locations.
+ */
+export const PiSettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("pi").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the Pi Agent binary.",
+        providerSettingsForm: { placeholder: "pi", clearWhenEmpty: "omit" },
+      }),
+    ),
+    agentDir: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Agent directory",
+        description:
+          "Optional PI_CODING_AGENT_DIR override for Pi configuration, extensions, and resources.",
+        providerSettingsForm: {
+          placeholder: "~/.pi/agent",
+          clearWhenEmpty: "omit",
+        },
+      }),
+    ),
+    sessionDir: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Session directory",
+        description: "Optional directory where Pi stores sessions for this instance.",
+        providerSettingsForm: {
+          placeholder: "~/.pi/agent/sessions",
+          clearWhenEmpty: "omit",
+        },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: ["binaryPath", "agentDir", "sessionDir"],
+  },
+);
+export type PiSettings = typeof PiSettings.Type;
+// The driver-facing name is explicit about the implementation kind while
+// `PiSettings` remains available alongside the other legacy settings names.
+export const PiAgentSettings = PiSettings;
+export type PiAgentSettings = PiSettings;
+
+/**
  * A read-only quota source outside this environment's provider CLIs. The
  * only kind today is a CLIProxyAPI hub, whose management API reports the
  * windows of every pooled account. The key travels in settings for now, like
@@ -915,6 +972,7 @@ export const ServerSettings = Schema.Struct({
     grok: GrokSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     antigravity: AntigravitySettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    piAgent: PiSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // New driver-agnostic instance map. Keyed by `ProviderInstanceId`; values
   // are `ProviderInstanceConfig` envelopes. The driver-specific config blob
@@ -1083,6 +1141,14 @@ const OpenCodeSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const PiSettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  binaryPath: Schema.optionalKey(TrimmedString),
+  agentDir: Schema.optionalKey(TrimmedString),
+  sessionDir: Schema.optionalKey(TrimmedString),
+  customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+
 export const ServerSettingsPatch = Schema.Struct({
   // Server settings
   enableLegacyTokenStreaming: Schema.optionalKey(Schema.Boolean),
@@ -1128,6 +1194,7 @@ export const ServerSettingsPatch = Schema.Struct({
       grok: Schema.optionalKey(GrokSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),
       antigravity: Schema.optionalKey(AntigravitySettingsPatch),
+      piAgent: Schema.optionalKey(PiSettingsPatch),
     }),
   ),
   // Whole-map replacement for the new instance config. Patching individual

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -3,7 +3,8 @@
  *
  * Each environment scans the provider CLIs' own on-disk session transcripts
  * (`~/.claude/projects/**\/*.jsonl`, `~/.codex/sessions/**\/*.jsonl`,
- * `~/.grok/sessions/**\/updates.jsonl`) rather than relying on T3 Code's own
+ * `~/.grok/sessions/**\/updates.jsonl`, `~/.pi/agent/sessions/**\/*.jsonl`)
+ * rather than relying on T3 Code's own
  * orchestration projections, so usage stays complete even for turns that were
  * never driven through T3 Code. This mirrors the approach `ccusage` takes.
  *
@@ -21,18 +22,18 @@ import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 5 as const;
+export const USAGE_CONTRACT_VERSION = 6 as const;
 
 /**
  * Oldest {@link UsageSummary} version a current client will still merge.
  *
- * v5 only adds `grok` to {@link UsageProviderKind}; v4 Claude/Codex buckets
- * remain valid, so mixed-version environments keep those totals instead of
- * treating every older server as stale.
+ * v5 adds `grok` and v6 adds `pi` to {@link UsageProviderKind}; v4
+ * Claude/Codex buckets remain valid, so mixed-version environments keep those
+ * totals instead of treating every older server as stale.
  */
 export const USAGE_MERGE_COMPATIBLE_SINCE = 4 as const;
 
-export const UsageProviderKind = Schema.Literals(["claude", "codex", "grok"]);
+export const UsageProviderKind = Schema.Literals(["claude", "codex", "grok", "pi"]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;
 
 /**

--- a/packages/shared/src/usageFormat.test.ts
+++ b/packages/shared/src/usageFormat.test.ts
@@ -6,8 +6,17 @@ import {
   formatDateTimeShort,
   formatHourShort,
   formatRelativeHourShort,
+  formatUsd,
   makeWindow,
 } from "./usageFormat.ts";
+
+describe("usage currency formatting", () => {
+  it("distinguishes a real sub-cent cost from zero", () => {
+    expect(formatUsd(0)).toBe("$0.00");
+    expect(formatUsd(0.00395484)).toBe("<$0.01");
+    expect(formatUsd(0.01)).toBe("$0.01");
+  });
+});
 
 describe("hourly usage formatting", () => {
   it("enumerates 24 fixed buckets across a rolling window", () => {

--- a/packages/shared/src/usageFormat.ts
+++ b/packages/shared/src/usageFormat.ts
@@ -16,6 +16,7 @@ const CURRENCY = new Intl.NumberFormat("en-US", {
 const INTEGER = new Intl.NumberFormat("en-US");
 
 export function formatUsd(value: number): string {
+  if (value > 0 && value < 0.01) return "<$0.01";
   return CURRENCY.format(value);
 }
 

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -1,5 +1,6 @@
 import {
   USAGE_CONTRACT_VERSION,
+  USAGE_MERGE_COMPATIBLE_SINCE,
   type EnvironmentId,
   type UsageBucket,
   type UsageDay,
@@ -158,7 +159,7 @@ describe("mergeUsage", () => {
           summary(
             [bucket()],
             [{ provider: "claude", hostId: "linux", homePath: "/b" }],
-            USAGE_CONTRACT_VERSION - 2,
+            USAGE_MERGE_COMPATIBLE_SINCE - 1,
           ),
         ),
       ],


### PR DESCRIPTION
## What Changed

- Added an Early Access `piAgent` provider using Pi’s official RPC mode.
- Added dynamic model and thinking-level discovery, streaming, tool activity, steering, interruption, compaction, and session resume.
- Preserved Pi extensions, packages, skills, prompts, custom providers, profiles, credentials, and sessions by launching the installed Pi binary.
- Added Pi usage and cost reporting from Pi’s session files.
- Added `$` skill discovery and RPC-native extension dialogs across web and mobile.
- Exposed only Full Access because narrower permission modes cannot currently be enforced through Pi RPC.

### Intentional limitations

- TUI-only `ctx.ui.custom` widgets cannot render over RPC.
- Generic extension tools show their title and lifecycle status, but raw arguments and returned details are not currently projected into the final card.
- Pi emits command-output deltas, but T3 does not currently project them into the client card.
- Non-Git projects and files written outside the selected worktree do not appear in the changed-files card.
- Generic ACP Registry support remains separate future work.

## Why

T3 Code already included a disabled Pi Agent entry, but users could not run their existing Pi installations through T3. Using Pi’s official RPC mode keeps the integration at the provider boundary and preserves the user’s existing Pi configuration without embedding the Pi SDK into the server.

The integration was exercised with real Pi models, custom skills, custom tools, web search, interruption, compaction, session resume, project generation, and usage reconciliation.

## Review fixes

The first review round identified lifecycle and state-reconciliation edge cases. The follow-up commit:

- keeps an interrupted Pi turn active until Pi emits its authoritative settlement, preventing late events from completing a retry turn;
- serializes duplicate interrupts and cleans up startup, shutdown, stale-transport, and per-thread-lock state;
- reconciles unsupported draft and thread runtime modes to Full Access on web, mobile, queued sends, and the server boundary;
- accepts dotted, Unicode, numeric-leading, and punctuation-delimited discovered skill names; and
- propagates Pi catalog transport failures so a dead RPC process cannot be reported as ready.

A second review follow-up removes the shadowed abort arm, validates malformed Pi model state, keeps retained tool output bounded after truncation, makes the exit fixture flush reliably, and keeps an explicit empty runtime-capability fallback visible.

Post-rebase verification: 228 focused tests passed across Pi RPC, adapter, provider, skill dispatch, orchestration, shared runtime, web/mobile model state, and mobile outbox behavior. Targeted server, web, mobile, and client-runtime typechecks passed. An isolated browser pass confirmed that switching a Codex draft from Auto to Pi immediately reconciles it to Full access and leaves Full access as the only runtime choice.

## UI Changes

Before, Pi Agent was unavailable as a usable provider. After this change, users can configure Pi Agent, select dynamically discovered models and thinking levels, invoke Pi skills with `$`, inspect tool activity, and view Pi usage.

<details>
<summary>Open screenshots and recordings</summary>

### Provider models and reasoning controls

![Pi model and reasoning controls](https://github.com/user-attachments/assets/6c453de6-1b97-4345-a1d1-99790703ae87)

### Pi Agent provider and model surface

![Pi Agent models](https://github.com/user-attachments/assets/473c5f60-a146-4d14-a8b9-29f9eac17217)

### Completed Pi/Sol project-generation turn

![Completed Pi Sol turn](https://github.com/user-attachments/assets/e5da5af2-c923-44db-88c9-29170fc81b93)

### Progress narration and configured web search

![Pi progress and web search](https://github.com/user-attachments/assets/b9d53706-54ee-4945-a4e1-132aa66a68c2)

### Usage provider and model breakdown

![Pi usage breakdown](https://github.com/user-attachments/assets/39d7ed55-eee8-46b3-af29-b2015728ee9f)

### Usage with Terra and Luna sessions

![Pi Terra and Luna usage](https://github.com/user-attachments/assets/32c93d83-a60a-4729-aa88-7f02b3d431d2)

### Manual skills discovered through `$`

![Pi skills picker](https://github.com/user-attachments/assets/c6365602-2291-49d8-9039-833f8bc4cf0b)

### Completed custom-skill audit

![Completed Pi custom skill](https://github.com/user-attachments/assets/0c82c384-b122-446e-8cf5-8e861137e8d9)

### Pi/Sol web-search test — 5× speed

https://github.com/user-attachments/assets/cc344642-d6d0-494c-8e98-9e7c4002d8a6

### Pi Tool Lab interaction

https://github.com/user-attachments/assets/a650dcd3-9382-4c9c-85fd-4fa8da2bbb0b

### Fishslop gameplay and restart

https://github.com/user-attachments/assets/4013f443-f993-45ee-9f91-f42bde559dc9

### Custom `ask_user` fallback and resumed turn

https://github.com/user-attachments/assets/f7447239-fd4e-465d-9565-f953dca61c36

### Native manual-skill dispatch

https://github.com/user-attachments/assets/850d0352-5410-4ae4-ba88-7cbffd4549aa

### `$html-communicator` audit — 5× speed

https://github.com/user-attachments/assets/9759eb70-2369-423e-b814-9e35dabd8e84

### Changed-files card — 5× speed

https://github.com/user-attachments/assets/72315ccb-9b25-4c8c-a1fd-07f833d5c8c8

</details>


## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Generated by GPT-5.6 Sol through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a large new provider driver/RPC path and changes orchestration turn-start/runtime-mode ordering; Pi is limited to full-access at the adapter boundary, but incorrect reconciliation could still send wrong modes to other providers.
> 
> **Overview**
> Adds an Early Access **Pi Agent** provider that talks to a user-managed Pi binary over official RPC, including catalog discovery, session resume, streaming turns, steering/interrupts, extension UI dialogs, and composer `$skill` → `/skill:name` dispatch.
> 
> **Runtime mode** is now reconciled against each provider’s `supportedRuntimeModes` on mobile (new-task flow, thread composer, settings sheet, outbox drain, and turn start) and at dispatch; the thread settings UI only offers filtered runtime choices. The orchestration decider **persists** a reconciled `runtimeMode` via `thread.runtime-mode.set` before `thread.turn.start` when it differs from the thread snapshot, and turn-start events use the command’s mode instead of the stale thread value.
> 
> Mobile also gains a **Pi Agent** icon, usage chart series for `pi`, and model options that carry provider runtime capabilities. **Codex** model picker labels re-attach reasoning effort from slugs when the backend strips it from display names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac926b30f50696d98d3bf9ca167bc171b76dec6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `PiAgentDriver` and provider integration across web and mobile
> - Adds `PiAgentDriver`, `PiAgentAdapter`, and `PiAgentProvider` to manage Pi RPC sessions, catalog discovery, and status checks. Pi Agent is disabled by default.
> - Adds `PiSettings` to server contracts, including binary path, agent directory, and session directory configuration.
> - Implements Pi usage parsing and tracking in [usageTranscripts.ts](https://github.com/pingdotgg/t3code/pull/9648/files#diff-639e969b22f50fb1c28800a8caacb40faa709fb5b829f6c1e0a06a1be5fd5871) and [UsageService.ts](https://github.com/pingdotgg/t3code/pull/9648/files#diff-1d90d173860922c384f65961de4b51bba0176aadd7982190e0dcf87e663f1a70), adding the `pi` provider kind to the usage contract.
> - Adds provider-level `supported-runtime-modes` to `ServerProvider` and introduces runtime-mode reconciliation across mobile, web, and server to filter unsupported modes and replace them with the safest supported mode.
> - Risk: `fallbackTextGenerationProvider` in [serverSettings.ts](https://github.com/pingdotgg/t3code/pull/9648/files#diff-ec910be99e19e00c0e09b15484059b34164d71de8d0026f4ba98471bbbb3680e) skips Pi Agent, so enabling Pi Agent alone no longer selects it as the text-generation fallback. Runtime-mode reconciliation writes corrected modes back to existing composer drafts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac926b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

