### PR TITLE
feat(web): optional toggle to show rate limits in sidebar

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -58,6 +58,7 @@ const clientSettings: ClientSettings = {
   sidebarThreadSortOrder: "created_at",
   sidebarThreadPreviewCount: 6,
   legacySidebarEnabled: false,
+  sidebarUsageLimitsEnabled: true,
   timestampFormat: "24-hour",
   wordWrap: true,
 };

--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -32,6 +32,7 @@ import {
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { readPullRequestListPreferences } from "../pullRequest/pullRequestListPreferences";
 import { SidebarProviderUpdatePill } from "./SidebarProviderUpdatePill";
+import { SidebarUsageLimits } from "./SidebarUsageLimits";
 import { SidebarUpdateArchitectureWarning, SidebarUpdatePill } from "./SidebarUpdatePill";
 
 export const SidebarChromeHeader = memo(function SidebarChromeHeader({
@@ -226,6 +227,7 @@ export const SidebarChromeFooter = memo(function SidebarChromeFooter() {
     <SidebarFooter className="p-[var(--sidebar-content-inset)]">
       <SidebarProviderUpdatePill />
       <SidebarUpdateArchitectureWarning />
+      <SidebarUsageLimits />
       <SidebarUtilityMenu />
     </SidebarFooter>
   );

--- a/apps/web/src/components/sidebar/SidebarUsageLimits.tsx
+++ b/apps/web/src/components/sidebar/SidebarUsageLimits.tsx
@@ -2,13 +2,14 @@ import type {
   ProviderDriverKind,
   ServerConfig,
   ServerProvider,
+  ServerProviderUsageLimits,
   ServerProviderUsageWindow,
   UsageLimitSourceAccount,
   UsageProviderKind,
 } from "@t3tools/contracts";
 import { formatResetsIn, providerLimitsLabel } from "@t3tools/shared/usageLimits";
 import { useParams } from "@tanstack/react-router";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 
 import { useComposerDraftStore } from "../../composerDraftStore";
 import { useClientSettings } from "../../hooks/useSettings";
@@ -63,25 +64,25 @@ function sourceAccountForProvider(
   return sameDriver.length === 1 ? (sameDriver[0] ?? null) : null;
 }
 
-function windowsForProvider(
+function limitsForProvider(
   config: ServerConfig,
   provider: ServerProvider,
-): ReadonlyArray<ServerProviderUsageWindow> {
+): ServerProviderUsageLimits | null {
   if (
     provider.usageLimits !== undefined &&
     provider.usageLimits.unavailable === undefined &&
     provider.usageLimits.windows.length > 0
   ) {
-    return provider.usageLimits.windows;
+    return provider.usageLimits;
   }
   const sourceAccount = sourceAccountForProvider(config, provider);
   if (
     sourceAccount?.usageLimits.unavailable === undefined &&
     sourceAccount?.usageLimits.windows.length
   ) {
-    return sourceAccount.usageLimits.windows;
+    return sourceAccount.usageLimits;
   }
-  return [];
+  return null;
 }
 
 function windowLabel(window: ServerProviderUsageWindow): string {
@@ -145,7 +146,6 @@ export function SidebarUsageLimits() {
     return null;
   });
   const serverConfigs = useServerConfigs();
-  const [now] = useState(() => Date.now());
   const environmentId =
     routeTarget?.kind === "server"
       ? routeTarget.threadRef.environmentId
@@ -155,12 +155,12 @@ export function SidebarUsageLimits() {
     activeThread?.session?.providerInstanceId ??
     activeThread?.modelSelection.instanceId ??
     null;
-  if (!enabled) return null;
-  if (environmentId === null || instanceId === null) return null;
-  const config = serverConfigs.get(environmentId);
+  const config = environmentId === null ? undefined : serverConfigs.get(environmentId);
   const provider = config?.providers.find((candidate) => candidate.instanceId === instanceId);
-  if (!config || !provider) return null;
-  const windows = windowsForProvider(config, provider).toSorted(compareWindowDuration);
+  const limits = enabled && config && provider ? limitsForProvider(config, provider) : null;
+  if (!limits || !provider) return null;
+  const now = Date.parse(limits.checkedAt);
+  const windows = limits.windows.toSorted(compareWindowDuration);
   const shortestWindow = windows[0];
   if (!shortestWindow) return null;
   const color = providerColor(provider.driver);

--- a/apps/web/src/components/sidebar/SidebarUsageLimits.tsx
+++ b/apps/web/src/components/sidebar/SidebarUsageLimits.tsx
@@ -1,0 +1,230 @@
+import type {
+  ProviderDriverKind,
+  ServerConfig,
+  ServerProvider,
+  ServerProviderUsageWindow,
+  UsageLimitSourceAccount,
+  UsageProviderKind,
+} from "@t3tools/contracts";
+import { formatResetsIn, providerLimitsLabel } from "@t3tools/shared/usageLimits";
+import { useParams } from "@tanstack/react-router";
+import { useMemo, useState } from "react";
+
+import { useComposerDraftStore } from "../../composerDraftStore";
+import { useClientSettings } from "../../hooks/useSettings";
+import { useServerConfigs, useThread } from "../../state/entities";
+import { resolveActiveThreadRouteRef, resolveThreadRouteTarget } from "../../threadRoutes";
+import { ProviderInstanceIcon } from "../chat/ProviderInstanceIcon";
+import { getDriverOption } from "../settings/providerDriverMeta";
+import { PROVIDER_PRESENTATION } from "../usage/usageProviders";
+
+function compactDuration(minutes: number | undefined): string | null {
+  if (minutes === undefined) return null;
+  if (minutes % 1_440 === 0) return `${minutes / 1_440}d`;
+  if (minutes % 60 === 0) return `${minutes / 60}h`;
+  return `${minutes}m`;
+}
+
+function remainingPercent(window: ServerProviderUsageWindow): number {
+  return Math.max(0, Math.min(100, 100 - window.usedPercent));
+}
+
+function compareWindowDuration(
+  left: ServerProviderUsageWindow,
+  right: ServerProviderUsageWindow,
+): number {
+  return (
+    (left.windowDurationMins ?? Number.POSITIVE_INFINITY) -
+    (right.windowDurationMins ?? Number.POSITIVE_INFINITY)
+  );
+}
+
+function providerColor(driver: ProviderDriverKind): string {
+  const kind: UsageProviderKind | null =
+    driver === "codex" ? "codex" : driver === "claudeAgent" ? "claude" : null;
+  return kind === null ? "var(--sidebar-foreground)" : PROVIDER_PRESENTATION[kind].color;
+}
+
+function normalizedEmail(value: string | undefined): string | null {
+  const email = value?.trim().toLowerCase();
+  return email ? email : null;
+}
+
+function sourceAccountForProvider(
+  config: ServerConfig,
+  provider: ServerProvider,
+): UsageLimitSourceAccount | null {
+  const accounts = (config.usageLimitSources ?? []).flatMap((source) => source.accounts);
+  const sameDriver = accounts.filter((account) => account.driver === provider.driver);
+  const providerEmail = normalizedEmail(provider.auth.email);
+  if (providerEmail !== null) {
+    return sameDriver.find((account) => normalizedEmail(account.email) === providerEmail) ?? null;
+  }
+  return sameDriver.length === 1 ? (sameDriver[0] ?? null) : null;
+}
+
+function windowsForProvider(
+  config: ServerConfig,
+  provider: ServerProvider,
+): ReadonlyArray<ServerProviderUsageWindow> {
+  if (
+    provider.usageLimits !== undefined &&
+    provider.usageLimits.unavailable === undefined &&
+    provider.usageLimits.windows.length > 0
+  ) {
+    return provider.usageLimits.windows;
+  }
+  const sourceAccount = sourceAccountForProvider(config, provider);
+  if (
+    sourceAccount?.usageLimits.unavailable === undefined &&
+    sourceAccount?.usageLimits.windows.length
+  ) {
+    return sourceAccount.usageLimits.windows;
+  }
+  return [];
+}
+
+function windowLabel(window: ServerProviderUsageWindow): string {
+  const duration = compactDuration(window.windowDurationMins);
+  return duration === null ? window.label : `${window.label} · ${duration}`;
+}
+
+function UsageWindowBar({
+  window,
+  color,
+  now,
+}: {
+  readonly window: ServerProviderUsageWindow;
+  readonly color: string;
+  readonly now: number;
+}) {
+  const remaining = remainingPercent(window);
+  const reset = formatResetsIn(window, now);
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex min-w-0 items-center gap-2 text-[11px] leading-none">
+        <span className="min-w-0 flex-1 truncate text-sidebar-muted-foreground">
+          {windowLabel(window)}
+        </span>
+        <span className="shrink-0 font-medium text-sidebar-foreground tabular-nums">
+          {Math.round(remaining)}% left
+        </span>
+      </div>
+      <div className="h-1.5 overflow-hidden rounded-full bg-sidebar-control-surface">
+        <div
+          className="h-full rounded-full"
+          style={{ width: `${remaining}%`, backgroundColor: color }}
+        />
+      </div>
+      {reset ? (
+        <span className="text-[10px] leading-none text-sidebar-muted-foreground/70 tabular-nums">
+          {reset}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+export function SidebarUsageLimits() {
+  const enabled = useClientSettings((settings) => settings.sidebarUsageLimitsEnabled);
+  const routeTarget = useParams({
+    strict: false,
+    select: (params) => resolveThreadRouteTarget(params),
+  });
+  const draftSession = useComposerDraftStore((store) =>
+    routeTarget?.kind === "draft" ? store.getDraftSession(routeTarget.draftId) : null,
+  );
+  const routeThreadRef = useMemo(
+    () => resolveActiveThreadRouteRef(routeTarget, draftSession),
+    [draftSession, routeTarget],
+  );
+  const activeThread = useThread(routeThreadRef);
+  const composerDraft = useComposerDraftStore((store) => {
+    if (routeTarget?.kind === "draft") return store.getComposerDraft(routeTarget.draftId);
+    if (routeTarget?.kind === "server") return store.getComposerDraft(routeTarget.threadRef);
+    return null;
+  });
+  const serverConfigs = useServerConfigs();
+  const [now] = useState(() => Date.now());
+  const environmentId =
+    routeTarget?.kind === "server"
+      ? routeTarget.threadRef.environmentId
+      : (draftSession?.environmentId ?? null);
+  const instanceId =
+    composerDraft?.activeProvider ??
+    activeThread?.session?.providerInstanceId ??
+    activeThread?.modelSelection.instanceId ??
+    null;
+  if (!enabled) return null;
+  if (environmentId === null || instanceId === null) return null;
+  const config = serverConfigs.get(environmentId);
+  const provider = config?.providers.find((candidate) => candidate.instanceId === instanceId);
+  if (!config || !provider) return null;
+  const windows = windowsForProvider(config, provider).toSorted(compareWindowDuration);
+  const shortestWindow = windows[0];
+  if (!shortestWindow) return null;
+  const color = providerColor(provider.driver);
+  const providerLabel = providerLimitsLabel(provider, (driver) => getDriverOption(driver)?.label);
+  const shortestRemaining = remainingPercent(shortestWindow);
+  const shortestDuration = compactDuration(shortestWindow.windowDurationMins);
+  const summary = `${providerLabel} ${shortestWindow.label}: ${Math.round(shortestRemaining)}% left`;
+
+  return (
+    <div className="group/sidebar-usage relative">
+      <div
+        role="img"
+        aria-label={summary}
+        tabIndex={0}
+        className="flex cursor-default flex-col gap-1.5 rounded-md px-2 py-1.5 outline-none hover:bg-sidebar-row-hover focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <div className="flex min-w-0 items-center gap-1.5 text-[11px] leading-none">
+          <ProviderInstanceIcon
+            driverKind={provider.driver}
+            displayName={providerLabel}
+            accentColor={provider.accentColor}
+            showBadge={Boolean(provider.accentColor)}
+            indicatorBackground="var(--sidebar)"
+            className="size-3.5 shrink-0"
+            iconClassName="size-3 text-sidebar-muted-foreground"
+          />
+          <span className="min-w-0 flex-1 truncate text-sidebar-muted-foreground">
+            {providerLabel}
+            {shortestDuration ? ` · ${shortestDuration}` : ""}
+          </span>
+          <span className="shrink-0 font-medium text-sidebar-foreground tabular-nums">
+            {Math.round(shortestRemaining)}% left
+          </span>
+        </div>
+        <div className="h-1 overflow-hidden rounded-full bg-sidebar-control-surface">
+          <div
+            className="h-full rounded-full"
+            style={{ width: `${shortestRemaining}%`, backgroundColor: color }}
+          />
+        </div>
+      </div>
+      <div className="pointer-events-none invisible absolute inset-x-0 bottom-full z-50 pb-1 opacity-0 transition-opacity group-focus-within/sidebar-usage:pointer-events-auto group-focus-within/sidebar-usage:visible group-focus-within/sidebar-usage:opacity-100 group-hover/sidebar-usage:pointer-events-auto group-hover/sidebar-usage:visible group-hover/sidebar-usage:opacity-100">
+        <div className="flex flex-col gap-3 rounded-lg border border-sidebar-border bg-sidebar p-3 text-sidebar-foreground shadow-lg">
+          <div className="flex min-w-0 items-center gap-2">
+            <ProviderInstanceIcon
+              driverKind={provider.driver}
+              displayName={providerLabel}
+              accentColor={provider.accentColor}
+              showBadge={Boolean(provider.accentColor)}
+              indicatorBackground="var(--sidebar)"
+              className="size-4 shrink-0"
+              iconClassName="size-3.5 text-sidebar-foreground/80"
+            />
+            <span className="min-w-0 flex-1 truncate text-xs font-medium">
+              {providerLabel} limits
+            </span>
+          </div>
+          <div className="flex flex-col gap-3">
+            {windows.map((window) => (
+              <UsageWindowBar key={window.id} window={window} color={color} now={now} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/usage/UsageLimits.tsx
+++ b/apps/web/src/components/usage/UsageLimits.tsx
@@ -24,7 +24,11 @@ import {
 import { GaugeIcon, TrendingDownIcon, TrendingUpIcon } from "lucide-react";
 import { Fragment, useState } from "react";
 
-import { usePrimarySettings } from "../../hooks/useSettings";
+import {
+  useClientSettings,
+  usePrimarySettings,
+  useUpdateClientSettings,
+} from "../../hooks/useSettings";
 import { environmentPresentations } from "../../state/presentation";
 import { serverEnvironment } from "../../state/server";
 import { useAtomCommand } from "../../state/use-atom-command";
@@ -42,6 +46,7 @@ import {
   AlertDialogTitle,
 } from "../ui/alert-dialog";
 import { Button } from "../ui/button";
+import { Switch } from "../ui/switch";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { PROVIDER_PRESENTATION } from "./usageProviders";
 
@@ -397,6 +402,22 @@ const SOURCE_KIND_LABEL: Record<UsageLimitSourceSnapshot["kind"], string> = {
   cliproxy: "CLI Proxy",
 };
 
+function SidebarLimitsToggle() {
+  const checked = useClientSettings((settings) => settings.sidebarUsageLimitsEnabled);
+  const updateSettings = useUpdateClientSettings();
+  return (
+    <label className="flex h-8 shrink-0 cursor-pointer items-center gap-2 rounded-md px-2 text-xs text-muted-foreground hover:bg-muted hover:text-foreground">
+      <span>Show in sidebar</span>
+      <Switch
+        checked={checked}
+        onCheckedChange={(next) => updateSettings({ sidebarUsageLimitsEnabled: Boolean(next) })}
+        aria-label="Show limits in sidebar"
+        size="sm"
+      />
+    </label>
+  );
+}
+
 type LimitsSource = ReturnType<typeof collectLimitSources>[number];
 
 /** Read-only accounts pooled by a configured usage source. */
@@ -435,6 +456,9 @@ export function UsageLimitsSection() {
 
   return (
     <div className="flex flex-col gap-8">
+      <div className="flex justify-end">
+        <SidebarLimitsToggle />
+      </div>
       {groups.length === 0 && sources.length === 0 ? (
         <p className="text-sm text-muted-foreground">
           No provider on a connected environment reports subscription limits.

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -18,6 +18,11 @@ provider health-check interval and update live while a turn runs. API-key accoun
 subscription windows and say so; that includes a Claude Code that reaches Anthropic through a proxy
 via `ANTHROPIC_AUTH_TOKEN`, since the CLI then treats itself as an API-key client.
 
+When an open chat's provider reports subscription limits, the bottom of the sidebar shows the
+remaining quota for its shortest window, such as the five-hour session. Hover or focus the indicator
+to see every window for that provider without leaving the chat. Turn **Show in sidebar** off at the
+top of the Limits view to hide the indicator; the Usage button remains in the sidebar.
+
 If you pool accounts behind a CLIProxyAPI hub, open **Settings → Providers → Usage providers**
 and choose **Add hub**. Select the device that should connect to the hub; its accounts appear on
 the Limits view. Remove hubs from the same settings section. Each limits row shows its provider

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -20,8 +20,9 @@ via `ANTHROPIC_AUTH_TOKEN`, since the CLI then treats itself as an API-key clien
 
 When an open chat's provider reports subscription limits, the bottom of the sidebar shows the
 remaining quota for its shortest window, such as the five-hour session. Hover or focus the indicator
-to see every window for that provider without leaving the chat. Turn **Show in sidebar** off at the
-top of the Limits view to hide the indicator; the Usage button remains in the sidebar.
+to see every window for that provider without leaving the chat. The indicator is hidden by default;
+turn **Show in sidebar** on at the top of the Limits view to display it. The Usage button remains in
+the sidebar.
 
 If you pool accounts behind a CLIProxyAPI hub, open **Settings → Providers → Usage providers**
 and choose **Add hub**. Select the device that should connect to the hub; its accounts appear on

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -331,7 +331,7 @@ export const ClientSettingsSchema = Schema.Struct({
   // old keys, so everyone, including prior beta opt-outs, resets to the new
   // default sidebar.
   legacySidebarEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
-  sidebarUsageLimitsEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  sidebarUsageLimitsEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   sidebarProjectGroupingMode: SidebarProjectGroupingMode.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE)),
   ),

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -331,6 +331,7 @@ export const ClientSettingsSchema = Schema.Struct({
   // old keys, so everyone, including prior beta opt-outs, resets to the new
   // default sidebar.
   legacySidebarEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  sidebarUsageLimitsEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   sidebarProjectGroupingMode: SidebarProjectGroupingMode.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE)),
   ),
@@ -1201,6 +1202,7 @@ export const ClientSettingsPatch = Schema.Struct({
   proactivePanelsEnabled: Schema.optionalKey(Schema.Boolean),
   showSkillsInSlashMenu: Schema.optionalKey(Schema.Boolean),
   legacySidebarEnabled: Schema.optionalKey(Schema.Boolean),
+  sidebarUsageLimitsEnabled: Schema.optionalKey(Schema.Boolean),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),
   sidebarProjectGroupingOverrides: Schema.optionalKey(
     Schema.Record(TrimmedNonEmptyString, SidebarProjectGroupingMode),


### PR DESCRIPTION
## What Changed

Adds an optional usage-limit indicator above the sidebar footer controls.

For the provider selected in the current chat, the compact indicator shows the remaining quota in its shortest reported window, such as Claude's five-hour limit. Hovering or focusing it expands an in-sidebar panel showing every reported limit window and reset countdown for that provider.

**The indicator is disabled by default.** It can be enabled with the **Show in sidebar** toggle at the top of the Usage → Limits view.

This is a web/desktop UI addition built on the provider usage-limit data introduced in #9507. It does not add another provider probe, polling loop, or usage-limit backend.

## Why

The Limits view provides the complete account overview, but checking it requires leaving the active chat. The shortest-duration window is usually the limit most likely to interrupt the current task, so showing that value in the sidebar makes it available at a glance.

Keeping the feature opt-in avoids adding permanent sidebar noise for users who do not need it. Expanding on hover or keyboard focus provides the remaining windows without duplicating the full Limits page.

This follows up on earlier sidebar proposals such as #4611, #6264, and #8138 while reusing the usage-limit architecture already merged through #9507.

## UI Changes

Before: provider limits are available only from Usage → Limits.

After: when **Show in sidebar** is enabled, the active provider's shortest usage window appears above the sidebar footer controls. Hovering or focusing it shows all reported windows inside the sidebar boundary.

<img width="1155" height="492" alt="image" src="https://github.com/user-attachments/assets/e414a2ea-ad17-447e-b0a4-5491f5310ecc" />

<img width="245" height="171" alt="image" src="https://github.com/user-attachments/assets/45e9d482-cd40-4964-8474-382b3aeb60cc" />

<img width="242" height="90" alt="image" src="https://github.com/user-attachments/assets/d600c771-1c56-4880-af1f-04bc1d0d25aa" />

<img width="253" height="265" alt="image" src="https://github.com/user-attachments/assets/cdfbae8d-bddf-470b-8175-22d935a6be5d" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add optional sidebar rate-limit indicator with `sidebarUsageLimitsEnabled` toggle
> - Adds a new `sidebarUsageLimitsEnabled` client setting (default `false`) so users can opt into showing usage limits in the sidebar footer
> - Renders a compact shortest-window remaining-percentage indicator and an expanded view with all sorted usage windows via the new `SidebarUsageLimits` component in [SidebarChrome.tsx](https://github.com/pingdotgg/t3code/pull/9649/files#diff-cbdc7d544762cec67fb7c23f9e66e80e1ca2158f0d100a878363a7ae01f77c11)
> - Resolves provider limits by preferring provider-level limits, falling back to a matching usage-source account selected by driver and normalized email
> - Adds a "Show in sidebar" toggle in the Limits view and documents the feature in [usage.md](https://github.com/pingdotgg/t3code/pull/9649/files#diff-d73591feaa8c26e8f16b7467464af0044ee0a9c288ef17901538a61715440e62)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f18044d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->