### PR TITLE
fix(server): unblock OpenCode approvals and stop

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -263,6 +263,68 @@ describe("pending user input answers", () => {
 });
 
 describe("pending approvals", () => {
+  it.each([{}, { requestType: "unknown" }])(
+    "exposes legacy OpenCode approvals without a known request kind: %j",
+    (legacyPayload) => {
+      const requested = makeActivity({
+        id: EventId.make("approval-legacy"),
+        kind: "approval.requested",
+        summary: "Approval requested",
+        createdAt: "2026-08-24T00:00:00.000Z",
+        payload: { requestId: "per-legacy", detail: "*", ...legacyPayload },
+      });
+
+      expect(derivePendingApprovals([requested])).toEqual([
+        {
+          requestId: "per-legacy",
+          requestKind: "command",
+          createdAt: requested.createdAt,
+          detail: "*",
+        },
+      ]);
+    },
+  );
+
+  it.each(["tool_user_input", "auth_tokens_refresh"])(
+    "does not turn %s into an approval",
+    (requestType) => {
+      const activity = makeActivity({
+        id: EventId.make("approval-non-approval"),
+        kind: "approval.requested",
+        summary: "Approval requested",
+        createdAt: "2026-08-24T00:00:00.000Z",
+        payload: { requestId: "not-an-approval", requestType },
+      });
+
+      expect(derivePendingApprovals([activity])).toEqual([]);
+    },
+  );
+
+  it.each(["approval.resolved", "provider.approval.respond.failed"])(
+    "removes legacy approvals after %s",
+    (kind) => {
+      const requested = makeActivity({
+        id: EventId.make("approval-legacy-open"),
+        kind: "approval.requested",
+        summary: "Approval requested",
+        createdAt: "2026-08-24T00:00:00.000Z",
+        payload: { requestId: "per-legacy", requestType: "unknown" },
+      });
+      const resolved = makeActivity({
+        id: EventId.make("approval-legacy-resolved"),
+        kind,
+        summary: "Approval resolved",
+        createdAt: "2026-08-24T00:00:01.000Z",
+        payload: {
+          requestId: "per-legacy",
+          detail: "Unknown pending permission request: per-legacy",
+        },
+      });
+
+      expect(derivePendingApprovals([requested, resolved])).toEqual([]);
+    },
+  );
+
   it("keeps app access approvals and persistence choices from remote environments", () => {
     const options = [
       { decision: "decline", label: "Decline" },

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -1754,10 +1754,16 @@ export function derivePendingApprovals(
       ? payload.options.filter(isProviderApprovalOption)
       : undefined;
 
-    if (activity.kind === "approval.requested" && requestId && requestKind) {
+    if (
+      activity.kind === "approval.requested" &&
+      requestId &&
+      payload?.requestType !== "tool_user_input" &&
+      payload?.requestType !== "auth_tokens_refresh"
+    ) {
       openByRequestId.set(requestId, {
         requestId,
-        requestKind,
+        // Older OpenCode requests can have no recognized approval kind.
+        requestKind: requestKind ?? "command",
         createdAt: activity.createdAt,
         ...(detail ? { detail } : {}),
         ...(appName ? { appName } : {}),

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -1,4 +1,5 @@
 import {
+  ApprovalRequestId,
   CheckpointRef,
   CommandId,
   CorrelationId,
@@ -2744,7 +2745,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
     }),
   );
 
-  it.effect("ignores non-stale provider approval response failures", () =>
+  it.effect("restores pending approvals when a provider reply fails", () =>
     Effect.gen(function* () {
       const projectionPipeline = yield* OrchestrationProjectionPipeline;
       const eventStore = yield* OrchestrationEventStore;
@@ -2826,6 +2827,24 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
             turnId: null,
             createdAt: "2026-02-26T12:45:02.000Z",
           },
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.approval-response-requested",
+        eventId: EventId.make("evt-nonstale-approval-response"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-nonstale-approval"),
+        occurredAt: "2026-02-26T12:45:02.500Z",
+        commandId: CommandId.make("cmd-nonstale-approval-response"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-nonstale-approval-response"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-nonstale-approval"),
+          requestId: ApprovalRequestId.make("approval-request-nonstale-existing"),
+          decision: "accept",
+          createdAt: "2026-02-26T12:45:02.500Z",
         },
       });
 
@@ -2921,6 +2940,67 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
         WHERE thread_id = 'thread-nonstale-approval'
       `;
       assert.deepEqual(threadRows, [{ pendingApprovalCount: 1 }]);
+
+      yield* appendAndProject({
+        type: "thread.activity-appended",
+        eventId: EventId.make("evt-nonstale-approval-resolved"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-nonstale-approval"),
+        occurredAt: "2026-02-26T12:45:05.000Z",
+        commandId: CommandId.make("cmd-nonstale-approval-resolved"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-nonstale-approval-resolved"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-nonstale-approval"),
+          activity: {
+            id: EventId.make("activity-nonstale-approval-resolved"),
+            tone: "approval",
+            kind: "approval.resolved",
+            summary: "Approval resolved",
+            payload: {
+              requestId: "approval-request-nonstale-existing",
+              decision: "accept",
+            },
+            turnId: null,
+            createdAt: "2026-02-26T12:45:05.000Z",
+          },
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.activity-appended",
+        eventId: EventId.make("evt-nonstale-approval-late-failure"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-nonstale-approval"),
+        occurredAt: "2026-02-26T12:45:06.000Z",
+        commandId: CommandId.make("cmd-nonstale-approval-late-failure"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-nonstale-approval-late-failure"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-nonstale-approval"),
+          activity: {
+            id: EventId.make("activity-nonstale-approval-late-failure"),
+            tone: "error",
+            kind: "provider.approval.respond.failed",
+            summary: "Provider approval response failed",
+            payload: {
+              requestId: "approval-request-nonstale-existing",
+              detail: "Provider timed out while responding to approval request",
+            },
+            turnId: null,
+            createdAt: "2026-02-26T12:45:06.000Z",
+          },
+        },
+      });
+
+      const resolvedThreadRows = yield* sql<{ readonly pendingApprovalCount: number }>`
+        SELECT pending_approval_count AS "pendingApprovalCount"
+        FROM projection_threads
+        WHERE thread_id = 'thread-nonstale-approval'
+      `;
+      assert.deepEqual(resolvedThreadRows, [{ pendingApprovalCount: 0 }]);
     }),
   );
 

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1728,6 +1728,44 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
               });
               return;
             }
+            if (Option.isNone(existingRow) || existingRow.value.status !== "resolved") {
+              return;
+            }
+
+            // Sending a reply clears the badge before the provider accepts it.
+            // A failed reply must restore the request unless a terminal event
+            // already closed it, including a reply from another client.
+            const requestActivities = (yield* projectionThreadActivityRepository.listByThreadId({
+              threadId: existingRow.value.threadId,
+            })).filter((activity) => extractActivityRequestId(activity.payload) === requestId);
+            const wasRequested = requestActivities.some(
+              (activity) => activity.kind === "approval.requested",
+            );
+            const wasResolved = requestActivities.some((activity) => {
+              if (activity.kind === "approval.resolved") {
+                return true;
+              }
+              if (activity.kind !== "provider.approval.respond.failed") {
+                return false;
+              }
+              const activityPayload =
+                typeof activity.payload === "object" && activity.payload !== null
+                  ? (activity.payload as Record<string, unknown>)
+                  : null;
+              return isStalePendingApprovalFailureDetail(
+                typeof activityPayload?.detail === "string"
+                  ? activityPayload.detail.toLowerCase()
+                  : null,
+              );
+            });
+            if (wasRequested && !wasResolved) {
+              yield* projectionPendingApprovalRepository.upsert({
+                ...existingRow.value,
+                status: "pending",
+                decision: null,
+                resolvedAt: null,
+              });
+            }
             return;
           }
           // Only approval-requested activities should create pending-approval

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -371,6 +371,124 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.lastError).toBe("turn failed");
   });
 
+  it.each([
+    { delivery: "buffered", enableLegacyTokenStreaming: false },
+    { delivery: "streamed", enableLegacyTokenStreaming: true },
+  ])("settles OpenCode aborted turns and saves $delivery assistant text", async (settings) => {
+    const harness = await createHarness({
+      serverSettings: { enableLegacyTokenStreaming: settings.enableLegacyTokenStreaming },
+    });
+    const threadId = asThreadId("thread-1");
+    const turnId = asTurnId("opencode-aborted-turn");
+    const base = {
+      provider: ProviderDriverKind.make("opencode"),
+      threadId,
+      turnId,
+      createdAt: "2026-01-01T00:00:01.000Z",
+    };
+    harness.emit({ ...base, type: "turn.started", eventId: asEventId("opencode-started") });
+    harness.emit({
+      ...base,
+      type: "content.delta",
+      eventId: asEventId("opencode-partial-text"),
+      itemId: asItemId("opencode-text-part"),
+      payload: { streamKind: "assistant_text", delta: "Work before the stop." },
+    });
+    harness.emit({
+      ...base,
+      type: "turn.aborted",
+      eventId: asEventId("opencode-aborted"),
+      createdAt: "2026-01-01T00:00:02.000Z",
+      payload: { reason: "Interrupted by user." },
+    });
+
+    await harness.drain();
+    const thread = (await harness.readModel()).threads.find((entry) => entry.id === threadId);
+    expect(thread?.session).toMatchObject({
+      status: "interrupted",
+      activeTurnId: null,
+      lastError: null,
+    });
+    expect(thread?.latestTurn).toMatchObject({
+      turnId,
+      state: "interrupted",
+      completedAt: "2026-01-01T00:00:02.000Z",
+    });
+    expect(thread?.messages).toEqual([
+      expect.objectContaining({
+        role: "assistant",
+        turnId,
+        text: "Work before the stop.",
+        streaming: false,
+      }),
+    ]);
+  });
+
+  it.each([
+    { source: "the previous turn", turnId: asTurnId("opencode-stopped-turn") },
+    { source: "an unspecified turn", turnId: undefined },
+  ])("keeps a new OpenCode turn running after an abort for $source", async (lateAbort) => {
+    const harness = await createHarness({
+      serverSettings: { enableLegacyTokenStreaming: true },
+    });
+    const threadId = asThreadId("thread-1");
+    const stoppedTurnId = asTurnId("opencode-stopped-turn");
+    const nextTurnId = asTurnId("opencode-next-turn");
+    const base = {
+      provider: ProviderDriverKind.make("opencode"),
+      threadId,
+      createdAt: "2026-01-01T00:00:01.000Z",
+    };
+    harness.emit({
+      ...base,
+      type: "turn.started",
+      eventId: asEventId("opencode-first-started"),
+      turnId: stoppedTurnId,
+    });
+    harness.emit({
+      ...base,
+      type: "turn.aborted",
+      eventId: asEventId("opencode-first-aborted"),
+      turnId: stoppedTurnId,
+      payload: { reason: "Interrupted by user." },
+    });
+    harness.emit({
+      ...base,
+      type: "turn.started",
+      eventId: asEventId("opencode-next-started"),
+      turnId: nextTurnId,
+    });
+    harness.emit({
+      ...base,
+      type: "content.delta",
+      eventId: asEventId("opencode-next-partial-text"),
+      turnId: nextTurnId,
+      itemId: asItemId("opencode-next-text-part"),
+      payload: { streamKind: "assistant_text", delta: "The next turn is running." },
+    });
+    await harness.drain();
+
+    harness.emit({
+      ...base,
+      type: "turn.aborted",
+      eventId: asEventId("opencode-late-abort"),
+      ...(lateAbort.turnId ? { turnId: lateAbort.turnId } : {}),
+      payload: { reason: "Interrupted by user." },
+    });
+    await harness.drain();
+
+    const thread = (await harness.readModel()).threads.find((entry) => entry.id === threadId);
+    expect(thread?.session).toMatchObject({ status: "running", activeTurnId: nextTurnId });
+    expect(thread?.latestTurn).toMatchObject({ turnId: nextTurnId, state: "running" });
+    expect(thread?.messages).toEqual([
+      expect.objectContaining({
+        turnId: nextTurnId,
+        text: "The next turn is running.",
+        streaming: true,
+      }),
+    ]);
+  });
+
   it("applies provider session.state.changed transitions directly", async () => {
     const harness = await createHarness();
     const waitingAt = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -427,7 +427,7 @@ describe("ProviderRuntimeIngestion", () => {
   it.each([
     { source: "the previous turn", turnId: asTurnId("opencode-stopped-turn") },
     { source: "an unspecified turn", turnId: undefined },
-  ])("keeps a new OpenCode turn running after an abort for $source", async (lateAbort) => {
+  ])("ignores late OpenCode aborts for $source across newer turns", async (lateAbort) => {
     const harness = await createHarness({
       serverSettings: { enableLegacyTokenStreaming: true },
     });
@@ -487,6 +487,78 @@ describe("ProviderRuntimeIngestion", () => {
         streaming: true,
       }),
     ]);
+
+    harness.emit({
+      ...base,
+      type: "turn.completed",
+      eventId: asEventId("opencode-next-completed"),
+      turnId: nextTurnId,
+      createdAt: "2026-01-01T00:00:02.000Z",
+      payload: { state: "completed" },
+    });
+    await harness.drain();
+
+    const pendingAt = "2026-01-01T00:00:03.000Z";
+    for (const hasPendingStart of [false, true]) {
+      if (hasPendingStart) {
+        await harness.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make("opencode-pending-start"),
+          threadId,
+          message: {
+            messageId: asMessageId("opencode-pending-message"),
+            role: "user",
+            text: "Start another turn.",
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt: pendingAt,
+        });
+        harness.emit({
+          ...base,
+          type: "session.state.changed",
+          eventId: asEventId("opencode-pending-starting"),
+          createdAt: pendingAt,
+          payload: { state: "starting" },
+        });
+      }
+      harness.emit({
+        ...base,
+        type: "turn.aborted",
+        eventId: asEventId(`opencode-late-abort-after-completion-${hasPendingStart}`),
+        ...(lateAbort.turnId ? { turnId: lateAbort.turnId } : {}),
+        createdAt: "2026-01-01T00:00:04.000Z",
+        payload: { reason: "Interrupted by user." },
+      });
+      await harness.drain();
+
+      const completedThread = (await harness.readModel()).threads.find(
+        (entry) => entry.id === threadId,
+      );
+      expect(completedThread?.session).toMatchObject({
+        status: hasPendingStart ? "starting" : "ready",
+        activeTurnId: null,
+      });
+      expect(completedThread?.latestTurn).toMatchObject({ turnId: nextTurnId, state: "completed" });
+    }
+
+    harness.emit({
+      ...base,
+      type: "turn.started",
+      eventId: asEventId("opencode-pending-started"),
+      turnId: asTurnId("opencode-pending-turn"),
+      createdAt: "2026-01-01T00:00:05.000Z",
+    });
+    await harness.drain();
+    const startedThread = (await harness.readModel()).threads.find(
+      (entry) => entry.id === threadId,
+    );
+    expect(startedThread?.latestTurn).toMatchObject({
+      turnId: asTurnId("opencode-pending-turn"),
+      state: "running",
+      requestedAt: pendingAt,
+    });
   });
 
   it("applies provider session.state.changed transitions directly", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1578,6 +1578,7 @@ const make = Effect.gen(function* () {
       const now = event.createdAt;
       const eventTurnId = toTurnId(event.turnId);
       const activeTurnId = thread.session?.activeTurnId ?? null;
+      const isTerminalTurn = event.type === "turn.completed" || event.type === "turn.aborted";
       const isCompactedThreadState =
         event.type === "thread.state.changed" && event.payload.state === "compacted";
       const pendingTurnStart =
@@ -1586,7 +1587,7 @@ const make = Effect.gen(function* () {
         event.type === "session.exited" ||
         event.type === "thread.started" ||
         event.type === "turn.started" ||
-        event.type === "turn.completed" ||
+        isTerminalTurn ||
         isCompactedThreadState
           ? yield* projectionTurnRepository.getPendingTurnStartByThreadId({
               threadId: thread.id,
@@ -1624,6 +1625,7 @@ const make = Effect.gen(function* () {
           case "turn.started":
             return !conflictsWithActiveTurn || conflictingTurnStartIsPendingTurnStart;
           case "turn.completed":
+          case "turn.aborted":
             if (conflictsWithActiveTurn || missingTurnForActiveTurn) {
               return false;
             }
@@ -1654,7 +1656,7 @@ const make = Effect.gen(function* () {
         event.type === "session.exited" ||
         event.type === "thread.started" ||
         event.type === "turn.started" ||
-        event.type === "turn.completed"
+        isTerminalTurn
       ) {
         const status = (() => {
           switch (event.type) {
@@ -1666,6 +1668,8 @@ const make = Effect.gen(function* () {
               return "running";
             case "session.exited":
               return "stopped";
+            case "turn.aborted":
+              return "interrupted";
             case "turn.completed":
               return normalizeRuntimeTurnState(event.payload.state) === "failed"
                 ? "error"
@@ -1680,7 +1684,7 @@ const make = Effect.gen(function* () {
         const nextActiveTurnId =
           event.type === "turn.started"
             ? (eventTurnId ?? null)
-            : event.type === "turn.completed" || event.type === "session.exited"
+            : isTerminalTurn || event.type === "session.exited"
               ? null
               : event.type === "session.state.changed" &&
                   !sessionStatusAllowsActiveTurn(
@@ -1694,7 +1698,7 @@ const make = Effect.gen(function* () {
             : event.type === "turn.completed" &&
                 normalizeRuntimeTurnState(event.payload.state) === "failed"
               ? (event.payload.errorMessage ?? thread.session?.lastError ?? "Turn failed")
-              : status === "ready"
+              : status === "ready" || status === "interrupted"
                 ? null
                 : (thread.session?.lastError ?? null);
 
@@ -1922,7 +1926,7 @@ const make = Effect.gen(function* () {
         });
       }
 
-      if (event.type === "turn.completed") {
+      if (isTerminalTurn) {
         const detailedThread = yield* getLoadedThreadDetail();
         const messages = detailedThread?.messages ?? [];
         const proposedPlans = detailedThread?.proposedPlans ?? [];
@@ -2055,7 +2059,7 @@ const make = Effect.gen(function* () {
       } else if (!conflictsWithActiveTurn) {
         if (event.type === "turn.plan.updated") {
           threadPlanProgress.recordPlanProgress(thread.id, event.payload.plan);
-        } else if (event.type === "turn.completed" || event.type === "turn.aborted") {
+        } else if (isTerminalTurn && shouldApplyThreadLifecycle) {
           threadPlanProgress.clearThreadPlanProgress(thread.id);
         }
       }

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1633,14 +1633,10 @@ const make = Effect.gen(function* () {
             if (activeTurnId !== null && eventTurnId !== undefined) {
               return sameId(activeTurnId, eventTurnId);
             }
-            // No active turn tracked: accept only completions that name their
-            // turn (covers a real completion whose turn.started was lost). An
-            // untargeted completion cannot prove it belongs to any turn this
-            // thread ran — the known emitter was the Claude resume handshake
-            // (system/init + result(num_turns: 0)), which is not a turn at
-            // all — and applying it here stomps the "starting" lifecycle
-            // state while a turn start is pending.
-            return eventTurnId !== undefined;
+            // A named completion can recover a lost turn.started event.
+            // An abort needs an active turn so a delayed stop cannot replace
+            // a ready session or clear a newer pending start.
+            return event.type === "turn.completed" && eventTurnId !== undefined;
           default:
             return true;
         }

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -5791,23 +5791,27 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
-  it.effect("maps native task updates and command results to client progress", () =>
+  it.effect("maps native task progress only while a turn is active", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
       const threadId = asThreadId("thread-native-progress");
       const sessionID = "http://127.0.0.1:9999/session";
+      const startProgress = promiseWithResolvers<OpenCodeEvent>();
+      const finishTurn = promiseWithResolvers<OpenCodeEvent>();
+      const lateProgress = promiseWithResolvers<OpenCodeEvent>();
       const todos = [
         { content: "Read files", status: "completed", priority: "high" },
         { content: "Fix OpenCode", status: "in_progress", priority: "high" },
         { content: "Run tests", status: "pending", priority: "medium" },
         { content: "Old task", status: "cancelled", priority: "low" },
       ];
+      const todoEvent = {
+        id: "evt-todos",
+        type: "todo.updated",
+        properties: { sessionID, todos },
+      } satisfies OpenCodeEvent;
       runtimeMock.state.subscribedEvents = [
-        {
-          id: "evt-todos",
-          type: "todo.updated",
-          properties: { sessionID, todos },
-        } satisfies OpenCodeEvent,
+        startProgress.promise,
         ...["todowrite", "bash"].map(
           (tool) =>
             ({
@@ -5835,6 +5839,9 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
               },
             }) satisfies OpenCodeEvent,
         ),
+        finishTurn.promise,
+        lateProgress.promise,
+        { id: "evt-progress-drained", type: "session.compacted", properties: { sessionID } },
       ];
       const eventsFiber = yield* adapter.streamEvents.pipe(
         Stream.filter(
@@ -5851,8 +5858,18 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         threadId,
         runtimeMode: "full-access",
       });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Work through the task list",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      startProgress.resolve(todoEvent);
       const events = yield* Fiber.join(eventsFiber);
       const plan = events.find((event) => event.type === "turn.plan.updated");
+      NodeAssert.equal(plan?.turnId, turn.turnId);
       NodeAssert.deepEqual(plan?.payload.plan, [
         { step: "Read files", status: "completed" },
         { step: "Fix OpenCode", status: "inProgress" },
@@ -5865,6 +5882,28 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         command: "pwd",
         result: "/repo\n",
       });
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      finishTurn.resolve({
+        id: "evt-progress-completed",
+        type: "session.status",
+        properties: { sessionID, status: { type: "idle" } },
+      });
+      yield* Fiber.join(completedFiber);
+      const lateEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.takeUntil((event) => event.type === "thread.state.changed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      lateProgress.resolve({ ...todoEvent, id: "evt-late-todos" });
+      NodeAssert.deepEqual(
+        (yield* Fiber.join(lateEventsFiber)).map((event) => event.type),
+        ["thread.state.changed"],
+      );
       yield* adapter.stopSession(threadId);
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -15,7 +15,11 @@ import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
 import { beforeEach } from "vite-plus/test";
-import type { PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2";
+import type {
+  Event as OpenCodeEvent,
+  PermissionRequest,
+  QuestionRequest,
+} from "@opencode-ai/sdk/v2";
 
 import {
   ApprovalRequestId,
@@ -85,23 +89,30 @@ const runtimeMock = {
     promptAsyncImplementation: null as (() => Promise<void>) | null,
     autoPromptEcho: true,
     autoConnect: true,
+    endEventStream: false,
     promptEchoEvents: [] as Array<unknown>,
     closeError: null as Error | null,
     messages: [] as MessageEntry[],
     subscribedEvents: [] as Array<unknown | Promise<unknown>>,
     eventSubscribeObserved: null as (() => void) | null,
+    eventStreamError: null as ((cause: unknown) => void) | null,
     permissionReplyCalls: [] as Array<{ requestID: string; reply: string }>,
-    permissionReplyImplementation: null as (() => Promise<void>) | null,
+    permissionReplyImplementation: null as ((signal?: AbortSignal) => Promise<void>) | null,
+    permissionReplySignals: [] as AbortSignal[],
     questionReplyCalls: [] as Array<{
       requestID: string;
       answers: ReadonlyArray<ReadonlyArray<string>>;
     }>,
+    questionReplyImplementation: null as ((signal?: AbortSignal) => Promise<void>) | null,
     sessionStatus: "idle" as "idle" | "busy",
     sessionStatusFailures: 0,
     sessionStatusCalls: 0,
     sessionStatusImplementation: null as (() => Promise<unknown>) | null,
     sessionGetIds: [] as string[],
     sessionGetObserved: null as ((sessionID: string) => void) | null,
+    sessionGetImplementation: null as
+      | ((sessionID: string, signal?: AbortSignal) => Promise<void>)
+      | null,
     missingSessionIds: new Set<string>(),
     transientErrorSessionIds: new Set<string>(),
     sessionDirectoryById: new Map<string, string>(),
@@ -137,20 +148,25 @@ const runtimeMock = {
     this.state.promptAsyncImplementation = null;
     this.state.autoPromptEcho = true;
     this.state.autoConnect = true;
+    this.state.endEventStream = false;
     this.state.promptEchoEvents.length = 0;
     this.state.closeError = null;
     this.state.messages = [];
     this.state.subscribedEvents = [];
     this.state.eventSubscribeObserved = null;
+    this.state.eventStreamError = null;
     this.state.permissionReplyCalls.length = 0;
     this.state.permissionReplyImplementation = null;
+    this.state.permissionReplySignals.length = 0;
     this.state.questionReplyCalls.length = 0;
+    this.state.questionReplyImplementation = null;
     this.state.sessionStatus = "idle";
     this.state.sessionStatusFailures = 0;
     this.state.sessionStatusCalls = 0;
     this.state.sessionStatusImplementation = null;
     this.state.sessionGetIds.length = 0;
     this.state.sessionGetObserved = null;
+    this.state.sessionGetImplementation = null;
     this.state.missingSessionIds.clear();
     this.state.transientErrorSessionIds.clear();
     this.state.sessionDirectoryById.clear();
@@ -222,9 +238,12 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             data: { id: runtimeMock.state.createdSessionIds.shift() ?? `${baseUrl}/session` },
           };
         },
-        get: async ({ sessionID }: { sessionID: string }) => {
+        get: async ({ sessionID }: { sessionID: string }, options?: { signal?: AbortSignal }) => {
           runtimeMock.state.sessionGetIds.push(sessionID);
           runtimeMock.state.sessionGetObserved?.(sessionID);
+          if (runtimeMock.state.sessionGetImplementation) {
+            await runtimeMock.state.sessionGetImplementation(sessionID, options?.signal);
+          }
           // The real client is `throwOnError: true`: non-2xx rejects rather
           // than resolving, so missing → 404 throw, transient → 500 throw.
           if (runtimeMock.state.transientErrorSessionIds.has(sessionID)) {
@@ -264,6 +283,12 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             runtimeMock.state.abortSignals.push(options.signal);
           }
           await runtimeMock.state.abortImplementation?.(sessionID, options?.signal);
+          runtimeMock.state.pendingPermissions = runtimeMock.state.pendingPermissions.filter(
+            (request) => request.sessionID !== sessionID,
+          );
+          runtimeMock.state.pendingQuestions = runtimeMock.state.pendingQuestions.filter(
+            (request) => request.sessionID !== sessionID,
+          );
         },
         children: async ({ sessionID }: { sessionID: string }) => {
           runtimeMock.state.sessionChildrenCalls.push(sessionID);
@@ -357,19 +382,60 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         },
       },
       event: {
-        subscribe: async () => {
+        subscribe: async (
+          _input: unknown,
+          options?: { signal?: AbortSignal; onSseError?: (cause: unknown) => void },
+        ) => {
           runtimeMock.state.eventSubscribeObserved?.();
+          runtimeMock.state.eventStreamError = options?.onSseError ?? null;
           return {
             stream: (async function* () {
-              if (runtimeMock.state.autoConnect) {
-                yield { id: "evt-auto-connected", type: "server.connected", properties: {} };
-              }
-              for (const event of runtimeMock.state.subscribedEvents) {
-                const resolved = await event;
-                while (runtimeMock.state.promptEchoEvents.length > 0) {
-                  yield runtimeMock.state.promptEchoEvents.shift();
+              const aborted = promiseWithResolvers<void>();
+              const onAbort = () => aborted.resolve(undefined);
+              options?.signal?.addEventListener("abort", onAbort, { once: true });
+              try {
+                if (runtimeMock.state.autoConnect) {
+                  yield { id: "evt-auto-connected", type: "server.connected", properties: {} };
                 }
-                yield resolved;
+                for (const event of runtimeMock.state.subscribedEvents) {
+                  if (options?.signal?.aborted) return;
+                  const resolved = await Promise.race([event, aborted.promise]);
+                  if (options?.signal?.aborted) return;
+                  while (runtimeMock.state.promptEchoEvents.length > 0) {
+                    yield runtimeMock.state.promptEchoEvents.shift();
+                  }
+                  const nativeEvent = resolved as OpenCodeEvent;
+                  if (nativeEvent.type === "permission.asked") {
+                    runtimeMock.state.pendingPermissions =
+                      runtimeMock.state.pendingPermissions.filter(
+                        (request) => request.id !== nativeEvent.properties.id,
+                      );
+                    runtimeMock.state.pendingPermissions.push(nativeEvent.properties);
+                  } else if (nativeEvent.type === "permission.replied") {
+                    runtimeMock.state.pendingPermissions =
+                      runtimeMock.state.pendingPermissions.filter(
+                        (request) => request.id !== nativeEvent.properties.requestID,
+                      );
+                  } else if (nativeEvent.type === "question.asked") {
+                    runtimeMock.state.pendingQuestions = runtimeMock.state.pendingQuestions.filter(
+                      (request) => request.id !== nativeEvent.properties.id,
+                    );
+                    runtimeMock.state.pendingQuestions.push(nativeEvent.properties);
+                  } else if (
+                    nativeEvent.type === "question.replied" ||
+                    nativeEvent.type === "question.rejected"
+                  ) {
+                    runtimeMock.state.pendingQuestions = runtimeMock.state.pendingQuestions.filter(
+                      (request) => request.id !== nativeEvent.properties.requestID,
+                    );
+                  }
+                  yield resolved;
+                }
+                if (!runtimeMock.state.endEventStream && !options?.signal?.aborted) {
+                  await aborted.promise;
+                }
+              } finally {
+                options?.signal?.removeEventListener("abort", onAbort);
               }
             })(),
           };
@@ -384,11 +450,18 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
               : runtimeMock.state.pendingPermissions,
           };
         },
-        reply: async ({ requestID, reply }: { requestID: string; reply: string }) => {
+        reply: async (
+          { requestID, reply }: { requestID: string; reply: string },
+          options?: { signal?: AbortSignal },
+        ) => {
           runtimeMock.state.permissionReplyCalls.push({ requestID, reply });
+          if (options?.signal) runtimeMock.state.permissionReplySignals.push(options.signal);
           if (runtimeMock.state.permissionReplyImplementation) {
-            await runtimeMock.state.permissionReplyImplementation();
+            await runtimeMock.state.permissionReplyImplementation(options?.signal);
           }
+          runtimeMock.state.pendingPermissions = runtimeMock.state.pendingPermissions.filter(
+            (request) => request.id !== requestID,
+          );
         },
       },
       question: {
@@ -400,14 +473,21 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
               : runtimeMock.state.pendingQuestions,
           };
         },
-        reply: async ({
-          requestID,
-          answers,
-        }: {
-          requestID: string;
-          answers: ReadonlyArray<ReadonlyArray<string>>;
-        }) => {
+        reply: async (
+          {
+            requestID,
+            answers,
+          }: {
+            requestID: string;
+            answers: ReadonlyArray<ReadonlyArray<string>>;
+          },
+          options?: { signal?: AbortSignal },
+        ) => {
           runtimeMock.state.questionReplyCalls.push({ requestID, answers });
+          await runtimeMock.state.questionReplyImplementation?.(options?.signal);
+          runtimeMock.state.pendingQuestions = runtimeMock.state.pendingQuestions.filter(
+            (request) => request.id !== requestID,
+          );
         },
       },
     }) as unknown as ReturnType<OpenCodeRuntimeShape["createOpenCodeSdkClient"]>,
@@ -2576,6 +2656,411 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect.each([
+    { permission: "external_directory", decision: "accept", reply: "once" },
+    { permission: "doom_loop", decision: "acceptForSession", reply: "always" },
+    { permission: "todowrite", decision: "decline", reply: "reject" },
+    { permission: "webfetch", decision: "cancel", reply: "reject" },
+    { permission: "custom_tool", decision: "accept", reply: "once" },
+  ] as const)(
+    "shows $permission approval and resolves its $decision reply without SSE",
+    ({ permission, decision, reply }) =>
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const threadId = asThreadId(`thread-permission-${permission}`);
+        const request = {
+          ...permissionRequest(`per_${permission}`, "http://127.0.0.1:9999/session"),
+          permission,
+          patterns: ["*"],
+        };
+        runtimeMock.state.subscribedEvents = [
+          {
+            id: "evt-permission",
+            type: "permission.asked",
+            properties: request,
+          } satisfies OpenCodeEvent,
+        ];
+        const openedFiber = yield* adapter.streamEvents.pipe(
+          Stream.filter((event) => event.threadId === threadId && event.type === "request.opened"),
+          Stream.runHead,
+          Effect.forkChild,
+        );
+        yield* adapter.startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "approval-required",
+        });
+        const opened = Option.getOrThrow(yield* Fiber.join(openedFiber));
+        NodeAssert.ok(opened.type === "request.opened");
+        NodeAssert.equal(opened.payload.requestType, "command_execution_approval");
+        NodeAssert.equal(opened.payload.detail, permission.replaceAll("_", " "));
+        NodeAssert.deepEqual(
+          opened.payload.options?.map((option) => option.label),
+          ["Allow once", "Allow for workspace", "Deny"],
+        );
+        const resolvedFiber = yield* adapter.streamEvents.pipe(
+          Stream.filter(
+            (event) => event.threadId === threadId && event.type === "request.resolved",
+          ),
+          Stream.runHead,
+          Effect.forkChild,
+        );
+        yield* adapter.respondToRequest(threadId, ApprovalRequestId.make(request.id), decision);
+        const resolved = Option.getOrThrow(yield* Fiber.join(resolvedFiber));
+        NodeAssert.equal(resolved.requestId, request.id);
+        yield* adapter.respondToRequest(threadId, ApprovalRequestId.make(request.id), decision);
+        NodeAssert.deepEqual(runtimeMock.state.permissionReplyCalls, [
+          { requestID: request.id, reply },
+        ]);
+        yield* adapter.stopSession(threadId);
+      }),
+  );
+
+  it.effect("keeps a permission reply retryable after its HTTP request times out", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-permission-timeout");
+      const request = permissionRequest("per_timeout", "http://127.0.0.1:9999/session");
+      const replyStarted = promiseWithResolvers<void>();
+      runtimeMock.state.permissionReplyImplementation = async () => {
+        replyStarted.resolve(undefined);
+        await new Promise<void>(() => {});
+      };
+      runtimeMock.state.subscribedEvents = [
+        { id: "evt-ask", type: "permission.asked", properties: request },
+      ];
+      const openedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "request.opened"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+      });
+      yield* Fiber.join(openedFiber);
+      const replyFiber = yield* adapter
+        .respondToRequest(threadId, ApprovalRequestId.make(request.id), "accept")
+        .pipe(Effect.exit, Effect.forkChild);
+      yield* Effect.promise(() => replyStarted.promise);
+      yield* Effect.yieldNow;
+      yield* advanceTestClock(10_000);
+      NodeAssert.equal(Exit.isFailure(yield* Fiber.join(replyFiber)), true);
+      NodeAssert.equal(runtimeMock.state.permissionReplySignals[0]?.aborted, true);
+      runtimeMock.state.permissionReplyImplementation = null;
+      const resolvedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "request.resolved"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.respondToRequest(threadId, ApprovalRequestId.make(request.id), "accept");
+      NodeAssert.equal(Option.getOrThrow(yield* Fiber.join(resolvedFiber)).requestId, request.id);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("keeps a recovering permission retryable until its native request is loaded", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-permission-recovering");
+      const request = permissionRequest("per_recovering", "ses_resumed");
+      const listStarted = promiseWithResolvers<void>();
+      const releaseList = promiseWithResolvers<PermissionRequest[]>();
+      runtimeMock.state.permissionListImplementation = async () => {
+        listStarted.resolve(undefined);
+        return await releaseList.promise;
+      };
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+        resumeCursor: { schemaVersion: 1, sessionId: request.sessionID },
+      });
+      yield* Effect.promise(() => listStarted.promise);
+      const reply = yield* adapter
+        .respondToRequest(threadId, ApprovalRequestId.make(request.id), "accept")
+        .pipe(Effect.result);
+      NodeAssert.equal(reply._tag, "Failure");
+      if (reply._tag === "Failure" && reply.failure._tag === "ProviderAdapterRequestError") {
+        NodeAssert.match(reply.failure.detail, /still loading/);
+      }
+      const openedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "request.opened"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      releaseList.resolve([request]);
+      yield* Fiber.join(openedFiber);
+      yield* adapter.respondToRequest(threadId, ApprovalRequestId.make(request.id), "accept");
+      NodeAssert.deepEqual(runtimeMock.state.permissionReplyCalls, [
+        { requestID: request.id, reply: "once" },
+      ]);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("closes missing permissions and questions after reconnect", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-missing-requests");
+      const sessionID = "http://127.0.0.1:9999/session";
+      const reconnect = promiseWithResolvers<unknown>();
+      runtimeMock.state.subscribedEvents = [
+        {
+          id: "evt-permission",
+          type: "permission.asked",
+          properties: permissionRequest("per_missing", sessionID),
+        },
+        {
+          id: "evt-question",
+          type: "question.asked",
+          properties: questionRequest("que_missing", sessionID),
+        },
+        reconnect.promise,
+      ];
+      const openedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "request.opened" || event.type === "user-input.requested"),
+        ),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+      });
+      yield* Fiber.join(openedFiber);
+      const resolvedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "request.resolved" || event.type === "user-input.resolved"),
+        ),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      runtimeMock.state.pendingPermissions = [];
+      runtimeMock.state.pendingQuestions = [];
+      reconnect.resolve({ id: "evt-reconnected", type: "server.connected", properties: {} });
+      const resolved = yield* Fiber.join(resolvedFiber);
+      NodeAssert.deepEqual(
+        resolved.map((event) => event.requestId),
+        ["per_missing", "que_missing"],
+      );
+      NodeAssert.deepEqual(runtimeMock.state.permissionReplyCalls, []);
+      NodeAssert.deepEqual(runtimeMock.state.questionReplyCalls, []);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("closes pending requests after Stop and ignores late requests from that turn", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-stop-requests");
+      const sessionID = "http://127.0.0.1:9999/session";
+      const startRequests = promiseWithResolvers<unknown>();
+      const lateRequests = promiseWithResolvers<unknown>();
+      runtimeMock.state.subscribedEvents = [
+        startRequests.promise,
+        {
+          id: "evt-question",
+          type: "question.asked",
+          properties: questionRequest("que_stop", sessionID),
+        },
+        lateRequests.promise,
+        {
+          id: "evt-late-question",
+          type: "question.asked",
+          properties: questionRequest("que_late", sessionID),
+        },
+        { id: "evt-drained", type: "session.compacted", properties: { sessionID } },
+      ];
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Work",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      const openedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "request.opened" || event.type === "user-input.requested"),
+        ),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      startRequests.resolve({
+        id: "evt-permission",
+        type: "permission.asked",
+        properties: permissionRequest("per_stop", sessionID),
+      });
+      yield* Fiber.join(openedFiber);
+      const stoppedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.takeUntil((event) => event.type === "turn.aborted"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.interruptTurn(threadId, turn.turnId);
+      const stopped = yield* Fiber.join(stoppedFiber);
+      NodeAssert.deepEqual(
+        stopped.map((event) => event.type),
+        ["request.resolved", "user-input.resolved", "turn.aborted"],
+      );
+      const lateFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.takeUntil((event) => event.type === "thread.state.changed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      lateRequests.resolve({
+        id: "evt-late-permission",
+        type: "permission.asked",
+        properties: permissionRequest("per_late", sessionID),
+      });
+      const late = yield* Fiber.join(lateFiber);
+      NodeAssert.deepEqual(
+        late.map((event) => event.type),
+        ["thread.state.changed"],
+      );
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("keeps progress live during automatic approval and never reopens a finished turn", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-auto-approval-progress");
+      const sessionID = "http://127.0.0.1:9999/session";
+      const ask = promiseWithResolvers<unknown>();
+      const idle = promiseWithResolvers<unknown>();
+      const replyStarted = promiseWithResolvers<void>();
+      const releaseReply = promiseWithResolvers<void>();
+      runtimeMock.state.permissionReplyImplementation = async () => {
+        replyStarted.resolve(undefined);
+        await releaseReply.promise;
+        throw new Error("reply response lost");
+      };
+      runtimeMock.state.subscribedEvents = [ask.promise, idle.promise];
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "Work",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      ask.resolve({
+        id: "evt-ask",
+        type: "permission.asked",
+        properties: permissionRequest("per_slow_auto", sessionID),
+      });
+      yield* Effect.promise(() => replyStarted.promise);
+      idle.resolve({
+        id: "evt-idle",
+        type: "session.status",
+        properties: { sessionID, status: { type: "idle" } },
+      });
+      const completed = yield* Fiber.join(completedFiber);
+      NodeAssert.equal(
+        completed.some((event) => event.type === "request.opened"),
+        false,
+      );
+      const remainingFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.takeUntil((event) => event.type === "session.exited"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      releaseReply.resolve(undefined);
+      yield* advanceTestClock(10_000);
+      yield* adapter.stopSession(threadId);
+      const remaining = yield* Fiber.join(remainingFiber);
+      NodeAssert.equal(
+        remaining.some((event) => event.type === "request.opened"),
+        false,
+      );
+    }),
+  );
+
+  it.effect("keeps automatic approval fallback available after a steer", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-auto-approval-steer");
+      const ask = promiseWithResolvers<unknown>();
+      const replyStarted = promiseWithResolvers<void>();
+      const releaseReply = promiseWithResolvers<void>();
+      runtimeMock.state.sessionStatus = "busy";
+      runtimeMock.state.permissionReplyImplementation = async () => {
+        replyStarted.resolve(undefined);
+        await releaseReply.promise;
+        throw new Error("reply failed");
+      };
+      runtimeMock.state.subscribedEvents = [ask.promise];
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const modelSelection = createModelSelection(
+        ProviderInstanceId.make("opencode"),
+        "opencode/kimi-k3",
+      );
+      const turn = yield* adapter.sendTurn({ threadId, input: "Work", modelSelection });
+      ask.resolve({
+        id: "evt-ask",
+        type: "permission.asked",
+        properties: permissionRequest("per_steer_auto", "http://127.0.0.1:9999/session"),
+      });
+      yield* Effect.promise(() => replyStarted.promise);
+      const steered = yield* adapter.sendTurn({
+        threadId,
+        input: "Keep the change small",
+        modelSelection,
+      });
+      NodeAssert.equal(steered.turnId, turn.turnId);
+      const openedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "request.opened"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      releaseReply.resolve(undefined);
+      NodeAssert.equal(
+        Option.getOrThrow(yield* Fiber.join(openedFiber)).requestId,
+        "per_steer_auto",
+      );
+      runtimeMock.state.permissionReplyImplementation = null;
+      yield* adapter.respondToRequest(threadId, ApprovalRequestId.make("per_steer_auto"), "accept");
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("routes child-session approval requests and replies through the parent thread", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
@@ -2691,6 +3176,9 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       Effect.gen(function* () {
         const adapter = yield* OpenCodeAdapter;
         const threadId = asThreadId(`thread-full-access-${requestId}`);
+        const replyStarted = promiseWithResolvers<void>();
+        runtimeMock.state.permissionReplyImplementation = async () =>
+          replyStarted.resolve(undefined);
         runtimeMock.state.subscribedEvents = [
           {
             id: "evt-child-created",
@@ -2709,11 +3197,11 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
             type: "permission.asked",
             properties: { id: requestId, sessionID, permission, patterns, metadata: {}, always },
           },
-          {
+          replyStarted.promise.then(() => ({
             id: "evt-permission-replied",
             type: "permission.replied",
             properties: { sessionID, requestID: requestId, reply: "once" },
-          },
+          })),
           // The suppressed ask emits nothing, so an empty question serves as a
           // sentinel that closes the collected stream once the pump is past it.
           {
@@ -3000,53 +3488,68 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
-  it.effect("retries ancestry for one live child request after a transient failure", () =>
-    Effect.gen(function* () {
-      const adapter = yield* OpenCodeAdapter;
-      const threadId = asThreadId("thread-child-request-ancestry-retry");
-      const parentId = "http://127.0.0.1:9999/session";
-      const ancestryAttempted = promiseWithResolvers<void>();
-      runtimeMock.state.sessionParentById.set("ses_existing_child", parentId);
-      runtimeMock.state.transientErrorSessionIds.add("ses_existing_child");
-      runtimeMock.state.sessionGetObserved = (sessionID) => {
-        if (sessionID === "ses_existing_child") {
-          ancestryAttempted.resolve(undefined);
+  it.effect.each(["failure", "timeout"] as const)(
+    "retries ancestry for a child request after a transient %s",
+    (lookupFailure) =>
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const threadId = asThreadId(`thread-child-request-ancestry-retry-${lookupFailure}`);
+        const parentId = "http://127.0.0.1:9999/session";
+        const ancestryAttempted = promiseWithResolvers<void>();
+        runtimeMock.state.sessionParentById.set("ses_existing_child", parentId);
+        runtimeMock.state.transientErrorSessionIds.add("ses_existing_child");
+        let lookupSignal: AbortSignal | undefined;
+        if (lookupFailure === "timeout") {
+          runtimeMock.state.sessionGetImplementation = async (_sessionID, signal) => {
+            lookupSignal = signal;
+            await new Promise<void>(() => {});
+          };
         }
-      };
-      runtimeMock.state.subscribedEvents = [
-        {
-          id: "evt-existing-child-permission",
-          type: "permission.asked",
-          properties: permissionRequest("per_retry", "ses_existing_child"),
-        },
-      ];
+        runtimeMock.state.sessionGetObserved = (sessionID) => {
+          if (sessionID === "ses_existing_child") {
+            ancestryAttempted.resolve(undefined);
+          }
+        };
+        runtimeMock.state.subscribedEvents = [
+          {
+            id: "evt-existing-child-permission",
+            type: "permission.asked",
+            properties: permissionRequest("per_retry", "ses_existing_child"),
+          },
+        ];
 
-      const eventsFiber = yield* adapter.streamEvents.pipe(
-        Stream.filter(
-          (event) =>
-            event.threadId === threadId &&
-            (event.type === "runtime.warning" || event.type === "request.opened"),
-        ),
-        Stream.take(2),
-        Stream.runCollect,
-        Effect.forkChild,
-      );
-      yield* adapter.startSession({
-        provider: ProviderDriverKind.make("opencode"),
-        threadId,
-        runtimeMode: "approval-required",
-      });
-      yield* Effect.promise(() => ancestryAttempted.promise);
-      runtimeMock.state.transientErrorSessionIds.delete("ses_existing_child");
-      yield* advanceTestClock(250);
+        const eventsFiber = yield* adapter.streamEvents.pipe(
+          Stream.filter(
+            (event) =>
+              event.threadId === threadId &&
+              (event.type === "runtime.warning" || event.type === "request.opened"),
+          ),
+          Stream.take(2),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        yield* adapter.startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "approval-required",
+        });
+        yield* Effect.promise(() => ancestryAttempted.promise);
+        if (lookupFailure === "timeout") {
+          yield* Effect.yieldNow;
+          yield* advanceTestClock(10_000);
+          NodeAssert.equal(lookupSignal?.aborted, true);
+          runtimeMock.state.sessionGetImplementation = null;
+        }
+        runtimeMock.state.transientErrorSessionIds.delete("ses_existing_child");
+        yield* advanceTestClock(250);
 
-      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
-      NodeAssert.deepEqual(
-        events.map((event) => event.type),
-        ["runtime.warning", "request.opened"],
-      );
-      yield* adapter.respondToRequest(threadId, ApprovalRequestId.make("per_retry"), "accept");
-    }),
+        const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+        NodeAssert.deepEqual(
+          events.map((event) => event.type),
+          ["runtime.warning", "request.opened"],
+        );
+        yield* adapter.respondToRequest(threadId, ApprovalRequestId.make("per_retry"), "accept");
+      }),
   );
 
   it.effect("does not resurrect a recovered child request after its live reply", () =>
@@ -3101,7 +3604,8 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       const response = yield* Effect.exit(
         adapter.respondToRequest(threadId, ApprovalRequestId.make(stale.id), "accept"),
       );
-      NodeAssert.equal(Exit.isFailure(response), true);
+      NodeAssert.equal(Exit.isSuccess(response), true);
+      NodeAssert.deepEqual(runtimeMock.state.permissionReplyCalls, []);
     }),
   );
 
@@ -3153,7 +3657,8 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       const response = yield* Effect.exit(
         adapter.respondToRequest(threadId, ApprovalRequestId.make(request.id), "accept"),
       );
-      NodeAssert.equal(Exit.isFailure(response), true);
+      NodeAssert.equal(Exit.isSuccess(response), true);
+      NodeAssert.deepEqual(runtimeMock.state.permissionReplyCalls, []);
     }),
   );
 
@@ -5284,6 +5789,210 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         NodeAssert.equal(completed.payload.detail, "A BBonus");
       }
     }),
+  );
+
+  it.effect("maps native task updates and command results to client progress", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-native-progress");
+      const sessionID = "http://127.0.0.1:9999/session";
+      const todos = [
+        { content: "Read files", status: "completed", priority: "high" },
+        { content: "Fix OpenCode", status: "in_progress", priority: "high" },
+        { content: "Run tests", status: "pending", priority: "medium" },
+        { content: "Old task", status: "cancelled", priority: "low" },
+      ];
+      runtimeMock.state.subscribedEvents = [
+        {
+          id: "evt-todos",
+          type: "todo.updated",
+          properties: { sessionID, todos },
+        } satisfies OpenCodeEvent,
+        ...["todowrite", "bash"].map(
+          (tool) =>
+            ({
+              id: `evt-${tool}`,
+              type: "message.part.updated",
+              properties: {
+                sessionID,
+                time: 2,
+                part: {
+                  id: `part-${tool}`,
+                  sessionID,
+                  messageID: "msg-tools",
+                  type: "tool",
+                  callID: `call-${tool}`,
+                  tool,
+                  state: {
+                    status: "completed",
+                    input: tool === "bash" ? { command: "pwd" } : { todos },
+                    output: tool === "bash" ? "/repo\n" : "Tasks updated",
+                    title: tool === "bash" ? "Working directory" : "Tasks updated",
+                    metadata: {},
+                    time: { start: 1, end: 2 },
+                  },
+                },
+              },
+            }) satisfies OpenCodeEvent,
+        ),
+      ];
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "turn.plan.updated" || event.type === "item.completed"),
+        ),
+        Stream.take(3),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const events = yield* Fiber.join(eventsFiber);
+      const plan = events.find((event) => event.type === "turn.plan.updated");
+      NodeAssert.deepEqual(plan?.payload.plan, [
+        { step: "Read files", status: "completed" },
+        { step: "Fix OpenCode", status: "inProgress" },
+        { step: "Run tests", status: "pending" },
+      ]);
+      const tools = events.filter((event) => event.type === "item.completed");
+      NodeAssert.equal(tools[0]?.payload.itemType, "dynamic_tool_call");
+      NodeAssert.equal(tools[1]?.payload.title, "Working directory");
+      NodeAssert.partialDeepStrictEqual(tools[1]?.payload.data, {
+        command: "pwd",
+        result: "/repo\n",
+      });
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("warns on disconnection and recovers a completion missed during reconnect", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-reconnect-completion");
+      const reconnect = promiseWithResolvers<unknown>();
+      runtimeMock.state.subscribedEvents = [reconnect.promise];
+      runtimeMock.state.sessionStatus = "busy";
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Work",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      const warningFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "runtime.warning"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      runtimeMock.state.eventStreamError?.(new Error("socket closed"));
+      const warning = Option.getOrThrow(yield* Fiber.join(warningFiber));
+      NodeAssert.ok(warning.type === "runtime.warning");
+      NodeAssert.equal(warning.payload.message, "OpenCode connection lost. Reconnecting.");
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      runtimeMock.state.sessionStatus = "idle";
+      reconnect.resolve({
+        id: "evt-reconnected",
+        type: "server.connected",
+        properties: {},
+      } satisfies OpenCodeEvent);
+      NodeAssert.equal(Option.getOrThrow(yield* Fiber.join(completedFiber)).turnId, turn.turnId);
+      NodeAssert.equal(
+        (yield* adapter.listSessions()).find((session) => session.threadId === threadId)?.status,
+        "ready",
+      );
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect(
+    "ends a running session on clean stream closure without discarding unresolved permissions",
+    () =>
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const threadId = asThreadId("thread-stream-closed");
+        const endStream = promiseWithResolvers<unknown>();
+        const request = permissionRequest("per_disconnect", "http://127.0.0.1:9999/session");
+        runtimeMock.state.pendingPermissions = [request];
+        runtimeMock.state.subscribedEvents = [endStream.promise];
+        const openedFiber = yield* adapter.streamEvents.pipe(
+          Stream.filter((event) => event.threadId === threadId && event.type === "request.opened"),
+          Stream.runHead,
+          Effect.forkChild,
+        );
+        const session = yield* adapter.startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "approval-required",
+        });
+        yield* Fiber.join(openedFiber);
+        yield* adapter.sendTurn({
+          threadId,
+          input: "Work",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode"),
+            "opencode/kimi-k3",
+          ),
+        });
+        const exitedFiber = yield* adapter.streamEvents.pipe(
+          Stream.filter((event) => event.threadId === threadId),
+          Stream.takeUntil((event) => event.type === "session.exited"),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        runtimeMock.state.endEventStream = true;
+        runtimeMock.state.abortImplementation = async () => {
+          throw new Error("server unreachable");
+        };
+        endStream.resolve({
+          id: "evt-busy",
+          type: "session.status",
+          properties: { sessionID: request.sessionID, status: { type: "busy" } },
+        });
+        const exited = yield* Fiber.join(exitedFiber);
+        NodeAssert.equal(
+          exited.some((event) => event.type === "request.resolved"),
+          false,
+        );
+        NodeAssert.match(
+          exited.find((event) => event.type === "runtime.error")?.payload.message ?? "",
+          /event stream ended/,
+        );
+        NodeAssert.equal(yield* adapter.hasSession(threadId), false);
+        runtimeMock.state.endEventStream = false;
+        runtimeMock.state.subscribedEvents = [];
+        runtimeMock.state.abortImplementation = null;
+        const recoveredFiber = yield* adapter.streamEvents.pipe(
+          Stream.filter((event) => event.threadId === threadId && event.type === "request.opened"),
+          Stream.runHead,
+          Effect.forkChild,
+        );
+        yield* adapter.startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "approval-required",
+          resumeCursor: session.resumeCursor,
+        });
+        NodeAssert.equal(
+          Option.getOrThrow(yield* Fiber.join(recoveredFiber)).requestId,
+          request.id,
+        );
+        yield* adapter.respondToRequest(threadId, ApprovalRequestId.make(request.id), "accept");
+        yield* adapter.stopSession(threadId);
+      }),
   );
 
   it.effect("lets OpenCode own session title generation and emits title metadata updates", () =>

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -417,6 +417,9 @@ type EventBaseInput = {
 
 function toToolLifecycleItemType(toolName: string): ToolLifecycleItemType {
   const normalized = toolName.toLowerCase();
+  if (normalized === "todowrite" || normalized === "todoread") {
+    return "dynamic_tool_call";
+  }
   if (normalized.includes("bash") || normalized.includes("command")) {
     return "command_execution";
   }
@@ -449,16 +452,15 @@ function toToolLifecycleItemType(toolName: string): ToolLifecycleItemType {
 
 function mapPermissionToRequestType(
   permission: string,
-): "command_execution_approval" | "file_read_approval" | "file_change_approval" | "unknown" {
+): "command_execution_approval" | "file_read_approval" | "file_change_approval" {
   switch (permission) {
-    case "bash":
-      return "command_execution_approval";
     case "read":
       return "file_read_approval";
     case "edit":
       return "file_change_approval";
     default:
-      return "unknown";
+      // Every OpenCode permission needs an actionable approval in each client.
+      return "command_execution_approval";
   }
 }
 
@@ -1062,6 +1064,10 @@ export function makeOpenCodeAdapter(
       context.interruptedTurnId = undefined;
       context.awaitingBusyAfterInterruption = false;
       context.reconcileIdleStatus = false;
+      for (const requestId of context.autoRepliedRequestIds) {
+        context.emittedTerminalRequestIds.add(requestId);
+      }
+      context.autoRepliedRequestIds.clear();
       applyProviderSessionUpdate(
         context,
         { status: "ready" },
@@ -1071,6 +1077,7 @@ export function makeOpenCodeAdapter(
       if (pendingIdleReconciliation?.fiber) {
         yield* Fiber.interrupt(pendingIdleReconciliation.fiber);
       }
+      yield* schedulePendingRequestRecovery(context);
       yield* emit({
         ...(yield* buildEventBase({
           threadId: context.session.threadId,
@@ -1425,6 +1432,7 @@ export function makeOpenCodeAdapter(
           { clearActiveTurnId: true, clearLastError: true },
         );
       }
+      yield* clearPendingOpenCodeRequests(context, { type: "session.abort" });
       yield* emit({
         ...(yield* buildEventBase({
           threadId: context.session.threadId,
@@ -1578,7 +1586,19 @@ export function makeOpenCodeAdapter(
 
       const seen = new Set<string>();
       const getSession = (sessionID: string) =>
-        runOpenCodeSdk("session.get", () => context.client.session.get({ sessionID })).pipe(
+        runOpenCodeSdk("session.get", (signal) =>
+          context.client.session.get({ sessionID }, { signal }),
+        ).pipe(
+          Effect.timeoutOrElse({
+            duration: "10 seconds",
+            orElse: () =>
+              Effect.fail(
+                new OpenCodeRuntimeError({
+                  operation: "session.get",
+                  detail: "OpenCode session ancestry lookup did not complete within 10 seconds.",
+                }),
+              ),
+          }),
           Effect.catchIf(
             (cause) => isOpenCodeNotFound(cause),
             () => Effect.succeed(undefined),
@@ -1610,6 +1630,52 @@ export function makeOpenCodeAdapter(
       return false;
     });
 
+    const openPermissionRequest = Effect.fn("openPermissionRequest")(function* (
+      context: OpenCodeSessionContext,
+      request: PermissionRequest,
+      raw: unknown,
+    ) {
+      const base = yield* buildEventBase({
+        threadId: context.session.threadId,
+        turnId: context.activeTurnId,
+        requestId: request.id,
+        raw,
+      });
+      const stopped = yield* Ref.get(context.stopped);
+      if (
+        stopped ||
+        context.emittedTerminalRequestIds.has(request.id) ||
+        context.pendingPermissions.has(request.id)
+      ) {
+        return;
+      }
+      const patterns = request.patterns.filter((pattern) => pattern !== "*");
+      const detail =
+        request.permission === "bash" && patterns.length > 0
+          ? patterns.join("\n")
+          : [request.permission.replaceAll("_", " "), ...patterns].join("\n");
+      context.autoRepliedRequestIds.delete(request.id);
+      context.pendingPermissions.set(request.id, request);
+      emitUnsafe({
+        ...base,
+        type: "request.opened",
+        payload: {
+          requestType: mapPermissionToRequestType(request.permission),
+          detail,
+          args: request.metadata,
+          options: [
+            { decision: "accept", label: "Allow once" },
+            {
+              decision: "acceptForSession",
+              label: "Allow for workspace",
+              warning: "Applies to matching requests in other OpenCode sessions in this workspace.",
+            },
+            { decision: "decline", label: "Deny" },
+          ],
+        },
+      });
+    });
+
     // Full access means the user already granted everything, but two upstream
     // paths never consult the session ruleset we send: doom-loop detection
     // (evaluated against the agent ruleset only) and subagent sessions (which
@@ -1622,15 +1688,12 @@ export function makeOpenCodeAdapter(
     const autoReplyFullAccess = Effect.fn("autoReplyFullAccess")(function* (
       context: OpenCodeSessionContext,
       request: PermissionRequest,
+      raw: unknown,
     ) {
-      // Mark before awaiting: retry and recovery fibers re-enter the ask path,
-      // and the matching `permission.replied` can arrive, while the SDK call
-      // is in flight. Marked ids skip the ask and swallow the terminal event.
-      context.resolvedRequestIds.add(request.id);
-      context.autoRepliedRequestIds.add(request.id);
-      const replied = yield* runOpenCodeSdk("permission.reply", () =>
-        context.client.permission.reply({ requestID: request.id, reply: "once" }),
+      const replied = yield* runOpenCodeSdk("permission.reply", (signal) =>
+        context.client.permission.reply({ requestID: request.id, reply: "once" }, { signal }),
       ).pipe(
+        Effect.timeout("10 seconds"),
         Effect.as(true),
         Effect.orElseSucceed(() => false),
       );
@@ -1638,9 +1701,8 @@ export function makeOpenCodeAdapter(
         // Fall back to the dialog. The id stays resolved so a recovered copy
         // of this ask cannot reopen after the user answers;
         // `pendingPermissions` gates re-asks while the dialog is open.
-        context.autoRepliedRequestIds.delete(request.id);
+        yield* openPermissionRequest(context, request, raw);
       }
-      return replied;
     });
 
     const emitPendingOpenCodeRequest = Effect.fn("emitPendingOpenCodeRequest")(function* (
@@ -1651,39 +1713,26 @@ export function makeOpenCodeAdapter(
       if (context.resolvedRequestIds.has(event.properties.id)) {
         return;
       }
+      if (context.activeTurnId === undefined && context.reconcileIdleStatus) {
+        context.resolvedRequestIds.add(event.properties.id);
+        return;
+      }
       if (event.type === "permission.asked") {
         const request = event.properties;
         if (context.pendingPermissions.has(request.id)) {
           return;
         }
-        if (
-          context.session.runtimeMode === "full-access" &&
-          (yield* autoReplyFullAccess(context, request))
-        ) {
+        if (context.session.runtimeMode === "full-access") {
+          // Reply outside the event pump so a slow HTTP response cannot hide
+          // progress, terminal replies, or the acknowledgment for Stop.
+          context.resolvedRequestIds.add(request.id);
+          context.autoRepliedRequestIds.add(request.id);
+          yield* autoReplyFullAccess(context, request, raw).pipe(
+            Effect.forkIn(context.sessionScope),
+          );
           return;
         }
-        const base = yield* buildEventBase({
-          threadId: context.session.threadId,
-          turnId: context.activeTurnId,
-          requestId: request.id,
-          raw,
-        });
-        // No yield between this check and the publish: a terminal
-        // `permission.replied` delivered on the pump in between would leave a
-        // dialog that can never close.
-        if (context.emittedTerminalRequestIds.has(request.id)) {
-          return;
-        }
-        context.pendingPermissions.set(request.id, request);
-        emitUnsafe({
-          ...base,
-          type: "request.opened",
-          payload: {
-            requestType: mapPermissionToRequestType(request.permission),
-            detail: request.patterns.length > 0 ? request.patterns.join("\n") : request.permission,
-            args: request.metadata,
-          },
-        });
+        yield* openPermissionRequest(context, request, raw);
         return;
       }
 
@@ -1691,14 +1740,19 @@ export function makeOpenCodeAdapter(
       if (context.pendingQuestions.has(request.id)) {
         return;
       }
+      const base = yield* buildEventBase({
+        threadId: context.session.threadId,
+        turnId: context.activeTurnId,
+        requestId: request.id,
+        raw,
+      });
+      const stopped = yield* Ref.get(context.stopped);
+      if (stopped || context.resolvedRequestIds.has(request.id)) {
+        return;
+      }
       context.pendingQuestions.set(request.id, request);
-      yield* emit({
-        ...(yield* buildEventBase({
-          threadId: context.session.threadId,
-          turnId: context.activeTurnId,
-          requestId: request.id,
-          raw,
-        })),
+      emitUnsafe({
+        ...base,
         type: "user-input.requested",
         payload: { questions: normalizeQuestionRequest(request) },
       });
@@ -1719,26 +1773,32 @@ export function makeOpenCodeAdapter(
     const emitTerminalOpenCodeRequest = Effect.fn("emitTerminalOpenCodeRequest")(function* (
       context: OpenCodeSessionContext,
       event: OpenCodeTerminalRequestEvent,
+      raw: unknown = event,
     ) {
       const requestId = event.properties.requestID;
       if (context.emittedTerminalRequestIds.has(requestId)) {
         return;
       }
-      context.emittedTerminalRequestIds.add(requestId);
       if (context.autoRepliedRequestIds.delete(requestId)) {
+        context.emittedTerminalRequestIds.add(requestId);
         return;
       }
+      const base = yield* buildEventBase({
+        threadId: context.session.threadId,
+        turnId: context.activeTurnId,
+        requestId,
+        raw,
+      });
+      if (context.emittedTerminalRequestIds.has(requestId)) return;
+      context.emittedTerminalRequestIds.add(requestId);
       if (event.type === "permission.replied") {
-        yield* emit({
-          ...(yield* buildEventBase({
-            threadId: context.session.threadId,
-            turnId: context.activeTurnId,
-            requestId,
-            raw: event,
-          })),
+        const request = context.pendingPermissions.get(requestId);
+        context.pendingPermissions.delete(requestId);
+        emitUnsafe({
+          ...base,
           type: "request.resolved",
           payload: {
-            requestType: "unknown",
+            requestType: request ? mapPermissionToRequestType(request.permission) : "unknown",
             decision: mapPermissionDecision(event.properties.reply),
           },
         });
@@ -1746,6 +1806,7 @@ export function makeOpenCodeAdapter(
       }
 
       const request = context.pendingQuestions.get(requestId);
+      context.pendingQuestions.delete(requestId);
       const answers =
         event.type === "question.replied" && request
           ? Object.fromEntries(
@@ -1755,16 +1816,71 @@ export function makeOpenCodeAdapter(
               ]),
             )
           : {};
-      yield* emit({
-        ...(yield* buildEventBase({
-          threadId: context.session.threadId,
-          turnId: context.activeTurnId,
-          requestId,
-          raw: event,
-        })),
+      emitUnsafe({
+        ...base,
         type: "user-input.resolved",
         payload: { answers },
       });
+    });
+
+    const closePendingOpenCodeRequests = Effect.fn("closePendingOpenCodeRequests")(function* (
+      context: OpenCodeSessionContext,
+      permissions: ReadonlyArray<PermissionRequest>,
+      questions: ReadonlyArray<QuestionRequest>,
+      raw: unknown,
+    ) {
+      for (const request of permissions) {
+        if (!context.pendingPermissions.has(request.id)) continue;
+        yield* resolvePendingOpenCodeRequest(context, request.id);
+        const base = yield* buildEventBase({
+          threadId: context.session.threadId,
+          turnId: context.activeTurnId,
+          requestId: request.id,
+          raw,
+        });
+        if (context.emittedTerminalRequestIds.has(request.id)) continue;
+        context.pendingPermissions.delete(request.id);
+        context.emittedTerminalRequestIds.add(request.id);
+        emitUnsafe({
+          ...base,
+          type: "request.resolved",
+          payload: { requestType: mapPermissionToRequestType(request.permission) },
+        });
+      }
+      for (const request of questions) {
+        if (!context.pendingQuestions.has(request.id)) continue;
+        yield* resolvePendingOpenCodeRequest(context, request.id);
+        const base = yield* buildEventBase({
+          threadId: context.session.threadId,
+          turnId: context.activeTurnId,
+          requestId: request.id,
+          raw,
+        });
+        if (context.emittedTerminalRequestIds.has(request.id)) continue;
+        context.pendingQuestions.delete(request.id);
+        context.emittedTerminalRequestIds.add(request.id);
+        emitUnsafe({ ...base, type: "user-input.resolved", payload: { answers: {} } });
+      }
+    });
+
+    const clearPendingOpenCodeRequests = Effect.fn("clearPendingOpenCodeRequests")(function* (
+      context: OpenCodeSessionContext,
+      raw: unknown,
+    ) {
+      context.pendingRequestRecovery = undefined;
+      for (const requestId of context.requestRelationRetries.keys()) {
+        yield* resolvePendingOpenCodeRequest(context, requestId);
+      }
+      for (const requestId of context.autoRepliedRequestIds) {
+        context.emittedTerminalRequestIds.add(requestId);
+      }
+      context.autoRepliedRequestIds.clear();
+      yield* closePendingOpenCodeRequests(
+        context,
+        [...context.pendingPermissions.values()],
+        [...context.pendingQuestions.values()],
+        raw,
+      );
     });
 
     const scheduleRequestRelationRetry = Effect.fn("scheduleRequestRelationRetry")(function* (
@@ -1854,10 +1970,21 @@ export function makeOpenCodeAdapter(
       const run = Effect.gen(function* () {
         let retryCount = 0;
         while (context.pendingRequestRecovery === recovery) {
-          const responses = yield* Effect.all({
-            permissions: runOpenCodeSdk("permission.list", () => context.client.permission.list()),
-            questions: runOpenCodeSdk("question.list", () => context.client.question.list()),
-          }).pipe(
+          // Only requests pending before the snapshot can be closed by it.
+          const priorPermissions = [...context.pendingPermissions.values()];
+          const priorQuestions = [...context.pendingQuestions.values()];
+          const responses = yield* Effect.all(
+            {
+              permissions: runOpenCodeSdk("permission.list", (signal) =>
+                context.client.permission.list(undefined, { signal }),
+              ),
+              questions: runOpenCodeSdk("question.list", (signal) =>
+                context.client.question.list(undefined, { signal }),
+              ),
+            },
+            { concurrency: 2 },
+          ).pipe(
+            Effect.timeout("10 seconds"),
             Effect.match({
               onFailure: (cause) => ({ type: "failure" as const, cause }),
               onSuccess: (value) => ({ type: "success" as const, value }),
@@ -1901,6 +2028,14 @@ export function makeOpenCodeAdapter(
             yield* Effect.sleep(`${delayMs} millis`);
             continue;
           }
+          const permissionIds = new Set(permissions.map((request) => request.id));
+          const questionIds = new Set(questions.map((request) => request.id));
+          yield* closePendingOpenCodeRequests(
+            context,
+            priorPermissions.filter((request) => !permissionIds.has(request.id)),
+            priorQuestions.filter((request) => !questionIds.has(request.id)),
+            { type: "pending-requests.recovered" },
+          );
           yield* Effect.forEach(
             permissions,
             (request) =>
@@ -1970,6 +2105,9 @@ export function makeOpenCodeAdapter(
         yield* schedulePendingRequestRecovery(context);
         if (!isFirstConnection) {
           yield* schedulePromptAdmissionRecovery(context, event);
+          if (context.activeTurnId !== undefined && context.promptAdmission === undefined) {
+            yield* scheduleIdleReconciliation(context, context.activeTurnId, event);
+          }
         }
         return;
       }
@@ -2046,6 +2184,7 @@ export function makeOpenCodeAdapter(
           context.awaitingBusyAfterInterruption) &&
         (event.type === "message.part.delta" ||
           event.type === "message.part.updated" ||
+          event.type === "todo.updated" ||
           (event.type === "message.updated" && event.properties.info.role === "assistant"));
       if (suppressInterruptedParentOutput) {
         return;
@@ -2125,7 +2264,11 @@ export function makeOpenCodeAdapter(
 
         case "message.part.delta": {
           const existingPart = context.partById.get(event.properties.partID);
-          if (!existingPart) {
+          if (
+            !existingPart ||
+            (existingPart.type !== "text" && existingPart.type !== "reasoning") ||
+            event.properties.field !== "text"
+          ) {
             break;
           }
           const role = messageRoleForPart(context, existingPart);
@@ -2180,7 +2323,9 @@ export function makeOpenCodeAdapter(
           if (part.type === "tool") {
             const itemType = toToolLifecycleItemType(part.tool);
             const title =
-              part.state.status === "running" ? (part.state.title ?? part.tool) : part.tool;
+              part.state.status === "running" || part.state.status === "completed"
+                ? (part.state.title ?? part.tool)
+                : part.tool;
             const detail = detailFromToolPart(part);
             const payload = {
               itemType,
@@ -2194,6 +2339,14 @@ export function makeOpenCodeAdapter(
               data: {
                 tool: part.tool,
                 state: part.state,
+                ...(typeof part.state.input.command === "string"
+                  ? { command: part.state.input.command }
+                  : {}),
+                ...(itemType === "file_change" ? { input: part.state.input } : {}),
+                ...(part.state.status === "completed" &&
+                (itemType === "command_execution" || itemType === "mcp_tool_call")
+                  ? { result: part.state.output }
+                  : {}),
               },
             };
             const runtimeEvent: ProviderRuntimeEvent = {
@@ -2224,7 +2377,6 @@ export function makeOpenCodeAdapter(
         }
 
         case "permission.replied": {
-          context.pendingPermissions.delete(event.properties.requestID);
           yield* emitTerminalOpenCodeRequest(context, event);
           break;
         }
@@ -2236,18 +2388,37 @@ export function makeOpenCodeAdapter(
 
         case "question.replied": {
           yield* emitTerminalOpenCodeRequest(context, event);
-          context.pendingQuestions.delete(event.properties.requestID);
           break;
         }
 
         case "question.rejected": {
-          context.pendingQuestions.delete(event.properties.requestID);
           yield* emitTerminalOpenCodeRequest(context, event);
           break;
         }
 
+        case "todo.updated": {
+          yield* emit({
+            ...(yield* buildEventBase({ threadId: context.session.threadId, turnId, raw: event })),
+            type: "turn.plan.updated",
+            payload: {
+              plan: event.properties.todos
+                .filter((todo) => todo.status !== "cancelled")
+                .map((todo) => ({
+                  step: trimText(todo.content) ?? "Task",
+                  status:
+                    todo.status === "completed"
+                      ? "completed"
+                      : todo.status === "in_progress"
+                        ? "inProgress"
+                        : "pending",
+                })),
+            },
+          });
+          break;
+        }
+
         case "session.status": {
-          if (event.properties.status.type === "busy") {
+          if (event.properties.status.type === "busy" || event.properties.status.type === "retry") {
             if (turnId === undefined) {
               break;
             }
@@ -2272,7 +2443,7 @@ export function makeOpenCodeAdapter(
               })),
               type: "runtime.warning",
               payload: {
-                message: event.properties.status.message,
+                message: `OpenCode retry ${event.properties.status.attempt}: ${event.properties.status.message}`,
                 detail: event.properties.status,
               },
             });
@@ -2335,6 +2506,7 @@ export function makeOpenCodeAdapter(
           context.activeAgent = undefined;
           context.activeVariant = undefined;
           context.reconcileIdleStatus = false;
+          yield* schedulePendingRequestRecovery(context);
           yield* updateProviderSession(
             context,
             {
@@ -2388,9 +2560,29 @@ export function makeOpenCodeAdapter(
       // shutdown) and cancels the in-flight `event.subscribe` fetch so
       // the async iterable unwinds cleanly.
       const eventsAbortController = new AbortController();
-      yield* Scope.addFinalizer(
-        context.sessionScope,
-        Effect.sync(() => eventsAbortController.abort()),
+      let lastStreamError: unknown;
+      let warnedAboutDisconnect = false;
+      const streamErrors = yield* Queue.unbounded<unknown>();
+      yield* Scope.addFinalizer(context.sessionScope, Queue.shutdown(streamErrors));
+      yield* Stream.fromQueue(streamErrors).pipe(
+        Stream.runForEach((cause) =>
+          Effect.gen(function* () {
+            if (warnedAboutDisconnect) return;
+            warnedAboutDisconnect = true;
+            yield* emit({
+              ...(yield* buildEventBase({
+                threadId: context.session.threadId,
+                turnId: context.activeTurnId,
+              })),
+              type: "runtime.warning",
+              payload: {
+                message: "OpenCode connection lost. Reconnecting.",
+                detail: openCodeRuntimeErrorDetail(cause),
+              },
+            });
+          }),
+        ),
+        Effect.forkIn(context.sessionScope),
       );
 
       // Fibers forked into `context.sessionScope` are interrupted
@@ -2399,6 +2591,10 @@ export function makeOpenCodeAdapter(
         runOpenCodeSdk("event.subscribe", () =>
           context.client.event.subscribe(undefined, {
             signal: eventsAbortController.signal,
+            onSseError: (cause) => {
+              lastStreamError = cause;
+              Queue.offerUnsafe(streamErrors, cause);
+            },
           }),
         ),
         (subscription) =>
@@ -2410,7 +2606,13 @@ export function makeOpenCodeAdapter(
                 detail: openCodeRuntimeErrorDetail(cause),
                 cause,
               }),
-          ).pipe(Stream.runForEach((event) => handleSubscribedEvent(context, event))),
+          ).pipe(
+            Stream.runForEach((event) => {
+              if (event.type === "server.connected") lastStreamError = undefined;
+              if (event.type === "server.connected") warnedAboutDisconnect = false;
+              return handleSubscribedEvent(context, event);
+            }),
+          ),
       ).pipe(
         Effect.exit,
         Effect.flatMap((exit) =>
@@ -2420,12 +2622,14 @@ export function makeOpenCodeAdapter(
             if (eventsAbortController.signal.aborted || (yield* Ref.get(context.stopped))) {
               return;
             }
-            if (Exit.isFailure(exit)) {
-              yield* emitUnexpectedExit(
-                context,
-                openCodeRuntimeErrorDetail(Cause.squash(exit.cause)),
-              );
-            }
+            yield* emitUnexpectedExit(
+              context,
+              Exit.isFailure(exit)
+                ? openCodeRuntimeErrorDetail(Cause.squash(exit.cause))
+                : lastStreamError !== undefined
+                  ? `OpenCode event stream disconnected: ${openCodeRuntimeErrorDetail(lastStreamError)}`
+                  : "OpenCode event stream ended unexpectedly. Send another message to reconnect.",
+            );
           }),
         ),
         Effect.forkIn(context.sessionScope),
@@ -2444,6 +2648,12 @@ export function makeOpenCodeAdapter(
           Effect.forkIn(context.sessionScope),
         );
       }
+      // Scope finalizers run in reverse order. Abort the pending read before
+      // interrupting the pump, whose iterator.return() waits for that read.
+      yield* Scope.addFinalizer(
+        context.sessionScope,
+        Effect.sync(() => eventsAbortController.abort()),
+      );
     });
 
     const startSession: OpenCodeAdapterShape["startSession"] = Effect.fn("startSession")(
@@ -3259,6 +3469,7 @@ export function makeOpenCodeAdapter(
           } else {
             context.cancellation = undefined;
             context.reconcileIdleStatus = true;
+            yield* clearPendingOpenCodeRequests(context, { type: "session.abort" });
           }
         }
         yield* Deferred.succeed(cancellation.completion, undefined).pipe(Effect.ignore);
@@ -3269,20 +3480,52 @@ export function makeOpenCodeAdapter(
       "respondToRequest",
     )(function* (threadId, requestId, decision) {
       const context = yield* ensureSessionContext(sessions, threadId);
-      if (!context.pendingPermissions.has(requestId)) {
+      const request = context.pendingPermissions.get(requestId);
+      if (!request) {
+        if (context.emittedTerminalRequestIds.has(requestId)) return;
         return yield* new ProviderAdapterRequestError({
           provider: PROVIDER,
           method: "permission.reply",
-          detail: `Unknown pending permission request: ${requestId}`,
+          detail:
+            context.pendingRequestRecovery || context.requestRelationRetries.has(requestId)
+              ? "OpenCode is still loading this permission request. Try again."
+              : `Unknown pending permission request: ${requestId}`,
         });
       }
 
-      yield* runOpenCodeSdk("permission.reply", () =>
-        context.client.permission.reply({
-          requestID: requestId,
-          reply: toOpenCodePermissionReply(decision),
+      const reply = toOpenCodePermissionReply(decision);
+      yield* runOpenCodeSdk("permission.reply", (signal) =>
+        context.client.permission.reply(
+          {
+            requestID: requestId,
+            reply,
+          },
+          { signal },
+        ),
+      ).pipe(
+        Effect.mapError(toRequestError),
+        Effect.timeoutOrElse({
+          duration: "10 seconds",
+          orElse: () =>
+            Effect.fail(
+              new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "permission.reply",
+                detail: "OpenCode permission reply did not complete within 10 seconds.",
+              }),
+            ),
         }),
-      ).pipe(Effect.mapError(toRequestError));
+      );
+      yield* resolvePendingOpenCodeRequest(context, requestId);
+      yield* emitTerminalOpenCodeRequest(
+        context,
+        {
+          id: `reply:${requestId}`,
+          type: "permission.replied",
+          properties: { sessionID: request.sessionID, requestID: requestId, reply },
+        },
+        { type: "permission.reply", requestID: requestId, reply },
+      );
     });
 
     const respondToUserInput: OpenCodeAdapterShape["respondToUserInput"] = Effect.fn(
@@ -3291,19 +3534,54 @@ export function makeOpenCodeAdapter(
       const context = yield* ensureSessionContext(sessions, threadId);
       const request = context.pendingQuestions.get(requestId);
       if (!request) {
+        if (context.emittedTerminalRequestIds.has(requestId)) return;
         return yield* new ProviderAdapterRequestError({
           provider: PROVIDER,
           method: "question.reply",
-          detail: `Unknown pending user-input request: ${requestId}`,
+          detail:
+            context.pendingRequestRecovery || context.requestRelationRetries.has(requestId)
+              ? "OpenCode is still loading this question. Try again."
+              : `Unknown pending user-input request: ${requestId}`,
         });
       }
 
-      yield* runOpenCodeSdk("question.reply", () =>
-        context.client.question.reply({
-          requestID: requestId,
-          answers: toOpenCodeQuestionAnswers(request, answers),
+      const questionAnswers = toOpenCodeQuestionAnswers(request, answers);
+      yield* runOpenCodeSdk("question.reply", (signal) =>
+        context.client.question.reply(
+          {
+            requestID: requestId,
+            answers: questionAnswers,
+          },
+          { signal },
+        ),
+      ).pipe(
+        Effect.mapError(toRequestError),
+        Effect.timeoutOrElse({
+          duration: "10 seconds",
+          orElse: () =>
+            Effect.fail(
+              new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "question.reply",
+                detail: "OpenCode question reply did not complete within 10 seconds.",
+              }),
+            ),
         }),
-      ).pipe(Effect.mapError(toRequestError));
+      );
+      yield* resolvePendingOpenCodeRequest(context, requestId);
+      yield* emitTerminalOpenCodeRequest(
+        context,
+        {
+          id: `reply:${requestId}`,
+          type: "question.replied",
+          properties: {
+            sessionID: request.sessionID,
+            requestID: requestId,
+            answers: questionAnswers,
+          },
+        },
+        { type: "question.reply", requestID: requestId },
+      );
     });
 
     const stopSession: OpenCodeAdapterShape["stopSession"] = Effect.fn("stopSession")(

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -2397,8 +2397,16 @@ export function makeOpenCodeAdapter(
         }
 
         case "todo.updated": {
-          yield* emit({
-            ...(yield* buildEventBase({ threadId: context.session.threadId, turnId, raw: event })),
+          if (turnId === undefined) break;
+          const base = yield* buildEventBase({
+            threadId: context.session.threadId,
+            turnId,
+            raw: event,
+          });
+          // Session-wide task updates must not reopen progress after a turn ends.
+          if (context.activeTurnId !== turnId) break;
+          emitUnsafe({
+            ...base,
             type: "turn.plan.updated",
             payload: {
               plan: event.properties.todos

--- a/apps/server/src/provider/opencodeRuntime.environment.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.environment.test.ts
@@ -1,12 +1,24 @@
 import type { OpencodeClient } from "@opencode-ai/sdk/v2";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it as effectIt } from "@effect/vitest";
+import {
+  HostProcessEnvironment,
+  HostProcessExecutablePath,
+  HostProcessPlatform,
+} from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
 import * as TestClock from "effect/testing/TestClock";
+import { FetchHttpClient, HttpClient } from "effect/unstable/http";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  OpenCodeRuntime,
   OpenCodeRuntimeError,
+  OpenCodeRuntimeLive,
   resolveOpenCodeConfigContent,
   resolveOpenCodeServerPassword,
   verifyOpenCodeServerVersion,
@@ -148,5 +160,80 @@ describe("verifyOpenCodeServerVersion", () => {
       expect(error.detail).toBe("Timed out while checking the OpenCode server version.");
       expect(requestSignal?.aborted).toBe(true);
     }).pipe(Effect.provide(TestClock.layer())),
+  );
+});
+
+describe("OpenCode server output", () => {
+  effectIt.live(
+    "drains stdout and stderr after startup so server requests can finish",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const environment = yield* HostProcessEnvironment;
+        const executablePath = yield* HostProcessExecutablePath;
+        const platform = yield* HostProcessPlatform;
+        const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-opencode-output-" });
+        const isWindows = platform === "win32";
+        const binaryPath = path.join(tempDir, isWindows ? "opencode.cmd" : "opencode");
+        const scriptPath = path.join(tempDir, "opencode.mjs");
+
+        yield* fs.writeFileString(
+          scriptPath,
+          `import { createServer } from "node:http";
+const writeOutput = (stream) => new Promise((resolve, reject) => {
+  stream.write("x".repeat(2 * 1024 * 1024), (error) => error ? reject(error) : resolve());
+});
+const server = createServer(async (request, response) => {
+  if (request.url.startsWith("/global/health")) {
+    response.setHeader("Content-Type", "application/json");
+    response.end(JSON.stringify({ healthy: true, version: "1.14.19" }));
+    return;
+  }
+  await Promise.all([writeOutput(process.stdout), writeOutput(process.stderr)]);
+  response.end("drained");
+});
+server.listen(0, "127.0.0.1", () => {
+  process.stdout.write("opencode server listening on http://127.0.0.1:" + server.address().port + "\\n");
+});
+`,
+        );
+        yield* fs.writeFileString(
+          binaryPath,
+          [
+            ...(isWindows ? ["@echo off"] : ["#!/bin/sh"]),
+            isWindows
+              ? '"%T3_TEST_NODE_BINARY%" "%T3_TEST_OPENCODE_SCRIPT%" %*'
+              : 'exec "$T3_TEST_NODE_BINARY" "$T3_TEST_OPENCODE_SCRIPT" "$@"',
+            "",
+          ].join("\n"),
+        );
+        if (!isWindows) {
+          yield* fs.chmod(binaryPath, 0o755);
+        }
+
+        const runtime = yield* OpenCodeRuntime;
+        const server = yield* runtime.startOpenCodeServerProcess({
+          binaryPath,
+          directory: tempDir,
+          port: 0,
+          environment: {
+            ...environment,
+            T3_TEST_NODE_BINARY: executablePath,
+            T3_TEST_OPENCODE_SCRIPT: scriptPath,
+          },
+        });
+        const response = yield* HttpClient.get(`${server.url}/output`);
+
+        expect(yield* response.text).toBe("drained");
+        expect(yield* server.isRunning).toBe(true);
+      }).pipe(
+        Effect.scoped,
+        Effect.provide([
+          OpenCodeRuntimeLive.pipe(Layer.provideMerge(NodeServices.layer)),
+          FetchHttpClient.layer,
+        ]),
+      ),
+    10_000,
   );
 });

--- a/apps/server/src/provider/opencodeRuntime.inventory.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.inventory.test.ts
@@ -1,12 +1,14 @@
 import * as NodeAssert from "node:assert/strict";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import type { OpencodeClient } from "@opencode-ai/sdk/v2";
+import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/v2";
 import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
+import * as Queue from "effect/Queue";
 import {
   HostProcessEnvironment,
   HostProcessExecutablePath,
@@ -18,6 +20,44 @@ import { OpenCodeRuntime, OpenCodeRuntimeLive } from "./opencodeRuntime.ts";
 const testLayer = OpenCodeRuntimeLive.pipe(Layer.provideMerge(NodeServices.layer));
 
 it.layer(testLayer)("OpenCodeRuntime inventory", (it) => {
+  it.effect("aborts pending SDK requests when inventory loading is interrupted", () =>
+    Effect.gen(function* () {
+      const runtime = yield* OpenCodeRuntime;
+      const started = yield* Queue.make<void>();
+      const aborted = yield* Queue.make<string>();
+      const client = createOpencodeClient({
+        baseUrl: "http://opencode.test",
+        fetch: Object.assign(
+          (input: string | Request | URL) => {
+            const request = input instanceof Request ? input : new Request(input.toString());
+            return new Promise<Response>((_resolve, reject) => {
+              request.signal.addEventListener(
+                "abort",
+                () => {
+                  Queue.offerUnsafe(aborted, new URL(request.url).pathname);
+                  reject(request.signal.reason);
+                },
+                { once: true },
+              );
+              Queue.offerUnsafe(started, undefined);
+            });
+          },
+          { preconnect: () => undefined },
+        ),
+      });
+
+      const inventoryFiber = yield* runtime.loadOpenCodeInventory(client).pipe(Effect.forkChild);
+      yield* Queue.takeN(started, 3);
+      yield* Fiber.interrupt(inventoryFiber);
+
+      NodeAssert.deepEqual((yield* Queue.takeAll(aborted)).toSorted(), [
+        "/agent",
+        "/provider",
+        "/skill",
+      ]);
+    }),
+  );
+
   it.effect("keeps provider inventory when agent discovery fails", () =>
     Effect.gen(function* () {
       const runtime = yield* OpenCodeRuntime;

--- a/apps/server/src/provider/opencodeRuntime.permissions.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.permissions.test.ts
@@ -1,15 +1,21 @@
 import * as NodeAssert from "node:assert/strict";
 
+import * as RegExpUtils from "effect/RegExp";
 import { describe, it } from "vite-plus/test";
 
-import { buildOpenCodePermissionRules } from "./opencodeRuntime.ts";
+import { buildOpenCodePermissionRules, toOpenCodePermissionReply } from "./opencodeRuntime.ts";
 
 function actionFor(
   runtimeMode: Parameters<typeof buildOpenCodePermissionRules>[0],
   permission: string,
+  target = "*",
 ) {
-  return buildOpenCodePermissionRules(runtimeMode).find((rule) => rule.permission === permission)
-    ?.action;
+  // OpenCode uses the last matching rule. Its wildcards match directory separators.
+  return buildOpenCodePermissionRules(runtimeMode).findLast(
+    (rule) =>
+      (rule.permission === "*" || rule.permission === permission) &&
+      new RegExp(`^${RegExpUtils.escape(rule.pattern).replaceAll("\\*", ".*")}$`, "s").test(target),
+  )?.action;
 }
 
 describe("buildOpenCodePermissionRules", () => {
@@ -27,12 +33,38 @@ describe("buildOpenCodePermissionRules", () => {
     NodeAssert.equal(actionFor("auto", "edit"), "ask");
   });
 
-  it("keeps asking for everything else in the auto modes", () => {
-    for (const runtimeMode of ["auto-accept-edits", "auto"] as const) {
+  it("allows workspace reads and task updates without asking in supervised modes", () => {
+    for (const runtimeMode of ["approval-required", "auto-accept-edits", "auto"] as const) {
+      for (const permission of ["read", "glob", "grep", "lsp", "skill", "todowrite"]) {
+        NodeAssert.equal(actionFor(runtimeMode, permission, "src/index.ts"), "allow");
+      }
+    }
+  });
+
+  it("preserves OpenCode's environment-file approval rules", () => {
+    for (const runtimeMode of ["approval-required", "auto-accept-edits", "auto"] as const) {
+      for (const target of [
+        ".env",
+        ".env.local",
+        "config/service.env",
+        "config/service.env.local",
+      ]) {
+        NodeAssert.equal(actionFor(runtimeMode, "read", target), "ask");
+      }
+      for (const target of [".env.example", "config/service.env.example"]) {
+        NodeAssert.equal(actionFor(runtimeMode, "read", target), "allow");
+      }
+    }
+  });
+
+  it("still asks before commands, network access, external directories and unknown tools", () => {
+    for (const runtimeMode of ["approval-required", "auto-accept-edits", "auto"] as const) {
       NodeAssert.equal(actionFor(runtimeMode, "bash"), "ask");
       NodeAssert.equal(actionFor(runtimeMode, "webfetch"), "ask");
+      NodeAssert.equal(actionFor(runtimeMode, "websearch"), "ask");
       NodeAssert.equal(actionFor(runtimeMode, "external_directory"), "ask");
-      NodeAssert.equal(actionFor(runtimeMode, "*"), "ask");
+      NodeAssert.equal(actionFor(runtimeMode, "doom_loop"), "ask");
+      NodeAssert.equal(actionFor(runtimeMode, "custom_tool"), "ask");
     }
   });
 
@@ -41,5 +73,17 @@ describe("buildOpenCodePermissionRules", () => {
       { permission: "*", pattern: "*", action: "allow" },
       { permission: "external_directory", pattern: "*", action: "allow" },
     ]);
+  });
+});
+
+describe("toOpenCodePermissionReply", () => {
+  it.each([
+    ["accept", "once"],
+    ["acceptForSession", "always"],
+    ["acceptAlways", "always"],
+    ["decline", "reject"],
+    ["cancel", "reject"],
+  ] as const)("maps %s to %s", (decision, reply) => {
+    NodeAssert.equal(toOpenCodePermissionReply(decision), reply);
   });
 });

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -80,6 +80,7 @@ export function resolveOpenCodeServerPassword(
 const OPENCODE_SERVER_READY_PREFIX = "opencode server listening";
 const DEFAULT_OPENCODE_SERVER_TIMEOUT_MS = 30_000;
 const DEFAULT_HOSTNAME = "127.0.0.1";
+const OPENCODE_SERVER_STARTUP_MAX_OUTPUT_CHARS = 64 * 1024;
 const OPENCODE_SKILL_DISCOVERY_MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
 export interface OpenCodeServerProcess {
   readonly url: string;
@@ -494,8 +495,19 @@ export function buildOpenCodePermissionRules(runtimeMode: RuntimeMode): Permissi
   // reviewer, OpenCode among them, fall back to Supervised for that mode.
   const editAction = runtimeMode === "auto-accept-edits" ? "allow" : "ask";
 
+  // Session rules override OpenCode's agent defaults. Allow reads and task
+  // updates, but keep its default approval rules for environment files.
   return [
     { permission: "*", pattern: "*", action: "ask" },
+    { permission: "read", pattern: "*", action: "allow" },
+    { permission: "read", pattern: "*.env", action: "ask" },
+    { permission: "read", pattern: "*.env.*", action: "ask" },
+    { permission: "read", pattern: "*.env.example", action: "allow" },
+    { permission: "glob", pattern: "*", action: "allow" },
+    { permission: "grep", pattern: "*", action: "allow" },
+    { permission: "lsp", pattern: "*", action: "allow" },
+    { permission: "skill", pattern: "*", action: "allow" },
+    { permission: "todowrite", pattern: "*", action: "allow" },
     { permission: "bash", pattern: "*", action: "ask" },
     { permission: "edit", pattern: "*", action: editAction },
     { permission: "webfetch", pattern: "*", action: "ask" },
@@ -514,6 +526,7 @@ export function toOpenCodePermissionReply(
     case "accept":
       return "once";
     case "acceptForSession":
+    case "acceptAlways":
       return "always";
     case "decline":
     case "cancel":
@@ -707,18 +720,24 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       );
       yield* Scope.addFinalizer(runtimeScope, terminateChild);
 
-      const stdoutRef = yield* Ref.make("");
-      const stderrRef = yield* Ref.make("");
+      const stdoutRef = yield* Ref.make<string | null>("");
+      const stderrRef = yield* Ref.make<string | null>("");
       const readyDeferred = yield* Deferred.make<string, OpenCodeRuntimeError>();
 
       const setReadyFromStdoutChunk = (chunk: string) =>
-        Ref.updateAndGet(stdoutRef, (stdout) => `${stdout}${chunk}`).pipe(
-          Effect.flatMap((nextStdout) => {
-            const parsed = parseServerUrlFromOutput(nextStdout);
-            return parsed
-              ? Deferred.succeed(readyDeferred, parsed).pipe(Effect.ignore)
-              : Effect.void;
-          }),
+        Ref.modify(stdoutRef, (stdout) => {
+          if (stdout === null) {
+            return [null, null] as const;
+          }
+          const nextStdout = `${stdout}${chunk}`;
+          return [
+            parseServerUrlFromOutput(nextStdout),
+            nextStdout.slice(-OPENCODE_SERVER_STARTUP_MAX_OUTPUT_CHARS),
+          ] as const;
+        }).pipe(
+          Effect.flatMap((parsed) =>
+            parsed ? Deferred.succeed(readyDeferred, parsed).pipe(Effect.ignore) : Effect.void,
+          ),
         );
 
       const stdoutFiber = yield* child.stdout.pipe(
@@ -729,7 +748,13 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       );
       const stderrFiber = yield* child.stderr.pipe(
         Stream.decodeText(),
-        Stream.runForEach((chunk) => Ref.update(stderrRef, (stderr) => `${stderr}${chunk}`)),
+        Stream.runForEach((chunk) =>
+          Ref.update(stderrRef, (stderr) =>
+            stderr === null
+              ? null
+              : `${stderr}${chunk}`.slice(-OPENCODE_SERVER_STARTUP_MAX_OUTPUT_CHARS),
+          ),
+        ),
         Effect.ignore,
         Effect.forkIn(runtimeScope),
       );
@@ -737,8 +762,8 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       const exitFiber = yield* child.exitCode.pipe(
         Effect.flatMap((code) =>
           Effect.gen(function* () {
-            const stdout = yield* Ref.get(stdoutRef);
-            const stderr = yield* Ref.get(stderrRef);
+            const stdout = (yield* Ref.get(stdoutRef)) ?? "";
+            const stderr = (yield* Ref.get(stderrRef)) ?? "";
             const exitCode = Number(code);
             yield* Deferred.fail(
               readyDeferred,
@@ -764,14 +789,11 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
         Deferred.await(readyDeferred).pipe(Effect.timeoutOption(timeoutMs)),
       );
 
-      // Startup-time fibers are no longer needed once ready has resolved (either
-      // way). The exit fiber is only interrupted on failure; on success it keeps
-      // the caller's `exitCode` effect observable until the scope closes.
-      yield* Fiber.interrupt(stdoutFiber).pipe(Effect.ignore);
-      yield* Fiber.interrupt(stderrFiber).pipe(Effect.ignore);
+      if (Exit.isFailure(readyExit) || Option.isNone(readyExit.value)) {
+        yield* Fiber.interruptAll([stdoutFiber, stderrFiber, exitFiber]).pipe(Effect.ignore);
+      }
 
       if (Exit.isFailure(readyExit)) {
-        yield* Fiber.interrupt(exitFiber).pipe(Effect.ignore);
         const squashed = Cause.squash(readyExit.cause);
         return yield* ensureRuntimeError(
           "startOpenCodeServerProcess",
@@ -782,12 +804,17 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
 
       const readyOption = readyExit.value;
       if (Option.isNone(readyOption)) {
-        yield* Fiber.interrupt(exitFiber).pipe(Effect.ignore);
         return yield* new OpenCodeRuntimeError({
           operation: "startOpenCodeServerProcess",
           detail: `Timed out waiting for OpenCode server start after ${timeoutMs}ms.`,
         });
       }
+
+      // Keep draining both pipes until the process scope closes. Stopping the
+      // readers can block OpenCode when its output buffers fill. Startup output
+      // is no longer needed, so discard later output instead of retaining it.
+      yield* Ref.set(stdoutRef, null);
+      yield* Ref.set(stderrRef, null);
 
       const url = readyOption.value;
       const version = yield* verifyOpenCodeServerVersion(
@@ -854,7 +881,7 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
   };
 
   const loadProviders = (client: OpencodeClient) =>
-    runOpenCodeSdk("provider.list", () => client.provider.list()).pipe(
+    runOpenCodeSdk("provider.list", (signal) => client.provider.list(undefined, { signal })).pipe(
       Effect.filterMapOrFail(
         (list) =>
           list.data
@@ -870,7 +897,7 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
     );
 
   const loadAgents = (client: OpencodeClient) =>
-    runOpenCodeSdk("app.agents", () => client.app.agents()).pipe(
+    runOpenCodeSdk("app.agents", (signal) => client.app.agents(undefined, { signal })).pipe(
       Effect.map((result) => result.data ?? []),
       Effect.orElseSucceed((): ReadonlyArray<Agent> => []),
     );

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -62,6 +62,37 @@ function makeActivity(overrides: {
 }
 
 describe("derivePendingApprovals", () => {
+  it.each([{}, { requestType: "unknown" }])(
+    "exposes legacy OpenCode approvals without a known request kind: %j",
+    (legacyPayload) => {
+      const requested = makeActivity({
+        kind: "approval.requested",
+        payload: { requestId: "per-legacy", detail: "*", ...legacyPayload },
+      });
+
+      expect(derivePendingApprovals([requested])).toEqual([
+        {
+          requestId: "per-legacy",
+          requestKind: "command",
+          createdAt: requested.createdAt,
+          detail: "*",
+        },
+      ]);
+    },
+  );
+
+  it.each(["tool_user_input", "auth_tokens_refresh"])(
+    "does not turn %s into an approval",
+    (requestType) => {
+      const activity = makeActivity({
+        kind: "approval.requested",
+        payload: { requestId: "not-an-approval", requestType },
+      });
+
+      expect(derivePendingApprovals([activity])).toEqual([]);
+    },
+  );
+
   it("tracks open approvals and removes resolved ones", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
@@ -90,7 +121,7 @@ describe("derivePendingApprovals", () => {
         kind: "approval.requested",
         summary: "File-change approval requested",
         tone: "approval",
-        payload: { requestId: "req-2", requestKind: "file-change" },
+        payload: { requestId: "req-2", requestType: "unknown" },
       }),
     ];
 
@@ -199,7 +230,7 @@ describe("derivePendingApprovals", () => {
         tone: "approval",
         payload: {
           requestId: "req-stale-1",
-          requestKind: "command",
+          requestType: "unknown",
         },
       }),
       makeActivity({

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -464,10 +464,16 @@ export function derivePendingApprovals(
       ? payload.options.filter(isProviderApprovalOption)
       : undefined;
 
-    if (activity.kind === "approval.requested" && requestId && requestKind) {
+    if (
+      activity.kind === "approval.requested" &&
+      requestId &&
+      payload?.requestType !== "tool_user_input" &&
+      payload?.requestType !== "auth_tokens_refresh"
+    ) {
       openByRequestId.set(requestId, {
         requestId,
-        requestKind,
+        // Older OpenCode requests can have no recognized approval kind.
+        requestKind: requestKind ?? "command",
         createdAt: activity.createdAt,
         ...(detail ? { detail } : {}),
         ...(appName ? { appName } : {}),

--- a/docs/user/providers-opencode.md
+++ b/docs/user/providers-opencode.md
@@ -17,14 +17,45 @@ With a server URL, T3 Code connects to that external server and uses only the pa
 provider settings. It does not send a local `OPENCODE_SERVER_PASSWORD` to an external server.
 OpenCode uses this password for HTTP Basic authentication.
 
+## Approvals
+
+In **Supervised** and **Auto** modes, OpenCode can read normal project files, search files, load
+skills, and update its task list without approval. Files such as `.env` and `.env.local` still
+require approval. `.env.example` does not. OpenCode does not have an AI approval reviewer, so
+**Auto** uses the same permission rules as **Supervised**.
+
+OpenCode asks before it runs commands, edits files, accesses the web, or accesses directories
+outside the workspace. **Auto-accept edits** also permits file edits without approval.
+**Full access** permits all these actions. Questions that need your answer can still appear.
+
+An **Approval** badge means OpenCode needs a decision. Open the thread to see the action and
+choose one of these options:
+
+- **Allow once** permits this request.
+- **Allow for workspace** permits matching requests in other OpenCode sessions in the same
+  workspace. It is not limited to the current thread.
+- **Deny** rejects this request. Use **Stop** to stop the whole turn.
+
+If a connection error prevents the reply, the approval stays available so you can try again.
+
+## Progress
+
+T3 Code shows OpenCode's response text and tool results while work runs. The web and desktop apps
+also show its task-list progress. A task-list update does not require approval.
+
+If the OpenCode connection closes unexpectedly, T3 Code shows an error. Send another prompt to
+reconnect to the same OpenCode session.
+
 ## Stop a turn
 
 When you select **Stop**, T3 Code stops the main OpenCode session and all nested child sessions.
 T3 Code waits for this cleanup before it marks the turn as stopped or sends the next prompt. It
-does not stop unrelated OpenCode sessions.
+does not stop unrelated OpenCode sessions. After Stop succeeds, pending approvals and questions
+are cleared.
 
-Stop reports an error if OpenCode cannot list or stop a child session. When T3 Code closes an
-OpenCode session, it also tries to stop the child sessions, but this teardown is best effort.
+Stop reports an error if OpenCode cannot stop the main session or list or stop a child session.
+When T3 Code closes an OpenCode session, it also tries to stop the child sessions, but this
+teardown is best effort.
 
 ## Refresh the model list
 

--- a/packages/client-runtime/src/work-log/presentation.test.ts
+++ b/packages/client-runtime/src/work-log/presentation.test.ts
@@ -15,6 +15,40 @@ import {
 } from "./presentation.js";
 
 describe("summarizeToolGroup", () => {
+  it.each(["command", "file-read", "file-change"])(
+    "keeps %s approvals out of tool execution counts",
+    (requestKind) => {
+      const approvals = [
+        {
+          label: "Approval requested",
+          sourceActivityKind: "approval.requested",
+          tone: "info",
+          requestKind,
+        },
+        {
+          label: "Approval resolved",
+          sourceActivityKind: "approval.resolved",
+          tone: "info",
+          requestKind,
+        },
+        {
+          label: "Provider approval response failed",
+          sourceActivityKind: "provider.approval.respond.failed",
+          tone: "error",
+        },
+      ] satisfies WorkLogPresentationEntry[];
+
+      expect(
+        summarizeToolGroup([
+          ...approvals,
+          { label: "Read", tone: "tool", itemType: "dynamic_tool_call" },
+        ]),
+      ).toBe("Received 3 updates and used 1 tool");
+      expect(summarizeToolGroup(approvals)).toBe("Received 3 updates");
+      expect(toolGroupSummaryKind(approvals)).toBe("update");
+    },
+  );
+
   it("deduplicates named sources ahead of ordinary actions", () => {
     const source = { key: "browser-use:chrome", name: "Chrome", kind: "integration" as const };
     expect(

--- a/packages/client-runtime/src/work-log/presentation.ts
+++ b/packages/client-runtime/src/work-log/presentation.ts
@@ -313,6 +313,13 @@ export function workLogEntryIsLocalCodeSearch(entry: WorkLogPresentationEntry): 
 }
 
 export function toolGroupAction(entry: WorkLogPresentationEntry): ToolGroupAction {
+  if (
+    entry.sourceActivityKind === "approval.requested" ||
+    entry.sourceActivityKind === "approval.resolved" ||
+    entry.sourceActivityKind === "provider.approval.respond.failed"
+  ) {
+    return "update";
+  }
   if (resolveWorkEntryToolPresentation(entry)?.icon === "browser") return "browser";
   if (
     entry.requestKind === "file-read" ||


### PR DESCRIPTION
OpenCode could show an Approval badge with no controls, appear stuck on TodoWrite, and keep showing a running turn after Stop.

This fixes the approval and turn lifecycle across the server, web, desktop, and mobile:

- Show every permission, including old saved requests. Keep failed replies retryable and close completed requests even when reply events are lost.
- Keep OpenCode output pipes drained and automatic replies out of the event loop. Handle disconnects, reconnects, and confirmed stops without stale requests or running states.
- Show native task progress and command results. Do not treat TodoWrite or approval history as file edits or executed commands.
- Label OpenCode's shared permission scope as **Allow for workspace**.

Verified with 576 focused tests, scoped typechecks and lint, and the real OpenCode 1.18.23 CLI using an isolated local test model. The client pass covered approvals, denial, questions, Stop, and follow-up prompts. Stop cleared the running state and closed the model connection in 343 ms in this test.

| Before | After |
| --- | --- |
| ![Approval badge without controls](https://files.tslop.org/2026/09/opencode-approval-before-4bf98b07.png) | ![Actionable OpenCode approval](https://files.tslop.org/2026/09/opencode-approval-after-e9862b9d.png) |

[Stop recording](https://files.tslop.org/2026/09/opencode-stop-5c02ad53.mp4)

Created with GPT-6 Astra (preview) in Codex.

Fixes #4795
Fixes #7113
Fixes #5760

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches approval projection, OpenCode session/event-pump lifecycle, and permission policy; behavior is heavily tested but errors could affect badges, stop, or what runs without a prompt.
> 
> **Overview**
> Fixes broken OpenCode **Approval** UX (badge with no controls), stuck turns after **Stop**, and misleading progress when TodoWrite or approval events were treated like real tool work.
> 
> **Clients** (`derivePendingApprovals` on web, mobile, and related tests) now surface legacy OpenCode requests even when the kind is unknown (default **`command`**), while excluding **`tool_user_input`** and **`auth_tokens_refresh`** from the approval queue.
> 
> **Projections** re-open pending approvals when a user’s reply was optimistically cleared but the provider reports a **non-stale** `provider.approval.respond.failed`, unless another client already resolved the request.
> 
> **Runtime ingestion** treats **`turn.aborted`** like other terminal turn events: **`interrupted`** session state, stricter guards so late aborts cannot stomp a newer turn, and assistant text finalized on abort.
> 
> **OpenCode adapter** is the bulk of the change: every permission maps to an actionable approval (with **Allow once / Allow for workspace / Deny**); full-access auto-replies run off the event pump with timeout and fallback to the dialog; reconnect closes missing pending requests and warns on SSE loss; **Stop** clears open permissions/questions; HTTP replies are idempotent with locally emitted terminal events; **`todo.updated`** drives **`turn.plan.updated`** only for the active turn; tool lifecycle payloads include command/output details.
> 
> **Permission rules** in supervised modes auto-allow workspace reads, search, skills, and **`todowrite`**, while keeping **`.env*`** asks; **`acceptAlways`** maps to OpenCode **`always`**.
> 
> **OpenCode server startup** keeps draining stdout/stderr so buffers cannot block requests. **Work log** presentation stops counting approval activities as executed tools. User docs describe approvals, progress, stop cleanup, and reconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9b37fc0a41e370ed3434927a158382a30d8cc0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OpenCode approval lifecycle, stop cleanup, and `turn.aborted` ingestion
> - Reworks [OpenCodeAdapter.ts](https://github.com/pingdotgg/t3code/pull/9653/files#diff-a4267388b15e5043ae1899beded972cbee9e52533ca3d9d65d438a91a9f7fbe7) so pending permissions and questions are closed or recovered when a turn completes, errors, or is aborted; adds a bounded, cancellable pending-request recovery loop and `openPermissionRequest` dialog helper with allow-once, workspace-allow, and deny decisions
> - Adds 10-second timeouts and abort-signal propagation to session lookups, permission/question replies, auto-replies, and inventory loads throughout the adapter and [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/9653/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8)
> - Defaults unrecognized or absent OpenCode request kinds to `command` approvals in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/9653/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) and [threadActivity.ts](https://github.com/pingdotgg/t3code/pull/9653/files#diff-a18e8ed6aa4a9d6b3d9e32ea2fa3034dfd7621b6af3d640ec1b95a8564c97eb5), and excludes `tool_user_input` and `auth_tokens_refresh` from pending approvals
> - Restores a resolved approval row to pending after a non-terminal `provider.approval.respond.failed` in [ProjectionPipeline.ts](https://github.com/pingdotgg/t3code/pull/9653/files#diff-fd69e677e48d4705b0235085da8402910510d529ec5a507d804037a88fca07f4)
> - Settles accepted `turn.aborted` events as interrupted in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/9653/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7), clearing the active turn, error, and finalizing assistant text; ignores late or untargeted aborts
> - Allows workspace reads, searches, LSP, skill use, and `todowrite` without approval in non-full-access modes, while keeping environment-file reads, commands, network, and external-directory access as ask operations
> - Maps `acceptAlways` decisions to OpenCode's `always` reply and caps server startup output at 64 KiB per stream
> - Risk: `mapPermissionToRequestType` no longer returns `unknown`; all unrecognized permissions now map to `command-execution` approval. `toToolLifecycleItemType` now classifies `todowrite`/`todoread` as dynamic tool calls instead of file-change. Reconnect and abort paths emit synthetic terminal events for pending requests, which out-of-tree consumers reading raw provider events may not expect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9b37fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->