### PR TITLE
fix(web): mute composer helper text

### DIFF
--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -1929,7 +1929,7 @@ function ComposerPromptEditorInner({
               terminalContexts.length > 0 ? null : (
                 <div
                   className={cn(
-                    "pointer-events-none absolute inset-0 leading-relaxed text-placeholder",
+                    "pointer-events-none absolute inset-0 leading-relaxed text-placeholder/75",
                     placeholderClassName,
                   )}
                 >


### PR DESCRIPTION
## What Changed

Reduced the composer helper text to 75% of each theme's placeholder color. This keeps the theme-specific hue while making the prompt visibly subordinate to entered text.

## Why

Some imported themes, including Tokyo Night, resolve their placeholder token to a bright fallback for contrast. At full opacity, the composer helper can look almost as prominent as primary text. Applying the opacity at the composer keeps the importer and global placeholder token unchanged.

## UI Changes

![Before and after composer helper text across all available themes](https://github.com/user-attachments/assets/929c2443-abc1-4393-8e13-0caab5a90ebc)

The comparison covers every theme shown in Settings in both light and dark mode.

## Validation

- `vp run --filter @t3tools/web typecheck`
- `git diff --check`
- Verified the computed live composer class and color in the web app

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] No animation or interaction changed, so a video is not applicable

Created with GPT-5.6-Sol via the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on composer placeholder styling with no logic, auth, or data impact.
> 
> **Overview**
> The composer empty-state helper text now uses **`text-placeholder/75`** instead of full **`text-placeholder`**, so it renders at 75% of each theme’s placeholder color.
> 
> That keeps theme-specific hues while making the hint clearly subordinate to typed prompt text—especially on themes where the placeholder token resolves to a bright fallback. The adjustment is **only** on the `ComposerPromptEditor` overlay; global placeholder tokens and other surfaces (e.g. `ChatComposer`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 571eab388e68e152f041b947f961f546a083b91f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mute composer placeholder text to 75% opacity in `ComposerPromptEditorInner`
> Changes the placeholder color utility from `text-placeholder` to `text-placeholder/75` in [ComposerPromptEditor.tsx](https://github.com/pingdotgg/t3code/pull/9654/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4). This reduces the visual prominence of the composer's helper/placeholder text. No layout, positioning, or pointer-event behavior is affected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 571eab3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
