### PR TITLE
fix(desktop): quit immediately on a second shortcut press

### DIFF
--- a/apps/desktop/src/window/QuitHold.test.ts
+++ b/apps/desktop/src/window/QuitHold.test.ts
@@ -252,24 +252,31 @@ describe("makeQuitShortcutHandler", () => {
     expect(harness.notifications).toEqual([]);
   });
 
-  it("honors a quick double press when both key releases beat their mode reads", async () => {
-    const resolvers: Array<(mode: QuitConfirmationMode) => void> = [];
-    const harness = makeHarness({
-      getMode: () => new Promise((resolve) => resolvers.push(resolve)),
-    });
-    await harness.send(makeInput({}));
-    await harness.send(makeInput({ type: "keyUp" }));
-    vi.advanceTimersByTime(QUIT_DOUBLE_PRESS_MS - 100);
-    await harness.send(makeInput({}));
-    await harness.send(makeInput({ type: "keyUp" }));
+  it.each(["direct", "hold", "double-click"] as const)(
+    "quits on a quick second press without waiting for a pending %s mode read",
+    async (mode) => {
+      const resolvers: Array<(mode: QuitConfirmationMode) => void> = [];
+      const harness = makeHarness({
+        getMode: () => new Promise((resolve) => resolvers.push(resolve)),
+      });
+      await harness.send(makeInput({}));
+      await harness.send(makeInput({ type: "keyUp" }));
+      vi.advanceTimersByTime(QUIT_DOUBLE_PRESS_MS - 100);
+      await harness.send(makeInput({}));
 
-    resolvers[1]?.("double-click");
-    await Promise.resolve();
-    await Promise.resolve();
+      expect(harness.quit).toHaveBeenCalledTimes(1);
+      expect(harness.notifications).toEqual([]);
 
-    expect(harness.quit).toHaveBeenCalledTimes(1);
-    expect(harness.notifications).toEqual([]);
-  });
+      await harness.send(makeInput({ type: "keyUp" }));
+
+      resolvers[0]?.(mode);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(harness.quit).toHaveBeenCalledTimes(1);
+      expect(harness.notifications).toEqual([]);
+    },
+  );
 
   it("discards a stale mode resolution from a superseded press", async () => {
     // Press #1's mode is still pending when the user releases and
@@ -376,6 +383,38 @@ describe("makeQuitShortcutHandler", () => {
     await harness.send(makeInput({}));
     expect(harness.quit).toHaveBeenCalledTimes(1);
     expect(harness.notifications).toEqual([HOLD_DOWN, UP]);
+  });
+
+  it("quits on a quick second press in hold mode when the first release is unseen", async () => {
+    const harness = makeHarness();
+    await harness.send(makeInput({}));
+    vi.advanceTimersByTime(QUIT_DOUBLE_PRESS_MS - 100);
+    await harness.send(makeInput({}));
+
+    expect(harness.concealWindow).not.toHaveBeenCalled();
+    expect(harness.quit).toHaveBeenCalledTimes(1);
+    expect(harness.notifications).toEqual([HOLD_DOWN, UP]);
+  });
+
+  it("does not count auto-repeat as a second press", async () => {
+    const harness = makeHarness();
+    await harness.send(makeInput({}));
+    await harness.holdFor(QUIT_DOUBLE_PRESS_MS - 100);
+
+    expect(harness.quit).not.toHaveBeenCalled();
+    expect(harness.notifications).toEqual([HOLD_DOWN]);
+  });
+
+  it("does not count a released tap after another shortcut interrupts it", async () => {
+    const harness = makeHarness();
+    await harness.send(makeInput({}));
+    await harness.send(makeInput({ type: "keyUp" }));
+    await harness.send(makeInput({ key: "c" }));
+    vi.advanceTimersByTime(100);
+    await harness.send(makeInput({}));
+
+    expect(harness.quit).not.toHaveBeenCalled();
+    expect(harness.notifications).toEqual([HOLD_DOWN, UP, HOLD_DOWN]);
   });
 
   it("cancels the hold when another key interrupts it", async () => {

--- a/apps/desktop/src/window/QuitHold.ts
+++ b/apps/desktop/src/window/QuitHold.ts
@@ -12,7 +12,8 @@ export const QUIT_DOUBLE_PRESS_MS = 500;
 // tap release can go completely unseen and a release-based timer would quit
 // anyway. Once held, quitting waits for Q keyUp or a quiet grace period after
 // repeats stop so they cannot reach the next app. Keyboards with
-// auto-repeat disabled fall back to the application menu Quit action.
+// auto-repeat disabled must use a double press or the application menu Quit action.
+// Supporting holds without repeats requires a native physical key-state check.
 export const QUIT_HOLD_RELEASE_GRACE_MS = 600;
 // A slow repeat rate can exceed the fixed grace. Waiting for two observed
 // cadences keeps the timer behind the next repeat without slowing normal rates.
@@ -52,8 +53,8 @@ export function makeQuitShortcutHandler(
   let lastRepeatAt = 0;
   let repeatCadenceMs = 0;
   // Incremented when a press is superseded or explicitly cancelled. A plain
-  // key release does not invalidate its pending mode read: direct mode and a
-  // completed second press must still be honored after that read settles.
+  // key release does not invalidate its pending mode read: a direct-mode
+  // press must still quit after that read settles.
   let generation = 0;
 
   const clearWatchdog = () => {
@@ -64,9 +65,9 @@ export function makeQuitShortcutHandler(
   };
 
   const release = (cancelPendingMode = true, keepDoublePressHint = false) => {
+    if (cancelPendingMode) generation += 1;
     if (!holding && !notified) return;
     const keepHint = keepDoublePressHint && mode === "double-click" && notified;
-    if (cancelPendingMode) generation += 1;
     holding = false;
     armed = false;
     quitOnRelease = false;
@@ -85,6 +86,7 @@ export function makeQuitShortcutHandler(
   // Dismisses any overlay first so a cancelled quit cannot leave a stale hint.
   const quitNow = () => {
     release();
+    lastPressAt = 0;
     options.quit();
   };
 
@@ -138,13 +140,10 @@ export function makeQuitShortcutHandler(
       // quit shortcut, so it must not cancel an active double-press window.
       if (key === modifierKey && !input.alt && !input.shift) return;
 
-      // Any other key (or an extra modifier) pressed mid-hold breaks the
-      // gesture; without this the hold timer keeps running through the
-      // interruption and the next qualifying repeat would quit early. The
-      // interrupted press also stops counting toward a double press, but only
-      // here, not in release(), which runs mid-restart on an unseen-release
-      // re-press and must not wipe that press's own tap timestamp.
-      if ((holding || notified) && !input.isAutoRepeat) {
+      // Other keys cancel the hold and the first tap, even after release.
+      // Keep this separate from release(), which also runs when a fresh Q
+      // keydown follows a keyUp that macOS did not deliver.
+      if (!input.isAutoRepeat) {
         lastPressAt = 0;
         release();
       }
@@ -171,6 +170,13 @@ export function makeQuitShortcutHandler(
     if (holding || notified) release();
 
     generation += 1;
+    // Every mode accepts two presses. Quit before reading settings so a slow
+    // read cannot delay the second press. Repeats never reach this branch.
+    if (previousPressAt !== 0 && now - previousPressAt <= QUIT_DOUBLE_PRESS_MS) {
+      quitNow();
+      return;
+    }
+
     const pressGeneration = generation;
     holding = true;
     heldSince = now;
@@ -181,13 +187,6 @@ export function makeQuitShortcutHandler(
           quitNow();
           return;
         }
-        // Keep a second press as an escape hatch when macOS misses the events
-        // that would complete a hold.
-        if (previousPressAt !== 0 && now - previousPressAt <= QUIT_DOUBLE_PRESS_MS) {
-          quitNow();
-          return;
-        }
-
         if (resolvedMode === "double-click") {
           const remainingMs = QUIT_DOUBLE_PRESS_MS - (Date.now() - now);
           if (remainingMs <= 0) {

--- a/apps/web/src/components/QuitHoldOverlay.tsx
+++ b/apps/web/src/components/QuitHoldOverlay.tsx
@@ -40,7 +40,9 @@ export function QuitHoldOverlay() {
   if (!visibleMode) return null;
   const shortcut = isMacPlatform(navigator.platform) ? "⌘Q" : "Ctrl+Q";
   const message =
-    visibleMode === "hold" ? `Hold ${shortcut} to Quit` : `Press ${shortcut} again to Quit`;
+    visibleMode === "hold"
+      ? `Hold ${shortcut} or press twice to quit`
+      : `Press ${shortcut} again to quit`;
   return (
     <div
       role="status"

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -2744,7 +2744,7 @@ export function GeneralSettingsPanel() {
         {isElectron ? (
           <SettingsRow
             {...searchableSetting("quit-confirmation")}
-            description="Choose whether the desktop app quits immediately, after a hold, or after two quick presses."
+            description="Hold mode also quits on two quick presses."
             resetAction={
               settings.confirmQuit !== DEFAULT_UNIFIED_SETTINGS.confirmQuit ? (
                 <SettingResetButton

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -89,6 +89,19 @@ Background submission from a new thread is the exception. `mod+enter` starts tha
 another new thread with the same workspace mode and base branch. **New worktree** remains selected,
 but the new thread does not reuse the worktree created for the thread that just started.
 
+## Desktop quit shortcut
+
+Use `Cmd+Q` on macOS or `Ctrl+Q` on Windows and Linux. In the default **Hold** mode, hold the
+shortcut for 1.2 seconds or press it twice within 500 milliseconds. The second press quits
+immediately. You can keep Command or Control held between presses, or release both keys.
+
+Hold mode needs keyboard repeat. If holding does not quit, use two quick presses or choose
+**Quit** from the application menu.
+
+Change **Quit shortcut** in **Settings** → **General** → **Confirmations**. **Direct** quits on
+the first press. **Double press** requires two quick presses and does not accept a hold. The
+application menu's **Quit** action always quits immediately.
+
 ## `when` Conditions
 
 A `when` expression is evaluated against context keys describing the current UI state. The keys


### PR DESCRIPTION
Double-pressing the quit shortcut could wait on a settings read. An unrelated shortcut between released taps could also cause an unintended quit.

Hold mode already accepts two presses within 500 ms. The second press now quits without waiting for settings. Other input cancels the first tap. The default mode and timing window stay unchanged. The hint and settings text explain both gestures.

Hold-to-quit still depends on keyboard-repeat events. Without them, it cancels after about 1.8 seconds. This PR documents that limit but does not add native macOS key-state checks.

## Checks

- 80 focused tests pass.
- Desktop typecheck and targeted lint pass. Lint reports existing warnings in the settings panel.
- Native macOS input was not verified on this Linux machine.
- Browser captures were skipped at the maintainer's request.

Created with GPT-6 Astra (preview) in Codex.
