### PR TITLE
perf(web): speed up terminal snapshots

### DIFF
--- a/apps/web/src/terminal/ghostty/core.test.ts
+++ b/apps/web/src/terminal/ghostty/core.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { ghosttyCellText } from "./core";
+import { GHOSTTY_CELL_WIDE, GhosttyTerminalCore, ghosttyCellText } from "./core";
+import { loadGhosttyRuntime } from "./runtime";
+
+vi.mock("./vendor/ghostty-vt.wasm?url", async () => ({
+  default: (await import("./vendor/ghostty-vt.wasm?inline")).default,
+}));
+vi.mock("./vendor/ghostty-write-pty.wasm?url&no-inline", async () => ({
+  default: (await import("./vendor/ghostty-write-pty.wasm?inline")).default,
+}));
 
 function codepointView(codepoints: ReadonlyArray<number>): DataView {
   const view = new DataView(new ArrayBuffer(codepoints.length * 4));
@@ -30,7 +38,111 @@ describe("ghosttyCellText", () => {
     expect([...text]).toEqual(["\u{1F642}", "\u{20E3}"]);
   });
 
+  it("converts a single astral codepoint", () => {
+    expect(ghosttyCellText(codepointView([0x1f642]), 1)).toBe("🙂");
+  });
+
   it("returns an empty string for empty cells", () => {
     expect(ghosttyCellText(codepointView([]), 0)).toBe("");
+  });
+});
+
+describe("GhosttyTerminalCore snapshots", () => {
+  const cores = new Set<GhosttyTerminalCore>();
+
+  async function createCore() {
+    const core = await GhosttyTerminalCore.create(
+      12,
+      3,
+      8,
+      16,
+      {
+        foreground: { r: 255, g: 255, b: 255 },
+        background: { r: 0, g: 0, b: 0 },
+        cursor: { r: 255, g: 255, b: 255 },
+      },
+      () => {},
+    );
+    cores.add(core);
+    return core;
+  }
+
+  afterEach(() => {
+    for (const core of cores) core.dispose();
+    cores.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("preserves styles, wide cells, and selection after shared memory grows", async () => {
+    const core = await createCore();
+    const runtime = await loadGhosttyRuntime();
+    const grapheme = `e${"\u0301".repeat(64)}`;
+    core.write(`\x1b[1;3;4;8;9;53;38;2;123;45;67;48;2;9;8;7m${grapheme}\x1b[0m界🙂`);
+    const cells = core.snapshot().rowData[0]!.cells;
+    expect(cells[0]).toEqual({
+      text: grapheme,
+      wide: 0,
+      foreground: { r: 123, g: 45, b: 67 },
+      background: { r: 9, g: 8, b: 7 },
+      bold: true,
+      italic: true,
+      invisible: true,
+      strikethrough: true,
+      overline: true,
+      underline: true,
+      selected: false,
+    });
+    expect(cells.slice(1, 5).map(({ text, wide }) => ({ text, wide }))).toEqual([
+      { text: "界", wide: 0 },
+      { text: "", wide: GHOSTTY_CELL_WIDE.spacerTail },
+      { text: "🙂", wide: 0 },
+      { text: "", wide: GHOSTTY_CELL_WIDE.spacerTail },
+    ]);
+
+    runtime.memory.grow(1);
+    core.setSelection({ x: 0, y: 0 }, { x: 2, y: 0 });
+    expect(core.snapshot().rowData[0]!.cells[0]).toEqual({ ...cells[0], selected: true });
+    core.clearSelection();
+    expect(core.snapshot().rowData[0]!.cells[0]).toEqual(cells[0]);
+
+    core.resetAndWrite("\x1b[2;7;38;2;40;100;200;48;2;12;34;56mC\x1b[0m");
+    expect(core.snapshot().rowData[0]!.cells[0]).toMatchObject({
+      text: "C",
+      foreground: { r: 22, g: 59, b: 112 },
+      background: { r: 40, g: 100, b: 200 },
+      bold: false,
+      underline: false,
+      selected: false,
+    });
+  });
+
+  it("reuses a grown grapheme buffer and releases it on disposal", async () => {
+    const core = await createCore();
+    const runtime = await loadGhosttyRuntime();
+    core.write("ASCII");
+    core.snapshot();
+
+    const grapheme = `z${"\u0301".repeat(256)}`;
+    core.resetAndWrite(`${grapheme}X`);
+    const alloc = vi.spyOn(runtime, "alloc");
+    const free = vi.spyOn(runtime, "free");
+    expect(
+      core
+        .snapshot()
+        .rowData[0]!.cells.slice(0, 2)
+        .map((cell) => cell.text),
+    ).toEqual([grapheme, "X"]);
+    expect(alloc).toHaveBeenCalledTimes(1);
+    const allocation = alloc.mock.results[0]!;
+    if (allocation.type !== "return") throw new Error("Grapheme allocation did not return");
+    const buffer = allocation.value;
+    const capacity = alloc.mock.calls[0]![0];
+
+    core.write("\rQ\u0301");
+    alloc.mockClear();
+    expect(core.snapshot().rowData[0]!.cells[0]!.text).toBe("Q\u0301");
+    expect(alloc).not.toHaveBeenCalled();
+    core.dispose();
+    expect(free).toHaveBeenCalledWith(buffer, capacity);
   });
 });

--- a/apps/web/src/terminal/ghostty/core.ts
+++ b/apps/web/src/terminal/ghostty/core.ts
@@ -174,6 +174,7 @@ function sameColor(left: GhosttyColor, right: GhosttyColor): boolean {
  * every codepoint into String.fromCodePoint at once.
  */
 export function ghosttyCellText(codepointView: DataView, graphemeLength: number): string {
+  if (graphemeLength === 1) return String.fromCodePoint(codepointView.getUint32(0, true));
   const CHUNK_SIZE = 4_096;
   let text = "";
   for (let start = 0; start < graphemeLength; start += CHUNK_SIZE) {
@@ -206,6 +207,8 @@ export class GhosttyTerminalCore {
   private ptyWriterId = 0;
   private ptyWriter: ((data: string) => void) | null = null;
   private scratch = 0;
+  private graphemes = 0;
+  private graphemeCapacity = 0;
   private style = 0;
   private scrollbar = 0;
   private rows: GhosttyRow[] = [];
@@ -878,6 +881,7 @@ export class GhosttyTerminalCore {
       this.runtime.free(this.scrollbar, this.runtime.layout("GhosttyTerminalScrollbar").size);
     }
     if (this.scratch) this.runtime.free(this.scratch, 16);
+    if (this.graphemes) this.runtime.free(this.graphemes, this.graphemeCapacity);
     for (const slot of [
       this.mouseEventSlot,
       this.mouseEncoderSlot,
@@ -944,6 +948,7 @@ export class GhosttyTerminalCore {
       ),
     );
     const cellsIterator = this.runtime.readPointer(this.rowCellsSlot);
+    const { size: styleSize, fields: styleFields } = this.runtime.layout("GhosttyStyle");
     const cells: GhosttyCell[] = [];
     while (
       cells.length < cols &&
@@ -951,7 +956,6 @@ export class GhosttyTerminalCore {
     ) {
       let foreground = this.getCellColor(cellsIterator, CELL_DATA.foreground, defaultForeground);
       let background = this.getCellColor(cellsIterator, CELL_DATA.background, defaultBackground);
-      const styleSize = this.runtime.layout("GhosttyStyle").size;
       this.runtime.bytes(this.style, styleSize).fill(0);
       this.runtime.setField(this.style, "GhosttyStyle", "size", styleSize);
       this.runtime.call(
@@ -960,30 +964,30 @@ export class GhosttyTerminalCore {
         CELL_DATA.style,
         this.style,
       );
-      const inverse = this.runtime.readField(this.style, "GhosttyStyle", "inverse") !== 0;
-      if (inverse) [foreground, background] = [background, foreground];
-      if (this.runtime.readField(this.style, "GhosttyStyle", "faint") !== 0) {
-        foreground = blend(foreground, background);
-      }
       const graphemeLength = this.getCellU32(cellsIterator, CELL_DATA.graphemesLength);
       let text = "";
       if (graphemeLength > 0) {
         const bufferSize = graphemeLength * 4;
-        const codepoints = this.runtime.alloc(bufferSize);
+        if (bufferSize > this.graphemeCapacity) {
+          const capacity = Math.max(bufferSize, this.graphemeCapacity * 2);
+          const buffer = this.runtime.alloc(capacity);
+          this.runtime.free(this.graphemes, this.graphemeCapacity);
+          this.graphemes = buffer;
+          this.graphemeCapacity = capacity;
+        }
         if (
           this.runtime.call(
             "ghostty_render_state_row_cells_get",
             cellsIterator,
             CELL_DATA.graphemes,
-            codepoints,
+            this.graphemes,
           ) === GHOSTTY_SUCCESS
         ) {
           // Read through a DataView: the byte-array allocator guarantees no
           // 4-byte alignment, which a Uint32Array view would require.
-          const codepointView = this.runtime.view(codepoints, bufferSize);
+          const codepointView = this.runtime.view(this.graphemes, bufferSize);
           text = ghosttyCellText(codepointView, graphemeLength);
         }
-        this.runtime.free(codepoints, bufferSize);
       }
       let wide = 0;
       if (text.length === 0 && cells.at(-1)?.text.length) {
@@ -1004,18 +1008,27 @@ export class GhosttyTerminalCore {
         );
         wide = this.runtime.view(this.scratch + 8, 4).getUint32(0, true);
       }
+      const selected = this.getCellBool(cellsIterator, CELL_DATA.selected);
+      // Read the style after allocation and ABI calls, which can grow WASM memory.
+      const styleView = this.runtime.view(this.style, styleSize);
+      if (styleView.getUint8(styleFields.inverse!.offset) !== 0) {
+        [foreground, background] = [background, foreground];
+      }
+      if (styleView.getUint8(styleFields.faint!.offset) !== 0) {
+        foreground = blend(foreground, background);
+      }
       cells.push({
         text,
         wide,
         foreground,
         background,
-        bold: this.runtime.readField(this.style, "GhosttyStyle", "bold") !== 0,
-        italic: this.runtime.readField(this.style, "GhosttyStyle", "italic") !== 0,
-        invisible: this.runtime.readField(this.style, "GhosttyStyle", "invisible") !== 0,
-        strikethrough: this.runtime.readField(this.style, "GhosttyStyle", "strikethrough") !== 0,
-        overline: this.runtime.readField(this.style, "GhosttyStyle", "overline") !== 0,
-        underline: this.runtime.readField(this.style, "GhosttyStyle", "underline") !== 0,
-        selected: this.getCellBool(cellsIterator, CELL_DATA.selected),
+        bold: styleView.getUint8(styleFields.bold!.offset) !== 0,
+        italic: styleView.getUint8(styleFields.italic!.offset) !== 0,
+        invisible: styleView.getUint8(styleFields.invisible!.offset) !== 0,
+        strikethrough: styleView.getUint8(styleFields.strikethrough!.offset) !== 0,
+        overline: styleView.getUint8(styleFields.overline!.offset) !== 0,
+        underline: styleView.getInt32(styleFields.underline!.offset, true) !== 0,
+        selected,
       });
     }
     while (cells.length < cols) cells.push(this.emptyCell(defaultForeground, defaultBackground));

--- a/apps/web/src/terminal/ghostty/runtime.ts
+++ b/apps/web/src/terminal/ghostty/runtime.ts
@@ -23,6 +23,7 @@ export class GhosttyRuntime {
   readonly memory: WebAssembly.Memory;
   readonly layouts: TypeLayouts;
   private readonly exports: WebAssembly.Exports;
+  private memoryView: DataView;
   private readonly ptyWriters = new Map<number, (data: string) => void>();
   private nextPtyWriterId = 1;
   private writePtyFunctionIndex = 0;
@@ -34,6 +35,7 @@ export class GhosttyRuntime {
       throw new Error("libghostty-vt did not export WebAssembly memory");
     }
     this.memory = memory;
+    this.memoryView = new DataView(memory.buffer);
     const jsonPointer = this.call("ghostty_type_json");
     const bytes = new Uint8Array(memory.buffer);
     let end = jsonPointer;
@@ -104,7 +106,7 @@ export class GhosttyRuntime {
   }
 
   readPointer(slot: number): number {
-    return new DataView(this.memory.buffer).getUint32(slot, true);
+    return this.currentMemoryView().getUint32(slot, true);
   }
 
   attachPtyWriter(terminal: number, writer: (data: string) => void): number {
@@ -132,27 +134,36 @@ export class GhosttyRuntime {
     return new Uint8Array(this.memory.buffer, pointer, size);
   }
 
+  /** Reuse scalar reads across cells, refreshing after any terminal grows shared WASM memory. */
+  private currentMemoryView(): DataView {
+    if (this.memoryView.buffer !== this.memory.buffer) {
+      this.memoryView = new DataView(this.memory.buffer);
+    }
+    return this.memoryView;
+  }
+
   setField(pointer: number, structName: string, fieldName: string, value: number): void {
     const field = this.layout(structName).fields[fieldName];
     if (!field) throw new Error(`libghostty-vt field is unavailable: ${structName}.${fieldName}`);
-    const view = this.view(pointer + field.offset, field.size);
+    const view = this.currentMemoryView();
+    const offset = pointer + field.offset;
     switch (field.type) {
       case "bool":
       case "u8":
-        view.setUint8(0, value);
+        view.setUint8(offset, value);
         return;
       case "u16":
-        view.setUint16(0, value, true);
+        view.setUint16(offset, value, true);
         return;
       case "i32":
-        view.setInt32(0, value, true);
+        view.setInt32(offset, value, true);
         return;
       case "u32":
       case "enum":
-        view.setUint32(0, value, true);
+        view.setUint32(offset, value, true);
         return;
       case "u64":
-        view.setBigUint64(0, BigInt(value), true);
+        view.setBigUint64(offset, BigInt(value), true);
         return;
       default:
         throw new Error(`Unsupported libghostty-vt field type: ${field.type}`);
@@ -162,20 +173,21 @@ export class GhosttyRuntime {
   readField(pointer: number, structName: string, fieldName: string): number {
     const field = this.layout(structName).fields[fieldName];
     if (!field) throw new Error(`libghostty-vt field is unavailable: ${structName}.${fieldName}`);
-    const view = this.view(pointer + field.offset, field.size);
+    const view = this.currentMemoryView();
+    const offset = pointer + field.offset;
     switch (field.type) {
       case "bool":
       case "u8":
-        return view.getUint8(0);
+        return view.getUint8(offset);
       case "u16":
-        return view.getUint16(0, true);
+        return view.getUint16(offset, true);
       case "i32":
-        return view.getInt32(0, true);
+        return view.getInt32(offset, true);
       case "u32":
       case "enum":
-        return view.getUint32(0, true);
+        return view.getUint32(offset, true);
       case "u64":
-        return Number(view.getBigUint64(0, true));
+        return Number(view.getBigUint64(offset, true));
       default:
         throw new Error(`Unsupported libghostty-vt field type: ${field.type}`);
     }


### PR DESCRIPTION
Busy terminals allocate a WASM grapheme buffer and build several memory views for each cell in a snapshot.

Reuse one growing grapheme buffer per terminal. Read each cell's style through one view and reuse scalar memory views, refreshing them when shared WASM memory grows. The terminal ABI and output are unchanged.

Source benchmark with the real WASM, Node 24.20, a full 120x40 grid, 10 warmups, and 60 samples:

| Per snapshot | Before | After |
| --- | ---: | ---: |
| Median time | 15.45 ms | 6.58 ms |
| WASM calls | 43,057 | 33,775 |
| WASM scratch allocations after warmup | 4,641 | 0 |

These are source benchmarks, not browser frame measurements. All 13 baseline snapshot cases matched, including styles, Unicode, selection, memory growth, resize, scroll, and reset.

Verified with 71 focused Ghostty tests, the web typecheck, and targeted lint. New tests check buffer reuse, cleanup, and styles after memory growth. No browser or device testing was used.

Part of [the performance audit](https://github.com/pingdotgg/t3code/issues/9661).

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot snapshot/render path and WASM memory lifetime; behavior is intended to be identical but regressions would affect terminal display and selection styling.
> 
> **Overview**
> **Ghostty terminal snapshots** are faster by cutting per-cell WASM scratch allocations and redundant memory views, without changing the snapshot API or cell output.
> 
> Each `GhosttyTerminalCore` now keeps a **reusable grapheme buffer** that grows when needed and is freed on `dispose()`, instead of allocating and freeing a codepoint buffer for every non-empty cell. `ghosttyCellText` adds a **single-codepoint fast path** for the common case.
> 
> The runtime caches a **`DataView` over WASM memory** and refreshes it when `memory.grow` replaces the buffer; scalar `readField` / `setField` / `readPointer` use that view. During row reads, **style flags are decoded from a `DataView` after** grapheme and wide-cell ABI work so styles, selection, and wide-cell spacers stay correct when shared memory grows mid-snapshot.
> 
> New WASM-backed tests cover buffer reuse, disposal, and correctness after artificial memory growth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0e5dc086de938bad69ba4fa0ae7759341f9a626. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Speed up terminal snapshots in `GhosttyTerminalCore`
> - `GhosttyTerminalCore` row snapshots reuse a growable WASM buffer for grapheme extraction and read style/selection data from a refreshed `DataView` after ABI calls.
> - `GhosttyRuntime` caches a full-memory `DataView` and updates it automatically when WASM memory grows, fixing detached views after memory growth.
> - `GhosttyTerminalCore.dispose` releases the persistent grapheme buffer.
> - Adds tests for snapshot rendering after memory growth, wide and astral characters, and grapheme buffer disposal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0e5dc0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->