### PR TITLE
fix(server): opencode tool rows show titles instead of raw output dumps

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -5286,6 +5286,68 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("uses OpenCode tool titles and hides raw tool output from timeline labels", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-tool-labels");
+      const readPart = {
+        id: "part-read-1",
+        sessionID: "http://127.0.0.1:9999/session",
+        messageID: "msg-tool-1",
+        type: "tool",
+        callID: "call-read-1",
+        tool: "read",
+        state: {
+          status: "completed",
+          input: { filePath: "/Users/baptistearno/.agents/skills/manage-skills/SKILL.md" },
+          output:
+            "<path>/Users/baptistearno/.agents/skills/manage-skills/SKILL.md</path>\n<type>file</type>\n<content>\n1: ---\n2: ...\n</content>",
+          title: ".agents/skills/manage-skills/SKILL.md",
+          metadata: {},
+          time: { start: 1, end: 2 },
+        },
+      };
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "message.part.updated",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            part: readPart,
+            time: 1,
+          },
+        },
+      ];
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(3),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.deepEqual(
+        events.map((event) => event.type),
+        ["session.started", "thread.started", "item.completed"],
+      );
+      const completed = events.find((event) => event.type === "item.completed");
+      NodeAssert.ok(completed?.type === "item.completed");
+      if (completed?.type === "item.completed") {
+        NodeAssert.equal(completed.payload.title, ".agents/skills/manage-skills/SKILL.md");
+        NodeAssert.ok(!("detail" in completed.payload));
+        NodeAssert.match(
+          String((completed.payload.data as { state: { output: string } }).state.output),
+          /<content>/,
+        );
+      }
+    }),
+  );
+
   it.effect("lets OpenCode own session title generation and emits title metadata updates", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -612,16 +612,7 @@ function messageRoleForPart(
 }
 
 function detailFromToolPart(part: Extract<Part, { type: "tool" }>): string | undefined {
-  switch (part.state.status) {
-    case "completed":
-      return part.state.output;
-    case "error":
-      return part.state.error;
-    case "running":
-      return part.state.title;
-    default:
-      return undefined;
-  }
+  return part.state.status === "error" ? part.state.error : undefined;
 }
 
 function toolStateCreatedAt(part: Extract<Part, { type: "tool" }>): string | undefined {
@@ -2179,8 +2170,8 @@ export function makeOpenCodeAdapter(
 
           if (part.type === "tool") {
             const itemType = toToolLifecycleItemType(part.tool);
-            const title =
-              part.state.status === "running" ? (part.state.title ?? part.tool) : part.tool;
+            const stateTitle = "title" in part.state ? part.state.title?.trim() : undefined;
+            const title = stateTitle ? stateTitle : part.tool;
             const detail = detailFromToolPart(part);
             const payload = {
               itemType,


### PR DESCRIPTION
With the OpenCode provider, tool rows in the timeline showed raw tool output. A read rendered as XML, a todowrite as JSON, both cut mid-string.

The adapter put state.output in detail, and the timeline label prefers detail. It also dropped OpenCode's own state.title on completion. Now rows use state.title (relative path, N todos, command) and only real errors go in detail. Full output still ships in data.state.

Before:
[{content: Documenter le système de routing..., status: in_progre...
<path>.../SKILL.md</path> <type>file</type> <content> 1: --- 2: ...

After:
1 todos
.agents/skills/manage-skills/SKILL.md

Checked with a focused adapter test (fails on old code, passes on new). Full OpenCodeAdapter file green (89/89), server typecheck clean. Fable reviewed, verdict merge.

Known follow-up, pre-existing: failed tools still fall back to the raw tool name, error states carry no title.

Built with Muse Spark via T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OpenCode tool rows to show titles instead of raw output dumps
> Updates `detailFromToolPart` in [OpenCodeAdapter.ts](https://github.com/pingdotgg/t3code/pull/9665/files#diff-a4267388b15e5043ae1899beded972cbee9e52533ca3d9d65d438a91a9f7fbe7) to only return a detail value for tool parts with an error status. Completed tool output and running-tool titles are no longer exposed through the derived detail field.
> - Adds an Effect-based test in [OpenCodeAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/9665/files#diff-2d1ef28752ab2f1ec0f021e6723508dc18e6a9294ebd20255ec3767afe34cf5f) verifying completed read-tool events use the tool title and keep raw output in event data.
> - Risk: consumers that relied on `detailFromToolPart` returning completed tool output will now receive no detail for non-error parts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc69679.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->