### PR TITLE
fix(web): show machine icons in the environment picker

### DIFF
--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -30,6 +30,7 @@ import {
 import {
   type DesktopWslState,
   type EnvironmentId,
+  type EnvironmentMachineKind,
   type FilesystemBrowseResult,
   type ProjectId,
   type SourceControlDiscoveryResult,
@@ -206,6 +207,7 @@ function getEnvironmentBrowsePlatform(os: string | null | undefined): string {
 interface AddProjectEnvironmentOption {
   readonly environmentId: EnvironmentId;
   readonly label: string;
+  readonly machine: EnvironmentMachineKind;
   readonly isPrimary: boolean;
   readonly isConnected: boolean;
   readonly status: string;
@@ -833,6 +835,7 @@ function OpenCommandPaletteDialog(props: {
           runtimeLabel: environment.label,
         }),
         isPrimary,
+        machine: resolveEnvironmentMachineKind(environment.serverConfig),
         isConnected: canCreateProjectInEnvironment(environment.connection.phase),
         status: connectionStatusText(environment.connection),
       };
@@ -1478,7 +1481,7 @@ function OpenCommandPaletteDialog(props: {
           : option.environmentId
         : option.status,
       disabled: !option.isConnected,
-      icon: <FolderPlusIcon className={ITEM_ICON_CLASS} />,
+      icon: <EnvironmentMachineIcon kind={option.machine} className={ITEM_ICON_CLASS} />,
       keepOpen: true,
       run: async () => {
         startAddProjectSourceSelection(option.environmentId);


### PR DESCRIPTION
The Add project environment picker shows a folder icon for every machine.

Use each environment's configured or detected machine icon, matching the sidebar and other environment pickers. This changes the shared web and desktop screen. Mobile already uses machine icons.

Checks: web typecheck and all 20 command-palette tests pass. Targeted lint reports only two existing warnings outside this change. Browser verification and screenshots were skipped at Theo's request.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in the command palette; no auth, data, or project-creation logic touched.
> 
> **Overview**
> The **Add project → Environments** step in the command palette no longer uses a generic folder icon for every row. Each option now carries an **`EnvironmentMachineKind`** from **`resolveEnvironmentMachineKind(environment.serverConfig)`**, and the list item icon is **`EnvironmentMachineIcon`** instead of **`FolderPlusIcon`**.
> 
> This matches the sidebar, branch toolbar, and other environment pickers on web/desktop; behavior and selection logic are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d7c28a4960d0428751f5076b3ff94aac20ee714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show machine icons for environment options in `CommandPalette`
> Adds a `machine` field to `AddProjectEnvironmentOption` in [CommandPalette.tsx](https://github.com/pingdotgg/t3code/pull/9668/files#diff-30c525d0ef54c6971e43ab0660a73ea227ef51e009f79e4083049d3349175a7a). The `OpenCommandPaletteDialog` builder now resolves each environment's machine kind from its server configuration and uses it to render an `EnvironmentMachineIcon` instead of the generic `FolderPlusIcon`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d7c28a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->