### PR TITLE
fix(web): remember the last selected usage tab

### DIFF
--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -64,10 +64,20 @@ export function UsagePage() {
     window: makeWindow(30),
   }));
   const [metric, setMetric] = useState<UsageMetric>(() => {
-    const stored = localStorage.getItem(USAGE_METRIC_STORAGE_KEY);
-    return isUsageMetric(stored) ? stored : "cost";
+    try {
+      const stored = localStorage.getItem(USAGE_METRIC_STORAGE_KEY);
+      return isUsageMetric(stored) ? stored : "cost";
+    } catch {
+      return "cost";
+    }
   });
-  useEffect(() => localStorage.setItem(USAGE_METRIC_STORAGE_KEY, metric), [metric]);
+  useEffect(() => {
+    try {
+      localStorage.setItem(USAGE_METRIC_STORAGE_KEY, metric);
+    } catch {
+      // Storage may be missing, blocked, or full; the in-memory selection still works.
+    }
+  }, [metric]);
   const showingLimits = metric === "limits";
   const [breakdown, setBreakdown] = useState<"model" | "time">("model");
   const { days: windowDays, window } = windowSelection;

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -1,6 +1,6 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
 import { CheckIcon, RefreshCwIcon, XIcon } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import type { DailyTotals, HourlyTotals } from "@t3tools/shared/usageMerge";
 
@@ -49,6 +49,7 @@ const METRIC_OPTIONS = [
 function isUsageMetric(value: string | null | undefined): value is UsageMetric {
   return METRIC_OPTIONS.some((option) => option.value === value);
 }
+const USAGE_METRIC_STORAGE_KEY = "t3code:usage-metric:v1";
 
 const WINDOW_OPTIONS = [
   { days: 1, label: "Past 24h" },
@@ -62,7 +63,11 @@ export function UsagePage() {
     days: 30,
     window: makeWindow(30),
   }));
-  const [metric, setMetric] = useState<UsageMetric>("cost");
+  const [metric, setMetric] = useState<UsageMetric>(() => {
+    const stored = localStorage.getItem(USAGE_METRIC_STORAGE_KEY);
+    return isUsageMetric(stored) ? stored : "cost";
+  });
+  useEffect(() => localStorage.setItem(USAGE_METRIC_STORAGE_KEY, metric), [metric]);
   const showingLimits = metric === "limits";
   const [breakdown, setBreakdown] = useState<"model" | "time">("model");
   const { days: windowDays, window } = windowSelection;


### PR DESCRIPTION
## Problem

On the Usage page, switching to the **Limits** (or **Tokens**) tab was forgotten as soon as you navigated away. Coming back always landed on **Cost**, so users who mostly care about their limits had to re-select the tab every time.

## Fix

The selected metric is now stored in `localStorage` (`t3code:usage-metric:v1`) and used as the initial state when the page mounts. Any stale or unknown stored value falls back to `cost` through the existing `isUsageMetric` guard. Mobile is unaffected: it has no Limits tab, Limits is a separate section there.

## Demo

https://github.com/user-attachments/assets/d06e55a7-3beb-4760-9860-768dcd2fbb95

Made with Claude Fable 5.1 via Claude Code in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist last selected usage metric tab in `UsagePage`
> Adds a React effect and a versioned local-storage key so the usage metric selection survives page reloads. The initial state reads from local storage only when the stored value is a recognized metric; otherwise it falls back to the cost metric. Local-storage access is guarded against missing or failing storage. Risk: stored metric values from older key versions are ignored and fall back to the cost metric.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf7a0b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->