### PR TITLE
perf(swift-ios): parse long responses with fewer scans

### DIFF
--- a/apps/swift-ios/Features/Chat/CodexMarkdownDirectives.swift
+++ b/apps/swift-ios/Features/Chat/CodexMarkdownDirectives.swift
@@ -60,6 +60,8 @@ struct CodexArtifactTemplate: Equatable, Sendable {
 
 enum CodexMarkdownDirectives {
     private static let artifactPrefix = "::artifact-template{"
+    private static let fileCitationPrefix = ":codex-file-citation{"
+    private static let fileCitationCharacters = Array(fileCitationPrefix)
 
     static func artifactTemplate(from line: String) -> CodexArtifactTemplate? {
         guard line.prefix(while: { $0 == " " }).count < 4, line.first != "\t" else {
@@ -93,6 +95,9 @@ enum CodexMarkdownDirectives {
     }
 
     static func replacingFileCitations(in source: String) -> String {
+        // Most messages have no citations. Keep them out of the character-by-character
+        // link and code scanner, including incomplete Markdown arriving in a stream.
+        guard source.contains(fileCitationPrefix) else { return source }
         let lines = source.components(separatedBy: "\n")
         var fence: Character?
         var fenceCount = 0
@@ -107,7 +112,8 @@ enum CodexMarkdownDirectives {
                 }
             }
             let leadingSpaces = line.prefix(while: { $0 == " " }).count
-            guard fence == nil, leadingSpaces < 4, line.first != "\t" else {
+            guard fence == nil, leadingSpaces < 4, line.first != "\t",
+                  line.contains(fileCitationPrefix) else {
                 return line
             }
             return replacingCitationsInInlineMarkdown(line)
@@ -139,8 +145,8 @@ enum CodexMarkdownDirectives {
                     continue
                 }
             }
-            if !isEscaped(at: cursor, in: characters),
-               characters[cursor...].starts(with: Array(":codex-file-citation{")),
+            if characters[cursor] == ":", !isEscaped(at: cursor, in: characters),
+               characters[cursor...].starts(with: fileCitationCharacters),
                let closing = directiveEnd(in: characters, from: cursor) {
                 let directive = String(characters[cursor...closing])
                 if let replacement = fileCitation(from: directive) {
@@ -155,7 +161,7 @@ enum CodexMarkdownDirectives {
     }
 
     static func fileCitation(from directive: String) -> String? {
-        let prefix = ":codex-file-citation{"
+        let prefix = fileCitationPrefix
         guard directive.hasPrefix(prefix), directive.hasSuffix("}"),
               let values = attributes(in: String(directive.dropFirst(prefix.count).dropLast())),
               let rawPath = values["path"] else { return nil }
@@ -281,7 +287,7 @@ enum CodexMarkdownDirectives {
     }
 
     private static func directiveEnd(in chars: [Character], from start: Int) -> Int? {
-        var cursor = start + ":codex-file-citation{".count
+        var cursor = start + fileCitationCharacters.count
         var quote: Character?
         while cursor < chars.count {
             let character = chars[cursor]

--- a/apps/swift-ios/Features/Chat/MarkdownDocument.swift
+++ b/apps/swift-ios/Features/Chat/MarkdownDocument.swift
@@ -489,6 +489,7 @@ private struct MarkdownBlockParser {
     /// Splits a GFM table row while preserving escapes for Foundation's inline parser.
     /// Pipes inside code spans or escaped with a backslash remain cell content.
     private func tableCells(in line: String) -> [String]? {
+        guard line.contains("|") else { return nil }
         let source = line.markdownTrimmed
         guard !source.isEmpty else { return nil }
 
@@ -586,11 +587,11 @@ private struct MarkdownBlockParser {
     }
 
     private func atxHeading(in line: String) -> (level: Int, text: String)? {
-        let characters = Array(line)
-        let indent = min(line.markdownLeadingSpaces, characters.count)
-        guard indent <= 3, indent < characters.count, characters[indent] == "#" else {
+        let indent = line.markdownLeadingSpaces
+        guard indent <= 3, line.dropFirst(indent).first == "#" else {
             return nil
         }
+        let characters = Array(line)
 
         var cursor = indent
         while cursor < characters.count, characters[cursor] == "#" {
@@ -632,11 +633,11 @@ private struct MarkdownBlockParser {
     }
 
     private func blockquoteContent(in line: String) -> String? {
-        let characters = Array(line)
-        let indent = min(line.markdownLeadingSpaces, characters.count)
-        guard indent <= 3, indent < characters.count, characters[indent] == ">" else {
+        let indent = line.markdownLeadingSpaces
+        guard indent <= 3, line.dropFirst(indent).first == ">" else {
             return nil
         }
+        let characters = Array(line)
         var cursor = indent + 1
         if cursor < characters.count, characters[cursor].isMarkdownWhitespace {
             cursor += 1
@@ -645,9 +646,12 @@ private struct MarkdownBlockParser {
     }
 
     private func listMarker(in line: String) -> ListMarker? {
+        let indent = line.markdownLeadingSpaces
+        guard indent <= 3, let marker = line.dropFirst(indent).first,
+              marker == "-" || marker == "+" || marker == "*" || marker.isNumber else {
+            return nil
+        }
         let characters = Array(line)
-        let indent = min(line.markdownLeadingSpaces, characters.count)
-        guard indent <= 3, indent < characters.count else { return nil }
 
         var cursor = indent
         var number: Int?
@@ -689,6 +693,7 @@ private struct MarkdownBlockParser {
     }
 
     private func taskState(in line: String) -> MarkdownTaskState? {
+        guard line.first == "[" else { return nil }
         let characters = Array(line)
         guard characters.count >= 3,
               characters[0] == "[",
@@ -719,13 +724,12 @@ private struct MarkdownBlockParser {
     }
 
     private func fenceMarker(in line: String) -> FenceMarker? {
-        let characters = Array(line)
-        let indent = min(line.markdownLeadingSpaces, characters.count)
-        guard indent <= 3,
-              indent < characters.count,
-              characters[indent] == "`" || characters[indent] == "~" else {
+        let indent = line.markdownLeadingSpaces
+        guard indent <= 3, let marker = line.dropFirst(indent).first,
+              marker == "`" || marker == "~" else {
             return nil
         }
+        let characters = Array(line)
 
         let character = characters[indent]
         var cursor = indent
@@ -747,13 +751,11 @@ private struct MarkdownBlockParser {
     }
 
     private func isClosingFence(_ line: String, matching opening: FenceMarker) -> Bool {
-        let characters = Array(line)
-        let indent = min(line.markdownLeadingSpaces, characters.count)
-        guard indent <= 3,
-              indent < characters.count,
-              characters[indent] == opening.character else {
+        let indent = line.markdownLeadingSpaces
+        guard indent <= 3, line.dropFirst(indent).first == opening.character else {
             return false
         }
+        let characters = Array(line)
 
         var cursor = indent
         while cursor < characters.count, characters[cursor] == opening.character {

--- a/apps/swift-ios/Tests/FeatureTests/MarkdownDocumentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/MarkdownDocumentTests.swift
@@ -6,6 +6,74 @@ import UIKit
 @Suite("Chat Markdown")
 struct MarkdownDocumentTests {
     @Test
+    func ordinaryMarkdownKeepsItsTextAndLineEndingsWithoutCitations() {
+        let source = """
+        # A long response
+
+        \(String(repeating: "[unfinished `code **text** café 日本語 👩🏽‍💻 ", count: 300))
+
+        [docs](https://t3.gg) and :codex-file-citation
+        """.replacingOccurrences(of: "\n", with: "\r\n")
+
+        #expect(CodexMarkdownDirectives.replacingFileCitations(in: source) == source)
+    }
+
+    @Test
+    func sparseCitationsKeepFenceStateAndUnrelatedLines() {
+        let directive = #":codex-file-citation{path="src/main.swift" line_range_start="12"}"#
+        let unfinishedLinks = String(repeating: "[unfinished ", count: 1_000)
+        let source = """
+        \(unfinishedLinks)
+
+        ```text
+        This fence opens on a line without a citation.
+        \(directive)
+        ```
+
+        See \(directive).
+        """
+
+        #expect(
+            CodexMarkdownDirectives.replacingFileCitations(in: source) == """
+            \(unfinishedLinks)
+
+            ```text
+            This fence opens on a line without a citation.
+            \(directive)
+            ```
+
+            See [main.swift](<src/main.swift#L12>).
+            """
+        )
+    }
+
+    @Test
+    func blockPrefixChecksKeepThreeSpaceIndentationAndRejectFourSpaces() {
+        for indent in ["", " ", "  ", "   "] {
+            #expect(
+                MarkdownDocument(parsing: "\(indent)# Heading").blocks
+                    == [.heading(level: 1, text: "Heading")]
+            )
+            #expect(
+                MarkdownDocument(parsing: "\(indent)> Body").blocks
+                    == [.blockquote(MarkdownDocument(parsing: "Body"))]
+            )
+            #expect(
+                MarkdownDocument(parsing: "\(indent)- Item").blocks
+                    == [.unorderedList([MarkdownListItem(task: nil, blocks: [.paragraph("Item")])])]
+            )
+            #expect(
+                MarkdownDocument(parsing: "\(indent)```swift\nlet value = 1\n\(indent)```").blocks
+                    == [.codeBlock(language: "swift", code: "let value = 1")]
+            )
+        }
+
+        for source in ["    # Heading", "    > Body", "    - Item", "    ```swift"] {
+            #expect(MarkdownDocument(parsing: source).blocks == [.paragraph(source)])
+        }
+    }
+
+    @Test
     func codexFileCitationsBecomeWorkspaceLinks() {
         let document = MarkdownDocument(
             parsing: #"See :codex-file-citation{path="docs/My file%#?.md" line_range_start="12"}."#


### PR DESCRIPTION
Long responses made the SwiftUI app scan each line for citations, tables, headings, and code fences even when the required syntax was absent. Some unfinished links caused repeated scans of the same text.

Skip those scans and character-array allocations when the required marker is missing. Rendering, layout, and scroll behavior stay unchanged.

Verification:

- Optimized macOS parser benchmark, 38.8 KB response: 8.5 ms before, 3.1 ms after. These are parser timings, not device frame rates.
- A 4,058-case comparison produced identical parsed output before and after.
- `MarkdownDocumentTests` and `MarkdownRenderCacheTests` passed in the iOS simulator.

Based on the main SwiftUI branch. This PR changes only Markdown parsing and its tests.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Parser-only fast paths with tests asserting identical behavior; no auth, networking, or data-model changes.
> 
> **Overview**
> Speeds up chat Markdown parsing on **long, citation-free messages** and streaming partial text by **bailing out early** when the relevant syntax is absent, instead of scanning every line character-by-character.
> 
> **`CodexMarkdownDirectives`**: Returns the source unchanged when it lacks `:codex-file-citation{`; only runs inline citation replacement on lines that contain that prefix. Citation detection reuses shared prefix constants and checks for `:` before matching the directive.
> 
> **`MarkdownDocument`**: Skips table row splitting when a line has no `|`. Headings, blockquotes, lists, fences, and task markers now use cheap indent/marker checks **before** allocating a `[Character]` array for the full line.
> 
> New **`MarkdownDocumentTests`** cover no-op citation passes (including `\r\n` and unfinished links), citations inside fences vs inline, and that 0–3 space indents still parse blocks while four spaces stay paragraphs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df36de22afcfa1d37d8c8e4cb2526b64f68a73f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reduce Markdown scans in `CodexMarkdownDirectives` and `MarkdownBlockParser`
> - Adds a shared file-citation prefix constant and precomputed character array so citation helpers stop rebuilding the same literal per call
> - Adds early returns in `replacingFileCitations` when no citation prefix is present and restricts inline scanning to lines containing the prefix
> - Reworks `atxHeading`, `blockquoteContent`, `listMarker`, `fenceMarker`, `isClosingFence`, `taskState`, and `tableCells` to inspect the string after leading spaces before creating character arrays, preserving the three-space indentation limit
> - Adds regression tests for CRLF preservation, fenced-content skipping, and three-space-vs-four-space block prefix recognition
> - Risk: block parsers now check leading-space-then-marker before building character arrays; the updated recognizers in `MarkdownBlockParser` must still reject four-space-indented blocks as paragraphs, covered by `MarkdownDocumentTests.blockPrefixChecksKeepThreeSpaceIndentationAndRejectFourSpaces`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df36de2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->