### PR TITLE
fix(swift-ios): keep thread catch-up complete and visible

### DIFF
--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -3524,6 +3524,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         guard activeThreadID == threadID,
               activeThreadEnvironmentID == client.environment.id else { return }
         guard force || detailStreamTask == nil else { return }
+        if force {
+            continuation.yield(.threadSync(id: threadID, state: .catchingUp))
+        }
         guard detailRefreshTask == nil else {
             detailRefreshPending = true
             return
@@ -3534,9 +3537,11 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         let sessionGeneration = environmentGeneration
         detailRefreshTask = Task { [weak self] in
             do {
-                // Four updates per second keeps streaming text responsive while
-                // coalescing bursty shell events into one detail snapshot.
-                try await Task.sleep(for: .milliseconds(250))
+                // Shell updates can be coalesced. A required replacement cannot
+                // apply more thread events until its snapshot arrives.
+                if !force {
+                    try await Task.sleep(for: .milliseconds(250))
+                }
             } catch {
                 self?.finishDetailRefresh(generation: generation, client: client)
                 return
@@ -3549,7 +3554,20 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                    environmentID: client.environment.id,
                    generation: sessionGeneration
                ) {
-                try? await self.refreshThread(id: threadID, client: client)
+                do {
+                    try await self.refreshThread(id: threadID, client: client)
+                } catch is CancellationError {
+                    // Closing a thread cancels its read without changing its status.
+                } catch {
+                    if !Task.isCancelled,
+                       self.detailRefreshGeneration == generation,
+                       self.activeThreadID == threadID,
+                       self.activeRawThread == nil || self.detailStreamTask == nil {
+                        self.continuation.yield(.threadSync(
+                            id: threadID, state: .failed(error.localizedDescription)
+                        ))
+                    }
+                }
             }
             self.finishDetailRefresh(generation: generation, client: client)
         }
@@ -3628,12 +3646,14 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                     expectedStreamGeneration: generation
                 )
                 guard !Task.isCancelled, let self,
-                      self.isCurrentDetail(route, generation: generation) else { return }
+                      self.isCurrentDetail(route, generation: generation),
+                      self.activeRawThread != nil,
+                      !self.detailRefreshPending else { return }
                 if self.serverConfigsByEnvironmentID[route.environmentID]?
                     .threadResumeCompletionMarker == true {
                     self.continuation.yield(.threadSync(id: route.uiID, state: .reconnecting))
                 } else {
-                    self.continuation.yield(.threadSync(id: route.uiID, state: .live))
+                    self.markDetailSynchronized(route)
                 }
             } catch is CancellationError {
                 return
@@ -3646,7 +3666,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     private func markDetailSynchronized(_ route: NativeThreadRoute) {
-        guard activeRawThread != nil else { return }
+        guard activeRawThread != nil, !detailRefreshPending else { return }
         // Flush the final message before publishing the completion state.
         // Otherwise the loading label can vanish one render before the text.
         flushDetailPublish(route)
@@ -3667,15 +3687,28 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             markDetailSynchronized(route)
             return
         case let .snapshot(snapshot):
-            guard activeRawThread == nil || snapshot.snapshotSequence > (activeThreadSequence ?? 0) else { return }
+            guard snapshot.snapshotSequence >= (activeThreadSequence ?? 0),
+                  activeRawThread == nil || snapshot.snapshotSequence > (activeThreadSequence ?? 0) else { return }
+            resetDetailRefresh()
             threadHistoryEpoch &+= 1
             pendingOlderThreadPage = nil
             activeThreadSequence = snapshot.snapshotSequence
             activeRawThread = snapshot.thread
             activeThreadPage = featurePage(snapshot.page)
             scheduleRawDetailPublish(route: route, mutation: .full)
+            if detailCompletionReceived { markDetailSynchronized(route) }
         case let .event(event):
             guard let current = activeRawThread else {
+                // Do not apply later events to a snapshot that missed earlier
+                // ones. It must cover every event skipped while replacing it.
+                if case let .number(value) = event["sequence"],
+                   let sequence = Int(exactly: value), sequence >= 0 {
+                    activeThreadSequence = max(activeThreadSequence ?? 0, sequence)
+                } else {
+                    // An event without a cursor needs a read started after it.
+                    threadHistoryEpoch &+= 1
+                    pendingOlderThreadPage = nil
+                }
                 scheduleDetailRefresh(threadID: route.uiID, client: route.client, force: true)
                 return
             }
@@ -3722,13 +3755,13 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         detailPublishTask = Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(80))
             guard let self else { return }
-            self.detailPublishTask = nil
             guard !Task.isCancelled,
                   self.detailStreamGeneration == streamGeneration,
                   self.activeThreadID == route.uiID,
                   self.activeRawThread != nil else {
                 return
             }
+            self.detailPublishTask = nil
             self.flushDetailPublish(route)
         }
     }
@@ -3774,7 +3807,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         let needsTrailingRefresh = detailRefreshPending
         detailRefreshPending = false
         if needsTrailingRefresh, let threadID = activeThreadID {
-            scheduleDetailRefresh(threadID: threadID, client: client)
+            // Events received without a base snapshot cannot be reduced. Read
+            // again even when the stream is open so those events are included.
+            scheduleDetailRefresh(threadID: threadID, client: client, force: true)
         }
     }
 
@@ -4090,6 +4125,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         }
         let environment = route.client.environment
         let generation = environmentGeneration
+        let historyEpoch = threadHistoryEpoch
         let supportsPagination = serverConfigsByEnvironmentID[
             environment.id
         ]?.threadSnapshotPagination == true
@@ -4104,8 +4140,24 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             throw CancellationError()
         }
         if activeThreadID == route.uiID {
-            guard snapshot.snapshotSequence >= (activeThreadSequence ?? 0) else { return }
+            if activeRawThread == nil, historyEpoch != threadHistoryEpoch {
+                return
+            }
+            guard snapshot.snapshotSequence >= (activeThreadSequence ?? 0) else {
+                if activeRawThread == nil {
+                    if !detailRefreshPending {
+                        throw NativeFeatureClientError.threadSnapshotOutdated
+                    }
+                } else if detailCompletionReceived
+                            || serverConfigsByEnvironmentID[environment.id]?.threadResumeCompletionMarker != true {
+                    markDetailSynchronized(route)
+                }
+                return
+            }
             discardPendingDetailPublish()
+            // This snapshot includes the skipped events, so their pending
+            // request is satisfied without another HTTP read.
+            detailRefreshPending = false
             threadHistoryEpoch &+= 1
             pendingOlderThreadPage = nil
             activeRawThread = snapshot.thread
@@ -4126,22 +4178,17 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             client: client, thread: snapshot.thread, sequence: snapshot.snapshotSequence,
             page: featurePage(snapshot.page)
         )
-        if activeThreadID == route.uiID, detailCompletionReceived {
+        if activeThreadID == route.uiID,
+           detailCompletionReceived
+            || serverConfigsByEnvironmentID[environment.id]?.threadResumeCompletionMarker != true {
             markDetailSynchronized(route)
         }
-        let hydrationBase = latestDetails[route.uiID] ?? detail
-        let hydrated = await hydratedAttachmentURLs(
-            in: hydrationBase,
+        scheduleAttachmentHydration(
+            in: detail,
+            threadID: route.uiID,
             client: client,
-            environmentID: environment.id,
-            generation: generation
+            environmentID: environment.id
         )
-        guard isKnownClient(client, environmentID: environment.id, generation: generation),
-              latestDetails[route.uiID] == hydrationBase,
-              hydrated != hydrationBase else {
-            return
-        }
-        publish(hydrated, threadID: route.uiID, synchronizeRenderedMessages: true)
     }
 
     private func emitSnapshot(
@@ -7054,6 +7101,7 @@ private enum NativeFeatureClientError: LocalizedError {
     case environmentNotFound
     case projectNotFound
     case threadNotFound
+    case threadSnapshotOutdated
     case workspaceNotFound
     case approvalNotFound
     case inputRequestNotFound
@@ -7071,6 +7119,7 @@ private enum NativeFeatureClientError: LocalizedError {
         case .environmentNotFound: "That T3 environment is no longer available."
         case .projectNotFound: "The selected project is no longer available."
         case .threadNotFound: "The selected thread is no longer available."
+        case .threadSnapshotOutdated: "The computer has not finished updating this thread. Try again."
         case .workspaceNotFound: "The thread workspace is no longer available."
         case .approvalNotFound: "The approval request is no longer active."
         case .inputRequestNotFound: "The input request is no longer active."

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -3525,6 +3525,11 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
               activeThreadEnvironmentID == client.environment.id else { return }
         guard force || detailStreamTask == nil else { return }
         if force {
+            // This required read owns recovery now. An older fallback must not
+            // replace its loading state with an error from a stale snapshot.
+            detailCatchUpTask?.cancel()
+            detailCatchUpTask = nil
+            detailCatchUpID = nil
             continuation.yield(.threadSync(id: threadID, state: .catchingUp))
         }
         guard detailRefreshTask == nil else {
@@ -3625,7 +3630,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     private func ensureDetailCatchUpFallback(_ route: NativeThreadRoute, generation: Int) {
-        guard detailCatchUpTask == nil else { return }
+        guard detailCatchUpTask == nil, detailRefreshTask == nil else { return }
         let id = UUID()
         detailCatchUpID = id
         let delay = catchUpDelay

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -123,6 +123,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     private var activeThreadSequence: Int?
     private var activeThreadPage: FeatureThreadPage?
     private var threadHistoryEpoch = 0
+    private var detailSnapshotRequiredAfterEpoch: Int?
     private var pendingOlderThreadPage: PendingOlderThreadPage?
 
     init(
@@ -3595,6 +3596,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 let supportsPagination = self?.serverConfigsByEnvironmentID[
                     route.environmentID
                 ]?.threadSnapshotPagination == true
+                let subscriptionEpoch = self?.threadHistoryEpoch ?? 0
                 do {
                     for try await item in await route.client.threadEvents(
                         threadID: route.wireID,
@@ -3605,7 +3607,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                         guard !Task.isCancelled, let self,
                               self.isCurrentDetail(route, generation: streamGeneration),
                               self.environmentGeneration == sessionGeneration else { return }
-                        self.consumeDetailStreamItem(item, route: route)
+                        self.consumeDetailStreamItem(
+                            item, route: route, subscriptionEpoch: subscriptionEpoch
+                        )
                     }
                 } catch is CancellationError {
                     return
@@ -3683,7 +3687,8 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
     private func consumeDetailStreamItem(
         _ item: ThreadStreamItem,
-        route: NativeThreadRoute
+        route: NativeThreadRoute,
+        subscriptionEpoch: Int
     ) {
         switch item {
         case .synchronized:
@@ -3692,9 +3697,14 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             markDetailSynchronized(route)
             return
         case let .snapshot(snapshot):
+            // A cursor-less event cannot prove that an already-requested
+            // snapshot includes it. Keep the post-event read until it does.
+            if let requiredEpoch = detailSnapshotRequiredAfterEpoch,
+               subscriptionEpoch < requiredEpoch { return }
             guard snapshot.snapshotSequence >= (activeThreadSequence ?? 0),
                   activeRawThread == nil || snapshot.snapshotSequence > (activeThreadSequence ?? 0) else { return }
             resetDetailRefresh()
+            detailSnapshotRequiredAfterEpoch = nil
             threadHistoryEpoch &+= 1
             pendingOlderThreadPage = nil
             activeThreadSequence = snapshot.snapshotSequence
@@ -3712,6 +3722,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 } else {
                     // An event without a cursor needs a read started after it.
                     threadHistoryEpoch &+= 1
+                    detailSnapshotRequiredAfterEpoch = threadHistoryEpoch
                     pendingOlderThreadPage = nil
                 }
                 scheduleDetailRefresh(threadID: route.uiID, client: route.client, force: true)
@@ -3720,6 +3731,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             let reduction = NativeThreadDetailReducer.apply(event, to: current)
             if reduction.sequence < 0 {
                 threadHistoryEpoch &+= 1
+                detailSnapshotRequiredAfterEpoch = threadHistoryEpoch
                 pendingOlderThreadPage = nil
                 activeRawThread = nil
                 discardPendingDetailPublish()
@@ -3827,6 +3839,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
     private func resetDetailStream() {
         detailStreamGeneration &+= 1
+        detailSnapshotRequiredAfterEpoch = nil
         detailStreamTask?.cancel()
         detailStreamTask = nil
         detailCatchUpTask?.cancel()
@@ -4163,6 +4176,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             // This snapshot includes the skipped events, so their pending
             // request is satisfied without another HTTP read.
             detailRefreshPending = false
+            detailSnapshotRequiredAfterEpoch = nil
             threadHistoryEpoch &+= 1
             pendingOlderThreadPage = nil
             activeRawThread = snapshot.thread

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -6003,9 +6003,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         environmentID: String
     ) {
         guard detail.messages.contains(where: { message in
-            message.attachments.contains {
-                $0.mimeType.hasPrefix("image/") && $0.url == nil
-            }
+            message.attachments.contains { $0.url == nil }
         }) else {
             return
         }

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -1133,6 +1133,9 @@ enum ThreadRefreshPresentation: Equatable {
         }
         if isOpening || loadState == .loading { return .loading }
         if case .failed = loadState { return .failed }
+        // A synchronized thread subscription is newer evidence than an
+        // environment's periodic shell probe. Socket loss has its own state.
+        if syncState == .live { return nil }
         switch connectionState {
         case .connecting, .reconnecting: return .reconnecting
         case .disconnected: return .offline

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -308,11 +308,12 @@ public struct ThreadDetailView: View {
 
                 Spacer(minLength: 6)
 
-                // The per-second timeline only exists for the live working
-                // duration; idle threads render a static status instead of
-                // waking every second forever.
+                // Cached work state is not proof that the agent is still
+                // running. Only current, working threads need a live timer.
                 Group {
-                    if currentThread.homeStatus == .working {
+                    if refreshPresentation != nil {
+                        EmptyView()
+                    } else if currentThread.homeStatus == .working {
                         TimelineView(.periodic(from: .now, by: 1)) { context in
                             headerStatus(at: context.date)
                         }
@@ -331,7 +332,7 @@ public struct ThreadDetailView: View {
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isHeader)
         .accessibilityAddTraits(
-            currentThread.hasLiveWorkingDuration ? .updatesFrequently : []
+            refreshPresentation == nil && currentThread.hasLiveWorkingDuration ? .updatesFrequently : []
         )
         .transaction { transaction in
             transaction.animation = nil
@@ -631,17 +632,23 @@ public struct ThreadDetailView: View {
     }
 
     private func timeline(_ detail: FeatureThreadDetail) -> some View {
-        let isWorking = detail.thread.state == .working
+        let hasActiveWork = detail.thread.state == .working
             || detail.thread.state == .queued
             || detail.thread.state == .monitoring
+        let isWorking = hasActiveWork && refreshPresentation == nil
         return Group {
-            if detail.messages.isEmpty, !isWorking {
-                ContentUnavailableView(
-                    "Ready for a task",
-                    systemImage: "sparkles",
-                    description: Text("Tell the agent what you want to build.")
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            if detail.messages.isEmpty, !hasActiveWork {
+                if refreshPresentation == nil {
+                    ContentUnavailableView(
+                        "Ready for a task",
+                        systemImage: "sparkles",
+                        description: Text("Tell the agent what you want to build.")
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    Color.clear
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
             } else {
                 FeatureTranscriptCollectionView(
                     threadID: thread.id,

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -965,7 +965,9 @@ public final class FeatureRootModel {
             store(value, delta: delta)
             upsert(value.thread)
         case let .threadSync(id, state):
-            threadSyncStates[id] = state
+            if threadSyncStates[id] != state {
+                threadSyncStates[id] = state
+            }
             if state == .live, case .failed = detailLoadStates[id] {
                 detailLoadStates[id] = nil
             }

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -59,8 +59,8 @@ struct FeatureRootModelTests {
         client.finishEvents()
         await run.value
         changes.continuation.finish()
-        let change = await changes.stream.first { _ in true }
-        #expect(change == nil)
+        let didChange = await changes.stream.contains { _ in true }
+        #expect(!didChange)
         #expect(model.threadSyncStates["thread"] == .catchingUp)
     }
 

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -37,6 +37,34 @@ struct FeatureRootModelTests {
     }
 
     @Test
+    func repeatedCatchUpEventsDoNotInvalidateViewState() async {
+        let client = FeatureClientStub()
+        let model = testRootModel(client: client)
+        let run = Task { await model.start() }
+        await withCheckedContinuation { continuation in
+            withObservationTracking {
+                _ = model.threadSyncStates["thread"]
+            } onChange: {
+                continuation.resume()
+            }
+            client.emit(.threadSync(id: "thread", state: .catchingUp))
+        }
+        let changes = AsyncStream<Void>.makeStream()
+        withObservationTracking {
+            _ = model.threadSyncStates["thread"]
+        } onChange: {
+            changes.continuation.yield()
+        }
+        client.emit(.threadSync(id: "thread", state: .catchingUp))
+        client.finishEvents()
+        await run.value
+        changes.continuation.finish()
+        let change = await changes.stream.first { _ in true }
+        #expect(change == nil)
+        #expect(model.threadSyncStates["thread"] == .catchingUp)
+    }
+
+    @Test
     func appearanceAppliesImmediatelyAndPersistsWithoutSavingTheDraft() async {
         let client = FeatureClientStub()
         let model = testRootModel(client: client)

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -37,6 +37,21 @@ struct FeatureRootModelTests {
     }
 
     @Test
+    func liveThreadSyncOutranksStaleEnvironmentReachability() {
+        for connectionState in [FeatureConnection.State.disconnected, .reconnecting] {
+            #expect(ThreadRefreshPresentation.resolve(
+                loadState: nil, connectionState: connectionState, isOpening: false, syncState: .live
+            ) == nil)
+            #expect(ThreadRefreshPresentation.resolve(
+                loadState: .loading, connectionState: connectionState, isOpening: false, syncState: .live
+            ) == .loading)
+            #expect(ThreadRefreshPresentation.resolve(
+                loadState: .failed("Timeout"), connectionState: connectionState, isOpening: false, syncState: .live
+            ) == .failed)
+        }
+    }
+
+    @Test
     func repeatedCatchUpEventsDoNotInvalidateViewState() async {
         let client = FeatureClientStub()
         let model = testRootModel(client: client)

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -272,6 +272,66 @@ final class NativeThreadCatchUpTests: XCTestCase {
         await fixture.client.disconnect()
     }
 
+    func testOldSocketSnapshotDoesNotCancelReadAfterCursorlessEvent() async throws {
+        let fixture = try await CatchUpFixture.make()
+        defer { fixture.cleanUp() }
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let stream = try await nextThreadRequest(&requests)
+        try await stream.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.holdThreadReads(true)
+        await fixture.http.setResponse(text: "Fresh after unknown event", sequence: 20)
+        try await stream.socket.chunk(id: stream.id, values: [.object(["kind": .string("unknown")])])
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        let read = try await nextHeldRead(&reads)
+
+        try await stream.snapshot(texts: ["Requested before unknown event"], sequence: 3)
+        try await stream.synchronize()
+        // This next event is a receipt that the old snapshot was handled first.
+        try await stream.sendMessage(text: "After old snapshot", sequence: 19)
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        read.succeed()
+        let cancelled = await read.finished.first { _ in true }
+        XCTAssertEqual(cancelled, false, "The required post-event read must still run.")
+        guard cancelled == false else {
+            await fixture.client.disconnect()
+            return
+        }
+        let messages = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(messages, ["Fresh after unknown event"])
+        await fixture.client.disconnect()
+    }
+
+    func testNewSubscriptionSnapshotCanRecoverAfterCursorlessEvent() async throws {
+        let fixture = try await CatchUpFixture.make()
+        defer { fixture.cleanUp() }
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let stream = try await nextThreadRequest(&requests)
+        try await stream.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.holdThreadReads(true)
+        try await stream.socket.chunk(id: stream.id, values: [.object(["kind": .string("unknown")])])
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        let read = try await nextHeldRead(&reads)
+
+        await stream.socket.close()
+        let resumed = try await nextThreadRequest(&requests)
+        try await resumed.snapshot(texts: ["New socket snapshot"], sequence: 20)
+        try await resumed.synchronize()
+        let messages = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(messages, ["New socket snapshot"])
+        read.fail()
+        let cancelled = await read.finished.first { _ in true }
+        XCTAssertEqual(cancelled, true, "The new subscription can replace the required HTTP read.")
+        await fixture.client.disconnect()
+    }
+
     func testLeavingThreadCancelsHeldReplacementAndItsPendingFollowUp() async throws {
         for disconnect in [false, true] {
             let fixture = try await CatchUpFixture.make()

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -153,6 +153,219 @@ final class NativeThreadCatchUpTests: XCTestCase {
         await fixture.client.disconnect()
     }
 
+    func testFailedRequiredSnapshotKeepsCachedTextAndOffersFreshRetry() async throws {
+        let fixture = try await CatchUpFixture.make()
+        defer { fixture.cleanUp() }
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        await fixture.http.setResponse(text: "Cached answer", sequence: 2)
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let stream = try await nextThreadRequest(&requests)
+        try await stream.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+
+        await fixture.http.holdThreadReads(true)
+        try await stream.invalidate(sequence: 10)
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        let read = try await nextHeldRead(&reads)
+        read.fail()
+        while let event = await events.next(isolation: #isolation) {
+            if case .threadSync(fixture.firstID, .failed) = event { break }
+            if case .threadSync(fixture.firstID, .live) = event {
+                XCTFail("A failed snapshot must not mark cached content current.")
+            }
+        }
+
+        await fixture.http.holdThreadReads(false)
+        await fixture.http.setResponse(text: "Fresh answer", sequence: 11)
+        let detail = try await fixture.client.loadThread(id: fixture.firstID, fresh: true)
+        XCTAssertEqual(detail.messages.map(\.text), ["Fresh answer"])
+        await fixture.client.disconnect()
+    }
+
+    func testRequiredSnapshotsCoverEveryEventReceivedDuringReplacement() async throws {
+        let fixture = try await CatchUpFixture.make()
+        defer { fixture.cleanUp() }
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let stream = try await nextThreadRequest(&requests)
+        try await stream.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.holdThreadReads(true)
+
+        await fixture.http.setResponse(text: "Before new messages", sequence: 10)
+        try await stream.invalidate(sequence: 10)
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        let first = try await nextHeldRead(&reads)
+        try await stream.sendMessage(text: "Eleven", sequence: 11)
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        await fixture.http.setResponse(text: "Eleven", sequence: 11)
+        first.succeed()
+
+        let second = try await nextHeldRead(&reads)
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        try await stream.sendMessage(text: "Twelve", sequence: 12)
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        await fixture.http.setResponse(texts: ["Eleven", "Twelve"], sequence: 12)
+        second.succeed()
+
+        let third = try await nextHeldRead(&reads)
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        third.succeed()
+        let messages = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(messages, ["Eleven", "Twelve"])
+        let count = await fixture.http.threadRequests.count
+        XCTAssertEqual(count, 4, "Each stale response needs one coalesced follow-up, not one read per event.")
+        await fixture.client.disconnect()
+    }
+
+    func testEventWithoutCursorNeedsSnapshotStartedAfterIt() async throws {
+        let fixture = try await CatchUpFixture.make()
+        defer { fixture.cleanUp() }
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let stream = try await nextThreadRequest(&requests)
+        try await stream.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.holdThreadReads(true)
+        await fixture.http.setResponse(text: "Before unknown event", sequence: 10)
+        try await stream.invalidate(sequence: 10)
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        let first = try await nextHeldRead(&reads)
+        try await stream.socket.chunk(id: stream.id, values: [.object(["kind": .string("unknown")])])
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        await fixture.http.setResponse(text: "After unknown event", sequence: 11)
+        first.succeed()
+        let second = try await nextHeldRead(&reads)
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        second.succeed()
+        let messages = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(messages, ["After unknown event"])
+        await fixture.client.disconnect()
+    }
+
+    func testSocketSnapshotCancelsFailedHTTPReplacement() async throws {
+        let fixture = try await CatchUpFixture.make()
+        defer { fixture.cleanUp() }
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let stream = try await nextThreadRequest(&requests)
+        try await stream.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.holdThreadReads(true)
+        try await stream.invalidate(sequence: 10)
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        let read = try await nextHeldRead(&reads)
+        try await stream.snapshot(texts: ["Recovered over the socket"], sequence: 11)
+        let messages = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(messages, ["Recovered over the socket"])
+        read.fail()
+        let cancelled = await read.finished.first { _ in true }
+        XCTAssertEqual(cancelled, true, "The obsolete HTTP read must not replace live state with an error.")
+        await fixture.client.disconnect()
+    }
+
+    func testLeavingThreadCancelsHeldReplacementAndItsPendingFollowUp() async throws {
+        for disconnect in [false, true] {
+            let fixture = try await CatchUpFixture.make()
+            defer { fixture.cleanUp() }
+            var requests = fixture.requests.makeAsyncIterator()
+            var events = fixture.client.events().makeAsyncIterator()
+            var reads = fixture.http.heldRequests.makeAsyncIterator()
+            _ = try await fixture.client.loadThread(id: fixture.firstID)
+            let stream = try await nextThreadRequest(&requests)
+            try await stream.synchronize()
+            _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+            await fixture.http.holdThreadReads(true)
+            try await stream.invalidate(sequence: 10)
+            await nextCatchUp(&events, threadID: fixture.firstID)
+            let read = try await nextHeldRead(&reads)
+            try await stream.sendMessage(text: "Do not publish after leaving", sequence: 11)
+            await nextCatchUp(&events, threadID: fixture.firstID)
+
+            if disconnect {
+                await fixture.client.disconnect()
+            } else {
+                fixture.client.releaseThread(id: fixture.firstID)
+                await fixture.http.holdThreadReads(false)
+                await fixture.http.setResponse(text: "Second thread", sequence: 20)
+                let detail = try await fixture.client.loadThread(id: fixture.secondID)
+                XCTAssertEqual(detail.thread.id, fixture.secondID)
+                XCTAssertEqual(detail.messages.map(\.text), ["Second thread"])
+            }
+            read.succeed()
+            let cancelled = await read.finished.first { _ in true }
+            XCTAssertEqual(cancelled, true)
+            let count = await fixture.http.threadRequests.count
+            XCTAssertEqual(count, disconnect ? 2 : 3, "A closed thread must not start its pending read.")
+            await fixture.client.disconnect()
+        }
+    }
+
+    func testAttachmentLookupDoesNotBlockRequiredTextRefresh() async throws {
+        let fixture = try await CatchUpFixture.make()
+        defer { fixture.cleanUp() }
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let stream = try await nextThreadRequest(&requests)
+        try await stream.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.holdThreadReads(true)
+        await fixture.http.setResponse(texts: ["Text ready"], sequence: 11, withImage: true)
+        try await stream.invalidate(sequence: 10)
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        let first = try await nextHeldRead(&reads)
+        try await stream.sendMessage(text: "Text ready", sequence: 11)
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        first.succeed()
+        while let request = await requests.next(isolation: #isolation) {
+            if request.tag == RPCMethod.assetsCreateURL.rawValue { break }
+        }
+        let messages = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(messages, ["Text ready"])
+        let firstReadCount = await fixture.http.threadRequests.count
+        XCTAssertEqual(firstReadCount, 2, "The first snapshot already includes the skipped message.")
+
+        // Leave the asset RPC unanswered. A later text refresh must start anyway.
+        await fixture.http.setResponse(texts: ["New text ready"], sequence: 12, withImage: true)
+        try await stream.invalidate(sequence: 12)
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        let second = try await nextHeldRead(&reads)
+        second.succeed()
+        let updated = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(updated, ["New text ready"])
+        await fixture.client.disconnect()
+    }
+
+    private func nextHeldRead(
+        _ iterator: inout AsyncStream<CatchUpHTTPRead>.Iterator
+    ) async throws -> CatchUpHTTPRead {
+        let read = await iterator.next(isolation: #isolation)
+        return try XCTUnwrap(read)
+    }
+
+    private func nextCatchUp(
+        _ iterator: inout AsyncStream<FeatureEvent>.Iterator, threadID: String
+    ) async {
+        while let event = await iterator.next(isolation: #isolation) {
+            if case .threadSync(threadID, .catchingUp) = event { return }
+            if case .threadSync(threadID, .live) = event {
+                XCTFail("The thread became live before its required snapshot was complete.")
+                return
+            }
+        }
+        XCTFail("The thread did not report its pending refresh.")
+    }
+
     private func nextThreadRequest(
         _ iterator: inout AsyncStream<CatchUpRequest>.Iterator
     ) async throws -> CatchUpRequest {
@@ -171,6 +384,9 @@ final class NativeThreadCatchUpTests: XCTestCase {
             case let .detail(detail), let .detailDelta(detail, _):
                 if detail.thread.id == threadID { messages = detail.messages.map(\.text) }
             case .threadSync(threadID, .live): return messages
+            case let .threadSync(threadID, .failed(error)):
+                XCTFail("The thread failed synchronization: \(error)")
+                return messages
             default: break
             }
         }
@@ -223,15 +439,32 @@ private struct CatchUpFixture {
 
 private actor CatchUpHTTPTransport: HTTPTransport {
     private(set) var threadRequests: [URLRequest] = []
-    private var message: String?
+    private var messages: [OrchestrationMessage] = []
     private var sequence = 2
+    private var holdsThreadReads = false
+    private let heldReadContinuation: AsyncStream<CatchUpHTTPRead>.Continuation
+    nonisolated let heldRequests: AsyncStream<CatchUpHTTPRead>
+
+    init() {
+        let reads = AsyncStream<CatchUpHTTPRead>.makeStream()
+        heldRequests = reads.stream
+        heldReadContinuation = reads.continuation
+    }
 
     func setResponse(text: String, sequence: Int) {
-        message = text
+        setResponse(texts: [text], sequence: sequence)
+    }
+
+    func setResponse(texts: [String], sequence: Int, withImage: Bool = false) {
+        messages = texts.enumerated().map { index, text in
+            catchUpMessage(text, index: index, withImage: withImage)
+        }
         self.sequence = sequence
     }
 
-    func data(for request: URLRequest) throws -> (Data, HTTPURLResponse) {
+    func holdThreadReads(_ hold: Bool) { holdsThreadReads = hold }
+
+    func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         let value: JSONValue
         switch request.url!.path {
         case "/api/auth/websocket-ticket":
@@ -248,22 +481,47 @@ private actor CatchUpHTTPTransport: HTTPTransport {
                 throw URLError(.unsupportedURL)
             }
             threadRequests.append(request)
-            let messages = message.map { text in
-                [OrchestrationMessage(
-                    id: "answer", role: "assistant", text: text, attachments: [],
-                    turnId: nil, streaming: false, createdAt: "2026-09-02T12:00:00Z",
-                    updatedAt: "2026-09-02T12:00:00Z"
-                )]
-            } ?? []
             value = try .encode(multiEnvironmentDetail(
                 projectID: "project", threadID: request.url!.lastPathComponent,
                 snapshotSequence: sequence, messages: messages
             ))
         }
-        return (try JSONEncoder.t3.encode(value), HTTPURLResponse(
+        let response = (try JSONEncoder.t3.encode(value), HTTPURLResponse(
             url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
         )!)
+        if holdsThreadReads, request.url!.path.hasPrefix("/api/orchestration/threads/") {
+            let finished = AsyncStream<Bool>.makeStream()
+            defer {
+                finished.continuation.yield(Task.isCancelled)
+                finished.continuation.finish()
+            }
+            return try await withCheckedThrowingContinuation { continuation in
+                heldReadContinuation.yield(CatchUpHTTPRead(
+                    response: response, continuation: continuation, finished: finished.stream
+                ))
+            }
+        }
+        return response
     }
+}
+
+private struct CatchUpHTTPRead: Sendable {
+    let response: (Data, HTTPURLResponse)
+    let continuation: CheckedContinuation<(Data, HTTPURLResponse), any Error>
+    let finished: AsyncStream<Bool>
+    func succeed() { continuation.resume(returning: response) }
+    func fail() { continuation.resume(throwing: URLError(.notConnectedToInternet)) }
+}
+
+private func catchUpMessage(_ text: String, index: Int, withImage: Bool = false) -> OrchestrationMessage {
+    OrchestrationMessage(
+        id: "answer-\(index)", role: "assistant", text: text,
+        attachments: withImage ? [.init(
+            type: "image", id: "image-\(index)", name: "test.png", mimeType: "image/png", sizeBytes: 20
+        )] : [],
+        turnId: nil, streaming: false, createdAt: "2026-09-02T12:00:00Z",
+        updatedAt: "2026-09-02T12:00:00Z"
+    )
 }
 
 private struct CatchUpConnector: WebSocketConnecting {
@@ -282,6 +540,27 @@ private struct CatchUpRequest: Sendable {
 
     func synchronize() async throws {
         try await socket.chunk(id: id, values: [.object(["kind": .string("synchronized")])])
+    }
+
+    func invalidate(sequence: Int) async throws {
+        try await socket.chunk(id: id, values: [.object([
+            "kind": .string("event"), "event": .object([
+                "type": .string("thread.reverted"), "sequence": .number(Double(sequence)),
+                "occurredAt": .string("2026-09-02T12:00:00Z"),
+                "payload": .object(["threadId": payload["threadId"]!]),
+            ]),
+        ])])
+    }
+
+    func snapshot(texts: [String], sequence: Int) async throws {
+        let snapshot = multiEnvironmentDetail(
+            projectID: "project", threadID: payload["threadId"]!.stringValue!,
+            snapshotSequence: sequence,
+            messages: texts.enumerated().map { catchUpMessage($0.element, index: $0.offset) }
+        )
+        try await socket.chunk(id: id, values: [.object([
+            "kind": .string("snapshot"), "snapshot": try .encode(snapshot),
+        ])])
     }
 
     func sendMessage(text: String, sequence: Int) async throws {

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -346,6 +346,48 @@ final class NativeThreadCatchUpTests: XCTestCase {
         await fixture.client.disconnect()
     }
 
+    func testNonImageAttachmentsResolveAfterTextCatchUpCompletes() async throws {
+        for (name, mimeType) in [("document.pdf", "application/pdf"), ("clip.mp4", "video/mp4")] {
+            let fixture = try await CatchUpFixture.make()
+            defer { fixture.cleanUp() }
+            var requests = fixture.requests.makeAsyncIterator()
+            var events = fixture.client.events().makeAsyncIterator()
+            _ = try await fixture.client.loadThread(id: fixture.firstID)
+            let stream = try await nextThreadRequest(&requests)
+            try await stream.synchronize()
+            _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+
+            await fixture.http.setResponse(text: "File ready", sequence: 10, attachment: .init(
+                type: "file", id: "file", name: name, mimeType: mimeType, sizeBytes: 20
+            ))
+            try await stream.invalidate(sequence: 10)
+            await nextCatchUp(&events, threadID: fixture.firstID)
+            // Text must become current before the asset URL request completes.
+            let messages = await messagesBeforeLive(&events, threadID: fixture.firstID)
+            XCTAssertEqual(messages, ["File ready"])
+
+            while let request = await requests.next(isolation: #isolation) {
+                guard request.tag == RPCMethod.assetsCreateURL.rawValue else { continue }
+                XCTAssertEqual(request.payload["resource"]?["mimeType"], .string(mimeType))
+                try await request.socket.succeed(id: request.id, value: .object([
+                    "relativeUrl": .string("/assets/\(name)"),
+                    "expiresAt": .number(Date.now.addingTimeInterval(3_600).timeIntervalSince1970 * 1_000),
+                ]))
+                break
+            }
+            var resolved: FeatureMessageAttachment?
+            while let event = await events.next(isolation: #isolation) {
+                guard case let .detail(detail) = event, detail.thread.id == fixture.firstID,
+                      let attachment = detail.messages.first?.attachments.first else { continue }
+                resolved = attachment
+                break
+            }
+            XCTAssertEqual(resolved?.mimeType, mimeType)
+            XCTAssertEqual(resolved?.url, URL(string: "https://one.example/assets/\(name)"))
+            await fixture.client.disconnect()
+        }
+    }
+
     private func nextHeldRead(
         _ iterator: inout AsyncStream<CatchUpHTTPRead>.Iterator
     ) async throws -> CatchUpHTTPRead {
@@ -451,8 +493,9 @@ private actor CatchUpHTTPTransport: HTTPTransport {
         heldReadContinuation = reads.continuation
     }
 
-    func setResponse(text: String, sequence: Int) {
-        setResponse(texts: [text], sequence: sequence)
+    func setResponse(text: String, sequence: Int, attachment: ChatAttachment? = nil) {
+        messages = [catchUpMessage(text, index: 0, attachment: attachment)]
+        self.sequence = sequence
     }
 
     func setResponse(texts: [String], sequence: Int, withImage: Bool = false) {
@@ -513,12 +556,14 @@ private struct CatchUpHTTPRead: Sendable {
     func fail() { continuation.resume(throwing: URLError(.notConnectedToInternet)) }
 }
 
-private func catchUpMessage(_ text: String, index: Int, withImage: Bool = false) -> OrchestrationMessage {
+private func catchUpMessage(
+    _ text: String, index: Int, withImage: Bool = false, attachment: ChatAttachment? = nil
+) -> OrchestrationMessage {
     OrchestrationMessage(
         id: "answer-\(index)", role: "assistant", text: text,
-        attachments: withImage ? [.init(
+        attachments: attachment.map { [$0] } ?? (withImage ? [.init(
             type: "image", id: "image-\(index)", name: "test.png", mimeType: "image/png", sizeBytes: 20
-        )] : [],
+        )] : []),
         turnId: nil, streaming: false, createdAt: "2026-09-02T12:00:00Z",
         updatedAt: "2026-09-02T12:00:00Z"
     )
@@ -623,6 +668,13 @@ private actor CatchUpSocket: WebSocketConnection {
     func chunk(id: Int, values: [JSONValue]) throws {
         try enqueue(.object([
             "_tag": .string("Chunk"), "requestId": .number(Double(id)), "values": .array(values),
+        ]))
+    }
+
+    func succeed(id: Int, value: JSONValue) throws {
+        try enqueue(.object([
+            "_tag": .string("Exit"), "requestId": .number(Double(id)),
+            "exit": .object(["_tag": .string("Success"), "value": value]),
         ]))
     }
 

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -384,7 +384,7 @@ final class NativeThreadCatchUpTests: XCTestCase {
             case let .detail(detail), let .detailDelta(detail, _):
                 if detail.thread.id == threadID { messages = detail.messages.map(\.text) }
             case .threadSync(threadID, .live): return messages
-            case let .threadSync(threadID, .failed(error)):
+            case let .threadSync(id, .failed(error)) where id == threadID:
                 XCTFail("The thread failed synchronization: \(error)")
                 return messages
             default: break

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -388,6 +388,51 @@ final class NativeThreadCatchUpTests: XCTestCase {
         }
     }
 
+    func testRequiredReadReplacesColdFallbackWithoutHidingItsOwnFailure() async throws {
+        let fixture = try await CatchUpFixture.make()
+        defer { fixture.cleanUp() }
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        await fixture.http.holdThreadReads(true)
+
+        // Fail the cold open so catch-up starts without a base snapshot.
+        let opening = Task { try await fixture.client.loadThread(id: fixture.firstID) }
+        let initial = try await nextHeldRead(&reads)
+        initial.fail()
+        do {
+            _ = try await opening.value
+            XCTFail("The initial snapshot should fail.")
+        } catch {}
+        let stream = try await nextThreadRequest(&requests)
+        while let event = await events.next(isolation: #isolation) {
+            if case .threadSync(fixture.firstID, .failed) = event { break }
+        }
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        await fixture.delay.release()
+        let fallback = try await nextHeldRead(&reads)
+
+        // The event needs a newer snapshot than the fallback captured.
+        await fixture.http.setResponse(text: "New message", sequence: 3)
+        try await stream.sendMessage(text: "New message", sequence: 3)
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        let replacement = try await nextHeldRead(&reads)
+        fallback.succeed()
+        let wasCancelled = await fallback.finished.first { _ in true }
+        XCTAssertEqual(wasCancelled, true, "The older fallback must stop when the required read takes over.")
+
+        replacement.fail()
+        var failure: String?
+        while let event = await events.next(isolation: #isolation) {
+            guard case let .threadSync(id, .failed(message)) = event,
+                  id == fixture.firstID else { continue }
+            failure = message
+            break
+        }
+        XCTAssertEqual(failure, URLError(.notConnectedToInternet).localizedDescription)
+        await fixture.client.disconnect()
+    }
+
     private func nextHeldRead(
         _ iterator: inout AsyncStream<CatchUpHTTPRead>.Iterator
     ) async throws -> CatchUpHTTPRead {

--- a/docs/user/swiftui-mobile.md
+++ b/docs/user/swiftui-mobile.md
@@ -28,6 +28,13 @@ settings. Supported environments offer an icon picker in their connection prefer
 Use **Refresh prices** in Usage to fetch new model rates without waiting for the daily refresh.
 A failed environment does not remove the usage data from other environments.
 
+## Thread connection state
+
+Cached messages stay readable while a thread catches up. A status above the composer shows when
+the content is incomplete or the computer cannot be reached. Use **Retry** if an update fails.
+Working indicators return after the thread is current. File previews can finish loading after
+the text is ready.
+
 ## Attachments and sharing
 
 One message can contain up to eight photos, videos, or files. Images can be up to 10 MB. Other


### PR DESCRIPTION
Messages could go missing when they arrived during a required thread snapshot read. The follow-up read was skipped because the WebSocket was still open, and the app could label incomplete cached content as current.

Track skipped event cursors and keep fetching until the replacement covers them. Required reads start without the fixed 250 ms delay and cancel older fallback reads. Cached messages stay visible with a catch-up or failure label. Confirmed live thread data takes precedence over stale environment status.

Image, PDF, and video URL requests no longer block text recovery. Late results from an old thread or connection cannot replace current content.

Verification:

- 83 focused native tests passed, including held snapshot responses, missing cursors, disconnect/navigation cancellation, and delayed PDF/video URLs. A final combined pass passed 180 tests.
- Simulator checked cached reopen, server loss, retry, and recovery against an isolated environment with 1,013 threads.
- Independent review passed after fixing attachment and connection-state findings.

Simulator states, with the same cached content kept visible:

| Current | Catching up | Could not update |
| --- | --- | --- |
| ![Current thread](https://files.tslop.org/2026/09/thread-current-9edc0c91.jpg) | ![Cached thread catching up](https://files.tslop.org/2026/09/thread-catch-up-5cb10462.jpg) | ![Cached thread with Retry](https://files.tslop.org/2026/09/thread-offline-9632b476.jpg) |

Based on the main SwiftUI branch. No transcript layout or scrolling changes.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches real-time thread streaming, snapshot/HTTP race recovery, and sync state presentation—high user-visible impact but bounded to iOS native client with strong test coverage.
> 
> **Overview**
> Fixes **thread detail sync** on iOS so messages are not dropped or shown as “live” while a mandatory snapshot is still in flight.
> 
> **`NativeFeatureClient`** now tracks when a replacement snapshot must include events that arrived without a usable cursor (`detailSnapshotRequiredAfterEpoch` / `threadHistoryEpoch`). **Forced** HTTP refreshes skip the 250 ms coalesce delay, cancel stale catch-up fallbacks, and surface `.catchingUp`; refresh failures can emit `.failed` without treating cancellation as an error. Socket snapshots from an older subscription are ignored until the required read completes; a fresher socket snapshot can supersede a held HTTP read. Trailing refreshes after coalesced work use `force: true` when there was no base thread to reduce. **`refreshThread`** rejects outdated snapshots (`threadSnapshotOutdated`) when history moved during the read, and **attachment URL hydration** is scheduled asynchronously for all attachments missing URLs so PDF/video/image lookups do not block text catch-up.
> 
> **UI** (`ThreadDetailView`, `ThreadRefreshPresentation`, `FeatureRootModel`): cached transcript stays visible during catch-up/retry; working timers and empty-state copy are suppressed while a refresh banner is shown; **`.live` thread sync** wins over stale environment disconnect/reconnect probes; duplicate `.threadSync` values no longer churn observation.
> 
> Adds extensive **catch-up integration tests** and brief **user docs** for thread connection status and Retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02ba3e240823b130babe7342e0b0fef7792f488e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread catch-up visibility and snapshot ordering in Swift iOS client
> - Thread detail sync now tracks a required snapshot epoch per stream subscription and rejects snapshots from older subscriptions, so stale reads can no longer satisfy a newer required replacement.
> - Required refreshes enter a `catching-up` state immediately, cancel stale fallback reads, force trailing reads to run without coalescing delay, and surface non-cancellation failures as failed thread-sync events instead of silently discarding them.
> - Invalid stream reductions now discard the cached raw thread and trigger a forced replacement read; valid snapshots reset refresh state, clear the required epoch, and can restore live synchronization.
> - Non-image attachment URL resolution (files, videos) now runs async and no longer blocks publication of current thread text; `scheduleAttachmentHydration` resolves every attachment without a URL.
> - UI in [ThreadDetailView.swift](https://github.com/pingdotgg/t3code/pull/9678/files#diff-c987f84bf3746c99e23dc49057c113592bca2c0bce299b9dd80fe73c9495af30) now shows refresh status above cached working indicators, hides stale environment reachability warnings when a thread is synced, and suppresses the ready-for-task empty state during refresh.
> - Risk: `refreshThread` ignores in-flight reads that cross an epoch change and may surface `NativeFeatureClientError.threadSnapshotOutdated` to callers when no replacement is pending; verify callers handle this new retryable error case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 02ba3e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->