### PR TITLE
fix(swift-ios): make swipe-to-settle removal smooth

### DIFF
--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -135,6 +135,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
             guard !isApplyingSnapshot, hasQueuedUpdate, let dataSource else { return }
             hasQueuedUpdate = false
             let previousItems = itemsByID
+            let previousThreadItemIDs = threadItemIDs
             let previousSelection = selectedThreadID
             selectedThreadID = parent.selectedThreadID
 
@@ -214,6 +215,18 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     && !currentIdentifiers.isEmpty
                     && collectionView.window != nil
                     && !UIAccessibility.isReduceMotionEnabled
+                if shouldAnimate {
+                    for threadID in resolvedSwipes.keys {
+                        guard let identifier = previousThreadItemIDs[threadID],
+                              identifier != threadItemIDs[threadID],
+                              let indexPath = dataSource.indexPath(for: identifier),
+                              let cell = collectionView.cellForItem(at: indexPath) else { continue }
+                        // UIKit fades deleted cells while their neighbors move up.
+                        // Hide the departed text so it cannot show through those rows.
+                        // The native swipe action view is outside contentView.
+                        cell.contentView.isHidden = true
+                    }
+                }
                 isApplyingSnapshot = true
                 dataSource.apply(
                     snapshot,
@@ -368,6 +381,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
             now: Date
         ) {
             guard let item = itemsByID[identifier] else { return }
+            cell.contentView.isHidden = false
             let pullRequestObservationIdentity: String?
             if case let .thread(thread, _, _, _, _, _) = item {
                 pullRequestObservationIdentity = thread.pullRequestObservationIdentity
@@ -1010,6 +1024,7 @@ private final class HomeCollectionCell: UICollectionViewListCell {
 
     override func prepareForReuse() {
         super.prepareForReuse()
+        contentView.isHidden = false
         onAccessibilityActivate = nil
     }
 }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -84,6 +84,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         private var dataSource: UICollectionViewDiffableDataSource<Section, HomeCollectionItem.ID>?
         private var registration: UICollectionView.CellRegistration<HomeCollectionCell, HomeCollectionItem.ID>?
         private var itemsByID: [HomeCollectionItem.ID: HomeCollectionItem] = [:]
+        private var threadItemIDs: [String: HomeCollectionItem.ID] = [:]
         private var pullRequestsByThreadID: [String: HomeThreadPullRequestPresentation] = [:]
         private var selectedThreadID: String?
         private weak var collectionView: UICollectionView?
@@ -91,6 +92,8 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         private var timerTick = 0
         private var timerInterval: TimeInterval = 0
         private var pendingSwipeCompletions: [String: PendingSwipeCompletion] = [:]
+        private var isApplyingSnapshot = false
+        private var hasQueuedUpdate = false
 
         init(parent: HomeThreadCollectionView) {
             self.parent = parent
@@ -121,57 +124,77 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         }
 
         func update(parent: HomeThreadCollectionView, collectionView: UICollectionView) {
+            self.parent = parent
+            hasQueuedUpdate = true
+            applyLatestSnapshot(in: collectionView)
+        }
+
+        /// Keep a row's content and size fixed during its removal. Stream updates
+        /// that arrive mid-animation are applied together after that animation.
+        private func applyLatestSnapshot(in collectionView: UICollectionView) {
+            guard !isApplyingSnapshot, hasQueuedUpdate, let dataSource else { return }
+            hasQueuedUpdate = false
             let previousItems = itemsByID
             let previousSelection = selectedThreadID
-            self.parent = parent
             selectedThreadID = parent.selectedThreadID
 
             var seenIdentifiers = Set<HomeCollectionItem.ID>()
+            var seenThreadIDs = Set<String>()
             let items = parent.collectionItems.filter { item in
-                seenIdentifiers.insert(item.id).inserted
+                if let threadID = item.id.threadID, !seenThreadIDs.insert(threadID).inserted {
+                    return false
+                }
+                return seenIdentifiers.insert(item.id).inserted
             }
             itemsByID = Dictionary(uniqueKeysWithValues: items.map { ($0.id, $0) })
+            threadItemIDs = Dictionary(uniqueKeysWithValues: items.compactMap { item in
+                item.id.threadID.map { ($0, item.id) }
+            })
             pullRequestsByThreadID = pullRequestsByThreadID.filter {
-                itemsByID[.thread($0.key)] != nil
+                threadItemIDs[$0.key] != nil
             }
             // After items land: picks 1 Hz when a working thread is present,
             // 60s otherwise, and is a no-op when the interval is unchanged.
             startTimer()
 
-            guard let dataSource else { return }
             let currentIdentifiers = dataSource.snapshot().itemIdentifiers
             let newIdentifiers = items.map(\.id)
-            let resolvedSwipeIDs = pendingSwipeCompletions.keys.filter { threadID in
-                guard let pending = pendingSwipeCompletions[threadID] else { return false }
-                guard case let .thread(thread, _, _, _, _) = itemsByID[.thread(threadID)] else {
+            let resolvedSwipes = pendingSwipeCompletions.filter { threadID, pending in
+                guard let identifier = threadItemIDs[threadID],
+                      case let .thread(thread, _, _, _, _, _) = itemsByID[identifier] else {
                     return true
                 }
-                return thread.isSettled == pending.settled
+                return thread.isEffectivelySettled() == pending.settled
             }
-            let resolvedSwipeCompletions = resolvedSwipeIDs.compactMap {
-                pendingSwipeCompletions.removeValue(forKey: $0)
-            }
-            let finishSwipes = {
-                resolvedSwipeCompletions.forEach { $0.finish(true) }
+            let finishUpdate = { [weak self, weak collectionView] in
+                guard let self else { return }
+                for (threadID, pending) in resolvedSwipes {
+                    guard self.pendingSwipeCompletions[threadID]?.id == pending.id else { continue }
+                    self.pendingSwipeCompletions.removeValue(forKey: threadID)?.finish(true)
+                }
+                self.isApplyingSnapshot = false
+                guard let collectionView else { return }
+                self.synchronizeSelection(in: collectionView)
+                self.applyLatestSnapshot(in: collectionView)
             }
 
             if currentIdentifiers == newIdentifiers {
                 let changed = newIdentifiers.filter { previousItems[$0] != itemsByID[$0] }
                 let selectionChanged = (previousSelection != selectedThreadID
                     ? [previousSelection, selectedThreadID] : [])
-                    .compactMap { $0.map(HomeCollectionItem.ID.thread) }
-                    .filter { newIdentifiers.contains($0) }
+                    .compactMap { $0.flatMap { threadItemIDs[$0] } }
                 let identifiers = Array(Set(changed + selectionChanged))
                 if !identifiers.isEmpty {
                     var snapshot = dataSource.snapshot()
                     snapshot.reconfigureItems(identifiers)
+                    isApplyingSnapshot = true
                     dataSource.apply(
                         snapshot,
                         animatingDifferences: false,
-                        completion: finishSwipes
+                        completion: finishUpdate
                     )
                 } else {
-                    finishSwipes()
+                    finishUpdate()
                 }
             } else {
                 var snapshot = NSDiffableDataSourceSnapshot<Section, HomeCollectionItem.ID>()
@@ -187,18 +210,15 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                         && (previousItems[identifier] != itemsByID[identifier]
                             || identifier.threadID.map(selectionChanged.contains) == true)
                 })
-                let shouldAnimate = !resolvedSwipeCompletions.isEmpty
+                let shouldAnimate = !resolvedSwipes.isEmpty
                     && !currentIdentifiers.isEmpty
                     && collectionView.window != nil
+                    && !UIAccessibility.isReduceMotionEnabled
+                isApplyingSnapshot = true
                 dataSource.apply(
                     snapshot,
                     animatingDifferences: shouldAnimate,
-                    completion: { [weak self, weak collectionView] in
-                        if let collectionView {
-                            self?.synchronizeSelection(in: collectionView)
-                        }
-                        finishSwipes()
-                    }
+                    completion: finishUpdate
                 )
             }
 
@@ -211,6 +231,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         }
 
         func cancelPendingSwipeActions() {
+            hasQueuedUpdate = false
             pendingSwipeCompletions.values.forEach { $0.finish(false) }
             pendingSwipeCompletions.removeAll()
         }
@@ -218,7 +239,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
             guard let item = item(at: indexPath) else { return }
             switch item {
-            case let .thread(thread, _, _, _, _):
+            case let .thread(thread, _, _, _, _, _):
                 let previousSelection = selectedThreadID
                 selectedThreadID = thread.id
                 parent.onOpen(thread.id)
@@ -242,7 +263,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
             contextMenuConfigurationForItemAt indexPath: IndexPath,
             point: CGPoint
         ) -> UIContextMenuConfiguration? {
-            guard case let .thread(thread, _, _, isArchived, _) = item(at: indexPath) else {
+            guard case let .thread(thread, _, _, isArchived, _, _) = item(at: indexPath) else {
                 return nil
             }
 
@@ -253,7 +274,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         }
 
         func trailingSwipeActions(at indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-            guard case let .thread(thread, _, _, isArchived, _) = item(at: indexPath) else {
+            guard case let .thread(thread, _, _, isArchived, _, _) = item(at: indexPath) else {
                 return nil
             }
 
@@ -301,7 +322,10 @@ struct HomeThreadCollectionView: UIViewRepresentable {
             finish: @escaping (Bool) -> Void
         ) {
             if case let .setSettled(settled) = action.intent {
-                pendingSwipeCompletions.removeValue(forKey: thread.id)?.finish(false)
+                guard pendingSwipeCompletions[thread.id] == nil else {
+                    finish(false)
+                    return
+                }
                 let completionID = UUID()
                 pendingSwipeCompletions[thread.id] = PendingSwipeCompletion(
                     id: completionID,
@@ -345,7 +369,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         ) {
             guard let item = itemsByID[identifier] else { return }
             let pullRequestObservationIdentity: String?
-            if case let .thread(thread, _, _, _, _) = item {
+            if case let .thread(thread, _, _, _, _, _) = item {
                 pullRequestObservationIdentity = thread.pullRequestObservationIdentity
             } else {
                 pullRequestObservationIdentity = nil
@@ -391,7 +415,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         private func configureAccessibility(_ cell: HomeCollectionCell, item: HomeCollectionItem) {
             cell.accessibilityCustomActions = nil
             switch item {
-            case let .thread(thread, context, _, isArchived, _):
+            case let .thread(thread, context, _, isArchived, _, _):
                 cell.isAccessibilityElement = true
                 cell.accessibilityTraits = selectedThreadID == thread.id
                     ? [.button, .selected]
@@ -485,8 +509,9 @@ struct HomeThreadCollectionView: UIViewRepresentable {
             threadID: String,
             cell: HomeCollectionCell
         ) {
-            guard case let .thread(thread, context, _, _, _) = itemsByID[.thread(threadID)],
-                  let indexPath = dataSource?.indexPath(for: .thread(threadID)),
+            guard let identifier = threadItemIDs[threadID],
+                  case let .thread(thread, context, _, _, _, _) = itemsByID[identifier],
+                  let indexPath = dataSource?.indexPath(for: identifier),
                   collectionView?.cellForItem(at: indexPath) === cell else {
                 return
             }
@@ -582,7 +607,8 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 collectionView.deselectItem(at: indexPath, animated: false)
             }
             guard let selectedThreadID,
-                  let indexPath = dataSource?.indexPath(for: .thread(selectedThreadID)),
+                  let identifier = threadItemIDs[selectedThreadID],
+                  let indexPath = dataSource?.indexPath(for: identifier),
                   !collectionView.indexPathsForSelectedItems.orEmpty.contains(indexPath) else {
                 return
             }
@@ -591,11 +617,12 @@ struct HomeThreadCollectionView: UIViewRepresentable {
 
         private func refreshSelection(in collectionView: UICollectionView, ids: [String]) {
             for id in ids {
-                guard let indexPath = dataSource?.indexPath(for: .thread(id)),
+                guard let identifier = threadItemIDs[id],
+                      let indexPath = dataSource?.indexPath(for: identifier),
                       let cell = collectionView.cellForItem(at: indexPath) as? HomeCollectionCell else {
                     continue
                 }
-                configure(cell, identifier: .thread(id), now: .now)
+                configure(cell, identifier: identifier, now: .now)
             }
         }
 
@@ -718,7 +745,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         /// second for the lifetime of the sidebar.
         private func startTimer() {
             let interval: TimeInterval = itemsByID.values.contains {
-                if case let .thread(thread, _, _, _, _) = $0 {
+                if case let .thread(thread, _, _, _, _, _) = $0 {
                     return thread.homeStatus == .working
                 }
                 return false
@@ -737,14 +764,16 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         }
 
         private func refreshVisibleTimes() {
-            guard let collectionView, let dataSource else { return }
+            guard !isApplyingSnapshot,
+                  let collectionView, let dataSource,
+                  !collectionView.isTracking, !collectionView.isDecelerating else { return }
             timerTick = (timerTick + 1) % 60
             let refreshRelativeAges = timerInterval >= 60 || timerTick == 0
             let now = Date.now
 
             for indexPath in collectionView.indexPathsForVisibleItems {
                 guard let identifier = dataSource.itemIdentifier(for: indexPath),
-                      case let .thread(thread, _, _, _, _) = itemsByID[identifier],
+                      case let .thread(thread, _, _, _, _, _) = itemsByID[identifier],
                       refreshRelativeAges || thread.homeStatus == .working,
                       let cell = collectionView.cellForItem(at: indexPath) as? HomeCollectionCell else {
                     continue
@@ -754,7 +783,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         }
     }
 
-    private var collectionItems: [HomeCollectionItem] {
+    var collectionItems: [HomeCollectionItem] {
         let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
         if !normalizedQuery.isEmpty {
             if presentation.searchResults.isEmpty {
@@ -766,7 +795,8 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     presentation.rowContexts[$0.id] ?? .fallback,
                     .rich,
                     $0.isArchived,
-                    forceRichRows
+                    forceRichRows,
+                    nil
                 )
             }
         }
@@ -777,7 +807,8 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 presentation.rowContexts[$0.id] ?? .fallback,
                 .rich,
                 false,
-                forceRichRows
+                forceRichRows,
+                .active
             )
         }
         if !presentation.pinned.isEmpty, !presentation.active.isEmpty {
@@ -792,7 +823,8 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     presentation.rowContexts[$0.id] ?? .fallback,
                     .rich,
                     false,
-                    forceRichRows
+                    forceRichRows,
+                    .active
                 )
             })
         }
@@ -806,7 +838,8 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                         presentation.rowContexts[$0.id] ?? .fallback,
                         forceRichRows ? .rich : .slim,
                         false,
-                        forceRichRows
+                        forceRichRows,
+                        .snoozed
                     )
                 })
             }
@@ -821,7 +854,8 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                         presentation.rowContexts[$0.id] ?? .fallback,
                         forceRichRows ? .rich : .slim,
                         false,
-                        forceRichRows
+                        forceRichRows,
+                        .settled
                     )
                 })
                 if presentation.settled.count > settledLimit {
@@ -839,7 +873,8 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                         presentation.rowContexts[$0.id] ?? .fallback,
                         forceRichRows ? .rich : .slim,
                         true,
-                        forceRichRows
+                        forceRichRows,
+                        .archived
                     )
                 })
             }
@@ -979,7 +1014,7 @@ private final class HomeCollectionCell: UICollectionViewListCell {
     }
 }
 
-private enum HomeShelf: String, Hashable {
+enum HomeShelf: String, Hashable {
     case active
     case snoozed
     case settled
@@ -990,9 +1025,11 @@ private enum HomeShelf: String, Hashable {
     }
 }
 
-private enum HomeCollectionItem: Equatable {
+enum HomeCollectionItem: Equatable {
     enum ID: Hashable {
-        case thread(String)
+        // A shelf change replaces the cell. Moving the same cell while it
+        // changes between rich and slim layouts makes its height jump mid-swipe.
+        case thread(String, HomeShelf?)
         case shelfHeader(HomeShelf)
         case empty(HomeShelf)
         case showMoreSettled
@@ -1000,12 +1037,12 @@ private enum HomeCollectionItem: Equatable {
         case pinnedDivider
 
         var threadID: String? {
-            guard case let .thread(id) = self else { return nil }
+            guard case let .thread(id, _) = self else { return nil }
             return id
         }
     }
 
-    case thread(FeatureThread, HomeThreadRowContext, FeatureThreadRow.Style, Bool, Bool)
+    case thread(FeatureThread, HomeThreadRowContext, FeatureThreadRow.Style, Bool, Bool, HomeShelf?)
     case shelfHeader(HomeShelf, Int, Bool)
     case empty(HomeShelf)
     case showMoreSettled(Int)
@@ -1014,7 +1051,7 @@ private enum HomeCollectionItem: Equatable {
 
     var id: ID {
         switch self {
-        case let .thread(thread, _, _, _, _): .thread(thread.id)
+        case let .thread(thread, _, _, _, _, shelf): .thread(thread.id, shelf)
         case let .shelfHeader(shelf, _, _): .shelfHeader(shelf)
         case let .empty(shelf): .empty(shelf)
         case .showMoreSettled: .showMoreSettled
@@ -1034,7 +1071,7 @@ private struct HomeCollectionCellContent: View {
     @ViewBuilder
     var body: some View {
         switch item {
-        case let .thread(thread, context, style, _, allowsMultilineTitle):
+        case let .thread(thread, context, style, _, allowsMultilineTitle, _):
             FeatureThreadRow(
                 thread: thread,
                 context: context,

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
@@ -737,7 +737,7 @@ struct HomeThreadSwipeActionTests {
     }
 
     @Test
-    func settledSearchRowsFinishTheSwipeWithoutLeavingTheSearchResults() async {
+    func settledSearchRowsFinishTheSwipeWithoutLeavingTheSearchResults() async throws {
         let client = SwipeSettlementClientStub()
         let active = thread(id: "search")
         let initialList = threadList(
@@ -772,6 +772,9 @@ struct HomeThreadSwipeActionTests {
         var results = completions.stream.makeAsyncIterator()
         #expect(await results.next() == true)
         #expect(collectionView.numberOfItems(inSection: 0) == 1)
+        collectionView.layoutIfNeeded()
+        let cell = try #require(collectionView.cellForItem(at: IndexPath(item: 0, section: 0)))
+        #expect(!cell.contentView.isHidden)
     }
 
     @Test
@@ -913,10 +916,87 @@ struct HomeThreadSwipeActionTests {
         #expect(retainedCell.accessibilityLabel == latest.title)
         let firstCell = try #require(collectionView.visibleCells.first { $0.accessibilityLabel == first.title })
         #expect(firstCell.accessibilityValue?.contains("Settled") == !rollbackFirst)
+        #expect(!firstCell.contentView.isHidden)
+        #expect(!retainedCell.contentView.isHidden)
         let threadCells = collectionView.visibleCells.filter { $0.accessibilityTraits.contains(.button) }
         let frames = threadCells.map(\.frame).sorted { $0.minY < $1.minY }
         for (before, after) in zip(frames, frames.dropFirst()) {
             #expect(before.maxY <= after.minY + 0.5)
+        }
+    }
+
+    @Test(.timeLimit(.minutes(1)), arguments: [false, true])
+    func departingTextIsHiddenWhileTheNextRowMovesIntoItsFrame(isSettledExpanded: Bool) async throws {
+        let client = SwipeSettlementClientStub()
+        let first = thread(id: "first")
+        let remaining = thread(id: "remaining")
+        let initial = threadList(
+            client: client,
+            snapshot: snapshot(threads: [first, remaining]),
+            isSettledExpanded: isSettledExpanded
+        )
+        let coordinator = initial.makeCoordinator()
+        let collectionView = testCollectionView()
+        coordinator.configure(collectionView)
+        collectionView.layoutIfNeeded()
+        let outgoing = try #require(collectionView.visibleCells.first { $0.accessibilityLabel == first.title })
+        let neighbor = try #require(collectionView.visibleCells.first { $0.accessibilityLabel == remaining.title })
+
+        let controller = UIViewController()
+        controller.view = collectionView
+        let window = UIWindow(frame: collectionView.frame)
+        window.rootViewController = controller
+        window.isHidden = false
+        defer {
+            window.isHidden = true
+            coordinator.invalidateTimer()
+            coordinator.cancelPendingSwipeActions()
+        }
+
+        var overlappingFrames = 0
+        var visibleOverlaps = 0
+        let probe = SwipeRemovalFrameProbe {
+            guard outgoing.superview === neighbor.superview,
+                  let outgoingFrame = outgoing.layer.presentation()?.frame,
+                  let neighborFrame = neighbor.layer.presentation()?.frame,
+                  outgoingFrame.intersection(neighborFrame).height > 1 else { return }
+            overlappingFrames += 1
+            let opacity = outgoing.layer.presentation()?.opacity ?? outgoing.layer.opacity
+            if !outgoing.contentView.isHidden, opacity > 0.01 {
+                visibleOverlaps += 1
+            }
+        }
+        defer { probe.stop() }
+        let completions = AsyncStream<Bool>.makeStream()
+        coordinator.performSwipe(.settle, for: first) { succeeded in
+            probe.stop()
+            completions.continuation.yield(succeeded)
+        }
+        var settled = first
+        settled.isSettled = true
+        settled.settledAt = now
+        coordinator.update(
+            parent: threadList(
+                client: client,
+                snapshot: snapshot(threads: [settled, remaining]),
+                isSettledExpanded: isSettledExpanded
+            ),
+            collectionView: collectionView
+        )
+
+        var results = completions.stream.makeAsyncIterator()
+        #expect(await results.next() == true)
+        #expect(visibleOverlaps == 0)
+        if UIView.areAnimationsEnabled, !UIAccessibility.isReduceMotionEnabled {
+            #expect(overlappingFrames > 0)
+        }
+        collectionView.layoutIfNeeded()
+        #expect(!neighbor.contentView.isHidden)
+        if isSettledExpanded {
+            let settledCell = try #require(collectionView.visibleCells.first {
+                $0.accessibilityLabel == first.title
+            })
+            #expect(!settledCell.contentView.isHidden)
         }
     }
 
@@ -1143,6 +1223,26 @@ enum PendingSettlementEvent: CaseIterable {
     case thread
     case detail
     case detailDelta
+}
+
+@MainActor
+private final class SwipeRemovalFrameProbe: NSObject {
+    private let onFrame: () -> Void
+    private var displayLink: CADisplayLink?
+
+    init(onFrame: @escaping () -> Void) {
+        self.onFrame = onFrame
+        super.init()
+        displayLink = CADisplayLink(target: self, selector: #selector(sample))
+        displayLink?.add(to: .main, forMode: .common)
+    }
+
+    @objc private func sample() { onFrame() }
+
+    func stop() {
+        displayLink?.invalidate()
+        displayLink = nil
+    }
 }
 
 @MainActor

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
@@ -926,7 +926,7 @@ struct HomeThreadSwipeActionTests {
     }
 
     @Test(.timeLimit(.minutes(1)), arguments: [false, true])
-    func departingTextIsHiddenWhileTheNextRowMovesIntoItsFrame(isSettledExpanded: Bool) async throws {
+    func departingTextIsHiddenBeforeNeighborFramesChange(isSettledExpanded: Bool) async throws {
         let client = SwipeSettlementClientStub()
         let first = thread(id: "first")
         let remaining = thread(id: "remaining")
@@ -953,23 +953,24 @@ struct HomeThreadSwipeActionTests {
             coordinator.cancelPendingSwipeActions()
         }
 
-        var overlappingFrames = 0
-        var visibleOverlaps = 0
-        let probe = SwipeRemovalFrameProbe {
-            guard outgoing.superview === neighbor.superview,
-                  let outgoingFrame = outgoing.layer.presentation()?.frame,
-                  let neighborFrame = neighbor.layer.presentation()?.frame,
-                  outgoingFrame.intersection(neighborFrame).height > 1 else { return }
-            overlappingFrames += 1
-            let opacity = outgoing.layer.presentation()?.opacity ?? outgoing.layer.opacity
-            if !outgoing.contentView.isHidden, opacity > 0.01 {
-                visibleOverlaps += 1
+        let originalIndexPath = try #require(collectionView.indexPath(for: outgoing))
+        let originalNeighborFrame = neighbor.frame
+        var hidBeforeSnapshot = false
+        // XCTest can complete UIKit animations without rendering any frames.
+        // Observe the visibility change before the collection starts its update.
+        let observation = outgoing.contentView.observe(\.isHidden, options: [.new]) { _, change in
+            MainActor.assumeIsolated {
+                guard change.newValue == true else { return }
+                if collectionView.indexPath(for: outgoing) == originalIndexPath,
+                   neighbor.frame == originalNeighborFrame,
+                   !neighbor.contentView.isHidden {
+                    hidBeforeSnapshot = true
+                }
             }
         }
-        defer { probe.stop() }
+        defer { observation.invalidate() }
         let completions = AsyncStream<Bool>.makeStream()
         coordinator.performSwipe(.settle, for: first) { succeeded in
-            probe.stop()
             completions.continuation.yield(succeeded)
         }
         var settled = first
@@ -986,10 +987,7 @@ struct HomeThreadSwipeActionTests {
 
         var results = completions.stream.makeAsyncIterator()
         #expect(await results.next() == true)
-        #expect(visibleOverlaps == 0)
-        if UIView.areAnimationsEnabled, !UIAccessibility.isReduceMotionEnabled {
-            #expect(overlappingFrames > 0)
-        }
+        #expect(hidBeforeSnapshot == !UIAccessibility.isReduceMotionEnabled)
         collectionView.layoutIfNeeded()
         #expect(!neighbor.contentView.isHidden)
         if isSettledExpanded {
@@ -1223,26 +1221,6 @@ enum PendingSettlementEvent: CaseIterable {
     case thread
     case detail
     case detailDelta
-}
-
-@MainActor
-private final class SwipeRemovalFrameProbe: NSObject {
-    private let onFrame: () -> Void
-    private var displayLink: CADisplayLink?
-
-    init(onFrame: @escaping () -> Void) {
-        self.onFrame = onFrame
-        super.init()
-        displayLink = CADisplayLink(target: self, selector: #selector(sample))
-        displayLink?.add(to: .main, forMode: .common)
-    }
-
-    @objc private func sample() { onFrame() }
-
-    func stop() {
-        displayLink?.invalidate()
-        displayLink = nil
-    }
 }
 
 @MainActor

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
@@ -580,6 +580,120 @@ struct HomeThreadSwipeActionTests {
         ])
     }
 
+    @Test(arguments: [false, true])
+    func settlingReplacesTheInboxCellInsteadOfMovingAndResizingIt(forceRichRows: Bool) throws {
+        let client = SwipeSettlementClientStub()
+        let active = thread(id: "active")
+        let remaining = thread(id: "remaining")
+        var previouslySettled = thread(id: "previously-settled")
+        previouslySettled.isSettled = true
+        previouslySettled.settledAt = now.addingTimeInterval(-60)
+        let initial = threadList(
+            client: client,
+            snapshot: snapshot(threads: [active, remaining, previouslySettled]),
+            isSettledExpanded: true,
+            forceRichRows: forceRichRows
+        )
+        var settled = active
+        settled.isSettled = true
+        settled.settledAt = now
+        let updated = threadList(
+            client: client,
+            snapshot: snapshot(threads: [settled, remaining, previouslySettled]),
+            isSettledExpanded: true,
+            forceRichRows: forceRichRows
+        )
+
+        let before = initial.collectionItems.map(\.id)
+        let after = updated.collectionItems.map(\.id)
+        let changes = after.difference(from: before).inferringMoves()
+        let changedThread = changes.filter { change in
+            switch change {
+            case let .remove(_, identifier, _), let .insert(_, identifier, _):
+                identifier.threadID == active.id
+            }
+        }
+        #expect(changedThread.count == 2)
+        for change in changedThread {
+            switch change {
+            case let .remove(_, _, associatedWith), let .insert(_, _, associatedWith):
+                #expect(associatedWith == nil)
+            }
+        }
+        let remainingID = try #require(before.first { $0.threadID == remaining.id })
+        #expect(after.contains(remainingID))
+        #expect(Set(after.compactMap(\.threadID)).count == 3)
+
+        let reopened = before.difference(from: after).inferringMoves()
+        #expect(reopened.count == 2)
+    }
+
+    @Test
+    func settlingKeepsTheSameCellInSearchResults() throws {
+        let client = SwipeSettlementClientStub()
+        let active = thread(id: "search")
+        var settled = active
+        settled.isSettled = true
+        let initial = threadList(client: client, snapshot: snapshot(threads: [active]), query: "Task")
+        let updated = threadList(client: client, snapshot: snapshot(threads: [settled]), query: "Task")
+
+        #expect(initial.collectionItems.map(\.id) == updated.collectionItems.map(\.id))
+    }
+
+    @Test
+    func repeatedSwipeOnTheSameRowDoesNotSendAnotherSettlement() {
+        let client = SwipeSettlementClientStub()
+        let active = thread(id: "active")
+        var requests = 0
+        let initial = threadList(client: client, snapshot: snapshot(threads: [active])) { _, _, _ in
+            requests += 1
+        }
+        let coordinator = initial.makeCoordinator()
+        let collectionView = testCollectionView()
+        coordinator.configure(collectionView)
+        defer {
+            coordinator.invalidateTimer()
+            coordinator.cancelPendingSwipeActions()
+        }
+
+        var firstResult: Bool?
+        var secondResult: Bool?
+        coordinator.performSwipe(.settle, for: active) { firstResult = $0 }
+        coordinator.performSwipe(.settle, for: active) { secondResult = $0 }
+
+        #expect(requests == 1)
+        #expect(firstResult == nil)
+        #expect(secondResult == false)
+        coordinator.cancelPendingSwipeActions()
+        #expect(firstResult == false)
+    }
+
+    @Test
+    func cancellationFinishesEachSwipeOnlyOnce() {
+        let client = SwipeSettlementClientStub()
+        let active = thread(id: "active")
+        var respond: ((Bool) -> Void)?
+        let initial = threadList(
+            client: client,
+            snapshot: snapshot(threads: [active]),
+            settlementResult: nil
+        ) { _, _, completion in
+            respond = completion
+        }
+        let coordinator = initial.makeCoordinator()
+        let collectionView = testCollectionView()
+        coordinator.configure(collectionView)
+        defer { coordinator.invalidateTimer() }
+        var results: [Bool] = []
+        coordinator.performSwipe(.settle, for: active) { results.append($0) }
+
+        coordinator.cancelPendingSwipeActions()
+        respond?(false)
+        coordinator.cancelPendingSwipeActions()
+
+        #expect(results == [false])
+    }
+
     @Test
     func swipeCompletionWaitsUntilTheCollectionHasRemovedTheThread() async {
         let client = SwipeSettlementClientStub()
@@ -587,7 +701,7 @@ struct HomeThreadSwipeActionTests {
         let remaining = thread(id: "remaining")
         let initial = snapshot(threads: [first, remaining])
         var requests: [SettlementRequest] = []
-        let initialList = threadList(client: client, snapshot: initial) { thread, settled in
+        let initialList = threadList(client: client, snapshot: initial) { thread, settled, _ in
             requests.append(SettlementRequest(id: thread.id, settled: settled))
         }
         let coordinator = initialList.makeCoordinator()
@@ -645,7 +759,8 @@ struct HomeThreadSwipeActionTests {
         }
 
         var settled = active
-        settled.isSettled = true
+        // Modern servers can report only the authoritative override.
+        settled.settlementFacts = .init(settlementOverride: .settled)
         settled.settledAt = now
         let updated = threadList(
             client: client,
@@ -657,6 +772,152 @@ struct HomeThreadSwipeActionTests {
         var results = completions.stream.makeAsyncIterator()
         #expect(await results.next() == true)
         #expect(collectionView.numberOfItems(inSection: 0) == 1)
+    }
+
+    @Test
+    func expandedSettledShelfKeepsAdjacentRowsAtTheirFullHeight() async throws {
+        let client = SwipeSettlementClientStub()
+        let active = thread(id: "active")
+        let remaining = thread(id: "remaining")
+        let initial = threadList(
+            client: client,
+            snapshot: snapshot(threads: [active, remaining]),
+            isSettledExpanded: true
+        )
+        let coordinator = initial.makeCoordinator()
+        let collectionView = testCollectionView()
+        coordinator.configure(collectionView)
+        collectionView.layoutIfNeeded()
+        defer {
+            coordinator.invalidateTimer()
+            coordinator.cancelPendingSwipeActions()
+        }
+        let original = try #require(collectionView.visibleCells.first { $0.accessibilityLabel == remaining.title })
+        let originalHeight = original.bounds.height
+        let completions = AsyncStream<Bool>.makeStream()
+        coordinator.performSwipe(.settle, for: active) { completions.continuation.yield($0) }
+
+        var settled = active
+        settled.isSettled = true
+        settled.settledAt = now
+        coordinator.update(
+            parent: threadList(
+                client: client,
+                snapshot: snapshot(threads: [settled, remaining]),
+                isSettledExpanded: true
+            ),
+            collectionView: collectionView
+        )
+        var results = completions.stream.makeAsyncIterator()
+        #expect(await results.next() == true)
+        collectionView.layoutIfNeeded()
+
+        let remainingCell = try #require(collectionView.visibleCells.first { $0.accessibilityLabel == remaining.title })
+        let settledCell = try #require(collectionView.visibleCells.first { $0.accessibilityLabel == active.title })
+        #expect(abs(remainingCell.bounds.height - originalHeight) < 0.5)
+        #expect(remainingCell.frame.maxY <= settledCell.frame.minY)
+        #expect(settledCell.bounds.height < remainingCell.bounds.height)
+        #expect(collectionView.visibleCells.filter { $0.accessibilityLabel == active.title }.count == 1)
+    }
+
+    @Test(.timeLimit(.minutes(1)), arguments: [false, true])
+    func streamUpdatesAndRollbackWaitForTheRemovalAnimation(rollbackFirst: Bool) async throws {
+        let client = SwipeSettlementClientStub()
+        let first = thread(id: "first")
+        let second = thread(id: "second")
+        let remaining = thread(id: "remaining")
+        var respondToFirst: ((Bool) -> Void)?
+        let initial = threadList(
+            client: client,
+            snapshot: snapshot(threads: [first, second, remaining]),
+            isSettledExpanded: true,
+            settlementResult: nil
+        ) { _, _, completion in respondToFirst = completion }
+        let coordinator = initial.makeCoordinator()
+        let collectionView = testCollectionView()
+        coordinator.configure(collectionView)
+        collectionView.layoutIfNeeded()
+
+        let controller = UIViewController()
+        controller.view = collectionView
+        let window = UIWindow(frame: collectionView.frame)
+        window.rootViewController = controller
+        window.isHidden = false
+        defer {
+            window.isHidden = true
+            coordinator.invalidateTimer()
+            coordinator.cancelPendingSwipeActions()
+        }
+        #expect(collectionView.window === window)
+        let retainedCell = try #require(collectionView.visibleCells.first {
+            $0.accessibilityLabel == remaining.title
+        })
+
+        let completions = AsyncStream<String>.makeStream()
+        var swipeResults: [String: [Bool]] = [:]
+        coordinator.performSwipe(.settle, for: first) { succeeded in
+            swipeResults[first.id, default: []].append(succeeded)
+            completions.continuation.yield(first.id)
+        }
+        var settledFirst = first
+        settledFirst.isSettled = true
+        settledFirst.settledAt = now
+        coordinator.update(
+            parent: threadList(
+                client: client,
+                snapshot: snapshot(threads: [settledFirst, second, remaining]),
+                isSettledExpanded: true
+            ),
+            collectionView: collectionView
+        )
+
+        var latest = remaining
+        for update in 0..<100 {
+            latest.title = "Latest server title \(update)"
+            coordinator.update(
+                parent: threadList(
+                    client: client,
+                    snapshot: snapshot(threads: [settledFirst, second, latest]),
+                    isSettledExpanded: true
+                ),
+                collectionView: collectionView
+            )
+        }
+        if !UIAccessibility.isReduceMotionEnabled, UIView.areAnimationsEnabled {
+            #expect(retainedCell.accessibilityLabel == remaining.title)
+        }
+
+        if rollbackFirst { respondToFirst?(false) }
+        coordinator.performSwipe(.settle, for: second) { succeeded in
+            swipeResults[second.id, default: []].append(succeeded)
+            completions.continuation.yield(second.id)
+        }
+        var settledSecond = second
+        settledSecond.isSettled = true
+        settledSecond.settledAt = now
+        coordinator.update(
+            parent: threadList(
+                client: client,
+                snapshot: snapshot(threads: [rollbackFirst ? first : settledFirst, settledSecond, latest]),
+                isSettledExpanded: true
+            ),
+            collectionView: collectionView
+        )
+
+        var results = completions.stream.makeAsyncIterator()
+        let finished = await [results.next(), results.next()].compactMap { $0 }
+        #expect(Set(finished) == [first.id, second.id])
+        #expect(swipeResults[first.id]?.count == 1)
+        #expect(swipeResults[second.id] == [true])
+        collectionView.layoutIfNeeded()
+        #expect(retainedCell.accessibilityLabel == latest.title)
+        let firstCell = try #require(collectionView.visibleCells.first { $0.accessibilityLabel == first.title })
+        #expect(firstCell.accessibilityValue?.contains("Settled") == !rollbackFirst)
+        let threadCells = collectionView.visibleCells.filter { $0.accessibilityTraits.contains(.button) }
+        let frames = threadCells.map(\.frame).sorted { $0.minY < $1.minY }
+        for (before, after) in zip(frames, frames.dropFirst()) {
+            #expect(before.maxY <= after.minY + 0.5)
+        }
     }
 
     @Test
@@ -808,8 +1069,10 @@ struct HomeThreadSwipeActionTests {
         snapshot: FeatureSnapshot,
         query: String = "",
         selectedThreadID: String? = nil,
-        settlementResult: Bool = true,
-        onSettle: @escaping (FeatureThread, Bool) -> Void = { _, _ in }
+        isSettledExpanded: Bool = false,
+        forceRichRows: Bool = false,
+        settlementResult: Bool? = true,
+        onSettle: @escaping (FeatureThread, Bool, @escaping (Bool) -> Void) -> Void = { _, _, _ in }
     ) -> HomeThreadCollectionView {
         HomeThreadCollectionView(
             presentation: HomePresentation(
@@ -821,12 +1084,12 @@ struct HomeThreadSwipeActionTests {
             projectFaviconClient: client,
             query: query,
             selectedThreadID: selectedThreadID,
-            forceRichRows: false,
+            forceRichRows: forceRichRows,
             hapticsEnabled: false,
             settings: snapshot.settings,
             pullRequestsByThreadID: [:],
             isSnoozedExpanded: false,
-            isSettledExpanded: false,
+            isSettledExpanded: isSettledExpanded,
             isArchiveExpanded: false,
             settledLimit: 12,
             onOpen: { _ in },
@@ -838,8 +1101,8 @@ struct HomeThreadSwipeActionTests {
             onRegenerateTitle: { _ in },
             onArchive: { _, _ in },
             onSettle: { thread, settled, completion in
-                onSettle(thread, settled)
-                completion(settlementResult)
+                onSettle(thread, settled, completion)
+                if let settlementResult { completion(settlementResult) }
             },
             onSnooze: { _, _ in },
             onPin: { _, _ in },


### PR DESCRIPTION
Settling an inbox thread could shrink and repaint the swiped row while it moved into Settled. Its fading text could also overlap the next row as the gap closed.

Use separate cell identities for each section, keep updates stable until removal finishes, and hide only the departing row's text before neighboring rows move. Native swipe controls remain visible. Reused and restored rows regain their content.

Incoming updates are combined during the animation. Duplicate swipes cannot send a second command. Timer updates do not repaint rows during scrolling, and Reduce Motion disables the structural animation.

Verification:

- 31 focused native tests passed, including expanded/collapsed Settled, rich rows, rollback, completion-once handling, and 100 updates during removal.
- The visibility test checks the outgoing content is hidden before the neighboring row starts moving, without assuming a simulator frame rate.
- Recorded repeated full swipes against an isolated 1,013-thread environment. Inspected individual frames for text overlap. Checked Reopen from the expanded Settled section and a full swipe with large accessibility text.

| Before | After |
| --- | --- |
| ![Row removal before](https://files.tslop.org/2026/09/settle-before-226ef9aa.gif) | ![Three full swipes after](https://files.tslop.org/2026/09/settle-after-dea7718c.gif) |

[Before recording](https://files.tslop.org/2026/09/settle-before-native-ab4bab68.mp4) · [After recording](https://files.tslop.org/2026/09/settle-final-e24ad40b.mp4)

Based on the main SwiftUI branch. Server settlement rules and transcript scrolling are unchanged.

Created with GPT-6 Astra (preview) in Codex.
