### PR TITLE
perf(swift-ios): speed up large snapshot timestamp parsing

### DIFF
--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -6246,14 +6246,11 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         parseValidDate(value) ?? .distantPast
     }
 
-    /// Every publish re-maps every thread, and most timestamps are unchanged
-    /// between publishes, so parsed dates are memoized. ISO8601DateFormatter
-    /// costs microseconds per call, which adds up to milliseconds per publish
-    /// across hundreds of threads during streaming.
+    /// Reuse unchanged timestamps across snapshot mappings. Keep the cache bounded
+    /// even when a long session receives many different event times.
     private func parseValidDate(_ value: String) -> Date? {
         if let cached = parsedDates[value] { return cached }
-        guard let parsed = Self.fractionalDateFormatter.date(from: value)
-            ?? Self.dateFormatter.date(from: value) else { return nil }
+        guard let parsed = NativeTimestampParser.parse(value) else { return nil }
         if parsedDates.count >= 4096 { parsedDates.removeAll(keepingCapacity: true) }
         parsedDates[value] = parsed
         return parsed
@@ -6267,7 +6264,6 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return formatter
     }()
-    private static let dateFormatter = ISO8601DateFormatter()
 }
 
 extension FeatureDeviceSession {

--- a/apps/swift-ios/App/NativeTimestampParser.swift
+++ b/apps/swift-ios/App/NativeTimestampParser.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+@MainActor
+enum NativeTimestampParser {
+    private static let fractionalStyle = Date.ISO8601FormatStyle(includingFractionalSeconds: true)
+    private static let wholeSecondStyle = Date.ISO8601FormatStyle()
+    private static let fractionalFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+    private static let wholeSecondFormatter = ISO8601DateFormatter()
+
+    static func parse(_ value: String) -> Date? {
+        if isStandardServerTimestamp(value) {
+            let style = value.utf8.count == 24 ? fractionalStyle : wholeSecondStyle
+            if let parsed = try? style.parse(value) {
+                // Match the existing formatter's millisecond date values.
+                return Date(timeIntervalSince1970: (parsed.timeIntervalSince1970 * 1_000).rounded() / 1_000)
+            }
+        }
+        return fractionalFormatter.date(from: value) ?? wholeSecondFormatter.date(from: value)
+    }
+
+    /// The modern parser accepts invalid clock values and keeps extra fractional
+    /// precision. Use it only for normal UTC server timestamps.
+    private static func isStandardServerTimestamp(_ value: String) -> Bool {
+        value.utf8.withContiguousStorageIfAvailable { bytes in
+            guard bytes.count == 20 || bytes.count == 24 else { return false }
+            for index in bytes.indices {
+                let byte = bytes[index]
+                switch index {
+                case 4, 7:
+                    guard byte == UInt8(ascii: "-") else { return false }
+                case 10:
+                    guard byte == UInt8(ascii: "T") else { return false }
+                case 13, 16:
+                    guard byte == UInt8(ascii: ":") else { return false }
+                case 19:
+                    guard byte == (bytes.count == 20 ? UInt8(ascii: "Z") : UInt8(ascii: ".")) else { return false }
+                case 23:
+                    guard byte == UInt8(ascii: "Z") else { return false }
+                default:
+                    guard (UInt8(ascii: "0")...UInt8(ascii: "9")).contains(byte) else { return false }
+                }
+            }
+            let hour = (bytes[11] - UInt8(ascii: "0")) * 10 + bytes[12] - UInt8(ascii: "0")
+            return hour < 24 && bytes[14] <= UInt8(ascii: "5") && bytes[17] <= UInt8(ascii: "5")
+        } ?? false
+    }
+}

--- a/apps/swift-ios/Tests/FeatureTests/NativeTimestampParserTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeTimestampParserTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import T3Code
+
+@MainActor
+@Suite("Native timestamps")
+struct NativeTimestampParserTests {
+    @Test
+    func standardServerTimestampsKeepExactDateValues() throws {
+        for date in ["1970-01-01", "2000-02-29", "2001-01-01", "2026-09-04", "9999-12-31"] {
+            for fraction in ["", ".000", ".001", ".123", ".333", ".789", ".999"] {
+                let source = "\(date)T12:34:56\(fraction)Z"
+                let expected = try #require(legacyDate(source))
+                #expect(NativeTimestampParser.parse(source) == expected, "\(source)")
+            }
+        }
+    }
+
+    @Test
+    func offsetsAndFractionalPrecisionKeepLegacyBehavior() throws {
+        for source in [
+            "2026-09-04T12:34:56.123+05:30",
+            "2026-09-04T12:34:56-07:00",
+            "2026-09-04T12:34:56+0530",
+            "2026-09-04T12:34:56+05",
+            "2026-09-04T12:34:56.1Z",
+            "2026-09-04T12:34:56.12Z",
+            "2026-09-04T12:34:56.123456Z",
+            "2026-09-04T12:34:56.999999999Z",
+            "2026-09-04T12:34:56.000001Z",
+        ] {
+            let expected = try #require(legacyDate(source))
+            #expect(NativeTimestampParser.parse(source) == expected, "\(source)")
+        }
+    }
+
+    @Test
+    func unusualFormsStillUseLegacyRules() {
+        for source in [
+            "2026-9-4T1:2:3Z",
+            "2026-09-04T12:34:56z",
+            "2026-09-04T12:34:56Z trailing text",
+            "2026-09-04T24:00:00Z",
+            "2026-02-30T12:00:00.123Z",
+            "0000-01-01T00:00:00Z",
+            "+012026-09-04T12:34:56Z",
+            "２０２６-09-04T12:34:56Z",
+        ] {
+            #expect(NativeTimestampParser.parse(source) == legacyDate(source), "\(source)")
+        }
+    }
+
+    @Test
+    func invalidClockValuesAndMalformedTimestampsStayRejected() {
+        for source in [
+            "", " ", "not a date", "2026-09-04", "2026-09-04T12:34:56",
+            "2026-13-01T00:00:00Z", "2026-00-01T00:00:00.000Z",
+            "2026-09-04T25:00:00.000Z", "2026-09-04T12:60:00Z",
+            "2026-09-04T12:99:00.123Z", "2016-12-31T23:59:60Z",
+            "2016-12-31T23:59:60.000Z", "2026-09-04T12:34:99.123Z",
+            "2026-09-04T12:34:56.123X",
+        ] {
+            #expect(legacyDate(source) == nil, "\(source)")
+            #expect(NativeTimestampParser.parse(source) == nil, "\(source)")
+        }
+    }
+
+    private func legacyDate(_ value: String) -> Date? {
+        Self.fractionalFormatter.date(from: value) ?? Self.wholeSecondFormatter.date(from: value)
+    }
+
+    private static let fractionalFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+    private static let wholeSecondFormatter = ISO8601DateFormatter()
+}


### PR DESCRIPTION
Large SwiftUI snapshots can exceed the 4,096-entry timestamp cache. Repeated mappings then parse every timestamp again, adding over 100 ms of main-thread work in the measured case.

Use Swift's ISO parser for canonical UTC server timestamps, with the existing formatter as a fallback for other formats. Keep the same millisecond values, rejected inputs, and bounded cache.

Verification:

- Optimized host benchmark, 8,192 uncached timestamps: about 138 ms before, 5 ms after. These are parser timings, not device frame rates.
- Exact comparison matched 19,151 accepted and rejected timestamp cases.
- An independent review compared another 14,082 cases with zero mismatches.
- 37 focused native tests passed, covering timestamps, multi-environment mapping, and thread recovery.

Based on the main SwiftUI branch. No timestamp display, sorting, or UI behavior changes.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Timestamp parsing affects thread ordering and invalid-date flags across snapshots; behavior is heavily tested for legacy parity, but any mismatch would be user-visible on the main actor.
> 
> **Overview**
> **Faster timestamp parsing** for repeated SwiftUI snapshot mappings by routing `parseValidDate` through a new **`NativeTimestampParser`** instead of per-call `ISO8601DateFormatter` work, while keeping the existing **4,096-entry string cache** and flush behavior.
> 
> `NativeTimestampParser` uses **`Date.ISO8601FormatStyle`** for well-formed UTC server strings (length 20 or 24, validated in UTF-8), **rounds to millisecond** `Date` values to match prior formatter output, and **falls back** to the legacy fractional/whole-second `ISO8601DateFormatter` pair for offsets, odd shapes, and invalid clock values the fast path must not accept.
> 
> Adds **`NativeTimestampParserTests`** asserting parity with the old formatter across normal, edge, and rejected inputs. `NativeFeatureClient` drops the unused whole-second formatter used only for parsing; the fractional formatter remains for encoding elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef28cd76e6a438810510094e629b7a32f0bb1b0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Speed up large snapshot timestamp parsing with `NativeTimestampParser`
> - Adds [NativeTimestampParser](https://github.com/pingdotgg/t3code/pull/9683/files#diff-a2ec1f2e0327e14e4c2fa7eed9092d3658bfa36119d66da9f95b08a6c86d638f), which uses `Date.ISO8601FormatStyle` for standard 20- or 24-byte UTC timestamps and falls back to legacy `ISO8601DateFormatter` instances for all other formats
> - Standard UTC timestamps are validated byte-level via `NativeTimestampParser.isStandardServerTimestamp` and rounded to millisecond precision
> - `NativeFeatureClient.parseValidDate` now delegates to `NativeTimestampParser`; the existing parsed-date cache and nil-for-unparseable behavior are unchanged
> - Removes the class-level whole-second `ISO8601DateFormatter` from `NativeFeatureClient` since parsing is centralized in the new parser
> - Adds [NativeTimestampParserTests](https://github.com/pingdotgg/t3code/pull/9683/files#diff-d9d15910ef24a310af5ab32a826145e38f18a6ec5c51764e577333a860a094af) comparing the new parser against the old formatter sequence across standard, offset, fractional, unusual, and invalid inputs
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef28cd7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->