### PR TITLE
perf(server): stop retaining unused OpenCode tool history

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -338,7 +338,6 @@ interface OpenCodeSessionContext {
   readonly partById: Map<string, Part>;
   readonly emittedTextByPartId: Map<string, string>;
   readonly completedAssistantPartIds: Set<string>;
-  readonly turns: Array<OpenCodeTurnSnapshot>;
   activeTurnId: TurnId | undefined;
   activeAgent: string | undefined;
   activeVariant: string | undefined;
@@ -474,31 +473,6 @@ function mapPermissionDecision(reply: "once" | "always" | "reject"): string {
     default:
       return "decline";
   }
-}
-
-function resolveTurnSnapshot(
-  context: OpenCodeSessionContext,
-  turnId: TurnId,
-): OpenCodeTurnSnapshot {
-  const existing = context.turns.find((turn) => turn.id === turnId);
-  if (existing) {
-    return existing;
-  }
-
-  const created: OpenCodeTurnSnapshot = { id: turnId, items: [] };
-  context.turns.push(created);
-  return created;
-}
-
-function appendTurnItem(
-  context: OpenCodeSessionContext,
-  turnId: TurnId | undefined,
-  item: unknown,
-): void {
-  if (!turnId) {
-    return;
-  }
-  resolveTurnSnapshot(context, turnId).items.push(item);
 }
 
 const ensureSessionContext = Effect.fn("ensureSessionContext")(function* (
@@ -2365,7 +2339,6 @@ export function makeOpenCodeAdapter(
                     : "item.updated",
               payload,
             };
-            appendTurnItem(context, turnId, part);
             yield* emit(runtimeEvent);
           }
           break;
@@ -2853,7 +2826,6 @@ export function makeOpenCodeAdapter(
           emittedTextByPartId: new Map(),
           messageRoleById: new Map(),
           completedAssistantPartIds: new Set(),
-          turns: [],
           activeTurnId: undefined,
           activeAgent: undefined,
           activeVariant: undefined,


### PR DESCRIPTION
OpenCode keeps every version of tool output in a session history array that nothing reads. The audit fixture retained 5,171,200 logical output bytes for a tool whose final output was 102,400 bytes.

Remove that array and its append helpers. Thread reads and rollback still fetch upstream messages. Keep the live part map and event delivery unchanged.

Verified with 116 existing adapter and provider tests, server typecheck, and targeted lint. No browser, device, or live state was used.

Part of https://github.com/pingdotgg/t3code/issues/9661. Other session-map retention remains separate work.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only memory optimization with no callers of the removed snapshot path; thread read/rollback still use upstream APIs.
> 
> **Overview**
> Removes the in-memory **`turns`** array on OpenCode session context and the **`resolveTurnSnapshot` / `appendTurnItem`** helpers that pushed every tool **`Part`** update into it during **`message.part.updated`** handling.
> 
> That history was never read in the adapter—only grown—so long tool streams could retain huge redundant output while live behavior stays on **`partById`**, text delta maps, and runtime event emission.
> 
> **`readThread`** and **`rollbackThread`** are unchanged: they still load conversation shape from **`session.messages`** / **`session.revert`**, not from session context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecc566951fe8f6b9c2d2489cba7477ae8f4f7514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused OpenCode turn-snapshot retention from `OpenCodeAdapter`
> - Removes the turn-snapshot collection from `OpenCodeSessionContext` and the `resolveTurnSnapshot` and `appendTurnItem` helpers, as this history was retained but never read.
> - The `makeOpenCodeAdapter` session-context initialization no longer allocates snapshot storage, and the event-part handler stops recording processed parts to per-turn snapshots before emitting the runtime event.
> - Behavioral Change: OpenCode session contexts no longer hold in-memory turn snapshots; runtime event emission is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ecc5669.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->