### PR TITLE
fix(web): disconnect a remote environment without removing it

### DIFF
--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1395,14 +1395,18 @@ function NetworkAccessDescription({
 type SavedBackendListRowProps = {
   environment: EnvironmentPresentation;
   removingEnvironmentId: EnvironmentId | null;
+  disconnectingEnvironmentId: EnvironmentId | null;
   onConnect: (environmentId: EnvironmentId) => void;
+  onDisconnect: (environmentId: EnvironmentId) => void;
   onRemove: (environmentId: EnvironmentId) => void;
 };
 
 function SavedBackendListRow({
   environment,
   removingEnvironmentId,
+  disconnectingEnvironmentId,
   onConnect,
+  onDisconnect,
   onRemove,
 }: SavedBackendListRowProps) {
   const environmentId = environment.environmentId;
@@ -1565,31 +1569,32 @@ function SavedBackendListRow({
             </Tooltip>
           ) : (
             <>
-              {!isConnected ? (
-                <Button
-                  size="xs"
-                  variant="outline"
-                  disabled={removingEnvironmentId === environmentId}
-                  onClick={() => void onRemove(environmentId)}
-                >
-                  {removingEnvironmentId === environmentId ? "Removing…" : "Remove"}
-                </Button>
-              ) : null}
               <Button
                 size="xs"
                 variant="outline"
-                disabled={isConnecting || removingEnvironmentId === environmentId}
+                disabled={removingEnvironmentId === environmentId}
+                onClick={() => void onRemove(environmentId)}
+              >
+                {removingEnvironmentId === environmentId ? "Removing…" : "Remove"}
+              </Button>
+              <Button
+                size="xs"
+                variant="outline"
+                disabled={
+                  removingEnvironmentId === environmentId ||
+                  disconnectingEnvironmentId === environmentId
+                }
                 onClick={() =>
-                  void (isConnected ? onRemove(environmentId) : onConnect(environmentId))
+                  void (isConnected || isConnecting
+                    ? onDisconnect(environmentId)
+                    : onConnect(environmentId))
                 }
               >
-                {isConnected
-                  ? removingEnvironmentId === environmentId
+                {isConnected || isConnecting
+                  ? disconnectingEnvironmentId === environmentId
                     ? "Disconnecting…"
                     : "Disconnect"
-                  : isConnecting
-                    ? "Connecting…"
-                    : "Connect"}
+                  : "Connect"}
               </Button>
             </>
           )}
@@ -1775,7 +1780,10 @@ export function ConnectionsSettings() {
     reportFailure: false,
   });
   const removeEnvironment = useAtomCommand(environmentCatalog.remove, { reportFailure: false });
-  const retryEnvironment = useAtomCommand(environmentCatalog.retryNow, { reportFailure: false });
+  const connectEnvironment = useAtomCommand(environmentCatalog.connect, { reportFailure: false });
+  const disconnectEnvironment = useAtomCommand(environmentCatalog.disconnect, {
+    reportFailure: false,
+  });
   const primaryEnvironmentId = primaryEnvironment?.environmentId ?? null;
   const primarySessionState = usePrimarySessionState();
   const currentSessionScopes = desktopBridge
@@ -1841,6 +1849,8 @@ export function ConnectionsSettings() {
   const [savedBackendError, setSavedBackendError] = useState<string | null>(null);
   const [isAddingSavedBackend, setIsAddingSavedBackend] = useState(false);
   const [removingSavedEnvironmentId, setRemovingSavedEnvironmentId] =
+    useState<EnvironmentId | null>(null);
+  const [disconnectingSavedEnvironmentId, setDisconnectingSavedEnvironmentId] =
     useState<EnvironmentId | null>(null);
   const [isUpdatingDesktopServerExposure, setIsUpdatingDesktopServerExposure] = useState(false);
   const [isDesktopServerExposureDialogOpen, setIsDesktopServerExposureDialogOpen] = useState(false);
@@ -2364,7 +2374,7 @@ export function ConnectionsSettings() {
   const handleConnectSavedBackend = useCallback(
     async (environmentId: EnvironmentId) => {
       setSavedBackendError(null);
-      const result = await retryEnvironment(environmentId);
+      const result = await connectEnvironment(environmentId);
       if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
         const error = squashAtomCommandFailure(result);
         const message = error instanceof Error ? error.message : "Failed to connect backend.";
@@ -2378,7 +2388,29 @@ export function ConnectionsSettings() {
         );
       }
     },
-    [retryEnvironment],
+    [connectEnvironment],
+  );
+
+  const handleDisconnectSavedBackend = useCallback(
+    async (environmentId: EnvironmentId) => {
+      setDisconnectingSavedEnvironmentId(environmentId);
+      setSavedBackendError(null);
+      const result = await disconnectEnvironment(environmentId);
+      setDisconnectingSavedEnvironmentId(null);
+      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+        const error = squashAtomCommandFailure(result);
+        const message = error instanceof Error ? error.message : "Failed to disconnect backend.";
+        setSavedBackendError(message);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not disconnect backend",
+            description: message,
+          }),
+        );
+      }
+    },
+    [disconnectEnvironment],
   );
 
   const handleRemoveSavedBackend = useCallback(
@@ -3580,7 +3612,9 @@ export function ConnectionsSettings() {
             key={environment.environmentId}
             environment={environment}
             removingEnvironmentId={removingSavedEnvironmentId}
+            disconnectingEnvironmentId={disconnectingSavedEnvironmentId}
             onConnect={handleConnectSavedBackend}
+            onDisconnect={handleDisconnectSavedBackend}
             onRemove={handleRemoveSavedBackend}
           />
         ))}

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -780,6 +780,37 @@ describe("EnvironmentRegistry", () => {
     }),
   );
 
+  it.effect("disconnect tears down the managed SSH tunnel but keeps the environment", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness([SSH_CONNECTION], [SSH_PROFILE]);
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* registry.start;
+        yield* awaitConnectionState(
+          registry,
+          SSH_CONNECTION.environmentId,
+          (state) => state.phase === "connected",
+        );
+
+        yield* registry.disconnect(SSH_CONNECTION.environmentId);
+        yield* awaitConnectionState(
+          registry,
+          SSH_CONNECTION.environmentId,
+          (state) => state.phase === "available",
+        );
+
+        expect(yield* Ref.get(harness.disconnectedSshTargets)).toEqual([SSH_TARGET]);
+        expect(
+          (yield* SubscriptionRef.get(registry.entries)).has(SSH_CONNECTION.environmentId),
+        ).toBe(true);
+        expect((yield* Ref.get(harness.storedProfiles)).has(SSH_CONNECTION.connectionId)).toBe(
+          true,
+        );
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
   it.effect("ignores connect and disconnect for environments that are no longer registered", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness([]);

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -720,6 +720,78 @@ describe("EnvironmentRegistry", () => {
     }),
   );
 
+  it.effect("disconnect stops reconnecting without dropping the registration", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness([TARGET]);
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* registry.start;
+        yield* awaitConnectionState(
+          registry,
+          TARGET.environmentId,
+          (state) => state.phase === "connected",
+        );
+
+        yield* registry.disconnect(TARGET.environmentId);
+        const disconnected = yield* awaitConnectionState(
+          registry,
+          TARGET.environmentId,
+          (state) => state.phase === "available",
+        );
+
+        expect(disconnected.desired).toBe(false);
+        expect(yield* Ref.get(harness.releasedSessions)).toBe(1);
+        expect((yield* SubscriptionRef.get(registry.entries)).has(TARGET.environmentId)).toBe(true);
+        expect((yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId)).toBe(true);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("connect resumes a disconnected environment", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness([TARGET]);
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* registry.start;
+        yield* awaitConnectionState(
+          registry,
+          TARGET.environmentId,
+          (state) => state.phase === "connected",
+        );
+
+        yield* registry.disconnect(TARGET.environmentId);
+        yield* awaitConnectionState(
+          registry,
+          TARGET.environmentId,
+          (state) => state.phase === "available",
+        );
+
+        yield* registry.connect(TARGET.environmentId);
+        yield* awaitConnectionState(
+          registry,
+          TARGET.environmentId,
+          (state) => state.phase === "connected",
+        );
+
+        expect(yield* Ref.get(harness.sessions)).toHaveLength(2);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("ignores connect and disconnect for environments that are no longer registered", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness([]);
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* registry.connect(EnvironmentId.make("removed-environment"));
+        yield* registry.disconnect(EnvironmentId.make("removed-environment"));
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
   it.effect("removes all relay-owned data without touching non-cloud connections", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness(

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -647,12 +647,39 @@ export const make = Effect.gen(function* () {
       Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
       Effect.withSpan("EnvironmentRegistry.connect"),
     );
+  // A managed SSH environment owns a tunnel that outlives the RPC session, so
+  // parking the supervisor is not enough to stop it. `resolver.prepare` runs on
+  // every attempt and brings the tunnel back on the next connect.
+  const disconnectManagedSsh = Effect.fn("EnvironmentRegistry.disconnectManagedSsh")(function* (
+    environmentId: EnvironmentId,
+  ) {
+    const target = (yield* getEntry(environmentId)).target;
+    if (target._tag !== "SshConnectionTarget") {
+      return;
+    }
+    const profile = yield* profiles.get(target.connectionId);
+    if (Option.isNone(profile) || !isSshConnectionProfile(profile.value)) {
+      return;
+    }
+    yield* ssh.disconnect(profile.value.target);
+  });
+
   const disconnect = (environmentId: EnvironmentId) =>
     withLeaseLock(
       environmentId,
-      acquireSupervisorLocked(environmentId).pipe(
-        Effect.flatMap((supervisor) => supervisor.disconnect),
-      ),
+      Effect.gen(function* () {
+        const supervisor = yield* acquireSupervisorLocked(environmentId);
+        yield* supervisor.disconnect;
+        yield* disconnectManagedSsh(environmentId).pipe(
+          Effect.tapError((error) =>
+            Effect.logWarning("Could not disconnect the managed SSH environment.", {
+              environmentId,
+              error,
+            }),
+          ),
+          Effect.ignore,
+        );
+      }),
     ).pipe(
       Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
       Effect.withSpan("EnvironmentRegistry.disconnect"),

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -273,23 +273,26 @@ export const make = Effect.gen(function* () {
       ),
   );
 
+  // Closes and replaces the running supervisor, so callers must already hold
+  // the environment's lease.
+  const acquireSupervisorLocked = Effect.fn("EnvironmentRegistry.acquireSupervisorLocked")(
+    function* (environmentId: EnvironmentId) {
+      const entry = yield* getEntry(environmentId);
+      const existing = (yield* SubscriptionRef.get(serviceScopes)).get(environmentId);
+      if (existing !== undefined) {
+        if (Equal.equals(existing.entry, entry)) {
+          return existing.supervisor;
+        }
+        yield* closeServiceScope(environmentId);
+      }
+      return yield* createServiceScope(entry);
+    },
+  );
+
   const acquireSupervisor = Effect.fn("EnvironmentRegistry.acquireSupervisor")(function* (
     environmentId: EnvironmentId,
   ) {
-    return yield* withLeaseLock(
-      environmentId,
-      Effect.gen(function* () {
-        const entry = yield* getEntry(environmentId);
-        const existing = (yield* SubscriptionRef.get(serviceScopes)).get(environmentId);
-        if (existing !== undefined) {
-          if (Equal.equals(existing.entry, entry)) {
-            return existing.supervisor;
-          }
-          yield* closeServiceScope(environmentId);
-        }
-        return yield* createServiceScope(entry);
-      }),
-    );
+    return yield* withLeaseLock(environmentId, acquireSupervisorLocked(environmentId));
   });
 
   const run: EnvironmentRegistry["Service"]["run"] = Effect.fn("EnvironmentRegistry.run")(
@@ -631,15 +634,26 @@ export const make = Effect.gen(function* () {
       Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
       Effect.withSpan("EnvironmentRegistry.retryNow"),
     );
+  // Acquisition and the intent change share one lease: releasing in between
+  // would let a concurrent register or platform reconcile swap in a fresh,
+  // connected supervisor while we flip the intent on the discarded one.
   const connect = (environmentId: EnvironmentId) =>
-    acquireSupervisor(environmentId).pipe(
-      Effect.flatMap((supervisor) => supervisor.connect),
+    withLeaseLock(
+      environmentId,
+      acquireSupervisorLocked(environmentId).pipe(
+        Effect.flatMap((supervisor) => supervisor.connect),
+      ),
+    ).pipe(
       Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
       Effect.withSpan("EnvironmentRegistry.connect"),
     );
   const disconnect = (environmentId: EnvironmentId) =>
-    acquireSupervisor(environmentId).pipe(
-      Effect.flatMap((supervisor) => supervisor.disconnect),
+    withLeaseLock(
+      environmentId,
+      acquireSupervisorLocked(environmentId).pipe(
+        Effect.flatMap((supervisor) => supervisor.disconnect),
+      ),
+    ).pipe(
       Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
       Effect.withSpan("EnvironmentRegistry.disconnect"),
     );

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -90,6 +90,8 @@ export class EnvironmentRegistry extends Context.Service<
       | PlatformEnvironmentRemovalError
     >;
     readonly retryNow: (environmentId: EnvironmentId) => Effect.Effect<void>;
+    readonly connect: (environmentId: EnvironmentId) => Effect.Effect<void>;
+    readonly disconnect: (environmentId: EnvironmentId) => Effect.Effect<void>;
     readonly state: (
       environmentId: EnvironmentId,
     ) => Effect.Effect<SupervisorConnectionState, EnvironmentNotRegisteredError>;
@@ -629,6 +631,18 @@ export const make = Effect.gen(function* () {
       Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
       Effect.withSpan("EnvironmentRegistry.retryNow"),
     );
+  const connect = (environmentId: EnvironmentId) =>
+    acquireSupervisor(environmentId).pipe(
+      Effect.flatMap((supervisor) => supervisor.connect),
+      Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+      Effect.withSpan("EnvironmentRegistry.connect"),
+    );
+  const disconnect = (environmentId: EnvironmentId) =>
+    acquireSupervisor(environmentId).pipe(
+      Effect.flatMap((supervisor) => supervisor.disconnect),
+      Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+      Effect.withSpan("EnvironmentRegistry.disconnect"),
+    );
   const state = Effect.fn("EnvironmentRegistry.state")(function* (environmentId: EnvironmentId) {
     const supervisor = yield* acquireSupervisor(environmentId);
     return yield* SubscriptionRef.get(supervisor.state);
@@ -668,6 +682,8 @@ export const make = Effect.gen(function* () {
     remove,
     removeRelayEnvironments,
     retryNow,
+    connect,
+    disconnect,
     state,
     stateChanges,
     run,

--- a/packages/client-runtime/src/state/connections.ts
+++ b/packages/client-runtime/src/state/connections.ts
@@ -115,6 +115,24 @@ export function createEnvironmentCatalogAtoms<R, E>(
         Effect.flatMap((registry) => registry.retryNow(environmentId)),
       ),
   });
+  const connect = createRuntimeCommand(runtime, {
+    label: "environment-catalog:connect",
+    scheduler: commandScheduler,
+    concurrency: serial,
+    execute: (environmentId: EnvironmentIdType) =>
+      EnvironmentRegistry.EnvironmentRegistry.pipe(
+        Effect.flatMap((registry) => registry.connect(environmentId)),
+      ),
+  });
+  const disconnect = createRuntimeCommand(runtime, {
+    label: "environment-catalog:disconnect",
+    scheduler: commandScheduler,
+    concurrency: serial,
+    execute: (environmentId: EnvironmentIdType) =>
+      EnvironmentRegistry.EnvironmentRegistry.pipe(
+        Effect.flatMap((registry) => registry.disconnect(environmentId)),
+      ),
+  });
 
   return {
     catalogAtom,
@@ -126,5 +144,7 @@ export function createEnvironmentCatalogAtoms<R, E>(
     remove,
     removeRelayEnvironments,
     retryNow,
+    connect,
+    disconnect,
   };
 }


### PR DESCRIPTION
## What Changed

`packages/client-runtime/src/connection/registry.ts` and `src/state/connections.ts` now expose `connect` and `disconnect` commands (the supervisor already implemented both, they were just never surfaced). `apps/web/src/components/settings/ConnectionsSettings.tsx` uses them: `SavedBackendListRow` now always renders its own "Remove" button plus a real Connect/Disconnect toggle driven by connection phase. That toggle is no longer disabled while connecting/reconnecting, and "Disconnect" now calls the disconnect command instead of the remove handler. The container wires the two new atom commands and tracks in-flight disconnect state separately from in-flight remove state. Added four tests in `packages/client-runtime/src/connection/registry.test.ts` covering disconnect-then-connect, no-op on an unregistered id, and SSH tunnel teardown on disconnect.

4 files changed, +248/-34.

## Why

Fixes #9685. A saved remote environment that goes unreachable sits in "Failed to connect. Reconnecting..." forever, and the only enabled action is Remove, which unregisters the environment and clears its cached data. There was no way to pause the retry loop and keep the environment. Separately, a still-connected row's only other button was labelled "Disconnect" but called the remove handler, so it silently deleted the environment instead of disconnecting it.

The capability already existed in `packages/client-runtime/src/connection/supervisor.ts` (`connect`/`disconnect`, the latter setting `desired: false` so the run loop clears the lease, resets the retry ladder, and parks in `available` instead of retrying). It just was not exposed through the registry or the state layer. This PR wires the existing capability through rather than adding new machinery.

One behavior note: `handleConnectSavedBackend` now calls `connect` (sets `desired: true` and signals an immediate attempt) instead of `retryNow`. `retryNow` only resets the backoff ladder and does not set `desired`, so after a real disconnect a retry signal alone would leave the supervisor parked in `available` instead of reconnecting.

**Surface check:** apps/web is fixed directly; apps/desktop wraps apps/web and picks up the same fix. apps/mobile (`SettingsEnvironmentsRouteScreen.tsx` / `ConnectionEnvironmentRow`) has no connect/disconnect toggle on this row, only Remove, so it does not carry this bug. The shared `connect`/`disconnect` commands are now available in `packages/client-runtime` if mobile adds this control later, but adding a new mobile affordance is out of scope for this PR. No contract/schema or server changes.

## UI Changes

Not motion or timing related, no video included.

Before, stuck reconnecting (Remove enabled, other button disabled reading "Connecting…"):

![Before, stuck reconnecting](https://raw.githubusercontent.com/Skilux/t3code-1/pr-assets-connections-disconnect/before-reconnecting.png)

Before, connected row (single button labelled "Disconnect" that actually removes):

![Before, connected row](https://raw.githubusercontent.com/Skilux/t3code-1/pr-assets-connections-disconnect/before-connected.png)

After, stuck reconnecting (Remove plus an enabled "Disconnect"):

![After, stuck reconnecting](https://raw.githubusercontent.com/Skilux/t3code-1/pr-assets-connections-disconnect/after-reconnecting.png)

After, disconnected and retained (row moves to "Available" with "Connect", still listed):

![After, disconnected and retained](https://raw.githubusercontent.com/Skilux/t3code-1/pr-assets-connections-disconnect/after-disconnected.png)

After, reconnected via Connect:

![After, reconnected](https://raw.githubusercontent.com/Skilux/t3code-1/pr-assets-connections-disconnect/after-reconnected.png)

## Verification

- `vp test run packages/client-runtime/src/connection/registry.test.ts`: 23 passed (19 pre-existing + 4 new). New tests: (a) `disconnect` on a connected environment moves it to phase `available` with `desired: false`, releases the session, keeps the registry entry and persisted target; (b) `connect` after a disconnect re-establishes a second session and returns to `connected`; (c) `connect`/`disconnect` on an unregistered environment id are no-ops; (d) disconnecting an SSH environment records the gateway teardown while the registry entry and stored profile survive (verified failing without the fix).
- Targeted `tsgo --noEmit`: `apps/web` clean; `packages/client-runtime` shows only two pre-existing suggestions in files this PR does not touch (`src/relay/discovery.ts`, `src/rpc/session.test.ts`).
- Targeted `vp lint` on the four touched files: one `react(preserve-manual-memoization)` warning at `ConnectionsSettings.tsx:2103`, confirmed pre-existing on main and unrelated to this change (`desktopServerExposureState`).
- Manual end-to-end check in a real web client (`node scripts/dev-runner.ts dev` against an isolated T3 home, paired against a second `node apps/server/src/bin.ts serve` instance as the remote environment): killed the remote backend, confirmed pre-fix behavior (row stuck reconnecting, Remove enabled, other button disabled/"Connecting…"), then with the fix (same row, same session, Vite HMR swap) confirmed Remove + enabled Disconnect, clicking Disconnect moved the row to Available with the error cleared and retries stopped while the environment stayed listed, and Connect after restarting the backend returned it to Connected.
- Environment for the manual check: macOS (Darwin 27.0.0, arm64), Node v26.8.1, pnpm 11.10.0, Chrome, upstream main at 7cf5b284e.


## Review follow-ups

Two AI review findings, both confirmed against the source and fixed:

- Macroscope, `registry.ts` lease race (9a847ea): `acquireSupervisor` released the per-environment lease before returning, so `connect`/`disconnect` flipped the intent outside it and a concurrent `register` or platform reconcile could swap in a fresh, connected supervisor in the gap. Acquisition and the intent change now share one lease via `acquireSupervisorLocked`.
- Cursor Bugbot, SSH tunnel left open (8cc9f68): a real behavior gap, since pre-PR the connected-row control removed the environment and `remove` tears the tunnel down. `disconnect` now calls `ssh.disconnect` for SSH targets, best effort. `resolver.prepare` runs `ssh.prepare` on every attempt, so the next connect re-establishes it.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (not applicable, not motion/timing related)

Claude Opus 5 (1M context) running in T3 Code via the Claude Code harness did this work.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `connect` and `disconnect` to `EnvironmentRegistry` and settings UI
> - Adds `connect` and `disconnect` operations to [registry.ts](https://github.com/pingdotgg/t3code/pull/9687/files#diff-ee90d1d763db46ddbfa1b641685acf6071253fc055b4abca6edaee99a0c536b8) and exposes them as catalog commands in [connections.ts](https://github.com/pingdotgg/t3code/pull/9687/files#diff-e45139eb531df2bfc0f7493d1dd5deb6e8c739bc8b158dfbe2a04d1586bbd4e2).
> - The `disconnect` operation releases the supervisor session and tears down managed SSH tunnels, ignoring cleanup errors.
> - The settings UI in [ConnectionsSettings.tsx](https://github.com/pingdotgg/t3code/pull/9687/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9) separates `Remove` and `Disconnect` actions, allowing connected environments to be disconnected without losing their registration.
> - Behavioral Change: The saved-backend `Connect` action now calls the explicit catalog `connect` command instead of the `retry-now` command.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8cc9f68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->