### PR TITLE
perf(mobile): reuse chat feed rows during streaming

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -415,6 +415,173 @@ function makeThread(
 }
 
 describe("buildThreadFeed", () => {
+  it("reuses unchanged feed and presentation rows during an assistant text update", () => {
+    const completedTurnId = TurnId.make("completed-turn");
+    const activeTurnId = TurnId.make("active-turn");
+    const thread = makeThread({
+      id: ThreadId.make("feed-reuse"),
+      projectId: ProjectId.make("project-1"),
+      title: "Feed reuse",
+      messages: [
+        {
+          id: MessageId.make("completed-message"),
+          role: "assistant",
+          text: "Completed response",
+          turnId: completedTurnId,
+          streaming: false,
+          createdAt: "2026-04-01T00:00:01.000Z",
+          updatedAt: "2026-04-01T00:00:01.000Z",
+        },
+        {
+          id: MessageId.make("streaming-message"),
+          role: "assistant",
+          text: "Current response",
+          turnId: activeTurnId,
+          streaming: true,
+          createdAt: "2026-04-01T00:00:04.000Z",
+          updatedAt: "2026-04-01T00:00:04.000Z",
+        },
+      ],
+      activities: [
+        makeActivity({
+          id: EventId.make("completed-tool"),
+          kind: "tool.completed",
+          summary: "Read files",
+          createdAt: "2026-04-01T00:00:02.000Z",
+          turnId: completedTurnId,
+          payload: { itemType: "file_read", status: "completed" },
+        }),
+        makeActivity({
+          id: EventId.make("active-tool"),
+          kind: "tool.updated",
+          summary: "Run checks",
+          createdAt: "2026-04-01T00:00:03.000Z",
+          turnId: activeTurnId,
+          payload: { itemType: "command_execution", command: "vp test", status: "inProgress" },
+        }),
+      ],
+    });
+    const latestTurn = {
+      turnId: activeTurnId,
+      state: "running" as const,
+      startedAt: "2026-04-01T00:00:03.000Z",
+      completedAt: null,
+    };
+    const expandedTurns = new Set([completedTurnId]);
+    const expandedGroups = new Set(["work-group:completed-tool", "work-group:active-tool"]);
+    const previousFeed = buildThreadFeed(thread);
+    const previousRows = deriveThreadFeedPresentation(
+      previousFeed,
+      latestTurn,
+      expandedTurns,
+      expandedGroups,
+      latestTurn.startedAt,
+    );
+    const updatedMessage = {
+      ...thread.messages[1]!,
+      text: "Current response with more text",
+      updatedAt: "2026-04-01T00:00:05.000Z",
+    };
+    const nextFeed = buildThreadFeed({
+      ...thread,
+      messages: [thread.messages[0]!, updatedMessage],
+    });
+    const nextRows = deriveThreadFeedPresentation(
+      nextFeed,
+      latestTurn,
+      expandedTurns,
+      expandedGroups,
+      latestTurn.startedAt,
+    );
+
+    expect(nextFeed).toHaveLength(previousFeed.length);
+    expect(nextRows).toHaveLength(previousRows.length);
+    for (const [before, after] of [
+      [previousFeed, nextFeed],
+      [previousRows, nextRows],
+    ] as const) {
+      for (const [index, row] of after.entries()) {
+        if (row.id === updatedMessage.id) {
+          expect(row).not.toBe(before[index]);
+          expect(row).toMatchObject({ message: updatedMessage });
+        } else {
+          expect(row).toBe(before[index]);
+        }
+      }
+    }
+    expect(nextRows.some((row) => row.type === "turn-fold")).toBe(true);
+    expect(nextRows.some((row) => row.type === "activity-group")).toBe(true);
+  });
+
+  it("regroups cached activities for message changes and pagination", () => {
+    const messages = [2, 4].map((second) => ({
+      id: MessageId.make(`message-${second}`),
+      role: "assistant" as const,
+      text: second === 2 ? "" : "Response",
+      streaming: false,
+      turnId: null,
+      createdAt: `2026-04-01T00:00:0${second}.000Z`,
+      updatedAt: `2026-04-01T00:00:0${second}.000Z`,
+    }));
+    const thread = makeThread({
+      id: ThreadId.make("feed-regroup"),
+      projectId: ProjectId.make("project-1"),
+      title: "Feed grouping",
+      messages,
+      activities: [1, 3, 5].map((second) =>
+        makeActivity({
+          id: EventId.make(`work-${second}`),
+          kind: "runtime.warning",
+          summary: `Notice ${second}`,
+          createdAt: `2026-04-01T00:00:0${second}.000Z`,
+        }),
+      ),
+    });
+    const initial = buildThreadFeed(thread);
+    expect(initial.map((row) => row.id)).toEqual(["work-1", "message-4", "work-5"]);
+    const split = buildThreadFeed({
+      ...thread,
+      messages: [{ ...messages[0]!, text: "Now visible" }, messages[1]!],
+    });
+    expect(split.map((row) => row.id)).toEqual([
+      "work-1",
+      "message-2",
+      "work-3",
+      "message-4",
+      "work-5",
+    ]);
+    expect(split[0]).not.toBe(initial[0]);
+    expect(split.at(-1)).toBe(initial.at(-1));
+    expect(initial[0]).toMatchObject({ activities: [{ id: "work-1" }, { id: "work-3" }] });
+
+    const reordered = buildThreadFeed({
+      ...thread,
+      messages: [messages[0]!, { ...messages[1]!, createdAt: "2026-04-01T00:00:06.000Z" }],
+    });
+    expect(reordered.map((row) => row.id)).toEqual(["work-1", "message-4"]);
+    expect(reordered[0]).toMatchObject({
+      activities: [{ id: "work-1" }, { id: "work-3" }, { id: "work-5" }],
+    });
+    const olderMessage = {
+      ...messages[1]!,
+      id: MessageId.make("older-message"),
+      createdAt: "2026-04-01T00:00:00.000Z",
+    };
+    const page = buildThreadFeed(thread, {
+      loadedMessages: [messages[1]!],
+      localMessages: [olderMessage],
+    });
+    expect(page.map((row) => row.id)).toEqual(["older-message", "message-4", "work-5"]);
+    const prepended = buildThreadFeed(thread, { loadedMessages: [olderMessage, ...messages] });
+    expect(prepended.map((row) => row.id)).toEqual([
+      "older-message",
+      "work-1",
+      "message-4",
+      "work-5",
+    ]);
+    expect(prepended.at(-1)).toBe(page.at(-1));
+  });
+
   it("keeps context compaction as a standalone timeline row", () => {
     const thread = makeThread({
       id: ThreadId.make("thread-context-compaction"),
@@ -696,7 +863,8 @@ describe("buildThreadFeed", () => {
     };
 
     for (const currentTurn of [null, latestTurn]) {
-      const feed = buildThreadFeed({ ...thread, latestTurn: currentTurn });
+      const currentThread = { ...thread, latestTurn: currentTurn };
+      const feed = buildThreadFeed(currentThread);
       expect(feed).toMatchObject([
         {
           type: "activity-group",
@@ -1618,6 +1786,30 @@ describe("buildThreadFeed", () => {
       "work-toggle:work-group:tool-completed",
       "assistant-final",
     ]);
+
+    const interrupted = deriveThreadFeedPresentation(
+      feed,
+      { ...thread.latestTurn!, state: "interrupted", completedAt: "2026-04-01T00:00:20.000Z" },
+      new Set(),
+    );
+    expect(interrupted[1]).toMatchObject({
+      type: "turn-fold",
+      label: "You stopped after 19s",
+      expanded: false,
+    });
+    const retimed = deriveThreadFeedPresentation(
+      buildThreadFeed({
+        ...thread,
+        messages: [
+          thread.messages[0]!,
+          { ...thread.messages[1]!, updatedAt: "2026-04-01T00:00:25.000Z" },
+        ],
+      }),
+      null,
+      new Set(),
+    );
+    expect(retimed[1]).toMatchObject({ type: "turn-fold", label: "Worked for 23s" });
+    expect(collapsed[1]).toMatchObject({ type: "turn-fold", label: "Worked for 17s" });
   });
 
   it("folds assistant messages between the first and terminal messages", () => {
@@ -1916,6 +2108,15 @@ describe("buildThreadFeed", () => {
         { id: "activity-3", groupedToolDetail: true, live: false },
       ],
     });
+    const unchanged = deriveThreadFeedPresentation(
+      feed,
+      null,
+      new Set(),
+      new Set(["work-group:activity-1", "unrelated-group"]),
+    );
+    expect(unchanged[0]).toBe(expanded[0]);
+    expect(unchanged[1]).toBe(expanded[1]);
+    expect(deriveThreadFeedPresentation(feed, null, new Set())).toEqual(collapsed);
   });
 
   it.each(
@@ -2271,6 +2472,43 @@ describe("buildThreadFeed", () => {
         { id: "call-a-1", lifecycleStatus: "completed", groupedToolDetail: true, live: false },
         { id: "call-b-2", lifecycleStatus: "completed", groupedToolDetail: true, live: false },
       ],
+    });
+
+    const correctedFeed = buildThreadFeed({
+      ...thread,
+      activities: thread.activities.map((activity) =>
+        activity.id === "call-a-3"
+          ? {
+              ...activity,
+              tone: "error",
+              payload: {
+                toolCallId: "call-a",
+                itemType: "command_execution",
+                status: "failed",
+                detail: "Corrected failure output",
+              },
+            }
+          : activity,
+      ),
+    });
+    const correctedGroup = correctedFeed.find((entry) => entry.type === "activity-group");
+    expect(correctedGroup).toMatchObject({
+      activities: [
+        { id: "call-a-1", lifecycleStatus: "failed", detail: "Corrected failure output" },
+        { id: "call-b-2", lifecycleStatus: "completed", detail: "second output" },
+      ],
+    });
+    expect(correctedGroup?.activities[0]?.getCopyText()).toContain("Corrected failure output");
+    expect(activityGroup?.activities[0]?.getCopyText()).toContain("first output");
+    const correctedRows = deriveThreadFeedPresentation(
+      correctedFeed,
+      null,
+      new Set([turnId]),
+      new Set([groupId]),
+    );
+    expect(correctedRows.find((entry) => entry.type === "activity-group")).toMatchObject({
+      id: "call-a-1",
+      activities: [{ status: "failure", workEntry: { tone: "error" } }],
     });
   });
 });

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -176,6 +176,32 @@ export type ThreadFeedLatestTurn = Pick<
   "turnId" | "state" | "startedAt" | "completedAt"
 >;
 
+type ThreadFeedActivityGroup = Extract<ThreadFeedEntry, { readonly type: "activity-group" }>;
+
+// These keys are immutable inputs. Weak caches release old histories with their source data.
+const activityEntriesCache = new WeakMap<
+  ReadonlyArray<OrchestrationThreadActivity>,
+  ReadonlyArray<Extract<RawThreadFeedEntry, { readonly type: "activity" }>>
+>();
+const messageEntriesCache = new WeakMap<
+  OrchestrationThread["messages"][number],
+  Extract<RawThreadFeedEntry, { readonly type: "message" }>
+>();
+const activityGroupsCache = new WeakMap<ThreadFeedActivity, ThreadFeedActivityGroup>();
+const presentedActivityGroupsCache = new WeakMap<
+  ThreadFeedActivityGroup,
+  {
+    readonly unsettledTurnId: TurnId | null;
+    readonly isWorking: boolean;
+    readonly activeTail: boolean;
+    readonly rows: ReadonlyArray<ThreadFeedEntry>;
+  }
+>();
+const turnFoldRowsCache = new WeakMap<
+  ThreadFeedEntry,
+  Extract<ThreadFeedEntry, { readonly type: "turn-fold" }>
+>();
+
 export function isContextCompactionActivityGroup(
   entry: Extract<ThreadFeedEntry, { readonly type: "activity-group" }>,
 ): boolean {
@@ -1266,11 +1292,31 @@ function isEmptyMessage(entry: RawThreadFeedEntry): boolean {
 
 function groupAdjacentActivities(entries: ReadonlyArray<RawThreadFeedEntry>): ThreadFeedEntry[] {
   const grouped: ThreadFeedEntry[] = [];
-  // Mutable backing array for the trailing group so appending an activity is
-  // O(1) instead of re-copying the group (which made this loop quadratic on
-  // long tool runs). The array is only mutated while it is the trailing group.
-  let openGroupActivities: ThreadFeedActivity[] | null = null;
-  let openGroupTurnId: TurnId | null = null;
+  let firstActivityEntry: Extract<RawThreadFeedEntry, { readonly type: "activity" }> | null = null;
+  let openGroupActivities: ThreadFeedActivity[] = [];
+  const flushGroup = () => {
+    if (firstActivityEntry === null) return;
+    const cached = activityGroupsCache.get(firstActivityEntry.activity);
+    if (
+      cached &&
+      cached.activities.length === openGroupActivities.length &&
+      cached.activities.every((activity, index) => activity === openGroupActivities[index])
+    ) {
+      grouped.push(cached);
+    } else {
+      const group: ThreadFeedActivityGroup = {
+        type: "activity-group",
+        id: firstActivityEntry.id,
+        createdAt: firstActivityEntry.createdAt,
+        turnId: firstActivityEntry.turnId,
+        activities: openGroupActivities,
+      };
+      activityGroupsCache.set(firstActivityEntry.activity, group);
+      grouped.push(group);
+    }
+    firstActivityEntry = null;
+    openGroupActivities = [];
+  };
 
   for (const entry of entries) {
     // Skip empty messages so they don't break activity grouping.
@@ -1279,39 +1325,22 @@ function groupAdjacentActivities(entries: ReadonlyArray<RawThreadFeedEntry>): Th
     }
 
     if (entry.type !== "activity") {
+      flushGroup();
       grouped.push(entry);
-      openGroupActivities = null;
       continue;
     }
 
-    if (entry.activity.workEntry.sourceActivityKind === "context-compaction") {
-      grouped.push({
-        type: "activity-group",
-        id: entry.id,
-        createdAt: entry.createdAt,
-        turnId: entry.turnId,
-        activities: [entry.activity],
-      });
-      openGroupActivities = null;
-      continue;
+    const isCompaction = entry.activity.workEntry.sourceActivityKind === "context-compaction";
+    if (isCompaction || firstActivityEntry?.turnId !== entry.turnId) {
+      flushGroup();
     }
-
-    if (openGroupActivities !== null && openGroupTurnId === entry.turnId) {
-      openGroupActivities.push(entry.activity);
-      continue;
+    firstActivityEntry ??= entry;
+    openGroupActivities.push(entry.activity);
+    if (isCompaction) {
+      flushGroup();
     }
-
-    openGroupActivities = [entry.activity];
-    openGroupTurnId = entry.turnId;
-    grouped.push({
-      type: "activity-group",
-      id: entry.id,
-      createdAt: entry.createdAt,
-      turnId: entry.turnId,
-      activities: openGroupActivities,
-    });
   }
-
+  flushGroup();
   return grouped;
 }
 
@@ -1509,14 +1538,26 @@ export function deriveThreadFeedPresentation(
       entry.turnId === unsettledTurnId;
     const fold = foldsByAnchorId.get(entry.id);
     if (fold) {
-      result.push({
-        type: "turn-fold",
-        id: `turn-fold:${fold.turnId}`,
-        createdAt: fold.createdAt,
-        turnId: fold.turnId,
-        label: fold.label,
-        expanded: expandedTurnIds.has(fold.turnId),
-      });
+      const expanded = expandedTurnIds.has(fold.turnId);
+      let row = turnFoldRowsCache.get(entry);
+      if (
+        !row ||
+        row.turnId !== fold.turnId ||
+        row.createdAt !== fold.createdAt ||
+        row.label !== fold.label ||
+        row.expanded !== expanded
+      ) {
+        row = {
+          type: "turn-fold",
+          id: `turn-fold:${fold.turnId}`,
+          createdAt: fold.createdAt,
+          turnId: fold.turnId,
+          label: fold.label,
+          expanded,
+        };
+        turnFoldRowsCache.set(entry, row);
+      }
+      result.push(row);
     }
     if (!collapsedEntryIds.has(entry.id)) {
       appendPresentedFeedEntry(
@@ -1549,6 +1590,41 @@ function appendPresentedFeedEntry(
     return;
   }
 
+  let cached = presentedActivityGroupsCache.get(entry);
+  if (
+    !cached ||
+    cached.unsettledTurnId !== unsettledTurnId ||
+    cached.isWorking !== isWorking ||
+    cached.activeTail !== activeTail ||
+    cached.rows.some(
+      (row) => row.type === "work-toggle" && expandedWorkGroupIds.has(row.groupId) !== row.expanded,
+    )
+  ) {
+    const rows: ThreadFeedEntry[] = [];
+    appendActivityGroupRows(
+      rows,
+      entry,
+      expandedWorkGroupIds,
+      unsettledTurnId,
+      isWorking,
+      activeTail,
+    );
+    cached = { unsettledTurnId, isWorking, activeTail, rows };
+    presentedActivityGroupsCache.set(entry, cached);
+  }
+  for (const row of cached.rows) {
+    result.push(row);
+  }
+}
+
+function appendActivityGroupRows(
+  result: ThreadFeedEntry[],
+  entry: ThreadFeedActivityGroup,
+  expandedWorkGroupIds: ReadonlySet<string>,
+  unsettledTurnId: TurnId | null,
+  isWorking: boolean,
+  activeTail: boolean,
+): void {
   const activities = omitSupersededLifecycleMarkers(
     entry.activities.filter(
       (activity) =>
@@ -1920,7 +1996,7 @@ export function buildPendingUserInputAnswers(
 }
 
 export function buildThreadFeed(
-  thread: OrchestrationThread,
+  thread: Pick<OrchestrationThread, "messages" | "activities">,
   options?: {
     readonly loadedMessages?: ReadonlyArray<OrchestrationThread["messages"][number]>;
     readonly localMessages?: ReadonlyArray<OrchestrationThread["messages"][number]>;
@@ -1932,74 +2008,78 @@ export function buildThreadFeed(
     : loadedMessages;
   const oldestLoadedMessageCreatedAt =
     options?.loadedMessages !== undefined ? (loadedMessages[0]?.createdAt ?? null) : null;
-  const workLogEntries = deriveWorkLogEntries(thread.activities);
+  const activityEntries = getThreadFeedActivityEntries(thread.activities);
   const entries = Arr.sortWith(
     [
-      ...messages.map<RawThreadFeedEntry>((message) => ({
-        type: "message",
-        id: message.id,
-        createdAt: message.createdAt,
-        message,
-      })),
-      ...workLogEntries
-        .filter((entry) => {
-          if (options?.loadedMessages === undefined) {
-            return true;
-          }
-          return (
-            oldestLoadedMessageCreatedAt === null || entry.createdAt >= oldestLoadedMessageCreatedAt
-          );
-        })
-        .map<RawThreadFeedEntry>((entry) => {
-          const summary = workEntryHeading(entry);
-          const detail = workEntryPreview(entry);
-          const getFullDetail = memoizeValue(() => buildWorkEntryExpandedBody(entry));
-          const getCopyText = memoizeValue(() => {
-            const copyLabel = capitalizePhrase(
-              normalizeCompactToolLabel(entry.toolTitle || entry.label),
-            );
-            const fullDetail = getFullDetail();
-            if (entry.command) {
-              const normalizedCommand =
-                entry.rawCommand && copyLabel.trim() !== entry.command.trim()
-                  ? entry.command
-                  : null;
-              return [copyLabel, normalizedCommand, fullDetail ?? entry.command]
-                .filter((value): value is string => Boolean(value))
-                .join("\n");
-            }
-            return [copyLabel, detail, fullDetail]
-              .filter((value, index, values): value is string => {
-                return Boolean(value) && values.indexOf(value) === index;
-              })
-              .join("\n");
-          });
-          return {
-            type: "activity",
-            id: entry.id,
-            createdAt: entry.createdAt,
-            turnId: entry.turnId,
-            activity: {
-              id: entry.id,
-              createdAt: entry.createdAt,
-              turnId: entry.turnId,
-              summary,
-              detail,
-              canExpand: workEntryHasExpandedBody(entry),
-              getFullDetail,
-              getCopyText,
-              icon: workEntryIcon(entry),
-              toolLike: workLogEntryIsToolLike(entry),
-              status: workEntryStatus(entry),
-              ...(entry.toolLifecycleStatus ? { lifecycleStatus: entry.toolLifecycleStatus } : {}),
-              workEntry: entry,
-            },
-          };
-        }),
+      ...messages.map((message) => {
+        let entry = messageEntriesCache.get(message);
+        if (!entry) {
+          entry = { type: "message", id: message.id, createdAt: message.createdAt, message };
+          messageEntriesCache.set(message, entry);
+        }
+        return entry;
+      }),
+      ...activityEntries.filter(
+        (entry) =>
+          oldestLoadedMessageCreatedAt === null || entry.createdAt >= oldestLoadedMessageCreatedAt,
+      ),
     ],
     (s) => new Date(s.createdAt),
     Order.Date,
   );
 
   return groupAdjacentActivities(entries);
+}
+
+function getThreadFeedActivityEntries(activities: ReadonlyArray<OrchestrationThreadActivity>) {
+  const cached = activityEntriesCache.get(activities);
+  if (cached) return cached;
+  const entries = deriveWorkLogEntries(activities).map(toThreadFeedActivityEntry);
+  activityEntriesCache.set(activities, entries);
+  return entries;
+}
+
+function toThreadFeedActivityEntry(
+  entry: DerivedWorkLogEntry,
+): Extract<RawThreadFeedEntry, { readonly type: "activity" }> {
+  const summary = workEntryHeading(entry);
+  const detail = workEntryPreview(entry);
+  const getFullDetail = memoizeValue(() => buildWorkEntryExpandedBody(entry));
+  const getCopyText = memoizeValue(() => {
+    const copyLabel = capitalizePhrase(normalizeCompactToolLabel(entry.toolTitle || entry.label));
+    const fullDetail = getFullDetail();
+    if (entry.command) {
+      const normalizedCommand =
+        entry.rawCommand && copyLabel.trim() !== entry.command.trim() ? entry.command : null;
+      return [copyLabel, normalizedCommand, fullDetail ?? entry.command]
+        .filter((value): value is string => Boolean(value))
+        .join("\n");
+    }
+    return [copyLabel, detail, fullDetail]
+      .filter((value, index, values): value is string => {
+        return Boolean(value) && values.indexOf(value) === index;
+      })
+      .join("\n");
+  });
+  return {
+    type: "activity",
+    id: entry.id,
+    createdAt: entry.createdAt,
+    turnId: entry.turnId,
+    activity: {
+      id: entry.id,
+      createdAt: entry.createdAt,
+      turnId: entry.turnId,
+      summary,
+      detail,
+      canExpand: workEntryHasExpandedBody(entry),
+      getFullDetail,
+      getCopyText,
+      icon: workEntryIcon(entry),
+      toolLike: workLogEntryIsToolLike(entry),
+      status: workEntryStatus(entry),
+      ...(entry.toolLifecycleStatus ? { lifecycleStatus: entry.toolLifecycleStatus } : {}),
+      workEntry: entry,
+    },
+  };
 }

--- a/apps/mobile/src/state/use-thread-composer-state.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.ts
@@ -126,21 +126,28 @@ export function useThreadComposerState() {
     () => (selectedThreadKey ? (queuedMessagesByThreadKey[selectedThreadKey] ?? []) : []),
     [queuedMessagesByThreadKey, selectedThreadKey],
   );
-  const selectedThreadFeed = useMemo(() => {
-    if (!selectedThreadDetail) {
-      return [];
-    }
+  const localFeedbackMessages = useMemo(() => {
     const submissions = selectedThreadKey
       ? (feedbackSubmissionsByThreadKey[selectedThreadKey] ?? [])
       : [];
-    return buildThreadFeed(selectedThreadDetail, {
-      localMessages: submissions.flatMap((submission) =>
-        submission.status === "interrupted"
-          ? []
-          : [codexFeedbackMessage(submission), codexFeedbackMessage(submission, "assistant")],
-      ),
-    });
-  }, [feedbackSubmissionsByThreadKey, selectedThreadDetail, selectedThreadKey]);
+    return submissions.flatMap((submission) =>
+      submission.status === "interrupted"
+        ? []
+        : [codexFeedbackMessage(submission), codexFeedbackMessage(submission, "assistant")],
+    );
+  }, [feedbackSubmissionsByThreadKey, selectedThreadKey]);
+  const selectedThreadMessages = selectedThreadDetail?.messages;
+  const selectedThreadActivities = selectedThreadDetail?.activities;
+  const selectedThreadFeed = useMemo(
+    () =>
+      selectedThreadMessages && selectedThreadActivities
+        ? buildThreadFeed(
+            { messages: selectedThreadMessages, activities: selectedThreadActivities },
+            { localMessages: localFeedbackMessages },
+          )
+        : [],
+    [localFeedbackMessages, selectedThreadActivities, selectedThreadMessages],
+  );
 
   const selectedDraft = selectedThreadKey ? composerDrafts[selectedThreadKey] : null;
   const draftMessage = selectedDraft?.text ?? "";


### PR DESCRIPTION
Each assistant-text update rebuilt the loaded mobile activity history and replaced every feed row.

Reuse activity presentation and row wrappers from immutable source objects. Check group membership, live state, expansion flags, and fold labels before reuse. Keep lifecycle collapse, ordering, and pagination behavior. The feed hook now depends on messages, activities, and local feedback instead of the whole thread.

Validation:

- 116 focused tests, mobile typecheck, lint, and formatting passed.
- 85 feed comparisons and 3,400 presentation comparisons matched the baseline, including expanded detail and copy callbacks. Cases include same-ID replacements, metadata updates, pagination, lifecycle changes, and fold expansion.
- The original 10,000-activity audit fixture improved from 20.85 ms to 6.24 ms median feed-build time. It now preserves 2,199 of 2,200 feed rows. The baseline preserved none.

Measurements used Node 24.20.0 with five warmups and 25 samples. These are source-function timings, not device or frame timings. No browser or device testing. No layout, native module, or fingerprint configuration changes.

Refs https://github.com/pingdotgg/t3code/issues/9661.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Caching ties row identity to object references; incorrect reuse could cause stale UI during streaming, though tests cover regrouping, lifecycle corrections, and expansion state.
> 
> **Overview**
> **Reduces mobile thread feed churn** while assistant text streams by reusing stable feed and presentation row objects instead of rebuilding everything on each update.
> 
> `buildThreadFeed` and `deriveThreadFeedPresentation` now memoize via **WeakMaps** keyed on immutable inputs: per-message rows, per-activities-array work-log entries, adjacent activity groups, expanded work-group presentation, and turn-fold rows. Unchanged groups are returned when membership and presentation inputs match; only the updated streaming message gets a new object.
> 
> `groupAdjacentActivities` was refactored around a flush pattern that consults the activity-group cache. `buildThreadFeed` accepts only `messages` and `activities` (not the full thread). The composer hook memoizes the feed on those arrays plus local feedback messages, so unrelated thread metadata no longer invalidates the feed.
> 
> Tests assert **reference stability** during streaming, correct regrouping when empty messages appear or pagination prepends history, and presentation behavior for interrupted turns and corrected tool failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b17f380cde95e5aa17f6cf5cb9475bd1d03a6e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reuse chat feed rows during streaming with weak caches in `buildThreadFeed`
> - Adds weak caches in [threadActivity.ts](https://github.com/pingdotgg/t3code/pull/9688/files#diff-a18e8ed6aa4a9d6b3d9e32ea2fa3034dfd7621b6af3d640ec1b95a8564c97eb5) for derived activity entries, message entries, grouped activities, presented activity-group rows, and turn-fold rows, keyed by immutable source objects
> - Reworks `groupAdjacentActivities` to compare activity sequences against cached groups and reuse unchanged groups, while still creating new groups when the activity sequence changes
> - Updates `deriveThreadFeedPresentation` and `appendPresentedFeedEntry` to reuse cached turn-fold and activity-group presentation rows when fold metadata, expansion state, and live-tail state remain equivalent
> - Extracts `getThreadFeedActivityEntries` and `toThreadFeedActivityEntry` helpers from `buildThreadFeed` to support activity-entry caching by activities-array identity
> - Narrows `buildThreadFeed` input to the messages and activities needed for feed construction, and updates `useThreadComposerState` to memoize the selected feed from message/activity array references rather than the full thread detail object
> - Risk: `useThreadComposerState` now depends on array reference stability of `messages` and `activities` from the selected thread detail; if those arrays are recreated on unrelated detail updates, the feed will rebuild as before but the perf benefit is lost
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b17f38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->