### PR TITLE
perf(server): omit repeated OpenCode progress logs

### DIFF
--- a/apps/server/src/provider/Layers/EventNdjsonLogger.test.ts
+++ b/apps/server/src/provider/Layers/EventNdjsonLogger.test.ts
@@ -341,6 +341,19 @@ describe("EventNdjsonLogger", () => {
           },
           threadId,
         );
+        yield* native.write(
+          {
+            event: {
+              type: "message.part.updated",
+              payload: {
+                properties: {
+                  part: { type: "tool", state: { status: "running", output: "progress" } },
+                },
+              },
+            },
+          },
+          threadId,
+        );
         yield* native.write({ type: "turn.completed", id: "native-final" }, threadId);
         yield* store.close();
 
@@ -355,6 +368,51 @@ describe("EventNdjsonLogger", () => {
             { stream: "CANON", payload: '{"type":"item.completed","id":"final"}' },
             { stream: "NTIVE", payload: '{"type":"turn.completed","id":"native-final"}' },
           ],
+        );
+      } finally {
+        NodeFS.rmSync(tempDir, { recursive: true, force: true });
+      }
+    }),
+  );
+
+  it.effect("keeps OpenCode tool input, final output, and errors in native logs", () =>
+    Effect.gen(function* () {
+      const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-provider-log-"));
+      const basePath = NodePath.join(tempDir, "events.log");
+      const threadId = ThreadId.make("thread-tool-lifecycle");
+
+      try {
+        const store = yield* makeEventNdjsonLogStore(basePath, { batchWindowMs: 0 });
+        const native = store.logger("native");
+        const input = { command: "run-build" };
+        const states = [
+          { status: "pending", input },
+          { status: "completed", input, output: "Build complete", time: { start: 1, end: 2 } },
+          { status: "error", input, error: "Build failed", time: { start: 3, end: 4 } },
+          { status: "unknown", input },
+          null,
+        ];
+        const events = states.map((state) => ({
+          event: {
+            type: "message.part.updated",
+            payload: { properties: { part: { type: "tool", state } } },
+          },
+        }));
+        for (const event of events) {
+          yield* native.write(event, threadId);
+        }
+        yield* store.close();
+
+        const payloads = NodeFS.readFileSync(
+          ownedLogPath(basePath, "thread-tool-lifecycle"),
+          "utf8",
+        )
+          .trim()
+          .split("\n")
+          .map((line) => parseLogLine(line).payload);
+        assert.deepEqual(
+          payloads,
+          events.map((event) => encodeUnknownJson(event)),
         );
       } finally {
         NodeFS.rmSync(tempDir, { recursive: true, force: true });

--- a/apps/server/src/provider/Layers/EventNdjsonLogger.ts
+++ b/apps/server/src/provider/Layers/EventNdjsonLogger.ts
@@ -229,7 +229,15 @@ function shouldPersist(stream: EventNdjsonStream, event: unknown): boolean {
       const part = Reflect.get(properties, "part");
       if (typeof part !== "object" || part === null) return true;
       const partType = Reflect.get(part, "type");
-      return partType !== "text" && partType !== "reasoning";
+      if (partType === "text" || partType === "reasoning") return false;
+      if (partType === "tool") {
+        // Running snapshots repeat growing output. Pending and terminal states stay in the log.
+        const state = Reflect.get(part, "state");
+        if (typeof state === "object" && state !== null) {
+          return Reflect.get(state, "status") !== "running";
+        }
+      }
+      return true;
     }
 
     return true;

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -230,6 +230,10 @@ sandbox.
 
 ## OpenCode server ownership and catalog
 
+Native OpenCode event logs skip text deltas and running tool snapshots. Pending, completed,
+and failed tool states remain, including final output and errors. This filter does not change
+events sent to clients or orchestration storage.
+
 Each OpenCode provider instance owns one lazy local server for catalog discovery and
 text-generation helpers through [`OpenCodeServerOwner.ts`][opencode-server-owner]. Concurrent
 borrowers share startup. The server closes 30 seconds after the last borrower releases it, or


### PR DESCRIPTION
OpenCode native logs repeat the full tool output while a command runs. A tool that ends with 100 KiB of output wrote 5.32 MB in the audit fixture.

Skip transient running-state snapshots before serialization. Keep pending, completed, and failed states, including final output and errors. Live client events and orchestration storage are unchanged.

The same fixture now writes 103 KB. All 16 logger tests, server typecheck, and targeted lint pass. The extended filtering test fails on the old code. No browser, device, or live state was used.

Part of https://github.com/pingdotgg/t3code/issues/9661.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only filter on native provider event persistence; no change to runtime events sent to clients or orchestration.
> 
> **Overview**
> Native OpenCode NDJSON audit logs no longer persist **`message.part.updated`** events for tool parts in **`running`** status, which repeatedly duplicate growing output and inflated log size in practice.
> 
> **`shouldPersist`** in `EventNdjsonLogger.ts` still drops text/reasoning part updates and now treats tool parts specially: pending, completed, error, and other non-running states (including input, final output, and errors) continue to be written. Live client delivery and orchestration storage are unchanged.
> 
> Tests cover filtering of running tool snapshots and retention across the full tool lifecycle; `providers.md` documents the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2b2cd772b8270e3dd3d1834b59f2078dabf8c97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter `running` OpenCode tool snapshots from native event logs
> - Updates `shouldPersist` in [EventNdjsonLogger.ts](https://github.com/pingdotgg/t3code/pull/9689/files#diff-9e7861bc2eacfd2573bb80a1ee8844469e360556c2d989224c7af3771489937f) to skip persisting `message.part.updated` events for tool parts whose status is `running`, while retaining pending, terminal, unknown, and null states.
> - Adds tests in [EventNdjsonLogger.test.ts](https://github.com/pingdotgg/t3code/pull/9689/files#diff-0b93abfd0b81e5b97c029e93f4d2080b149fb3fa932a6319c914a9f9119e677b) covering the running-state filter and the full OpenCode tool lifecycle (pending, completed, error, unknown, null).
> - Documents the filter behavior in [providers.md](https://github.com/pingdotgg/t3code/pull/9689/files#diff-3d909027abc31a863f0c0e5ecef5aa50ac285620ad827db723eb0a4ac46d3f85), noting client events and orchestration storage are unaffected.
> - Behavioral Change: native OpenCode logs no longer contain running tool snapshots; final output and error data for terminal states are still retained.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2b2cd7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->