### PR TITLE
perf(clients): avoid waiting to read cached relay tokens

### DIFF
--- a/packages/client-runtime/src/relay/managedRelay.test.ts
+++ b/packages/client-runtime/src/relay/managedRelay.test.ts
@@ -1,5 +1,8 @@
 import { EnvironmentId } from "@t3tools/contracts";
-import { RelayEnvironmentStatusScope } from "@t3tools/contracts/relay";
+import {
+  RelayEnvironmentConnectScope,
+  RelayEnvironmentStatusScope,
+} from "@t3tools/contracts/relay";
 import { describe, expect, it } from "@effect/vitest";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -188,6 +191,102 @@ describe("ManagedRelayClient", () => {
       yield* relayClient.getEnvironmentStatus(statusInput);
       expect(tokenExchangeCount).toBe(3);
     }).pipe(Effect.provide(managedRelayTestLayer(fetchFn)));
+  });
+
+  it.effect("uses a cached token while another scope waits for an exchange", () => {
+    const exchangeStarted = Promise.withResolvers<void>();
+    const releaseExchange = Promise.withResolvers<void>();
+    let tokenExchangeCount = 0;
+    const statusTokens: Array<string | null> = [];
+    let persistedTokens: ReadonlyArray<ManagedRelay.ManagedRelayAccessTokenCacheEntry> = [
+      {
+        accountId: "user-1",
+        clientId: "t3-mobile",
+        relayUrl: "https://relay.example.test",
+        thumbprint: "client-thumbprint",
+        scopes: [RelayEnvironmentStatusScope],
+        accessToken: "cached-status-token",
+        expiresAtMillis: Number.MAX_SAFE_INTEGER,
+      },
+    ];
+    const accessTokenStore: ManagedRelay.ManagedRelayAccessTokenStore = {
+      load: Effect.sync(() => persistedTokens),
+      save: (entries) =>
+        Effect.sync(() => {
+          persistedTokens = entries;
+        }),
+      clear: Effect.sync(() => {
+        persistedTokens = [];
+      }),
+    };
+    const fetchFn = ((input, init) => {
+      if (String(input).endsWith("/v1/client/dpop-token")) {
+        tokenExchangeCount += 1;
+        exchangeStarted.resolve();
+        return releaseExchange.promise.then(() =>
+          Response.json({
+            access_token: "expanded-scope-token",
+            issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
+            token_type: "DPoP",
+            expires_in: 1_800,
+            scope: `${RelayEnvironmentStatusScope} ${RelayEnvironmentConnectScope}`,
+          }),
+        );
+      }
+      statusTokens.push(new Headers(init?.headers).get("authorization"));
+      return Promise.resolve(
+        Response.json({
+          environmentId: "env-1",
+          endpoint: {
+            httpBaseUrl: "https://desktop.example.test/",
+            wsBaseUrl: "wss://desktop.example.test/ws",
+            providerKind: "cloudflare_tunnel",
+          },
+          status: "online",
+          checkedAt: "2026-09-04T00:00:00.000Z",
+        }),
+      );
+    }) satisfies typeof globalThis.fetch;
+
+    return Effect.gen(function* () {
+      const relayClient = yield* ManagedRelay.ManagedRelayClient;
+      const statusInput = {
+        clerkToken: clerkToken("user-1", "session-1"),
+        scopes: [RelayEnvironmentStatusScope],
+        environmentId: EnvironmentId.make("env-1"),
+      } as const;
+      const expandedScopeInput = {
+        ...statusInput,
+        scopes: [RelayEnvironmentStatusScope, RelayEnvironmentConnectScope],
+      } as const;
+      const firstMiss = yield* relayClient
+        .getEnvironmentStatus(expandedScopeInput)
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => exchangeStarted.promise);
+      const secondMiss = yield* relayClient
+        .getEnvironmentStatus(expandedScopeInput)
+        .pipe(Effect.forkChild);
+
+      const status = yield* relayClient.getEnvironmentStatus(statusInput);
+      expect(status.status).toBe("online");
+      expect(statusTokens).toEqual(["DPoP cached-status-token"]);
+
+      releaseExchange.resolve();
+      yield* Fiber.join(firstMiss);
+      yield* Fiber.join(secondMiss);
+      expect(tokenExchangeCount).toBe(1);
+      expect(persistedTokens.map((token) => token.accessToken)).toEqual([
+        "cached-status-token",
+        "expanded-scope-token",
+      ]);
+      yield* relayClient.resetTokenCache;
+      expect(persistedTokens).toEqual([]);
+      yield* relayClient.getEnvironmentStatus(expandedScopeInput);
+      expect(tokenExchangeCount).toBe(2);
+    }).pipe(
+      Effect.ensuring(Effect.sync(() => releaseExchange.resolve())),
+      Effect.provide(managedRelayTestLayer(fetchFn, undefined, accessTokenStore)),
+    );
   });
 
   it.effect("reuses a persisted token across runtimes and Clerk session token rotation", () => {

--- a/packages/client-runtime/src/relay/managedRelay.ts
+++ b/packages/client-runtime/src/relay/managedRelay.ts
@@ -546,18 +546,32 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
           expiresAtMillis: nowMillis + response.expires_in * 1_000,
         } satisfies ManagedRelayAccessTokenCacheEntry;
       }
+      const match = {
+        accountId: accountId.value,
+        clientId: options.clientId,
+        relayUrl,
+        thumbprint: input.thumbprint,
+        scopes: input.scopes,
+        nowMillis,
+      };
+      // Cache hits do not need to wait for an unrelated exchange or store write.
+      const cached = (yield* SynchronizedRef.get(cachedTokens)).find((token) =>
+        tokenMatches(token, match),
+      );
+      if (cached) {
+        yield* Effect.annotateCurrentSpan({
+          "relay.token_cache.result": "hit",
+        });
+        return cached;
+      }
       return yield* SynchronizedRef.modifyEffect(cachedTokens, (tokens) =>
         Effect.gen(function* () {
-          const activeTokens = tokens.filter((token) => token.expiresAtMillis > nowMillis + 5_000);
+          const lookupMillis = yield* Clock.currentTimeMillis;
+          const activeTokens = tokens.filter(
+            (token) => token.expiresAtMillis > lookupMillis + 5_000,
+          );
           const cached = activeTokens.find((token) =>
-            tokenMatches(token, {
-              accountId: accountId.value,
-              clientId: options.clientId,
-              relayUrl,
-              thumbprint: input.thumbprint,
-              scopes: input.scopes,
-              nowMillis,
-            }),
+            tokenMatches(token, { ...match, nowMillis: lookupMillis }),
           );
           if (cached) {
             yield* Effect.annotateCurrentSpan({
@@ -576,7 +590,7 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
             thumbprint: input.thumbprint,
             scopes: input.scopes,
             accessToken: response.access_token,
-            expiresAtMillis: nowMillis + response.expires_in * 1_000,
+            expiresAtMillis: lookupMillis + response.expires_in * 1_000,
           };
           const nextTokens = [...activeTokens, next];
           if (options.accessTokenStore) {


### PR DESCRIPTION
A slow relay token exchange makes requests for other scopes wait, even when they already have a usable cached token.

Read valid cached tokens without entering the exchange lock. Recheck misses under the existing lock with a fresh clock. Account, client, relay, key, scope, and expiry checks stay unchanged.

All 25 relay client and state tests pass, with scoped typecheck and lint. A controlled-exchange test proves that a cached request completes while another scope is blocked. It checks shared refreshes, saved entries, and reset behavior. No browser, device, or live relay was used.

Part of https://github.com/pingdotgg/t3code/issues/9661.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency and caching around relay OAuth token acquisition; incorrect locking could cause duplicate exchanges or stale tokens, though scope/expiry matching logic is unchanged.
> 
> **Overview**
> **Managed relay token lookup** no longer blocks on in-flight DPoP exchanges when a matching cached token already exists. `obtainAccessToken` adds a lock-free read via `SynchronizedRef.get` and `tokenMatches`; only cache misses still enter `tokenCacheCriticalSection`, where expiry and new token `expiresAtMillis` use a fresh `lookupMillis` from the clock.
> 
> A new test simulates a stalled scope expansion exchange while a narrower-scope status call runs concurrently—it must complete with the persisted cached bearer, then assert a single exchange, merged persistence, and refresh after `resetTokenCache`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aad547d0c4fca69fd9c283592ac66cb4eaa2330. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test for concurrent cached relay token reads in `ManagedRelayClient`
> Adds a test in [managedRelay.test.ts](https://github.com/pingdotgg/t3code/pull/9691/files#diff-16ae8de129c4f913d99272775b76bec0f55a3e182364ab6e413a5d0a5e315f9b) that seeds a persisted status-scope token, then starts two concurrent requests requiring status and connect scopes. Verifies a status-only request uses the cached token without waiting for an in-progress broader-scope exchange, concurrent misses for the same broader scope share one exchange, both tokens persist, and reset clears the store.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6aad547.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->