### PR TITLE
perf(server): avoid full patches for checkpoint summaries

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,7 +28,6 @@
     "@effect/sql-sqlite-bun": "catalog:",
     "@ff-labs/fff-node": "0.9.4",
     "@opencode-ai/sdk": "^1.3.15",
-    "@pierre/diffs": "catalog:",
     "effect": "catalog:",
     "msgpackr-extract": "3.0.4",
     "node-pty": "^1.1.0",

--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -4,6 +4,7 @@ import * as NodePath from "node:path";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
 import { ThreadId, type VcsError } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
@@ -12,6 +13,7 @@ import * as Scope from "effect/Scope";
 import { describe, expect } from "vite-plus/test";
 
 import { checkpointRefForThreadTurn } from "./Utils.ts";
+import { parseTurnDiffFilesFromNumstat } from "./Diffs.ts";
 import * as CheckpointStore from "./CheckpointStore.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
 import * as VcsProcess from "../vcs/VcsProcess.ts";
@@ -250,6 +252,182 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
         expect(whitespaceIgnoredDiff).toContain("+        <div>");
         expect(whitespaceIgnoredDiff).not.toContain("-      <h1>Title</h1>");
         expect(whitespaceIgnoredDiff).not.toContain("+          <h1>Title</h1>");
+
+        for (const ignoreWhitespace of [false, true]) {
+          const numstat = yield* checkpointStore.diffCheckpoints({
+            cwd: tmp,
+            fromCheckpointRef,
+            toCheckpointRef,
+            ignoreWhitespace,
+            format: "numstat",
+          });
+          expect(parseTurnDiffFilesFromNumstat(numstat)).toEqual([
+            {
+              path: "Component.tsx",
+              additions: ignoreWhitespace ? 4 : 6,
+              deletions: ignoreWhitespace ? 0 : 2,
+            },
+          ]);
+        }
+      }),
+    );
+  });
+
+  describe("checkpoint file summaries", () => {
+    it.effect("counts changes whose full patch exceeds the output limit", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const threadId = ThreadId.make("large-checkpoint-summary");
+        const fromCheckpointRef = checkpointRefForThreadTurn(threadId, 0);
+        const toCheckpointRef = checkpointRefForThreadTurn(threadId, 1);
+        const filePath = NodePath.join(tmp, "README.md");
+        const lineCount = 20_000;
+        yield* writeTextFile(filePath, `${"before".repeat(50)}\n`.repeat(lineCount));
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef: fromCheckpointRef });
+        yield* writeTextFile(filePath, `${"after".repeat(60)}\n`.repeat(lineCount));
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef: toCheckpointRef });
+
+        const numstat = yield* checkpointStore.diffCheckpoints({
+          cwd: tmp,
+          fromCheckpointRef,
+          toCheckpointRef,
+          ignoreWhitespace: false,
+          format: "numstat",
+        });
+
+        expect(parseTurnDiffFilesFromNumstat(numstat)).toEqual([
+          { path: "README.md", additions: lineCount, deletions: lineCount },
+        ]);
+        expect(numstat.length).toBeLessThan(100);
+      }),
+    );
+
+    it.effect("preserves file paths and turn ranges without changing the user index", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        yield* git(tmp, ["config", "diff.renames", "copies"]);
+        const fileSystem = yield* FileSystem.FileSystem;
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const threadId = ThreadId.make("checkpoint-summary-paths");
+        const baseline = checkpointRefForThreadTurn(threadId, 0);
+        const firstTurn = checkpointRefForThreadTurn(threadId, 1);
+        const secondTurn = checkpointRefForThreadTurn(threadId, 2);
+        const copiedText = Array.from({ length: 20 }, (_, index) => `copy line ${index}\n`).join(
+          "",
+        );
+        const platform = yield* HostProcessPlatform;
+        const renamedPath = platform === "win32" ? "renamed café.txt" : "renamed\tcafé\nname.txt";
+        const addedPath = platform === "win32" ? "new café.txt" : "new\tfile\n名.txt";
+        for (const [path, contents] of Object.entries({
+          "copy-source.txt": copiedText,
+          "deleted.txt": "delete me\n",
+          "rename-old.txt": "before\nkeep one\nkeep two\nkeep three\n",
+          "binary.bin": "\0before",
+        })) {
+          yield* writeTextFile(NodePath.join(tmp, path), contents);
+        }
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef: baseline });
+
+        yield* fileSystem.rename(
+          NodePath.join(tmp, "rename-old.txt"),
+          NodePath.join(tmp, renamedPath),
+        );
+        yield* fileSystem.remove(NodePath.join(tmp, "deleted.txt"));
+        for (const [path, contents] of Object.entries({
+          "copy-source.txt": `${copiedText}one more\n`,
+          "copied.txt": copiedText,
+          [renamedPath]: "after\nkeep one\nkeep two\nkeep three\n",
+          "binary.bin": "\0after",
+          "empty.txt": "",
+          [addedPath]: "first\nsecond\n",
+        })) {
+          yield* writeTextFile(NodePath.join(tmp, path), contents);
+        }
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef: firstTurn });
+        const userIndex = yield* fileSystem.readFile(NodePath.join(tmp, ".git/index"));
+        const input = {
+          cwd: tmp,
+          fromCheckpointRef: baseline,
+          toCheckpointRef: firstTurn,
+          ignoreWhitespace: false,
+          format: "numstat" as const,
+        };
+        const firstSummary = parseTurnDiffFilesFromNumstat(
+          yield* checkpointStore.diffCheckpoints(input),
+        );
+        const expectedFiles = [
+          { path: "binary.bin", additions: 0, deletions: 0 },
+          { path: "copied.txt", additions: 0, deletions: 0 },
+          { path: "copy-source.txt", additions: 1, deletions: 0 },
+          { path: "deleted.txt", additions: 0, deletions: 1 },
+          { path: "empty.txt", additions: 0, deletions: 0 },
+          { path: addedPath, additions: 2, deletions: 0 },
+          { path: renamedPath, additions: 1, deletions: 1 },
+        ].toSorted((left, right) => left.path.localeCompare(right.path));
+        expect(firstSummary).toEqual(expectedFiles);
+
+        yield* fileSystem.remove(NodePath.join(tmp, "empty.txt"));
+        yield* writeTextFile(NodePath.join(tmp, "copy-source.txt"), "replacement\n");
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef: secondTurn });
+        const secondSummary = parseTurnDiffFilesFromNumstat(
+          yield* checkpointStore.diffCheckpoints({
+            ...input,
+            fromCheckpointRef: firstTurn,
+            toCheckpointRef: secondTurn,
+          }),
+        );
+        expect(secondSummary).toEqual([
+          { path: "copy-source.txt", additions: 1, deletions: 21 },
+          { path: "empty.txt", additions: 0, deletions: 0 },
+        ]);
+
+        const inclusiveSummary = parseTurnDiffFilesFromNumstat(
+          yield* checkpointStore.diffCheckpoints({ ...input, toCheckpointRef: secondTurn }),
+        );
+        expect(inclusiveSummary).toEqual(
+          expectedFiles
+            .filter((file) => file.path !== "empty.txt")
+            .map((file) =>
+              file.path === "copy-source.txt" ? { ...file, additions: 1, deletions: 20 } : file,
+            ),
+        );
+        expect(
+          yield* checkpointStore.diffCheckpoints({ ...input, toCheckpointRef: baseline }),
+        ).toBe("");
+        expect(yield* fileSystem.readFile(NodePath.join(tmp, ".git/index"))).toEqual(userIndex);
+      }),
+    );
+
+    it.effect("uses HEAD for a missing baseline only when requested", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const threadId = ThreadId.make("checkpoint-summary-fallback");
+        const fromCheckpointRef = checkpointRefForThreadTurn(threadId, 0);
+        const toCheckpointRef = checkpointRefForThreadTurn(threadId, 1);
+        yield* writeTextFile(NodePath.join(tmp, "README.md"), "changed\n");
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef: toCheckpointRef });
+        const input = {
+          cwd: tmp,
+          fromCheckpointRef,
+          toCheckpointRef,
+          ignoreWhitespace: false,
+          format: "numstat" as const,
+        };
+
+        const error = yield* Effect.flip(checkpointStore.diffCheckpoints(input));
+        expect(error._tag).toBe("VcsProcessExitError");
+        const numstat = yield* checkpointStore.diffCheckpoints({
+          ...input,
+          fallbackFromToHead: true,
+        });
+        expect(parseTurnDiffFilesFromNumstat(numstat)).toEqual([
+          { path: "README.md", additions: 1, deletions: 1 },
+        ]);
       }),
     );
   });

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -39,6 +39,7 @@ export interface DiffCheckpointsInput {
   readonly toCheckpointRef: CheckpointRef;
   readonly fallbackFromToHead?: boolean;
   readonly ignoreWhitespace: boolean;
+  readonly format?: "patch" | "numstat";
 }
 
 export interface DeleteCheckpointRefsInput {
@@ -77,8 +78,9 @@ export class CheckpointStore extends Context.Service<
     ) => Effect.Effect<boolean, CheckpointStoreError>;
 
     /**
-     * Compute a patch diff between two checkpoint refs.
+     * Compute a diff between two checkpoint refs. Defaults to a full patch.
      *
+     * Numstat output has NUL-delimited paths for file summaries.
      * Can optionally treat a missing "from" ref as `HEAD`.
      */
     readonly diffCheckpoints: (

--- a/apps/server/src/checkpointing/Diffs.test.ts
+++ b/apps/server/src/checkpointing/Diffs.test.ts
@@ -1,68 +1,54 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { parseTurnDiffFilesFromUnifiedDiff } from "./Diffs.ts";
+import { parseTurnDiffFilesFromNumstat } from "./Diffs.ts";
 
-describe("parseTurnDiffFilesFromUnifiedDiff", () => {
-  it("returns empty list for empty diff", () => {
-    expect(parseTurnDiffFilesFromUnifiedDiff("")).toEqual([]);
+describe("parseTurnDiffFilesFromNumstat", () => {
+  it("returns an empty list when no files changed", () => {
+    expect(parseTurnDiffFilesFromNumstat("")).toEqual([]);
   });
 
-  it("parses per-file additions and deletions", () => {
-    const diff = [
-      "diff --git a/a.txt b/a.txt",
-      "index 1111111..2222222 100644",
-      "--- a/a.txt",
-      "+++ b/a.txt",
-      "@@ -1,2 +1,3 @@",
-      " one",
-      "-two",
-      "+two updated",
-      "+three",
-      "diff --git a/src/b.ts b/src/b.ts",
-      "index 3333333..4444444 100644",
-      "--- a/src/b.ts",
-      "+++ b/src/b.ts",
-      "@@ -3,2 +3,0 @@",
-      "-old",
-      "-stale",
-      "",
-    ].join("\n");
-
-    expect(parseTurnDiffFilesFromUnifiedDiff(diff)).toEqual([
+  it("sorts files and preserves addition and deletion counts", () => {
+    const numstat = ["0\t2\tsrc/b.ts", "2\t1\ta.txt", ""].join("\0");
+    expect(parseTurnDiffFilesFromNumstat(numstat)).toEqual([
       { path: "a.txt", additions: 2, deletions: 1 },
       { path: "src/b.ts", additions: 0, deletions: 2 },
     ]);
   });
 
-  it("parses rename-only diffs with zero line changes", () => {
-    const diff = [
-      "diff --git a/src/old.ts b/src/new.ts",
-      "similarity index 100%",
-      "rename from src/old.ts",
-      "rename to src/new.ts",
+  it("uses destination paths for renames and copies", () => {
+    const numstat = [
+      "0\t0\t",
+      "src/old.ts",
+      "src/new.ts",
+      "2\t1\t",
+      "src/source.ts",
+      "src/copied.ts",
+      "1\t0\tother.ts",
       "",
-    ].join("\n");
+    ].join("\0");
 
-    expect(parseTurnDiffFilesFromUnifiedDiff(diff)).toEqual([
+    expect(parseTurnDiffFilesFromNumstat(numstat)).toEqual([
+      { path: "other.ts", additions: 1, deletions: 0 },
+      { path: "src/copied.ts", additions: 2, deletions: 1 },
       { path: "src/new.ts", additions: 0, deletions: 0 },
     ]);
   });
 
-  it("normalizes CRLF input before parsing", () => {
-    const diff = [
-      "diff --git a/a.txt b/a.txt",
-      "index 1111111..2222222 100644",
-      "--- a/a.txt",
-      "+++ b/a.txt",
-      "@@ -1 +1,2 @@",
-      "-one",
-      "+one updated",
-      "+two",
-      "",
-    ].join("\r\n");
+  it("keeps binary files and empty files with zero line changes", () => {
+    const numstat = ["-\t-\timage.png", "0\t0\tempty.txt", ""].join("\0");
+    expect(parseTurnDiffFilesFromNumstat(numstat)).toEqual([
+      { path: "empty.txt", additions: 0, deletions: 0 },
+      { path: "image.png", additions: 0, deletions: 0 },
+    ]);
+  });
 
-    expect(parseTurnDiffFilesFromUnifiedDiff(diff)).toEqual([
-      { path: "a.txt", additions: 2, deletions: 1 },
+  it("preserves Unicode, tabs, line endings, and spaces in paths", () => {
+    const path = " café\tline\r\nname.txt ";
+    const numstat = `3\t2\t\0old\tname\n.txt\0${path}\0`;
+
+    expect(parseTurnDiffFilesFromNumstat(numstat)).toEqual([{ path, additions: 3, deletions: 2 }]);
+    expect(parseTurnDiffFilesFromNumstat(`1\t0\t${path}\0`)).toEqual([
+      { path, additions: 1, deletions: 0 },
     ]);
   });
 });

--- a/apps/server/src/checkpointing/Diffs.ts
+++ b/apps/server/src/checkpointing/Diffs.ts
@@ -1,27 +1,33 @@
-import { parsePatchFiles } from "@pierre/diffs/utils/parsePatchFiles";
-
 export interface TurnDiffFileSummary {
   readonly path: string;
   readonly additions: number;
   readonly deletions: number;
 }
 
-export function parseTurnDiffFilesFromUnifiedDiff(
-  diff: string,
-): ReadonlyArray<TurnDiffFileSummary> {
-  const normalized = diff.replace(/\r\n/g, "\n").trim();
-  if (normalized.length === 0) {
-    return [];
-  }
+/** Reads Git's NUL-delimited numstat output without decoding display paths. */
+export function parseTurnDiffFilesFromNumstat(numstat: string): ReadonlyArray<TurnDiffFileSummary> {
+  const records = numstat.split("\0");
+  const files: TurnDiffFileSummary[] = [];
 
-  const parsedPatches = parsePatchFiles(normalized);
-  const files = parsedPatches.flatMap((patch) =>
-    patch.files.map((file) => ({
-      path: file.name,
-      additions: file.hunks.reduce((total, hunk) => total + hunk.additionLines, 0),
-      deletions: file.hunks.reduce((total, hunk) => total + hunk.deletionLines, 0),
-    })),
-  );
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index]!;
+    const counts = /^(\d+|-)\t(\d+|-)\t/.exec(record);
+    if (!counts) continue;
+
+    let path = record.slice(counts[0].length);
+    if (path.length === 0) {
+      // Renames and copies use two more records: the source and destination.
+      path = records[index + 2] ?? "";
+      index += 2;
+    }
+    if (path.length === 0) continue;
+
+    files.push({
+      path,
+      additions: counts[1] === "-" ? 0 : Number(counts[1]),
+      deletions: counts[2] === "-" ? 0 : Number(counts[2]),
+    });
+  }
 
   return files.toSorted((left, right) => left.path.localeCompare(right.path));
 }

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -27,6 +27,7 @@ import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as PubSub from "effect/PubSub";
+import * as Queue from "effect/Queue";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import { it as effectIt } from "@effect/vitest";
@@ -43,7 +44,8 @@ import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
 import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQuery.ts";
 import * as ThreadBackgroundLiveness from "../ThreadBackgroundLiveness.ts";
 import * as ThreadPlanProgress from "../ThreadPlanProgress.ts";
-import { RuntimeReceiptBusLive } from "./RuntimeReceiptBus.ts";
+import { RuntimeReceiptBusTest } from "./RuntimeReceiptBus.ts";
+import * as RuntimeReceiptBus from "../Services/RuntimeReceiptBus.ts";
 import { OrchestrationEventStoreLive } from "../../persistence/Layers/OrchestrationEventStore.ts";
 import { OrchestrationCommandReceiptRepositoryLive } from "../../persistence/Layers/OrchestrationCommandReceipts.ts";
 import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
@@ -262,7 +264,8 @@ describe("CheckpointReactor", () => {
     | OrchestrationEngineService
     | CheckpointReactor
     | CheckpointStore.CheckpointStore
-    | ProjectionSnapshotQuery,
+    | ProjectionSnapshotQuery
+    | RuntimeReceiptBus.RuntimeReceiptBus,
     unknown
   > | null = null;
   let scope: Scope.Closeable | null = null;
@@ -356,7 +359,7 @@ describe("CheckpointReactor", () => {
     const layer = CheckpointReactorLive.pipe(
       Layer.provideMerge(orchestrationLayer),
       Layer.provideMerge(projectionSnapshotLayer),
-      Layer.provideMerge(RuntimeReceiptBusLive),
+      Layer.provideMerge(RuntimeReceiptBusTest),
       Layer.provideMerge(Layer.succeed(ProviderService, provider.service)),
       Layer.provideMerge(Layer.mock(PullRequestService)({ refreshAfterTurn })),
       Layer.provideMerge(vcsStatusBroadcasterLayer),
@@ -380,8 +383,21 @@ describe("CheckpointReactor", () => {
     const checkpointStore = await runtime.runPromise(
       Effect.service(CheckpointStore.CheckpointStore),
     );
-    scope = await Effect.runPromise(Scope.make("sequential"));
-    await Effect.runPromise(reactor.start().pipe(Scope.provide(scope)));
+    const receiptBus = await runtime.runPromise(
+      Effect.service(RuntimeReceiptBus.RuntimeReceiptBus),
+    );
+    const testScope = await Effect.runPromise(Scope.make("sequential"));
+    scope = testScope;
+    const receipts = await Effect.runPromise(
+      Effect.gen(function* () {
+        const receipts = yield* Queue.unbounded<RuntimeReceiptBus.OrchestrationRuntimeReceipt>();
+        yield* Stream.runForEach(receiptBus.streamEventsForTest, (receipt) =>
+          Queue.offer(receipts, receipt),
+        ).pipe(Effect.forkIn(testScope, { startImmediately: true }));
+        yield* reactor.start().pipe(Scope.provide(testScope));
+        return receipts;
+      }),
+    );
     const drain = () => Effect.runPromise(reactor.drain);
 
     const createdAt = "2026-01-01T00:00:00.000Z";
@@ -470,16 +486,19 @@ describe("CheckpointReactor", () => {
       provider,
       cwd,
       drain,
+      nextReceipt: Queue.take(receipts),
       pullRequestRefreshes,
     };
   }
 
-  it("captures pre-turn baseline on turn.started and post-turn checkpoint on turn.completed", async () => {
-    const harness = await createHarness({ seedFilesystemCheckpoints: false });
-    const createdAt = "2026-01-01T00:00:00.000Z";
+  effectIt.effect("captures baseline and large turn summaries before completion receipts", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() =>
+        createHarness({ seedFilesystemCheckpoints: false }),
+      );
+      const createdAt = "2026-01-01T00:00:00.000Z";
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
+      yield* harness.engine.dispatch({
         type: "thread.session.set",
         commandId: CommandId.make("cmd-session-set-capture"),
         threadId: ThreadId.make("thread-1"),
@@ -493,62 +512,83 @@ describe("CheckpointReactor", () => {
           updatedAt: createdAt,
         },
         createdAt,
-      }),
-    );
+      });
 
-    harness.provider.emit({
-      type: "turn.started",
-      eventId: EventId.make("evt-turn-started-1"),
-      provider: ProviderDriverKind.make("codex"),
+      harness.provider.emit({
+        type: "turn.started",
+        eventId: EventId.make("evt-turn-started-1"),
+        provider: ProviderDriverKind.make("codex"),
 
-      createdAt: "2026-01-01T00:00:00.000Z",
-      threadId: ThreadId.make("thread-1"),
-      turnId: asTurnId("turn-1"),
-    });
-    await waitForGitRefExists(
-      harness.cwd,
-      checkpointRefForThreadTurn(ThreadId.make("thread-1"), 0),
-    );
+        createdAt: "2026-01-01T00:00:00.000Z",
+        threadId: ThreadId.make("thread-1"),
+        turnId: asTurnId("turn-1"),
+      });
+      expect(yield* harness.nextReceipt).toMatchObject({
+        type: "checkpoint.baseline.captured",
+        checkpointTurnCount: 0,
+      });
 
-    NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "v2\n", "utf8");
-    harness.provider.emit({
-      type: "turn.completed",
-      eventId: EventId.make("evt-turn-completed-1"),
-      provider: ProviderDriverKind.make("codex"),
+      NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "v2\n", "utf8");
+      const largeFileLineCount = 25_000;
+      NodeFS.writeFileSync(
+        NodePath.join(harness.cwd, "large.txt"),
+        `${"payload".repeat(64)}\n`.repeat(largeFileLineCount),
+        "utf8",
+      );
+      harness.provider.emit({
+        type: "turn.completed",
+        eventId: EventId.make("evt-turn-completed-1"),
+        provider: ProviderDriverKind.make("codex"),
 
-      createdAt: "2026-01-01T00:00:00.000Z",
-      threadId: ThreadId.make("thread-1"),
-      turnId: asTurnId("turn-1"),
-      payload: { state: "completed" },
-    });
+        createdAt: "2026-01-01T00:00:00.000Z",
+        threadId: ThreadId.make("thread-1"),
+        turnId: asTurnId("turn-1"),
+        payload: { state: "completed" },
+      });
 
-    await waitForEvent(harness.engine, (event) => event.type === "thread.turn-diff-completed");
-    const thread = await waitForThread(
-      harness.readModel,
-      (entry) => entry.latestTurn?.turnId === "turn-1" && entry.checkpoints.length === 1,
-    );
-    expect(thread.checkpoints[0]?.checkpointTurnCount).toBe(1);
-    expect(
-      gitRefExists(harness.cwd, checkpointRefForThreadTurn(ThreadId.make("thread-1"), 0)),
-    ).toBe(true);
-    expect(
-      gitRefExists(harness.cwd, checkpointRefForThreadTurn(ThreadId.make("thread-1"), 1)),
-    ).toBe(true);
-    expect(
-      gitShowFileAtRef(
-        harness.cwd,
-        checkpointRefForThreadTurn(ThreadId.make("thread-1"), 0),
-        "README.md",
-      ),
-    ).toBe("v1\n");
-    expect(
-      gitShowFileAtRef(
-        harness.cwd,
-        checkpointRefForThreadTurn(ThreadId.make("thread-1"), 1),
-        "README.md",
-      ),
-    ).toBe("v2\n");
-  });
+      expect(yield* harness.nextReceipt).toMatchObject({
+        type: "checkpoint.diff.finalized",
+        turnId: "turn-1",
+        checkpointTurnCount: 1,
+      });
+      const thread = (yield* Effect.promise(harness.readModel)).threads.find(
+        (entry) => entry.id === "thread-1",
+      );
+      expect(thread?.checkpoints[0]).toMatchObject({
+        checkpointTurnCount: 1,
+        files: [
+          { path: "large.txt", kind: "modified", additions: largeFileLineCount, deletions: 0 },
+          { path: "README.md", kind: "modified", additions: 1, deletions: 1 },
+        ],
+      });
+      expect(yield* harness.nextReceipt).toMatchObject({
+        type: "turn.processing.quiesced",
+        turnId: "turn-1",
+        checkpointTurnCount: 1,
+      });
+      yield* Effect.promise(harness.drain);
+      expect(
+        gitRefExists(harness.cwd, checkpointRefForThreadTurn(ThreadId.make("thread-1"), 0)),
+      ).toBe(true);
+      expect(
+        gitRefExists(harness.cwd, checkpointRefForThreadTurn(ThreadId.make("thread-1"), 1)),
+      ).toBe(true);
+      expect(
+        gitShowFileAtRef(
+          harness.cwd,
+          checkpointRefForThreadTurn(ThreadId.make("thread-1"), 0),
+          "README.md",
+        ),
+      ).toBe("v1\n");
+      expect(
+        gitShowFileAtRef(
+          harness.cwd,
+          checkpointRefForThreadTurn(ThreadId.make("thread-1"), 1),
+          "README.md",
+        ),
+      ).toBe("v2\n");
+    }),
+  );
 
   it("refreshes local git status state on turn completion using the session cwd", async () => {
     const gitStatusRefreshCalls: string[] = [];

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -21,7 +21,7 @@ import * as Stream from "effect/Stream";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
 
-import { parseTurnDiffFilesFromUnifiedDiff } from "../../checkpointing/Diffs.ts";
+import { parseTurnDiffFilesFromNumstat } from "../../checkpointing/Diffs.ts";
 import {
   checkpointRefForThreadTurn,
   resolveThreadWorkspaceCwd,
@@ -270,10 +270,11 @@ const make = Effect.gen(function* () {
         toCheckpointRef: targetCheckpointRef,
         fallbackFromToHead: false,
         ignoreWhitespace: false,
+        format: "numstat",
       })
       .pipe(
         Effect.map((diff) =>
-          parseTurnDiffFilesFromUnifiedDiff(diff).map((file) => ({
+          parseTurnDiffFilesFromNumstat(diff).map((file) => ({
             path: file.path,
             kind: "modified" as const,
             additions: file.additions,

--- a/apps/server/src/vcs/GitVcsDriver.test.ts
+++ b/apps/server/src/vcs/GitVcsDriver.test.ts
@@ -7,7 +7,7 @@ import * as PlatformError from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { assert, it } from "@effect/vitest";
 
-import { GitCommandError } from "@t3tools/contracts";
+import { CheckpointRef, GitCommandError } from "@t3tools/contracts";
 import * as ServerConfig from "../config.ts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
 import * as VcsProcess from "./VcsProcess.ts";
@@ -108,3 +108,37 @@ it.effect("GitVcsDriver forwards execute env to the VCS process", () => {
     ),
   );
 });
+
+it.effect("rejects truncated checkpoint numstat instead of returning a partial file list", () =>
+  Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.makeVcsDriverShape();
+
+    const error = yield* Effect.flip(
+      driver.checkpoints.diffCheckpoints({
+        cwd: "/repo",
+        fromCheckpointRef: CheckpointRef.make("refs/t3/checkpoints/from"),
+        toCheckpointRef: CheckpointRef.make("refs/t3/checkpoints/to"),
+        ignoreWhitespace: false,
+        format: "numstat",
+      }),
+    );
+
+    assert.strictEqual(error._tag, "VcsProcessOutputReadError");
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        NodeServices.layer,
+        Layer.mock(VcsProcess.VcsProcess)({
+          run: () =>
+            Effect.succeed({
+              exitCode: ChildProcessSpawner.ExitCode(0),
+              stdout: ["1\t0\tfirst.txt", "2\t0\tlast"].join("\0"),
+              stderr: "",
+              stdoutTruncated: true,
+              stderrTruncated: false,
+            }),
+        }),
+      ),
+    ),
+  ),
+);

--- a/apps/server/src/vcs/GitVcsDriver.test.ts
+++ b/apps/server/src/vcs/GitVcsDriver.test.ts
@@ -7,7 +7,7 @@ import * as PlatformError from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { assert, it } from "@effect/vitest";
 
-import { CheckpointRef, GitCommandError } from "@t3tools/contracts";
+import { GitCommandError } from "@t3tools/contracts";
 import * as ServerConfig from "../config.ts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
 import * as VcsProcess from "./VcsProcess.ts";
@@ -68,6 +68,7 @@ runVcsDriverContractSuite<GitVcsDriver.GitVcsDriver, GitContractError>({
 it.effect("GitVcsDriver forwards execute env to the VCS process", () => {
   let observedEnv: NodeJS.ProcessEnv | undefined;
   let observedAppendTruncationMarker: boolean | undefined;
+  let observedOutputMode: VcsProcess.VcsProcessInput["outputMode"];
 
   return Effect.gen(function* () {
     const driver = yield* GitVcsDriver.makeVcsDriverShape();
@@ -80,12 +81,14 @@ it.effect("GitVcsDriver forwards execute env to the VCS process", () => {
         GIT_INDEX_FILE: "/tmp/t3-index",
       },
       appendTruncationMarker: true,
+      outputMode: "error",
     });
 
     assert.deepStrictEqual(observedEnv, {
       GIT_INDEX_FILE: "/tmp/t3-index",
     });
     assert.strictEqual(observedAppendTruncationMarker, true);
+    assert.strictEqual(observedOutputMode, "error");
   }).pipe(
     Effect.provide(
       Layer.mergeAll(
@@ -95,6 +98,7 @@ it.effect("GitVcsDriver forwards execute env to the VCS process", () => {
             Effect.sync(() => {
               observedEnv = input.env;
               observedAppendTruncationMarker = input.appendTruncationMarker;
+              observedOutputMode = input.outputMode;
               return {
                 exitCode: ChildProcessSpawner.ExitCode(0),
                 stdout: "",
@@ -108,37 +112,3 @@ it.effect("GitVcsDriver forwards execute env to the VCS process", () => {
     ),
   );
 });
-
-it.effect("rejects truncated checkpoint numstat instead of returning a partial file list", () =>
-  Effect.gen(function* () {
-    const driver = yield* GitVcsDriver.makeVcsDriverShape();
-
-    const error = yield* Effect.flip(
-      driver.checkpoints.diffCheckpoints({
-        cwd: "/repo",
-        fromCheckpointRef: CheckpointRef.make("refs/t3/checkpoints/from"),
-        toCheckpointRef: CheckpointRef.make("refs/t3/checkpoints/to"),
-        ignoreWhitespace: false,
-        format: "numstat",
-      }),
-    );
-
-    assert.strictEqual(error._tag, "VcsProcessOutputReadError");
-  }).pipe(
-    Effect.provide(
-      Layer.mergeAll(
-        NodeServices.layer,
-        Layer.mock(VcsProcess.VcsProcess)({
-          run: () =>
-            Effect.succeed({
-              exitCode: ChildProcessSpawner.ExitCode(0),
-              stdout: ["1\t0\tfirst.txt", "2\t0\tlast"].join("\0"),
-              stderr: "",
-              stdoutTruncated: true,
-              stderrTruncated: false,
-            }),
-        }),
-      ),
-    ),
-  ),
-);

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -12,6 +12,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 import {
   GitCommandError,
   VcsProcessExitError,
+  VcsProcessOutputReadError,
   type VcsSwitchRefInput,
   type VcsSwitchRefResult,
   type VcsCreateRefInput,
@@ -838,6 +839,7 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
         "checkpoint.from_ref": input.fromCheckpointRef,
         "checkpoint.to_ref": input.toCheckpointRef,
         "checkpoint.ignore_whitespace": input.ignoreWhitespace,
+        "checkpoint.format": input.format ?? "patch",
         "checkpoint.fallback_from_to_head": input.fallbackFromToHead,
       });
 
@@ -869,7 +871,7 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
         cwd: input.cwd,
         args: [
           "diff",
-          "--patch",
+          ...(input.format === "numstat" ? ["--numstat", "-z"] : ["--patch"]),
           "--no-color",
           "--no-ext-diff",
           "--no-textconv",
@@ -889,6 +891,16 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
           cwd: input.cwd,
           exitCode: result.exitCode,
           detail: result.stderr.trim() || "Checkpoint ref is unavailable for diff operation.",
+        });
+      }
+
+      if (input.format === "numstat" && result.stdoutTruncated) {
+        return yield* new VcsProcessOutputReadError({
+          operation,
+          command: "git diff",
+          cwd: input.cwd,
+          stream: "stdout",
+          cause: new Error("Checkpoint numstat output was truncated."),
         });
       }
 

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -12,7 +12,6 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 import {
   GitCommandError,
   VcsProcessExitError,
-  VcsProcessOutputReadError,
   type VcsSwitchRefInput,
   type VcsSwitchRefResult,
   type VcsCreateRefInput,
@@ -432,6 +431,7 @@ const gitCommand = (
     readonly allowNonZeroExit?: boolean;
     readonly timeoutMs?: number;
     readonly maxOutputBytes?: number;
+    readonly outputMode?: VcsProcess.VcsProcessInput["outputMode"];
     readonly appendTruncationMarker?: boolean;
   },
 ) =>
@@ -448,6 +448,7 @@ const gitCommand = (
       : {}),
     ...(options?.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
     ...(options?.maxOutputBytes !== undefined ? { maxOutputBytes: options.maxOutputBytes } : {}),
+    ...(options?.outputMode !== undefined ? { outputMode: options.outputMode } : {}),
     ...(options?.appendTruncationMarker !== undefined
       ? { appendTruncationMarker: options.appendTruncationMarker }
       : {}),
@@ -486,6 +487,7 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
       ...(input.allowNonZeroExit !== undefined ? { allowNonZeroExit: input.allowNonZeroExit } : {}),
       ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
       ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
+      ...(input.outputMode !== undefined ? { outputMode: input.outputMode } : {}),
       ...(input.appendTruncationMarker !== undefined
         ? { appendTruncationMarker: input.appendTruncationMarker }
         : {}),
@@ -882,6 +884,7 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
         ],
         allowNonZeroExit: true,
         maxOutputBytes: CHECKPOINT_DIFF_MAX_OUTPUT_BYTES,
+        outputMode: input.format === "numstat" ? "error" : "truncate",
       });
 
       if (result.exitCode !== 0) {
@@ -891,16 +894,6 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
           cwd: input.cwd,
           exitCode: result.exitCode,
           detail: result.stderr.trim() || "Checkpoint ref is unavailable for diff operation.",
-        });
-      }
-
-      if (input.format === "numstat" && result.stdoutTruncated) {
-        return yield* new VcsProcessOutputReadError({
-          operation,
-          command: "git diff",
-          cwd: input.cwd,
-          stream: "stdout",
-          cause: new Error("Checkpoint numstat output was truncated."),
         });
       }
 

--- a/apps/server/src/vcs/VcsDriver.ts
+++ b/apps/server/src/vcs/VcsDriver.ts
@@ -31,6 +31,7 @@ export interface VcsDiffCheckpointsInput {
   readonly toCheckpointRef: CheckpointRef;
   readonly fallbackFromToHead?: boolean;
   readonly ignoreWhitespace: boolean;
+  readonly format?: "patch" | "numstat";
 }
 
 export interface VcsDeleteCheckpointRefsInput {

--- a/apps/server/src/vcs/VcsProcess.test.ts
+++ b/apps/server/src/vcs/VcsProcess.test.ts
@@ -1,5 +1,6 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { describe, expect, it } from "@effect/vitest";
+import { assert, describe, expect, it } from "@effect/vitest";
+import { HostProcessWorkingDirectory } from "@t3tools/shared/hostProcess";
 import * as Duration from "effect/Duration";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
@@ -356,6 +357,24 @@ describe("VcsProcess.run", () => {
 
       expect(result.stdoutTruncated).toBe(true);
       expect(result.stdout).not.toContain("[truncated]");
+    }).pipe(provideLive),
+  );
+
+  it.effect("fails with measured byte counts when output must not be truncated", () =>
+    Effect.gen(function* () {
+      const error = yield* run({
+        operation: "test.output-limit",
+        command: "node",
+        args: ["-e", "process.stdout.write('x'.repeat(2048))"],
+        cwd: yield* HostProcessWorkingDirectory,
+        maxOutputBytes: 128,
+        outputMode: "error",
+      }).pipe(Effect.flip);
+
+      assert(error._tag === "VcsProcessOutputLimitError");
+      expect(error.stream).toBe("stdout");
+      expect(error.maxBytes).toBe(128);
+      expect(error.observedBytes).toBeGreaterThan(error.maxBytes);
     }).pipe(provideLive),
   );
 

--- a/apps/server/src/vcs/VcsProcess.ts
+++ b/apps/server/src/vcs/VcsProcess.ts
@@ -29,6 +29,7 @@ export interface VcsProcessInput {
   readonly allowNonZeroExit?: boolean;
   readonly timeoutMs?: number;
   readonly maxOutputBytes?: number;
+  readonly outputMode?: ProcessRunner.ProcessRunInput["outputMode"];
   readonly appendTruncationMarker?: boolean;
 }
 
@@ -125,7 +126,7 @@ export const make = Effect.gen(function* () {
         ...(input.env !== undefined ? { env: input.env } : {}),
         timeout: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
         maxOutputBytes: input.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
-        outputMode: "truncate",
+        outputMode: input.outputMode ?? "truncate",
         truncatedMarker: input.appendTruncationMarker ? OUTPUT_TRUNCATED_MARKER : "",
         timeoutBehavior: "error",
       })

--- a/docs/internals/glossary.md
+++ b/docs/internals/glossary.md
@@ -147,7 +147,7 @@ The starting checkpoint for diffing a thread timeline. This flow is surfaced thr
 
 #### Checkpoint diff
 
-The patch difference between two checkpoints. Query logic lives in [CheckpointDiffQuery.ts][20], diff parsing lives in [Diffs.ts][23], and finalization is coordinated by [CheckpointReactor.ts][6].
+The difference between two checkpoints. [CheckpointDiffQuery.ts][20] reads full patches on demand. [CheckpointReactor.ts][6] uses NUL-delimited Git numstat output for automatic file summaries, parsed by [Diffs.ts][23].
 
 #### Turn diff
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,9 +496,6 @@ importers:
       '@opencode-ai/sdk':
         specifier: ^1.3.15
         version: 1.15.13
-      '@pierre/diffs':
-        specifier: 'catalog:'
-        version: 1.3.0-beta.10(patch_hash=7ef7cb0cbabb17c15cdb137554068b36f15f6f5265e73fb51452aa3380db91aa)(@shikijs/themes@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       effect:
         specifier: 4.0.0-beta.103
         version: 4.0.0-beta.103(patch_hash=af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6)


### PR DESCRIPTION
Automatic checkpoint summaries build and parse full patches only to count lines. Patches over 10 MB can leave the saved totals incomplete.

Automatic summaries now use NUL-delimited Git numstat. Full patches remain the default for on-demand diffs. The server no longer lists `@pierre/diffs` as a runtime dependency. Rename and copy destinations, binary and empty files, whitespace modes, and completion receipt order stay unchanged.

## Verification

- 59 focused tests pass, plus server typecheck and targeted lint.
- The 20-file audit fixture returns 490 bytes instead of a 12,758,220-byte patch, with identical totals. Git plus parsing took 399 ms with patches and 103 ms with numstat, using the median of three warm runs.
- The integrated 25,000-line case fails on the old implementation at 22,222 lines and passes with complete counts. It waits on receipts and checks the saved summary. User index bytes stay unchanged in real Git tests.

Part of the [performance audit](https://github.com/pingdotgg/t3code/issues/9661), item S9.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how checkpoint diffs are produced and how output limits are enforced; numstat over the byte cap now errors rather than returning partial counts, though on-demand patch diffs are unchanged.
> 
> **Overview**
> **Automatic turn checkpoint summaries** no longer build or parse multi‑MB unified patches just to count lines. `CheckpointReactor` now requests `diffCheckpoints` with `format: "numstat"`, and **`parseTurnDiffFilesFromNumstat`** replaces `@pierre/diffs`-based unified-diff parsing (dependency removed from `apps/server`).
> 
> **Checkpoint and Git VCS APIs** gain an optional `format: "patch" | "numstat"` on `diffCheckpoints` (patch remains the default for on-demand diffs). For numstat, `GitVcsDriver` runs `git diff --numstat -z` and sets VCS process **`outputMode: "error"`** so stdout over the 10 MB cap fails instead of truncating—keeping summary totals trustworthy on huge changes.
> 
> Tests cover numstat parsing (renames/copies, binary/empty files, odd paths), real-git checkpoint summaries including large files and index preservation, `VcsProcess` output-limit errors, and receipt ordering for large-turn completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2e999dd00e45206fdebf17f4418a81005a0a271. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use Git numstat for checkpoint summaries instead of full patches
> - Replaces unified-patch parsing with a NUL-delimited numstat reader (`parseTurnDiffFilesFromNumstat`) so file summaries stay complete even when the full patch would exceed the output limit
> - Adds an optional `format` field (`patch` | `numstat`) to the checkpoint-diff APIs in `VcsDriver`, `GitVcsDriver`, and `CheckpointStore`; `patch` remains the default
> - Adds an output-mode option to `VcsProcess`/`gitCommand` that can fail on limit overflow instead of truncating; numstat requests use error-on-limit, patches keep truncation
> - Removes the external patch-diff parser dependency and updates the glossary to distinguish on-demand patches from automatic numstat summaries
> - Behavioral Change: `GitVcsDriver` checkpoint diffs now fail on output-limit overflow in numstat mode instead of silently truncating; `CheckpointReactor` turn summaries now come from numstat, so binary/empty files report zero additions and deletions rather than being parsed from patch hunks
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2e999d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->