### PR TITLE
fix(codex): make account switching reliable

### DIFF
--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -114,7 +114,13 @@ function ModelRow(props: {
 }) {
   return (
     <Pressable
-      accessibilityLabel={[props.option.label, props.option.subtitle].filter(Boolean).join(", ")}
+      accessibilityLabel={[
+        props.option.label,
+        props.option.subtitle,
+        props.option.unavailableReason,
+      ]
+        .filter(Boolean)
+        .join(", ")}
       accessibilityRole="radio"
       accessibilityState={{
         checked: props.selected,
@@ -146,13 +152,18 @@ function ModelRow(props: {
               <Text className="text-3xs font-t3-bold text-foreground-muted">Legacy</Text>
             </View>
           ) : null}
-          {props.option.isUnavailable ? (
+          {props.option.isUnavailable && !props.option.unavailableReason ? (
             <Text className="text-xs text-foreground">Unavailable</Text>
           ) : null}
         </View>
         {props.option.subtitle ? (
           <Text className="text-xs text-foreground-muted" numberOfLines={1}>
             {props.option.subtitle}
+          </Text>
+        ) : null}
+        {props.option.unavailableReason ? (
+          <Text className="text-xs text-warning-foreground" numberOfLines={2}>
+            {props.option.unavailableReason}
           </Text>
         ) : null}
       </View>

--- a/apps/mobile/src/lib/modelOptions.test.ts
+++ b/apps/mobile/src/lib/modelOptions.test.ts
@@ -13,6 +13,46 @@ import {
 } from "./modelOptions";
 
 describe("mobile model options", () => {
+  it("marks models unavailable while their account limit is exhausted", () => {
+    const config = {
+      providers: [
+        {
+          instanceId: "codex_work",
+          driver: "codex",
+          displayName: "Codex Work",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          models: [
+            {
+              slug: "gpt-5.6-sol",
+              name: "GPT-5.6 Sol",
+              isCustom: false,
+              capabilities: null,
+            },
+          ],
+          usageLimits: {
+            checkedAt: "2026-09-04T00:00:00.000Z",
+            windows: [
+              {
+                id: "primary",
+                kind: "session",
+                label: "Session",
+                usedPercent: 100,
+                resetsAt: "2999-09-04T02:00:00.000Z",
+              },
+            ],
+          },
+        },
+      ],
+    } as unknown as ServerConfig;
+
+    expect(buildModelOptions(config, null)[0]).toMatchObject({
+      isUnavailable: true,
+      unavailableReason: expect.stringContaining("Usage limit reached"),
+    });
+  });
+
   it("groups models by provider and flags legacy entries", () => {
     const config = {
       providers: [

--- a/apps/mobile/src/lib/modelOptions.ts
+++ b/apps/mobile/src/lib/modelOptions.ts
@@ -7,6 +7,7 @@ import {
   buildExplicitProviderOptionSelectionsFromDescriptors,
   getProviderOptionDescriptors,
 } from "@t3tools/shared/model";
+import { rateLimitReason } from "@t3tools/shared/usageLimits";
 
 export type ModelOption = {
   readonly key: string;
@@ -18,6 +19,7 @@ export type ModelOption = {
   readonly isDefault: boolean;
   readonly isLegacy: boolean;
   readonly isUnavailable?: boolean;
+  readonly unavailableReason?: string;
   readonly capabilities: ModelCapabilities | null;
   readonly selection: ModelSelection;
 };
@@ -164,6 +166,7 @@ export function buildModelOptions(
     }
 
     const providerLabel = providerDisplayLabel(provider);
+    const unavailableReason = rateLimitReason(provider.usageLimits, Date.now());
     for (const model of provider.models) {
       const key = `${provider.instanceId}:${model.slug}`;
       options.set(key, {
@@ -175,6 +178,7 @@ export function buildModelOptions(
         providerDriver: provider.driver,
         isDefault: model.isDefault === true,
         isLegacy: model.isLegacy === true,
+        ...(unavailableReason ? { isUnavailable: true, unavailableReason } : {}),
         capabilities: model.capabilities,
         selection: normalizeSelectionOptions(
           {
@@ -213,6 +217,7 @@ export function buildModelOptions(
         displayName: provider?.displayName ?? instanceConfig?.displayName,
         instanceId: fallbackModelSelection.instanceId,
       });
+      const unavailableReason = rateLimitReason(provider?.usageLimits, Date.now());
       options.set(key, {
         key,
         label: model?.name ?? fallbackModelSelection.model,
@@ -222,9 +227,10 @@ export function buildModelOptions(
         providerDriver,
         isDefault: false,
         isLegacy: model?.isLegacy === true,
-        ...(isModelSelectionUnavailable(config, fallbackModelSelection)
+        ...(isModelSelectionUnavailable(config, fallbackModelSelection) || unavailableReason
           ? { isUnavailable: true }
           : {}),
+        ...(unavailableReason ? { unavailableReason } : {}),
         capabilities: model?.capabilities ?? null,
         selection: fallbackModelSelection,
       });

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -1292,6 +1292,40 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
     }),
   );
 
+  it.effect("classifies Codex usage-limit errors", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+
+      yield* runtime.emit({
+        id: asEventId("evt-usage-limit-error"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-1"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        method: "error",
+        turnId: asTurnId("turn-1"),
+        payload: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          error: {
+            message: "Usage limit reached",
+            codexErrorInfo: "usageLimitExceeded",
+          },
+          willRetry: false,
+        },
+      } satisfies ProviderEvent);
+
+      const firstEvent = yield* Fiber.join(firstEventFiber);
+
+      NodeAssert.equal(firstEvent._tag, "Some");
+      if (firstEvent._tag !== "Some" || firstEvent.value.type !== "runtime.error") {
+        return;
+      }
+      NodeAssert.equal(firstEvent.value.payload.class, "rate_limit");
+    }),
+  );
+
   it.effect("maps process stderr notifications to runtime.warning", () =>
     Effect.gen(function* () {
       const { adapter, runtime } = yield* startLifecycleRuntime();

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1888,13 +1888,15 @@ function mapToRuntimeEvents(
     const payload = readPayload(EffectCodexSchema.V2ErrorNotification, event.payload);
     const message = payload?.error.message ?? event.message ?? "Provider runtime error";
     const willRetry = payload?.willRetry === true;
+    const errorClass =
+      payload?.error.codexErrorInfo === "usageLimitExceeded" ? "rate_limit" : "provider_error";
     return [
       {
         type: willRetry ? "runtime.warning" : "runtime.error",
         ...runtimeEventBase(event, canonicalThreadId),
         payload: {
           message,
-          ...(!willRetry ? { class: "provider_error" as const } : {}),
+          ...(!willRetry ? { class: errorClass } : {}),
           ...(event.payload !== undefined ? { detail: event.payload } : {}),
         },
       },

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -658,6 +658,69 @@ it.effect("ProviderServiceLive rejects new sessions for disabled custom instance
 
 const routing = makeProviderServiceLayer();
 
+const codexWorkInstanceId = ProviderInstanceId.make("codex_work");
+const primaryCodex = makeFakeCodexAdapter();
+const workCodex = makeFakeCodexAdapter();
+const codexAccountRegistryBase = makeAdapterRegistryMock({
+  [CODEX_DRIVER]: primaryCodex.adapter,
+});
+const codexAccountSwitching = makeProviderServiceLayer({
+  registry: {
+    ...codexAccountRegistryBase,
+    getByInstance: (instanceId) =>
+      instanceId === codexWorkInstanceId
+        ? Effect.succeed(workCodex.adapter)
+        : codexAccountRegistryBase.getByInstance(instanceId),
+    getInstanceInfo: (instanceId) =>
+      instanceId === codexInstanceId || instanceId === codexWorkInstanceId
+        ? Effect.succeed({
+            instanceId,
+            driverKind: CODEX_DRIVER,
+            displayName: undefined,
+            enabled: true,
+            continuationIdentity: {
+              driverKind: CODEX_DRIVER,
+              continuationKey: "codex:shared",
+            },
+          })
+        : codexAccountRegistryBase.getInstanceInfo(instanceId),
+    listInstances: () => Effect.succeed([codexInstanceId, codexWorkInstanceId]),
+  },
+});
+
+codexAccountSwitching.layer("ProviderServiceLive Codex account switching", (it) => {
+  it.effect("stops the old Codex writer before resuming on another instance", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const threadId = asThreadId("thread-codex-account-switch");
+      const firstSession = yield* provider.startSession(threadId, {
+        provider: CODEX_DRIVER,
+        providerInstanceId: codexInstanceId,
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      primaryCodex.stopSession.mockClear();
+      workCodex.startSession.mockClear();
+
+      yield* provider.startSession(threadId, {
+        provider: CODEX_DRIVER,
+        providerInstanceId: codexWorkInstanceId,
+        threadId,
+        resumeCursor: firstSession.resumeCursor,
+        runtimeMode: "full-access",
+      });
+
+      assert.equal(primaryCodex.stopSession.mock.calls.length, 1);
+      assert.equal(workCodex.startSession.mock.calls.length, 1);
+      assert.isBelow(
+        primaryCodex.stopSession.mock.invocationCallOrder[0] ?? Infinity,
+        workCodex.startSession.mock.invocationCallOrder[0] ?? -Infinity,
+      );
+    }),
+  );
+});
+
 const antigravityDriver = ProviderDriverKind.make("antigravity");
 const replacementAntigravity = makeFakeCodexAdapter(antigravityDriver);
 const originalAntigravityInstanceId = ProviderInstanceId.make("antigravity-personal");

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -667,12 +667,14 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
   const stopStaleSessionsForThread = Effect.fn("stopStaleSessionsForThread")(function* (input: {
     readonly threadId: ThreadId;
     readonly currentInstanceId: ProviderInstanceId;
+    readonly provider?: ProviderDriverKind;
   }) {
     const currentAdapters = yield* getAdapterEntries;
     yield* Effect.forEach(
       currentAdapters,
       ([instanceId, adapter]) =>
-        instanceId === input.currentInstanceId
+        instanceId === input.currentInstanceId ||
+        (input.provider !== undefined && adapter.provider !== input.provider)
           ? Effect.void
           : Effect.gen(function* () {
               const hasSession = yield* adapter.hasSession(input.threadId);
@@ -790,6 +792,13 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           "provider.cwd.effective": effectiveCwd ?? "",
         });
         const adapter = yield* registry.getByInstance(resolvedInstanceId);
+        // Codex cannot resume one thread in two app-server processes at once.
+        // Stop same-driver instances first; unrelated providers remain live if start fails.
+        yield* stopStaleSessionsForThread({
+          threadId,
+          currentInstanceId: resolvedInstanceId,
+          provider: resolvedProvider,
+        });
         yield* prepareMcpSession(threadId, resolvedInstanceId);
         const session = yield* adapter
           .startSession({

--- a/apps/server/src/provider/Layers/ProviderUsageLimitsIngestion.test.ts
+++ b/apps/server/src/provider/Layers/ProviderUsageLimitsIngestion.test.ts
@@ -1,0 +1,59 @@
+import {
+  EventId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+  type ProviderRuntimeEvent,
+  type ServerProvider,
+} from "@t3tools/contracts";
+import { it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Stream from "effect/Stream";
+
+import type { ProviderInstance } from "../ProviderDriver.ts";
+import { ProviderInstanceRegistry } from "../Services/ProviderInstanceRegistry.ts";
+import { ProviderService } from "../Services/ProviderService.ts";
+import { ProviderUsageLimitsIngestionLive } from "./ProviderUsageLimitsIngestion.ts";
+
+it.effect("refreshes the rate-limited provider instance", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const instanceId = ProviderInstanceId.make("codex_work");
+      const refreshed = yield* Deferred.make<void>();
+      const instance = {
+        instanceId,
+        snapshot: {
+          refresh: Deferred.succeed(refreshed, undefined).pipe(Effect.as({} as ServerProvider)),
+        },
+      } as ProviderInstance;
+      const event = {
+        type: "runtime.error",
+        eventId: EventId.make("event-rate-limit"),
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: instanceId,
+        threadId: ThreadId.make("thread-1"),
+        createdAt: "2026-09-04T00:00:00.000Z",
+        payload: { message: "Usage limit reached", class: "rate_limit" },
+      } satisfies ProviderRuntimeEvent;
+
+      yield* Layer.build(
+        ProviderUsageLimitsIngestionLive.pipe(
+          Layer.provide(
+            Layer.succeed(ProviderInstanceRegistry, {
+              getInstance: () => Effect.succeed(instance),
+            } as unknown as ProviderInstanceRegistry["Service"]),
+          ),
+          Layer.provide(
+            Layer.succeed(ProviderService, {
+              streamEvents: Stream.make(event),
+            } as ProviderService["Service"]),
+          ),
+        ),
+      );
+
+      yield* Deferred.await(refreshed);
+    }),
+  ),
+);

--- a/apps/server/src/provider/Layers/ProviderUsageLimitsIngestion.ts
+++ b/apps/server/src/provider/Layers/ProviderUsageLimitsIngestion.ts
@@ -1,6 +1,6 @@
 /**
- * ProviderUsageLimitsIngestionLive — folds `account.rate-limits.updated`
- * runtime events into the owning instance's published snapshot.
+ * ProviderUsageLimitsIngestionLive — keeps owning-instance usage snapshots
+ * current from runtime telemetry.
  *
  * Adapters normalise their native payloads before emitting, so this layer
  * never sees a driver shape: it routes the typed update to the instance and
@@ -23,7 +23,11 @@ export const ProviderUsageLimitsIngestionLive = Layer.effectDiscard(
     const instanceRegistry = yield* ProviderInstanceRegistry;
 
     yield* providerService.streamEvents.pipe(
-      Stream.filter((event) => event.type === "account.rate-limits.updated"),
+      Stream.filter(
+        (event) =>
+          event.type === "account.rate-limits.updated" ||
+          (event.type === "runtime.error" && event.payload.class === "rate_limit"),
+      ),
       Stream.runForEach((event) =>
         Effect.gen(function* () {
           if (!event.providerInstanceId) {
@@ -34,7 +38,11 @@ export const ProviderUsageLimitsIngestionLive = Layer.effectDiscard(
             return;
           }
           const checkedAt = DateTime.formatIso(yield* DateTime.now);
-          yield* instance.snapshot.applyUsageLimits({ ...event.payload.limits, checkedAt });
+          if (event.type === "account.rate-limits.updated") {
+            yield* instance.snapshot.applyUsageLimits({ ...event.payload.limits, checkedAt });
+          } else {
+            yield* instance.snapshot.refresh;
+          }
           // One bad event must not end the subscriber for every later one.
         }).pipe(Effect.ignoreCause({ log: true })),
       ),

--- a/apps/web/src/components/chat/ModelListRow.tsx
+++ b/apps/web/src/components/chat/ModelListRow.tsx
@@ -36,6 +36,7 @@ export const ModelListRow = memo(function ModelListRow(props: {
   useTriggerLabel?: boolean;
   showNewBadge?: boolean;
   unavailable?: boolean;
+  rateLimited?: boolean;
   jumpLabel?: string | null;
   disabledReason?: string | null;
   onToggleFavorite: () => void;
@@ -80,6 +81,15 @@ export const ModelListRow = memo(function ModelListRow(props: {
           {props.unavailable ? (
             <Badge variant="outline" size="sm">
               Unavailable
+            </Badge>
+          ) : null}
+          {props.rateLimited ? (
+            <Badge
+              variant="outline"
+              size="sm"
+              className="border-warning/35 text-warning-foreground"
+            >
+              Limited
             </Badge>
           ) : null}
         </div>

--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -5,9 +5,10 @@ import {
   type ResolvedKeybindingsConfig,
 } from "@t3tools/contracts";
 import { resolveSelectableModel } from "@t3tools/shared/model";
+import { rateLimitReason } from "@t3tools/shared/usageLimits";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
 import { memo, useMemo, useState, useCallback, useEffect, useLayoutEffect, useRef } from "react";
-import { ChevronRightIcon, SearchIcon } from "lucide-react";
+import { CircleAlertIcon, ChevronRightIcon, SearchIcon } from "lucide-react";
 import { ModelListRow } from "./ModelListRow";
 import { ModelPickerSidebar } from "./ModelPickerSidebar";
 import { getProviderStatusMessage, hasProviderSetup } from "./ProviderStatusBanner";
@@ -269,6 +270,22 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
     () => new Map(instanceEntries.map((entry) => [entry.instanceId, entry])),
     [instanceEntries],
   );
+  const [rateLimitNow] = useState(Date.now);
+  const rateLimitReasonByInstanceId = useMemo(() => {
+    return new Map(
+      instanceEntries.flatMap((entry) => {
+        const reason = rateLimitReason(entry.snapshot.usageLimits, rateLimitNow);
+        return reason ? [[entry.instanceId, reason] as const] : [];
+      }),
+    );
+  }, [instanceEntries, rateLimitNow]);
+  const modelDisabledReason = useCallback(
+    (instanceId: ProviderInstanceId, model: string) =>
+      getModelDisabledReason?.(instanceId, model) ??
+      rateLimitReasonByInstanceId.get(instanceId) ??
+      null,
+    [getModelDisabledReason, rateLimitReasonByInstanceId],
+  );
   const matchesLockedProvider = useCallback(
     (entry: Pick<ProviderInstanceEntry, "driverKind" | "continuationGroupKey">): boolean => {
       if (props.lockedProvider === null) return true;
@@ -349,18 +366,17 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
 
   const isLocked = props.lockedProvider !== null;
   const isSearching = searchQuery.trim().length > 0;
-  const lockedDisabledInstanceIds = useMemo(() => {
-    if (!isLocked) {
-      return undefined;
-    }
-    const disabled = new Set<ProviderInstanceId>();
-    for (const entry of instanceEntries) {
-      if (!matchesLockedProvider(entry)) {
-        disabled.add(entry.instanceId);
+  const disabledInstanceIds = useMemo(() => {
+    const disabled = new Set(rateLimitReasonByInstanceId.keys());
+    if (isLocked) {
+      for (const entry of instanceEntries) {
+        if (!matchesLockedProvider(entry)) {
+          disabled.add(entry.instanceId);
+        }
       }
     }
-    return disabled;
-  }, [instanceEntries, isLocked, matchesLockedProvider]);
+    return disabled.size > 0 ? disabled : undefined;
+  }, [instanceEntries, isLocked, matchesLockedProvider, rateLimitReasonByInstanceId]);
   const sidebarInstanceEntries = useMemo(() => {
     const enabledEntries = instanceEntries.filter(isProviderInstancePickerVisible);
     if (!isLocked) {
@@ -518,6 +534,9 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
 
   const selectedEntry =
     selectedInstanceId === "favorites" ? undefined : entryByInstanceId.get(selectedInstanceId);
+  const selectedRateLimitReason = selectedEntry
+    ? rateLimitReasonByInstanceId.get(selectedEntry.instanceId)
+    : undefined;
   const providerSetupEntries =
     !isSearching && props.onOpenProviderSetup
       ? instanceEntries.filter(
@@ -547,7 +566,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
 
   const handleModelSelect = useCallback(
     (modelSlug: string, instanceId: ProviderInstanceId) => {
-      if (getModelDisabledReason?.(instanceId, modelSlug)) {
+      if (modelDisabledReason(instanceId, modelSlug)) {
         return;
       }
       const options = modelOptionsByInstance.get(instanceId);
@@ -566,7 +585,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
         onInstanceModelChange(instanceId, resolvedModel);
       }
     },
-    [entryByInstanceId, getModelDisabledReason, modelOptionsByInstance, onInstanceModelChange],
+    [entryByInstanceId, modelDisabledReason, modelOptionsByInstance, onInstanceModelChange],
   );
 
   const toggleFavorite = useCallback(
@@ -590,7 +609,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
     >();
     let selectableModelIndex = 0;
     for (const model of visibleModels) {
-      if (getModelDisabledReason?.(model.instanceId, model.slug)) {
+      if (modelDisabledReason(model.instanceId, model.slug)) {
         continue;
       }
       const jumpCommand = modelPickerJumpCommandForIndex(selectableModelIndex);
@@ -601,7 +620,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       selectableModelIndex += 1;
     }
     return mapping;
-  }, [getModelDisabledReason, visibleModels]);
+  }, [modelDisabledReason, visibleModels]);
   const modelJumpModelKeys = useMemo(
     () => [...modelJumpCommandByKey.keys()],
     [modelJumpCommandByKey],
@@ -739,10 +758,11 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
             instanceEntries={sidebarInstanceEntries}
             showFavorites
             {...(selectableUnavailableInstanceIds ? { selectableUnavailableInstanceIds } : {})}
-            {...(lockedDisabledInstanceIds
+            {...(disabledInstanceIds
               ? {
-                  disabledInstanceIds: lockedDisabledInstanceIds,
+                  disabledInstanceIds,
                   getDisabledInstanceTooltip: (entry: ProviderInstanceEntry) =>
+                    rateLimitReasonByInstanceId.get(entry.instanceId) ??
                     `${entry.displayName} is unavailable in this thread. Start a new thread to switch providers.`,
                 }
               : {})}
@@ -839,6 +859,16 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
               </div>
             </div>
 
+            {selectedRateLimitReason ? (
+              <div
+                role="status"
+                className="mx-2 mt-2 flex items-start gap-2 rounded-md bg-warning-surface px-2 py-1.5 text-xs leading-snug text-warning-foreground"
+              >
+                <CircleAlertIcon className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+                <span>{selectedRateLimitReason} Choose another account.</span>
+              </div>
+            ) : null}
+
             {/* Model list */}
             <div className="relative min-h-0 flex-1 overflow-hidden pr-px">
               <ComboboxListVirtualized className="size-full min-w-0 p-0 not-empty:p-0">
@@ -877,8 +907,8 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                     if (!model) {
                       return null;
                     }
-                    const disabledReason =
-                      getModelDisabledReason?.(model.instanceId, model.slug) ?? null;
+                    const disabledReason = modelDisabledReason(model.instanceId, model.slug);
+                    const isRateLimited = rateLimitReasonByInstanceId.has(model.instanceId);
                     return (
                       <ModelListRow
                         key={modelKey}
@@ -897,6 +927,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                         useTriggerLabel={false}
                         showNewBadge={model.badge === "new"}
                         unavailable={model.isUnavailable === true}
+                        rateLimited={isRateLimited}
                         jumpLabel={modelJumpLabelByKey.get(modelKey) ?? null}
                         disabledReason={disabledReason}
                         onToggleFavorite={() => toggleFavorite(model.instanceId, model.slug)}

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -4,6 +4,7 @@ import {
   type ProviderDriverKind,
   type ResolvedKeybindingsConfig,
 } from "@t3tools/contracts";
+import { rateLimitReason } from "@t3tools/shared/usageLimits";
 import { memo, useEffect, useMemo, useState } from "react";
 import type { VariantProps } from "class-variance-authority";
 import { Badge } from "../ui/badge";
@@ -88,6 +89,8 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   const triggerLabel = selectedModel
     ? `${getTriggerDisplayModelLabel(selectedModel)}${selectedModel.isUnavailable ? " (Unavailable)" : ""}`
     : triggerTitle;
+  const [rateLimitNow] = useState(Date.now);
+  const activeRateLimitReason = rateLimitReason(activeEntry?.snapshot.usageLimits, rateLimitNow);
   const showInstanceBadge =
     activeEntry !== null && shouldShowInstanceBadge(activeEntry, props.instanceEntries);
 
@@ -208,11 +211,21 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
             >
               {triggerTitle}
             </TooltipTrigger>
-            <TooltipPopup side="top">{triggerLabel}</TooltipPopup>
+            <TooltipPopup side="top">
+              {activeRateLimitReason ? `${triggerLabel}. ${activeRateLimitReason}` : triggerLabel}
+            </TooltipPopup>
           </Tooltip>
           {selectedModel?.isUnavailable ? (
             <Badge variant="outline" size="sm">
               Unavailable
+            </Badge>
+          ) : activeRateLimitReason ? (
+            <Badge
+              variant="outline"
+              size="sm"
+              className="border-warning/35 text-warning-foreground"
+            >
+              Limited
             </Badge>
           ) : null}
         </span>

--- a/docs/user/providers-codex.md
+++ b/docs/user/providers-codex.md
@@ -130,6 +130,10 @@ click the blurred email to reveal it.
 
 Use display names and accent colors to make accounts easy to tell apart in the model picker.
 
+When Codex reports that an account has reached its usage limit, T3 Code marks that account as
+limited in the model picker and disables its models until the reported limit resets. Choose another
+configured account to continue the thread.
+
 ## I Need A Different API Key Or Endpoint
 
 Use the provider's Environment variables section in Settings.

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -96,6 +96,7 @@ export type RuntimeSessionExitKind = typeof RuntimeSessionExitKind.Type;
 
 const RuntimeErrorClass = Schema.Literals([
   "provider_error",
+  "rate_limit",
   "transport_error",
   "permission_error",
   "validation_error",

--- a/packages/shared/src/usageLimits.test.ts
+++ b/packages/shared/src/usageLimits.test.ts
@@ -16,6 +16,7 @@ import {
   limitsNotice,
   paceOf,
   providersWithLimits,
+  rateLimitReason,
 } from "./usageLimits.ts";
 
 const now = Date.parse("2026-09-03T12:00:00.000Z");
@@ -86,6 +87,27 @@ describe("limitsNotice", () => {
         unavailable: { reason: "probeFailed", message: "Codex timed out." },
       }),
     ).toBe("Codex timed out.");
+  });
+});
+
+describe("rateLimitReason", () => {
+  it("disables exhausted windows only until their latest reset", () => {
+    const limits = {
+      checkedAt: "2026-09-03T11:00:00.000Z",
+      windows: [
+        { ...window, usedPercent: 100 },
+        { ...window, id: "weekly", usedPercent: 100, resetsAt: "2026-09-04T12:00:00.000Z" },
+      ],
+    };
+
+    expect(rateLimitReason(limits, now)).toBe("Usage limit reached. Resets in 1d 0h.");
+    expect(rateLimitReason(limits, Date.parse("2026-09-04T12:00:00.000Z"))).toBeNull();
+    expect(
+      rateLimitReason(
+        { ...limits, windows: [{ ...window, usedPercent: 100, resetsAt: undefined }] },
+        now,
+      ),
+    ).toBe("Usage limit reached.");
   });
 });
 

--- a/packages/shared/src/usageLimits.ts
+++ b/packages/shared/src/usageLimits.ts
@@ -209,3 +209,20 @@ export function formatResetsIn(window: ServerProviderUsageWindow, now: number): 
   if (resetsAt === null) return null;
   return resetsAt <= now ? "resets now" : `resets in ${formatDuration(resetsAt - now)}`;
 }
+
+/** Picker warning while any exhausted account window is still active. */
+export function rateLimitReason(
+  limits: ServerProviderUsageLimits | undefined,
+  now: number,
+): string | null {
+  const exhausted = limits?.windows.filter((window) => {
+    if (window.usedPercent < 100) return false;
+    const resetsAt = resetMillis(window);
+    return resetsAt === null || resetsAt > now;
+  });
+  if (!exhausted?.length) return null;
+  const resets = exhausted.map(resetMillis);
+  if (resets.some((reset) => reset === null)) return "Usage limit reached.";
+  const resetsAt = Math.max(...resets.filter((reset): reset is number => reset !== null));
+  return `Usage limit reached. Resets in ${formatDuration(resetsAt - now)}.`;
+}


### PR DESCRIPTION
Switching Codex accounts on an existing thread can leave the previous app-server session holding the thread writer, forcing a server restart. Accounts that have exhausted their quota also remain selectable, making repeated failures likely.

Stop stale sessions for the same provider driver before starting the replacement account. Classify structured Codex usage-limit errors, refresh the existing per-account usage snapshot, and mark exhausted accounts unavailable with a reset warning across web, desktop, and mobile.

Focused verification: 125 tests; server, web, mobile, shared, and contracts typechecks; targeted lint and formatting; UI audit.

Generated by GPT-5.6 Sol using Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider session teardown ordering when switching Codex instances on a thread, which is correctness-critical but scoped and covered by new tests; UI and snapshot refresh behavior are additive.
> 
> **Overview**
> Fixes **Codex account switching on an existing thread** by stopping other same-driver provider sessions on that thread **before** starting the new instance, so the old app-server writer cannot keep holding the thread.
> 
> Adds end-to-end **usage-limit handling**: Codex `usageLimitExceeded` errors map to `runtime.error` with class **`rate_limit`**; ingestion refreshes the account usage snapshot on those events (not only `account.rate-limits.updated`). Shared **`rateLimitReason`** drives web, mobile, and model-option builders to mark exhausted accounts unavailable, show reset messaging, and block selection until limits clear.
> 
> Web model picker and mobile thread settings surface **Limited** badges, disabled instances, and warnings; contracts gain the `rate_limit` error class. User docs describe limited Codex accounts in the picker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d69c7623b0239d343bd044ec14de2a7c0a146203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex account switching and surface usage-limit state across clients
> - `ProviderService.startSession` now stops existing sessions for other instances of the same provider driver before starting the target adapter; `stopStaleSessionsForThread` accepts a provider filter to scope cleanup to the resolved driver.
> - `CodexAdapter.mapToRuntimeEvents` classifies non-retryable `usageLimitExceeded` Codex errors as `rate_limit` instead of `provider_error`; `ProviderUsageLimitsIngestionLive` refreshes the owning instance snapshot on such errors.
> - Adds shared `rateLimitReason` in [usageLimits.ts](https://github.com/pingdotgg/t3code/pull/9696/files#diff-68cfbbd2d613fbb904208024425af193a1c663fa233b1c58b58735a924530b7f) to detect active exhausted usage windows and format a reset message.
> - Mobile ([modelOptions.ts](https://github.com/pingdotgg/t3code/pull/9696/files#diff-e728e5b82529c8d8d8ae7017fbd0ee4021eea3e722dc156b9f3b209951cc7dea)) and web ([ModelPickerContent.tsx](https://github.com/pingdotgg/t3code/pull/9696/files#diff-af6ec8809b715e3718ef62e155f706b7bfc2b5331a509865043ed81e0f10f50c)) now mark rate-limited models unavailable, display "Limited" badges, and pass the reason to tooltips and assistive tech.
> - Behavioral Change: `rate_limit` is added to the runtime error class schema in [providerRuntime.ts](https://github.com/pingdotgg/t3code/pull/9696/files#diff-448aaf2dfbb7547d852cc74c6bba5caea16c3c782a5f9cfbf43da71648ec61f7); consumers that do not handle the new class may misclassify these events.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d69c762. 11 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->