### PR TITLE
perf(marketing): stop continuous homepage motion

### DIFF
--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -17,16 +17,6 @@ const screenshot = await getImage({
   quality: 90,
 });
 
-const desktopEndorsementRows = [
-  tweets.filter((_, index) => index % 2 === 0),
-  tweets.filter((_, index) => index % 2 === 1),
-];
-
-const mobileEndorsementRows = [
-  tweets.filter((_, index) => index % 3 === 0),
-  tweets.filter((_, index) => index % 3 === 1),
-  tweets.filter((_, index) => index % 3 === 2),
-];
 ---
 
 <Layout>
@@ -121,80 +111,29 @@ const mobileEndorsementRows = [
       </div>
     </div>
 
-    <div class="endorsement-carousel endorsement-carousel--desktop" aria-label="Developer endorsements">
-        {
-          desktopEndorsementRows.map((row, rowIndex) => (
-            <div class:list={["endorsement-row", rowIndex === 1 && "is-reverse"]}>
-              <div class="endorsement-track">
-                {[0, 1].map((groupIndex) => (
-                  <div class="endorsement-track-group" aria-hidden={groupIndex === 1 ? "true" : undefined}>
-                    {row.map((tweet) => (
-                      <a
-                        class="endorsement-card"
-                        href={tweet.link}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label={`Read ${tweet.handle}'s post on X`}
-                        tabindex={groupIndex === 1 ? "-1" : undefined}
-                      >
-                        <div class="endorsement-author">
-                          <img
-                            src={`/pfps/${tweet.handle}.webp`}
-                            alt=""
-                            width="28"
-                            height="28"
-                            loading="lazy"
-                            decoding="async"
-                          />
-                          <div class="endorsement-handle">@{tweet.handle}</div>
-                        </div>
-                        <p>{tweet.excerpt ?? tweet.content}</p>
-                      </a>
-                    ))}
-                  </div>
-                ))}
-              </div>
-            </div>
-          ))
-        }
-    </div>
-
-    <div class="endorsement-carousel endorsement-carousel--mobile" aria-label="Developer endorsements">
-        {
-          mobileEndorsementRows.map((row, rowIndex) => (
-            <div class:list={["endorsement-row", rowIndex === 1 && "is-reverse"]}>
-              <div class="endorsement-track">
-                {[0, 1].map((groupIndex) => (
-                  <div class="endorsement-track-group" aria-hidden={groupIndex === 1 ? "true" : undefined}>
-                    {row.map((tweet) => (
-                      <a
-                        class="endorsement-card"
-                        href={tweet.link}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label={`Read ${tweet.handle}'s post on X`}
-                        tabindex={groupIndex === 1 ? "-1" : undefined}
-                      >
-                        <div class="endorsement-author">
-                          <img
-                            src={`/pfps/${tweet.handle}.webp`}
-                            alt=""
-                            width="28"
-                            height="28"
-                            loading="lazy"
-                            decoding="async"
-                          />
-                          <div class="endorsement-handle">@{tweet.handle}</div>
-                        </div>
-                        <p>{tweet.excerpt ?? tweet.content}</p>
-                      </a>
-                    ))}
-                  </div>
-                ))}
-              </div>
-            </div>
-          ))
-        }
+    <div class="endorsement-carousel" role="region" aria-label="Developer endorsements" tabindex="0">
+      {tweets.map((tweet) => (
+        <a
+          class="endorsement-card"
+          href={tweet.link}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`Read ${tweet.handle}'s post on X`}
+        >
+          <div class="endorsement-author">
+            <img
+              src={`/pfps/${tweet.handle}.webp`}
+              alt=""
+              width="28"
+              height="28"
+              loading="lazy"
+              decoding="async"
+            />
+            <div class="endorsement-handle">@{tweet.handle}</div>
+          </div>
+          <p>{tweet.excerpt ?? tweet.content}</p>
+        </a>
+      ))}
     </div>
   </section>
 
@@ -480,28 +419,6 @@ const mobileEndorsementRows = [
   }
 
   init();
-
-  // Marks lean a few pixels toward the pointer, each by its own depth.
-  const hero = document.querySelector<HTMLElement>(".hero");
-  const field = document.querySelector<HTMLElement>(".hero-float");
-  const fine = window.matchMedia("(pointer: fine) and (prefers-reduced-motion: no-preference)").matches;
-  if (hero && field && fine) {
-    let raf = 0;
-    let nx = 0;
-    let ny = 0;
-    const apply = () => {
-      raf = 0;
-      field.style.setProperty("--px", `${(nx * 18).toFixed(1)}px`);
-      field.style.setProperty("--py", `${(ny * 14).toFixed(1)}px`);
-    };
-    hero.addEventListener("pointermove", (e) => {
-      const r = hero.getBoundingClientRect();
-      nx = ((e.clientX - r.left) / r.width - 0.5) * 2;
-      ny = ((e.clientY - r.top) / r.height - 0.5) * 2;
-      if (!raf) raf = requestAnimationFrame(apply);
-    });
-    hero.addEventListener("pointerleave", () => { nx = 0; ny = 0; if (!raf) raf = requestAnimationFrame(apply); });
-  }
 </script>
 
 <style>
@@ -673,18 +590,12 @@ const mobileEndorsementRows = [
   :global([data-platform="linux"]) .dl-icon--linux { display: block; }
   :global(html:not([data-platform])) .dl-icon--apple { display: block; }
 
-  /* Floating harness marks. Six points on an ellipse around the hero copy:
-     two small at the top, two high and wide, two low and close. Symmetric,
-     and none of them touch the screenshot. Each mark flies in from its own
-     side on load, then drifts on its own period, and the whole set leans a
-     few pixels toward the pointer. */
+  /* Harness marks stay in their final positions after the entry animation. */
   .hero-float {
     position: absolute;
     inset: 0;
     pointer-events: none;
     z-index: 1;
-    --px: 0px;
-    --py: 0px;
   }
 
   .hero-float-mark {
@@ -694,8 +605,6 @@ const mobileEndorsementRows = [
     width: var(--s);
     height: var(--s);
     margin-left: calc(var(--s) / -2);
-    translate: calc(var(--px) * var(--depth)) calc(var(--py) * var(--depth));
-    transition: translate 0.7s cubic-bezier(0.2, 0.7, 0.2, 1);
   }
 
   .hero-float-card {
@@ -709,9 +618,7 @@ const mobileEndorsementRows = [
     box-shadow:
       0 20px 48px -16px rgba(0, 0, 0, 0.65),
       0 2px 0 0 rgba(255, 255, 255, 0.04) inset;
-    animation:
-      mark-in 1s cubic-bezier(0.2, 0.7, 0.2, 1) var(--d) both,
-      mark-drift var(--dur) ease-in-out calc(var(--d) + 1s) infinite;
+    animation: mark-in 1s cubic-bezier(0.2, 0.7, 0.2, 1) var(--d) both;
   }
 
   .hero-float-card img {
@@ -730,21 +637,16 @@ const mobileEndorsementRows = [
     from { opacity: 0; transform: translate(var(--fx), var(--fy)) rotate(calc(var(--rot) + 24deg)) scale(0.6); }
     to { opacity: 1; transform: translate(0, 0) rotate(var(--rot)) scale(1); }
   }
-  @keyframes mark-drift {
-    0%, 100% { transform: translate(0, 0) rotate(var(--rot)); }
-    50% { transform: translate(var(--dx), var(--dy)) rotate(calc(var(--rot) + var(--wob))); }
-  }
 
-  .hf-opencode    { --x: max(-300px, -19vw); --y: 20px;  --s: 64px; --rot: 6deg;  --depth: 0.6; --d: 620ms; --dur: 8.5s;  --dx: 2px;  --dy: -8px;  --wob: 3deg;  --fx: -40px;  --fy: -80px; }
-  .hf-antigravity { --x: min(300px, 19vw);   --y: 20px;  --s: 64px; --rot: -5deg; --depth: 0.6; --d: 580ms; --dur: 9.8s;  --dx: -2px; --dy: -9px;  --wob: -3deg; --fx: 40px;   --fy: -80px; }
-  .hf-claude   { --x: max(-560px, -38vw);  --y: 128px; --s: 96px; --rot: -8deg; --depth: 1.2; --d: 380ms; --dur: 10.5s; --dx: 4px;  --dy: -12px; --wob: -2deg; --fx: -160px; --fy: -40px; --tint: rgba(217, 119, 87, 0.22); }
-  .hf-codex    { --x: min(560px, 38vw);    --y: 128px; --s: 96px; --rot: 7deg;  --depth: 1.2; --d: 460ms; --dur: 9.2s;  --dx: -4px; --dy: -10px; --wob: 2deg;  --fx: 160px;  --fy: -40px; }
-  .hf-grok     { --x: max(-440px, -30vw);  --y: 440px; --s: 80px; --rot: 4deg;  --depth: 0.9; --d: 540ms; --dur: 11.5s; --dx: 3px;  --dy: -9px;  --wob: -3deg; --fx: -120px; --fy: 80px; }
-  .hf-cursor   { --x: min(440px, 30vw);    --y: 440px; --s: 80px; --rot: -5deg; --depth: 0.9; --d: 700ms; --dur: 7.8s;  --dx: -3px; --dy: -11px; --wob: 3deg;  --fx: 120px;  --fy: 80px; }
+  .hf-opencode    { --x: max(-300px, -19vw); --y: 20px; --s: 64px; --rot: 6deg; --d: 620ms; --fx: -40px; --fy: -80px; }
+  .hf-antigravity { --x: min(300px, 19vw); --y: 20px; --s: 64px; --rot: -5deg; --d: 580ms; --fx: 40px; --fy: -80px; }
+  .hf-claude   { --x: max(-560px, -38vw); --y: 128px; --s: 96px; --rot: -8deg; --d: 380ms; --fx: -160px; --fy: -40px; --tint: rgba(217, 119, 87, 0.22); }
+  .hf-codex    { --x: min(560px, 38vw); --y: 128px; --s: 96px; --rot: 7deg; --d: 460ms; --fx: 160px; --fy: -40px; }
+  .hf-grok     { --x: max(-440px, -30vw); --y: 440px; --s: 80px; --rot: 4deg; --d: 540ms; --fx: -120px; --fy: 80px; }
+  .hf-cursor   { --x: min(440px, 30vw); --y: 440px; --s: 80px; --rot: -5deg; --d: 700ms; --fx: 120px; --fy: 80px; }
 
   @media (prefers-reduced-motion: reduce) {
     .hero-float-card { animation: none; transform: rotate(var(--rot)); }
-    .hero-float-mark { transition: none; }
   }
 
   @media (max-width: 1180px) {
@@ -767,12 +669,12 @@ const mobileEndorsementRows = [
     }
 
     /* Four above the headline, two beside the CTA. Keeps the copy clear. */
-    .hf-claude      { --x: -37vw; --y: 44px;  --s: 64px; --rot: -10deg; }
-    .hf-opencode    { --x: -12vw; --y: 52px;  --s: 56px; --rot: -4deg; }
-    .hf-antigravity { --x: 12vw;  --y: 52px;  --s: 56px; --rot: 5deg; }
-    .hf-codex       { --x: 37vw;  --y: 44px;  --s: 64px; --rot: 8deg; }
+    .hf-claude      { --x: -37vw; --y: 44px; --s: 64px; --rot: -10deg; }
+    .hf-opencode    { --x: -12vw; --y: 52px; --s: 56px; --rot: -4deg; }
+    .hf-antigravity { --x: 12vw; --y: 52px; --s: 56px; --rot: 5deg; }
+    .hf-codex       { --x: 37vw; --y: 44px; --s: 64px; --rot: 8deg; }
     .hf-grok     { --x: -36vw; --y: 474px; --s: 64px; --rot: -6deg; }
-    .hf-cursor   { --x: 36vw;  --y: 474px; --s: 64px; --rot: 7deg; }
+    .hf-cursor   { --x: 36vw; --y: 474px; --s: 64px; --rot: 7deg; }
   }
 
   @media (max-width: 340px) {
@@ -896,67 +798,19 @@ const mobileEndorsementRows = [
   }
 
   .endorsement-carousel {
-    position: relative;
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-auto-flow: column;
+    grid-template-rows: repeat(2, 132px);
+    grid-auto-columns: clamp(264px, 22vw, 308px);
     gap: 12px;
-  }
-
-  .endorsement-carousel--mobile {
-    display: none;
-  }
-
-  .endorsement-carousel::before,
-  .endorsement-carousel::after {
-    content: "";
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    z-index: 2;
-    width: max(48px, calc((100vw - 1240px) / 2 + 56px));
-    pointer-events: none;
-  }
-
-  .endorsement-carousel::before {
-    left: 0;
-    background: linear-gradient(90deg, var(--bg), transparent);
-  }
-
-  .endorsement-carousel::after {
-    right: 0;
-    background: linear-gradient(270deg, var(--bg), transparent);
-  }
-
-  .endorsement-row {
-    overflow: hidden;
-  }
-
-  .endorsement-track {
-    width: max-content;
-    display: flex;
-    animation: endorsementMarquee 76s linear infinite;
-    will-change: transform;
-  }
-
-  .endorsement-track-group {
-    display: flex;
-    gap: 12px;
-    padding-right: 12px;
-  }
-
-  .endorsement-row.is-reverse .endorsement-track {
-    animation-direction: reverse;
-    animation-duration: 84s;
-  }
-
-  .endorsement-carousel:hover .endorsement-track,
-  .endorsement-carousel:focus-within .endorsement-track {
-    animation-play-state: paused;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    padding: 4px max(32px, calc((100vw - 1240px) / 2 + 32px));
+    scroll-padding-inline: max(32px, calc((100vw - 1240px) / 2 + 32px));
   }
 
   .endorsement-card {
     position: relative;
-    width: clamp(264px, 22vw, 308px);
     height: 132px;
     padding: 14px 16px;
     display: flex;
@@ -1134,7 +988,6 @@ const mobileEndorsementRows = [
     width: 7px; height: 14px;
     background: var(--fg);
     margin-left: 4px;
-    animation: blink 1s steps(2) infinite;
   }
 
   .open-pitch {
@@ -1252,19 +1105,6 @@ const mobileEndorsementRows = [
     margin-bottom: 24px;
   }
 
-  @keyframes blink {
-    50% { opacity: 0; }
-  }
-
-  @keyframes endorsementMarquee {
-    from {
-      transform: translateX(0);
-    }
-    to {
-      transform: translateX(-50%);
-    }
-  }
-
   /* ── Responsive ────────────────────────────────────────── */
   @media (max-width: 960px) {
     .hero-preview {
@@ -1291,25 +1131,13 @@ const mobileEndorsementRows = [
     .endorsements-head {
       margin-bottom: 40px;
     }
-    .endorsement-carousel--desktop {
-      display: none;
-    }
-    .endorsement-carousel--mobile {
-      display: flex;
-    }
-    .endorsement-carousel::before,
-    .endorsement-carousel::after {
-      width: 28px;
-    }
-    .endorsement-track {
-      animation-duration: 68s;
-    }
-    .endorsement-row.is-reverse .endorsement-track {
-      animation-duration: 76s;
+    .endorsement-carousel {
+      grid-template-rows: repeat(3, 132px);
+      grid-auto-columns: 268px;
+      padding-inline: 20px;
+      scroll-padding-inline: 20px;
     }
     .endorsement-card {
-      width: 268px;
-      height: 132px;
       padding: 14px;
     }
     .endorsement-card p {


### PR DESCRIPTION
The home page keeps decorative animations running and renders four copies of each endorsement for scrolling loops.

Use one manually scrollable list with two rows on desktop and three on mobile. Stop icon drift, pointer parallax, and caret blinking. Keep the short entry animations. All endorsement text and links stay unchanged.

| Generated output | Before | After |
| --- | ---: | ---: |
| Endorsement cards | 84 | 21 |
| Image elements | 98 | 35 |
| HTML bytes | 86,917 | 49,185 |

The production build and Astro check pass with zero diagnostics. A generated-page comparison verifies every endorsement text and link. The list is keyboard-focusable and has space for the existing focus ring. No browser, device, screenshots, or GPU measurements were used, as requested.

Part of https://github.com/pingdotgg/t3code/issues/9661.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing-only presentation and performance tweaks on the homepage; no API, auth, or data-path changes.
> 
> **Overview**
> **Reduces marketing homepage motion and DOM weight** by dropping always-on animations and duplicate endorsement markup in `index.astro`.
> 
> The **endorsements** section no longer uses separate desktop/mobile auto-scrolling marquees with duplicated track groups. It renders **one card per tweet** in a **keyboard-focusable**, horizontally scrollable CSS grid (**2 rows** on desktop, **3** on mobile). Tweet text and outbound links are unchanged; the change mainly cuts rendered cards and related images.
> 
> **Hero and decorative UI** stop continuous motion: harness icons keep the **entry** animation only (no infinite drift or pointer parallax), and the open-source terminal **caret no longer blinks**. Related marquee, drift, blink keyframes and parallax script are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef503e6a46147ee2e65d14ca25484250e235d25b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop continuous homepage motion in marketing index page
> - Replaces the endorsement marquee with a horizontally scrollable multi-row grid (two rows on desktop, three rows below 960px) that renders each tweet once instead of duplicating tracks for auto-scroll
> - Removes hero floating-mark pointer tracking, drift, and wobble so marks stay at their final position after the entry animation
> - Removes the terminal cursor blink animation
> - Risk: endorsement section is now user-scrolled only; screen-reader and keyboard users rely on the new region landmark and container focusability in [index.astro](https://github.com/pingdotgg/t3code/pull/9697/files#diff-44a2946e1eacc7096aee1ba8a172800aa7d94150585e21ff8486d94f4776677a) instead of continuous auto-scroll
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef503e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->