### PR TITLE
perf(server): stop rebuilding terminal history per chunk

### DIFF
--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1090,6 +1090,25 @@ it.layer(
     }),
   );
 
+  it.effect("caps incrementally appended history without losing partial or empty lines", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager(3);
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("line1\n");
+      process.emitData("\n");
+      process.emitData("line3");
+      process.emitData("-continued\nline4");
+      yield* manager.close({ threadId: "thread-1" });
+
+      const reopened = yield* manager.open(openInput());
+      expect(reopened.history).toBe("\nline3-continued\nline4");
+    }),
+  );
+
   it.effect("strips replay-unsafe terminal query and reply sequences from persisted history", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -276,6 +276,70 @@ const createManager = (
 const withHostPlatform = (platform: NodeJS.Platform) =>
   Layer.succeed(HostProcessPlatform, platform);
 
+// The previous split/join algorithm is the reference for retained text.
+function retainedHistory(text: string, maxLines: number): string {
+  const terminated = text.endsWith("\n");
+  const lines = text.split("\n");
+  if (terminated) lines.pop();
+  const retained = lines.slice(Math.max(0, lines.length - maxLines)).join("\n");
+  return terminated ? `${retained}\n` : retained;
+}
+
+it("preserves history across arbitrary chunks, Unicode, ANSI sequences, and clear", () => {
+  let randomSeed = 0x20260904;
+  const fragments = [
+    "",
+    "a",
+    "\n",
+    "\n\n",
+    "\r",
+    "\r\n",
+    "café",
+    "名",
+    "🚀",
+    "\u001b[31m",
+    "\u001b[0m",
+    "\u001b]8;;url\u0007",
+    "\ud83d",
+    "\ude80",
+  ];
+  const nextFragment = () => {
+    randomSeed = (Math.imul(randomSeed, 1_664_525) + 1_013_904_223) >>> 0;
+    return fragments[randomSeed % fragments.length]!;
+  };
+
+  for (const maxLines of [0, 1, 3, 5, 5_000]) {
+    let expected = retainedHistory("before\ninitial\n", maxLines);
+    const history = new TerminalManager.BoundedTerminalHistory(maxLines, expected);
+    expect(history.value()).toBe(expected);
+
+    for (let step = 0; step < 300; step += 1) {
+      if (step % 73 === 0) {
+        history.clear();
+        expected = "";
+        expect(history.value()).toBe(expected);
+      }
+      const chunk = nextFragment() + nextFragment();
+      history.append(chunk);
+      expected = retainedHistory(expected + chunk, maxLines);
+      expect(history.value()).toBe(expected);
+    }
+  }
+});
+
+it("preserves retained lines as older storage is compacted", () => {
+  for (const maxLines of [3, 5_000]) {
+    let expected = "";
+    const history = new TerminalManager.BoundedTerminalHistory(maxLines, expected);
+    for (let batch = 0; batch < 40; batch += 1) {
+      const chunk = Array.from({ length: 300 }, (_, line) => `${batch}:${line}\n`).join("");
+      history.append(chunk);
+      expected = retainedHistory(expected + chunk, maxLines);
+      expect(history.value()).toBe(expected);
+    }
+  }
+});
+
 it.layer(
   Layer.merge(NodeServices.layer, ProcessRunner.layer.pipe(Layer.provide(NodeServices.layer))),
   { excludeTestServices: true },

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -238,14 +238,14 @@ export interface TerminalStartInput extends TerminalOpenInput {
   rows: number;
 }
 
-export interface TerminalSessionState {
+interface TerminalSessionState {
   threadId: string;
   terminalId: string;
   cwd: string;
   worktreePath: string | null;
   status: TerminalSessionStatus;
   pid: number | null;
-  history: string;
+  history: BoundedTerminalHistory;
   pendingHistoryControlSequence: string;
   pendingProcessEvents: Array<PendingProcessEvent>;
   pendingProcessEventIndex: number;
@@ -266,7 +266,7 @@ export interface TerminalSessionState {
 }
 
 interface PersistHistoryRequest {
-  history: string;
+  history: BoundedTerminalHistory;
   immediate: boolean;
 }
 
@@ -281,7 +281,7 @@ type DrainProcessEventAction =
       threadId: string;
       terminalId: string;
       sequence: number;
-      history: string | null;
+      history: BoundedTerminalHistory | null;
       data: string;
     }
   | {
@@ -340,7 +340,7 @@ function snapshot(session: TerminalSessionState): TerminalSessionSnapshot {
     worktreePath: session.worktreePath,
     status: session.status,
     pid: session.pid,
-    history: session.history,
+    history: session.history.value(),
     exitCode: session.exitCode,
     exitSignal: session.exitSignal,
     label: terminalWireLabel(session),
@@ -794,6 +794,63 @@ function capHistory(history: string, maxLines: number): string {
   if (lines.length <= maxLines) return history;
   const capped = lines.slice(lines.length - maxLines).join("\n");
   return hasTrailingNewline ? `${capped}\n` : capped;
+}
+
+class BoundedTerminalHistory {
+  private readonly maxLines: number;
+  private lines: Array<string>;
+  private start = 0;
+  private trailingNewline: boolean;
+  private cachedValue: string | null = null;
+
+  constructor(maxLines: number, initial: string) {
+    this.maxLines = maxLines;
+    const capped = capHistory(initial, maxLines);
+    this.trailingNewline = capped.endsWith("\n");
+    this.lines = capped.length === 0 ? [] : capped.split("\n");
+    if (this.trailingNewline) this.lines.pop();
+  }
+
+  append(text: string): void {
+    if (text.length === 0) return;
+
+    const trailingNewline = text.endsWith("\n");
+    const appendedLines = text.split("\n");
+    if (trailingNewline) appendedLines.pop();
+
+    const activeLines = this.lines.length - this.start;
+    if (activeLines === 0 || this.trailingNewline) {
+      for (const line of appendedLines) this.lines.push(line);
+    } else {
+      this.lines[this.lines.length - 1] += appendedLines[0] ?? "";
+      for (let index = 1; index < appendedLines.length; index += 1) {
+        this.lines.push(appendedLines[index] ?? "");
+      }
+    }
+    this.trailingNewline = trailingNewline;
+
+    const overflow = this.lines.length - this.start - this.maxLines;
+    if (overflow > 0) this.start += overflow;
+    if (this.start > 2_048 && this.start * 2 >= this.lines.length) {
+      this.lines = this.lines.slice(this.start);
+      this.start = 0;
+    }
+    this.cachedValue = null;
+  }
+
+  clear(): void {
+    this.lines = [];
+    this.start = 0;
+    this.trailingNewline = false;
+    this.cachedValue = "";
+  }
+
+  value(): string {
+    if (this.cachedValue !== null) return this.cachedValue;
+    const joined = this.lines.slice(this.start).join("\n");
+    this.cachedValue = this.trailingNewline ? `${joined}\n` : joined;
+    return this.cachedValue;
+  }
 }
 
 function isCsiFinalByte(codePoint: number): boolean {
@@ -1372,22 +1429,24 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         return;
       }
 
-      yield* fileSystem.writeFileString(historyPath(threadId, terminalId), request.history).pipe(
-        Effect.catch((error) =>
-          Effect.logWarning("failed to persist terminal history", {
-            threadId,
-            terminalId,
-            error,
-          }),
-        ),
-      );
+      yield* fileSystem
+        .writeFileString(historyPath(threadId, terminalId), request.history.value())
+        .pipe(
+          Effect.catch((error) =>
+            Effect.logWarning("failed to persist terminal history", {
+              threadId,
+              terminalId,
+              error,
+            }),
+          ),
+        );
     }),
   });
 
   const queuePersist = Effect.fn("terminal.queuePersist")(function* (
     threadId: string,
     terminalId: string,
-    history: string,
+    history: BoundedTerminalHistory,
   ) {
     yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
       history,
@@ -1405,7 +1464,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   const persistHistory = Effect.fn("terminal.persistHistory")(function* (
     threadId: string,
     terminalId: string,
-    history: string,
+    history: BoundedTerminalHistory,
   ) {
     yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
       history,
@@ -1661,10 +1720,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
           );
           session.pendingHistoryControlSequence = sanitized.pendingControlSequence;
           if (sanitized.visibleText.length > 0) {
-            session.history = capHistory(
-              `${session.history}${sanitized.visibleText}`,
-              historyLineLimit,
-            );
+            session.history.append(sanitized.visibleText);
           }
           const eventStamp = advanceEventSequence(session);
 
@@ -2160,7 +2216,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         worktreePath: input.worktreePath ?? null,
         status: "starting",
         pid: null,
-        history,
+        history: new BoundedTerminalHistory(historyLineLimit, history),
         pendingHistoryControlSequence: "",
         pendingProcessEvents: [],
         pendingProcessEventIndex: 0,
@@ -2221,7 +2277,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.cwd = input.cwd;
       liveSession.worktreePath = nextWorktreePath;
       liveSession.runtimeEnv = nextRuntimeEnv;
-      liveSession.history = "";
+      liveSession.history.clear();
       liveSession.pendingHistoryControlSequence = "";
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
@@ -2230,7 +2286,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     } else if (liveSession.status === "exited" || liveSession.status === "error") {
       liveSession.runtimeEnv = nextRuntimeEnv;
       liveSession.worktreePath = nextWorktreePath;
-      liveSession.history = "";
+      liveSession.history.clear();
       liveSession.pendingHistoryControlSequence = "";
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
@@ -2535,7 +2591,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       Effect.gen(function* () {
         const terminalId = input.terminalId;
         const session = yield* requireSession(input.threadId, terminalId);
-        session.history = "";
+        session.history.clear();
         session.pendingHistoryControlSequence = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
@@ -2572,7 +2628,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             worktreePath: input.worktreePath ?? null,
             status: "starting",
             pid: null,
-            history: "",
+            history: new BoundedTerminalHistory(historyLineLimit, ""),
             pendingHistoryControlSequence: "",
             pendingProcessEvents: [],
             pendingProcessEventIndex: 0,
@@ -2608,7 +2664,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         const cols = input.cols ?? session.cols;
         const rows = input.rows ?? session.rows;
 
-        session.history = "";
+        session.history.clear();
         session.pendingHistoryControlSequence = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -796,7 +796,7 @@ function capHistory(history: string, maxLines: number): string {
   return hasTrailingNewline ? `${capped}\n` : capped;
 }
 
-class BoundedTerminalHistory {
+export class BoundedTerminalHistory {
   private readonly maxLines: number;
   private lines: Array<string>;
   private start = 0;
@@ -830,7 +830,10 @@ class BoundedTerminalHistory {
     this.trailingNewline = trailingNewline;
 
     const overflow = this.lines.length - this.start - this.maxLines;
-    if (overflow > 0) this.start += overflow;
+    if (overflow > 0) {
+      this.lines.fill("", this.start, this.start + overflow);
+      this.start += overflow;
+    }
     if (this.start > 2_048 && this.start * 2 >= this.lines.length) {
       this.lines = this.lines.slice(this.start);
       this.start = 0;

--- a/docs/internals/terminal-runtime.md
+++ b/docs/internals/terminal-runtime.md
@@ -1,0 +1,46 @@
+# Terminal runtime
+
+The environment server owns terminal processes, retained output history, and
+session lifecycle. Web and desktop clients attach to the same server-owned
+session over the environment RPC connection. Desktop must not replace this
+with a renderer-owned PTY: reconnect, remote access, and multi-client attach
+all depend on the environment remaining authoritative.
+
+## Output path
+
+PTY output follows this path:
+
+```text
+PTY callback
+  -> ordered process-event drain
+  -> bounded retained-history append
+  -> live terminal output event
+  -> coalesced history persistence
+```
+
+Live output events contain only the new PTY data. A full retained-history
+snapshot is materialized only when a client attaches or when the coalescing
+persistence worker writes the latest state.
+
+Retained history uses an incremental bounded line buffer. Appending one PTY
+chunk may scan and allocate for that new chunk, but it must not split, join, or
+copy the entire retained history for every callback. Empty lines, incomplete
+final lines, trailing newlines, and the configured line limit are preserved
+exactly when history is materialized.
+
+This is a performance invariant, not an implementation detail to discard
+during refactors. Measure sustained-output changes against a full retained
+history so terminal throughput does not regress unnoticed.
+
+## Persistence and transport changes
+
+History persistence is keyed by terminal session and coalesces pending writes.
+The worker reads the newest bounded-history state after its debounce instead
+of receiving a newly materialized full string for every PTY callback. Clear,
+restart, close, and final flush operations still force the latest state to
+disk before their lifecycle boundary completes.
+
+If measurements later justify a binary terminal data channel, keep snapshots,
+lifecycle commands, and PTY ownership on the environment server. Do not share
+the terminal data channel with port-forward payloads: a bulk TCP transfer must
+not head-of-line block interactive terminal input or output.

--- a/docs/internals/terminal-runtime.md
+++ b/docs/internals/terminal-runtime.md
@@ -1,10 +1,10 @@
 # Terminal runtime
 
 The environment server owns terminal processes, retained output history, and
-session lifecycle. Web and desktop clients attach to the same server-owned
-session over the environment RPC connection. Desktop must not replace this
-with a renderer-owned PTY: reconnect, remote access, and multi-client attach
-all depend on the environment remaining authoritative.
+session lifecycle. Web, desktop, and mobile clients attach to the same
+server-owned session over the environment RPC connection. The desktop renderer
+does not own a separate PTY. Clients can reconnect to a running PTY or share
+it with another client.
 
 ## Output path
 
@@ -18,8 +18,8 @@ PTY callback
   -> coalesced history persistence
 ```
 
-Live output events contain only the new PTY data. A full retained-history
-snapshot is materialized only when a client attaches or when the coalescing
+Live output events contain only the new PTY data. Full retained history is
+materialized only when the server returns a snapshot or when the coalescing
 persistence worker writes the latest state.
 
 Retained history uses an incremental bounded line buffer. Appending one PTY
@@ -28,19 +28,21 @@ copy the entire retained history for every callback. Empty lines, incomplete
 final lines, trailing newlines, and the configured line limit are preserved
 exactly when history is materialized.
 
-This is a performance invariant, not an implementation detail to discard
-during refactors. Measure sustained-output changes against a full retained
-history so terminal throughput does not regress unnoticed.
+Discard each line's string reference as soon as the line leaves retained
+history. Array compaction can run later.
 
-## Persistence and transport changes
+The server's line limit does not limit the byte size of retained history.
+Shared web and mobile client state currently retains at most 512 KiB. A server
+byte limit would change persisted scrollback and needs a separate retention
+decision.
+
+Measure sustained-output changes against a full retained history so terminal
+throughput does not regress unnoticed.
+
+## Persistence
 
 History persistence is keyed by terminal session and coalesces pending writes.
 The worker reads the newest bounded-history state after its debounce instead
 of receiving a newly materialized full string for every PTY callback. Clear,
 restart, close, and final flush operations still force the latest state to
 disk before their lifecycle boundary completes.
-
-If measurements later justify a binary terminal data channel, keep snapshots,
-lifecycle commands, and PTY ownership on the environment server. Do not share
-the terminal data channel with port-forward payloads: a bulk TCP transfer must
-not head-of-line block interactive terminal input or output.


### PR DESCRIPTION
The server copies and splits all retained terminal history for each output update.

This PR continues [#9357](https://github.com/pingdotgg/t3code/pull/9357) by will (@burnmandont), with the original Git author preserved. The incremental buffer processes new text and materializes full history for snapshots and persistence. This continuation releases evicted line references immediately and adds differential tests.

The default remains 5,000 lines. No wire changes, new byte cap, or output batching.

## Verification

57 Manager tests, server typecheck, and targeted lint pass. Tests cover chunk boundaries, Unicode, ANSI text, empty lines, clear, compaction, and the existing persistence and lifecycle paths.

Actual-source benchmark, 1,000 appends plus final history read and UTF-8 byte count. Medians of three warm runs:

| Retained history | Previous | Incremental |
| --- | ---: | ---: |
| 5,000 full lines | 1,104 ms | 1.6 ms |
| 4 MiB without newlines | 2,086 ms | 2.4 ms |

Both implementations produce identical bytes in each case. These timings exclude construction, real PTY, persistence, and transport work. The one-line buffer check confirms that a removed 4 MiB line has no remaining buffer reference.

Part of the [performance audit](https://github.com/pingdotgg/t3code/issues/9661), item S1. A server byte bound remains separate work. Client streaming is tracked separately.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path terminal scrollback and persistence semantics; regressions would show up as wrong transcripts on reconnect, but behavior is heavily tested against the prior cap algorithm.
> 
> **Overview**
> Replaces **per-chunk full-history split/join** in `TerminalManager` with an exported **`BoundedTerminalHistory`** that appends PTY output incrementally, enforces the line cap by dropping oldest lines (with periodic compaction), and only **materializes the full string** for snapshots and disk writes via `value()`.
> 
> Session state, persistence enqueue/flush, clear/restart/context-change paths now hold the buffer object and call **`append` / `clear`** instead of assigning capped strings. The coalescing persist worker still debounces but reads **`history.value()`** at write time so it no longer needs a freshly rebuilt string on every output callback.
> 
> Adds **differential tests** (random chunks, Unicode/ANSI, compaction) plus an integration case for **partial and empty lines** under a low line limit, and documents the PTY output path in **`docs/internals/terminal-runtime.md`**. Default **5,000-line** retention and wire behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cd9442e87f4939c3efe801cf9ba772ae2d78df5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop rebuilding terminal history per chunk in `TerminalManager`
> - Adds `BoundedTerminalHistory` class in [Manager.ts](https://github.com/pingdotgg/t3code/pull/9703/files#diff-9b98fe5056129db24d311ed1bd8f66a72127cf90fa7529da47e0725f2813532e) that maintains retained lines incrementally via `append()` and only materializes the full string when `value()` is called
> - Replaces string concatenation followed by `capHistory` in the process-event drain handler with incremental `append()` on the session's bounded history
> - Changes `PersistHistoryRequest`, `DrainProcessEventAction`, and `TerminalSessionState` to carry `BoundedTerminalHistory` instead of a materialized string; persistence worker calls `value()` at write time
> - Session lifecycle handlers (open, clear, restart) now reset the bounded-history buffer through `clear()` rather than replacing a history string
> - Adds regression tests covering fragmented input, compaction under repeated large batches, and an integration test verifying retained history after terminal reopen
> - Adds runtime documentation in [terminal-runtime.md](https://github.com/pingdotgg/t3code/pull/9703/files#diff-4f904b46fd85be158efcd03299ebb178b130e99524f5213213f9fe7b484f7b07) covering PTY sessions, incremental history, and retention semantics
> - Risk: `TerminalSessionState` is no longer exported and its `history` field changed from `string` to `BoundedTerminalHistory`; any out-of-tree code referencing this interface will break
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4cd9442. 2 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>docs/internals/terminal-runtime.md — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 17](https://github.com/pingdotgg/t3code/blob/4cd9442e87f4939c3efe801cf9ba772ae2d78df5/docs/internals/terminal-runtime.md#L17): The documented output ordering is reversed: it says the live terminal output event precedes coalesced persistence, but `drainProcessEvents` calls `queuePersist` at `Manager.ts:1774-1777` before it calls `publishEvent` at `Manager.ts:1779-1784`. This makes the runtime design document inaccurate for consumers relying on the specified ordering. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->