### PR TITLE
feat(preview): let agents open tabs in a specific browser profile

### DIFF
--- a/apps/server/src/mcp/PreviewAutomationBroker.test.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.test.ts
@@ -655,6 +655,68 @@ it.effect("pins a provider session to its initial host despite later focus chang
   ),
 );
 
+it.effect("does not send profile selection to a host that would ignore it", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const broker = yield* makeBroker;
+      const connected = yield* Deferred.make<void>();
+      const events = yield* broker.connect(makeHost());
+      yield* Stream.runForEach(events, () => Deferred.succeed(connected, undefined)).pipe(
+        Effect.forkScoped,
+      );
+      yield* Deferred.await(connected);
+
+      const error = yield* broker
+        .invoke<void>({
+          scope,
+          operation: "open",
+          input: { profileId: "incognito", reuseExistingTab: false },
+        })
+        .pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(PreviewAutomationNoAvailableHostError);
+    }),
+  ),
+);
+
+it.effect("routes a profile open to a capable host and pins subsequent calls to its new tab", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const broker = yield* makeBroker;
+      const connected = yield* Deferred.make<void>();
+      const events = yield* broker.connect(makeHost({ supportsOpenProfile: true }));
+      const requests = requestsFrom(
+        events.pipe(Stream.tap(() => Deferred.succeed(connected, undefined))),
+      );
+      const legacyConnected = yield* Deferred.make<void>();
+      const legacyEvents = yield* broker.connect(makeHost({ clientId: "legacy" }));
+      yield* Stream.runForEach(legacyEvents, () =>
+        Deferred.succeed(legacyConnected, undefined),
+      ).pipe(Effect.forkScoped);
+      const routed: RoutedRequest[] = [];
+      yield* Stream.runForEach(requests, (request) => {
+        routed.push(request);
+        return broker.respond({
+          clientId: "client-1",
+          connectionId: request.connectionId,
+          requestId: request.requestId,
+          ok: true,
+          result: { tabId: "tab-feature-a", profileId: "profile-feature-a" },
+        });
+      }).pipe(Effect.forkScoped);
+      yield* Deferred.await(connected);
+      yield* Deferred.await(legacyConnected);
+
+      const input = { profileId: "profile-feature-a", reuseExistingTab: false };
+      yield* broker.invoke({ scope, operation: "open", input });
+      yield* broker.invoke({ scope, operation: "snapshot", input: {} });
+
+      expect(routed[0]?.input).toEqual(input);
+      expect(routed[1]?.tabId).toBe("tab-feature-a");
+    }),
+  ),
+);
+
 it.effect("does not route new operations to legacy hosts that did not advertise support", () =>
   Effect.scoped(
     Effect.gen(function* () {

--- a/apps/server/src/mcp/PreviewAutomationBroker.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.ts
@@ -1,4 +1,5 @@
 import {
+  BrowserProfileId,
   PREVIEW_AUTOMATION_V1_OPERATIONS,
   PreviewAutomationClientDisconnectedError,
   PreviewAutomationControlInterruptedError,
@@ -63,6 +64,7 @@ interface ClientConnection {
   readonly connectionId: string;
   readonly environmentId: PreviewAutomationHost["environmentId"];
   readonly supportedOperations: ReadonlySet<PreviewAutomationOperation>;
+  readonly supportsOpenProfile: boolean;
   readonly focused: boolean;
   readonly focusOrder: number;
   readonly queue: Queue.Queue<PreviewAutomationStreamEvent>;
@@ -161,10 +163,16 @@ const readResultTabId = (result: unknown): PreviewTabId | null | undefined => {
   return tabId === null || isPreviewTabId(tabId) ? tabId : undefined;
 };
 
-const supportsOperation = (
+const hasOpenProfile = Schema.is(Schema.Struct({ profileId: BrowserProfileId }));
+
+const supportsRequest = (
   connection: ClientConnection,
-  operation: PreviewAutomationOperation,
-): boolean => connection.supportedOperations.has(operation);
+  request: PreviewAutomationInvokeInput,
+): boolean =>
+  connection.supportedOperations.has(request.operation) &&
+  (request.operation !== "open" ||
+    !hasOpenProfile(request.input) ||
+    connection.supportsOpenProfile);
 
 type RemoteDetailKind = "null" | "array" | "object" | "string" | "number" | "boolean";
 
@@ -331,6 +339,7 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
       connectionId,
       environmentId: host.environmentId,
       supportedOperations: new Set(host.supportedOperations ?? PREVIEW_AUTOMATION_V1_OPERATIONS),
+      supportsOpenProfile: host.supportsOpenProfile ?? false,
       focused: false,
       focusOrder: 0,
       queue,
@@ -449,7 +458,7 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
       // capability failure and can deliberately start a fresh provider
       // session. A dead lease is pruned above and may fail over.
       const connection =
-        hasLiveAssignment && supportsOperation(assignedConnection, input.operation)
+        hasLiveAssignment && supportsRequest(assignedConnection, input)
           ? assignedConnection
           : hasLiveAssignment
             ? undefined
@@ -457,7 +466,7 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
                 .filter(
                   (host) =>
                     host.environmentId === input.scope.environmentId &&
-                    supportsOperation(host, input.operation),
+                    supportsRequest(host, input),
                 )
                 .sort(
                   (left, right) =>

--- a/apps/server/src/mcp/toolkits/preview/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/preview/handlers.test.ts
@@ -3,6 +3,13 @@ import { describe, expect, it } from "vite-plus/test";
 import { normalizePreviewOpenInput } from "./handlers.ts";
 
 describe("normalizePreviewOpenInput", () => {
+  it("opens a new tab when a profile is supplied", () => {
+    expect(normalizePreviewOpenInput({ profileId: "profile-feature-a" })).toEqual({
+      profileId: "profile-feature-a",
+      reuseExistingTab: false,
+    });
+  });
+
   it("leaves an unstated visibility for the client preference to decide", () => {
     // Filling `open` in here would outrank `browserAutoShowFloatingPreview`,
     // which is desktop-local and cannot be read from the server.

--- a/apps/server/src/mcp/toolkits/preview/handlers.ts
+++ b/apps/server/src/mcp/toolkits/preview/handlers.ts
@@ -30,7 +30,7 @@ export function normalizePreviewOpenInput(
   return {
     ...input,
     ...(open === undefined ? {} : { open, show: open }),
-    reuseExistingTab: input.reuseExistingTab ?? true,
+    reuseExistingTab: input.reuseExistingTab ?? input.profileId === undefined,
   };
 }
 

--- a/apps/server/src/mcp/toolkits/preview/tools.ts
+++ b/apps/server/src/mcp/toolkits/preview/tools.ts
@@ -61,7 +61,7 @@ export const PreviewStatusTool = Tool.make("preview_status", {
 export const PreviewOpenTool = browserTool(
   Tool.make("preview_open", {
     description:
-      "Initialize a collaborative browser tab and open its thread-bound inline preview by default. Set open=false for background-only automation. Pass tabId to reuse a specific existing tab, set reuseExistingTab=false to create another tab, or omit both to use this agent session's current tab.",
+      "Initialize a collaborative browser tab and open its thread-bound inline preview by default. Set open=false for background-only automation. Pass profileId to create a new tab in an existing browser profile. Otherwise, pass tabId to reuse a specific existing tab, set reuseExistingTab=false to create another tab, or omit both to use this agent session's current tab.",
     parameters: PreviewAutomationOpenInput,
     success: PreviewAutomationStatus,
     failure: PreviewAutomationError,

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -3,6 +3,7 @@
 import { RegistryContext, useAtomSet, useAtomValue } from "@effect/atom-react";
 import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
 import {
+  DEFAULT_BROWSER_PROFILE_ID,
   FILL_PREVIEW_VIEWPORT,
   PREVIEW_AUTOMATION_OPERATIONS,
   type EnvironmentId,
@@ -41,7 +42,7 @@ import {
   acquireBrowserSurfaceActivity,
   useBrowserSurfaceStore,
 } from "~/browser/browserSurfaceStore";
-import { browserDefaultOpenViewport, resolveBrowserDefaults } from "~/browser/browserDefaults";
+import { resolveBrowserDefaults } from "~/browser/browserDefaults";
 import { runBrowserViewportMutation } from "~/browser/browserViewportActions";
 import { previewRuntimeTabId } from "~/browser/previewRuntimeTabId";
 import { isElectron } from "~/env";
@@ -77,6 +78,7 @@ import {
   resolvePreviewAutomationTarget,
 } from "./previewAutomationTarget";
 import { isPreviewViewportReady } from "./previewViewportReadiness";
+import { previewAutomationOpenOptions } from "./previewAutomationOpenOptions";
 import { shouldRollbackPreviewViewport } from "./previewViewportRollback";
 
 const PREVIEW_PRESENTATION_SETTLE_TIMEOUT_MS = 500;
@@ -228,13 +230,14 @@ const currentStatus = async (
     runtimeTabId && renderingActive
       ? await readRenderedViewport(runtimeTabId).catch(() => null)
       : null;
-  const viewportStatus = {
+  const snapshotStatus = {
+    ...(snapshot ? { profileId: snapshot.profileId ?? DEFAULT_BROWSER_PROFILE_ID } : {}),
     ...(viewportSetting === undefined ? {} : { viewportSetting }),
     ...(viewport === null ? {} : { viewport }),
   };
   if (runtimeTabId && tabId && previewBridge && state.desktopByTabId[tabId]) {
     const status = await previewBridge.automation.status(runtimeTabId);
-    return { ...status, tabId, visible, ...viewportStatus };
+    return { ...status, tabId, visible, ...snapshotStatus };
   }
   const navStatus = snapshot?.navStatus;
   return {
@@ -244,7 +247,7 @@ const currentStatus = async (
     url: navStatus && navStatus._tag !== "Idle" ? navStatus.url : null,
     title: navStatus && navStatus._tag !== "Idle" ? navStatus.title : null,
     loading: navStatus?._tag === "Loading",
-    ...viewportStatus,
+    ...snapshotStatus,
   };
 };
 
@@ -287,6 +290,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
       clientId: automationClientId,
       environmentId,
       supportedOperations: [...PREVIEW_AUTOMATION_OPERATIONS],
+      supportsOpenProfile: true,
     }),
     [automationClientId, environmentId],
   );
@@ -400,7 +404,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             let activeTabId = resolvePreviewAutomationOpenTab(
               state,
               request.tabId,
-              input.reuseExistingTab ?? true,
+              input.profileId === undefined && (input.reuseExistingTab ?? true),
             );
             let activeSnapshot = activeTabId
               ? (state.sessions[activeTabId] ?? state.snapshot ?? undefined)
@@ -413,9 +417,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                 input: {
                   threadId: request.threadId,
                   ...(resolvedInputUrl ? { url: resolvedInputUrl } : {}),
-                  // An agent that didn't state a size gets the user's
-                  // configured default, same as a hand-opened tab.
-                  viewport: browserDefaultOpenViewport(await resolveBrowserDefaults()),
+                  ...previewAutomationOpenOptions(input, await resolveBrowserDefaults()),
                 },
               });
               if (result._tag === "Failure") {

--- a/apps/web/src/components/preview/previewAutomationErrors.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.ts
@@ -1,4 +1,5 @@
 import {
+  BrowserProfileId,
   EnvironmentId,
   type PreviewAutomationHost,
   PreviewAutomationOperation,
@@ -113,6 +114,19 @@ export class PreviewAutomationRecordingNotActiveError extends Schema.TaggedError
   }
 }
 
+export class PreviewAutomationProfileNotFoundError extends Schema.TaggedErrorClass<PreviewAutomationProfileNotFoundError>()(
+  "PreviewAutomationProfileNotFoundError",
+  { profileId: BrowserProfileId },
+) {
+  get responseTag() {
+    return "PreviewAutomationExecutionError" as const;
+  }
+
+  override get message(): string {
+    return `Browser profile ${this.profileId} does not exist on this desktop. Choose an existing profile from Settings → Integrations → Browser profiles.`;
+  }
+}
+
 export class PreviewAutomationTargetNotEditableHostError extends Schema.TaggedErrorClass<PreviewAutomationTargetNotEditableHostError>()(
   "PreviewAutomationTargetNotEditableHostError",
   {
@@ -206,6 +220,7 @@ export class PreviewAutomationOperationError extends Schema.TaggedErrorClass<Pre
 }
 
 export const PreviewAutomationHostError = Schema.Union([
+  PreviewAutomationProfileNotFoundError,
   PreviewAutomationOverlayTimeoutError,
   PreviewAutomationNavigationTimeoutError,
   PreviewAutomationViewportTimeoutError,

--- a/apps/web/src/components/preview/previewAutomationOpenOptions.test.ts
+++ b/apps/web/src/components/preview/previewAutomationOpenOptions.test.ts
@@ -1,0 +1,52 @@
+import { resolveBrowserProfiles } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import type { BrowserDefaults } from "~/browser/browserDefaults";
+
+import {
+  PreviewAutomationProfileNotFoundError,
+  serializePreviewAutomationHostError,
+} from "./previewAutomationErrors";
+import { previewAutomationOpenOptions } from "./previewAutomationOpenOptions";
+
+const defaults: BrowserDefaults = {
+  viewport: { _tag: "freeform", width: 1280, height: 800 },
+  zoomFactor: 1,
+  appearance: "system",
+  autoShowFloatingPreview: true,
+  profiles: resolveBrowserProfiles([
+    { id: "profile-feature-a", name: "Feature A", kind: "persistent" },
+  ]),
+  profileId: "profile-feature-a",
+};
+
+describe("previewAutomationOpenOptions", () => {
+  it.each(["default", "incognito", "profile-feature-a"])(
+    "opens in the explicitly requested %s profile",
+    (profileId) => {
+      expect(previewAutomationOpenOptions({ profileId }, defaults)).toEqual({
+        viewport: defaults.viewport,
+        profileId,
+      });
+    },
+  );
+
+  it("preserves existing behavior when no profile was requested", () => {
+    expect(previewAutomationOpenOptions({}, defaults)).toEqual({ viewport: defaults.viewport });
+  });
+
+  it("rejects an unknown or deleted profile rather than falling back to another login", () => {
+    expect(() => previewAutomationOpenOptions({ profileId: "profile-deleted" }, defaults)).toThrow(
+      PreviewAutomationProfileNotFoundError,
+    );
+  });
+
+  it("returns a useful profile error through the automation error protocol", () => {
+    const error = new PreviewAutomationProfileNotFoundError({ profileId: "profile-deleted" });
+    expect(serializePreviewAutomationHostError(error)).toEqual({
+      _tag: "PreviewAutomationExecutionError",
+      message: error.message,
+      detail: { profileId: "profile-deleted" },
+    });
+  });
+});

--- a/apps/web/src/components/preview/previewAutomationOpenOptions.ts
+++ b/apps/web/src/components/preview/previewAutomationOpenOptions.ts
@@ -1,0 +1,18 @@
+import { findBrowserProfile, type PreviewAutomationOpenInput } from "@t3tools/contracts";
+
+import type { BrowserDefaults } from "~/browser/browserDefaults";
+
+import { PreviewAutomationProfileNotFoundError } from "./previewAutomationErrors";
+
+export function previewAutomationOpenOptions(
+  input: PreviewAutomationOpenInput,
+  defaults: BrowserDefaults,
+) {
+  if (input.profileId !== undefined && !findBrowserProfile(defaults.profiles, input.profileId)) {
+    throw new PreviewAutomationProfileNotFoundError({ profileId: input.profileId });
+  }
+  return {
+    viewport: defaults.viewport,
+    ...(input.profileId === undefined ? {} : { profileId: input.profileId }),
+  };
+}

--- a/docs/user/browser-import.md
+++ b/docs/user/browser-import.md
@@ -15,3 +15,25 @@ On Linux, Chromium-based browsers use your desktop keyring to protect their cook
 includes the keyring reader; no separate command-line tool is needed. Allow the desktop unlock
 prompt if one appears. If the keyring cannot be accessed, T3 Code reports that failure when no
 cookies can be imported. Partitioned cookies are skipped.
+
+## Separate task logins
+
+For parallel tasks that need different logins, create a **Blank profile** for each task under
+**Settings → Integrations → Browser profiles → Add profile**. In the panel tab bar, open
+**+ → Browser** and choose that profile.
+
+Agents can read an open tab's `profileId` with `preview_status` and pass that ID to `preview_open`
+to create another tab in the same profile. The built-in IDs are `default` and `incognito`;
+custom profiles use their ID, not their display name. For example:
+
+```json
+{ "profileId": "incognito", "url": "http://localhost:3001" }
+```
+
+Supplying `profileId` always creates a new tab. It cannot be combined with `tabId` or
+`reuseExistingTab: true`. Subsequent agent actions use the new tab, and the original tab keeps its
+profile and login. Unknown profiles are rejected; this does not create a profile.
+
+A new tab shares cookies with other tabs in its profile. Incognito is also shared within an
+environment until T3 Code closes, so use separate blank profiles for independent tasks. Both the
+server and desktop must support explicit profile selection; an older desktop cannot handle it.

--- a/packages/contracts/src/preview.test.ts
+++ b/packages/contracts/src/preview.test.ts
@@ -34,6 +34,33 @@ const decodeAutomationError = Schema.decodeUnknownSync(PreviewAutomationError);
 const decodeAutomationStatus = Schema.decodeUnknownSync(PreviewAutomationStatus);
 
 describe("PreviewAutomationOpenInput", () => {
+  it.each(["default", "incognito", "profile-feature-a"])(
+    "accepts profile %s for a new tab",
+    (profileId) => {
+      expect(decodeOpenInput({ profileId })).toEqual({ profileId });
+      expect(decodeOpenInput({ profileId, reuseExistingTab: false })).toEqual({
+        profileId,
+        reuseExistingTab: false,
+      });
+    },
+  );
+
+  it("rejects profile selection when reusing a tab", () => {
+    expect(() => decodeOpenInput({ profileId: "incognito", tabId: "tab-app" })).toThrow(
+      "profileId opens a new tab",
+    );
+    expect(() => decodeOpenInput({ profileId: "incognito", reuseExistingTab: true })).toThrow(
+      "profileId opens a new tab",
+    );
+  });
+
+  it.each(["", "profile\u0000other", "x".repeat(65)])(
+    "rejects invalid profile ID %j",
+    (profileId) => {
+      expect(() => decodeOpenInput({ profileId })).toThrow();
+    },
+  );
+
   it("accepts the inline preview visibility flag", () => {
     expect(decodeOpenInput({ open: false })).toEqual({ open: false });
   });

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -1,6 +1,7 @@
 import { Schema } from "effect";
 
 import { EnvironmentId, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { BrowserProfileId } from "./browserProfile.ts";
 import {
   PREVIEW_VIEWPORT_MAX_AREA,
   PreviewRenderedViewportSize,
@@ -70,6 +71,7 @@ export const PreviewAutomationStatus = Schema.Struct({
   url: Schema.NullOr(Schema.String),
   title: Schema.NullOr(Schema.String),
   loading: Schema.Boolean,
+  profileId: Schema.optional(BrowserProfileId),
   /** Optional for compatibility with desktop hosts predating viewport sizing. */
   viewportSetting: Schema.optional(PreviewViewportSetting),
   /** Measured guest-page viewport in CSS pixels when a webview is ready. */
@@ -79,6 +81,10 @@ export type PreviewAutomationStatus = typeof PreviewAutomationStatus.Type;
 
 export const PreviewAutomationOpenInput = Schema.Struct({
   ...PreviewAutomationTabTargetFields,
+  profileId: Schema.optional(BrowserProfileId).annotate({
+    description:
+      "Existing browser profile ID, including default or incognito. Opens a new tab in that profile; cannot be combined with tabId or reuseExistingTab=true. Profiles belong to the desktop running the preview. A new tab does not clear the profile's cookies.",
+  }),
   url: Schema.optional(BoundedUrl).annotate({
     description: `Optional initial page URL. ${URL_GUIDANCE} Omit to open a blank tab.`,
   }),
@@ -97,7 +103,7 @@ export const PreviewAutomationOpenInput = Schema.Struct({
   reuseExistingTab: Schema.optional(
     Schema.Boolean.annotate({
       description:
-        "Reuse tabId when supplied, otherwise this agent session's current tab. Defaults to true; set false to create a new tab.",
+        "Reuse tabId when supplied, otherwise this agent session's current tab. Defaults to true unless profileId is supplied; set false to create a new tab.",
     }),
   ),
 })
@@ -106,6 +112,12 @@ export const PreviewAutomationOpenInput = Schema.Struct({
       (input) =>
         !(input.tabId !== undefined && input.reuseExistingTab === false) ||
         "tabId cannot be combined with reuseExistingTab=false.",
+    ),
+    Schema.makeFilter(
+      (input) =>
+        input.profileId === undefined ||
+        (input.tabId === undefined && input.reuseExistingTab !== true) ||
+        "profileId opens a new tab and cannot be combined with tabId or reuseExistingTab=true.",
     ),
   )
   .annotate({
@@ -581,6 +593,7 @@ export const PreviewAutomationHost = Schema.Struct({
    * a newer server safely coexist with an older desktop during rollout.
    */
   supportedOperations: Schema.optional(Schema.Array(PreviewAutomationOperation)),
+  supportsOpenProfile: Schema.optional(Schema.Boolean),
 });
 export type PreviewAutomationHost = typeof PreviewAutomationHost.Type;
 


### PR DESCRIPTION
## What changed

When agents check different app versions in parallel, they need separate browser logins. The preview UI already supports browser profiles, but `preview_open` cannot select one. This exposes an optional `profileId` so an agent can open a new tab in an existing profile without reusing another task's login.

**Changes:**

- Accept `profileId` on `preview_open`, always creating a new tab and rejecting conflicting tab-reuse options or unknown profiles.
- Include the active profile ID in preview status so agents can identify and reuse a profile deliberately.
- Route explicit profile requests only to desktops that support them, avoiding silent fallback to another cookie jar.

## Why

Changing a global default is awkward for concurrent tasks. Per-call selection uses the existing profile and tab-creation machinery, while calls without `profileId` retain their current behavior. This does not add profile creation or management, and opening a new tab does not clear that profile's cookies.

Related: [#9402](https://github.com/pingdotgg/t3code/pull/9402) makes agent-opened tabs honor the configured default profile. This PR adds explicit per-call selection; it does not depend on that PR.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after screenshots: not applicable; no UI changes
- [x] Animation/interaction video: not applicable; no visual interaction or timing changes

Implemented with GPT-6 through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how preview tabs are created and which desktop host handles opens, directly affecting cookie/login isolation; mitigations include explicit capability negotiation and rejecting unknown profiles instead of falling back.
> 
> **Overview**
> Agents can pass optional **`profileId`** on **`preview_open`** to spin up a **new tab** in an existing desktop browser profile (`default`, `incognito`, or custom IDs), so parallel tasks can keep separate logins without changing global defaults.
> 
> **Contracts and MCP behavior:** `PreviewAutomationOpenInput` gains `profileId` with schema rules that forbid combining it with `tabId` or `reuseExistingTab: true`; default tab reuse is off when a profile is set. **`preview_status`** can return **`profileId`**. Desktop hosts advertise **`supportsOpenProfile`**; the automation broker only routes profile opens to capable hosts and returns **no host** rather than sending profile selection to legacy desktops.
> 
> **Desktop:** Opens honor the requested profile via **`previewAutomationOpenOptions`** (unknown profiles fail with **`PreviewAutomationProfileNotFoundError`**). Current Electron hosts register **`supportsOpenProfile: true`**. User docs describe the agent workflow for separate task logins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d33b6eecc6c0a7946f000f94742d57b4f59de532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `profileId` support to `PreviewAutomationOpenInput` for opening tabs in specific browser profiles
> - Adds optional `profileId` field to the `PreviewAutomationOpenInput` contract, validated against known browser profile IDs, and rejects combining it with `tabId` or `reuseExistingTab=true`
> - Extends `PreviewAutomationHost` registration with a boolean capability flag; the broker routes profile open requests only to hosts that advertise profile support
> - The desktop host advertises profile selection, validates requested profiles against local browser defaults, and throws `PreviewAutomationProfileNotFoundError` for unknown profiles
> - `normalizePreviewOpenInput` now defaults `reuseExistingTab` to `false` when `profileId` is present, creating a new tab instead of reusing
> - `PreviewAutomationStatus` includes the tab's `profileId`, defaulting to the default profile when the snapshot lacks one
> - Behavioral Change: existing hosts that omit the new capability field are recorded as unable to handle profile opens; broker rejects profile open requests when no capable host is connected
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d33b6ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->