### PR TITLE
feat(web): navigate recent prompts with arrow keys

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -89,7 +89,9 @@ import { readLocalApi } from "../localApi";
 import { useDiffPanelStore } from "../diffPanelStore";
 import {
   collapseExpandedComposerCursor,
+  ATTACHMENT_ONLY_BOOTSTRAP_PROMPT,
   type ComposerSubmissionIntent,
+  deriveComposerPromptHistory,
   parseStandaloneComposerSlashCommand,
 } from "../composer-logic";
 import {
@@ -439,8 +441,6 @@ import {
 } from "../versionSkew";
 import { useAssetUrls } from "../assets/assetUrls";
 
-const ATTACHMENT_ONLY_BOOTSTRAP_PROMPT =
-  "[User attached one or more files without additional text. Respond using the conversation context and the attached files.]";
 const EMPTY_ACTIVITIES: OrchestrationThreadActivity[] = [];
 const EMPTY_PROVIDERS: ServerProvider[] = [];
 const EMPTY_PROVIDER_SKILLS: ServerProvider["skills"] = [];
@@ -2873,6 +2873,10 @@ function ChatViewContent(props: ChatViewProps) {
     feedbackSubmissions,
     optimisticUserMessages,
   ]);
+  const promptHistory = useMemo(
+    () => deriveComposerPromptHistory(timelineMessages),
+    [timelineMessages],
+  );
   const timelineEntries = useMemo(
     () =>
       deriveTimelineEntries(timelineMessages, activeThread?.proposedPlans ?? [], workLogEntries),
@@ -7779,6 +7783,7 @@ function ChatViewContent(props: ChatViewProps) {
                             activeThreadId={activeThreadId}
                             activeThreadEnvironmentId={activeThread?.environmentId}
                             activeThread={activeThread}
+                            promptHistory={promptHistory}
                             isServerThread={isServerThread}
                             isLocalDraftThread={isLocalDraftThread}
                             forceExpandedOnMobile={forceExpandedMobileComposer && isDraftHeroState}

--- a/apps/web/src/components/ComposerPromptEditor.test.ts
+++ b/apps/web/src/components/ComposerPromptEditor.test.ts
@@ -10,6 +10,10 @@ import {
   $isRangeSelection,
   COMMAND_PRIORITY_EDITOR,
   createEditor,
+  KEY_ARROW_DOWN_COMMAND,
+  KEY_ARROW_LEFT_COMMAND,
+  KEY_ARROW_RIGHT_COMMAND,
+  KEY_ARROW_UP_COMMAND,
   PASTE_COMMAND,
 } from "lexical";
 
@@ -22,6 +26,7 @@ import {
 } from "./ComposerCitationNode";
 import { splitPromptIntoComposerSegments } from "../composer-editor-mentions";
 import type { AssistantCitationSourceAnchor } from "~/lib/assistantTextSelection";
+import { registerComposerCommandKeys } from "./ComposerPromptEditor";
 
 vi.mock("./chat/AssistantCitationChip", () => ({ AssistantCitationChip: () => null }));
 
@@ -85,6 +90,36 @@ class TestClipboardEvent extends Event {
     } as unknown as DataTransfer;
   }
 }
+
+class TestKeyboardEvent extends Event {
+  readonly isComposing = false;
+  readonly keyCode = 0;
+}
+
+describe("registerComposerCommandKeys", () => {
+  it("handles history navigation and lets history-exit arrows reach the editor", () => {
+    const editor = createEditor();
+    const keys: string[] = [];
+    const unregister = registerComposerCommandKeys(editor, (key) => {
+      keys.push(key);
+      return key === "ArrowUp" || key === "ArrowDown";
+    });
+    const left = new TestKeyboardEvent("keydown", { cancelable: true });
+    const right = new TestKeyboardEvent("keydown", { cancelable: true });
+    const up = new TestKeyboardEvent("keydown", { cancelable: true });
+    const down = new TestKeyboardEvent("keydown", { cancelable: true });
+
+    expect(editor.dispatchCommand(KEY_ARROW_LEFT_COMMAND, left as KeyboardEvent)).toBe(false);
+    expect(editor.dispatchCommand(KEY_ARROW_RIGHT_COMMAND, right as KeyboardEvent)).toBe(false);
+    expect(editor.dispatchCommand(KEY_ARROW_UP_COMMAND, up as KeyboardEvent)).toBe(true);
+    expect(editor.dispatchCommand(KEY_ARROW_DOWN_COMMAND, down as KeyboardEvent)).toBe(true);
+    expect(keys).toEqual(["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"]);
+    expect([left.defaultPrevented, right.defaultPrevented]).toEqual([false, false]);
+    expect([up.defaultPrevented, down.defaultPrevented]).toEqual([true, true]);
+
+    unregister();
+  });
+});
 
 describe("registerComposerInlineTokenPaste", () => {
   afterEach(() => {

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -39,6 +39,7 @@ import {
   SKIP_DOM_SELECTION_TAG,
   DecoratorNode,
   type ElementNode,
+  type LexicalEditor,
   type LexicalNode,
   type SerializedLexicalNode,
   type EditorState,
@@ -898,6 +899,14 @@ export interface ComposerPromptEditorHandle {
   };
 }
 
+export type ComposerCommandKey =
+  | "ArrowDown"
+  | "ArrowLeft"
+  | "ArrowRight"
+  | "ArrowUp"
+  | "Enter"
+  | "Tab";
+
 interface ComposerPromptEditorProps {
   value: string;
   cursor: number;
@@ -917,10 +926,7 @@ interface ComposerPromptEditorProps {
     terminalContextIds: string[],
   ) => void;
   onVisibleSelectionChange?: () => void;
-  onCommandKeyDown?: (
-    key: "ArrowDown" | "ArrowUp" | "Enter" | "Tab",
-    event: KeyboardEvent,
-  ) => boolean;
+  onCommandKeyDown?: (key: ComposerCommandKey, event: KeyboardEvent) => boolean;
   onPageScrollKeyDown?: (key: "PageUp" | "PageDown") => void;
   onPageScrollKeyUp?: (key: string) => void;
   onPageScrollRelease?: () => void;
@@ -928,64 +934,74 @@ interface ComposerPromptEditorProps {
   editorRef: React.RefObject<ComposerPromptEditorHandle | null>;
 }
 
+export function registerComposerCommandKeys(
+  editor: LexicalEditor,
+  onCommandKeyDown?: (key: ComposerCommandKey, event: KeyboardEvent) => boolean,
+) {
+  const handleCommand = (key: ComposerCommandKey, event: KeyboardEvent | null): boolean => {
+    if (!onCommandKeyDown || !event) return false;
+    if (key === "Enter" && (event.isComposing || event.keyCode === 229)) {
+      event.stopPropagation();
+      return true;
+    }
+    const handled = onCommandKeyDown(key, event);
+    if (handled) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    return handled;
+  };
+
+  const unregisterArrowDown = editor.registerCommand(
+    KEY_ARROW_DOWN_COMMAND,
+    (event) => handleCommand("ArrowDown", event),
+    COMMAND_PRIORITY_HIGH,
+  );
+  const unregisterArrowUp = editor.registerCommand(
+    KEY_ARROW_UP_COMMAND,
+    (event) => handleCommand("ArrowUp", event),
+    COMMAND_PRIORITY_HIGH,
+  );
+  const unregisterArrowLeft = editor.registerCommand(
+    KEY_ARROW_LEFT_COMMAND,
+    (event) => handleCommand("ArrowLeft", event),
+    COMMAND_PRIORITY_HIGH,
+  );
+  const unregisterArrowRight = editor.registerCommand(
+    KEY_ARROW_RIGHT_COMMAND,
+    (event) => handleCommand("ArrowRight", event),
+    COMMAND_PRIORITY_HIGH,
+  );
+  const unregisterEnter = editor.registerCommand(
+    KEY_ENTER_COMMAND,
+    (event) => handleCommand("Enter", event),
+    COMMAND_PRIORITY_HIGH,
+  );
+  const unregisterTab = editor.registerCommand(
+    KEY_TAB_COMMAND,
+    (event) => handleCommand("Tab", event),
+    COMMAND_PRIORITY_HIGH,
+  );
+
+  return () => {
+    unregisterArrowDown();
+    unregisterArrowUp();
+    unregisterArrowLeft();
+    unregisterArrowRight();
+    unregisterEnter();
+    unregisterTab();
+  };
+}
+
 function ComposerCommandKeyPlugin(props: {
-  onCommandKeyDown?: (
-    key: "ArrowDown" | "ArrowUp" | "Enter" | "Tab",
-    event: KeyboardEvent,
-  ) => boolean;
+  onCommandKeyDown?: (key: ComposerCommandKey, event: KeyboardEvent) => boolean;
 }) {
   const [editor] = useLexicalComposerContext();
 
-  useEffect(() => {
-    const handleCommand = (
-      key: "ArrowDown" | "ArrowUp" | "Enter" | "Tab",
-      event: KeyboardEvent | null,
-    ): boolean => {
-      if (!props.onCommandKeyDown || !event) {
-        return false;
-      }
-
-      if (key === "Enter" && (event.isComposing || event.keyCode === 229)) {
-        event.stopPropagation();
-        return true;
-      }
-
-      const handled = props.onCommandKeyDown(key, event);
-      if (handled) {
-        event.preventDefault();
-        event.stopPropagation();
-      }
-      return handled;
-    };
-
-    const unregisterArrowDown = editor.registerCommand(
-      KEY_ARROW_DOWN_COMMAND,
-      (event) => handleCommand("ArrowDown", event),
-      COMMAND_PRIORITY_HIGH,
-    );
-    const unregisterArrowUp = editor.registerCommand(
-      KEY_ARROW_UP_COMMAND,
-      (event) => handleCommand("ArrowUp", event),
-      COMMAND_PRIORITY_HIGH,
-    );
-    const unregisterEnter = editor.registerCommand(
-      KEY_ENTER_COMMAND,
-      (event) => handleCommand("Enter", event),
-      COMMAND_PRIORITY_HIGH,
-    );
-    const unregisterTab = editor.registerCommand(
-      KEY_TAB_COMMAND,
-      (event) => handleCommand("Tab", event),
-      COMMAND_PRIORITY_HIGH,
-    );
-
-    return () => {
-      unregisterArrowDown();
-      unregisterArrowUp();
-      unregisterEnter();
-      unregisterTab();
-    };
-  }, [editor, props]);
+  useEffect(
+    () => registerComposerCommandKeys(editor, props.onCommandKeyDown),
+    [editor, props.onCommandKeyDown],
+  );
 
   return null;
 }

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -40,10 +40,13 @@ import {
   type ComposerSubmissionIntent,
   type ComposerTrigger,
   collapseExpandedComposerCursor,
+  composerPromptHistoryDirectionForKey,
   composerSubmissionIntentForEnter,
   detectComposerTrigger,
   expandCollapsedComposerCursor,
   formatAssistantCitationForComposer,
+  navigateComposerPromptHistory,
+  type ComposerPromptHistoryNavigation,
   replaceTextRange,
 } from "../../composer-logic";
 import { DISCONNECTED_COMPOSER_PLACEHOLDER } from "../../composerPlaceholder";
@@ -1145,6 +1148,7 @@ export interface ChatComposerProps {
   activeThreadId: ThreadId | null;
   activeThreadEnvironmentId: EnvironmentId | undefined;
   activeThread: Thread | undefined;
+  promptHistory: ReadonlyArray<string>;
   isServerThread: boolean;
   isLocalDraftThread: boolean;
   forceExpandedOnMobile: boolean;
@@ -1279,6 +1283,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     activeThreadId,
     activeThreadEnvironmentId: _activeThreadEnvironmentId,
     activeThread,
+    promptHistory,
     isServerThread: _isServerThread,
     isLocalDraftThread: _isLocalDraftThread,
     forceExpandedOnMobile,
@@ -1809,6 +1814,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
    * the next draft.
    */
   const pendingImageCompressionsRef = useRef<Map<ThreadId, number>>(new Map());
+  const promptHistoryNavigationRef = useRef<ComposerPromptHistoryNavigation | null>(null);
 
   // ------------------------------------------------------------------
   // Derived: composer send state
@@ -2467,6 +2473,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       cursorAdjacentToMention: boolean,
       terminalContextIds: string[],
     ) => {
+      promptHistoryNavigationRef.current = null;
       expandComposerForEditorChange();
       if (activePendingProgress?.activeQuestion && pendingUserInputs.length > 0) {
         if (activePendingProgress.activeQuestion.allowCustomAnswer === false) return;
@@ -2809,6 +2816,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       });
       setComposerSubmissionError(submission.validationMessage);
       if (!submission.didDispatch) return;
+      promptHistoryNavigationRef.current = null;
       if (shouldBlurMobileComposerOnSubmit()) {
         blurMobileComposerAfterSend();
       }
@@ -2902,14 +2910,42 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   // Callbacks: command key
   // ------------------------------------------------------------------
+  const navigatePromptHistory = (key: "ArrowDown" | "ArrowLeft" | "ArrowRight" | "ArrowUp") => {
+    const targetKey = composerTargetKey(composerDraftTarget);
+    const direction = composerPromptHistoryDirectionForKey(key);
+    if (!direction) return false;
+    const next = navigateComposerPromptHistory({
+      direction,
+      history: promptHistory,
+      navigation: promptHistoryNavigationRef.current,
+      prompt: promptRef.current,
+      targetKey,
+    });
+    if (!next) return false;
+
+    promptHistoryNavigationRef.current = next.navigation;
+    if (direction === "exit") return false;
+    promptRef.current = next.prompt;
+    setComposerDraftPrompt(composerDraftTarget, next.prompt);
+    setComposerCursor(collapseExpandedComposerCursor(next.prompt, next.prompt.length));
+    setComposerTrigger(null);
+    return true;
+  };
+
   const onComposerCommandKey = (
-    key: "ArrowDown" | "ArrowUp" | "Enter" | "Tab",
+    key: "ArrowDown" | "ArrowLeft" | "ArrowRight" | "ArrowUp" | "Enter" | "Tab",
     event: KeyboardEvent,
   ) => {
     if (key === "Tab" && event.shiftKey) {
       if (!planModeUiEnabled) return false;
       toggleInteractionMode();
       return true;
+    }
+    if (
+      (key === "ArrowDown" || key === "ArrowLeft" || key === "ArrowRight" || key === "ArrowUp") &&
+      promptHistoryNavigationRef.current !== null
+    ) {
+      return navigatePromptHistory(key);
     }
     const { trigger } = resolveActiveComposerTrigger();
     const menuIsActive = composerMenuOpenRef.current || trigger !== null;
@@ -2928,6 +2964,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         onSelectComposerItem(selectedItem);
         return true;
       }
+    }
+    if (
+      (key === "ArrowDown" || key === "ArrowUp") &&
+      !activePendingProgress &&
+      !isComposerApprovalState
+    ) {
+      return navigatePromptHistory(key);
     }
     const submissionIntent =
       key === "Enter"

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -7,13 +7,17 @@ import {
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  ATTACHMENT_ONLY_BOOTSTRAP_PROMPT,
   clampCollapsedComposerCursor,
   collapseExpandedComposerCursor,
+  composerPromptHistoryDirectionForKey,
   composerSubmissionIntentForEnter,
   detectComposerTrigger,
+  deriveComposerPromptHistory,
   expandCollapsedComposerCursor,
   formatAssistantCitationForComposer,
   isCollapsedCursorAdjacentToInlineToken,
+  navigateComposerPromptHistory,
   parseStandaloneComposerSlashCommand,
   replaceTextRange,
 } from "./composer-logic";
@@ -106,6 +110,134 @@ describe("composerSubmissionIntentForEnter", () => {
         isDraftThread: false,
       }),
     ).toBe("foreground");
+  });
+});
+
+describe("navigateComposerPromptHistory", () => {
+  it.each([
+    ["ArrowUp", "previous"],
+    ["ArrowDown", "next"],
+    ["ArrowLeft", "exit"],
+    ["ArrowRight", "exit"],
+    ["Enter", null],
+  ])("maps %s to %s", (key, direction) => {
+    expect(composerPromptHistoryDirectionForKey(key)).toBe(direction);
+  });
+
+  it("does not start with Down Arrow or without history", () => {
+    expect(
+      navigateComposerPromptHistory({
+        direction: "next",
+        history: ["first"],
+        navigation: null,
+        prompt: "unfinished",
+        targetKey: "thread",
+      }),
+    ).toBeNull();
+    expect(
+      navigateComposerPromptHistory({
+        direction: "previous",
+        history: [],
+        navigation: null,
+        prompt: "unfinished",
+        targetKey: "thread",
+      }),
+    ).toBeNull();
+  });
+
+  it("moves backward, stops at the oldest prompt, and restores the draft", () => {
+    const history = ["first", "second"];
+    const latest = navigateComposerPromptHistory({
+      direction: "previous",
+      history,
+      navigation: null,
+      prompt: "unfinished",
+      targetKey: "thread",
+    });
+    expect(latest).toEqual({
+      navigation: { draft: "unfinished", index: 1, targetKey: "thread" },
+      prompt: "second",
+    });
+
+    const previous = navigateComposerPromptHistory({
+      direction: "previous",
+      history,
+      navigation: latest?.navigation ?? null,
+      prompt: latest?.prompt ?? "",
+      targetKey: "thread",
+    });
+    expect(previous?.prompt).toBe("first");
+    expect(
+      navigateComposerPromptHistory({
+        direction: "previous",
+        history,
+        navigation: previous?.navigation ?? null,
+        prompt: previous?.prompt ?? "",
+        targetKey: "thread",
+      }),
+    ).toEqual(previous);
+
+    const next = navigateComposerPromptHistory({
+      direction: "next",
+      history,
+      navigation: previous?.navigation ?? null,
+      prompt: previous?.prompt ?? "",
+      targetKey: "thread",
+    });
+    const draft = navigateComposerPromptHistory({
+      direction: "next",
+      history,
+      navigation: next?.navigation ?? null,
+      prompt: next?.prompt ?? "",
+      targetKey: "thread",
+    });
+    expect(draft).toEqual({ navigation: null, prompt: "unfinished" });
+  });
+
+  it("exits without changing the recalled prompt", () => {
+    expect(
+      navigateComposerPromptHistory({
+        direction: "exit",
+        history: ["first"],
+        navigation: { draft: "unfinished", index: 0, targetKey: "thread" },
+        prompt: "first",
+        targetKey: "thread",
+      }),
+    ).toEqual({ navigation: null, prompt: "first" });
+  });
+
+  it("starts a new history session after the thread changes", () => {
+    expect(
+      navigateComposerPromptHistory({
+        direction: "previous",
+        history: ["new thread prompt"],
+        navigation: { draft: "old draft", index: 0, targetKey: "thread-a" },
+        prompt: "new draft",
+        targetKey: "thread-b",
+      }),
+    ).toEqual({
+      navigation: { draft: "new draft", index: 0, targetKey: "thread-b" },
+      prompt: "new thread prompt",
+    });
+  });
+});
+
+describe("deriveComposerPromptHistory", () => {
+  it("returns only the ten most recent non-empty user prompts", () => {
+    const messages = [
+      { role: "user", text: "too old" },
+      { role: "assistant", text: "response" },
+      { role: "user", text: ATTACHMENT_ONLY_BOOTSTRAP_PROMPT },
+      { role: "user", text: "   " },
+      ...Array.from({ length: 10 }, (_, index) => ({
+        role: "user",
+        text: `prompt ${String(index + 1)}`,
+      })),
+    ];
+
+    expect(deriveComposerPromptHistory(messages)).toEqual(
+      Array.from({ length: 10 }, (_, index) => `prompt ${String(index + 1)}`),
+    );
   });
 });
 

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -7,11 +7,25 @@ import {
   splitPromptIntoComposerSegments,
   type ComposerPromptSegment,
 } from "./composer-editor-mentions";
-import { INLINE_TERMINAL_CONTEXT_PLACEHOLDER } from "./lib/terminalContext";
+import {
+  deriveDisplayedUserMessageState,
+  INLINE_TERMINAL_CONTEXT_PLACEHOLDER,
+} from "./lib/terminalContext";
 
 export type ComposerTriggerKind = "path" | "slash-command" | "skill";
 export type ComposerSlashCommand = "model" | "plan" | "default";
 export type ComposerSubmissionIntent = "foreground" | "background";
+
+export interface ComposerPromptHistoryNavigation {
+  draft: string;
+  index: number;
+  targetKey: string;
+}
+
+export type ComposerPromptHistoryDirection = "exit" | "next" | "previous";
+
+export const ATTACHMENT_ONLY_BOOTSTRAP_PROMPT =
+  "[User attached one or more files without additional text. Respond using the conversation context and the attached files.]";
 
 export interface ComposerTrigger {
   kind: ComposerTriggerKind;
@@ -34,6 +48,61 @@ export function composerSubmissionIntentForEnter(input: {
     return null;
   }
   return input.modifierKey && input.isDraftThread ? "background" : "foreground";
+}
+
+export function composerPromptHistoryDirectionForKey(
+  key: string,
+): ComposerPromptHistoryDirection | null {
+  if (key === "ArrowUp") return "previous";
+  if (key === "ArrowDown") return "next";
+  return key === "ArrowLeft" || key === "ArrowRight" ? "exit" : null;
+}
+
+export function deriveComposerPromptHistory(
+  messages: ReadonlyArray<{ role: string; text: string }>,
+): string[] {
+  const history: string[] = [];
+  for (let index = messages.length - 1; index >= 0 && history.length < 10; index -= 1) {
+    const message = messages[index];
+    if (!message || message.role !== "user" || message.text === ATTACHMENT_ONLY_BOOTSTRAP_PROMPT) {
+      continue;
+    }
+    const text = deriveDisplayedUserMessageState(message.text).visibleText;
+    if (text.trim()) history.push(text);
+  }
+  return history.toReversed();
+}
+
+export function navigateComposerPromptHistory(input: {
+  direction: ComposerPromptHistoryDirection;
+  history: ReadonlyArray<string>;
+  navigation: ComposerPromptHistoryNavigation | null;
+  prompt: string;
+  targetKey: string;
+}): { navigation: ComposerPromptHistoryNavigation | null; prompt: string } | null {
+  const activeNavigation =
+    input.navigation?.targetKey === input.targetKey ? input.navigation : null;
+  if (input.direction === "exit") {
+    return activeNavigation ? { navigation: null, prompt: input.prompt } : null;
+  }
+  if (input.history.length === 0 || (input.direction === "next" && activeNavigation === null)) {
+    return null;
+  }
+
+  const navigation = activeNavigation ?? {
+    draft: input.prompt,
+    index: input.history.length - 1,
+    targetKey: input.targetKey,
+  };
+  if (input.direction === "previous") {
+    const index = Math.max(0, navigation.index - (activeNavigation === null ? 0 : 1));
+    return { navigation: { ...navigation, index }, prompt: input.history[index] ?? "" };
+  }
+  if (navigation.index === input.history.length - 1) {
+    return { navigation: null, prompt: navigation.draft };
+  }
+  const index = navigation.index + 1;
+  return { navigation: { ...navigation, index }, prompt: input.history[index] ?? "" };
 }
 
 const isInlineTokenSegment = (segment: ComposerPromptSegment): boolean => segment.type !== "text";

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -4,6 +4,11 @@ Messages can contain up to 120,000 characters. If a draft is longer, T3 Code kee
 composer and shows how many characters need to be removed. Shorten the draft or split it into
 multiple messages, then send again in the same thread.
 
+On web and desktop, press Up Arrow to recall up to ten recent prompts from the current thread.
+Press Up Arrow or Down Arrow to move through them. Moving past the newest prompt restores the
+unfinished draft. Press Left Arrow or Right Arrow, or edit the recalled prompt, to stop moving
+through prompt history.
+
 On mobile, an empty composer shows an interrupt button while the agent is working. Adding text
 or an attachment replaces it with the send button. This applies to both compact and expanded
 composers.


### PR DESCRIPTION
Prompt history is not available in the composer, so users must retype a recent prompt when they want to correct or extend it.

This change lets web and desktop users use Up Arrow and Down Arrow to move through the 10 most recent text prompts. It restores the current draft after the newest prompt. Left Arrow, Right Arrow, or an edit exits history navigation. Mobile behavior does not change.

Tests:
- vp test run apps/web/src/composer-logic.test.ts apps/web/src/components/ComposerPromptEditor.test.ts
- vp run typecheck in apps/web
- Real-client keyboard behavior check

## Before

An unfinished draft is in the composer.

![Before: an unfinished draft is in the composer](https://github.com/user-attachments/assets/8094be44-244f-4e31-baf8-b231b635ba9b)

## After

Up Arrow recalls the most recent prompt.

![After: Up Arrow recalls the most recent prompt](https://github.com/user-attachments/assets/9909d65a-6430-4656-9ebf-ca3b2b5eb13f)

## Video

https://github.com/user-attachments/assets/ae6204f1-c85f-41e7-bd80-4cb6b5d5f28c

Built with GPT-5.6 Sol through the Codex harness.