### PR TITLE
perf(web): stop replaying terminal buffers on rollover

### DIFF
--- a/apps/mobile/src/features/terminal/terminalMenu.test.ts
+++ b/apps/mobile/src/features/terminal/terminalMenu.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { type KnownTerminalSession } from "@t3tools/client-runtime/state/terminal";
+import {
+  EMPTY_TERMINAL_BUFFER_STATE,
+  type KnownTerminalSession,
+} from "@t3tools/client-runtime/state/terminal";
 import { DEFAULT_TERMINAL_ID, EnvironmentId, ThreadId } from "@t3tools/contracts";
 
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
@@ -55,7 +58,7 @@ function makeKnownSession(input: {
             updatedAt: input.updatedAt ?? "2026-04-15T20:00:00.000Z",
           }
         : null,
-      buffer: "",
+      output: EMPTY_TERMINAL_BUFFER_STATE.output,
       status: input.status,
       error: null,
       hasRunningSubprocess: false,

--- a/apps/mobile/src/state/use-terminal-session.ts
+++ b/apps/mobile/src/state/use-terminal-session.ts
@@ -2,6 +2,7 @@ import {
   combineTerminalSessionState,
   EMPTY_TERMINAL_BUFFER_STATE,
   EMPTY_TERMINAL_SESSION_STATE,
+  terminalOutputText,
   type KnownTerminalSession,
   type TerminalSessionState,
 } from "@t3tools/client-runtime/state/terminal";
@@ -11,10 +12,16 @@ import { useMemo } from "react";
 import { useEnvironmentQuery } from "./query";
 import { terminalEnvironment } from "./terminal";
 
+type LegacyTerminalSessionState = TerminalSessionState & { readonly buffer: string };
+const EMPTY_LEGACY_TERMINAL_SESSION_STATE: LegacyTerminalSessionState = {
+  ...EMPTY_TERMINAL_SESSION_STATE,
+  buffer: "",
+};
+
 export function useAttachedTerminalSession(input: {
   readonly environmentId: EnvironmentId | null;
   readonly terminal: TerminalAttachInput | null;
-}): TerminalSessionState {
+}): LegacyTerminalSessionState {
   const attach = useEnvironmentQuery(
     input.environmentId !== null && input.terminal !== null
       ? terminalEnvironment.attach({
@@ -31,10 +38,14 @@ export function useAttachedTerminalSession(input: {
           input: null,
         }),
   );
+  const output = attach.data?.output ?? EMPTY_TERMINAL_BUFFER_STATE.output;
+  // Installed native binaries still accept initialBuffer. Keep materialization
+  // at this mobile boundary until the native streaming API is released.
+  const buffer = useMemo(() => terminalOutputText(output), [output]);
 
   return useMemo(() => {
     if (input.environmentId === null || input.terminal === null) {
-      return EMPTY_TERMINAL_SESSION_STATE;
+      return EMPTY_LEGACY_TERMINAL_SESSION_STATE;
     }
     const summary =
       metadata.data?.find(
@@ -42,9 +53,12 @@ export function useAttachedTerminalSession(input: {
           terminal.threadId === input.terminal?.threadId &&
           terminal.terminalId === input.terminal?.terminalId,
       ) ?? null;
-    const state = combineTerminalSessionState(summary, attach.data ?? EMPTY_TERMINAL_BUFFER_STATE);
+    const state = {
+      ...combineTerminalSessionState(summary, attach.data ?? EMPTY_TERMINAL_BUFFER_STATE),
+      buffer,
+    };
     return attach.error === null ? state : { ...state, error: attach.error, status: "error" };
-  }, [attach.data, attach.error, input.environmentId, input.terminal, metadata.data]);
+  }, [attach.data, attach.error, buffer, input.environmentId, input.terminal, metadata.data]);
 }
 
 export function useKnownTerminalSessions(input: {

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -3,7 +3,13 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
-import { type TerminalSessionState } from "@t3tools/client-runtime/state/terminal";
+import {
+  INITIAL_TERMINAL_OUTPUT_CURSOR,
+  readTerminalOutputUpdate,
+  type TerminalOutputCursor,
+  type TerminalOutputUpdate,
+  type TerminalSessionState,
+} from "@t3tools/client-runtime/state/terminal";
 import {
   Plus,
   Square,
@@ -99,8 +105,15 @@ function writeSystemMessage(terminal: GhosttyTerminalSurface, message: string): 
   terminal.write(`\r\n[terminal] ${message}\r\n`);
 }
 
-function writeTerminalBuffer(terminal: GhosttyTerminalSurface, buffer: string): void {
-  terminal.resetAndWrite(buffer);
+export function writeTerminalOutputUpdate(
+  terminal: Pick<GhosttyTerminalSurface, "resetAndWrite" | "write">,
+  update: TerminalOutputUpdate,
+): void {
+  if (update.type === "reset") {
+    terminal.resetAndWrite(update.data);
+  } else if (update.type === "append") {
+    terminal.write(update.data);
+  }
 }
 
 function parseTerminalColor(value: string, fallback: GhosttyColor): GhosttyColor {
@@ -380,9 +393,10 @@ export function TerminalViewport({
       input: { threadId, terminalId, cols, rows },
     }),
   );
-  const terminalBuffer = terminalSession.buffer;
+  const terminalOutput = terminalSession.output;
   const terminalError = terminalSession.error;
   const terminalStatus = terminalSession.status;
+  const outputCursorRef = useRef<TerminalOutputCursor>(INITIAL_TERMINAL_OUTPUT_CURSOR);
   const synchronizedStatusRef = useRef<TerminalSessionState["status"]>("closed");
   const synchronizeTerminalStatus = useEffectEvent(
     (terminal: GhosttyTerminalSurface, status: TerminalSessionState["status"]) => {
@@ -403,14 +417,14 @@ export function TerminalViewport({
   );
   const terminalVersion = terminalSession.version;
   const previousSessionRef = useRef({
-    buffer: terminalBuffer,
+    output: terminalOutput,
     error: terminalError,
     status: terminalStatus,
     version: terminalVersion,
   });
   const latestSessionRef = useRef(previousSessionRef.current);
   latestSessionRef.current = {
-    buffer: terminalBuffer,
+    output: terminalOutput,
     error: terminalError,
     status: terminalStatus,
     version: terminalVersion,
@@ -474,7 +488,14 @@ export function TerminalViewport({
       }
       const latestSession = latestSessionRef.current;
       previousSessionRef.current = latestSession;
-      if (latestSession.buffer.length > 0) terminal.resetAndWrite(latestSession.buffer);
+      const initialOutput = readTerminalOutputUpdate(
+        latestSession.output,
+        INITIAL_TERMINAL_OUTPUT_CURSOR,
+      );
+      if (initialOutput.type === "reset" && initialOutput.data.length > 0) {
+        writeTerminalOutputUpdate(terminal, initialOutput);
+      }
+      outputCursorRef.current = initialOutput.cursor;
       if (latestSession.error !== null) writeSystemMessage(terminal, latestSession.error);
       // Attaching to a session that already exited must still run exit handling
       // once, so mount synchronization starts from the empty "closed" state.
@@ -845,7 +866,7 @@ export function TerminalViewport({
   useEffect(() => {
     const terminal = terminalRef.current;
     const current = {
-      buffer: terminalBuffer,
+      output: terminalOutput,
       error: terminalError,
       status: terminalStatus,
       version: terminalVersion,
@@ -857,18 +878,13 @@ export function TerminalViewport({
 
     const previous = previousSessionRef.current;
     synchronizeTerminalStatus(terminal, current.status);
-    if (current.version === previous.version) {
+    if (current.version === previous.version && current.output === previous.output) {
       return;
     }
 
-    if (
-      current.buffer.length >= previous.buffer.length &&
-      current.buffer.startsWith(previous.buffer)
-    ) {
-      terminal.write(current.buffer.slice(previous.buffer.length));
-    } else {
-      writeTerminalBuffer(terminal, current.buffer);
-    }
+    const outputUpdate = readTerminalOutputUpdate(current.output, outputCursorRef.current);
+    writeTerminalOutputUpdate(terminal, outputUpdate);
+    outputCursorRef.current = outputUpdate.cursor;
     terminal.clearSelection();
 
     if (current.error !== null && current.error !== previous.error) {
@@ -881,7 +897,7 @@ export function TerminalViewport({
       });
     }
     previousSessionRef.current = current;
-  }, [autoFocus, terminalBuffer, terminalError, terminalStatus, terminalVersion]);
+  }, [autoFocus, terminalOutput, terminalError, terminalStatus, terminalVersion]);
 
   useEffect(() => {
     if (!autoFocus) return;

--- a/apps/web/src/terminal/ghostty/core.test.ts
+++ b/apps/web/src/terminal/ghostty/core.test.ts
@@ -1,5 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  applyTerminalAttachStreamEvent,
+  DEFAULT_MAX_TERMINAL_BUFFER_BYTES,
+  INITIAL_TERMINAL_OUTPUT_CURSOR,
+  nextTerminalAttachSeedState,
+  readTerminalOutputUpdate,
+  terminalOutputText,
+  type TerminalBufferState,
+} from "@t3tools/client-runtime/state/terminal";
 
+import { writeTerminalOutputUpdate } from "../../components/ThreadTerminalDrawer";
 import { GHOSTTY_CELL_WIDE, GhosttyTerminalCore, ghosttyCellText } from "./core";
 import { loadGhosttyRuntime } from "./runtime";
 
@@ -65,6 +75,34 @@ describe("GhosttyTerminalCore snapshots", () => {
     );
     cores.add(core);
     return core;
+  }
+
+  function createSession(history: string) {
+    return applyTerminalAttachStreamEvent(nextTerminalAttachSeedState(), {
+      type: "snapshot",
+      snapshot: {
+        threadId: "terminal-stream-test",
+        terminalId: "term-1",
+        cwd: "/repo",
+        worktreePath: null,
+        status: "running",
+        pid: 123,
+        history,
+        exitCode: null,
+        exitSignal: null,
+        label: "Terminal",
+        updatedAt: "2026-09-04T00:00:00.000Z",
+      },
+    });
+  }
+
+  function append(state: TerminalBufferState, data: string) {
+    return applyTerminalAttachStreamEvent(state, {
+      type: "output",
+      threadId: "terminal-stream-test",
+      terminalId: "term-1",
+      data,
+    });
   }
 
   afterEach(() => {
@@ -144,5 +182,174 @@ describe("GhosttyTerminalCore snapshots", () => {
     expect(alloc).not.toHaveBeenCalled();
     core.dispose();
     expect(free).toHaveBeenCalledWith(buffer, capacity);
+  });
+
+  it.each(["varied", "identical"] as const)(
+    "preserves Ghostty state through a full MiB of %s output without rollover resets",
+    async (kind) => {
+      const [core, reference] = await Promise.all([createCore(), createCore()]);
+      const initial = "\x1b[31m";
+      let state = createSession(initial);
+      const first = readTerminalOutputUpdate(state.output, INITIAL_TERMINAL_OUTPUT_CURSOR);
+      writeTerminalOutputUpdate(core, first);
+      reference.resetAndWrite(initial);
+      let cursor = first.cursor;
+      const reset = vi.spyOn(core, "resetAndWrite");
+      const inputs: string[] = [];
+      let receivedCharacters = 0;
+
+      for (let index = 0; index < 128; index += 1) {
+        const data =
+          kind === "identical"
+            ? "x".repeat(8192)
+            : `${index.toString().padStart(4, "0")}\r\n${"x".repeat(8186)}`;
+        inputs.push(data);
+        state = append(state, data);
+        const update = readTerminalOutputUpdate(state.output, cursor);
+        if (update.type !== "append") throw new Error(`Expected append, received ${update.type}`);
+        receivedCharacters += update.data.length;
+        writeTerminalOutputUpdate(core, update);
+        cursor = update.cursor;
+      }
+
+      reference.write(inputs.join(""));
+      expect(receivedCharacters).toBe(1024 * 1024);
+      expect(state.output.retainedBytes).toBe(DEFAULT_MAX_TERMINAL_BUFFER_BYTES);
+      expect(reset).not.toHaveBeenCalled();
+      expect(core.snapshot()).toEqual(reference.snapshot());
+    },
+  );
+
+  it("preserves Unicode and split ANSI parser state across batched renderer reads", async () => {
+    const [core, reference] = await Promise.all([createCore(), createCore()]);
+    let state = createSession("");
+    const first = readTerminalOutputUpdate(state.output, INITIAL_TERMINAL_OUTPUT_CURSOR);
+    writeTerminalOutputUpdate(core, first);
+    let cursor = first.cursor;
+    const reset = vi.spyOn(core, "resetAndWrite");
+    const inputs = [
+      `${"a".repeat(16_383)}🙂`,
+      "\x1b[3",
+      "1m",
+      "e",
+      "\u0301界🙂",
+      "\x1b[0",
+      "m\r\n",
+      "\x1b]8;;https://t3.codes\x1b",
+      "\\link",
+      "\x1b]8;;\x1b",
+      "\\\x1b[?1049h",
+      "alternate",
+      "\x1b[?1049l",
+      "\r\nend",
+    ];
+    let received = "";
+    for (const [index, data] of inputs.entries()) {
+      state = append(state, data);
+      if (index % 3 !== 0 && index !== inputs.length - 1) continue;
+      const update = readTerminalOutputUpdate(state.output, cursor);
+      if (update.type !== "append") throw new Error(`Expected append, received ${update.type}`);
+      received += update.data;
+      writeTerminalOutputUpdate(core, update);
+      cursor = update.cursor;
+    }
+
+    reference.write(inputs.join(""));
+    expect(received).toBe(inputs.join(""));
+    expect(reset).not.toHaveBeenCalled();
+    expect(core.snapshot()).toEqual(reference.snapshot());
+  });
+
+  it("recovers a lagging renderer once from bounded output and resumes appending", async () => {
+    const [core, reference] = await Promise.all([createCore(), createCore()]);
+    let state = createSession("\x1b[31mold");
+    const initial = readTerminalOutputUpdate(state.output, INITIAL_TERMINAL_OUTPUT_CURSOR);
+    writeTerminalOutputUpdate(core, initial);
+    const reset = vi.spyOn(core, "resetAndWrite");
+    const data = "line\r\n".repeat(8192);
+    for (let index = 0; index < 16; index += 1) state = append(state, data);
+
+    const recovery = readTerminalOutputUpdate(state.output, initial.cursor);
+    if (recovery.type !== "reset") throw new Error(`Expected reset, received ${recovery.type}`);
+    expect(new TextEncoder().encode(recovery.data).byteLength).toBe(
+      DEFAULT_MAX_TERMINAL_BUFFER_BYTES,
+    );
+    writeTerminalOutputUpdate(core, recovery);
+    reference.resetAndWrite(recovery.data);
+    expect(core.snapshot()).toEqual(reference.snapshot());
+
+    state = append(state, "\r\nlatest");
+    const next = readTerminalOutputUpdate(state.output, recovery.cursor);
+    expect(next.type).toBe("append");
+    writeTerminalOutputUpdate(core, next);
+    reference.write("\r\nlatest");
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(core.snapshot()).toEqual(reference.snapshot());
+  });
+
+  it("replays the latest retained output when WASM arrives after several events", async () => {
+    const pendingCore = createCore();
+    let state = createSession("before");
+    state = append(state, "\r\nduring ");
+    state = append(state, "🙂 load");
+    const core = await pendingCore;
+    const first = readTerminalOutputUpdate(state.output, INITIAL_TERMINAL_OUTPUT_CURSOR);
+    writeTerminalOutputUpdate(core, first);
+    const reference = await createCore();
+    reference.resetAndWrite(terminalOutputText(state.output));
+    const reset = vi.spyOn(core, "resetAndWrite");
+
+    state = append(state, "\r\nafter");
+    const next = readTerminalOutputUpdate(state.output, first.cursor);
+    expect(next).toMatchObject({ type: "append", data: "\r\nafter" });
+    writeTerminalOutputUpdate(core, next);
+    reference.write("\r\nafter");
+    expect(reset).not.toHaveBeenCalled();
+    expect(core.snapshot()).toEqual(reference.snapshot());
+  });
+
+  it("resets real Ghostty for a repeated snapshot, clear, restart, and a fresh attach", async () => {
+    const [core, reference] = await Promise.all([createCore(), createCore()]);
+    let state = createSession("hello");
+    const initial = readTerminalOutputUpdate(state.output, INITIAL_TERMINAL_OUTPUT_CURSOR);
+    writeTerminalOutputUpdate(core, initial);
+    let cursor = initial.cursor;
+
+    const snapshot = {
+      threadId: "terminal-stream-test",
+      terminalId: "term-1",
+      cwd: "/repo",
+      worktreePath: null,
+      status: "running" as const,
+      pid: 456,
+      history: "hello",
+      exitCode: null,
+      exitSignal: null,
+      label: "Terminal",
+      updatedAt: "2026-09-04T00:00:01.000Z",
+    };
+    const events = [
+      { type: "snapshot", snapshot },
+      { type: "cleared", threadId: snapshot.threadId, terminalId: snapshot.terminalId },
+      { type: "restarted", threadId: snapshot.threadId, terminalId: snapshot.terminalId, snapshot },
+    ] as const;
+    for (const event of events) {
+      core.write("\r\nstale local text");
+      state = applyTerminalAttachStreamEvent(state, event);
+      const update = readTerminalOutputUpdate(state.output, cursor);
+      expect(update.type).toBe("reset");
+      writeTerminalOutputUpdate(core, update);
+      cursor = update.cursor;
+      reference.resetAndWrite(event.type === "cleared" ? "" : "hello");
+      expect(core.snapshot()).toEqual(reference.snapshot());
+    }
+
+    core.write("\r\nstale local text");
+    state = createSession("hello");
+    const reattached = readTerminalOutputUpdate(state.output, cursor);
+    expect(reattached.type).toBe("reset");
+    writeTerminalOutputUpdate(core, reattached);
+    reference.resetAndWrite("hello");
+    expect(core.snapshot()).toEqual(reference.snapshot());
   });
 });

--- a/apps/web/src/terminal/ghostty/core.test.ts
+++ b/apps/web/src/terminal/ghostty/core.test.ts
@@ -60,7 +60,7 @@ describe("ghosttyCellText", () => {
 describe("GhosttyTerminalCore snapshots", () => {
   const cores = new Set<GhosttyTerminalCore>();
 
-  async function createCore() {
+  async function createCore(onData: (data: string) => void = () => {}) {
     const core = await GhosttyTerminalCore.create(
       12,
       3,
@@ -71,7 +71,7 @@ describe("GhosttyTerminalCore snapshots", () => {
         background: { r: 0, g: 0, b: 0 },
         cursor: { r: 255, g: 255, b: 255 },
       },
-      () => {},
+      onData,
     );
     cores.add(core);
     return core;
@@ -258,6 +258,31 @@ describe("GhosttyTerminalCore snapshots", () => {
     expect(received).toBe(inputs.join(""));
     expect(reset).not.toHaveBeenCalled();
     expect(core.snapshot()).toEqual(reference.snapshot());
+  });
+
+  it("answers a live VT query when batched reads cross a chunk compaction", async () => {
+    const replies: string[] = [];
+    const core = await createCore((data) => replies.push(data));
+    core.write("\x1b[5n");
+    expect(replies).toEqual(["\x1b[0n"]);
+    replies.length = 0;
+
+    let state = createSession("");
+    const initial = readTerminalOutputUpdate(state.output, INITIAL_TERMINAL_OUTPUT_CURSOR);
+    writeTerminalOutputUpdate(core, initial);
+    let cursor = initial.cursor;
+    for (let index = 0; index < 1000; index += 1) {
+      state = append(state, "x");
+      const update = readTerminalOutputUpdate(state.output, cursor);
+      writeTerminalOutputUpdate(core, update);
+      cursor = update.cursor;
+    }
+    for (let index = 0; index < 24; index += 1) state = append(state, "x");
+    state = append(state, "\x1b[5n");
+    const update = readTerminalOutputUpdate(state.output, cursor);
+    writeTerminalOutputUpdate(core, update);
+
+    expect({ type: update.type, replies }).toEqual({ type: "append", replies: ["\x1b[0n"] });
   });
 
   it("recovers a lagging renderer once from bounded output and resumes appending", async () => {

--- a/packages/client-runtime/src/state/terminal.ts
+++ b/packages/client-runtime/src/state/terminal.ts
@@ -13,7 +13,7 @@ import { subscribe, type EnvironmentRpcInput } from "../rpc/client.ts";
 import {
   applyTerminalAttachStreamEvent,
   applyTerminalMetadataStreamEvent,
-  EMPTY_TERMINAL_BUFFER_STATE,
+  nextTerminalAttachSeedState,
 } from "./terminalSession.ts";
 
 export function createTerminalEnvironmentAtoms<R, E>(
@@ -40,8 +40,10 @@ export function createTerminalEnvironmentAtoms<R, E>(
     attach: createEnvironmentSubscriptionAtomFamily(runtime, {
       label: "environment-data:terminal:attach",
       subscribe: (input: EnvironmentRpcInput<typeof WS_METHODS.terminalAttach>) =>
-        subscribe(WS_METHODS.terminalAttach, input).pipe(
-          Stream.scan(EMPTY_TERMINAL_BUFFER_STATE, applyTerminalAttachStreamEvent),
+        Stream.suspend(() =>
+          subscribe(WS_METHODS.terminalAttach, input).pipe(
+            Stream.scan(nextTerminalAttachSeedState(), applyTerminalAttachStreamEvent),
+          ),
         ),
     }),
     events: createEnvironmentRpcSubscriptionAtomFamily(runtime, {

--- a/packages/client-runtime/src/state/terminalOutput.ts
+++ b/packages/client-runtime/src/state/terminalOutput.ts
@@ -1,5 +1,6 @@
 export interface TerminalOutputChunk {
-  readonly id: number;
+  /** UTF-16 string offset within this generation and reset. */
+  readonly startOffset: number;
   readonly data: string;
   readonly byteLength: number;
 }
@@ -9,24 +10,20 @@ export interface TerminalOutputState {
   readonly chunks: ReadonlyArray<TerminalOutputChunk>;
   readonly retainedBytes: number;
   readonly resetVersion: number;
-  readonly latestChunkId: number;
-  /**
-   * A cursor below this id cannot safely append after chunks are merged or trimmed.
-   */
-  readonly compactedThroughId: number;
+  readonly nextOffset: number;
 }
 
 export interface TerminalOutputCursor {
   readonly generation: number;
   readonly resetVersion: number;
-  readonly lastChunkId: number;
+  readonly offset: number;
 }
 
 /** Forces the first `readTerminalOutputUpdate` to resynchronize from a reset. */
 export const INITIAL_TERMINAL_OUTPUT_CURSOR = Object.freeze<TerminalOutputCursor>({
   generation: -1,
   resetVersion: -1,
-  lastChunkId: 0,
+  offset: 0,
 });
 
 export type TerminalOutputUpdate =
@@ -57,8 +54,7 @@ export const EMPTY_TERMINAL_OUTPUT_STATE = Object.freeze<TerminalOutputState>({
   chunks: Object.freeze([]),
   retainedBytes: 0,
   resetVersion: 0,
-  latestChunkId: 0,
-  compactedThroughId: 0,
+  nextOffset: 0,
 });
 
 interface Utf8Chunk {
@@ -129,19 +125,22 @@ function trimBufferToBytes(buffer: string, maxBufferBytes: number): string {
 
 function splitOutputChunks(
   data: string,
-  firstChunkId: number,
+  firstOffset: number,
   maxChunkBytes = DEFAULT_TERMINAL_CHUNK_BYTES,
 ): {
   readonly chunks: ReadonlyArray<TerminalOutputChunk>;
-  readonly latestChunkId: number;
+  readonly nextOffset: number;
   readonly byteLength: number;
 } {
   const split = splitStringByUtf8Bytes(data, maxChunkBytes);
   let byteLength = 0;
-  const chunks = split.map((chunk, index) => {
+  let nextOffset = firstOffset;
+  const chunks = split.map((chunk) => {
     byteLength += chunk.byteLength;
+    const startOffset = nextOffset;
+    nextOffset += chunk.data.length;
     return {
-      id: firstChunkId + index,
+      startOffset,
       data: chunk.data,
       byteLength: chunk.byteLength,
     };
@@ -149,39 +148,34 @@ function splitOutputChunks(
 
   return {
     chunks,
-    latestChunkId: firstChunkId + chunks.length - 1,
+    nextOffset,
     byteLength,
   };
 }
 
 /**
- * Merge adjacent chunks up to the standard chunk size so a long
- * run of tiny interactive writes cannot exhaust the chunk budget and force a
- * full renderer reset. Merged chunks take the id of their last constituent.
+ * Merge adjacent chunks without changing their string positions. A reader can
+ * still append the unread suffix when its cursor falls inside a merged chunk.
  */
-function compactRetainedChunks(chunks: ReadonlyArray<TerminalOutputChunk>): {
-  readonly chunks: ReadonlyArray<TerminalOutputChunk>;
-  readonly compactedThroughId: number | null;
-} {
+function compactRetainedChunks(chunks: ReadonlyArray<TerminalOutputChunk>) {
   const compacted: TerminalOutputChunk[] = [];
-  let compactedThroughId: number | null = null;
   for (const chunk of chunks) {
     const previous = compacted.at(-1);
     if (
       previous !== undefined &&
+      previous.startOffset + previous.data.length === chunk.startOffset &&
       previous.byteLength + chunk.byteLength <= DEFAULT_TERMINAL_CHUNK_BYTES
     ) {
       compacted[compacted.length - 1] = {
-        id: chunk.id,
+        startOffset: previous.startOffset,
         data: `${previous.data}${chunk.data}`,
         byteLength: previous.byteLength + chunk.byteLength,
       };
-      compactedThroughId = chunk.id;
     } else {
       compacted.push(chunk);
     }
   }
-  return { chunks: compacted, compactedThroughId };
+  return compacted;
 }
 
 // Scan only the removed prefix instead of encoding retained output again.
@@ -198,6 +192,7 @@ function trimOutputChunkStart(
   }
   return {
     ...chunk,
+    startOffset: chunk.startOffset + offset,
     data: chunk.data.slice(offset),
     byteLength: chunk.byteLength - droppedBytes,
   };
@@ -208,34 +203,31 @@ function appendOutput(
   data: string,
   maxBufferBytes: number,
 ): TerminalOutputState {
-  const appended = splitOutputChunks(
-    data,
-    current.latestChunkId + 1,
-    Math.min(DEFAULT_TERMINAL_CHUNK_BYTES, Math.max(1, maxBufferBytes)),
-  );
-  if (appended.chunks.length === 0) return current;
+  if (data.length === 0) return current;
   if (maxBufferBytes <= 0) {
     return {
       generation: current.generation,
       chunks: [],
       retainedBytes: 0,
       resetVersion: current.resetVersion + 1,
-      latestChunkId: appended.latestChunkId,
-      compactedThroughId: appended.latestChunkId,
+      nextOffset: current.nextOffset + data.length,
     };
   }
+  const appended = splitOutputChunks(
+    data,
+    current.nextOffset,
+    Math.min(DEFAULT_TERMINAL_CHUNK_BYTES, Math.max(1, maxBufferBytes)),
+  );
 
   const chunks = [...current.chunks, ...appended.chunks];
   let retainedBytes = current.retainedBytes + appended.byteLength;
   let firstRetainedIndex = 0;
-  let compactedThroughId = current.compactedThroughId;
   while (retainedBytes > maxBufferBytes && firstRetainedIndex < chunks.length) {
     const first = chunks[firstRetainedIndex]!;
     const bytesToDrop = retainedBytes - maxBufferBytes;
     if (bytesToDrop < first.byteLength) {
       const trimmed = trimOutputChunkStart(first, bytesToDrop);
       retainedBytes -= first.byteLength - trimmed.byteLength;
-      compactedThroughId = Math.max(compactedThroughId, first.id);
       if (trimmed.byteLength > 0) {
         chunks[firstRetainedIndex] = trimmed;
       } else {
@@ -248,36 +240,14 @@ function appendOutput(
   }
 
   let retainedChunks = firstRetainedIndex === 0 ? chunks : chunks.slice(firstRetainedIndex);
-  if (retainedChunks.length === 0) {
-    return {
-      generation: current.generation,
-      chunks: [],
-      retainedBytes: 0,
-      resetVersion: current.resetVersion + 1,
-      latestChunkId: appended.latestChunkId,
-      compactedThroughId: appended.latestChunkId,
-    };
-  }
   if (retainedChunks.length > MAX_TERMINAL_OUTPUT_CHUNKS) {
-    // Compact only chunks that predate this append: an up-to-date cursor sits
-    // on the previous latest chunk id, and merged spans keep the id of their
-    // last constituent, so that boundary survives compaction.
-    const retainedOldCount = Math.max(0, retainedChunks.length - appended.chunks.length);
-    const compacted = compactRetainedChunks(retainedChunks.slice(0, retainedOldCount));
-    const compactedChunks = [...compacted.chunks, ...retainedChunks.slice(retainedOldCount)];
-    if (compactedChunks.length > MAX_TERMINAL_OUTPUT_CHUNKS) {
-      return resetOutput(
-        {
-          ...current,
-          latestChunkId: appended.latestChunkId,
-        },
-        retainedChunks.map((chunk) => chunk.data).join(""),
-        maxBufferBytes,
-      );
-    }
-    retainedChunks = compactedChunks;
-    if (compacted.compactedThroughId !== null) {
-      compactedThroughId = Math.max(compactedThroughId, compacted.compactedThroughId);
+    retainedChunks = compactRetainedChunks(retainedChunks);
+    const excessChunks = retainedChunks.length - MAX_TERMINAL_OUTPUT_CHUNKS;
+    if (excessChunks > 0) {
+      for (const chunk of retainedChunks.slice(0, excessChunks)) {
+        retainedBytes -= chunk.byteLength;
+      }
+      retainedChunks = retainedChunks.slice(excessChunks);
     }
   }
 
@@ -286,8 +256,7 @@ function appendOutput(
     chunks: retainedChunks,
     retainedBytes,
     resetVersion: current.resetVersion,
-    latestChunkId: appended.latestChunkId,
-    compactedThroughId,
+    nextOffset: appended.nextOffset,
   };
 }
 
@@ -299,7 +268,7 @@ function resetOutput(
   const retained = trimBufferToBytes(data, maxBufferBytes);
   const reset = splitOutputChunks(
     retained,
-    current.latestChunkId + 1,
+    0,
     Math.min(DEFAULT_TERMINAL_CHUNK_BYTES, Math.max(1, maxBufferBytes)),
   );
   return {
@@ -307,8 +276,7 @@ function resetOutput(
     chunks: reset.chunks,
     retainedBytes: reset.byteLength,
     resetVersion: current.resetVersion + 1,
-    latestChunkId: reset.latestChunkId,
-    compactedThroughId: current.latestChunkId,
+    nextOffset: reset.nextOffset,
   };
 }
 
@@ -323,26 +291,28 @@ export function readTerminalOutputUpdate(
   const nextCursor = {
     generation: output.generation,
     resetVersion: output.resetVersion,
-    lastChunkId: output.latestChunkId,
+    offset: output.nextOffset,
   };
   const firstChunk = output.chunks[0];
   if (
     cursor.generation !== output.generation ||
     cursor.resetVersion !== output.resetVersion ||
-    // The cursor may precede a trimmed chunk or sit inside merged data.
-    cursor.lastChunkId < output.compactedThroughId ||
-    (firstChunk !== undefined && firstChunk.id > cursor.lastChunkId + 1)
+    cursor.offset < (firstChunk?.startOffset ?? output.nextOffset)
   ) {
     return { type: "reset", data: terminalOutputText(output), cursor: nextCursor };
   }
 
-  const appended = output.chunks.filter((chunk) => chunk.id > cursor.lastChunkId);
+  const appended = output.chunks.filter(
+    (chunk) => chunk.startOffset + chunk.data.length > cursor.offset,
+  );
   if (appended.length === 0) {
     return { type: "none", cursor: nextCursor };
   }
   return {
     type: "append",
-    data: appended.map((chunk) => chunk.data).join(""),
+    data: appended
+      .map((chunk) => chunk.data.slice(Math.max(0, cursor.offset - chunk.startOffset)))
+      .join(""),
     cursor: nextCursor,
   };
 }

--- a/packages/client-runtime/src/state/terminalOutput.ts
+++ b/packages/client-runtime/src/state/terminalOutput.ts
@@ -1,0 +1,330 @@
+export interface TerminalOutputChunk {
+  readonly id: number;
+  readonly data: string;
+  readonly byteLength: number;
+  readonly delivery: "replay" | "live";
+}
+
+export interface TerminalOutputState {
+  readonly chunks: ReadonlyArray<TerminalOutputChunk>;
+  readonly retainedBytes: number;
+  readonly resetVersion: number;
+  readonly latestChunkId: number;
+  /**
+   * Highest chunk id that has been folded into a merged chunk. Ids at or below
+   * this value may span several original chunks, so a cursor pointing below it
+   * can no longer prove it sits on a chunk boundary and must resynchronize.
+   */
+  readonly compactedThroughId: number;
+}
+
+export interface TerminalOutputCursor {
+  readonly resetVersion: number;
+  readonly lastChunkId: number;
+}
+
+/** Forces the first `readTerminalOutputUpdate` to resynchronize from a reset. */
+export const INITIAL_TERMINAL_OUTPUT_CURSOR = Object.freeze<TerminalOutputCursor>({
+  resetVersion: -1,
+  lastChunkId: 0,
+});
+
+export type TerminalOutputUpdate =
+  | {
+      readonly type: "none";
+      readonly cursor: TerminalOutputCursor;
+    }
+  | {
+      readonly type: "reset";
+      readonly data: string;
+      readonly cursor: TerminalOutputCursor;
+    }
+  | {
+      readonly type: "append";
+      readonly cursor: TerminalOutputCursor;
+      readonly segments: ReadonlyArray<{
+        readonly data: string;
+        readonly delivery: "replay" | "live";
+      }>;
+    };
+
+// Retention needs enough headroom for the renderer to consume several adjacent
+// 64 KB server batches without falling behind and resetting its scrollback.
+export const DEFAULT_MAX_TERMINAL_BUFFER_BYTES = 512 * 1024;
+const DEFAULT_TERMINAL_CHUNK_BYTES = 16 * 1024;
+const MAX_TERMINAL_OUTPUT_CHUNKS = 1_024;
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+/** Keep attach replay size and live client retention as separate budgets. */
+export function terminalOutputRetentionBytes(replayBytes?: number): number {
+  return Math.max(DEFAULT_MAX_TERMINAL_BUFFER_BYTES, replayBytes ?? 0);
+}
+
+export interface Utf8Chunk {
+  readonly data: string;
+  readonly byteLength: number;
+}
+
+/**
+ * Split a string into chunks of at most `maxBytes` UTF-8 bytes without cutting
+ * a code point in half. Used by the terminal pipeline on both the server
+ * (bounded output batches, streamed history) and clients (retained output
+ * chunks) so both sides split identical streams at identical byte boundaries.
+ *
+ * A chunk that fits whole is returned as the original string, so the common
+ * small-write path pays one encode and no decode.
+ */
+export function splitStringByUtf8Bytes(data: string, maxBytes: number): ReadonlyArray<Utf8Chunk> {
+  if (data.length === 0) return [];
+
+  const encoded = textEncoder.encode(data);
+  if (encoded.byteLength <= maxBytes) {
+    return [{ data, byteLength: encoded.byteLength }];
+  }
+
+  const chunks: Utf8Chunk[] = [];
+  let offset = 0;
+  while (offset < encoded.byteLength) {
+    let end = Math.min(offset + maxBytes, encoded.byteLength);
+    while (end < encoded.byteLength && ((encoded[end] ?? 0) & 0xc0) === 0x80) {
+      end -= 1;
+    }
+    // A degenerate budget smaller than one code point still has to advance:
+    // include the whole code point rather than looping forever.
+    if (end === offset) {
+      end = Math.min(offset + maxBytes, encoded.byteLength);
+      while (end < encoded.byteLength && ((encoded[end] ?? 0) & 0xc0) === 0x80) {
+        end += 1;
+      }
+    }
+    const bytes = encoded.subarray(offset, end);
+    chunks.push({ data: textDecoder.decode(bytes), byteLength: bytes.byteLength });
+    offset = end;
+  }
+
+  return chunks;
+}
+
+function trimBufferToBytes(buffer: string, maxBufferBytes: number): string {
+  if (maxBufferBytes <= 0) {
+    return "";
+  }
+
+  const encoded = textEncoder.encode(buffer);
+  if (encoded.byteLength <= maxBufferBytes) {
+    return buffer;
+  }
+
+  let start = encoded.byteLength - maxBufferBytes;
+  while (start < encoded.length) {
+    const byte = encoded[start];
+    if (byte === undefined || (byte & 0b1100_0000) !== 0b1000_0000) {
+      break;
+    }
+    start += 1;
+  }
+
+  return textDecoder.decode(encoded.subarray(start));
+}
+
+function splitOutputChunks(
+  data: string,
+  firstChunkId: number,
+  delivery: "replay" | "live",
+  maxChunkBytes = DEFAULT_TERMINAL_CHUNK_BYTES,
+): {
+  readonly chunks: ReadonlyArray<TerminalOutputChunk>;
+  readonly latestChunkId: number;
+  readonly byteLength: number;
+} {
+  const split = splitStringByUtf8Bytes(data, maxChunkBytes);
+  let byteLength = 0;
+  const chunks = split.map((chunk, index) => {
+    byteLength += chunk.byteLength;
+    return {
+      id: firstChunkId + index,
+      data: chunk.data,
+      byteLength: chunk.byteLength,
+      delivery,
+    };
+  });
+
+  return {
+    chunks,
+    latestChunkId: firstChunkId + chunks.length - 1,
+    byteLength,
+  };
+}
+
+/**
+ * Merge adjacent same-delivery chunks up to the standard chunk size so a long
+ * run of tiny interactive writes cannot exhaust the chunk budget and force a
+ * full renderer reset. Merged chunks take the id of their last constituent.
+ */
+function compactRetainedChunks(chunks: ReadonlyArray<TerminalOutputChunk>): {
+  readonly chunks: ReadonlyArray<TerminalOutputChunk>;
+  readonly compactedThroughId: number | null;
+} {
+  const compacted: TerminalOutputChunk[] = [];
+  let compactedThroughId: number | null = null;
+  for (const chunk of chunks) {
+    const previous = compacted.at(-1);
+    if (
+      previous !== undefined &&
+      previous.delivery === chunk.delivery &&
+      previous.byteLength + chunk.byteLength <= DEFAULT_TERMINAL_CHUNK_BYTES
+    ) {
+      compacted[compacted.length - 1] = {
+        id: chunk.id,
+        data: `${previous.data}${chunk.data}`,
+        byteLength: previous.byteLength + chunk.byteLength,
+        delivery: chunk.delivery,
+      };
+      compactedThroughId = chunk.id;
+    } else {
+      compacted.push(chunk);
+    }
+  }
+  return { chunks: compacted, compactedThroughId };
+}
+
+function appendOutput(
+  current: TerminalOutputState,
+  data: string,
+  maxBufferBytes: number,
+  delivery: "replay" | "live",
+): TerminalOutputState {
+  const appended = splitOutputChunks(
+    data,
+    current.latestChunkId + 1,
+    delivery,
+    Math.min(DEFAULT_TERMINAL_CHUNK_BYTES, Math.max(1, maxBufferBytes)),
+  );
+  if (appended.chunks.length === 0) return current;
+  if (maxBufferBytes <= 0) {
+    return {
+      chunks: [],
+      retainedBytes: 0,
+      resetVersion: current.resetVersion + 1,
+      latestChunkId: appended.latestChunkId,
+      compactedThroughId: appended.latestChunkId,
+    };
+  }
+
+  const chunks = [...current.chunks, ...appended.chunks];
+  let retainedBytes = current.retainedBytes + appended.byteLength;
+  let firstRetainedIndex = 0;
+  while (retainedBytes > maxBufferBytes && firstRetainedIndex < chunks.length) {
+    retainedBytes -= chunks[firstRetainedIndex]?.byteLength ?? 0;
+    firstRetainedIndex += 1;
+  }
+
+  let retainedChunks = firstRetainedIndex === 0 ? chunks : chunks.slice(firstRetainedIndex);
+  if (retainedChunks.length === 0) {
+    return {
+      chunks: [],
+      retainedBytes: 0,
+      resetVersion: current.resetVersion + 1,
+      latestChunkId: appended.latestChunkId,
+      compactedThroughId: appended.latestChunkId,
+    };
+  }
+  let compactedThroughId = current.compactedThroughId;
+  if (retainedChunks.length > MAX_TERMINAL_OUTPUT_CHUNKS) {
+    // Compact only chunks that predate this append: an up-to-date cursor sits
+    // on the previous latest chunk id, and merged spans keep the id of their
+    // last constituent, so that boundary survives compaction.
+    const retainedOldCount = Math.max(0, retainedChunks.length - appended.chunks.length);
+    const compacted = compactRetainedChunks(retainedChunks.slice(0, retainedOldCount));
+    const compactedChunks = [...compacted.chunks, ...retainedChunks.slice(retainedOldCount)];
+    if (compactedChunks.length > MAX_TERMINAL_OUTPUT_CHUNKS) {
+      return resetOutput(
+        {
+          ...current,
+          latestChunkId: appended.latestChunkId,
+        },
+        retainedChunks.map((chunk) => chunk.data).join(""),
+        maxBufferBytes,
+      );
+    }
+    retainedChunks = compactedChunks;
+    if (compacted.compactedThroughId !== null) {
+      compactedThroughId = Math.max(compactedThroughId, compacted.compactedThroughId);
+    }
+  }
+
+  return {
+    chunks: retainedChunks,
+    retainedBytes,
+    resetVersion: current.resetVersion,
+    latestChunkId: appended.latestChunkId,
+    compactedThroughId,
+  };
+}
+
+function resetOutput(
+  current: TerminalOutputState,
+  data: string,
+  maxBufferBytes: number,
+): TerminalOutputState {
+  const retained = trimBufferToBytes(data, maxBufferBytes);
+  const reset = splitOutputChunks(
+    retained,
+    current.latestChunkId + 1,
+    "replay",
+    Math.min(DEFAULT_TERMINAL_CHUNK_BYTES, Math.max(1, maxBufferBytes)),
+  );
+  return {
+    chunks: reset.chunks,
+    retainedBytes: reset.byteLength,
+    resetVersion: current.resetVersion + 1,
+    latestChunkId: reset.latestChunkId,
+    compactedThroughId: current.latestChunkId,
+  };
+}
+
+export function terminalOutputText(output: TerminalOutputState): string {
+  return output.chunks.map((chunk) => chunk.data).join("");
+}
+
+export function readTerminalOutputUpdate(
+  output: TerminalOutputState,
+  cursor: TerminalOutputCursor,
+): TerminalOutputUpdate {
+  const nextCursor = {
+    resetVersion: output.resetVersion,
+    lastChunkId: output.latestChunkId,
+  };
+  const firstChunk = output.chunks[0];
+  if (
+    cursor.resetVersion !== output.resetVersion ||
+    // The cursor may sit inside a merged chunk, so it no longer names a
+    // provable boundary in the retained stream.
+    cursor.lastChunkId < output.compactedThroughId ||
+    (firstChunk !== undefined && firstChunk.id > cursor.lastChunkId + 1)
+  ) {
+    return { type: "reset", data: terminalOutputText(output), cursor: nextCursor };
+  }
+
+  const appended = output.chunks.filter((chunk) => chunk.id > cursor.lastChunkId);
+  if (appended.length === 0) {
+    return { type: "none", cursor: nextCursor };
+  }
+  const segments: Array<{ data: string; delivery: "replay" | "live" }> = [];
+  for (const chunk of appended) {
+    const previous = segments.at(-1);
+    if (previous?.delivery === chunk.delivery) {
+      previous.data += chunk.data;
+    } else {
+      segments.push({ data: chunk.data, delivery: chunk.delivery });
+    }
+  }
+  return {
+    type: "append",
+    segments,
+    cursor: nextCursor,
+  };
+}
+
+export { appendOutput, resetOutput };

--- a/packages/client-runtime/src/state/terminalOutput.ts
+++ b/packages/client-runtime/src/state/terminalOutput.ts
@@ -2,29 +2,29 @@ export interface TerminalOutputChunk {
   readonly id: number;
   readonly data: string;
   readonly byteLength: number;
-  readonly delivery: "replay" | "live";
 }
 
 export interface TerminalOutputState {
+  readonly generation: number;
   readonly chunks: ReadonlyArray<TerminalOutputChunk>;
   readonly retainedBytes: number;
   readonly resetVersion: number;
   readonly latestChunkId: number;
   /**
-   * Highest chunk id that has been folded into a merged chunk. Ids at or below
-   * this value may span several original chunks, so a cursor pointing below it
-   * can no longer prove it sits on a chunk boundary and must resynchronize.
+   * A cursor below this id cannot safely append after chunks are merged or trimmed.
    */
   readonly compactedThroughId: number;
 }
 
 export interface TerminalOutputCursor {
+  readonly generation: number;
   readonly resetVersion: number;
   readonly lastChunkId: number;
 }
 
 /** Forces the first `readTerminalOutputUpdate` to resynchronize from a reset. */
 export const INITIAL_TERMINAL_OUTPUT_CURSOR = Object.freeze<TerminalOutputCursor>({
+  generation: -1,
   resetVersion: -1,
   lastChunkId: 0,
 });
@@ -42,40 +42,39 @@ export type TerminalOutputUpdate =
   | {
       readonly type: "append";
       readonly cursor: TerminalOutputCursor;
-      readonly segments: ReadonlyArray<{
-        readonly data: string;
-        readonly delivery: "replay" | "live";
-      }>;
+      readonly data: string;
     };
 
-// Retention needs enough headroom for the renderer to consume several adjacent
-// 64 KB server batches without falling behind and resetting its scrollback.
 export const DEFAULT_MAX_TERMINAL_BUFFER_BYTES = 512 * 1024;
 const DEFAULT_TERMINAL_CHUNK_BYTES = 16 * 1024;
 const MAX_TERMINAL_OUTPUT_CHUNKS = 1_024;
 const textEncoder = new TextEncoder();
-const textDecoder = new TextDecoder();
+// A BOM at a retained chunk boundary is terminal data, not an encoding marker.
+const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true });
 
-/** Keep attach replay size and live client retention as separate budgets. */
-export function terminalOutputRetentionBytes(replayBytes?: number): number {
-  return Math.max(DEFAULT_MAX_TERMINAL_BUFFER_BYTES, replayBytes ?? 0);
-}
+export const EMPTY_TERMINAL_OUTPUT_STATE = Object.freeze<TerminalOutputState>({
+  generation: 0,
+  chunks: Object.freeze([]),
+  retainedBytes: 0,
+  resetVersion: 0,
+  latestChunkId: 0,
+  compactedThroughId: 0,
+});
 
-export interface Utf8Chunk {
+interface Utf8Chunk {
   readonly data: string;
   readonly byteLength: number;
 }
 
 /**
  * Split a string into chunks of at most `maxBytes` UTF-8 bytes without cutting
- * a code point in half. Used by the terminal pipeline on both the server
- * (bounded output batches, streamed history) and clients (retained output
- * chunks) so both sides split identical streams at identical byte boundaries.
+ * a code point in half. The retained-output budget always supplies a positive
+ * size. Only new output is encoded on live updates.
  *
  * A chunk that fits whole is returned as the original string, so the common
  * small-write path pays one encode and no decode.
  */
-export function splitStringByUtf8Bytes(data: string, maxBytes: number): ReadonlyArray<Utf8Chunk> {
+function splitStringByUtf8Bytes(data: string, maxBytes: number): ReadonlyArray<Utf8Chunk> {
   if (data.length === 0) return [];
 
   const encoded = textEncoder.encode(data);
@@ -131,7 +130,6 @@ function trimBufferToBytes(buffer: string, maxBufferBytes: number): string {
 function splitOutputChunks(
   data: string,
   firstChunkId: number,
-  delivery: "replay" | "live",
   maxChunkBytes = DEFAULT_TERMINAL_CHUNK_BYTES,
 ): {
   readonly chunks: ReadonlyArray<TerminalOutputChunk>;
@@ -146,7 +144,6 @@ function splitOutputChunks(
       id: firstChunkId + index,
       data: chunk.data,
       byteLength: chunk.byteLength,
-      delivery,
     };
   });
 
@@ -158,7 +155,7 @@ function splitOutputChunks(
 }
 
 /**
- * Merge adjacent same-delivery chunks up to the standard chunk size so a long
+ * Merge adjacent chunks up to the standard chunk size so a long
  * run of tiny interactive writes cannot exhaust the chunk budget and force a
  * full renderer reset. Merged chunks take the id of their last constituent.
  */
@@ -172,14 +169,12 @@ function compactRetainedChunks(chunks: ReadonlyArray<TerminalOutputChunk>): {
     const previous = compacted.at(-1);
     if (
       previous !== undefined &&
-      previous.delivery === chunk.delivery &&
       previous.byteLength + chunk.byteLength <= DEFAULT_TERMINAL_CHUNK_BYTES
     ) {
       compacted[compacted.length - 1] = {
         id: chunk.id,
         data: `${previous.data}${chunk.data}`,
         byteLength: previous.byteLength + chunk.byteLength,
-        delivery: chunk.delivery,
       };
       compactedThroughId = chunk.id;
     } else {
@@ -189,21 +184,39 @@ function compactRetainedChunks(chunks: ReadonlyArray<TerminalOutputChunk>): {
   return { chunks: compacted, compactedThroughId };
 }
 
+// Scan only the removed prefix instead of encoding retained output again.
+function trimOutputChunkStart(
+  chunk: TerminalOutputChunk,
+  bytesToDrop: number,
+): TerminalOutputChunk {
+  let offset = 0;
+  let droppedBytes = 0;
+  while (droppedBytes < bytesToDrop && offset < chunk.data.length) {
+    const codepoint = chunk.data.codePointAt(offset)!;
+    droppedBytes += codepoint <= 0x7f ? 1 : codepoint <= 0x7ff ? 2 : codepoint <= 0xffff ? 3 : 4;
+    offset += codepoint <= 0xffff ? 1 : 2;
+  }
+  return {
+    ...chunk,
+    data: chunk.data.slice(offset),
+    byteLength: chunk.byteLength - droppedBytes,
+  };
+}
+
 function appendOutput(
   current: TerminalOutputState,
   data: string,
   maxBufferBytes: number,
-  delivery: "replay" | "live",
 ): TerminalOutputState {
   const appended = splitOutputChunks(
     data,
     current.latestChunkId + 1,
-    delivery,
     Math.min(DEFAULT_TERMINAL_CHUNK_BYTES, Math.max(1, maxBufferBytes)),
   );
   if (appended.chunks.length === 0) return current;
   if (maxBufferBytes <= 0) {
     return {
+      generation: current.generation,
       chunks: [],
       retainedBytes: 0,
       resetVersion: current.resetVersion + 1,
@@ -215,14 +228,29 @@ function appendOutput(
   const chunks = [...current.chunks, ...appended.chunks];
   let retainedBytes = current.retainedBytes + appended.byteLength;
   let firstRetainedIndex = 0;
+  let compactedThroughId = current.compactedThroughId;
   while (retainedBytes > maxBufferBytes && firstRetainedIndex < chunks.length) {
-    retainedBytes -= chunks[firstRetainedIndex]?.byteLength ?? 0;
+    const first = chunks[firstRetainedIndex]!;
+    const bytesToDrop = retainedBytes - maxBufferBytes;
+    if (bytesToDrop < first.byteLength) {
+      const trimmed = trimOutputChunkStart(first, bytesToDrop);
+      retainedBytes -= first.byteLength - trimmed.byteLength;
+      compactedThroughId = Math.max(compactedThroughId, first.id);
+      if (trimmed.byteLength > 0) {
+        chunks[firstRetainedIndex] = trimmed;
+      } else {
+        firstRetainedIndex += 1;
+      }
+      break;
+    }
+    retainedBytes -= first.byteLength;
     firstRetainedIndex += 1;
   }
 
   let retainedChunks = firstRetainedIndex === 0 ? chunks : chunks.slice(firstRetainedIndex);
   if (retainedChunks.length === 0) {
     return {
+      generation: current.generation,
       chunks: [],
       retainedBytes: 0,
       resetVersion: current.resetVersion + 1,
@@ -230,7 +258,6 @@ function appendOutput(
       compactedThroughId: appended.latestChunkId,
     };
   }
-  let compactedThroughId = current.compactedThroughId;
   if (retainedChunks.length > MAX_TERMINAL_OUTPUT_CHUNKS) {
     // Compact only chunks that predate this append: an up-to-date cursor sits
     // on the previous latest chunk id, and merged spans keep the id of their
@@ -255,6 +282,7 @@ function appendOutput(
   }
 
   return {
+    generation: current.generation,
     chunks: retainedChunks,
     retainedBytes,
     resetVersion: current.resetVersion,
@@ -272,10 +300,10 @@ function resetOutput(
   const reset = splitOutputChunks(
     retained,
     current.latestChunkId + 1,
-    "replay",
     Math.min(DEFAULT_TERMINAL_CHUNK_BYTES, Math.max(1, maxBufferBytes)),
   );
   return {
+    generation: current.generation,
     chunks: reset.chunks,
     retainedBytes: reset.byteLength,
     resetVersion: current.resetVersion + 1,
@@ -293,14 +321,15 @@ export function readTerminalOutputUpdate(
   cursor: TerminalOutputCursor,
 ): TerminalOutputUpdate {
   const nextCursor = {
+    generation: output.generation,
     resetVersion: output.resetVersion,
     lastChunkId: output.latestChunkId,
   };
   const firstChunk = output.chunks[0];
   if (
+    cursor.generation !== output.generation ||
     cursor.resetVersion !== output.resetVersion ||
-    // The cursor may sit inside a merged chunk, so it no longer names a
-    // provable boundary in the retained stream.
+    // The cursor may precede a trimmed chunk or sit inside merged data.
     cursor.lastChunkId < output.compactedThroughId ||
     (firstChunk !== undefined && firstChunk.id > cursor.lastChunkId + 1)
   ) {
@@ -311,18 +340,9 @@ export function readTerminalOutputUpdate(
   if (appended.length === 0) {
     return { type: "none", cursor: nextCursor };
   }
-  const segments: Array<{ data: string; delivery: "replay" | "live" }> = [];
-  for (const chunk of appended) {
-    const previous = segments.at(-1);
-    if (previous?.delivery === chunk.delivery) {
-      previous.data += chunk.data;
-    } else {
-      segments.push({ data: chunk.data, delivery: chunk.delivery });
-    }
-  }
   return {
     type: "append",
-    segments,
+    data: appended.map((chunk) => chunk.data).join(""),
     cursor: nextCursor,
   };
 }

--- a/packages/client-runtime/src/state/terminalSession.test.ts
+++ b/packages/client-runtime/src/state/terminalSession.test.ts
@@ -361,6 +361,40 @@ describe("terminal session reducers", () => {
     }
   });
 
+  it.each([0, -1])("discards output without encoding when the byte budget is %s", (maxBytes) => {
+    const initial = applyTerminalAttachStreamEvent(EMPTY_TERMINAL_BUFFER_STATE, {
+      type: "snapshot",
+      snapshot: BASE_SNAPSHOT,
+    });
+    const cursor = readTerminalOutputUpdate(initial.output, INITIAL_TERMINAL_OUTPUT_CURSOR).cursor;
+    const data = "x".repeat(65_536);
+    const encode = vi.spyOn(TextEncoder.prototype, "encode");
+    try {
+      const discarded = applyTerminalAttachStreamEvent(
+        initial,
+        { type: "output", threadId: TARGET.threadId, terminalId: TARGET.terminalId, data },
+        maxBytes,
+      );
+      expect(encode).not.toHaveBeenCalled();
+      expect(discarded.output.nextOffset).toBe(initial.output.nextOffset + data.length);
+      expect(discarded.output.retainedBytes).toBe(0);
+      expect(readTerminalOutputUpdate(discarded.output, cursor)).toMatchObject({
+        type: "reset",
+        data: "",
+      });
+
+      const empty = applyTerminalAttachStreamEvent(
+        initial,
+        { type: "output", threadId: TARGET.threadId, terminalId: TARGET.terminalId, data: "" },
+        maxBytes,
+      );
+      expect(empty.output).toBe(initial.output);
+      expect(encode).not.toHaveBeenCalled();
+    } finally {
+      encode.mockRestore();
+    }
+  });
+
   it("resets for repeated snapshots, clear, and restart even when output text repeats", () => {
     let state = applyTerminalAttachStreamEvent(EMPTY_TERMINAL_BUFFER_STATE, {
       type: "snapshot",
@@ -404,7 +438,7 @@ describe("terminal session reducers", () => {
       snapshot: { ...BASE_SNAPSHOT, history: "other" },
     });
     expect(next.output.resetVersion).toBe(first.output.resetVersion);
-    expect(next.output.latestChunkId).toBe(first.output.latestChunkId);
+    expect(next.output.nextOffset).toBe(first.output.nextOffset);
     expect(readTerminalOutputUpdate(next.output, cursor)).toMatchObject({
       type: "reset",
       data: "other",
@@ -436,24 +470,25 @@ describe("terminal session reducers", () => {
     expect(terminalOutputText(state.output)).toBe(received);
   });
 
-  it("recovers from a compaction boundary with the retained snapshot", () => {
+  it("appends every unread character across a compaction boundary", () => {
     let state = applyTerminalAttachStreamEvent(EMPTY_TERMINAL_BUFFER_STATE, {
       type: "snapshot",
       snapshot: { ...BASE_SNAPSHOT, history: "" },
     });
     let cursor = readTerminalOutputUpdate(state.output, INITIAL_TERMINAL_OUTPUT_CURSOR).cursor;
-    for (let index = 0; index < 1200; index += 1) {
+    const writes = Array.from({ length: 1200 }, (_, index) => ["x", "é", "界", "🙂"][index % 4]!);
+    for (const [index, data] of writes.entries()) {
       state = applyTerminalAttachStreamEvent(state, {
         type: "output",
         threadId: TARGET.threadId,
         terminalId: TARGET.terminalId,
-        data: "x",
+        data,
       });
       if (index === 99) cursor = readTerminalOutputUpdate(state.output, cursor).cursor;
     }
     expect(readTerminalOutputUpdate(state.output, cursor)).toMatchObject({
-      type: "reset",
-      data: "x".repeat(1200),
+      type: "append",
+      data: writes.slice(100).join(""),
     });
   });
 });

--- a/packages/client-runtime/src/state/terminalSession.test.ts
+++ b/packages/client-runtime/src/state/terminalSession.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 
 import { EnvironmentId, TerminalSessionSnapshot, ThreadId } from "@t3tools/contracts";
 
@@ -6,8 +6,13 @@ import {
   applyTerminalAttachStreamEvent,
   applyTerminalMetadataStreamEvent,
   combineTerminalSessionState,
+  DEFAULT_MAX_TERMINAL_BUFFER_BYTES,
   EMPTY_TERMINAL_BUFFER_STATE,
+  INITIAL_TERMINAL_OUTPUT_CURSOR,
+  nextTerminalAttachSeedState,
+  readTerminalOutputUpdate,
   selectRunningSubprocessTerminalIds,
+  terminalOutputText,
 } from "./terminalSession.ts";
 
 const TARGET = {
@@ -126,11 +131,11 @@ describe("terminal session reducers", () => {
     );
 
     expect(output).toMatchObject({
-      buffer: "lo world",
       status: "running",
       error: null,
       version: 2,
     });
+    expect(terminalOutputText(output.output)).toBe("lo world");
   });
 
   it("does not advance the lifecycle for the initial attach snapshot", () => {
@@ -220,6 +225,235 @@ describe("terminal session reducers", () => {
       4,
     );
 
-    expect(state.buffer).toBe("🙂");
+    expect(terminalOutputText(state.output)).toBe("🙂");
+  });
+
+  it("preserves a BOM code point at a new output chunk boundary", () => {
+    const initial = applyTerminalAttachStreamEvent(EMPTY_TERMINAL_BUFFER_STATE, {
+      type: "snapshot",
+      snapshot: { ...BASE_SNAPSHOT, history: "" },
+    });
+    const cursor = readTerminalOutputUpdate(initial.output, INITIAL_TERMINAL_OUTPUT_CURSOR).cursor;
+    const data = `${"x".repeat(16_384)}\uFEFF${"y".repeat(20)}`;
+    const state = applyTerminalAttachStreamEvent(initial, {
+      type: "output",
+      threadId: TARGET.threadId,
+      terminalId: TARGET.terminalId,
+      data,
+    });
+
+    expect(terminalOutputText(state.output)).toBe(data);
+    expect(readTerminalOutputUpdate(state.output, cursor)).toMatchObject({ type: "append", data });
+    expect(state.output.retainedBytes).toBe(new TextEncoder().encode(data).byteLength);
+  });
+
+  it("preserves a leading BOM in the retained snapshot tail", () => {
+    const state = applyTerminalAttachStreamEvent(
+      EMPTY_TERMINAL_BUFFER_STATE,
+      { type: "snapshot", snapshot: { ...BASE_SNAPSHOT, history: "discard\uFEFFtail" } },
+      7,
+    );
+
+    expect(terminalOutputText(state.output)).toBe("\uFEFFtail");
+    expect(state.output.retainedBytes).toBe(7);
+  });
+
+  it("trims whole Unicode code points from a partially retained chunk", () => {
+    let state = applyTerminalAttachStreamEvent(
+      EMPTY_TERMINAL_BUFFER_STATE,
+      { type: "snapshot", snapshot: { ...BASE_SNAPSHOT, history: "é界🙂end" } },
+      12,
+    );
+    let cursor = readTerminalOutputUpdate(state.output, INITIAL_TERMINAL_OUTPUT_CURSOR).cursor;
+    for (const [data, expected, retainedBytes] of [
+      ["x", "界🙂endx", 11],
+      ["yz", "🙂endxyz", 10],
+      ["abc", "endxyzabc", 9],
+    ] as const) {
+      state = applyTerminalAttachStreamEvent(
+        state,
+        { type: "output", threadId: TARGET.threadId, terminalId: TARGET.terminalId, data },
+        12,
+      );
+      const update = readTerminalOutputUpdate(state.output, cursor);
+      expect(update).toMatchObject({ type: "append", data });
+      expect(terminalOutputText(state.output)).toBe(expected);
+      expect(state.output.retainedBytes).toBe(retainedBytes);
+      cursor = update.cursor;
+    }
+  });
+
+  it("delivers all output when several events arrive before a renderer reads", () => {
+    const initial = applyTerminalAttachStreamEvent(EMPTY_TERMINAL_BUFFER_STATE, {
+      type: "snapshot",
+      snapshot: BASE_SNAPSHOT,
+    });
+    const cursor = readTerminalOutputUpdate(initial.output, INITIAL_TERMINAL_OUTPUT_CURSOR).cursor;
+    let state = initial;
+    for (const data of [" one", " two", " three"]) {
+      state = applyTerminalAttachStreamEvent(state, {
+        type: "output",
+        threadId: TARGET.threadId,
+        terminalId: TARGET.terminalId,
+        data,
+      });
+    }
+    const update = readTerminalOutputUpdate(state.output, cursor);
+    expect(update).toMatchObject({ type: "append", data: " one two three" });
+    expect(readTerminalOutputUpdate(state.output, update.cursor).type).toBe("none");
+  });
+
+  it("preserves the byte-limited tail and resets a cursor before a partially trimmed chunk", () => {
+    const initial = applyTerminalAttachStreamEvent(EMPTY_TERMINAL_BUFFER_STATE, {
+      type: "snapshot",
+      snapshot: { ...BASE_SNAPSHOT, history: "" },
+    });
+    const staleCursor = readTerminalOutputUpdate(
+      initial.output,
+      INITIAL_TERMINAL_OUTPUT_CURSOR,
+    ).cursor;
+    const first = applyTerminalAttachStreamEvent(initial, {
+      type: "output",
+      threadId: TARGET.threadId,
+      terminalId: TARGET.terminalId,
+      data: "hello",
+    });
+    const caughtUpCursor = readTerminalOutputUpdate(first.output, staleCursor).cursor;
+    const state = applyTerminalAttachStreamEvent(
+      first,
+      { type: "output", threadId: TARGET.threadId, terminalId: TARGET.terminalId, data: " world" },
+      8,
+    );
+
+    expect(readTerminalOutputUpdate(state.output, caughtUpCursor)).toMatchObject({
+      type: "append",
+      data: " world",
+    });
+    expect(readTerminalOutputUpdate(state.output, staleCursor)).toMatchObject({
+      type: "reset",
+      data: "lo world",
+    });
+    expect(state.output.retainedBytes).toBe(8);
+  });
+
+  it("does not encode retained history again when appending at the byte limit", () => {
+    let state = applyTerminalAttachStreamEvent(EMPTY_TERMINAL_BUFFER_STATE, {
+      type: "snapshot",
+      snapshot: { ...BASE_SNAPSHOT, history: "x".repeat(DEFAULT_MAX_TERMINAL_BUFFER_BYTES) },
+    });
+    const data = "y".repeat(8192);
+    const encode = vi.spyOn(TextEncoder.prototype, "encode");
+    try {
+      for (let index = 0; index < 100; index += 1) {
+        state = applyTerminalAttachStreamEvent(state, {
+          type: "output",
+          threadId: TARGET.threadId,
+          terminalId: TARGET.terminalId,
+          data,
+        });
+      }
+      expect(encode.mock.calls.reduce((total, [text]) => total + (text?.length ?? 0), 0)).toBe(
+        data.length * 100,
+      );
+      expect(state.output.retainedBytes).toBe(DEFAULT_MAX_TERMINAL_BUFFER_BYTES);
+    } finally {
+      encode.mockRestore();
+    }
+  });
+
+  it("resets for repeated snapshots, clear, and restart even when output text repeats", () => {
+    let state = applyTerminalAttachStreamEvent(EMPTY_TERMINAL_BUFFER_STATE, {
+      type: "snapshot",
+      snapshot: BASE_SNAPSHOT,
+    });
+    let cursor = readTerminalOutputUpdate(state.output, INITIAL_TERMINAL_OUTPUT_CURSOR).cursor;
+    state = applyTerminalAttachStreamEvent(state, { type: "snapshot", snapshot: BASE_SNAPSHOT });
+    const repeated = readTerminalOutputUpdate(state.output, cursor);
+    expect(repeated).toMatchObject({ type: "reset", data: "hello" });
+    expect(state.version).toBe(2);
+    cursor = repeated.cursor;
+
+    state = applyTerminalAttachStreamEvent(state, {
+      type: "cleared",
+      threadId: TARGET.threadId,
+      terminalId: TARGET.terminalId,
+    });
+    const cleared = readTerminalOutputUpdate(state.output, cursor);
+    expect(cleared).toMatchObject({ type: "reset", data: "" });
+    state = applyTerminalAttachStreamEvent(state, {
+      type: "restarted",
+      threadId: TARGET.threadId,
+      terminalId: TARGET.terminalId,
+      snapshot: BASE_SNAPSHOT,
+    });
+    expect(readTerminalOutputUpdate(state.output, cleared.cursor)).toMatchObject({
+      type: "reset",
+      data: "hello",
+    });
+    expect(state.lifecycleVersion).toBe(2);
+  });
+
+  it("does not reuse a renderer cursor when a fresh attach has matching counters", () => {
+    const first = applyTerminalAttachStreamEvent(nextTerminalAttachSeedState(), {
+      type: "snapshot",
+      snapshot: BASE_SNAPSHOT,
+    });
+    const cursor = readTerminalOutputUpdate(first.output, INITIAL_TERMINAL_OUTPUT_CURSOR).cursor;
+    const next = applyTerminalAttachStreamEvent(nextTerminalAttachSeedState(), {
+      type: "snapshot",
+      snapshot: { ...BASE_SNAPSHOT, history: "other" },
+    });
+    expect(next.output.resetVersion).toBe(first.output.resetVersion);
+    expect(next.output.latestChunkId).toBe(first.output.latestChunkId);
+    expect(readTerminalOutputUpdate(next.output, cursor)).toMatchObject({
+      type: "reset",
+      data: "other",
+    });
+    expect(next.lifecycleVersion).toBe(0);
+  });
+
+  it("keeps appending while compacting metadata for many small writes", () => {
+    let state = applyTerminalAttachStreamEvent(EMPTY_TERMINAL_BUFFER_STATE, {
+      type: "snapshot",
+      snapshot: { ...BASE_SNAPSHOT, history: "" },
+    });
+    let cursor = readTerminalOutputUpdate(state.output, INITIAL_TERMINAL_OUTPUT_CURSOR).cursor;
+    let received = "";
+    for (let index = 0; index < 2500; index += 1) {
+      state = applyTerminalAttachStreamEvent(state, {
+        type: "output",
+        threadId: TARGET.threadId,
+        terminalId: TARGET.terminalId,
+        data: "x",
+      });
+      const update = readTerminalOutputUpdate(state.output, cursor);
+      if (update.type !== "append") throw new Error(`Expected append, received ${update.type}`);
+      received += update.data;
+      cursor = update.cursor;
+    }
+    expect(received).toBe("x".repeat(2500));
+    expect(state.output.chunks.length).toBeLessThan(1024);
+    expect(terminalOutputText(state.output)).toBe(received);
+  });
+
+  it("recovers from a compaction boundary with the retained snapshot", () => {
+    let state = applyTerminalAttachStreamEvent(EMPTY_TERMINAL_BUFFER_STATE, {
+      type: "snapshot",
+      snapshot: { ...BASE_SNAPSHOT, history: "" },
+    });
+    let cursor = readTerminalOutputUpdate(state.output, INITIAL_TERMINAL_OUTPUT_CURSOR).cursor;
+    for (let index = 0; index < 1200; index += 1) {
+      state = applyTerminalAttachStreamEvent(state, {
+        type: "output",
+        threadId: TARGET.threadId,
+        terminalId: TARGET.terminalId,
+        data: "x",
+      });
+      if (index === 99) cursor = readTerminalOutputUpdate(state.output, cursor).cursor;
+    }
+    expect(readTerminalOutputUpdate(state.output, cursor)).toMatchObject({
+      type: "reset",
+      data: "x".repeat(1200),
+    });
   });
 });

--- a/packages/client-runtime/src/state/terminalSession.ts
+++ b/packages/client-runtime/src/state/terminalSession.ts
@@ -6,10 +6,27 @@ import type {
   TerminalSummary,
   ThreadId,
 } from "@t3tools/contracts";
+import {
+  appendOutput,
+  DEFAULT_MAX_TERMINAL_BUFFER_BYTES,
+  EMPTY_TERMINAL_OUTPUT_STATE,
+  resetOutput,
+  type TerminalOutputState,
+} from "./terminalOutput.ts";
+
+export {
+  DEFAULT_MAX_TERMINAL_BUFFER_BYTES,
+  INITIAL_TERMINAL_OUTPUT_CURSOR,
+  readTerminalOutputUpdate,
+  terminalOutputText,
+  type TerminalOutputCursor,
+  type TerminalOutputState,
+  type TerminalOutputUpdate,
+} from "./terminalOutput.ts";
 
 export interface TerminalSessionState {
   readonly summary: TerminalSummary | null;
-  readonly buffer: string;
+  readonly output: TerminalOutputState;
   readonly status: TerminalSessionSnapshot["status"] | "closed";
   readonly error: string | null;
   readonly hasRunningSubprocess: boolean;
@@ -19,7 +36,7 @@ export interface TerminalSessionState {
 }
 
 export interface TerminalBufferState {
-  readonly buffer: string;
+  readonly output: TerminalOutputState;
   readonly status: TerminalSessionSnapshot["status"] | "closed";
   readonly error: string | null;
   readonly updatedAt: string | null;
@@ -47,7 +64,7 @@ export function selectRunningSubprocessTerminalIds(
 }
 
 export const EMPTY_TERMINAL_BUFFER_STATE = Object.freeze<TerminalBufferState>({
-  buffer: "",
+  output: EMPTY_TERMINAL_OUTPUT_STATE,
   status: "closed",
   error: null,
   updatedAt: null,
@@ -57,7 +74,7 @@ export const EMPTY_TERMINAL_BUFFER_STATE = Object.freeze<TerminalBufferState>({
 
 export const EMPTY_TERMINAL_SESSION_STATE = Object.freeze<TerminalSessionState>({
   summary: null,
-  buffer: "",
+  output: EMPTY_TERMINAL_OUTPUT_STATE,
   status: "closed",
   error: null,
   hasRunningSubprocess: false,
@@ -66,43 +83,31 @@ export const EMPTY_TERMINAL_SESSION_STATE = Object.freeze<TerminalSessionState>(
   lifecycleVersion: 0,
 });
 
-export const DEFAULT_MAX_TERMINAL_BUFFER_BYTES = 512 * 1024;
-const textEncoder = new TextEncoder();
-const textDecoder = new TextDecoder();
+let terminalAttachGeneration = 0;
 
-function trimBufferToBytes(buffer: string, maxBufferBytes: number): string {
-  if (maxBufferBytes <= 0) {
-    return "";
-  }
-
-  const encoded = textEncoder.encode(buffer);
-  if (encoded.byteLength <= maxBufferBytes) {
-    return buffer;
-  }
-
-  let start = encoded.byteLength - maxBufferBytes;
-  while (start < encoded.length) {
-    const byte = encoded[start];
-    if (byte === undefined || (byte & 0b1100_0000) !== 0b1000_0000) {
-      break;
-    }
-    start += 1;
-  }
-
-  return textDecoder.decode(encoded.subarray(start));
+/** A reinstalled attach stream must not reuse an old renderer's output cursor. */
+export function nextTerminalAttachSeedState(): TerminalBufferState {
+  return {
+    ...EMPTY_TERMINAL_BUFFER_STATE,
+    output: {
+      ...EMPTY_TERMINAL_OUTPUT_STATE,
+      generation: ++terminalAttachGeneration,
+    },
+  };
 }
 
 export function terminalBufferStateFromSnapshot(
   snapshot: TerminalSessionSnapshot,
   maxBufferBytes: number,
+  current: TerminalBufferState = EMPTY_TERMINAL_BUFFER_STATE,
 ): TerminalBufferState {
   return {
-    buffer: trimBufferToBytes(snapshot.history, maxBufferBytes),
+    output: resetOutput(current.output, snapshot.history, maxBufferBytes),
     status: snapshot.status,
     error: null,
     updatedAt: snapshot.updatedAt,
-    version: 1,
-    lifecycleVersion: 0,
+    version: current.version + 1,
+    lifecycleVersion: current.lifecycleVersion,
   };
 }
 
@@ -118,7 +123,7 @@ export function combineTerminalSessionState(
 ): TerminalSessionState {
   return {
     summary,
-    buffer: buffer.buffer,
+    output: buffer.output,
     status: buffer.version > 0 ? buffer.status : (summary?.status ?? buffer.status),
     error: buffer.error,
     hasRunningSubprocess: summary?.hasRunningSubprocess ?? false,
@@ -136,19 +141,19 @@ export function applyTerminalAttachStreamEvent(
   switch (event.type) {
     case "snapshot":
       return {
-        ...terminalBufferStateFromSnapshot(event.snapshot, maxBufferBytes),
+        ...terminalBufferStateFromSnapshot(event.snapshot, maxBufferBytes, current),
         lifecycleVersion:
           current.version === 0 ? current.lifecycleVersion : current.lifecycleVersion + 1,
       };
     case "restarted":
       return {
-        ...terminalBufferStateFromSnapshot(event.snapshot, maxBufferBytes),
+        ...terminalBufferStateFromSnapshot(event.snapshot, maxBufferBytes, current),
         lifecycleVersion: current.lifecycleVersion + 1,
       };
     case "output":
       return {
         ...current,
-        buffer: trimBufferToBytes(`${current.buffer}${event.data}`, maxBufferBytes),
+        output: appendOutput(current.output, event.data, maxBufferBytes),
         status: current.status === "closed" ? "running" : current.status,
         error: null,
         version: current.version + 1,
@@ -156,7 +161,7 @@ export function applyTerminalAttachStreamEvent(
     case "cleared":
       return {
         ...current,
-        buffer: "",
+        output: resetOutput(current.output, "", maxBufferBytes),
         error: null,
         version: current.version + 1,
       };


### PR DESCRIPTION
Live terminal output repeatedly encodes the retained 512 KiB buffer. After rollover, the web renderer resets and replays it. Identical retained strings can also hide new output.

Keep byte-counted output chunks and UTF-16 cursors. Web and desktop append only unseen data, including after chunk compaction. Reset on snapshots, lifecycle changes, or a true gap in retained data. Keep the wire format, native ABI, retention limit, and terminal visibility behavior unchanged. Mobile keeps its current buffer interface through a JS adapter.

This ports the client append helpers from Wout Stiens' [PR #9027](https://github.com/pingdotgg/t3code/pull/9027), with author and co-author credit preserved. Its server and native work remain separate.

Verified with 56 focused tests, client-runtime/web/mobile typechecks, and targeted lint. Real Ghostty tests process varied and identical 1 MiB streams with zero rollover resets and match the unsplit reference state. They also verify live terminal query replies across compaction. Zero and negative retention budgets skip encoding. No browser or device run.

Refs [#9661](https://github.com/pingdotgg/t3code/issues/9661).

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core terminal session types drop the string `buffer` in favor of structured output; web rendering path changes materially but is heavily tested. Wire format and retention limits are unchanged.
> 
> **Overview**
> Replaces the monolithic terminal string `buffer` with **`TerminalOutputState`** (UTF-8–safe chunks, 512 KiB retention, generation/`resetVersion` tracking) and **`readTerminalOutputUpdate`** so clients get **append** vs **reset** deltas instead of diffing full strings.
> 
> **Web** `ThreadTerminalDrawer` keeps a renderer cursor and calls **`writeTerminalOutputUpdate`** (append or reset) on the Ghostty surface, avoiding full-buffer replay on rollover and fixing cases where identical retained text hid new output. **Attach** subscriptions seed with **`nextTerminalAttachSeedState()`** so reattached streams don’t reuse stale cursors.
> 
> **Mobile** still exposes a legacy **`buffer`** via **`terminalOutputText`** on attach output until native streaming ships. **`TerminalSessionState` / `TerminalBufferState` now use `output` instead of `buffer`**—external callers expecting a raw string need to migrate or use **`terminalOutputText`**.
> 
> Coverage adds client-runtime reducer tests and Ghostty integration tests (1 MiB streams, Unicode/ANSI batching, lag recovery, snapshot/clear/restart).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f8681114420dfb856e7e5f5c1d3043b1dabc2a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace terminal string buffer with bounded chunked output state and cursor-based updates
> - Introduces `TerminalOutputState` in [terminalOutput.ts](https://github.com/pingdotgg/t3code/pull/9707/files#diff-08dcea88f386a6633f398323f3e455bad8303c95544d5bd8df42b47eefc157d7): chunked retained output with a UTF-8 byte budget, generation/reset-version metadata, `appendOutput`/`resetOutput` reducers, and `readTerminalOutputUpdate` which returns a reset, append, or no-op based on cursor position.
> - Updates the terminal session reducer in [terminalSession.ts](https://github.com/pingdotgg/t3code/pull/9707/files#diff-c939205ce2272b9eb963a11eb634ba5d09e9525a249ac2c259ef8b5fda367828) to store structured output instead of a string buffer; snapshot/restart/clear events reset output, output events append within the byte budget, and each attach subscription seeds a fresh generation via `nextTerminalAttachSeedState`.
> - Rewrites `TerminalViewport` synchronization in [ThreadTerminalDrawer.tsx](https://github.com/pingdotgg/t3code/pull/9707/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636) to track an output cursor and apply only unread appends, resetting the Ghostty surface only when the cursor is stale or a new generation is attached.
> - Mobile adapter in [use-terminal-session.ts](https://github.com/pingdotgg/t3code/pull/9707/files#diff-46d88d4573504d4cab7369e76ab88703d3ef24a08ed77e459a1871f34f5e2631) derives a compatibility string buffer from `terminalOutputText` so existing callers still receive text.
> - Behavioral Change: terminal output is now bounded by a default byte budget; output older than the budget is evicted. A renderer whose cursor falls outside retained output receives a single bounded reset. Mobile callers get only the currently retained text in the derived buffer, not the full history.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f86811.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->