### PR TITLE
perf(relay): avoid repeated activity decoding

### DIFF
--- a/infra/relay/src/agentActivity/AgentActivityPublisher.test.ts
+++ b/infra/relay/src/agentActivity/AgentActivityPublisher.test.ts
@@ -517,7 +517,7 @@ describe("AgentActivityPublisher", () => {
   });
 
   it.effect(
-    "does not build Live Activity aggregates for links with Live Activities disabled",
+    "delivers notifications without querying activity rows when Live Activities are disabled",
     () => {
       const notificationState: RelayAgentActivityState = {
         ...state,
@@ -549,13 +549,7 @@ describe("AgentActivityPublisher", () => {
                     AgentActivityRows.AgentActivityRows,
                     makeAgentActivityRows({
                       listForUser: () =>
-                        Effect.succeed([
-                          {
-                            ...state,
-                            environmentId: "other-env" as RelayAgentActivityState["environmentId"],
-                            threadId: "other-thread" as RelayAgentActivityState["threadId"],
-                          },
-                        ]),
+                        Effect.die("Notification-only delivery must not read rows"),
                     }),
                   ),
                   Layer.succeed(

--- a/infra/relay/src/agentActivity/AgentActivityPublisher.ts
+++ b/infra/relay/src/agentActivity/AgentActivityPublisher.ts
@@ -58,7 +58,9 @@ export const make = Effect.gen(function* () {
     readonly state: RelayAgentActivityState | null;
     readonly nowMs: number;
   }) {
-    const activeStates = yield* rows.listForUser({ userId: input.deliveryUser.userId });
+    const activeStates = input.deliveryUser.liveActivitiesEnabled
+      ? yield* rows.listForUser({ userId: input.deliveryUser.userId })
+      : [];
     const liveActivityAggregate = input.deliveryUser.liveActivitiesEnabled
       ? makeAggregateState({
           activeStates,

--- a/infra/relay/src/agentActivity/AgentActivityRows.test.ts
+++ b/infra/relay/src/agentActivity/AgentActivityRows.test.ts
@@ -19,6 +19,42 @@ const state: RelayAgentActivityState = {
 };
 
 describe("AgentActivityRows", () => {
+  it.effect("validates database JSON objects and ignores invalid activity rows", () => {
+    const queryRows = [
+      { stateJson: null },
+      { stateJson: JSON.stringify(state) },
+      { stateJson: { ...state, phase: "invalid" } },
+      { stateJson: { ...state, unrelated: "ignored" } },
+    ];
+    const db = {
+      select: () => ({
+        from: () => ({
+          innerJoin: () => ({
+            where: () => ({
+              orderBy: () => Effect.succeed(queryRows),
+            }),
+          }),
+        }),
+      }),
+    } as unknown as RelayDb.RelayDb["Service"];
+
+    return Effect.gen(function* () {
+      const rows = yield* AgentActivityRows.AgentActivityRows;
+      expect(yield* rows.listForUser({ userId: "user-2" })).toEqual([state]);
+      expect(
+        yield* rows.getForUserThread({
+          userId: "user-2",
+          environmentId: "env-1",
+          threadId: "thread-1",
+        }),
+      ).toEqual(state);
+    }).pipe(
+      Effect.provide(
+        AgentActivityRows.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, db))),
+      ),
+    );
+  });
+
   it.effect("preserves activity context on persistence failures", () => {
     const cause = new Error("database unavailable");
     const failingDb = {

--- a/infra/relay/src/agentActivity/AgentActivityRows.ts
+++ b/infra/relay/src/agentActivity/AgentActivityRows.ts
@@ -92,15 +92,12 @@ export class AgentActivityRows extends Context.Service<
 >()("t3code-relay/agentActivity/AgentActivityRows") {}
 
 const decodeJsonString = Schema.decodeEffect(Schema.fromJsonString(Schema.Unknown));
-const encodeJsonValue = Schema.encodeEffect(Schema.fromJsonString(Schema.Unknown));
 
 const encodeRelayAgentActivityStateJson = Schema.encodeEffect(
   Schema.fromJsonString(RelayAgentActivityStateSchema),
 );
 
-const decodeRelayAgentActivityStateJson = Schema.decodeUnknownOption(
-  Schema.fromJsonString(RelayAgentActivityStateSchema),
-);
+const decodeRelayAgentActivityState = Schema.decodeUnknownOption(RelayAgentActivityStateSchema);
 
 export const make = Effect.gen(function* () {
   const db = yield* RelayDb.RelayDb;
@@ -229,13 +226,8 @@ export const make = Effect.gen(function* () {
         )
         .orderBy(desc(relayAgentActivityRows.updatedAt))
         .pipe(
-          Effect.flatMap((rows) =>
-            Effect.forEach(rows, (row) => encodeJsonValue(row.stateJson), {
-              concurrency: "unbounded",
-            }),
-          ),
           Effect.map((rows) =>
-            rows.flatMap((row) => Option.toArray(decodeRelayAgentActivityStateJson(row))),
+            rows.flatMap((row) => Option.toArray(decodeRelayAgentActivityState(row.stateJson))),
           ),
           Effect.mapError(
             (cause) =>
@@ -271,14 +263,9 @@ export const make = Effect.gen(function* () {
         )
         .orderBy(desc(relayAgentActivityRows.updatedAt))
         .pipe(
-          Effect.flatMap((rows) =>
-            Effect.forEach(rows, (row) => encodeJsonValue(row.stateJson), {
-              concurrency: "unbounded",
-            }),
-          ),
           Effect.map((rows) => {
             for (const row of rows) {
-              const decoded = decodeRelayAgentActivityStateJson(row);
+              const decoded = decodeRelayAgentActivityState(row.stateJson);
               if (Option.isSome(decoded)) {
                 return decoded.value;
               }


### PR DESCRIPTION
Every activity read converts Postgres JSON objects to strings and parses them again. Notification-only publications read the activity list even though they do not use it.

Validate JSON objects directly and skip the unused read. Keep query results, notification delivery, and retry identity checks unchanged.

The real service returned identical JSON for 10,000 rows in a disposable local Postgres database. Median read time fell from 343 ms to 202 ms. All 60 focused tests, relay typecheck, and targeted lint pass. No browser, device, live state, or manual deployment was used.

Expired-row filtering and pruning remain separate work in https://github.com/pingdotgg/t3code/issues/9661.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches relay delivery and persistence decoding paths; behavior should be equivalent but invalid rows are silently filtered and notification-only users no longer load cross-thread activity lists.
> 
> **Overview**
> **Agent activity reads** no longer stringify Postgres `jsonb` and parse it again on `listForUser` / `getForUserThread`; rows are validated in place with `RelayAgentActivityState` schema, and invalid or null payloads are dropped (new test covers mixed shapes including legacy string JSON).
> 
> **Notification-only delivery** skips `listForUser` when `liveActivitiesEnabled` is false, since aggregates for push-only users are built from the current publish state only; the publisher test now fails if rows are queried in that path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e34ae550f16a8c6f59486000e75d29306076df39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip activity-row queries when Live Activities disabled and decode `stateJson` directly in `AgentActivityRows`
> - `AgentActivityPublisher.publishForDeliveryUser` now skips `AgentActivityRows.listForUser` when `liveActivitiesEnabled` is false, using an empty active-state list instead.
> - `AgentActivityRows.listForUser` and `getForUserThread` decode each row's `stateJson` field directly against `RelayAgentActivityStateSchema`, removing the intermediate JSON-string encoding step.
> - Invalid rows are skipped (omitted from `listForUser`, passed over until the first valid row in `getForUserThread`).
> - Behavioral Change: `decodeRelayAgentActivityState` no longer applies the removed JSON-value encoding helper; any caller relying on the old JSON-string round-trip path must decode `stateJson` directly against the schema.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e34ae55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->