### PR TITLE
fix(web): keep PR checkout available in threads

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -8393,10 +8393,8 @@ export default function ChatView(props: ChatViewProps) {
       />
     ) : renderedRightPanelSurface?.kind === "pull-request" ? (
       // No onClose: the surface tab's own X owns closing here, and a second X in the header
-      // would be the same action twice. The thread context also drops the checkout button, so it
-      // is only right for the thread's own pull request, whose branch is already under the
-      // reader's feet. A link the agent wrote can open any other one here, and that one has to be
-      // checkable out like it is anywhere else.
+      // would be the same action twice. Thread context keeps hand-offs for the thread's own pull
+      // request in its composer; a link the agent wrote can open any other pull request here.
       <PullRequestDetailPanel
         key={`${renderedRightPanelSurface.host ?? ""}:${renderedRightPanelSurface.repository}#${renderedRightPanelSurface.number}`}
         environmentId={activeThread.environmentId}

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -491,11 +491,7 @@ export function PullRequestDetailPanel({
   onActed?: () => void;
   /** Page-owned detail columns use this to clear the selected pull request. */
   onClose?: () => void;
-  /**
-   * Beside a thread, the checkout affordance disappears: the panel is showing that thread's
-   * own pull request, so the branch is already under the reader's feet — and checking it out
-   * again is at best a no-op and at worst git refusing a branch two checkouts.
-   */
+  /** Whether task hand-offs land in this thread or open a new one. */
   context?: "page" | "thread";
   /**
    * The open thread's composer. Beside the thread whose own pull request this is, hand-offs
@@ -871,23 +867,24 @@ export function PullRequestDetailPanel({
     projects,
     reference.projectId,
   ]);
-  // Beside a thread there is nothing to pick: the hand-offs land in that thread's composer, and
-  // the thread is already on one server's copy of the branch.
-  const pickableEnvironments = useMemo(
+  // Checkout remains useful beside the pull request's own thread because it can target another
+  // connected machine. A shell command can only act on the machine where it is pasted.
+  const checkoutEnvironments = useMemo(
     () =>
-      context === "page"
-        ? resolvePickableEnvironments(
-            { environmentId, projectId: reference.projectId },
-            projects,
-            environments.map((environment) => ({
-              environmentId: environment.environmentId,
-              label: environment.label,
-              machine: resolveEnvironmentMachineKind(environment.serverConfig),
-            })),
-          )
-        : [],
-    [context, environmentId, environments, projects, reference.projectId],
+      resolvePickableEnvironments(
+        { environmentId, projectId: reference.projectId },
+        projects,
+        environments.map((environment) => ({
+          environmentId: environment.environmentId,
+          label: environment.label,
+          machine: resolveEnvironmentMachineKind(environment.serverConfig),
+        })),
+      ),
+    [environmentId, environments, projects, reference.projectId],
   );
+  // Task hand-offs beside the pull request's own thread still land in its composer, so an
+  // environment choice there would claim to do something that those actions ignore.
+  const handoffEnvironments = context === "page" ? checkoutEnvironments : [];
   // Which server the reader chose, and only for the pull request they chose it on: this one panel
   // shows a different pull request every time it is opened, and the choice does not follow.
   const [actingScope, setActingScope] = useState<{
@@ -899,8 +896,12 @@ export function PullRequestDetailPanel({
   // Null wherever there is no choice on offer — one server, or a chosen one that has since gone —
   // and then the panel's own server and its own checkout are the answer, as they always were.
   const acting =
-    pickableEnvironments.find((entry) => entry.environmentId === chosenEnvironmentId) ?? null;
+    checkoutEnvironments.find((entry) => entry.environmentId === chosenEnvironmentId) ?? null;
   const actingEnvironmentId = acting?.environmentId ?? environmentId;
+  // The thread's own repository is already on this pull request. In-place checkout matters again
+  // when the reader picks another machine, or when the panel is showing a different pull request.
+  const checkoutInRepositoryDisabled =
+    context === "thread" && actingEnvironmentId === environmentId;
   const prepareThread = usePreparePullRequestThreadAction({
     environmentId: actingEnvironmentId,
     cwd: acting?.workspaceRoot ?? detail?.workspaceRoot ?? null,
@@ -1652,71 +1653,71 @@ export function PullRequestDetailPanel({
                   threadRef={null}
                 />
               ) : null}
-              {/* Checking a pull request out is the reason to open one here at all, so it is a
-                  button of its own rather than a side effect of asking an agent for something.
-                  It asks where, because the two answers are not interchangeable: one leaves your
-                  work where it is, the other moves the repository you are standing in. Only on
-                  the page: beside a thread the branch is already checked out right there. */}
-              {context === "page" ? (
-                <Menu>
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <MenuTrigger
-                          disabled={handoff !== null}
-                          render={
-                            <Button
-                              size="xs"
-                              variant="outline"
-                              aria-label={
-                                handoff?.startsWith("checkout") ? "Checking out..." : "Check out"
-                              }
-                            >
-                              <GitBranchIcon aria-hidden className="size-3.5" />
-                              <span className="@max-[35rem]/pr-header:hidden">
-                                {handoff?.startsWith("checkout") ? "Checking out..." : "Check out"}
-                              </span>
-                              <ChevronDownIcon
-                                aria-hidden
-                                className="size-3.5 text-muted-foreground"
-                              />
-                            </Button>
-                          }
-                        />
-                      }
-                    />
-                    <TooltipPopup>Check out this pull request</TooltipPopup>
-                  </Tooltip>
-                  <MenuPopup align="end" side="bottom" className="min-w-72">
-                    <MenuItem onClick={() => startCheckout("worktree")}>
-                      <GitBranchIcon className="mt-0.5 size-3.5 shrink-0 self-start" />
-                      <span className="flex min-w-0 flex-col">
-                        <span>In a separate worktree</span>
-                        <span className="text-xs text-muted-foreground">
-                          Its own folder and thread. Nothing you have open moves.
-                        </span>
-                      </span>
-                    </MenuItem>
-                    <MenuItem onClick={() => startCheckout("local")}>
-                      <FolderGit2Icon className="mt-0.5 size-3.5 shrink-0 self-start" />
-                      <span className="flex min-w-0 flex-col">
-                        <span>In this repository</span>
-                        <span className="text-xs text-muted-foreground">
-                          Switches the branch you are working in, like `gh pr checkout`.
-                        </span>
-                      </span>
-                    </MenuItem>
-                    {pickableEnvironments.length > 0 ? (
-                      <ActOnEnvironmentPicker
-                        environments={pickableEnvironments}
-                        value={actingEnvironmentId}
-                        onChange={(next) => setActingScope({ pullRequestKey, environmentId: next })}
+              {/* Checkout stays available in every pull request view. Even when this thread is
+                  already on the branch, the reader may want to prepare it on another machine. */}
+              <Menu>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <MenuTrigger
                         disabled={handoff !== null}
+                        render={
+                          <Button
+                            size="xs"
+                            variant="outline"
+                            aria-label={
+                              handoff?.startsWith("checkout") ? "Checking out..." : "Check out"
+                            }
+                          >
+                            <GitBranchIcon aria-hidden className="size-3.5" />
+                            <span className="@max-[35rem]/pr-header:hidden">
+                              {handoff?.startsWith("checkout") ? "Checking out..." : "Check out"}
+                            </span>
+                            <ChevronDownIcon
+                              aria-hidden
+                              className="size-3.5 text-muted-foreground"
+                            />
+                          </Button>
+                        }
                       />
-                    ) : null}
-                  </MenuPopup>
-                </Menu>
-              ) : null}
+                    }
+                  />
+                  <TooltipPopup>Check out this pull request</TooltipPopup>
+                </Tooltip>
+                <MenuPopup align="end" side="bottom" className="min-w-72">
+                  <MenuItem onClick={() => startCheckout("worktree")}>
+                    <GitBranchIcon className="mt-0.5 size-3.5 shrink-0 self-start" />
+                    <span className="flex min-w-0 flex-col">
+                      <span>In a separate worktree</span>
+                      <span className="text-xs text-muted-foreground">
+                        Its own folder and thread. Nothing you have open moves.
+                      </span>
+                    </span>
+                  </MenuItem>
+                  <MenuItem
+                    disabled={checkoutInRepositoryDisabled}
+                    onClick={() => startCheckout("local")}
+                  >
+                    <FolderGit2Icon className="mt-0.5 size-3.5 shrink-0 self-start" />
+                    <span className="flex min-w-0 flex-col">
+                      <span>In this repository</span>
+                      <span className="text-xs text-muted-foreground">
+                        {checkoutInRepositoryDisabled
+                          ? "This pull request is already checked out here."
+                          : "Switches the branch you are working in, like `gh pr checkout`."}
+                      </span>
+                    </span>
+                  </MenuItem>
+                  {checkoutEnvironments.length > 0 ? (
+                    <ActOnEnvironmentPicker
+                      environments={checkoutEnvironments}
+                      value={actingEnvironmentId}
+                      onChange={(next) => setActingScope({ pullRequestKey, environmentId: next })}
+                      disabled={handoff !== null}
+                    />
+                  ) : null}
+                </MenuPopup>
+              </Menu>
               {/* Said where the Merge button is, because it is the answer to why nobody has
                   pressed it: the merge is already asked for, and the host is holding it. */}
               {autoMergeArmed && primaryAction !== "auto-merge-armed" ? (
@@ -1937,9 +1938,9 @@ export function PullRequestDetailPanel({
                     <HammerIcon className="size-3.5" />
                     {handoff === "findings" ? "Preparing..." : handoffLabels.fixFindings}
                   </MenuItem>
-                  {pickableEnvironments.length > 0 ? (
+                  {handoffEnvironments.length > 0 ? (
                     <ActOnEnvironmentPicker
-                      environments={pickableEnvironments}
+                      environments={handoffEnvironments}
                       value={actingEnvironmentId}
                       onChange={(next) => setActingScope({ pullRequestKey, environmentId: next })}
                       disabled={handoff !== null}


### PR DESCRIPTION
## Problem

Opening a pull request beside its own thread hid the orchestrated checkout control and left only the copyable `gh pr checkout` command. That removed the environment-aware path users need to prepare the pull request on another connected machine.

## Fix

Keep the checkout menu available in both pull request contexts and resolve matching environments for it in either place. The thread's own repository shows the in-place option disabled, with an explanation, and enables it after the user selects another machine. Task hand-offs in the More menu remain thread-local, so they only offer an environment picker on the pull request page where that choice is honored.

## Verification

- Web unit suite: 3,673 tests passed
- `vp run --filter @t3tools/web typecheck`
- Targeted lint on the two changed components
- Integrated web check against traced thread `24f5de82-5fe8-4155-a407-788d4c3ded8c`, including the own-thread checkout menu

## UI

The after image uses a screenshot-only second-machine fixture so the environment choices are visible.

| Before | After |
| --- | --- |
| ![PR thread panel without the checkout control](https://codex-file-host.shawnadedeji.workers.dev/files/t3code-pr-checkout-button/a0996c4c3ceb-f6733d37-7c10-46eb-8d75-c81a558fcb76-7d5f479e-c3db-40da-ab9e-98e671d655ed.png) | ![PR thread panel with the checkout menu open](https://codex-file-host.shawnadedeji.workers.dev/files/t3code-pr-checkout-button/2f9908601eea-t3code-checkout-button-after-machines-crop.png) |

Built with GPT-5.6-Sol in T3 Code using the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes git checkout affordances and environment targeting in thread vs page PR views; mis-wiring could show wrong targets or redundant checkouts, but scope is limited to the PR detail panel UI.
> 
> **Overview**
> Restores the **Check out** menu on pull request panels opened beside a thread, which had been limited to the standalone PR page.
> 
> Checkout now always resolves pickable environments in both `page` and `thread` contexts (`checkoutEnvironments`). **In this repository** is disabled with explanatory copy when the panel is in thread context and the selected machine is the thread’s own environment; worktree checkout and the environment picker stay available so users can prepare the PR on another connected machine.
> 
> Task hand-offs in the More menu still ignore environment selection in thread context: `handoffEnvironments` is only populated on the page, so the hand-off picker no longer appears beside a thread. Comments in `ChatView` and prop docs are updated to match this split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b86205827c20fed7025ca07756e9fb2cf2fd676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose PR checkout controls in thread context in `PullRequestDetailPanel`
> - Makes the header checkout menu render in every context instead of only the page view, so PRs shown inside threads have checkout controls.
> - Keeps separate-worktree checkout always available; disables the in-repository checkout option when thread context is acting on the panel's own environment, with context-specific explanatory text.
> - Populates the environment picker from a new always-available checkout-environment list, while task hand-offs still use a page-only list because thread hand-offs stay in the composer.
> - Behavioral Change: in-repository checkout is now disabled for the specific case of thread context plus the panel's own selected acting environment; separate-worktree and other-environment checkout remain available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 125bcaf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added checkout controls to pull-request views on both pages and threads.
  - Checkout targets can use connected environments independently of hand-off targets.
  - Local checkout is unavailable when the selected environment is already on the thread’s pull request, while checkout on another machine remains available.
  - Thread hand-offs now expose environment selection from the pull-request page.

- **Improvements**
  - Clarified pull-request handling for thread and agent-linked pull requests in the pull-request panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->