### PR TITLE
Resolve a branch's remote and origin from one read when they match

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -1004,6 +1004,29 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("a branch tracking origin resolves each remote context from one read", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "main"]);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/single-origin-read"]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "feature/single-origin-read"]);
+
+      const gitConfigReads: string[] = [];
+      const { manager } = yield* makeManager({ gitConfigReads });
+
+      yield* manager.branchPullRequest({ cwd: repoDir, branch: "feature/single-origin-read" });
+
+      // The repository identity check and the branch head context each resolve
+      // the branch's remote alongside origin. For a branch tracking origin both
+      // sides name the same remote, so each resolves from a single read rather
+      // than racing two identical `git config` spawns: two reads here, not four.
+      expect(gitConfigReads.filter((key) => key === "remote.origin.url")).toHaveLength(2);
+    }),
+  );
+
   it.effect("turn-end refresh finds a new PR and keeps known PRs cached", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -135,6 +135,11 @@ const PR_LOOKUP_CACHE_TTL = Duration.seconds(60);
 const PR_LOOKUP_FAILURE_BASE_TTL = Duration.seconds(20);
 const PR_LOOKUP_FAILURE_MAX_TTL = Duration.minutes(15);
 const PR_LOOKUP_CACHE_CAPACITY = 2_048;
+const EMPTY_REPOSITORY_CONTEXT = {
+  remoteUrlKey: null,
+  repositoryNameWithOwner: null,
+  ownerLogin: null,
+} as const;
 const isSourceControlProviderError = Schema.is(SourceControlProviderError);
 
 /**
@@ -1244,11 +1249,7 @@ export const make = Effect.gen(function* () {
     remoteName: string | null,
   ) {
     if (!remoteName) {
-      return {
-        remoteUrlKey: null,
-        repositoryNameWithOwner: null,
-        ownerLogin: null,
-      };
+      return EMPTY_REPOSITORY_CONTEXT;
     }
 
     const remoteUrl = yield* readConfigValueNullable(cwd, `remote.${remoteName}.url`);
@@ -1260,17 +1261,34 @@ export const make = Effect.gen(function* () {
     };
   });
 
+  /** Resolve a branch's remote and `origin` together, collapsing the pair to a
+   * single lookup when they name the same remote. Deliberately not cached
+   * across calls: `branchPullRequest` compares this identity against the one
+   * recorded in a cached pull request to notice a repointed remote, and a
+   * stale answer would let a cached pull request survive that check. */
+  const resolveHeadAndOriginContexts = (cwd: string, remoteName: string | null) =>
+    remoteName === "origin" || remoteName === null
+      ? resolveRemoteRepositoryContext(cwd, "origin").pipe(
+          Effect.map(
+            (origin) => [remoteName === null ? EMPTY_REPOSITORY_CONTEXT : origin, origin] as const,
+          ),
+        )
+      : Effect.all(
+          [
+            resolveRemoteRepositoryContext(cwd, remoteName),
+            resolveRemoteRepositoryContext(cwd, "origin"),
+          ],
+          { concurrency: "unbounded" },
+        );
+
   const resolvePrLookupRepositoryIdentity = Effect.fn("resolvePrLookupRepositoryIdentity")(
     function* (cwd: string, branch: string, remoteNameOverride?: string) {
       const remoteName =
         remoteNameOverride ?? (yield* readConfigValueNullable(cwd, `branch.${branch}.remote`));
-      const [headRemote, targetRemote] = yield* Effect.all(
-        [
-          resolveRemoteRepositoryContext(cwd, remoteName),
-          resolveRemoteRepositoryContext(cwd, "origin"),
-        ],
-        { concurrency: "unbounded" },
-      );
+      // Both contexts resolve at the same instant from the same checkout, so a
+      // branch tracking origin - the common case - reads remote.origin.url once
+      // instead of racing two identical `git config` spawns against each other.
+      const [headRemote, targetRemote] = yield* resolveHeadAndOriginContexts(cwd, remoteName);
       return {
         remoteName,
         headRemoteUrlKey:
@@ -1294,12 +1312,9 @@ export const make = Effect.gen(function* () {
     const shouldProbeLocalBranchSelector =
       headBranchFromUpstream.length === 0 || headBranch === details.branch;
 
-    const [remoteRepository, originRepository] = yield* Effect.all(
-      [
-        resolveRemoteRepositoryContext(cwd, remoteName),
-        resolveRemoteRepositoryContext(cwd, "origin"),
-      ],
-      { concurrency: "unbounded" },
+    const [remoteRepository, originRepository] = yield* resolveHeadAndOriginContexts(
+      cwd,
+      remoteName,
     );
 
     const isCrossRepository =


### PR DESCRIPTION
Partially addresses #9714.

## What changed

`resolvePrLookupRepositoryIdentity` and `resolveBranchHeadContext` each resolve
the branch's remote alongside `origin`:

```ts
const [headRemote, targetRemote] = yield* Effect.all(
  [
    resolveRemoteRepositoryContext(cwd, remoteName),
    resolveRemoteRepositoryContext(cwd, "origin"),
  ],
  { concurrency: "unbounded" },
);
```

For a branch tracking `origin` — the common case — `remoteName` *is* `"origin"`,
so these are two concurrent spawns of the same `git config --get
remote.origin.url` returning the same value. This collapses that pair to a
single lookup when the two name the same remote, via a small shared helper used
by both call sites.

## Why it should exist

On a self-hosted server, `ThreadSettlementReactor.sweep` calls
`branchPullRequest` for every unsettled thread once a minute, and each call runs
the identity check regardless of whether the pull request lookup itself is a
cache hit. Over a 99.5-minute trace on an install with 26 worktrees and 15
unsettled threads, `resolveRemoteRepositoryContext` ran 1,056 times — exactly
`(242 + 286) × 2`, two per `resolvePrLookupRepositoryIdentity` and two per
`resolveBranchHeadContext` — and `GitVcsDriver.readConfigValue` was the parent
of 1,666 of the 5,161 git spawns in that window, the single largest source.

Measured with the existing `gitConfigReads` test spy, a cold `branchPullRequest`
for a branch tracking origin:

| | `remote.origin.url` reads |
|---|---|
| before | 4 |
| after | 2 |

The remaining two are the identity check and the head context, which stay
independent.

## What this deliberately does not do

My first attempt cached `resolveRemoteRepositoryContext` across calls with a
TTL. That is wrong, and the suite caught it: `branchPullRequest` compares the
identity it resolves now against the one recorded in the cached pull request
specifically to notice a remote repointed at a different repository, so a cached
identity lets a stale pull request survive that check. It failed the existing
"repointed remote" test, which returned the old repository's merged PR instead
of `null`. That test still passes here, because both call sites still resolve
independently and nothing is retained between calls — this only removes a
duplicate read within a single resolution, where both values were already being
computed at the same instant from the same checkout.

That leaves the larger per-sweep repetition in #9714 unaddressed. It needs a
scope-bounded approach rather than a cache, and I did not want to mix that into
this change.

## Testing

- `vp test run src/git/GitManager.test.ts src/git/GitWorkflowService.test.ts src/orchestration/ThreadSettlementReactor.test.ts` — 120 passed
- `tsgo --noEmit` in `apps/server` — clean
- `vp fmt --check` on both changed files — clean
- Adds one test asserting the read count, which fails with 4 against `main`

No UI change, so no screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized GitManager optimization with no cross-call caching; behavior for distinct remotes and repointed-remote tests is unchanged.
> 
> **Overview**
> **GitManager** now resolves a branch’s tracking remote and `origin` through a shared `resolveHeadAndOriginContexts` helper. When both names point at `origin` (or the branch has no remote), it performs one `remote.origin.url` read and reuses the result for both sides instead of spawning two concurrent identical `git config` lookups.
> 
> `resolvePrLookupRepositoryIdentity` and `resolveBranchHeadContext` both use this helper, cutting duplicate reads within each call (e.g. cold `branchPullRequest` on an origin-tracking branch goes from four `remote.origin.url` reads to two). A shared `EMPTY_REPOSITORY_CONTEXT` replaces inline empty objects for the no-remote case. The helper is intentionally **not** cached across calls so repointed-remote identity checks stay fresh.
> 
> Adds a test that asserts the reduced `git config` read count via the existing `gitConfigReads` spy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0abe8e560134af44527fb7abe82577755bea8d50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve matching branch and origin remotes with a single config read
> - Adds `resolveHeadAndOriginContexts` to [GitManager.ts](https://github.com/pingdotgg/t3code/pull/9719/files#diff-cd0cda31b0a40baa44db979a23ee89f041c9bae39aa597513a8628cccebd0337), which resolves a branch's remote and origin together; when both are `origin`, it performs one origin lookup and reuses it for both contexts.
> - Updates `resolvePrLookupRepositoryIdentity` and `resolveBranchHeadContext` to use the new coordinator instead of resolving the two remotes independently.
> - Adds a shared `EMPTY_REPOSITORY_CONTEXT` constant returned on the no-remote path, replacing per-call allocation of an equivalent object.
> - Adds a test in [GitManager.test.ts](https://github.com/pingdotgg/t3code/pull/9719/files#diff-913ade748b9dbddd4912c2fd2d736a754c232ed342415f121860f38508455eb1) asserting `remote.origin.url` is read twice (not four times) during branch PR resolution.
> - Behavioral Change: the coordinator is intentionally not cached, so each call to `resolveHeadAndOriginContexts` still performs its own resolution; distinct non-origin remotes continue to resolve concurrently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0abe8e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->