### PR TITLE
test(server): allow either valid file-search match

### DIFF
--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -218,7 +218,10 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
           kind: "file",
         });
 
-        expect(result.entries).toEqual([{ path: "src/index.ts", kind: "file" }]);
+        // Native ranking can put either matching file first.
+        expect(result.entries).toHaveLength(1);
+        expect(result.entries[0]?.kind).toBe("file");
+        expect(["src/index.ts", "src/internal.ts"]).toContain(result.entries[0]?.path);
         expect(result.truncated).toBe(true);
       }),
     );


### PR DESCRIPTION
The file-filter test failed on main when native search returned `src/internal.ts` before `src/index.ts`. Both match the query, and the same commit passed on retry.

Check that the limit returns one matching file and reports truncation. Do not require a specific native ranking between those two files. Production code is unchanged.

All 30 WorkspaceEntries tests and targeted lint pass. Found while monitoring the performance work in https://github.com/pingdotgg/t3code/issues/9661.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion change; no production or search behavior changes.
> 
> **Overview**
> Fixes a flaky **WorkspaceEntries** search test that assumed native file search always ranked `src/index.ts` ahead of `src/internal.ts` for query `"src"` with `kind: "file"` and `limit: 1`.
> 
> The test now asserts **one** file result, that it is a file, that its path is either matching file, and that **`truncated`** stays **true**—without pinning tie-break order between equally valid matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 118529149cd47cf1ba1b9876e368a110b077b25d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Relax `WorkspaceEntries` file-search test to accept either valid match
> Updates the test case in [WorkspaceEntries.test.ts](https://github.com/pingdotgg/t3code/pull/9720/files#diff-6d95ae743d3d76a69c3093d3bfe3097cfa1d2a7e58a9e45e5f26d304479160b8) to assert that a single file result is returned, without pinning it to `src/index.ts`. The result may now be either matching source file. The truncation assertion is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1185291.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->