### PR TITLE
fix(web): resolve review conversations from pull request summary

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -551,7 +551,13 @@ export function PullRequestSummaryTab({
   const setThreadResolution = useAtomCommand(pullRequestEnvironment.setThreadResolution, {
     reportFailure: false,
   });
-  const [resolutionPending, setResolutionPending] = useState(false);
+  // Include the pull request because this component remains mounted when the panel changes PRs.
+  const [resolutionScope, setResolutionScope] = useState<{
+    readonly pullRequest: string;
+    readonly threadId: string;
+  } | null>(null);
+  const resolvingThreadId =
+    resolutionScope?.pullRequest === detail.url ? resolutionScope.threadId : null;
   // Keyed by the pull request, like the comment window above it, so an editor left open never
   // reappears over the next pull request's description.
   const [bodyScope, setBodyScope] = useState<string | null>(null);
@@ -608,22 +614,32 @@ export function PullRequestSummaryTab({
     },
   };
 
-  const resolutionButton = (thread: PullRequestReviewThread, className?: string) =>
-    detail.capabilities.review.resolve && detail.viewerPermissions.resolve ? (
+  const resolutionButton = (thread: PullRequestReviewThread, className?: string) => {
+    if (!detail.capabilities.review.resolve || !detail.viewerPermissions.resolve) return null;
+    const resolving = resolvingThreadId === thread.id;
+    const verb = thread.isResolved ? "Unresolve" : "Resolve";
+    const working = thread.isResolved ? "Unresolving..." : "Resolving...";
+    return (
       <Button
         size="xs"
         variant="ghost"
         className={cn("shrink-0", className)}
-        disabled={resolutionPending}
-        aria-label={`${thread.isResolved ? "Unresolve" : "Resolve"} review conversation on ${thread.path}${thread.line === null ? "" : ` line ${thread.line}`}`}
+        disabled={resolvingThreadId !== null}
+        aria-busy={resolving || undefined}
+        aria-label={`${verb} review conversation on ${thread.path}${thread.line === null ? "" : ` line ${thread.line}`}`}
         onClick={async () => {
-          if (resolutionPending) return;
-          setResolutionPending(true);
+          if (resolvingThreadId !== null) return;
+          const scope = { pullRequest: detail.url, threadId: thread.id };
+          setResolutionScope(scope);
           const result = await setThreadResolution({
             environmentId,
             input: { ...reference, threadId: thread.id, resolved: !thread.isResolved },
           });
-          setResolutionPending(false);
+          setResolutionScope((current) =>
+            current?.pullRequest === scope.pullRequest && current.threadId === scope.threadId
+              ? null
+              : current,
+          );
           if (result._tag === "Failure") {
             toastManager.add({
               type: "error",
@@ -638,9 +654,10 @@ export function PullRequestSummaryTab({
           onRefresh();
         }}
       >
-        {thread.isResolved ? "Unresolve" : "Resolve"}
+        {resolving ? working : verb}
       </Button>
-    ) : null;
+    );
+  };
 
   return (
     <div className="h-full overflow-y-auto" data-pull-request-summary-scroll>

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -4,8 +4,10 @@ import type {
   PullRequestComment,
   PullRequestDetailView,
   PullRequestRef,
+  PullRequestReviewThread,
   ScopedThreadRef,
 } from "@t3tools/contracts";
+import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
 import {
   ArrowDownUpIcon,
   ChevronDownIcon,
@@ -46,10 +48,12 @@ import { PullRequestLabelPicker } from "./PullRequestLabelPicker";
 import { PullRequestReviewerPicker } from "./PullRequestReviewerPicker";
 import { PullRequestActivityUnavailableState } from "./PullRequestActivityUnavailableState";
 import {
+  firstVisibleThreadCommentIds,
   latestPullRequestReviewOutcomes,
   orderPullRequestComments,
   pullRequestFindingKey,
   pullRequestReviewOutcome,
+  readableFailure,
   visibleBody,
   type PullRequestFinding,
 } from "./pullRequestDetail.logic";
@@ -161,6 +165,7 @@ function CollapsedComment({
   label,
   body,
   reactionBar,
+  action,
 }: {
   comment: PullRequestComment;
   editing: CommentEditing;
@@ -168,30 +173,34 @@ function CollapsedComment({
   /** Null where the remark is nothing but its verdict, which a dismissal usually is. */
   body: string | null;
   reactionBar: ReactNode;
+  action?: ReactNode;
 }) {
   const [open, setOpen] = useState(false);
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
       <article className="group rounded-lg border border-border/60 [contain-intrinsic-block-size:44px] [content-visibility:auto]">
-        <CollapsibleTrigger
+        <div
           className={cn(
-            "flex w-full items-center gap-2 p-3 text-left transition-opacity hover:opacity-100",
+            "flex items-center transition-opacity hover:opacity-100 focus-within:opacity-100",
             open ? "opacity-100" : "opacity-65",
           )}
         >
-          <span className="flex min-w-0 flex-1 items-center gap-2 text-xs text-muted-foreground">
-            <CommentAuthor actor={comment.author} />
-            <span>{formatRelativeTimeLabel(comment.createdAt)}</span>
-            <span>{label}</span>
-          </span>
-          <ChevronDownIcon
-            aria-hidden
-            className={cn(
-              "size-3.5 shrink-0 text-muted-foreground transition-transform",
-              open && "rotate-180",
-            )}
-          />
-        </CollapsibleTrigger>
+          <CollapsibleTrigger className="flex min-w-0 flex-1 items-center gap-2 p-3 text-left">
+            <span className="flex min-w-0 flex-1 items-center gap-2 text-xs text-muted-foreground">
+              <CommentAuthor actor={comment.author} />
+              <span>{formatRelativeTimeLabel(comment.createdAt)}</span>
+              <span>{label}</span>
+            </span>
+            <ChevronDownIcon
+              aria-hidden
+              className={cn(
+                "size-3.5 shrink-0 text-muted-foreground transition-transform",
+                open && "rotate-180",
+              )}
+            />
+          </CollapsibleTrigger>
+          {action ? <div className="pr-3">{action}</div> : null}
+        </div>
         <CollapsiblePanel>
           {open ? (
             <div className="px-3 pb-3">
@@ -525,6 +534,7 @@ export function PullRequestSummaryTab({
       thread.comments.map((comment) => [comment.id, thread] as const),
     ),
   );
+  const resolutionCommentIds = firstVisibleThreadCommentIds(visibleComments, threadByCommentId);
 
   const openLink = useOpenLink(threadRef);
   const openCheck = (url: string) => {
@@ -538,6 +548,10 @@ export function PullRequestSummaryTab({
   const updateComment = useAtomCommand(pullRequestEnvironment.updateComment, {
     reportFailure: false,
   });
+  const setThreadResolution = useAtomCommand(pullRequestEnvironment.setThreadResolution, {
+    reportFailure: false,
+  });
+  const [resolutionPending, setResolutionPending] = useState(false);
   // Keyed by the pull request, like the comment window above it, so an editor left open never
   // reappears over the next pull request's description.
   const [bodyScope, setBodyScope] = useState<string | null>(null);
@@ -593,6 +607,40 @@ export function PullRequestSummaryTab({
       onRefresh();
     },
   };
+
+  const resolutionButton = (thread: PullRequestReviewThread, className?: string) =>
+    detail.capabilities.review.resolve && detail.viewerPermissions.resolve ? (
+      <Button
+        size="xs"
+        variant="ghost"
+        className={cn("shrink-0", className)}
+        disabled={resolutionPending}
+        aria-label={`${thread.isResolved ? "Unresolve" : "Resolve"} review conversation on ${thread.path}${thread.line === null ? "" : ` line ${thread.line}`}`}
+        onClick={async () => {
+          if (resolutionPending) return;
+          setResolutionPending(true);
+          const result = await setThreadResolution({
+            environmentId,
+            input: { ...reference, threadId: thread.id, resolved: !thread.isResolved },
+          });
+          setResolutionPending(false);
+          if (result._tag === "Failure") {
+            toastManager.add({
+              type: "error",
+              title: "The conversation could not be updated",
+              description: readableFailure(
+                squashAtomCommandFailure(result),
+                "The host refused it. Check that you have write access or opened this change request.",
+              ),
+            });
+            return;
+          }
+          onRefresh();
+        }}
+      >
+        {thread.isResolved ? "Unresolve" : "Resolve"}
+      </Button>
+    ) : null;
 
   return (
     <div className="h-full overflow-y-auto" data-pull-request-summary-scroll>
@@ -879,6 +927,8 @@ export function PullRequestSummaryTab({
                 {commentOrder === "oldest" ? showOldestCommentsButton : null}
                 {visibleComments.map((comment) => {
                   const thread = threadByCommentId.get(comment.id);
+                  const showsResolutionAction =
+                    thread !== undefined && resolutionCommentIds.has(comment.id);
                   const body = visibleBody(comment.body);
                   const outcome = pullRequestReviewOutcome(comment.reviewState);
                   if (thread?.isResolved || outcome === "dismissed") {
@@ -900,6 +950,7 @@ export function PullRequestSummaryTab({
                             onRefresh={onRefresh}
                           />
                         }
+                        action={showsResolutionAction ? resolutionButton(thread) : null}
                       />
                     );
                   }
@@ -964,6 +1015,7 @@ export function PullRequestSummaryTab({
                               : fixFindingLabel}
                           </Button>
                         ) : null}
+                        {showsResolutionAction ? resolutionButton(thread, "-mt-1") : null}
                       </div>
                       {comment.path ? (
                         <Tooltip>

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -39,6 +39,7 @@ import {
   resolveBaseFreshness,
   buildPullRequestTimeline,
   editPullRequestThreadComment,
+  firstVisibleThreadCommentIds,
   writePullRequestDetailSnapshot,
 } from "./pullRequestDetail.logic";
 import type { ReviewCommentContext } from "~/reviewCommentContext";
@@ -112,6 +113,20 @@ describe("pull request activity refresh", () => {
   });
 });
 describe("review thread comment pages", () => {
+  it("assigns thread actions to only the first visible comment in each conversation", () => {
+    const firstThread = { id: "t1" };
+    const secondThread = { id: "t2" };
+    const threads = new Map([
+      ["c1", firstThread],
+      ["c2", firstThread],
+      ["c3", secondThread],
+    ]);
+
+    expect([
+      ...firstVisibleThreadCommentIds([{ id: "c2" }, { id: "c1" }, { id: "c3" }], threads),
+    ]).toEqual(["c2", "c3"]);
+  });
+
   it("appends new comments once and keeps refreshed base comments", () => {
     expect(
       mergePullRequestThreadComments(

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -114,7 +114,7 @@ export function mergePullRequestThreadComments<T extends { readonly id: string }
   ];
 }
 
-/** The first row currently shown for each review conversation owns its thread-level actions. */
+/** The first row shown for a conversation owns its thread actions, not every reply of it. */
 export function firstVisibleThreadCommentIds(
   comments: ReadonlyArray<{ readonly id: string }>,
   threadByCommentId: ReadonlyMap<string, { readonly id: string }>,

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -114,6 +114,22 @@ export function mergePullRequestThreadComments<T extends { readonly id: string }
   ];
 }
 
+/** The first row currently shown for each review conversation owns its thread-level actions. */
+export function firstVisibleThreadCommentIds(
+  comments: ReadonlyArray<{ readonly id: string }>,
+  threadByCommentId: ReadonlyMap<string, { readonly id: string }>,
+): ReadonlySet<string> {
+  const threadIds = new Set<string>();
+  return new Set(
+    comments.flatMap((comment) => {
+      const thread = threadByCommentId.get(comment.id);
+      if (!thread || threadIds.has(thread.id)) return [];
+      threadIds.add(thread.id);
+      return [comment.id];
+    }),
+  );
+}
+
 export function editPullRequestThreadComment<
   T extends { readonly id: string; readonly body: string },
 >(comments: ReadonlyArray<T>, commentId: string, body: string): ReadonlyArray<T> {

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -74,7 +74,8 @@ uses the project's instructions and recent commit subjects.
 
 Open **Pull requests** to review changes and comments, request reviewers, check out a branch,
 or merge. You can edit review titles and descriptions and your own comments where the host allows it.
-GitLab calls these merge requests.
+On GitHub, GitLab, and Bitbucket, resolve or unresolve review conversations from the **Summary** or
+**Code** tab. GitLab calls these merge requests.
 
 GitHub, GitLab, and Azure DevOps support auto-merge while checks are outstanding. GitHub also
 supports approving waiting fork workflows and opening a revert pull request for a merged change.


### PR DESCRIPTION
## What Changed

Adds Resolve and Unresolve controls to review conversations in the pull request Summary tab.

The action appears once per visible conversation, respects host capabilities and viewer permissions, reports pending and failure states, and refreshes the pull request after a successful update. The user documentation now lists the Summary tab alongside the existing Code tab support.

## Why

Review conversations shown in Summary could only be resolved by switching to the Code tab or opening the pull request on its host. This adds the existing resolution capability where those conversations are already being reviewed.

## UI Changes

Before screenshot: 
<img width="792" height="949" alt="image" src="https://github.com/user-attachments/assets/cd1efc79-5f72-46fb-97be-6fee6d0e538b" />

After screenshot: <img width="790" height="945" alt="image" src="https://github.com/user-attachments/assets/88aaa8b4-9364-4976-a334-1efca4ad6b68" />

Resolve/Unresolve video: 

https://github.com/user-attachments/assets/14a583aa-4159-4669-9e3e-6c16bff96c84


## Verification

- `vp test run src/components/pullRequest/pullRequestDetail.logic.test.ts` (94 tests passed)
- Manually verified Resolve and Unresolve in the web client
- Manually verified Resolve and Unresolve in the desktop client

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Built with GPT-5.6-sol using the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add resolve/unresolve buttons for review conversations in PR Summary tab
> - Adds a permission-gated Resolve/Unresolve button to the first visible comment of each review thread in [PullRequestSummaryTab.tsx](https://github.com/pingdotgg/t3code/pull/9723/files#diff-3578fc02114ff4bcfd64244d105a7bdaec27c244e8ee0af529b95c0f32c6cdb2), using an environment command to toggle thread resolution state
> - Adds `firstVisibleThreadCommentIds` in [pullRequestDetail.logic.ts](https://github.com/pingdotgg/t3code/pull/9723/files#diff-2c5f917dba9decc3bd48ec3231f7b0db073e8b642379cf000265960a03718c18) to return one comment ID per distinct thread, so the action attaches only to the first visible comment
> - Extends `CollapsedComment` with an optional `action` prop so a header action control sits beside the expand/collapse trigger without being part of it
> - Disables resolution buttons while a request is pending, shows a toast on failure, and refreshes pull-request detail on success
> - Updates [source-control.md](https://github.com/pingdotgg/t3code/pull/9723/files#diff-a171985f6d647c7bc51efc65cf1a0b7261bb1313fe7c275c74f3836f919d1c05) documenting that conversations can be resolved or unresolved from the Summary or Code tab for GitHub, GitLab, and Bitbucket
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2020fc3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only extension of an existing thread-resolution API with permission gating; no new auth or data paths beyond what the Code tab already uses.
> 
> **Overview**
> Reviewers can **resolve or unresolve** review conversations directly on the pull request **Summary** tab, using the same host command as the Code tab instead of switching views.
> 
> The control shows on the **first visible comment** per thread (via new `firstVisibleThreadCommentIds`), only when capabilities and permissions allow. **`CollapsedComment`** gains an optional header **action** slot so the button sits beside expand/collapse without nesting interactive elements. Pending state is scoped per PR, failures surface through **`readableFailure`**, and a successful toggle refreshes detail.
> 
> User docs now mention Summary alongside Code for GitHub, GitLab, and Bitbucket.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2020fc32aa868ad88842092947b0ffcc8443b0be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->