### PR TITLE
perf(mobile): keep image bytes outside draft JSON

### DIFF
--- a/apps/mobile/src/features/review/ReviewCommentComposerSheet.tsx
+++ b/apps/mobile/src/features/review/ReviewCommentComposerSheet.tsx
@@ -55,20 +55,29 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
   >({});
   const [attachments, setAttachments] = useState<ReadonlyArray<DraftComposerImageAttachment>>([]);
   const attachmentsRef = useRef(attachments);
-  attachmentsRef.current = attachments;
-  // Attachments live in local state until submit copies them into the thread
-  // draft, but their image bytes already live in the app-owned attachment
-  // directory. Whatever is still here when the sheet unmounts was neither
-  // submitted nor removed; release those copies so dismissal does not leak
-  // storage. Cleanup is reference-checked, so submitted files stay.
-  useEffect(
-    () => () => {
-      if (attachmentsRef.current.length > 0) {
-        scheduleUnusedComposerAttachmentCleanup(attachmentsRef.current);
-      }
-    },
-    [],
-  );
+  const isMountedRef = useRef(true);
+  // Store file references before React commits, so closing the sheet can release them.
+  const replaceAttachments = useCallback((next: ReadonlyArray<DraftComposerImageAttachment>) => {
+    attachmentsRef.current = next;
+    setAttachments(next);
+  }, []);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      scheduleUnusedComposerAttachmentCleanup(attachmentsRef.current);
+    };
+  }, []);
+
+  function appendImages(images: ReadonlyArray<DraftComposerImageAttachment>): void {
+    if (!isMountedRef.current) {
+      scheduleUnusedComposerAttachmentCleanup(images);
+      return;
+    }
+    if (images.length > 0) {
+      replaceAttachments([...attachmentsRef.current, ...images]);
+    }
+  }
   const [previewFile, setPreviewFile] = useState<FilePreviewSource | null>(null);
 
   const selectedLines = useMemo(
@@ -103,11 +112,9 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
       try {
         const images = await convertPastedImagesToAttachments({
           uris,
-          existingCount: attachments.length,
+          existingCount: attachmentsRef.current.length,
         });
-        if (images.length > 0) {
-          setAttachments((current) => [...current, ...images]);
-        }
+        appendImages(images);
       } catch (error) {
         console.error("[review comment] error converting pasted images", error);
       }
@@ -143,11 +150,9 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
   }, [selectedLines, selectedTheme, target]);
 
   async function handlePickImages(): Promise<void> {
-    const result = await pickComposerImages({ existingCount: attachments.length });
-    if (result.images.length > 0) {
-      setAttachments((current) => [...current, ...result.images]);
-    }
-    if (result.error) {
+    const result = await pickComposerImages({ existingCount: attachmentsRef.current.length });
+    appendImages(result.images);
+    if (result.error && isMountedRef.current) {
       setPendingConnectionError(result.error);
     }
   }
@@ -161,11 +166,11 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
       environmentId,
       threadId,
       text: formatReviewCommentContext(target, commentText),
-      attachments,
+      attachments: attachmentsRef.current,
     });
-    setAttachments([]);
+    replaceAttachments([]);
     dismissComposer();
-  }, [attachments, commentText, dismissComposer, environmentId, target, threadId]);
+  }, [commentText, dismissComposer, environmentId, replaceAttachments, target, threadId]);
 
   return (
     <View className="flex-1 bg-sheet">
@@ -291,10 +296,9 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
                         onPressPreview={setPreviewFile}
                         removeButtonPlacement="gutter"
                         onRemove={(imageId) => {
-                          const removed = attachments.find((image) => image.id === imageId);
-                          setAttachments((current) =>
-                            current.filter((image) => image.id !== imageId),
-                          );
+                          const current = attachmentsRef.current;
+                          const removed = current.find((image) => image.id === imageId);
+                          replaceAttachments(current.filter((image) => image.id !== imageId));
                           if (removed) {
                             scheduleUnusedComposerAttachmentCleanup([removed]);
                           }

--- a/apps/mobile/src/features/review/ReviewCommentComposerSheet.tsx
+++ b/apps/mobile/src/features/review/ReviewCommentComposerSheet.tsx
@@ -1,7 +1,7 @@
 import { useNavigation, type StaticScreenProps } from "@react-navigation/native";
 import { TextInputWrapper } from "expo-paste-input";
 import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Platform, Pressable, ScrollView, View, useWindowDimensions } from "react-native";
 import { KeyboardAvoidingView, KeyboardStickyView } from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -15,6 +15,7 @@ import { cn } from "../../lib/cn";
 import type { DraftComposerImageAttachment } from "../../lib/composerImages";
 import { convertPastedImagesToAttachments, pickComposerImages } from "../../lib/composerImages";
 import { useNativePaste } from "../../lib/useNativePaste";
+import { scheduleUnusedComposerAttachmentCleanup } from "../../state/use-composer-drafts";
 import { setPendingConnectionError } from "../../state/use-remote-environment-registry";
 import { appendReviewCommentToDraft } from "../../state/use-thread-composer-state";
 import {
@@ -53,6 +54,21 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
     Record<string, ReadonlyArray<ReviewHighlightedToken>>
   >({});
   const [attachments, setAttachments] = useState<ReadonlyArray<DraftComposerImageAttachment>>([]);
+  const attachmentsRef = useRef(attachments);
+  attachmentsRef.current = attachments;
+  // Attachments live in local state until submit copies them into the thread
+  // draft, but their image bytes already live in the app-owned attachment
+  // directory. Whatever is still here when the sheet unmounts was neither
+  // submitted nor removed; release those copies so dismissal does not leak
+  // storage. Cleanup is reference-checked, so submitted files stay.
+  useEffect(
+    () => () => {
+      if (attachmentsRef.current.length > 0) {
+        scheduleUnusedComposerAttachmentCleanup(attachmentsRef.current);
+      }
+    },
+    [],
+  );
   const [previewFile, setPreviewFile] = useState<FilePreviewSource | null>(null);
 
   const selectedLines = useMemo(
@@ -275,9 +291,13 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
                         onPressPreview={setPreviewFile}
                         removeButtonPlacement="gutter"
                         onRemove={(imageId) => {
+                          const removed = attachments.find((image) => image.id === imageId);
                           setAttachments((current) =>
                             current.filter((image) => image.id !== imageId),
                           );
+                          if (removed) {
+                            scheduleUnusedComposerAttachmentCleanup([removed]);
+                          }
                         }}
                       />
                     </View>

--- a/apps/mobile/src/features/sharing/incoming-share-model.test.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-model.test.ts
@@ -36,6 +36,9 @@ describe("incoming native shares", () => {
       originalName: "Screenshot.png",
     };
     const removeOwnedFile = vi.fn(() => Promise.resolve());
+    const readBase64 = vi.fn(async () => "unused");
+    const persistedUri = "file:///documents/t3-composer-attachments/Screenshot.png";
+    const persistFile = vi.fn(async () => persistedUri);
 
     const result = await buildIncomingShareDraft({
       id: "share-1",
@@ -43,7 +46,9 @@ describe("incoming native shares", () => {
       payloads,
       resolvedPayloads: [resolvedImage],
       fileReader: {
-        readBase64: async () => "YWJj",
+        readBase64,
+        persistFile,
+        readSize: async (uri) => (uri === persistedUri ? 3 : null),
         removeOwnedFile,
       },
     });
@@ -60,13 +65,16 @@ describe("incoming native shares", () => {
           name: "Screenshot.png",
           mimeType: "image/png",
           sizeBytes: 3,
-          dataUrl: "data:image/png;base64,YWJj",
-          previewUri: "data:image/png;base64,YWJj",
+          fileUri: persistedUri,
+          previewUri: persistedUri,
         },
       ],
       warnings: [],
     });
+    expect(persistFile).toHaveBeenCalledWith(image.value, "Screenshot.png");
+    expect(readBase64).not.toHaveBeenCalled();
     expect(removeOwnedFile).toHaveBeenCalledWith(image.value);
+    expect(removeOwnedFile).not.toHaveBeenCalledWith(persistedUri);
     expect(hasIncomingShareContent(result)).toBe(true);
   });
 

--- a/apps/mobile/src/features/sharing/incoming-share-model.test.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-model.test.ts
@@ -78,6 +78,45 @@ describe("incoming native shares", () => {
     expect(hasIncomingShareContent(result)).toBe(true);
   });
 
+  it.each(["unknown", "unavailable"] as const)(
+    "releases a shared image when its stored size is %s",
+    async (measurement) => {
+      const image: SharePayload = {
+        shareType: "image",
+        value: "file:///shared/photo.png",
+        mimeType: "image/png",
+      };
+      const persistedUri = "file:///documents/t3-composer-attachments/photo.png";
+      const removeOwnedFile = vi.fn(async (_uri: string) => undefined);
+      const result = await buildIncomingShareDraft({
+        id: "share-unmeasured",
+        createdAt: "2026-07-15T10:00:00.000Z",
+        payloads: [image],
+        resolvedPayloads: [
+          {
+            ...image,
+            contentUri: image.value,
+            contentType: "image",
+            contentMimeType: "image/png",
+            contentSize: 3,
+            originalName: "photo.png",
+          },
+        ],
+        fileReader: {
+          readBase64: async () => "unused",
+          persistFile: async () => persistedUri,
+          ...(measurement === "unknown" ? { readSize: async () => null } : {}),
+          removeOwnedFile,
+        },
+      });
+
+      expect(result.attachments).toEqual([]);
+      expect(result.warnings).toEqual(["'photo.png' is empty or could not be read."]);
+      expect(removeOwnedFile).toHaveBeenCalledWith(persistedUri);
+      expect(removeOwnedFile).toHaveBeenCalledWith(image.value);
+    },
+  );
+
   it("skips oversized images and releases the temporary native file", async () => {
     const image: SharePayload = {
       shareType: "image",

--- a/apps/mobile/src/features/sharing/incoming-share-model.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-model.ts
@@ -413,8 +413,7 @@ export async function buildIncomingShareDraft(input: {
         // attachment directory so the composer stays valid after the source
         // file and App Group entry are gone, without inlining the bytes.
         persistedImageUri = await input.fileReader.persistFile(uri, imageName);
-        const sizeBytes =
-          (await input.fileReader.readSize?.(persistedImageUri)) ?? resolved?.contentSize ?? null;
+        const sizeBytes = (await input.fileReader.readSize?.(persistedImageUri)) ?? null;
         if (sizeBytes === null || sizeBytes <= 0) {
           warnings.push(`'${imageName}' is empty or could not be read.`);
           await releaseOwnedFiles(input.fileReader, [persistedImageUri]);

--- a/apps/mobile/src/features/sharing/incoming-share-model.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-model.ts
@@ -405,29 +405,61 @@ export async function buildIncomingShareDraft(input: {
       continue;
     }
 
+    const imageName = resolved?.originalName ?? fallbackName(uri, index, mimeType);
+    let persistedImageUri: string | undefined;
     try {
+      if (input.fileReader.persistFile) {
+        // The share provider's file is temporary. Copy it into the durable
+        // attachment directory so the composer stays valid after the source
+        // file and App Group entry are gone, without inlining the bytes.
+        persistedImageUri = await input.fileReader.persistFile(uri, imageName);
+        const sizeBytes =
+          (await input.fileReader.readSize?.(persistedImageUri)) ?? resolved?.contentSize ?? null;
+        if (sizeBytes === null || sizeBytes <= 0) {
+          warnings.push(`'${imageName}' is empty or could not be read.`);
+          await releaseOwnedFiles(input.fileReader, [persistedImageUri]);
+          continue;
+        }
+        if (sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
+          warnings.push(`'${imageName}' exceeds the 10 MB attachment limit.`);
+          await releaseOwnedFiles(input.fileReader, [persistedImageUri]);
+          continue;
+        }
+        attachments.push({
+          id: `${input.id}:image:${index}`,
+          type: "image",
+          name: imageName,
+          mimeType,
+          sizeBytes,
+          fileUri: persistedImageUri,
+          previewUri: persistedImageUri,
+        });
+        continue;
+      }
+      // Readers without persistFile keep the legacy inline shape.
       const base64 = await input.fileReader.readBase64(uri);
       const sizeBytes = resolved?.contentSize ?? estimateBase64ByteSize(base64);
       if (sizeBytes <= 0 || sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
-        warnings.push(
-          `'${resolved?.originalName ?? fallbackName(uri, index, mimeType)}' exceeds the 10 MB attachment limit.`,
-        );
+        warnings.push(`'${imageName}' exceeds the 10 MB attachment limit.`);
         continue;
       }
       const dataUrl = `data:${mimeType};base64,${base64}`;
       attachments.push({
         id: `${input.id}:image:${index}`,
         type: "image",
-        name: resolved?.originalName ?? fallbackName(uri, index, mimeType),
+        name: imageName,
         mimeType,
         sizeBytes,
         dataUrl,
-        // The share provider's file is temporary. A data-backed preview keeps
-        // the composer valid after its source file and App Group entry are gone.
         previewUri: dataUrl,
       });
     } catch {
       warnings.push(`Could not read '${fallbackName(uri, index, mimeType)}'.`);
+      // A copy persisted before the failure has no attachment referencing it;
+      // release it or it leaks in the app's attachment directory.
+      if (persistedImageUri !== undefined) {
+        await releaseOwnedFiles(input.fileReader, [persistedImageUri]);
+      }
     } finally {
       await releaseOwnedFiles(input.fileReader, [uri, payload.value]);
     }

--- a/apps/mobile/src/lib/composer-image-schema.ts
+++ b/apps/mobile/src/lib/composer-image-schema.ts
@@ -8,7 +8,7 @@ export const DraftComposerImageAttachmentSchema = Schema.Struct({
   name: Schema.String,
   mimeType: Schema.String,
   sizeBytes: Schema.Number,
-  // Accept future file-backed records before enabling the new image writers.
+  // New images use owned files. Older drafts keep their inline bytes.
   fileUri: Schema.optional(Schema.String.check(Schema.isNonEmpty())),
   dataUrl: Schema.optional(Schema.String.check(Schema.isNonEmpty())),
   uploadedAttachmentId: Schema.optional(Schema.String),

--- a/apps/mobile/src/lib/composerFiles.test.ts
+++ b/apps/mobile/src/lib/composerFiles.test.ts
@@ -233,6 +233,23 @@ describe("composer file attachments", () => {
       expect(mocks.copy).not.toHaveBeenCalled();
     });
 
+    it("keeps JPEG fallback filenames inside the owned directory", async () => {
+      mocks.open.mockImplementation(() => otherMagic());
+      mocks.pickMedia.mockResolvedValue({
+        canceled: false,
+        assets: [{ ...photo, fileName: "folder/../../photo\\name\n.HEIC", base64: "/9j/2Q==" }],
+      });
+
+      const result = await pickComposerImages({ existingCount: 0 });
+      const fileUri =
+        "file:///documents/t3-composer-attachments/attachment-id-folder-..-..-photo-name-.jpg";
+      expect(result.error).toBeNull();
+      expect(result.images[0]?.fileUri).toBe(fileUri);
+      expect(result.images[0]?.name).toBe("folder/../../photo\\name\n.jpg");
+      await removePersistedComposerAttachmentFile(fileUri);
+      expect(mocks.delete).toHaveBeenCalledExactlyOnceWith(fileUri);
+    });
+
     it("rejects an oversized JPEG fallback before writing it", async () => {
       const base64 = "/9j/" + "A".repeat(Math.ceil(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / 3) * 4);
       mocks.open.mockImplementation(() => otherMagic());

--- a/apps/mobile/src/lib/composerFiles.test.ts
+++ b/apps/mobile/src/lib/composerFiles.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   open: vi.fn(),
   size: vi.fn(),
   readBase64: vi.fn(),
+  write: vi.fn(),
 }));
 
 vi.mock("expo-file-system", () => {
@@ -61,6 +62,10 @@ vi.mock("expo-file-system", () => {
       return mocks.readBase64(this.uri);
     }
 
+    async write(data: string, options?: { readonly encoding?: string }): Promise<void> {
+      mocks.write(this.uri, data, options);
+    }
+
     delete(): void {
       mocks.delete(this.uri);
     }
@@ -102,25 +107,34 @@ describe("composer file attachments", () => {
     mocks.open.mockReset();
     mocks.size.mockReset();
     mocks.readBase64.mockReset();
+    mocks.write.mockReset();
     mocks.size.mockImplementation((uri: string) => (uri.startsWith("content:") ? null : 42));
   });
 
   describe("photo library image conversion", () => {
-    const jpeg = "/9j/2Q==";
+    const jpegMagic = () => ({
+      readBytes: () => new Uint8Array([0xff, 0xd8, 0xff]),
+      close: vi.fn(),
+    });
+    const otherMagic = () => ({
+      readBytes: () => new Uint8Array([0x00, 0x11, 0x22]),
+      close: vi.fn(),
+    });
     const photo: ImagePickerAsset = {
       uri: "file:///picker/photo.heic",
       type: "image",
       fileName: "photo.HEIC",
       mimeType: "image/heic",
       fileSize: 20 * 1024 * 1024,
-      base64: jpeg,
+      base64: null,
       width: 1,
       height: 1,
     };
 
     it.each(["image/heic", "image/heif", undefined])(
-      "attaches the native JPEG conversion with matching metadata when the source MIME is %s",
+      "records the picker's silent JPEG transcode when the metadata says %s",
       async (mimeType) => {
+        mocks.open.mockImplementation(() => jpegMagic());
         mocks.pickMedia.mockResolvedValue({
           canceled: false,
           assets: [{ ...photo, mimeType }],
@@ -128,6 +142,10 @@ describe("composer file attachments", () => {
 
         const result = await pickComposerImages({ existingCount: 0 });
 
+        expect(mocks.pickMedia).toHaveBeenCalledWith(
+          expect.objectContaining({ base64: true, quality: 1 }),
+        );
+        const fileUri = "file:///documents/t3-composer-attachments/attachment-id-photo.jpg";
         expect(result).toEqual({
           images: [
             {
@@ -135,73 +153,116 @@ describe("composer file attachments", () => {
               type: "image",
               name: "photo.jpg",
               mimeType: "image/jpeg",
-              sizeBytes: 4,
-              dataUrl: `data:image/jpeg;base64,${jpeg}`,
-              previewUri: `data:image/jpeg;base64,${jpeg}`,
+              sizeBytes: 42,
+              fileUri,
+              previewUri: fileUri,
             },
           ],
           error: null,
         });
+        expect(mocks.copy).toHaveBeenCalledWith(photo.uri, fileUri);
       },
     );
 
     it.each([
-      { extension: "png", mimeType: "image/png", base64: "iVBORw0KGgo=" },
-      { extension: "gif", mimeType: "image/gif", base64: "R0lGODlh" },
-      { extension: "webp", mimeType: "image/webp", base64: "UklGRgQAAABXRUJQ" },
-    ])("preserves original $extension bytes instead of the picker's JPEG", async (original) => {
+      { extension: "png", mimeType: "image/png" },
+      { extension: "gif", mimeType: "image/gif" },
+      { extension: "webp", mimeType: "image/webp" },
+    ])("keeps original $extension files the picker did not transcode", async (original) => {
       const name = `photo.${original.extension}`;
+      mocks.open.mockImplementation(() => otherMagic());
       mocks.pickMedia.mockResolvedValue({
         canceled: false,
         assets: [{ ...photo, fileName: name, mimeType: original.mimeType }],
       });
-      mocks.readBase64.mockResolvedValue(original.base64);
 
       const result = await pickComposerImages({ existingCount: 0 });
 
       expect(result.error).toBeNull();
+      const fileUri = `file:///documents/t3-composer-attachments/attachment-id-${name}`;
       expect(result.images).toEqual([
-        expect.objectContaining({
-          name,
-          mimeType: original.mimeType,
-          dataUrl: `data:${original.mimeType};base64,${original.base64}`,
-          sizeBytes: Buffer.from(original.base64, "base64").byteLength,
-        }),
+        expect.objectContaining({ name, mimeType: original.mimeType, fileUri, sizeBytes: 42 }),
       ]);
+      expect(mocks.readBase64).not.toHaveBeenCalled();
     });
 
-    it("checks the converted JPEG size even when the HEIC source was smaller", async () => {
-      const oversized =
-        jpeg.slice(0, 4) + "A".repeat(Math.ceil(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / 3) * 4);
-      mocks.pickMedia.mockResolvedValue({
-        canceled: false,
-        assets: [{ ...photo, fileSize: 42, base64: oversized }],
-      });
+    it("rejects an image whose stored copy exceeds the attachment limit", async () => {
+      mocks.open.mockImplementation(() => jpegMagic());
+      mocks.pickMedia.mockResolvedValue({ canceled: false, assets: [{ ...photo, fileSize: 42 }] });
+      mocks.size.mockImplementation((uri: string) =>
+        uri.startsWith("file:///documents/") ? PROVIDER_SEND_TURN_MAX_IMAGE_BYTES + 1 : 42,
+      );
 
       await expect(pickComposerImages({ existingCount: 0 })).resolves.toEqual({
         images: [],
-        error: "'photo.HEIC' exceeds the 10 MB attachment limit.",
+        error: "'photo.jpg' exceeds the 10 MB attachment limit.",
       });
+      expect(mocks.delete).toHaveBeenCalledWith(
+        "file:///documents/t3-composer-attachments/attachment-id-photo.jpg",
+      );
     });
 
-    it("does not relabel unconverted HEIC bytes as JPEG", async () => {
+    it("lands the picker's JPEG export for an unconverted HEIC photo", async () => {
+      mocks.open.mockImplementation(() => otherMagic());
+      // "/9j/" is the base64 encoding of the JPEG magic number FF D8 FF.
+      const jpegBase64 = "/9j/heic-as-jpeg";
       mocks.pickMedia.mockResolvedValue({
         canceled: false,
-        assets: [{ ...photo, base64: "AAAAGGZ0eXBoZWlj" }],
+        assets: [{ ...photo, base64: jpegBase64 }],
       });
+
+      const result = await pickComposerImages({ existingCount: 0 });
+
+      const fileUri = "file:///documents/t3-composer-attachments/attachment-id-photo.jpg";
+      expect(result).toEqual({
+        images: [
+          expect.objectContaining({
+            name: "photo.jpg",
+            mimeType: "image/jpeg",
+            fileUri,
+            previewUri: fileUri,
+            sizeBytes: 42,
+          }),
+        ],
+        error: null,
+      });
+      // The JPEG export is written once; the HEIC original is never copied.
+      expect(mocks.write).toHaveBeenCalledWith(fileUri, jpegBase64, {
+        encoding: "base64",
+      });
+      expect(mocks.copy).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { label: "no export", base64: null },
+      // Android's quality-1 export is the raw original, not a JPEG transcode.
+      { label: "a non-JPEG export", base64: "AAAAGGZ0eXBoZWlj" },
+    ])("rejects unconverted HEIC with $label", async ({ base64 }) => {
+      mocks.open.mockImplementation(() => otherMagic());
+      mocks.pickMedia.mockResolvedValue({ canceled: false, assets: [{ ...photo, base64 }] });
 
       const result = await pickComposerImages({ existingCount: 0 });
 
       expect(result.images).toEqual([]);
       expect(result.error).toContain("not a supported image type");
+      expect(mocks.copy).not.toHaveBeenCalled();
+      expect(mocks.write).not.toHaveBeenCalled();
     });
 
-    it("retains a converted photo when another original cannot be read", async () => {
-      mocks.pickMedia.mockResolvedValue({
-        canceled: false,
-        assets: [{ ...photo, fileName: "missing.gif", mimeType: "image/gif" }, photo],
+    it("retains a copied photo when another asset cannot be copied", async () => {
+      const failing = {
+        ...photo,
+        uri: "file:///picker/missing.gif",
+        fileName: "missing.gif",
+        mimeType: "image/gif",
+      };
+      mocks.open.mockImplementation((uri: string) =>
+        uri === photo.uri ? jpegMagic() : otherMagic(),
+      );
+      mocks.copy.mockImplementation((uri: string) => {
+        if (uri === failing.uri) throw new Error("Failed to read 'missing.gif'.");
       });
-      mocks.readBase64.mockRejectedValue(new Error("missing file"));
+      mocks.pickMedia.mockResolvedValue({ canceled: false, assets: [failing, photo] });
 
       const result = await pickComposerImages({ existingCount: 0 });
 
@@ -232,9 +293,9 @@ describe("composer file attachments", () => {
       height: 1080,
     };
 
-    it("retains mixed photos and videos, keeping video bytes in durable file storage", async () => {
+    it("retains mixed photos and videos, keeping both in durable file storage", async () => {
       mocks.pickMedia.mockResolvedValue({ canceled: false, assets: [image, video] });
-      mocks.size.mockReturnValue(video.fileSize);
+      mocks.size.mockImplementation((uri: string) => (uri.includes("clip") ? video.fileSize : 3));
 
       const result = await pickComposerMedia({ existingCount: 0, maxVideoBytes: 50 * 1024 * 1024 });
 
@@ -246,7 +307,13 @@ describe("composer file attachments", () => {
       );
       expect(result).toEqual({
         attachments: [
-          expect.objectContaining({ type: "image", dataUrl: "data:image/png;base64,YWJj" }),
+          expect.objectContaining({
+            type: "image",
+            name: "photo.png",
+            sizeBytes: 3,
+            fileUri: "file:///documents/t3-composer-attachments/attachment-id-photo.png",
+            previewUri: "file:///documents/t3-composer-attachments/attachment-id-photo.png",
+          }),
           {
             id: "attachment-id",
             type: "file",
@@ -277,7 +344,10 @@ describe("composer file attachments", () => {
         expect.objectContaining({ type: "image", name: "photo.png" }),
       ]);
       expect(result.error).toBeNull();
-      expect(mocks.copy).not.toHaveBeenCalled();
+      expect(mocks.copy).toHaveBeenCalledExactlyOnceWith(
+        image.uri,
+        "file:///documents/t3-composer-attachments/attachment-id-photo.png",
+      );
     });
 
     it("does not persist videos when the destination lacks file support", async () => {
@@ -287,7 +357,10 @@ describe("composer file attachments", () => {
 
       expect(result.attachments).toEqual([expect.objectContaining({ type: "image" })]);
       expect(result.error).toBe("Video attachments are unavailable here.");
-      expect(mocks.copy).not.toHaveBeenCalled();
+      expect(mocks.copy).toHaveBeenCalledExactlyOnceWith(
+        image.uri,
+        "file:///documents/t3-composer-attachments/attachment-id-photo.png",
+      );
     });
 
     it("uses local video metadata when the picker omits its name, MIME type, or size", async () => {
@@ -345,7 +418,7 @@ describe("composer file attachments", () => {
           canceled: false,
           assets: [{ ...video, fileSize: reported }, image],
         });
-        mocks.size.mockReturnValue(stored);
+        mocks.size.mockImplementation((uri: string) => (uri.includes("clip") ? stored : 3));
 
         const result = await pickComposerMedia({ existingCount: 0, maxVideoBytes: limit });
 
@@ -369,7 +442,10 @@ describe("composer file attachments", () => {
       expect(result.attachments).toEqual([expect.objectContaining({ type: "image" })]);
       expect(result.error).toBe("You can attach up to 8 attachments per message.");
       expect(mocks.pickMedia).toHaveBeenCalledWith(expect.objectContaining({ selectionLimit: 1 }));
-      expect(mocks.copy).not.toHaveBeenCalled();
+      expect(mocks.copy).toHaveBeenCalledExactlyOnceWith(
+        image.uri,
+        "file:///documents/t3-composer-attachments/attachment-id-photo.png",
+      );
     });
 
     it("reports a native video retrieval error and ends the foreground handoff", async () => {

--- a/apps/mobile/src/lib/composerFiles.test.ts
+++ b/apps/mobile/src/lib/composerFiles.test.ts
@@ -233,6 +233,19 @@ describe("composer file attachments", () => {
       expect(mocks.copy).not.toHaveBeenCalled();
     });
 
+    it("rejects an oversized JPEG fallback before writing it", async () => {
+      const base64 = "/9j/" + "A".repeat(Math.ceil(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / 3) * 4);
+      mocks.open.mockImplementation(() => otherMagic());
+      mocks.size.mockReturnValue(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES + 1);
+      mocks.pickMedia.mockResolvedValue({ canceled: false, assets: [{ ...photo, base64 }] });
+
+      await expect(pickComposerImages({ existingCount: 0 })).resolves.toEqual({
+        images: [],
+        error: "'photo.jpg' exceeds the 10 MB attachment limit.",
+      });
+      expect(mocks.write.mock.calls.length).toBe(0);
+    });
+
     it.each([
       { label: "no export", base64: null },
       // Android's quality-1 export is the raw original, not a JPEG transcode.

--- a/apps/mobile/src/lib/composerImages.test.ts
+++ b/apps/mobile/src/lib/composerImages.test.ts
@@ -3,24 +3,44 @@ import { PROVIDER_SEND_TURN_MAX_ATTACHMENTS } from "@t3tools/contracts";
 
 const files = new Map<string, { base64: string; deleted: boolean }>();
 
-vi.mock("expo-file-system", () => ({
-  File: class {
+vi.mock("expo-file-system", () => {
+  class Directory {
     readonly uri: string;
 
-    constructor(uri: string) {
-      this.uri = uri;
+    constructor(root: string | { readonly uri: string }, name: string) {
+      this.uri = `${typeof root === "string" ? root : root.uri}/${name}`;
+    }
+
+    create(): void {}
+  }
+
+  class File {
+    readonly uri: string;
+
+    constructor(source: string | Directory, name?: string) {
+      this.uri = source instanceof Directory ? `${source.uri}/${name}` : source;
     }
 
     get exists(): boolean {
       return files.has(this.uri) && files.get(this.uri)?.deleted === false;
     }
 
-    async base64(): Promise<string> {
+    get size(): number | null {
+      const entry = files.get(this.uri);
+      if (!entry || entry.deleted) {
+        return null;
+      }
+      return Buffer.from(entry.base64, "base64").byteLength;
+    }
+
+    create(): void {}
+
+    async copy(destination: File): Promise<void> {
       const entry = files.get(this.uri);
       if (!entry || entry.deleted) {
         throw new Error("missing file");
       }
-      return entry.base64;
+      files.set(destination.uri, { base64: entry.base64, deleted: false });
     }
 
     delete(): void {
@@ -29,8 +49,15 @@ vi.mock("expo-file-system", () => ({
         entry.deleted = true;
       }
     }
-  },
-}));
+  }
+
+  return {
+    Directory,
+    File,
+    FileMode: { ReadOnly: "r", WriteOnly: "w" },
+    Paths: { document: { uri: "file:///documents" } },
+  };
+});
 
 vi.mock("./uuid", () => ({
   uuidv4: () => "attachment-id",
@@ -53,7 +80,7 @@ describe("native pasted image cleanup", () => {
     expect(isOwnedPastedImageUri("https://example.com/t3-composer-paste/id.png")).toBe(false);
   });
 
-  it("converts owned files to data-backed previews and deletes the source", async () => {
+  it("copies owned files into durable storage without inlining bytes, deleting the source", async () => {
     const uri =
       "file:///private/var/mobile/Containers/Data/Application/app/tmp/t3-composer-paste/id.png";
     files.set(uri, { base64: "aGVsbG8=", deleted: false });
@@ -63,13 +90,20 @@ describe("native pasted image cleanup", () => {
       existingCount: 0,
     });
 
+    const fileUri = "file:///documents/t3-composer-attachments/attachment-id-pasted-image.png";
     expect(attachments).toEqual([
-      expect.objectContaining({
-        dataUrl: "data:image/png;base64,aGVsbG8=",
-        previewUri: "data:image/png;base64,aGVsbG8=",
-      }),
+      {
+        id: "attachment-id",
+        type: "image",
+        name: "pasted-image.png",
+        mimeType: "image/png",
+        sizeBytes: 5,
+        fileUri,
+        previewUri: fileUri,
+      },
     ]);
     expect(files.get(uri)?.deleted).toBe(true);
+    expect(files.get(fileUri)?.deleted).toBe(false);
   });
 
   it("deletes rejected and overflow owned files without deleting user-owned files", async () => {
@@ -90,5 +124,10 @@ describe("native pasted image cleanup", () => {
     expect(files.get(rejected)?.deleted).toBe(true);
     expect(files.get(overflow)?.deleted).toBe(true);
     expect(files.get(userOwned)?.deleted).toBe(false);
+    // The rejected paste's partial durable copy must not leak either.
+    expect(
+      files.get("file:///documents/t3-composer-attachments/attachment-id-pasted-image.png")
+        ?.deleted,
+    ).toBe(true);
   });
 });

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -57,6 +57,14 @@ export function isFileBackedComposerAttachment(
 const OWNED_PASTED_IMAGE_DIRECTORY = "t3-composer-paste";
 const ATTACHMENT_COPY_CHUNK_BYTES = 64 * 1024;
 
+function sanitizeComposerAttachmentFileName(name: string) {
+  return (
+    Array.from(name, (character) =>
+      character === "/" || character === "\\" || character.charCodeAt(0) < 32 ? "-" : character,
+    ).join("") || "file"
+  );
+}
+
 export async function persistComposerAttachmentFile(
   uri: string,
   name: string,
@@ -65,10 +73,7 @@ export async function persistComposerAttachmentFile(
   const { Directory, File, FileMode, Paths } = await import("expo-file-system");
   const directory = new Directory(Paths.document, COMPOSER_ATTACHMENT_DIRECTORY);
   directory.create({ idempotent: true, intermediates: true });
-  const safeName =
-    Array.from(name, (character) =>
-      character === "/" || character === "\\" || character.charCodeAt(0) < 32 ? "-" : character,
-    ).join("") || "file";
+  const safeName = sanitizeComposerAttachmentFileName(name);
   const destination = new File(directory, `${uuidv4()}-${safeName}`);
   const source = new File(uri);
   const sourceSize = source.size;
@@ -153,7 +158,10 @@ async function persistComposerImageBase64(base64: string, name: string): Promise
   const { Directory, File, Paths } = await import("expo-file-system");
   const directory = new Directory(Paths.document, COMPOSER_ATTACHMENT_DIRECTORY);
   directory.create({ idempotent: true, intermediates: true });
-  const destination = new File(directory, `${uuidv4()}-${name}`);
+  const destination = new File(
+    directory,
+    `${uuidv4()}-${sanitizeComposerAttachmentFileName(name)}`,
+  );
   destination.create();
   try {
     await destination.write(base64, { encoding: "base64" });

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -47,7 +47,7 @@ export type DraftComposerAttachment = DraftComposerImageAttachment | DraftCompos
 /** Any composer attachment whose bytes live in the app-owned attachment directory. */
 export type FileBackedComposerAttachment = DraftComposerAttachment & { readonly fileUri: string };
 
-/** Files have a local copy. Images can have one after a file-backed draft is restored. */
+/** Files and new images have local copies. Older images may still be inline. */
 export function isFileBackedComposerAttachment(
   attachment: DraftComposerAttachment,
 ): attachment is FileBackedComposerAttachment {
@@ -145,8 +145,11 @@ export async function persistComposerAttachmentFile(
   return destination.uri;
 }
 
-/** Lands in-memory image bytes (clipboard pastes) in the owned attachment directory. */
+/** Writes clipboard or picker JPEG bytes into the owned attachment directory. */
 async function persistComposerImageBase64(base64: string, name: string): Promise<string> {
+  if (estimateBase64ByteSize(base64) > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
+    throw new Error(fileAttachmentTooLargeMessage(name, PROVIDER_SEND_TURN_MAX_IMAGE_BYTES));
+  }
   const { Directory, File, Paths } = await import("expo-file-system");
   const directory = new Directory(Paths.document, COMPOSER_ATTACHMENT_DIRECTORY);
   directory.create({ idempotent: true, intermediates: true });

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -23,9 +23,9 @@ import { uuidv4 } from "./uuid";
 export interface DraftComposerImageAttachment extends Omit<UploadChatImageAttachment, "dataUrl"> {
   readonly id: string;
   readonly previewUri: string;
-  /** Owned image bytes from a file-backed draft. Current writers still use inline bytes. */
+  /** Owned image bytes for newly picked, pasted, and shared attachments. */
   readonly fileUri?: string;
-  /** Inline bytes from current writers and older drafts. */
+  /** Inline image bytes stored by older builds. */
   readonly dataUrl?: string;
   readonly uploadedAttachmentId?: string;
   readonly uploadEnvironmentId?: EnvironmentId;
@@ -145,6 +145,29 @@ export async function persistComposerAttachmentFile(
   return destination.uri;
 }
 
+/** Lands in-memory image bytes (clipboard pastes) in the owned attachment directory. */
+async function persistComposerImageBase64(base64: string, name: string): Promise<string> {
+  const { Directory, File, Paths } = await import("expo-file-system");
+  const directory = new Directory(Paths.document, COMPOSER_ATTACHMENT_DIRECTORY);
+  directory.create({ idempotent: true, intermediates: true });
+  const destination = new File(directory, `${uuidv4()}-${name}`);
+  destination.create();
+  try {
+    await destination.write(base64, { encoding: "base64" });
+  } catch (error) {
+    // A failed write must not leave a partial copy no attachment will release.
+    try {
+      if (destination.exists) {
+        destination.delete();
+      }
+    } catch (cleanupError) {
+      console.warn("[composer-attachments] could not remove a partial write", cleanupError);
+    }
+    throw error;
+  }
+  return destination.uri;
+}
+
 export async function removePersistedComposerAttachmentFile(uri: string): Promise<void> {
   try {
     const { File, Paths } = await import("expo-file-system");
@@ -192,6 +215,69 @@ async function createComposerFileAttachment(input: {
   } catch (error) {
     await removePersistedComposerAttachmentFile(fileUri);
     throw error;
+  }
+}
+
+/** Validates an already-owned image copy and builds its attachment; deletes the copy on failure. */
+async function ownedComposerImageAttachment(input: {
+  readonly fileUri: string;
+  readonly name: string;
+  readonly mimeType: string;
+}): Promise<DraftComposerImageAttachment> {
+  const { File } = await import("expo-file-system");
+  try {
+    const sizeBytes = new File(input.fileUri).size ?? 0;
+    if (sizeBytes <= 0) {
+      throw new Error(`'${input.name}' is empty or could not be read.`);
+    }
+    if (sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
+      throw new Error(
+        fileAttachmentTooLargeMessage(input.name, PROVIDER_SEND_TURN_MAX_IMAGE_BYTES),
+      );
+    }
+    return {
+      id: uuidv4(),
+      type: "image",
+      name: input.name,
+      mimeType: input.mimeType,
+      sizeBytes,
+      fileUri: input.fileUri,
+      previewUri: input.fileUri,
+    };
+  } catch (error) {
+    await removePersistedComposerAttachmentFile(input.fileUri);
+    throw error;
+  }
+}
+
+/** Copies a picked or pasted image into app-owned storage, validating the stored bytes. */
+async function createComposerImageAttachment(input: {
+  readonly uri: string;
+  readonly name: string;
+  readonly mimeType: string;
+}): Promise<DraftComposerImageAttachment> {
+  const fileUri = await persistComposerAttachmentFile(
+    input.uri,
+    input.name,
+    PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+  );
+  return ownedComposerImageAttachment({ fileUri, name: input.name, mimeType: input.mimeType });
+}
+
+/** Reads only the file's magic number; picker exports can be many megabytes. */
+async function hasJpegMagicBytes(uri: string): Promise<boolean> {
+  try {
+    const { File, FileMode } = await import("expo-file-system");
+    const handle = new File(uri).open(FileMode.ReadOnly);
+    try {
+      const bytes = handle.readBytes(3);
+      return bytes.byteLength === 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+    } finally {
+      handle.close();
+    }
+  } catch {
+    // An unreadable file surfaces as a copy failure later; trust the metadata.
+    return false;
   }
 }
 
@@ -326,9 +412,13 @@ export async function pickComposerMedia(input: {
       mediaTypes: input.maxVideoBytes === undefined ? ["images"] : ["images", "videos"],
       allowsMultipleSelection: true,
       selectionLimit: remainingSlots,
+      shouldDownloadFromNetwork: true,
+      // The picker's file copy keeps HEIC-family originals as HEIC on every
+      // path, so its JPEG base64 export is the only supported-bytes source
+      // for them. quality 1 keeps the fast original-file copy path; the
+      // base64 string stays transient and is never persisted.
       base64: true,
       quality: 1,
-      shouldDownloadFromNetwork: true,
     });
   } catch (error) {
     return {
@@ -383,57 +473,48 @@ export async function pickComposerMedia(input: {
       continue;
     }
 
-    let base64 = asset.base64;
-    if (!base64) {
-      error = `Failed to read '${asset.fileName ?? "image"}'.`;
-      continue;
-    }
-
     let name = asset.fileName?.trim() || "image";
-    // The iOS picker returns JPEG base64 even when its metadata describes HEIC,
-    // PNG, or GIF. Keep supported originals so transparency and animation survive;
-    // use the native JPEG conversion for formats providers cannot accept.
-    if (base64.startsWith("/9j/")) {
-      if (
-        mimeType &&
-        mimeType !== "image/jpeg" &&
-        isProviderSendTurnSupportedImageMimeType(mimeType)
-      ) {
-        try {
-          const { File } = await import("expo-file-system");
-          base64 = await new File(asset.uri).base64();
-        } catch {
-          error = `Failed to read '${name}'.`;
-          continue;
-        }
-      } else {
-        mimeType = "image/jpeg";
-        if (!/\.jpe?g$/i.test(name)) {
-          name = `${name.replace(/\.[^.]+$/, "")}.jpg`;
-        }
+    // The iOS picker can export JPEG bytes while its metadata still describes
+    // the HEIC (or another) original. The file's magic number is the truth:
+    // record JPEG when the picker silently transcoded.
+    if (mimeType !== "image/jpeg" && (await hasJpegMagicBytes(asset.uri))) {
+      mimeType = "image/jpeg";
+      if (!/\.jpe?g$/i.test(name)) {
+        name = `${name.replace(/\.[^.]+$/, "")}.jpg`;
       }
     }
     if (!mimeType || !isProviderSendTurnSupportedImageMimeType(mimeType)) {
-      error = `'${name}' is not a supported image type. Attach GIF, JPEG, PNG, or WebP images.`;
+      // HEIC and friends: providers cannot accept the original bytes, so land
+      // the picker's JPEG export in the owned directory instead of rejecting
+      // the photo. iPhone camera-roll photos are HEIC by default. iOS always
+      // exports JPEG; Android's quality-1 export is the raw original, so only
+      // accept an export that actually carries the JPEG magic number ("/9j/"
+      // is base64 for FF D8 FF).
+      if (!asset.base64?.startsWith("/9j/")) {
+        error = `'${name}' is not a supported image type. Attach GIF, JPEG, PNG, or WebP images.`;
+        continue;
+      }
+      const jpegName = /\.jpe?g$/i.test(name) ? name : `${name.replace(/\.[^.]+$/, "")}.jpg`;
+      try {
+        const jpegUri = await persistComposerImageBase64(asset.base64, jpegName);
+        attachments.push(
+          await ownedComposerImageAttachment({
+            fileUri: jpegUri,
+            name: jpegName,
+            mimeType: "image/jpeg",
+          }),
+        );
+      } catch (cause) {
+        error = cause instanceof Error ? cause.message : `Failed to read '${name}'.`;
+      }
       continue;
     }
 
-    const sizeBytes = estimateBase64ByteSize(base64);
-    if (sizeBytes <= 0 || sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
-      error = `'${asset.fileName ?? "image"}' exceeds the 10 MB attachment limit.`;
-      continue;
+    try {
+      attachments.push(await createComposerImageAttachment({ uri: asset.uri, name, mimeType }));
+    } catch (cause) {
+      error = cause instanceof Error ? cause.message : `Failed to read '${name}'.`;
     }
-
-    const dataUrl = `data:${mimeType};base64,${base64}`;
-    attachments.push({
-      id: uuidv4(),
-      type: "image",
-      name,
-      mimeType,
-      sizeBytes,
-      dataUrl,
-      previewUri: mimeType === asset.mimeType?.toLowerCase() ? asset.uri : dataUrl,
-    });
   }
 
   return {
@@ -487,6 +568,18 @@ export async function pasteComposerClipboard(input: { readonly existingCount: nu
       };
     }
 
+    // The clipboard only yields inline bytes; land them in the owned
+    // attachment directory once so drafts persist a path instead of megabytes.
+    let fileUri: string;
+    try {
+      fileUri = await persistComposerImageBase64(base64, "pasted-image.png");
+    } catch (cause) {
+      return {
+        images: [],
+        text: null,
+        error: cause instanceof Error ? cause.message : "Clipboard image could not be saved.",
+      };
+    }
     return {
       images: [
         {
@@ -495,8 +588,8 @@ export async function pasteComposerClipboard(input: { readonly existingCount: nu
           name: "pasted-image.png",
           mimeType: "image/png",
           sizeBytes,
-          dataUrl: image.data,
-          previewUri: image.data,
+          fileUri,
+          previewUri: fileUri,
         },
       ],
       text: null,
@@ -568,22 +661,14 @@ export async function convertPastedImagesToAttachments(input: {
       if (index >= Math.max(0, remainingSlots)) {
         continue;
       }
-      const file = new File(uri);
-      const base64 = await file.base64();
-      const sizeBytes = estimateBase64ByteSize(base64);
-      if (sizeBytes <= 0 || sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
-        continue;
-      }
       const mimeType = mimeTypeFromUri(uri);
-      results.push({
-        id: uuidv4(),
-        type: "image",
-        name: `pasted-image.${mimeType.split("/")[1] ?? "png"}`,
-        mimeType,
-        sizeBytes,
-        dataUrl: `data:${mimeType};base64,${base64}`,
-        previewUri: ownedTemporaryFile ? `data:${mimeType};base64,${base64}` : uri,
-      });
+      results.push(
+        await createComposerImageAttachment({
+          uri,
+          name: `pasted-image.${mimeType.split("/")[1] ?? "png"}`,
+          mimeType,
+        }),
+      );
     } catch (error) {
       console.warn("Failed to read pasted image", uri, error);
     } finally {

--- a/apps/mobile/src/state/thread-outbox-model.ts
+++ b/apps/mobile/src/state/thread-outbox-model.ts
@@ -27,8 +27,8 @@ import type { DraftComposerAttachment } from "../lib/composerImages";
 import { scopedThreadKey } from "../lib/scopedEntities";
 import { resolveProviderInteractionMode } from "../features/threads/legacy-plan-mode";
 
-// Keep current writes until a compatible native baseline includes the v4 reader.
-const THREAD_OUTBOX_SCHEMA_VERSION = 3;
+// v4 stores image bytes in owned files instead of inline data URLs.
+const THREAD_OUTBOX_SCHEMA_VERSION = 4;
 const THREAD_OUTBOX_MAX_RETRY_DELAY_MS = 16_000;
 
 const QueuedThreadCreationSchema = Schema.Struct({
@@ -44,7 +44,7 @@ const QueuedThreadCreationSchema = Schema.Struct({
 });
 
 export const QueuedThreadMessageSchema = Schema.Struct({
-  schemaVersion: Schema.Literals([1, 2, THREAD_OUTBOX_SCHEMA_VERSION, 4]),
+  schemaVersion: Schema.Literals([1, 2, 3, THREAD_OUTBOX_SCHEMA_VERSION]),
   environmentId: EnvironmentId,
   threadId: ThreadId,
   messageId: MessageId,


### PR DESCRIPTION
> [!IMPORTANT]
> Hold for a new native runtime on each platform. Its embedded JavaScript must include the storage guards from [PR #9710](https://github.com/pingdotgg/t3code/pull/9710) and the readers from [PR #9713](https://github.com/pingdotgg/t3code/pull/9713). A rebuild with the old runtime fingerprint is not enough. Do not merge into the current OTA baseline.

Mobile image drafts repeatedly write image bytes into JSON. One 8 MiB pasted PNG produces 22,369,919 bytes of draft JSON.

New images now use app-owned files. Drafts, queued messages, and incoming shares store metadata. The same PNG needs 587 bytes of draft JSON, and its restored bytes match. Older inline images still work. PNG and GIF originals and the HEIC JPEG fallback remain supported.

Review-sheet cleanup now handles late picker results and closes before React commits an attachment update. Oversized JPEG exports are rejected before a file write. Both file writers sanitize stored filenames. Shared images require the stored copy's measured size.

Based on Wout Stiens' mobile work in [PR #9049](https://github.com/pingdotgg/t3code/pull/9049). The inherited source history and writer import retain contributor credit. Corrections are separate commits.

Verified with 257 focused tests, mobile typecheck, and targeted lint. Headless React checks cover both review-sheet cleanup races. Real-file checks preserve read leases and confirm that the merged readers decode new drafts and v4 queues. Measurements use source functions and a Node filesystem adapter, not a device. No native build, device, or browser verification ran.

Created with GPT-6 Astra (preview) in Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep mobile image attachment bytes outside draft JSON as owned files
> - Picked, pasted, and shared images are now copied into app-owned storage and represented as file-backed attachments instead of inline base64 data URLs in draft JSON
> - `pickComposerMedia` detects JPEG magic bytes to normalize silently transcoded images, accepts valid JPEG exports for unsupported HEIC-family metadata, and rejects non-JPEG unsupported exports
> - `buildIncomingShareDraft` uses a `persistFile` path when the reader supports it, validating persisted copy size and cleaning up invalid or oversized copies; readers without persistence keep the legacy inline shape
> - `ReviewCommentComposerSheet` now tracks attachments via refs, releases files on unmount and removal, drops images arriving after unmount, and reads the ref-backed list at submission
> - Bumps thread-outbox schema version from 3 to 4; queued message validation still accepts versions 1–4
> - Risk: existing drafts with inline image bytes still load, but newly created attachments are file-backed; `ownedComposerImageAttachment` deletes the owned file when stored size is empty or over the limit, and `persistComposerImageBase64` removes partial destination files on write failure
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ffefa00.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->