### PR TITLE
fix(relay): bound stalled push requests

### DIFF
--- a/infra/relay/src/agentActivity/ApnsClient.test.ts
+++ b/infra/relay/src/agentActivity/ApnsClient.test.ts
@@ -4,10 +4,13 @@ import { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import type { RelayAgentActivityAggregateState } from "@t3tools/contracts/relay";
 import { describe, expect, it } from "@effect/vitest";
 import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
+import * as TestClock from "effect/testing/TestClock";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientError from "effect/unstable/http/HttpClientError";
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
@@ -361,4 +364,80 @@ describe("ApnsClient", () => {
       ApnsProviderTokens.__resetApnsProviderTokenCacheForTest();
     }).pipe(Effect.provide(layer));
   });
+
+  for (const requestKind of ["live-activity", "push-notification"] as const) {
+    for (const stage of ["send", "read-response"] as const) {
+      it.effect(`aborts a stalled ${requestKind} ${stage} after ten seconds`, () =>
+        Effect.gen(function* () {
+          const started = yield* Deferred.make<void>();
+          const signals: AbortSignal[] = [];
+          const stalledHttpClient = HttpClient.make((request, _url, signal) => {
+            signals.push(signal);
+            const stall = Deferred.succeed(started, undefined).pipe(Effect.andThen(Effect.never));
+            if (stage === "send") return stall;
+            const response = HttpClientResponse.fromWeb(request, new Response("", { status: 200 }));
+            Object.defineProperty(response, "text", { value: stall });
+            return Effect.succeed(response);
+          });
+          const layer = ApnsClient.layer.pipe(
+            Layer.provide(Layer.succeed(HttpClient.HttpClient, stalledHttpClient)),
+            Layer.provide(
+              Layer.succeed(ApnsProviderTokens.ApnsProviderTokens, {
+                getJwt: () => Effect.succeed("test-jwt"),
+              }),
+            ),
+          );
+          const apns = yield* ApnsClient.ApnsClient.pipe(Effect.provide(layer));
+          const credentials = {
+            teamId: "team-timeout",
+            keyId: "key-timeout",
+            privateKey: Redacted.make("unused-test-key"),
+            bundleId: "com.t3tools.test",
+            environment: "sandbox",
+          } satisfies ApnsCredentials;
+          const send =
+            requestKind === "live-activity"
+              ? apns.sendLiveActivityRequest({
+                  credentials,
+                  issuedAtUnixSeconds: 123,
+                  request: apns.makeLiveActivityRequest({
+                    event: "update",
+                    token: "long-push-token",
+                    state,
+                    nowEpochSeconds: 123,
+                    nowIso: DateTime.formatIso(now),
+                  }),
+                })
+              : apns.sendPushNotificationRequest({
+                  credentials,
+                  issuedAtUnixSeconds: 123,
+                  request: apns.makePushNotificationRequest({
+                    token: "long-push-token",
+                    notification: {
+                      title: "Thread",
+                      body: "Done",
+                      environmentId: "env",
+                      threadId: "thread",
+                      deepLink: "/",
+                    },
+                  }),
+                });
+          const fiber = yield* send.pipe(Effect.flip, Effect.forkChild);
+          yield* Deferred.await(started);
+          yield* TestClock.adjust("10 seconds");
+          expect(signals[0]?.aborted).toBe(true);
+          const error = yield* Fiber.join(fiber);
+          expect(error).toMatchObject({
+            _tag: "ApnsHttpRequestError",
+            requestKind,
+            event: requestKind === "live-activity" ? "update" : null,
+            stage,
+            status: stage === "read-response" ? 200 : null,
+            tokenSuffix: "sh-token",
+            cause: { _tag: "TimeoutError" },
+          });
+        }),
+      );
+    }
+  }
 });

--- a/infra/relay/src/agentActivity/ApnsClient.ts
+++ b/infra/relay/src/agentActivity/ApnsClient.ts
@@ -15,6 +15,8 @@ import * as ApnsProviderTokens from "./ApnsProviderTokens.ts";
 export { ApnsJwtEncodingError, ApnsJwtSigningError } from "./apnsJwt.ts";
 
 const LIVE_ACTIVITY_NAME = "AgentActivity";
+// Bound sending and reading separately so neither stage can hold a batch open.
+const APNS_HTTP_STAGE_TIMEOUT = "10 seconds";
 // Updates only flow on domain events, so a healthy agent can be silent for
 // minutes (long tool calls, pending approvals). Two minutes made iOS dim
 // perfectly healthy activities; ten minutes still bounds how long a dead
@@ -246,6 +248,7 @@ export const make = Effect.gen(function* () {
       }),
       HttpClientRequest.bodyJson(input.request.payload),
       Effect.flatMap(httpClient.execute),
+      Effect.timeout(APNS_HTTP_STAGE_TIMEOUT),
       Effect.mapError(
         (cause) =>
           new ApnsHttpRequestError({
@@ -261,6 +264,7 @@ export const make = Effect.gen(function* () {
       ),
     );
     const responseText = yield* response.text.pipe(
+      Effect.timeout(APNS_HTTP_STAGE_TIMEOUT),
       Effect.mapError(
         (cause) =>
           new ApnsHttpRequestError({
@@ -306,6 +310,7 @@ export const make = Effect.gen(function* () {
         }),
         HttpClientRequest.bodyJson(input.request.payload),
         Effect.flatMap(httpClient.execute),
+        Effect.timeout(APNS_HTTP_STAGE_TIMEOUT),
         Effect.mapError(
           (cause) =>
             new ApnsHttpRequestError({
@@ -321,6 +326,7 @@ export const make = Effect.gen(function* () {
         ),
       );
       const responseText = yield* response.text.pipe(
+        Effect.timeout(APNS_HTTP_STAGE_TIMEOUT),
         Effect.mapError(
           (cause) =>
             new ApnsHttpRequestError({

--- a/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
@@ -5,11 +5,15 @@ import type {
 import * as NodeCryptoLayer from "@effect/platform-node/NodeCrypto";
 import { describe, expect, it } from "@effect/vitest";
 import * as NodeCrypto from "node:crypto";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
 import * as Redacted from "effect/Redacted";
 import * as References from "effect/References";
+import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
 import {
   FetchHttpClient,
   HttpClient,
@@ -974,6 +978,79 @@ describe("ApnsDeliveries", () => {
       ),
     );
   });
+
+  it.effect("continues a signed delivery batch after an APNs timeout", () =>
+    Effect.gen(function* () {
+      const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];
+      const markedDeliveries: Array<
+        Parameters<LiveActivities.LiveActivities["Service"]["markDelivery"]>[0]
+      > = [];
+      const secondTarget = {
+        ...target,
+        device_id: "device-2",
+        activity_push_token: "second-token",
+      };
+      const jobs = [target, secondTarget].map((device) =>
+        signApnsDeliveryJob({
+          secret: signingConfig.apnsDeliveryJobSigningSecret,
+          payload: makeApnsDeliveryJobPayload({
+            kind: "live_activity_update",
+            userId: device.user_id,
+            deviceId: device.device_id,
+            token: device.activity_push_token!,
+            aggregate,
+            createdAt: "1970-01-01T00:00:00.000Z",
+            expiresAt: "1970-01-01T00:10:00.000Z",
+            jobId: `job-timeout-${device.device_id}`,
+          }),
+        }),
+      );
+      const started = yield* Deferred.make<void>();
+      const results: Array<{ deviceId: string; ok: boolean }> = [];
+      const layer = makeLayer({
+        attempts,
+        markedDeliveries,
+        currentTargets: [target, secondTarget],
+        config: signingConfig,
+        execute: (request) =>
+          request.url.endsWith("/activity-token")
+            ? Deferred.succeed(started, undefined).pipe(Effect.andThen(Effect.never))
+            : Effect.succeed(
+                HttpClientResponse.fromWeb(request, new Response("", { status: 200 })),
+              ),
+      });
+      const batch = yield* Effect.gen(function* () {
+        const deliveries = yield* ApnsDeliveries.ApnsDeliveries;
+        yield* Stream.fromIterable(jobs).pipe(
+          Stream.runForEach((job) =>
+            deliveries.processSignedJob(job).pipe(
+              Effect.tap((result) =>
+                Effect.sync(() => {
+                  results.push(result);
+                }),
+              ),
+            ),
+          ),
+        );
+      }).pipe(Effect.provide(layer), Effect.forkChild);
+
+      yield* Deferred.await(started);
+      yield* TestClock.adjust("10 seconds");
+      yield* Fiber.join(batch);
+      expect(results).toMatchObject([
+        { deviceId: "device-1", ok: false },
+        { deviceId: "device-2", ok: true },
+      ]);
+      expect(attempts).toMatchObject([
+        {
+          sourceJobId: "job-timeout-device-1",
+          apnsReason: expect.stringContaining("request failed"),
+        },
+        { sourceJobId: "job-timeout-device-2", apnsStatus: 200 },
+      ]);
+      expect(markedDeliveries).toMatchObject([{ deviceId: "device-2" }]);
+    }),
+  );
 
   it.effect("processes signed push notification jobs through APNs and records attempts", () => {
     const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];


### PR DESCRIPTION
A stalled Apple push request can hold the relay's sequential delivery batch open.

Give the HTTP send and response-body read ten seconds each. Both Live Activity and alert requests keep the existing error context and transport-failure handling. A timeout aborts the request, records the failed attempt, and lets the next signed job run. No retry policy changes.

The HTTP stages can take up to twenty seconds combined. JWT retrieval is outside these deadlines. A response timeout does not prove that Apple rejected the push, so this change does not add retries that could duplicate an alert.

Verified with 53 focused APNs tests, relay typecheck, and changed-file lint. Four stall tests failed before the change and pass now. They check transport cancellation for both request kinds and both stages. A signed two-device batch test confirms that the next job completes after the first times out. All HTTP calls use test clients. No live APNs request ran.

Part of [the performance audit](https://github.com/pingdotgg/t3code/issues/9661), item R2. Cross-device concurrency remains separate.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live APNs delivery timing and failure modes for all push traffic; mis-tuned timeouts could mark slow-but-successful sends as failed without retry, though existing attempt/batch semantics are preserved.
> 
> **Overview**
> **Stalled Apple push HTTP can no longer block sequential delivery batches indefinitely.** `ApnsClient` now applies a **10-second** `Effect.timeout` to each HTTP **send** and **response-body read** for both Live Activity and alert push paths, with failures still surfaced as `ApnsHttpRequestError` (including `stage` and a `TimeoutError` cause).
> 
> Timeouts are applied per stage so a hung send or read cannot hold the whole batch open; JWT fetch stays outside these deadlines, and retry behavior is unchanged (no extra retries on ambiguous response timeouts).
> 
> New tests cover abort/cancellation after 10s for all four combinations (request kind × stage) and a two-device signed-job stream where the first device times out, records a failed attempt, and the second still delivers successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 701101821cede05c5d6a0f4fa2f206169b0e764c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound stalled APNs push requests with 10-second timeout in `ApnsClient.make`
> Adds a shared `APNS_HTTP_STAGE_TIMEOUT` constant of ten seconds and applies it independently to HTTP execution and response-body reading in `ApnsClient.sendLiveActivityRequest` and `ApnsClient.sendPushNotificationRequest` in [ApnsClient.ts](https://github.com/pingdotgg/t3code/pull/9734/files#diff-82639ee23f151886bc577cd1def586205d54b4910ed581af8c0f7ff714e260ed). Requests that exceed the timeout now abort their HTTP signal and return an `ApnsHttpRequestError` identifying the request kind and failed stage, instead of waiting indefinitely. Send-stage timeouts retain a null status; response-read timeouts include the received response status.
> - Adds deterministic tests covering both request kinds across send and response-read stages, plus a batch-delivery test verifying one stalled job fails while the next job still succeeds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7011018.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->