### PR TITLE
fix(web): preserve preview annotations across reloads

### DIFF
--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -2525,6 +2525,49 @@ function createMockStorage() {
 }
 
 describe("composer draft persistence", () => {
+  it("restores persisted preview annotations after reload", () => {
+    const threadId = ThreadId.make("preview-annotation-draft");
+    const annotation = {
+      id: "annotation-1",
+      pageUrl: "http://localhost:3000/dashboard",
+      pageTitle: "Dashboard",
+      comment: "Align these cards.",
+      elements: [],
+      regions: [],
+      strokes: [],
+      styleChanges: [],
+      screenshot: null,
+      createdAt: "2026-09-04T12:00:00.000Z",
+    };
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        merge: (
+          persistedState: unknown,
+          currentState: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => ReturnType<typeof useComposerDraftStore.getState>;
+      };
+    };
+
+    const mergedState = persistApi.getOptions().merge(
+      {
+        draftsByThreadId: {
+          [threadId]: {
+            prompt: "",
+            attachments: [],
+            previewAnnotations: [annotation],
+          },
+        },
+        draftThreadsByThreadId: {},
+        projectDraftThreadIdByProjectKey: {},
+      },
+      useComposerDraftStore.getInitialState(),
+    );
+
+    expect(mergedState.draftsByThreadKey[threadKeyFor(threadId)]?.previewAnnotations).toEqual([
+      annotation,
+    ]);
+  });
+
   it("defers attachment reads and serialization until typing stops, then restores the last draft", async () => {
     await useComposerDraftStore.persist.clearStorage();
     vi.useFakeTimers();

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -61,6 +61,7 @@ import { UnifiedSettings } from "@t3tools/contracts/settings";
 import { ReviewCommentContextSchema, type ReviewCommentContext } from "./reviewCommentContext";
 const isRuntimeMode = Schema.is(RuntimeMode);
 const isProviderDriverKind = Schema.is(ProviderDriverKind);
+const isPreviewAnnotationPayload = Schema.is(PreviewAnnotationPayloadSchema);
 const isReviewCommentContext = Schema.is(ReviewCommentContextSchema);
 
 export const COMPOSER_DRAFT_STORAGE_KEY = "t3code:composer-drafts:v1";
@@ -1880,6 +1881,9 @@ function normalizePersistedDraftsByThreadId(
           return normalized ? [normalized] : [];
         })
       : [];
+    const previewAnnotations = Array.isArray(draftCandidate.previewAnnotations)
+      ? draftCandidate.previewAnnotations.filter(isPreviewAnnotationPayload)
+      : [];
     const reviewComments = Array.isArray(draftCandidate.reviewComments)
       ? draftCandidate.reviewComments.filter(isReviewCommentContext)
       : [];
@@ -1950,6 +1954,7 @@ function normalizePersistedDraftsByThreadId(
       files.length === 0 &&
       terminalContexts.length === 0 &&
       elementContexts.length === 0 &&
+      previewAnnotations.length === 0 &&
       reviewComments.length === 0 &&
       !hasModelData &&
       !runtimeMode &&
@@ -1975,6 +1980,7 @@ function normalizePersistedDraftsByThreadId(
       ...(files.length > 0 ? { files } : {}),
       ...(terminalContexts.length > 0 ? { terminalContexts } : {}),
       ...(elementContexts.length > 0 ? { elementContexts } : {}),
+      ...(previewAnnotations.length > 0 ? { previewAnnotations } : {}),
       ...(reviewComments.length > 0 ? { reviewComments } : {}),
       ...(hasModelData
         ? {


### PR DESCRIPTION
## What Changed

Preserve schema-valid preview annotations while normalizing persisted composer drafts, including drafts whose only user content is an annotation. Add regression coverage through the public persistence merge path.

```mermaid
flowchart LR
  A["Persisted draft<br/>previewAnnotations"] --> B["normalizePersistedDraftsByThreadId<br/>validate and preserve"]
  B --> C["Hydrated composer draft<br/>annotation restored"]
```

## Why

normalizePersistedDraftsByThreadId rebuilt persisted drafts without previewAnnotations, so a reload removed attached preview context. The field was already serialized and consumed during hydration; this restores the missing normalization step.

Reported in https://github.com/pingdotgg/t3code/pull/3053#discussion_r3409044907.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable: persistence-only change)
- [x] I included a video for animation/interaction changes (not applicable)

Made with GPT-5.6-sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized persistence normalization fix with schema validation and a targeted test; no auth or API surface changes.
> 
> **Overview**
> Fixes composer draft rehydration so **preview annotations** survive a page reload instead of being dropped during persistence merge.
> 
> `normalizePersistedDraftsByThreadId` now **validates** `previewAnnotations` with `PreviewAnnotationPayloadSchema`, **counts them as user content** so annotation-only drafts are not discarded, and **copies them** into the normalized draft state. A regression test exercises the public persist `merge` path to ensure annotations round-trip after reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09283ef646b717105fcd735d0c7047b9b75c054d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `normalizePersistedDraftsByThreadId` to preserve preview annotations across reloads
> Adds schema validation for persisted preview annotations in `normalizePersistedDraftsByThreadId`. Valid annotations are retained in normalized drafts and no longer cause the draft to be discarded as empty; invalid entries are dropped. Includes a test in [composerDraftStore.test.ts](https://github.com/pingdotgg/t3code/pull/9735/files#diff-61714da43700c6105d471eadf7c6f4e80aee8189d14bed8e4362b66dded855e1) verifying that a preview annotation survives persisted-state merging.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09283ef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preview annotations now persist correctly when composer drafts are merged or reloaded.
  * Empty drafts containing preview annotations are retained as expected.

* **Tests**
  * Added coverage verifying preview annotations survive a persistence round trip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->