### PR TITLE
fix(marketing): add Open Graph and canonical metadata

### DIFF
--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from "astro/config";
 
 export default defineConfig({
+  site: "https://t3.codes",
   server: {
     port: Number(process.env.PORT ?? 4173),
   },

--- a/apps/marketing/src/layouts/Layout.astro
+++ b/apps/marketing/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import { Image } from "astro:assets";
 import appIcon from "../assets/icon.webp";
+import appDesktop from "../assets/app-desktop.webp";
 import dmSansLatinUrl from "../assets/fonts/dm-sans-latin.woff2?url";
 import "../styles/fonts.css";
 import {
@@ -21,6 +22,9 @@ const {
   description = "T3 Code. The open-source control plane for coding agents.",
   pageClass,
 } = Astro.props;
+
+const canonical = new URL(Astro.url.pathname, Astro.site);
+const socialImage = new URL(appDesktop.src, Astro.site);
 ---
 
 <html lang="en">
@@ -28,6 +32,14 @@ const {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
+    <link rel="canonical" href={canonical} />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="T3 Code" />
+    <meta property="og:url" content={canonical} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:image" content={socialImage} />
+    <meta name="twitter:card" content="summary_large_image" />
     <link
       rel="preload"
       href={dmSansLatinUrl}


### PR DESCRIPTION
Links to t3.codes render as bare URLs. `Layout.astro` emits three meta tags (charset, viewport, description), so there is nothing for X, Discord, Slack or LinkedIn to build a card from.

Setting `site` lets Astro resolve absolute URLs. The layout already takes per-page `title` and `description`, so the tags follow them and no page needed changing:

```
/          → "T3 Code"
/download/ → "Download — T3 Code"
```

`astro build` goes from 3 meta tags to 10, with a correct canonical on all six pages. `astro check` is clean.

Two calls that are yours:

- `og:image` imports `app-desktop.webp` from `src/assets` the same way this layout imports its icon, so it gets a hashed, optimised URL and no binary is added. It is 2880×1800 (1.6:1, where cards want 1.91:1), and LinkedIn lists WebP as unsupported on desktop and iOS. It still beats no image everywhere else. If you would rather ship a dedicated card, drop one in and I will repoint it.
- Left out deliberately: sitemap (needs a new dependency), `robots.txt`, `llms.txt`. Happy to send those separately if you want them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Head-only metadata and Astro site config; no auth, data, or runtime behavior changes.
> 
> **Overview**
> Sets **`site: "https://t3.codes"`** in Astro config so the marketing app can emit absolute URLs for SEO and link previews.
> 
> **`Layout.astro`** now derives a per-page **canonical** URL from the current path and adds **Open Graph** tags (`og:type`, `og:site_name`, `og:url`, `og:title`, `og:description`, `og:image`) plus **`twitter:card`** (`summary_large_image`). Title and description still come from existing layout props, so every page that uses this layout picks up the tags without edits. **`og:image`** points at the existing optimized **`app-desktop.webp`** asset via Astro’s asset pipeline (hashed build URL).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5685c5f8623025c0270578831c502fa4f10ecc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add canonical and Open Graph metadata to marketing site layout
> - Sets the production site origin to `https://t3.codes` in the Astro config so `Astro.site` resolves for absolute URL generation
> - Adds canonical link, Open Graph tags, and a Twitter large-image card to `Layout.astro` using the current page pathname and the desktop application image asset
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5685c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->