### PR TITLE
fix(web): fold single trailing activity

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -784,7 +784,7 @@ describe("deriveMessagesTimelineRows", () => {
     ).toBeDefined();
   });
 
-  it("keeps a trailing tool group visible but folds a single activity", () => {
+  it("keeps a tool group after the terminal response visible when the turn is folded", () => {
     const turnId = TurnId.make("turn-1");
     const timelineEntries = [
       {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -784,7 +784,7 @@ describe("deriveMessagesTimelineRows", () => {
     ).toBeDefined();
   });
 
-  it("keeps a tool group after the terminal response visible when the turn is folded", () => {
+  it("keeps a trailing tool group visible but folds a single activity", () => {
     const turnId = TurnId.make("turn-1");
     const timelineEntries = [
       {
@@ -829,11 +829,10 @@ describe("deriveMessagesTimelineRows", () => {
       })),
     ];
 
-    const rows = deriveMessagesTimelineRows({
-      timelineEntries,
+    const input = {
       latestTurn: {
         turnId,
-        state: "error",
+        state: "error" as const,
         startedAt: "2026-01-01T00:00:00Z",
         completedAt: "2026-01-01T00:00:10Z",
       },
@@ -841,7 +840,8 @@ describe("deriveMessagesTimelineRows", () => {
       activeTurnStartedAt: null,
       turnDiffSummaryByAssistantMessageId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
-    });
+    };
+    const rows = deriveMessagesTimelineRows({ ...input, timelineEntries });
 
     expect(rows.map((row) => row.id)).toEqual([
       "turn-fold:turn-1",
@@ -864,6 +864,11 @@ describe("deriveMessagesTimelineRows", () => {
       showAssistantMeta: false,
       showAssistantCopyButton: false,
     });
+    expect(
+      deriveMessagesTimelineRows({ ...input, timelineEntries: timelineEntries.slice(0, 3) }).map(
+        (row) => row.id,
+      ),
+    ).toEqual(["turn-fold:turn-1", "assistant-final-entry"]);
   });
 
   it("folds all assistant messages before the terminal message", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -540,8 +540,8 @@ function workEntryIsActiveTurnActivity(entry: WorkLogEntry): boolean {
 
 /**
  * Settled turns fold activity before their terminal assistant message behind
- * a "Worked for ..." row. Work that lands after that message stays visible so
- * failed or interrupted turns do not hide their trailing tool-call summary.
+ * a "Worked for ..." row. A single ordinary activity after that message joins
+ * the fold, while larger groups and failures stay visible as a trailing summary.
  */
 function deriveTurnFolds(input: {
   timelineEntries: ReadonlyArray<TimelineEntry>;
@@ -621,7 +621,11 @@ function deriveTurnFolds(input: {
       }
       const isCompaction =
         entry.kind === "work" && entry.entry.sourceActivityKind === "context-compaction";
-      if (!isCompaction && index > terminalEntryIndex) {
+      const isSingleTrailingActivity =
+        group.entries.length === terminalEntryIndex + 2 &&
+        entry.kind === "work" &&
+        !workEntryDisplayIndicatesToolFailure(entry.entry);
+      if (!isCompaction && index > terminalEntryIndex && !isSingleTrailingActivity) {
         continue;
       }
       // Agent-spawn CTA rows never fold: workflows outlive their launching

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1097,7 +1097,7 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("tool call failed");
   });
 
-  it("renders trailing tool calls as part of the terminal assistant block", () => {
+  it("renders a failed trailing tool call as part of the terminal assistant block", () => {
     const turnId = TurnId.make("turn-trailing-tools");
     const assistantMessageId = MessageId.make("assistant-trailing-tools");
     const markup = renderToStaticMarkup(
@@ -1135,7 +1135,7 @@ describe("MessagesTimeline", () => {
               label: "Ran command",
               tone: "tool",
               itemType: "command_execution",
-              toolLifecycleStatus: "completed",
+              toolLifecycleStatus: "failed",
             },
           },
         ]}

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1097,7 +1097,7 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("tool call failed");
   });
 
-  it("renders a failed trailing tool call as part of the terminal assistant block", () => {
+  it("renders trailing tool calls as part of the terminal assistant block", () => {
     const turnId = TurnId.make("turn-trailing-tools");
     const assistantMessageId = MessageId.make("assistant-trailing-tools");
     const markup = renderToStaticMarkup(


### PR DESCRIPTION
Single trailing activity rows could appear below the "Worked for ..." fold. This folds one ordinary trailing activity while leaving larger groups, failures, agent spawns, and compaction visible. Verified with 84 focused tests, web typecheck, targeted lint, and the real expand/collapse interaction.

![single trailing activity expanding from and collapsing into the worked for row](https://uploads-production-47e4.up.railway.app/files/ae86f60b-93fd-4eed-bd0f-72191381800c/collapse-trailing-activity.gif)

Created with `gpt-5.6-sol` in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only timeline folding logic with targeted unit and render tests; no API or data-path changes.
> 
> **Overview**
> Settled turns no longer leave a lone successful tool row dangling below the final assistant message and the **Worked for…** fold.
> 
> **`deriveTurnFolds`** now treats one non-failing work entry immediately after the terminal assistant message as part of the fold (same hidden set as pre-terminal activity). Multiple trailing entries, failed tools, compaction, and agent-spawn rows still stay visible as trailing summaries.
> 
> Tests cover the folded single-trailing case and align the trailing-tool integration fixture with **failed** lifecycle so failures remain outside the fold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c785d5d962ce5677e3543b6c5c6c6977b5fc941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix folding of single trailing activity in `chat.deriveMessagesTimelineRows`
> Fixes the timeline row derivation so a single trailing activity folds correctly into the turn-fold row rather than producing extra rows. The test in [MessagesTimeline.logic.test.ts](https://github.com/pingdotgg/t3code/pull/9739/files#diff-e1bf628eaf9220069a00bdd08d5e22144ed7c8bb723b4cafa3ffb550083c2a72) now refactors the settled-error setup into a reusable typed input and asserts that a shortened timeline yields only the turn-fold row and terminal assistant row, with no trailing work toggle or assistant metadata row.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c785d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->