### PR TITLE
fix(desktop): keep preview picking active across subframe navigation

### DIFF
--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -3167,7 +3167,10 @@ describe("PreviewManager", () => {
             listeners.set(event, listener);
           }),
           once: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
-            listeners.set(event, listener);
+            listeners.set(event, (...args) => {
+              listeners.delete(event);
+              listener(...args);
+            });
           }),
           off: vi.fn(),
           ipc: { on: vi.fn(), off: vi.fn(), removeListener: vi.fn() },
@@ -3193,6 +3196,8 @@ describe("PreviewManager", () => {
         expect(pick.pollUnsafe()).toBeUndefined();
 
         listeners.get("did-start-navigation")?.({}, "https://example.com/next", false, true);
+        yield* Effect.yieldNow;
+        expect(pick.pollUnsafe()).toBeDefined();
         expect(yield* Fiber.join(pick)).toBeNull();
       }),
     ),

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -3191,11 +3191,21 @@ describe("PreviewManager", () => {
         const pick = yield* manager.pickElement("tab_1").pipe(Effect.forkChild);
         yield* Effect.yieldNow;
 
-        listeners.get("did-start-navigation")?.({}, "about:blank", false, false);
+        listeners.get("did-start-navigation")?.({
+          url: "about:blank",
+          isSameDocument: false,
+          isMainFrame: false,
+          frame: null,
+        });
         yield* Effect.yieldNow;
         expect(pick.pollUnsafe()).toBeUndefined();
 
-        listeners.get("did-start-navigation")?.({}, "https://example.com/next", false, true);
+        listeners.get("did-start-navigation")?.({
+          url: "https://example.com/next",
+          isSameDocument: false,
+          isMainFrame: true,
+          frame: null,
+        });
         yield* Effect.yieldNow;
         expect(pick.pollUnsafe()).toBeDefined();
         expect(yield* Fiber.join(pick)).toBeNull();

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -2503,12 +2503,9 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         };
         const onDestroyed = () => settle(null);
         const onNavigated = (
-          _event: Electron.Event,
-          _url: string,
-          _isInPlace: boolean,
-          isMainFrame: boolean,
+          event: Electron.Event<Electron.WebContentsDidStartNavigationEventParams>,
         ) => {
-          if (isMainFrame) settle(null);
+          if (event.isMainFrame) settle(null);
         };
         const registerPickElement = Effect.fn("PreviewManager.registerPickElement")(function* () {
           // Two picks on one tab can overlap. Swap this session in and cancel

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -2529,7 +2529,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           yield* attempt({ operation: "pickElement.register", tabId, webContentsId: wc.id }, () => {
             wc.ipc.on(ELEMENT_PICKED_CHANNEL, onMessage);
             wc.once("destroyed", onDestroyed);
-            wc.once("did-start-navigation", onNavigated);
+            wc.on("did-start-navigation", onNavigated);
             if (!wc.isFocused()) wc.focus();
             wc.send(START_PICK_CHANNEL, annotationTheme);
           });


### PR DESCRIPTION
## What Changed

- Keep the preview element-pick navigation listener active until the pick session is cleaned up.
- Read `isMainFrame` from the current Electron navigation event details instead of deprecated positional arguments.
- Make the regression test model Electron `once` semantics and cover a subframe navigation followed by a main-frame navigation.

## Why

Electron removes a `once` listener after the first matching event, even when that event comes from a subframe. A subframe navigation could therefore consume the listener and leave the picker promise and listeners active when the main frame navigated afterward. Electron 43 exposes frame details on the event object, so the handler and regression test use that current shape.

```mermaid
sequenceDiagram
    participant S as Subframe
    participant P as Picker session
    participant M as Main frame
    S->>P: did-start-navigation
    Note over P: Ignore event and keep listener
    M->>P: did-start-navigation
    P->>P: Settle and remove listeners
```

## Verification

- `pnpm exec vp test run src/preview/Manager.test.ts` (80 tests)
- `pnpm --filter @t3tools/desktop typecheck`
- Targeted lint and format checks for both changed files
- Fallow audit against `main` for `@t3tools/desktop` (pass; zero introduced findings)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots are not applicable because there is no visual UI change
- [x] Video is not applicable because there is no animation or timing change

Made with GPT-5.6-sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized preview pick-session behavior with listener removal already handled in `pickElement` cleanup; regression test added for the subframe-then-main-frame case.
> 
> **Overview**
> Fixes preview **element picking** ending too early when a subframe navigates before the main document does.
> 
> `pickElement` now registers a persistent `did-start-navigation` listener (removed in the existing pick cleanup) instead of `once`, because Electron drops one-shot listeners on the first event—including non–main-frame navigations that should not cancel the pick. The handler reads **`event.isMainFrame`** from the navigation event object.
> 
> Tests update the webview **`once` mock** to match real Electron behavior and assert the pick stays in flight after a subframe navigation and only settles when the main frame navigates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c482cbd2cfe2e52f1bbdb4efcaa3c30be2bf6ff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `PreviewManager` element picking losing navigation listener on subframe nav
> Changes the `did-start-navigation` subscription in `PreviewManager.makeNativeOperations` from a one-time listener to a regular listener so it keeps receiving navigation events until the pick settles. The callback now consumes the typed navigation event and only settles the pick with `null` when `main-frame` is true; non-main-frame events leave the pick pending. Tests in [Manager.test.ts](https://github.com/pingdotgg/t3code/pull/9741/files#diff-ebb5a62378521a03aed245fc2ed6968df6c2c9db6a709340dc336a924be4068b) were updated to model one-time listener semantics, pass structured navigation events, and assert the pick settles after a main-frame navigation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c482cbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved element picking in the preview while navigation is in progress.
  * Picking remains active when content within a subframe navigates.
  * Picking now settles correctly when the main page begins navigating.
  * Repeated navigation starts are handled consistently, helping prevent picking from becoming inactive prematurely or responding inconsistently during page changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->