### PR TITLE
fix(web): show project settings for new threads

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1970,6 +1970,14 @@ export default function ChatView(props: ChatViewProps) {
   const handleNewThreadInActiveProject = useCallback(() => {
     startNewThreadForProject(activeProjectRef, handleNewThread);
   }, [activeProjectRef, handleNewThread]);
+  const activeDraftLogicalProjectKey = !isServerThread ? draftThread?.logicalProjectKey : undefined;
+  const handleOpenDraftProjectSettings = useCallback(() => {
+    if (!activeDraftLogicalProjectKey) return;
+    void navigate({
+      to: "/projects/$projectKey",
+      params: { projectKey: activeDraftLogicalProjectKey },
+    });
+  }, [activeDraftLogicalProjectKey, navigate]);
   const activeEnvironmentShell = useEnvironmentQuery(
     activeThread ? environmentShell.stateAtom(activeThread.environmentId) : null,
   );
@@ -7729,6 +7737,9 @@ export default function ChatView(props: ChatViewProps) {
             rightPanelOpen={rightPanelOpen}
             gitCwd={gitCwd}
             onNewThreadInProject={handleNewThreadInActiveProject}
+            {...(activeDraftLogicalProjectKey
+              ? { onOpenProjectSettings: handleOpenDraftProjectSettings }
+              : {})}
             onRunProjectScript={runProjectScript}
             onAddProjectScript={saveProjectScript}
             onUpdateProjectScript={updateProjectScript}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1970,7 +1970,11 @@ export default function ChatView(props: ChatViewProps) {
   const handleNewThreadInActiveProject = useCallback(() => {
     startNewThreadForProject(activeProjectRef, handleNewThread);
   }, [activeProjectRef, handleNewThread]);
-  const activeDraftLogicalProjectKey = !isServerThread ? draftThread?.logicalProjectKey : undefined;
+  const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
+  const activeDraftLogicalProjectKey =
+    !isServerThread && activeProject
+      ? deriveLogicalProjectKeyFromSettings(activeProject, projectGroupingSettings)
+      : undefined;
   const handleOpenDraftProjectSettings = useCallback(() => {
     if (!activeDraftLogicalProjectKey) return;
     void navigate({
@@ -1985,7 +1989,6 @@ export default function ChatView(props: ChatViewProps) {
   const activeProjectKey = activeProject
     ? `${activeProject.environmentId}:${activeProject.workspaceRoot}`
     : null;
-  const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const clientSettingsHydrated = useClientSettingsHydrated();
   const [pendingFileSurfaceIdsByProject, setPendingFileSurfaceIdsByProject] = useState<
     ReadonlyMap<string, ReadonlySet<string>>

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -35,6 +35,7 @@ import { useRemoteOpenState, type RemoteOpenMode } from "../../remoteOpen";
 import { usePrimaryEnvironmentId } from "../../state/environments";
 import { useT3ProjectFileScripts } from "~/hooks/useT3ProjectFileScripts";
 import { useThreadActionMenu } from "~/hooks/useThreadActionMenu";
+import { readLocalApi } from "~/localApi";
 import { threadEnvironment } from "../../state/threads";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { observeResponsiveBreakpointFade, usePanelAnimationSettings } from "../../panelAnimations";
@@ -66,6 +67,7 @@ interface ChatHeaderProps {
   gitCwd: string | null;
   readonly onOpenPullRequest?: ((number: number) => void) | undefined;
   onNewThreadInProject: () => void;
+  onOpenProjectSettings?: (() => void) | undefined;
   onRunProjectScript: (script: ProjectScript) => void;
   onAddProjectScript: (input: NewProjectScriptInput) => Promise<ProjectScriptActionResult>;
   onUpdateProjectScript: (
@@ -137,6 +139,7 @@ export const ChatHeader = memo(function ChatHeader({
   gitCwd,
   onOpenPullRequest,
   onNewThreadInProject,
+  onOpenProjectSettings,
   onRunProjectScript,
   onAddProjectScript,
   onUpdateProjectScript,
@@ -275,15 +278,29 @@ export const ChatHeader = memo(function ChatHeader({
   );
   const handleHeaderContextMenu = useCallback(
     (event: ReactMouseEvent) => {
-      if (!isServerThread || renamingTitle !== null) return;
+      if (renamingTitle !== null) return;
       // The right-side controls (git, scripts, open-in) keep their own
       // behavior; only the breadcrumb area opens the thread menu.
       if ((event.target as HTMLElement).closest("[data-chat-header-actions]")) return;
+      if (!isServerThread && onOpenProjectSettings === undefined) return;
       cancelPendingTitleMenu();
       event.preventDefault();
+      if (!isServerThread) {
+        const api = readLocalApi();
+        if (!api) return;
+        void api.contextMenu
+          .show([{ id: "project-settings", label: "Project settings", icon: "settings" }], {
+            x: event.clientX,
+            y: event.clientY,
+          })
+          .then((action) => {
+            if (action === "project-settings") onOpenProjectSettings?.();
+          });
+        return;
+      }
       openMenu({ x: event.clientX, y: event.clientY });
     },
-    [cancelPendingTitleMenu, isServerThread, openMenu, renamingTitle],
+    [cancelPendingTitleMenu, isServerThread, onOpenProjectSettings, openMenu, renamingTitle],
   );
   const handleRenameKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLInputElement>) => {


### PR DESCRIPTION
new-thread drafts returned before preventing the breadcrumb context-menu event, so desktop showed its generic edit menu. this adds the existing project settings action for draft breadcrumbs and routes it through the draft's logical project key while preserving established-thread actions and left-click behavior.

verified with the focused chat-header test, web typecheck, targeted lint and formatting, and the live draft-to-project-settings flow.

### before

![before: generic desktop edit menu on the new-thread project breadcrumb](https://uploads-production-47e4.up.railway.app/files/7489410b-45e9-420b-92fb-e060f411c217/a5490ff1-546f-4986-9170-e5cbae7abf75-8161b33f-49bd-4fa7-b54c-7ca6fbc3ff80.png)

### after

![after: project settings menu on the new-thread project breadcrumb](https://uploads-production-47e4.up.railway.app/files/cbcb2d94-c236-4fa9-8be5-70ff7638aa10/after.png)

### interaction

![right-click project settings menu opening the project's settings page](https://uploads-production-47e4.up.railway.app/files/b0cf330b-1a8a-4f7f-bea2-4707d8943376/interaction.gif)

built with `gpt-5.6-sol` via the codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI/navigation change for draft-thread header context menus with no auth or data-model impact.
> 
> **Overview**
> **Fixes the new-thread project breadcrumb** so right-click opens **Project settings** instead of the generic desktop edit menu on draft threads.
> 
> `ChatView` now derives the draft’s **logical project key** (same grouping settings as established threads) and passes an optional `onOpenProjectSettings` handler that navigates to `/projects/$projectKey`. `ChatHeader` accepts that callback and, for non-server threads, calls `preventDefault` and shows a native **Project settings** item via `readLocalApi().contextMenu` before returning—so the event is no longer left to bubble into the default OS menu. Established server threads still use the existing thread action context menu; left-click rename behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8fe702cd313cc1315d085d0ca655000175558b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Project settings` context-menu item for draft thread breadcrumbs
> - `ChatView` derives a logical project key for the active draft project and passes a navigation callback to `WorkspacePageHeader` when that key exists.
> - `ChatHeader` accepts an optional project-settings callback. Right-clicking the breadcrumb area of a draft chat shows a `Project settings` context menu item at the pointer that invokes the callback.
> - Server-thread right-clicks retain the existing thread menu behavior and do not receive the project-settings action.
> - Risk: title-area right-click handling in [ChatHeader.tsx](https://github.com/pingdotgg/t3code/pull/9743/files#diff-124f699b87245f05f11a8bf7ef3d0b17dbe34657c443a51e23125ce90e0fcf0c) is no longer limited to server threads; verify draft threads without a project key do not render an empty menu item.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8fe702.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->