### PR TITLE
fix(web): refine server update notice

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2394,7 +2394,10 @@ export default function ChatView(props: ChatViewProps) {
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <button type="button" className="cursor-help rounded-sm text-left">
+                  <button
+                    type="button"
+                    className="block max-w-full cursor-help truncate rounded-sm text-left"
+                  >
                     Server update available
                   </button>
                 }

--- a/apps/web/src/components/chat/ComposerBanner.tsx
+++ b/apps/web/src/components/chat/ComposerBanner.tsx
@@ -178,7 +178,7 @@ function Row({
   layout = "inline",
   ...props
 }: useRender.ComponentProps<"div"> & {
-  layout?: "inline" | "wrap-actions";
+  layout?: "inline" | "wrap-actions" | "wrap-actions-narrow";
 }) {
   const rowProps = {
     className: cn(
@@ -187,6 +187,8 @@ function Row({
       "[&:is(button)]:cursor-pointer [&:is(button)]:rounded-[0.5rem] [&:is(button)]:focus-visible:outline-2 [&:is(button)]:focus-visible:-outline-offset-2 [&:is(button)]:focus-visible:outline-ring",
       layout === "wrap-actions" &&
         "@max-[400px]:*:data-[slot=composer-banner-content]:min-h-(--composer-banner-icon-column)",
+      layout === "wrap-actions-narrow" &&
+        "@max-[320px]:*:data-[slot=composer-banner-content]:min-h-(--composer-banner-icon-column)",
       className,
     ),
     "data-composer-banner-row": "true",
@@ -247,6 +249,7 @@ function Actions({ className, ...props }: ComponentProps<"span">) {
       className={cn(
         "col-start-3 row-start-1 flex flex-wrap items-center justify-end gap-1",
         "@max-[400px]:group-data-[composer-banner-layout=wrap-actions]/banner-row:has-[>:nth-child(2)]:col-start-2 @max-[400px]:group-data-[composer-banner-layout=wrap-actions]/banner-row:has-[>:nth-child(2)]:col-end-4 @max-[400px]:group-data-[composer-banner-layout=wrap-actions]/banner-row:has-[>:nth-child(2)]:row-start-2 @max-[400px]:group-data-[composer-banner-layout=wrap-actions]/banner-row:has-[>:nth-child(2)]:-ms-2 @max-[400px]:group-data-[composer-banner-layout=wrap-actions]/banner-row:has-[>:nth-child(2)]:justify-start",
+        "@max-[320px]:group-data-[composer-banner-layout=wrap-actions-narrow]/banner-row:has-[>:nth-child(2)]:col-start-2 @max-[320px]:group-data-[composer-banner-layout=wrap-actions-narrow]/banner-row:has-[>:nth-child(2)]:col-end-4 @max-[320px]:group-data-[composer-banner-layout=wrap-actions-narrow]/banner-row:has-[>:nth-child(2)]:row-start-2 @max-[320px]:group-data-[composer-banner-layout=wrap-actions-narrow]/banner-row:has-[>:nth-child(2)]:-ms-2 @max-[320px]:group-data-[composer-banner-layout=wrap-actions-narrow]/banner-row:has-[>:nth-child(2)]:justify-start",
         className,
       )}
       {...props}

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -269,7 +269,7 @@ function ComposerBannerStackAlert({
       variant={item.variant}
       density="comfortable"
     >
-      <ComposerBanner.Row layout="wrap-actions">
+      <ComposerBanner.Row layout="wrap-actions-narrow">
         <ComposerBanner.Icon className="h-(--composer-banner-icon-column) self-start">
           {item.icon}
         </ComposerBanner.Icon>

--- a/apps/web/src/components/chat/ComposerServerUpdateStatus.tsx
+++ b/apps/web/src/components/chat/ComposerServerUpdateStatus.tsx
@@ -1,5 +1,5 @@
 import type { ServerUpdateState } from "@t3tools/client-runtime/state/server";
-import { CircleAlertIcon, InfoIcon, LoaderCircleIcon } from "lucide-react";
+import { CircleAlertIcon, LoaderCircleIcon, UploadIcon } from "lucide-react";
 import { useId, useState } from "react";
 
 import { serverUpdateStageLabel } from "../ServerUpdateAction";
@@ -17,7 +17,7 @@ export function ComposerServerUpdateIcon({
   if (status === "failed") {
     return <CircleAlertIcon aria-hidden className="text-error" />;
   }
-  return <InfoIcon aria-hidden />;
+  return <UploadIcon aria-hidden />;
 }
 
 /** One text line, clipped at the end so the error detail never squeezes its title. */

--- a/apps/web/src/components/chat/ComposerServerUpdateStatus.tsx
+++ b/apps/web/src/components/chat/ComposerServerUpdateStatus.tsx
@@ -1,5 +1,5 @@
 import type { ServerUpdateState } from "@t3tools/client-runtime/state/server";
-import { CircleAlertIcon, LoaderCircleIcon, UploadIcon } from "lucide-react";
+import { CircleAlertIcon, DownloadIcon, LoaderCircleIcon } from "lucide-react";
 import { useId, useState } from "react";
 
 import { serverUpdateStageLabel } from "../ServerUpdateAction";
@@ -17,7 +17,7 @@ export function ComposerServerUpdateIcon({
   if (status === "failed") {
     return <CircleAlertIcon aria-hidden className="text-error" />;
   }
-  return <UploadIcon aria-hidden />;
+  return <DownloadIcon aria-hidden />;
 }
 
 /** One text line, clipped at the end so the error detail never squeezes its title. */


### PR DESCRIPTION
The server update notice used an arrow that pointed opposite the download flow. Narrow composers also moved its actions to a second row as soon as the right panel opened.

The idle notice now uses Lucide's download icon. Notice actions stay inline down to 320px, while the title truncates before it can crowd longer actions. Running and failed states still use their spinner and error icons.

Verified with the focused web typecheck and lint, plus real-app resizing at 400px and 340px composer widths in light and dark themes.

Before

![server update notice with the previous info icon](https://uploads-production-47e4.up.railway.app/files/7599fd00-bb52-4f01-a9b4-a0b6abe95c82/t3code-upload-icon-before-crop.png)

After

![server update notice with the download icon](https://uploads-production-47e4.up.railway.app/files/a13feb24-6108-4e1b-b429-41aba00c196e/composer-update-download-after.png)

Right panel resize

https://github.com/user-attachments/assets/076b1e9f-6b75-42ec-a599-f5bb6fd599cc

Built by gpt-5.6-sol through the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refine server update notice button styling and narrow-screen action wrapping
> - Changes the version-mismatch trigger in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/9744/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to a block-level button with text truncation, constrained to container width
> - Adds `wrap-actions-narrow` layout to [ComposerBanner.tsx](https://github.com/pingdotgg/t3code/pull/9744/files#diff-319ed522cd774163e07b333af3237cea096961657d60773abcc503c31bb3aebe) so banner rows reflow and move multi-action controls to a second row at widths ≤ 320px
> - Switches stack-generated alerts in [ComposerBannerStack.tsx](https://github.com/pingdotgg/t3code/pull/9744/files#diff-70e682f5637e29152782d8d01713cd41d0ced0860f99ad7cefbdc07da06e364b) from the 400px `wrap-actions` breakpoint to the new 320px `wrap-actions-narrow` breakpoint
> - Replaces the informational icon with a download icon for non-running/non-failed statuses in [ComposerServerUpdateStatus.tsx](https://github.com/pingdotgg/t3code/pull/9744/files#diff-df14dfe2a74c0c150d12cddedf4e6230fe8234554fa8332e43e2017dc5c8914d)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 253d6bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->