### PR TITLE
perf(mobile): bound the parsed review cache

### DIFF
--- a/apps/mobile/src/features/review/reviewState.test.ts
+++ b/apps/mobile/src/features/review/reviewState.test.ts
@@ -1,10 +1,30 @@
-import { assert, it } from "vite-plus/test";
+import { afterEach, assert, it } from "vite-plus/test";
 
+import { appAtomRegistry } from "../../state/atom-registry";
+import { getCachedNativeReviewDiffData } from "./nativeReviewDiffAdapter";
 import {
+  getCachedReviewParsedDiff,
   getReviewAsyncStateSnapshot,
   setReviewAsyncError,
   setReviewTurnDiffLoading,
 } from "./reviewState";
+
+const reviewInput = {
+  threadKey: "env-local:thread-review",
+  sectionId: "turn:1",
+  diff: [
+    "diff --git a/src/a.ts b/src/a.ts",
+    "new file mode 100644",
+    "--- /dev/null",
+    "+++ b/src/a.ts",
+    "@@ -0,0 +1 @@",
+    "+export const value = 1;",
+  ].join("\n"),
+};
+
+afterEach(() => {
+  appAtomRegistry.reset();
+});
 
 it("stores review async loading and error state in atoms", () => {
   const threadKey = `env-local:thread-review-state-${Date.now()}`;
@@ -24,4 +44,88 @@ it("stores review async loading and error state in atoms", () => {
     loadingTurnIds: {},
     error: null,
   });
+});
+
+it("reuses unchanged parsed diffs and replaces changed sections", () => {
+  const parsed = getCachedReviewParsedDiff(reviewInput);
+
+  assert.strictEqual(
+    getCachedReviewParsedDiff({ ...reviewInput, diff: `\n${reviewInput.diff}\n` }),
+    parsed,
+  );
+
+  const changed = { ...reviewInput, diff: reviewInput.diff.replace("value = 1", "value = 2") };
+  const updated = getCachedReviewParsedDiff(changed);
+  assert.notStrictEqual(updated, parsed);
+  assert.strictEqual(getCachedReviewParsedDiff(changed), updated);
+});
+
+it("evicts the least recently used section across threads without changing live results or IDs", () => {
+  const recentInput = { ...reviewInput, threadKey: "env-local:thread-recent" };
+  const oldestInput = { ...reviewInput, threadKey: "env-remote:thread-oldest" };
+  const recent = getCachedReviewParsedDiff(recentInput);
+  const oldest = getCachedReviewParsedDiff(oldestInput);
+  const native = getCachedNativeReviewDiffData({ parsedDiff: oldest });
+  for (let index = 0; index < 6; index += 1) {
+    getCachedReviewParsedDiff({ ...reviewInput, threadKey: `env-local:thread-${index}` });
+  }
+
+  assert.strictEqual(getCachedReviewParsedDiff(recentInput), recent);
+  getCachedReviewParsedDiff({ ...reviewInput, threadKey: "env-local:thread-new" });
+
+  assert.strictEqual(getCachedReviewParsedDiff(recentInput), recent);
+  const rebuilt = getCachedReviewParsedDiff(oldestInput);
+  assert.notStrictEqual(rebuilt, oldest);
+  assert.deepStrictEqual(rebuilt, oldest);
+  assert.strictEqual(getCachedNativeReviewDiffData({ parsedDiff: oldest }), native);
+  assert.deepStrictEqual(getCachedNativeReviewDiffData({ parsedDiff: rebuilt }), native);
+});
+
+it("limits cached diffs to 4 Mi source characters before the entry limit", () => {
+  const firstInput = { ...reviewInput, diff: "x".repeat(2 * 1024 * 1024) };
+  const secondInput = { ...firstInput, sectionId: "turn:2" };
+  const first = getCachedReviewParsedDiff(firstInput);
+  const second = getCachedReviewParsedDiff(secondInput);
+
+  getCachedReviewParsedDiff({ ...firstInput, sectionId: "turn:3" });
+
+  assert.strictEqual(getCachedReviewParsedDiff(secondInput), second);
+  assert.notStrictEqual(getCachedReviewParsedDiff(firstInput), first);
+});
+
+it("reclaims the source budget when a cached section changes", () => {
+  const firstInput = { ...reviewInput, diff: "x".repeat(2 * 1024 * 1024) };
+  const secondInput = { ...firstInput, sectionId: "turn:2" };
+  getCachedReviewParsedDiff(firstInput);
+  const second = getCachedReviewParsedDiff(secondInput);
+
+  getCachedReviewParsedDiff({ ...firstInput, diff: null });
+  getCachedReviewParsedDiff({ ...firstInput, sectionId: "turn:3" });
+
+  assert.strictEqual(getCachedReviewParsedDiff(secondInput), second);
+});
+
+it("counts the full source and skips oversized diffs without evicting cached sections", () => {
+  const cached = getCachedReviewParsedDiff(reviewInput);
+  const oversizedInput = {
+    ...reviewInput,
+    sectionId: "turn:oversized",
+    diff: `${reviewInput.diff}${" ".repeat(4 * 1024 * 1024)}`,
+  };
+  const first = getCachedReviewParsedDiff(oversizedInput);
+  const second = getCachedReviewParsedDiff(oversizedInput);
+
+  assert.notStrictEqual(second, first);
+  assert.deepStrictEqual(second, first);
+  assert.strictEqual(getCachedReviewParsedDiff(reviewInput), cached);
+});
+
+it("drops parsed diffs when the app registry resets", () => {
+  const parsed = getCachedReviewParsedDiff(reviewInput);
+
+  appAtomRegistry.reset();
+
+  const rebuilt = getCachedReviewParsedDiff(reviewInput);
+  assert.notStrictEqual(rebuilt, parsed);
+  assert.deepStrictEqual(rebuilt, parsed);
 });

--- a/apps/mobile/src/features/review/reviewState.ts
+++ b/apps/mobile/src/features/review/reviewState.ts
@@ -87,12 +87,21 @@ const reviewViewedFileIdsByThreadKeyAtom = Atom.family((threadKey: string) =>
   ),
 );
 
-const reviewParsedDiffBySectionCacheKeyAtom = Atom.family((cacheKey: string) =>
-  Atom.make<{ readonly diff: string | null; readonly parsed: ReviewParsedDiff } | null>(null).pipe(
-    Atom.keepAlive,
-    Atom.withLabel(`mobile:review:parsed-diffs:${cacheKey}`),
-  ),
-);
+export const MAX_CACHED_REVIEW_DIFFS = 8;
+// This bounds source string length, not the parsed or native heap size.
+export const MAX_CACHED_REVIEW_SOURCE_CHARACTERS = 4 * 1024 * 1024;
+
+interface CachedReviewParsedDiff {
+  readonly diff: string | null;
+  readonly parsed: ReviewParsedDiff;
+  readonly sourceCharacterCount: number;
+}
+
+// The factory keeps this mutable cache local to the registry and releases it on reset or disposal.
+const reviewParsedDiffCacheAtom = Atom.make(() => ({
+  entries: new Map<string, CachedReviewParsedDiff>(),
+  sourceCharacterCount: 0,
+})).pipe(Atom.keepAlive, Atom.withLabel("mobile:review:parsed-diffs"));
 
 export interface ReviewCacheForThread {
   readonly threadKey: string | null;
@@ -256,6 +265,20 @@ export function updateReviewViewedFileIds(
   });
 }
 
+/** Returns the larger of current input and matching cached source, without changing recency. */
+export function getReviewParsedDiffSourceCharacterCount(input: {
+  readonly threadKey: string;
+  readonly sectionId: string;
+  readonly diff: string | null;
+}): number {
+  const sourceCharacterCount = input.diff?.length ?? 0;
+  const cache = appAtomRegistry.get(reviewParsedDiffCacheAtom);
+  const cached = cache.entries.get(buildSectionCacheKey(input.threadKey, input.sectionId));
+  return cached && cached.diff === (input.diff?.trim() ?? null)
+    ? Math.max(sourceCharacterCount, cached.sourceCharacterCount)
+    : sourceCharacterCount;
+}
+
 export function getCachedReviewParsedDiff(input: {
   readonly threadKey: string | null;
   readonly sectionId: string | null;
@@ -267,16 +290,39 @@ export function getCachedReviewParsedDiff(input: {
 
   const cacheKey = buildSectionCacheKey(input.threadKey, input.sectionId);
   const normalizedDiff = input.diff?.trim() ?? null;
-  const atom = reviewParsedDiffBySectionCacheKeyAtom(cacheKey);
-  const cached = appAtomRegistry.get(atom);
+  const cache = appAtomRegistry.get(reviewParsedDiffCacheAtom);
+  const cached = cache.entries.get(cacheKey);
   if (cached && cached.diff === normalizedDiff) {
+    cache.entries.delete(cacheKey);
+    cache.entries.set(cacheKey, cached);
     return cached.parsed;
   }
 
   const parsed = buildReviewParsedDiff(input.diff, input.sectionId);
-  appAtomRegistry.set(atom, {
+  if (cached) {
+    cache.entries.delete(cacheKey);
+    cache.sourceCharacterCount -= cached.sourceCharacterCount;
+  }
+  const sourceCharacterCount = input.diff?.length ?? 0;
+  if (sourceCharacterCount > MAX_CACHED_REVIEW_SOURCE_CHARACTERS) {
+    return parsed;
+  }
+
+  for (const [oldestKey, oldest] of cache.entries) {
+    if (
+      cache.entries.size < MAX_CACHED_REVIEW_DIFFS &&
+      cache.sourceCharacterCount + sourceCharacterCount <= MAX_CACHED_REVIEW_SOURCE_CHARACTERS
+    ) {
+      break;
+    }
+    cache.entries.delete(oldestKey);
+    cache.sourceCharacterCount -= oldest.sourceCharacterCount;
+  }
+  cache.entries.set(cacheKey, {
     diff: normalizedDiff,
     parsed,
+    sourceCharacterCount,
   });
+  cache.sourceCharacterCount += sourceCharacterCount;
   return parsed;
 }

--- a/apps/mobile/src/features/review/useReviewDiffPrewarming.test.ts
+++ b/apps/mobile/src/features/review/useReviewDiffPrewarming.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, assert, it, vi } from "vite-plus/test";
+
+import { appAtomRegistry } from "../../state/atom-registry";
+import { getCachedNativeReviewDiffData } from "./nativeReviewDiffAdapter";
+import * as ReviewModel from "./reviewModel";
+import { getCachedReviewParsedDiff, MAX_CACHED_REVIEW_SOURCE_CHARACTERS } from "./reviewState";
+import { getReviewDiffPrewarmSections, prewarmReviewDiffSection } from "./useReviewDiffPrewarming";
+
+const threadKey = "env:thread-prewarm";
+const reviewDiff = [
+  "diff --git a/src/a.ts b/src/a.ts",
+  "new file mode 100644",
+  "--- /dev/null",
+  "+++ b/src/a.ts",
+  "@@ -0,0 +1 @@",
+  "+export const value = 1;",
+].join("\n");
+
+function makeSection(index: number, diff: string | null = reviewDiff) {
+  return {
+    id: `turn:${index}`,
+    kind: "turn",
+    title: `Turn ${index}`,
+    subtitle: null,
+    isLoading: false,
+    diff,
+  } satisfies ReviewModel.ReviewSectionItem;
+}
+
+function prepareSelection(
+  sections: ReadonlyArray<ReviewModel.ReviewSectionItem>,
+  selectedSectionId: string,
+) {
+  const section = sections.find((candidate) => candidate.id === selectedSectionId);
+  assert.ok(section);
+  const input = { threadKey, sectionId: section.id, diff: section.diff };
+  const parsed = getCachedReviewParsedDiff(input);
+  const native = getCachedNativeReviewDiffData({ parsedDiff: parsed });
+  for (const pending of getReviewDiffPrewarmSections({ threadKey, sections, selectedSectionId })) {
+    prewarmReviewDiffSection({ threadKey: input.threadKey, section: pending });
+  }
+  assert.strictEqual(getCachedReviewParsedDiff(input), parsed);
+  assert.strictEqual(getCachedNativeReviewDiffData({ parsedDiff: parsed }), native);
+  return { parsed, native };
+}
+
+afterEach(() => {
+  appAtomRegistry.reset();
+  vi.restoreAllMocks();
+});
+
+it("warms the nearest sections within the remaining entry budget", () => {
+  const sections = Array.from({ length: 12 }, (_, index) => makeSection(index));
+
+  const pending = getReviewDiffPrewarmSections({
+    threadKey,
+    sections,
+    selectedSectionId: "turn:5",
+  });
+
+  assert.deepStrictEqual(
+    pending.map((section) => section.id),
+    ["turn:4", "turn:6", "turn:3", "turn:7", "turn:2", "turn:8", "turn:1"],
+  );
+});
+
+it("reserves the selected source budget and skips unloaded or oversized sections", () => {
+  const halfBudget = "x".repeat(2 * 1024 * 1024);
+  const sections = [
+    makeSection(0),
+    makeSection(1, halfBudget),
+    makeSection(2, "x".repeat(MAX_CACHED_REVIEW_SOURCE_CHARACTERS + 1)),
+    makeSection(3, halfBudget),
+    makeSection(4, null),
+    makeSection(5),
+  ];
+
+  const pending = getReviewDiffPrewarmSections({
+    threadKey,
+    sections,
+    selectedSectionId: "turn:3",
+  });
+
+  assert.deepStrictEqual(
+    pending.map((section) => section.id),
+    ["turn:1"],
+  );
+  prepareSelection(sections, "turn:3");
+});
+
+it("reserves a larger retained source when the selected input loses whitespace", () => {
+  const parsed = getCachedReviewParsedDiff({
+    threadKey,
+    sectionId: "turn:0",
+    diff: reviewDiff.padEnd(MAX_CACHED_REVIEW_SOURCE_CHARACTERS, " "),
+  });
+  const native = getCachedNativeReviewDiffData({ parsedDiff: parsed });
+
+  const selected = prepareSelection([makeSection(0), makeSection(1)], "turn:0");
+
+  assert.strictEqual(selected.parsed, parsed);
+  assert.strictEqual(selected.native, native);
+});
+
+it("reserves a larger retained source when a neighboring input loses whitespace", () => {
+  const parsed = getCachedReviewParsedDiff({
+    threadKey,
+    sectionId: "turn:1",
+    diff: reviewDiff.padEnd(MAX_CACHED_REVIEW_SOURCE_CHARACTERS - reviewDiff.length, " "),
+  });
+  const native = getCachedNativeReviewDiffData({ parsedDiff: parsed });
+
+  prepareSelection([makeSection(0), makeSection(1), makeSection(2)], "turn:0");
+
+  assert.strictEqual(
+    getCachedReviewParsedDiff({
+      threadKey,
+      sectionId: "turn:1",
+      diff: reviewDiff,
+    }),
+    parsed,
+  );
+  assert.strictEqual(getCachedNativeReviewDiffData({ parsedDiff: parsed }), native);
+});
+
+it.each([null, "turn:missing"])(
+  "does not prewarm without a selected section: %s",
+  (selectedSectionId) => {
+    assert.deepStrictEqual(
+      getReviewDiffPrewarmSections({ threadKey, sections: [makeSection(0)], selectedSectionId }),
+      [],
+    );
+  },
+);
+
+it("does not prewarm when the selected section exceeds the source budget", () => {
+  const sections = [
+    makeSection(0, "x".repeat(MAX_CACHED_REVIEW_SOURCE_CHARACTERS + 1)),
+    makeSection(1),
+  ];
+
+  assert.deepStrictEqual(
+    getReviewDiffPrewarmSections({ threadKey, sections, selectedSectionId: "turn:0" }),
+    [],
+  );
+});
+
+it("does not parse an oversized direct prewarm that the cache cannot retain", () => {
+  const parse = vi.spyOn(ReviewModel, "buildReviewParsedDiff");
+
+  prewarmReviewDiffSection({
+    threadKey,
+    section: makeSection(0, "x".repeat(MAX_CACHED_REVIEW_SOURCE_CHARACTERS + 1)),
+  });
+
+  assert.strictEqual(parse.mock.calls.length, 0);
+});
+
+it("reuses selected and native results across repeated nearby selections", () => {
+  const parse = vi.spyOn(ReviewModel, "buildReviewParsedDiff");
+  const sections = Array.from({ length: 10 }, (_, index) => makeSection(index));
+  const first = prepareSelection(sections, "turn:0");
+  assert.strictEqual(parse.mock.calls.length, 8);
+  parse.mockClear();
+  const second = prepareSelection(sections, "turn:1");
+
+  for (let pass = 0; pass < 3; pass += 1) {
+    const firstAgain = prepareSelection(sections, "turn:0");
+    assert.strictEqual(firstAgain.parsed, first.parsed);
+    assert.strictEqual(firstAgain.native, first.native);
+    const secondAgain = prepareSelection(sections, "turn:1");
+    assert.strictEqual(secondAgain.parsed, second.parsed);
+    assert.strictEqual(secondAgain.native, second.native);
+  }
+
+  assert.strictEqual(parse.mock.calls.length, 0);
+});

--- a/apps/mobile/src/features/review/useReviewDiffPrewarming.ts
+++ b/apps/mobile/src/features/review/useReviewDiffPrewarming.ts
@@ -2,7 +2,12 @@ import { useEffect } from "react";
 
 import { getCachedNativeReviewDiffData } from "./nativeReviewDiffAdapter";
 import type { ReviewSectionItem } from "./reviewModel";
-import { getCachedReviewParsedDiff } from "./reviewState";
+import {
+  getCachedReviewParsedDiff,
+  getReviewParsedDiffSourceCharacterCount,
+  MAX_CACHED_REVIEW_DIFFS,
+  MAX_CACHED_REVIEW_SOURCE_CHARACTERS,
+} from "./reviewState";
 
 interface IdleDeadlineLike {
   readonly didTimeout: boolean;
@@ -35,7 +40,7 @@ export function prewarmReviewDiffSection(input: {
   readonly section: ReviewSectionItem;
 }): void {
   const { section, threadKey } = input;
-  if (section.diff === null) {
+  if (section.diff === null || section.diff.length > MAX_CACHED_REVIEW_SOURCE_CHARACTERS) {
     return;
   }
 
@@ -47,7 +52,54 @@ export function prewarmReviewDiffSection(input: {
   getCachedNativeReviewDiffData({ parsedDiff, comments: [] });
 }
 
-/** Warms one cached section per idle period, after navigation animations finish. */
+/** Selects nearby loaded sections that fit in the cache with the selected section. */
+export function getReviewDiffPrewarmSections(input: {
+  readonly threadKey: string;
+  readonly sections: ReadonlyArray<ReviewSectionItem>;
+  readonly selectedSectionId: string | null;
+}): ReadonlyArray<ReviewSectionItem> {
+  const { threadKey, sections, selectedSectionId } = input;
+  const selectedIndex = sections.findIndex((section) => section.id === selectedSectionId);
+  const selectedSection = sections[selectedIndex];
+  if (!selectedSection) {
+    return [];
+  }
+
+  let sourceCharacterCount = getReviewParsedDiffSourceCharacterCount({
+    threadKey,
+    sectionId: selectedSection.id,
+    diff: selectedSection.diff,
+  });
+  if (sourceCharacterCount > MAX_CACHED_REVIEW_SOURCE_CHARACTERS) {
+    return [];
+  }
+
+  const pendingSections: ReviewSectionItem[] = [];
+  for (let distance = 1; distance < sections.length; distance += 1) {
+    for (const index of [selectedIndex - distance, selectedIndex + distance]) {
+      if (pendingSections.length >= MAX_CACHED_REVIEW_DIFFS - 1) {
+        return pendingSections;
+      }
+      const section = sections[index];
+      if (!section || section.diff === null) {
+        continue;
+      }
+      const sectionCharacterCount = getReviewParsedDiffSourceCharacterCount({
+        threadKey,
+        sectionId: section.id,
+        diff: section.diff,
+      });
+      if (sourceCharacterCount + sectionCharacterCount > MAX_CACHED_REVIEW_SOURCE_CHARACTERS) {
+        continue;
+      }
+      pendingSections.push(section);
+      sourceCharacterCount += sectionCharacterCount;
+    }
+  }
+  return pendingSections;
+}
+
+/** Warms one nearby section per idle period, after navigation animations finish. */
 export function useReviewDiffPrewarming(input: {
   readonly threadKey: string | null;
   readonly sections: ReadonlyArray<ReviewSectionItem>;
@@ -60,9 +112,11 @@ export function useReviewDiffPrewarming(input: {
       return;
     }
 
-    const pendingSections = sections.filter(
-      (section) => section.id !== selectedSectionId && section.diff !== null,
-    );
+    const pendingSections = getReviewDiffPrewarmSections({
+      threadKey,
+      sections,
+      selectedSectionId,
+    });
     if (pendingSections.length === 0) {
       return;
     }


### PR DESCRIPTION
Mobile review keeps every parsed diff and its native rows until the app registry resets. Opening more sections keeps adding memory.

The cache now keeps up to eight entries and 4,194,304 source characters. Nearby prewarming uses the same budget and reserves room for the selected section. Oversized diffs are not cached or prewarmed. Current view references and row IDs stay valid.

In a Node source proof with 64 sections, retained parsed diffs and prepared native row sets each fall from 64 to 8. The retained heap delta falls from 47.9 MB to 10.7 MB. In the 10-section prewarming proof, switching between the first two sections adds no parses after warmup. These are not device measurements.

M6 in the [performance audit](https://github.com/pingdotgg/t3code/issues/9661) remains partial. Raw patches, drafts, comments, and preferences are unchanged. The source-character limit is not an exact heap-byte limit.

Verified with 31 focused tests, mobile typecheck, targeted lint, and real-source GC and prewarming proofs. No native code changed. No browser, device, or native build verification ran.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes review diff caching and idle prewarming semantics; wrong eviction or budget accounting could cause extra parses or stale assumptions, but behavior is heavily tested and scoped to mobile review performance.
> 
> **Overview**
> **Bounds mobile review parsed-diff memory** by replacing unbounded per-section atom caches with a single LRU store capped at **8 sections** and **4 MiB of raw diff source** (not parsed/native heap).
> 
> `getCachedReviewParsedDiff` now tracks source length, evicts oldest entries when limits are hit, skips caching oversized patches (still returns a fresh parse), and clears on `appAtomRegistry.reset`. Whitespace-trimmed hits refresh LRU order; content changes reclaim budget for that section.
> 
> **Prewarming** no longer warms every other loaded section. `getReviewDiffPrewarmSections` picks **nearest neighbors** that fit the shared entry and character budget (reserving the selected section, including when cached source was retained with trailing whitespace). `prewarmReviewDiffSection` bails on null or oversized diffs without parsing.
> 
> New unit tests cover LRU across threads, source-budget eviction/reclaim, oversized behavior, registry reset, and prewarm selection/reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0369853be859be7b61d7ad3f0bb02e57e24617ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound parsed review diff cache to 8 entries and 4 MiB source budget
> - Replaces the per-section atom-family cache with a single registry-owned LRU map in [reviewState.ts](https://github.com/pingdotgg/t3code/pull/9749/files#diff-a145eaf17ad99ab8a2239744c6c3b2e537ae84242cf1237625364bbce949825e), enforcing an 8-entry maximum and a 4 MiB aggregate source-character limit across all threads
> - Adds `getReviewParsedDiffSourceCharacterCount` so prewarming callers account for the full retained source length, including whitespace absent from an equivalent normalized input
> - Reworks `useReviewDiffPrewarming` to plan prewarming of at most 7 loaded neighboring sections ordered by distance from the selection, skipping neighbors that exceed the remaining source budget
> - Direct prewarming now returns early for oversized sources without invoking parsed-diff construction
> - Risk: `getCachedReviewParsedDiff` evicts oldest entries globally across thread keys when either the entry count or source budget is exceeded; callers expecting unbounded retention will see parsed results rebuilt on cache misses
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0369853.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->