### PR TITLE
feat(web): simplify sidebar drag destination cues

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1522,7 +1522,9 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
               remain visible AND clickable while the row is hovered. Only
               the time/jump label yields to the settle affordance. */}
             {prBadge}
-            {dragDestination ?? (
+            {sortable?.isDragging ? (
+              dragDestination
+            ) : (
               <span className="relative ml-auto flex h-6 min-w-8 shrink-0 items-center justify-end">
                 <span
                   className={cn(
@@ -1675,7 +1677,9 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                   actions on hover/keyboard focus or while the popover is open. Keeping
                   the hidden state out of flow lets the project label reclaim
                   space without either state overlapping it. */}
-              {dragDestination ?? (
+              {sortable?.isDragging ? (
+                dragDestination
+              ) : (
                 <span className="group/sidebar-status-slot relative ml-auto flex h-5 min-w-8 shrink-0 items-stretch justify-end text-xs">
                   {/* Read-only status labels yield to the hover actions. Woke is
                     itself an action, so it stays pointer-enabled and visible

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -568,7 +568,6 @@ function SidebarSectionPlaceholder(props: {
 function SidebarDragBoundary(props: {
   marker: "pinned-header" | "pinned-divider";
   label: string;
-  hint: string | null;
   visible: boolean;
   isDropTarget: boolean;
 }) {
@@ -587,7 +586,6 @@ function SidebarDragBoundary(props: {
             )}
           >
             {props.label}
-            {props.hint ? <span className="font-normal">{props.hint}</span> : null}
           </span>
           <span
             aria-hidden
@@ -603,7 +601,6 @@ function SidebarDragBoundary(props: {
 function SidebarSectionHeader(props: {
   marker: "snoozed-header" | "settled-header";
   label: string;
-  hint?: string | null;
   isDropTarget?: boolean;
   toggle: { expanded: boolean; onToggle: () => void };
 }) {
@@ -624,7 +621,6 @@ function SidebarSectionHeader(props: {
           props.isDropTarget && "bg-primary/30",
         )}
       />
-      {props.hint ? <span className="truncate text-[11px] font-normal">{props.hint}</span> : null}
       <ChevronDownIcon
         aria-hidden
         className={cn(
@@ -910,7 +906,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // sortable bag applied to the row root so the whole row drags (the
   // pointer sensor's distance constraint keeps plain clicks working).
   sortable?: SortableThreadRowBag | undefined;
-  dropSection: SidebarSection | null;
+  dropSection: Exclude<SidebarSection, "snoozed"> | null;
   // Compact wake countdown ("2h") for rows in the snoozed shelf.
   snoozeWakeLabelText: string | null;
   // When a snooze ended (timer or early wake); drives the Woke pill until
@@ -1331,14 +1327,13 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
         role="status"
         className="pointer-events-none ml-auto inline-flex h-5 shrink-0 items-center gap-1 rounded-sm border border-primary/30 bg-sidebar px-1.5 text-[11px] font-medium text-primary"
       >
+        <span className="sr-only">Move to </span>
         <span aria-hidden>→</span>
         {props.dropSection === "pinned"
           ? "Pinned"
           : props.dropSection === "active"
             ? "Active"
-            : props.dropSection === "settled"
-              ? "Settled"
-              : "Snoozed"}
+            : "Settled"}
       </span>
     ) : null;
 
@@ -1442,31 +1437,32 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       <TooltipPopup side="top">Unsent draft</TooltipPopup>
     </Tooltip>
   ) : null;
-  const pinIndicator = props.isPinned ? (
-    props.pinningSupported ? (
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <button
-              type="button"
-              aria-label="Unpin thread"
-              onClick={handleUnpinClick}
-              className="inline-flex cursor-pointer items-center rounded-sm text-muted-foreground/65 outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
-            />
-          }
-        >
-          <PinIcon aria-hidden className="size-3 shrink-0" />
-        </TooltipTrigger>
-        <TooltipPopup>Unpin thread</TooltipPopup>
-      </Tooltip>
-    ) : (
-      <PinIcon
-        aria-label="Pinned"
-        role="img"
-        className="size-3 shrink-0 text-muted-foreground/65"
-      />
-    )
-  ) : null;
+  const pinIndicator =
+    props.isPinned && !sortable?.isDragging ? (
+      props.pinningSupported ? (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                aria-label="Unpin thread"
+                onClick={handleUnpinClick}
+                className="inline-flex cursor-pointer items-center rounded-sm text-muted-foreground/65 outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            }
+          >
+            <PinIcon aria-hidden className="size-3 shrink-0" />
+          </TooltipTrigger>
+          <TooltipPopup>Unpin thread</TooltipPopup>
+        </Tooltip>
+      ) : (
+        <PinIcon
+          aria-label="Pinned"
+          role="img"
+          className="size-3 shrink-0 text-muted-foreground/65"
+        />
+      )
+    ) : null;
 
   if (variant === "slim") {
     return (
@@ -4534,7 +4530,11 @@ export default function Sidebar() {
                             isPinned={thread.pinnedAt != null}
                             sortable={sortable}
                             dropSection={
-                              dragState?.activeKey === threadKey ? dragTargetSection : null
+                              dragState?.activeKey === threadKey &&
+                              dragTargetSection !== dragState.activeSection &&
+                              dragTargetSection !== "snoozed"
+                                ? dragTargetSection
+                                : null
                             }
                             snoozeWakeLabelText={
                               section === "snoozed" && thread.snoozedUntil != null
@@ -4634,14 +4634,6 @@ export default function Sidebar() {
                         dragTargetSection !== "pinned"
                           ? 1
                           : 0);
-                      const activeHint =
-                        from === "pinned"
-                          ? "Drop to unpin"
-                          : from === "settled"
-                            ? "Drop to un-settle"
-                            : from === "snoozed"
-                              ? "Drop to wake"
-                              : null;
                       const items: ReactNode[] = [
                         <SidebarDraftBlock
                           key="draft-sessions"
@@ -4667,7 +4659,6 @@ export default function Sidebar() {
                                 key="pinned-header"
                                 marker="pinned-header"
                                 label="Pinned"
-                                hint={from !== null && from !== "pinned" ? "Drop to pin" : null}
                                 isDropTarget={dragTargetSection === "pinned"}
                                 visible={from !== null}
                               />,
@@ -4679,7 +4670,6 @@ export default function Sidebar() {
                                 key="pinned-divider"
                                 marker="pinned-divider"
                                 label="Active"
-                                hint={dragTargetSection === "active" ? activeHint : null}
                                 isDropTarget={dragTargetSection === "active"}
                                 visible={from !== null && previewPinnedCount > 0}
                               />,
@@ -4690,7 +4680,7 @@ export default function Sidebar() {
                               <SidebarSectionPlaceholder
                                 key="active-placeholder"
                                 marker="active-placeholder"
-                                label={activeHint ?? "Drop here"}
+                                label="Active"
                                 showHint={from !== null}
                                 isDropTarget={dragTargetSection === "active"}
                               />,
@@ -4723,11 +4713,6 @@ export default function Sidebar() {
                                     ? "Settled"
                                     : `Settled (${settledThreads.length})`
                                 }
-                                hint={
-                                  dragTargetSection === "settled" && from !== "settled"
-                                    ? "Drop to settle"
-                                    : null
-                                }
                                 isDropTarget={dragTargetSection === "settled"}
                                 toggle={{
                                   expanded: settledShelfExpanded,
@@ -4741,7 +4726,7 @@ export default function Sidebar() {
                               <SidebarSectionPlaceholder
                                 key="settled-placeholder"
                                 marker="settled-placeholder"
-                                label="Drop to settle"
+                                label="Settled"
                                 showHint={from !== null && from !== "settled"}
                                 isDropTarget={dragTargetSection === "settled"}
                               />,

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -33,9 +33,10 @@ thread into the active list un-settles it. A snoozed thread can be dragged out o
 shelf, which wakes it, but threads cannot be dragged into the shelf because snoozing needs a wake
 time. Dragging a pinned thread out of the pinned section does not ask for unpin confirmation.
 Pinned and active boundary labels appear only while dragging, without moving the rows. The
-destination boundary highlights and the thread shows which section it will land in. When there
-are no pins, drag to the top edge to pin a thread. Drop instructions also appear for empty sections
-and a collapsed settled shelf.
+destination boundary highlights. When you cross into another section, the dragged thread shows
+its destination, such as **→ Active**. Its pin marker hides during the drag. Reordering within
+the same section does not show a destination badge. When there are no pins, drag to the top edge
+to pin a thread. Section labels also identify empty sections and a collapsed settled shelf.
 
 Drag within the pinned or active section to change its order. Other rows slide aside to show the
 spot where the thread will land. Drops into either section keep the position you choose. On

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -34,9 +34,10 @@ shelf, which wakes it, but threads cannot be dragged into the shelf because snoo
 time. Dragging a pinned thread out of the pinned section does not ask for unpin confirmation.
 Pinned and active boundary labels appear only while dragging, without moving the rows. The
 destination boundary highlights. When you cross into another section, the dragged thread shows
-its destination, such as **→ Active**. Its pin marker hides during the drag. Reordering within
-the same section does not show a destination badge. When there are no pins, drag to the top edge
-to pin a thread. Section labels also identify empty sections and a collapsed settled shelf.
+its destination, such as **→ Active**. Its usual pin, status, and hover actions hide during the
+drag. Reordering within the same section does not show a destination badge. When there are no
+pins, drag to the top edge to pin a thread. Section labels also identify empty sections and a
+collapsed settled shelf.
 
 Drag within the pinned or active section to change its order. Other rows slide aside to show the
 spot where the thread will land. Drops into either section keep the position you choose. On


### PR DESCRIPTION
Dragging between sections repeats the move instruction on the boundary while the dragged thread still shows its old pin. This optional follow-up to [#9731](https://github.com/pingdotgg/t3code/pull/9731) puts that feedback on the thread: **→ Pinned**, **→ Active**, or **→ Settled** appears when crossing sections. The usual pin, status, and hover actions hide during dragging; reordering within a section shows no destination badge. Boundaries keep their section names and highlight.

The sortable layout, drop behavior, and movement animations are unchanged. This affects the shared web/desktop sidebar, including compact rows dragged out of Snoozed or Settled. It can be accepted or closed independently of the parent PR.

Verified with 207 focused sidebar tests, web typecheck, targeted lint, and an independent code review. React Doctor reported only existing sidebar complexity warnings. The recordings exercise pinning and unpinning on matching fixtures; the dark screenshots cover a compact Settled row moving toward Active.

**Before and after — pinned thread moving into Active**

| Before — parent | After — experiment |
| --- | --- |
| ![Before: boundary repeats Drop to unpin and dragged row retains the pin](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/afd8e95bc063d6c6/base-drag.png) | ![After: neutral boundary label and one Active destination badge on the dragged row](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/eea365b76c160cc4/head-drag.png) |

**Before recording** — pickup, unpin, then pin again:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/0c102f7a0712df0e/base-drag.mp4

**After recording** — the same sequence with the destination cue on the row:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4c317de36b39b3fc/head-drag.mp4

**Compact row in dark mode — Settled to Active**

| Before — parent | After — experiment |
| --- | --- |
| ![Before: compact row drag with repeated boundary action text](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/bb01c162143c384d/base-compact-active-dark.png) | ![After: compact row carries the Active badge while the boundary keeps its label](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/11b5fef9e0d63c39/head-compact-active-dark.png) |

The light-mode screenshots and recordings compare parent `33e70c44a3` with head `0186450688`, using matching fixtures and viewport. They are cropped to the Pinned and Active sections. The existing compact-row evidence remains representative; these fixes do not change its presentation.

Prepared with Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Simplify sidebar drag destination cues and add accessible `Move to` badge
> - Removes contextual hint text from `SidebarDragBoundary`, `SidebarSectionHeader`, and `SidebarThreadRow` during drag operations
> - Adds an accessible hidden "Move to" prefix to the destination badge shown only on the actively dragged row when it crosses into a different section (pinned, active, or settled)
> - Hides pin indicators, status, and hover-action slots during a drag, replacing them with the destination badge in both slim and card layouts
> - Snoozed is no longer offered as a drag destination; same-section reordering shows no badge
> - Updates [thread-sidebar.md](https://github.com/pingdotgg/t3code/pull/9750/files#diff-7bdc679f37b354bbc78160b5dc7435fb0d2d5a7d72c6a7015a8b682032a7150a) to reflect the new drag-and-drop behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85bf36e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar drag affordances; drop logic and server commands are unchanged per the PR scope.
> 
> **Overview**
> Sidebar drag-and-drop feedback moves from repeated boundary hints onto the **dragged row**, with boundaries kept as section names plus highlight only.
> 
> **Row behavior:** When a drag crosses into a different section (pinned, active, or settled—not snoozed), the active row shows a **→ Pinned / Active / Settled** badge with an accessible **Move to** prefix. Same-section reorder shows no badge. During drag, the pin control, status/time slot, and hover actions are hidden in favor of that badge.
> 
> **Boundaries & placeholders:** `SidebarDragBoundary`, `SidebarSectionHeader`, and empty-section placeholders no longer take contextual hints (e.g. “Drop to pin”); labels are static section names. `dropSection` is typed to exclude snoozed.
> 
> **Docs:** `thread-sidebar.md` describes the new cues and that reordering within a section does not show a destination badge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84346fbb527b868fa8d0ff40ab652b7b3851edc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

