### PR TITLE
fix(models): make GPT-6-Astra current

### DIFF
--- a/apps/server/src/provider/model-manifest.json
+++ b/apps/server/src/provider/model-manifest.json
@@ -1,8 +1,9 @@
 {
   "version": 1,
-  "updatedAt": "2026-09-03T09:58:00Z",
+  "updatedAt": "2026-09-04T19:10:48Z",
   "currentModels": {
     "codex": [
+      "gpt-6-astra",
       "gpt-5.6-luna",
       "gpt-5.6-terra",
       "gpt-5.6-sol",


### PR DESCRIPTION
`gpt-6-astra` is discovered by Codex, but the model manifest does not list it as current. Clients therefore place it under Legacy models.

This adds `gpt-6-astra` to `currentModels.codex` and advances `updatedAt` so running servers can fetch the correction.

## Verification

- `vp test run apps/server/src/provider/ModelManifest.test.ts`
- Verified the web model picker against worktree-local state with the same discovered-model fixture before and after the change.
- Desktop uses the shared web picker. Mobile consumes the same server-provided `isLegacy` metadata, so both clients receive the corrected classification.

## Evidence

Before, GPT-6-Astra appears under Legacy models.

![Before: GPT-6-Astra under Legacy models](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/8b18b1ce9375c7e1/t3code-astra-before.png)

After, GPT-6-Astra appears with the current Codex models and the legacy count drops from three to two.

![After: GPT-6-Astra listed as a current model](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/14514452aad1c4ad/t3code-astra-after.png)

Prepared with GPT-5.6-Sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON manifest entry and timestamp update; no application logic changes.
> 
> **Overview**
> **GPT-6-Astra** was discoverable via Codex but missing from `currentModels.codex`, so clients marked it **Legacy**. This PR adds `gpt-6-astra` to that list (first among current Codex models) and bumps `updatedAt` so deployed servers can pick up the updated manifest.
> 
> Downstream, `classifyModels` will set `isLegacy: false` for that slug, which fixes the web/desktop model picker and mobile metadata that rely on server-provided classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b8e788d55aff3b2a0048b52752dfc1f532493ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `gpt-6-astra` to provider model manifest
> Updates [model-manifest.json](https://github.com/pingdotgg/t3code/pull/9762/files#diff-fdf6ac0d1183f70794b15b8034d7d7405e3a3d35139c12a62e154b44322ea175) with the `gpt-6-astra` model identifier and refreshes the manifest timestamp. Consumers of the manifest will now see `gpt-6-astra` as an available model.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b8e788.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->