### PR TITLE
fix(web): reset automatic pull to default

### DIFF
--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -990,6 +990,11 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
           <SettingsRow
             title="Automatically pull"
             description="Keeps the default branch current in the background when the checkout has no local changes or commits."
+            resetAction={
+              autoPull ? (
+                <SettingResetButton label="automatic pull" onClick={() => setAutoPull(false)} />
+              ) : null
+            }
             control={
               <Switch
                 checked={autoPull}


### PR DESCRIPTION
Project settings now show the reset control when automatic pull is enabled. Clicking it restores the project preference to its off default, matching the other overridden settings controls. Verified with the web typecheck, targeted formatting and lint, and the full enable-reset interaction in dark and light themes at desktop and compact widths.

Before

![automatic pull enabled without a reset control](https://uploads-production-47e4.up.railway.app/files/de6fb4b1-b024-4a07-b2b8-628b20779f4d/dd1a378d-4bbb-46e9-9dff-7ee269ab5745-d139c4ba-8b32-4e5b-b966-71f07641905c.png)

After

![automatic pull enabled with the reset control](https://uploads-production-47e4.up.railway.app/files/3fd41c57-e370-4ff0-8373-2090924e62ea/auto-pull-on-with-reset.png)

Interaction

![automatic pull reset interaction](https://uploads-production-47e4.up.railway.app/files/a15048e3-7112-45df-a7c8-337c0a1ba417/auto-pull-reset.gif)

Built with `gpt-5.6-sol` in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI addition that reuses the established reset pattern and existing persistence logic for `autoPull`.
> 
> **Overview**
> The **Automatically pull** row on project settings now exposes the same **reset** affordance as model, workspace, and icon overrides.
> 
> When automatic pull is **on**, a `SettingResetButton` appears and turns the preference **off** via the existing `setAutoPull(false)` / `updateAllMembers` path, aligning UX with other non-default project options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da1634f060c768c4e2c5ebd2b3c6f7c125699b0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add reset control to 'Automatically pull' in `ProjectSettingsPanel`
> Renders a reset button on the automatic-pull settings row when automatic pulling is enabled. Clicking it sets the automatic-pull state to false, reverting to the default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da1634f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

