### PR TITLE
fix(web): stop panel motion during navigation

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -15,7 +15,11 @@ import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings"
 import { cn, isMacPlatform } from "../lib/utils";
 import { primaryServerKeybindingsAtom } from "../state/server";
 import { useEnvironmentIdentificationMode, useLegacySidebarEnabled } from "../hooks/useSettings";
-import { usePanelAnimationSettings } from "../panelAnimations";
+import {
+  PanelAnimationSuppressionProvider,
+  usePanelAnimationSettings,
+  usePanelNavigationSuppression,
+} from "../panelAnimations";
 import LegacyThreadSidebar from "./LegacySidebar";
 import ThreadSidebar from "./Sidebar";
 import { SettingsSidebarNav } from "./settings/SettingsSidebarNav";
@@ -145,6 +149,8 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   // Settings routes show the settings nav in place of whichever thread
   // sidebar is active.
   const pathname = useLocation({ select: (location) => location.pathname });
+  const panelAnimationsSuppressed = usePanelNavigationSuppression(pathname);
+  const routePanelAnimationsActive = panelAnimationsActive && !panelAnimationsSuppressed;
   const isOnSettings = pathname === "/settings" || pathname.startsWith("/settings/");
   const isMacosDesktop = isElectron && isMacPlatform(navigator.platform);
   const [sidebarWidth, setSidebarWidth] = useState(readInitialThreadSidebarWidth);
@@ -213,42 +219,44 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   }, [navigate, pathname]);
 
   return (
-    <SidebarProvider
-      className="h-dvh! min-h-0!"
-      data-panel-animations={panelAnimationsActive ? "true" : "false"}
-      defaultOpen
-      style={sidebarProviderStyle}
-    >
-      <ProjectProjectionRetention />
-      <Sidebar
-        side="left"
-        collapsible="offcanvas"
-        data-app-sidebar=""
-        className="border-r border-sidebar-border bg-sidebar text-sidebar-foreground"
-        resizable={{
-          maxWidth: sidebarMaximumWidth,
-          minWidth: THREAD_SIDEBAR_MIN_WIDTH,
-          shouldAcceptWidth: ({ currentWidth, nextWidth, wrapper }) =>
-            nextWidth <= currentWidth ||
-            wrapper.clientWidth - nextWidth >= THREAD_MAIN_CONTENT_MIN_WIDTH,
-          storageKey: THREAD_SIDEBAR_WIDTH_STORAGE_KEY,
-          onResize: setSidebarWidth,
-        }}
+    <PanelAnimationSuppressionProvider value={panelAnimationsSuppressed}>
+      <SidebarProvider
+        className="h-dvh! min-h-0!"
+        data-panel-animations={routePanelAnimationsActive ? "true" : "false"}
+        defaultOpen
+        style={sidebarProviderStyle}
       >
-        {isOnSettings ? (
-          <>
-            <SidebarChromeHeader isElectron={isElectron} />
-            <SettingsSidebarNav pathname={pathname} />
-          </>
-        ) : legacySidebarEnabled ? (
-          <LegacyThreadSidebar />
-        ) : (
-          <ThreadSidebar />
-        )}
-        <SidebarRail onDoubleClick={resetSidebarWidth} />
-      </Sidebar>
-      {children}
-      <SidebarControl />
-    </SidebarProvider>
+        <ProjectProjectionRetention />
+        <Sidebar
+          side="left"
+          collapsible="offcanvas"
+          data-app-sidebar=""
+          className="border-r border-sidebar-border bg-sidebar text-sidebar-foreground"
+          resizable={{
+            maxWidth: sidebarMaximumWidth,
+            minWidth: THREAD_SIDEBAR_MIN_WIDTH,
+            shouldAcceptWidth: ({ currentWidth, nextWidth, wrapper }) =>
+              nextWidth <= currentWidth ||
+              wrapper.clientWidth - nextWidth >= THREAD_MAIN_CONTENT_MIN_WIDTH,
+            storageKey: THREAD_SIDEBAR_WIDTH_STORAGE_KEY,
+            onResize: setSidebarWidth,
+          }}
+        >
+          {isOnSettings ? (
+            <>
+              <SidebarChromeHeader isElectron={isElectron} />
+              <SettingsSidebarNav pathname={pathname} />
+            </>
+          ) : legacySidebarEnabled ? (
+            <LegacyThreadSidebar />
+          ) : (
+            <ThreadSidebar />
+          )}
+          <SidebarRail onDoubleClick={resetSidebarWidth} />
+        </Sidebar>
+        {children}
+        <SidebarControl />
+      </SidebarProvider>
+    </PanelAnimationSuppressionProvider>
   );
 }

--- a/apps/web/src/panelAnimations.test.tsx
+++ b/apps/web/src/panelAnimations.test.tsx
@@ -1,0 +1,64 @@
+import { act, useLayoutEffect } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { usePanelNavigationSuppression } from "./panelAnimations";
+
+let renderer: ReactTestRenderer | null = null;
+let pendingFrames: FrameRequestCallback[] = [];
+let observed: boolean[] = [];
+
+function SuppressionProbe({ navigationKey }: { navigationKey: string }) {
+  const suppressed = usePanelNavigationSuppression(navigationKey);
+  useLayoutEffect(() => {
+    observed.push(suppressed);
+  }, [suppressed]);
+  return null;
+}
+
+beforeEach(() => {
+  pendingFrames = [];
+  observed = [];
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("window", {
+    requestAnimationFrame: vi.fn((callback: FrameRequestCallback) => {
+      pendingFrames.push(callback);
+      return pendingFrames.length;
+    }),
+    cancelAnimationFrame: vi.fn(),
+  });
+});
+
+afterEach(async () => {
+  await act(() => renderer?.unmount());
+  vi.unstubAllGlobals();
+});
+
+async function paintPendingFrame() {
+  const callback = pendingFrames.shift();
+  await act(() => callback?.(0));
+}
+
+describe("usePanelNavigationSuppression", () => {
+  it("suppresses initial and navigated panel state until each route has painted", async () => {
+    await act(() => {
+      renderer = create(<SuppressionProbe navigationKey="/thread/one" />);
+    });
+    expect(observed.at(-1)).toBe(true);
+
+    await paintPendingFrame();
+    expect(observed.at(-1)).toBe(true);
+    await paintPendingFrame();
+    expect(observed.at(-1)).toBe(false);
+
+    await act(() => {
+      renderer?.update(<SuppressionProbe navigationKey="/thread/two" />);
+    });
+    expect(observed.at(-1)).toBe(true);
+
+    await paintPendingFrame();
+    expect(observed.at(-1)).toBe(true);
+    await paintPendingFrame();
+    expect(observed.at(-1)).toBe(false);
+  });
+});

--- a/apps/web/src/panelAnimations.ts
+++ b/apps/web/src/panelAnimations.ts
@@ -1,8 +1,35 @@
-import { useEffect, useRef, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
 import { type PanelAnimationDurationMs } from "@t3tools/contracts/settings";
 
 import { useMediaQuery } from "./hooks/useMediaQuery";
 import { useClientSettings } from "./hooks/useSettings";
+
+const PanelAnimationSuppressionContext = createContext(false);
+
+export const PanelAnimationSuppressionProvider = PanelAnimationSuppressionContext.Provider;
+
+/**
+ * Suppresses panel motion for the first painted frame of an initial route or navigation.
+ * State restored by a route must be visible immediately; later user actions can animate.
+ */
+export function usePanelNavigationSuppression(navigationKey: string): boolean {
+  const [paintedNavigationKey, setPaintedNavigationKey] = useState<string | null>(null);
+  const suppressed = paintedNavigationKey !== navigationKey;
+
+  useEffect(() => {
+    if (!suppressed) return;
+    let releaseFrame = 0;
+    const paintFrame = window.requestAnimationFrame(() => {
+      releaseFrame = window.requestAnimationFrame(() => setPaintedNavigationKey(navigationKey));
+    });
+    return () => {
+      window.cancelAnimationFrame(paintFrame);
+      window.cancelAnimationFrame(releaseFrame);
+    };
+  }, [navigationKey, suppressed]);
+
+  return suppressed;
+}
 
 export function observeResponsiveBreakpointFade(options: {
   target: HTMLElement;
@@ -47,7 +74,8 @@ export function usePanelAnimationSettings(): {
 } {
   const durationMs = useClientSettings((settings) => settings.panelAnimationDurationMs);
   const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
-  return { active: durationMs > 0 && !prefersReducedMotion, durationMs };
+  const suppressed = useContext(PanelAnimationSuppressionContext);
+  return { active: durationMs > 0 && !prefersReducedMotion && !suppressed, durationMs };
 }
 
 /** Keeps closing panel content mounted until its opt-in transition ends. */


### PR DESCRIPTION
Thread-specific panel state was being restored with the same transition used for an explicit panel toggle. Switching threads therefore replayed panel motion even though the user only navigated.

This suppresses panel animations through the first painted frame of initial load and pathname navigation, then restores the configured animation behavior for later user interactions. The suppression covers both the layout animation attribute and panel presence hooks so the right panel, terminal drawer, and related spacing stay in sync.

## Evidence

Before — navigation replays panel motion:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/1529ed5c8f69b154/t3-panel-before-evidence.webm

![Before: panel state after thread navigation](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/6609bf7fa1432ba1/t3-panel-before.png)

After — the destination panel state is present on the first frame:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/f164c91a61fd593e/t3-panel-after-evidence.webm

![After: panel restored immediately on the destination thread](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/e98d4098b56d7416/t3-panel-after.png)

## Verification

- `vp test run apps/web/src/panelAnimations.test.tsx`
- `vp run -F @t3tools/web --fail-if-no-match typecheck`
- `vp fmt apps/web/src/components/AppSidebarLayout.tsx apps/web/src/panelAnimations.ts apps/web/src/panelAnimations.test.tsx --check`
- `vp lint apps/web/src/components/AppSidebarLayout.tsx apps/web/src/panelAnimations.ts apps/web/src/panelAnimations.test.tsx`
- Browser verification at 400ms: navigation rendered the destination panel at 540px on the first frame; a direct toggle still progressed from 1px through the configured transition.

Generated with GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only animation timing around navigation; explicit panel toggles still animate after the brief suppression window.
> 
> **Overview**
> **Suppresses panel animations on initial load and route changes** so restored thread panel state (right panel, terminal drawer, layout spacing) appears on the first frame instead of replaying the toggle transition when navigating between threads.
> 
> Adds `usePanelNavigationSuppression`, keyed by pathname, which stays active through two `requestAnimationFrame` ticks after each navigation, plus a `PanelAnimationSuppressionProvider` so `usePanelAnimationSettings` treats animations as off while suppressed. `AppSidebarLayout` drives both the provider and `data-panel-animations` from that flag so CSS transitions and panel presence hooks stay aligned.
> 
> Includes a unit test for the suppression hook across initial mount and pathname updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d506f53b37184a10bc4627cb74af55dd7f436d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop panel animations during navigation in `AppSidebarLayout`
> - Adds `PanelAnimationSuppressionProvider` context and `usePanelNavigationSuppression` hook to [panelAnimations.ts](https://github.com/pingdotgg/t3code/pull/9766/files#diff-84c6246b9fbc93031552a0356c907b5be86e4a15f15e0562e8a028eb39079a63). The hook suppresses animations for two `requestAnimationFrame` callbacks after a navigation key changes.
> - Updates `usePanelAnimationSettings` to return `active=false` when the suppression context is true, overriding configured duration and reduced-motion settings.
> - Wires the suppression provider into [AppSidebarLayout.tsx](https://github.com/pingdotgg/t3code/pull/9766/files#diff-b580a936d60a70bebcccf38ac9a82ca5f4440c99445dbccb0c176ebe5dc1d301) using the current pathname as the navigation key.
> - Risk: `usePanelAnimationSettings.active` now reads a new React context; consumers rendered outside the provider default to `false` (unsuppressed), preserving existing behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d506f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->