### PR TITLE
fix(web): open composer selectors below controls

### DIFF
--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -114,7 +114,7 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
           </span>
         </span>
       </SelectTrigger>
-      <SelectPopup {...composerFloatingLayerProps}>
+      <SelectPopup alignItemWithTrigger={false} {...composerFloatingLayerProps}>
         <SelectGroup>
           <SelectGroupLabel>Workspace</SelectGroupLabel>
           <SelectItem value="local">

--- a/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
@@ -102,7 +102,7 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
           </span>
         </span>
       </SelectTrigger>
-      <SelectPopup {...composerFloatingLayerProps}>
+      <SelectPopup alignItemWithTrigger={false} {...composerFloatingLayerProps}>
         <SelectGroup>
           <SelectGroupLabel>Run on</SelectGroupLabel>
           {availableEnvironments.map((env) => (


### PR DESCRIPTION
the composer run-on and workspace selectors used item alignment, which caused their popups to overlap their triggers. this disables item alignment for those two popups so they open below the controls while leaving the branch selector unchanged.

before:

![workspace selector overlapping its trigger before the fix](https://uploads-production-47e4.up.railway.app/files/52acc172-b97b-4091-ad10-dc8daf48dcd2/t3code-dropdown-before.png)

after:

![workspace selector opening below its trigger after the fix](https://uploads-production-47e4.up.railway.app/files/f49d6511-307d-42ce-9574-bcc1613bf6b5/t3code-dropdown-after.png)

verified with the web typecheck, targeted lint, diff checks, and live browser interaction at 1280x800. written by gpt-5.6-sol in the codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only positioning tweak on two composer toolbar selects; no auth, data, or API changes.
> 
> **Overview**
> Fixes composer **Workspace** and **Run on** dropdowns so their menus no longer sit on top of the trigger buttons.
> 
> Both selectors now pass **`alignItemWithTrigger={false}`** on `SelectPopup` (with existing `composerFloatingLayerProps` unchanged), turning off item-aligned positioning that was causing overlap. The branch selector is intentionally left as-is.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c511dcae4a3783457a65670c2a5bebc1be42694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix composer selector popups to open below controls
> Sets `alignItemWithTrigger={false}` on the environment and environment-mode selector popups in [BranchToolbarEnvModeSelector.tsx](https://github.com/pingdotgg/t3code/pull/9767/files#diff-f6e603d70ca6bba6f4bb6ec0c74ab245223570c8a33c292fb1d25529770f3f67) and [BranchToolbarEnvironmentSelector.tsx](https://github.com/pingdotgg/t3code/pull/9767/files#diff-3759c9280378eadf1bb9c4b0f2e904767a2ba23386070a9a38f60a6ae124278a). Menu items now use the popup's standard layout instead of aligning with the trigger.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c511dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->