### PR TITLE
fix(web): align provider controls with machine tabs

### DIFF
--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -191,8 +191,10 @@ function ProviderSettingsPlaceholder({
   readonly children?: ReactNode;
 }) {
   return (
-    <SettingsSection {...searchableSetting("providers")} variant="plain">
-      {deviceTabs}
+    <SettingsSection {...searchableSetting("providers")} hideTitle variant="plain">
+      {deviceTabs ? (
+        <div className="flex min-h-11 min-w-0 items-center px-3 sm:px-4">{deviceTabs}</div>
+      ) : null}
       <div
         className={cn(
           providerCardClassName,
@@ -323,7 +325,7 @@ function ProviderSettingsPanelContent(target: ProviderSettingsTarget) {
     options.length === 1 && options[0]?.entry.target._tag === "PrimaryConnectionTarget";
   const deviceTabs =
     !onlyPrimaryDevice && options.length > 0 ? (
-      <ScrollArea hideScrollbars scrollFade className="mx-3 h-11 min-w-0 rounded-none sm:mx-4">
+      <ScrollArea hideScrollbars scrollFade className="h-11 min-w-0 flex-1 rounded-none">
         <div role="group" aria-label="Devices" className="flex h-full w-max min-w-full px-1">
           {options.map((environment) => {
             const machine = resolveEnvironmentMachineKind(environment.serverConfig);
@@ -977,11 +979,10 @@ export function EnvironmentProviderSettings({
 
   return (
     <>
-      <SettingsSection
-        {...searchableSetting("providers")}
-        variant="plain"
-        headerAction={
-          <div className="flex min-w-0 items-center gap-2">
+      <SettingsSection {...searchableSetting("providers")} hideTitle variant="plain">
+        <div className="flex min-h-11 min-w-0 items-center gap-2 px-3 sm:px-4">
+          {deviceTabs}
+          <div className="ml-auto flex min-w-0 shrink-0 items-center gap-2">
             {readOnly ? (
               <span className="min-w-0 truncate text-xs text-muted-foreground">
                 <ProviderLastChecked lastCheckedAt={lastCheckedAt} />
@@ -1030,9 +1031,7 @@ export function EnvironmentProviderSettings({
               </>
             )}
           </div>
-        }
-      >
-        {deviceTabs}
+        </div>
         {readOnly ? (
           <div className={cn(providerCardClassName, "overflow-hidden")}>
             <SettingsRow


### PR DESCRIPTION
removes the duplicate providers heading and puts the machine tabs, refresh status, and add-provider control on one toolbar. the searchable heading and existing primary, remote, disconnected, and read-only behavior stay intact.

verified with 53 focused tests, web typecheck, file-scoped lint and formatting, plus real-app checks at 1280×800 and 640×800.

before

![provider settings before the toolbar change](https://uploads-production-47e4.up.railway.app/files/fe09a611-12d4-47ed-8896-8efae6dcce84/t3-provider-before.png)

after

![provider settings after the toolbar change](https://uploads-production-47e4.up.railway.app/files/08fe41fc-1231-4c17-bb8e-3236e5858a4a/t3-provider-after.png)

built with `gpt-5.6-sol` through the codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout in the provider settings panel with no auth, data, or API changes.
> 
> **Overview**
> **Provider settings** no longer shows a separate section title row; the searchable `providers` section uses **`hideTitle`** so the duplicate heading is gone.
> 
> **Machine/device tabs**, **last-checked / refresh**, and **add provider** now share one top toolbar: tabs use `flex-1` in a `ScrollArea` (margins removed), with actions in an `ml-auto` group. Placeholder states (loading, unavailable, empty) use the same padded toolbar row when device tabs are shown.
> 
> Behavior for primary-only devices, read-only sessions, and search targeting is unchanged—only layout and chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52f7285da6b88100b2f3a72c8eed63157fe45552. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render device tabs in a dedicated toolbar row in provider settings UI
> Reworks the layout of provider settings views to place device tabs, status text, and the add-provider control into a single toolbar row with explicit padding and minimum height. Removes the `SettingsSection` title from both placeholder and environment provider views, and lets the surrounding row own horizontal padding instead of the `ScrollArea`.
>
> - Affects `ProviderSettingsPlaceholder`, `ProviderSettingsPanelContent`, and `EnvironmentProviderSettings` in [ProviderSettingsPanel.tsx](https://github.com/pingdotgg/t3code/pull/9769/files#diff-f12e4babdd78afe45c2a0146ab2c0ef5a097d301ebed3350f53de81fc57349d3)
> - Behavioral Change: `SettingsSection` no longer shows a title in these views; consumers relying on that title will see it gone.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52f7285.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->