### PR TITLE
fix(contracts): include tool.denied in runtime event types

### DIFF
--- a/packages/contracts/src/providerRuntime.test.ts
+++ b/packages/contracts/src/providerRuntime.test.ts
@@ -1,11 +1,19 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, expectTypeOf, it } from "vite-plus/test";
 import * as Schema from "effect/Schema";
 
-import { classifyTaskAgentKind, ProviderRuntimeEvent } from "./providerRuntime.ts";
+import {
+  classifyTaskAgentKind,
+  ProviderRuntimeEvent,
+  type ProviderRuntimeEventType,
+} from "./providerRuntime.ts";
 
 const decodeRuntimeEvent = Schema.decodeUnknownSync(ProviderRuntimeEvent);
 
 describe("ProviderRuntimeEvent", () => {
+  it("includes every runtime event in the public event type", () => {
+    expectTypeOf<ProviderRuntimeEvent["type"]>().toEqualTypeOf<ProviderRuntimeEventType>();
+  });
+
   it("requires input and output totals for complete turn usage", () => {
     const completeEvent = {
       type: "turn.completed",

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -186,6 +186,7 @@ const ProviderRuntimeEventType = Schema.Literals([
   "hook.completed",
   "tool.progress",
   "tool.summary",
+  "tool.denied",
   "auth.status",
   "account.updated",
   "account.rate-limits.updated",


### PR DESCRIPTION
## What changed

Add `tool.denied` to `ProviderRuntimeEventType`. A type assertion checks that the alias matches `ProviderRuntimeEvent["type"]`.

## Why

`tool.denied` is already a valid runtime event, but the exported event-type alias omits it. Code using that alias cannot represent every valid event. There are no production consumers of the alias in this repository, so this fixes contract consistency without changing runtime behavior.

```mermaid
flowchart LR
    Event["Existing tool.denied event"] --> Union["ProviderRuntimeEvent: already included"]
    Event --> Alias["ProviderRuntimeEventType: now included"]
```

## Validation

- The new type assertion fails before the fix with TS2344 identifying `tool.denied`. `tsgo --noEmit -p packages/contracts/tsconfig.json` passes after the fix.
- `vp test run packages/contracts/src/providerRuntime.test.ts --maxWorkers=1 --no-file-parallelism`: 12 tests pass.
- Targeted lint, format check, and `git diff --check` pass.
- Fallow 3.22.0 audit of `packages/contracts` against `cd713679b`: pass, no introduced findings. Existing test-discovery and estimated-coverage warnings are unchanged.

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why.
- No UI, product-default, or diagnostic-suppression changes. Screenshots and video do not apply.

Model: GPT-5. Harness: Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contract-only type alignment with no runtime or behavioral changes; no in-repo production uses of the alias were found.
> 
> **Overview**
> Aligns the exported **`ProviderRuntimeEventType`** alias with the full **`ProviderRuntimeEvent`** union by adding the missing **`tool.denied`** literal. The event was already modeled and decodable on the union; only the public type-name list was incomplete, so consumers of the alias could not express that event in TypeScript.
> 
> Adds a compile-time test that **`ProviderRuntimeEvent["type"]`** and **`ProviderRuntimeEventType`** stay in sync via **`expectTypeOf`**, so a future drift (like the pre-fix omission of **`tool.denied`**) fails at type-check time rather than silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74dd7a0381a5fd54bdcc202c9bb9e7d0490f5b67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `tool.denied` to `ProviderRuntimeEventType` schema
> Adds the `tool.denied` literal to the `ProviderRuntimeEventType` schema in [providerRuntime.ts](https://github.com/pingdotgg/t3code/pull/9770/files#diff-448aaf2dfbb7547d852cc74c6bba5caea16c3c782a5f9cfbf43da71648ec61f7), so `ProviderRuntimeEvent` decoding accepts events of that type and the exported union includes it. Also adds a compile-time test in [providerRuntime.test.ts](https://github.com/pingdotgg/t3code/pull/9770/files#diff-c96827e89e162893d8a0ae8be51ced135651bbee97cc54e0ee9bf175f2a1b509) asserting the public `ProviderRuntimeEventType` matches the schema-derived type.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 74dd7a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `tool.denied` provider runtime event type.
* **Tests**
  * Added type coverage to verify all runtime event variants are represented in the public event type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->