### PR TITLE
perf(web): reduce minimap work during streaming and scrolling

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import { MessageId, TurnId } from "@t3tools/contracts";
 import {
+  createTimelineMinimapProjector,
   computeStableMessagesTimelineRows,
   computeMessageDurationStart,
   deriveMessagesTimelineRows,
@@ -11,6 +12,7 @@ import {
   resolveWorkGroupScrollIndex,
   shouldFollowWorkGroupAppend,
   shouldPreserveAssistantLineBreaks,
+  updateTimelineMinimapMarkers,
   type MessagesTimelineRow,
   workEntryDisplayLabel,
 } from "./MessagesTimeline.logic";
@@ -21,6 +23,95 @@ import {
   type WorkLogEntry,
 } from "../../session-logic";
 import { isImageAttachment, type ChatMessage, type TurnDiffSummary } from "../../types";
+
+describe("minimap marker updates", () => {
+  const items = Array.from({ length: 6 }, (_, index) => ({
+    id: `marker-${index}`,
+    rowIndex: index,
+    userText: "User message",
+    assistantText: null,
+  }));
+  const state = {
+    scroll: 10,
+    scrollLength: 20,
+    positionAtIndex: (index: number) => index * 10,
+    sizeAtIndex: () => 10,
+  };
+
+  function strip(initial: string | undefined) {
+    let value = initial;
+    let writes = 0;
+    return {
+      dataset: {
+        get inView() {
+          return value;
+        },
+        set inView(next: string | undefined) {
+          value = next;
+          writes += 1;
+        },
+      },
+      get writes() {
+        return writes;
+      },
+    };
+  }
+
+  it("writes only markers whose visible state changes", () => {
+    const nodes = new Map(items.map((item) => [item.id, strip("false")]));
+    const writes = () => [...nodes.values()].reduce((total, node) => total + node.writes, 0);
+    updateTimelineMinimapMarkers(state, items, nodes);
+    expect([...nodes.values()].map((node) => node.dataset.inView)).toEqual([
+      "false",
+      "true",
+      "true",
+      "false",
+      "false",
+      "false",
+    ]);
+    expect(writes()).toBe(2);
+    updateTimelineMinimapMarkers(state, items, nodes);
+    expect(writes()).toBe(2);
+
+    updateTimelineMinimapMarkers({ ...state, scroll: 20 }, items, nodes);
+    expect([...nodes.values()].map((node) => node.dataset.inView)).toEqual([
+      "false",
+      "false",
+      "true",
+      "true",
+      "false",
+      "false",
+    ]);
+    expect(writes()).toBe(4);
+
+    updateTimelineMinimapMarkers({ ...state, positionAtIndex: () => Number.NaN }, items, nodes);
+    expect([...nodes.values()].every((node) => node.dataset.inView === "false")).toBe(true);
+    expect(writes()).toBe(6);
+  });
+
+  it("initializes replacement refs and corrects recycled nodes without touching removed refs", () => {
+    const nodes = new Map(items.map((item) => [item.id, strip("false")]));
+    updateTimelineMinimapMarkers(state, items, nodes);
+    const removed = nodes.get("marker-1")!;
+    const replacement = strip(undefined);
+    nodes.set("marker-1", replacement);
+    updateTimelineMinimapMarkers(state, items, nodes);
+    expect(replacement.dataset.inView).toBe("true");
+    expect(replacement.writes).toBe(1);
+
+    nodes.delete("marker-1");
+    nodes.set("marker-5", replacement);
+    const mounted = strip("false");
+    nodes.set("marker-1", mounted);
+    updateTimelineMinimapMarkers(state, items, nodes);
+    expect(replacement.dataset.inView).toBe("false");
+    expect(replacement.writes).toBe(2);
+    expect(mounted.dataset.inView).toBe("true");
+    expect(mounted.writes).toBe(1);
+    expect(removed.dataset.inView).toBe("true");
+    expect(removed.writes).toBe(1);
+  });
+});
 
 describe("streaming row projection", () => {
   function fixture(text = "") {
@@ -101,6 +192,133 @@ describe("streaming row projection", () => {
     } satisfies Parameters<typeof deriveMessagesTimelineRows>[0];
     return { messages, work, timeline, input, time, turnId, historyTurnId };
   }
+
+  it("keeps full minimap previews and row indexes when turns are reordered", () => {
+    const initial = fixture();
+    const source = deriveMessagesTimelineRowsWithState(initial.input).rows;
+    const messageRows = source.filter((row) => row.kind === "message");
+    const user = messageRows.find((row) => row.message.role === "user")!;
+    const assistant = messageRows.find((row) => row.message.role === "assistant")!;
+    const work = source.find((row) => row.kind !== "message")!;
+    const userRow = (id: string, text: string) => ({
+      ...user,
+      id,
+      message: { ...user.message, id: MessageId.make(id), text },
+    });
+    const assistantRow = (id: string, text: string) => ({
+      ...assistant,
+      id,
+      message: { ...assistant.message, id: MessageId.make(id), text },
+    });
+    const longText = "\nall\ttext\u00a0".repeat(600) + "end";
+    const rows = Object.freeze([
+      assistantRow("leading", "Ignore this earlier response"),
+      userRow("user-a", " \tPrompt\u00a0A\n"),
+      assistantRow("earlier-a", "Not the final response"),
+      work,
+      assistantRow("final-a", " \n\t"),
+      userRow("user-b", "Keep the full text"),
+      assistantRow("final-b", longText),
+      userRow("user-c", "Unanswered"),
+    ]);
+    const project = createTimelineMinimapProjector();
+    const first = project(rows);
+    expect(first).toEqual([
+      { id: "user-a", rowIndex: 1, userText: "Prompt A", assistantText: null },
+      {
+        id: "user-b",
+        rowIndex: 5,
+        userText: "Keep the full text",
+        assistantText: "all text ".repeat(600) + "end",
+      },
+      { id: "user-c", rowIndex: 7, userText: "Unanswered", assistantText: null },
+    ]);
+    Object.freeze(first);
+    for (const item of first) Object.freeze(item);
+    expect(project([rows[5]!, rows[6]!, rows[1]!, rows[4]!, rows[7]!])).toEqual([
+      { ...first[1]!, rowIndex: 0 },
+      { ...first[0]!, rowIndex: 2 },
+      { ...first[2]!, rowIndex: 4 },
+    ]);
+    expect(first.map((item) => item.rowIndex)).toEqual([1, 5, 7]);
+  });
+
+  it("reuses unchanged minimap text and refreshes a new message version with the same ID", () => {
+    const initial = fixture("First  part\n");
+    let reads = 0;
+    const countTextReads = (message: ChatMessage): ChatMessage => {
+      const text = message.text;
+      return {
+        ...message,
+        get text() {
+          reads += 1;
+          return text;
+        },
+      };
+    };
+    const rows = deriveMessagesTimelineRowsWithState(initial.input).rows.map((row) =>
+      row.kind === "message" ? { ...row, message: countTextReads(row.message) } : row,
+    );
+    const live = rows.filter((row) => row.kind === "message").find((row) => row.message.streaming)!;
+    const project = createTimelineMinimapProjector();
+    const first = project(rows);
+    expect(reads).toBe(4);
+    expect(project(rows)).toEqual(first);
+    expect(reads).toBe(4);
+
+    const changedMessage = countTextReads({ ...initial.messages.at(-1)!, text: "Next\tpart" });
+    const changed = rows.map((row) => (row === live ? { ...live, message: changedMessage } : row));
+    expect(project(changed).at(-1)?.assistantText).toBe("Next part");
+    expect(reads).toBe(5);
+    expect(first.at(-1)?.assistantText).toBe("First part");
+
+    const blankMessage = countTextReads({ ...initial.messages.at(-1)!, text: " \n" });
+    const blank = rows.map((row) => (row === live ? { ...live, message: blankMessage } : row));
+    expect(project(blank).at(-1)?.assistantText).toBeNull();
+    expect(project(blank).at(-1)?.assistantText).toBeNull();
+    expect(reads).toBe(6);
+  });
+
+  it("drops an unused preview even when its completed reply remains in raw history", () => {
+    const initial = fixture("Earlier final");
+    const rows = deriveMessagesTimelineRowsWithState(initial.input).rows;
+    const live = rows.filter((row) => row.kind === "message").find((row) => row.message.streaming)!;
+    let earlierReads = 0;
+    const earlierMessage = {
+      ...initial.messages.at(-1)!,
+      streaming: false,
+      get text() {
+        earlierReads += 1;
+        return "Earlier final";
+      },
+    };
+    const earlierRows = rows.map((row) =>
+      row === live ? { ...live, message: earlierMessage } : row,
+    );
+    const project = createTimelineMinimapProjector();
+    expect(project(earlierRows).at(-1)?.assistantText).toBe("Earlier final");
+    expect(earlierReads).toBe(1);
+
+    const retainedHistory = [
+      ...earlierRows,
+      {
+        ...live,
+        id: "later-final",
+        message: {
+          ...initial.messages.at(-1)!,
+          id: MessageId.make("later-final"),
+          text: "Later final",
+          streaming: false,
+        },
+      },
+    ];
+    expect(project(retainedHistory).at(-1)?.assistantText).toBe("Later final");
+    expect(earlierReads).toBe(1);
+
+    // Returning to the earlier reply must rebuild the preview that was evicted.
+    expect(project(earlierRows).at(-1)?.assistantText).toBe("Earlier final");
+    expect(earlierReads).toBe(2);
+  });
 
   it.each([
     ["", "Now visible"],

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -169,6 +169,94 @@ export function shouldPreserveAssistantLineBreaks(text: string): boolean {
   return /^★ Insight(?:\s|─)/mu.test(text);
 }
 
+export interface TimelineMinimapItem {
+  readonly id: string;
+  readonly rowIndex: number;
+  readonly userText: string | null;
+  readonly assistantText: string | null;
+}
+
+interface TimelinePositionState {
+  readonly contentLength?: number;
+  readonly scroll?: number;
+  readonly scrollLength?: number;
+  readonly positionAtIndex?: (index: number) => number | undefined;
+  readonly sizeAtIndex?: (index: number) => number | undefined;
+}
+
+/** Reuse immutable message previews, retaining only the latest projection. */
+export function createTimelineMinimapProjector() {
+  let previews = new Map<ChatMessage, string | null>();
+
+  return (rows: ReadonlyArray<MessagesTimelineRow>): TimelineMinimapItem[] => {
+    const nextPreviews = new Map<ChatMessage, string | null>();
+    const preview = (message: ChatMessage | null) => {
+      if (message === null) return null;
+      const current = nextPreviews.get(message);
+      if (current !== undefined) return current;
+      const cached = previews.get(message);
+      const value = cached === undefined ? compactMinimapPreview(message.text) : cached;
+      nextPreviews.set(message, value);
+      return value;
+    };
+    const items: TimelineMinimapItem[] = [];
+    let finalAssistant: ChatMessage | null = null;
+    // Read backward so the first assistant found is the turn's final message.
+    for (let index = rows.length - 1; index >= 0; index -= 1) {
+      const row = rows[index];
+      if (row?.kind !== "message") continue;
+      if (row.message.role === "assistant") {
+        finalAssistant ??= row.message;
+      } else if (row.message.role === "user") {
+        items.push({
+          id: row.id,
+          rowIndex: index,
+          userText: preview(row.message),
+          assistantText: preview(finalAssistant),
+        });
+        finalAssistant = null;
+      }
+    }
+    previews = nextPreviews;
+    return items.toReversed();
+  };
+}
+
+function compactMinimapPreview(text: string | null | undefined) {
+  const compact = text?.replace(/\s+/g, " ").trim() ?? "";
+  return compact.length > 0 ? compact : null;
+}
+
+function resolveTimelineRowTop(state: TimelinePositionState, rowIndex: number) {
+  const top = state.positionAtIndex?.(rowIndex);
+  return typeof top === "number" && Number.isFinite(top) ? top : null;
+}
+
+function resolveTimelineRowHeight(state: TimelinePositionState, rowIndex: number) {
+  const height = state.sizeAtIndex?.(rowIndex);
+  return typeof height === "number" && Number.isFinite(height) ? height : null;
+}
+
+/** Read each current node so mounted or recycled refs always get the right marker state. */
+export function updateTimelineMinimapMarkers(
+  state: TimelinePositionState,
+  minimapItems: ReadonlyArray<TimelineMinimapItem>,
+  minimapStripMap: ReadonlyMap<string, Pick<HTMLSpanElement, "dataset">>,
+): void {
+  const scrollTop = state.scroll ?? 0;
+  const scrollBottom = scrollTop + (state.scrollLength ?? 0);
+  for (const item of minimapItems) {
+    const strip = minimapStripMap.get(item.id);
+    if (!strip) continue;
+    const rowTop = resolveTimelineRowTop(state, item.rowIndex);
+    const rowHeight = resolveTimelineRowHeight(state, item.rowIndex);
+    const inView =
+      rowTop !== null && rowTop < scrollBottom && rowTop + Math.max(1, rowHeight ?? 1) > scrollTop;
+    const next = inView ? "true" : "false";
+    if (strip.dataset.inView !== next) strip.dataset.inView = next;
+  }
+}
+
 export function resolveTimelineMinimapHeightStyle(itemCount: number): string {
   const naturalHeight = Math.max(1, (itemCount - 1) * TIMELINE_MINIMAP_ITEM_SPACING);
   return `min(${naturalHeight}px, ${TIMELINE_MINIMAP_MAX_HEIGHT_CSS})`;

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -124,6 +124,7 @@ import {
 } from "./AssistantCitationSource";
 import { useAssistantCitationTarget, type CitationHistoryPage } from "./useAssistantCitationTarget";
 import {
+  createTimelineMinimapProjector,
   computeStableMessagesTimelineRows,
   deriveMessagesTimelineRowsWithState,
   type MessagesTimelineRowsProjection,
@@ -140,12 +141,14 @@ import {
   shouldFollowWorkGroupAppend,
   shouldPreserveAssistantLineBreaks,
   toolGroupAction,
+  updateTimelineMinimapMarkers,
   workEntryDisplayLabel,
   workEntryIsVisibleInGroup,
   type StableMessagesTimelineRowsState,
   type MessagesTimelineRow,
   TIMELINE_MINIMAP_MIN_ITEMS,
   type TimelineLatestTurn,
+  type TimelineMinimapItem,
   type WorkGroupScrollAnchor,
 } from "./MessagesTimeline.logic";
 import { TerminalContextInlineChip } from "./TerminalContextInlineChip";
@@ -547,7 +550,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     revertTurnCountByUserMessageId,
   ]);
   const rows = useStableRows(rawRows);
-  const minimapItems = useMemo(() => deriveTimelineMinimapItems(rows), [rows]);
+  const [projectMinimap] = useState(createTimelineMinimapProjector);
+  const minimapItems = useMemo(() => projectMinimap(rows), [projectMinimap, rows]);
   const [timelineViewportElement, setTimelineViewportElement] = useState<HTMLDivElement | null>(
     null,
   );
@@ -601,24 +605,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       return;
     }
 
-    const scrollTop = state.scroll ?? 0;
-    const scrollBottom = scrollTop + (state.scrollLength ?? 0);
-
-    for (const item of minimapItems) {
-      const strip = minimapStripMap.get(item.id);
-      if (!strip) {
-        continue;
-      }
-
-      const rowTop = resolveTimelineRowTop(state, item.rowIndex);
-      const rowHeight = resolveTimelineRowHeight(state, item.rowIndex);
-      const inView =
-        rowTop !== null &&
-        rowTop < scrollBottom &&
-        rowTop + Math.max(1, rowHeight ?? 1) > scrollTop;
-
-      strip.dataset.inView = inView ? "true" : "false";
-    }
+    updateTimelineMinimapMarkers(state, minimapItems, minimapStripMap);
   }, [citationPositioning, listRef, minimapItems, minimapStripMap, onIsAtEndChange]);
 
   useEffect(() => {
@@ -823,76 +810,6 @@ function keyExtractor(item: MessagesTimelineRow) {
 
 function getItemType(item: MessagesTimelineRow) {
   return item.kind === "message" ? `message:${item.message.role}` : item.kind;
-}
-
-interface TimelineMinimapItem {
-  readonly id: string;
-  readonly rowIndex: number;
-  readonly userText: string | null;
-  readonly assistantText: string | null;
-}
-
-interface TimelinePositionState {
-  readonly contentLength?: number;
-  readonly scroll?: number;
-  readonly scrollLength?: number;
-  readonly positionAtIndex?: (index: number) => number | undefined;
-  readonly sizeAtIndex?: (index: number) => number | undefined;
-}
-
-function deriveTimelineMinimapItems(
-  rows: ReadonlyArray<MessagesTimelineRow>,
-): TimelineMinimapItem[] {
-  const items: TimelineMinimapItem[] = [];
-  for (let index = 0; index < rows.length; index += 1) {
-    const row = rows[index];
-    if (row?.kind !== "message" || row.message.role !== "user") {
-      continue;
-    }
-
-    items.push({
-      id: row.id,
-      rowIndex: index,
-      userText: compactMinimapPreview(row.message.text),
-      assistantText: compactMinimapPreview(resolveFinalAssistantTextForTurn(rows, index)),
-    });
-  }
-  return items;
-}
-
-function resolveFinalAssistantTextForTurn(
-  rows: ReadonlyArray<MessagesTimelineRow>,
-  userRowIndex: number,
-) {
-  let finalAssistantText: string | null = null;
-  for (let index = userRowIndex + 1; index < rows.length; index += 1) {
-    const row = rows[index];
-    if (row?.kind !== "message") {
-      continue;
-    }
-    if (row.message.role === "user") {
-      break;
-    }
-    if (row.message.role === "assistant") {
-      finalAssistantText = row.message.text ?? null;
-    }
-  }
-  return finalAssistantText;
-}
-
-function compactMinimapPreview(text: string | null | undefined) {
-  const compact = text?.replace(/\s+/g, " ").trim() ?? "";
-  return compact.length > 0 ? compact : null;
-}
-
-function resolveTimelineRowTop(state: TimelinePositionState, rowIndex: number) {
-  const top = state.positionAtIndex?.(rowIndex);
-  return typeof top === "number" && Number.isFinite(top) ? top : null;
-}
-
-function resolveTimelineRowHeight(state: TimelinePositionState, rowIndex: number) {
-  const height = state.sizeAtIndex?.(rowIndex);
-  return typeof height === "number" && Number.isFinite(height) ? height : null;
 }
 
 function timelineMinimapEventTargetsPreview(target: EventTarget): boolean {


### PR DESCRIPTION
Streaming rebuilt full minimap previews for every loaded turn. Scrolling rewrote every marker's visibility attribute, even when nothing changed.

The minimap now reuses previews by immutable message identity and skips unchanged marker writes. Its cache keeps only the latest projection, so unused completed replies do not retain extra preview strings. Preview text, row indexes, geometry, and navigation stay unchanged.

## Checks

- All 241 focused tests and web typecheck passed. Lint has no new warnings.
- The Node source proof reduced a 10-turn update from 0.266 ms to 0.017 ms. A 1,000-turn stress case fell from 29.74 ms to 0.26 ms.
- Repeating unchanged geometry for 1,000 markers produced zero attribute writes instead of 100,000 across 100 scroll events.
- Parity, ref recycling, old-snapshot collection, and retained-history cache checks passed.

Small cold cases added about 0.002 ms or improved. The 1,000-turn cold stress case added 0.23 to 1.2 ms across runs. These are source measurements, not browser frame times. No browser or device run was used.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only performance refactor in the timeline minimap with behavior-preserving tests; no auth, data, or API changes.
> 
> **Overview**
> **Reduces chat timeline minimap cost** during streaming and scroll by caching preview text and skipping redundant DOM updates.
> 
> Minimap item building moves from `MessagesTimeline.tsx` into **`createTimelineMinimapProjector`**: a stable projector caches compact user/assistant preview strings keyed by **`ChatMessage` object identity**, evicts previews not in the latest projection, and still updates **`rowIndex`** when rows reorder. Scroll handling delegates to **`updateTimelineMinimapMarkers`**, which sets each strip’s **`data-in-view`** only when visibility actually changes (including remounted/recycled refs).
> 
> The component keeps one projector instance via **`useState(createTimelineMinimapProjector)`** instead of recomputing all previews on every row change. New unit tests cover marker write counts, ref recycling, cache reuse, and parity when turns reorder or supersede earlier replies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e9eca825767e9c615dda1329d65e59b982d12e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache minimap previews and skip redundant marker writes in `MessagesTimeline`
> - Extracts minimap projection and marker-update logic from [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/9771/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) into [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/9771/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe)
> - `createTimelineMinimapProjector` caches preview strings by `ChatMessage` object identity for only the latest projection, scans rows backward to pair each user row with its first assistant row, and returns null for blank previews
> - `updateTimelineMinimapMarkers` resolves the visible interval from scroll state, computes row intersections using finite row positions, and writes dataset only when the marker's visible state actually changes
> - Risk: `resolveTimelineRowTop` and `resolveTimelineRowHeight` return false when row positions are non-finite; marker visibility falls back to false in that case
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e9eca8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->