### PR TITLE
feat(mobile): split the usage page into Usage and Limits tabs

### DIFF
--- a/apps/mobile/src/features/usage/UsageLimitsSection.tsx
+++ b/apps/mobile/src/features/usage/UsageLimitsSection.tsx
@@ -296,11 +296,12 @@ export function useRefreshLimits() {
   const [now, setNow] = useState(() => Date.now());
   const [refreshing, setRefreshing] = useState(false);
   const [failedLabels, setFailedLabels] = useState<readonly string[]>([]);
+  // Always toggles `refreshing`, even with nothing to probe: Android's
+  // RefreshControl keeps its spinner up until it sees true then false.
   const refresh = async () => {
     const connected = [...presentations].filter(
       ([, presentation]) => presentation.connection.phase === "connected",
     );
-    if (connected.length === 0) return;
     setRefreshing(true);
     try {
       const results = await Promise.all(

--- a/apps/mobile/src/features/usage/UsageLimitsSection.tsx
+++ b/apps/mobile/src/features/usage/UsageLimitsSection.tsx
@@ -285,6 +285,8 @@ function SourceAccountLimits(props: {
  * environment; the fresh snapshots then arrive over the config stream.
  * Countdowns and pace anchor to `now` rather than ticking, so a refresh also
  * re-anchors the clock: quota and elapsed time move together, or not at all.
+ * Environments whose probe failed are named, since their rows keep showing
+ * the previous quota with nothing else to say so.
  */
 export function useRefreshLimits() {
   const presentations = useAtomValue(environmentPresentations.presentationsAtom);
@@ -293,27 +295,38 @@ export function useRefreshLimits() {
   });
   const [now, setNow] = useState(() => Date.now());
   const [refreshing, setRefreshing] = useState(false);
+  const [failedLabels, setFailedLabels] = useState<readonly string[]>([]);
   const refresh = async () => {
-    const environmentIds = [...presentations.keys()];
-    if (environmentIds.length === 0) return;
+    const connected = [...presentations].filter(
+      ([, presentation]) => presentation.connection.phase === "connected",
+    );
+    if (connected.length === 0) return;
     setRefreshing(true);
     try {
-      await Promise.all(
-        environmentIds.map((environmentId) => refreshProviders({ environmentId, input: {} })),
+      const results = await Promise.all(
+        connected.map(([environmentId]) => refreshProviders({ environmentId, input: {} })),
+      );
+      setFailedLabels(
+        connected
+          .filter((_, index) => results[index]?._tag === "Failure")
+          .map(([, presentation]) => presentation.entry.target.label),
       );
     } finally {
       setNow(Date.now());
       setRefreshing(false);
     }
   };
-  return { now, refreshing, refresh };
+  return { now, refreshing, failedLabels, refresh };
 }
 
 /**
  * Subscription quota windows from every connected environment's providers,
  * read from the config each environment already streams.
  */
-export function UsageLimitsSection(props: { readonly now: number }) {
+export function UsageLimitsSection(props: {
+  readonly now: number;
+  readonly failedLabels: readonly string[];
+}) {
   const { now } = props;
   const presentations = useAtomValue(environmentPresentations.presentationsAtom);
   const groups = collectLimitsGroups(presentations);
@@ -329,6 +342,13 @@ export function UsageLimitsSection(props: { readonly now: number }) {
 
   return (
     <>
+      {props.failedLabels.length > 0 ? (
+        <View className="rounded-[16px] border-continuous bg-card px-4 py-3">
+          <Text className="text-sm text-foreground-muted">
+            {props.failedLabels.join(", ")} could not refresh limits. Showing the last known values.
+          </Text>
+        </View>
+      ) : null}
       {groups.map((group) => (
         <SettingsSection
           key={group.environmentId}

--- a/apps/mobile/src/features/usage/UsageLimitsSection.tsx
+++ b/apps/mobile/src/features/usage/UsageLimitsSection.tsx
@@ -278,14 +278,16 @@ function SourceAccountLimits(props: {
 
 /**
  * Re-probes every provider (and usage-limit source) on each connected
- * environment; the fresh snapshots then arrive over the config stream, so
- * nothing else needs to move. Resolves once every environment has answered.
+ * environment; the fresh snapshots then arrive over the config stream.
+ * Countdowns and pace anchor to `now` rather than ticking, so a refresh also
+ * re-anchors the clock: quota and elapsed time move together, or not at all.
  */
 export function useRefreshLimits() {
   const presentations = useAtomValue(environmentPresentations.presentationsAtom);
   const refreshProviders = useAtomCommand(serverEnvironment.refreshProviders, {
     reportFailure: false,
   });
+  const [now, setNow] = useState(() => Date.now());
   const [refreshing, setRefreshing] = useState(false);
   const refresh = async () => {
     const environmentIds = [...presentations.keys()];
@@ -296,23 +298,22 @@ export function useRefreshLimits() {
         environmentIds.map((environmentId) => refreshProviders({ environmentId, input: {} })),
       );
     } finally {
+      setNow(Date.now());
       setRefreshing(false);
     }
   };
-  return { refreshing, refresh };
+  return { now, refreshing, refresh };
 }
 
 /**
  * Subscription quota windows from every connected environment's providers,
- * read from the config each environment already streams. Countdowns anchor to
- * render time rather than ticking.
+ * read from the config each environment already streams.
  */
-export function UsageLimitsSection() {
+export function UsageLimitsSection(props: { readonly now: number }) {
+  const { now } = props;
   const presentations = useAtomValue(environmentPresentations.presentationsAtom);
   const groups = collectLimitsGroups(presentations);
   const sources = collectLimitSources(presentations);
-  // Anchored once per mount on purpose: countdowns must not tick.
-  const [now] = useState(() => Date.now());
 
   if (groups.length === 0 && sources.length === 0) {
     return (

--- a/apps/mobile/src/features/usage/UsageLimitsSection.tsx
+++ b/apps/mobile/src/features/usage/UsageLimitsSection.tsx
@@ -7,6 +7,7 @@ import type {
   ServerProviderResetCredits,
   ServerProviderUsageWindow,
   UsageLimitSourceAccount,
+  UsageProviderKind,
 } from "@t3tools/contracts";
 import {
   collectLimitSources,
@@ -22,30 +23,46 @@ import { type ReactNode, useState } from "react";
 import { Alert, Pressable, View } from "react-native";
 
 import { AppText as Text } from "../../components/AppText";
+import { ProviderIcon } from "../../components/ProviderIcon";
 import { environmentPresentations } from "../../state/presentation";
 import { serverEnvironment } from "../../state/server";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { SettingsSection } from "../settings/components/SettingsSection";
+import { useProviderColors } from "./usageProviders";
 
 const PACE_LABEL = { ahead: "ahead of pace", on: "on pace", under: "under pace" } as const;
 const DRIVER_LABEL: Partial<Record<string, string>> = { codex: "Codex", claudeAgent: "Claude" };
 
+type Driver = ServerProvider["driver"];
+
+/** The series colour the usage chart uses for this driver, so the two views read as one. */
+function useBarColor(driver: Driver): string | null {
+  const colors = useProviderColors();
+  const kind: UsageProviderKind | null =
+    driver === "codex" ? "codex" : driver === "claudeAgent" ? "claude" : null;
+  return kind ? colors[kind] : null;
+}
+
 /**
  * One window as a bar spanning its whole duration: the fill is quota spent,
- * the hairline is how far into the window the clock is.
+ * the hairline is how far into the window the clock is. Pace sits under the
+ * left edge, the countdown under the right, so a row reads in one glance.
  */
-function WindowBar(props: { readonly window: ServerProviderUsageWindow; readonly now: number }) {
+function WindowRow(props: {
+  readonly window: ServerProviderUsageWindow;
+  readonly color: string | null;
+  readonly now: number;
+}) {
   const { window, now } = props;
   const used = Math.round(Math.max(0, Math.min(100, window.usedPercent)));
   const elapsed = elapsedShare(window, now);
   const pace = paceOf(window, now);
   const resetsIn = formatResetsIn(window, now);
-  const detail = [pace ? PACE_LABEL[pace] : null, resetsIn].filter(Boolean).join(" · ");
   return (
-    <View className="gap-1.5">
+    <View className="gap-1">
       <View className="flex-row items-baseline justify-between gap-3">
-        <Text className="text-base text-foreground">{window.label}</Text>
-        <Text className="text-base tabular-nums text-foreground">{used}% used</Text>
+        <Text className="text-sm text-foreground">{window.label}</Text>
+        <Text className="text-sm font-t3-medium tabular-nums text-foreground">{used}%</Text>
       </View>
       <View className="h-3 justify-center">
         <View className="h-1.5 flex-row overflow-hidden rounded-full bg-subtle">
@@ -57,7 +74,10 @@ function WindowBar(props: { readonly window: ServerProviderUsageWindow; readonly
                   ? "h-full rounded-full bg-warning"
                   : "h-full rounded-full bg-foreground"
             }
-            style={{ flex: used }}
+            style={[
+              { flex: used },
+              used < 70 && props.color ? { backgroundColor: props.color } : null,
+            ]}
           />
           <View style={{ flex: 100 - used }} />
         </View>
@@ -68,12 +88,19 @@ function WindowBar(props: { readonly window: ServerProviderUsageWindow; readonly
           />
         ) : null}
       </View>
-      {detail ? <Text className="text-xs text-foreground-tertiary">{detail}</Text> : null}
+      {pace || resetsIn ? (
+        <View className="flex-row justify-between gap-3">
+          <Text className="text-xs text-foreground-tertiary">{pace ? PACE_LABEL[pace] : ""}</Text>
+          <Text className="text-xs tabular-nums text-foreground-tertiary">{resetsIn ?? ""}</Text>
+        </View>
+      ) : null}
     </View>
   );
 }
 
+/** One account: icon, name and plan on a single line, then its windows. */
 function AccountLimits(props: {
+  readonly driver: Driver;
   readonly label: string;
   readonly instanceLabel: string;
   readonly detail: string | undefined;
@@ -83,23 +110,31 @@ function AccountLimits(props: {
   readonly footer?: ReactNode;
 }) {
   const { limits, now } = props;
+  const color = useBarColor(props.driver);
   if (!limits) return null;
   const notice = limitsNotice(limits);
   return (
     <View className={props.first ? "gap-3 p-4" : "gap-3 border-t border-border-subtle p-4"}>
-      <View className="flex-row flex-wrap items-baseline gap-x-2 gap-y-1">
-        <Text className="text-lg text-foreground">{props.label}</Text>
+      <View className="flex-row items-center gap-2">
+        <ProviderIcon provider={props.driver} size={16} />
+        <Text className="text-base font-t3-medium text-foreground">{props.label}</Text>
         {props.instanceLabel !== props.label ? (
-          <Text className="shrink text-xs text-foreground-tertiary">· {props.instanceLabel}</Text>
+          <Text className="text-xs text-foreground-tertiary">{props.instanceLabel}</Text>
         ) : null}
         {props.detail ? (
-          <Text className="shrink text-sm text-foreground-muted">· {props.detail}</Text>
+          <Text className="min-w-0 flex-1 text-sm text-foreground-muted" numberOfLines={1}>
+            {props.detail}
+          </Text>
         ) : null}
       </View>
       {notice ? (
         <Text className="text-sm text-foreground-muted">{notice}</Text>
       ) : (
-        limits.windows.map((window) => <WindowBar key={window.id} window={window} now={now} />)
+        <View className="gap-3">
+          {limits.windows.map((window) => (
+            <WindowRow key={window.id} window={window} color={color} now={now} />
+          ))}
+        </View>
       )}
       {props.footer}
     </View>
@@ -170,7 +205,7 @@ function ResetCredits(props: {
   };
 
   return (
-    <View className="gap-2">
+    <View className="flex-row flex-wrap items-center gap-x-3 gap-y-1">
       <Text className="text-xs tabular-nums text-foreground-tertiary">{summary}</Text>
       {credits.availableCount > 0 ? (
         <Pressable
@@ -178,7 +213,7 @@ function ResetCredits(props: {
           accessibilityState={{ disabled: busy }}
           disabled={busy}
           onPress={confirm}
-          className="self-start rounded-full bg-subtle-strong px-3 py-1.5"
+          className="rounded-full bg-subtle-strong px-3 py-1.5"
         >
           <Text className="text-sm font-t3-medium text-foreground">
             {busy ? "Using credit…" : "Use a reset credit"}
@@ -200,6 +235,7 @@ function ProviderLimits(props: {
   const credits = provider.usageLimits?.resetCredits;
   return (
     <AccountLimits
+      driver={provider.driver}
       label={DRIVER_LABEL[provider.driver] ?? String(provider.driver)}
       instanceLabel={providerLimitsLabel(provider, (driver) => DRIVER_LABEL[driver])}
       detail={provider.auth.label}
@@ -229,6 +265,7 @@ function SourceAccountLimits(props: {
   const { account } = props;
   return (
     <AccountLimits
+      driver={account.driver}
       label={DRIVER_LABEL[account.driver] ?? String(account.driver)}
       instanceLabel="CLI Proxy"
       detail={account.plan}
@@ -237,6 +274,32 @@ function SourceAccountLimits(props: {
       first={props.first}
     />
   );
+}
+
+/**
+ * Re-probes every provider (and usage-limit source) on each connected
+ * environment; the fresh snapshots then arrive over the config stream, so
+ * nothing else needs to move. Resolves once every environment has answered.
+ */
+export function useRefreshLimits() {
+  const presentations = useAtomValue(environmentPresentations.presentationsAtom);
+  const refreshProviders = useAtomCommand(serverEnvironment.refreshProviders, {
+    reportFailure: false,
+  });
+  const [refreshing, setRefreshing] = useState(false);
+  const refresh = async () => {
+    const environmentIds = [...presentations.keys()];
+    if (environmentIds.length === 0) return;
+    setRefreshing(true);
+    try {
+      await Promise.all(
+        environmentIds.map((environmentId) => refreshProviders({ environmentId, input: {} })),
+      );
+    } finally {
+      setRefreshing(false);
+    }
+  };
+  return { refreshing, refresh };
 }
 
 /**
@@ -250,10 +313,34 @@ export function UsageLimitsSection() {
   const sources = collectLimitSources(presentations);
   // Anchored once per mount on purpose: countdowns must not tick.
   const [now] = useState(() => Date.now());
-  if (groups.length === 0 && sources.length === 0) return null;
+
+  if (groups.length === 0 && sources.length === 0) {
+    return (
+      <Text className="py-16 text-center text-base text-foreground-muted">
+        No provider on a connected environment reports subscription limits.
+      </Text>
+    );
+  }
 
   return (
     <>
+      {groups.map((group) => (
+        <SettingsSection
+          key={group.environmentId}
+          title={group.environmentLabel ?? "Providers"}
+          card
+        >
+          {group.providers.map((provider, index) => (
+            <ProviderLimits
+              key={provider.instanceId}
+              provider={provider}
+              environmentId={group.environmentId}
+              now={now}
+              first={index === 0}
+            />
+          ))}
+        </SettingsSection>
+      ))}
       {sources.map((source) => (
         <SettingsSection key={source.key} card>
           {source.error ? (
@@ -274,23 +361,6 @@ export function UsageLimitsSection() {
               />
             ))
           )}
-        </SettingsSection>
-      ))}
-      {groups.map((group) => (
-        <SettingsSection
-          key={group.environmentId}
-          title={group.environmentLabel ? `Limits · ${group.environmentLabel}` : "Limits"}
-          card
-        >
-          {group.providers.map((provider, index) => (
-            <ProviderLimits
-              key={provider.instanceId}
-              provider={provider}
-              environmentId={group.environmentId}
-              now={now}
-              first={index === 0}
-            />
-          ))}
         </SettingsSection>
       ))}
     </>

--- a/apps/mobile/src/features/usage/UsageLimitsSection.tsx
+++ b/apps/mobile/src/features/usage/UsageLimitsSection.tsx
@@ -117,15 +117,19 @@ function AccountLimits(props: {
     <View className={props.first ? "gap-3 p-4" : "gap-3 border-t border-border-subtle p-4"}>
       <View className="flex-row items-center gap-2">
         <ProviderIcon provider={props.driver} size={16} />
-        <Text className="text-base font-t3-medium text-foreground">{props.label}</Text>
-        {props.instanceLabel !== props.label ? (
-          <Text className="text-xs text-foreground-tertiary">{props.instanceLabel}</Text>
-        ) : null}
-        {props.detail ? (
-          <Text className="min-w-0 flex-1 text-sm text-foreground-muted" numberOfLines={1}>
-            {props.detail}
-          </Text>
-        ) : null}
+        <View className="min-w-0 flex-1 flex-row items-baseline gap-2">
+          <Text className="text-base font-t3-medium text-foreground">{props.label}</Text>
+          {props.instanceLabel !== props.label ? (
+            <Text className="shrink text-xs text-foreground-tertiary" numberOfLines={1}>
+              · {props.instanceLabel}
+            </Text>
+          ) : null}
+          {props.detail ? (
+            <Text className="shrink text-sm text-foreground-muted" numberOfLines={1}>
+              · {props.detail}
+            </Text>
+          ) : null}
+        </View>
       </View>
       {notice ? (
         <Text className="text-sm text-foreground-muted">{notice}</Text>

--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -17,26 +17,44 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { AndroidScreenHeader } from "../../components/AndroidScreenHeader";
 import { AppText as Text } from "../../components/AppText";
+import { cn } from "../../lib/cn";
 import { NativeStackScreenOptions } from "../../native/StackHeader";
 import { useUsage, type EnvironmentUsageStatus } from "../../state/usage";
 import { SettingsSection } from "../settings/components/SettingsSection";
 import { UsageDailyChart } from "./UsageDailyChart";
-import { UsageLimitsSection } from "./UsageLimitsSection";
+import { UsageLimitsSection, useRefreshLimits } from "./UsageLimitsSection";
 import type { UsageChartMetric } from "./usageChartData";
 import { PROVIDER_LABEL, useProviderColors } from "./usageProviders";
 
+type UsageTab = "usage" | "limits";
+const TAB_OPTIONS = [
+  { value: "usage", label: "Usage" },
+  { value: "limits", label: "Limits" },
+] as const satisfies readonly { value: UsageTab; label: string }[];
+
 const WINDOW_OPTIONS = [
-  { days: 1, label: "Past 24h" },
-  { days: 7, label: "7 days" },
-  { days: 30, label: "30 days" },
-  { days: 90, label: "90 days" },
+  { days: 1, label: "24h" },
+  { days: 7, label: "7d" },
+  { days: 30, label: "30d" },
+  { days: 90, label: "90d" },
 ] as const;
+
+const METRIC_OPTIONS = [
+  { value: "cost", label: "Cost" },
+  { value: "tokens", label: "Tokens" },
+] as const satisfies readonly { value: UsageChartMetric; label: string }[];
 
 const CHART_HEIGHT = 180;
 
+/**
+ * Two tabs over one screen. Usage is the transcript-derived spend for a
+ * period; Limits is the live subscription quota, which has no period. Both
+ * pull to refresh, each refreshing its own data.
+ */
 export function UsageRouteScreen() {
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
+  const [tab, setTab] = useState<UsageTab>("usage");
   const [windowSelection, setWindowSelection] = useState(() => ({
     days: 30,
     window: makeWindow(30),
@@ -45,6 +63,7 @@ export function UsageRouteScreen() {
   const { days: windowDays, window } = windowSelection;
   const isPast24Hours = windowDays === 1;
   const { merged, environments, isPending, isPartial, refresh } = useUsage(window);
+  const limits = useRefreshLimits();
 
   const days = useMemo(
     () => enumerateDays(window.sinceDay, window.untilDay),
@@ -73,7 +92,8 @@ export function UsageRouteScreen() {
   // The pull spinner tracks re-scans of environments that have answered
   // before. The initial scan renders its own placeholder, and an unreachable
   // environment stays pending forever — neither may pin the spinner on.
-  const refreshing = environments.some((entry) => entry.isPending && entry.summary !== null);
+  const refreshingUsage = environments.some((entry) => entry.isPending && entry.summary !== null);
+  const showingLimits = tab === "limits";
   const selectWindow = (days: number) => {
     setWindowSelection({
       days,
@@ -108,41 +128,70 @@ export function UsageRouteScreen() {
         className="flex-1"
         contentContainerClassName="gap-6 px-5 pt-4"
         contentContainerStyle={{ paddingBottom: Math.max(insets.bottom, 18) + 18 }}
-        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={refreshWindow} />}
+        refreshControl={
+          <RefreshControl
+            refreshing={showingLimits ? limits.refreshing : refreshingUsage}
+            onRefresh={showingLimits ? () => void limits.refresh() : refreshWindow}
+          />
+        }
       >
-        <SegmentedControl
-          options={WINDOW_OPTIONS.map((option) => ({ value: option.days, label: option.label }))}
-          selected={windowDays}
-          onSelect={selectWindow}
-        />
+        <SegmentedControl options={TAB_OPTIONS} selected={tab} onSelect={setTab} />
 
-        <UsageCoverageNotice environments={environments} merged={merged} isPartial={isPartial} />
-
-        {isPending ? (
-          <Text className="py-16 text-center text-base text-foreground-muted">
-            Scanning provider transcripts…
-          </Text>
-        ) : environments.length === 0 ? (
-          <Text className="py-16 text-center text-base text-foreground-muted">
-            Connect an environment to see usage.
-          </Text>
+        {showingLimits ? (
+          <UsageLimitsSection />
         ) : (
           <>
-            <ChartCard
+            {/* Period and metric together: neither applies to Limits, and
+                both change every number below, so they share one bar. */}
+            <View className="flex-row items-center gap-3">
+              <SegmentedControl
+                options={WINDOW_OPTIONS.map((option) => ({
+                  value: option.days,
+                  label: option.label,
+                }))}
+                selected={windowDays}
+                onSelect={selectWindow}
+                size="compact"
+                className="flex-1"
+              />
+              <SegmentedControl
+                options={METRIC_OPTIONS}
+                selected={metric}
+                onSelect={setMetric}
+                size="compact"
+                className="w-36"
+              />
+            </View>
+            <UsageCoverageNotice
+              environments={environments}
               merged={merged}
-              days={chartDays}
-              daily={chartTotals}
-              metric={metric}
-              onMetricChange={setMetric}
-              sinceDay={window.sinceDay}
-              untilDay={window.untilDay}
-              isPast24Hours={isPast24Hours}
-              timeZone={window.timeZone}
+              isPartial={isPartial}
             />
-            <ProviderSection merged={merged} metric={metric} />
-            <UsageLimitsSection />
-            <TotalsSection merged={merged} isPast24Hours={isPast24Hours} />
-            <ModelsSection merged={merged} />
+            {isPending ? (
+              <Text className="py-16 text-center text-base text-foreground-muted">
+                Scanning provider transcripts…
+              </Text>
+            ) : environments.length === 0 ? (
+              <Text className="py-16 text-center text-base text-foreground-muted">
+                Connect an environment to see usage.
+              </Text>
+            ) : (
+              <>
+                <ChartCard
+                  merged={merged}
+                  days={chartDays}
+                  daily={chartTotals}
+                  metric={metric}
+                  sinceDay={window.sinceDay}
+                  untilDay={window.untilDay}
+                  isPast24Hours={isPast24Hours}
+                  timeZone={window.timeZone}
+                />
+                <ProviderSection merged={merged} metric={metric} />
+                <TotalsSection merged={merged} isPast24Hours={isPast24Hours} />
+                <ModelsSection merged={merged} />
+              </>
+            )}
           </>
         )}
       </ScrollView>
@@ -154,9 +203,18 @@ function SegmentedControl<Value extends number | string>(props: {
   readonly options: readonly { readonly value: Value; readonly label: string }[];
   readonly selected: Value;
   readonly onSelect: (value: Value) => void;
+  /** The tab bar is full height; filters under it are shorter so it stays primary. */
+  readonly size?: "default" | "compact";
+  readonly className?: string;
 }) {
+  const compact = props.size === "compact";
   return (
-    <View className="flex-row overflow-hidden rounded-full border-continuous bg-card">
+    <View
+      className={cn(
+        "flex-row overflow-hidden rounded-full border-continuous bg-card",
+        props.className,
+      )}
+    >
       {props.options.map((option) => {
         const active = option.value === props.selected;
         return (
@@ -165,16 +223,17 @@ function SegmentedControl<Value extends number | string>(props: {
             accessibilityRole="button"
             accessibilityState={{ selected: active }}
             onPress={() => props.onSelect(option.value)}
-            className={
-              active
-                ? "flex-1 items-center rounded-full bg-subtle-strong py-2"
-                : "flex-1 items-center py-2"
-            }
+            className={cn(
+              "flex-1 items-center justify-center rounded-full",
+              compact ? "h-9" : "h-11",
+              active && "bg-subtle-strong",
+            )}
           >
             <Text
-              className={
-                active ? "text-sm font-t3-medium text-foreground" : "text-sm text-foreground-muted"
-              }
+              className={cn(
+                compact ? "text-xs" : "text-sm",
+                active ? "font-t3-medium text-foreground" : "text-foreground-muted",
+              )}
             >
               {option.label}
             </Text>
@@ -191,7 +250,6 @@ function ChartCard(props: {
   readonly days: readonly string[];
   readonly daily: readonly DailyTotals[];
   readonly metric: UsageChartMetric;
-  readonly onMetricChange: (metric: UsageChartMetric) => void;
   readonly sinceDay: string;
   readonly untilDay: string;
   readonly isPast24Hours: boolean;
@@ -203,21 +261,18 @@ function ChartCard(props: {
 
   return (
     <View className="gap-4 rounded-[24px] border-continuous bg-card p-4">
-      <View className="flex-row items-start justify-between gap-3">
-        <View className="min-w-0 flex-1 gap-0.5">
-          <Text className="text-sm text-foreground-muted">
-            {metric === "cost" ? "Raw token cost" : "Processed tokens"}
-          </Text>
-          <Text className="text-4xl font-t3-bold tabular-nums text-foreground">
-            {metric === "cost" ? `${formatUsd(merged.costUsd)}*` : formatTokens(merged.totalTokens)}
-          </Text>
-          <Text className="text-sm text-foreground-muted">
-            {metric === "cost"
-              ? "* if billed at full API rate"
-              : `Across ${formatCount(merged.sessions)} sessions`}
-          </Text>
-        </View>
-        <MetricToggle metric={metric} onChange={props.onMetricChange} />
+      <View className="gap-0.5">
+        <Text className="text-sm text-foreground-muted">
+          {metric === "cost" ? "Raw token cost" : "Processed tokens"}
+        </Text>
+        <Text className="text-4xl font-t3-bold tabular-nums text-foreground">
+          {metric === "cost" ? `${formatUsd(merged.costUsd)}*` : formatTokens(merged.totalTokens)}
+        </Text>
+        <Text className="text-sm text-foreground-muted">
+          {metric === "cost"
+            ? "* if billed at full API rate"
+            : `Across ${formatCount(merged.sessions)} sessions`}
+        </Text>
       </View>
 
       {hasActivity ? (
@@ -258,38 +313,6 @@ function ChartCard(props: {
             : formatDayShort(props.untilDay)}
         </Text>
       </View>
-    </View>
-  );
-}
-
-function MetricToggle(props: {
-  readonly metric: UsageChartMetric;
-  readonly onChange: (metric: UsageChartMetric) => void;
-}) {
-  return (
-    <View className="flex-row overflow-hidden rounded-full bg-subtle">
-      {(["cost", "tokens"] as const).map((option) => {
-        const active = option === props.metric;
-        return (
-          <Pressable
-            key={option}
-            accessibilityRole="button"
-            accessibilityState={{ selected: active }}
-            onPress={() => props.onChange(option)}
-            className={active ? "rounded-full bg-subtle-strong px-3 py-1.5" : "px-3 py-1.5"}
-          >
-            <Text
-              className={
-                active
-                  ? "text-xs font-t3-medium uppercase text-foreground"
-                  : "text-xs uppercase text-foreground-muted"
-              }
-            >
-              {option}
-            </Text>
-          </Pressable>
-        );
-      })}
     </View>
   );
 }

--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -32,11 +32,13 @@ const TAB_OPTIONS = [
   { value: "limits", label: "Limits" },
 ] as const satisfies readonly { value: UsageTab; label: string }[];
 
+// Labels are abbreviated to share a row with the metric toggle; screen
+// readers get the full phrase.
 const WINDOW_OPTIONS = [
-  { days: 1, label: "24h" },
-  { days: 7, label: "7d" },
-  { days: 30, label: "30d" },
-  { days: 90, label: "90d" },
+  { value: 1, label: "24h", accessibilityLabel: "Past 24 hours" },
+  { value: 7, label: "7d", accessibilityLabel: "Past 7 days" },
+  { value: 30, label: "30d", accessibilityLabel: "Past 30 days" },
+  { value: 90, label: "90d", accessibilityLabel: "Past 90 days" },
 ] as const;
 
 const METRIC_OPTIONS = [
@@ -135,7 +137,7 @@ export function UsageRouteScreen() {
           />
         }
       >
-        <SegmentedControl options={TAB_OPTIONS} selected={tab} onSelect={setTab} />
+        <SegmentedControl options={TAB_OPTIONS} selected={tab} onSelect={setTab} role="tab" />
 
         {showingLimits ? (
           <UsageLimitsSection now={limits.now} />
@@ -145,10 +147,7 @@ export function UsageRouteScreen() {
                 both change every number below, so they share one bar. */}
             <View className="flex-row items-center gap-3">
               <SegmentedControl
-                options={WINDOW_OPTIONS.map((option) => ({
-                  value: option.days,
-                  label: option.label,
-                }))}
+                options={WINDOW_OPTIONS}
                 selected={windowDays}
                 onSelect={selectWindow}
                 size="compact"
@@ -200,16 +199,23 @@ export function UsageRouteScreen() {
 }
 
 function SegmentedControl<Value extends number | string>(props: {
-  readonly options: readonly { readonly value: Value; readonly label: string }[];
+  readonly options: readonly {
+    readonly value: Value;
+    readonly label: string;
+    readonly accessibilityLabel?: string;
+  }[];
   readonly selected: Value;
   readonly onSelect: (value: Value) => void;
   /** The tab bar is full height; filters under it are shorter so it stays primary. */
   readonly size?: "default" | "compact";
+  /** "tab" for the view switcher; filters stay plain buttons. */
+  readonly role?: "tab" | "button";
   readonly className?: string;
 }) {
   const compact = props.size === "compact";
   return (
     <View
+      accessibilityRole={props.role === "tab" ? "tablist" : undefined}
       className={cn(
         "flex-row overflow-hidden rounded-full border-continuous bg-card",
         props.className,
@@ -220,7 +226,8 @@ function SegmentedControl<Value extends number | string>(props: {
         return (
           <Pressable
             key={String(option.value)}
-            accessibilityRole="button"
+            accessibilityRole={props.role ?? "button"}
+            accessibilityLabel={option.accessibilityLabel}
             accessibilityState={{ selected: active }}
             onPress={() => props.onSelect(option.value)}
             className={cn(

--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -138,7 +138,7 @@ export function UsageRouteScreen() {
         <SegmentedControl options={TAB_OPTIONS} selected={tab} onSelect={setTab} />
 
         {showingLimits ? (
-          <UsageLimitsSection />
+          <UsageLimitsSection now={limits.now} />
         ) : (
           <>
             {/* Period and metric together: neither applies to Limits, and

--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -11,7 +11,7 @@ import {
   formatUsd,
   makeWindow,
 } from "@t3tools/shared/usageFormat";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Platform, Pressable, RefreshControl, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -96,6 +96,14 @@ export function UsageRouteScreen() {
   // environment stays pending forever — neither may pin the spinner on.
   const refreshingUsage = environments.some((entry) => entry.isPending && entry.summary !== null);
   const showingLimits = tab === "limits";
+  // One ScrollView serves both tabs, so the offset would otherwise carry over
+  // and a short Limits list could open scrolled past its own content.
+  const scrollRef = useRef<ScrollView>(null);
+  const selectTab = (next: UsageTab) => {
+    if (next === tab) return;
+    setTab(next);
+    scrollRef.current?.scrollTo({ y: 0, animated: false });
+  };
   const selectWindow = (days: number) => {
     setWindowSelection({
       days,
@@ -125,6 +133,7 @@ export function UsageRouteScreen() {
         </>
       ) : null}
       <ScrollView
+        ref={scrollRef}
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
         className="flex-1"
@@ -137,10 +146,10 @@ export function UsageRouteScreen() {
           />
         }
       >
-        <SegmentedControl options={TAB_OPTIONS} selected={tab} onSelect={setTab} role="tab" />
+        <SegmentedControl options={TAB_OPTIONS} selected={tab} onSelect={selectTab} role="tab" />
 
         {showingLimits ? (
-          <UsageLimitsSection now={limits.now} />
+          <UsageLimitsSection now={limits.now} failedLabels={limits.failedLabels} />
         ) : (
           <>
             {/* Period and metric together: neither applies to Limits, and

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -18,6 +18,8 @@ update model pricing.
 compares quota consumed with time elapsed in each window, so you can judge your pace before the
 next reset.
 
+If a window looks stale, refresh Limits to re-check every provider and hub.
+
 API-key accounts may not report subscription limits. This also applies to Claude connections
 using a proxy through `ANTHROPIC_AUTH_TOKEN`.
 


### PR DESCRIPTION
The mobile Usage page put subscription limits in the middle of one long scroll, between Providers and Totals, so the page read as an undifferentiated list and the two different kinds of data (transcript-derived spend for a period, live quota with no period) were hard to tell apart.

Usage and Limits are now two tabs at the top of the page, matching the web app's Cost / Tokens / Limits toggle. On Usage, a second, shorter row holds the period and the cost/tokens toggle together, replacing the chart card's own toggle. Limits rows lead with the provider icon, use the chart's provider colour on the bar until it turns amber/red, and put pace under the left edge and the reset countdown under the right. Pull-to-refresh is per tab: Usage rescans transcripts as before; Limits re-probes every provider on every connected environment, which mobile could not do before.

Mobile still cannot add a CLIProxyAPI hub; that stays web-only. Hubs added on web show up on mobile.

## Before / after

Usage tab, 30 days, cost:

![Before: one long scroll with a four-way period picker on top; after: Usage/Limits tabs, then a period + cost/tokens row](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/ccebf53ec30a35c1/pr-usage.png)

Usage tab, 7 days, tokens:

![Before: tokens toggle inside the chart card; after: tokens selected in the filter row](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/e623e99821307c98/pr-usage-tokens.png)

Limits:

![Before: Limits card buried mid-scroll between Providers and Totals; after: dedicated Limits tab with provider icons and coloured bars](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/da503801c7334892/pr-limits.png)

## Verification

- `tsc --noEmit` for `apps/mobile`, plus `vp lint` and `vp fmt --check` on the touched files.
- Driven on an iPhone 17 Pro simulator (iOS 26.5) against a disposable copy of real usage data: tab switch, period and metric selection, Limits rendering with a Codex subscription (reset credits shown) and a Claude API-key account, pull-to-refresh on both tabs.
- Android not exercised on a device; the screen uses the same JS segmented controls on both platforms and the Android header path is unchanged.

Docs: one line in `docs/user/usage.md` on refreshing Limits, in the guide's task-focused voice; the tab layout itself is not described, per the docs rules.

Built with Claude Fable 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly mobile UI and navigation; Limits refresh reuses the existing provider refresh command with failure messaging and stale-data fallback.
> 
> **Overview**
> The mobile **Usage** screen is split into **Usage** and **Limits** tabs so transcript spend and live subscription quota are no longer one long scroll.
> 
> On **Usage**, period (abbreviated labels + accessibility) and **Cost/Tokens** sit in a shared compact segmented row; the chart card no longer has its own metric toggle. Pull-to-refresh still rescans transcripts; switching tabs scrolls back to the top.
> 
> On **Limits**, **`useRefreshLimits`** re-probes every provider on each connected environment via **`refreshProviders`**, re-anchors pace/countdowns to a new **`now`**, surfaces named environments when refresh fails, and shows an empty state when nothing reports limits. Rows use **provider icons**, chart-matching bar colors (until warning/destructive thresholds), and pace vs reset countdown on opposite sides. Provider limit sections render before CLI proxy source sections, with updated section titles.
> 
> **`SegmentedControl`** gains compact sizing, optional tablist semantics, and optional accessibility labels. User docs add one line on refreshing Limits when data looks stale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fd4e7732c58c4eada9c48eb2ffe1460bbbd129f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split mobile usage page into Usage and Limits tabs
> - Splits the usage screen into two tabs: Usage keeps charts, totals, and model breakdowns; Limits shows provider and source-account quota windows.
> - Reworks `usage.UsageLimitsSection` to show a no-limits empty state, report refresh failures while retaining last-known values, and render connected providers before source accounts.
> - Adds `usage.useBarColor` to color low-usage bars (<70%) with provider-specific colors for Codex and Claude drivers; warning and destructive colors still apply above that threshold.
> - Adds `usage.useRefreshLimits` so pull-to-refresh on the Limits tab re-probes every connected environment concurrently, records failed labels, and updates the limits clock.
> - Generalizes `SegmentedControl` to support tab semantics, accessibility labels, and compact sizing; removes the standalone `MetricToggle` since metric selection now uses the generalized control.
> - Updates [docs/user/usage.md](https://github.com/pingdotgg/t3code/pull/9775/files#diff-d73591feaa8c26e8f16b7467464af0044ee0a9c288ef17901538a61715440e62) with guidance to refresh Limits when a quota window looks stale.
> - Risk: switching tabs resets scroll to top and removes inline limits from the Usage view, so any consumer expecting limits under Usage must use the Limits tab.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5fd4e77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->