### PR TITLE
fix(web): restore the running tool label shine

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1918,14 +1918,21 @@ function LiveActivityRow({
   iconName,
   toolIcon,
   failed = false,
+  active = false,
 }: {
   label: string;
   iconName?: WorkEntryIconName;
   toolIcon?: ToolActivityIcon | undefined;
   failed?: boolean;
+  active?: boolean;
 }) {
   return (
-    <div className="min-h-6 w-fit max-w-full min-w-0 overflow-hidden rounded-md text-sm leading-relaxed">
+    <div
+      className={cn(
+        "min-h-6 w-fit max-w-full min-w-0 overflow-hidden rounded-md text-sm leading-relaxed",
+        active && "motion-safe:animate-status-pulse",
+      )}
+    >
       <LiveActivityContent
         label={label}
         iconName={iconName}
@@ -2004,6 +2011,7 @@ function LiveWorkEntryTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "
         iconName={workEntryIconName(row.entry)}
         toolIcon={row.entry.toolIcon ?? row.entry.toolSource?.icon}
         failed={failed}
+        active={row.active}
       />
     </button>
   );

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1927,18 +1927,14 @@ function LiveActivityRow({
   active?: boolean;
 }) {
   return (
-    <div
-      className={cn(
-        "min-h-6 w-fit max-w-full min-w-0 overflow-hidden rounded-md text-sm leading-relaxed",
-        active && "motion-safe:animate-status-pulse",
-      )}
-    >
+    <div className="min-h-6 w-fit max-w-full min-w-0 overflow-hidden rounded-md text-sm leading-relaxed">
       <LiveActivityContent
         label={label}
         iconName={iconName}
         toolIcon={toolIcon}
         failed={failed}
         announceFailure={failed}
+        active={active}
       />
     </div>
   );
@@ -1950,12 +1946,14 @@ function LiveActivityContent({
   toolIcon,
   failed = false,
   announceFailure = false,
+  active = false,
 }: {
   label: string;
   iconName: WorkEntryIconName | undefined;
   toolIcon?: ToolActivityIcon | undefined;
   failed?: boolean;
   announceFailure?: boolean;
+  active?: boolean;
 }) {
   const showTrailingFailureMark =
     failed && iconName !== undefined && !toolIconAcceptsTint(iconName, toolIcon);
@@ -1985,7 +1983,7 @@ function LiveActivityContent({
           />
         </span>
       ) : null}
-      <span className="min-w-0 flex-1 truncate">{label}</span>
+      <span className={cn("min-w-0 flex-1 truncate", active && "live-tool-shine")}>{label}</span>
       {showTrailingFailureMark ? (
         <XIcon aria-hidden className={cn("size-3 shrink-0", failedToolIconClassName)} />
       ) : null}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -442,8 +442,8 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   @media (prefers-reduced-motion: no-preference) and (forced-colors: none) {
     color: transparent;
     background-image:
-      linear-gradient(to right, transparent, var(--foreground), transparent),
-      linear-gradient(var(--secondary-label), var(--secondary-label));
+      linear-gradient(to right, transparent, var(--contrast-foreground), transparent),
+      linear-gradient(var(--contrast-secondary-label), var(--contrast-secondary-label));
     background-size:
       4.5rem 100%,
       100% 100%;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -425,6 +425,34 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   }
 }
 
+@keyframes live-tool-shine {
+  from {
+    background-position:
+      -4.5rem 0,
+      0 0;
+  }
+  to {
+    background-position:
+      calc(100% + 4.5rem) 0,
+      0 0;
+  }
+}
+
+@utility live-tool-shine {
+  @media (prefers-reduced-motion: no-preference) and (forced-colors: none) {
+    color: transparent;
+    background-image:
+      linear-gradient(to right, transparent, var(--foreground), transparent),
+      linear-gradient(var(--secondary-label), var(--secondary-label));
+    background-size:
+      4.5rem 100%,
+      100% 100%;
+    background-repeat: no-repeat;
+    background-clip: text;
+    animation: live-tool-shine 2.2s steps(30) infinite;
+  }
+}
+
 @property --assistant-citation-highlight-opacity {
   syntax: "<number>";
   inherits: true;

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -174,7 +174,8 @@ On web and desktop, loading and syncing statuses fill the available banner width
 stash tab. Task progress appears above the composer, while the timeline's working timer shows
 only elapsed time.
 
-Loading, syncing, and server-update icons are static. Live tool labels do not shimmer.
+Loading, syncing, and server-update icons are static. The current live tool label pulses while work
+continues.
 
 On web and desktop, additional notices peek out above the attached banner. Hover over the peek
 to reveal them, or focus **Show other notices** with `Tab` and press `Enter` or `Space`. Press

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -174,8 +174,7 @@ On web and desktop, loading and syncing statuses fill the available banner width
 stash tab. Task progress appears above the composer, while the timeline's working timer shows
 only elapsed time.
 
-Loading, syncing, and server-update icons are static. The current live tool label pulses while work
-continues.
+Loading, syncing, and server-update icons are static. Live tool labels do not shimmer.
 
 On web and desktop, additional notices peek out above the attached banner. Hover over the peek
 to reveal them, or focus **Show other notices** with `Tab` and press `Enter` or `Space`. Press


### PR DESCRIPTION
Restores the left-to-right shine on the last running tool label after #9709 removed it. A 4.5rem highlight sweeps across one text element every 2.2 seconds, capped at 30 steps per cycle; inactive rows, reduced motion, and forced colors retain static text.

Verified with 38 timeline tests, web typecheck, targeted lint, and real OpenCode tool calls in dark and light themes, including opening tool details and observing the shine stop on completion. The enlarged GIF samples one cycle of the real browser animation clock at its original 2.2-second duration.

![Shine sweeping across the active tool label](https://uploads-production-47e4.up.railway.app/files/78ef1030-b16b-4e35-bad9-14eb21c28f2c/tool-shine-closeup.gif)

Model: gpt-5.6-sol. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely visual styling on active timeline labels; no logic, data, or API changes beyond threading an existing `active` flag.
> 
> **Overview**
> Restores the **left-to-right shine** on the label for the currently running live work/tool row in the chat timeline (behavior removed in a prior change).
> 
> `LiveActivityRow` / `LiveActivityContent` gain an optional **`active`** prop; `LiveWorkEntryTimelineRow` passes **`row.active`** so only the in-progress entry gets the effect. The label applies the new **`live-tool-shine`** utility when active.
> 
> **`index.css`** adds that utility: a stepped **2.2s** infinite sweep of a **4.5rem** highlight across text via `background-clip: text`. Animation runs only when **`prefers-reduced-motion: no-preference`** and **forced-colors** is off; inactive rows stay static.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad0cdf60575f82e464f1c1e74a0f8310c7c8c9c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore animated shine on the active running tool label
> - Adds an `active` prop to `LiveActivityRow` and `LiveActivityContent`, forwarded from `LiveWorkEntryTimelineRow`, so the active tool label can receive active-state styling.
> - Conditionally applies the `live-tool-shine` class to the label span in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/9777/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) when the row is active.
> - Adds the `live-tool-shine` keyframes and utility class in [index.css](https://github.com/pingdotgg/t3code/pull/9777/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd), which renders text with a repeating horizontal shine sweep. The effect is disabled when reduced motion is requested or forced colors are active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad0cdf6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->