### PR TITLE
fix(web): clarify Antigravity download progress

### DIFF
--- a/apps/web/src/components/settings/ProviderSetupSection.tsx
+++ b/apps/web/src/components/settings/ProviderSetupSection.tsx
@@ -171,7 +171,7 @@ function ProviderSetupActions({
   const actionsDisabled = pendingLabel !== null || queryError !== null;
   const installationStatusMessage =
     installation?.phase === "downloading"
-      ? `Downloading ${(installation.downloadedBytes / 1_000_000).toFixed(1)} MB${installation.totalBytes === null ? "" : ` of ${(installation.totalBytes / 1_000_000).toFixed(1)} MB`}.`
+      ? "Downloading Antigravity."
       : installation?.phase === "extracting"
         ? "Extracting Antigravity."
         : installation?.phase === "verifying"
@@ -183,6 +183,16 @@ function ProviderSetupActions({
                 ? "The configured Antigravity runtime is unavailable."
                 : "The configured Antigravity runtime has not been checked."
               : "Install the official Antigravity runtime before signing in.";
+  const downloadSizeMessage =
+    installation?.phase === "downloading"
+      ? `${(installation.downloadedBytes / 1_000_000).toFixed(1)} MB${installation.totalBytes === null ? "" : ` of ${(installation.totalBytes / 1_000_000).toFixed(1)} MB`}`
+      : undefined;
+  const downloadPercentage =
+    installation?.phase === "downloading" &&
+    installation.totalBytes !== null &&
+    installation.totalBytes > 0
+      ? Math.floor((installation.downloadedBytes / installation.totalBytes) * 100)
+      : null;
 
   async function runCommand<A, E>(
     label: string,
@@ -265,18 +275,29 @@ function ProviderSetupActions({
     <div className="grid gap-3">
       <div className="grid gap-2">
         <p className="font-medium">Runtime</p>
-        <p role="status" className="text-muted-foreground">
-          {installationStatusMessage}
-        </p>
+        <div className="flex items-center justify-between gap-3">
+          <p role="status" className="text-muted-foreground">
+            {installationStatusMessage}
+          </p>
+          {downloadPercentage !== null ? (
+            <span className="shrink-0 tabular-nums text-muted-foreground">
+              {downloadPercentage}%
+            </span>
+          ) : null}
+        </div>
         {installation?.phase === "downloading" &&
         installation.totalBytes !== null &&
         installation.totalBytes > 0 ? (
           <progress
             aria-label="Antigravity download"
-            className="h-1 w-full accent-foreground"
+            aria-valuetext={downloadSizeMessage}
+            className="h-2 w-full appearance-none overflow-hidden rounded-full bg-muted [&::-moz-progress-bar]:rounded-full [&::-moz-progress-bar]:bg-primary [&::-webkit-progress-bar]:rounded-full [&::-webkit-progress-bar]:bg-muted [&::-webkit-progress-value]:rounded-full [&::-webkit-progress-value]:bg-primary"
             value={installation.downloadedBytes}
             max={installation.totalBytes}
           />
+        ) : null}
+        {downloadSizeMessage ? (
+          <p className="tabular-nums text-muted-foreground">{downloadSizeMessage}</p>
         ) : null}
         {installation?.message && installation.message !== installationStatusMessage ? (
           <p className="text-muted-foreground [overflow-wrap:anywhere]">{installation.message}</p>


### PR DESCRIPTION
## What Changed

Make Antigravity's download progress match the existing Relay Client installer: a rounded, theme-colored native progress bar, a whole-number percentage, and tabular byte counts.

Keep the runtime live-region message stable during download. Byte details update below it and remain available through the progress element's `aria-valuetext`. No animations or dependencies added.

## Why

The current bar falls back to browser styling, has no percentage, and rewrites the live-region message on every byte update. Separating phase feedback from byte counts makes progress easier to read without those repeated live-region changes.

```mermaid
flowchart LR
    State[Installation state] --> Phase[Phase message in live region]
    State --> Bar[Native progress bar]
    State --> Percent[Whole-number percentage]
    State --> Bytes[Byte text and accessible value]
```

This changes only the shared web/desktop Settings component. Remote environments keep the same state and commands. Mobile has no Antigravity installer. Other providers, contracts, and setup instructions are unchanged.

## UI Changes

PNG screenshots at 2x density. Both render the real component with simulated provider state in an isolated preview, not an end-to-end installation.

| Before | After |
| --- | --- |
| ![Before: browser-styled Antigravity download bar](https://github.com/user-attachments/assets/71174381-46ab-4580-afba-587a136170a2) | ![After: themed progress bar, percentage and separate byte count](https://github.com/user-attachments/assets/9f01091d-097e-4fe5-a12c-4bf97908534b) |

## Verification

- 11 existing `ProviderSetupSection.test.tsx` tests passed, one worker.
- Targeted lint, formatting and web typecheck passed.
- Fallow audit passed, one thread and web workspace only, with deep CSS disabled. No introduced findings.
- Browser fixture checks passed for 0/55/99/100%, unknown and zero totals, phase changes, cancellation and retry availability. Two byte updates produced zero runtime live-region text changes, down from two. Checked light/dark and 390px width.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] Video not applicable: no new animation or interaction

Model: GPT-5. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes in the Antigravity settings UI with no auth, install logic, or API contract changes.
> 
> **Overview**
> **Antigravity runtime download** in Settings now shows progress like the Relay installer: a stable phase line, a themed rounded progress bar, a whole-number **%**, and byte counts on their own line.
> 
> During download, the `role="status"` text stays **"Downloading Antigravity."** instead of updating on every byte tick. **`downloadSizeMessage`** and **`downloadPercentage`** drive the bar, the right-aligned percent, the line below, and **`aria-valuetext`** on the native `<progress>` element. The bar uses taller, theme-aware styling (`bg-muted` / `bg-primary`) instead of the default browser chrome.
> 
> Scope is **`ProviderSetupSection`** only; install state and commands are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3a8b600ddd5f0957bc7ac1f5d181fddf98ba90f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify Antigravity download progress with percentage and size
> - Separates byte counts from the primary status message, which now uses a generic downloading label in [ProviderSetupSection.tsx](https://github.com/pingdotgg/t3code/pull/9793/files#diff-afefbca1e028990183ce04428f56bf1af854a73d4730fea1a0aec7bb379ca44b)
> - Displays the download percentage beside the status text and the downloaded/total megabytes beneath the progress bar
> - Adds accessible value text to the progress element to expose the download size to screen readers
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3a8b60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated runtime download status messaging to display “Downloading Antigravity.”
  * Added download percentage and size details during runtime downloads.
  * Restyled the download progress bar with improved visibility and accessibility text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->