### PR TITLE
fix(web): center pull request link previews

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestLinkPreview.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestLinkPreview.tsx
@@ -84,7 +84,7 @@ export function PullRequestLinkPreview({
   return (
     <PreviewCard open={open} onOpenChange={setOpen}>
       <PreviewCardTrigger render={trigger} delay={350} closeDelay={120} />
-      <PreviewCardPopup className="w-80 max-w-[calc(100vw-2rem)] p-3">
+      <PreviewCardPopup align="center" className="w-80 max-w-[calc(100vw-2rem)] p-3">
         {detail === null ? (
           <p className="text-xs leading-relaxed text-muted-foreground wrap-anywhere">
             {detailQuery.isPending ? "Loading pull request details…" : originalUrl}


### PR DESCRIPTION
pr hover cards currently align with the link's left edge, making the card appear offset. center this preview over its link using the existing popup alignment prop.

verified with web typecheck, targeted lint, 72 existing chatmarkdown tests, and the real app at 1280 px in dark mode and 800 px in light mode. the card and link centers match within 0.2 px.

before

![pr preview aligned with the link's left edge](https://uploads-production-47e4.up.railway.app/files/fbc560e6-9dc9-463b-9e5e-d7e859b47723/pr-hover-before.png)

after

![pr preview centered over its link](https://uploads-production-47e4.up.railway.app/files/8d85b64b-8e7e-4dc4-a4da-1e61ebcd006d/pr-hover-after.png)

model: gpt-5.6-sol. harness: codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI positioning prop on PR link previews; no auth, data, or logic changes.
> 
> **Overview**
> Pull request link hover previews were positioned with the popup’s default **start** alignment, so the card sat flush with the link’s left edge and looked offset.
> 
> **`PullRequestLinkPreview`** now passes **`align="center"`** on **`PreviewCardPopup`**, centering the preview over the trigger link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd072533e0d6051ecec4d441dbbf1cb02e4d8642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Center pull request link preview popup in `PullRequestLinkPreview`
> Switches the preview popup alignment to center in [PullRequestLinkPreview.tsx](https://github.com/pingdotgg/t3code/pull/9794/files#diff-71623da755eca2bad67ed1be7a4479910554eabae34d2de60ca746f29d2ca523), keeping the existing size and padding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd07253.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
