### PR TITLE
feat(web): add last seen to authorized clients

### DIFF
--- a/apps/server/src/auth/SessionStore.test.ts
+++ b/apps/server/src/auth/SessionStore.test.ts
@@ -379,7 +379,7 @@ it.layer(NodeServices.layer)("SessionStore.layer", (it) => {
     }).pipe(Effect.provide(makeSessionStoreLayer())),
   );
 
-  it.effect("persists lastConnectedAt on first connect and updates it after reconnect", () =>
+  it.effect("tracks the connection start and final disconnect time", () =>
     Effect.gen(function* () {
       const sessions = yield* SessionStore.SessionStore;
       const issued = yield* sessions.issue({
@@ -405,11 +405,20 @@ it.layer(NodeServices.layer)("SessionStore.layer", (it) => {
       expect(stillConnected[0]?.lastConnectedAt?.toString()).toBe(firstConnectedAt?.toString());
 
       yield* sessions.markDisconnected(issued.sessionId);
+      const afterFirstDisconnect = yield* sessions.listActive();
+
+      expect(afterFirstDisconnect[0]?.connected).toBe(true);
+      expect(afterFirstDisconnect[0]?.lastConnectedAt?.toString()).toBe(
+        firstConnectedAt?.toString(),
+      );
+
       yield* sessions.markDisconnected(issued.sessionId);
       const afterDisconnect = yield* sessions.listActive();
+      const disconnectedAt = afterDisconnect[0]?.lastConnectedAt;
 
       expect(afterDisconnect[0]?.connected).toBe(false);
-      expect(afterDisconnect[0]?.lastConnectedAt?.toString()).toBe(firstConnectedAt?.toString());
+      expect(disconnectedAt).not.toBeNull();
+      expect(disconnectedAt?.toString()).not.toBe(firstConnectedAt?.toString());
 
       yield* TestClock.adjust(Duration.seconds(1));
       yield* sessions.markConnected(issued.sessionId);
@@ -417,7 +426,7 @@ it.layer(NodeServices.layer)("SessionStore.layer", (it) => {
 
       expect(afterReconnect[0]?.connected).toBe(true);
       expect(afterReconnect[0]?.lastConnectedAt).not.toBeNull();
-      expect(afterReconnect[0]?.lastConnectedAt?.toString()).not.toBe(firstConnectedAt?.toString());
+      expect(afterReconnect[0]?.lastConnectedAt?.toString()).not.toBe(disconnectedAt?.toString());
     }).pipe(Effect.provide(Layer.merge(makeSessionStoreLayer(), TestClock.layer()))),
   );
   it.effect("records client connection metadata without clearing prior values", () =>

--- a/apps/server/src/auth/SessionStore.ts
+++ b/apps/server/src/auth/SessionStore.ts
@@ -530,6 +530,16 @@ export const make = Effect.gen(function* () {
       );
     });
 
+  const setLastConnectedAtNow = (sessionId: AuthSessionId) =>
+    DateTime.now.pipe(
+      Effect.flatMap((lastConnectedAt) =>
+        authSessions.setLastConnectedAt({
+          sessionId,
+          lastConnectedAt,
+        }),
+      ),
+    );
+
   const markConnected: SessionStore["Service"]["markConnected"] = (sessionId) =>
     Ref.modify(connectedSessionsRef, (current) => {
       const next = new Map(current);
@@ -538,16 +548,7 @@ export const make = Effect.gen(function* () {
       return [wasDisconnected, next] as const;
     }).pipe(
       Effect.flatMap((wasDisconnected) =>
-        wasDisconnected
-          ? DateTime.now.pipe(
-              Effect.flatMap((lastConnectedAt) =>
-                authSessions.setLastConnectedAt({
-                  sessionId,
-                  lastConnectedAt,
-                }),
-              ),
-            )
-          : Effect.void,
+        wasDisconnected ? setLastConnectedAtNow(sessionId) : Effect.void,
       ),
       Effect.flatMap(() => loadActiveSession(sessionId)),
       Effect.flatMap((session) =>
@@ -587,7 +588,7 @@ export const make = Effect.gen(function* () {
           );
 
   const markDisconnected: SessionStore["Service"]["markDisconnected"] = (sessionId) =>
-    Ref.update(connectedSessionsRef, (current) => {
+    Ref.modify(connectedSessionsRef, (current) => {
       const next = new Map(current);
       const remaining = (next.get(sessionId) ?? 0) - 1;
       if (remaining > 0) {
@@ -595,8 +596,11 @@ export const make = Effect.gen(function* () {
       } else {
         next.delete(sessionId);
       }
-      return next;
+      return [remaining === 0, next] as const;
     }).pipe(
+      Effect.flatMap((becameDisconnected) =>
+        becameDisconnected ? setLastConnectedAtNow(sessionId) : Effect.void,
+      ),
       Effect.flatMap(() => loadActiveSession(sessionId)),
       Effect.flatMap((session) =>
         Option.isSome(session) ? emitUpsert(session.value) : Effect.void,

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -44,7 +44,11 @@ import * as Option from "effect/Option";
 
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { cn } from "../../lib/utils";
-import { formatElapsedDurationLabel, formatExpiresInLabel } from "../../timestampFormat";
+import {
+  formatElapsedDurationLabel,
+  formatExpiresInLabel,
+  formatRelativeTimeLabel,
+} from "../../timestampFormat";
 import { resolveDesktopPairingUrl, resolveHostedPairingUrl } from "./pairingUrls";
 import {
   applyWslEnableSelection,
@@ -952,6 +956,11 @@ const ConnectedClientListRow = memo(function ConnectedClientListRow({
     : lastConnectedAt
       ? `Last connected at ${formatAccessTimestamp(lastConnectedAt)}`
       : "Not connected yet.";
+  const lastSeenLabel = isLive
+    ? "Last seen now"
+    : lastConnectedAt
+      ? `Last seen ${formatRelativeTimeLabel(lastConnectedAt)}`
+      : "Never seen";
   const deviceInfoBits = [
     clientSession.client.deviceType !== "unknown"
       ? clientSession.client.deviceType[0]?.toUpperCase() + clientSession.client.deviceType.slice(1)
@@ -991,6 +1000,7 @@ const ConnectedClientListRow = memo(function ConnectedClientListRow({
             ) : null}
             <AccessScopeSummary scopes={clientSession.scopes} label="Client scopes" />
           </p>
+          <p className="text-xs text-muted-foreground/70">{lastSeenLabel}</p>
         </div>
         <div className="flex w-full shrink-0 items-center gap-2 sm:w-auto sm:justify-end">
           {!clientSession.current ? (


### PR DESCRIPTION
## What Changed

Adds a relative "Last seen" line to each authorized client.

Live sessions show "Last seen now". Older sessions show values such as "Last seen 12m ago". Sessions without a timestamp show "Never seen".

## UI Changes

Before: 

<img width="900" height="210" alt="t3-authorized-clients-before" src="https://github.com/user-attachments/assets/f6c75cb8-46ce-445f-9f86-8645ccf91f27" />

After:

<img width="900" height="240" alt="t3-authorized-clients-after" src="https://github.com/user-attachments/assets/35584490-3463-4fa4-b223-d93cbd4d2cf2" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change

Checks: targeted timestamp tests and web typecheck passed.

Built by Codex on behalf of Exotic using GPT-5.6 Sol in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persisted semantics of `lastConnectedAt` on auth sessions, which may affect other readers of that field beyond the new UI.
> 
> **Overview**
> Adds a **Last seen** line on each authorized client in Connections settings, using relative time when offline and **Last seen now** while the session is live (or **Never seen** when no timestamp exists).
> 
> To support that, **`SessionStore`** now persists `lastConnectedAt` when a session’s **last** connection drops (ref-count hits zero), not only on the first connect. Partial disconnects (e.g. one of several sockets) leave the timestamp and connected state unchanged; a full disconnect writes the disconnect time, and a later reconnect updates it again. Connect path is refactored to share a `setLastConnectedAtNow` helper.
> 
> **Note:** anything that treated `lastConnectedAt` as “when the client last connected” will now see the final disconnect time for idle sessions instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5762c9ebf3912248752a6a984872205365eea23f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add last-seen timestamp tracking to authorized client connections
> - `markDisconnected` in `SessionStore` now persists the current time to `lastConnectedAt` only when the final connection reference disconnects; intermediate disconnects just decrement the count.
> - `ConnectedClientListRow` in the web settings displays a last-seen label: live clients show "Last seen now", disconnected clients show a relative time, and clients without a timestamp show "Never seen".
> - Tests in [SessionStore.test.ts](https://github.com/pingdotgg/t3code/pull/9798/files#diff-a997252f7c5162ff828b958faa2380421a24fa18f69b4e63bc9b567c3a8da1a3) verify that intermediate disconnects preserve the initial timestamp, final disconnects update it, and reconnects produce a newer timestamp.
> - Behavioral Change: `lastConnectedAt` is now updated on final disconnect rather than only on connect, so consumers reading that field may see disconnect times where they previously saw the last connection start time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5762c9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->