### PR TITLE
fix(web): give toggle thumbs consistent inset spacing

### DIFF
--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -12,7 +12,7 @@ function Switch({
   return (
     <SwitchPrimitive.Root
       className={cn(
-        "inline-flex h-[calc(var(--thumb-size)+2px)] w-[calc(var(--thumb-size)*2-2px)] shrink-0 cursor-pointer items-center rounded-full p-px outline-none transition-[background-color,box-shadow] duration-200 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background data-checked:bg-primary data-unchecked:bg-input data-disabled:cursor-not-allowed data-disabled:opacity-64",
+        "inline-flex h-[calc(var(--thumb-size)+2px)] w-[calc(var(--thumb-size)*2-2px)] shrink-0 cursor-pointer items-center rounded-full p-[2px] outline-none transition-[background-color,box-shadow] duration-200 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background data-checked:bg-primary data-unchecked:bg-input data-disabled:cursor-not-allowed data-disabled:opacity-64",
         size === "sm"
           ? "[--thumb-size:--spacing(4)] sm:[--thumb-size:--spacing(3.5)]"
           : "[--thumb-size:--spacing(5)] sm:[--thumb-size:--spacing(4)]",
@@ -24,7 +24,7 @@ function Switch({
     >
       <SwitchPrimitive.Thumb
         className={cn(
-          "pointer-events-none block aspect-square h-full origin-left in-[[role=switch]:active,[data-slot=label]:active,[data-slot=field-label]:active]:not-data-disabled:scale-x-110 in-[[role=switch]:active,[data-slot=label]:active,[data-slot=field-label]:active]:rounded-[var(--thumb-size)/calc(var(--thumb-size)*1.1)] rounded-(--thumb-size) bg-background shadow-sm/5 will-change-transform [transition:translate_.15s,border-radius_.15s,scale_.1s_.1s,transform-origin_.15s] data-checked:origin-[var(--thumb-size)_50%] data-checked:translate-x-[calc(var(--thumb-size)-4px)]",
+          "pointer-events-none block size-[calc(var(--thumb-size)-2px)] shrink-0 origin-left in-[[role=switch]:active,[data-slot=label]:active,[data-slot=field-label]:active]:not-data-disabled:scale-x-110 in-[[role=switch]:active,[data-slot=label]:active,[data-slot=field-label]:active]:rounded-[var(--thumb-size)/calc(var(--thumb-size)*1.1)] rounded-(--thumb-size) bg-background shadow-sm/5 will-change-transform [transition:translate_.15s,border-radius_.15s,scale_.1s_.1s,transform-origin_.15s] data-checked:origin-right data-checked:translate-x-[calc(var(--thumb-size)-4px)]",
         )}
         data-slot="switch-thumb"
       />


### PR DESCRIPTION
Small toggle thumbs crowded the track edges, making their spacing look uneven. Give the shared web/desktop switch a fixed 2px inset and an explicitly sized thumb, preserving track dimensions and anchoring the pressed thumb at its resting edge.

Verified both sizes and on/off states in the real app at desktop and narrow widths with light and dark themes; web typecheck, targeted lint, and formatting pass.

Before:

![Before: toggle thumbs crowd the track edges](https://uploads-production-47e4.up.railway.app/files/c07a8574-b4cf-467d-8a71-64d8d857a340/toggle-before.png)

After:

![After: consistent spacing around toggle thumbs](https://uploads-production-47e4.up.railway.app/files/40aa90dd-f56e-4241-acfb-e0bfd7dfaf9f/toggle-after.png)

Model: `gpt-5.6-sol`. Harness: Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to the Switch component with no behavior, data, or auth impact.
> 
> **Overview**
> Fixes uneven thumb spacing on the shared **Switch** by standardizing track inset and thumb sizing instead of letting the thumb fill the track height.
> 
> The switch track padding moves from `p-px` to **`p-[2px]`** so both sides get a fixed inset while overall track dimensions stay the same. The thumb is sized explicitly with **`size-[calc(var(--thumb-size)-2px)]`** (replacing full-height / aspect-square sizing), and the checked-state transform origin is **`origin-right`** so press/active scaling stays anchored at the thumb’s resting edge when on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc5177276d74886d33fbd7ae3f194bc164daaec0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix inconsistent inset spacing for `Switch` thumb
> Changes the `Switch` root padding from 1px to 2px and sizes the thumb to `var(--thumb-size) - 2px` with `flex-shrink: 0`. Moves the checked-state transform origin to the right edge.
>
> Risk: thumb size is now fixed rather than filling the track height; any custom `--thumb-size` values may need rechecking.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc51772.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->