### PR TITLE
feat(web): make pending questions easy to find without moving threads

### DIFF
--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -2924,6 +2924,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
 
   return (
     <SidebarContent
+      showPendingQuestions
       className="gap-0"
       fixedHeader={
         // Lifted above the stage backdrop, whose fade bleeds below the

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -2859,6 +2859,7 @@ interface SidebarProjectsContentProps {
   suppressProjectClickForContextMenuRef: React.RefObject<boolean>;
   attachProjectListAutoAnimateRef: (node: HTMLElement | null) => void;
   projectsLength: number;
+  navigateToThread: (threadRef: ScopedThreadRef) => void;
 }
 
 const SidebarProjectsContent = memo(function SidebarProjectsContent(
@@ -2924,7 +2925,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
 
   return (
     <SidebarContent
-      showPendingQuestions
+      onPendingQuestionNavigate={props.navigateToThread}
       className="gap-0"
       fixedHeader={
         // Lifted above the stage backdrop, whose fade bleeds below the
@@ -3764,6 +3765,7 @@ export default function LegacySidebar() {
         suppressProjectClickForContextMenuRef={suppressProjectClickForContextMenuRef}
         attachProjectListAutoAnimateRef={attachProjectListAutoAnimateRef}
         projectsLength={projects.length}
+        navigateToThread={navigateToThread}
       />
       <SidebarChromeFooter />
     </>

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -702,6 +702,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
       ref={rowRef}
       className="w-full"
       data-thread-item
+      data-pending-question={thread.hasPendingUserInput || undefined}
       onMouseLeave={handleMouseLeave}
       onBlurCapture={handleBlurCapture}
     >
@@ -713,7 +714,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
         className={`${resolveThreadRowClassName({
           isActive,
           isSelected,
-        })} relative isolate`}
+        })} relative isolate${thread.hasPendingUserInput ? " sidebar-question-pending" : ""}`}
         onClick={handleRowClick}
         onDoubleClick={handleRowDoubleClick}
         onKeyDown={handleRowKeyDown}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1176,6 +1176,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // content; surface is reserved for interaction (hover, multi-select, route).
   const rowSurfaceClassName = cn(
     "group/sidebar-row relative w-full cursor-pointer overflow-hidden rounded-md text-left outline-none select-none",
+    thread.hasPendingUserInput && "sidebar-question-pending",
     props.isActive
       ? "bg-sidebar-row-active text-sidebar-foreground"
       : isSelected
@@ -1321,6 +1322,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     return (
       <li
         data-thread-item
+        data-pending-question={thread.hasPendingUserInput || undefined}
         className="list-none [content-visibility:auto] [contain-intrinsic-size:auto_34px]"
       >
         <Tooltip>
@@ -1472,6 +1474,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   return (
     <li
       data-thread-item
+      data-pending-question={thread.hasPendingUserInput || undefined}
       ref={sortable?.setNodeRef}
       style={
         sortable

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3607,6 +3607,7 @@ export default function Sidebar() {
     <>
       <SidebarChromeHeader isElectron={isElectron} />
       <SidebarContent
+        showPendingQuestions
         className="gap-0"
         fixedHeader={
           // Lifted above the stage backdrop, whose fade bleeds below the

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3607,7 +3607,7 @@ export default function Sidebar() {
     <>
       <SidebarChromeHeader isElectron={isElectron} />
       <SidebarContent
-        showPendingQuestions
+        onPendingQuestionNavigate={navigateToThread}
         className="gap-0"
         fixedHeader={
           // Lifted above the stage backdrop, whose fade bleeds below the

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -9,6 +9,7 @@ import { CheckIcon } from "lucide-react";
 import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "../ui/collapsible";
 import { cn } from "~/lib/utils";
 import { ComposerBanner } from "./ComposerBanner";
+import ChatMarkdown from "../ChatMarkdown";
 
 interface PendingUserInputPanelProps {
   pendingUserInputs: PendingUserInput[];
@@ -202,7 +203,11 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
       </CollapsibleTrigger>
       <CollapsiblePanel>
         <ComposerBanner.Body className="pe-1 pb-1">
-          <p className="text-sm text-foreground/85">{activeQuestion.question}</p>
+          <ChatMarkdown
+            text={activeQuestion.question}
+            cwd={undefined}
+            className="text-sm text-foreground/85"
+          />
           {activeQuestion.multiSelect ? (
             <p className="mt-1 text-secondary-label text-xs">Select one or more options.</p>
           ) : null}

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -48,6 +48,7 @@ function singleToolCallLabel(entry: WorkLogEntry): string {
 }
 
 export function workEntryDisplayLabel(entry: WorkLogEntry, workspaceRoot: string | undefined) {
+  if (entry.userInputSummary) return entry.label;
   const toolPresentation = resolveWorkEntryToolPresentation(entry);
   if (toolPresentation) return toolPresentation.displayName;
   if (entry.command) return entry.command;

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -3147,7 +3147,9 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
         : "text-foreground/80";
   const accessibleDisplayText = showFailedIndicator
     ? `${previewText}, tool call failed`
-    : previewText;
+    : workEntry.userInputSummary
+      ? `${previewText}: ${workEntry.userInputSummary}`
+      : previewText;
   const rowToggleProps = canExpand
     ? {
         role: "button" as const,
@@ -3192,7 +3194,8 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
             <p className="flex min-w-0 w-full items-baseline gap-1.5 text-sm leading-relaxed">
               <span
                 className={cn(
-                  "min-w-0 flex-1",
+                  "min-w-0",
+                  workEntry.userInputSummary ? "shrink-0" : "flex-1",
                   expanded || (commandMatchesVisibleLabel && !canExpand)
                     ? "whitespace-pre-wrap break-words select-text"
                     : "truncate",
@@ -3203,6 +3206,11 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
               >
                 {previewText}
               </span>
+              {workEntry.userInputSummary ? (
+                <span className="min-w-0 truncate text-secondary-label">
+                  {workEntry.userInputSummary}
+                </span>
+              ) : null}
             </p>
           </div>
           {showFailedIndicator &&

--- a/apps/web/src/components/sidebar/SidebarQuestionIndicators.tsx
+++ b/apps/web/src/components/sidebar/SidebarQuestionIndicators.tsx
@@ -1,5 +1,6 @@
 import { ArrowDownIcon, ArrowUpIcon } from "lucide-react";
 import { useEffect, useRef, useState, type RefObject } from "react";
+import { Button } from "~/components/ui/button";
 
 /** Tracks only pending rows, and only when the list or its viewport changes. */
 export function SidebarQuestionIndicators({
@@ -68,11 +69,12 @@ export function SidebarQuestionIndicators({
     if (!directions[direction]) return null;
     const Icon = direction === "above" ? ArrowUpIcon : ArrowDownIcon;
     return (
-      <button
+      <Button
         key={direction}
-        type="button"
+        variant="outline"
+        size="icon-sm"
         aria-label={`Show pending question ${direction}`}
-        className={`absolute left-1/2 z-20 flex size-7 -translate-x-1/2 items-center justify-center rounded-full border border-indigo-400/70 bg-sidebar text-indigo-600 shadow-sm hover:bg-sidebar-row-hover focus-visible:outline-2 focus-visible:outline-ring dark:text-indigo-300 ${direction === "above" ? "top-1" : "bottom-1"}`}
+        className={`absolute left-1/2 z-20 -translate-x-1/2 rounded-full border-indigo-400/70 bg-sidebar text-indigo-600 before:rounded-full hover:bg-sidebar-row-hover dark:bg-sidebar dark:text-indigo-300 [--control-icon-color:currentColor] ${direction === "above" ? "top-1" : "bottom-1"}`}
         onClick={() => {
           const row = targets.current[direction];
           row?.scrollIntoView({ block: "center", behavior: "instant" });
@@ -82,7 +84,7 @@ export function SidebarQuestionIndicators({
         }}
       >
         <Icon aria-hidden="true" className="sidebar-question-arrow size-4" />
-      </button>
+      </Button>
     );
   });
 }

--- a/apps/web/src/components/sidebar/SidebarQuestionIndicators.tsx
+++ b/apps/web/src/components/sidebar/SidebarQuestionIndicators.tsx
@@ -1,34 +1,27 @@
+import { scopeThreadRef, scopedThreadKey } from "@t3tools/client-runtime/environment";
+import type { ScopedThreadRef } from "@t3tools/contracts";
 import { ArrowDownIcon } from "lucide-react";
-import { useEffect, useRef, useState, type RefObject } from "react";
+import { useMemo, useRef } from "react";
 import { Button } from "~/components/ui/button";
+import { useThreadShells } from "~/state/entities";
 
-/** Keeps pending questions reachable without changing the list's order. */
+/** Keeps all pending questions reachable, including threads in collapsed lists. */
 export function SidebarQuestionIndicators({
-  containerRef,
+  onNavigate,
 }: {
-  containerRef: RefObject<HTMLDivElement | null>;
+  onNavigate: (threadRef: ScopedThreadRef) => void;
 }) {
-  const rows = useRef<HTMLElement[]>([]);
-  const lastTarget = useRef<HTMLElement | null>(null);
-  const [count, setCount] = useState(0);
-
-  useEffect(() => {
-    const content = containerRef.current?.querySelector('[data-sidebar="content"]');
-    if (!content) return;
-    const reconcile = () => {
-      rows.current = Array.from(content.querySelectorAll<HTMLElement>("[data-pending-question]"));
-      setCount(rows.current.length);
-    };
-    const mutations = new MutationObserver(reconcile);
-    mutations.observe(content, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      attributeFilter: ["data-pending-question"],
-    });
-    reconcile();
-    return () => mutations.disconnect();
-  }, [containerRef]);
+  const threads = useThreadShells();
+  const pending = useMemo(
+    () =>
+      threads
+        .filter((thread) => thread.archivedAt === null && thread.hasPendingUserInput)
+        .toSorted((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+        .map((thread) => scopeThreadRef(thread.environmentId, thread.id)),
+    [threads],
+  );
+  const lastTarget = useRef<string | null>(null);
+  const count = pending.length;
 
   return (
     <div className="shrink-0 px-2 pb-2">
@@ -39,16 +32,12 @@ export function SidebarQuestionIndicators({
         aria-label={`Next pending question (${count})`}
         className="w-full justify-between border-indigo-400/50 bg-sidebar text-indigo-600 transition-none active:scale-100 dark:bg-sidebar dark:text-indigo-300 [--control-icon-color:currentColor]"
         onClick={() => {
-          const candidates = rows.current.filter((row) => row.getClientRects().length > 0);
           const nextIndex =
-            (candidates.findIndex((row) => row === lastTarget.current) + 1) % candidates.length;
-          const row = candidates[nextIndex];
-          if (!row) return;
-          lastTarget.current = row;
-          row.scrollIntoView({ block: "center", behavior: "instant" });
-          const control = row.querySelector<HTMLElement>('[role="button"], a, button');
-          control?.focus({ preventScroll: true });
-          control?.click();
+            (pending.findIndex((ref) => scopedThreadKey(ref) === lastTarget.current) + 1) % count;
+          const next = pending[nextIndex];
+          if (!next) return;
+          lastTarget.current = scopedThreadKey(next);
+          onNavigate(next);
         }}
       >
         <span>

--- a/apps/web/src/components/sidebar/SidebarQuestionIndicators.tsx
+++ b/apps/web/src/components/sidebar/SidebarQuestionIndicators.tsx
@@ -1,50 +1,23 @@
-import { ArrowDownIcon, ArrowUpIcon } from "lucide-react";
+import { ArrowDownIcon } from "lucide-react";
 import { useEffect, useRef, useState, type RefObject } from "react";
 import { Button } from "~/components/ui/button";
 
-/** Tracks only pending rows, and only when the list or its viewport changes. */
+/** Keeps pending questions reachable without changing the list's order. */
 export function SidebarQuestionIndicators({
   containerRef,
 }: {
   containerRef: RefObject<HTMLDivElement | null>;
 }) {
-  const targets = useRef<{ above: HTMLElement | null; below: HTMLElement | null }>({
-    above: null,
-    below: null,
-  });
-  const [directions, setDirections] = useState({ above: false, below: false });
+  const rows = useRef<HTMLElement[]>([]);
+  const lastTarget = useRef<HTMLElement | null>(null);
+  const [count, setCount] = useState(0);
 
   useEffect(() => {
-    const container = containerRef.current;
-    const viewport = container?.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]');
-    const content = container?.querySelector<HTMLElement>('[data-sidebar="content"]');
-    if (!viewport || !content) return;
-    let rows: HTMLElement[] = [];
-    const measure = () => {
-      const bounds = viewport.getBoundingClientRect();
-      // A row inside the scroll fade is no longer a useful visible target.
-      const top = bounds.top + 24;
-      const bottom = bounds.bottom - 24;
-      let above: HTMLElement | null = null;
-      let below: HTMLElement | null = null;
-      for (const row of rows) {
-        const rect = row.getBoundingClientRect();
-        const visible = rect.height > 0 && rect.bottom > top && rect.top < bottom;
-        row.toggleAttribute("data-question-visible", visible);
-        if (rect.height === 0) continue;
-        if (rect.bottom <= top) above = row;
-        if (rect.top >= bottom && below === null) below = row;
-      }
-      targets.current = { above, below };
-      setDirections((current) =>
-        current.above === (above !== null) && current.below === (below !== null)
-          ? current
-          : { above: above !== null, below: below !== null },
-      );
-    };
+    const content = containerRef.current?.querySelector('[data-sidebar="content"]');
+    if (!content) return;
     const reconcile = () => {
-      rows = Array.from(content.querySelectorAll<HTMLElement>("[data-pending-question]"));
-      measure();
+      rows.current = Array.from(content.querySelectorAll<HTMLElement>("[data-pending-question]"));
+      setCount(rows.current.length);
     };
     const mutations = new MutationObserver(reconcile);
     mutations.observe(content, {
@@ -53,38 +26,36 @@ export function SidebarQuestionIndicators({
       attributes: true,
       attributeFilter: ["data-pending-question"],
     });
-    const resize = new ResizeObserver(measure);
-    resize.observe(viewport);
-    resize.observe(content);
-    viewport.addEventListener("scroll", measure, { passive: true });
     reconcile();
-    return () => {
-      mutations.disconnect();
-      resize.disconnect();
-      viewport.removeEventListener("scroll", measure);
-    };
+    return () => mutations.disconnect();
   }, [containerRef]);
 
-  return (["above", "below"] as const).map((direction) => {
-    if (!directions[direction]) return null;
-    const Icon = direction === "above" ? ArrowUpIcon : ArrowDownIcon;
-    return (
+  return (
+    <div className="shrink-0 px-2 pb-2">
       <Button
-        key={direction}
         variant="outline"
-        size="icon-sm"
-        aria-label={`Show pending question ${direction}`}
-        className={`absolute left-1/2 z-20 -translate-x-1/2 rounded-full border-indigo-400/70 bg-sidebar text-indigo-600 before:rounded-full hover:bg-sidebar-row-hover dark:bg-sidebar dark:text-indigo-300 [--control-icon-color:currentColor] ${direction === "above" ? "top-1" : "bottom-1"}`}
+        size="sm"
+        disabled={count === 0}
+        aria-label={`Next pending question (${count})`}
+        className="w-full justify-between border-indigo-400/50 bg-sidebar text-indigo-600 transition-none active:scale-100 dark:bg-sidebar dark:text-indigo-300 [--control-icon-color:currentColor]"
         onClick={() => {
-          const row = targets.current[direction];
-          row?.scrollIntoView({ block: "center", behavior: "instant" });
-          row
-            ?.querySelector<HTMLElement>('[role="button"], a, button')
-            ?.focus({ preventScroll: true });
+          const candidates = rows.current.filter((row) => row.getClientRects().length > 0);
+          const nextIndex =
+            (candidates.findIndex((row) => row === lastTarget.current) + 1) % candidates.length;
+          const row = candidates[nextIndex];
+          if (!row) return;
+          lastTarget.current = row;
+          row.scrollIntoView({ block: "center", behavior: "instant" });
+          const control = row.querySelector<HTMLElement>('[role="button"], a, button');
+          control?.focus({ preventScroll: true });
+          control?.click();
         }}
       >
-        <Icon aria-hidden="true" className="sidebar-question-arrow size-4" />
+        <span>
+          Needs input · <span className="tabular-nums">{count}</span>
+        </span>
+        <ArrowDownIcon aria-hidden="true" className="size-4" />
       </Button>
-    );
-  });
+    </div>
+  );
 }

--- a/apps/web/src/components/sidebar/SidebarQuestionIndicators.tsx
+++ b/apps/web/src/components/sidebar/SidebarQuestionIndicators.tsx
@@ -1,0 +1,88 @@
+import { ArrowDownIcon, ArrowUpIcon } from "lucide-react";
+import { useEffect, useRef, useState, type RefObject } from "react";
+
+/** Tracks only pending rows, and only when the list or its viewport changes. */
+export function SidebarQuestionIndicators({
+  containerRef,
+}: {
+  containerRef: RefObject<HTMLDivElement | null>;
+}) {
+  const targets = useRef<{ above: HTMLElement | null; below: HTMLElement | null }>({
+    above: null,
+    below: null,
+  });
+  const [directions, setDirections] = useState({ above: false, below: false });
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const viewport = container?.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]');
+    const content = container?.querySelector<HTMLElement>('[data-sidebar="content"]');
+    if (!viewport || !content) return;
+    let rows: HTMLElement[] = [];
+    const measure = () => {
+      const bounds = viewport.getBoundingClientRect();
+      // A row inside the scroll fade is no longer a useful visible target.
+      const top = bounds.top + 24;
+      const bottom = bounds.bottom - 24;
+      let above: HTMLElement | null = null;
+      let below: HTMLElement | null = null;
+      for (const row of rows) {
+        const rect = row.getBoundingClientRect();
+        const visible = rect.height > 0 && rect.bottom > top && rect.top < bottom;
+        row.toggleAttribute("data-question-visible", visible);
+        if (rect.height === 0) continue;
+        if (rect.bottom <= top) above = row;
+        if (rect.top >= bottom && below === null) below = row;
+      }
+      targets.current = { above, below };
+      setDirections((current) =>
+        current.above === (above !== null) && current.below === (below !== null)
+          ? current
+          : { above: above !== null, below: below !== null },
+      );
+    };
+    const reconcile = () => {
+      rows = Array.from(content.querySelectorAll<HTMLElement>("[data-pending-question]"));
+      measure();
+    };
+    const mutations = new MutationObserver(reconcile);
+    mutations.observe(content, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["data-pending-question"],
+    });
+    const resize = new ResizeObserver(measure);
+    resize.observe(viewport);
+    resize.observe(content);
+    viewport.addEventListener("scroll", measure, { passive: true });
+    reconcile();
+    return () => {
+      mutations.disconnect();
+      resize.disconnect();
+      viewport.removeEventListener("scroll", measure);
+    };
+  }, [containerRef]);
+
+  return (["above", "below"] as const).map((direction) => {
+    if (!directions[direction]) return null;
+    const Icon = direction === "above" ? ArrowUpIcon : ArrowDownIcon;
+    return (
+      <button
+        key={direction}
+        type="button"
+        aria-label={`Show pending question ${direction}`}
+        className={`absolute left-1/2 z-20 flex size-7 -translate-x-1/2 items-center justify-center rounded-full border border-indigo-400/70 bg-sidebar text-indigo-600 shadow-sm hover:bg-sidebar-row-hover focus-visible:outline-2 focus-visible:outline-ring dark:text-indigo-300 ${direction === "above" ? "top-1" : "bottom-1"}`}
+        onClick={() => {
+          const row = targets.current[direction];
+          row?.scrollIntoView({ block: "center", behavior: "instant" });
+          row
+            ?.querySelector<HTMLElement>('[role="button"], a, button')
+            ?.focus({ preventScroll: true });
+        }}
+      >
+        <Icon aria-hidden="true" className="sidebar-question-arrow size-4" />
+      </button>
+    );
+  });
+}

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -702,6 +702,7 @@ function SidebarContent({
     <>
       {fixedHeader ? <div className="w-full shrink-0">{fixedHeader}</div> : null}
       <div ref={containerRef} className="relative flex min-h-0 flex-1 flex-col">
+        <SidebarQuestionIndicators containerRef={containerRef} />
         <ScrollArea hideScrollbars scrollFade className="h-auto min-h-0 flex-1">
           <div
             className={cn(
@@ -713,7 +714,6 @@ function SidebarContent({
             {...props}
           />
         </ScrollArea>
-        <SidebarQuestionIndicators containerRef={containerRef} />
       </div>
     </>
   );

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -693,16 +693,18 @@ function SidebarSeparator({ className, ...props }: React.ComponentProps<typeof S
 function SidebarContent({
   className,
   fixedHeader,
+  showPendingQuestions = false,
   ...props
 }: React.ComponentProps<"div"> & {
   fixedHeader?: React.ReactNode;
+  showPendingQuestions?: boolean;
 }) {
   const containerRef = React.useRef<HTMLDivElement>(null);
   return (
     <>
       {fixedHeader ? <div className="w-full shrink-0">{fixedHeader}</div> : null}
       <div ref={containerRef} className="relative flex min-h-0 flex-1 flex-col">
-        <SidebarQuestionIndicators containerRef={containerRef} />
+        {showPendingQuestions ? <SidebarQuestionIndicators containerRef={containerRef} /> : null}
         <ScrollArea hideScrollbars scrollFade className="h-auto min-h-0 flex-1">
           <div
             className={cn(

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -693,18 +693,19 @@ function SidebarSeparator({ className, ...props }: React.ComponentProps<typeof S
 function SidebarContent({
   className,
   fixedHeader,
-  showPendingQuestions = false,
+  onPendingQuestionNavigate,
   ...props
 }: React.ComponentProps<"div"> & {
   fixedHeader?: React.ReactNode;
-  showPendingQuestions?: boolean;
+  onPendingQuestionNavigate?: React.ComponentProps<typeof SidebarQuestionIndicators>["onNavigate"];
 }) {
-  const containerRef = React.useRef<HTMLDivElement>(null);
   return (
     <>
       {fixedHeader ? <div className="w-full shrink-0">{fixedHeader}</div> : null}
-      <div ref={containerRef} className="relative flex min-h-0 flex-1 flex-col">
-        {showPendingQuestions ? <SidebarQuestionIndicators containerRef={containerRef} /> : null}
+      <div className="relative flex min-h-0 flex-1 flex-col">
+        {onPendingQuestionNavigate ? (
+          <SidebarQuestionIndicators onNavigate={onPendingQuestionNavigate} />
+        ) : null}
         <ScrollArea hideScrollbars scrollFade className="h-auto min-h-0 flex-1">
           <div
             className={cn(

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -7,6 +7,7 @@ import { cn } from "~/lib/utils";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { ScrollArea } from "~/components/ui/scroll-area";
+import { SidebarQuestionIndicators } from "~/components/sidebar/SidebarQuestionIndicators";
 import { Separator } from "~/components/ui/separator";
 import {
   Sheet,
@@ -696,20 +697,24 @@ function SidebarContent({
 }: React.ComponentProps<"div"> & {
   fixedHeader?: React.ReactNode;
 }) {
+  const containerRef = React.useRef<HTMLDivElement>(null);
   return (
     <>
       {fixedHeader ? <div className="w-full shrink-0">{fixedHeader}</div> : null}
-      <ScrollArea hideScrollbars scrollFade className="h-auto min-h-0 flex-1">
-        <div
-          className={cn(
-            "flex w-full min-w-0 flex-col gap-2 group-data-[collapsible=icon]:overflow-hidden",
-            className,
-          )}
-          data-sidebar="content"
-          data-slot="sidebar-content"
-          {...props}
-        />
-      </ScrollArea>
+      <div ref={containerRef} className="relative flex min-h-0 flex-1 flex-col">
+        <ScrollArea hideScrollbars scrollFade className="h-auto min-h-0 flex-1">
+          <div
+            className={cn(
+              "flex w-full min-w-0 flex-col gap-2 group-data-[collapsible=icon]:overflow-hidden",
+              className,
+            )}
+            data-sidebar="content"
+            data-slot="sidebar-content"
+            {...props}
+          />
+        </ScrollArea>
+        <SidebarQuestionIndicators containerRef={containerRef} />
+      </div>
     </>
   );
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1909,3 +1909,40 @@ code {
     transform: scaleX(0.9);
   }
 }
+
+/* Match terminal status cadence; only visible pending rows animate. */
+.sidebar-question-pending::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  pointer-events: none;
+  border: 1px solid var(--color-indigo-400);
+  border-radius: inherit;
+  animation: status-pulse 2s infinite paused;
+}
+
+[data-question-visible] .sidebar-question-pending::after {
+  animation-play-state: running;
+}
+
+.sidebar-question-arrow {
+  animation: sidebar-question-nudge 2s steps(4) infinite;
+}
+
+@keyframes sidebar-question-nudge {
+  0%,
+  100% {
+    transform: translateY(-2px);
+  }
+  50% {
+    transform: translateY(2px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-question-pending::after,
+  .sidebar-question-arrow {
+    animation: none;
+  }
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1910,7 +1910,7 @@ code {
   }
 }
 
-/* Match terminal status cadence; only visible pending rows animate. */
+/* Static emphasis keeps pending questions visible without ongoing animation. */
 .sidebar-question-pending::after {
   content: "";
   position: absolute;
@@ -1919,30 +1919,4 @@ code {
   pointer-events: none;
   border: 1px solid var(--color-indigo-400);
   border-radius: inherit;
-  animation: status-pulse 2s infinite paused;
-}
-
-[data-question-visible] .sidebar-question-pending::after {
-  animation-play-state: running;
-}
-
-.sidebar-question-arrow {
-  animation: sidebar-question-nudge 2s steps(4) infinite;
-}
-
-@keyframes sidebar-question-nudge {
-  0%,
-  100% {
-    transform: translateY(-2px);
-  }
-  50% {
-    transform: translateY(2px);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .sidebar-question-pending::after,
-  .sidebar-question-arrow {
-    animation: none;
-  }
 }

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -88,6 +88,7 @@ export interface WorkLogEntry {
   toolCallId?: string;
   label: string;
   detail?: string;
+  userInputSummary?: string;
   viewedImagePath?: string;
   command?: string;
   rawCommand?: string;
@@ -845,6 +846,7 @@ export function deriveWorkLogEntries(
 ): WorkLogEntry[] {
   const ordered = [...activities].toSorted(compareActivitiesByOrder);
   const entries: DerivedWorkLogEntry[] = [];
+  const questionsByRequestId = new Map<string, ReadonlyArray<UserInputQuestion>>();
   for (const activity of ordered) {
     if (activity.tone !== "error" && isWorktreeSetupActivity(activity.kind)) continue;
     if (activity.kind === "tool.started") continue;
@@ -861,7 +863,62 @@ export function deriveWorkLogEntries(
     if (isNoContentRuntimeWarning(activity)) continue;
     if (isPlanBoundaryToolActivity(activity)) continue;
     if (isAgentInternalActivity(activity)) continue;
-    entries.push(toDerivedWorkLogEntry(activity));
+    const entry = toDerivedWorkLogEntry(activity);
+    if (activity.kind === "user-input.requested" || activity.kind === "user-input.resolved") {
+      const payload = asRecord(activity.payload);
+      const requestId = asTrimmedString(payload?.requestId);
+      if (activity.kind === "user-input.requested" && requestId) {
+        const questions = parseUserInputQuestions(payload);
+        if (questions) questionsByRequestId.set(requestId, questions);
+      } else if (activity.kind === "user-input.resolved") {
+        const answers = asRecord(payload?.answers);
+        if (answers) {
+          const questions = requestId ? questionsByRequestId.get(requestId) : undefined;
+          const submittedAnswers = Object.entries(answers).flatMap(([id, value]) => {
+            const question = questions?.find((question) => question.id === id);
+            const values =
+              typeof value === "string"
+                ? [value]
+                : Array.isArray(value)
+                  ? value
+                  : asRecord(value)?.answers;
+            const answer = Array.isArray(values)
+              ? values
+                  .filter((part): part is string => typeof part === "string")
+                  .map(
+                    (part) =>
+                      question?.options.find((option) => (option.value ?? option.label) === part)
+                        ?.label ?? part,
+                  )
+                  .join(", ")
+              : "";
+            return answer.trim() ? [{ id, answer }] : [];
+          });
+          const detail = submittedAnswers
+            .map(({ id, answer }) => {
+              const question = questions?.find((question) => question.id === id);
+              if (!question) return `${id}\nAnswer: ${answer}`;
+              const options = question.options.map(
+                (option) =>
+                  `- ${option.label}${option.description ? `: ${option.description}` : ""}`,
+              );
+              return [question.header, question.question, ...options, `Answer: ${answer}`].join(
+                "\n",
+              );
+            })
+            .join("\n\n");
+          if (detail) {
+            entries.push({
+              ...entry,
+              userInputSummary: submittedAnswers.map(({ answer }) => answer).join("; "),
+              detail: [detail, entry.detail].filter(Boolean).join("\n\n"),
+            });
+            continue;
+          }
+        }
+      }
+    }
+    entries.push(entry);
   }
   return collapseDerivedWorkLogEntries(entries);
 }


### PR DESCRIPTION
Pending questions now have a fixed Needs input count that opens each waiting thread in turn, while thread order stays unchanged and a static border marks pending rows. Submitted answers appear beside the activity label, expand into the original question details, and composer questions render Markdown links.

Verified next-question navigation in the real app with 80 demo threads and 8 pending questions, no border animation, web typecheck, targeted lint, and the existing 318-test pass from the initial implementation.

Original sidebar (sampled capture):

![Original pending question sidebar](https://uploads-production-47e4.up.railway.app/files/eb895ee6-8ef4-41cc-b0e8-2c1582240b2d/before.gif)

Previous animated proposal:

![Before: directional arrow in sidebar](https://uploads-production-47e4.up.railway.app/files/d6465a0c-746b-4a42-b697-33e2779a0deb/question-static-before-sidebar.png)

Final static navigation, same demo threads:

![After: fixed Needs input control and static border](https://uploads-production-47e4.up.railway.app/files/8fe49de6-65a3-4ad8-949f-7aeda4b0024b/question-static-after-sidebar.png)

Implemented with gpt-5.6-sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly sidebar and timeline presentation; work-log derivation changes how resolved user-input rows read in the activity feed but does not touch auth or persistence.
> 
> **Overview**
> Adds a fixed **Needs input · N** control at the top of the sidebar (via `SidebarQuestionIndicators`) that cycles through non-archived threads with `hasPendingUserInput`, calling `navigateToThread` without reordering the list. Pending rows are highlighted with `data-pending-question`, the `sidebar-question-pending` indigo border overlay, and the same styling in both `Sidebar` and `LegacySidebar`.
> 
> Resolved user-input activities in `deriveWorkLogEntries` now populate optional `userInputSummary` and richer `detail` (questions, options, answers); the message timeline shows the summary next to the work-log label and includes it in accessible text. Pending composer questions render through `ChatMarkdown` instead of plain text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbbcb3e44b1fb0a92952d7d1568623c7e8e1aba2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pending-question sidebar indicators and user-input summaries to timeline
> - Adds `SidebarQuestionIndicators` component that lists non-archived threads with pending user input, shows a count, and cycles to the next pending thread when activated
> - `SidebarContent` renders the indicator above its scroll area when a navigation callback is supplied; both `Sidebar` and `LegacySidebar` wire up the callback
> - Sidebar thread rows in both sidebars receive a `pending-question` class and data attribute; a CSS overlay adds an indigo border to marked rows
> - `ComposerPendingUserInputCard` now renders the active question as `ChatMarkdown` instead of plain text
> - `deriveWorkLogEntries` in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/9810/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) parses submitted answers for resolved user-input activities and attaches a compact `userInputSummary` plus structured detail to the work-log entry; `PlainWorkEntryRow` displays the summary as truncated secondary text
> - Risk: `WorkLogEntry.userInputSummary` is a new optional field — existing consumers of `WorkLogEntry` that do not handle the field will simply ignore it, but timeline rendering changes for entries that now carry summaries
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cbbcb3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->