### PR TITLE
feat(web): highlight visible settings sections

### DIFF
--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -22,12 +22,13 @@ import {
   Settings2Icon,
   XIcon,
 } from "lucide-react";
-import { useLocation, useNavigate } from "@tanstack/react-router";
+import { useLocation, useNavigate, useRouterState } from "@tanstack/react-router";
 
 import { Button } from "../ui/button";
 import { Collapsible, CollapsiblePanel } from "../ui/collapsible";
 import { Input } from "../ui/input";
 import { Kbd } from "../ui/kbd";
+import { cn } from "../../lib/utils";
 import {
   SidebarContent,
   SidebarFooter,
@@ -42,6 +43,11 @@ import {
 } from "../ui/sidebar";
 import { SidebarUtilityMenu } from "../sidebar/SidebarChrome";
 import { scrollToSettingsTarget } from "./settingsLayout";
+import {
+  getVisibleSettingsSectionIds,
+  observeSettingsSectionVisibility,
+  type SettingsSectionVisibilityState,
+} from "./settingsSectionVisibility";
 import {
   searchSettings,
   SETTINGS_SECTION_LABELS,
@@ -99,6 +105,7 @@ const SETTINGS_PAGE_SECTIONS: Partial<
   "/settings/appearance": [
     { label: "Colors & themes", targetId: "appearance" },
     { label: "Interface", targetId: "appearance-interface" },
+    { label: "Motion", targetId: "motion" },
     { label: "Typography", targetId: "typography" },
   ],
   "/settings/source-control": [
@@ -135,10 +142,16 @@ function SettingsSubmenuCollapse({
 export function SettingsSidebarNav({ pathname }: { pathname: string }) {
   const navigate = useNavigate();
   const currentHash = useLocation({ select: (location) => location.hash });
+  const resolvedPathname = useRouterState({
+    select: (state) => state.resolvedLocation?.pathname,
+  });
   const { isMobile, setOpenMobile, open, setOpen } = useSidebar();
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState("");
   const [activeResultIndex, setActiveResultIndex] = useState(0);
+  const [sectionVisibility, setSectionVisibility] = useState<SettingsSectionVisibilityState | null>(
+    null,
+  );
   const searchableItems = useAvailableSettingsSearchItems();
   const results = useMemo(() => searchSettings(query, searchableItems), [query, searchableItems]);
   const isSearching = query.trim().length > 0;
@@ -146,6 +159,33 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
   const activeSettingsPath = SETTINGS_NAV_ITEMS.find(
     (item) => pathname === item.to || pathname.startsWith(`${item.to}/`),
   )?.to;
+  const observedVisibilityScope = useMemo(() => {
+    const path = SETTINGS_NAV_ITEMS.find(
+      (item) =>
+        resolvedPathname === item.to || resolvedPathname?.startsWith(`${item.to}/`) === true,
+    )?.to;
+    const pageSections = path ? SETTINGS_PAGE_SECTIONS[path] : undefined;
+    return path && pageSections ? { path, pageSections } : null;
+  }, [resolvedPathname]);
+  const visiblePageSectionIds = getVisibleSettingsSectionIds({
+    activePath: activeSettingsPath,
+    scope: observedVisibilityScope,
+    visibility: sectionVisibility,
+  });
+
+  useEffect(() => {
+    if (!observedVisibilityScope) return;
+    const container = document.querySelector<HTMLElement>("[data-settings-page-layout]");
+    if (!container) return;
+
+    return observeSettingsSectionVisibility({
+      container,
+      targetIds: observedVisibilityScope.pageSections.map((section) => section.targetId),
+      onChange(targetIds) {
+        setSectionVisibility({ scope: observedVisibilityScope, targetIds: new Set(targetIds) });
+      },
+    });
+  }, [observedVisibilityScope]);
 
   useEffect(() => {
     setActiveResultIndex((index) => Math.min(index, Math.max(results.length - 1, 0)));
@@ -387,7 +427,12 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
                               <SidebarMenuSubButton
                                 render={<button type="button" />}
                                 size="sm"
-                                className="w-full text-sidebar-muted-foreground/65"
+                                data-visible={visiblePageSectionIds.has(section.targetId)}
+                                className={cn(
+                                  "w-full text-sidebar-muted-foreground/65",
+                                  visiblePageSectionIds.has(section.targetId) &&
+                                    "font-medium text-sidebar-foreground",
+                                )}
                                 onClick={() => handlePageSectionClick(item.to, section.targetId)}
                               >
                                 <span className="ms-0.5">{section.label}</span>

--- a/apps/web/src/components/settings/settingsSectionVisibility.test.ts
+++ b/apps/web/src/components/settings/settingsSectionVisibility.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  getVisibleSettingsSectionIds,
+  observeSettingsSectionVisibility,
+  type SettingsSectionVisibilityEnvironment,
+} from "./settingsSectionVisibility";
+
+type VisibilityEntry = Pick<
+  IntersectionObserverEntry,
+  "intersectionRatio" | "isIntersecting" | "target"
+>;
+
+function createHarness(
+  targetIds: ReadonlyArray<string>,
+  initialRoot: Element | null = { name: "initial-root" } as unknown as Element,
+) {
+  const targets = new Map(
+    targetIds.map((targetId) => [targetId, { targetId } as unknown as Element]),
+  );
+  const observed = new Set<Element>();
+  const unobserve = vi.fn((target: Element) => observed.delete(target));
+  const disconnectIntersections = vi.fn();
+  const disconnectMutations = vi.fn();
+  const intersectionCallbacks: Array<(entries: ReadonlyArray<VisibilityEntry>) => void> = [];
+  const intersectionRoots: Element[] = [];
+  let root = initialRoot;
+  let onMutation = () => {};
+
+  const environment: SettingsSectionVisibilityEnvironment = {
+    findRoot: () => root,
+    findTarget: (_root, targetId) => targets.get(targetId) ?? null,
+    createIntersectionObserver(callback, observedRoot) {
+      intersectionCallbacks.push(callback);
+      intersectionRoots.push(observedRoot);
+      return {
+        observe: (target) => observed.add(target),
+        unobserve,
+        disconnect: disconnectIntersections,
+      };
+    },
+    createMutationObserver(callback) {
+      onMutation = callback;
+      return { disconnect: disconnectMutations };
+    },
+  };
+
+  return {
+    environment,
+    targets,
+    observed,
+    unobserve,
+    disconnectIntersections,
+    disconnectMutations,
+    intersectionCallbacks,
+    intersectionRoots,
+    intersect(entries: ReadonlyArray<VisibilityEntry>) {
+      intersectionCallbacks.at(-1)?.(entries);
+    },
+    mutate() {
+      onMutation();
+    },
+    replaceRoot(nextRoot: Element | null) {
+      root = nextRoot;
+      onMutation();
+    },
+  };
+}
+
+function visibleEntry(
+  target: Element,
+  { isIntersecting = true, intersectionRatio = 1 } = {},
+): VisibilityEntry {
+  return { target, isIntersecting, intersectionRatio };
+}
+
+describe("settings section visibility", () => {
+  it("does not reuse visibility when returning to the same sectioned route", () => {
+    const firstGeneralVisit = { path: "/settings/general" };
+    const firstVisibility = {
+      scope: firstGeneralVisit,
+      targetIds: new Set(["text-generation"]),
+    };
+
+    expect(
+      getVisibleSettingsSectionIds({
+        activePath: "/settings/general",
+        scope: firstGeneralVisit,
+        visibility: firstVisibility,
+      }),
+    ).toEqual(new Set(["text-generation"]));
+    expect(
+      getVisibleSettingsSectionIds({
+        activePath: "/settings/providers",
+        scope: null,
+        visibility: firstVisibility,
+      }),
+    ).toEqual(new Set());
+
+    const secondGeneralVisit = { path: "/settings/general" };
+    expect(
+      getVisibleSettingsSectionIds({
+        activePath: "/settings/general",
+        scope: secondGeneralVisit,
+        visibility: firstVisibility,
+      }),
+    ).toEqual(new Set());
+  });
+
+  it("accumulates visible sections and emits them in sidebar order", () => {
+    const harness = createHarness(["one", "two", "three"]);
+    const emissions: ReadonlyArray<string>[] = [];
+    observeSettingsSectionVisibility({
+      container: {} as Element,
+      targetIds: ["one", "two", "three"],
+      onChange: (visible) => emissions.push(visible),
+      environment: harness.environment,
+    });
+
+    harness.intersect([visibleEntry(harness.targets.get("two")!)]);
+    harness.intersect([visibleEntry(harness.targets.get("one")!)]);
+
+    expect(emissions).toEqual([[], ["two"], ["one", "two"]]);
+  });
+
+  it("treats zero-ratio and non-intersecting entries as hidden", () => {
+    const harness = createHarness(["one", "two"]);
+    const emissions: ReadonlyArray<string>[] = [];
+    observeSettingsSectionVisibility({
+      container: {} as Element,
+      targetIds: ["one", "two"],
+      onChange: (visible) => emissions.push(visible),
+      environment: harness.environment,
+    });
+
+    const one = harness.targets.get("one")!;
+    const two = harness.targets.get("two")!;
+    harness.intersect([visibleEntry(one), visibleEntry(two)]);
+    harness.intersect([visibleEntry(one, { intersectionRatio: 0 })]);
+    harness.intersect([visibleEntry(two, { isIntersecting: false })]);
+
+    expect(emissions).toEqual([[], ["one", "two"], ["two"], []]);
+  });
+
+  it("resyncs replaced and removed targets without retaining stale visibility", () => {
+    const harness = createHarness(["dynamic"]);
+    const emissions: ReadonlyArray<string>[] = [];
+    observeSettingsSectionVisibility({
+      container: {} as Element,
+      targetIds: ["dynamic"],
+      onChange: (visible) => emissions.push(visible),
+      environment: harness.environment,
+    });
+
+    const firstTarget = harness.targets.get("dynamic")!;
+    harness.intersect([visibleEntry(firstTarget)]);
+    const replacementTarget = { targetId: "dynamic-replacement" } as unknown as Element;
+    harness.targets.set("dynamic", replacementTarget);
+    harness.mutate();
+
+    expect(harness.unobserve).toHaveBeenCalledWith(firstTarget);
+    expect(harness.observed.has(replacementTarget)).toBe(true);
+    expect(emissions.at(-1)).toEqual([]);
+
+    harness.intersect([visibleEntry(firstTarget)]);
+    expect(emissions.at(-1)).toEqual([]);
+    harness.intersect([visibleEntry(replacementTarget)]);
+    expect(emissions.at(-1)).toEqual(["dynamic"]);
+
+    harness.targets.delete("dynamic");
+    harness.mutate();
+    expect(harness.unobserve).toHaveBeenCalledWith(replacementTarget);
+    expect(emissions.at(-1)).toEqual([]);
+  });
+
+  it("rebinds when navigation replaces the settings scroll root", () => {
+    const harness = createHarness(["section"]);
+    const emissions: ReadonlyArray<string>[] = [];
+    observeSettingsSectionVisibility({
+      container: {} as Element,
+      targetIds: ["section"],
+      onChange: (visible) => emissions.push(visible),
+      environment: harness.environment,
+    });
+
+    const firstTarget = harness.targets.get("section")!;
+    harness.intersect([visibleEntry(firstTarget)]);
+    const firstObserverCallback = harness.intersectionCallbacks[0]!;
+    const nextRoot = { name: "next-root" } as unknown as Element;
+    const nextTarget = { targetId: "next-section" } as unknown as Element;
+    harness.targets.set("section", nextTarget);
+    harness.replaceRoot(nextRoot);
+
+    expect(harness.disconnectIntersections).toHaveBeenCalledOnce();
+    expect(harness.intersectionRoots.at(-1)).toBe(nextRoot);
+    expect(harness.observed.has(nextTarget)).toBe(true);
+    expect(emissions.at(-1)).toEqual([]);
+
+    firstObserverCallback([visibleEntry(firstTarget)]);
+    expect(emissions.at(-1)).toEqual([]);
+    harness.intersect([visibleEntry(nextTarget)]);
+    expect(emissions.at(-1)).toEqual(["section"]);
+  });
+
+  it("starts observing when the settings scroll root mounts later", () => {
+    const harness = createHarness(["section"], null);
+    const emissions: ReadonlyArray<string>[] = [];
+    observeSettingsSectionVisibility({
+      container: {} as Element,
+      targetIds: ["section"],
+      onChange: (visible) => emissions.push(visible),
+      environment: harness.environment,
+    });
+
+    expect(emissions).toEqual([[]]);
+    expect(harness.intersectionRoots).toEqual([]);
+
+    const root = { name: "mounted-root" } as unknown as Element;
+    harness.replaceRoot(root);
+    harness.intersect([visibleEntry(harness.targets.get("section")!)]);
+
+    expect(harness.intersectionRoots).toEqual([root]);
+    expect(emissions.at(-1)).toEqual(["section"]);
+  });
+
+  it("disconnects both observers and ignores callbacks after cleanup", () => {
+    const harness = createHarness(["one"]);
+    const onChange = vi.fn();
+    const cleanup = observeSettingsSectionVisibility({
+      container: {} as Element,
+      targetIds: ["one"],
+      onChange,
+      environment: harness.environment,
+    });
+
+    cleanup();
+    harness.intersect([visibleEntry(harness.targets.get("one")!)]);
+    harness.mutate();
+
+    expect(harness.disconnectIntersections).toHaveBeenCalledOnce();
+    expect(harness.disconnectMutations).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith([]);
+  });
+});

--- a/apps/web/src/components/settings/settingsSectionVisibility.ts
+++ b/apps/web/src/components/settings/settingsSectionVisibility.ts
@@ -1,0 +1,186 @@
+type VisibilityEntry = Pick<
+  IntersectionObserverEntry,
+  "intersectionRatio" | "isIntersecting" | "target"
+>;
+
+export type SettingsSectionVisibilityScope = {
+  readonly path: string;
+};
+
+export type SettingsSectionVisibilityState = {
+  readonly scope: SettingsSectionVisibilityScope;
+  readonly targetIds: ReadonlySet<string>;
+};
+
+const EMPTY_VISIBLE_SETTINGS_SECTION_IDS: ReadonlySet<string> = new Set();
+
+export function getVisibleSettingsSectionIds({
+  activePath,
+  scope,
+  visibility,
+}: {
+  readonly activePath: string | undefined;
+  readonly scope: SettingsSectionVisibilityScope | null;
+  readonly visibility: SettingsSectionVisibilityState | null;
+}): ReadonlySet<string> {
+  if (!scope || activePath !== scope.path || visibility?.scope !== scope) {
+    return EMPTY_VISIBLE_SETTINGS_SECTION_IDS;
+  }
+  return visibility.targetIds;
+}
+
+type ElementObserver = {
+  observe(target: Element): void;
+  unobserve(target: Element): void;
+  disconnect(): void;
+};
+
+type MutationSubscription = {
+  disconnect(): void;
+};
+
+export type SettingsSectionVisibilityEnvironment = {
+  findRoot(container: Element): Element | null;
+  findTarget(root: Element, targetId: string): Element | null;
+  createIntersectionObserver(
+    onEntries: (entries: ReadonlyArray<VisibilityEntry>) => void,
+    root: Element,
+  ): ElementObserver;
+  createMutationObserver(onMutation: () => void, container: Element): MutationSubscription;
+};
+
+function createBrowserEnvironment(): SettingsSectionVisibilityEnvironment {
+  return {
+    findRoot(container) {
+      return container.querySelector("[data-settings-page-scroll]");
+    },
+    findTarget(root, targetId) {
+      const target = root.ownerDocument.getElementById(targetId);
+      return target && root.contains(target) ? target : null;
+    },
+    createIntersectionObserver(onEntries, scrollRoot) {
+      const observer = new IntersectionObserver(onEntries, {
+        root: scrollRoot,
+        threshold: 0,
+      });
+      return observer;
+    },
+    createMutationObserver(onMutation, container) {
+      const observer = new MutationObserver(onMutation);
+      observer.observe(container, { childList: true, subtree: true });
+      return observer;
+    },
+  };
+}
+
+export function observeSettingsSectionVisibility({
+  container,
+  targetIds,
+  onChange,
+  environment = createBrowserEnvironment(),
+}: {
+  readonly container: Element;
+  readonly targetIds: ReadonlyArray<string>;
+  readonly onChange: (visibleTargetIds: ReadonlyArray<string>) => void;
+  readonly environment?: SettingsSectionVisibilityEnvironment;
+}): () => void {
+  const orderedTargetIds = [...new Set(targetIds)];
+  const targetsById = new Map<string, Element>();
+  const targetIdsByElement = new Map<Element, string>();
+  const visibleTargetIds = new Set<string>();
+  let lastEmission: string | null = null;
+  let stopped = false;
+  let root: Element | null = null;
+  let intersectionObserver: ElementObserver | null = null;
+  let observerGeneration = 0;
+
+  const emit = () => {
+    const visibleInOrder = orderedTargetIds.filter((targetId) => visibleTargetIds.has(targetId));
+    const emissionKey = visibleInOrder.join("\0");
+    if (emissionKey === lastEmission) return;
+    lastEmission = emissionKey;
+    onChange(visibleInOrder);
+  };
+
+  const handleEntries = (entries: ReadonlyArray<VisibilityEntry>, generation: number) => {
+    if (stopped || generation !== observerGeneration) return;
+    let changed = false;
+    for (const entry of entries) {
+      const targetId = targetIdsByElement.get(entry.target);
+      if (!targetId || targetsById.get(targetId) !== entry.target) continue;
+      const visible = entry.isIntersecting && entry.intersectionRatio > 0;
+      if (visible === visibleTargetIds.has(targetId)) continue;
+      changed = true;
+      if (visible) {
+        visibleTargetIds.add(targetId);
+      } else {
+        visibleTargetIds.delete(targetId);
+      }
+    }
+    if (changed) emit();
+  };
+
+  const syncTargets = () => {
+    if (stopped) return;
+    let changed = false;
+    const nextRoot = environment.findRoot(container);
+
+    if (nextRoot !== root) {
+      observerGeneration += 1;
+      intersectionObserver?.disconnect();
+      intersectionObserver = null;
+      root = nextRoot;
+      targetsById.clear();
+      targetIdsByElement.clear();
+      changed = visibleTargetIds.size > 0;
+      visibleTargetIds.clear();
+
+      if (root) {
+        const generation = observerGeneration;
+        intersectionObserver = environment.createIntersectionObserver(
+          (entries) => handleEntries(entries, generation),
+          root,
+        );
+      }
+    }
+
+    if (!root || !intersectionObserver) {
+      if (changed) emit();
+      return;
+    }
+
+    for (const targetId of orderedTargetIds) {
+      const previousTarget = targetsById.get(targetId) ?? null;
+      const nextTarget = environment.findTarget(root, targetId);
+      if (previousTarget === nextTarget) continue;
+
+      if (previousTarget) {
+        intersectionObserver.unobserve(previousTarget);
+        targetsById.delete(targetId);
+        targetIdsByElement.delete(previousTarget);
+        changed = visibleTargetIds.delete(targetId) || changed;
+      }
+      if (nextTarget) {
+        targetsById.set(targetId, nextTarget);
+        targetIdsByElement.set(nextTarget, targetId);
+        intersectionObserver.observe(nextTarget);
+      }
+    }
+
+    if (changed) emit();
+  };
+
+  const mutationObserver = environment.createMutationObserver(syncTargets, container);
+  syncTargets();
+  emit();
+
+  return () => {
+    stopped = true;
+    observerGeneration += 1;
+    intersectionObserver?.disconnect();
+    mutationObserver.disconnect();
+    targetsById.clear();
+    targetIdsByElement.clear();
+    visibleTargetIds.clear();
+  };
+}

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -69,7 +69,10 @@ function SettingsContentLayout() {
   }, [navigateBackWithinApp]);
 
   return (
-    <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground isolate">
+    <SidebarInset
+      className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground isolate"
+      data-settings-page-layout
+    >
       <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-foreground">
         <WorkspacePageHeader electron={isElectron}>
           <div className="flex w-full items-center gap-3">


### PR DESCRIPTION
## Problem

The nested section links did not indicate which settings sections were currently visible in the viewport.

## Fix

Track every section intersecting the settings viewport and give only those labels a subtle medium-weight, foreground-color treatment. Row backgrounds remain transparent. The observer follows the resolved route, handles asynchronously mounted sections and replaced scroll roots, and scopes results to a single resolved page visit so stale visibility cannot return during navigation. Appearance also gains its missing Motion link.

This is the second layer of the stack and depends on [#9811](https://github.com/pingdotgg/t3code/pull/9811).

## UI evidence

| Before | After at page top |
| --- | --- |
| ![Before: all nested labels use the same muted treatment](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/b4fa467a4b4861be/reworked-motion-general.png) | ![After: visible Organization and Behavior labels are slightly darker and bolder](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/53eb43b22d88cfce/final2-visible-general-subtle.png) |

![After scrolling: visible lower-section labels receive the same subtle treatment, with transparent row backgrounds](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d2c9e656dd897f21/final2-visible-general-scrolled-subtle.png)

Scroll and route demonstration:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/fd680341d0a94ff4/final2-visible-sections.webm

## Verification

- `vp test run apps/web/src/components/settings/settingsSectionVisibility.test.ts` — 7 tests
- `vp run --filter @t3tools/web typecheck`
- Focused formatting and lint for the changed settings files; lint exits successfully with the existing search-index effect warning
- Integrated Chromium pass for entry from chat, General ↔ Appearance navigation, multi-section scrolling, async Source Control sections, Connections, and sectioned → unsectioned → sectioned navigation
- Computed styles confirm visible labels use weight 500 with transparent backgrounds; non-visible labels use weight 400
- Sidebar axe scan: zero violations

Model and harness: GPT-5.6-Sol in T3 Code (Codex harness).
