### PR TITLE
fix(web): keep font picker keyboard selection in sync

### DIFF
--- a/apps/web/src/components/settings/FontFamilyPicker.tsx
+++ b/apps/web/src/components/settings/FontFamilyPicker.tsx
@@ -144,7 +144,9 @@ export function FontFamilyPicker({
     return requireMonospace ? enumeration.families.filter(isMonospaceFamily) : enumeration.families;
   }, [enumeration, requireMonospace]);
 
-  const items = useMemo(() => {
+  const collectionItems = useMemo(() => [DEFAULT_FONT_VALUE, ...families], [families]);
+
+  const filteredItems = useMemo(() => {
     const trimmedQuery = query.trim().toLowerCase();
     const result: string[] = [];
     if (trimmedQuery.length === 0) result.push(DEFAULT_FONT_VALUE);
@@ -187,8 +189,8 @@ export function FontFamilyPicker({
 
   return (
     <Combobox
-      items={items}
-      filteredItems={items}
+      items={collectionItems}
+      filteredItems={filteredItems}
       autoHighlight
       virtualized
       open={open}
@@ -235,12 +237,16 @@ export function FontFamilyPicker({
             <ComboboxListVirtualized className="size-full min-w-0 p-0">
               <LegendList<string>
                 ref={listRef}
-                data={items}
+                data={filteredItems}
+                // LegendList memoizes rows by item identity. Invalidate them
+                // when filtering moves a surviving item to a different index,
+                // because Base UI highlights and selects virtualized items by index.
+                extraData={filteredItems}
                 keyExtractor={(item) => item}
                 renderItem={({ item, index }) => renderItem(item, index)}
                 estimatedItemSize={30}
                 drawDistance={360}
-                style={{ height: Math.min(items.length * 30, 288) }}
+                style={{ height: Math.min(filteredItems.length * 30, 288) }}
               />
             </ComboboxListVirtualized>
           </div>


### PR DESCRIPTION
Filtering the font picker can leave visible rows with their old indices, so the first match is not highlighted and Enter does not select it. Keep the full collection separate from the filtered list and refresh virtualized rows when filtering changes their indices.

This is limited to keyboard selection in the existing font picker. The open #7494 addresses monospace detection performance in the same component; this change addresses a separate interaction bug.

Validation: web typecheck and formatting pass; targeted lint reports only two existing effect warnings. In Chromium with installed fonts, typing “Jet” on upstream leaves both results unhighlighted and Enter leaves the picker open. With this fix, the first result highlights, arrow keys move the highlight, and Enter applies JetBrains Mono and closes the picker. No separate Electron run.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/fcc6f45d-e3b7-43fc-8b64-384913a81ef2) | ![After](https://github.com/user-attachments/assets/c06e0608-1dfd-41c2-b4a0-c4e825a655df) |

**Before video**

https://github.com/user-attachments/assets/b58d647b-f967-438a-9ced-c5f64b334dd4

**After video**

https://github.com/user-attachments/assets/16d55536-6468-4dcb-9322-46c54d584a63

Model: GPT-6. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings UI interaction fix only; no auth, data, or persistence changes.
> 
> **Overview**
> Fixes **keyboard highlight and Enter selection** in the font family picker when the user types a search query.
> 
> The combobox now receives the **full font list** as `items` and a **search-filtered list** as `filteredItems`, instead of using one list for both. The virtualized `LegendList` renders `filteredItems` and passes **`extraData={filteredItems}`** so row memoization refreshes when filtering changes item indices—keeping Base UI’s index-based highlight/selection aligned with what’s on screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baa063eda221d661dfb273e79e7252c03d29bbfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix keyboard selection sync in `FontFamilyPicker` Combobox
> The `FontFamilyPicker` Combobox now receives the full stable collection (default value plus all families) while the virtualized list renders only query-filtered items. Filtered items are passed as `LegendList` `extraData` so memoized rows refresh when filtering changes their indexes, and list height uses the filtered item count.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized baa063e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->