### PR TITLE
fix(web): recognize dead-key Backquote shortcuts

### DIFF
--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -65,6 +65,35 @@ describe("KeybindingsSettings.logic", () => {
     ).toBe("mod+shift+k");
   });
 
+  it.each(["Dead", "Unidentified", "`"])(
+    "captures Ctrl+Backquote when the browser reports %s",
+    (key) => {
+      expect(
+        keybindingFromKeyboardEvent(
+          { key, code: "Backquote", metaKey: false, ctrlKey: true, altKey: false, shiftKey: false },
+          "Linux",
+        ),
+      ).toBe("mod+`");
+    },
+  );
+
+  it("does not guess other dead keys or capture unmodified input", () => {
+    const modifiers = { metaKey: false, ctrlKey: true, altKey: false, shiftKey: false };
+    expect(
+      keybindingFromKeyboardEvent({ key: "Dead", code: "Quote", ...modifiers }, "Linux"),
+    ).toBeNull();
+    expect(keybindingFromKeyboardEvent({ key: "Dead", ...modifiers }, "Linux")).toBeNull();
+    expect(
+      keybindingFromKeyboardEvent(
+        { key: "Dead", code: "Backquote", ...modifiers, ctrlKey: false },
+        "Linux",
+      ),
+    ).toBeNull();
+    expect(
+      keybindingFromKeyboardEvent({ key: "§", code: "Backquote", ...modifiers }, "Linux"),
+    ).toBe("mod+§");
+  });
+
   it("serializes shortcuts and when expressions for upserts", () => {
     expect(
       shortcutToKeybindingInput({

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -291,7 +291,7 @@ function titleCaseCommandSegment(segment: string): string {
   return words.join(" ");
 }
 
-export function normalizeShortcutKeyToken(key: string): string | null {
+export function normalizeShortcutKeyToken(key: string, code?: string): string | null {
   const normalized = key.toLowerCase();
   if (
     normalized === "meta" ||
@@ -318,14 +318,19 @@ export function normalizeShortcutKeyToken(key: string): string | null {
     return normalized;
   }
   if (normalized === "pageup" || normalized === "pagedown") return normalized;
+  if ((normalized === "dead" || normalized === "unidentified") && code === "Backquote") {
+    return "`";
+  }
   return null;
 }
 
 export function keybindingFromKeyboardEvent(
-  event: Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey">,
+  event: Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey"> & {
+    code?: string;
+  },
   platform: string,
 ): string | null {
-  const keyToken = normalizeShortcutKeyToken(event.key);
+  const keyToken = normalizeShortcutKeyToken(event.key, event.code);
   if (!keyToken) return null;
 
   const parts: string[] = [];

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -790,6 +790,24 @@ describe("resolveShortcutCommand", () => {
     );
   });
 
+  it.each(["Dead", "Unidentified", "`"])(
+    "toggles the terminal with Ctrl+Backquote when the browser reports %s",
+    (key) => {
+      const keybindings = compile([{ shortcut: modShortcut("`"), command: "terminal.toggle" }]);
+      assert.strictEqual(
+        resolveShortcutCommand(event({ key, code: "Backquote", ctrlKey: true }), keybindings, {
+          platform: "Linux",
+        }),
+        "terminal.toggle",
+      );
+      assert.isNull(
+        resolveShortcutCommand(event({ key, code: "Backquote" }), keybindings, {
+          platform: "Linux",
+        }),
+      );
+    },
+  );
+
   it("matches bracket shortcuts using the physical key code", () => {
     assert.strictEqual(
       resolveShortcutCommand(

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -50,6 +50,7 @@ const TERMINAL_LINE_START = "\u0001";
 const TERMINAL_LINE_END = "\u0005";
 const TERMINAL_DELETE_TO_LINE_START = "\u0015";
 const EVENT_CODE_KEY_ALIASES: Readonly<Record<string, readonly string[]>> = {
+  Backquote: ["`"],
   BracketLeft: ["["],
   BracketRight: ["]"],
   Digit0: ["0"],


### PR DESCRIPTION
When a browser reports Ctrl+Backquote as `key: "Dead"`, Settings cannot record it and a saved Backquote binding does not match the event. Use `code: "Backquote"` to recover the key during capture for Dead/Unidentified events and add Backquote to the runtime's existing physical-key aliases.

Validation: all 70 tests in the keybinding capture and shortcut matching suites pass. Four new cases fail against unchanged upstream and pass with the fix. Web typecheck, targeted lint, and formatting pass. Chromium verification sends the Dead/Backquote/Ctrl event through the browser input protocol: upstream leaves the capture field empty; the fix records and saves the binding, and the same event opens and closes the terminal drawer. This simulates the browser event; no physical keyboard-layout or separate Electron test was run.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/783722b2-bedc-46a5-a221-f3333c00547b) | ![After](https://github.com/user-attachments/assets/2e972032-97c1-48d6-83d1-b2f325d67e02) |

**Before video**

https://github.com/user-attachments/assets/169f78fc-1f3a-4d63-a08b-3b3d4518c854

**After video**

https://github.com/user-attachments/assets/21daf25a-5d19-42af-aa7d-f65647b32005

Model: GPT-6. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to key token normalization and one physical-key alias; dead-key inference is limited to Backquote with explicit code.
> 
> **Overview**
> Fixes **Ctrl+Backquote** (and similar) shortcuts when the browser reports **`key: "Dead"`** or **`"Unidentified"`** instead of a literal backtick—Settings could not record the binding and saved shortcuts would not fire.
> 
> **Settings capture:** `normalizeShortcutKeyToken` and `keybindingFromKeyboardEvent` now accept optional **`KeyboardEvent.code`**. When `key` is Dead/Unidentified and **`code === "Backquote"`**, capture resolves to **`mod+\`**. Other dead keys stay ignored (no broad guessing); unmodified Backquote still returns null.
> 
> **Runtime matching:** Adds **`Backquote → [`]`** to the existing physical-key alias map in `resolveEventKeys`, so the same events match bindings stored as **`` ` ``** (e.g. terminal toggle).
> 
> New tests cover capture, non-Backquote dead keys, and `resolveShortcutCommand` for Dead/Unidentified/`` ` `` with **`code: "Backquote"`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dc4ab210a095a67e5233bb2b0e416efd1283042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Backquote` shortcut recognition for dead-key keyboard events
> - Browsers on certain keyboard layouts report Ctrl+Backquote as `Dead` or `Unidentified` instead of the literal backtick, causing the shortcut to fail
> - `normalizeShortcutKeyToken` now accepts an optional physical `code` and normalizes `Dead`/`Unidentified` to `backtick` only when `code` is `Backquote`; unrelated dead keys are still rejected
> - `keybindingFromKeyboardEvent` forwards the event's `code` to the normalizer, and `EVENT_CODE_KEY_ALIASES` maps `Backquote` to the `backtick` token for command resolution
> - Risk: none — unmodified `Backquote` input and non-`Backquote` dead keys remain unsupported
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7dc4ab2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->