### PR TITLE
feat(web): support multi-repository diff workspaces

### DIFF
--- a/apps/server/src/review/ReviewService.test.ts
+++ b/apps/server/src/review/ReviewService.test.ts
@@ -3,7 +3,9 @@ import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
+import { symlinksSupported } from "@t3tools/shared/testing/symlinks";
 
 import { ServerConfig } from "../config.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
@@ -106,6 +108,72 @@ describe("ReviewService", () => {
       assert.deepStrictEqual(result.sources, []);
       assert.deepStrictEqual(detectCalls, [{ cwd: workspaceRoot }]);
     }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect.skipIf(!symlinksSupported)(
+    "enforces a requested project workspace root with canonical paths",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const serverRoot = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-server-" });
+        const projectRoot = path.join(serverRoot, "workspace");
+        const nestedRepository = path.join(projectRoot, "backend");
+        const siblingRepository = path.join(serverRoot, "sibling-repository");
+        const outsideRepository = yield* fs.makeTempDirectoryScoped({
+          prefix: "t3-review-outside-",
+        });
+        yield* fs.makeDirectory(projectRoot);
+        yield* fs.makeDirectory(nestedRepository);
+        yield* fs.makeDirectory(siblingRepository);
+        const siblingLink = path.join(projectRoot, "frontend");
+        const outsideLink = path.join(projectRoot, "external");
+        yield* fs.symlink(siblingRepository, siblingLink);
+        yield* fs.symlink(outsideRepository, outsideLink);
+        const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-base-" });
+        const detectCalls: Array<{ readonly cwd: string }> = [];
+
+        const result = yield* Effect.gen(function* () {
+          const review = yield* ReviewService.ReviewService;
+          const unscoped = yield* review.getDiffPreview({ cwd: siblingLink });
+          const siblingError = yield* review
+            .getDiffPreview({ cwd: siblingLink, workspaceRoot: projectRoot })
+            .pipe(Effect.flip);
+          const contentsError = yield* review
+            .getDiffFileContents({
+              cwd: siblingLink,
+              workspaceRoot: projectRoot,
+              sourceKind: "working-tree",
+              changeType: "change",
+              baseRef: "HEAD",
+              headRef: null,
+              oldPath: "file.ts",
+              newPath: "file.ts",
+            })
+            .pipe(Effect.flip);
+          const nested = yield* review.getDiffPreview({
+            cwd: nestedRepository,
+            workspaceRoot: projectRoot,
+          });
+          const outsideError = yield* review
+            .getDiffPreview({ cwd: outsideLink, workspaceRoot: projectRoot })
+            .pipe(Effect.flip);
+          return { unscoped, siblingError, contentsError, nested, outsideError };
+        }).pipe(Effect.provide(makeLayer({ workspaceRoot: serverRoot, baseDir, detectCalls })));
+
+        assert.deepStrictEqual(result.unscoped.sources, []);
+        assert.strictEqual(result.siblingError._tag, "VcsRepositoryDetectionError");
+        if (result.siblingError._tag !== "VcsRepositoryDetectionError") return;
+        assert.match(result.siblingError.detail, /selected repository must stay inside/);
+        assert.strictEqual(result.contentsError._tag, "VcsRepositoryDetectionError");
+        if (result.contentsError._tag !== "VcsRepositoryDetectionError") return;
+        assert.match(result.contentsError.detail, /selected repository must stay inside/);
+        assert.deepStrictEqual(result.nested.sources, []);
+        assert.strictEqual(result.outsideError._tag, "VcsRepositoryDetectionError");
+        if (result.outsideError._tag !== "VcsRepositoryDetectionError") return;
+        assert.match(result.outsideError.detail, /configured workspace root/);
+        assert.deepStrictEqual(detectCalls, [{ cwd: siblingLink }, { cwd: nestedRepository }]);
+      }).pipe(Effect.provide(NodeServices.layer)),
   );
 
   it.effect("preserves unexpected path-resolution failures", () =>

--- a/apps/server/src/review/ReviewService.ts
+++ b/apps/server/src/review/ReviewService.ts
@@ -62,34 +62,55 @@ export const make = Effect.gen(function* () {
     return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
   };
 
+  const isWithinRequestedWorkspaceRoot = (candidate: string, root: string) => {
+    const relative = path.relative(root, candidate);
+    return (
+      relative === "" ||
+      (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+    );
+  };
+
   const assertWorkspaceBoundCwd = Effect.fn("ReviewService.assertWorkspaceBoundCwd")(function* (
     operation: "ReviewService.getDiffPreview" | "ReviewService.getDiffFileContents",
     cwd: string,
+    configuredWorkspaceRoot?: string,
   ) {
-    const [candidate, workspaceRoot, worktreesRoot] = yield* Effect.all([
+    const [candidate, workspaceRoot, worktreesRoot, requestedWorkspaceRoot] = yield* Effect.all([
       canonicalizePath(cwd),
       canonicalizePath(config.cwd),
       canonicalizePath(config.worktreesDir),
+      configuredWorkspaceRoot === undefined
+        ? Effect.succeed(null)
+        : canonicalizePath(configuredWorkspaceRoot),
     ]);
 
-    if (isWithinRoot(candidate, workspaceRoot) || isWithinRoot(candidate, worktreesRoot)) {
-      return;
+    if (!isWithinRoot(candidate, workspaceRoot) && !isWithinRoot(candidate, worktreesRoot)) {
+      return yield* new VcsRepositoryDetectionError({
+        operation,
+        cwd,
+        detail:
+          operation === "ReviewService.getDiffPreview"
+            ? "Review diff preview cwd must stay within the configured workspace root."
+            : "Review diff file contents cwd must stay within the configured workspace root.",
+      });
     }
 
-    return yield* new VcsRepositoryDetectionError({
-      operation,
-      cwd,
-      detail:
-        operation === "ReviewService.getDiffPreview"
-          ? "Review diff preview cwd must stay within the configured workspace root."
-          : "Review diff file contents cwd must stay within the configured workspace root.",
-    });
+    if (
+      requestedWorkspaceRoot !== null &&
+      !isWithinRequestedWorkspaceRoot(candidate, requestedWorkspaceRoot)
+    ) {
+      return yield* new VcsRepositoryDetectionError({
+        operation,
+        cwd,
+        detail: "The selected repository must stay inside the project folder.",
+      });
+    }
   });
 
   const getDiffPreview: ReviewService["Service"]["getDiffPreview"] = Effect.fn(
     "ReviewService.getDiffPreview",
   )(function* (input) {
-    yield* assertWorkspaceBoundCwd("ReviewService.getDiffPreview", input.cwd);
+    yield* assertWorkspaceBoundCwd("ReviewService.getDiffPreview", input.cwd, input.workspaceRoot);
 
     const handle = yield* vcsRegistry.detect({ cwd: input.cwd, requestedKind: "auto" });
     if (!handle) {
@@ -118,7 +139,11 @@ export const make = Effect.gen(function* () {
   const getDiffFileContents: ReviewService["Service"]["getDiffFileContents"] = Effect.fn(
     "ReviewService.getDiffFileContents",
   )(function* (input) {
-    yield* assertWorkspaceBoundCwd("ReviewService.getDiffFileContents", input.cwd);
+    yield* assertWorkspaceBoundCwd(
+      "ReviewService.getDiffFileContents",
+      input.cwd,
+      input.workspaceRoot,
+    );
 
     const handle = yield* vcsRegistry.detect({ cwd: input.cwd, requestedKind: "auto" });
     if (handle?.kind !== "git") {

--- a/apps/server/src/vcs/VcsStatusBroadcaster.test.ts
+++ b/apps/server/src/vcs/VcsStatusBroadcaster.test.ts
@@ -588,6 +588,104 @@ describe("VcsStatusBroadcaster", () => {
     },
   );
 
+  it.effect.skipIf(!symlinksSupported)(
+    "rejects configured status paths that canonically escape before loading status",
+    () => {
+      const state = {
+        currentLocalStatus: baseLocalStatus,
+        currentRemoteStatus: baseRemoteStatus,
+        localStatusCalls: 0,
+        remoteStatusCalls: 0,
+        localInvalidationCalls: 0,
+        remoteInvalidationCalls: 0,
+      };
+
+      return Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const serverRoot = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-vcs-status-server-",
+        });
+        const workspaceRoot = path.join(serverRoot, "workspace");
+        const siblingRepository = path.join(serverRoot, "sibling-repository");
+        const outsideRepository = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-vcs-status-outside-",
+        });
+        yield* fileSystem.makeDirectory(workspaceRoot);
+        yield* fileSystem.makeDirectory(siblingRepository);
+        const siblingLink = path.join(workspaceRoot, "frontend");
+        const outsideLink = path.join(workspaceRoot, "external");
+        yield* fileSystem.symlink(siblingRepository, siblingLink);
+        yield* fileSystem.symlink(outsideRepository, outsideLink);
+
+        const broadcaster = yield* VcsStatusBroadcaster.VcsStatusBroadcaster;
+        const getError = yield* broadcaster
+          .getStatus({ cwd: siblingLink, workspaceRoot })
+          .pipe(Effect.flip);
+        assert.strictEqual(getError._tag, "GitManagerError");
+        if (getError._tag !== "GitManagerError") return;
+        assert.strictEqual(getError.operation, "VcsStatusBroadcaster.getStatus");
+        assert.match(getError.detail, /selected repository must stay inside the project folder/);
+
+        const streamError = yield* broadcaster
+          .streamStatus({ cwd: outsideLink, workspaceRoot })
+          .pipe(Stream.runHead, Effect.flip);
+        assert.strictEqual(streamError._tag, "GitManagerError");
+        if (streamError._tag !== "GitManagerError") return;
+        assert.strictEqual(streamError.operation, "VcsStatusBroadcaster.streamStatus");
+
+        const refreshError = yield* broadcaster
+          .refreshStatus(siblingLink, { workspaceRoot })
+          .pipe(Effect.flip);
+        assert.strictEqual(refreshError._tag, "GitManagerError");
+        if (refreshError._tag !== "GitManagerError") return;
+        assert.strictEqual(refreshError.operation, "VcsStatusBroadcaster.refreshStatus");
+        assert.equal(state.localStatusCalls, 0);
+        assert.equal(state.remoteStatusCalls, 0);
+        assert.equal(state.localInvalidationCalls, 0);
+        assert.equal(state.remoteInvalidationCalls, 0);
+      }).pipe(Effect.provide(makeTestLayer(state)));
+    },
+  );
+
+  it.effect.skipIf(!symlinksSupported)(
+    "allows nested status paths and preserves unscoped status reads",
+    () => {
+      const state = {
+        currentLocalStatus: baseLocalStatus,
+        currentRemoteStatus: baseRemoteStatus,
+        localStatusCalls: 0,
+        remoteStatusCalls: 0,
+        localInvalidationCalls: 0,
+        remoteInvalidationCalls: 0,
+      };
+
+      return Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const workspaceRoot = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-vcs-status-workspace-",
+        });
+        const nestedRepository = path.join(workspaceRoot, "backend");
+        const outsideRepository = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-vcs-status-unscoped-",
+        });
+        const outsideLink = path.join(workspaceRoot, "frontend");
+        yield* fileSystem.makeDirectory(nestedRepository);
+        yield* fileSystem.symlink(outsideRepository, outsideLink);
+
+        const broadcaster = yield* VcsStatusBroadcaster.VcsStatusBroadcaster;
+        assert.deepStrictEqual(
+          yield* broadcaster.getStatus({ cwd: nestedRepository, workspaceRoot }),
+          baseStatus,
+        );
+        assert.deepStrictEqual(yield* broadcaster.getStatus({ cwd: outsideLink }), baseStatus);
+        assert.equal(state.localStatusCalls, 2);
+        assert.equal(state.remoteStatusCalls, 2);
+      }).pipe(Effect.provide(makeTestLayer(state)));
+    },
+  );
+
   it.effect("streams a local snapshot first and remote updates later", () => {
     const state = {
       currentLocalStatus: baseLocalStatus,

--- a/apps/server/src/vcs/VcsStatusBroadcaster.ts
+++ b/apps/server/src/vcs/VcsStatusBroadcaster.ts
@@ -6,6 +6,7 @@ import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
 import * as PubSub from "effect/PubSub";
 import * as Ref from "effect/Ref";
 import * as Schedule from "effect/Schedule";
@@ -21,6 +22,7 @@ import type {
   VcsStatusResult,
   VcsStatusStreamEvent,
 } from "@t3tools/contracts";
+import { GitManagerError } from "@t3tools/contracts";
 import { mergeGitStatusParts } from "@t3tools/shared/git";
 
 import * as BackgroundPolicy from "../background/BackgroundPolicy.ts";
@@ -141,6 +143,10 @@ interface StreamStatusOptions {
   readonly automaticRemoteRefreshInterval?: Effect.Effect<Duration.Duration, never>;
 }
 
+interface RefreshStatusOptions {
+  readonly workspaceRoot?: string;
+}
+
 export class VcsAutoPullPolicy extends Context.Reference<{
   readonly isEnabled: (cwd: string) => Effect.Effect<boolean, never>;
 }>("t3/vcs/VcsAutoPullPolicy", {
@@ -184,7 +190,10 @@ export class VcsStatusBroadcaster extends Context.Service<
     readonly refreshLocalStatus: (
       cwd: string,
     ) => Effect.Effect<VcsStatusLocalResult, GitManagerServiceError>;
-    readonly refreshStatus: (cwd: string) => Effect.Effect<VcsStatusResult, GitManagerServiceError>;
+    readonly refreshStatus: (
+      cwd: string,
+      options?: RefreshStatusOptions,
+    ) => Effect.Effect<VcsStatusResult, GitManagerServiceError>;
     /**
      * Refresh a loaded cwd after a turn if background policy allows it.
      * GitManager retries missing PRs for the current branch and keeps known
@@ -215,6 +224,7 @@ export const make = Effect.gen(function* () {
   const workflow = yield* GitWorkflowService.GitWorkflowService;
   const backgroundPolicy = yield* BackgroundPolicy.BackgroundPolicy;
   const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
   const changesPubSub = yield* Effect.acquireRelease(
     PubSub.unbounded<VcsStatusChange>(),
     (pubsub) => PubSub.shutdown(pubsub),
@@ -236,6 +246,40 @@ export const make = Effect.gen(function* () {
     return lock.withPermits(1)(effect);
   };
   const pollersRef = yield* SynchronizedRef.make(new Map<string, ActiveRemotePoller>());
+
+  const assertConfiguredWorkspaceBoundCwd = Effect.fn(
+    "VcsStatusBroadcaster.assertConfiguredWorkspaceBoundCwd",
+  )(function* (input: VcsStatusInput, operation: string) {
+    if (input.workspaceRoot === undefined) return;
+
+    const [candidate, workspaceRoot] = yield* Effect.all([
+      fs.realPath(path.resolve(input.cwd)),
+      fs.realPath(path.resolve(input.workspaceRoot)),
+    ]).pipe(
+      Effect.mapError(
+        (cause) =>
+          new GitManagerError({
+            operation: `${operation}.canonicalizePath`,
+            cwd: input.cwd,
+            detail: "Failed to resolve a path while validating the configured workspace root.",
+            cause,
+          }),
+      ),
+    );
+    const relative = path.relative(workspaceRoot, candidate);
+    if (
+      relative === "" ||
+      (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+    ) {
+      return;
+    }
+
+    return yield* new GitManagerError({
+      operation,
+      cwd: input.cwd,
+      detail: "The selected repository must stay inside the project folder.",
+    });
+  });
 
   const getCachedStatus = Effect.fn("VcsStatusBroadcaster.getCachedStatus")(function* (
     cwd: string,
@@ -367,6 +411,7 @@ export const make = Effect.gen(function* () {
   const getStatus: VcsStatusBroadcaster["Service"]["getStatus"] = Effect.fn(
     "VcsStatusBroadcaster.getStatus",
   )(function* (input) {
+    yield* assertConfiguredWorkspaceBoundCwd(input, "VcsStatusBroadcaster.getStatus");
     const cwd = yield* withFileSystem(normalizeCwd(input.cwd));
     const cached = yield* getCachedStatus(cwd);
     if (cached?.local && cached.remote) {
@@ -464,7 +509,14 @@ export const make = Effect.gen(function* () {
 
   const refreshStatus: VcsStatusBroadcaster["Service"]["refreshStatus"] = Effect.fn(
     "VcsStatusBroadcaster.refreshStatus",
-  )(function* (rawCwd) {
+  )(function* (rawCwd, options) {
+    yield* assertConfiguredWorkspaceBoundCwd(
+      {
+        cwd: rawCwd,
+        ...(options?.workspaceRoot === undefined ? {} : { workspaceRoot: options.workspaceRoot }),
+      },
+      "VcsStatusBroadcaster.refreshStatus",
+    );
     const cwd = yield* withFileSystem(normalizeCwd(rawCwd));
     // invalidateStatus (not the two partial invalidations) so an explicit
     // refresh also bypasses GitManager's slow PR-lookup cache.
@@ -689,6 +741,7 @@ export const make = Effect.gen(function* () {
   const streamStatus: VcsStatusBroadcaster["Service"]["streamStatus"] = (input, options) =>
     Stream.unwrap(
       Effect.gen(function* () {
+        yield* assertConfiguredWorkspaceBoundCwd(input, "VcsStatusBroadcaster.streamStatus");
         const cwd = yield* withFileSystem(normalizeCwd(input.cwd));
         const subscription = yield* PubSub.subscribe(changesPubSub);
         const initialLocal = yield* getOrLoadLocalStatus(cwd);

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -2402,7 +2402,10 @@ const makeWsRpcLayer = (
         [WS_METHODS.vcsRefreshStatus]: (input) =>
           observeRpcEffect(
             WS_METHODS.vcsRefreshStatus,
-            vcsStatusBroadcaster.refreshStatus(input.cwd),
+            vcsStatusBroadcaster.refreshStatus(
+              input.cwd,
+              input.workspaceRoot === undefined ? {} : { workspaceRoot: input.workspaceRoot },
+            ),
             {
               "rpc.aggregate": "vcs",
             },

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -34,6 +34,7 @@ import {
   getStartedThreadModelChangeBlockReason,
   hasEnvironmentReconnectWarningGraceElapsed,
   hasServerAcknowledgedLocalDispatch,
+  isDiffSurfaceAvailable,
   isBranchMismatchDismissedForSession,
   reconcileMountedTerminalThreadIds,
   reconcileRetainedMountedThreadIds,
@@ -1248,6 +1249,28 @@ describe("resolveSendEnvMode", () => {
   it("keeps worktree mode only for git repositories", () => {
     expect(resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: true })).toBe("worktree");
     expect(resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: false })).toBe("local");
+  });
+});
+
+describe("isDiffSurfaceAvailable", () => {
+  it("allows a configured nested repository in a local non-Git workspace", () => {
+    expect(
+      isDiffSurfaceAvailable({
+        isServerThread: true,
+        isGitRepo: false,
+        hasConfiguredRepositories: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps non-Git workspaces without configured repositories unavailable", () => {
+    expect(
+      isDiffSurfaceAvailable({
+        isServerThread: true,
+        isGitRepo: false,
+        hasConfiguredRepositories: false,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -640,6 +640,14 @@ export function resolveSendEnvMode(input: {
   return input.isGitRepo ? input.requestedEnvMode : "local";
 }
 
+export function isDiffSurfaceAvailable(input: {
+  isServerThread: boolean;
+  isGitRepo: boolean;
+  hasConfiguredRepositories: boolean;
+}): boolean {
+  return input.isServerThread && (input.isGitRepo || input.hasConfiguredRepositories);
+}
+
 export function resolveBackgroundDraftWorkspaceOptions(input: {
   envMode: DraftThreadEnvMode;
   branch: string | null;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -143,6 +143,7 @@ import {
   type TurnDiffSummary,
 } from "../types";
 import { useTheme } from "../hooks/useTheme";
+import { useT3ProjectFileState } from "../hooks/useT3ProjectFileScripts";
 import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
 import { isCommandPaletteOpen } from "../commandPaletteBus";
@@ -360,6 +361,7 @@ import {
   deriveComposerSendState,
   dismissBranchMismatchForSession,
   hasEnvironmentReconnectWarningGraceElapsed,
+  isDiffSurfaceAvailable,
   latestTurnStartFailureId,
   scheduleEnvironmentReconnectWarning,
   hasServerAcknowledgedLocalDispatch,
@@ -3069,6 +3071,9 @@ export default function ChatView(props: ChatViewProps) {
   const activeProjectCwd = activeProject?.workspaceRoot ?? null;
   const activeThreadWorktreePath = activeThread?.worktreePath ?? null;
   const activeWorkspaceRoot = activeThreadWorktreePath ?? activeProjectCwd ?? undefined;
+  const projectFile = useT3ProjectFileState(activeThread?.environmentId ?? null, activeProjectCwd);
+  const hasConfiguredDiffRepositories =
+    activeThreadWorktreePath === null && (projectFile.file?.repositories?.length ?? 0) > 0;
   const activeTerminalLaunchContext =
     terminalUiLaunchContext?.threadId === activeThreadId ? terminalUiLaunchContext : null;
   // Default true while loading to avoid toolbar flicker.
@@ -3718,11 +3723,16 @@ export default function ChatView(props: ChatViewProps) {
     },
     [activeThreadRef, openPreview],
   );
+  const diffSurfaceAvailable = isDiffSurfaceAvailable({
+    isServerThread,
+    isGitRepo,
+    hasConfiguredRepositories: hasConfiguredDiffRepositories,
+  });
   const addDiffSurface = useCallback(() => {
-    if (!activeThreadRef || !isServerThread || !isGitRepo) return;
+    if (!activeThreadRef || !diffSurfaceAvailable) return;
     useRightPanelStore.getState().open(activeThreadRef, "diff");
     onDiffPanelOpen?.();
-  }, [activeThreadRef, isGitRepo, isServerThread, onDiffPanelOpen]);
+  }, [activeThreadRef, diffSurfaceAvailable, onDiffPanelOpen]);
   const addFilesSurface = useCallback(() => {
     if (!activeThreadRef || !activeProject) return;
     useRightPanelStore.getState().open(activeThreadRef, "files");
@@ -8167,7 +8177,7 @@ export default function ChatView(props: ChatViewProps) {
           onAddAgents={addAgentsSurface}
           browserAvailable={isPreviewSupportedInRuntime()}
           terminalAvailable={activeProject !== null}
-          diffAvailable={isServerThread && isGitRepo}
+          diffAvailable={diffSurfaceAvailable}
           filesAvailable={activeProject !== null}
           pullRequestAvailable={pullRequestSurfaceAvailable}
           agentsAvailable
@@ -8217,7 +8227,7 @@ export default function ChatView(props: ChatViewProps) {
             onAddAgents={addAgentsSurface}
             browserAvailable={isPreviewSupportedInRuntime()}
             terminalAvailable={activeProject !== null}
-            diffAvailable={isServerThread && isGitRepo}
+            diffAvailable={diffSurfaceAvailable}
             filesAvailable={activeProject !== null}
             pullRequestAvailable={pullRequestSurfaceAvailable}
             agentsAvailable

--- a/apps/web/src/components/DiffPanel.logic.test.ts
+++ b/apps/web/src/components/DiffPanel.logic.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { openDiffFilePrimaryAction, resolveConfiguredRepositoryRoot } from "../diffFileActions";
+
+import {
+  resolveNestedDiffRepositoryPath,
+  resolveUnresolvableRepositoryMessage,
+  shouldRetryDiffPreviewAtEnvironmentCwd,
+} from "./DiffPanel.logic";
+
+describe("diff repository scope", () => {
+  it.each([
+    { isTurnSelected: true, expected: "/project/src/root.ts" },
+    { isTurnSelected: false, expected: "/project/frontend/src/root.ts" },
+  ])(
+    "opens files in the correct tree with turn selection $isTurnSelected",
+    ({ isTurnSelected, expected }) => {
+      const nestedPath = resolveNestedDiffRepositoryPath({
+        isTurnSelected,
+        repositoryPath: "frontend",
+      });
+      const openInEditor = vi.fn();
+      openDiffFilePrimaryAction({
+        threadRef: null,
+        filePath: "src/root.ts",
+        activeCwd: "/project",
+        repositoryRoot: {
+          path: nestedPath ? resolveConfiguredRepositoryRoot(nestedPath, "/project")! : "/project",
+          kind: nestedPath ? "configured" : "detected",
+        },
+        openInEditor,
+      });
+      expect(openInEditor).toHaveBeenCalledWith(expected);
+    },
+  );
+});
+
+const WORKSPACE_ROOT_ERROR =
+  "Review diff preview cwd must stay within the configured workspace root.";
+
+const retryInput = (
+  overrides: Partial<Parameters<typeof shouldRetryDiffPreviewAtEnvironmentCwd>[0]> = {},
+) => ({
+  isTurnSelected: false,
+  nestedRepositoryPath: null,
+  previewError: WORKSPACE_ROOT_ERROR,
+  environmentCwd: "/srv/workspace",
+  activeGitCwd: "/home/dev/project",
+  ...overrides,
+});
+
+describe("shouldRetryDiffPreviewAtEnvironmentCwd", () => {
+  it("retries a workspace root rejection at the environment cwd", () => {
+    expect(shouldRetryDiffPreviewAtEnvironmentCwd(retryInput())).toBe(true);
+  });
+
+  it("never retries for a selected nested repository", () => {
+    // Every other condition holds; the retry would read the environment's own
+    // repository and show its diff under the selected repository's label.
+    expect(
+      shouldRetryDiffPreviewAtEnvironmentCwd(
+        retryInput({ nestedRepositoryPath: "services/api", activeGitCwd: "/home/dev/project/api" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not retry without a workspace root rejection", () => {
+    expect(shouldRetryDiffPreviewAtEnvironmentCwd(retryInput({ previewError: null }))).toBe(false);
+    expect(
+      shouldRetryDiffPreviewAtEnvironmentCwd(
+        retryInput({ previewError: "fatal: not a git repository" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not retry the directory that already failed", () => {
+    expect(
+      shouldRetryDiffPreviewAtEnvironmentCwd(
+        retryInput({ environmentCwd: "/home/dev/project", activeGitCwd: "/home/dev/project" }),
+      ),
+    ).toBe(false);
+    expect(shouldRetryDiffPreviewAtEnvironmentCwd(retryInput({ environmentCwd: undefined }))).toBe(
+      false,
+    );
+  });
+
+  it("does not retry while a turn diff is selected", () => {
+    expect(shouldRetryDiffPreviewAtEnvironmentCwd(retryInput({ isTurnSelected: true }))).toBe(
+      false,
+    );
+  });
+});
+
+describe("resolveUnresolvableRepositoryMessage", () => {
+  it("names the repository that could not be located", () => {
+    const message = resolveUnresolvableRepositoryMessage({
+      isTurnSelected: false,
+      repositoryPath: "services/api",
+      hasUnresolvableRepository: true,
+    });
+
+    expect(message).toContain("services/api");
+    expect(message).toContain("t3.json");
+  });
+
+  it("stays silent while the repository resolves", () => {
+    expect(
+      resolveUnresolvableRepositoryMessage({
+        isTurnSelected: false,
+        repositoryPath: "services/api",
+        hasUnresolvableRepository: false,
+      }),
+    ).toBe(null);
+    expect(
+      resolveUnresolvableRepositoryMessage({
+        isTurnSelected: false,
+        repositoryPath: null,
+        hasUnresolvableRepository: false,
+      }),
+    ).toBe(null);
+  });
+
+  it("stays silent for a turn diff, which does not depend on the repository", () => {
+    expect(
+      resolveUnresolvableRepositoryMessage({
+        isTurnSelected: true,
+        repositoryPath: "services/api",
+        hasUnresolvableRepository: true,
+      }),
+    ).toBe(null);
+  });
+});

--- a/apps/web/src/components/DiffPanel.logic.ts
+++ b/apps/web/src/components/DiffPanel.logic.ts
@@ -1,0 +1,59 @@
+/** Checkpoints belong to the project even when a nested repository is the default. */
+export function resolveNestedDiffRepositoryPath(input: {
+  isTurnSelected: boolean;
+  repositoryPath: string | undefined;
+}): string | null {
+  return input.isTurnSelected || input.repositoryPath === "."
+    ? null
+    : (input.repositoryPath ?? null);
+}
+
+/**
+ * Explains that a repository configured for this project could not be located,
+ * or `null` when there is nothing to explain.
+ *
+ * Refusing to guess a location leaves the panel without a diff to show, and an
+ * unexplained empty panel looks like a bug rather than a configuration problem.
+ * Turn diffs come from checkpoints and cover the whole project, so they render
+ * either way and say nothing about the repository.
+ */
+export function resolveUnresolvableRepositoryMessage(input: {
+  isTurnSelected: boolean;
+  hasUnresolvableRepository: boolean;
+  repositoryPath: string | null;
+}): string | null {
+  if (input.isTurnSelected || !input.hasUnresolvableRepository || input.repositoryPath === null) {
+    return null;
+  }
+  return `The repository "${input.repositoryPath}" could not be found inside the project folder. Check the repositories entry in t3.json.`;
+}
+
+/** Marker of the server-side rejection the environment-cwd retry exists for. */
+const WORKSPACE_ROOT_ERROR_MARKER = "configured workspace root";
+
+/**
+ * Whether a failed branch diff preview may be retried at the environment's own
+ * working directory.
+ *
+ * The retry covers a project whose root the server refuses because it sits
+ * outside the configured workspace root. It must not run for an explicitly
+ * selected nested repository: the retry reads a different repository, so the
+ * panel would show that repository's diff under the selected repository's label
+ * while file clicks are still re-based onto the selected repository's root.
+ * Suppressing it surfaces the server's rejection instead.
+ */
+export function shouldRetryDiffPreviewAtEnvironmentCwd(input: {
+  isTurnSelected: boolean;
+  nestedRepositoryPath: string | null;
+  previewError: string | null;
+  environmentCwd: string | undefined;
+  activeGitCwd: string | undefined;
+}): boolean {
+  return (
+    !input.isTurnSelected &&
+    input.nestedRepositoryPath === null &&
+    input.previewError?.includes(WORKSPACE_ROOT_ERROR_MARKER) === true &&
+    input.environmentCwd !== undefined &&
+    input.environmentCwd !== input.activeGitCwd
+  );
+}

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -33,6 +33,7 @@ import { cn } from "~/lib/utils";
 import { selectThreadDiffPanelSelection, useDiffPanelStore } from "../diffPanelStore";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useTheme } from "../hooks/useTheme";
+import { useT3ProjectFileState } from "../hooks/useT3ProjectFileScripts";
 import {
   buildFileDiffContentVersion,
   buildFileDiffIdentityKey,
@@ -85,6 +86,7 @@ import { reviewEnvironment } from "../state/review";
 import { vcsEnvironment } from "../state/vcs";
 import { buildBaseRefChoices, filterBaseRefChoices } from "../lib/baseRefChoices";
 import { createGitDiffFileContentsLoader } from "../lib/diffFileContents";
+import { resolvePathLinkTarget } from "../terminal-links";
 
 type DiffThemeType = "light" | "dark";
 const AUTOMATIC_BASE_REF = "__automatic_base_ref__";
@@ -125,6 +127,7 @@ export default function DiffPanel({
     Schema.Boolean,
   );
   const [baseRefQuery, setBaseRefQuery] = useState("");
+  const [selectedRepositoryPath, setSelectedRepositoryPath] = useState<string | null>(null);
   const [collapsedDiffFiles, setCollapsedDiffFiles] = useState<CollapsedDiffFilesState>(() => ({
     scopeKey: null,
     fileKeys: EMPTY_COLLAPSED_DIFF_FILE_KEYS,
@@ -151,6 +154,26 @@ export default function DiffPanel({
   const activeRepositoryRoot = activeThread?.worktreePath
     ? undefined
     : activeProject?.repositoryIdentity?.rootPath;
+  const projectFile = useT3ProjectFileState(
+    activeThread?.environmentId ?? null,
+    activeProject?.workspaceRoot ?? null,
+  );
+  const configuredRepositories =
+    activeThread?.worktreePath === null || activeThread?.worktreePath === undefined
+      ? (projectFile.file?.repositories ?? [])
+      : [];
+  const effectiveRepositoryPath = selectedRepositoryPath ?? configuredRepositories[0]?.path ?? null;
+  const selectedRepository = configuredRepositories.find(
+    (repository) => repository.path === effectiveRepositoryPath,
+  );
+  const activeGitCwd =
+    activeCwd && selectedRepository
+      ? selectedRepository.path === "."
+        ? activeCwd
+        : resolvePathLinkTarget(selectedRepository.path, activeCwd)
+      : activeCwd;
+  const selectedRepositoryLabel =
+    selectedRepository?.name ?? selectedRepository?.path ?? "Workspace";
   const serverConfig = useAtomValue(
     serverEnvironment.configValueAtom(activeThread?.environmentId ?? null),
   );
@@ -160,10 +183,10 @@ export default function DiffPanel({
   );
   const getDiffFileContents = useAtomCommand(reviewEnvironment.diffFileContents);
   const gitStatusQuery = useEnvironmentQuery(
-    activeThread !== null && activeThread !== undefined && activeCwd != null
+    activeThread !== null && activeThread !== undefined && activeGitCwd != null
       ? vcsEnvironment.status({
           environmentId: activeThread.environmentId,
-          input: { cwd: activeCwd },
+          input: { cwd: activeGitCwd },
         })
       : null,
   );
@@ -259,11 +282,11 @@ export default function DiffPanel({
     { enabled: isGitRepo && selectedTurn !== undefined },
   );
   const primaryBranchDiffPreview = useEnvironmentQuery(
-    selectedTurnId === null && activeThread && activeCwd
+    selectedTurnId === null && activeThread && activeGitCwd
       ? reviewEnvironment.diffPreview({
           environmentId: activeThread.environmentId,
           input: {
-            cwd: activeCwd,
+            cwd: activeGitCwd,
             ...(selectedBaseRef ? { baseRef: selectedBaseRef } : {}),
             ignoreWhitespace: diffIgnoreWhitespace,
           },
@@ -274,7 +297,7 @@ export default function DiffPanel({
     selectedTurnId === null &&
     primaryBranchDiffPreview.error?.includes("configured workspace root") === true &&
     serverConfig?.cwd !== undefined &&
-    serverConfig.cwd !== activeCwd;
+    serverConfig.cwd !== activeGitCwd;
   const fallbackBranchDiffPreview = useEnvironmentQuery(
     shouldRetryBranchDiffAtEnvironmentCwd && activeThread && serverConfig
       ? reviewEnvironment.diffPreview({
@@ -292,7 +315,7 @@ export default function DiffPanel({
     : primaryBranchDiffPreview;
   const refreshBranchDiffPreview = branchDiffPreview.refresh;
   const canRefreshGitDiff =
-    isGitRepo && selectedTurnId === null && activeThread != null && activeCwd != null;
+    isGitRepo && selectedTurnId === null && activeThread != null && activeGitCwd != null;
   const activeThreadRefreshKey = routeThreadRef
     ? `${routeThreadRef.environmentId}:${routeThreadRef.threadId}`
     : null;
@@ -480,7 +503,10 @@ export default function DiffPanel({
         threadRef: routeThreadRef,
         filePath,
         activeCwd,
-        repositoryRoot: activeRepositoryRoot,
+        repositoryRoot:
+          selectedRepository && activeCwd && selectedRepository.path !== "."
+            ? resolvePathLinkTarget(selectedRepository.path, activeCwd)
+            : activeRepositoryRoot,
         openInEditor: (targetPath) => {
           void (async () => {
             const result = await openInPreferredEditor(targetPath);
@@ -500,7 +526,7 @@ export default function DiffPanel({
         },
       });
     },
-    [activeCwd, activeRepositoryRoot, openInPreferredEditor, routeThreadRef],
+    [activeCwd, activeRepositoryRoot, openInPreferredEditor, routeThreadRef, selectedRepository],
   );
   const toggleDiffFileCollapsed = useCallback(
     (fileKey: string) => {
@@ -532,6 +558,7 @@ export default function DiffPanel({
 
   const selectTurn = (turnId: TurnId) => {
     if (!routeThreadRef) return;
+    setSelectedRepositoryPath(null);
     useDiffPanelStore.getState().selectTurn(routeThreadRef, turnId);
   };
   const selectGitScope = (scope: "branch" | "unstaged") => {
@@ -542,10 +569,43 @@ export default function DiffPanel({
     if (!routeThreadRef) return;
     useDiffPanelStore.getState().selectBranchBaseRef(routeThreadRef, baseRef);
   };
+  const selectRepository = (path: string) => {
+    if (!routeThreadRef) return;
+    setSelectedRepositoryPath(path);
+  };
 
   const headerRow = (
     <>
       <div className="flex min-w-0 flex-1 items-center gap-3 [-webkit-app-region:no-drag]">
+        {configuredRepositories.length > 0 && selectedTurnId === null && (
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              className="inline-flex h-6 max-w-full items-center gap-1 rounded-md px-2 text-xs font-medium text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label={`Diff repository: ${selectedRepositoryLabel}`}
+            >
+              <span className="truncate">{selectedRepositoryLabel}</span>
+              <ChevronDownIcon className="size-3.5 shrink-0 opacity-70" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-60">
+              {configuredRepositories.map((repository) => (
+                <DropdownMenuItem
+                  key={repository.path}
+                  className={
+                    repository.path === effectiveRepositoryPath ? "bg-foreground/[0.08]" : undefined
+                  }
+                  onClick={() => selectRepository(repository.path)}
+                >
+                  <span className="truncate">{repository.name ?? repository.path}</span>
+                  {repository.name && (
+                    <span className="ml-auto truncate text-xs text-muted-foreground">
+                      {repository.path}
+                    </span>
+                  )}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
         <DropdownMenu>
           <DropdownMenuTrigger
             className="inline-flex h-6 max-w-full items-center gap-1 rounded-md bg-accent px-2 text-xs font-medium text-accent-foreground outline-none transition-colors hover:bg-accent/80 focus-visible:ring-2 focus-visible:ring-ring"

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -27,10 +27,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useCodeViewFileReveal } from "./diffs/useCodeViewFileReveal";
 import { useOpenInPreferredEditor } from "../editorPreferences";
 import { type DraftId } from "../composerDraftStore";
-import { openDiffFilePrimaryAction } from "../diffFileActions";
+import { openDiffFilePrimaryAction, resolveConfiguredRepositoryRoot } from "../diffFileActions";
 import { useCheckpointDiff } from "~/lib/checkpointDiffState";
 import { cn } from "~/lib/utils";
-import { selectThreadDiffPanelSelection, useDiffPanelStore } from "../diffPanelStore";
+import {
+  selectThreadDiffPanelSelection,
+  selectThreadDiffRepositoryPath,
+  useDiffPanelStore,
+} from "../diffPanelStore";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useTheme } from "../hooks/useTheme";
 import { useT3ProjectFileState } from "../hooks/useT3ProjectFileScripts";
@@ -51,6 +55,11 @@ import { useProject, useThread } from "../state/entities";
 import { resolveThreadRouteRef } from "../threadRoutes";
 import { useClientSettings, useUpdateClientSettings } from "../hooks/useSettings";
 import { formatShortTimestamp } from "../timestampFormat";
+import {
+  resolveNestedDiffRepositoryPath,
+  resolveUnresolvableRepositoryMessage,
+  shouldRetryDiffPreviewAtEnvironmentCwd,
+} from "./DiffPanel.logic";
 import { DiffFilePathCopyButton } from "./DiffFilePathCopyButton";
 import { DiffPanelLoadingState, DiffPanelShell, type DiffPanelMode } from "./DiffPanelShell";
 import { DiffStatLabel } from "./chat/DiffStatLabel";
@@ -86,7 +95,6 @@ import { reviewEnvironment } from "../state/review";
 import { vcsEnvironment } from "../state/vcs";
 import { buildBaseRefChoices, filterBaseRefChoices } from "../lib/baseRefChoices";
 import { createGitDiffFileContentsLoader } from "../lib/diffFileContents";
-import { resolvePathLinkTarget } from "../terminal-links";
 
 type DiffThemeType = "light" | "dark";
 const AUTOMATIC_BASE_REF = "__automatic_base_ref__";
@@ -127,7 +135,6 @@ export default function DiffPanel({
     Schema.Boolean,
   );
   const [baseRefQuery, setBaseRefQuery] = useState("");
-  const [selectedRepositoryPath, setSelectedRepositoryPath] = useState<string | null>(null);
   const [collapsedDiffFiles, setCollapsedDiffFiles] = useState<CollapsedDiffFilesState>(() => ({
     scopeKey: null,
     fileKeys: EMPTY_COLLAPSED_DIFF_FILE_KEYS,
@@ -162,16 +169,47 @@ export default function DiffPanel({
     activeThread?.worktreePath === null || activeThread?.worktreePath === undefined
       ? (projectFile.file?.repositories ?? [])
       : [];
-  const effectiveRepositoryPath = selectedRepositoryPath ?? configuredRepositories[0]?.path ?? null;
+  // Repository state follows its actual path, including the configured default.
+  // Only the workspace root retains the legacy bare thread key.
+  const selectedRepositoryPath = useDiffPanelStore((state) =>
+    selectThreadDiffRepositoryPath(
+      state.selectedRepositoryByThreadKey,
+      routeThreadRef,
+      configuredRepositories,
+    ),
+  );
+  const effectiveRepositoryPath = selectedRepositoryPath ?? ".";
   const selectedRepository = configuredRepositories.find(
     (repository) => repository.path === effectiveRepositoryPath,
   );
+  const diffSelection = useDiffPanelStore((state) =>
+    selectThreadDiffPanelSelection(
+      state.byThreadKey,
+      routeThreadRef,
+      selectedRepositoryPath,
+      initialGitScope === "unstaged",
+    ),
+  );
+  const nestedRepositoryPath = resolveNestedDiffRepositoryPath({
+    isTurnSelected: diffSelection.kind === "turn",
+    repositoryPath: selectedRepository?.path,
+  });
+  const nestedRepositoryRoot =
+    nestedRepositoryPath !== null && activeCwd
+      ? resolveConfiguredRepositoryRoot(nestedRepositoryPath, activeCwd)
+      : null;
+  // A configured repository path we cannot resolve inside the workspace leaves us
+  // without a working directory on purpose: falling back to the workspace root
+  // would show and open a different repository's files than the selection claims.
   const activeGitCwd =
-    activeCwd && selectedRepository
-      ? selectedRepository.path === "."
-        ? activeCwd
-        : resolvePathLinkTarget(selectedRepository.path, activeCwd)
-      : activeCwd;
+    nestedRepositoryPath !== null ? (nestedRepositoryRoot ?? undefined) : activeCwd;
+  // Nested repositories report diff paths relative to their own root, while a
+  // workspace nested inside a larger repository reports them relative to that
+  // enclosing repository.
+  const diffRepositoryRoot =
+    nestedRepositoryPath !== null ? (nestedRepositoryRoot ?? undefined) : activeRepositoryRoot;
+  const hasUnresolvableRepository = nestedRepositoryPath !== null && nestedRepositoryRoot === null;
+  const configuredWorkspaceRoot = nestedRepositoryPath !== null ? activeCwd : undefined;
   const selectedRepositoryLabel =
     selectedRepository?.name ?? selectedRepository?.path ?? "Workspace";
   const serverConfig = useAtomValue(
@@ -186,16 +224,12 @@ export default function DiffPanel({
     activeThread !== null && activeThread !== undefined && activeGitCwd != null
       ? vcsEnvironment.status({
           environmentId: activeThread.environmentId,
-          input: { cwd: activeGitCwd },
+          input: {
+            cwd: activeGitCwd,
+            ...(configuredWorkspaceRoot ? { workspaceRoot: configuredWorkspaceRoot } : {}),
+          },
         })
       : null,
-  );
-  const diffSelection = useDiffPanelStore((state) =>
-    selectThreadDiffPanelSelection(
-      state.byThreadKey,
-      routeThreadRef,
-      initialGitScope === "unstaged",
-    ),
   );
   const isGitRepo = gitStatusQuery.data?.isRepo ?? true;
   const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
@@ -287,17 +321,20 @@ export default function DiffPanel({
           environmentId: activeThread.environmentId,
           input: {
             cwd: activeGitCwd,
+            ...(configuredWorkspaceRoot ? { workspaceRoot: configuredWorkspaceRoot } : {}),
             ...(selectedBaseRef ? { baseRef: selectedBaseRef } : {}),
             ignoreWhitespace: diffIgnoreWhitespace,
           },
         })
       : null,
   );
-  const shouldRetryBranchDiffAtEnvironmentCwd =
-    selectedTurnId === null &&
-    primaryBranchDiffPreview.error?.includes("configured workspace root") === true &&
-    serverConfig?.cwd !== undefined &&
-    serverConfig.cwd !== activeGitCwd;
+  const shouldRetryBranchDiffAtEnvironmentCwd = shouldRetryDiffPreviewAtEnvironmentCwd({
+    isTurnSelected: selectedTurnId !== null,
+    nestedRepositoryPath,
+    previewError: primaryBranchDiffPreview.error,
+    environmentCwd: serverConfig?.cwd,
+    activeGitCwd,
+  });
   const fallbackBranchDiffPreview = useEnvironmentQuery(
     shouldRetryBranchDiffAtEnvironmentCwd && activeThread && serverConfig
       ? reviewEnvironment.diffPreview({
@@ -346,6 +383,7 @@ export default function DiffPanel({
     return createGitDiffFileContentsLoader(getDiffFileContents, {
       environmentId: activeThread.environmentId,
       cwd: preview.cwd,
+      ...(configuredWorkspaceRoot ? { workspaceRoot: configuredWorkspaceRoot } : {}),
       sourceKind: selectedGitSource.kind,
       baseRef: selectedGitSource.baseRef,
       headRef: selectedGitSource.headRef,
@@ -354,6 +392,7 @@ export default function DiffPanel({
   }, [
     activeThread,
     branchDiffPreview.data,
+    configuredWorkspaceRoot,
     getDiffFileContents,
     selectedGitSource,
     selectedTurnId,
@@ -421,6 +460,11 @@ export default function DiffPanel({
     ? activeCheckpointDiff.isPending
     : branchDiffPreview.isPending;
   const selectedPatchError = selectedTurn ? activeCheckpointDiff.error : branchDiffPreview.error;
+  const unresolvableRepositoryMessage = resolveUnresolvableRepositoryMessage({
+    isTurnSelected: selectedTurnId !== null,
+    hasUnresolvableRepository,
+    repositoryPath: nestedRepositoryPath,
+  });
   const hasResolvedPatch = typeof selectedPatch === "string";
   const hasNoNetChanges = hasResolvedPatch && selectedPatch.trim().length === 0;
   const renderablePatch = useMemo(
@@ -499,14 +543,19 @@ export default function DiffPanel({
 
   const openDiffFile = useCallback(
     (filePath: string) => {
+      // Without a resolvable repository root the diff path cannot be re-based onto
+      // the workspace, and opening it as-is would land on an unrelated file.
+      if (hasUnresolvableRepository) return;
       openDiffFilePrimaryAction({
         threadRef: routeThreadRef,
         filePath,
         activeCwd,
-        repositoryRoot:
-          selectedRepository && activeCwd && selectedRepository.path !== "."
-            ? resolvePathLinkTarget(selectedRepository.path, activeCwd)
-            : activeRepositoryRoot,
+        repositoryRoot: diffRepositoryRoot
+          ? {
+              path: diffRepositoryRoot,
+              kind: nestedRepositoryPath !== null ? "configured" : "detected",
+            }
+          : undefined,
         openInEditor: (targetPath) => {
           void (async () => {
             const result = await openInPreferredEditor(targetPath);
@@ -526,7 +575,14 @@ export default function DiffPanel({
         },
       });
     },
-    [activeCwd, activeRepositoryRoot, openInPreferredEditor, routeThreadRef, selectedRepository],
+    [
+      activeCwd,
+      diffRepositoryRoot,
+      hasUnresolvableRepository,
+      nestedRepositoryPath,
+      openInPreferredEditor,
+      routeThreadRef,
+    ],
   );
   const toggleDiffFileCollapsed = useCallback(
     (fileKey: string) => {
@@ -558,20 +614,23 @@ export default function DiffPanel({
 
   const selectTurn = (turnId: TurnId) => {
     if (!routeThreadRef) return;
-    setSelectedRepositoryPath(null);
+    // The store drops the repository override, so a turn opened from the chat
+    // timeline lands on the same key the panel reads.
     useDiffPanelStore.getState().selectTurn(routeThreadRef, turnId);
   };
   const selectGitScope = (scope: "branch" | "unstaged") => {
     if (!routeThreadRef) return;
-    useDiffPanelStore.getState().selectGitScope(routeThreadRef, scope);
+    useDiffPanelStore.getState().selectGitScope(routeThreadRef, scope, selectedRepositoryPath);
   };
   const selectBranchBaseRef = (baseRef: string | null) => {
     if (!routeThreadRef) return;
-    useDiffPanelStore.getState().selectBranchBaseRef(routeThreadRef, baseRef);
+    useDiffPanelStore
+      .getState()
+      .selectBranchBaseRef(routeThreadRef, baseRef, selectedRepositoryPath);
   };
   const selectRepository = (path: string) => {
     if (!routeThreadRef) return;
-    setSelectedRepositoryPath(path);
+    useDiffPanelStore.getState().selectRepository(routeThreadRef, path);
   };
 
   const headerRow = (
@@ -966,9 +1025,11 @@ export default function DiffPanel({
                 incomplete.
               </p>
             )}
-            {selectedPatchError && !renderablePatch && (
+            {(selectedPatchError ?? unresolvableRepositoryMessage) && !renderablePatch && (
               <div className="px-3">
-                <p className="mb-2 text-[11px] text-error/80">{selectedPatchError}</p>
+                <p className="mb-2 text-[11px] text-error/80">
+                  {selectedPatchError ?? unresolvableRepositoryMessage}
+                </p>
               </div>
             )}
             {!renderablePatch ? (

--- a/apps/web/src/diffFileActions.test.ts
+++ b/apps/web/src/diffFileActions.test.ts
@@ -2,7 +2,11 @@ import { scopeThreadRef } from "@t3tools/client-runtime/environment";
 import { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { openDiffFilePrimaryAction, resolveDiffPathForWorkspace } from "./diffFileActions";
+import {
+  openDiffFilePrimaryAction,
+  resolveConfiguredRepositoryRoot,
+  resolveDiffPathForWorkspace,
+} from "./diffFileActions";
 import { selectThreadRightPanelState, useRightPanelStore } from "./rightPanelStore";
 
 const THREAD_REF = scopeThreadRef(
@@ -56,7 +60,7 @@ describe("openDiffFilePrimaryAction", () => {
       threadRef: THREAD_REF,
       filePath: "frontend/Dockerfile",
       activeCwd: "/repo/frontend",
-      repositoryRoot: "/repo",
+      repositoryRoot: { path: "/repo", kind: "detected" },
       openInEditor,
     });
 
@@ -70,13 +74,75 @@ describe("openDiffFilePrimaryAction", () => {
   });
 
   it("preserves repository-relative paths in a separate worktree", () => {
+    // A worktree is its own repository root, so the diff paths already are
+    // workspace-relative and no root has to be reconciled.
     expect(
       resolveDiffPathForWorkspace({
         filePath: "frontend/Dockerfile",
         workspaceRoot: "/worktrees/feature",
-        repositoryRoot: "/repo",
+        repositoryRoot: undefined,
       }),
     ).toBe("frontend/Dockerfile");
+  });
+
+  it.each([
+    { workspaceRoot: "/ws", repositoryRoot: "/elsewhere/repo" },
+    { workspaceRoot: "C:\\ws", repositoryRoot: "D:\\elsewhere\\repo" },
+  ])(
+    "does not open a diff file from an unrelated configured repository root: $repositoryRoot",
+    ({ workspaceRoot, repositoryRoot }) => {
+      const openInEditor = vi.fn();
+
+      openDiffFilePrimaryAction({
+        threadRef: THREAD_REF,
+        filePath: "src/foo.ts",
+        activeCwd: workspaceRoot,
+        repositoryRoot: { path: repositoryRoot, kind: "configured" },
+        openInEditor,
+      });
+
+      expect(
+        selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, THREAD_REF),
+      ).toMatchObject({ isOpen: false });
+      expect(openInEditor).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { workspaceRoot: "/ws", repositoryRoot: "/data/code/ws" },
+    { workspaceRoot: "C:\\ws", repositoryRoot: "D:\\data\\code\\ws" },
+  ])(
+    "still opens a diff file when a detected repository root does not nest: $repositoryRoot",
+    ({ workspaceRoot, repositoryRoot }) => {
+      // Detected roots come from `git rev-parse --show-toplevel`, which resolves
+      // symlinks, while the workspace root does not. Behind a symlinked project
+      // folder (`~/code -> /data/code`, or macOS `/tmp` -> `/private/tmp`) the two
+      // describe the same tree without nesting, and the diff path is still
+      // workspace-relative. Configured roots must keep refusing this case.
+      const openInEditor = vi.fn();
+
+      openDiffFilePrimaryAction({
+        threadRef: null,
+        filePath: "src/foo.ts",
+        activeCwd: workspaceRoot,
+        repositoryRoot: { path: repositoryRoot, kind: "detected" },
+        openInEditor,
+      });
+
+      expect(openInEditor).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("keeps the relative path intact below a Windows root that changes length when lowercased", () => {
+    // `İ` (U+0130) lowercases to two code units, so the prefix length measured on
+    // the lowercased comparison form does not apply to the original path.
+    expect(
+      resolveDiffPathForWorkspace({
+        filePath: "ws/src/foo.ts",
+        workspaceRoot: "C:\\Projekte\\İstanbul\\ws",
+        repositoryRoot: { path: "C:\\Projekte\\İstanbul", kind: "detected" },
+      }),
+    ).toBe("src/foo.ts");
   });
 
   it("handles Windows roots and mixed diff separators", () => {
@@ -84,7 +150,7 @@ describe("openDiffFilePrimaryAction", () => {
       resolveDiffPathForWorkspace({
         filePath: "Frontend/src\\index.ts",
         workspaceRoot: "C:\\repo\\frontend",
-        repositoryRoot: "C:\\repo",
+        repositoryRoot: { path: "C:\\repo", kind: "detected" },
       }),
     ).toBe("src/index.ts");
   });
@@ -97,7 +163,7 @@ describe("openDiffFilePrimaryAction", () => {
       resolveDiffPathForWorkspace({
         filePath: "frontend/index.ts",
         workspaceRoot,
-        repositoryRoot,
+        repositoryRoot: { path: repositoryRoot, kind: "detected" },
       }),
     ).toBe("index.ts");
   });
@@ -111,7 +177,7 @@ describe("openDiffFilePrimaryAction", () => {
         threadRef: THREAD_REF,
         filePath,
         activeCwd: "/repo/frontend",
-        repositoryRoot: "/repo",
+        repositoryRoot: { path: "/repo", kind: "detected" },
         openInEditor,
       });
 
@@ -121,4 +187,141 @@ describe("openDiffFilePrimaryAction", () => {
       expect(openInEditor).not.toHaveBeenCalled();
     },
   );
+  it("opens files of a repository nested inside the workspace", () => {
+    const openInEditor = vi.fn();
+
+    openDiffFilePrimaryAction({
+      threadRef: null,
+      filePath: "src/foo.ts",
+      activeCwd: "/ws",
+      repositoryRoot: { path: "/ws/frontend", kind: "configured" },
+      openInEditor,
+    });
+
+    expect(openInEditor).toHaveBeenCalledWith("/ws/frontend/src/foo.ts");
+  });
+
+  it("keeps nested repository files workspace-relative for the file viewer", () => {
+    const openInEditor = vi.fn();
+
+    openDiffFilePrimaryAction({
+      threadRef: THREAD_REF,
+      filePath: "src/foo.ts",
+      activeCwd: "/ws",
+      repositoryRoot: { path: "/ws/frontend", kind: "configured" },
+      openInEditor,
+    });
+
+    // The file viewer resolves its path against the workspace root, so the
+    // nested repository offset has to stay in the path.
+    expect(
+      selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, THREAD_REF),
+    ).toMatchObject({
+      isOpen: true,
+      activeSurfaceId: "file:frontend/src/foo.ts",
+    });
+    expect(openInEditor).not.toHaveBeenCalled();
+  });
+
+  it("opens files of a Windows repository nested inside the workspace", () => {
+    expect(
+      resolveDiffPathForWorkspace({
+        filePath: "src\\foo.ts",
+        workspaceRoot: "C:\\ws",
+        repositoryRoot: { path: "C:\\ws\\Frontend", kind: "configured" },
+      }),
+    ).toBe("Frontend/src/foo.ts");
+  });
+
+  it("resolves workspace-root diff files without a repository selection", () => {
+    const openInEditor = vi.fn();
+
+    openDiffFilePrimaryAction({
+      threadRef: null,
+      filePath: "src/foo.ts",
+      activeCwd: "/ws",
+      openInEditor,
+    });
+
+    expect(openInEditor).toHaveBeenCalledWith("/ws/src/foo.ts");
+  });
+
+  it("resolves worktree diff files against the worktree root", () => {
+    const openInEditor = vi.fn();
+
+    openDiffFilePrimaryAction({
+      threadRef: null,
+      filePath: "src/foo.ts",
+      activeCwd: "/worktrees/feature",
+      repositoryRoot: undefined,
+      openInEditor,
+    });
+
+    expect(openInEditor).toHaveBeenCalledWith("/worktrees/feature/src/foo.ts");
+  });
+
+  it("strips the workspace prefix when the workspace sits inside the repository", () => {
+    const openInEditor = vi.fn();
+
+    openDiffFilePrimaryAction({
+      threadRef: null,
+      filePath: "frontend/src/foo.ts",
+      activeCwd: "/repo/frontend",
+      repositoryRoot: { path: "/repo", kind: "detected" },
+      openInEditor,
+    });
+
+    expect(openInEditor).toHaveBeenCalledWith("/repo/frontend/src/foo.ts");
+  });
+
+  it("matches workspace prefixes case-insensitively on Windows", () => {
+    expect(
+      resolveDiffPathForWorkspace({
+        filePath: "Frontend/src/index.ts",
+        workspaceRoot: "C:\\repo\\Frontend",
+        repositoryRoot: { path: "C:\\repo", kind: "detected" },
+      }),
+    ).toBe("src/index.ts");
+  });
+});
+
+describe("resolveConfiguredRepositoryRoot", () => {
+  it.each([
+    { repositoryPath: ".", workspaceRoot: "/ws", expected: "/ws" },
+    { repositoryPath: "frontend", workspaceRoot: "/ws", expected: "/ws/frontend" },
+    { repositoryPath: "services/api", workspaceRoot: "/ws", expected: "/ws/services/api" },
+    { repositoryPath: "./services/api", workspaceRoot: "/ws", expected: "/ws/services/api" },
+    { repositoryPath: "frontend", workspaceRoot: "/ws/", expected: "/ws/frontend" },
+    { repositoryPath: "frontend", workspaceRoot: "/", expected: "/frontend" },
+    { repositoryPath: "services/api", workspaceRoot: "C:\\ws", expected: "C:\\ws\\services\\api" },
+    { repositoryPath: "services\\api", workspaceRoot: "C:\\ws", expected: "C:\\ws\\services\\api" },
+    { repositoryPath: ".", workspaceRoot: "C:\\ws", expected: "C:\\ws" },
+  ])(
+    "resolves $repositoryPath below $workspaceRoot",
+    ({ repositoryPath, workspaceRoot, expected }) => {
+      expect(resolveConfiguredRepositoryRoot(repositoryPath, workspaceRoot)).toBe(expected);
+    },
+  );
+
+  it.each([
+    "",
+    "/absolute/repo",
+    "\\\\server\\share",
+    "\\drive-relative",
+    "C:/repo",
+    "C:\\repo",
+    "C:repo",
+    "..",
+    "../sibling",
+    "frontend/../../escape",
+    "~",
+    "~/client",
+    "~user/client",
+    "nested/~/client",
+    "weird:path",
+    "nested/weird:path",
+  ])("rejects the configured path: %s", (repositoryPath) => {
+    expect(resolveConfiguredRepositoryRoot(repositoryPath, "/ws")).toBeNull();
+    expect(resolveConfiguredRepositoryRoot(repositoryPath, "C:\\ws")).toBeNull();
+  });
 });

--- a/apps/web/src/diffFileActions.ts
+++ b/apps/web/src/diffFileActions.ts
@@ -1,14 +1,32 @@
 import type { ScopedThreadRef } from "@t3tools/contracts";
-import { isWindowsAbsolutePath, normalizeProjectPathForComparison } from "@t3tools/shared/path";
+import {
+  isWindowsAbsolutePath,
+  normalizeProjectPathForComparison,
+  normalizeProjectPathForDispatch,
+} from "@t3tools/shared/path";
 
 import { useRightPanelStore } from "./rightPanelStore";
 import { resolvePathLinkTarget } from "./terminal-links";
+
+/**
+ * Where the repository root a diff path is relative to came from.
+ *
+ * `configured` roots are built from the workspace root plus the segments of a
+ * `t3.json` entry, so they always nest below the workspace. `detected` roots are
+ * reported by git on the server and can disagree with the workspace root even
+ * when both describe the same tree, because git resolves symlinks and the
+ * workspace root does not.
+ */
+interface DiffRepositoryRoot {
+  readonly path: string;
+  readonly kind: "configured" | "detected";
+}
 
 interface OpenDiffFilePrimaryActionInput {
   readonly threadRef: ScopedThreadRef | null;
   readonly filePath: string;
   readonly activeCwd: string | undefined;
-  readonly repositoryRoot?: string | undefined;
+  readonly repositoryRoot?: DiffRepositoryRoot | undefined;
   readonly openInEditor: (targetPath: string) => void;
 }
 
@@ -25,51 +43,120 @@ function normalizedRelativePathSegments(filePath: string): ReadonlyArray<string>
   return segments;
 }
 
-function repositoryRelativeWorkspaceSegments(
-  workspaceRoot: string | undefined,
-  repositoryRoot: string | undefined,
+function pathSegments(value: string): ReadonlyArray<string> {
+  return value.split(/[\\/]+/).filter(Boolean);
+}
+
+/**
+ * Segments of `nestedPath` below `baseRoot`, `[]` when they are the same
+ * directory, or `null` when `nestedPath` does not live below `baseRoot`.
+ * Segments keep their original casing; comparison is case-insensitive on
+ * Windows-style roots.
+ */
+function nestedPathSegments(
+  baseRoot: string | undefined,
+  nestedPath: string | undefined,
 ): ReadonlyArray<string> | null {
-  if (!workspaceRoot || !repositoryRoot) return null;
+  if (!baseRoot || !nestedPath) return null;
 
-  const normalizedWorkspaceRoot = normalizeProjectPathForComparison(workspaceRoot);
-  const normalizedRepositoryRoot = normalizeProjectPathForComparison(repositoryRoot);
-  if (normalizedWorkspaceRoot === normalizedRepositoryRoot) return [];
+  const dispatchNestedPath = normalizeProjectPathForDispatch(nestedPath);
+  const normalizedBaseRoot = normalizeProjectPathForComparison(baseRoot);
+  const normalizedNestedPath = normalizeProjectPathForComparison(dispatchNestedPath);
+  if (normalizedBaseRoot === normalizedNestedPath) return [];
 
-  const separator = normalizedRepositoryRoot.includes("\\") ? "\\" : "/";
-  const repositoryPrefix = normalizedRepositoryRoot.endsWith(separator)
-    ? normalizedRepositoryRoot
-    : `${normalizedRepositoryRoot}${separator}`;
-  if (!normalizedWorkspaceRoot.startsWith(repositoryPrefix)) return null;
+  const separator = normalizedBaseRoot.includes("\\") ? "\\" : "/";
+  const basePrefix = normalizedBaseRoot.endsWith(separator)
+    ? normalizedBaseRoot
+    : `${normalizedBaseRoot}${separator}`;
+  if (!normalizedNestedPath.startsWith(basePrefix)) return null;
 
-  return normalizedWorkspaceRoot
-    .slice(repositoryPrefix.length)
-    .split(/[\\/]+/)
-    .filter(Boolean);
+  // Drop as many leading segments as the base root has rather than slicing by
+  // the matched prefix length: comparison normalization lowercases Windows
+  // paths, and Unicode lowercasing can change a string's length, so a length
+  // measured on the comparison form does not carry over to the original casing.
+  return pathSegments(dispatchNestedPath).slice(pathSegments(normalizedBaseRoot).length);
+}
+
+/**
+ * Resolves a repository path configured in `t3.json` against the workspace root.
+ *
+ * Configuration paths are strictly workspace-relative: unlike a terminal link
+ * there is no `~` expansion and no `:line:column` suffix, and anything that
+ * could escape the workspace yields `null` so callers can refuse the path
+ * instead of silently reading a different tree.
+ */
+export function resolveConfiguredRepositoryRoot(
+  repositoryPath: string,
+  workspaceRoot: string,
+): string | null {
+  const trimmed = repositoryPath.trim();
+  if (trimmed === ".") return workspaceRoot;
+  if (trimmed.startsWith("/") || trimmed.startsWith("\\")) return null;
+  // `isWindowsAbsolutePath` covers UNC and `C:/`, but not drive-relative `C:foo`.
+  if (isWindowsAbsolutePath(trimmed) || /^[a-zA-Z]:/.test(trimmed)) return null;
+
+  const segments = trimmed
+    .replaceAll("\\", "/")
+    .split("/")
+    .filter((segment) => segment.length > 0 && segment !== ".");
+  if (segments.length === 0) return null;
+  const escapesWorkspace = segments.some(
+    (segment) => segment === ".." || segment.startsWith("~") || segment.includes(":"),
+  );
+  if (escapesWorkspace) return null;
+
+  const separator = isWindowsAbsolutePath(workspaceRoot) ? "\\" : "/";
+  const base = normalizeProjectPathForDispatch(workspaceRoot);
+  const joined = segments.join(separator);
+  return base.endsWith("/") || base.endsWith("\\")
+    ? `${base}${joined}`
+    : `${base}${separator}${joined}`;
 }
 
 export function resolveDiffPathForWorkspace(input: {
   readonly filePath: string;
   readonly workspaceRoot: string | undefined;
-  readonly repositoryRoot: string | undefined;
+  readonly repositoryRoot: DiffRepositoryRoot | undefined;
 }): string | null {
   const fileSegments = normalizedRelativePathSegments(input.filePath);
   if (!fileSegments) return null;
 
-  const workspaceSegments = repositoryRelativeWorkspaceSegments(
-    input.workspaceRoot,
-    input.repositoryRoot,
-  );
-  if (!workspaceSegments || workspaceSegments.length === 0) {
+  // Without a repository root the diff path is workspace-relative by definition.
+  const repositoryRoot = input.repositoryRoot?.path;
+  if (!repositoryRoot) {
     return fileSegments.join("/");
   }
 
-  const caseInsensitive = input.repositoryRoot
-    ? isWindowsAbsolutePath(input.repositoryRoot)
-    : false;
+  // Otherwise the diff path is relative to the repository while callers resolve
+  // against the workspace, so the two roots have to be reconciled: the workspace
+  // can sit below the repository (strip the shared prefix) or the repository can
+  // sit below the workspace (prepend its offset).
+  const workspaceSegments = nestedPathSegments(repositoryRoot, input.workspaceRoot);
+  if (workspaceSegments === null) {
+    const repositorySegments = nestedPathSegments(input.workspaceRoot, repositoryRoot);
+    if (repositorySegments !== null) {
+      return [...repositorySegments, ...fileSegments].join("/");
+    }
+    // Roots that do not nest either way mean different things per origin. A
+    // configured root is built from the workspace root, so this is unreachable
+    // by construction and a mismatch means the input is not what we think it is
+    // — refuse rather than open a same-named file in an unrelated tree. A
+    // detected root routinely differs from the workspace root for the same tree
+    // (git resolves symlinks, the workspace root does not), so the diff path is
+    // still the best relative path we have.
+    return input.repositoryRoot.kind === "configured" ? null : fileSegments.join("/");
+  }
+  if (workspaceSegments.length === 0) {
+    return fileSegments.join("/");
+  }
+
+  const caseInsensitive = isWindowsAbsolutePath(repositoryRoot);
   const belongsToWorkspace = workspaceSegments.every((segment, index) => {
     const candidate = fileSegments[index];
     if (candidate === undefined) return false;
-    return caseInsensitive ? candidate.toLowerCase() === segment : candidate === segment;
+    return caseInsensitive
+      ? candidate.toLowerCase() === segment.toLowerCase()
+      : candidate === segment;
   });
   if (!belongsToWorkspace) return null;
 

--- a/apps/web/src/diffPanelStore.test.ts
+++ b/apps/web/src/diffPanelStore.test.ts
@@ -1,52 +1,78 @@
-import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
 import { EnvironmentId, ThreadId, TurnId } from "@t3tools/contracts";
 import { beforeEach, describe, expect, it } from "vite-plus/test";
 
-import { selectThreadDiffPanelSelection, useDiffPanelStore } from "./diffPanelStore";
+import {
+  selectThreadDiffPanelSelection,
+  selectThreadDiffRepositoryPath,
+  useDiffPanelStore,
+} from "./diffPanelStore";
 
 const THREAD_REF = scopeThreadRef(EnvironmentId.make("environment-1"), ThreadId.make("thread-1"));
+// Its scoped key starts with the one above, which a prefix match must not treat
+// as the same thread.
+const SIMILAR_THREAD_REF = scopeThreadRef(
+  EnvironmentId.make("environment-1"),
+  ThreadId.make("thread-10"),
+);
+const NESTED_REPOSITORY = "services/api";
+const CONFIGURED_REPOSITORIES = [{ path: "." }, { path: NESTED_REPOSITORY }];
+const NESTED_FIRST_REPOSITORIES = [{ path: NESTED_REPOSITORY }, { path: "." }];
+
+const selectionFor = (
+  ref: typeof THREAD_REF,
+  repositoryPath: string | null = null,
+  hasWorkingTreeChanges = false,
+) =>
+  selectThreadDiffPanelSelection(
+    useDiffPanelStore.getState().byThreadKey,
+    ref,
+    repositoryPath,
+    hasWorkingTreeChanges,
+  );
+
+const repositoryFor = (
+  ref: typeof THREAD_REF,
+  configuredRepositories: ReadonlyArray<{ readonly path: string }> = CONFIGURED_REPOSITORIES,
+) =>
+  selectThreadDiffRepositoryPath(
+    useDiffPanelStore.getState().selectedRepositoryByThreadKey,
+    ref,
+    configuredRepositories,
+  );
 
 describe("diffPanelStore", () => {
   beforeEach(() =>
     useDiffPanelStore.setState({
       byThreadKey: {},
       branchBaseRefByThreadKey: {},
+      selectedRepositoryByThreadKey: {},
     }),
   );
 
   it("defaults each thread to branch changes when the working tree is clean", () => {
-    expect(
-      selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, THREAD_REF),
-    ).toEqual({ kind: "branch", baseRef: null });
+    expect(selectionFor(THREAD_REF)).toEqual({ kind: "branch", baseRef: null });
   });
 
   it("defaults each thread to working changes when the working tree is dirty", () => {
-    expect(
-      selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, THREAD_REF, true),
-    ).toEqual({ kind: "unstaged" });
+    expect(selectionFor(THREAD_REF, null, true)).toEqual({ kind: "unstaged" });
   });
 
   it("preserves an explicit scope selection when the working tree state changes", () => {
-    useDiffPanelStore.getState().selectGitScope(THREAD_REF, "branch");
+    useDiffPanelStore.getState().selectGitScope(THREAD_REF, "branch", null);
 
-    expect(
-      selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, THREAD_REF, true),
-    ).toEqual({ kind: "branch", baseRef: null });
+    expect(selectionFor(THREAD_REF, null, true)).toEqual({ kind: "branch", baseRef: null });
   });
 
   it("clears incompatible selection fields when changing scopes", () => {
     const store = useDiffPanelStore.getState();
     store.selectTurn(THREAD_REF, TurnId.make("turn-1"), "src/app.ts");
-    store.selectGitScope(THREAD_REF, "unstaged");
+    store.selectGitScope(THREAD_REF, "unstaged", null);
 
-    expect(
-      selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, THREAD_REF),
-    ).toEqual({ kind: "unstaged" });
+    expect(selectionFor(THREAD_REF)).toEqual({ kind: "unstaged" });
 
-    useDiffPanelStore.getState().selectBranchBaseRef(THREAD_REF, " origin/main ");
-    expect(
-      selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, THREAD_REF),
-    ).toEqual({ kind: "branch", baseRef: "origin/main" });
+    useDiffPanelStore.getState().selectBranchBaseRef(THREAD_REF, " origin/main ", null);
+    expect(selectionFor(THREAD_REF)).toEqual({ kind: "branch", baseRef: "origin/main" });
   });
 
   it("increments the reveal request when opening the same turn file again", () => {
@@ -54,19 +80,20 @@ describe("diffPanelStore", () => {
     useDiffPanelStore.getState().selectTurn(THREAD_REF, turnId, "src/app.ts");
     useDiffPanelStore.getState().selectTurn(THREAD_REF, turnId, "src/app.ts");
 
-    expect(
-      selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, THREAD_REF),
-    ).toEqual({ kind: "turn", turnId, filePath: "src/app.ts", revealRequestId: 2 });
+    expect(selectionFor(THREAD_REF)).toEqual({
+      kind: "turn",
+      turnId,
+      filePath: "src/app.ts",
+      revealRequestId: 2,
+    });
   });
 
   it("restores the selected branch base after visiting another scope", () => {
-    useDiffPanelStore.getState().selectBranchBaseRef(THREAD_REF, "origin/main");
-    useDiffPanelStore.getState().selectGitScope(THREAD_REF, "unstaged");
-    useDiffPanelStore.getState().selectGitScope(THREAD_REF, "branch");
+    useDiffPanelStore.getState().selectBranchBaseRef(THREAD_REF, "origin/main", null);
+    useDiffPanelStore.getState().selectGitScope(THREAD_REF, "unstaged", null);
+    useDiffPanelStore.getState().selectGitScope(THREAD_REF, "branch", null);
 
-    expect(
-      selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, THREAD_REF),
-    ).toEqual({ kind: "branch", baseRef: "origin/main" });
+    expect(selectionFor(THREAD_REF)).toEqual({ kind: "branch", baseRef: "origin/main" });
   });
 
   it("reconciles a missing turn selection to the latest available turn", () => {
@@ -75,13 +102,210 @@ describe("diffPanelStore", () => {
     useDiffPanelStore.getState().selectTurn(THREAD_REF, missingTurnId, "src/app.ts");
     useDiffPanelStore.getState().reconcileTurnSelection(THREAD_REF, [latestTurnId]);
 
-    expect(
-      selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, THREAD_REF),
-    ).toEqual({
+    expect(selectionFor(THREAD_REF)).toEqual({
       kind: "turn",
       turnId: latestTurnId,
       filePath: "src/app.ts",
       revealRequestId: 1,
     });
+  });
+
+  it("keeps a branch base per repository across repository switches", () => {
+    useDiffPanelStore.getState().selectBranchBaseRef(THREAD_REF, "origin/main", null);
+    useDiffPanelStore.getState().selectBranchBaseRef(THREAD_REF, "origin/api", NESTED_REPOSITORY);
+
+    expect(selectionFor(THREAD_REF, NESTED_REPOSITORY)).toEqual({
+      kind: "branch",
+      baseRef: "origin/api",
+    });
+    expect(selectionFor(THREAD_REF, null)).toEqual({ kind: "branch", baseRef: "origin/main" });
+  });
+
+  it("starts a newly selected repository from the default instead of the previous base", () => {
+    useDiffPanelStore.getState().selectBranchBaseRef(THREAD_REF, "origin/main", null);
+
+    expect(selectionFor(THREAD_REF, NESTED_REPOSITORY)).toEqual({ kind: "branch", baseRef: null });
+  });
+
+  it("keeps scopes separate per repository", () => {
+    useDiffPanelStore.getState().selectGitScope(THREAD_REF, "unstaged", NESTED_REPOSITORY);
+
+    expect(selectionFor(THREAD_REF, NESTED_REPOSITORY)).toEqual({ kind: "unstaged" });
+    expect(selectionFor(THREAD_REF, null)).toEqual({ kind: "branch", baseRef: null });
+  });
+
+  it("reads state persisted before repositories as the default repository", () => {
+    // State written before the panel knew about repositories lives on the bare
+    // thread key and has to stay readable without a migration. It represents
+    // the workspace root, while configured repositories use their actual paths.
+    useDiffPanelStore.setState({
+      byThreadKey: {
+        [scopedThreadKey(THREAD_REF)]: { kind: "branch", baseRef: "origin/persisted" },
+      },
+    });
+
+    expect(selectionFor(THREAD_REF, null)).toEqual({ kind: "branch", baseRef: "origin/persisted" });
+
+    // Writing the workspace root updates that same persisted entry.
+    useDiffPanelStore.getState().selectBranchBaseRef(THREAD_REF, "origin/main", null);
+    expect(useDiffPanelStore.getState().byThreadKey[scopedThreadKey(THREAD_REF)]).toEqual({
+      kind: "branch",
+      baseRef: "origin/main",
+    });
+  });
+
+  it("keeps an explicitly picked workspace root apart from the default repository", () => {
+    // A workspace configured as [{ path: "services/api" }, { path: "." }] keeps
+    // the nested default on its own key, while "." normalizes to the workspace key.
+    useDiffPanelStore.getState().selectBranchBaseRef(THREAD_REF, "origin/api", NESTED_REPOSITORY);
+    useDiffPanelStore.getState().selectBranchBaseRef(THREAD_REF, "origin/root", null);
+
+    expect(selectionFor(THREAD_REF, NESTED_REPOSITORY)).toEqual({
+      kind: "branch",
+      baseRef: "origin/api",
+    });
+    expect(selectionFor(THREAD_REF, null)).toEqual({ kind: "branch", baseRef: "origin/root" });
+  });
+
+  it("uses the configured default path and keeps its base ref when repositories reorder", () => {
+    // The panel records the resolved default path when the user first edits its
+    // scope, so a later t3.json reorder keeps addressing the same repository.
+    useDiffPanelStore.getState().selectRepository(THREAD_REF, NESTED_REPOSITORY);
+    useDiffPanelStore.getState().selectBranchBaseRef(THREAD_REF, "origin/api", NESTED_REPOSITORY);
+
+    expect(repositoryFor(THREAD_REF, NESTED_FIRST_REPOSITORIES)).toBe(NESTED_REPOSITORY);
+    expect(selectionFor(THREAD_REF, repositoryFor(THREAD_REF, NESTED_FIRST_REPOSITORIES))).toEqual({
+      kind: "branch",
+      baseRef: "origin/api",
+    });
+    expect(repositoryFor(THREAD_REF, CONFIGURED_REPOSITORIES)).toBe(NESTED_REPOSITORY);
+  });
+
+  it("falls back to the new default without overwriting a removed repository's state", () => {
+    useDiffPanelStore.getState().selectBranchBaseRef(THREAD_REF, "origin/api", NESTED_REPOSITORY);
+    const changedRepositories = [{ path: "backend" }];
+
+    expect(repositoryFor(THREAD_REF, changedRepositories)).toBe("backend");
+    expect(selectionFor(THREAD_REF, "backend")).toEqual({ kind: "branch", baseRef: null });
+    expect(selectionFor(THREAD_REF, NESTED_REPOSITORY)).toEqual({
+      kind: "branch",
+      baseRef: "origin/api",
+    });
+  });
+
+  it("selects a repository per thread", () => {
+    useDiffPanelStore.getState().selectRepository(THREAD_REF, NESTED_REPOSITORY);
+
+    expect(repositoryFor(THREAD_REF)).toBe(NESTED_REPOSITORY);
+    expect(repositoryFor(SIMILAR_THREAD_REF)).toBe(null);
+  });
+
+  it("falls back to the default repository when the selection is no longer configured", () => {
+    useDiffPanelStore.getState().selectRepository(THREAD_REF, "frontend");
+
+    // t3.json is checked in, so "frontend" can disappear while the choice
+    // persists — for instance after pulling a colleague's change.
+    const repositoryPath = repositoryFor(THREAD_REF, CONFIGURED_REPOSITORIES);
+    expect(repositoryPath).toBe(null);
+
+    // The diff shown then belongs to the default repository, so its base ref has
+    // to land there too instead of under the repository that is gone.
+    useDiffPanelStore.getState().selectBranchBaseRef(THREAD_REF, "origin/main", repositoryPath);
+    expect(selectionFor(THREAD_REF, null)).toEqual({ kind: "branch", baseRef: "origin/main" });
+    expect(selectionFor(THREAD_REF, "frontend")).toEqual({ kind: "branch", baseRef: null });
+  });
+
+  it("keeps a selection that is still configured", () => {
+    useDiffPanelStore.getState().selectRepository(THREAD_REF, NESTED_REPOSITORY);
+
+    expect(repositoryFor(THREAD_REF, [{ path: NESTED_REPOSITORY }])).toBe(NESTED_REPOSITORY);
+    // An empty list means the configuration has not loaded yet; the stale entry
+    // stays in the store so the choice returns once t3.json arrives.
+    expect(repositoryFor(THREAD_REF, [])).toBe(null);
+    expect(useDiffPanelStore.getState().selectedRepositoryByThreadKey).toEqual({
+      [scopedThreadKey(THREAD_REF)]: NESTED_REPOSITORY,
+    });
+  });
+
+  it("drops the repository selection when a turn is selected", () => {
+    const turnId = TurnId.make("turn-1");
+    useDiffPanelStore.getState().selectRepository(THREAD_REF, NESTED_REPOSITORY);
+    useDiffPanelStore.getState().selectTurn(THREAD_REF, turnId);
+
+    expect(repositoryFor(THREAD_REF)).toBe(null);
+    expect(selectionFor(THREAD_REF, null)).toEqual({
+      kind: "turn",
+      turnId,
+      filePath: null,
+      revealRequestId: 1,
+    });
+  });
+
+  it("keeps a bare turn visible while the panel resolves the configured default path", () => {
+    const turnId = TurnId.make("turn-1");
+    useDiffPanelStore.getState().selectTurn(THREAD_REF, turnId);
+
+    expect(selectionFor(THREAD_REF, NESTED_REPOSITORY)).toEqual({
+      kind: "turn",
+      turnId,
+      filePath: null,
+      revealRequestId: 1,
+    });
+  });
+
+  it("switches back from a turn when a repository is selected, including the default", () => {
+    const turnId = TurnId.make("turn-1");
+    useDiffPanelStore.getState().selectBranchBaseRef(THREAD_REF, "origin/root", null);
+    useDiffPanelStore.getState().selectTurn(THREAD_REF, turnId);
+    useDiffPanelStore.getState().selectRepository(THREAD_REF, NESTED_REPOSITORY);
+
+    expect(selectionFor(THREAD_REF, NESTED_REPOSITORY)).toEqual({
+      kind: "branch",
+      baseRef: null,
+    });
+
+    useDiffPanelStore.getState().selectTurn(THREAD_REF, turnId);
+    useDiffPanelStore.getState().selectRepository(THREAD_REF, null);
+    expect(selectionFor(THREAD_REF, null)).toEqual({ kind: "branch", baseRef: "origin/root" });
+  });
+
+  it("restores the root base when leaving a turn through a nested scope and workspace root", () => {
+    const store = useDiffPanelStore.getState();
+    store.selectBranchBaseRef(THREAD_REF, "origin/root", null);
+    store.selectTurn(THREAD_REF, TurnId.make("turn-1"));
+    store.selectGitScope(THREAD_REF, "unstaged", NESTED_REPOSITORY);
+    store.selectRepository(THREAD_REF, ".");
+
+    expect(repositoryFor(THREAD_REF, NESTED_FIRST_REPOSITORIES)).toBe(null);
+    expect(selectionFor(THREAD_REF, null)).toEqual({ kind: "branch", baseRef: "origin/root" });
+  });
+
+  it("removes every repository entry of a thread without touching similar thread keys", () => {
+    const store = useDiffPanelStore.getState();
+    store.selectBranchBaseRef(THREAD_REF, "origin/main", null);
+    store.selectBranchBaseRef(THREAD_REF, "origin/api", NESTED_REPOSITORY);
+    store.selectRepository(THREAD_REF, NESTED_REPOSITORY);
+    store.selectBranchBaseRef(SIMILAR_THREAD_REF, "origin/other", null);
+    store.selectBranchBaseRef(SIMILAR_THREAD_REF, "origin/other-api", NESTED_REPOSITORY);
+    store.selectRepository(SIMILAR_THREAD_REF, NESTED_REPOSITORY);
+
+    useDiffPanelStore.getState().removeThread(THREAD_REF);
+
+    expect(selectionFor(THREAD_REF, null)).toEqual({ kind: "branch", baseRef: null });
+    expect(selectionFor(THREAD_REF, NESTED_REPOSITORY)).toEqual({ kind: "branch", baseRef: null });
+    expect(repositoryFor(THREAD_REF)).toBe(null);
+    // A dropped base ref must not resurface when the scope is picked again.
+    useDiffPanelStore.getState().selectGitScope(THREAD_REF, "branch", NESTED_REPOSITORY);
+    expect(selectionFor(THREAD_REF, NESTED_REPOSITORY)).toEqual({ kind: "branch", baseRef: null });
+
+    expect(selectionFor(SIMILAR_THREAD_REF, null)).toEqual({
+      kind: "branch",
+      baseRef: "origin/other",
+    });
+    expect(selectionFor(SIMILAR_THREAD_REF, NESTED_REPOSITORY)).toEqual({
+      kind: "branch",
+      baseRef: "origin/other-api",
+    });
+    expect(repositoryFor(SIMILAR_THREAD_REF)).toBe(NESTED_REPOSITORY);
   });
 });

--- a/apps/web/src/diffPanelStore.ts
+++ b/apps/web/src/diffPanelStore.ts
@@ -13,13 +13,45 @@ export type DiffPanelSelection =
 const DEFAULT_SELECTION: DiffPanelSelection = { kind: "branch", baseRef: null };
 const DEFAULT_WORKING_TREE_SELECTION: DiffPanelSelection = { kind: "unstaged" };
 
+// `scopedThreadKey` joins two ids with ":", and a repository path configured in
+// t3.json rejects control characters, so NUL cannot occur inside either half of
+// a repository-scoped key.
+const REPOSITORY_KEY_SEPARATOR = "\u0000";
+
+/**
+ * Repository-scoped key for one thread's diff panel state. The default
+ * repository is `null` — callers resolve their default to it, whatever its
+ * configured path is — and maps to the bare thread key, so state persisted
+ * before the panel knew about repositories keeps working without a migration.
+ * Every other repository, including an explicitly picked workspace root `"."`
+ * that is not the default, gets a key of its own.
+ */
+function diffPanelKey(ref: ScopedThreadRef, repositoryPath: string | null | undefined): string {
+  const threadKey = scopedThreadKey(ref);
+  if (repositoryPath === null || repositoryPath === undefined) {
+    return threadKey;
+  }
+  return `${threadKey}${REPOSITORY_KEY_SEPARATOR}${repositoryPath}`;
+}
+
 interface DiffPanelStoreState {
   byThreadKey: Record<string, DiffPanelSelection>;
   branchBaseRefByThreadKey: Record<string, string | null>;
-  selectGitScope: (ref: ScopedThreadRef, scope: "branch" | "unstaged") => void;
-  selectBranchBaseRef: (ref: ScopedThreadRef, baseRef: string | null) => void;
+  /** Repository override per thread, keyed by the bare thread key. */
+  selectedRepositoryByThreadKey: Record<string, string | null>;
+  selectGitScope: (
+    ref: ScopedThreadRef,
+    scope: "branch" | "unstaged",
+    repositoryPath: string | null,
+  ) => void;
+  selectBranchBaseRef: (
+    ref: ScopedThreadRef,
+    baseRef: string | null,
+    repositoryPath: string | null,
+  ) => void;
   selectTurn: (ref: ScopedThreadRef, turnId: TurnId, filePath?: string) => void;
   reconcileTurnSelection: (ref: ScopedThreadRef, availableTurnIds: ReadonlyArray<TurnId>) => void;
+  selectRepository: (ref: ScopedThreadRef, repositoryPath: string | null) => void;
   removeThread: (ref: ScopedThreadRef) => void;
 }
 
@@ -28,68 +60,111 @@ function normalizeBaseRef(baseRef: string | null): string | null {
   return normalized ? normalized : null;
 }
 
+/** Returns the same record when nothing matched, so unrelated state keeps its identity. */
+function withoutMatchingKeys<T>(
+  entries: Record<string, T>,
+  matches: (key: string) => boolean,
+): Record<string, T> {
+  const remaining = Object.entries(entries).filter(([key]) => !matches(key));
+  return remaining.length === Object.keys(entries).length ? entries : Object.fromEntries(remaining);
+}
+
+function restoreBareBranchAfterTurn(
+  entries: Record<string, DiffPanelSelection>,
+  threadKey: string,
+  baseRef: string | null,
+): Record<string, DiffPanelSelection> {
+  return entries[threadKey]?.kind === "turn"
+    ? { ...entries, [threadKey]: { kind: "branch", baseRef } }
+    : entries;
+}
+
 export const useDiffPanelStore = create<DiffPanelStoreState>()(
   persist(
     (set) => ({
       byThreadKey: {},
       branchBaseRefByThreadKey: {},
-      selectGitScope: (ref, scope) =>
+      selectedRepositoryByThreadKey: {},
+      selectGitScope: (ref, scope, repositoryPath) =>
         set((state) => {
-          const threadKey = scopedThreadKey(ref);
-          const previous = state.byThreadKey[threadKey];
+          const panelKey = diffPanelKey(ref, repositoryPath);
+          const previous = state.byThreadKey[panelKey];
           const previousBaseRef =
             previous?.kind === "branch"
               ? previous.baseRef
-              : (state.branchBaseRefByThreadKey[threadKey] ?? null);
+              : (state.branchBaseRefByThreadKey[panelKey] ?? null);
+          const byThreadKey = restoreBareBranchAfterTurn(
+            state.byThreadKey,
+            scopedThreadKey(ref),
+            state.branchBaseRefByThreadKey[scopedThreadKey(ref)] ?? null,
+          );
           return {
             byThreadKey: {
-              ...state.byThreadKey,
-              [threadKey]:
+              ...byThreadKey,
+              [panelKey]:
                 scope === "branch"
                   ? { kind: "branch", baseRef: previousBaseRef }
                   : { kind: "unstaged" },
             },
             branchBaseRefByThreadKey:
               previous?.kind === "branch"
-                ? { ...state.branchBaseRefByThreadKey, [threadKey]: previous.baseRef }
+                ? { ...state.branchBaseRefByThreadKey, [panelKey]: previous.baseRef }
                 : state.branchBaseRefByThreadKey,
           };
         }),
-      selectBranchBaseRef: (ref, baseRef) =>
+      selectBranchBaseRef: (ref, baseRef, repositoryPath) =>
         set((state) => {
-          const threadKey = scopedThreadKey(ref);
+          const panelKey = diffPanelKey(ref, repositoryPath);
           const normalizedBaseRef = normalizeBaseRef(baseRef);
+          const byThreadKey = restoreBareBranchAfterTurn(
+            state.byThreadKey,
+            scopedThreadKey(ref),
+            state.branchBaseRefByThreadKey[scopedThreadKey(ref)] ?? null,
+          );
           return {
             byThreadKey: {
-              ...state.byThreadKey,
-              [threadKey]: { kind: "branch", baseRef: normalizedBaseRef },
+              ...byThreadKey,
+              [panelKey]: { kind: "branch", baseRef: normalizedBaseRef },
             },
             branchBaseRefByThreadKey: {
               ...state.branchBaseRefByThreadKey,
-              [threadKey]: normalizedBaseRef,
+              [panelKey]: normalizedBaseRef,
             },
           };
         }),
       selectTurn: (ref, turnId, filePath) =>
         set((state) => {
+          // Turn diffs come from checkpoints and cover the whole workspace rather
+          // than one repository, so they live on the bare thread key and drop the
+          // repository override. That also lets the chat timeline open a turn
+          // without knowing which repository the panel currently shows.
           const threadKey = scopedThreadKey(ref);
           const previous = state.byThreadKey[threadKey];
+          const byThreadKey = {
+            ...state.byThreadKey,
+            [threadKey]: {
+              kind: "turn" as const,
+              turnId,
+              filePath: filePath?.trim() || null,
+              revealRequestId: previous?.kind === "turn" ? previous.revealRequestId + 1 : 1,
+            },
+          };
+          if ((state.selectedRepositoryByThreadKey[threadKey] ?? null) === null) {
+            return { byThreadKey };
+          }
           return {
-            byThreadKey: {
-              ...state.byThreadKey,
-              [threadKey]: {
-                kind: "turn",
-                turnId,
-                filePath: filePath?.trim() || null,
-                revealRequestId: previous?.kind === "turn" ? previous.revealRequestId + 1 : 1,
-              },
+            byThreadKey,
+            selectedRepositoryByThreadKey: {
+              ...state.selectedRepositoryByThreadKey,
+              [threadKey]: null,
             },
           };
         }),
       reconcileTurnSelection: (ref, availableTurnIds) =>
         set((state) => {
-          const threadKey = scopedThreadKey(ref);
-          const previous = state.byThreadKey[threadKey];
+          // Checkpoint turns are workspace-wide and always live on the bare key.
+          const panelKey = scopedThreadKey(ref);
+          const previous = state.byThreadKey[panelKey];
           const latestTurnId = availableTurnIds[0];
           if (
             previous?.kind !== "turn" ||
@@ -101,20 +176,59 @@ export const useDiffPanelStore = create<DiffPanelStoreState>()(
           return {
             byThreadKey: {
               ...state.byThreadKey,
-              [threadKey]: { ...previous, turnId: latestTurnId },
+              [panelKey]: { ...previous, turnId: latestTurnId },
+            },
+          };
+        }),
+      selectRepository: (ref, repositoryPath) =>
+        set((state) => {
+          const threadKey = scopedThreadKey(ref);
+          const bareSelection = state.byThreadKey[threadKey];
+          if (
+            (state.selectedRepositoryByThreadKey[threadKey] ?? null) === repositoryPath &&
+            bareSelection?.kind !== "turn"
+          ) {
+            return state;
+          }
+          const byThreadKey = restoreBareBranchAfterTurn(
+            state.byThreadKey,
+            threadKey,
+            state.branchBaseRefByThreadKey[threadKey] ?? null,
+          );
+          return {
+            byThreadKey,
+            selectedRepositoryByThreadKey: {
+              ...state.selectedRepositoryByThreadKey,
+              [threadKey]: repositoryPath,
             },
           };
         }),
       removeThread: (ref) =>
         set((state) => {
           const threadKey = scopedThreadKey(ref);
-          if (!(threadKey in state.byThreadKey) && !(threadKey in state.branchBaseRefByThreadKey)) {
+          const repositoryPrefix = `${threadKey}${REPOSITORY_KEY_SEPARATOR}`;
+          // A thread owns one entry per repository. Matching the bare key exactly
+          // and repository keys only through the separator keeps a thread whose
+          // key merely starts with this one ("thread-1" vs "thread-10") intact.
+          const ownedByThread = (key: string) =>
+            key === threadKey || key.startsWith(repositoryPrefix);
+          const byThreadKey = withoutMatchingKeys(state.byThreadKey, ownedByThread);
+          const branchBaseRefByThreadKey = withoutMatchingKeys(
+            state.branchBaseRefByThreadKey,
+            ownedByThread,
+          );
+          const selectedRepositoryByThreadKey = withoutMatchingKeys(
+            state.selectedRepositoryByThreadKey,
+            ownedByThread,
+          );
+          if (
+            byThreadKey === state.byThreadKey &&
+            branchBaseRefByThreadKey === state.branchBaseRefByThreadKey &&
+            selectedRepositoryByThreadKey === state.selectedRepositoryByThreadKey
+          ) {
             return state;
           }
-          const { [threadKey]: _removed, ...byThreadKey } = state.byThreadKey;
-          const { [threadKey]: _removedBaseRef, ...branchBaseRefByThreadKey } =
-            state.branchBaseRefByThreadKey;
-          return { byThreadKey, branchBaseRefByThreadKey };
+          return { byThreadKey, branchBaseRefByThreadKey, selectedRepositoryByThreadKey };
         }),
     }),
     {
@@ -126,6 +240,7 @@ export const useDiffPanelStore = create<DiffPanelStoreState>()(
       partialize: (state) => ({
         byThreadKey: state.byThreadKey,
         branchBaseRefByThreadKey: state.branchBaseRefByThreadKey,
+        selectedRepositoryByThreadKey: state.selectedRepositoryByThreadKey,
       }),
     },
   ),
@@ -134,11 +249,44 @@ export const useDiffPanelStore = create<DiffPanelStoreState>()(
 export function selectThreadDiffPanelSelection(
   byThreadKey: Record<string, DiffPanelSelection>,
   ref: ScopedThreadRef | null | undefined,
+  repositoryPath: string | null = null,
   hasWorkingTreeChanges = false,
 ): DiffPanelSelection {
   if (!ref) return DEFAULT_SELECTION;
   return (
-    byThreadKey[scopedThreadKey(ref)] ??
+    (byThreadKey[scopedThreadKey(ref)]?.kind === "turn"
+      ? byThreadKey[scopedThreadKey(ref)]
+      : undefined) ??
+    byThreadKey[diffPanelKey(ref, repositoryPath)] ??
     (hasWorkingTreeChanges ? DEFAULT_WORKING_TREE_SELECTION : DEFAULT_SELECTION)
   );
+}
+
+/**
+ * The repository a thread's diff panel state belongs to: its persisted choice,
+ * or the configured default repository. `null` identifies the workspace root.
+ *
+ * A choice that is not among the currently configured repositories resolves to
+ * the default. `t3.json` is checked in, so a repository can vanish under a
+ * running client — and a selection that outlives its repository would key scope
+ * and base ref to one repository while the panel shows another's diff. The
+ * stale entry is left in place rather than cleaned up here: the configuration
+ * still loads asynchronously, and resetting on an empty list would discard a
+ * valid choice.
+ */
+export function selectThreadDiffRepositoryPath(
+  selectedRepositoryByThreadKey: Record<string, string | null>,
+  ref: ScopedThreadRef | null | undefined,
+  configuredRepositories: ReadonlyArray<{ readonly path: string }>,
+): string | null {
+  if (!ref) return null;
+  const selected = selectedRepositoryByThreadKey[scopedThreadKey(ref)] ?? null;
+  const repositoryPath =
+    selected !== null && configuredRepositories.some((repository) => repository.path === selected)
+      ? selected
+      : (configuredRepositories[0]?.path ?? null);
+  // `null` is the stable key for the workspace root and for legacy/turn state.
+  // Other configured paths, including the default, must remain path-specific so
+  // reordering t3.json cannot transfer a base ref to another repository.
+  return repositoryPath === "." ? null : repositoryPath;
 }

--- a/apps/web/src/hooks/useT3ProjectFileScripts.ts
+++ b/apps/web/src/hooks/useT3ProjectFileScripts.ts
@@ -30,10 +30,17 @@ export interface T3ProjectFileState {
  * file exists but is broken — which the runtime otherwise swallows silently.
  */
 export function useT3ProjectFileState(
-  environmentId: EnvironmentId,
+  environmentId: EnvironmentId | null,
   cwd: string | null,
 ): T3ProjectFileState {
-  const query = useProjectFileQuery(environmentId, cwd ?? "", T3_PROJECT_FILE_NAME, cwd !== null);
+  // The query is disabled without an active environment; the placeholder only
+  // keeps this hook unconditional while a route is resolving.
+  const query = useProjectFileQuery(
+    environmentId ?? ("" as EnvironmentId),
+    cwd ?? "",
+    T3_PROJECT_FILE_NAME,
+    cwd !== null && environmentId !== null,
+  );
   const contents = query.data && !query.data.truncated ? query.data.contents : null;
   const isPending = query.isPending;
   return useMemo(() => {
@@ -58,7 +65,7 @@ export function useT3ProjectFileState(
  * an empty list.
  */
 export function useT3ProjectFileScripts(
-  environmentId: EnvironmentId,
+  environmentId: EnvironmentId | null,
   cwd: string | null,
 ): ReadonlyArray<T3ProjectFileScript> {
   return useT3ProjectFileState(environmentId, cwd).scripts;

--- a/apps/web/src/lib/diffFileContents.test.ts
+++ b/apps/web/src/lib/diffFileContents.test.ts
@@ -9,6 +9,7 @@ import { createGitDiffFileContentsLoader } from "./diffFileContents";
 const SOURCE = {
   environmentId: EnvironmentId.make("environment-1"),
   cwd: "/workspace",
+  workspaceRoot: "/workspace",
   sourceKind: "branch-range" as const,
   baseRef: "main",
   headRef: "feature",
@@ -46,6 +47,7 @@ describe("createGitDiffFileContentsLoader", () => {
       environmentId: "environment-1",
       input: {
         cwd: "/workspace",
+        workspaceRoot: "/workspace",
         sourceKind: "branch-range",
         changeType: "rename-changed",
         baseRef: "main",

--- a/apps/web/src/lib/diffFileContents.ts
+++ b/apps/web/src/lib/diffFileContents.ts
@@ -18,6 +18,7 @@ import { resolveFileDiffPath } from "./diffRendering";
 interface GitDiffFileContentsSource {
   readonly environmentId: EnvironmentId;
   readonly cwd: string;
+  readonly workspaceRoot?: string;
   readonly sourceKind: ReviewDiffPreviewSourceKind;
   readonly baseRef: string | null;
   readonly headRef: string | null;
@@ -85,6 +86,7 @@ export function createGitDiffFileContentsLoader<E>(
       environmentId: source.environmentId,
       input: {
         cwd: source.cwd,
+        ...(source.workspaceRoot ? { workspaceRoot: source.workspaceRoot } : {}),
         sourceKind: source.sourceKind,
         changeType,
         baseRef: source.baseRef,

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -33,10 +33,11 @@ folder's root:
 }
 ```
 
-The Diff panel then lets you choose which repository to inspect. Repository paths must stay inside
-the project folder. This selection is for Git status and diffs; commits, pushes, pull requests,
-worktrees, and checkpoints continue to use the project root. Use local threads for this setup:
-Git worktrees do not automatically include nested repositories.
+The Diff panel then lets you choose which repository to inspect, even when the shared parent folder
+is not itself a Git repository. Repository paths must stay inside the project folder. This selection
+is for Git status and diffs; commits, pushes, pull requests, worktrees, and checkpoints continue to
+use the project root. Use local threads for this setup: Git worktrees do not automatically include
+nested repositories.
 
 ### GitLab
 

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -17,6 +17,27 @@ Install [GitHub CLI](https://cli.github.com/) 2.81.0 or newer, then sign in:
 gh auth login
 ```
 
+### Review a shared workspace with multiple repositories
+
+When a project folder contains separate Git repositories, keep the project pointed at their shared
+parent folder so one agent can work across all of them. Add the repositories to `t3.json` at that
+folder's root:
+
+```json
+{
+  "defaultThreadEnvMode": "local",
+  "repositories": [
+    { "path": "frontend", "name": "Frontend" },
+    { "path": "backend", "name": "Backend" }
+  ]
+}
+```
+
+The Diff panel then lets you choose which repository to inspect. Repository paths must stay inside
+the project folder. This selection is for Git status and diffs; commits, pushes, pull requests,
+worktrees, and checkpoints continue to use the project root. Use local threads for this setup:
+Git worktrees do not automatically include nested repositories.
+
 ### GitLab
 
 Install [GitLab CLI](https://gitlab.com/gitlab-org/cli), then sign in:

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -34,7 +34,9 @@ folder's root:
 ```
 
 The Diff panel then lets you choose which repository to inspect, even when the shared parent folder
-is not itself a Git repository. Repository paths must stay inside the project folder. This selection
+is not itself a Git repository. Repository paths must stay inside the project folder, including
+when they follow symbolic links. Do not use `..` segments, home-directory shortcuts, or drive letters.
+This selection
 is for Git status and diffs; commits, pushes, pull requests, worktrees, and checkpoints continue to
 use the project root. Use local threads for this setup: Git worktrees do not automatically include
 nested repositories.

--- a/packages/client-runtime/src/state/review.ts
+++ b/packages/client-runtime/src/state/review.ts
@@ -28,6 +28,7 @@ export function createReviewEnvironmentAtoms<R, E>(
           JSON.stringify([
             environmentId,
             input.cwd,
+            input.workspaceRoot,
             input.sourceKind,
             input.baseRef,
             input.headRef,

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -102,6 +102,7 @@ export type GitResolvedPullRequest = typeof GitResolvedPullRequest.Type;
 
 export const VcsStatusInput = Schema.Struct({
   cwd: TrimmedNonEmptyStringSchema,
+  workspaceRoot: Schema.optional(TrimmedNonEmptyStringSchema),
 });
 export type VcsStatusInput = typeof VcsStatusInput.Type;
 

--- a/packages/contracts/src/review.ts
+++ b/packages/contracts/src/review.ts
@@ -5,6 +5,7 @@ import { VcsError } from "./vcs.ts";
 
 export const ReviewDiffPreviewInput = Schema.Struct({
   cwd: TrimmedNonEmptyString,
+  workspaceRoot: Schema.optional(TrimmedNonEmptyString),
   baseRef: Schema.optional(TrimmedNonEmptyString),
   ignoreWhitespace: Schema.optionalKey(Schema.Boolean),
 });
@@ -27,6 +28,7 @@ export type ReviewDiffPreviewSource = typeof ReviewDiffPreviewSource.Type;
 
 export const ReviewDiffFileContentsInput = Schema.Struct({
   cwd: TrimmedNonEmptyString,
+  workspaceRoot: Schema.optional(TrimmedNonEmptyString),
   sourceKind: ReviewDiffPreviewSourceKind,
   changeType: Schema.Literals(["change", "rename-pure", "rename-changed", "new", "deleted"]),
   baseRef: Schema.NullOr(TrimmedNonEmptyString),

--- a/packages/contracts/src/t3ProjectFile.test.ts
+++ b/packages/contracts/src/t3ProjectFile.test.ts
@@ -21,11 +21,19 @@ describe("T3ProjectFile", () => {
         },
         { name: "Test", command: "pnpm test" },
       ],
+      repositories: [
+        { path: "frontend", name: "Frontend" },
+        { path: "services/api", name: "API" },
+      ],
     });
 
     expect(decoded.iconPath).toBe("assets/logo.svg");
     expect(decoded.scripts).toHaveLength(2);
     expect(decoded.scripts?.[1]).toEqual({ name: "Test", command: "pnpm test" });
+    expect(decoded.repositories).toEqual([
+      { path: "frontend", name: "Frontend" },
+      { path: "services/api", name: "API" },
+    ]);
   });
 
   it("decodes an empty object and ignores unknown fields", () => {
@@ -57,5 +65,14 @@ describe("T3ProjectFile", () => {
     expect(decode({ defaultThreadEnvMode: "worktree" }).defaultThreadEnvMode).toBe("worktree");
     expect(decode({ defaultThreadEnvMode: "local" }).defaultThreadEnvMode).toBe("local");
     expect(() => decode({ defaultThreadEnvMode: "remote" })).toThrow();
+  });
+
+  it("accepts workspace-relative repository paths and rejects escapes", () => {
+    expect(
+      decode({ repositories: [{ path: "." }, { path: "services/api" }] }).repositories,
+    ).toEqual([{ path: "." }, { path: "services/api" }]);
+    expect(() => decode({ repositories: [{ path: "../outside" }] })).toThrow();
+    expect(() => decode({ repositories: [{ path: "services/../outside" }] })).toThrow();
+    expect(() => decode({ repositories: [{ path: "/absolute" }] })).toThrow();
   });
 });

--- a/packages/contracts/src/t3ProjectFile.test.ts
+++ b/packages/contracts/src/t3ProjectFile.test.ts
@@ -71,8 +71,31 @@ describe("T3ProjectFile", () => {
     expect(
       decode({ repositories: [{ path: "." }, { path: "services/api" }] }).repositories,
     ).toEqual([{ path: "." }, { path: "services/api" }]);
+    expect(decode({ repositories: [{ path: "frontend" }] }).repositories).toEqual([
+      { path: "frontend" },
+    ]);
+    expect(decode({ repositories: [{ path: " frontend " }] }).repositories).toEqual([
+      { path: "frontend" },
+    ]);
     expect(() => decode({ repositories: [{ path: "../outside" }] })).toThrow();
+    expect(() => decode({ repositories: [{ path: " ../outside" }] })).toThrow();
     expect(() => decode({ repositories: [{ path: "services/../outside" }] })).toThrow();
+    expect(() => decode({ repositories: [{ path: " ~/client" }] })).toThrow();
     expect(() => decode({ repositories: [{ path: "/absolute" }] })).toThrow();
+    expect(() => decode({ repositories: [{ path: " /absolute" }] })).toThrow();
+    expect(() => decode({ repositories: [{ path: "frontend/../.." }] })).toThrow();
+    expect(() => decode({ repositories: [{ path: " C:/outside" }] })).toThrow();
+    expect(() => decode({ repositories: [{ path: "   " }] })).toThrow();
+  });
+
+  it("rejects repository paths that could escape the workspace via ~ or drive letters", () => {
+    expect(() => decode({ repositories: [{ path: "~" }] })).toThrow();
+    expect(() => decode({ repositories: [{ path: "~/client" }] })).toThrow();
+    expect(() => decode({ repositories: [{ path: "~user/client" }] })).toThrow();
+    expect(() => decode({ repositories: [{ path: "C:" }] })).toThrow();
+    expect(() => decode({ repositories: [{ path: "C:/Users/foo" }] })).toThrow();
+    expect(() => decode({ repositories: [{ path: "C:foo" }] })).toThrow();
+    expect(() => decode({ repositories: [{ path: "services/C:api" }] })).toThrow();
+    expect(() => decode({ repositories: [{ path: "foo\x01bar" }] })).toThrow();
   });
 });

--- a/packages/contracts/src/t3ProjectFile.ts
+++ b/packages/contracts/src/t3ProjectFile.ts
@@ -12,6 +12,9 @@ export const T3_PROJECT_FILE_SCHEMA_URL = "https://t3.codes/schema/t3.json";
 
 const T3_PROJECT_FILE_PATH_MAX_LENGTH = 512;
 const T3_PROJECT_FILE_MAX_SCRIPTS = 50;
+const T3_PROJECT_FILE_MAX_REPOSITORIES = 20;
+const WORKSPACE_RELATIVE_PATH_PATTERN =
+  /^(?:\.|(?:(?!\.{1,2}(?:\/|$))[^/\\]+)(?:\/(?:(?!\.{1,2}(?:\/|$))[^/\\]+))*)$/;
 
 // Annotations go on the encoded (string) side so they survive into the
 // published JSON Schema; decoding still trims and re-validates non-emptiness.
@@ -59,6 +62,31 @@ export const T3ProjectFileScript = Schema.Struct({
 });
 export type T3ProjectFileScript = typeof T3ProjectFileScript.Type;
 
+/**
+ * A Git repository inside a project workspace. Paths are intentionally relative
+ * so opening a shared workspace cannot grant the UI access outside it.
+ */
+export const T3ProjectFileRepository = Schema.Struct({
+  path: trimmedNonEmpty(
+    {
+      description:
+        'Workspace-relative Git repository path, such as "frontend" or "services/api". Use "." for the workspace root.',
+    },
+    T3_PROJECT_FILE_PATH_MAX_LENGTH,
+  ).check(Schema.isPattern(WORKSPACE_RELATIVE_PATH_PATTERN)),
+  name: Schema.optionalKey(
+    trimmedNonEmpty(
+      {
+        description: "Optional display name shown when selecting a repository in the diff panel.",
+      },
+      128,
+    ),
+  ),
+}).annotate({
+  description: "A Git repository configured inside a shared T3 Code workspace.",
+});
+export type T3ProjectFileRepository = typeof T3ProjectFileRepository.Type;
+
 export const T3ProjectFile = Schema.Struct({
   $schema: Schema.optionalKey(
     Schema.String.annotate({
@@ -86,6 +114,14 @@ export const T3ProjectFile = Schema.Struct({
         description: "Project scripts shared with everyone who opens this repository in T3 Code.",
       })
       .check(Schema.isMaxLength(T3_PROJECT_FILE_MAX_SCRIPTS)),
+  ),
+  repositories: Schema.optionalKey(
+    Schema.Array(T3ProjectFileRepository)
+      .annotate({
+        description:
+          "Git repositories inside this workspace that can be selected in the diff panel. Git actions remain scoped to the project root.",
+      })
+      .check(Schema.isMaxLength(T3_PROJECT_FILE_MAX_REPOSITORIES)),
   ),
 }).annotate({
   title: "T3 project file",

--- a/packages/contracts/src/t3ProjectFile.ts
+++ b/packages/contracts/src/t3ProjectFile.ts
@@ -13,8 +13,14 @@ export const T3_PROJECT_FILE_SCHEMA_URL = "https://t3.codes/schema/t3.json";
 const T3_PROJECT_FILE_PATH_MAX_LENGTH = 512;
 const T3_PROJECT_FILE_MAX_SCRIPTS = 50;
 const T3_PROJECT_FILE_MAX_REPOSITORIES = 20;
-const WORKSPACE_RELATIVE_PATH_PATTERN =
-  /^(?:\.|(?:(?!\.{1,2}(?:\/|$))[^/\\]+)(?:\/(?:(?!\.{1,2}(?:\/|$))[^/\\]+))*)$/;
+// Each path segment must not be "." or "..", must not start with "~" (blocks
+// shell/home-directory expansion), and must not contain "/", "\", ":" (blocks
+// Windows drive letters like "C:" and NTFS alternate data streams like
+// "foo:bar"), or ASCII control characters.
+const WORKSPACE_RELATIVE_PATH_SEGMENT = "(?:(?!\\.{1,2}(?:/|\\s*$))(?!~)[^/\\\\:\\x00-\\x1f]+)";
+const WORKSPACE_RELATIVE_PATH_PATTERN = new RegExp(
+  `^\\s*(?!\\s)(?:\\.|${WORKSPACE_RELATIVE_PATH_SEGMENT}(?:/${WORKSPACE_RELATIVE_PATH_SEGMENT})*)\\s*$`,
+);
 
 // Annotations go on the encoded (string) side so they survive into the
 // published JSON Schema; decoding still trims and re-validates non-emptiness.
@@ -62,18 +68,23 @@ export const T3ProjectFileScript = Schema.Struct({
 });
 export type T3ProjectFileScript = typeof T3ProjectFileScript.Type;
 
+const workspaceRelativePath = Schema.String.annotate({
+  description:
+    'Workspace-relative Git repository path, such as "frontend" or "services/api". Use "." for the workspace root.',
+}).check(
+  Schema.isNonEmpty(),
+  Schema.isMaxLength(T3_PROJECT_FILE_PATH_MAX_LENGTH),
+  Schema.isPattern(WORKSPACE_RELATIVE_PATH_PATTERN),
+);
+
 /**
  * A Git repository inside a project workspace. Paths are intentionally relative
  * so opening a shared workspace cannot grant the UI access outside it.
  */
 export const T3ProjectFileRepository = Schema.Struct({
-  path: trimmedNonEmpty(
-    {
-      description:
-        'Workspace-relative Git repository path, such as "frontend" or "services/api". Use "." for the workspace root.',
-    },
-    T3_PROJECT_FILE_PATH_MAX_LENGTH,
-  ).check(Schema.isPattern(WORKSPACE_RELATIVE_PATH_PATTERN)),
+  path: workspaceRelativePath.pipe(
+    Schema.decodeTo(workspaceRelativePath, SchemaTransformation.trim()),
+  ),
   name: Schema.optionalKey(
     trimmedNonEmpty(
       {

--- a/packages/shared/src/t3ProjectFile.test.ts
+++ b/packages/shared/src/t3ProjectFile.test.ts
@@ -35,11 +35,38 @@ describe("buildT3ProjectFileJsonSchema", () => {
       "$schema",
       "defaultThreadEnvMode",
       "iconPath",
+      "repositories",
       "scripts",
     ]);
     expect(schema.required).toBeUndefined();
     expect(schema.properties.iconPath?.description).toContain("Workspace-relative path");
     expect(schema.properties.defaultThreadEnvMode?.description).toContain("new threads start");
+
+    const repository = schema.properties.repositories?.items;
+    expect(repository?.required).toEqual(["path"]);
+    expect(Object.keys(repository?.properties ?? {}).sort()).toEqual(["name", "path"]);
+    const repositoryPath = repository?.properties.path as {
+      allOf?: ReadonlyArray<Record<string, unknown>>;
+    };
+    const repositoryPattern = repositoryPath.allOf?.find(
+      (constraint): constraint is { pattern: string } => typeof constraint.pattern === "string",
+    )?.pattern;
+    expect(repositoryPattern).toBeDefined();
+    const matchesWorkspaceRelativePath = new RegExp(repositoryPattern ?? "(?!)");
+    expect(matchesWorkspaceRelativePath.test("services/api")).toBe(true);
+    expect(matchesWorkspaceRelativePath.test(" frontend ")).toBe(true);
+    for (const invalidPath of [
+      "../outside",
+      "C:/outside",
+      " ../outside ",
+      " ~/outside ",
+      " /outside ",
+      " .. ",
+      "services/.. ",
+      "   ",
+    ]) {
+      expect(matchesWorkspaceRelativePath.test(invalidPath), invalidPath).toBe(false);
+    }
 
     const script = schema.properties.scripts?.items;
     expect(script?.required).toEqual(["name", "command"]);


### PR DESCRIPTION
Adds an optional `repositories` list to `t3.json` so the Diff panel can inspect separate Git repositories below a shared project folder, even when the parent is not a Git repository.

Diff files open relative to the selected repository, and comparison branches remain independent when switching repositories or changing their configured order. Checkpoint diffs retain the project root. Repository paths are validated in both the runtime and published schema; configured status and diff requests reject symbolic links that leave the project folder.

This covers status and diffs. Commits, pushes, pull requests, worktrees and checkpoints continue to use the project root. User documentation includes configuration and path constraints.

Validation: 226 focused tests passed; web, shared, contracts, client-runtime and server typechecks passed; targeted lint and formatting passed. Four React lint warnings remain in DiffPanel. Browser acceptance and the full CI suite were not run locally.

Prepared in the Codex harness with GPT-5.6 Luna/Sol implementation and GPT-6 Astra review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly UI gating and diff cwd scoping with schema validation on repository paths; no auth or server-side Git workflow changes.
> 
> **Overview**
> Adds an optional **`repositories`** list to **`t3.json`** so shared parent folders can declare nested Git repos (workspace-relative paths with optional display names, validated to block escapes).
> 
> **Diff availability** no longer requires the project root to be a Git repo: **`isDiffSurfaceAvailable`** enables the Diff tab on server threads when the workspace is non-Git but **`t3.json`** lists at least one repository. **ChatView** reads that config via **`useT3ProjectFileState`** (local threads without a worktree) and wires **`diffAvailable`** / **`addDiffSurface`** through the new helper.
> 
> **DiffPanel** adds a repository picker for branch/unstaged views, runs status and diff preview against the selected repo’s resolved **`cwd`**, and adjusts “open in editor” roots accordingly; turn-based diffs still reset repository selection. **`useT3ProjectFileState`** now accepts a nullable **`environmentId`** so hooks stay safe while routes resolve.
> 
> User docs describe the multi-repo setup; scope stays **status and diffs only**—commits, PRs, worktrees, and checkpoints remain at the project root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2b8371ef71a95d5cf346e7dfc0d0bb704fe915c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add multi-repository diff support for non-Git workspaces via `t3.json` config
> - Adds `repositories` array (up to 20 entries) to the T3 project-file schema in [t3ProjectFile.ts](https://github.com/pingdotgg/t3code/pull/9816/files#diff-7fe789298bc2033184c621a885f3d186578bb9a9268be9ac97ca257213b1d059), accepting workspace-relative paths and optional display names while rejecting parent escapes, absolute paths, and backslashes
> - Updates `DiffPanel` in [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/9816/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3) to load configured repositories, add a repository dropdown for branch-scope views, and resolve Git status, diff previews, and editor paths against the selected repository root
> - Updates `ChatView` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/9816/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to enable the diff surface for server threads whose T3 project file declares repositories, even when the workspace root is not a Git repository
> - Fixes `useT3ProjectFileState` in [useT3ProjectFileScripts.ts](https://github.com/pingdotgg/t3code/pull/9816/files#diff-a767c0eb9f43ec207923b7adea8c5ce246af85195b5c3fe850577da17059292c) to accept a null environment and skip the project-file query when no environment or cwd is present
> - Risk: Worktree threads do not contribute configured repositories to diff-surface availability; selecting a turn in `DiffPanel` resets the repository selection to the first configured repository, which may surprise users who manually switched repos
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d2b8371. 6 files reviewed, 4 issues evaluated, 1 issue filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/components/DiffPanel.tsx — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 173](https://github.com/pingdotgg/t3code/blob/d2b8371ef71a95d5cf346e7dfc0d0bb704fe915c/apps/web/src/components/DiffPanel.tsx#L173): `repositories.path` is validated as a workspace-relative path, and the schema permits `~/…` as a path whose first directory is literally `~`. Passing it to `resolvePathLinkTarget` instead applies that helper's terminal-link expansion and resolves it relative to the user's home directory instead of the workspace. Thus a valid configured repository such as `~/client` is queried outside the workspace rather than at `<workspace>/~/client`. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
