### PR TITLE
fix(usage): keep offline providers from hiding live limits

### DIFF
--- a/packages/shared/src/usageLimits.test.ts
+++ b/packages/shared/src/usageLimits.test.ts
@@ -125,10 +125,21 @@ describe("collectLimitsGroups", () => {
     const limits = { checkedAt: "2026-09-03T11:00:00.000Z", windows: [window] };
     const codex = provider({ usageLimits: limits });
     const one = new Map([
-      ["env-a", { entry: { target: { label: "Laptop" } }, serverConfig: { providers: [codex] } }],
+      [
+        "env-a",
+        {
+          entry: { target: { label: "Laptop" } },
+          connection: { phase: "connected" },
+          serverConfig: { providers: [codex] },
+        },
+      ],
       [
         "env-b",
-        { entry: { target: { label: "Desktop" } }, serverConfig: { providers: [provider({})] } },
+        {
+          entry: { target: { label: "Desktop" } },
+          connection: { phase: "connected" },
+          serverConfig: { providers: [provider({})] },
+        },
       ],
     ] as const);
     expect(collectLimitsGroups(one as never).map((group) => group.environmentLabel)).toEqual([
@@ -136,8 +147,22 @@ describe("collectLimitsGroups", () => {
     ]);
 
     const two = new Map([
-      ["env-a", { entry: { target: { label: "Laptop" } }, serverConfig: { providers: [codex] } }],
-      ["env-b", { entry: { target: { label: "Desktop" } }, serverConfig: { providers: [codex] } }],
+      [
+        "env-a",
+        {
+          entry: { target: { label: "Laptop" } },
+          connection: { phase: "connected" },
+          serverConfig: { providers: [codex] },
+        },
+      ],
+      [
+        "env-b",
+        {
+          entry: { target: { label: "Desktop" } },
+          connection: { phase: "connected" },
+          serverConfig: { providers: [codex] },
+        },
+      ],
     ] as const);
     expect(collectLimitsGroups(two as never).map((group) => group.environmentLabel)).toEqual([
       "Laptop",
@@ -177,6 +202,7 @@ describe("collectLimitSources", () => {
         EnvironmentId.make("env-a"),
         {
           entry: { target: { label: "Laptop" } },
+          connection: { phase: "connected" },
           serverConfig: { providers, usageLimitSources: [{ ...source, accounts }] },
         },
       ],
@@ -203,12 +229,54 @@ describe("collectLimitSources", () => {
     const input = presentations([]);
     input.set(EnvironmentId.make("env-b"), {
       entry: { target: { label: "Desktop" } },
+      connection: { phase: "connected" },
       serverConfig: { providers: [native], usageLimitSources: [] },
     });
 
     expect(collectLimitSources(input)).toMatchObject([
       { accounts: [], hiddenAccountCount: 1, environmentId: "env-a" },
     ]);
+  });
+
+  it.each(["codex", "claudeAgent"])(
+    "restores hub limits while the native %s environment is disconnected",
+    (kind) => {
+      const driver = ProviderDriverKind.make(kind);
+      const accounts = [{ ...account, driver }];
+      const input = presentations([], accounts);
+      const desktop = {
+        entry: { target: { label: "Desktop" } },
+        connection: { phase: "connected" },
+        serverConfig: { providers: [{ ...native, driver }], usageLimitSources: [] },
+      };
+      input.set(EnvironmentId.make("env-b"), desktop);
+      expect(collectLimitSources(input)[0]?.hiddenAccountCount).toBe(1);
+
+      for (const phase of ["offline", "connecting", "reconnecting", "error", "available"]) {
+        desktop.connection.phase = phase;
+        expect(collectLimitSources(input)).toMatchObject([{ accounts, hiddenAccountCount: 0 }]);
+        expect(collectLimitsGroups(input)).toEqual([]);
+      }
+
+      desktop.connection.phase = "connected";
+      expect(collectLimitSources(input)).toMatchObject([{ accounts: [], hiddenAccountCount: 1 }]);
+      expect(collectLimitsGroups(input)[0]?.providers).toEqual(desktop.serverConfig.providers);
+    },
+  );
+
+  it("omits cached sources from offline environments without adding their labels", () => {
+    const input = presentations([]);
+    input.set(EnvironmentId.make("env-b"), {
+      entry: { target: { label: "Desktop" } },
+      connection: { phase: "offline" },
+      serverConfig: { providers: [], usageLimitSources: [source] },
+    });
+
+    expect(collectLimitSources(input)).toMatchObject([
+      { environmentId: "env-a", label: "hub", accounts: [account] },
+    ]);
+    input.delete(EnvironmentId.make("env-a"));
+    expect(collectLimitSources(input)).toEqual([]);
   });
 
   it("keeps other providers, other emails, and unidentified accounts with the same plan", () => {
@@ -261,6 +329,7 @@ describe("collectLimitSources", () => {
         EnvironmentId.make("env-a"),
         {
           entry: { target: { label: "Laptop" } },
+          connection: { phase: "connected" },
           serverConfig: {
             providers: [native],
             usageLimitSources: [{ ...source, error: "Hub unavailable" }],
@@ -277,11 +346,19 @@ describe("collectLimitSources", () => {
     const one = new Map([
       [
         "env-a",
-        { entry: { target: { label: "Laptop" } }, serverConfig: { usageLimitSources: [source] } },
+        {
+          entry: { target: { label: "Laptop" } },
+          connection: { phase: "connected" },
+          serverConfig: { usageLimitSources: [source] },
+        },
       ],
       [
         "env-b",
-        { entry: { target: { label: "Desktop" } }, serverConfig: { usageLimitSources: [] } },
+        {
+          entry: { target: { label: "Desktop" } },
+          connection: { phase: "connected" },
+          serverConfig: { usageLimitSources: [] },
+        },
       ],
     ] as const);
     expect(collectLimitSources(one as never).map((entry) => [entry.key, entry.label])).toEqual([
@@ -291,11 +368,19 @@ describe("collectLimitSources", () => {
     const two = new Map([
       [
         "env-a",
-        { entry: { target: { label: "Laptop" } }, serverConfig: { usageLimitSources: [source] } },
+        {
+          entry: { target: { label: "Laptop" } },
+          connection: { phase: "connected" },
+          serverConfig: { usageLimitSources: [source] },
+        },
       ],
       [
         "env-b",
-        { entry: { target: { label: "Desktop" } }, serverConfig: { usageLimitSources: [source] } },
+        {
+          entry: { target: { label: "Desktop" } },
+          connection: { phase: "connected" },
+          serverConfig: { usageLimitSources: [source] },
+        },
       ],
     ] as const);
     expect(collectLimitSources(two as never).map((entry) => entry.label)).toEqual([

--- a/packages/shared/src/usageLimits.ts
+++ b/packages/shared/src/usageLimits.ts
@@ -53,12 +53,14 @@ export function collectLimitsGroups(
     EnvironmentId,
     {
       readonly entry: { readonly target: { readonly label: string } };
+      readonly connection: { readonly phase: string };
       readonly serverConfig: { readonly providers: readonly ServerProvider[] } | null;
     }
   >,
 ): readonly LimitsGroup[] {
   const groups: LimitsGroup[] = [];
   for (const [environmentId, presentation] of presentations) {
+    if (presentation.connection.phase !== "connected") continue;
     const providers = providersWithLimits(presentation.serverConfig?.providers ?? []);
     if (providers.length === 0) continue;
     groups.push({ environmentId, environmentLabel: presentation.entry.target.label, providers });
@@ -78,6 +80,7 @@ export function collectLimitSources(
     EnvironmentId,
     {
       readonly entry: { readonly target: { readonly label: string } };
+      readonly connection: { readonly phase: string };
       readonly serverConfig: {
         readonly providers?: readonly ServerProvider[] | undefined;
         readonly usageLimitSources?: UsageLimitSourceSnapshots | undefined;
@@ -91,8 +94,11 @@ export function collectLimitSources(
     readonly hiddenAccountCount: number;
   }
 > {
+  const connected = [...presentations].filter(
+    ([, presentation]) => presentation.connection.phase === "connected",
+  );
   const nativeAccounts = new Set<string>();
-  for (const presentation of presentations.values()) {
+  for (const [, presentation] of connected) {
     for (const provider of providersWithLimits(presentation.serverConfig?.providers ?? [])) {
       const key = accountKey(provider.driver, provider.auth.email);
       if (
@@ -109,7 +115,7 @@ export function collectLimitSources(
     readonly environmentLabel: string;
     readonly sources: UsageLimitSourceSnapshots;
   }> = [];
-  for (const [environmentId, presentation] of presentations) {
+  for (const [environmentId, presentation] of connected) {
     const sources = presentation.serverConfig?.usageLimitSources ?? [];
     if (sources.length === 0) continue;
     perEnvironment.push({


### PR DESCRIPTION
## What Changed

Ignore non-connected environments when collecting native limits and CLI Proxy accounts. The shared selectors serve web, desktop, and mobile; no cache or component changes are needed.

## Why

A disconnected environment retains its last provider snapshot. Its account was still hiding a matching live CLI Proxy account, leaving cached quota on screen. Native-provider precedence should apply only to connected environments, and resume when they reconnect.

```mermaid
flowchart LR
    A[Environment presentations] --> B[Connected environments only]
    B --> C[Native limit rows]
    B --> D[Source accounts]
    C --> E[Deduplicate source accounts]
    D --> E
    C --> F[Web / desktop / mobile Limits]
    E --> F
```

## UI Changes

Same simulated account on an offline desktop and an online hub. Captured in the running web app with Chromium at 2× density, using fixture presentations at the selector boundary. Before uses the selectors from base commit `b906ce2d73`; after uses this branch. This is UI verification, not an end-to-end network-disconnect test.

Before: the offline desktop's cached 20% hides the hub's live 70%.

![Before: cached offline quota hides the online hub](https://github.com/user-attachments/assets/28a139e9-f07c-4e38-90bc-4fb15432645a)

After: the live CLI Proxy quota is visible.

![After: online hub quota remains visible](https://github.com/user-attachments/assets/81ebc980-5960-4461-b107-877853d31682)

## Verification

- `vp test run src/usageLimits.test.ts --maxWorkers 1` in `packages/shared`: 23 passed. The three new regression cases failed before the fix. Covers Codex and Claude, all non-connected phases, reconnect, and source labels.
- Targeted format/lint and typechecks for shared, web, and mobile: passed.
- Fallow review/audit, scoped to shared with one thread: passed; no introduced findings. One inherited unused-test-file report remains.
- Browser fixture: checked before/after, native reconnect, all offline, and hub reconnect. No mobile-device run.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes — not applicable; no new motion or controls

Model: GPT-5. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to shared limit selectors with regression tests; behavior improves when environments disconnect but does not touch auth or persistence.
> 
> **Overview**
> **Limits aggregation now only considers environments whose `connection.phase` is `connected`.** Offline or reconnecting machines keep cached provider/source snapshots in memory, but those snapshots no longer drive the Limits UI or hide live hub quota.
> 
> `collectLimitsGroups` skips non-connected environments entirely, so stale native provider rows disappear while disconnected. `collectLimitSources` builds native-account precedence and hub source rows from connected environments only, which restores matching CLI Proxy accounts when a native desktop goes offline and re-applies hiding when it reconnects.
> 
> Presentation maps passed into these helpers must include `connection`; web and mobile already have that on environment presentations. Tests add `connection: { phase: "connected" }` to fixtures and cover disconnect phases, hub restore, and dropping cached sources from offline envs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4b8ee3158bc9aa26697c58a0ed8fde2419861ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `collectLimitSources` and `collectLimitsGroups` to ignore offline providers
> - Fixes a bug where disconnected environments could suppress native accounts or emit cached usage-limit sources, hiding live limits from connected providers.
> - Both functions now require a connection phase on each presentation and skip any presentation whose phase is not `connected` before collecting providers, native accounts, or source rows.
> - Connected environments retain the existing provider filtering and environment-label behavior.
> - Risk: callers of `collectLimitsGroups` and `collectLimitSources` must now supply a `connection` phase on every presentation; existing callers without that field will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4b8ee3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Usage limits now reflect only environments that are currently connected.
  - Cached usage limits from the native provider remain available when its environment is temporarily disconnected.
  - Cached limit sources from offline environments are excluded to prevent stale or misleading limit information.
  - Environment labels continue to display correctly when connection details are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->