### PR TITLE
fix(links): respect case in POSIX file links

### DIFF
--- a/apps/web/src/filePathDisplay.test.ts
+++ b/apps/web/src/filePathDisplay.test.ts
@@ -38,4 +38,25 @@ describe("formatWorkspaceRelativePath", () => {
       ),
     ).toBe("t3code/apps/web/src/session-logic.ts:501:9");
   });
+
+  it("does not format a case-distinct POSIX sibling as workspace-relative", () => {
+    expect(
+      formatWorkspaceRelativePath(
+        "/tmp/t3code-case-test/project/probe.txt",
+        "/tmp/t3code-case-test/Project",
+      ),
+    ).toBe("/tmp/t3code-case-test/project/probe.txt");
+  });
+
+  it("keeps double-slash POSIX paths case-sensitive", () => {
+    expect(formatWorkspaceRelativePath("//tmp/project/probe.txt", "//tmp/Project")).toBe(
+      "//tmp/project/probe.txt",
+    );
+  });
+
+  it("keeps Windows workspace formatting case-insensitive", () => {
+    expect(
+      formatWorkspaceRelativePath("C:/Users/MIKE/Project/src/main.ts", "c:/users/mike/project"),
+    ).toBe("project/src/main.ts");
+  });
 });

--- a/apps/web/src/filePathDisplay.ts
+++ b/apps/web/src/filePathDisplay.ts
@@ -1,6 +1,7 @@
 import {
   fileBasename,
   formatFilePathPosition,
+  isWindowsFilesystemPath,
   splitFilePathPosition,
   stripSlashPrefixedWindowsDrive,
 } from "@t3tools/client-runtime/markdown-links";
@@ -30,10 +31,13 @@ export function formatWorkspaceRelativePath(
       normalizePathSeparators(trimTrailingPathSeparators(workspaceRoot)),
     );
     const workspaceLabel = fileBasename(normalizedWorkspaceRoot);
-    const pathForCompare = normalizedPath.toLowerCase();
-    const workspaceForCompare = normalizedWorkspaceRoot.toLowerCase();
+    const caseInsensitive = isWindowsFilesystemPath(workspaceRoot);
+    const pathForCompare = caseInsensitive ? normalizedPath.toLowerCase() : normalizedPath;
+    const workspaceForCompare = caseInsensitive
+      ? normalizedWorkspaceRoot.toLowerCase()
+      : normalizedWorkspaceRoot;
     const workspaceWithSeparator = `${workspaceForCompare}/`;
-    const workspaceLabelWithSeparator = `${workspaceLabel.toLowerCase()}/`;
+    const workspaceLabelWithSeparator = `${caseInsensitive ? workspaceLabel.toLowerCase() : workspaceLabel}/`;
 
     if (pathForCompare === workspaceForCompare) {
       displayPath = workspaceLabel;

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -254,6 +254,54 @@ describe("resolveMarkdownFileLinkTarget", () => {
     });
   });
 
+  it("does not classify a case-distinct POSIX sibling as a workspace file", () => {
+    expect(
+      resolveMarkdownFileLinkMeta(
+        "/tmp/t3code-case-test/project/probe.txt",
+        "/tmp/t3code-case-test/Project",
+      ),
+    ).toMatchObject({
+      displayPath: "/tmp/t3code-case-test/project/probe.txt",
+      workspaceRelativePath: null,
+    });
+  });
+
+  it("keeps Windows workspace comparisons case-insensitive", () => {
+    expect(
+      resolveMarkdownFileLinkMeta("C:/Users/MIKE/Project/src/main.ts", "c:/users/mike/project"),
+    ).toMatchObject({
+      displayPath: "project/src/main.ts",
+      workspaceRelativePath: "src/main.ts",
+    });
+  });
+
+  it("keeps drive-root workspace comparisons case-insensitive", () => {
+    expect(resolveMarkdownFileLinkMeta("C:/Users/MIKE/project.ts", "c:/")).toMatchObject({
+      displayPath: "c:/Users/MIKE/project.ts",
+      workspaceRelativePath: "Users/MIKE/project.ts",
+    });
+  });
+
+  it("keeps backslash UNC workspace comparisons case-insensitive", () => {
+    expect(
+      resolveMarkdownFileLinkMeta(
+        "\\\\server\\share\\PROJECT\\src\\main.ts",
+        "\\\\Server\\Share\\Project",
+      ),
+    ).toMatchObject({
+      displayPath: "Project/src/main.ts",
+      workspaceRelativePath: "src/main.ts",
+    });
+  });
+
+  it("preserves trailing whitespace in encoded workspace file paths", () => {
+    expect(resolveMarkdownFileLinkMeta("/tmp/repo/file.ts%20", "/tmp/repo")).toMatchObject({
+      targetPath: "/tmp/repo/file.ts ",
+      displayPath: "repo/file.ts ",
+      workspaceRelativePath: "file.ts ",
+    });
+  });
+
   it("normalizes slash-prefixed windows drive paths before resolving", () => {
     expect(
       resolveMarkdownFileLinkTarget(

--- a/packages/client-runtime/src/markdownLinks.test.ts
+++ b/packages/client-runtime/src/markdownLinks.test.ts
@@ -4,6 +4,7 @@ import {
   fileBasename,
   inlineCodeFilePathCandidate,
   isConventionalFilePosition,
+  isWindowsFilesystemPath,
   parseFileUrlHref,
   parseMarkdownFileLink,
   splitFilePathPosition,
@@ -97,6 +98,7 @@ describe("parseMarkdownFileLink", () => {
     ["apps/mobile/src/index.ts:10", "apps/mobile/src/index.ts"],
     ["docs/My%20Folder/checklist.xml", "docs/My Folder/checklist.xml"],
     ["Updated%20cutover%20checklist.md", "Updated cutover checklist.md"],
+    ["/tmp/repo/file.ts%20", "/tmp/repo/file.ts "],
     ["./scripts/deploy", "./scripts/deploy"],
     ["~/notes/today.md", "~/notes/today.md"],
     ["AGENTS.md", "AGENTS.md"],
@@ -160,11 +162,38 @@ describe("workspaceRelativeFilePath", () => {
     ["/repo/project/src/main.ts", "/repo/project/", "src/main.ts"],
     ["C:\\Users\\mike\\t3code\\apps\\web\\a.ts", "C:/Users/mike/t3code", "apps/web/a.ts"],
     ["/C:/Users/mike/t3code/apps/web/a.ts", "C:/Users/mike/t3code", "apps/web/a.ts"],
-    ["/Repo/Project/src/main.ts", "/repo/project", "src/main.ts"],
+    ["C:/Users/MIKE/project/src/main.ts", "c:/users/mike/project", "src/main.ts"],
+    ["C:/Users/MIKE/project.ts", "c:/", "Users/MIKE/project.ts"],
+    ["C:/Users/mike/project.ts", "C:/", "Users/mike/project.ts"],
+    ["/usr/bin/tool", "/", "usr/bin/tool"],
+    ["\\\\server\\share\\PROJECT\\src\\main.ts", "\\\\Server\\Share\\Project", "src/main.ts"],
+    ["\\\\SERVER\\Share\\file.ts", "\\\\server\\share\\", "file.ts"],
+    ["/tmp/repo/file.ts ", "/tmp/repo", "file.ts "],
+    ["/Repo/Project/src/main.ts", "/repo/project", null],
+    ["/tmp/t3code-case-test/project/probe.txt", "/tmp/t3code-case-test/Project", null],
+    ["//tmp/project/probe.txt", "//tmp/Project", null],
     ["/tmp/report.ts", "/repo/project", null],
     ["/repo/project-two/a.ts", "/repo/project", null],
     ["/repo/project/a.ts", undefined, null],
   ])("relates %s to %s", (path, workspaceRoot, relativePath) => {
     expect(workspaceRelativeFilePath(path, workspaceRoot)).toBe(relativePath);
+  });
+});
+
+describe("isWindowsFilesystemPath", () => {
+  it.each([
+    ["C:/Users/mike/project", true],
+    ["c:/", true],
+    ["C:", true],
+    ["/C:/Users/mike/project", true],
+    ["C:\\Users\\mike\\project", true],
+    ["\\\\Server\\Share\\Project", true],
+    ["\\\\server\\share\\", true],
+    ["/repo/project", false],
+    ["/", false],
+    ["//tmp/Project", false],
+    ["relative/path/a.ts", false],
+  ])("classifies %s as %s", (path, expected) => {
+    expect(isWindowsFilesystemPath(path)).toBe(expected);
   });
 });

--- a/packages/client-runtime/src/markdownLinks.ts
+++ b/packages/client-runtime/src/markdownLinks.ts
@@ -208,6 +208,17 @@ export function stripSlashPrefixedWindowsDrive(path: string): string {
   return SLASH_PREFIXED_WINDOWS_DRIVE_PATTERN.test(path) ? path.slice(1) : path;
 }
 
+/**
+ * Workspace containment compares case-insensitively only on Windows
+ * filesystems (drive-letter paths and backslash UNC shares). POSIX paths
+ * stay case-sensitive — including double-slash `//` paths, which are not
+ * UNC shares.
+ */
+export function isWindowsFilesystemPath(path: string): boolean {
+  const normalizedPath = stripSlashPrefixedWindowsDrive(path.replaceAll("\\", "/"));
+  return /^[A-Za-z]:(?:\/|$)/.test(normalizedPath) || path.startsWith("\\\\");
+}
+
 export function splitMarkdownLinkSearchAndHash(value: string): {
   readonly path: string;
   readonly hash: string;
@@ -342,6 +353,9 @@ export function workspaceRelativeFilePath(
   const normalizedRoot = stripSlashPrefixedWindowsDrive(
     workspaceRoot.replaceAll("\\", "/"),
   ).replace(/\/+$/, "");
-  if (!normalizedPath.toLowerCase().startsWith(`${normalizedRoot.toLowerCase()}/`)) return null;
+  const caseInsensitive = isWindowsFilesystemPath(workspaceRoot);
+  const pathForCompare = caseInsensitive ? normalizedPath.toLowerCase() : normalizedPath;
+  const rootForCompare = caseInsensitive ? normalizedRoot.toLowerCase() : normalizedRoot;
+  if (!pathForCompare.startsWith(`${rootForCompare}/`)) return null;
   return normalizedPath.slice(normalizedRoot.length + 1);
 }


### PR DESCRIPTION
File-link resolution lowercases every path, so two POSIX siblings that differ only by case resolve to the same target.

Only fold case for Windows filesystem paths (drive-letter or UNC roots); POSIX paths keep their case. Covers POSIX siblings, double-slash POSIX vs UNC, drive roots, UNC share roots, and encoded trailing spaces.

Ports the containment rule of #9309 into the current shared resolver in packages/client-runtime (consumed by web and mobile) instead of the stale web-local diff.

Built with muse-spark-1.3-contributor via OpenCode in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core path containment used by markdown file links and workspace-relative display across clients; behavior shifts for POSIX case mismatches but is narrowly scoped and heavily tested.
> 
> **Overview**
> **POSIX workspace containment is now case-sensitive**, so paths like `/tmp/.../project` are no longer treated as inside `/tmp/.../Project`. Previously, workspace-relative resolution lowercased every path and could collapse case-distinct siblings.
> 
> The shared resolver in `packages/client-runtime` adds **`isWindowsFilesystemPath`** and uses it in **`workspaceRelativeFilePath`** so only Windows drive-letter roots and backslash UNC shares compare case-insensitively; POSIX paths (including `//` double-slash, which are not UNC) keep exact casing. **`formatWorkspaceRelativePath`** in the web app follows the same rule.
> 
> Tests cover Windows/UNC/drive-root behavior, encoded trailing spaces on file paths, and markdown link metadata that must not mark case-mismatched POSIX paths as workspace files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca0e9c5c8d7b75d693a9dcd7eef9e557f3ccb814. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix case sensitivity in POSIX workspace file links
> Workspace containment checks were case-insensitive for all paths, causing case-distinct POSIX siblings to be wrongly treated as workspace members. The fix adds `isWindowsFilesystemPath` to classify drive-letter and backslash UNC paths as Windows, then applies case-insensitive comparison only for those roots and case-sensitive comparison for POSIX roots.
>
> - `workspaceRelativeFilePath` in [markdownLinks.ts](https://github.com/pingdotgg/t3code/pull/9825/files#diff-61bfbb3d21cf76210b9a3622411fbb27acab9e95f653467b9af1a46f7d02df91) and `formatWorkspaceRelativePath` in [filePathDisplay.ts](https://github.com/pingdotgg/t3code/pull/9825/files#diff-7640b2df83d60fd94a94f484d23cf365a93878741c5a21cb2ae57e8e4559600b) both select case sensitivity from the workspace root via the new classifier.
> - Double-slash forward-slash paths are not treated as UNC paths, so they stay POSIX and case-sensitive.
> - Risk: POSIX workspace roots that previously matched case-variant paths now reject them; any consumer relying on the old case-insensitive POSIX behavior will see those paths fall outside the workspace.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca0e9c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->