### PR TITLE
fix(web): re-add bulk thread archiving to new sidebar

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -136,8 +136,10 @@ import { buildThreadActionMenuItems } from "./threadActionMenu.logic";
 import {
   animateSidebarLayoutChanges,
   applySidebarThreadDrop,
+  archiveSelectedThreadEntries,
   buildBulkTitleRegenerationContextMenuItem,
   buildBulkUnpinContextMenuItem,
+  buildMultiSelectThreadContextMenuItems,
   deleteSelectedThreadEntries,
   filterSidebarProjectScopeItems,
   formatWorkingDurationLabel,
@@ -3539,6 +3541,9 @@ export default function Sidebar() {
         const thread = threadByKeyRef.current.get(threadKey);
         return thread ? [thread] : [];
       });
+      const hasRunningThread = selectedThreads.some(
+        (thread) => thread.session?.status === "running" && thread.session.activeTurnId != null,
+      );
       const canSnoozeSelection = selectedThreads.every(
         (thread) =>
           serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSnooze === true &&
@@ -3586,8 +3591,7 @@ export default function Sidebar() {
                 ]
               : []),
             ...(titleRegenerationMenuItem ? [titleRegenerationMenuItem] : []),
-            { id: "mark-unread", label: `Mark unread (${count})` },
-            { id: "delete", label: `Delete (${count})`, destructive: true },
+            ...buildMultiSelectThreadContextMenuItems({ count, hasRunningThread }),
           ],
           position,
         ),
@@ -3706,6 +3710,49 @@ export default function Sidebar() {
         clearSelection();
         return;
       }
+      if (clicked.value === "archive") {
+        if (confirmThreadArchive) {
+          const confirmed = await settlePromise(() =>
+            api.dialogs.confirm(`Archive ${count} thread${count === 1 ? "" : "s"}?`),
+          );
+          if (confirmed._tag === "Failure" || !confirmed.value) return;
+        }
+
+        const archiveOutcome = await archiveSelectedThreadEntries({
+          entries: selectedThreads.map((thread) => {
+            const threadRef = scopeThreadRef(thread.environmentId, thread.id);
+            return { threadKey: scopedThreadKey(threadRef), threadRef };
+          }),
+          archive: ({ threadRef }, onArchived) => archiveThread(threadRef, { onArchived }),
+        });
+        for (const failure of archiveOutcome.followupFailures) {
+          if (isAtomCommandInterrupted(failure)) continue;
+          const error = squashAtomCommandFailure(failure);
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Thread archived, but navigation failed",
+              description: error instanceof Error ? error.message : "An error occurred.",
+            }),
+          );
+        }
+        if (archiveOutcome.mutationFailure) {
+          removeFromSelection(archiveOutcome.archivedThreadKeys);
+          if (!isAtomCommandInterrupted(archiveOutcome.mutationFailure)) {
+            const error = squashAtomCommandFailure(archiveOutcome.mutationFailure);
+            toastManager.add(
+              stackedThreadToast({
+                type: "error",
+                title: "Failed to archive threads",
+                description: error instanceof Error ? error.message : "An error occurred.",
+              }),
+            );
+          }
+          return;
+        }
+        removeFromSelection(threadKeys);
+        return;
+      }
       if (clicked.value !== "delete") return;
       if (confirmThreadDelete) {
         const confirmed = await settlePromise(() =>
@@ -3747,10 +3794,12 @@ export default function Sidebar() {
       );
     },
     [
+      archiveThread,
       attemptSettle,
       attemptSnooze,
       attemptUnpin,
       clearSelection,
+      confirmThreadArchive,
       confirmThreadDelete,
       deleteThread,
       markThreadUnread,


### PR DESCRIPTION
## What Changed

- Add an Archive action to the current sidebar's multi-thread context menu.
- Disable bulk archive while any selected thread has an active turn.
- Honor the archive confirmation setting and preserve partial-success handling.

## Why

The legacy sidebar supported archiving multiple selected threads, but the current sidebar omitted that action. Users had to archive threads one at a time even though the shared bulk-action behavior already existed.

## UI Changes

| Before | After |
| --- | --- |
| <img width="800" alt="Multi-select menu before bulk archive" src="https://github.com/user-attachments/assets/9f43d738-116b-4fbc-8f83-a99c282831d6" /> | <img width="800" alt="Multi-select menu with bulk archive" src="https://github.com/user-attachments/assets/2a47bc39-4f6d-4650-b6f4-73037afe1ba0" /> |

### Interaction branches

Archive is disabled while a selected thread has an active turn. After stopping it, Archive becomes available; the recording covers canceling once and then confirming.

https://github.com/user-attachments/assets/ec936506-cd59-48d2-8878-e35b76515a3c

### Confirmation disabled

With archive confirmation disabled, the selected threads archive immediately.

https://github.com/user-attachments/assets/00727284-9dc4-44db-95df-0f9784f724ea

## Verification

- `vp test run apps/web/src/components/Sidebar.logic.test.ts` (118 tests passed)
- `vp run --filter @t3tools/web typecheck`
- `git diff --check`
- Integrated browser pass covering the running-thread guard, confirmation cancel/accept paths, and confirmation-disabled path

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Prepared with GPT-5.6 Sol using the Codex harness in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-add bulk thread archiving to `Sidebar` multi-selection menu
> - The multi-selection menu in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/9834/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) now uses the shared bulk thread-menu builder instead of inline menu entries, passing the selection count and whether any resolved selected thread has a running session with an active turn.
> - Adds archive handling for selected threads: optional confirmation prompt, per-thread `archiveThread` invocation, toast reporting for navigation or mutation failures, and removal of processed threads from the selection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb3115b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only bulk lifecycle action reusing existing archive helpers and single-thread patterns; no new auth or data paths.
> 
> **Overview**
> Restores **bulk Archive** on the new sidebar’s multi-select context menu, matching behavior that already lived in shared `Sidebar.logic` and the legacy sidebar.
> 
> The menu no longer inlines only mark-unread and delete; it uses `buildMultiSelectThreadContextMenuItems` with the selection count and whether any selected thread has a **running active turn**, which **disables** Archive until those threads stop. Choosing Archive optionally confirms via `confirmThreadArchive`, then archives through `archiveSelectedThreadEntries` and `archiveThread`, with toasts for navigation follow-up or mutation failures and selection cleanup that keeps partial successes in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79fc8355bb738c815545945829112c785b9779fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->