### PR TITLE
fix(server): preserve Antigravity startup diagnostics

### DIFF
--- a/apps/server/src/provider/AntigravityInstallation.test.ts
+++ b/apps/server/src/provider/AntigravityInstallation.test.ts
@@ -424,6 +424,81 @@ it.layer(NodeServices.layer)("Antigravity installation", (it) => {
     }),
   );
 
+  it.effect.each([
+    {
+      name: "IPv6 diagnostic",
+      stderr: [
+        "Check failed: AddressFamilySupported(AF_INET6, &loopback6_ok)\n",
+        "Failed to create an AF_INET6 socket.\n",
+      ],
+      expected: "Failed to create an AF_INET6 socket.",
+    },
+    {
+      name: "bounded diagnostic tail",
+      stderr: [`discarded prefix ${"x".repeat(8_000)}\n`, "last startup diagnostic\n"],
+      expected: "last startup diagnostic",
+    },
+    {
+      name: "no diagnostic",
+      stderr: [],
+      expected: "The downloaded Antigravity runtime could not start in this environment.",
+    },
+  ])("preserves startup diagnostics when validation exits before initialize: $name", (testCase) =>
+    Effect.gen(function* () {
+      const encoder = new TextEncoder();
+      const spawner = ChildProcessSpawner.make(
+        Effect.fn("test.spawnFailingAntigravityValidator")(function* (command) {
+          if (command._tag !== "StandardCommand") {
+            return yield* Effect.die("Expected one validation process.");
+          }
+          const helper = command.args[0] === "-e";
+          const exited = yield* Deferred.make<ChildProcessSpawner.ExitCode>();
+          const terminate = Deferred.succeed(exited, ChildProcessSpawner.ExitCode(1)).pipe(
+            Effect.asVoid,
+          );
+          yield* Effect.addFinalizer(() => terminate);
+          return ChildProcessSpawner.makeHandle({
+            pid: ChildProcessSpawner.ProcessId(helper ? 1 : 2),
+            exitCode: helper
+              ? Effect.succeed(ChildProcessSpawner.ExitCode(0))
+              : Deferred.await(exited),
+            isRunning: Deferred.isDone(exited).pipe(Effect.map((done) => !done)),
+            kill: () => terminate,
+            unref: Effect.succeed(Effect.void),
+            stdin: Sink.drain,
+            stdout: helper
+              ? Stream.empty
+              : Stream.fromEffect(Deferred.await(exited)).pipe(Stream.flatMap(() => Stream.empty)),
+            stderr: helper
+              ? Stream.make(
+                  encoder.encode(
+                    `${ANTIGRAVITY_AUTH_BROWSER_MARKER}${encodeJsonString(command.args.at(-1))}\n`,
+                  ),
+                )
+              : Stream.fromIterable(testCase.stderr.map((line) => encoder.encode(line))).pipe(
+                  Stream.ensuring(terminate),
+                ),
+            all: Stream.empty,
+            getInputFd: () => Sink.drain,
+            getOutputFd: () => Stream.empty,
+          });
+        }),
+      );
+      const { installation, stagingReleased } = yield* makeHarness({
+        previous: true,
+        useDefaultValidation: true,
+      }).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+      yield* installation.start;
+      const state = yield* terminalState(installation);
+      expect(state.phase).toBe("failed");
+      expect(state.message).toContain(testCase.expected);
+      expect(state.message?.length).toBeLessThan(4_200);
+      expect(state.message).not.toContain("discarded prefix");
+      yield* Deferred.await(stagingReleased);
+      yield* expectPreviousRelease(installation);
+    }),
+  );
+
   it.effect("accepts an encoded Content-Length when the body is compressed", () =>
     Effect.gen(function* () {
       // dl.google.com gzips the archive and reports the encoded size. The decoded

--- a/apps/server/src/provider/AntigravityInstallation.test.ts
+++ b/apps/server/src/provider/AntigravityInstallation.test.ts
@@ -439,6 +439,24 @@ it.layer(NodeServices.layer)("Antigravity installation", (it) => {
       expected: "last startup diagnostic",
     },
     {
+      name: "unterminated diagnostic",
+      stderr: ["Failed to create an AF_INET6 socket."],
+      expected: "Failed to create an AF_INET6 socket.",
+    },
+    {
+      name: "oversized diagnostic",
+      stderr: [`discarded prefix ${"x".repeat(65_536)} last startup diagnostic\n`],
+      expected: "last startup diagnostic",
+    },
+    {
+      name: "fragmented oversized authorization message",
+      stderr: [
+        `${ANTIGRAVITY_AUTH_BROWSER_MARKER}${"x".repeat(65_536)}`,
+        "secret-authorization-tail\nlast startup diagnostic",
+      ],
+      expected: "last startup diagnostic",
+    },
+    {
       name: "no diagnostic",
       stderr: [],
       expected: "The downloaded Antigravity runtime could not start in this environment.",
@@ -453,6 +471,7 @@ it.layer(NodeServices.layer)("Antigravity installation", (it) => {
           }
           const helper = command.args[0] === "-e";
           const exited = yield* Deferred.make<ChildProcessSpawner.ExitCode>();
+          const exitObserved = yield* Deferred.make<void>();
           const terminate = Deferred.succeed(exited, ChildProcessSpawner.ExitCode(1)).pipe(
             Effect.asVoid,
           );
@@ -461,22 +480,26 @@ it.layer(NodeServices.layer)("Antigravity installation", (it) => {
             pid: ChildProcessSpawner.ProcessId(helper ? 1 : 2),
             exitCode: helper
               ? Effect.succeed(ChildProcessSpawner.ExitCode(0))
-              : Deferred.await(exited),
+              : Deferred.await(exited).pipe(
+                  Effect.tap(() => Deferred.succeed(exitObserved, undefined)),
+                ),
             isRunning: Deferred.isDone(exited).pipe(Effect.map((done) => !done)),
             kill: () => terminate,
             unref: Effect.succeed(Effect.void),
             stdin: Sink.drain,
             stdout: helper
               ? Stream.empty
-              : Stream.fromEffect(Deferred.await(exited)).pipe(Stream.flatMap(() => Stream.empty)),
+              : Stream.fromEffect(terminate).pipe(Stream.flatMap(() => Stream.empty)),
             stderr: helper
               ? Stream.make(
                   encoder.encode(
                     `${ANTIGRAVITY_AUTH_BROWSER_MARKER}${encodeJsonString(command.args.at(-1))}\n`,
                   ),
                 )
-              : Stream.fromIterable(testCase.stderr.map((line) => encoder.encode(line))).pipe(
-                  Stream.ensuring(terminate),
+              : Stream.fromEffect(Deferred.await(exitObserved)).pipe(
+                  Stream.flatMap(() =>
+                    Stream.fromIterable(testCase.stderr.map((line) => encoder.encode(line))),
+                  ),
                 ),
             all: Stream.empty,
             getInputFd: () => Sink.drain,
@@ -494,6 +517,7 @@ it.layer(NodeServices.layer)("Antigravity installation", (it) => {
       expect(state.message).toContain(testCase.expected);
       expect(state.message?.length).toBeLessThan(4_200);
       expect(state.message).not.toContain("discarded prefix");
+      expect(state.message).not.toContain("secret-authorization-tail");
       yield* Deferred.await(stagingReleased);
       yield* expectPreviousRelease(installation);
     }),

--- a/apps/server/src/provider/AntigravityInstallation.ts
+++ b/apps/server/src/provider/AntigravityInstallation.ts
@@ -43,6 +43,7 @@ import {
 const DRIVER = ProviderDriverKind.make("antigravity");
 const DOWNLOAD_TIMEOUT = "45 minutes";
 const VALIDATION_TIMEOUT = "90 seconds";
+const VALIDATION_DIAGNOSTIC_MAX_CHARS = 4_096;
 const FREE_SPACE_MARGIN = 256 * 1024 * 1024;
 const RECORD_MAX_BYTES = 8 * 1024;
 const RELEASE_RECORD = ".install-complete.json";
@@ -476,7 +477,8 @@ export const makeAntigravityInstallation = Effect.fn("AntigravityInstallation.ma
           platform,
           baseEnv: environment,
         });
-        const runtime = yield* makeAntigravityAcpRuntime({
+        let diagnosticTail = "";
+        const initialized = yield* makeAntigravityAcpRuntime({
           spawn: buildAntigravityAcpSpawnInput({
             installation: executable,
             profile,
@@ -486,8 +488,27 @@ export const makeAntigravityInstallation = Effect.fn("AntigravityInstallation.ma
           cwd: profileDirectory,
           childProcessSpawner: spawner,
           clientInfo: { name: "t3-code", version: "0.0.0" },
-        });
-        const initialized = yield* runtime.initialize();
+          onDiagnostic: (message) =>
+            Effect.sync(() => {
+              diagnosticTail = `${diagnosticTail}${message}\n`.slice(
+                -VALIDATION_DIAGNOSTIC_MAX_CHARS,
+              );
+            }),
+        }).pipe(
+          Effect.flatMap((runtime) => runtime.initialize()),
+          Effect.mapError((cause) =>
+            installationError(
+              "verify",
+              [
+                "The downloaded Antigravity runtime could not start in this environment.",
+                diagnosticTail.trim(),
+              ]
+                .filter(Boolean)
+                .join("\n\n"),
+              cause,
+            ),
+          ),
+        );
         if (
           initialized.agentInfo?.name !== "antigravity-acp" ||
           initialized.agentInfo.version !== expectedVersion ||

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -104,6 +104,8 @@ export interface AcpSessionRuntimeOptions {
   ) => EffectAcpSchema.SessionNotification;
   /** Receives bounded stderr chunks. Redact secrets before logging. A failure closes the runtime. */
   readonly onStderr?: (text: string) => Effect.Effect<void, EffectAcpErrors.AcpError>;
+  /** Flushes diagnostics when stderr ends. Failed initialization drains an exited child's stderr first. */
+  readonly onStderrEnd?: Effect.Effect<void>;
   readonly requestLogger?: (event: AcpSessionRequestLogEvent) => Effect.Effect<void, never>;
   readonly protocolLogging?: {
     readonly logIncoming?: boolean;
@@ -449,13 +451,16 @@ export const make = (
         ),
       );
 
-    yield* child.stderr.pipe(
+    const stderrFiber = yield* child.stderr.pipe(
       Stream.decodeText(),
-      Stream.runForEach((chunk) =>
-        (options.onStderr
-          ? options.onStderr(chunk.slice(-maxStderrChunkLength))
-          : Effect.void
-        ).pipe(
+      Stream.runForEach(
+        Effect.fn("AcpSessionRuntime.handleStderr")(
+          function* (chunk: string) {
+            if (!options.onStderr) return;
+            for (let offset = 0; offset < chunk.length; offset += maxStderrChunkLength) {
+              yield* options.onStderr(chunk.slice(offset, offset + maxStderrChunkLength));
+            }
+          },
           Effect.catch((error) =>
             Effect.gen(function* () {
               yield* Deferred.fail(stderrFailure, error);
@@ -465,6 +470,7 @@ export const make = (
           ),
         ),
       ),
+      Effect.ensuring(options.onStderrEnd ?? Effect.void),
       Effect.ignore,
       Effect.forkIn(runtimeScope),
     );
@@ -971,7 +977,20 @@ export const make = (
       handleUnknownExtNotification: acp.handleUnknownExtNotification,
       handleExtRequest: acp.handleExtRequest,
       handleExtNotification: acp.handleExtNotification,
-      initialize: () => ensureConnected.pipe(Effect.andThen(sendInitialize)),
+      initialize: () =>
+        ensureConnected.pipe(
+          Effect.andThen(sendInitialize),
+          Effect.onError(() =>
+            Effect.gen(function* () {
+              if (!options.onStderrEnd) return;
+              const running = yield* child.isRunning.pipe(Effect.orElseSucceed(() => true));
+              if (running) return;
+              // A descendant may inherit stderr, so a closed process cannot wait forever for EOF.
+              yield* Fiber.await(stderrFiber).pipe(Effect.timeoutOption("1 second"));
+              yield* options.onStderrEnd;
+            }),
+          ),
+        ),
       start: () => start,
       getEvents: () => Stream.fromQueue(eventQueue),
       drainEvents,

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.test.ts
@@ -8,8 +8,15 @@ import {
   type RuntimeMode,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import * as Deferred from "effect/Deferred";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
@@ -19,7 +26,69 @@ import {
   antigravityPermissionMode,
   applyAntigravityAcpModelSelection,
   buildAntigravityPrompt,
+  makeAntigravityAcpRuntime,
 } from "./AntigravityAcpSupport.ts";
+
+it.effect.each([false, true])(
+  "drains exited validation stderr with inherited pipe: %s",
+  (inherited) =>
+    Effect.gen(function* () {
+      const releaseStderr = yield* Deferred.make<void>();
+      const draining = yield* Deferred.make<void>();
+      const completed = yield* Deferred.make<void>();
+      const diagnostics: string[] = [];
+      const childProcessSpawner = ChildProcessSpawner.make(() =>
+        Effect.succeed(
+          ChildProcessSpawner.makeHandle({
+            pid: ChildProcessSpawner.ProcessId(1),
+            exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(1)),
+            isRunning: Deferred.succeed(draining, undefined).pipe(Effect.as(false)),
+            kill: () => Effect.void,
+            unref: Effect.succeed(Effect.void),
+            stdin: Sink.drain,
+            stdout: Stream.empty,
+            stderr: inherited
+              ? Stream.make(new TextEncoder().encode("final startup diagnostic")).pipe(
+                  Stream.concat(
+                    Stream.fromEffect(Deferred.await(releaseStderr)).pipe(
+                      Stream.flatMap(() => Stream.empty),
+                    ),
+                  ),
+                )
+              : Stream.fromEffect(Deferred.await(releaseStderr)).pipe(
+                  Stream.map(() => new TextEncoder().encode("final startup diagnostic")),
+                ),
+            all: Stream.empty,
+            getInputFd: () => Sink.drain,
+            getOutputFd: () => Stream.empty,
+          }),
+        ),
+      );
+      const runtime = yield* makeAntigravityAcpRuntime({
+        spawn: { command: "antigravity-fixture", args: [] },
+        cwd: "/fixture",
+        childProcessSpawner,
+        clientInfo: { name: "test", version: "1" },
+        onDiagnostic: (message) => Effect.sync(() => void diagnostics.push(message)),
+      });
+      const initialization = yield* runtime.initialize().pipe(
+        Effect.exit,
+        Effect.tap(() => Deferred.succeed(completed, undefined)),
+        Effect.forkScoped,
+      );
+      expect(
+        yield* Effect.raceFirst(
+          Deferred.await(draining).pipe(Effect.as("draining")),
+          Deferred.await(completed).pipe(Effect.as("completed")),
+        ),
+      ).toBe("draining");
+      expect(yield* Deferred.isDone(completed)).toBe(false);
+      if (inherited) yield* TestClock.adjust("1 second");
+      else yield* Deferred.succeed(releaseStderr, undefined);
+      expect(Exit.isFailure(yield* Fiber.join(initialization))).toBe(true);
+      expect(diagnostics).toEqual(["final startup diagnostic"]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
 
 const modelConfig = {
   id: "model",

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.ts
@@ -37,6 +37,8 @@ export interface AntigravityAcpRuntimeInput extends Omit<
 > {
   readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
   readonly onAuthorizationUrl?: (url: string) => Effect.Effect<void, EffectAcpErrors.AcpError>;
+  /** Receives native stderr lines with authorization messages excluded. */
+  readonly onDiagnostic?: (message: string) => Effect.Effect<void>;
   /**
    * Advertise `fs.readTextFile` and `fs.writeTextFile`. The agent then routes
    * workspace reads and writes through T3, which turns each edit into a
@@ -73,9 +75,10 @@ export const makeAntigravityAcpRuntime = Effect.fn("makeAntigravityAcpRuntime")(
       transformStdout: makeAntigravityStdoutTransform(
         input.onAuthorizationUrl ? { onAuthorizationUrl: input.onAuthorizationUrl } : {},
       ),
-      onStderr: makeAntigravityStderrHandler(
-        input.onAuthorizationUrl ? { onAuthorizationUrl: input.onAuthorizationUrl } : {},
-      ),
+      onStderr: makeAntigravityStderrHandler({
+        ...(input.onAuthorizationUrl ? { onAuthorizationUrl: input.onAuthorizationUrl } : {}),
+        ...(input.onDiagnostic ? { onDiagnostic: input.onDiagnostic } : {}),
+      }),
       transformSessionUpdate: normalizeAntigravitySessionUpdate,
     }).pipe(
       Layer.provide(

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.ts
@@ -31,6 +31,7 @@ export interface AntigravityAcpRuntimeInput extends Omit<
   | "cancelBehavior"
   | "clientCapabilities"
   | "onStderr"
+  | "onStderrEnd"
   | "resumeMethod"
   | "transformSessionUpdate"
   | "transformStdout"
@@ -59,6 +60,10 @@ export const makeAntigravityAcpRuntime = Effect.fn("makeAntigravityAcpRuntime")(
   EffectAcpErrors.AcpError,
   Crypto.Crypto | Scope.Scope
 > {
+  const handleStderr = makeAntigravityStderrHandler({
+    ...(input.onAuthorizationUrl ? { onAuthorizationUrl: input.onAuthorizationUrl } : {}),
+    ...(input.onDiagnostic ? { onDiagnostic: input.onDiagnostic } : {}),
+  });
   const context = yield* Layer.build(
     AcpSessionRuntime.layer({
       ...input,
@@ -75,10 +80,8 @@ export const makeAntigravityAcpRuntime = Effect.fn("makeAntigravityAcpRuntime")(
       transformStdout: makeAntigravityStdoutTransform(
         input.onAuthorizationUrl ? { onAuthorizationUrl: input.onAuthorizationUrl } : {},
       ),
-      onStderr: makeAntigravityStderrHandler({
-        ...(input.onAuthorizationUrl ? { onAuthorizationUrl: input.onAuthorizationUrl } : {}),
-        ...(input.onDiagnostic ? { onDiagnostic: input.onDiagnostic } : {}),
-      }),
+      onStderr: handleStderr,
+      ...(input.onDiagnostic ? { onStderrEnd: handleStderr.flushDiagnostics } : {}),
       transformSessionUpdate: normalizeAntigravitySessionUpdate,
     }).pipe(
       Layer.provide(

--- a/apps/server/src/provider/antigravityAuthSupport.test.ts
+++ b/apps/server/src/provider/antigravityAuthSupport.test.ts
@@ -391,6 +391,38 @@ describe("Antigravity stdout compatibility", () => {
 });
 
 describe("Antigravity stderr compatibility", () => {
+  it.effect.each([
+    { name: "native", prefix: ANTIGRAVITY_AUTH_STDOUT_PREFIX },
+    { name: "browser", prefix: ANTIGRAVITY_AUTH_BROWSER_MARKER },
+    { name: "indented native", prefix: ` ${ANTIGRAVITY_AUTH_STDOUT_PREFIX}` },
+    { name: "indented browser", prefix: ` ${ANTIGRAVITY_AUTH_BROWSER_MARKER}` },
+    { name: "logged native", prefix: `INFO ${ANTIGRAVITY_AUTH_STDOUT_PREFIX}` },
+    { name: "logged browser", prefix: `INFO ${ANTIGRAVITY_AUTH_BROWSER_MARKER}` },
+    {
+      name: "long log prefix",
+      prefix: `${"logged prefix ".repeat(4_096)}${ANTIGRAVITY_AUTH_BROWSER_MARKER}`,
+    },
+    {
+      name: "long indentation",
+      prefix: `${" ".repeat(32_768)}${ANTIGRAVITY_AUTH_BROWSER_MARKER}`,
+    },
+  ])("discards oversized auth messages across fragment boundaries: $name", ({ prefix }) =>
+    Effect.gen(function* () {
+      const diagnostics: string[] = [];
+      const handleStderr = makeAntigravityStderrHandler({
+        onDiagnostic: (message) => Effect.sync(() => void diagnostics.push(message)),
+      });
+      yield* handleStderr(prefix.slice(0, 12));
+      yield* handleStderr(`${prefix.slice(12)}${"x".repeat(32_768)}`);
+      yield* handleStderr("secret-authorization-tail");
+      yield* handleStderr.flushDiagnostics;
+      yield* handleStderr("\nlast startup diagnostic");
+      yield* handleStderr.flushDiagnostics;
+      yield* handleStderr.flushDiagnostics;
+      expect(diagnostics).toEqual(["last startup diagnostic"]);
+    }),
+  );
+
   it.effect("keeps sign-in URLs out of collected native diagnostics", () =>
     Effect.gen(function* () {
       const diagnostics: string[] = [];
@@ -407,6 +439,8 @@ describe("Antigravity stderr compatibility", () => {
       yield* handleStderr(` ${ANTIGRAVITY_AUTH_STDOUT_PREFIX}${authorizationUrl}\n`);
       yield* handleStderr(` ${ANTIGRAVITY_AUTH_BROWSER_MARKER}${authorizationUrl}\n`);
       yield* handleStderr(`${ANTIGRAVITY_AUTH_BROWSER_MARKER}${authorizationUrl}\n`);
+      yield* handleStderr(`INFO ${ANTIGRAVITY_AUTH_STDOUT_PREFIX}${authorizationUrl}\n`);
+      yield* handleStderr(`INFO ${ANTIGRAVITY_AUTH_BROWSER_MARKER}${authorizationUrl}\n`);
       expect(diagnostics).toEqual(["Failed to create an AF_INET6 socket."]);
     }),
   );

--- a/apps/server/src/provider/antigravityAuthSupport.test.ts
+++ b/apps/server/src/provider/antigravityAuthSupport.test.ts
@@ -391,6 +391,26 @@ describe("Antigravity stdout compatibility", () => {
 });
 
 describe("Antigravity stderr compatibility", () => {
+  it.effect("keeps sign-in URLs out of collected native diagnostics", () =>
+    Effect.gen(function* () {
+      const diagnostics: string[] = [];
+      const handleStderr = makeAntigravityStderrHandler({
+        onAuthorizationUrl: () => Effect.void,
+        onDiagnostic: (message) => Effect.sync(() => void diagnostics.push(message)),
+      });
+      yield* handleStderr("Failed to create an AF_");
+      yield* handleStderr("INET6 socket.\r\n");
+      yield* handleStderr(`${ANTIGRAVITY_AUTH_STDOUT_PREFIX}${authorizationUrl}\n`);
+      yield* handleStderr(
+        `${ANTIGRAVITY_AUTH_BROWSER_MARKER}${encodeUnknownJson(authorizationUrl)}\n`,
+      );
+      yield* handleStderr(` ${ANTIGRAVITY_AUTH_STDOUT_PREFIX}${authorizationUrl}\n`);
+      yield* handleStderr(` ${ANTIGRAVITY_AUTH_BROWSER_MARKER}${authorizationUrl}\n`);
+      yield* handleStderr(`${ANTIGRAVITY_AUTH_BROWSER_MARKER}${authorizationUrl}\n`);
+      expect(diagnostics).toEqual(["Failed to create an AF_INET6 socket."]);
+    }),
+  );
+
   it.effect("forwards fragmented native sign-in URLs from runtime 1.1.1", () =>
     Effect.gen(function* () {
       const urls: string[] = [];

--- a/apps/server/src/provider/antigravityAuthSupport.ts
+++ b/apps/server/src/provider/antigravityAuthSupport.ts
@@ -470,23 +470,20 @@ export function makeAntigravityStderrHandler(
   } = {},
 ) {
   let pending = "";
+  let oversizedLine: "diagnostic" | "discard" | undefined;
+  const isAuthorizationLine = (message: string) =>
+    message.includes(ANTIGRAVITY_AUTH_STDOUT_PREFIX) ||
+    message.includes(ANTIGRAVITY_AUTH_BROWSER_MARKER);
   const handleLine = (line: string) => {
     const message = line.endsWith("\r") ? line.slice(0, -1) : line;
-    if (message.length > maxBrowserHelperLineLength) {
-      return Effect.void;
-    }
     const url = message.startsWith(ANTIGRAVITY_AUTH_STDOUT_PREFIX)
       ? Effect.succeed(message.slice(ANTIGRAVITY_AUTH_STDOUT_PREFIX.length))
       : message.startsWith(ANTIGRAVITY_AUTH_BROWSER_MARKER)
         ? decodeBrowserHelperUrl(message.slice(ANTIGRAVITY_AUTH_BROWSER_MARKER.length))
         : undefined;
     if (url === undefined) {
-      // Malformed or indented auth messages must not enter installation diagnostics.
-      const trimmed = message.trimStart();
-      if (
-        trimmed.startsWith(ANTIGRAVITY_AUTH_STDOUT_PREFIX) ||
-        trimmed.startsWith(ANTIGRAVITY_AUTH_BROWSER_MARKER)
-      ) {
+      // Malformed or log-prefixed auth messages must not enter installation diagnostics.
+      if (isAuthorizationLine(message)) {
         return Effect.void;
       }
       return input.onDiagnostic?.(message) ?? Effect.void;
@@ -503,10 +500,47 @@ export function makeAntigravityStderrHandler(
     );
   };
 
-  return Effect.fn("antigravityAuthSupport.handleStderr")(function* (text: string) {
-    const lines = `${pending}${text}`.split("\n");
-    pending = lines.pop() ?? "";
-    if (pending.length > maxBrowserHelperLineLength) pending = "";
-    yield* Effect.forEach(lines, handleLine, { discard: true });
+  const finishLine = () => {
+    const message = pending;
+    const kind = oversizedLine;
+    pending = "";
+    oversizedLine = undefined;
+    if (kind === "discard") {
+      return Effect.void;
+    }
+    if (kind === "diagnostic") return input.onDiagnostic?.(message) ?? Effect.void;
+    return handleLine(message);
+  };
+
+  const handleStderr = Effect.fn("antigravityAuthSupport.handleStderr")(function* (text: string) {
+    let offset = 0;
+    while (offset < text.length) {
+      const newline = text.indexOf("\n", offset);
+      const end = newline === -1 ? text.length : newline;
+      if (oversizedLine !== "discard") {
+        pending += text.slice(offset, end);
+        if (pending.length > maxBrowserHelperLineLength) {
+          oversizedLine =
+            isAuthorizationLine(pending) || pending.trimStart().length === 0
+              ? "discard"
+              : "diagnostic";
+          pending = oversizedLine === "discard" ? "" : pending.slice(-maxBrowserHelperLineLength);
+        }
+      }
+      if (newline !== -1) yield* finishLine();
+      offset = end + 1;
+    }
+  });
+
+  return Object.assign(handleStderr, {
+    flushDiagnostics: Effect.suspend(() => {
+      if (pending.length === 0 || oversizedLine === "discard" || isAuthorizationLine(pending)) {
+        return Effect.void;
+      }
+      const message = pending.endsWith("\r") ? pending.slice(0, -1) : pending;
+      pending = "";
+      oversizedLine = undefined;
+      return input.onDiagnostic?.(message) ?? Effect.void;
+    }),
   });
 }

--- a/apps/server/src/provider/antigravityAuthSupport.ts
+++ b/apps/server/src/provider/antigravityAuthSupport.ts
@@ -460,12 +460,13 @@ export function makeAntigravityStdoutTransform(
     });
 }
 
-/** Receives native 1.1.1 sign-in URLs and T3 browser-helper URLs without logging stderr. */
+/** Routes sign-in URLs separately from optional native diagnostic lines. */
 export function makeAntigravityStderrHandler(
   input: {
     readonly onAuthorizationUrl?: (
       authorizationUrl: string,
     ) => Effect.Effect<void, AcpErrors.AcpError>;
+    readonly onDiagnostic?: (message: string) => Effect.Effect<void>;
   } = {},
 ) {
   let pending = "";
@@ -479,7 +480,17 @@ export function makeAntigravityStderrHandler(
       : message.startsWith(ANTIGRAVITY_AUTH_BROWSER_MARKER)
         ? decodeBrowserHelperUrl(message.slice(ANTIGRAVITY_AUTH_BROWSER_MARKER.length))
         : undefined;
-    if (url === undefined) return Effect.void;
+    if (url === undefined) {
+      // Malformed or indented auth messages must not enter installation diagnostics.
+      const trimmed = message.trimStart();
+      if (
+        trimmed.startsWith(ANTIGRAVITY_AUTH_STDOUT_PREFIX) ||
+        trimmed.startsWith(ANTIGRAVITY_AUTH_BROWSER_MARKER)
+      ) {
+        return Effect.void;
+      }
+      return input.onDiagnostic?.(message) ?? Effect.void;
+    }
     return url.pipe(
       Effect.flatMap(parseAntigravityAuthorizationUrl),
       Effect.matchEffect({


### PR DESCRIPTION
Antigravity installation discarded the runtime's stderr, so startup failures such as disabled IPv6 appeared only as a generic validation error.

Keep the last 4 KiB of native diagnostic lines and include them when startup validation fails. Drain an exited validator's stderr before reporting failure, flush a final line without a newline, and preserve the tail of oversized native errors. The drain has a one-second bound for inherited pipes that never close. Sign-in URLs, including malformed, log-prefixed, and oversized browser-helper messages, remain excluded. The existing installed runtime stays active after validation fails.

Fixes [#9800](https://github.com/pingdotgg/t3code/issues/9800).

Verification:

- A fake runtime emits an AF_INET6 socket failure and exits before ACP initialization. Reproduced against [5a433244d](https://github.com/pingdotgg/t3code/commit/5a433244d0b827176df8b76a05959cd1a7a98ce2), committed September 4, 2026. The base installation message contains only the generic error; this change preserves the diagnostic.
- Five additional regression cases fail against the first PR revision: unterminated and oversized diagnostics, fragmented oversized auth output, delayed stderr after process exit, and an inherited pipe. The installation fixture observes process exit before stderr is emitted; the delayed-stream test uses receipts, and the inherited-pipe test uses a virtual clock.
- Focused tests cover bounded output, absent output, fragmented lines, authentication URL exclusion, and retaining the prior installation. No Google runtime download or account is needed.
- `vp test run src/provider/AntigravityInstallation.test.ts src/provider/antigravityAuthSupport.test.ts src/provider/acp/AntigravityAcpSupport.test.ts --maxWorkers=2`: 104 passed.
- Targeted lint and the server typecheck passed.

This verifies error propagation with a deterministic process fixture, not native startup on an IPv6-disabled WSL kernel. Screenshots are not applicable to this server-side diagnostic fix.

GPT 6 Astra via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install failure messaging and stderr parsing on the Antigravity/ACP path; mistakes could leak auth material into diagnostics, though the change explicitly filters sign-in output.
> 
> **Overview**
> Antigravity install validation no longer surfaces only a generic “could not start” message when the runtime dies before ACP `initialize`. The server now keeps a **bounded tail (4 KiB)** of native stderr lines and appends them to the failed **verify** state message.
> 
> **ACP runtime / stderr plumbing:** `AcpSessionRuntime` adds optional `onStderrEnd` and, when `initialize` fails on an already-exited child, **drains remaining stderr** (with a **1s cap** for inherited pipes that never EOF). Large stderr chunks are fed to handlers in slices. `makeAntigravityStderrHandler` is reworked to **split OAuth/sign-in traffic from diagnostics**, drop oversized auth fragments, expose **`flushDiagnostics`** for lines without a trailing newline, and wire through `makeAntigravityAcpRuntime` via **`onDiagnostic`**.
> 
> **Tests** cover IPv6-style failures, bounded/oversized/unterminated diagnostics, delayed stderr after exit, inherited pipes, and keeping URLs/secrets out of user-visible diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2126d7abfa59f200acccd0ff3fe11fbec77f8e7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add startup-diagnostics validation-failure tests for `AntigravityInstallation`
> Adds a parameterized test covering IPv6 diagnostics, bounded diagnostic tails, unterminated stderr, oversized diagnostics, fragmented oversized authorization messages, and absent diagnostics. The test uses a custom child-process spawner, waits for installation failure, and checks that the final native startup diagnostic is preserved while discarded prefixes and authorization content are excluded. It also confirms staging cleanup and that the previous release remains active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2126d7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->