### PR TITLE
fix(server): capture turn checkpoints after all edits finish

### DIFF
--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -679,6 +679,21 @@ describe("CheckpointReactor", () => {
         const turnId = asTurnId("turn-1");
         const assistantMessageId = MessageId.make("assistant:mid-turn");
         const createdAt = "2026-01-01T00:00:00.000Z";
+        yield* harness.engine.dispatch({
+          type: "thread.session.set",
+          commandId: CommandId.make("cmd-mid-turn-running"),
+          threadId,
+          session: {
+            threadId,
+            status: "running",
+            providerName: "codex",
+            runtimeMode: "approval-required",
+            activeTurnId: turnId,
+            lastError: null,
+            updatedAt: createdAt,
+          },
+          createdAt,
+        });
         harness.provider.emit({
           type: "turn.started",
           eventId: EventId.make("evt-mid-turn-start"),
@@ -708,6 +723,21 @@ describe("CheckpointReactor", () => {
         yield* Effect.promise(harness.drain);
 
         NodeFS.writeFileSync(NodePath.join(harness.cwd, "late.ts"), "export const late = 2;\n");
+        yield* harness.engine.dispatch({
+          type: "thread.session.set",
+          commandId: CommandId.make("cmd-mid-turn-settled"),
+          threadId,
+          session: {
+            threadId,
+            status: terminalEventType === "turn.aborted" ? "interrupted" : "ready",
+            providerName: "codex",
+            runtimeMode: "approval-required",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: createdAt,
+          },
+          createdAt,
+        });
         harness.provider.emit({
           eventId: EventId.make("evt-mid-turn-complete"),
           provider: ProviderDriverKind.make("codex"),
@@ -735,6 +765,9 @@ describe("CheckpointReactor", () => {
         );
         expect(thread?.checkpoints).toHaveLength(1);
         expect(thread?.checkpoints[0]?.status).toBe("ready");
+        expect(thread?.latestTurn?.state).toBe(
+          terminalEventType === "turn.aborted" ? "interrupted" : "completed",
+        );
         expect(thread?.checkpoints[0]?.assistantMessageId).toBe(assistantMessageId);
         expect(thread?.checkpoints[0]?.files.map((file) => file.path)).toEqual([
           "early.ts",

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -12,6 +12,7 @@ import {
 } from "@t3tools/contracts";
 import {
   CommandId,
+  CheckpointRef,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   EventId,
   MessageId,
@@ -667,7 +668,107 @@ describe("CheckpointReactor", () => {
     }),
   );
 
-  it("refreshes local git status state on turn completion using the session cwd", async () => {
+  effectIt.effect("captures every edit after a mid-turn diff update in the same turn", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() =>
+        createHarness({ seedFilesystemCheckpoints: false }),
+      );
+      const threadId = ThreadId.make("thread-1");
+      const turnId = asTurnId("turn-1");
+      const assistantMessageId = MessageId.make("assistant:mid-turn");
+      const createdAt = "2026-01-01T00:00:00.000Z";
+      harness.provider.emit({
+        type: "turn.started",
+        eventId: EventId.make("evt-mid-turn-start"),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt,
+        threadId,
+        turnId,
+      });
+      expect(yield* harness.nextReceipt).toMatchObject({
+        type: "checkpoint.baseline.captured",
+      });
+
+      NodeFS.writeFileSync(NodePath.join(harness.cwd, "early.ts"), "export const early = 1;\n");
+      yield* harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.make("cmd-mid-turn-diff"),
+        threadId,
+        turnId,
+        completedAt: createdAt,
+        checkpointRef: CheckpointRef.make("provider-diff:mid-turn"),
+        assistantMessageId,
+        status: "missing",
+        files: [],
+        checkpointTurnCount: 1,
+        createdAt,
+      });
+      yield* Effect.promise(harness.drain);
+
+      NodeFS.writeFileSync(NodePath.join(harness.cwd, "late.ts"), "export const late = 2;\n");
+      harness.provider.emit({
+        type: "turn.completed",
+        eventId: EventId.make("evt-mid-turn-complete"),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt,
+        threadId,
+        turnId,
+        payload: { state: "completed" },
+      });
+      expect(yield* harness.nextReceipt).toMatchObject({
+        type: "checkpoint.diff.finalized",
+        turnId,
+        checkpointTurnCount: 1,
+      });
+      expect(yield* harness.nextReceipt).toMatchObject({
+        type: "turn.processing.quiesced",
+        turnId,
+      });
+      yield* Effect.promise(harness.drain);
+      const thread = (yield* Effect.promise(harness.readModel)).threads.find(
+        (entry) => entry.id === threadId,
+      );
+      expect(thread?.checkpoints).toHaveLength(1);
+      expect(thread?.checkpoints[0]?.assistantMessageId).toBe(assistantMessageId);
+      expect(thread?.checkpoints[0]?.files.map((file) => file.path)).toEqual([
+        "early.ts",
+        "late.ts",
+      ]);
+      expect(
+        gitShowFileAtRef(harness.cwd, checkpointRefForThreadTurn(threadId, 1), "late.ts"),
+      ).toBe("export const late = 2;\n");
+
+      const followUpTurnId = asTurnId("turn-2");
+      harness.provider.emit({
+        type: "turn.started",
+        eventId: EventId.make("evt-follow-up-start"),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt,
+        threadId,
+        turnId: followUpTurnId,
+      });
+      harness.provider.emit({
+        type: "turn.completed",
+        eventId: EventId.make("evt-follow-up-complete"),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt,
+        threadId,
+        turnId: followUpTurnId,
+        payload: { state: "completed" },
+      });
+      expect(yield* harness.nextReceipt).toMatchObject({
+        type: "checkpoint.diff.finalized",
+        turnId: followUpTurnId,
+        checkpointTurnCount: 2,
+      });
+      const followUp = (yield* Effect.promise(harness.readModel)).threads.find(
+        (entry) => entry.id === threadId,
+      );
+      expect(
+        followUp?.checkpoints.find((checkpoint) => checkpoint.turnId === followUpTurnId),
+      ).toMatchObject({ checkpointTurnCount: 2, files: [] });
+    }),
+  );
     const gitStatusRefreshCalls: string[] = [];
     const harness = await createHarness({
       seedFilesystemCheckpoints: false,

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -668,107 +668,135 @@ describe("CheckpointReactor", () => {
     }),
   );
 
-  effectIt.effect("captures every edit after a mid-turn diff update in the same turn", () =>
-    Effect.gen(function* () {
-      const harness = yield* Effect.promise(() =>
-        createHarness({ seedFilesystemCheckpoints: false }),
-      );
-      const threadId = ThreadId.make("thread-1");
-      const turnId = asTurnId("turn-1");
-      const assistantMessageId = MessageId.make("assistant:mid-turn");
-      const createdAt = "2026-01-01T00:00:00.000Z";
-      harness.provider.emit({
-        type: "turn.started",
-        eventId: EventId.make("evt-mid-turn-start"),
-        provider: ProviderDriverKind.make("codex"),
-        createdAt,
-        threadId,
-        turnId,
-      });
-      expect(yield* harness.nextReceipt).toMatchObject({
-        type: "checkpoint.baseline.captured",
-      });
+  effectIt.effect.each(["turn.completed", "turn.aborted"] as const)(
+    "captures every edit after a mid-turn diff update on %s",
+    (terminalEventType) =>
+      Effect.gen(function* () {
+        const harness = yield* Effect.promise(() =>
+          createHarness({ seedFilesystemCheckpoints: false }),
+        );
+        const threadId = ThreadId.make("thread-1");
+        const turnId = asTurnId("turn-1");
+        const assistantMessageId = MessageId.make("assistant:mid-turn");
+        const createdAt = "2026-01-01T00:00:00.000Z";
+        harness.provider.emit({
+          type: "turn.started",
+          eventId: EventId.make("evt-mid-turn-start"),
+          provider: ProviderDriverKind.make("codex"),
+          createdAt,
+          threadId,
+          turnId,
+        });
+        expect(yield* harness.nextReceipt).toMatchObject({
+          type: "checkpoint.baseline.captured",
+        });
 
-      NodeFS.writeFileSync(NodePath.join(harness.cwd, "early.ts"), "export const early = 1;\n");
-      yield* harness.engine.dispatch({
-        type: "thread.turn.diff.complete",
-        commandId: CommandId.make("cmd-mid-turn-diff"),
-        threadId,
-        turnId,
-        completedAt: createdAt,
-        checkpointRef: CheckpointRef.make("provider-diff:mid-turn"),
-        assistantMessageId,
-        status: "missing",
-        files: [],
-        checkpointTurnCount: 1,
-        createdAt,
-      });
-      yield* Effect.promise(harness.drain);
+        NodeFS.writeFileSync(NodePath.join(harness.cwd, "early.ts"), "export const early = 1;\n");
+        yield* harness.engine.dispatch({
+          type: "thread.turn.diff.complete",
+          commandId: CommandId.make("cmd-mid-turn-diff"),
+          threadId,
+          turnId,
+          completedAt: createdAt,
+          checkpointRef: CheckpointRef.make("provider-diff:mid-turn"),
+          assistantMessageId,
+          status: "missing",
+          files: [],
+          checkpointTurnCount: 1,
+          createdAt,
+        });
+        yield* Effect.promise(harness.drain);
 
-      NodeFS.writeFileSync(NodePath.join(harness.cwd, "late.ts"), "export const late = 2;\n");
-      harness.provider.emit({
-        type: "turn.completed",
-        eventId: EventId.make("evt-mid-turn-complete"),
-        provider: ProviderDriverKind.make("codex"),
-        createdAt,
-        threadId,
-        turnId,
-        payload: { state: "completed" },
-      });
-      expect(yield* harness.nextReceipt).toMatchObject({
-        type: "checkpoint.diff.finalized",
-        turnId,
-        checkpointTurnCount: 1,
-      });
-      expect(yield* harness.nextReceipt).toMatchObject({
-        type: "turn.processing.quiesced",
-        turnId,
-      });
-      yield* Effect.promise(harness.drain);
-      const thread = (yield* Effect.promise(harness.readModel)).threads.find(
-        (entry) => entry.id === threadId,
-      );
-      expect(thread?.checkpoints).toHaveLength(1);
-      expect(thread?.checkpoints[0]?.assistantMessageId).toBe(assistantMessageId);
-      expect(thread?.checkpoints[0]?.files.map((file) => file.path)).toEqual([
-        "early.ts",
-        "late.ts",
-      ]);
-      expect(
-        gitShowFileAtRef(harness.cwd, checkpointRefForThreadTurn(threadId, 1), "late.ts"),
-      ).toBe("export const late = 2;\n");
+        NodeFS.writeFileSync(NodePath.join(harness.cwd, "late.ts"), "export const late = 2;\n");
+        harness.provider.emit({
+          eventId: EventId.make("evt-mid-turn-complete"),
+          provider: ProviderDriverKind.make("codex"),
+          createdAt,
+          threadId,
+          turnId,
+          ...(terminalEventType === "turn.completed"
+            ? { type: "turn.completed", payload: { state: "completed" } }
+            : { type: "turn.aborted", payload: { reason: "Interrupted by user." } }),
+        });
+        yield* Effect.promise(harness.drain);
+        expect(gitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 1))).toBe(true);
+        expect(yield* harness.nextReceipt).toMatchObject({
+          type: "checkpoint.diff.finalized",
+          turnId,
+          checkpointTurnCount: 1,
+        });
+        expect(yield* harness.nextReceipt).toMatchObject({
+          type: "turn.processing.quiesced",
+          turnId,
+        });
+        yield* Effect.promise(harness.drain);
+        const thread = (yield* Effect.promise(harness.readModel)).threads.find(
+          (entry) => entry.id === threadId,
+        );
+        expect(thread?.checkpoints).toHaveLength(1);
+        expect(thread?.checkpoints[0]?.status).toBe("ready");
+        expect(thread?.checkpoints[0]?.assistantMessageId).toBe(assistantMessageId);
+        expect(thread?.checkpoints[0]?.files.map((file) => file.path)).toEqual([
+          "early.ts",
+          "late.ts",
+        ]);
+        expect(
+          gitShowFileAtRef(harness.cwd, checkpointRefForThreadTurn(threadId, 1), "late.ts"),
+        ).toBe("export const late = 2;\n");
 
-      const followUpTurnId = asTurnId("turn-2");
-      harness.provider.emit({
-        type: "turn.started",
-        eventId: EventId.make("evt-follow-up-start"),
-        provider: ProviderDriverKind.make("codex"),
-        createdAt,
-        threadId,
-        turnId: followUpTurnId,
-      });
-      harness.provider.emit({
-        type: "turn.completed",
-        eventId: EventId.make("evt-follow-up-complete"),
-        provider: ProviderDriverKind.make("codex"),
-        createdAt,
-        threadId,
-        turnId: followUpTurnId,
-        payload: { state: "completed" },
-      });
-      expect(yield* harness.nextReceipt).toMatchObject({
-        type: "checkpoint.diff.finalized",
-        turnId: followUpTurnId,
-        checkpointTurnCount: 2,
-      });
-      const followUp = (yield* Effect.promise(harness.readModel)).threads.find(
-        (entry) => entry.id === threadId,
-      );
-      expect(
-        followUp?.checkpoints.find((checkpoint) => checkpoint.turnId === followUpTurnId),
-      ).toMatchObject({ checkpointTurnCount: 2, files: [] });
-    }),
+        const followUpTurnId = asTurnId("turn-2");
+        harness.provider.emit({
+          type: "turn.started",
+          eventId: EventId.make("evt-follow-up-start"),
+          provider: ProviderDriverKind.make("codex"),
+          createdAt,
+          threadId,
+          turnId: followUpTurnId,
+        });
+        harness.provider.emit({
+          type: "turn.completed",
+          eventId: EventId.make("evt-follow-up-complete"),
+          provider: ProviderDriverKind.make("codex"),
+          createdAt,
+          threadId,
+          turnId: followUpTurnId,
+          payload: { state: "completed" },
+        });
+        expect(yield* harness.nextReceipt).toMatchObject({
+          type: "checkpoint.diff.finalized",
+          turnId: followUpTurnId,
+          checkpointTurnCount: 2,
+        });
+        const followUp = (yield* Effect.promise(harness.readModel)).threads.find(
+          (entry) => entry.id === threadId,
+        );
+        expect(
+          followUp?.checkpoints.find((checkpoint) => checkpoint.turnId === followUpTurnId),
+        ).toMatchObject({ checkpointTurnCount: 2, files: [] });
+      }),
   );
+
+  it("does not capture an aborted turn without a matching start or active session", async () => {
+    const harness = await createHarness({ seedFilesystemCheckpoints: false });
+    harness.provider.emit({
+      type: "turn.aborted",
+      eventId: EventId.make("evt-untracked-abort"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      threadId: ThreadId.make("thread-1"),
+      turnId: asTurnId("turn-untracked"),
+      payload: { reason: "Interrupted before the turn started." },
+    });
+    await harness.drain();
+
+    const thread = (await harness.readModel()).threads.find((entry) => entry.id === "thread-1");
+    expect(thread?.checkpoints).toEqual([]);
+    expect(
+      gitRefExists(harness.cwd, checkpointRefForThreadTurn(ThreadId.make("thread-1"), 1)),
+    ).toBe(false);
+  });
+
+  it("refreshes local git status state on turn completion using the session cwd", async () => {
     const gitStatusRefreshCalls: string[] = [];
     const harness = await createHarness({
       seedFilesystemCheckpoints: false,

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -216,9 +216,7 @@ const make = Effect.gen(function* () {
     return cwd;
   });
 
-  // Shared tail for both capture paths: creates the git checkpoint ref, diffs
-  // it against the previous turn, then dispatches the domain events to update
-  // the orchestration read model.
+  // Capture the completed turn's files, then publish its summary and receipts.
   const captureAndDispatchCheckpoint = Effect.fn("captureAndDispatchCheckpoint")(function* (input: {
     readonly threadId: ThreadId;
     readonly turnId: TurnId;
@@ -413,73 +411,11 @@ const make = Effect.gen(function* () {
         cwd: checkpointCwd,
         turnCount: nextTurnCount,
         status: checkpointStatusFromRuntime(event.payload.state),
-        assistantMessageId: undefined,
+        assistantMessageId: existingPlaceholder?.assistantMessageId ?? undefined,
         createdAt: event.createdAt,
       });
     },
   );
-
-  // Captures a real git checkpoint when a placeholder checkpoint (status "missing")
-  // is detected via a domain event. This replaces the placeholder with a real
-  // git-ref-based checkpoint.
-  //
-  // ProviderRuntimeIngestion creates placeholder checkpoints on turn.diff.updated
-  // events from the Codex runtime. This handler fires when the corresponding
-  // domain event arrives, allowing the reactor to capture the actual filesystem
-  // state into a git ref and dispatch a replacement checkpoint.
-  const captureCheckpointFromPlaceholder = Effect.fn("captureCheckpointFromPlaceholder")(function* (
-    event: Extract<OrchestrationEvent, { type: "thread.turn-diff-completed" }>,
-  ) {
-    const { threadId, turnId, checkpointTurnCount, status } = event.payload;
-
-    // Only replace placeholders; skip events from our own real captures.
-    if (status !== "missing") {
-      return;
-    }
-
-    const thread = yield* resolveThreadDetail(threadId);
-    if (!thread) {
-      yield* Effect.logWarning("checkpoint capture from placeholder skipped: thread not found", {
-        threadId,
-      });
-      return;
-    }
-
-    // If a real checkpoint already exists for this turn, skip.
-    if (
-      thread.checkpoints.some(
-        (checkpoint) => checkpoint.turnId === turnId && checkpoint.status !== "missing",
-      )
-    ) {
-      yield* Effect.logDebug(
-        "checkpoint capture from placeholder skipped: real checkpoint already exists",
-        { threadId, turnId },
-      );
-      return;
-    }
-
-    const projects = yield* resolveThreadProjects(thread.projectId);
-    const checkpointCwd = yield* resolveCheckpointCwd({
-      threadId,
-      thread,
-      projects,
-      preferSessionRuntime: true,
-    });
-    if (!checkpointCwd) {
-      return;
-    }
-
-    yield* captureAndDispatchCheckpoint({
-      threadId,
-      turnId,
-      thread,
-      cwd: checkpointCwd,
-      turnCount: checkpointTurnCount,
-      status: "ready",
-      assistantMessageId: event.payload.assistantMessageId ?? undefined,
-      createdAt: event.payload.completedAt,
-    });
-  });
 
   const ensurePreTurnBaselineFromTurnStart = Effect.fn("ensurePreTurnBaselineFromTurnStart")(
     function* (event: Extract<ProviderRuntimeEvent, { type: "turn.started" }>) {
@@ -876,25 +812,6 @@ const make = Effect.gen(function* () {
       );
       return;
     }
-
-    // When ProviderRuntimeIngestion creates a placeholder checkpoint (status "missing")
-    // from a turn.diff.updated runtime event, capture the real git checkpoint to
-    // replace it. ProviderService broadcasts runtime events to each subscriber.
-    // This domain-event path also captures checkpoints from turn diff updates.
-    if (event.type === "thread.turn-diff-completed") {
-      yield* captureCheckpointFromPlaceholder(event).pipe(
-        Effect.catch((error) =>
-          Effect.flatMap(nowIso, (createdAt) =>
-            appendCaptureFailureActivity({
-              threadId: event.payload.threadId,
-              turnId: event.payload.turnId,
-              detail: error.message,
-              createdAt,
-            }).pipe(Effect.catch(() => Effect.void)),
-          ),
-        ),
-      );
-    }
   });
 
   const processRuntimeEvent = Effect.fn("processRuntimeEvent")(function* (
@@ -987,8 +904,7 @@ const make = Effect.gen(function* () {
         if (
           event.type !== "thread.turn-start-requested" &&
           event.type !== "thread.message-sent" &&
-          event.type !== "thread.checkpoint-revert-requested" &&
-          event.type !== "thread.turn-diff-completed"
+          event.type !== "thread.checkpoint-revert-requested"
         ) {
           return Effect.void;
         }

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -351,9 +351,9 @@ const make = Effect.gen(function* () {
     });
   });
 
-  // Captures a real git checkpoint when a turn completes via a runtime event.
+  // Capture the files left by a completed or interrupted turn.
   const captureCheckpointFromTurnCompletion = Effect.fn("captureCheckpointFromTurnCompletion")(
-    function* (event: Extract<ProviderRuntimeEvent, { type: "turn.completed" }>) {
+    function* (event: Extract<ProviderRuntimeEvent, { type: "turn.completed" | "turn.aborted" }>) {
       const turnId = toTurnId(event.turnId);
       if (!turnId) {
         return;
@@ -410,7 +410,10 @@ const make = Effect.gen(function* () {
         thread,
         cwd: checkpointCwd,
         turnCount: nextTurnCount,
-        status: checkpointStatusFromRuntime(event.payload.state),
+        status:
+          event.type === "turn.aborted"
+            ? "ready"
+            : checkpointStatusFromRuntime(event.payload.state),
         assistantMessageId: existingPlaceholder?.assistantMessageId ?? undefined,
         createdAt: event.createdAt,
       });
@@ -856,7 +859,13 @@ const make = Effect.gen(function* () {
         pending.delete(event.threadId);
         yield* pullRequests.refreshAfterTurn;
       }
-      if (event.type === "turn.aborted") return;
+      if (
+        event.type === "turn.aborted" &&
+        !isTrackedTurn &&
+        !sameId(thread?.session?.activeTurnId, turnId)
+      ) {
+        return;
+      }
       yield* captureCheckpointFromTurnCompletion(event).pipe(
         Effect.catch((error) =>
           Effect.flatMap(nowIso, (createdAt) =>

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1573,7 +1573,10 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             yield* projectionTurnRepository.upsertByTurnId({
               ...existingTurn.value,
               assistantMessageId: event.payload.assistantMessageId,
-              state: turnStillRunning ? existingTurn.value.state : nextState,
+              state:
+                turnStillRunning || existingTurn.value.state === "interrupted"
+                  ? existingTurn.value.state
+                  : nextState,
               checkpointTurnCount: event.payload.checkpointTurnCount,
               checkpointRef: event.payload.checkpointRef,
               checkpointStatus: event.payload.status,

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -372,6 +372,103 @@ describe("orchestration projector", () => {
       }),
   );
 
+  effectIt.effect.each([null, "ready", "interrupted", "stopped"] as const)(
+    "replaces a missing checkpoint without inventing interruption for a %s session",
+    (sessionStatus) =>
+      Effect.gen(function* () {
+        const now = "2026-09-04T23:00:00.000Z";
+        const threadId = "thread-placeholder";
+        const event = (sequence: number, type: OrchestrationEvent["type"], payload: unknown) =>
+          makeEvent({
+            sequence,
+            type,
+            payload,
+            aggregateKind: "thread",
+            aggregateId: threadId,
+            occurredAt: now,
+            commandId: `placeholder-${sequence}`,
+          });
+        let model = yield* projectEvent(
+          createEmptyReadModel(now),
+          event(1, "thread.created", {
+            threadId,
+            projectId: "project-1",
+            title: "Placeholder",
+            modelSelection: { instanceId: "codex", model: "test" },
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            branch: null,
+            worktreePath: null,
+            createdAt: now,
+            updatedAt: now,
+          }),
+        );
+        const checkpoint = {
+          threadId,
+          turnId: "turn-placeholder",
+          checkpointTurnCount: 1,
+          checkpointRef: "provider-diff:placeholder",
+          files: [],
+          assistantMessageId: "assistant:placeholder",
+          completedAt: now,
+        };
+        if (sessionStatus === "interrupted" || sessionStatus === "stopped") {
+          model = yield* projectEvent(
+            model,
+            event(2, "thread.session-set", {
+              threadId,
+              session: {
+                threadId,
+                status: "running",
+                providerName: "codex",
+                runtimeMode: "full-access",
+                activeTurnId: "turn-placeholder",
+                lastError: null,
+                updatedAt: now,
+              },
+            }),
+          );
+        }
+        model = yield* projectEvent(
+          model,
+          event(3, "thread.turn-diff-completed", {
+            ...checkpoint,
+            status: "missing",
+          }),
+        );
+        if (sessionStatus !== null) {
+          model = yield* projectEvent(
+            model,
+            event(4, "thread.session-set", {
+              threadId,
+              session: {
+                threadId,
+                status: sessionStatus,
+                providerName: "codex",
+                runtimeMode: "full-access",
+                activeTurnId: null,
+                lastError: null,
+                updatedAt: now,
+              },
+            }),
+          );
+        }
+        model = yield* projectEvent(
+          model,
+          event(5, "thread.turn-diff-completed", {
+            ...checkpoint,
+            status: "ready",
+            checkpointRef: "refs/t3/checkpoints/thread-placeholder/turn/1",
+          }),
+        );
+        expect(model.threads[0]?.latestTurn?.state).toBe(
+          sessionStatus === "interrupted" || sessionStatus === "stopped"
+            ? "interrupted"
+            : "completed",
+        );
+      }),
+  );
+
   it("updates canonical thread runtime mode from thread.runtime-mode-set", async () => {
     const createdAt = "2026-02-23T08:00:00.000Z";
     const updatedAt = "2026-02-23T08:00:05.000Z";

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -7,6 +7,7 @@ import {
   type OrchestrationEvent,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import { it as effectIt } from "@effect/vitest";
 import { describe, expect, it } from "vite-plus/test";
 
 import { createEmptyReadModel, projectEvent } from "./projector.ts";
@@ -239,110 +240,137 @@ describe("orchestration projector", () => {
     expect(next.threads).toEqual([]);
   });
 
-  it("tracks latest turn id from session lifecycle events", async () => {
-    const createdAt = "2026-02-23T08:00:00.000Z";
-    const startedAt = "2026-02-23T08:00:05.000Z";
-    const model = createEmptyReadModel(createdAt);
+  effectIt.effect.each([
+    ["ready", "completed"],
+    ["interrupted", "interrupted"],
+  ] as const)(
+    "preserves the turn state after a %s session captures its checkpoint",
+    ([status, state]) =>
+      Effect.gen(function* () {
+        const createdAt = "2026-02-23T08:00:00.000Z";
+        const startedAt = "2026-02-23T08:00:05.000Z";
+        const model = createEmptyReadModel(createdAt);
 
-    const afterCreate = await Effect.runPromise(
-      projectEvent(
-        model,
-        makeEvent({
-          sequence: 1,
-          type: "thread.created",
-          aggregateKind: "thread",
-          aggregateId: "thread-1",
-          occurredAt: createdAt,
-          commandId: "cmd-create",
-          payload: {
-            threadId: "thread-1",
-            projectId: "project-1",
-            title: "demo",
-            modelSelection: {
-              provider: ProviderDriverKind.make("codex"),
-              model: "gpt-5.3-codex",
-            },
-            runtimeMode: "full-access",
-            branch: null,
-            worktreePath: null,
-            createdAt,
-            updatedAt: createdAt,
-          },
-        }),
-      ),
-    );
-
-    const settledAt = "2026-02-23T08:01:00.000Z";
-    const [afterRunning, afterReady] = await Effect.runPromise(
-      Effect.flatMap(
-        projectEvent(
-          afterCreate,
+        const afterCreate = yield* projectEvent(
+          model,
           makeEvent({
-            sequence: 2,
-            type: "thread.session-set",
+            sequence: 1,
+            type: "thread.created",
             aggregateKind: "thread",
             aggregateId: "thread-1",
-            occurredAt: startedAt,
-            commandId: "cmd-running",
+            occurredAt: createdAt,
+            commandId: "cmd-create",
             payload: {
               threadId: "thread-1",
-              session: {
-                threadId: "thread-1",
-                status: "running",
-                providerName: "codex",
-                providerSessionId: "session-1",
-                providerThreadId: "provider-thread-1",
-                runtimeMode: "approval-required",
-                activeTurnId: "turn-1",
-                lastError: null,
-                updatedAt: startedAt,
+              projectId: "project-1",
+              title: "demo",
+              modelSelection: {
+                provider: ProviderDriverKind.make("codex"),
+                model: "gpt-5.3-codex",
               },
+              runtimeMode: "full-access",
+              branch: null,
+              worktreePath: null,
+              createdAt,
+              updatedAt: createdAt,
             },
           }),
-        ),
-        (running) =>
-          Effect.map(
-            projectEvent(
-              running,
-              makeEvent({
-                sequence: 3,
-                type: "thread.session-set",
-                aggregateKind: "thread",
-                aggregateId: "thread-1",
-                occurredAt: settledAt,
-                commandId: "cmd-ready",
-                payload: {
+        );
+
+        const settledAt = "2026-02-23T08:01:00.000Z";
+        const [afterRunning, afterReady] = yield* Effect.flatMap(
+          projectEvent(
+            afterCreate,
+            makeEvent({
+              sequence: 2,
+              type: "thread.session-set",
+              aggregateKind: "thread",
+              aggregateId: "thread-1",
+              occurredAt: startedAt,
+              commandId: "cmd-running",
+              payload: {
+                threadId: "thread-1",
+                session: {
                   threadId: "thread-1",
-                  session: {
-                    threadId: "thread-1",
-                    status: "ready",
-                    providerName: "codex",
-                    providerSessionId: "session-1",
-                    providerThreadId: "provider-thread-1",
-                    runtimeMode: "approval-required",
-                    activeTurnId: null,
-                    lastError: null,
-                    updatedAt: settledAt,
-                  },
+                  status: "running",
+                  providerName: "codex",
+                  providerSessionId: "session-1",
+                  providerThreadId: "provider-thread-1",
+                  runtimeMode: "approval-required",
+                  activeTurnId: "turn-1",
+                  lastError: null,
+                  updatedAt: startedAt,
                 },
-              }),
-            ),
-            (ready) => [running, ready] as const,
+              },
+            }),
           ),
-      ),
-    );
+          (running) =>
+            Effect.map(
+              projectEvent(
+                running,
+                makeEvent({
+                  sequence: 3,
+                  type: "thread.session-set",
+                  aggregateKind: "thread",
+                  aggregateId: "thread-1",
+                  occurredAt: settledAt,
+                  commandId: "cmd-ready",
+                  payload: {
+                    threadId: "thread-1",
+                    session: {
+                      threadId: "thread-1",
+                      status,
+                      providerName: "codex",
+                      providerSessionId: "session-1",
+                      providerThreadId: "provider-thread-1",
+                      runtimeMode: "approval-required",
+                      activeTurnId: null,
+                      lastError: null,
+                      updatedAt: settledAt,
+                    },
+                  },
+                }),
+              ),
+              (ready) => [running, ready] as const,
+            ),
+        );
 
-    const thread = afterRunning.threads[0];
-    expect(thread?.latestTurn?.turnId).toBe("turn-1");
-    expect(thread?.session?.status).toBe("running");
+        const thread = afterRunning.threads[0];
+        expect(thread?.latestTurn?.turnId).toBe("turn-1");
+        expect(thread?.session?.status).toBe("running");
 
-    // Leaving the "running" session status settles the running turn with the
-    // session timestamp as the turn end.
-    const settledThread = afterReady.threads[0];
-    expect(settledThread?.latestTurn?.turnId).toBe("turn-1");
-    expect(settledThread?.latestTurn?.state).toBe("completed");
-    expect(settledThread?.latestTurn?.completedAt).toBe(settledAt);
-  });
+        // Leaving the "running" session status settles the running turn with the
+        // session timestamp as the turn end.
+        const settledThread = afterReady.threads[0];
+        expect(settledThread?.latestTurn?.turnId).toBe("turn-1");
+        expect(settledThread?.latestTurn?.state).toBe(state);
+        expect(settledThread?.latestTurn?.completedAt).toBe(settledAt);
+
+        const captured = yield* projectEvent(
+          afterReady,
+          makeEvent({
+            sequence: 4,
+            type: "thread.turn-diff-completed",
+            aggregateKind: "thread",
+            aggregateId: "thread-1",
+            occurredAt: settledAt,
+            commandId: "cmd-final-checkpoint",
+            payload: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              checkpointTurnCount: 1,
+              checkpointRef: "refs/t3/checkpoints/thread-1/turn/1",
+              status: "ready",
+              files: [],
+              assistantMessageId: "assistant:turn-1",
+              completedAt: settledAt,
+            },
+          }),
+        );
+        expect(captured.threads[0]?.latestTurn?.state).toBe(state);
+        expect(captured.threads[0]?.checkpoints[0]?.status).toBe("ready");
+      }),
+  );
 
   it("updates canonical thread runtime mode from thread.runtime-mode-set", async () => {
     const createdAt = "2026-02-23T08:00:00.000Z";

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -64,7 +64,7 @@ function retainThreadActivities(activities: OrchestrationThread["activities"]) {
 
 function checkpointStatusToLatestTurnState(status: "ready" | "missing" | "error") {
   if (status === "error") return "error" as const;
-  if (status === "missing") return "interrupted" as const;
+  // Match SQL and client projections: a missing git ref is not an interruption.
   return "completed" as const;
 }
 

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -746,7 +746,11 @@ export function projectEvent(
               ? thread.latestTurn
               : {
                   turnId: payload.turnId,
-                  state: checkpointStatusToLatestTurnState(payload.status),
+                  state:
+                    thread.latestTurn?.turnId === payload.turnId &&
+                    thread.latestTurn.state === "interrupted"
+                      ? "interrupted"
+                      : checkpointStatusToLatestTurnState(payload.status),
                   requestedAt:
                     thread.latestTurn?.turnId === payload.turnId
                       ? thread.latestTurn.requestedAt

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -1129,33 +1129,52 @@ describe("applyThreadDetailEvent", () => {
   });
 
   describe("thread.turn-diff-completed", () => {
-    it("adds a checkpoint and updates latestTurn", () => {
-      const result = applyThreadDetailEvent(baseThread, {
-        ...baseEventFields,
-        sequence: 13,
-        occurredAt: "2026-04-01T12:00:00.000Z",
-        aggregateKind: "thread",
-        aggregateId: ThreadId.make("thread-1"),
-        type: "thread.turn-diff-completed",
-        payload: {
-          threadId: ThreadId.make("thread-1"),
-          turnId: TurnId.make("turn-1"),
-          checkpointTurnCount: 1,
-          checkpointRef: CheckpointRef.make("ref-1"),
-          status: "ready",
-          files: [],
-          assistantMessageId: MessageId.make("msg-3"),
-          completedAt: "2026-04-01T12:00:00.000Z",
-        },
-      });
+    it.each([null, "interrupted"] as const)(
+      "adds a checkpoint without replacing a %s turn outcome",
+      (previousState) => {
+        const result = applyThreadDetailEvent(
+          {
+            ...baseThread,
+            latestTurn:
+              previousState === null
+                ? null
+                : {
+                    turnId: TurnId.make("turn-1"),
+                    state: previousState,
+                    requestedAt: "2026-04-01T11:00:00.000Z",
+                    startedAt: "2026-04-01T11:00:00.000Z",
+                    completedAt: "2026-04-01T12:00:00.000Z",
+                    assistantMessageId: null,
+                  },
+          },
+          {
+            ...baseEventFields,
+            sequence: 13,
+            occurredAt: "2026-04-01T12:00:00.000Z",
+            aggregateKind: "thread",
+            aggregateId: ThreadId.make("thread-1"),
+            type: "thread.turn-diff-completed",
+            payload: {
+              threadId: ThreadId.make("thread-1"),
+              turnId: TurnId.make("turn-1"),
+              checkpointTurnCount: 1,
+              checkpointRef: CheckpointRef.make("ref-1"),
+              status: "ready",
+              files: [],
+              assistantMessageId: MessageId.make("msg-3"),
+              completedAt: "2026-04-01T12:00:00.000Z",
+            },
+          },
+        );
 
-      expect(result.kind).toBe("updated");
-      if (result.kind === "updated") {
-        expect(result.thread.checkpoints).toHaveLength(1);
-        expect(result.thread.latestTurn?.turnId).toBe("turn-1");
-        expect(result.thread.latestTurn?.state).toBe("completed");
-      }
-    });
+        expect(result.kind).toBe("updated");
+        if (result.kind === "updated") {
+          expect(result.thread.checkpoints).toHaveLength(1);
+          expect(result.thread.latestTurn?.turnId).toBe("turn-1");
+          expect(result.thread.latestTurn?.state).toBe(previousState ?? "completed");
+        }
+      },
+    );
   });
 
   describe("thread.reverted", () => {

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -521,7 +521,10 @@ export function applyThreadDetailEvent(
         (thread.latestTurn === null || thread.latestTurn.turnId === event.payload.turnId)
           ? {
               turnId: event.payload.turnId,
-              state: checkpointStatusToTurnState(event.payload.status),
+              state:
+                thread.latestTurn?.state === "interrupted"
+                  ? "interrupted"
+                  : checkpointStatusToTurnState(event.payload.status),
               requestedAt: thread.latestTurn?.requestedAt ?? event.payload.completedAt,
               startedAt: thread.latestTurn?.startedAt ?? event.payload.completedAt,
               completedAt: event.payload.completedAt,


### PR DESCRIPTION
Codex can publish a diff update before it finishes editing files. T3 Code converted that update into a finished checkpoint, then skipped the real turn completion because a checkpoint already existed. Later edits appeared in the following turn instead.

Keep the placeholder until the turn ends and captures the final files. The capture keeps its turn count and assistant-message association. Interrupted turns still capture their edits when their start or active session matches; unrelated aborts do not create checkpoints. Server projections and the shared client reducer preserve an interrupted turn's outcome when its checkpoint becomes ready.

Fixes [#1434](https://github.com/pingdotgg/t3code/issues/1434). Earlier investigation and a different proposed fix are in [#1442](https://github.com/pingdotgg/t3code/pull/1442), which closed unmerged.

Verification repeated after rebasing onto [4d3907f63](https://github.com/pingdotgg/t3code/commit/4d3907f63d71644e1918d76cd104b036535a1173), fetched September 4, 2026, Pacific time:

- The new regression fails against the unchanged baseline implementation: expected `early.ts` and `late.ts`, received only `early.ts`.
- With this fix, both completed and interrupted turns capture both files, and a no-edit follow-up has an empty diff. A separate control checks that an unrelated abort creates no checkpoint.
- The review regression reproduced an interrupted turn becoming completed in the command projector, SQL-backed checkpoint reactor, and client reducer. All three now preserve the interrupted outcome while keeping the real checkpoint ready.
- A subsequent review reproduced a missing placeholder being mistaken for an interruption. The command projector now matches the existing SQL/client checkpoint fallback instead of inventing an interrupted outcome from a missing Git ref. Null/ready session cases and real interrupted/stopped session controls cover the distinction.
- `vp test run apps/server/src/orchestration/Layers/CheckpointReactor.test.ts apps/server/src/orchestration/projector.test.ts apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts packages/client-runtime/src/state/threadReducer.test.ts --maxWorkers=2`: 103 tests pass, including the newly merged nested-workspace capture/revert control.
- Targeted lint and server/client-runtime typechecks pass.

The regression uses a real Git repository and the checkpoint reactor, with typed completion receipts and worker drains. No UI layout changes; the before/after proof is the filesystem-backed regression.

Human approval required before merging. The cumulative change now includes turn-lifecycle preservation across server and client projections. The existing newer-active-turn guard remains: if a new turn starts before the old abort is processed, the reactor skips the old snapshot rather than capture newer edits under the interrupted turn. Stop followed immediately by another message still needs a lifecycle-ordering decision. This PR does not claim to solve that boundary or the unrelated cross-thread restore behavior in [#5512](https://github.com/pingdotgg/t3code/issues/5512).

GPT 6 Astra via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes turn checkpoint timing and turn-state projection across server reactor, SQL projections, and client reducer—core orchestration behavior with filesystem/git side effects.
> 
> **Overview**
> Fixes **mid-turn Codex diff updates** being treated as the final checkpoint, which skipped real capture at turn end and stranded later file edits on the next turn.
> 
> **Checkpoint reactor** now captures git checkpoints only when a turn **completes or aborts** (not when a `missing` placeholder arrives from `thread.turn-diff-completed`). It **reuses** the placeholder’s turn count and assistant message id, ignores aborts that never started or weren’t the active session, and no longer listens for turn-diff domain events for capture.
> 
> **Projections** (SQL pipeline, command projector, client `threadReducer`) **keep an interrupted turn outcome** when the real checkpoint becomes `ready`, and stop treating checkpoint status `missing` as interruption—matching the prior SQL/client behavior so placeholders don’t flip turns to interrupted.
> 
> Regression tests cover mid-turn diff → terminal complete/abort, untracked aborts, and turn-state preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7d4da3f75b0682f6b7fb0df6ef6bc513142e6dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Capture turn checkpoints on terminal events instead of `thread.turn-diff-completed`
> - The `CheckpointReactor` now defers checkpoint capture to the terminal provider runtime event (`turn.completed` or eligible `turn.aborted`), so the checkpoint reflects the final filesystem state after all edits finish.
> - Removes the `captureCheckpointFromPlaceholder` handler and stops the reactor worker from enqueueing `thread.turn-diff-completed` events as capture inputs.
> - Aborted turns that are neither reactor-tracked nor the active session turn are ignored; eligible aborted turns produce a `ready` checkpoint and carry over any existing placeholder assistant message ID.
> - The orchestration projector (`projector.ts`), SQL projection pipeline (`ProjectionPipeline.ts`), and client `threadReducer` all preserve an existing `interrupted` turn state when a later checkpoint event updates that turn; a `missing` checkpoint status no longer maps to `interrupted`.
> - Behavioral Change: `thread.turn-diff-completed` events no longer trigger checkpoint capture in `CheckpointReactor.ts`; any code expecting a mid-turn checkpoint from that event path must rely on the terminal event instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7d4da3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->