### PR TITLE
fix(ssh): exec managed servers without npm wrappers

### DIFF
--- a/packages/ssh/src/runnerProcess.test.ts
+++ b/packages/ssh/src/runnerProcess.test.ts
@@ -1,0 +1,167 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import * as NodeNet from "node:net";
+
+import { buildRemoteT3RunnerScript } from "./tunnel.ts";
+
+const Started = Schema.Struct({
+  pid: Schema.Number,
+  port: Schema.Number,
+  args: Schema.Array(Schema.String),
+});
+const decodeStarted = Schema.decodeUnknownSync(Schema.fromJsonString(Started));
+
+describe.skipIf(HostProcessPlatform.defaultValue() === "win32")(
+  "remote runner process ownership",
+  () => {
+    it.live.each(["npx", "npm"] as const)(
+      "keeps the server PID and graceful shutdown through the %s fallback",
+      (packageManager) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+          const fixture = yield* fs.makeTempDirectoryScoped({ prefix: "t3-runner-" });
+          const bin = path.join(fixture, "bin");
+          const cliPath = path.join(fixture, "installed cli.mjs");
+          const callsPath = path.join(fixture, "package-manager-calls.jsonl");
+          const packageSpec = "t3@0.0.35";
+          yield* fs.makeDirectory(bin);
+          yield* fs.symlink(process.execPath, path.join(bin, "node"));
+          yield* fs.writeFileString(
+            cliPath,
+            `#!/usr/bin/env node
+import * as net from "node:net";
+const server = net.createServer((socket) => {
+  socket.end();
+  server.close();
+});
+process.on("SIGTERM", () => server.close(() => {
+  process.stdout.write("graceful shutdown\\n");
+}));
+server.listen(Number(process.env.T3_TEST_PORT ?? 0), "127.0.0.1", () => {
+  process.stdout.write(JSON.stringify({
+    pid: process.pid,
+    port: server.address().port,
+    args: process.argv.slice(2),
+  }) + "\\n");
+});
+`,
+          );
+          yield* fs.chmod(cliPath, 0o700);
+          yield* fs.writeFileString(
+            path.join(bin, packageManager),
+            `#!/usr/bin/env node
+const fs = require("node:fs");
+const childProcess = require("node:child_process");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.T3_TEST_CALLS, JSON.stringify(args) + "\\n");
+if (args.includes("--package")) {
+  process.stdout.write(process.env.T3_TEST_CLI + "\\n");
+} else {
+  const child = childProcess.spawn(process.execPath, [process.env.T3_TEST_CLI, ...args], { stdio: "inherit" });
+  child.once("exit", (code) => { process.exitCode = code ?? 1; });
+}
+`,
+          );
+          yield* fs.chmod(path.join(bin, packageManager), 0o700);
+
+          const runServer = (port = 0) =>
+            Effect.gen(function* () {
+              const child = yield* spawner.spawn(
+                ChildProcess.make("/bin/sh", ["-s", "--", "serve", "a path with spaces"], {
+                  cwd: fixture,
+                  env: {
+                    PATH: bin,
+                    T3_TEST_CLI: cliPath,
+                    T3_TEST_CALLS: callsPath,
+                    T3_TEST_PORT: String(port),
+                  },
+                  detached: false,
+                  stdin: Stream.make(
+                    new TextEncoder().encode(buildRemoteT3RunnerScript({ packageSpec })),
+                  ),
+                }),
+              );
+              const ready = yield* Deferred.make<typeof Started.Type>();
+              const stdout: string[] = [];
+              const output = yield* child.stdout.pipe(
+                Stream.decodeText(),
+                Stream.splitLines,
+                Stream.runForEach((line) =>
+                  Effect.gen(function* () {
+                    stdout.push(line);
+                    if (stdout.length === 1) {
+                      yield* Deferred.succeed(ready, decodeStarted(line));
+                    }
+                  }),
+                ),
+                Effect.forkScoped,
+              );
+              const stderr = yield* child.stderr.pipe(
+                Stream.decodeText(),
+                Stream.mkString,
+                Effect.forkScoped,
+              );
+              const receipt = yield* Effect.raceFirst(
+                Deferred.await(ready),
+                Fiber.join(output).pipe(
+                  Effect.flatMap(() => Fiber.join(stderr)),
+                  Effect.flatMap((message) =>
+                    Effect.die(new Error(`Runner exited before listening: ${message}`)),
+                  ),
+                ),
+              );
+              // A failed PID assertion must still close the owned fixture server, including an npm child.
+              yield* Effect.addFinalizer(() =>
+                Effect.gen(function* () {
+                  if (yield* child.isRunning) {
+                    yield* Effect.callback<void>((resume) => {
+                      const connection = NodeNet.connect(receipt.port, "127.0.0.1");
+                      connection.on("error", () => undefined);
+                      connection.once("close", () => resume(Effect.void));
+                      return Effect.sync(() => connection.destroy());
+                    });
+                    yield* child.exitCode;
+                  }
+                }).pipe(Effect.orDie),
+              );
+              assert.equal(receipt.pid, child.pid);
+              assert.deepEqual(receipt.args, ["serve", "a path with spaces"]);
+              yield* child.kill({ killSignal: "SIGTERM" });
+              assert.equal(yield* child.exitCode, 0);
+              yield* Fiber.join(output);
+              assert.include(stdout, "graceful shutdown");
+              return receipt.port;
+            }).pipe(Effect.scoped);
+
+          const port = yield* runServer();
+          assert.equal(yield* runServer(port), port);
+          const calls = (yield* fs.readFileString(callsPath))
+            .trim()
+            .split("\n")
+            .map((line) => JSON.parse(line));
+          const expectedCall = [
+            ...(packageManager === "npm" ? ["exec"] : []),
+            "--yes",
+            "--package",
+            packageSpec,
+            "--",
+            "sh",
+            "-c",
+            "command -v t3",
+          ];
+          assert.deepEqual(calls, [expectedCall, expectedCall]);
+        }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+    );
+  },
+);

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -105,8 +105,7 @@ describe("ssh tunnel scripts", () => {
 
     assert.include(script, "T3_NODE_SCRIPT_PATH=''");
     assert.include(script, 'exec t3 "$@"');
-    assert.include(script, "exec npx --yes 't3@latest' \"$@\"");
-    assert.include(script, "exec npm exec --yes 't3@latest' -- \"$@\"");
+    assert.include(script, 'exec "$T3_CLI_PATH" "$@"');
     assert.include(script, "could not install 't3@latest'");
     assert.include(script, "require_installed_t3_cli npx --yes --package 't3@latest'");
     assert.include(script, "require_installed_t3_cli npm exec --yes --package 't3@latest'");
@@ -141,8 +140,6 @@ describe("ssh tunnel scripts", () => {
       packageSpec: "t3@nightly; touch /tmp/t3-owned",
     });
 
-    assert.include(script, "exec npx --yes 't3@nightly; touch /tmp/t3-owned' \"$@\"");
-    assert.include(script, "exec npm exec --yes 't3@nightly; touch /tmp/t3-owned' -- \"$@\"");
     assert.include(
       script,
       "require_installed_t3_cli npx --yes --package 't3@nightly; touch /tmp/t3-owned'",

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -440,13 +440,14 @@ require_installed_t3_cli() {
   printf 'Remote host installed %s but npm produced no t3 executable, which usually means a native dependency (node-pty) failed to build. Install a C toolchain on the remote host (Debian/Ubuntu: build-essential, Fedora/RHEL: gcc-c++ make, macOS: xcode-select --install) and try again.\\n' @@T3_PACKAGE_SPEC@@ >&2
   return 1
 }
+# The launcher records this PID, so exec the CLI without an npm wrapper process.
 if command -v npx >/dev/null 2>&1; then
   require_installed_t3_cli npx --yes --package @@T3_PACKAGE_SPEC@@ || exit 1
-  exec npx --yes @@T3_PACKAGE_SPEC@@ "$@"
+  exec "$T3_CLI_PATH" "$@"
 fi
 if command -v npm >/dev/null 2>&1; then
   require_installed_t3_cli npm exec --yes --package @@T3_PACKAGE_SPEC@@ || exit 1
-  exec npm exec --yes @@T3_PACKAGE_SPEC@@ -- "$@"
+  exec "$T3_CLI_PATH" "$@"
 fi
 printf 'Remote host is missing the t3 CLI and could not install @@T3_PACKAGE_SPEC@@ because node/npm/npx are unavailable on PATH. Install Node or configure a supported version manager for non-interactive shells.\\n' >&2
 exit 1


### PR DESCRIPTION
SSH-managed servers started through npx/npm can outlive Disconnect or app shutdown. The launcher records the npm wrapper's PID, so its stop script signals npm while the actual server keeps its listener and database open.

Exec the CLI path already resolved by the install preflight. This keeps the launcher's PID attached to the server without changing package selection, install-error handling, Node discovery, WSL routing, or external-server ownership.

Closes #2614.

## Verification

Reproduced on main [087cfb8a](https://github.com/pingdotgg/t3code/commit/087cfb8ae262f344f7e409f5a8c0eda6f0ef12f9) using the generated launch/stop scripts, actual npm/npx, and an offline local fixture package. Only the fixture's state path was substituted. No production data, remote machines, or provider processes were used.

| Generated launch/stop result | Before | After |
| --- | --- | --- |
| Recorded PID | 270404 | 291786 |
| Server PID | 270440 | 291786 |
| Stop reports success | Yes | Yes |
| Server still answers after stop | Yes | No |

The new regression runs the real POSIX runner with controlled npm/npx executables and a real Node listener. Both cases fail on the original runner with a PID mismatch. With this change, both preserve arguments and pinned package selection, receive SIGTERM, shut down gracefully, and restart on the same port.

- `vp test run packages/ssh/src/runnerProcess.test.ts packages/ssh/src/tunnel.test.ts --maxWorkers=2`: 15 passed.
- Scoped SSH typecheck and lint for the three changed files passed.
- `git diff --check` passed.

This is Linux process evidence, not a Windows desktop or macOS end-to-end run. The POSIX test skips native Windows. Existing orphaned processes are not retroactively removed. Screenshots do not apply to this process-lifecycle change.

GPT 6 Astra via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote process lifecycle and shutdown for SSH-managed servers; behavior is well-covered by new integration tests but affects production disconnect/stop paths on Linux/macOS remotes.
> 
> **Overview**
> Fixes SSH-managed remote servers **orphaning** after disconnect or shutdown: the launch script stored the **npm/npx wrapper PID**, so stop only killed the wrapper while the real `t3 serve` process kept listening.
> 
> After the existing `require_installed_t3_cli` preflight, the remote runner now **`exec`s the resolved `T3_CLI_PATH`** instead of re-invoking `npx`/`npm exec`, so the recorded PID is the server process. Install checks, package pinning, and error messages are unchanged.
> 
> Adds **`runnerProcess.test.ts`**, a POSIX live test (skipped on Windows) that feeds the generated script through fake `npx`/`npm` and asserts PID match, argument forwarding, SIGTERM graceful shutdown, and port reuse. **`tunnel.test.ts`** expectations were updated for the new `exec "$T3_CLI_PATH"` lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af2b6be644801b8d878b92df8381c9dbe74b79cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `buildRemoteT3RunnerScript` to exec resolved `T3_CLI_PATH` instead of npm wrappers
> - The npx and npm fallback branches in the generated remote shell script now `exec` the resolved `T3_CLI_PATH` rather than invoking the package manager with the package spec as the final process.
> - Package managers are still used by `require_installed_t3_cli` to locate the `t3` executable; only the final launch step changes.
> - Because the launcher replaces itself with the CLI process, the PID it records is the CLI server's PID and signals (e.g. SIGTERM) are delivered directly to that process.
> - Updates tunnel script generation tests to assert execution through `T3_CLI_PATH` and adds a live test suite verifying PID preservation, argument forwarding, and graceful shutdown for both npx and npm fallback paths.
> - Behavioral Change: generated remote runner scripts that previously ended with `npx`/`npm` invocation now end with `exec` of the resolved CLI path; out-of-tree consumers of the generated script will see a different final command.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized af2b6be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->