### PR TITLE
fix(source-control): allow clones to finish without a deadline

### DIFF
--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -2,10 +2,15 @@ import * as NodePath from "@effect/platform-node/NodePath";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Deferred from "effect/Deferred";
 import * as FileSystem from "effect/FileSystem";
+import * as Fiber from "effect/Fiber";
 import * as Path from "effect/Path";
 import * as Layer from "effect/Layer";
 import * as PlatformError from "effect/PlatformError";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 import { GitCommandError, SourceControlProviderError } from "@t3tools/contracts";
@@ -195,6 +200,59 @@ it.effect("clones a looked-up repository into the requested destination", () =>
       ),
     );
   }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.effect("allows a clone to finish after more than two minutes", () =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const parent = yield* fs.makeTempDirectoryScoped();
+    const path = yield* Path.Path;
+    const destinationPath = path.join(parent, "t3code");
+    const started = yield* Deferred.make<void>();
+    const git = yield* GitVcsDriver.make.pipe(
+      Effect.provideService(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() =>
+          Effect.succeed(
+            ChildProcessSpawner.makeHandle({
+              pid: ChildProcessSpawner.ProcessId(1),
+              exitCode: Deferred.succeed(started, undefined).pipe(
+                Effect.andThen(Effect.sleep("3 minutes")),
+                Effect.as(ChildProcessSpawner.ExitCode(0)),
+              ),
+              isRunning: Effect.succeed(true),
+              kill: () => Effect.void,
+              unref: Effect.succeed(Effect.void),
+              stdin: Sink.drain,
+              stdout: Stream.empty,
+              stderr: Stream.empty,
+              all: Stream.empty,
+              getInputFd: () => Sink.drain,
+              getOutputFd: () => Stream.empty,
+            }),
+          ),
+        ),
+      ),
+    );
+    const clone = yield* Effect.gen(function* () {
+      const service = yield* SourceControlRepositoryService.SourceControlRepositoryService;
+      return yield* service.cloneRepository({ remoteUrl: CLONE_URLS.sshUrl, destinationPath });
+    }).pipe(Effect.provide(makeLayer({ git })), Effect.forkChild);
+
+    yield* Deferred.await(started);
+    yield* TestClock.adjust("3 minutes");
+    assert.deepStrictEqual(yield* Fiber.join(clone), {
+      cwd: destinationPath,
+      remoteUrl: CLONE_URLS.sshUrl,
+      repository: null,
+    });
+  }).pipe(
+    Effect.provide(
+      ServerConfig.layerTest(process.cwd(), { prefix: "t3-clone-timeout-" }).pipe(
+        Layer.provideMerge(NodeServices.layer),
+      ),
+    ),
+  ),
 );
 
 it.effect("preserves destination probe failures instead of treating them as missing paths", () => {

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -197,7 +197,7 @@ export const make = Effect.gen(function* () {
       operation: "SourceControlRepositoryService.cloneRepository",
       cwd: preparedDestination.parentPath,
       args: ["clone", remoteUrl, preparedDestination.directoryName],
-      timeoutMs: 120_000,
+      timeoutMs: null,
       maxOutputBytes: 256 * 1024,
     });
 


### PR DESCRIPTION
Cloning a large repository or using a slow connection fails after two minutes because the server kills Git at a fixed deadline.

Set the clone timeout to `null`, matching the existing push behavior. This is one production-line change in the shared service used by web, desktop, and mobile.

Reproduced before the fix with the real Git driver and a simulated three-minute process: `Git command timed out.`, wrapped in the reported generic repository error. The same virtual-clock regression now passes. All 8 repository-service tests, server typecheck, targeted lint, and formatting pass. No network download or browser verification is claimed.

Fixes #9780.

Created with GPT-6 in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shared clone path for web, desktop, and mobile no longer enforces a server deadline, so stuck clones can run indefinitely until killed elsewhere, though behavior is intentional and output limits remain.
> 
> **Overview**
> **Removes the fixed two-minute kill on server-side `git clone`**, so large repos or slow networks are no longer aborted with a timeout error.
> 
> `SourceControlRepositoryService.cloneRepository` now passes `timeoutMs: null` to the Git driver instead of `120_000`, aligning clone with other long-running Git work (e.g. push). Output is still capped at 256 KiB.
> 
> A new effect test simulates a clone that exits after three minutes using `TestClock` and a mocked child process, asserting the operation completes successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63bb6f36e52ed5d8a20df5c51db27f8045f85837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove 120-second timeout from `cloneRepository` Git command
> The Git clone process previously had a fixed 120-second execution deadline, which could abort large or slow clones before they finished. `cloneRepository` now runs with no configured timeout, so the command continues until it completes or fails on its own. A new test uses a fake Git process with a simulated three-minute runtime to verify the clone still succeeds past the old limit.
> - Risk: removing the timeout means a hung clone process can run indefinitely; any caller relying on the 120s deadline will now block until the process exits or fails.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63bb6f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->