### PR TITLE
fix(web): keep worktree origin preference visible

### DIFF
--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -2601,37 +2601,35 @@ export function GeneralSettingsPanel() {
           }
         />
 
-        {settings.defaultThreadEnvMode === "worktree" ? (
-          <SettingsRow
-            serverScoped
-            className="bg-muted/20 sm:pl-9"
-            title={searchableSetting("start-from-origin").title}
-            description="Creates the worktree from the latest matching branch on origin instead of your local branch."
-            resetAction={
-              settings.newWorktreesStartFromOrigin !==
-              DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
-                <SettingResetButton
-                  label="new worktrees start from origin"
-                  onClick={() =>
-                    updateSettings({
-                      newWorktreesStartFromOrigin:
-                        DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
-                    })
-                  }
-                />
-              ) : null
-            }
-            control={
-              <Switch
-                checked={settings.newWorktreesStartFromOrigin}
-                onCheckedChange={(checked) =>
-                  updateSettings({ newWorktreesStartFromOrigin: Boolean(checked) })
+        <SettingsRow
+          serverScoped
+          className="bg-muted/20 sm:pl-9"
+          title={searchableSetting("start-from-origin").title}
+          description="Creates the worktree from the latest matching branch on origin instead of your local branch."
+          resetAction={
+            settings.newWorktreesStartFromOrigin !==
+            DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
+              <SettingResetButton
+                label="new worktrees start from origin"
+                onClick={() =>
+                  updateSettings({
+                    newWorktreesStartFromOrigin:
+                      DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+                  })
                 }
-                aria-label="Start new worktrees from origin by default"
               />
-            }
-          />
-        ) : null}
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.newWorktreesStartFromOrigin}
+              onCheckedChange={(checked) =>
+                updateSettings({ newWorktreesStartFromOrigin: Boolean(checked) })
+              }
+              aria-label="Start new worktrees from origin by default"
+            />
+          }
+        />
         <SettingsRow
           serverScoped
           {...searchableSetting("add-project-starts-in")}


### PR DESCRIPTION
`Start from origin` affects manually created worktrees even when new threads default to Local, but General settings hid the option in that mode.

Keep the existing row visible for both Local and New worktree. Only the visibility guard is removed. The stored value, default, reset action, server scope and worktree creation behavior are unchanged.

Fixes [#8876](https://github.com/pingdotgg/t3code/issues/8876). Carries forward [Lucenx9](https://github.com/Lucenx9)'s approach from the closed, unmerged [#9030](https://github.com/pingdotgg/t3code/pull/9030).

## Verification

The audit orchestrator reproduced the visibility bug in an actual browser on main [087cfb8a](https://github.com/pingdotgg/t3code/commit/087cfb8ae262f344f7e409f5a8c0eda6f0ef12f9). Local hides the active setting; New worktree reveals it checked; resetting New threads hides it again. I inspected both baseline screenshots. This settings file is unchanged on the current base [0dd5c64b](https://github.com/pingdotgg/t3code/commit/0dd5c64bcfac7974d81bac76740ecd83540077e8).

- Settings logic, settings search, and thread-action tests: 50 passed.
- Web package typecheck passed.
- Targeted lint passed with eight existing warnings outside the changed block.
- `git diff --check` passed.

Current-head CI and reviews passed. In the integrated browser, Local mode now keeps the control visible; switching it off survives reload, and Reset restores the original true default. No animation or timing behavior changes.

## Browser evidence

Before — Local mode hides the setting:

![Before: Local mode without the Start from origin setting](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/fef26edb58782929/8876-before-local.png)

After — Local mode shows the existing setting:

![After: Local mode with Start from origin visible](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/981d124ffd85d751/8876-after-local-visible-final.png)

GPT 6 Astra via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI visibility change in settings; no changes to stored values or worktree creation logic.
> 
> **Overview**
> **Start from origin** in General settings is no longer hidden when **New threads** defaults to Local.
> 
> The **Start new worktrees from origin** row under Projects & threads is always shown. The conditional that only rendered it when `defaultThreadEnvMode === "worktree"` is removed. The switch, copy, reset control, and `newWorktreesStartFromOrigin` persistence are unchanged—users can see and edit the preference that still applies to manually created worktrees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 952363a3780bcb3935163496ec4597bdc141a08f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Always show 'start from origin' worktree setting in `GeneralSettingsPanel`
> Removes the condition in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/9846/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) that hid the "start new worktrees from origin by default" control unless the default thread environment mode was worktree. The row, reset action, and switch now render unconditionally. Setting value and update behavior are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 952363a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->