### PR TITLE
fix(web): reload saved colors when reopening the theme editor

### DIFF
--- a/apps/web/src/components/settings/ThemeEditorHost.test.tsx
+++ b/apps/web/src/components/settings/ThemeEditorHost.test.tsx
@@ -1,0 +1,191 @@
+import type { ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { reactHookHarness as hooks } from "../../test/reactHookHarness";
+import {
+  getThemeDefinition,
+  installCustomTheme,
+  invalidateCustomThemes,
+  parseThemeFile,
+  removeCustomTheme,
+  THEME_FILE_VERSION,
+  themeColorToHex,
+  updateCustomTheme,
+  type ThemeDefinition,
+} from "../../themePalette";
+import type { ThemeEditorSession } from "./themeEditorStore";
+
+const state = vi.hoisted(() => ({
+  session: null as ThemeEditorSession | null,
+  closeThemeEditor: vi.fn(),
+  onStoreChange: vi.fn(),
+  subscriptions: new Set<() => void>(),
+  theme: {
+    theme: "system",
+    themeHalves: null,
+    setTheme: vi.fn(),
+    refreshTheme: vi.fn(),
+  },
+}));
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  const { reactHookHarness } = await import("../../test/reactHookHarness");
+  return {
+    ...actual,
+    useCallback: reactHookHarness.useCallback,
+    useSyncExternalStore: (
+      subscribe: (listener: () => void) => () => void,
+      getSnapshot: () => unknown,
+    ) => {
+      const subscription = reactHookHarness.useRef<(() => void) | null>(null);
+      if (!subscription.current) {
+        subscription.current = subscribe(() => state.onStoreChange());
+        state.subscriptions.add(subscription.current);
+      }
+      return getSnapshot();
+    },
+  };
+});
+
+vi.mock("react/compiler-runtime", async () => {
+  const { reactHookHarness } = await import("../../test/reactHookHarness");
+  return { c: reactHookHarness.useMemoCache };
+});
+
+vi.mock("../../hooks/useTheme", () => ({ useTheme: () => state.theme }));
+vi.mock("./themeEditorStore", () => ({
+  useThemeEditorStore: (select: (store: typeof state) => unknown) => select(state),
+}));
+vi.mock("../ui/toast", () => ({
+  toastManager: { add: vi.fn() },
+  stackedThreadToast: (value: unknown) => value,
+}));
+
+import { ThemeEditorHost } from "./ThemeEditorHost";
+
+function renderEditor() {
+  hooks.beginRender();
+  const host = ThemeEditorHost() as ReactElement<{
+    children: ReactElement<{
+      editingTheme: ThemeDefinition | null;
+      seedTheme: ThemeDefinition | null;
+    }>;
+  }> | null;
+  return host?.props.children.props ?? null;
+}
+
+describe("ThemeEditorHost", () => {
+  beforeEach(() => {
+    hooks.reset();
+    state.session = null;
+    state.onStoreChange.mockReset();
+    const storage = new Map<string, string>();
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    invalidateCustomThemes();
+  });
+
+  afterEach(() => {
+    for (const unsubscribe of state.subscriptions) unsubscribe();
+    state.subscriptions.clear();
+    vi.unstubAllGlobals();
+    invalidateCustomThemes();
+  });
+
+  it.each(["editingTheme", "seedTheme"] as const)(
+    "reopens the same %s with its saved colors",
+    (field) => {
+      const theme = installCustomTheme(
+        parseThemeFile({
+          version: THEME_FILE_VERSION,
+          id: "saved-colors",
+          name: "Saved colors",
+          appearance: "dark",
+          colors: { accent: "#1f6e4a" },
+        }),
+      );
+      const session = {
+        id: 1,
+        editingThemeId: field === "editingTheme" ? theme.id : null,
+        seedThemeId: field === "seedTheme" ? theme.id : null,
+        seedName: null,
+        initialAppearance: "dark" as const,
+      };
+      state.session = session;
+      expect(themeColorToHex(renderEditor()?.[field]?.colors.accent ?? "")).toBe("#1f6e4a");
+
+      updateCustomTheme({ ...theme, colors: { ...theme.colors, accent: "#7241b8" } });
+      expect(themeColorToHex(getThemeDefinition(theme.id)?.colors.accent ?? "")).toBe("#7241b8");
+      state.session = null;
+      expect(renderEditor()).toBeNull();
+      state.session = { ...session, id: 2 };
+
+      expect(themeColorToHex(renderEditor()?.[field]?.colors.accent ?? "")).toBe("#7241b8");
+    },
+  );
+
+  it.each(["editingTheme", "seedTheme"] as const)(
+    "refreshes an open %s when the library changes",
+    (field) => {
+      const theme = installCustomTheme(
+        parseThemeFile({
+          version: THEME_FILE_VERSION,
+          id: "updated-theme",
+          name: "Updated theme",
+          appearance: "dark",
+          colors: { accent: "#1f6e4a" },
+        }),
+      );
+      state.session = {
+        id: 1,
+        editingThemeId: field === "editingTheme" ? theme.id : null,
+        seedThemeId: field === "seedTheme" ? theme.id : null,
+        seedName: null,
+        initialAppearance: "dark",
+      };
+      let editor = renderEditor();
+      state.onStoreChange.mockImplementation(() => {
+        editor = renderEditor();
+      });
+
+      updateCustomTheme({ ...theme, colors: { ...theme.colors, accent: "#7241b8" } });
+
+      expect(themeColorToHex(editor?.[field]?.colors.accent ?? "")).toBe("#7241b8");
+    },
+  );
+
+  it("does not keep editing a theme removed from the library", () => {
+    const theme = installCustomTheme(
+      parseThemeFile({
+        version: THEME_FILE_VERSION,
+        id: "removed-theme",
+        name: "Removed theme",
+        appearance: "dark",
+        colors: { accent: "#1f6e4a" },
+      }),
+    );
+    state.session = {
+      id: 1,
+      editingThemeId: theme.id,
+      seedThemeId: null,
+      seedName: null,
+      initialAppearance: "dark",
+    };
+    let editor = renderEditor();
+    expect(editor?.editingTheme?.id).toBe(theme.id);
+    state.onStoreChange.mockImplementation(() => {
+      editor = renderEditor();
+    });
+
+    removeCustomTheme(theme.id);
+
+    expect(editor?.editingTheme).toBeNull();
+  });
+});

--- a/apps/web/src/components/settings/ThemeEditorHost.tsx
+++ b/apps/web/src/components/settings/ThemeEditorHost.tsx
@@ -1,7 +1,12 @@
-import { lazy, Suspense, useCallback } from "react";
+import { lazy, Suspense, useCallback, useSyncExternalStore } from "react";
 
 import { useTheme } from "../../hooks/useTheme";
-import { getThemeDefinition, type ThemeAppearance, type ThemeDefinition } from "../../themePalette";
+import {
+  getThemeDefinition,
+  subscribeToCustomThemes,
+  type ThemeAppearance,
+  type ThemeDefinition,
+} from "../../themePalette";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import { useThemeEditorStore } from "./themeEditorStore";
 
@@ -12,6 +17,14 @@ const ThemeEditorPanel = lazy(() =>
   import("./ThemeEditorPanel").then((module) => ({ default: module.ThemeEditorPanel })),
 );
 
+function useThemeDefinition(id: string | null | undefined) {
+  return useSyncExternalStore(
+    subscribeToCustomThemes,
+    () => (id ? (getThemeDefinition(id) ?? null) : null),
+    () => null,
+  );
+}
+
 /**
  * Renders the theme editor above the router. The editor paints its draft on
  * the live app, so it has to outlive the settings route: the point is to walk
@@ -21,6 +34,9 @@ export function ThemeEditorHost() {
   const session = useThemeEditorStore((store) => store.session);
   const closeThemeEditor = useThemeEditorStore((store) => store.closeThemeEditor);
   const { theme, setTheme, themeHalves, refreshTheme } = useTheme();
+  // A saved definition can change without its id changing between sessions.
+  const editingTheme = useThemeDefinition(session?.editingThemeId);
+  const seedTheme = useThemeDefinition(session?.seedThemeId);
 
   // The panel reports which path it actually took: a theme removed while its
   // editor is open resolves to null there, so the save becomes a create even
@@ -94,13 +110,6 @@ export function ThemeEditorHost() {
   );
 
   if (!session) return null;
-
-  // Resolve on every render: an edit or import can change the stored
-  // definitions while a session is open.
-  const editingTheme = session.editingThemeId
-    ? (getThemeDefinition(session.editingThemeId) ?? null)
-    : null;
-  const seedTheme = session.seedThemeId ? (getThemeDefinition(session.seedThemeId) ?? null) : null;
 
   return (
     <Suspense fallback={null}>


### PR DESCRIPTION
Editing a custom theme saved its new colors, but reopening the editor could load the original palette. The React Compiler cached the theme lookup by its unchanged ID.

Read edited and seed themes through the existing theme-library subscription so saves, imports, and removals refresh the editor's source data. No palette design or storage format changes.

Fixes [#8185](https://github.com/pingdotgg/t3code/issues/8185).

Validation: 41 focused tests, web typecheck, and targeted lint pass. The compiled current-main editor fails all three save/reopen/removal regressions; the corrected compiled editor passes all three. The permanent reactive tests also fail against the original source and pass with this change.

Integrated web verification passed with this production patch applied to main [4f1092c](https://github.com/pingdotgg/t3code/commit/4f1092cec2ebaa6ed0e49821238dfe6f1add362d): create a green theme (`#1f6e4a`), edit its accent to purple (`#7241b8`), save, and reopen. Purple survives a browser reload, and Duplicate starts with the updated palette.

### Before

After saving purple, reopening the editor restores the old green value.

![Before: reopened theme editor incorrectly shows the original green accent](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/66e674d77f681642/8185-after-save-reverted-green.png)

[Before recording: saved purple reopens as green](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d776fe66b7a02886/8185-before-short.mp4)

### After

Reopening the editor retains the saved purple value.

![After: reopened theme editor retains the saved purple accent](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/09a51b055aca55a7/8185-after-fixed-purple.png)

[After recording: saved purple remains purple on reopening](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/ee35d8f2be2ce36d/8185-after-short.mp4)

GPT 6 Astra via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ThemeEditorHost` to reload saved colors via `useSyncExternalStore` subscription
> - Adds `useThemeDefinition` hook in [ThemeEditorHost.tsx](https://github.com/pingdotgg/t3code/pull/9847/files#diff-bd01345d750f11440089beb858a464e5f96c2898c0ed249069705111bfd01943) that subscribes to custom-theme changes with `useSyncExternalStore` and resolves the referenced theme id to its current `ThemeDefinition`, or null when absent.
> - Replaces the previous direct per-render `getThemeDefinition` lookups in `ThemeEditorHost` so the open `ThemeEditorPanel` receives updated definitions when a custom theme is changed or removed.
> - Adds test coverage in [ThemeEditorHost.test.tsx](https://github.com/pingdotgg/t3code/pull/9847/files#diff-0c7f8cd8981887e44e8110f6e7f4dd9ddeb85b6c1ab20158c31a3fc12ccaacfa) for reopening the editor with updated colors, refreshing an open editor on subscription callbacks, and stopping edits when the referenced theme is removed.
> - Risk: removed themes now resolve to `null` instead of keeping the stale definition; verify `ThemeEditorPanel` handles a null `editingTheme`/`seedTheme` gracefully.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97b540c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized settings UI change reusing an established theme-library subscription pattern; main behavioral shift is null definitions after removal instead of stale objects.
> 
> **Overview**
> Fixes a bug where **reopening the theme editor** could show the old palette after a save, because per-render `getThemeDefinition` lookups were effectively stale under the React Compiler when the theme **id** did not change.
> 
> **`ThemeEditorHost`** now resolves `editingTheme` and `seedTheme` through a new **`useThemeDefinition`** hook that uses **`useSyncExternalStore`** with the existing **`subscribeToCustomThemes`** subscription, so library updates (save, import, remove) refresh what the panel receives without changing storage or palette APIs.
> 
> Adds **`ThemeEditorHost.test.tsx`** covering reopen with updated colors for both editing and seed themes, live refresh while the editor is open, and clearing **`editingTheme`** when the theme is removed from the library.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97b540cade2a0535b4556e86194f4fc0657fd738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->