### PR TITLE
fix(server): preserve native provider executable paths during updates

### DIFF
--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -1,6 +1,7 @@
 // @effect-diagnostics nodeBuiltinImport:off
 import { expect, it } from "@effect/vitest";
 import * as NodeFS from "node:fs";
+import * as NodeChildProcess from "node:child_process";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
@@ -8,6 +9,7 @@ import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import { HttpClient } from "effect/unstable/http";
 import {
   createProviderVersionAdvisory,
@@ -362,9 +364,9 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           provider: driver("nativePackageTool"),
           packageName: "@example/native-package-tool",
           update: {
-            command: "native-package-tool update",
+            command: `${nativePackageToolPath} update`,
 
-            executable: "native-package-tool",
+            executable: nativePackageToolPath,
 
             args: ["update"],
 
@@ -399,9 +401,9 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           provider: driver("scopedPackageTool"),
           packageName: "@example/scoped-package-tool",
           update: {
-            command: "scoped-package-tool upgrade",
+            command: `${scopedPackageToolPath} upgrade`,
 
-            executable: "scoped-package-tool",
+            executable: scopedPackageToolPath,
 
             args: ["upgrade"],
 
@@ -410,6 +412,50 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
         });
       }),
   );
+
+  it.effect.skipIf(windowsHost)("runs an explicit native updater outside PATH", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-native-update-" });
+      const nativeBinDir = NodePath.join(tempDir, "with spaces", ".scoped-package-tool", "bin");
+      yield* fs.makeDirectory(nativeBinDir, { recursive: true });
+      const binaryPath = NodePath.join(nativeBinDir, "scoped-package-tool");
+      yield* fs.writeFileString(binaryPath, "#!/bin/sh\nprintf '%s' \"$1\"\n");
+      yield* fs.chmod(binaryPath, 0o755);
+
+      const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
+        scopedPackageToolUpdate,
+        { binaryPath, env: { PATH: "" } },
+      );
+      const update = capabilities.update;
+      expect(update).not.toBeNull();
+      if (!update) return;
+      const result = NodeChildProcess.spawnSync(update.executable, update.args, {
+        env: { PATH: "" },
+        encoding: "utf8",
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("upgrade");
+    }).pipe(Effect.scoped),
+  );
+
+  it.each([
+    "/Users/example/.local/bin/native-package-tool",
+    "C:\\Users\\Example User\\.local\\bin\\native-package-tool.exe",
+  ])("preserves a configured native executable path: %s", (binaryPath) => {
+    expect(nativePackageToolUpdate.resolve({ binaryPath }).update?.executable).toBe(binaryPath);
+  });
+
+  it("uses the resolved launcher when its symlink target identifies a native install", () => {
+    const launcher = "/custom tools/native-launcher";
+    const capabilities = nativePackageToolUpdate.resolve({
+      binaryPath: launcher,
+      resolvedCommandPath: launcher,
+      realCommandPath: "/Users/example/.local/bin/native-package-tool",
+    });
+    expect(capabilities.update?.executable).toBe(launcher);
+  });
 
   it("switches native-package-tool to Homebrew updates when the binary resolves through Homebrew", () => {
     expect(

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -209,6 +209,7 @@ function makeHomebrewProviderMaintenanceCapabilities(
 
 function makeNativeProviderMaintenanceCapabilities(
   definition: PackageManagedProviderMaintenanceDefinition,
+  commandPath: string,
 ): ProviderMaintenanceCapabilities | null {
   if (!definition.nativeUpdate) {
     return null;
@@ -217,7 +218,7 @@ function makeNativeProviderMaintenanceCapabilities(
   return makeProviderMaintenanceCapabilities({
     provider: definition.provider,
     packageName: definition.npmPackageName,
-    updateExecutable: definition.nativeUpdate.executable,
+    updateExecutable: commandPath,
     updateArgs: definition.nativeUpdate.args,
     updateLockKey: definition.nativeUpdate.lockKey,
   });
@@ -297,7 +298,7 @@ export function resolvePackageManagedProviderMaintenance(
       commandPaths.some((commandPath) => nativeUpdate.isCommandPath(commandPath))
     ) {
       return (
-        makeNativeProviderMaintenanceCapabilities(definition) ??
+        makeNativeProviderMaintenanceCapabilities(definition, resolvedCommandPath) ??
         makeNpmGlobalProviderMaintenanceCapabilities(definition)
       );
     }


### PR DESCRIPTION
Native provider updates discarded the resolved executable path and invoked a bare command name. A provider configured outside PATH could run normally but fail its one-click update with ENOENT.

Keep the resolved launcher path for native updates, including symlinked launchers. Installer detection, update arguments, and locking stay unchanged. This covers the native OpenCode and Claude paths; package-managed updates keep their existing commands.

Addresses the native OpenCode and Claude update-path failure in [#6115](https://github.com/pingdotgg/t3code/issues/6115). The report also mentions package-managed Codex and general shell discovery; those paths are not changed here, so the issue should remain open.

Validation against main [ed2bdbb](https://github.com/pingdotgg/t3code/commit/ed2bdbb278c4fedf6ce79d4925908b759f7fd992):

- Before: all four new regressions fail. A disposable fake updater at an absolute path with spaces fails with `spawnSync scoped-package-tool ENOENT` under an empty PATH.
- After: 33 maintenance/resolver tests pass, including the same executable fixture, Windows-style path preservation, and symlink-launcher selection. Server typecheck and targeted lint pass.
- No real provider installation or update was run. Windows path selection is covered by a pure fixture; the executable test ran on Linux.

This is only path preservation. Broader installer ownership and mise routing remain in [#9325](https://github.com/pingdotgg/t3code/pull/9325) and [#9225](https://github.com/pingdotgg/t3code/pull/9225).

GPT 6 Astra via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve resolved native provider executable paths during updates
> - Fixes native provider maintenance so updates execute through the resolved command path rather than the bare command name from the provider definition.
> - `makeNativeProviderMaintenanceCapabilities` now accepts a command-path parameter and uses it as the update executable. `resolvePackageManagedProviderMaintenance` passes the resolved path when it or its real target matches the native command-path predicate.
> - The real target path remains used for native-install identification; only the executable path changes.
> - Adds tests covering executables outside PATH, paths with spaces, Unix/Windows absolute paths, and symlink resolution where the launcher differs from the installation target.
> - Risk: native updaters previously invoked by bare command name now require the resolved path to exist on disk; if the resolved path becomes stale after an external relocation, updates will fail to launch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f608540.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->