### PR TITLE
fix: recover threads after worktree deletion

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -10,6 +10,7 @@ import {
   ProviderDriverKind,
   ProviderInstanceId,
   ProviderSetupError,
+  GitCommandError,
 } from "@t3tools/contracts";
 import { createModelSelection } from "@t3tools/shared/model";
 import {
@@ -186,6 +187,7 @@ describe("ProviderCommandReactor", () => {
     readonly startSessionEffect?: (
       session: ProviderSession,
     ) => Effect.Effect<ProviderSession, ProviderServiceError>;
+    readonly createWorktreeEffect?: GitWorkflowService.GitWorkflowService["Service"]["createWorktree"];
     readonly tryHandlePromptCommandEffect?: ProviderAuthService["Service"]["tryHandlePromptCommand"];
   }) {
     const now = "2026-01-01T00:00:00.000Z";
@@ -307,9 +309,17 @@ describe("ProviderCommandReactor", () => {
       }),
     );
     const pruneWorktrees = vi.fn((_: { readonly cwd: string }) => Effect.void);
-    const createWorktree = vi.fn(
-      (input: { readonly refName: string; readonly path: string | null }) =>
-        Effect.succeed({ worktree: { path: input.path ?? "", refName: input.refName } }),
+    const createWorktree = vi.fn<
+      GitWorkflowService.GitWorkflowService["Service"]["createWorktree"]
+    >(
+      (worktreeInput) =>
+        input?.createWorktreeEffect?.(worktreeInput) ??
+        Effect.succeed({
+          worktree: {
+            path: worktreeInput.path ?? "",
+            refName: worktreeInput.newRefName ?? worktreeInput.refName,
+          },
+        }),
     );
     const refreshStatus = vi.fn((_: string) =>
       Effect.succeed({
@@ -2293,6 +2303,103 @@ describe("ProviderCommandReactor", () => {
     expect(harness.createWorktree.mock.invocationCallOrder[0]).toBeLessThan(
       harness.startSession.mock.invocationCallOrder[0]!,
     );
+  });
+
+  it("stops turn start until a missing worktree is rebound", async () => {
+    const harness = await createHarness({
+      createWorktreeEffect: () =>
+        Effect.fail(
+          new GitCommandError({
+            operation: "GitVcsDriver.createWorktree",
+            command: "git worktree add",
+            cwd: "/tmp/provider-project",
+            detail: "invalid reference: feature/deleted",
+          }),
+        ),
+    });
+    const now = "2026-01-01T00:00:00.000Z";
+    const worktreePath = NodePath.join(harness.stateDir, "deleted-worktree");
+
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.make("cmd-thread-deleted-worktree"),
+        threadId: ThreadId.make("thread-1"),
+        branch: "feature/deleted",
+        worktreePath,
+      }),
+    );
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-deleted-worktree"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-deleted-worktree"),
+          role: "user",
+          text: "continue",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await harness.drain();
+    const thread = (await harness.readModel()).threads.find(
+      (entry) => entry.id === ThreadId.make("thread-1"),
+    );
+    const expectedDetail = `This thread's worktree no longer exists at ${worktreePath}, and T3 could not recreate branch 'feature/deleted'. Restore that worktree or select another branch for this thread, then retry.`;
+    expect(thread?.session).toMatchObject({
+      status: "error",
+      activeTurnId: null,
+      lastError: expectedDetail,
+    });
+    expect(thread?.activities).toContainEqual(
+      expect.objectContaining({
+        kind: "provider.turn.start.failed",
+        payload: expect.objectContaining({ detail: expectedDetail }),
+      }),
+    );
+    expect(harness.startSession).not.toHaveBeenCalled();
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+    expect(await harness.readPendingTurnStarts()).toEqual([]);
+
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.make("cmd-thread-rebind-workspace"),
+        threadId: ThreadId.make("thread-1"),
+        branch: "main",
+        worktreePath: null,
+      }),
+    );
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-rebound-workspace"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-rebound-workspace"),
+          role: "user",
+          text: "continue from main",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
+      cwd: "/tmp/provider-project",
+    });
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({
+      input: "continue from main",
+    });
   });
 
   it("forwards codex model options through session start and turn send", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -487,8 +487,7 @@ const make = Effect.gen(function* () {
   /**
    * Recreates a thread's worktree from its branch when the directory has
    * disappeared. Provider sessions resume into the persisted cwd, so a missing
-   * worktree makes every later turn fail as a bogus "session not found".
-   * Best-effort: on failure the turn proceeds and reports the real error.
+   * worktree must be repaired or rebound before another turn can start.
    */
   const ensureThreadWorktree = Effect.fnUntraced(function* (thread: {
     readonly id: ThreadId;
@@ -498,15 +497,19 @@ const make = Effect.gen(function* () {
   }) {
     const { worktreePath, branch } = thread;
     if (!worktreePath || !branch) {
-      return;
+      return null;
     }
-    const exists = yield* fileSystem.exists(worktreePath).pipe(Effect.orElseSucceed(() => true));
-    if (exists) {
-      return;
+    const isDirectory = yield* fileSystem.stat(worktreePath).pipe(
+      Effect.map((worktreeStat) => worktreeStat.type === "Directory"),
+      Effect.catch((statError) => Effect.succeed(statError.reason._tag !== "NotFound")),
+    );
+    if (isDirectory) {
+      return null;
     }
+    const repairFailureDetail = `This thread's worktree no longer exists at ${worktreePath}, and T3 could not recreate branch '${branch}'. Restore that worktree or select another branch for this thread, then retry.`;
     const project = yield* resolveProject(thread.projectId);
     if (!project) {
-      return;
+      return repairFailureDetail;
     }
     const cwd = project.workspaceRoot;
     yield* Effect.logWarning("provider command reactor recreating missing worktree", {
@@ -516,8 +519,9 @@ const make = Effect.gen(function* () {
     });
     // A directory deleted without `git worktree remove` leaves an admin entry
     // that makes `git worktree add` refuse the path; prune clears it.
-    yield* gitWorkflow.pruneWorktrees({ cwd }).pipe(
+    return yield* gitWorkflow.pruneWorktrees({ cwd }).pipe(
       Effect.andThen(gitWorkflow.createWorktree({ cwd, refName: branch, path: worktreePath })),
+      Effect.as(null as string | null),
       Effect.catchCause((cause) =>
         Cause.hasInterruptsOnly(cause)
           ? Effect.failCause(cause)
@@ -525,7 +529,7 @@ const make = Effect.gen(function* () {
               threadId: thread.id,
               worktreePath,
               cause: Cause.pretty(cause),
-            }),
+            }).pipe(Effect.as(repairFailureDetail)),
       ),
     );
   });
@@ -1294,7 +1298,19 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    yield* ensureThreadWorktree(thread);
+    const worktreeRepairFailure = yield* ensureThreadWorktree(thread);
+    if (worktreeRepairFailure !== null) {
+      yield* setThreadSessionErrorOnTurnStartFailure({
+        threadId: event.payload.threadId,
+        detail: worktreeRepairFailure,
+        createdAt: event.payload.createdAt,
+      }).pipe(
+        Effect.flatMap(() =>
+          appendTurnStartFailure("Provider turn start failed", worktreeRepairFailure),
+        ),
+      );
+      return;
+    }
 
     const isCompactCommand = isCompactCommandMessage(message);
     const nonCompactUserMessageCount = thread.messages.filter(

--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -10,6 +10,7 @@ import {
   resolveEffectiveEnvMode,
   resolveEnvModeLabel,
   resolveBranchTriggerLabel,
+  resolveBranchWorkspaceCwd,
   resolveBranchToolbarPrBranch,
   resolveBranchToolbarValue,
   resolveLockedWorkspaceLabel,
@@ -20,6 +21,7 @@ import {
   shouldIncludeBranchPickerItem,
   shouldShowComposerContextStrip,
   shouldShowEnvironmentIndicator,
+  shouldShowGitControls,
 } from "./BranchToolbar.logic";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
@@ -469,6 +471,41 @@ describe("shouldShowComposerContextStrip", () => {
   });
 });
 
+describe("shouldShowGitControls", () => {
+  it("shows controls for the active Git workspace", () => {
+    expect(
+      shouldShowGitControls({
+        activeWorkspaceIsGitRepo: true,
+        hasActiveProject: true,
+        hasActiveWorktree: false,
+        projectCheckoutIsGitRepo: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("shows recovery controls when the worktree is missing but the project checkout is valid", () => {
+    expect(
+      shouldShowGitControls({
+        activeWorkspaceIsGitRepo: false,
+        hasActiveProject: true,
+        hasActiveWorktree: true,
+        projectCheckoutIsGitRepo: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides controls when neither workspace is a Git repository", () => {
+    expect(
+      shouldShowGitControls({
+        activeWorkspaceIsGitRepo: false,
+        hasActiveProject: true,
+        hasActiveWorktree: true,
+        projectCheckoutIsGitRepo: false,
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("resolveEffectiveEnvMode", () => {
   it("treats draft threads already attached to a worktree as current-checkout mode", () => {
     expect(
@@ -708,6 +745,38 @@ describe("resolveBranchSelectionTarget", () => {
       nextWorktreePath: "/repo/.t3/worktrees/feature-a",
       reuseExistingWorktree: false,
     });
+  });
+});
+
+describe("resolveBranchWorkspaceCwd", () => {
+  it("keeps using an available worktree", () => {
+    expect(
+      resolveBranchWorkspaceCwd({
+        activeProjectCwd: "/repo",
+        activeWorktreePath: "/repo/.t3/worktrees/feature-a",
+        activeWorktreeIsRepo: true,
+      }),
+    ).toBe("/repo/.t3/worktrees/feature-a");
+  });
+
+  it("uses the project checkout when the thread worktree is unavailable", () => {
+    expect(
+      resolveBranchWorkspaceCwd({
+        activeProjectCwd: "/repo",
+        activeWorktreePath: "/repo/.t3/worktrees/deleted",
+        activeWorktreeIsRepo: false,
+      }),
+    ).toBe("/repo");
+  });
+
+  it("uses the project checkout for a local thread", () => {
+    expect(
+      resolveBranchWorkspaceCwd({
+        activeProjectCwd: "/repo",
+        activeWorktreePath: null,
+        activeWorktreeIsRepo: null,
+      }),
+    ).toBe("/repo");
   });
 });
 

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -68,6 +68,18 @@ export function shouldShowComposerContextStrip(input: {
   );
 }
 
+export function shouldShowGitControls(input: {
+  activeWorkspaceIsGitRepo: boolean;
+  hasActiveProject: boolean;
+  hasActiveWorktree: boolean;
+  projectCheckoutIsGitRepo: boolean | null;
+}): boolean {
+  if (input.activeWorkspaceIsGitRepo) return true;
+  return (
+    input.hasActiveProject && input.hasActiveWorktree && input.projectCheckoutIsGitRepo !== false
+  );
+}
+
 // Labels collapse to icons when the strip's content no longer fits. A small
 // hysteresis on the way back out keeps the boundary from flapping.
 const CONTEXT_STRIP_COMPACT_EXPAND_HYSTERESIS_PX = 16;
@@ -261,6 +273,17 @@ export function resolveBranchSelectionTarget(input: {
     nextWorktreePath,
     reuseExistingWorktree: false,
   };
+}
+
+export function resolveBranchWorkspaceCwd(input: {
+  activeProjectCwd: string | null;
+  activeWorktreePath: string | null;
+  activeWorktreeIsRepo: boolean | null;
+}): string | null {
+  const { activeProjectCwd, activeWorktreePath, activeWorktreeIsRepo } = input;
+  return activeWorktreePath !== null && activeWorktreeIsRepo !== false
+    ? activeWorktreePath
+    : activeProjectCwd;
 }
 
 // Git rejects ASCII space and the ASCII control characters (tab, newline and

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -38,6 +38,7 @@ import { composerFloatingLayerProps } from "./chat/composerEventScope";
 import {
   deriveLocalBranchNameFromRemoteRef,
   resolveBranchTriggerLabel,
+  resolveBranchWorkspaceCwd,
   resolveBranchToolbarPrBranch,
   resolveBranchSelectionTarget,
   resolveBranchToolbarValue,
@@ -140,7 +141,7 @@ export function BranchToolbarBranchSelector({
       : (serverThread?.branch ?? draftThread?.branch ?? null);
   const activeWorktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
   const activeProjectCwd = activeProject?.workspaceRoot ?? null;
-  const branchCwd = activeWorktreePath ?? activeProjectCwd;
+  const branchStatusCwd = activeWorktreePath ?? activeProjectCwd;
   const hasServerThread = serverThread !== null;
   const effectiveEnvMode =
     effectiveEnvModeOverride ??
@@ -213,13 +214,19 @@ export function BranchToolbarBranchSelector({
   const deferredBranchQuery = useDeferredValue(branchQuery);
 
   const branchStatusQuery = useEnvironmentQuery(
-    branchCwd === null
+    branchStatusCwd === null
       ? null
       : vcsEnvironment.status({
           environmentId,
-          input: { cwd: branchCwd },
+          input: { cwd: branchStatusCwd },
         }),
   );
+  const branchCwd = resolveBranchWorkspaceCwd({
+    activeProjectCwd,
+    activeWorktreePath,
+    activeWorktreeIsRepo: branchStatusQuery.data?.isRepo ?? null,
+  });
+  const usableActiveWorktreePath = branchCwd === activeWorktreePath ? activeWorktreePath : null;
   const trimmedBranchQuery = branchQuery.trim();
   const deferredTrimmedBranchQuery = deferredBranchQuery.trim();
   // The server filters refs by substring, so it has to be given the sanitized
@@ -242,7 +249,9 @@ export function BranchToolbarBranchSelector({
   const isFetchingNextPage = branchRefState.isFetchingNextPage;
   const isInitialBranchesLoadPending = branchRefState.isPending && branchRefState.data === null;
   const currentGitBranch =
-    branchStatusQuery.data?.refName ?? refs.find((refName) => refName.current)?.name ?? null;
+    branchStatusQuery.data?.refName ??
+    (activeWorktreePath === null ? refs.find((refName) => refName.current)?.name : null) ??
+    null;
   const sourceControlPresentation = useMemo(
     () => getSourceControlPresentation(branchStatusQuery.data?.sourceControlProvider),
     [branchStatusQuery.data?.sourceControlProvider],
@@ -402,7 +411,7 @@ export function BranchToolbarBranchSelector({
 
     const selectionTarget = resolveBranchSelectionTarget({
       activeProjectCwd,
-      activeWorktreePath,
+      activeWorktreePath: usableActiveWorktreePath,
       refName,
     });
 
@@ -471,7 +480,7 @@ export function BranchToolbarBranchSelector({
       });
       if (createBranchResult._tag === "Success") {
         setOptimisticBranch(createBranchResult.value.refName);
-        setThreadBranch(createBranchResult.value.refName, activeWorktreePath);
+        setThreadBranch(createBranchResult.value.refName, usableActiveWorktreePath);
         return;
       }
       setOptimisticBranch(previousBranch);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -312,6 +312,7 @@ import {
   resolveLocalCheckoutBranchMismatch,
   shouldShowComposerContextStrip,
   shouldShowEnvironmentIndicator,
+  shouldShowGitControls,
 } from "./BranchToolbar.logic";
 import {
   getProviderStatusBannerKey,
@@ -3002,6 +3003,18 @@ export default function ChatView(props: ChatViewProps) {
           input: { cwd: gitStatusCwd },
         }),
   );
+  const projectGitStatusCwd =
+    activeThread?.worktreePath && gitStatusQuery.data?.isRepo === false
+      ? (activeProject?.workspaceRoot ?? null)
+      : null;
+  const projectGitStatusQuery = useEnvironmentQuery(
+    projectGitStatusCwd === null
+      ? null
+      : vcsEnvironment.status({
+          environmentId,
+          input: { cwd: projectGitStatusCwd },
+        }),
+  );
   useWorkspaceMutationRefresh({
     enabled: gitStatusCwd !== null,
     mutationId: workspaceMutationId,
@@ -3073,18 +3086,24 @@ export default function ChatView(props: ChatViewProps) {
     terminalUiLaunchContext?.threadId === activeThreadId ? terminalUiLaunchContext : null;
   // Default true while loading to avoid toolbar flicker.
   const isGitRepo = gitStatusQuery.data?.isRepo ?? true;
+  const showGitControls = shouldShowGitControls({
+    activeWorkspaceIsGitRepo: isGitRepo,
+    hasActiveProject: activeProject !== null,
+    hasActiveWorktree: activeThreadWorktreePath !== null,
+    projectCheckoutIsGitRepo: projectGitStatusQuery.data?.isRepo ?? null,
+  });
   // Keep a hidden, off-flow strip mounted for existing threads so the composer
   // can measure whether its relocated controls fit. The visible chrome remains
   // content-driven: Git/environment context or controls that actually fit.
   const mountComposerContextStrip = shouldShowComposerContextStrip({
     hasActiveProject: activeProject !== null,
-    isGitRepo,
+    isGitRepo: showGitControls,
     showEnvironmentIndicator: showComposerEnvironmentIndicator,
     hostsRestingComposerControls: routeKind === "server",
   });
   const showComposerContextStrip = shouldShowComposerContextStrip({
     hasActiveProject: activeProject !== null,
-    isGitRepo,
+    isGitRepo: showGitControls,
     showEnvironmentIndicator: showComposerEnvironmentIndicator,
     hostsRestingComposerControls: routeKind === "server" && restingComposerControlsVisible,
   });
@@ -7972,7 +7991,7 @@ export default function ChatView(props: ChatViewProps) {
                             gitCwd={gitCwd}
                             restingControlsHost={restingComposerControlsHost}
                             restingControlsHaveLeadingContext={
-                              isGitRepo || showComposerEnvironmentIndicator
+                              showGitControls || showComposerEnvironmentIndicator
                             }
                             onRestingControlsVisibilityChange={setRestingComposerControlsVisible}
                             getTimelineScrollableNode={getTimelineScrollableNode}
@@ -8025,7 +8044,7 @@ export default function ChatView(props: ChatViewProps) {
                               <BranchToolbar
                                 environmentId={activeThread.environmentId}
                                 threadId={activeThread.id}
-                                showGitControls={isGitRepo}
+                                showGitControls={showGitControls}
                                 {...(routeKind === "draft" && draftId ? { draftId } : {})}
                                 onEnvModeChange={onEnvModeChange}
                                 startFromOrigin={startFromOrigin}


### PR DESCRIPTION
## What Changed

- Stop a turn before provider startup when T3 cannot recreate its missing worktree.
- Show an actionable error that tells the user to restore the worktree or select another branch.
- Keep the branch selector available and load refs from the project checkout when the saved worktree is gone.
- Rebind the thread to the selected checkout so later turns keep the existing history and resume normally.

## Why

T3 already tries to recreate a missing worktree. That recovery fails when the worktree branch was also deleted. T3 then started the provider in the deleted directory and showed a provider spawn error on every new turn.

This change completes the branch-deleted case discussed in #6197. It builds on the automatic recreation from #7839 and the missing-folder error from #5040.

## UI Changes

### Before rebinding

<img width="1920" height="1056" alt="A thread with a deleted worktree shows the recovery branch selector" src="https://github.com/user-attachments/assets/4b94af3a-7af2-49c6-a8e8-dba3bed4744f" />

### After rebinding

<img width="1920" height="1056" alt="The same thread continues after rebinding to main" src="https://github.com/user-attachments/assets/10431f50-edea-4224-a664-74bd531fbb52" />

## Verification

- `pnpm exec vp test run apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts apps/web/src/components/BranchToolbar.logic.test.ts --maxWorkers=2` (139 tests)
- `pnpm exec vp run --filter @t3tools/web typecheck`
- `pnpm exec vp run --filter t3 typecheck`
- Targeted lint and format checks for all changed files
- Isolated browser test with a disposable T3 home: create a thread worktree, delete its worktree and branch, restart T3, rebind the thread to `main`, and continue the same thread

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] This change does not add animation
