### PR TITLE
perf(server): reuse local submodule objects when creating worktrees

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -1409,57 +1409,141 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         }),
     );
 
-    it.effect("checks out submodules in a new worktree", () =>
-      Effect.gen(function* () {
-        const fileSystem = yield* FileSystem.FileSystem;
-        const pathService = yield* Path.Path;
+    for (const sourceState of ["populated", "shallow", "uninitialized"] as const) {
+      it.effect(`checks out independent submodules from a ${sourceState} source worktree`, () =>
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          const pathService = yield* Path.Path;
 
-        // Git refuses `file:` submodule transports by default (CVE-2022-39253)
-        // and ignores repo-level config for it, so a local fixture needs the
-        // env allowance. Real submodules are https/ssh and need none of this.
-        const previousAllowedProtocol = process.env.GIT_ALLOW_PROTOCOL;
-        process.env.GIT_ALLOW_PROTOCOL = "file";
-        yield* Effect.addFinalizer(() =>
-          Effect.sync(() => {
-            if (previousAllowedProtocol === undefined) {
-              delete process.env.GIT_ALLOW_PROTOCOL;
-            } else {
-              process.env.GIT_ALLOW_PROTOCOL = previousAllowedProtocol;
-            }
-          }),
-        );
+          // Git refuses `file:` submodule transports by default (CVE-2022-39253)
+          // and ignores repo-level config for it, so a local fixture needs the
+          // env allowance. Real submodules are https/ssh and need none of this.
+          const previousAllowedProtocol = process.env.GIT_ALLOW_PROTOCOL;
+          process.env.GIT_ALLOW_PROTOCOL = "file";
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              if (previousAllowedProtocol === undefined) {
+                delete process.env.GIT_ALLOW_PROTOCOL;
+              } else {
+                process.env.GIT_ALLOW_PROTOCOL = previousAllowedProtocol;
+              }
+            }),
+          );
 
-        // A real submodule: `git worktree add` leaves these empty, which is
-        // what silently strips shared tooling out of every new worktree.
-        const submoduleRepo = yield* makeTmpDir("git-submodule-");
-        yield* initRepoWithCommit(submoduleRepo);
-        yield* writeTextFile(submoduleRepo, "SHARED.md", "# shared\n");
-        yield* git(submoduleRepo, ["add", "."]);
-        yield* git(submoduleRepo, ["commit", "-m", "shared"]);
+          // A real submodule: `git worktree add` leaves these empty, which is
+          // what silently strips shared tooling out of every new worktree.
+          const submoduleRepo = yield* makeTmpDir("git-submodule-");
+          yield* initRepoWithCommit(submoduleRepo);
+          yield* writeTextFile(submoduleRepo, "SHARED.md", "# shared\n");
+          yield* git(submoduleRepo, ["add", "."]);
+          yield* git(submoduleRepo, ["commit", "-m", "shared"]);
 
-        const cwd = yield* makeTmpDir();
-        const { initialBranch } = yield* initRepoWithCommit(cwd);
-        yield* git(cwd, ["submodule", "add", submoduleRepo, "shared"]);
-        yield* git(cwd, ["commit", "-m", "add submodule"]);
+          const nestedRepo = yield* makeTmpDir("git-nested-submodule-");
+          yield* initRepoWithCommit(nestedRepo);
+          yield* git(submoduleRepo, ["submodule", "add", nestedRepo, "nested module"]);
+          yield* git(submoduleRepo, ["commit", "-am", "nested submodule"]);
 
-        const worktreePath = pathService.join(
-          yield* makeTmpDir("git-worktrees-"),
-          "submodule-worktree",
-        );
-        const driver = yield* GitVcsDriver.GitVcsDriver;
-        yield* driver.createWorktree({
-          cwd,
-          path: worktreePath,
-          refName: initialBranch,
-          newRefName: "feature/submodules",
-        });
+          const cwd = yield* makeTmpDir();
+          const { initialBranch } = yield* initRepoWithCommit(cwd);
+          yield* git(cwd, [
+            "submodule",
+            "add",
+            "--name",
+            "shared tooling",
+            submoduleRepo,
+            "shared",
+          ]);
+          yield* git(cwd, ["submodule", "add", nestedRepo, "other module"]);
+          yield* git(cwd, ["commit", "-m", "add submodule"]);
 
-        assert.equal(
-          yield* fileSystem.exists(pathService.join(worktreePath, "shared", "SHARED.md")),
-          true,
-        );
-      }),
-    );
+          const source = pathService.join(yield* makeTmpDir(), "source worktree");
+          yield* git(cwd, ["worktree", "add", "--detach", source, initialBranch]);
+          yield* git(source, ["submodule", "update", "--init", "--recursive"]);
+          if (sourceState === "shallow") {
+            yield* git(pathService.join(source, "shared"), ["fetch", "--depth=1", "origin"]);
+            assert.equal(
+              yield* git(pathService.join(source, "shared"), [
+                "rev-parse",
+                "--is-shallow-repository",
+              ]),
+              "true",
+            );
+          }
+          if (sourceState === "uninitialized") {
+            yield* git(source, ["submodule", "deinit", "--force", "--all"]);
+          }
+          // The remote can advance after the source was populated. Clone references
+          // must not replace the gitlink with either the source or remote HEAD.
+          yield* writeTextFile(submoduleRepo, "LATER.md", "later remote commit\n");
+          yield* git(submoduleRepo, ["add", "."]);
+          yield* git(submoduleRepo, ["commit", "-m", "advance remote"]);
+          const pinned = yield* git(submoduleRepo, ["rev-parse", "HEAD"]);
+          yield* git(cwd, ["update-index", "--cacheinfo", `160000,${pinned},shared`]);
+          yield* git(cwd, ["commit", "-m", "pin commit missing from source"]);
+          yield* writeTextFile(submoduleRepo, "NEWEST.md", "not the selected commit\n");
+          yield* git(submoduleRepo, ["add", "."]);
+          yield* git(submoduleRepo, ["commit", "-m", "advance beyond selected pin"]);
+
+          const worktreePath = pathService.join(
+            yield* makeTmpDir("git-worktrees-"),
+            "submodule-worktree",
+          );
+          const driver = yield* GitVcsDriver.GitVcsDriver;
+          yield* driver.createWorktree({
+            cwd: source,
+            path: worktreePath,
+            refName: initialBranch,
+            newRefName: "feature/submodules",
+          });
+
+          assert.equal(
+            yield* fileSystem.exists(pathService.join(worktreePath, "shared", "SHARED.md")),
+            true,
+          );
+          assert.equal(
+            yield* git(pathService.join(worktreePath, "shared"), ["rev-parse", "HEAD"]),
+            pinned,
+          );
+          assert.equal(
+            yield* fileSystem.exists(pathService.join(worktreePath, "shared", "LATER.md")),
+            true,
+          );
+          assert.equal(
+            yield* fileSystem.exists(pathService.join(worktreePath, "shared", "NEWEST.md")),
+            false,
+          );
+          // Remove the actual reference object stores, including the nested one.
+          // The destination must keep working after their lifetime ends.
+          for (const submodule of sourceState === "uninitialized"
+            ? []
+            : ["shared", "other module"]) {
+            const gitDir = yield* git(pathService.join(source, submodule), [
+              "rev-parse",
+              "--absolute-git-dir",
+            ]);
+            yield* fileSystem.remove(gitDir, { recursive: true });
+          }
+          for (const submodule of ["shared", "shared/nested module", "other module"]) {
+            const destination = pathService.join(worktreePath, submodule);
+            const alternates = yield* git(destination, [
+              "rev-parse",
+              "--git-path",
+              "objects/info/alternates",
+            ]);
+            assert.equal(
+              yield* fileSystem.exists(pathService.resolve(destination, alternates)),
+              false,
+            );
+            yield* git(destination, ["fsck", "--full", "--no-dangling"]);
+            yield* git(destination, ["reset", "--hard", "HEAD"]);
+            assert.equal(
+              yield* fileSystem.exists(pathService.join(destination, "README.md")),
+              true,
+            );
+          }
+        }),
+      );
+    }
 
     it.effect("still creates the worktree when submodule checkout fails", () =>
       Effect.gen(function* () {

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -1,5 +1,6 @@
 // @effect-diagnostics nodeBuiltinImport:off - realpathSync.native resolves Windows 8.3 short names, which the Effect realPath does not.
 import * as NodeFS from "node:fs";
+import * as NodeURL from "node:url";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { assert, it, describe } from "@effect/vitest";
@@ -1409,7 +1410,14 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         }),
     );
 
-    for (const sourceState of ["populated", "shallow", "uninitialized"] as const) {
+    for (const sourceState of [
+      "cached",
+      "populated",
+      "shallow",
+      "uninitialized",
+      "inactive",
+      "update-none",
+    ] as const) {
       it.effect(`checks out independent submodules from a ${sourceState} source worktree`, () =>
         Effect.gen(function* () {
           const fileSystem = yield* FileSystem.FileSystem;
@@ -1440,7 +1448,12 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
 
           const nestedRepo = yield* makeTmpDir("git-nested-submodule-");
           yield* initRepoWithCommit(nestedRepo);
-          yield* git(submoduleRepo, ["submodule", "add", nestedRepo, "nested module"]);
+          yield* git(submoduleRepo, [
+            "submodule",
+            "add",
+            NodeURL.pathToFileURL(nestedRepo).href,
+            "nested module",
+          ]);
           yield* git(submoduleRepo, ["commit", "-am", "nested submodule"]);
 
           const cwd = yield* makeTmpDir();
@@ -1450,10 +1463,15 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
             "add",
             "--name",
             "shared tooling",
-            submoduleRepo,
+            NodeURL.pathToFileURL(submoduleRepo).href,
             "shared",
           ]);
-          yield* git(cwd, ["submodule", "add", nestedRepo, "other module"]);
+          yield* git(cwd, [
+            "submodule",
+            "add",
+            NodeURL.pathToFileURL(nestedRepo).href,
+            "other module",
+          ]);
           yield* git(cwd, ["commit", "-m", "add submodule"]);
 
           const source = pathService.join(yield* makeTmpDir(), "source worktree");
@@ -1472,17 +1490,58 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
           if (sourceState === "uninitialized") {
             yield* git(source, ["submodule", "deinit", "--force", "--all"]);
           }
-          // The remote can advance after the source was populated. Clone references
-          // must not replace the gitlink with either the source or remote HEAD.
-          yield* writeTextFile(submoduleRepo, "LATER.md", "later remote commit\n");
-          yield* git(submoduleRepo, ["add", "."]);
-          yield* git(submoduleRepo, ["commit", "-m", "advance remote"]);
-          const pinned = yield* git(submoduleRepo, ["rev-parse", "HEAD"]);
-          yield* git(cwd, ["update-index", "--cacheinfo", `160000,${pinned},shared`]);
-          yield* git(cwd, ["commit", "-m", "pin commit missing from source"]);
-          yield* writeTextFile(submoduleRepo, "NEWEST.md", "not the selected commit\n");
-          yield* git(submoduleRepo, ["add", "."]);
-          yield* git(submoduleRepo, ["commit", "-m", "advance beyond selected pin"]);
+          let pinned = yield* git(submoduleRepo, ["rev-parse", "HEAD"]);
+          if (sourceState !== "cached") {
+            // The remote can advance after the source was populated. Clone references
+            // must not replace the gitlink with either the source or remote HEAD.
+            yield* writeTextFile(submoduleRepo, "LATER.md", "later remote commit\n");
+            yield* git(submoduleRepo, ["add", "."]);
+            yield* git(submoduleRepo, ["commit", "-m", "advance remote"]);
+            pinned = yield* git(submoduleRepo, ["rev-parse", "HEAD"]);
+            yield* git(cwd, ["update-index", "--cacheinfo", `160000,${pinned},shared`]);
+            yield* git(cwd, ["commit", "-m", "pin commit missing from source"]);
+            yield* writeTextFile(submoduleRepo, "NEWEST.md", "not the selected commit\n");
+            yield* git(submoduleRepo, ["add", "."]);
+            yield* git(submoduleRepo, ["commit", "-m", "advance beyond selected pin"]);
+          }
+          const excludesOther = sourceState === "inactive" || sourceState === "update-none";
+          if (sourceState === "inactive") {
+            yield* git(cwd, ["config", "--unset", "submodule.other module.active"]);
+            yield* git(cwd, ["config", "submodule.active", "shared"]);
+          }
+          if (sourceState === "update-none") {
+            yield* git(cwd, [
+              "config",
+              "--file",
+              ".gitmodules",
+              "submodule.other module.update",
+              "none",
+            ]);
+            yield* git(cwd, ["add", ".gitmodules"]);
+            yield* git(cwd, ["commit", "-m", "skip other module"]);
+          }
+          const sourceSubmodule = pathService.join(source, "shared");
+          if (sourceState !== "uninitialized") {
+            yield* writeTextFile(sourceSubmodule, "SHARED.md", "uncommitted edit\n");
+            yield* writeTextFile(sourceSubmodule, "STAGED.md", "staged edit\n");
+            yield* git(sourceSubmodule, ["add", "STAGED.md"]);
+            yield* writeTextFile(sourceSubmodule, "UNTRACKED.md", "untracked edit\n");
+          }
+          const sourceCwd =
+            sourceState === "cached" ? pathService.join(source, "project subdirectory") : source;
+          yield* fileSystem.makeDirectory(sourceCwd, { recursive: true });
+          const sourceStatus = yield* git(source, ["status", "--porcelain"]);
+          const packetTrace = pathService.join(yield* makeTmpDir(), "packets.log");
+          if (sourceState === "cached") {
+            const previousPacketTrace = process.env.GIT_TRACE_PACKET;
+            process.env.GIT_TRACE_PACKET = packetTrace;
+            yield* Effect.addFinalizer(() =>
+              Effect.sync(() => {
+                if (previousPacketTrace === undefined) delete process.env.GIT_TRACE_PACKET;
+                else process.env.GIT_TRACE_PACKET = previousPacketTrace;
+              }),
+            );
+          }
 
           const worktreePath = pathService.join(
             yield* makeTmpDir("git-worktrees-"),
@@ -1490,7 +1549,7 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
           );
           const driver = yield* GitVcsDriver.GitVcsDriver;
           yield* driver.createWorktree({
-            cwd: source,
+            cwd: sourceCwd,
             path: worktreePath,
             refName: initialBranch,
             newRefName: "feature/submodules",
@@ -1506,12 +1565,34 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
           );
           assert.equal(
             yield* fileSystem.exists(pathService.join(worktreePath, "shared", "LATER.md")),
-            true,
+            sourceState !== "cached",
           );
           assert.equal(
             yield* fileSystem.exists(pathService.join(worktreePath, "shared", "NEWEST.md")),
             false,
           );
+          assert.equal(yield* git(source, ["status", "--porcelain"]), sourceStatus);
+          if (sourceState !== "uninitialized") {
+            assert.equal(
+              yield* fileSystem.readFileString(pathService.join(sourceSubmodule, "SHARED.md")),
+              "uncommitted edit\n",
+            );
+          }
+          assert.equal(
+            yield* fileSystem.exists(pathService.join(worktreePath, "shared", "STAGED.md")),
+            false,
+          );
+          assert.equal(
+            yield* fileSystem.exists(pathService.join(worktreePath, "shared", "UNTRACKED.md")),
+            false,
+          );
+          if (sourceState === "cached") {
+            // file:// forces the fetch transport rather than local hardlinks.
+            // A fully cached clone advertises refs but requests no object pack.
+            const packets = yield* fileSystem.readFileString(packetTrace);
+            assert.include(packets, "packet:");
+            assert.notMatch(packets, /\bwant [0-9a-f]{40}/);
+          }
           // Remove the actual reference object stores, including the nested one.
           // The destination must keep working after their lifetime ends.
           for (const submodule of sourceState === "uninitialized"
@@ -1523,7 +1604,15 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
             ]);
             yield* fileSystem.remove(gitDir, { recursive: true });
           }
-          for (const submodule of ["shared", "shared/nested module", "other module"]) {
+          assert.equal(
+            yield* fileSystem.exists(pathService.join(worktreePath, "other module", "README.md")),
+            !excludesOther,
+          );
+          for (const submodule of [
+            "shared",
+            "shared/nested module",
+            ...(excludesOther ? [] : ["other module"]),
+          ]) {
             const destination = pathService.join(worktreePath, submodule);
             const alternates = yield* git(destination, [
               "rev-parse",

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -1416,6 +1416,8 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
       "shallow",
       "uninitialized",
       "inactive",
+      "inactive-true",
+      "unreachable",
       "update-none",
     ] as const) {
       it.effect(`checks out independent submodules from a ${sourceState} source worktree`, () =>
@@ -1504,10 +1506,17 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
             yield* git(submoduleRepo, ["add", "."]);
             yield* git(submoduleRepo, ["commit", "-m", "advance beyond selected pin"]);
           }
-          const excludesOther = sourceState === "inactive" || sourceState === "update-none";
-          if (sourceState === "inactive") {
+          const excludesOther =
+            sourceState === "inactive" ||
+            sourceState === "inactive-true" ||
+            sourceState === "update-none";
+          if (sourceState === "inactive" || sourceState === "inactive-true") {
             yield* git(cwd, ["config", "--unset", "submodule.other module.active"]);
-            yield* git(cwd, ["config", "submodule.active", "shared"]);
+            yield* git(cwd, [
+              "config",
+              "submodule.active",
+              sourceState === "inactive-true" ? "true" : "shared",
+            ]);
           }
           if (sourceState === "update-none") {
             yield* git(cwd, [
@@ -1519,6 +1528,20 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
             ]);
             yield* git(cwd, ["add", ".gitmodules"]);
             yield* git(cwd, ["commit", "-m", "skip other module"]);
+          }
+          if (sourceState === "unreachable") {
+            const gitmodules = yield* fileSystem.readFileString(
+              pathService.join(cwd, ".gitmodules"),
+            );
+            yield* writeTextFile(
+              cwd,
+              ".gitmodules",
+              '[submodule "missing"]\n\tpath = missing\n\turl = /nonexistent/repo.git\n' +
+                gitmodules,
+            );
+            yield* git(cwd, ["update-index", "--add", "--cacheinfo", `160000,${pinned},missing`]);
+            yield* git(cwd, ["add", ".gitmodules"]);
+            yield* git(cwd, ["commit", "-m", "put unreachable submodule before healthy siblings"]);
           }
           const sourceSubmodule = pathService.join(source, "shared");
           if (sourceState !== "uninitialized") {
@@ -1554,6 +1577,19 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
             refName: initialBranch,
             newRefName: "feature/submodules",
           });
+
+          if (sourceState === "unreachable") {
+            // Git clones the remaining siblings before retrying the failed clone;
+            // it may abort before checking out their files.
+            for (const submodule of ["shared", "other module"]) {
+              assert.equal(
+                yield* fileSystem.exists(pathService.join(worktreePath, submodule, ".git")),
+                true,
+              );
+            }
+            assert.equal(yield* git(source, ["status", "--porcelain"]), sourceStatus);
+            return;
+          }
 
           assert.equal(
             yield* fileSystem.exists(pathService.join(worktreePath, "shared", "SHARED.md")),

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -2866,7 +2866,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         entries.some(
           (entry) =>
             /^submodule\.(active|fetchjobs|.*\.(active|update))\n/.test(entry) &&
-            !entry.endsWith(".active\ntrue"),
+            !/^submodule\..+\.active\ntrue$/.test(entry),
         )
       ) {
         return null;
@@ -2936,6 +2936,14 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         Effect.orElseSucceed(() => input.cwd),
       );
       yield* prepareSubmodules(sourceRoot, worktreePath).pipe(
+        Effect.catch(() =>
+          runGit("GitVcsDriver.updateSubmodules", worktreePath, [
+            "submodule",
+            "update",
+            "--init",
+            "--recursive",
+          ]),
+        ),
         Effect.catch((cause) =>
           Effect.logWarning("worktree submodule checkout failed; submodule paths are empty", {
             worktreePath,

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -2831,6 +2831,79 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     },
   );
 
+  const prepareSubmodules = Effect.fn("GitVcsDriver.prepareSubmodules")(function* (
+    source: string,
+    destination: string,
+  ): Effect.fn.Return<void, GitCommandError> {
+    const ordinaryUpdate = runGit("GitVcsDriver.createWorktree.updateSubmodules", destination, [
+      "submodule",
+      "update",
+      "--init",
+      "--recursive",
+    ]);
+    const submodules = yield* Effect.gen(function* () {
+      if (!(yield* fileSystem.exists(path.join(destination, ".gitmodules")))) return [];
+      const [config, gitmodules] = yield* Effect.all([
+        executeGit(
+          "GitVcsDriver.submoduleConfig",
+          destination,
+          ["config", "--null", "--get-regexp", "^submodule\\."],
+          { allowNonZeroExit: true },
+        ),
+        executeGit(
+          "GitVcsDriver.submodulePaths",
+          destination,
+          ["config", "--null", "--file", ".gitmodules", "--get-regexp", "^submodule\\."],
+          { allowNonZeroExit: true },
+        ),
+      ]);
+      const configs = [config, gitmodules];
+      const entries = configs.flatMap(splitNullSeparatedGitStdoutPaths);
+      // Explicit paths override Git's active/update policies and parallel cloning.
+      // Leave custom policies to the ordinary command rather than reimplement them.
+      if (
+        configs.some((result) => result.stdoutTruncated || result.exitCode > 1) ||
+        entries.some(
+          (entry) =>
+            /^submodule\.(active|fetchjobs|.*\.(active|update))\n/.test(entry) &&
+            !entry.endsWith(".active\ntrue"),
+        )
+      ) {
+        return null;
+      }
+      return splitNullSeparatedGitStdoutPaths(gitmodules).flatMap((entry) => {
+        const separator = entry.indexOf("\n");
+        return entry.slice(0, separator).endsWith(".path") ? [entry.slice(separator + 1)] : [];
+      });
+    }).pipe(Effect.orElseSucceed(() => null));
+    if (submodules === null) return yield* ordinaryUpdate;
+    for (const submodule of submodules) {
+      const reference = path.resolve(source, submodule);
+      const args = ["submodule", "update", "--init", "--", submodule];
+      // git submodule accepts only one reference. Clone each direct child with
+      // its matching source, then recurse with the child's own source path.
+      const hasReference = yield* fileSystem
+        .exists(path.join(reference, ".git"))
+        .pipe(Effect.orElseSucceed(() => false));
+      if (hasReference) {
+        yield* runGit("GitVcsDriver.cloneSubmoduleWithReference", destination, [
+          "submodule",
+          "update",
+          "--init",
+          "--reference",
+          reference,
+          "--dissociate",
+          "--",
+          submodule,
+        ]).pipe(Effect.catch(() => runGit("GitVcsDriver.cloneSubmodule", destination, args)));
+      } else {
+        yield* runGit("GitVcsDriver.cloneSubmodule", destination, args);
+      }
+      // Dissociation keeps the destination independent of source pruning/deletion.
+      yield* prepareSubmodules(reference, path.join(destination, submodule));
+    }
+  });
+
   const createWorktree: GitVcsDriver.GitVcsDriver["Service"]["createWorktree"] = Effect.fn(
     "createWorktree",
   )(function* (input) {
@@ -2855,40 +2928,14 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       .exists(path.join(worktreePath, ".gitmodules"))
       .pipe(Effect.orElseSucceed(() => false));
     if (hasSubmodules) {
-      const references = yield* executeGit(
-        "GitVcsDriver.createWorktree.submoduleReferences",
-        input.cwd,
-        ["submodule", "foreach", "--quiet", "--recursive", 'printf "%s\\0" "$displaypath"'],
-      ).pipe(
-        Effect.map(splitNullSeparatedGitStdoutPaths),
-        Effect.orElseSucceed(() => []),
-      );
-      // Borrow only during cloning: removing or pruning the source must not
-      // break the new worktree. Git still fetches objects absent from references.
-      const referenceArgs = references.length
-        ? [
-            "--dissociate",
-            ...references.flatMap((ref) => ["--reference", path.resolve(input.cwd, ref)]),
-          ]
-        : [];
-      yield* runGit("GitVcsDriver.createWorktree.updateSubmodules", worktreePath, [
-        "submodule",
-        "update",
-        "--init",
-        "--recursive",
-        ...referenceArgs,
+      const sourceRoot = yield* runGitStdout("GitVcsDriver.submoduleSourceRoot", input.cwd, [
+        "rev-parse",
+        "--show-toplevel",
       ]).pipe(
-        // A reference can disappear or be unsuitable (for example, shallow).
-        // Retry without this optimization before retaining best-effort failure.
-        Effect.catch((cause) =>
-          referenceArgs.length
-            ? runGit(
-                "GitVcsDriver.createWorktree.updateSubmodulesWithoutReferences",
-                worktreePath,
-                ["submodule", "update", "--init", "--recursive"],
-              )
-            : Effect.fail(cause),
-        ),
+        Effect.map((stdout) => stdout.trim()),
+        Effect.orElseSucceed(() => input.cwd),
+      );
+      yield* prepareSubmodules(sourceRoot, worktreePath).pipe(
         Effect.catch((cause) =>
           Effect.logWarning("worktree submodule checkout failed; submodule paths are empty", {
             worktreePath,

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -2849,19 +2849,46 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
 
     // `git worktree add` leaves submodules empty, so a repo that keeps agent
     // skills, tooling or source in one gets a worktree that is quietly missing
-    // them. Best-effort: the objects are usually already in the parent's
-    // `.git/modules`, but a first-ever clone needs the network, and failing to
-    // populate a submodule must not roll back the caller's thread.
+    // them. Submodule Git directories belong to each worktree, so Git otherwise
+    // clones the objects again even when the source already has them locally.
     const hasSubmodules = yield* fileSystem
       .exists(path.join(worktreePath, ".gitmodules"))
       .pipe(Effect.orElseSucceed(() => false));
     if (hasSubmodules) {
+      const references = yield* executeGit(
+        "GitVcsDriver.createWorktree.submoduleReferences",
+        input.cwd,
+        ["submodule", "foreach", "--quiet", "--recursive", 'printf "%s\\0" "$displaypath"'],
+      ).pipe(
+        Effect.map(splitNullSeparatedGitStdoutPaths),
+        Effect.orElseSucceed(() => []),
+      );
+      // Borrow only during cloning: removing or pruning the source must not
+      // break the new worktree. Git still fetches objects absent from references.
+      const referenceArgs = references.length
+        ? [
+            "--dissociate",
+            ...references.flatMap((ref) => ["--reference", path.resolve(input.cwd, ref)]),
+          ]
+        : [];
       yield* runGit("GitVcsDriver.createWorktree.updateSubmodules", worktreePath, [
         "submodule",
         "update",
         "--init",
         "--recursive",
+        ...referenceArgs,
       ]).pipe(
+        // A reference can disappear or be unsuitable (for example, shallow).
+        // Retry without this optimization before retaining best-effort failure.
+        Effect.catch((cause) =>
+          referenceArgs.length
+            ? runGit(
+                "GitVcsDriver.createWorktree.updateSubmodulesWithoutReferences",
+                worktreePath,
+                ["submodule", "update", "--init", "--recursive"],
+              )
+            : Effect.fail(cause),
+        ),
         Effect.catch((cause) =>
           Effect.logWarning("worktree submodule checkout failed; submodule paths are empty", {
             worktreePath,


### PR DESCRIPTION
fixing since i do a lot of work on a repo with a decent amount of submodule content, so everytime i start a new thread (I have it start a new worktree based on origin for new threads), and send my first message, it would take ~18 seconds to setup the worktree, this does some work to cut that down. 

======= below this line is ai slop =========

## What Changed

Fresh worktrees clone submodule history again even when the source checkout already has the objects. Initialize each destination submodule using its matching source checkout as a temporary Git `--reference`, then `--dissociate` so the destination owns its objects. Repeat for nested submodules. Missing objects still come from the configured remote, and unsuitable references fall back to an ordinary clone.

Git's submodule wrapper retains only the last `--reference`, so each clone now receives exactly one matching reference. Custom submodule active/update policies and clone concurrency settings retain the ordinary recursive command. If preparation still fails, retry the ordinary recursive update so Git can process remaining siblings before the existing best-effort warning.

The production diff is 98 changed lines in the shared server Git driver; the only other changed file is its focused test suite. No new settings, persistent cache, dependencies, or client/protocol changes.

Closes #9853.

## Why

An observed first-message startup spent 0.522 s fetching origin, 0.296 s adding the worktree, and 17.417 s initializing submodules. This change targets the dominant submodule step while preserving automatic population and independent worktrees.

### Worktree setup measurements

**72.1% less time · 15.82 seconds saved on average**

| Implementation | Run 1 | Run 2 | Average | Time reduction |
|---|---:|---:|---:|---:|
| Before | 21.19 s | 22.71 s | **21.95 s** | **0%** |
| After | 6.20 s | 6.05 s | **6.13 s** | **72.1%** |

*Actual `createWorktree()` calls, including submodule initialization. Linux/btrfs · Git 2.55 · approximately 1 GiB of packed submodule history. Two runs per version, interleaved, using fresh destinations and the same pinned commit. Excludes origin fetch and provider startup; caches were not flushed.*

<details>
<summary>Measurement method and limits</summary>

These measurements were taken on `57a6e533d`, replacing the earlier implementation's measurements. The subsequent correction handles global `submodule.active=true` selection and failure fallback; it does not change the successful path exercised by this benchmark. Baseline: `8faf031c2dac4f147c43fe32e326b76678c20c94`. Node 26.8.1, disk-backed destinations, the same remote, `pack.threads=2`, and `nice 10`. Execution order was before, after, after, before. The baseline driver was loaded from the original source with only benchmark import paths adjusted.

The measured driver call includes worktree creation, submodule preparation, base-ref configuration and cache invalidation. Each run checked the exact submodule HEAD and absence of persistent alternates. The original ~18-second trace and these benchmarks are separate samples on a shared machine with network variability. Two observations per version establish a local improvement, not a universal speedup; network byte savings were not measured directly.

The large-repository timing above measures one large submodule. The separate edge-case matrix below measures multiple/nested submodules, custom policies, and fallback overhead on Linux/btrfs. Local-path remotes may already benefit from Git's local clone optimizations; the new fixtures use file:// transport to avoid hardlink cloning.

</details>

### Edge-case measurements on the final commit

The matrix below compares the original driver (`8faf031c`) with the unchanged PR head (`1001b4cc0`). **120 measured calls: 12 scenarios, five calls per implementation per scenario.** Destination state matched the original driver in every measured call.

| Scenario | Before, mean | After, mean | Time reduction |
|---|---:|---:|---:|
| 1 cached submodule | 122.5 ms | 100.5 ms | +17.9% |
| 4 cached sibling submodules | 410.4 ms | 325.5 ms | +20.7% |
| 2 parents + 2 nested submodules | 347.3 ms | 306.4 ms | +11.8% |
| 12 tiny cached submodules | 240.4 ms | 404.5 ms | -68.2% |
| Active pathspec: 2 of 4 selected | 205.3 ms | 193.1 ms | +5.9% |
| Literal active=true pathspec | 109.2 ms | 116.8 ms | -6.9% |
| update=none: 1 of 4 skipped | 267.5 ms | 284.9 ms | -6.5% |
| Custom fetchJobs=4 | 227.2 ms | 227.8 ms | -0.3% |
| Stale + dirty source, 4 modules | 319.1 ms | 268.0 ms | +16.0% |
| Shallow sources, 4 modules | 308.3 ms | 433.2 ms | -40.5% |
| Uninitialized sources, 4 modules | 327.1 ms | 371.5 ms | -13.6% |
| Unreachable first module + 4 healthy siblings | 326.5 ms | 347.7 ms | -6.5% |

*Positive percentages mean less elapsed time; negative percentages mean more. These are synthetic local `file://` transport fixtures on Linux/btrfs, separate from the approximately 1 GiB repository measurement above. Ordinary modules contain approximately 16 MiB of history each (four revisions of a 4 MiB random payload); the tiny modules contain a README only. Nested modules use spaces in their paths, and submodule names differ from their paths.*

The slower cases have small absolute costs in these fixtures, even where the percentage increase is large. The command paths and packet traces explain the likely sources of overhead; the timings measure the whole driver call, not the milliseconds attributable to each subprocess:

- **12 tiny cached modules: +164.1 ms (240.4 → 404.5 ms).** The optimized runs made zero object `want` requests, so reuse worked. Each module still requires a separate update invocation, reference setup, and dissociation to preserve independence. With only README-sized histories to transfer, this setup costs more than the transfer work it saves.
- **Four shallow sources: +124.9 ms (308.3 → 433.2 ms).** Git rejects shallow repositories as clone references, so the attempted reference clones retry as ordinary clones. The fixture shows no reduction in object requests; reference attempts and per-module setup add work. See [Git's reference validation](https://github.com/git/git/blob/v2.55.0/odb.c#L296-L300).
- **Four uninitialized sources: +44.4 ms (327.1 → 371.5 ms).** There are no initialized source checkouts to borrow from. The driver checks for references and invokes updates per module, but each module still needs ordinary cloning.
- **An unreachable first module: +21.1 ms (326.5 → 347.7 ms).** The per-module attempt fails before the driver retries the ordinary recursive command, which processes the healthy siblings. This fixture fails immediately at a local missing URL; a slow remote failure can make retries more costly.

Custom active/update/concurrency settings use Git's ordinary recursive path after the configuration checks. Their measured mean differences range from **12.2 ms less to 17.4 ms more**; the fetchJobs=4 difference is **0.6 ms more**, with substantial sample variation. Those small differences do not establish either an optimization or a precise overhead cost for custom policies.

For interactive first-message setup, the **44–164 ms** penalties in the tiny/shallow/uninitialized fixtures are likely minor: they are paid once when creating a worktree, not on every subsequent message in that worktree. This is a practical assessment, not a measured perceptibility result. The separate large-repository sample saved **15.82 seconds**; that is context for the tradeoff, not a promise that the same user receives both results. More modules or slower failures can increase the penalty, so the negative rows remain visible rather than being treated as universally negligible.

<details>
<summary>Method, behavioral checks, and every timing sample</summary>

Every sample runs the actual `createWorktree()` driver call, using a fresh disk-backed destination. Source fixtures are initialized before timing, and each scenario uses the same source and selected commit for both implementations. Execution order is before, after, after, before, before, after, after, before, before, after. Caches were not flushed; runs were serial on a shared machine, at `nice 10`, with `pack.threads=2`. Fixture setup, validation, and cleanup are outside the measured interval. Origin fetch and provider startup are excluded. Packet tracing is enabled identically for both implementations. Transport is local, so these fixtures measure no Internet latency or bandwidth savings.

For each destination, compare module initialization, HEAD, tracked-file lists, working-tree status, payload hash, and README presence against the baseline. Source status is checked after every call; the dirty-source scenario additionally checks the original edited file and excludes staged/untracked source files from the destination. Its selected commit is missing from the source reference, and the remote advances beyond that selected commit. Every initialized destination is checked for absence of persistent alternates. Cached single/sibling/nested/tiny cases make no object `want` requests with the optimization. The existing source-deletion/fsck tests remain separate coverage.

Active selection, update=none, and fetchJobs scenarios retain their selected/skipped modules. In the unreachable-module case, healthy siblings are cloned as with native Git, but Git may abort before checking out their files; successful worktree creation is not a claim of complete submodule population after a failure. All 120 calls matched the corresponding baseline state in these checks.

Times below are milliseconds, listed in execution order within each implementation. Means and percentages above use unrounded samples. Five observations describe these local runs; they do not establish a universal speedup or statistical significance for small differences.

| Scenario | Before: all five samples (ms) | After: all five samples (ms) |
|---|---|---|
| 1 cached submodule | 144.7, 117.7, 118.3, 116.3, 115.4 | 111.5, 104.6, 96.4, 94.5, 95.5 |
| 4 cached sibling submodules | 374.3, 362.3, 377.4, 354.0, 584.2 | 330.1, 328.8, 333.2, 320.8, 314.8 |
| 2 parents + 2 nested submodules | 348.9, 346.6, 348.3, 343.2, 349.3 | 302.4, 305.0, 305.8, 315.4, 303.2 |
| 12 tiny cached submodules | 235.2, 248.4, 239.3, 244.7, 234.7 | 396.9, 407.0, 398.6, 420.0, 400.2 |
| Active pathspec: 2 of 4 selected | 185.0, 200.2, 255.2, 196.5, 189.5 | 194.7, 191.5, 193.6, 198.0, 187.7 |
| Literal active=true pathspec | 112.2, 108.1, 110.0, 104.4, 111.2 | 108.8, 116.5, 117.0, 121.9, 119.5 |
| update=none: 1 of 4 skipped | 258.3, 262.8, 271.5, 275.4, 269.6 | 271.6, 271.0, 272.5, 274.3, 335.1 |
| Custom fetchJobs=4 | 153.8, 157.9, 161.3, 163.4, 499.7 | 167.2, 417.0, 168.9, 166.4, 219.8 |
| Stale + dirty source, 4 modules | 333.7, 318.4, 325.1, 310.2, 308.2 | 272.8, 280.9, 268.5, 261.1, 256.6 |
| Shallow sources, 4 modules | 306.6, 306.1, 311.1, 309.6, 308.1 | 411.2, 409.7, 419.5, 512.1, 413.7 |
| Uninitialized sources, 4 modules | 309.0, 308.5, 300.8, 361.5, 355.7 | 354.8, 345.2, 380.0, 390.5, 387.0 |
| Unreachable first module + 4 healthy siblings | 332.9, 326.2, 321.9, 326.7, 325.0 | 351.0, 350.3, 345.7, 345.3, 346.0 |

</details>

### Regression coverage

- **65 tests pass** in `GitVcsDriverCore.test.ts` on Node 24.20.0. The cached fixture uses two siblings and a nested submodule over `file://` transport; packet tracing asserts no object `want` requests when the matching source repositories already contain all objects. This assertion fails on the original PR implementation (`462f597`) and passes with the correction.
- Fixtures cover stale/populated, shallow and uninitialized sources; spaces and differing submodule names; a caller in a project subdirectory; a selected commit missing from the source; and a remote newer than the selected commit.
- Staged, unstaged and untracked source changes remain untouched and are not copied into the destination. Destination submodules retain the selected gitlinks and pass `fsck` and `reset --hard` after source object stores are deleted.
- Active-submodule selection (including the literal `submodule.active=true` pathspec) and `update=none` keep their ordinary Git behavior. An unreachable first submodule still allows Git to clone healthy siblings. Both added edge-case tests fail on `57a6e533d`, pass against the original baseline, and pass with the correction. The existing best-effort checkout-failure test remains passing.
- Targeted lint, formatting, server-only typecheck and `git diff --check` pass. Typecheck reports existing unrelated Effect suggestions, with no errors. No correctness regression was observed in this coverage. The edge-case measurements above record both speedups and timing regressions.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Focused behavioral tests and before/after measurements are included

Model and harness: GPT-6 / Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Git submodule initialization during worktree creation with new branching and fallbacks; incorrect reference handling could yield wrong commits or slow paths, though failures still degrade to the prior recursive update behavior.
> 
> **Overview**
> **Worktree creation** no longer relies on a plain recursive `git submodule update` when the caller’s checkout already has submodule repos locally. After `git worktree add`, the driver resolves the source repo top-level from `input.cwd` and runs new **`prepareSubmodules`**, which walks each submodule path, clones with **`--reference`** on the matching source checkout when a `.git` exists there, **`--dissociate`** so the new worktree owns its objects, then recurses for nested submodules.
> 
> Repos with non-default **`submodule.active` / `update` / parallel fetch** settings, missing references, or failed reference clones still use the original **`submodule update --init --recursive`** path (with the same best-effort warning if checkout fails).
> 
> **Tests** replace one happy-path case with a parametrized matrix (cached, populated, shallow, uninitialized, inactive, unreachable, `update=none`, etc.) covering nested submodules, pinned gitlinks, independence after deleting source object stores, untouched source dirty state, and packet tracing for the fully cached clone case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1001b4cc06ac0679c857f00bc1ab7f4bded51d2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reuse local source submodule objects when creating worktrees in `GitVcsDriver`
> Adds a recursive `prepareSubmodules` helper that clones each configured direct child submodule from the matching source submodule repository with dissociated objects, then recurses into nested children the same way. `createWorktree` now resolves the top-level source repository from the caller's working directory and invokes this helper before falling back to the ordinary recursive `git submodule update`.
> - When custom active/fetch-jobs/update policies are set, or when repository/gitmodules inspection fails, the code falls back to ordinary recursive `git submodule update` for the whole destination.
> - Individual per-submodule reference-clone failures fall back to a normal update for that child only; the overall worktree creation still completes with a warning if both population paths fail.
> - Expands the integration test suite in [GitVcsDriverCore.test.ts](https://github.com/pingdotgg/t3code/pull/9854/files#diff-ac30488287dac9aa8d4cb819c508d77d2e47267d4aae35819e6fa24b86312c26) to eight source-state scenarios (cached, populated, shallow, uninitialized, inactive, explicitly active, unreachable, update-disabled) with direct and nested submodules.
> - Risk: `prepareSubmodules` inspects `.gitmodules` and repo config to decide whether reference-based cloning is safe; if that inspection is wrong it could skip the optimization or produce a partial clone — verify behavior in [GitVcsDriverCore.ts](https://github.com/pingdotgg/t3code/pull/9854/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8) when custom `submodule.active` or `submodule.<name>.update` policies are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1001b4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->