### PR TITLE
fix(server): quote copied native provider update commands

### DIFF
--- a/apps/server/src/provider/Drivers/CursorDriver.test.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.test.ts
@@ -1,0 +1,62 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, it } from "@effect/vitest";
+import { ProviderInstanceId } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { HttpClient } from "effect/unstable/http";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+
+import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
+import { ServerConfig } from "../../config.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import { NoOpProviderEventLoggers, ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
+import { CursorDriver } from "./CursorDriver.ts";
+
+const testLayer = ServerConfig.layerTest(process.cwd(), {
+  prefix: "t3-cursor-driver-copy-command-",
+}).pipe(
+  Layer.provideMerge(NodeServices.layer),
+  Layer.provideMerge(ServerSettingsService.layerTest()),
+  Layer.provideMerge(
+    Layer.mock(BackgroundPolicy.BackgroundPolicy)({
+      shouldRunScopeWork: () => Effect.succeed(false),
+    }),
+  ),
+  Layer.provideMerge(Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers)),
+  Layer.provideMerge(
+    Layer.succeed(
+      HttpClient.HttpClient,
+      HttpClient.make(() => Effect.die("Disabled Cursor must not make an HTTP request")),
+    ),
+  ),
+);
+
+it.layer(testLayer)("CursorDriver", (it) => {
+  it.effect("formats a copied update command for the injected Windows environment", () =>
+    Effect.gen(function* () {
+      const binaryPath = "C:\\Users\\Example User\\.local\\bin\\cursor-agent.exe";
+      const instance = yield* CursorDriver.create({
+        instanceId: ProviderInstanceId.make("cursor-copy-command"),
+        displayName: "Cursor test",
+        enabled: false,
+        environment: [],
+        config: { ...CursorDriver.defaultConfig(), binaryPath },
+      });
+
+      expect(instance.snapshot.maintenanceCapabilities.update).toMatchObject({
+        command: `& '${binaryPath}' update`,
+        executable: binaryPath,
+        args: ["update"],
+      });
+      expect((yield* instance.snapshot.refresh).status).toBe("disabled");
+    }).pipe(
+      Effect.provideService(HostProcessPlatform, "win32"),
+      Effect.provideService(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() => Effect.die("Disabled Cursor must not spawn a process")),
+      ),
+      Effect.scoped,
+    ),
+  );
+});

--- a/apps/server/src/provider/Drivers/CursorDriver.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.ts
@@ -62,6 +62,7 @@ const UPDATE: ProviderMaintenanceCapabilitiesResolver = {
       updateExecutable: options?.binaryPath?.trim() || "cursor-agent",
       updateArgs: ["update"],
       updateLockKey: "cursor-agent",
+      ...(options?.platform ? { platform: options.platform } : {}),
     }),
 };
 

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -447,6 +447,77 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     expect(nativePackageToolUpdate.resolve({ binaryPath }).update?.executable).toBe(binaryPath);
   });
 
+  for (const directoryName of ["plain", "with spaces", "with 'quotes' and $dollars"]) {
+    it.effect.skipIf(windowsHost)(
+      `runs the copied native update command from a ${directoryName} path`,
+      () =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-copy-native-update-" });
+          const binDir = NodePath.join(tempDir, directoryName, ".scoped-package-tool", "bin");
+          yield* fs.makeDirectory(binDir, { recursive: true });
+          const binaryPath = NodePath.join(binDir, "scoped-package-tool");
+          yield* fs.writeFileString(binaryPath, '#!/bin/sh\nprintf "%s" "$1"\n');
+          yield* fs.chmod(binaryPath, 0o755);
+
+          const capabilities = scopedPackageToolUpdate.resolve({ binaryPath });
+          const advisory = createProviderVersionAdvisory({
+            driver: driver("scopedPackageTool"),
+            currentVersion: "1.0.0",
+            latestVersion: "2.0.0",
+            maintenanceCapabilities: capabilities,
+          });
+          expect(advisory.updateCommand).not.toBeNull();
+          if (!advisory.updateCommand) return;
+          const result = NodeChildProcess.spawnSync("/bin/sh", ["-c", advisory.updateCommand], {
+            env: { PATH: "" },
+            encoding: "utf8",
+          });
+          expect(result.error).toBeUndefined();
+          expect(result.status, result.stderr).toBe(0);
+          expect(result.stdout).toBe("upgrade");
+        }).pipe(Effect.scoped),
+    );
+  }
+
+  it.each([
+    {
+      binaryPath: "C:\\Users\\Example\\.local\\bin\\native-package-tool.exe",
+      command: "C:\\Users\\Example\\.local\\bin\\native-package-tool.exe update",
+    },
+    {
+      binaryPath: "C:\\Users\\Example User\\.local\\bin\\native-package-tool.exe",
+      command: "& 'C:\\Users\\Example User\\.local\\bin\\native-package-tool.exe' update",
+    },
+    {
+      binaryPath: "C:\\Users\\O'Connor\\.local\\bin\\native-package-tool.exe",
+      command: "& 'C:\\Users\\O''Connor\\.local\\bin\\native-package-tool.exe' update",
+    },
+    {
+      binaryPath: "C:\\Users\\O\u2019Connor\\.local\\bin\\native-package-tool.exe",
+      command: "& 'C:\\Users\\O\u2019\u2019Connor\\.local\\bin\\native-package-tool.exe' update",
+    },
+  ])("formats a copied PowerShell native update for $binaryPath", ({ binaryPath, command }) => {
+    expect(nativePackageToolUpdate.resolve({ binaryPath, platform: "win32" }).update).toEqual({
+      command,
+      executable: binaryPath,
+      args: ["update"],
+      lockKey: "native-package-tool-native",
+    });
+  });
+
+  it.effect("uses the environment's platform for copied native update commands", () =>
+    Effect.gen(function* () {
+      const binaryPath = "C:\\Users\\Example User\\.local\\bin\\native-package-tool.exe";
+      const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
+        nativePackageToolUpdate,
+        { binaryPath, env: { PATH: "" } },
+      );
+      expect(capabilities.update?.command).toBe(`& '${binaryPath}' update`);
+      expect(capabilities.update?.executable).toBe(binaryPath);
+    }).pipe(Effect.provideService(HostProcessPlatform, "win32")),
+  );
+
   it("uses the resolved launcher when its symlink target identifies a native install", () => {
     const launcher = "/custom tools/native-launcher";
     const capabilities = nativePackageToolUpdate.resolve({

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -5,6 +5,7 @@ import {
 } from "@t3tools/contracts";
 import { compareSemverVersions } from "@t3tools/shared/semver";
 import { resolveCommandPath } from "@t3tools/shared/shell";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
@@ -52,6 +53,7 @@ export interface ProviderMaintenanceCommandAction {
 
 export interface ProviderMaintenanceCapabilityResolutionOptions {
   readonly binaryPath?: string | null;
+  readonly platform?: NodeJS.Platform;
   readonly env?: NodeJS.ProcessEnv;
   readonly resolvedCommandPath?: string | null;
   readonly realCommandPath?: string | null;
@@ -94,18 +96,34 @@ function nonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+function quoteUpdateExecutable(executable: string, platform: NodeJS.Platform): string {
+  const safePath = platform === "win32" ? /^[\w./:\\-]+$/ : /^[\w./:-]+$/;
+  if (safePath.test(executable)) return executable;
+  // Windows terminals default to PowerShell, where a quoted executable needs &.
+  return platform === "win32"
+    ? `& '${executable.replace(/['\u2018\u2019]/g, "$&$&")}'`
+    : `'${executable.replaceAll("'", "'\\''")}'`;
+}
+
 export function makeProviderMaintenanceCapabilities(input: {
   readonly provider: ProviderDriverKind;
   readonly packageName: string | null;
   readonly updateExecutable: string | null;
   readonly updateArgs: ReadonlyArray<string>;
   readonly updateLockKey: string | null;
+  readonly platform?: NodeJS.Platform;
 }): ProviderMaintenanceCapabilities {
   const update =
     input.updateExecutable === null || input.updateLockKey === null
       ? null
       : {
-          command: [input.updateExecutable, ...input.updateArgs].join(" "),
+          command: [
+            quoteUpdateExecutable(
+              input.updateExecutable,
+              input.platform ?? HostProcessPlatform.defaultValue(),
+            ),
+            ...input.updateArgs,
+          ].join(" "),
           executable: input.updateExecutable,
           args: input.updateArgs,
           lockKey: input.updateLockKey,
@@ -210,6 +228,7 @@ function makeHomebrewProviderMaintenanceCapabilities(
 function makeNativeProviderMaintenanceCapabilities(
   definition: PackageManagedProviderMaintenanceDefinition,
   commandPath: string,
+  platform: NodeJS.Platform,
 ): ProviderMaintenanceCapabilities | null {
   if (!definition.nativeUpdate) {
     return null;
@@ -221,6 +240,7 @@ function makeNativeProviderMaintenanceCapabilities(
     updateExecutable: commandPath,
     updateArgs: definition.nativeUpdate.args,
     updateLockKey: definition.nativeUpdate.lockKey,
+    platform,
   });
 }
 
@@ -298,8 +318,11 @@ export function resolvePackageManagedProviderMaintenance(
       commandPaths.some((commandPath) => nativeUpdate.isCommandPath(commandPath))
     ) {
       return (
-        makeNativeProviderMaintenanceCapabilities(definition, resolvedCommandPath) ??
-        makeNpmGlobalProviderMaintenanceCapabilities(definition)
+        makeNativeProviderMaintenanceCapabilities(
+          definition,
+          resolvedCommandPath,
+          options?.platform ?? HostProcessPlatform.defaultValue(),
+        ) ?? makeNpmGlobalProviderMaintenanceCapabilities(definition)
       );
     }
     if (commandPaths.some(isVitePlusGlobalCommandPath)) {
@@ -361,8 +384,9 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
   options?: Omit<ProviderMaintenanceCapabilityResolutionOptions, "realCommandPath">,
 ) {
   const binaryPath = nonEmptyString(options?.binaryPath);
+  const platform = options?.platform ?? (yield* HostProcessPlatform);
   if (!binaryPath) {
-    return resolver.resolve(options);
+    return resolver.resolve({ ...options, platform });
   }
 
   const env = options?.env ?? (yield* readCommandLookupEnv);
@@ -371,7 +395,7 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
       Effect.catchTag("CommandResolutionError", () => Effect.succeed(null)),
     )) ?? (hasPathSeparator(binaryPath) ? binaryPath : null);
   if (!resolvedCommandPath) {
-    return resolver.resolve(options);
+    return resolver.resolve({ ...options, platform });
   }
 
   const fileSystem = yield* FileSystem.FileSystem;
@@ -380,6 +404,7 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
     .pipe(Effect.orElseSucceed(() => resolvedCommandPath));
   return resolver.resolve({
     ...options,
+    platform,
     env,
     resolvedCommandPath,
     realCommandPath,


### PR DESCRIPTION
Native updater paths preserved by [#9850](https://github.com/pingdotgg/t3code/pull/9850) were copied from Settings without shell quoting. A path containing spaces worked with **Update now**, but **Copy update command** produced a command that failed in the terminal.

Quote the executable in the copied command using the environment's platform. POSIX paths use single quotes; Windows uses the existing PowerShell default and its call operator when quoting is needed. The executable and argument array used by one-click updates stay unchanged. Package-manager command strings stay unchanged too.

This follows up [#9850](https://github.com/pingdotgg/t3code/pull/9850). The broader installation-discovery report [#6115](https://github.com/pingdotgg/t3code/issues/6115) remains open.

### Before and after

The tests create disposable executable stubs, obtain the exact `versionAdvisory.updateCommand` copied by Settings, and run that string through `/bin/sh` with an empty `PATH`. No provider is installed or updated.

| Native path | Before | After |
| --- | --- | --- |
| Plain path | Exit 0, `upgrade` | Exit 0, `upgrade` |
| Path with spaces | Exit 127, truncated executable not found | Exit 0, `upgrade` |
| Path with apostrophes and `$` | Exit 127 | Exit 0, `upgrade` |

The failure was reproduced on [2d5464a](https://github.com/pingdotgg/t3code/commit/2d5464afbc19058be8c125d5ee70481d721d14f4). The original fix was based on [896fe82](https://github.com/pingdotgg/t3code/commit/896fe82f2f191eb8ac0fd620e19c25dd48253592). It is now refreshed onto [ce4712d5](https://github.com/pingdotgg/t3code/commit/ce4712d5b04fb998f79fe132245289191147e5d5), including the upstream CI mirror repair; no additional workflow changes were made. The changed behavior is copied command text, so executable before/after evidence is provided instead of layout screenshots.

### Verification

- 42 focused maintenance, runner, and Cursor driver tests pass, including all three shell executions, PowerShell path formatting, apostrophe escaping, and injected environment-platform handling.
- A disabled Cursor driver fixture reproduces the missing injected-platform handoff before its fix and passes afterward. It rejects any process spawn or HTTP request.
- Server typecheck, targeted lint, formatting, and `git diff --check` pass.
- Actual shell execution was tested on Linux. PowerShell formatting is covered by fixtures; native Windows execution was not available.
- Web and desktop copy the server-provided advisory string. Formatting follows the environment platform, not the connecting client's OS. No mobile UI or wire schema changes.

### Review limitation

The [Effect Service Conventions check](https://github.com/pingdotgg/t3code/runs/101230716919) concluded **NEUTRAL**, not success. It flags the synchronous helpers' ambient-platform fallback. Current production drivers acquire and forward the environment platform; six focused Windows/platform controls pass on this head, including the actual disabled Cursor driver. The orchestrator reviewed the concern and deferred a broader required-parameter refactor as nonblocking for this scope. Future synchronous native callers must supply their intended platform explicitly. All executed CI tests pass; the neutral check is not described as green.

GPT 6 Astra via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the copied command string for provider maintenance; one-click updates and package-manager commands are untouched, with a minor requirement that effectful resolution paths provide `HostProcessPlatform`.
> 
> **Overview**
> **Copy update command** for native provider updaters now quotes the executable when the path needs shell escaping, so pasted commands work in terminals (paths with spaces, quotes, or `$` no longer break on POSIX; Windows gets PowerShell-style `& '...'` with doubled apostrophes).
> 
> `makeProviderMaintenanceCapabilities` builds the display `command` via new `quoteUpdateExecutable` using an optional **`platform`** on maintenance resolution options. `resolveProviderMaintenanceCapabilitiesEffect` supplies `HostProcessPlatform` when callers omit it, and native/Cursor resolvers forward `platform` so formatting matches the server host—not the UI client. **Update now** still uses unquoted `executable` + `args`; npm/brew-style command strings are unchanged.
> 
> Tests add POSIX shell runs of the copied advisory string, Windows command fixtures, platform injection through the effect resolver, and a disabled **CursorDriver** case for a spaced Windows binary path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e589282ab156ff69b4f523343dc88cce99d9884a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Quote copied native provider update commands for target platform
> - Adds `quoteUpdateExecutable` to [providerMaintenance.ts](https://github.com/pingdotgg/t3code/pull/9856/files#diff-e29fae218a488cafd27faaeea37f0b7c1dccd03ba4a994975736ddf89e3bde14), which quotes executable paths containing spaces or shell-significant characters using POSIX single-quote escaping or PowerShell call-operator syntax with doubled apostrophes
> - Introduces an optional `platform` field on `ProviderMaintenanceCapabilityResolutionOptions` and threads it through `resolveProviderMaintenanceCapabilitiesEffect`, `resolvePackageManagedProviderMaintenance`, and `makeNativeProviderMaintenanceCapabilities` so update descriptors format commands for the requested platform instead of always joining the raw path with arguments
> - Adds tests covering Windows paths with spaces and apostrophes, POSIX paths with shell-significant characters, and platform injection through the effectful resolver in [providerMaintenance.test.ts](https://github.com/pingdotgg/t3code/pull/9856/files#diff-40e44f8465f8c4e465f1d73d81229b1ff72980f8fa6e6711363d9ef9c1fb54ad) and [CursorDriver.test.ts](https://github.com/pingdotgg/t3code/pull/9856/files#diff-4de666e13f9fd279b35a8ec15462d2a5f937594e737ac2506c674cdd6eaefebd)
> - Risk: `resolveProviderMaintenanceCapabilitiesEffect` now requires `HostProcessPlatform` when the caller does not supply a platform explicitly; callers that previously relied on the resolver without this service available will fail
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e589282.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


