### PR TITLE
fix(client): remove reverted prompts from live history

### DIFF
--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -1183,6 +1183,15 @@ describe("applyThreadDetailEvent", () => {
           },
           {
             id: MessageId.make("msg-3"),
+            role: "user",
+            text: "Second",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-04-01T02:30:00.000Z",
+            updatedAt: "2026-04-01T02:30:00.000Z",
+          },
+          {
+            id: MessageId.make("msg-4"),
             role: "assistant",
             text: "Response 2",
             turnId: TurnId.make("turn-2"),
@@ -1207,7 +1216,7 @@ describe("applyThreadDetailEvent", () => {
             checkpointRef: CheckpointRef.make("ref-2"),
             status: "ready",
             files: [],
-            assistantMessageId: MessageId.make("msg-3"),
+            assistantMessageId: MessageId.make("msg-4"),
             completedAt: "2026-04-01T03:00:00.000Z",
           },
         ],
@@ -1231,9 +1240,190 @@ describe("applyThreadDetailEvent", () => {
         // turn-2 checkpoint is filtered out (turnCount 2 > revert target 1)
         expect(result.thread.checkpoints).toHaveLength(1);
         expect(result.thread.checkpoints[0]?.turnId).toBe("turn-1");
-        // msg-3 (turn-2) is filtered, msg-1 (no turn) and msg-2 (turn-1) remain
+        // The second turnless user prompt and its turn-2 response are filtered.
         expect(result.thread.messages).toHaveLength(2);
+        expect(result.thread.messages.map((message) => message.id)).toEqual(["msg-1", "msg-2"]);
         expect(result.thread.latestTurn?.turnId).toBe("turn-1");
+      }
+    });
+
+    it("uses retained turns from the loaded pagination window", () => {
+      const loadedTurns = [90, 91, 92].map((turnCount) => ({
+        turnCount,
+        turnId: TurnId.make(`turn-${turnCount}`),
+      }));
+      const messages: OrchestrationThread["messages"] = loadedTurns.flatMap(
+        ({ turnCount }, index) => [
+          {
+            id: MessageId.make(`user-${turnCount}`),
+            role: "user" as const,
+            text: `Prompt ${turnCount}`,
+            turnId: null,
+            streaming: false,
+            createdAt: `2026-04-01T00:00:0${index * 2}.000Z`,
+            updatedAt: `2026-04-01T00:00:0${index * 2}.000Z`,
+          },
+          {
+            id: MessageId.make(`assistant-${turnCount}`),
+            role: "assistant" as const,
+            text: `Response ${turnCount}`,
+            turnId: null,
+            streaming: false,
+            createdAt: `2026-04-01T00:00:0${index * 2 + 1}.000Z`,
+            updatedAt: `2026-04-01T00:00:0${index * 2 + 1}.000Z`,
+          },
+        ],
+      );
+      const threadWithWindow: OrchestrationThread = {
+        ...baseThread,
+        messages,
+        checkpoints: loadedTurns.map(({ turnCount, turnId }, index) => ({
+          turnId,
+          checkpointTurnCount: turnCount,
+          checkpointRef: CheckpointRef.make(`ref-${turnCount}`),
+          status: "ready",
+          files: [],
+          assistantMessageId: MessageId.make(`assistant-${turnCount}`),
+          completedAt: `2026-04-01T00:01:0${index}.000Z`,
+        })),
+      };
+
+      const result = applyThreadDetailEvent(threadWithWindow, {
+        ...baseEventFields,
+        sequence: 15,
+        occurredAt: "2026-04-01T04:00:00.000Z",
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        type: "thread.reverted",
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          turnCount: 91,
+        },
+      });
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.messages.map((message) => message.id)).toEqual([
+          "user-90",
+          "assistant-90",
+          "user-91",
+          "assistant-91",
+        ]);
+      }
+    });
+
+    it.each([0, 1])(
+      "drops turnless prompts when no checkpoint survives a revert to %i",
+      (turnCount) => {
+        const messages: OrchestrationThread["messages"] = ["system", "user"].map((role) => ({
+          id: MessageId.make(role),
+          role: role as "system" | "user",
+          text: role,
+          turnId: null,
+          streaming: false,
+          createdAt: "2026-04-01T01:00:00.000Z",
+          updatedAt: "2026-04-01T01:00:00.000Z",
+        }));
+        const result = applyThreadDetailEvent(
+          {
+            ...baseThread,
+            messages,
+            checkpoints: [
+              {
+                turnId: TurnId.make("turn-2"),
+                checkpointTurnCount: 2,
+                checkpointRef: CheckpointRef.make("ref-2"),
+                status: "ready",
+                files: [],
+                assistantMessageId: null,
+                completedAt: "2026-04-01T01:01:00.000Z",
+              },
+            ],
+          },
+          {
+            ...baseEventFields,
+            sequence: 17,
+            occurredAt: "2026-04-01T02:00:00.000Z",
+            aggregateKind: "thread",
+            aggregateId: ThreadId.make("thread-1"),
+            type: "thread.reverted",
+            payload: { threadId: ThreadId.make("thread-1"), turnCount },
+          },
+        );
+        expect(result.kind).toBe("updated");
+        if (result.kind === "updated") {
+          expect(result.thread.messages.map((message) => message.id)).toEqual(["system"]);
+        }
+      },
+    );
+
+    it("retains every message before the latest retained checkpoint", () => {
+      const message = (
+        id: string,
+        role: "user" | "assistant",
+        createdAt: string,
+      ): OrchestrationThread["messages"][number] => ({
+        id: MessageId.make(id),
+        role,
+        text: id,
+        turnId: null,
+        streaming: false,
+        createdAt,
+        updatedAt: createdAt,
+      });
+      const threadWithSteering: OrchestrationThread = {
+        ...baseThread,
+        messages: [
+          message("user-1", "user", "2026-04-01T01:00:00.000Z"),
+          message("assistant-commentary-1", "assistant", "2026-04-01T01:01:00.000Z"),
+          message("user-steering-1", "user", "2026-04-01T01:02:00.000Z"),
+          message("assistant-final-1", "assistant", "2026-04-01T01:03:00.000Z"),
+          message("user-2", "user", "2026-04-01T02:00:00.000Z"),
+          message("assistant-final-2", "assistant", "2026-04-01T02:01:00.000Z"),
+        ],
+        checkpoints: [
+          {
+            turnId: TurnId.make("turn-1"),
+            checkpointTurnCount: 1,
+            checkpointRef: CheckpointRef.make("ref-1"),
+            status: "ready",
+            files: [],
+            assistantMessageId: null,
+            completedAt: "2026-04-01T01:04:00.000Z",
+          },
+          {
+            turnId: TurnId.make("turn-2"),
+            checkpointTurnCount: 2,
+            checkpointRef: CheckpointRef.make("ref-2"),
+            status: "ready",
+            files: [],
+            assistantMessageId: null,
+            completedAt: "2026-04-01T02:02:00.000Z",
+          },
+        ],
+      };
+
+      const result = applyThreadDetailEvent(threadWithSteering, {
+        ...baseEventFields,
+        sequence: 16,
+        occurredAt: "2026-04-01T03:00:00.000Z",
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        type: "thread.reverted",
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          turnCount: 1,
+        },
+      });
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.messages.map((entry) => entry.id)).toEqual([
+          "user-1",
+          "assistant-commentary-1",
+          "user-steering-1",
+          "assistant-final-1",
+        ]);
       }
     });
   });

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -548,7 +548,12 @@ export function applyThreadDetailEvent(
       );
 
       const retainedTurnIds = new Set(Arr.map(checkpoints, (entry) => entry.turnId));
-      const messages = retainMessagesAfterRevert(thread.messages, retainedTurnIds);
+      const latestCheckpoint = checkpoints.at(-1) ?? null;
+      const messages = retainMessagesAfterRevert(
+        thread.messages,
+        retainedTurnIds,
+        latestCheckpoint,
+      );
       const proposedPlans = pipe(
         thread.proposedPlans,
         Arr.filter((plan) => plan.turnId === null || retainedTurnIds.has(plan.turnId)),
@@ -557,8 +562,6 @@ export function applyThreadDetailEvent(
         thread.activities,
         Arr.filter((activity) => activity.turnId === null || retainedTurnIds.has(activity.turnId)),
       );
-      const latestCheckpoint = checkpoints.at(-1) ?? null;
-
       return {
         kind: "updated",
         thread: {
@@ -741,16 +744,18 @@ function rebindCheckpointAssistantMessage(
 function retainMessagesAfterRevert(
   messages: ReadonlyArray<OrchestrationMessage>,
   retainedTurnIds: ReadonlySet<string>,
+  latestCheckpoint: OrchestrationCheckpointSummary | null,
 ): OrchestrationMessage[] {
-  // Keep messages that belong to a retained turn, plus system messages and
-  // messages without a turn binding (pre-turn-0 user messages).
-  return Arr.filter(messages, (message) => {
-    if (message.role === "system") {
-      return true;
-    }
-    if (message.turnId === null) {
-      return true;
-    }
-    return retainedTurnIds.has(message.turnId);
+  const checkpointMessageId = latestCheckpoint?.assistantMessageId ?? null;
+  const checkpointMessageIndex =
+    checkpointMessageId === null
+      ? -1
+      : messages.findIndex((message) => message.id === checkpointMessageId);
+
+  return messages.filter((message, index) => {
+    if (message.role === "system") return true;
+    if (message.turnId !== null) return retainedTurnIds.has(message.turnId);
+    if (checkpointMessageIndex >= 0) return index <= checkpointMessageIndex;
+    return latestCheckpoint !== null && message.createdAt <= latestCheckpoint.completedAt;
   });
 }


### PR DESCRIPTION
After a successful revert, the live client keeps user prompts without a turn ID even when the server has removed them. Reloading the thread produces different history.

**Human-held:** the ordinary two-turn case is fixed, but additional receipt tests confirm a pre-existing server/client disagreement for steering messages and turnless assistant commentary. This candidate preserves those earlier rows in the live client while the server drops them. Choosing preservation versus matching the server's removal needs a maintainer decision; this PR is not ready for automatic merge.

Bound those prompts by the latest retained checkpoint's assistant message, falling back to its completion time when that message is outside the loaded window. Preserve messages bound to retained turns and system messages. This carries forward only Amit Ray's retention correction and regression tests from closed [#6044](https://github.com/pingdotgg/t3code/pull/6044), with an additional no-surviving-checkpoint control. The author [invited reuse](https://github.com/pingdotgg/t3code/pull/6044#issuecomment-5372126063), and maintainer edits on that closed branch are unavailable.

Addresses the live-history portion of [#5685](https://github.com/pingdotgg/t3code/issues/5685). Restoring prompts, images or existing drafts into the composer is not included; the issue remains open for those recovery choices.

### Before and after

A disposable SQLite orchestration engine generated two turns and checkpoint records at [82f64cd8](https://github.com/pingdotgg/t3code/commit/82f64cd8d046ab4ee8588f7bcbc1e66a4a0c80fe). After its committed revert-completion receipt:

| History | Before | After |
| --- | --- | --- |
| Persisted server snapshot | Prompt 1, Answer 1 | Prompt 1, Answer 1 |
| Actual shared client reducer, given that exact persisted event | Prompt 1, Answer 1, **Prompt 2** | Prompt 1, Answer 1 |

The receipt fixture waits on engine receipts and worker drains, without sleeps. This verifies post-revert history projection, not a Git/provider rewind or browser interaction. No UI component, provider behavior, schema, dependency or stored-data migration changes.

Additional receipt-derived controls use real persisted snapshots, not reducer-only expected arrays:

| Case | Result at this candidate |
| --- | --- |
| Ordinary two-turn history | Live and persisted histories match |
| Missing checkpoint assistant ID, completion-time fallback | Match |
| Loaded client window starts after the retained checkpoint | Match for the loaded message IDs |
| Same-turn steering before the retained checkpoint | Live keeps the steering prompt; persisted history drops it |
| Turnless assistant commentary before the retained checkpoint | Live keeps the commentary; persisted history drops it |

The last two are unresolved history-policy limits, not claims of complete parity. Server retention and contracts remain unchanged.

### Checks

- 49 focused shared-client reducer and pagination tests pass. The original, paginated-window and steering-history regressions failed on main before the correction.
- Checkpoint-zero and no-retained-checkpoint controls preserve system messages and remove turnless prompts.
- Client-runtime typecheck, targeted lint and diff checks pass.
- Web, desktop and mobile consume this shared reducer. No native-device run is claimed.

The earlier CI attempt was infrastructure-blocked by Ubuntu HTTP mirror timeouts. This branch is now refreshed onto [ce4712d5](https://github.com/pingdotgg/t3code/commit/ce4712d5b04fb998f79fe132245289191147e5d5), which includes the upstream HTTPS mirror repair. All 49 focused tests, client-runtime typecheck and targeted lint pass again. A new current-head CI cycle is running. No extra workflow change or check bypass was made. The human history-policy hold above remains in place.

Original correction by [Amit Ray](https://github.com/amitray007). Prepared and verified with GPT 6 Astra via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared revert projection logic used by web/desktop/mobile; wrong bounds could drop or keep the wrong messages in chat history, though scope is limited to `thread.reverted` handling and is heavily regression-tested.
> 
> **Overview**
> Fixes **live thread history** after a `thread.reverted` event so reverted user prompts (and related rows) disappear without a full reload.
> 
> **`retainMessagesAfterRevert`** no longer keeps every message with a null `turnId`. Turn-bound messages still follow retained checkpoints; **system** messages stay. **Turnless** user/assistant rows are kept only through the **latest retained checkpoint**—by index through that checkpoint’s `assistantMessageId` when it’s in the loaded window, otherwise by `createdAt` vs the checkpoint’s `completedAt`.
> 
> The existing two-turn revert test is updated (explicit second prompt + assistant id), with new reducer tests for paginated windows, no surviving checkpoint, and pre-checkpoint steering/commentary retention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 576461e11220e74494d443954a5c2b29b101ff53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
