### PR TITLE
fix(server): retain GitLab approval system notes

### DIFF
--- a/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
@@ -913,6 +913,64 @@ layer("GitLabPullRequestCli.layer", (it) => {
     }),
   );
 
+  it.effect("reads approval history after a full page of unrelated system notes", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(
+          output(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify(
+              Array.from({ length: 100 }, (_, index) => ({
+                id: index + 1,
+                system: true,
+                body: "assigned to @reviewer",
+                created_at: "2026-07-01T00:00:00Z",
+              })),
+            ),
+          ),
+        ),
+      );
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(
+          output(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([
+              {
+                id: 101,
+                system: true,
+                body: "approved this merge request",
+                author: { username: "reviewer" },
+                created_at: "2026-07-02T00:00:00Z",
+              },
+              {
+                id: 102,
+                system: true,
+                body: "unapproved this merge request",
+                author: { username: "reviewer" },
+                created_at: "2026-07-03T00:00:00Z",
+              },
+            ]),
+          ),
+        ),
+      );
+
+      const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
+      const { comments, truncated } = yield* cli.listNotes({
+        cwd: "/w",
+        repository: "acme/web",
+        number: 7,
+      });
+
+      expect(comments).toMatchObject([
+        { id: "101", kind: "review", reviewState: "APPROVED" },
+        { id: "102", kind: "review", reviewState: "DISMISSED" },
+      ]);
+      expect(argsOfCall(1).join(" ")).toContain("page=2");
+      assert.strictEqual(mockedExecute.mock.calls.length, 2);
+      assert.isFalse(truncated);
+    }),
+  );
+
   it.effect("stops the note walk at its bound and says the conversation was cut short", () =>
     Effect.gen(function* () {
       // GitLab that never answers short: the walk has to end itself.

--- a/apps/server/src/pullRequest/gitLabMergeRequestJson.test.ts
+++ b/apps/server/src/pullRequest/gitLabMergeRequestJson.test.ts
@@ -247,6 +247,71 @@ describe("decodeViewerJson", () => {
 });
 
 describe("decodeNotesJson", () => {
+  it("retains approval and withdrawal notes without classifying authored comments as verdicts", () => {
+    const notes = expectSuccess(
+      decodeNotesJson(
+        JSON.stringify([
+          {
+            id: 1,
+            body: "approved this merge request",
+            author: { username: "reviewer" },
+            system: true,
+            created_at: "2026-07-01T00:00:00Z",
+          },
+          {
+            id: 2,
+            body: "unapproved this merge request",
+            author: { username: "reviewer" },
+            system: true,
+            created_at: "2026-07-02T00:00:00Z",
+          },
+          {
+            id: 3,
+            body: "approved this merge request",
+            author: { username: "author" },
+            system: false,
+            created_at: "2026-07-03T00:00:00Z",
+          },
+          {
+            id: 4,
+            body: "assigned to @reviewer",
+            system: true,
+            created_at: "2026-07-04T00:00:00Z",
+          },
+          {
+            id: 5,
+            body: "approved this merge request with a custom message",
+            system: true,
+            created_at: "2026-07-05T00:00:00Z",
+          },
+        ]),
+      ),
+    );
+
+    expect(notes.rawCount).toBe(5);
+    expect(notes.comments).toMatchObject([
+      {
+        id: "1",
+        kind: "review",
+        body: "approved this merge request",
+        author: { login: "reviewer" },
+        createdAt: "2026-07-01T00:00:00Z",
+        reviewState: "APPROVED",
+        path: null,
+      },
+      {
+        id: "2",
+        kind: "review",
+        body: "unapproved this merge request",
+        author: { login: "reviewer" },
+        createdAt: "2026-07-02T00:00:00Z",
+        reviewState: "DISMISSED",
+        path: null,
+      },
+      { id: "3", kind: "issue-comment", reviewState: null },
+    ]);
+  });
+
   it("keeps comments and drops GitLab's own activity notes", () => {
     const notes = expectSuccess(
       decodeNotesJson(

--- a/apps/server/src/pullRequest/gitLabMergeRequestJson.ts
+++ b/apps/server/src/pullRequest/gitLabMergeRequestJson.ts
@@ -515,13 +515,6 @@ export function decodeProjectMergeCapabilitiesJson(
   });
 }
 
-/**
- * Comments only. System notes are GitLab's own activity feed entries, and a `DiffNote` is the
- * root of a line-level discussion, which is what the review-comment kind means.
- *
- * The raw note count comes back alongside, because dropping notes hides whether the page was
- * full: a caller cannot tell "no more notes" from "a page of activity entries" without it.
- */
 /** The three revisions a positioned comment is written against. */
 export interface GitLabDiffRefs {
   readonly baseSha: string;
@@ -594,6 +587,21 @@ export function decodeDiffRefsJson(
   );
 }
 
+function systemNoteReviewState(body: string): "APPROVED" | "DISMISSED" | null {
+  switch (body.trim()) {
+    case "approved this merge request":
+      return "APPROVED";
+    case "unapproved this merge request":
+      return "DISMISSED";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Comments and approval history. Other system activity stays excluded. The raw count includes
+ * every note so a page containing only skipped activity does not end pagination early.
+ */
 export function decodeNotesJson(
   raw: string,
 ): Result.Result<
@@ -609,19 +617,23 @@ export function decodeNotesJson(
     const note = decodeNoteEntry(entry);
     if (Exit.isFailure(note)) continue;
     const value = note.value;
-    if (value.system === true) continue;
     const body = value.body ?? "";
+    const reviewState = value.system === true ? systemNoteReviewState(body) : null;
+    if (value.system === true && reviewState === null) continue;
     if (body.trim().length === 0) continue;
     const isDiffNote = value.type?.trim() === "DiffNote";
     comments.push({
       id: String(value.id),
-      kind: isDiffNote ? "review-comment" : "issue-comment",
+      kind: reviewState !== null ? "review" : isDiffNote ? "review-comment" : "issue-comment",
       author: toActor(value.author),
       body,
       createdAt: value.created_at,
       url: null,
-      path: trimmed(value.position?.new_path) ?? trimmed(value.position?.old_path),
-      reviewState: null,
+      path:
+        reviewState !== null
+          ? null
+          : (trimmed(value.position?.new_path) ?? trimmed(value.position?.old_path)),
+      reviewState,
     });
   }
   return Result.succeed({ comments, rawCount: decoded.success.length });

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -60,6 +60,7 @@ import {
 import { PullRequestMarkdown } from "./PullRequestMarkdown";
 import { PullRequestMarkdownEditor } from "./PullRequestMarkdownEditor";
 import { PullRequestReactionBar } from "./PullRequestReactions";
+import { canReactPullRequestComment } from "./pullRequestReactions.logic";
 import { PullRequestConversationGhost } from "./PullRequestGhosts";
 import { pullRequestLabelColor } from "./pullRequestList.logic";
 import { sectionCollapseAnchorScrollTop } from "./pullRequestSummaryScroll.logic";
@@ -893,7 +894,7 @@ export function PullRequestSummaryTab({
                           <PullRequestReactionBar
                             className="mt-2"
                             reactions={comment.reactions ?? []}
-                            canReact={detail.capabilities.reactions === true}
+                            canReact={canReactPullRequestComment(detail, comment)}
                             subjectId={comment.id}
                             environmentId={environmentId}
                             reference={reference}
@@ -922,7 +923,7 @@ export function PullRequestSummaryTab({
                   const reactionBar = (
                     <PullRequestReactionBar
                       reactions={comment.reactions ?? []}
-                      canReact={detail.capabilities.reactions === true}
+                      canReact={canReactPullRequestComment(detail, comment)}
                       subjectId={comment.id}
                       environmentId={environmentId}
                       reference={reference}

--- a/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
@@ -42,6 +42,7 @@ import { canEditPullRequestComment } from "./pullRequestEditing.logic";
 import { PullRequestMarkdown } from "./PullRequestMarkdown";
 import { PullRequestMarkdownEditor } from "./PullRequestMarkdownEditor";
 import { PullRequestReactionBar } from "./PullRequestReactions";
+import { canReactPullRequestComment } from "./pullRequestReactions.logic";
 import {
   PullRequestActorAvatar,
   PullRequestDiffStat,
@@ -619,7 +620,13 @@ export function PullRequestTimelineTab({
                   stale={isPullRequestVerdictStale(event.at, newestCommitAt)}
                   cwd={detail.workspaceRoot}
                   onOpen={openOnHost}
-                  reactions={reactions}
+                  reactions={{
+                    ...reactions,
+                    canReact:
+                      event.kind === "review"
+                        ? canReactPullRequestComment(detail, { kind: event.kind })
+                        : reactions.canReact,
+                  }}
                 />
               );
             }

--- a/apps/web/src/components/pullRequest/pullRequestReactions.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestReactions.logic.test.ts
@@ -1,13 +1,56 @@
-import type { PullRequestReaction, PullRequestReactionContent } from "@t3tools/contracts";
+import type {
+  PullRequestComment,
+  PullRequestDetail,
+  PullRequestReaction,
+  PullRequestReactionContent,
+} from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
   applyPendingPullRequestReactions,
+  canReactPullRequestComment,
   PULL_REQUEST_REACTION_ORDER,
   pullRequestReactionEmoji,
   pullRequestReactionName,
   pullRequestReactionTooltip,
 } from "./pullRequestReactions.logic";
+
+describe("comment reaction permissions", () => {
+  it.each<{
+    provider: PullRequestDetail["provider"];
+    kind: PullRequestComment["kind"];
+    expected: boolean;
+  }>([
+    { provider: "gitlab", kind: "review", expected: false },
+    { provider: "gitlab", kind: "issue-comment", expected: true },
+    { provider: "gitlab", kind: "review-comment", expected: true },
+    { provider: "github", kind: "review", expected: true },
+  ])("$provider $kind is reactable: $expected", ({ provider, kind, expected }) => {
+    const capabilities: PullRequestDetail["capabilities"] = {
+      diff: true,
+      comment: true,
+      actions: [],
+      mergeMethods: [],
+      search: true,
+      reactions: true,
+      review: { inlineComment: true, reply: true, resolve: true, verdicts: [] },
+      reviewers: { request: true, listCandidates: true },
+    };
+    expect(canReactPullRequestComment({ provider, capabilities }, { kind })).toBe(expected);
+    expect(
+      canReactPullRequestComment(
+        { provider, capabilities: { ...capabilities, reactions: false } },
+        { kind },
+      ),
+    ).toBe(false);
+    expect(
+      canReactPullRequestComment(
+        { provider, capabilities: { ...capabilities, reactions: undefined } },
+        { kind },
+      ),
+    ).toBe(false);
+  });
+});
 
 function reaction(overrides: Partial<PullRequestReaction> = {}): PullRequestReaction {
   return {

--- a/apps/web/src/components/pullRequest/pullRequestReactions.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestReactions.logic.ts
@@ -1,4 +1,20 @@
-import type { PullRequestReaction, PullRequestReactionContent } from "@t3tools/contracts";
+import type {
+  PullRequestComment,
+  PullRequestDetail,
+  PullRequestReaction,
+  PullRequestReactionContent,
+} from "@t3tools/contracts";
+
+/** GitLab review rows come from system notes, which cannot receive emoji awards. */
+export function canReactPullRequestComment(
+  detail: Pick<PullRequestDetail, "provider" | "capabilities">,
+  comment: Pick<PullRequestComment, "kind">,
+): boolean {
+  return (
+    detail.capabilities.reactions === true &&
+    !(detail.provider === "gitlab" && comment.kind === "review")
+  );
+}
 
 /** The picker's order, which is GitHub's: the two verdicts first, then the rest as it lists them. */
 export const PULL_REQUEST_REACTION_ORDER: ReadonlyArray<PullRequestReactionContent> = [


### PR DESCRIPTION
GitLab approval and withdrawal notes are discarded with all system activity, so the existing review view receives no record of either event. This is a bounded candidate for [#9802](https://github.com/pingdotgg/t3code/issues/9802), not a complete system timeline.

Keep only the exact approval and unapproval bodies generated by [GitLab's note service](https://github.com/gitlabhq/gitlabhq/blob/0ec898cd5e65f183ca66caa017378c6de7d5e59b/app/services/system_notes/merge_requests_service.rb#L165), and only when `system` is true. Map them to the existing `review` kind with `APPROVED` or `DISMISSED`, preserving the note ID, author, body, and timestamp. Other system notes remain hidden. An ordinary comment containing the same words remains a comment.

No new API requests, schema fields, or dependencies. The existing review kind avoids offering an edit button for GitLab-generated notes. GitLab also [rejects emoji awards on system notes](https://github.com/gitlabhq/gitlabhq/blob/0ec898cd5e65f183ca66caa017378c6de7d5e59b/app/models/note.rb#L538), so the web and desktop Summary and Timeline hide reaction controls for GitLab review rows. Ordinary GitLab comments and description reactions keep their existing behavior. GitLab's adapter emits `review` only for these system-derived notes. Raw note counts remain unchanged so a full page of skipped activity does not stop pagination early.

Verification on main [82f64cd8](https://github.com/pingdotgg/t3code/commit/82f64cd8d046ab4ee8588f7bcbc1e66a4a0c80fe):

- Before: the production decoder drops both approval and withdrawal. The real CLI note walker follows a full page of unrelated system activity, then still returns no comments from the page containing both events. Both new regressions fail on unchanged main.
- After: the decoder and CLI output retain the two historical reviews, preserve their author/timestamps, exclude unrelated system activity, and do not classify an authored lookalike as a verdict.
- `vp test run apps/server/src/pullRequest/gitLabMergeRequestJson.test.ts apps/server/src/pullRequest/GitLabPullRequestCli.test.ts apps/server/src/pullRequest/GitLabPullRequestProvider.test.ts apps/web/src/components/pullRequest/pullRequestReactions.logic.test.ts apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts apps/web/src/components/pullRequest/pullRequestEditing.logic.test.ts --maxWorkers=2`: 228 tests pass. Reaction permission cases cover GitLab system-derived reviews, ordinary notes, inline comments, other-provider reviews, and disabled or absent host capability. The GitLab review case fails when the helper uses the previous capability-only predicate.
- Targeted lint/format and server/web typechecks pass. Lint reports one pre-existing array-index-key warning in Summary's loading skeleton. No native client was launched; desktop shares these web views and mobile has no corresponding reaction controls.

Human decision required; leave unmerged. Reusing the review kind feeds the existing comment/timeline presentation and current-review badges from [#7077](https://github.com/pingdotgg/t3code/pull/7077). Those badges use a commit-date heuristic, not GitLab's authoritative current approval state. Automatic approval resets, other system-note variants, and localized/custom bodies are not implemented here. A maintainer must decide whether this historical-note mapping is acceptable or whether approvals need a distinct presentation/current-state read.

The local evidence is decoder/CLI output, not a live GitLab account or integrated client capture. An anonymous GitLab notes request returned 401; no credentials or production state were changed. Integrated visual evidence remains pending. Do not close the broader issue from this candidate alone.

Refreshed September 5 onto main [ce4712d](https://github.com/pingdotgg/t3code/commit/ce4712d5b04fb998f79fe132245289191147e5d5), which fixes the Ubuntu CI mirror transport upstream. The seven changed source/test files are byte-identical to the previously reviewed candidate. All 228 focused tests, server/web typechecks and targeted lint/format pass again, with the same existing skeleton warning. Current-head CI, Bugbot, UI and Effect checks pass at [c1c5990](https://github.com/pingdotgg/t3code/commit/c1c5990ca71d9f3c563d07f4d9ca405abf91637b). Correctness and approvability checks skipped the unchanged rebase; the prior human-review requirement remains. There are no review threads or active change requests. The previous [CI run 33936579569](https://github.com/pingdotgg/t3code/actions/runs/33936579569) exhausted its one retry on the old HTTP mirror failure; it is not counted as passing. This PR adds no workflow changes or bypasses. Human approval and integrated visual evidence remain required, so it is not merge-ready.

Prepared by GPT 6 Astra via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to GitLab note decoding and UI reaction gating, with regression tests; review badges still use commit-date heuristics rather than GitLab’s live approval state.
> 
> **Overview**
> GitLab merge request conversations previously dropped **all** system notes, so approvals and unapprovals never reached the review UI. **`decodeNotesJson`** now keeps only exact `system: true` bodies (`approved this merge request` / `unapproved this merge request`), maps them to **`review`** comments with **`APPROVED`** / **`DISMISSED`**, and still filters other system activity. User-authored text that looks like an approval stays a normal comment; **`rawCount`** is unchanged so note pagination does not stop on a page of skipped system notes.
> 
> The web layer adds **`canReactPullRequestComment`**, which turns off emoji reactions on GitLab **`review`** rows (system notes cannot be awarded on GitLab). Summary and Timeline use that helper instead of the global reactions capability alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1c5990ca71d9f3c563d07f4d9ca405abf91637b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
