### PR TITLE
fix(release): install the correct Windows Spectre component

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -519,7 +519,7 @@ jobs:
           $setupExe = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
           $proc = Start-Process -FilePath $setupExe `
             -ArgumentList "modify", "--installPath", "`"$installPath`"", "--add", `
-            "Microsoft.VisualStudio.Component.VC.Tools.x86.x64.Spectre", "--quiet", "--norestart" `
+            "Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre", "--quiet", "--norestart" `
             -Wait -PassThru -NoNewWindow
           if ($null -eq $proc -or $proc.ExitCode -ne 0) {
             $code = if ($null -ne $proc) { $proc.ExitCode } else { 1 }


### PR DESCRIPTION
windows release builds fail the msvc prerequisite check because the workflow requests a nonexistent spectre component; visual studio logs "no matching package found" but exits successfully ([failed job](https://github.com/pingdotgg/t3code/actions/runs/33935149711/job/101221649662)). replace it with `Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre`, the latest x64/x86 spectre libraries listed in [microsoft's component catalog](https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022).

verified the installer warning in both recent failed windows jobs, checked the replacement against microsoft's catalog, and passed workflow formatting and `git diff --check`; a windows release build remains unverified. the existing prerequisite check still verifies that the libraries are installed.

model: `gpt-5.6-sol`; harness: codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI workflow component ID change with no application or security logic touched.
> 
> **Overview**
> Fixes Windows release builds that fail MSVC prerequisite checks because the **Install Spectre-mitigated MSVC libs** step in `release.yml` requested a Visual Studio component ID that does not exist (`Microsoft.VisualStudio.Component.VC.Tools.x86.x64.Spectre`). The installer could log "no matching package found" without actually installing the libraries.
> 
> The workflow now adds **`Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre`**, which matches Microsoft's component catalog for Spectre-mitigated x86/x64 MSVC runtimes. The existing desktop build prerequisite check still validates that those libraries are present before packaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe9d4c4e21ef8d36b47181f2d86da88fe22b7c71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows release workflow to install Spectre-mitigated MSVC runtimes
> Corrects the component ID requested in the Windows release step of [release.yml](https://github.com/pingdotgg/t3code/pull/9859/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34). It now asks the Visual Studio Installer for the Spectre-mitigated MSVC runtimes component instead of the tools component.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe9d4c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->