### PR TITLE
fix(ci): add fallback Ubuntu package mirrors

### DIFF
--- a/.github/actions/setup-apt-mirrors/action.yml
+++ b/.github/actions/setup-apt-mirrors/action.yml
@@ -1,0 +1,21 @@
+name: Setup APT mirrors
+description: Configure Ubuntu package downloads with automatic mirror failover.
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        printf '%s\tpriority:%s\n' \
+          https://archive.ubuntu.com/ubuntu 1 \
+          https://mirrors.edge.kernel.org/ubuntu 2 \
+          https://mirror.math.princeton.edu/pub/ubuntu 3 \
+          | sudo tee /etc/apt/ubuntu-mirrors.txt > /dev/null
+
+        # APT's mirror transport retries each file against the next server.
+        sudo find /etc/apt -maxdepth 2 -type f \( -name '*.list' -o -name '*.sources' \) \
+          -exec sed -i -E \
+          's#https?://(([^/]+\.)?archive|security)\.ubuntu\.com/ubuntu/?#mirror+file:/etc/apt/ubuntu-mirrors.txt#g' {} +
+
+        # Move on to a fallback before an unreachable server exhausts the job.
+        printf '%s\n' 'Acquire::http::Timeout "15";' 'Acquire::https::Timeout "15";' \
+          | sudo tee /etc/apt/apt.conf.d/80-mirror-timeouts > /dev/null

--- a/.github/actions/setup-apt-mirrors/action.yml
+++ b/.github/actions/setup-apt-mirrors/action.yml
@@ -5,16 +5,17 @@ runs:
   steps:
     - shell: bash
       run: |
+        # Replace the existing Blacksmith mirror list as well as direct sources.
         printf '%s\tpriority:%s\n' \
           https://archive.ubuntu.com/ubuntu 1 \
           https://mirrors.edge.kernel.org/ubuntu 2 \
           https://mirror.math.princeton.edu/pub/ubuntu 3 \
-          | sudo tee /etc/apt/ubuntu-mirrors.txt > /dev/null
+          | sudo tee /etc/apt/blacksmith-ubuntu-mirrors.txt > /dev/null
 
         # APT's mirror transport retries each file against the next server.
         sudo find /etc/apt -maxdepth 2 -type f \( -name '*.list' -o -name '*.sources' \) \
           -exec sed -i -E \
-          's#https?://(([^/]+\.)?archive|security)\.ubuntu\.com/ubuntu/?#mirror+file:/etc/apt/ubuntu-mirrors.txt#g' {} +
+          's#https?://(([^/]+\.)?archive|security)\.ubuntu\.com/ubuntu/?#mirror+file:/etc/apt/blacksmith-ubuntu-mirrors.txt#g' {} +
 
         # Move on to a fallback before an unreachable server exhausts the job.
         printf '%s\n' 'Acquire::http::Timeout "15";' 'Acquire::https::Timeout "15";' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
       - name: Typecheck
         run: vpr typecheck
 
+      - uses: ./.github/actions/setup-apt-mirrors
+
       - name: Install browser secret helper build libraries
         run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev pkg-config
 
@@ -87,6 +89,8 @@ jobs:
 
       - name: Ensure Electron runtime is installed
         run: vp run --filter @t3tools/desktop ensure:electron
+
+      - uses: ./.github/actions/setup-apt-mirrors
 
       - name: Install browser secret helper build libraries
         run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev pkg-config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,6 +216,8 @@ jobs:
       - name: Typecheck
         run: vp run typecheck
 
+      - uses: ./.github/actions/setup-apt-mirrors
+
       - name: Install browser secret helper build libraries
         run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev pkg-config
 
@@ -526,6 +528,9 @@ jobs:
             Write-Error "Visual Studio Installer failed with exit code $code"
             exit $code
           }
+
+      - uses: ./.github/actions/setup-apt-mirrors
+        if: matrix.platform == 'linux'
 
       - name: Install Linux desktop build libraries
         if: matrix.platform == 'linux'


### PR DESCRIPTION
ubuntu package downloads repeatedly time out on port 80 in the blacksmith runners, blocking ci and releases ([failed job](https://github.com/pingdotgg/t3code/actions/runs/33935889803/job/101225179082)). configure apt's built-in mirror transport to try ubuntu over https, then kernel.org, then princeton, with 15-second connection timeouts.

a shared action replaces blacksmith's existing mirror list, covers all four ubuntu dependency-install steps and preserves repository suites, components, signing keys, and third-party sources. verified signed index retrieval and the exact `libsecret-1-dev` package download through each fallback, with preceding servers deliberately unavailable, exercised both source formats using the actual action script, and passed formatting and `git diff --check`.

model: `gpt-5.6-sol`; harness: codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release runner configuration only; no application code, auth, or data paths change. Minor risk that broad `sed` on APT sources could mis-rewrite unusual mirror URLs.
> 
> **Overview**
> Adds a composite GitHub Action that configures APT **mirror failover** when default Ubuntu archive/security URLs time out on Blacksmith runners.
> 
> The action writes a prioritized mirror list (`archive.ubuntu.com`, `mirrors.edge.kernel.org`, Princeton), rewrites existing `.list` / `.sources` entries to APT’s `mirror+file:` transport (without changing suites, keys, or third-party repos), and sets **15-second** HTTP/HTTPS acquire timeouts so jobs move to the next mirror quickly.
> 
> **CI** (`check`, `test`) and **release** (`quality`, Linux desktop build) now run `./.github/actions/setup-apt-mirrors` immediately before `apt-get` steps that install `libsecret-1-dev` / desktop build deps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e1b5c8f3fc4c7b30e00278108e56ad2a080adbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setup-apt-mirrors` composite action for fallback Ubuntu package mirrors in CI
> - Adds [action.yml](https://github.com/pingdotgg/t3code/pull/9864/files#diff-d35796808493ab61f3e9bc633bee6a1e623451f99b8855608932cc5c458a0a62) which writes three Ubuntu mirror endpoints and priorities to the Blacksmith mirror list, rewrites archive/security source URLs to use that list, and sets 15-second HTTP/HTTPS APT timeouts
> - Inserts the action before build-library installation in [ci.yml](https://github.com/pingdotgg/t3code/pull/9864/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) (check and non-server test jobs) and [release.yml](https://github.com/pingdotgg/t3code/pull/9864/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34) (preflight job and Linux-only matrix branch)
> - Risk: if all three configured mirrors are unreachable, APT falls back to the 15-second timeout per host; reviewers should verify the mirror URLs in `action.yml` are correct for the Blacksmith runner environment
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73d225a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
