### PR TITLE
fix(web): paint synchronized terminal updates atomically

### DIFF
--- a/apps/web/src/terminal/ghostty/core.test.ts
+++ b/apps/web/src/terminal/ghostty/core.test.ts
@@ -111,6 +111,33 @@ describe("GhosttyTerminalCore snapshots", () => {
     vi.restoreAllMocks();
   });
 
+  it("tracks split synchronized-output markers and ends an expired group", async () => {
+    const core = await createCore();
+    expect(core.isSynchronizedOutput()).toBe(false);
+    core.write("\x1b[?20");
+    expect(core.isSynchronizedOutput()).toBe(false);
+    core.write("26hpartial");
+    expect(core.isSynchronizedOutput()).toBe(true);
+    core.endSynchronizedOutput();
+    expect(core.isSynchronizedOutput()).toBe(false);
+    core.write("\x1b[?2026hnext\x1b[?2026");
+    expect(core.isSynchronizedOutput()).toBe(true);
+    core.write("l");
+    expect(core.isSynchronizedOutput()).toBe(false);
+    core.write("\x1b[?2026h");
+    core.resetAndWrite("reset");
+    expect(core.isSynchronizedOutput()).toBe(false);
+  });
+
+  it("lets Ghostty end synchronized output when the terminal grid resizes", async () => {
+    const core = await createCore();
+    core.write("\x1b[?2026hpartial");
+    expect(core.isSynchronizedOutput()).toBe(true);
+    core.resize(13, 3, 8, 16);
+    expect(core.isSynchronizedOutput()).toBe(false);
+    expect(core.snapshot().rowData[0]?.text).toBe("partial");
+  });
+
   it("preserves styles, wide cells, and selection after shared memory grows", async () => {
     const core = await createCore();
     const runtime = await loadGhosttyRuntime();

--- a/apps/web/src/terminal/ghostty/core.ts
+++ b/apps/web/src/terminal/ghostty/core.ts
@@ -454,6 +454,23 @@ export class GhosttyTerminalCore {
     );
   }
 
+  isSynchronizedOutput(): boolean {
+    this.ensureActive();
+    this.runtime.bytes(this.scratch, 1)[0] = 0;
+    return (
+      this.runtime.call("ghostty_terminal_mode_get", this.terminal, 2026, this.scratch) ===
+        GHOSTTY_SUCCESS && this.runtime.bytes(this.scratch, 1)[0] !== 0
+    );
+  }
+
+  endSynchronizedOutput(): void {
+    this.ensureActive();
+    this.assertSuccess(
+      "ghostty_terminal_mode_set",
+      this.runtime.call("ghostty_terminal_mode_set", this.terminal, 2026, 0),
+    );
+  }
+
   isAlternateScreen(): boolean {
     this.ensureActive();
     this.runtime.bytes(this.scratch, 4).fill(0);

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -151,6 +151,7 @@ describe("GhosttyTerminalSurface visibility", () => {
     const onData = vi.fn<(data: string) => void>();
 
     return {
+      canvas,
       mount,
       frames,
       paint,
@@ -210,6 +211,161 @@ describe("GhosttyTerminalSurface visibility", () => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it("paints one complete synchronized frame across split markers while answering VT queries", async () => {
+    const harness = createHarness();
+    const surface = await harness.create();
+    surface.write("\x1b[?1049h\x1b[HOLD first\x1b[2;1HOLD second");
+    harness.flushFrame();
+    harness.snapshot.mockClear();
+    harness.paint.mockClear();
+
+    surface.write("\x1b[?20");
+    expect(harness.frames.size).toBe(1);
+    surface.write("26h\x1b[HNEW first\x1b[5n");
+    expect(harness.onData).toHaveBeenCalledWith("\x1b[0n");
+    expect(harness.frames.size).toBe(0);
+    harness.flushFrame();
+    vi.advanceTimersByTime(200);
+    surface.write("\x1b[2;1HNEW second\x1b[?2026");
+    harness.flushFrame();
+    expect(harness.snapshot).not.toHaveBeenCalled();
+    expect(harness.paint).not.toHaveBeenCalled();
+
+    surface.write("l");
+    harness.flushFrame();
+    expect(harness.snapshot).toHaveBeenCalledTimes(1);
+    expect(harness.renderedSnapshot.rowData.slice(0, 2).map((row) => row.text)).toEqual([
+      "NEW first",
+      "NEW second",
+    ]);
+    expect(
+      harness.paint.mock.calls.some(
+        ([operation, args]) => operation === "fillText" && String(args[0]).includes("NEW first"),
+      ),
+    ).toBe(true);
+    vi.advanceTimersByTime(1_000);
+    harness.flushFrame();
+    expect(harness.snapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("expires an unterminated update once without extending its deadline on later output", async () => {
+    const harness = createHarness();
+    const surface = await harness.create();
+    surface.write("before");
+    harness.flushFrame();
+    harness.snapshot.mockClear();
+    surface.write("\x1b[?2026h\rpartial");
+    vi.advanceTimersByTime(499);
+    expect(harness.snapshot).not.toHaveBeenCalled();
+    surface.write(" frame");
+    vi.advanceTimersByTime(1);
+    expect(harness.snapshot).toHaveBeenCalledTimes(1);
+    expect(harness.renderedSnapshot.rowData[0]?.text).toBe("partial frame");
+    vi.advanceTimersByTime(2_000);
+    harness.flushFrame();
+    expect(harness.snapshot).toHaveBeenCalledTimes(1);
+
+    surface.write("\rnormal ");
+    harness.flushFrame();
+    expect(harness.snapshot).toHaveBeenCalledTimes(2);
+    surface.write("\x1b[?2026h\rnext group");
+    harness.flushFrame();
+    expect(harness.snapshot).toHaveBeenCalledTimes(2);
+    surface.write("\x1b[?2026l");
+    harness.flushFrame();
+    expect(harness.snapshot).toHaveBeenCalledTimes(3);
+  });
+
+  it.each(["hide", "zero-size", "dispose"] as const)(
+    "cancels a synchronized-output deadline on %s",
+    async (action) => {
+      const harness = createHarness();
+      const surface = await harness.create();
+      surface.write("before");
+      harness.flushFrame();
+      surface.write("\x1b[?2026hpartial");
+      harness.snapshot.mockClear();
+      if (action === "hide") surface.setVisible(false);
+      else if (action === "zero-size") {
+        harness.mount.clientWidth = 0;
+        harness.resize();
+      } else surface.dispose();
+      vi.advanceTimersByTime(1_000);
+      harness.flushFrame();
+      expect(harness.snapshot).not.toHaveBeenCalled();
+      if (action === "dispose") return;
+      if (action === "hide") surface.setVisible(true);
+      else {
+        harness.mount.clientWidth = 168;
+        harness.resize();
+      }
+      expect(harness.snapshot).not.toHaveBeenCalled();
+      surface.write("\x1b[?2026l");
+      harness.flushFrame();
+      expect(harness.snapshot).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("replays a reset immediately and cancels the previous synchronized deadline", async () => {
+    const harness = createHarness();
+    const surface = await harness.create();
+    surface.write("\x1b[?2026hpartial");
+    harness.snapshot.mockClear();
+    surface.resetAndWrite("replacement");
+    harness.flushFrame();
+    expect(harness.snapshot).toHaveBeenCalledTimes(1);
+    expect(harness.renderedSnapshot.rowData[0]?.text).toBe("replacement");
+    vi.advanceTimersByTime(1_000);
+    harness.flushFrame();
+    expect(harness.snapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([false, true])(
+    "defers DPR backing-store changes until synchronized output closes, restored=%s",
+    async (restore) => {
+      const harness = createHarness();
+      const surface = await harness.create();
+      surface.write("old");
+      harness.flushFrame();
+      const width = harness.canvas.width;
+      const height = harness.canvas.height;
+      surface.write("\x1b[?2026h\rnew");
+      harness.snapshot.mockClear();
+      window.devicePixelRatio = 2;
+      harness.resize();
+      expect([harness.canvas.width, harness.canvas.height]).toEqual([width, height]);
+      expect(harness.snapshot).not.toHaveBeenCalled();
+      if (restore) {
+        window.devicePixelRatio = 1;
+        harness.resize();
+      }
+      surface.write("\x1b[?2026l");
+      harness.flushFrame();
+      expect([harness.canvas.width, harness.canvas.height]).toEqual([
+        width * (restore ? 1 : 2),
+        height * (restore ? 1 : 2),
+      ]);
+      expect(harness.renderedSnapshot.rowData[0]?.text).toBe("new");
+    },
+  );
+
+  it("repaints a real grid resize immediately after Ghostty ends the synchronized mode", async () => {
+    const harness = createHarness();
+    const surface = await harness.create();
+    surface.write("old");
+    harness.flushFrame();
+    surface.write("\x1b[?2026h\rnew");
+    harness.snapshot.mockClear();
+    harness.mount.clientWidth = 176;
+    harness.resize();
+    expect(harness.snapshot).toHaveBeenCalledTimes(1);
+    expect(harness.canvas.width).toBe(176);
+    expect(harness.renderedSnapshot.rowData[0]?.text).toBe("new");
+    vi.advanceTimersByTime(1_000);
+    harness.flushFrame();
+    expect(harness.snapshot).toHaveBeenCalledTimes(1);
   });
 
   it("stops hidden snapshots and paint while preserving live VT replies and the next cursor", async () => {

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -37,6 +37,8 @@ const CONTENT_PADDING = 4;
 const MIN_SCROLLBAR_THUMB_HEIGHT = 18;
 /** Half a blink cycle: the visible and hidden phases are equally long. */
 const CURSOR_BLINK_INTERVAL_MS = 500;
+/** End an unterminated synchronized update instead of freezing the last frame. */
+const SYNCHRONIZED_OUTPUT_RENDER_TIMEOUT_MS = 500;
 const TERMINAL_FONT_LOAD_TEXT = "iMW0@# .";
 const TERMINAL_FONT_LOAD_VARIANTS = [
   "normal 400",
@@ -570,6 +572,7 @@ export class GhosttyTerminalSurface {
   private readonly scrollbarThumb: HTMLDivElement;
   private snapshot: GhosttySnapshot | null = null;
   private frame = 0;
+  private synchronizedRenderTimer: number | null = null;
   private cursorTimer: number | null = null;
   private compositionInputToSuppress: string | null = null;
   private compositionSuppressionTimer: number | null = null;
@@ -609,6 +612,12 @@ export class GhosttyTerminalSurface {
   private focused = false;
   private resizeNotified = false;
   private canvasConfigured = false;
+  private canvasDevicePixelRatio = 0;
+  private pendingCanvasConfiguration: {
+    readonly width: number;
+    readonly height: number;
+    readonly ratio: number;
+  } | null = null;
   private theme: GhosttyTheme;
   private readonly suppressedKeyCodes = new Set<string>();
   private pasteShortcutToken = 0;
@@ -761,6 +770,7 @@ export class GhosttyTerminalSurface {
 
   resetAndWrite(data: string): void {
     if (this.disposed) return;
+    this.cancelSynchronizedRenderTimer();
     this.lastMouseMotionData = "";
     this.core.resetAndWrite(data);
     this.synchronizeMouseTrackingState();
@@ -863,15 +873,18 @@ export class GhosttyTerminalSurface {
     if (
       this.canvas.width !== pixelWidth ||
       this.canvas.height !== pixelHeight ||
-      !this.canvasConfigured
+      !this.canvasConfigured ||
+      this.canvasDevicePixelRatio !== ratio
     ) {
-      this.canvas.width = pixelWidth;
-      this.canvas.height = pixelHeight;
-      this.context.setTransform(ratio, 0, 0, ratio, 0, 0);
-      this.canvasConfigured = true;
+      // A backing-size change clears the canvas. Apply it with the gated paint
+      // so a DPR change cannot erase a frame while synchronized output is open.
+      this.pendingCanvasConfiguration = { width: pixelWidth, height: pixelHeight, ratio };
       this.forceFullRender = true;
       this.scrollbarDirty = true;
       shouldRender = true;
+    } else {
+      // A resize can return to the painted size before its queued frame runs.
+      this.pendingCanvasConfiguration = null;
     }
     const grid = terminalGridSize(width, height, this.metrics, CONTENT_PADDING);
     this.mountHeight = height;
@@ -1701,7 +1714,8 @@ export class GhosttyTerminalSurface {
   }
 
   private requestRender(): void {
-    if (this.disposed || !this.visible || !this.hasSize || this.frame !== 0) return;
+    if (this.disposed || !this.visible || !this.hasSize) return;
+    if (this.deferSynchronizedRender() || this.frame !== 0) return;
     this.frame = window.requestAnimationFrame(() => {
       this.frame = 0;
       this.renderFrame();
@@ -1709,6 +1723,7 @@ export class GhosttyTerminalSurface {
   }
 
   private cancelRender(): void {
+    this.cancelSynchronizedRenderTimer();
     if (this.frame !== 0) {
       window.cancelAnimationFrame(this.frame);
       this.frame = 0;
@@ -1717,6 +1732,36 @@ export class GhosttyTerminalSurface {
       window.clearTimeout(this.cursorTimer);
       this.cursorTimer = null;
     }
+  }
+
+  private cancelSynchronizedRenderTimer(): void {
+    if (this.synchronizedRenderTimer === null) return;
+    window.clearTimeout(this.synchronizedRenderTimer);
+    this.synchronizedRenderTimer = null;
+  }
+
+  private deferSynchronizedRender(): boolean {
+    if (!this.core.isSynchronizedOutput()) {
+      this.cancelSynchronizedRenderTimer();
+      return false;
+    }
+    // A frame queued before the opening marker would now consume partial rows.
+    if (this.frame !== 0) {
+      window.cancelAnimationFrame(this.frame);
+      this.frame = 0;
+    }
+    if (this.cursorTimer !== null) {
+      window.clearTimeout(this.cursorTimer);
+      this.cursorTimer = null;
+    }
+    if (this.synchronizedRenderTimer === null) {
+      this.synchronizedRenderTimer = window.setTimeout(() => {
+        this.synchronizedRenderTimer = null;
+        this.core.endSynchronizedOutput();
+        this.renderFrame();
+      }, SYNCHRONIZED_OUTPUT_RENDER_TIMEOUT_MS);
+    }
+    return true;
   }
 
   private renderFrame(): void {
@@ -1733,6 +1778,16 @@ export class GhosttyTerminalSurface {
       this.forceFullRender = true;
       this.cancelRender();
       return;
+    }
+    if (this.deferSynchronizedRender()) return;
+    const canvasConfiguration = this.pendingCanvasConfiguration;
+    if (canvasConfiguration !== null) {
+      this.pendingCanvasConfiguration = null;
+      this.canvas.width = canvasConfiguration.width;
+      this.canvas.height = canvasConfiguration.height;
+      this.context.setTransform(canvasConfiguration.ratio, 0, 0, canvasConfiguration.ratio, 0, 0);
+      this.canvasConfigured = true;
+      this.canvasDevicePixelRatio = canvasConfiguration.ratio;
     }
     this.snapshot = this.core.snapshot();
     // A cursor that is not blinking right now must be drawn, never caught in an


### PR DESCRIPTION
Terminal programs can split a DEC synchronized-output update across PTY chunks. The web renderer currently paints and clears dirty rows before the closing marker, displaying part of the new frame with part of the previous one.

Defer snapshots and canvas backing-store changes while mode 2026 is open. Closing the group paints the accumulated frame. An unterminated group gets one 500 ms deadline, which ends that mode and paints once; later output cannot keep extending the deadline. Hidden, zero-sized, disposed, and reset surfaces cancel their pending deadline. Actual grid resize retains libghostty's documented behavior of ending synchronized mode immediately.

This extracts only the web synchronization gate and deferred canvas configuration from Wout Stiens' broader [#9027](https://github.com/pingdotgg/t3code/pull/9027), with author credit preserved. It does not change that PR or include its streaming, replay, native, or theme work. The new lifecycle tests use the existing real Surface, renderer, and vendored WASM fixture.

Refs [#7790](https://github.com/pingdotgg/t3code/issues/7790). This fixes premature painting, not a verified permanent freeze. Native Android and an actual Neovim session remain unverified, so the issue should stay open for those variants.

## Verification

- Baseline [ce4712d5](https://github.com/pingdotgg/t3code/commit/ce4712d5b04fb998f79fe132245289191147e5d5): the production Surface paints `NEW first` above `OLD second` while the group remains open. The same isolated assertion passes with this patch.
- 89 focused Ghostty tests pass, including split opening/closing CSI markers, live VT query replies, normal output, unterminated and subsequent groups, cancellation, reset, DPR changes, and grid resize. Existing 1 MiB rollover/reference-state controls remain green.
- Web typecheck and targeted lint pass. One pre-existing `new Array` lint warning remains outside the changed lines.
- Actual browser before/after recording is pending orchestrator verification. Test DOM/layout and frame scheduling are controlled doubles, not screenshots or native-device evidence.

## Human decision

The 500 ms recovery duration is carried from the existing proposal, not an established application policy. Review that duration and the decision to end an unterminated group before merging. No automatic merge is requested.

Original extraction credit: Wout Stiens. Prepared with GPT 6 Astra via Codex in T3 Code.



## Current browser verification

Current-client verification on [84b99f3f](https://github.com/pingdotgg/t3code/commit/84b99f3fb), with the exact two production-file changes from [9aacd204](https://github.com/pingdotgg/t3code/commit/9aacd204f77ef82cf5613924e1483336afab4e89) integrated for the after run.

The disposable fixture runs in the real integrated terminal. Each synchronized group writes FIRST, waits 160 ms, writes SECOND, then closes the group. Before the patch, the recording contains FIRST 02 / SECOND 01. The after recording shows the previous complete frame retained until the next pair is available. This is a controlled terminal-output reproduction in Chromium 152, not a native nvim/lazygit session or proof for every source of flicker in the linked reports.

Before:

![Before: terminal displays mismatched frame numbers during a synchronized update](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4428e46d7764a316/7790-before-frame.png)

[Before recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/1c160c3888eaf79f/7790-before-sync-output.webm)

After:

![After: terminal retains a complete pair of frame numbers](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/47d2bff8ed00ca7c/7790-after-frame.png)

[After recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/22dd41c4e98bdb17/7790-after-sync-output.webm)

Recordings use the existing live browser tab, sampled at 20 fps with wall-clock timing preserved. The fixture writes only to its terminal and restores the alternate-screen and cursor modes on exit. No provider turn was started.

The full four-file change and focused tests have been reviewed. This remains **human-held**: the 500 ms recovery deadline for an unterminated synchronized update is a behavior decision, not a value established by this fixture.

Audited by GPT 6 Astra via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes central terminal paint scheduling and canvas lifecycle; bugs could cause visible flicker, stuck frames, or delayed repaints, but scope is limited to the web Ghostty surface with broad new test coverage.
> 
> **Overview**
> The web Ghostty terminal no longer snapshots or paints while **DEC synchronized output** (mode `2026`) is active, so multi-chunk updates (including CSI markers split across PTY writes) appear as one frame instead of mixing old and new rows.
> 
> `GhosttyTerminalCore` exposes **`isSynchronizedOutput`** and **`endSynchronizedOutput`** so the surface can gate rendering. While the mode is open, **`requestRender` / `renderFrame`** defer work, cancel in-flight animation frames, and start a single **500 ms** timer for groups that never close; when it fires, the core ends the mode and paints once (later output does not extend the deadline). **Hide, zero-size, dispose, and `resetAndWrite`** clear that timer; **canvas DPR/backing-store** changes are queued until the group closes so resizing does not clear the buffer mid-update. **Grid resize** still ends synchronized mode per Ghostty and repaints immediately.
> 
> New **core** and **surface** tests cover split markers, VT queries during deferral, timeout behavior, cancellation, DPR deferral, and resize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aacd204f77ef82cf5613924e1483336afab4e89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `GhosttyTerminalSurface` to paint synchronized terminal updates atomically
> - Suppresses snapshots and painting while synchronized output (private mode 2026) is active, so a complete frame is rendered once the mode closes
> - Adds a `500` ms timeout (`SYNCHRONIZED_OUTPUT_RENDER_TIMEOUT_MS`) that ends an unterminated synchronized group and renders once
> - Defers canvas backing-store size and DPR changes until rendering resumes, preventing intermediate updates from erasing a synchronized frame
> - Cancels the pending synchronized-output timeout on hide, zero-size, dispose, and `resetAndWrite`, and cancels a frame queued before synchronized output opened
> - `GhosttyTerminalCore` exposes `isSynchronizedOutput` and `endSynchronizedOutput` via the Ghostty runtime
> - Behavioral Change: `resize`/`fit` no longer apply canvas backing-store dimensions immediately; they are stored as pending configuration in `GhosttyTerminalSurface` and applied at the next allowed render. `requestRender` now checks synchronized-output deferral before the queued-frame check.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9aacd20.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
