### PR TITLE
fix(web): avoid bulk legacy sidebar collapse animations

### DIFF
--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -212,6 +212,7 @@ import {
   type SidebarProjectGroupMember,
   type SidebarProjectSnapshot,
 } from "../sidebarProjectGrouping";
+import { useSidebarThreadListAutoAnimate } from "./sidebar/useSidebarThreadListAutoAnimate";
 const SIDEBAR_SORT_LABELS: Record<SidebarProjectSortOrder, string> = {
   updated_at: "Last user message",
   created_at: "Created at",
@@ -950,7 +951,6 @@ interface SidebarProjectThreadListProps {
   confirmingArchiveThreadKey: string | null;
   setConfirmingArchiveThreadKey: React.Dispatch<React.SetStateAction<string | null>>;
   confirmArchiveButtonRefs: React.RefObject<Map<string, HTMLButtonElement>>;
-  attachThreadListAutoAnimateRef: (node: HTMLElement | null) => void;
   handleThreadClick: (
     event: React.MouseEvent,
     threadRef: ScopedThreadRef,
@@ -1006,7 +1006,6 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
     confirmingArchiveThreadKey,
     setConfirmingArchiveThreadKey,
     confirmArchiveButtonRefs,
-    attachThreadListAutoAnimateRef,
     handleThreadClick,
     navigateToThread,
     handleMultiSelectContextMenu,
@@ -1021,6 +1020,9 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
   } = props;
   const showMoreButtonRender = useMemo(() => <button type="button" />, []);
   const showLessButtonRender = useMemo(() => <button type="button" />, []);
+  const attachThreadListAutoAnimateRef = useSidebarThreadListAutoAnimate(
+    shouldShowThreadPanel ? renderedThreads.length : 0,
+  );
 
   return (
     <SidebarMenuSub
@@ -1119,7 +1121,6 @@ interface SidebarProjectItemProps {
   archiveThread: ReturnType<typeof useThreadActions>["archiveThread"];
   deleteThread: ReturnType<typeof useThreadActions>["deleteThread"];
   threadJumpLabelByKey: ReadonlyMap<string, string>;
-  attachThreadListAutoAnimateRef: (node: HTMLElement | null) => void;
   expandThreadListForProject: (projectKey: string) => void;
   collapseThreadListForProject: (projectKey: string) => void;
   dragInProgressRef: React.RefObject<boolean>;
@@ -1140,7 +1141,6 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     archiveThread,
     deleteThread,
     threadJumpLabelByKey,
-    attachThreadListAutoAnimateRef,
     expandThreadListForProject,
     collapseThreadListForProject,
     dragInProgressRef,
@@ -2440,7 +2440,6 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         confirmingArchiveThreadKey={confirmingArchiveThreadKey}
         setConfirmingArchiveThreadKey={setConfirmingArchiveThreadKey}
         confirmArchiveButtonRefs={confirmArchiveButtonRefs}
-        attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
         handleThreadClick={handleThreadClick}
         navigateToThread={navigateToThread}
         handleMultiSelectContextMenu={handleMultiSelectContextMenu}
@@ -2850,7 +2849,6 @@ interface SidebarProjectsContentProps {
   newThreadShortcutLabel: string | null;
   commandPaletteShortcutLabel: string | null;
   threadJumpLabelByKey: ReadonlyMap<string, string>;
-  attachThreadListAutoAnimateRef: (node: HTMLElement | null) => void;
   expandThreadListForProject: (projectKey: string) => void;
   collapseThreadListForProject: (projectKey: string) => void;
   dragInProgressRef: React.RefObject<boolean>;
@@ -2892,7 +2890,6 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     newThreadShortcutLabel,
     commandPaletteShortcutLabel,
     threadJumpLabelByKey,
-    attachThreadListAutoAnimateRef,
     expandThreadListForProject,
     collapseThreadListForProject,
     dragInProgressRef,
@@ -3036,7 +3033,6 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                         archiveThread={archiveThread}
                         deleteThread={deleteThread}
                         threadJumpLabelByKey={threadJumpLabelByKey}
-                        attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
                         expandThreadListForProject={expandThreadListForProject}
                         collapseThreadListForProject={collapseThreadListForProject}
                         dragInProgressRef={dragInProgressRef}
@@ -3069,7 +3065,6 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 archiveThread={archiveThread}
                 deleteThread={deleteThread}
                 threadJumpLabelByKey={threadJumpLabelByKey}
-                attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
                 expandThreadListForProject={expandThreadListForProject}
                 collapseThreadListForProject={collapseThreadListForProject}
                 dragInProgressRef={dragInProgressRef}
@@ -3352,15 +3347,6 @@ export default function LegacySidebar() {
     }
     autoAnimate(node, SIDEBAR_LIST_ANIMATION_OPTIONS);
     animatedProjectListsRef.current.add(node);
-  }, []);
-
-  const animatedThreadListsRef = useRef(new WeakSet<HTMLElement>());
-  const attachThreadListAutoAnimateRef = useCallback((node: HTMLElement | null) => {
-    if (!node || animatedThreadListsRef.current.has(node)) {
-      return;
-    }
-    autoAnimate(node, SIDEBAR_LIST_ANIMATION_OPTIONS);
-    animatedThreadListsRef.current.add(node);
   }, []);
 
   const visibleThreads = useMemo(
@@ -3754,7 +3740,6 @@ export default function LegacySidebar() {
         newThreadShortcutLabel={newThreadShortcutLabel}
         commandPaletteShortcutLabel={commandPaletteShortcutLabel}
         threadJumpLabelByKey={visibleThreadJumpLabelByKey}
-        attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
         expandThreadListForProject={expandThreadListForProject}
         collapseThreadListForProject={collapseThreadListForProject}
         dragInProgressRef={dragInProgressRef}

--- a/apps/web/src/components/sidebar/autoAnimateCleanup.test.tsx
+++ b/apps/web/src/components/sidebar/autoAnimateCleanup.test.tsx
@@ -1,0 +1,304 @@
+import type { AnimationController } from "@formkit/auto-animate";
+import * as NodeModule from "node:module";
+import * as NodeURL from "node:url";
+import { act } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+// Run the installed library with controlled browser scheduling. Layout and frame
+// timings are covered by the real-client sidebar performance recording.
+class TestElement {
+  readonly nodeName = "DIV";
+  readonly style = {};
+  readonly offsetWidth = 1000;
+  readonly offsetHeight = 1000;
+  readonly clientWidth = 1000;
+  readonly clientHeight = 1000;
+  parentElement: TestElement | null = null;
+  isConnected = true;
+  private childNodes: TestElement[] = [];
+  get children() {
+    return Object.assign(this.childNodes, {
+      item: (index: number) => this.childNodes[index] ?? null,
+    });
+  }
+  get parentNode() {
+    return this.parentElement;
+  }
+  getBoundingClientRect = vi.fn(() => ({
+    top: 0,
+    left: 0,
+    right: 100,
+    bottom: 20,
+    width: 100,
+    height: 20,
+  }));
+  appendChild(child: TestElement) {
+    child.parentElement = this;
+    child.isConnected = this.isConnected;
+    this.childNodes.push(child);
+  }
+  remove() {
+    if (this.parentElement) {
+      this.parentElement.childNodes = this.parentElement.childNodes.filter((node) => node !== this);
+    }
+    this.parentElement = null;
+    this.isConnected = false;
+  }
+  animate = vi.fn(() => {
+    const listeners: Array<() => void> = [];
+    let finishAnimation!: () => void;
+    const finished = new Promise<void>((resolve) => {
+      finishAnimation = resolve;
+    });
+    return {
+      finished,
+      playState: "running",
+      cancel: vi.fn(),
+      addEventListener: (_event: string, listener: () => void) => listeners.push(listener),
+      finish: () => {
+        finishAnimation();
+        listeners.forEach((listener) => listener());
+      },
+    };
+  });
+}
+
+class TestObserver {
+  static instances: TestObserver[] = [];
+  readonly observed = new Set<TestElement>();
+  records: MutationRecord[] = [];
+  constructor(readonly callback: (records: MutationRecord[]) => void) {
+    TestObserver.instances.push(this);
+  }
+  observe(node: TestElement) {
+    this.observed.add(node);
+  }
+  unobserve(node: TestElement) {
+    this.observed.delete(node);
+  }
+  disconnect() {
+    this.observed.clear();
+    this.records = [];
+  }
+  takeRecords() {
+    const records = this.records;
+    this.records = [];
+    return records;
+  }
+}
+
+let parent: TestElement;
+let root: TestElement;
+let idleCallbacks: Array<() => void>;
+let controllers: AnimationController[];
+let renderer: ReactTestRenderer | null;
+let moduleInstance = 0;
+const libraryUrl = NodeURL.pathToFileURL(
+  NodeModule.createRequire(import.meta.url).resolve("@formkit/auto-animate"),
+);
+let library: typeof import("@formkit/auto-animate") | undefined;
+
+function queueRemoval(child: TestElement) {
+  const record = {
+    target: parent,
+    addedNodes: [],
+    removedNodes: [child],
+    previousSibling: null,
+    nextSibling: null,
+  } as unknown as MutationRecord;
+  child.remove();
+  // The parent mutation observer is the one observing only the list.
+  const observer = TestObserver.instances.find(
+    (item) => item.observed.has(parent) && item.observed.size === 1,
+  )!;
+  observer.records.push(record);
+  return observer;
+}
+
+async function start() {
+  // External ESM imports survive vi.resetModules; each case needs fresh browser globals.
+  library ??= (await import(
+    /* @vite-ignore */ `${libraryUrl.href}?cleanup-test=${moduleInstance++}`
+  )) as typeof import("@formkit/auto-animate");
+  const controller = library.autoAnimate(parent as unknown as HTMLElement);
+  controllers.push(controller);
+  return controller;
+}
+
+function expectStopped() {
+  expect(vi.getTimerCount()).toBe(0);
+  expect(TestObserver.instances.flatMap((observer) => [...observer.observed])).toEqual([root]);
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  library = undefined;
+  vi.useFakeTimers();
+  vi.spyOn(Math, "random").mockReturnValue(1);
+  TestObserver.instances = [];
+  parent = new TestElement();
+  root = new TestElement();
+  idleCallbacks = [];
+  controllers = [];
+  renderer = null;
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("Element", TestElement);
+  vi.stubGlobal("HTMLElement", TestElement);
+  vi.stubGlobal(
+    "HTMLBodyElement",
+    class {
+      readonly nodeName = "BODY";
+    },
+  );
+  vi.stubGlobal("window", {
+    ResizeObserver: TestObserver,
+    addEventListener() {},
+    matchMedia: () => ({ matches: false }),
+    scrollX: 0,
+    scrollY: 0,
+  });
+  vi.stubGlobal("document", { documentElement: root, body: root });
+  vi.stubGlobal("ResizeObserver", TestObserver);
+  vi.stubGlobal("MutationObserver", TestObserver);
+  vi.stubGlobal("IntersectionObserver", TestObserver);
+  vi.stubGlobal("requestIdleCallback", (callback: () => void) => idleCallbacks.push(callback));
+  vi.stubGlobal("getComputedStyle", () => ({
+    position: "relative",
+    boxSizing: "content-box",
+    borderTopWidth: "0px",
+    borderLeftWidth: "0px",
+    getPropertyValue: () => "0px",
+  }));
+});
+
+afterEach(() => {
+  act(() => renderer?.unmount());
+  controllers.forEach((controller) => controller.destroy?.());
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("AutoAnimate controller cleanup", () => {
+  it("cancels delayed polling when destroyed before its staggered start", async () => {
+    parent.appendChild(new TestElement());
+    const controller = await start();
+    controller.destroy?.();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expectStopped();
+    expect(parent.getBoundingClientRect).not.toHaveBeenCalled();
+  });
+
+  it("tears down running intervals and position observers", async () => {
+    parent.appendChild(new TestElement());
+    const controller = await start();
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(vi.getTimerCount()).toBe(2);
+    expect(parent.getBoundingClientRect).toHaveBeenCalled();
+    controller.destroy?.();
+    expectStopped();
+  });
+
+  it("ignores an old polling callback after destroy and recreation", async () => {
+    const controller = await start();
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(idleCallbacks).toHaveLength(1);
+    controller.destroy?.();
+    const next = await start();
+    await vi.advanceTimersByTimeAsync(250);
+    expect(vi.getTimerCount()).toBe(1);
+    idleCallbacks.splice(0).forEach((callback) => callback());
+    expect(vi.getTimerCount()).toBe(1);
+    next.destroy?.();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expectStopped();
+  });
+
+  it("ignores queued root-resize work after destroying its parent", async () => {
+    const controller = await start();
+    await vi.advanceTimersByTimeAsync(250);
+    const resize = TestObserver.instances.find((observer) => observer.observed.has(root))!;
+    resize.callback([{ target: root } as unknown as MutationRecord]);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(idleCallbacks).toHaveLength(1);
+    controller.destroy?.();
+    idleCallbacks.splice(0).forEach((callback) => callback());
+    await vi.advanceTimersByTimeAsync(10_000);
+    expectStopped();
+  });
+
+  it("does not restore observers from an already-running position update", async () => {
+    const controller = await start();
+    // Fire the debounce without flushing its awaited continuation.
+    vi.advanceTimersByTime(250);
+    controller.destroy?.();
+    await Promise.resolve();
+    expectStopped();
+  });
+
+  it("cleans removed children before mutation observer delivery", async () => {
+    const child = new TestElement();
+    parent.appendChild(child);
+    const controller = await start();
+    await vi.advanceTimersByTimeAsync(2_000);
+    queueRemoval(child);
+    controller.destroy?.();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expectStopped();
+  });
+
+  it("stops tracking a child after its removal animation finishes", async () => {
+    const child = new TestElement();
+    parent.appendChild(child);
+    const controller = await start();
+    await vi.advanceTimersByTimeAsync(2_000);
+    const observer = queueRemoval(child);
+    observer.callback(observer.takeRecords());
+    child.animate.mock.results[0]!.value.finish();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(TestObserver.instances.some((item) => item.observed.has(child))).toBe(false);
+    controller.destroy?.();
+    expectStopped();
+  });
+
+  it("can repeatedly destroy and recreate without accumulating work", async () => {
+    for (let cycle = 0; cycle < 5; cycle++) {
+      const controller = await start();
+      await vi.advanceTimersByTimeAsync(cycle % 2 === 0 ? 100 : 2_000);
+      controller.destroy?.();
+      controller.destroy?.();
+      expectStopped();
+    }
+  });
+
+  it("registers an initially large sidebar only after it becomes small", async () => {
+    const { useSidebarThreadListAutoAnimate } = await import("./useSidebarThreadListAutoAnimate");
+    function ThreadList({ rowCount }: { rowCount: number }) {
+      return <ul ref={useSidebarThreadListAutoAnimate(rowCount)} />;
+    }
+    act(() => {
+      renderer = create(<ThreadList rowCount={101} />, { createNodeMock: () => parent });
+    });
+    expectStopped();
+    act(() => renderer!.update(<ThreadList rowCount={1} />));
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(vi.getTimerCount()).toBe(1);
+    act(() => renderer!.update(<ThreadList rowCount={101} />));
+    expectStopped();
+    act(() => renderer!.update(<ThreadList rowCount={1} />));
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(vi.getTimerCount()).toBe(1);
+    act(() => renderer!.unmount());
+    renderer = null;
+    expectStopped();
+  });
+
+  it("does not initialize browser work during server rendering", async () => {
+    vi.stubGlobal("window", undefined);
+    const controller = await start();
+    controller.destroy?.();
+    expect(vi.getTimerCount()).toBe(0);
+    expect(TestObserver.instances).toEqual([]);
+  });
+});

--- a/apps/web/src/components/sidebar/autoAnimateCleanup.test.tsx
+++ b/apps/web/src/components/sidebar/autoAnimateCleanup.test.tsx
@@ -272,6 +272,27 @@ describe("AutoAnimate controller cleanup", () => {
     }
   });
 
+  it("does not resume observing a removed child from queued root-resize work", async () => {
+    const child = new TestElement();
+    parent.appendChild(child);
+    const controller = await start();
+    await vi.advanceTimersByTimeAsync(250);
+    const resize = TestObserver.instances.find((observer) => observer.observed.has(root))!;
+    resize.callback([{ target: root } as unknown as MutationRecord]);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(idleCallbacks).toHaveLength(2);
+    const observer = queueRemoval(child);
+    observer.callback(observer.takeRecords());
+    child.animate.mock.results[0]!.value.finish();
+    parent.animate.mock.results[0]!.value.finish();
+    await vi.advanceTimersByTimeAsync(1);
+    idleCallbacks.splice(0).forEach((callback) => callback());
+    await vi.advanceTimersByTimeAsync(250);
+    expect(TestObserver.instances.some((item) => item.observed.has(child))).toBe(false);
+    controller.destroy?.();
+    expectStopped();
+  });
+
   it("registers an initially large sidebar only after it becomes small", async () => {
     const { useSidebarThreadListAutoAnimate } = await import("./useSidebarThreadListAutoAnimate");
     function ThreadList({ rowCount }: { rowCount: number }) {

--- a/apps/web/src/components/sidebar/autoAnimateCleanup.test.tsx
+++ b/apps/web/src/components/sidebar/autoAnimateCleanup.test.tsx
@@ -116,12 +116,12 @@ function queueRemoval(child: TestElement) {
   return observer;
 }
 
-async function start() {
+async function start(node = parent) {
   // External ESM imports survive vi.resetModules; each case needs fresh browser globals.
   library ??= (await import(
     /* @vite-ignore */ `${libraryUrl.href}?cleanup-test=${moduleInstance++}`
   )) as typeof import("@formkit/auto-animate");
-  const controller = library.autoAnimate(parent as unknown as HTMLElement);
+  const controller = library.autoAnimate(node as unknown as HTMLElement);
   controllers.push(controller);
   return controller;
 }
@@ -228,6 +228,23 @@ describe("AutoAnimate controller cleanup", () => {
     expectStopped();
   });
 
+  it("ignores queued root-resize work after recreating the same parent", async () => {
+    const controller = await start();
+    await vi.advanceTimersByTimeAsync(250);
+    const resize = TestObserver.instances.find((observer) => observer.observed.has(root))!;
+    resize.callback([{ target: root } as unknown as MutationRecord]);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(idleCallbacks).toHaveLength(1);
+    controller.destroy?.();
+    const next = await start();
+    await vi.advanceTimersByTimeAsync(250);
+    expect(vi.getTimerCount()).toBe(1);
+    idleCallbacks.splice(0).forEach((callback) => callback());
+    expect(vi.getTimerCount()).toBe(1);
+    next.destroy?.();
+    expectStopped();
+  });
+
   it("does not restore observers from an already-running position update", async () => {
     const controller = await start();
     // Fire the debounce without flushing its awaited continuation.
@@ -270,6 +287,33 @@ describe("AutoAnimate controller cleanup", () => {
       controller.destroy?.();
       expectStopped();
     }
+  });
+
+  it("preserves a moved child's live registration in another animated parent", async () => {
+    const child = new TestElement();
+    parent.appendChild(child);
+    const first = await start();
+    const destination = new TestElement();
+    const second = await start(destination);
+    await vi.advanceTimersByTimeAsync(2_000);
+    queueRemoval(child);
+    destination.appendChild(child);
+    const observer = TestObserver.instances.find(
+      (item) => item.observed.has(destination) && item.observed.size === 1,
+    )!;
+    observer.callback([
+      { target: destination, addedNodes: [child], removedNodes: [] } as unknown as MutationRecord,
+    ]);
+    child.animate.mock.results[0]!.value.finish();
+    destination.animate.mock.results[0]!.value.finish();
+    await vi.advanceTimersByTimeAsync(1);
+    const tracking = TestObserver.instances.filter((item) => item.observed.has(child));
+    expect(tracking).toHaveLength(2);
+    first.destroy?.();
+    expect(tracking.every((item) => item.observed.has(child))).toBe(true);
+    expect(vi.getTimerCount()).toBe(2);
+    second.destroy?.();
+    expectStopped();
   });
 
   it("does not resume observing a removed child from queued root-resize work", async () => {

--- a/apps/web/src/components/sidebar/useSidebarThreadListAutoAnimate.test.tsx
+++ b/apps/web/src/components/sidebar/useSidebarThreadListAutoAnimate.test.tsx
@@ -1,0 +1,153 @@
+import type { AnimationController } from "@formkit/auto-animate";
+import { act, StrictMode } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { autoAnimate } = vi.hoisted(() => ({ autoAnimate: vi.fn() }));
+vi.mock("@formkit/auto-animate", () => ({ autoAnimate }));
+
+import { useSidebarThreadListAutoAnimate } from "./useSidebarThreadListAutoAnimate";
+
+let renderer: ReactTestRenderer | null;
+let controllers: AnimationController[];
+
+function ThreadList({ rowCount, nodeKey = "list" }: { rowCount: number; nodeKey?: string }) {
+  const attach = useSidebarThreadListAutoAnimate(rowCount);
+  return <ul key={nodeKey} ref={attach} />;
+}
+
+function mount(rowCount: number) {
+  act(() => {
+    renderer = create(<ThreadList rowCount={rowCount} />, {
+      createNodeMock: () => ({}) as HTMLElement,
+    });
+  });
+  return controllers[0]!;
+}
+
+function update(rowCount: number, nodeKey = "list") {
+  act(() => renderer!.update(<ThreadList rowCount={rowCount} nodeKey={nodeKey} />));
+}
+
+beforeEach(() => {
+  renderer = null;
+  controllers = [];
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  autoAnimate.mockReset();
+  autoAnimate.mockImplementation((parent: HTMLElement): AnimationController => {
+    let enabled = true;
+    const controller = {
+      parent,
+      enable: vi.fn(() => {
+        enabled = true;
+      }),
+      disable: () => {
+        enabled = false;
+      },
+      isEnabled: () => enabled,
+      destroy: vi.fn(() => {
+        enabled = false;
+      }),
+    };
+    controllers.push(controller);
+    return controller;
+  });
+});
+
+afterEach(async () => {
+  await act(() => renderer?.unmount());
+  vi.unstubAllGlobals();
+});
+
+describe("legacy sidebar thread-list animation", () => {
+  it.each([
+    [0, true],
+    [1, true],
+    [20, true],
+    [21, false],
+    [101, false],
+  ])("sets animation for %i visible thread rows to %s", (rowCount, enabled) => {
+    expect(mount(rowCount).isEnabled()).toBe(enabled);
+  });
+
+  it("keeps one controller and ordinary animation for small changes", () => {
+    const controller = mount(19);
+    update(20);
+    update(19);
+    expect(controllers).toHaveLength(1);
+    expect(controller.isEnabled()).toBe(true);
+    expect(controller.destroy).not.toHaveBeenCalled();
+  });
+
+  it.each([0, 1, 20])(
+    "bypasses bulk collapse to %i rows before restoring small-list animation",
+    async (rowCount) => {
+      const controller = mount(20);
+      update(101);
+      expect(controller.isEnabled()).toBe(false);
+
+      update(rowCount);
+      expect(controller.isEnabled()).toBe(false);
+      await Promise.resolve();
+      expect(controller.isEnabled()).toBe(true);
+
+      update(rowCount === 20 ? 19 : rowCount + 1);
+      expect(controller.isEnabled()).toBe(true);
+    },
+  );
+
+  it("does not re-enable a large list after a newer render", async () => {
+    const controller = mount(101);
+    update(1);
+    update(101);
+    await Promise.resolve();
+    expect(controller.isEnabled()).toBe(false);
+  });
+
+  it("keeps a second small commit disabled until the bulk removal is processed", async () => {
+    const controller = mount(101);
+    update(1);
+    update(2);
+    expect(controller.isEnabled()).toBe(false);
+    await Promise.resolve();
+    expect(controller.isEnabled()).toBe(true);
+  });
+
+  it("destroys the controller on unmount and cancels its pending re-enable", async () => {
+    const controller = mount(101);
+    update(1);
+    act(() => renderer!.unmount());
+    renderer = null;
+    await Promise.resolve();
+    expect(controller.destroy).toHaveBeenCalledOnce();
+    expect(controller.isEnabled()).toBe(false);
+  });
+
+  it.each([1, 101])(
+    "recreates controller state after replacing a %i-row node",
+    async (rowCount) => {
+      const oldController = mount(101);
+      update(rowCount);
+      update(101, "replacement");
+      await Promise.resolve();
+      expect(oldController.destroy).toHaveBeenCalledOnce();
+      expect(oldController.isEnabled()).toBe(false);
+      expect(controllers).toHaveLength(2);
+      expect(controllers[1]!.isEnabled()).toBe(false);
+    },
+  );
+
+  it("recreates and cleans up the controller during StrictMode replay", () => {
+    act(() => {
+      renderer = create(
+        <StrictMode>
+          <ThreadList rowCount={101} />
+        </StrictMode>,
+        { createNodeMock: () => ({}) as HTMLElement },
+      );
+    });
+    expect(controllers).toHaveLength(2);
+    expect(controllers[0]!.destroy).toHaveBeenCalledOnce();
+    expect(controllers[1]!.isEnabled()).toBe(false);
+  });
+});

--- a/apps/web/src/components/sidebar/useSidebarThreadListAutoAnimate.test.tsx
+++ b/apps/web/src/components/sidebar/useSidebarThreadListAutoAnimate.test.tsx
@@ -22,7 +22,6 @@ function mount(rowCount: number) {
       createNodeMock: () => ({}) as HTMLElement,
     });
   });
-  return controllers[0]!;
 }
 
 function update(rowCount: number, nodeKey = "list") {
@@ -61,17 +60,20 @@ afterEach(async () => {
 
 describe("legacy sidebar thread-list animation", () => {
   it.each([
-    [0, true],
-    [1, true],
-    [20, true],
-    [21, false],
-    [101, false],
-  ])("sets animation for %i visible thread rows to %s", (rowCount, enabled) => {
-    expect(mount(rowCount).isEnabled()).toBe(enabled);
+    [0, 1],
+    [1, 1],
+    [20, 1],
+    [21, 0],
+    [101, 0],
+  ])("registers %i visible thread rows with %i observers", (rowCount, count) => {
+    mount(rowCount);
+    expect(controllers).toHaveLength(count);
+    if (count) expect(controllers[0]!.isEnabled()).toBe(true);
   });
 
   it("keeps one controller and ordinary animation for small changes", () => {
-    const controller = mount(19);
+    mount(19);
+    const controller = controllers[0]!;
     update(20);
     update(19);
     expect(controllers).toHaveLength(1);
@@ -80,74 +82,74 @@ describe("legacy sidebar thread-list animation", () => {
   });
 
   it.each([0, 1, 20])(
-    "bypasses bulk collapse to %i rows before restoring small-list animation",
-    async (rowCount) => {
-      const controller = mount(20);
+    "unregisters large lists and recreates animation after collapsing to %i rows",
+    (rowCount) => {
+      mount(20);
+      const controller = controllers[0]!;
       update(101);
+      expect(controller.destroy).toHaveBeenCalledOnce();
       expect(controller.isEnabled()).toBe(false);
 
       update(rowCount);
       expect(controller.isEnabled()).toBe(false);
-      await Promise.resolve();
-      expect(controller.isEnabled()).toBe(true);
+      expect(controllers).toHaveLength(2);
+      expect(controllers[1]!.isEnabled()).toBe(true);
 
       update(rowCount === 20 ? 19 : rowCount + 1);
-      expect(controller.isEnabled()).toBe(true);
+      expect(controllers).toHaveLength(2);
+      expect(controllers[1]!.isEnabled()).toBe(true);
     },
   );
 
-  it("does not re-enable a large list after a newer render", async () => {
-    const controller = mount(101);
+  it("does not leave an observer after a rapid collapse and expansion", () => {
+    mount(101);
+    expect(controllers).toHaveLength(0);
     update(1);
+    const controller = controllers[0]!;
     update(101);
-    await Promise.resolve();
-    expect(controller.isEnabled()).toBe(false);
-  });
-
-  it("keeps a second small commit disabled until the bulk removal is processed", async () => {
-    const controller = mount(101);
-    update(1);
-    update(2);
-    expect(controller.isEnabled()).toBe(false);
-    await Promise.resolve();
-    expect(controller.isEnabled()).toBe(true);
-  });
-
-  it("destroys the controller on unmount and cancels its pending re-enable", async () => {
-    const controller = mount(101);
-    update(1);
-    act(() => renderer!.unmount());
-    renderer = null;
-    await Promise.resolve();
     expect(controller.destroy).toHaveBeenCalledOnce();
     expect(controller.isEnabled()).toBe(false);
   });
 
-  it.each([1, 101])(
-    "recreates controller state after replacing a %i-row node",
-    async (rowCount) => {
-      const oldController = mount(101);
-      update(rowCount);
-      update(101, "replacement");
-      await Promise.resolve();
-      expect(oldController.destroy).toHaveBeenCalledOnce();
-      expect(oldController.isEnabled()).toBe(false);
-      expect(controllers).toHaveLength(2);
-      expect(controllers[1]!.isEnabled()).toBe(false);
-    },
-  );
+  it("reuses the recreated observer for consecutive small commits", () => {
+    mount(101);
+    update(1);
+    const controller = controllers[0]!;
+    update(2);
+    expect(controllers).toHaveLength(1);
+    expect(controller.isEnabled()).toBe(true);
+  });
+
+  it("destroys the small-list controller on unmount", () => {
+    mount(1);
+    const controller = controllers[0]!;
+    act(() => renderer!.unmount());
+    renderer = null;
+    expect(controller.destroy).toHaveBeenCalledOnce();
+    expect(controller.isEnabled()).toBe(false);
+  });
+
+  it.each([1, 101])("recreates controller state after replacing a %i-row node", (rowCount) => {
+    mount(1);
+    const oldController = controllers[0]!;
+    update(rowCount, "replacement");
+    expect(oldController.destroy).toHaveBeenCalledOnce();
+    expect(oldController.isEnabled()).toBe(false);
+    expect(controllers).toHaveLength(rowCount === 1 ? 2 : 1);
+    if (rowCount === 1) expect(controllers[1]!.isEnabled()).toBe(true);
+  });
 
   it("recreates and cleans up the controller during StrictMode replay", () => {
     act(() => {
       renderer = create(
         <StrictMode>
-          <ThreadList rowCount={101} />
+          <ThreadList rowCount={1} />
         </StrictMode>,
         { createNodeMock: () => ({}) as HTMLElement },
       );
     });
     expect(controllers).toHaveLength(2);
     expect(controllers[0]!.destroy).toHaveBeenCalledOnce();
-    expect(controllers[1]!.isEnabled()).toBe(false);
+    expect(controllers[1]!.isEnabled()).toBe(true);
   });
 });

--- a/apps/web/src/components/sidebar/useSidebarThreadListAutoAnimate.ts
+++ b/apps/web/src/components/sidebar/useSidebarThreadListAutoAnimate.ts
@@ -1,0 +1,62 @@
+import { autoAnimate, type AnimationController } from "@formkit/auto-animate";
+import { useCallback, useLayoutEffect, useRef } from "react";
+
+export const MAX_ANIMATED_SIDEBAR_THREAD_ROWS = 20;
+
+interface ThreadListAnimation {
+  controller: AnimationController;
+  visibleRowCount: number;
+  pendingEnable: boolean;
+}
+
+export function useSidebarThreadListAutoAnimate(visibleRowCount: number) {
+  const animationRef = useRef<ThreadListAnimation | null>(null);
+  const attach = useCallback((node: HTMLElement | null) => {
+    if (!node) return;
+
+    const animation = {
+      controller: autoAnimate(node, { duration: 180, easing: "ease-out" }),
+      visibleRowCount: 0,
+      pendingEnable: false,
+    };
+    animationRef.current = animation;
+
+    return () => {
+      animation.controller.destroy?.();
+      animationRef.current = null;
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    const animation = animationRef.current;
+    if (!animation) return;
+
+    const previousRowCount = animation.visibleRowCount;
+    animation.visibleRowCount = visibleRowCount;
+    if (previousRowCount === visibleRowCount) return;
+    if (
+      previousRowCount <= MAX_ANIMATED_SIDEBAR_THREAD_ROWS &&
+      visibleRowCount <= MAX_ANIMATED_SIDEBAR_THREAD_ROWS
+    ) {
+      if (!animation.pendingEnable) animation.controller.enable();
+      return;
+    }
+
+    animation.controller.disable();
+    if (visibleRowCount > MAX_ANIMATED_SIDEBAR_THREAD_ROWS || animation.pendingEnable) return;
+
+    // MutationObserver must process the bulk removal before later small changes can animate.
+    animation.pendingEnable = true;
+    queueMicrotask(() => {
+      animation.pendingEnable = false;
+      if (
+        animationRef.current === animation &&
+        animation.visibleRowCount <= MAX_ANIMATED_SIDEBAR_THREAD_ROWS
+      ) {
+        animation.controller.enable();
+      }
+    });
+  });
+
+  return attach;
+}

--- a/apps/web/src/components/sidebar/useSidebarThreadListAutoAnimate.ts
+++ b/apps/web/src/components/sidebar/useSidebarThreadListAutoAnimate.ts
@@ -4,9 +4,8 @@ import { useCallback, useLayoutEffect, useRef } from "react";
 export const MAX_ANIMATED_SIDEBAR_THREAD_ROWS = 20;
 
 interface ThreadListAnimation {
-  controller: AnimationController;
-  visibleRowCount: number;
-  pendingEnable: boolean;
+  node: HTMLElement;
+  controller: AnimationController | null;
 }
 
 export function useSidebarThreadListAutoAnimate(visibleRowCount: number) {
@@ -14,15 +13,11 @@ export function useSidebarThreadListAutoAnimate(visibleRowCount: number) {
   const attach = useCallback((node: HTMLElement | null) => {
     if (!node) return;
 
-    const animation = {
-      controller: autoAnimate(node, { duration: 180, easing: "ease-out" }),
-      visibleRowCount: 0,
-      pendingEnable: false,
-    };
+    const animation: ThreadListAnimation = { node, controller: null };
     animationRef.current = animation;
 
     return () => {
-      animation.controller.destroy?.();
+      animation.controller?.destroy?.();
       animationRef.current = null;
     };
   }, []);
@@ -31,31 +26,14 @@ export function useSidebarThreadListAutoAnimate(visibleRowCount: number) {
     const animation = animationRef.current;
     if (!animation) return;
 
-    const previousRowCount = animation.visibleRowCount;
-    animation.visibleRowCount = visibleRowCount;
-    if (previousRowCount === visibleRowCount) return;
-    if (
-      previousRowCount <= MAX_ANIMATED_SIDEBAR_THREAD_ROWS &&
-      visibleRowCount <= MAX_ANIMATED_SIDEBAR_THREAD_ROWS
-    ) {
-      if (!animation.pendingEnable) animation.controller.enable();
+    if (visibleRowCount > MAX_ANIMATED_SIDEBAR_THREAD_ROWS) {
+      // disable() still reinserts removed nodes. Disconnect before mutation delivery instead.
+      animation.controller?.destroy?.();
+      animation.controller = null;
       return;
     }
 
-    animation.controller.disable();
-    if (visibleRowCount > MAX_ANIMATED_SIDEBAR_THREAD_ROWS || animation.pendingEnable) return;
-
-    // MutationObserver must process the bulk removal before later small changes can animate.
-    animation.pendingEnable = true;
-    queueMicrotask(() => {
-      animation.pendingEnable = false;
-      if (
-        animationRef.current === animation &&
-        animation.visibleRowCount <= MAX_ANIMATED_SIDEBAR_THREAD_ROWS
-      ) {
-        animation.controller.enable();
-      }
-    });
+    animation.controller ??= autoAnimate(animation.node, { duration: 180, easing: "ease-out" });
   });
 
   return attach;

--- a/patches/@formkit__auto-animate@0.9.0.patch
+++ b/patches/@formkit__auto-animate@0.9.0.patch
@@ -1,5 +1,5 @@
 diff --git a/index.mjs b/index.mjs
-index 7ad811c..075ef36 100644
+index 7ad811c..fb275fd 100644
 --- a/index.mjs
 +++ b/index.mjs
 @@ -142,17 +142,20 @@ function updatePos(el, debounce = true) {
@@ -25,7 +25,7 @@ index 7ad811c..075ef36 100644
  }
  /**
   * Updates all positions that are currently being tracked.
-@@ -160,7 +163,13 @@ function updatePos(el, debounce = true) {
+@@ -160,7 +163,14 @@ function updatePos(el, debounce = true) {
  function updateAllPos() {
      clearTimeout(debounces.get(root));
      debounces.set(root, setTimeout(() => {
@@ -33,14 +33,15 @@ index 7ad811c..075ef36 100644
 +        parents.forEach((parent) => {
 +            const observer = mutationObservers.get(parent);
 +            forEach(parent, (el) => lowPriority(() => {
-+                if (mutationObservers.get(parent) === observer)
++                if (mutationObservers.get(parent) === observer &&
++                    (el === parent || el.parentElement === parent))
 +                    updatePos(el);
 +            }));
 +        });
      }, 100));
  }
  /**
-@@ -172,9 +181,14 @@ function updateAllPos() {
+@@ -172,9 +182,14 @@ function updateAllPos() {
   * @param el - Element
   */
  function poll(el) {
@@ -58,7 +59,7 @@ index 7ad811c..075ef36 100644
  }
  /**
   * Perform some operation that is non critical at some point.
-@@ -537,10 +551,16 @@ function add(el) {
+@@ -537,10 +552,16 @@ function add(el) {
  function cleanUp(el, styles) {
      var _a;
      el.remove();
@@ -75,7 +76,7 @@ index 7ad811c..075ef36 100644
      setTimeout(() => {
          if (DEL in el)
              delete el[DEL];
-@@ -774,9 +794,18 @@ function autoAnimate(el, config = {}) {
+@@ -774,9 +795,18 @@ function autoAnimate(el, config = {}) {
              parents.delete(el);
              options.delete(el);
              const mo = mutationObservers.get(el);

--- a/patches/@formkit__auto-animate@0.9.0.patch
+++ b/patches/@formkit__auto-animate@0.9.0.patch
@@ -1,0 +1,97 @@
+diff --git a/index.mjs b/index.mjs
+index 7ad811c..075ef36 100644
+--- a/index.mjs
++++ b/index.mjs
+@@ -142,17 +142,20 @@ function updatePos(el, debounce = true) {
+             ? 500
+             : optionsOrPlugin.duration
+         : 0;
+-    debounces.set(el, setTimeout(async () => {
++    const timeout = setTimeout(async () => {
+         const currentAnimation = animations.get(el);
+         try {
+             await (currentAnimation === null || currentAnimation === void 0 ? void 0 : currentAnimation.finished);
++            if (debounces.get(el) !== timeout)
++                return;
+             coords.set(el, getCoords(el));
+             observePosition(el);
+         }
+         catch {
+             // ignore errors as the `.finished` promise is rejected when animations were cancelled
+         }
+-    }, delay));
++    }, delay);
++    debounces.set(el, timeout);
+ }
+ /**
+  * Updates all positions that are currently being tracked.
+@@ -160,7 +163,13 @@ function updatePos(el, debounce = true) {
+ function updateAllPos() {
+     clearTimeout(debounces.get(root));
+     debounces.set(root, setTimeout(() => {
+-        parents.forEach((parent) => forEach(parent, (el) => lowPriority(() => updatePos(el))));
++        parents.forEach((parent) => {
++            const observer = mutationObservers.get(parent);
++            forEach(parent, (el) => lowPriority(() => {
++                if (mutationObservers.get(parent) === observer)
++                    updatePos(el);
++            }));
++        });
+     }, 100));
+ }
+ /**
+@@ -172,9 +181,14 @@ function updateAllPos() {
+  * @param el - Element
+  */
+ function poll(el) {
+-    setTimeout(() => {
+-        intervals.set(el, setInterval(() => lowPriority(updatePos.bind(null, el)), 2000));
+-    }, Math.round(2000 * Math.random()));
++    clearInterval(intervals.get(el));
++    intervals.set(el, setTimeout(() => {
++        const interval = setInterval(() => lowPriority(() => {
++            if (intervals.get(el) === interval)
++                updatePos(el);
++        }), 2000);
++        intervals.set(el, interval);
++    }, Math.round(2000 * Math.random())));
+ }
+ /**
+  * Perform some operation that is non critical at some point.
+@@ -537,10 +551,16 @@ function add(el) {
+ function cleanUp(el, styles) {
+     var _a;
+     el.remove();
++    clearInterval(intervals.get(el));
++    intervals.delete(el);
++    clearTimeout(debounces.get(el));
++    debounces.delete(el);
++    resize === null || resize === void 0 ? void 0 : resize.unobserve(el);
+     coords.delete(el);
+     siblings.delete(el);
+     animations.delete(el);
+     (_a = intersections.get(el)) === null || _a === void 0 ? void 0 : _a.disconnect();
++    intersections.delete(el);
+     setTimeout(() => {
+         if (DEL in el)
+             delete el[DEL];
+@@ -774,9 +794,18 @@ function autoAnimate(el, config = {}) {
+             parents.delete(el);
+             options.delete(el);
+             const mo = mutationObservers.get(el);
++            const nodes = new Set();
++            forEach(el, (node) => nodes.add(node));
++            // DOM removals may be queued when a layout effect destroys the controller.
++            for (const mutation of (mo === null || mo === void 0 ? void 0 : mo.takeRecords()) || []) {
++                for (const node of mutation.removedNodes) {
++                    if (node instanceof Element)
++                        nodes.add(node);
++                }
++            }
+             mo === null || mo === void 0 ? void 0 : mo.disconnect();
+             mutationObservers.delete(el);
+-            forEach(el, (node) => {
++            nodes.forEach((node) => {
+                 // unobserve resize
+                 resize === null || resize === void 0 ? void 0 : resize.unobserve(node);
+                 // cancel animations

--- a/patches/@formkit__auto-animate@0.9.0.patch
+++ b/patches/@formkit__auto-animate@0.9.0.patch
@@ -1,5 +1,5 @@
 diff --git a/index.mjs b/index.mjs
-index 7ad811c..fb275fd 100644
+index 7ad811c..1b5bbee 100644
 --- a/index.mjs
 +++ b/index.mjs
 @@ -142,17 +142,20 @@ function updatePos(el, debounce = true) {
@@ -82,10 +82,10 @@ index 7ad811c..fb275fd 100644
              const mo = mutationObservers.get(el);
 +            const nodes = new Set();
 +            forEach(el, (node) => nodes.add(node));
-+            // DOM removals may be queued when a layout effect destroys the controller.
++            // Include queued removals unless another animated parent now owns the node.
 +            for (const mutation of (mo === null || mo === void 0 ? void 0 : mo.takeRecords()) || []) {
 +                for (const node of mutation.removedNodes) {
-+                    if (node instanceof Element)
++                    if (node instanceof Element && !parents.has(node.parentElement))
 +                        nodes.add(node);
 +                }
 +            }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ patchedDependencies:
   '@effect/vitest@4.0.0-beta.103': a16b1e870d8c29e4a98b17cc4c638a4ff471753d8ca3487f78a22b759caf951b
   '@expo/metro-config@57.0.12': 96f1a75347e6ea02dc4b7034ace815d8ee39e18b8166ebfb573d9e58328f0dc2
   '@ff-labs/fff-node@0.9.4': ab9ff544009e1891cfe3930105862d3699007f38922a79f3c98d90018deca368
-  '@formkit/auto-animate@0.9.0': 7e4366c46d6a3697239431be6bf62d5183d7668c59c9ee23f07795527f11e28f
+  '@formkit/auto-animate@0.9.0': 2b46160ebd6f1da6dbbc10b3a7b9c38b3d4b83f8c7ec5acc5f18864a0b3e6f11
   '@legendapp/list@3.3.5': 03ec41339cd915ecb9a774a6b90cc2197c29038f7db67c4d2e55cd3971e5be43
   '@pierre/diffs@1.3.0-beta.10': 7ef7cb0cbabb17c15cdb137554068b36f15f6f5265e73fb51452aa3380db91aa
   '@react-native-ai/apple@0.12.0': 2d09870c2848d185cb05b53ed823a46e12dba519324d8dd8e584e28731990f9d
@@ -575,7 +575,7 @@ importers:
         version: 4.0.0-beta.103(effect@4.0.0-beta.103(patch_hash=af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6))(react@19.2.6)(scheduler@0.27.0)
       '@formkit/auto-animate':
         specifier: ^0.9.0
-        version: 0.9.0(patch_hash=7e4366c46d6a3697239431be6bf62d5183d7668c59c9ee23f07795527f11e28f)
+        version: 0.9.0(patch_hash=2b46160ebd6f1da6dbbc10b3a7b9c38b3d4b83f8c7ec5acc5f18864a0b3e6f11)
       '@legendapp/list':
         specifier: 'catalog:'
         version: 3.3.5(patch_hash=03ec41339cd915ecb9a774a6b90cc2197c29038f7db67c4d2e55cd3971e5be43)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -12780,7 +12780,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@formkit/auto-animate@0.9.0(patch_hash=7e4366c46d6a3697239431be6bf62d5183d7668c59c9ee23f07795527f11e28f)': {}
+  '@formkit/auto-animate@0.9.0(patch_hash=2b46160ebd6f1da6dbbc10b3a7b9c38b3d4b83f8c7ec5acc5f18864a0b3e6f11)': {}
 
   '@hono/node-server@1.19.14(hono@4.12.27)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ patchedDependencies:
   '@effect/vitest@4.0.0-beta.103': a16b1e870d8c29e4a98b17cc4c638a4ff471753d8ca3487f78a22b759caf951b
   '@expo/metro-config@57.0.12': 96f1a75347e6ea02dc4b7034ace815d8ee39e18b8166ebfb573d9e58328f0dc2
   '@ff-labs/fff-node@0.9.4': ab9ff544009e1891cfe3930105862d3699007f38922a79f3c98d90018deca368
-  '@formkit/auto-animate@0.9.0': 2b46160ebd6f1da6dbbc10b3a7b9c38b3d4b83f8c7ec5acc5f18864a0b3e6f11
+  '@formkit/auto-animate@0.9.0': 9d572f2efc25482b1becb96b46112a752ae6ff0f5552223fb1de3427e3b33143
   '@legendapp/list@3.3.5': 03ec41339cd915ecb9a774a6b90cc2197c29038f7db67c4d2e55cd3971e5be43
   '@pierre/diffs@1.3.0-beta.10': 7ef7cb0cbabb17c15cdb137554068b36f15f6f5265e73fb51452aa3380db91aa
   '@react-native-ai/apple@0.12.0': 2d09870c2848d185cb05b53ed823a46e12dba519324d8dd8e584e28731990f9d
@@ -575,7 +575,7 @@ importers:
         version: 4.0.0-beta.103(effect@4.0.0-beta.103(patch_hash=af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6))(react@19.2.6)(scheduler@0.27.0)
       '@formkit/auto-animate':
         specifier: ^0.9.0
-        version: 0.9.0(patch_hash=2b46160ebd6f1da6dbbc10b3a7b9c38b3d4b83f8c7ec5acc5f18864a0b3e6f11)
+        version: 0.9.0(patch_hash=9d572f2efc25482b1becb96b46112a752ae6ff0f5552223fb1de3427e3b33143)
       '@legendapp/list':
         specifier: 'catalog:'
         version: 3.3.5(patch_hash=03ec41339cd915ecb9a774a6b90cc2197c29038f7db67c4d2e55cd3971e5be43)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -12780,7 +12780,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@formkit/auto-animate@0.9.0(patch_hash=2b46160ebd6f1da6dbbc10b3a7b9c38b3d4b83f8c7ec5acc5f18864a0b3e6f11)': {}
+  '@formkit/auto-animate@0.9.0(patch_hash=9d572f2efc25482b1becb96b46112a752ae6ff0f5552223fb1de3427e3b33143)': {}
 
   '@hono/node-server@1.19.14(hono@4.12.27)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,7 @@ patchedDependencies:
   '@effect/vitest@4.0.0-beta.103': a16b1e870d8c29e4a98b17cc4c638a4ff471753d8ca3487f78a22b759caf951b
   '@expo/metro-config@57.0.12': 96f1a75347e6ea02dc4b7034ace815d8ee39e18b8166ebfb573d9e58328f0dc2
   '@ff-labs/fff-node@0.9.4': ab9ff544009e1891cfe3930105862d3699007f38922a79f3c98d90018deca368
+  '@formkit/auto-animate@0.9.0': 7e4366c46d6a3697239431be6bf62d5183d7668c59c9ee23f07795527f11e28f
   '@legendapp/list@3.3.5': 03ec41339cd915ecb9a774a6b90cc2197c29038f7db67c4d2e55cd3971e5be43
   '@pierre/diffs@1.3.0-beta.10': 7ef7cb0cbabb17c15cdb137554068b36f15f6f5265e73fb51452aa3380db91aa
   '@react-native-ai/apple@0.12.0': 2d09870c2848d185cb05b53ed823a46e12dba519324d8dd8e584e28731990f9d
@@ -574,7 +575,7 @@ importers:
         version: 4.0.0-beta.103(effect@4.0.0-beta.103(patch_hash=af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6))(react@19.2.6)(scheduler@0.27.0)
       '@formkit/auto-animate':
         specifier: ^0.9.0
-        version: 0.9.0
+        version: 0.9.0(patch_hash=7e4366c46d6a3697239431be6bf62d5183d7668c59c9ee23f07795527f11e28f)
       '@legendapp/list':
         specifier: 'catalog:'
         version: 3.3.5(patch_hash=03ec41339cd915ecb9a774a6b90cc2197c29038f7db67c4d2e55cd3971e5be43)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -12779,7 +12780,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@formkit/auto-animate@0.9.0': {}
+  '@formkit/auto-animate@0.9.0(patch_hash=7e4366c46d6a3697239431be6bf62d5183d7668c59c9ee23f07795527f11e28f)': {}
 
   '@hono/node-server@1.19.14(hono@4.12.27)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -161,6 +161,7 @@ patchedDependencies:
   "@effect/vitest@4.0.0-beta.103": patches/@effect__vitest@4.0.0-beta.103.patch
   "@expo/metro-config@57.0.12": patches/@expo__metro-config@57.0.12.patch
   "@ff-labs/fff-node@0.9.4": patches/@ff-labs__fff-node@0.9.4.patch
+  "@formkit/auto-animate@0.9.0": patches/@formkit__auto-animate@0.9.0.patch
   "@legendapp/list@3.3.5": patches/@legendapp__list@3.3.5.patch
   "@pierre/diffs@1.3.0-beta.10": patches/@pierre%2Fdiffs@1.3.0-beta.10.patch
   "@react-native-ai/apple@0.12.0": patches/@react-native-ai__apple@0.12.0.patch


### PR DESCRIPTION
Collapsing a legacy-sidebar project with many visible threads can block the UI for seconds. Closes #3962.

HUMAN HOLD. The large-list animation tradeoff and the new dependency patch need maintainer approval. Do not merge automatically. All executed current-head CI jobs and Bugbot pass. UI and Effect checks pass; Correctness is skipped. Approvability is NEUTRAL and requires maintainer review of the animation cutoff and shared dependency patch. There are no unresolved review threads. The current-package integrated check and final human decision remain outstanding.

Keep the existing 180 ms animation for at most 20 visible thread rows. Larger lists have no AutoAnimate controller. Crossing above the limit destroys the controller in a layout effect before mutation delivery; returning to a small list creates a fresh controller against the updated DOM. The active thread retained by a collapsed project still counts. AutoAnimate's `disable()` was insufficient because it still reinserts removed elements.

This adapts Julius Marminge's original [b778911](https://github.com/pingdotgg/t3code/commit/b7789116f7c455caa8543790efec26c6ccb3092f) to the current LegacySidebar. The older [#4345](https://github.com/pingdotgg/t3code/pull/4345) was closed after the sidebar redesign with a request for this follow-up if still reproducible.

## Deterministic cleanup

Review found that AutoAnimate 0.9.0 starts polling through an untracked timeout. Destroying a controller before that timeout fires leaves polling alive. Removed children and queued position updates can also retain observers.

The bounded package patch retains that existing startup handle in the existing timer map, rejects stale queued updates, and releases removed-child timers and observers. Destruction includes removals awaiting mutation delivery, but leaves a moved child with its new registered parent. No new timer, timer-delay workaround, version bump or periodic task is introduced.

The patch touches the package's exported `index.mjs` entry, used by the web callers and wrappers. It adds a maintenance commitment and affects resource cleanup for the other web AutoAnimate callers too. Default Sidebar and project-list animation policy are unchanged. Thread selection, settings, provider behavior, contracts and mobile are unchanged. Desktop uses the same web component; this does not change local/remote transport.

## Verification

Current candidate [c26605d6](https://github.com/pingdotgg/t3code/commit/c26605d6109bd98eb3b5dd6d53948cf732405f04), based on main [ac90950f](https://github.com/pingdotgg/t3code/commit/ac90950f1ac315bcef5f92b53c5e0d6579daeefd):

- All 13 actual-package lifecycle cases pass. The same tests have nine failures against unpatched 0.9.0. They cover destruction before delayed startup, running interval teardown, polling and root-resize callbacks, an awaited position update, pending and completed child removal, moving a child to another animated parent, repeated destroy/recreate, initially large then small lists, and no browser work during SSR. Browser scheduling and DOM primitives are controlled in these tests; they are not browser performance measurements.
- All 15 React hook lifecycle cases pass, including the 20/21-row boundary, replacement, unmount and StrictMode.
- 161 focused tests pass across `autoAnimateCleanup.test.tsx`, `useSidebarThreadListAutoAnimate.test.tsx`, `Sidebar.logic.test.ts`, `Sidebar.snooze.test.ts` and `ui/sidebar.test.tsx`, run with `vp test run <files> --maxWorkers=2`.
- Web typecheck and targeted formatting/lint pass. LegacySidebar retains three existing warnings in untouched ref/memoization code.
- The patch applies cleanly to the original package. Offline lockfile-only regeneration changes only its patch references and performs zero downloads or installs. No repository-wide checks were run locally.

The orchestrator requested an ownership control: move a child from animated A to animated B, deliver B's mutation, then destroy A while its removal record is queued. It passes on unpatched 0.9.0, failed in 33 ms against [39b6fb1f](https://github.com/pingdotgg/t3code/commit/39b6fb1fb5ee60057ff29207a3f7e1efcaad06f5), and passes now. The repair checks the existing parent registry; it does not add a new ownership model. A queued root-resize callback also stays inert after destroying and recreating the same parent.

## Real-client before and after

The orchestrator tested the same disposable 103-thread project in Chromium 152, using Legacy Sidebar and retaining the active File links audit row.

Before, main [d7fe47fd](https://github.com/pingdotgg/t3code/commit/d7fe47fd0957a34fc2e8bb05f12db19bac3403b6): collapse produced an 1881 ms long task, 105 animation calls and 311 computed-style reads.

![Before: collapsed legacy sidebar retaining the active thread](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/55dd8c17e82ed456/3962-before-settled.png)

![Before recording: 103-row collapse on main](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/925ec91f66e8d947/3962-before-103-live.webm)

After, main [7f8cf30c](https://github.com/pingdotgg/t3code/commit/7f8cf30ca479474f8c6e0a85f6e0a1169bcca365) with the exact production hook from [870eb1f7](https://github.com/pingdotgg/t3code/commit/870eb1f7bb61b73cfbd3af326bcd08c7846b0c5c): 55 ms, zero animation calls and one computed-style read.

![After: the same active thread remains after bulk collapse](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/1cd7ec77d46c0489/3962-revised-103-after.png)

![After recording: revised 103-row collapse](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/31946323d9bb65ac/3962-revised-103-after.webm)

A subsequent six-row-to-one-row collapse took 128 ms, made eight animation calls and 20 computed-style reads. This confirms ordinary small-list animation resumes after bulk changes.

Both recordings capture the live tab at 20 fps with the same wall-clock method. They demonstrate the unchanged controller-registration strategy, not the later dependency cleanup patch. The cleanup patch has focused actual-library evidence above; a current-package integrated check remains a final review gate.

For comparison, the earlier disable-only [97710b9](https://github.com/pingdotgg/t3code/commit/97710b996feb019c19fbd31412609d069fa52051) still took 1806 ms despite zero animation calls. That candidate did not fix the freeze.

Original approach by Julius Marminge. Adapted and verified by GPT 6 Astra via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> A patched dependency changes global AutoAnimate teardown for every web caller; the 20-row cutoff and destroy-before-mutation timing must stay correct to avoid regressions or lingering timers.
> 
> **Overview**
> Fixes **multi-second UI freezes** when collapsing a legacy-sidebar project with many visible threads by **not running AutoAnimate on large thread lists**.
> 
> **Thread-list animation** moves from a shared ref on `LegacySidebar` into **`useSidebarThreadListAutoAnimate`** on each `SidebarProjectThreadList`. AutoAnimate is created only when visible rows are **≤ 20**; crossing above that **destroys** the controller in a layout effect (before DOM mutations), and small lists get a fresh controller when row count drops again. The shared `attachThreadListAutoAnimateRef` prop is removed from parent components. **Project-list** animation in `LegacySidebar` is unchanged.
> 
> **`@formkit/auto-animate@0.9.0` is patched** (registered in `pnpm-workspace.yaml`) so `destroy()` cancels pending poll/debounce timers, tears down observers on removed nodes, and ignores stale position updates—behavior all web AutoAnimate callers inherit, not just the legacy sidebar.
> 
> Adds **`useSidebarThreadListAutoAnimate.test.tsx`** and **`autoAnimateCleanup.test.tsx`** for the 20-row boundary, StrictMode/unmount, and library lifecycle cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c26605d6109bd98eb3b5dd6d53948cf732405f04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable legacy sidebar thread-list animations above `20` rows and fix `@formkit/auto-animate` cleanup
> - Adds `useSidebarThreadListAutoAnimate` hook so each thread sub-list owns its AutoAnimate controller; lists with at most 20 visible rows get a 180ms ease-out animation, larger lists get none, and controllers are destroyed on unmount or node replacement
> - Removes the shared thread-list auto-animation ref callback threaded through `SidebarProjectsContent`, `SidebarProjectItem`, and `SidebarProjectThreadList` in [LegacySidebar.tsx](https://github.com/pingdotgg/t3code/pull/9868/files#diff-ef6c49faf62e0e2403f09772084537ac313e826ae0f90db230a898204f3bdd86)\- Patches `@formkit/auto-animate@0.9.0` (registered in [pnpm-workspace.yaml](https://github.com/pingdotgg/t3code/pull/9868/files#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794c)) so `destroy` cleans queued removals, timers, and observer registrations, and stale polling/debounce callbacks no longer re-observe removed or moved elements
> - Risk: the `@formkit/auto-animate` patch rewrites `updatePos`, `updateAllPos`, `poll`, `cleanUp`, and `destroy` behavior; any other consumer of this dependency in the repo will receive the patched logic
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c26605d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->