### PR TITLE
fix(web): show retained runtime diagnostics in the work log

### DIFF
--- a/apps/web/src/session-logic.runtime-diagnostics.test.ts
+++ b/apps/web/src/session-logic.runtime-diagnostics.test.ts
@@ -1,0 +1,75 @@
+import { EventId, TurnId, type OrchestrationThreadActivity } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { deriveWorkLogEntries } from "./session-logic";
+import { workEntryDisplayLabel } from "./components/chat/MessagesTimeline.logic";
+
+// These are the already-truncated fields emitted by ProviderRuntimeIngestion
+// for the malformed-skill diagnostic reported in issue 1084.
+const retainedMessage =
+  "2026-03-14T16:11:12.550224Z ERROR codex_core::codex: failed to load skill /home/sebherrerabe/repos/devsuite/.agent/skills/monorepo-scaffolding/SKILL.md: invalid YAML: mapping va...";
+const warningSummary =
+  "2026-03-14T16:11:12.550224Z ERROR codex_core::codex: failed to load skill /home/sebherrerabe/repos/devsuite/.agent/sk...";
+
+function makeActivity(
+  overrides: Partial<OrchestrationThreadActivity> = {},
+): OrchestrationThreadActivity {
+  return {
+    id: EventId.make("diagnostic"),
+    createdAt: "2026-09-05T00:00:00.000Z",
+    kind: "runtime.error",
+    tone: "error",
+    summary: "Runtime error",
+    payload: { message: retainedMessage },
+    turnId: TurnId.make("turn-1"),
+    ...overrides,
+  };
+}
+
+describe("runtime diagnostics in the work log", () => {
+  it("shows the retained error message in place of its generic row label", () => {
+    const [entry] = deriveWorkLogEntries([makeActivity()]);
+
+    expect(entry).toMatchObject({ label: "Runtime error", detail: retainedMessage });
+    expect(entry && workEntryDisplayLabel(entry, undefined)).toBe(retainedMessage);
+  });
+
+  it("shows the retained warning message beyond its truncated label", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeActivity({ kind: "runtime.warning", tone: "info", summary: warningSummary }),
+    ]);
+
+    expect(entry).toMatchObject({ label: warningSummary, detail: retainedMessage });
+    expect(entry && workEntryDisplayLabel(entry, undefined)).toBe(retainedMessage);
+  });
+
+  it("keeps an existing diagnostic detail when one is provided", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeActivity({ payload: { message: retainedMessage, detail: "Run claude auth login." } }),
+    ]);
+
+    expect(entry?.detail).toBe("Run claude auth login.");
+  });
+
+  it("does not repeat a short warning already visible in the label", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeActivity({
+        kind: "runtime.warning",
+        tone: "info",
+        summary: "Reconnecting... 2/5",
+        payload: { message: "Reconnecting... 2/5" },
+      }),
+    ]);
+
+    expect(entry?.label).toBe("Reconnecting... 2/5");
+    expect(entry?.detail).toBeUndefined();
+  });
+
+  it("does not interpret an unrelated activity message as a runtime diagnostic", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeActivity({ kind: "tool.completed", tone: "tool", summary: "Read file" }),
+    ]);
+
+    expect(entry?.detail).toBeUndefined();
+  });
+});

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -964,6 +964,14 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   const viewedImagePath = asTrimmedString(asRecord(payload?.data)?.imagePath);
   if (detail) {
     entry.detail = detail;
+  } else if (activity.kind === "runtime.error" || activity.kind === "runtime.warning") {
+    const message = asTrimmedString(payload?.message);
+    if (
+      message &&
+      normalizePreviewForComparison(message) !== normalizePreviewForComparison(activity.summary)
+    ) {
+      entry.detail = message;
+    }
   }
   if (viewedImagePath) {
     entry.viewedImagePath = viewedImagePath;


### PR DESCRIPTION
Runtime errors in the work log can show only "Runtime error", even though the activity contains a diagnostic message. Long warnings similarly hide the portion retained beyond their short row label.

Use the existing retained message as the row's detail when a runtime error or warning has no other detail. The existing work-log rendering then shows the diagnostic and allows expansion. Explicit detail still wins, short warnings are not duplicated, and other activity kinds are unchanged.

This addresses only the hidden retained-text portion of [#1084](https://github.com/pingdotgg/t3code/issues/1084). The issue stays open: the server still truncates stored diagnostic messages to 180 characters, and this change does not recover the missing line/column tail, alter error banners, or change provider error handling.

### Verification

- On [ce4712d5](https://github.com/pingdotgg/t3code/commit/ce4712d5b04fb998f79fe132245289191147e5d5), the new work-log tests use already-truncated diagnostic fields obtained from ingestion receipts. The error/warning cases fail without this patch and pass with it.
- 211 focused work-log, timeline and diagnostic tests pass. Web typecheck, targeted lint and diff checks pass.
- Web and desktop share this renderer. Mobile, contracts and server retention are unchanged.

### Before and after

Verified in Chrome 152 using the same disposable SQLite activity and the exact production patch from [f036019](https://github.com/pingdotgg/t3code/commit/f036019cdd0e901086b685f505890bb49ccd3213). Before uses main [d7fe47f](https://github.com/pingdotgg/t3code/commit/d7fe47fd0957a34fc2e8bb05f12db19bac3403b6); after uses [d28077e](https://github.com/pingdotgg/t3code/commit/d28077e585d5123b9a562f4ebef257969c81aa31) plus this patch. The intervening main change only quotes provider update commands.

This is a synthetic, redacted projection replay. It proves that the client displays the already-retained message and exposes the existing expansion control. It does not exercise native provider collection or recover the diagnostic tail already truncated by the server.

Before: the work log shows only "Runtime error".

![Before: the retained diagnostic is hidden behind a generic Runtime error row](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/067f8fccade3ce82/1084-before-retained-diagnostic.png)

After: the retained diagnostic replaces that label and can be expanded.

![After: the same activity displays its retained diagnostic and expansion control](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/50c0a3192214476f/1084-after-retained-diagnostic.png)

GPT 6 Astra via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show retained runtime diagnostics in work log for error and warning activities
> Adds a fallback in `session.toDerivedWorkLogEntry` that reads a trimmed message from the activity payload for runtime error and runtime warning entries when no existing detail is present. The fallback only applies when the normalized message differs from the activity summary, so already-visible warnings are not duplicated. Existing detail continues to take precedence. Tests in [session-logic.runtime-diagnostics.test.ts](https://github.com/pingdotgg/t3code/pull/9870/files#diff-c1b7de440c57cef6da71177ef0b0fec1684b357f470a3c3aa4bd7746ee260c30) cover error message display, long warning messages, explicit detail preservation, duplicate suppression, and non-runtime activity exclusion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f036019.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized work-log derivation and display logic for runtime diagnostic activities only, with focused regression tests and no server or auth changes.
> 
> **Overview**
> Work log rows for **runtime errors and warnings** no longer drop the truncated diagnostic already stored on the activity payload. When `toDerivedWorkLogEntry` has no other detail, it now copies `payload.message` into `entry.detail` for `runtime.error` / `runtime.warning`, but only if the normalized message differs from the row summary so short warnings are not duplicated.
> 
> Existing explicit `detail` still wins, and non-runtime activities are unchanged. The timeline can then surface the retained text via `workEntryDisplayLabel` and the existing expand behavior. This is a **client projection fix** for issue #1084; server-side 180-character truncation is untouched.
> 
> New tests in `session-logic.runtime-diagnostics.test.ts` lock in error vs long-warning display, detail precedence, duplicate suppression, and exclusion of other activity kinds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f036019cdd0e901086b685f505890bb49ccd3213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
