### PR TITLE
fix(web): restore file scroll position

### DIFF
--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 
 import { getSyntaxHighlighterPromise } from "../lib/syntaxHighlighting";
 import { GitHubIcon } from "./Icons";
+import { remarkSourceLineAnchors } from "../markdown-source-line-anchors";
 import { Button } from "./ui/button";
 import { setMarkdownTaskChecked } from "./files/filePreviewMode";
 
@@ -745,5 +746,21 @@ describe("ChatMarkdown Windows file links", () => {
     expect(html).not.toContain("javascript:");
     expect(html).not.toContain("d:alert");
     expect(html).not.toContain("chat-markdown-file-link");
+  });
+});
+
+describe("ChatMarkdown source line anchors", () => {
+  it("keeps the anchor on alert blockquotes and fenced code", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        cwd="/tmp/project"
+        text={"Intro\n\n> [!NOTE]\n> Careful here.\n\n```ts\nconst answer = 42;\n```\n"}
+        extraRemarkPlugins={[remarkSourceLineAnchors]}
+      />,
+    );
+
+    expect(html).toContain('role="note"');
+    expect(html).toMatch(/role="note"[^>]*data-source-line="3"/);
+    expect(html).toMatch(/chat-markdown-codeblock[^>]*data-source-line="6"/);
   });
 });

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -437,7 +437,10 @@ const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
   ...defaultSchema,
   attributes: {
     ...defaultSchema.attributes,
-    "*": (defaultSchema.attributes?.["*"] ?? []).filter((attribute) => attribute !== "title"),
+    "*": [
+      ...(defaultSchema.attributes?.["*"] ?? []).filter((attribute) => attribute !== "title"),
+      "dataSourceLine",
+    ],
     code: [...(defaultSchema.attributes?.code ?? []), "dataCodeMeta", "dataInlineCode"],
     blockquote: [...(defaultSchema.attributes?.blockquote ?? []), "dataAlert"],
     div: [...(defaultSchema.attributes?.div ?? []), ...CODEX_ARTIFACT_TEMPLATE_HAST_PROPERTIES],
@@ -631,7 +634,7 @@ function nodeToPlainText(node: ReactNode): string {
 
 function extractCodeBlock(
   children: ReactNode,
-): { className: string | undefined; code: string } | null {
+): { className: string | undefined; code: string; sourceLine: number | string | undefined } | null {
   const childNodes = Children.toArray(children);
   if (childNodes.length !== 1) {
     return null;
@@ -639,9 +642,12 @@ function extractCodeBlock(
 
   const onlyChild = childNodes[0];
   if (
-    !isValidElement<{ className?: string; children?: ReactNode; node?: { tagName?: string } }>(
-      onlyChild,
-    )
+    !isValidElement<{
+      className?: string;
+      children?: ReactNode;
+      node?: { tagName?: string };
+      "data-source-line"?: number | string;
+    }>(onlyChild)
   ) {
     return null;
   }
@@ -653,6 +659,7 @@ function extractCodeBlock(
 
   return {
     className: onlyChild.props.className,
+    sourceLine: onlyChild.props["data-source-line"],
     code: nodeToPlainText(onlyChild.props.children),
   };
 }
@@ -888,12 +895,14 @@ function MarkdownCodeBlock({
   language,
   fenceTitle,
   theme,
+  sourceLine,
   children,
 }: {
   code: string;
   language: string;
   fenceTitle: string | null;
   theme: "light" | "dark";
+  sourceLine?: number | string | undefined;
   children: ReactNode;
 }) {
   const [copied, setCopied] = useState(false);
@@ -944,6 +953,7 @@ function MarkdownCodeBlock({
     <div
       className="chat-markdown-codeblock my-[0.65rem] overflow-hidden rounded-[var(--radius)] border border-border/70 bg-secondary leading-snug dark:border-transparent dark:bg-input/32"
       data-language={language}
+      data-source-line={sourceLine}
       data-wrap={wrapped ? "true" : "false"}
     >
       <div className="chat-markdown-codeblock-header flex items-center justify-between gap-2 pt-1.5 pr-1.5 pb-0 pl-3 select-none">
@@ -2661,8 +2671,15 @@ const CHAT_MARKDOWN_COMPONENTS = {
     }
     // Not a <blockquote>: the stylesheet mutes those, and an alert's body is ordinary
     // text under a colored title — which is how the host renders it.
+    const sourceLine = (props as Record<string, unknown>)["data-source-line"];
     return (
-      <div role="note" className={cn("my-1 border-l-2 pl-3", alert.borderClassName)}>
+      <div
+        role="note"
+        className={cn("my-1 border-l-2 pl-3", alert.borderClassName)}
+        data-source-line={
+          typeof sourceLine === "number" || typeof sourceLine === "string" ? sourceLine : undefined
+        }
+      >
         <p className={cn("flex items-center gap-1.5 font-medium", alert.titleClassName)}>
           <alert.Icon aria-hidden className="size-3.5 shrink-0" />
           {alert.label}
@@ -3094,6 +3111,7 @@ const CHAT_MARKDOWN_COMPONENTS = {
         language={language}
         fenceTitle={fenceTitle}
         theme={resolvedTheme}
+        sourceLine={codeBlock.sourceLine}
       >
         <RenderErrorBoundary
           resetKeys={[codeBlock.code, language, diffThemeName, isStreaming]}

--- a/apps/web/src/components/files/FileMarkdownPreview.tsx
+++ b/apps/web/src/components/files/FileMarkdownPreview.tsx
@@ -1,7 +1,10 @@
 import type { ScopedThreadRef } from "@t3tools/contracts";
 
 import ChatMarkdown from "~/components/ChatMarkdown";
+import { remarkSourceLineAnchors } from "~/markdown-source-line-anchors";
 import { resolvePathLinkTarget } from "~/terminal-links";
+
+const FILE_MARKDOWN_REMARK_PLUGINS = [remarkSourceLineAnchors];
 
 export function FileMarkdownPreview(props: {
   readonly cwd: string;
@@ -28,6 +31,7 @@ export function FileMarkdownPreview(props: {
       imageBaseDir={imageBaseDir}
       threadRef={props.threadRef}
       className="mx-auto max-w-4xl px-6 py-5"
+      extraRemarkPlugins={FILE_MARKDOWN_REMARK_PLUGINS}
       onTaskListChange={props.onTaskListChange}
     />
   );

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -18,6 +18,7 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import { scopedThreadKey } from "@t3tools/client-runtime/environment";
 import { mediaFileReference } from "@t3tools/client-runtime/media-reference";
 import { Code2, Eye, FolderTree, Globe2 } from "lucide-react";
 import * as Schema from "effect/Schema";
@@ -50,10 +51,17 @@ import { useEnvironmentHttpBaseUrl, usePrimaryEnvironmentId } from "~/state/envi
 import { previewEnvironment } from "~/state/preview";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { useAtomQueryRunner } from "~/state/use-atom-query-runner";
+import {
+  fileScrollPositionKey,
+  readHandledFileReveal,
+  rememberHandledFileReveal,
+} from "~/fileScrollState";
 
 import FileBrowserPanel from "./FileBrowserPanel";
 import { FileBreadcrumbs } from "./FileBreadcrumbs";
 import { FileMarkdownPreview } from "./FileMarkdownPreview";
+import { RestorableFileScroll } from "./RestorableFileScroll";
+import { rememberFileScrollPositionFromViewport } from "./fileScrollViewport";
 import {
   type FileCommentAnnotationEntry,
   type FileCommentAnnotationGroup,
@@ -144,6 +152,10 @@ const FILE_LINK_REVEAL_UNSAFE_CSS = `
   }
 `;
 type FilePostRender = NonNullable<FileOptions<unknown>["onPostRender"]>;
+
+function fileSourceLineCount(contents: string): number {
+  return contents.length === 0 ? 1 : contents.split(/\r\n|\r|\n/).length;
+}
 
 function WorkspaceImagePreview(props: {
   readonly environmentId: EnvironmentId;
@@ -428,12 +440,17 @@ interface FileRevealState {
 
 function useFileLineReveal(
   relativePath: string | null,
+  positionKey: string | null,
   revealLine: number | null,
   revealRequestId: number,
-): FilePostRender {
+): { onPostRender: FilePostRender; revealPerformed: boolean } {
   const [revealStatesByPath] = useState(() => new Map<string, FileRevealState>());
+  // True once this reveal request has scrolled the file, in this panel or an earlier mount of it.
+  // Read at render so a reopened file restores its saved position instead of re-revealing.
+  const revealPerformed =
+    positionKey !== null && readHandledFileReveal(positionKey) === revealRequestId;
 
-  return useCallback<FilePostRender>(
+  const onPostRender = useCallback<FilePostRender>(
     (fileContainer, instance, phase) => {
       if (relativePath === null) return;
 
@@ -441,7 +458,7 @@ function useFileLineReveal(
       const state: FileRevealState = existingState ?? {
         frameId: null,
         cancelGuard: null,
-        handledRequestId: null,
+        handledRequestId: positionKey === null ? null : readHandledFileReveal(positionKey),
         latestRequestId: null,
       };
       if (!existingState) revealStatesByPath.set(relativePath, state);
@@ -583,14 +600,16 @@ function useFileLineReveal(
 
           scrollContainer.scrollTop = targetTop;
           state.handledRequestId = revealRequestId;
+          if (positionKey !== null) rememberHandledFileReveal(positionKey, revealRequestId);
           guardScrollTarget(line);
         });
       };
 
       scheduleReveal(0);
     },
-    [revealStatesByPath, relativePath, revealLine, revealRequestId],
+    [revealStatesByPath, relativePath, positionKey, revealLine, revealRequestId],
   );
+  return { onPostRender, revealPerformed };
 }
 
 interface EditableFileSurfaceProps {
@@ -599,6 +618,8 @@ interface EditableFileSurfaceProps {
   relativePath: string;
   composerDraftTarget: ScopedThreadRef | DraftId;
   contents: string;
+  scrollPositionKey: string | null;
+  restoreScrollPosition: boolean;
   resolvedTheme: "light" | "dark";
   revealRequestId: number;
   wordWrap: boolean;
@@ -617,6 +638,8 @@ function EditableFileSurface({
   relativePath,
   composerDraftTarget,
   contents,
+  scrollPositionKey,
+  restoreScrollPosition,
   resolvedTheme,
   revealRequestId,
   wordWrap,
@@ -827,60 +850,68 @@ function EditableFileSurface({
   return (
     <EditProvider editor={editor}>
       <div ref={surfaceRef} className="flex min-h-0 flex-1">
-        <Virtualizer
-          className="file-preview-virtualizer min-h-0 flex-1 overflow-auto"
-          config={{
-            overscrollSize: 600,
-            intersectionObserverMargin: 1200,
-          }}
+        <RestorableFileScroll
+          positionKey={scrollPositionKey}
+          restorePosition={restoreScrollPosition}
+          sourceLineCount={fileSourceLineCount(contents)}
+          surface="source"
+          viewportSelector=".file-preview-virtualizer"
         >
-          <File<FileCommentAnnotationGroup>
-            file={{
-              name: relativePath,
-              contents,
-              cacheKey: projectFileEditorCacheKey(
-                environmentId,
-                cwd,
-                relativePath,
+          <Virtualizer
+            className="file-preview-virtualizer min-h-0 flex-1 overflow-auto"
+            config={{
+              overscrollSize: 600,
+              intersectionObserverMargin: 1200,
+            }}
+          >
+            <File<FileCommentAnnotationGroup>
+              file={{
+                name: relativePath,
                 contents,
-                editor.getFile(),
-              ),
-            }}
-            options={{
-              disableFileHeader: true,
-              enableGutterUtility: !hasOpenCommentForm,
-              enableLineSelection: !hasOpenCommentForm,
-              onGutterUtilityClick: setSelectedRange,
-              onLineSelectionChange: setSelectedRange,
-              onLineSelectionEnd: handleLineSelectionEnd,
-              overflow: wordWrap ? "wrap" : "scroll",
-              theme: resolveDiffThemeName(resolvedTheme),
-              preferredHighlighter: PREFERRED_HIGHLIGHTER,
-              themeType: resolvedTheme,
-              unsafeCSS: FILE_LINK_REVEAL_UNSAFE_CSS,
-              onPostRender: handlePostRender,
-            }}
-            selectedLines={selectedRange}
-            lineAnnotations={lineAnnotations}
-            renderAnnotation={(annotation) => (
-              <div className="py-1">
-                {annotation.metadata.entries.map((entry) => (
-                  <DiffCommentAnnotation
-                    key={entry.id}
-                    kind={entry.kind}
-                    rangeLabel={formatFileCommentRange(entry.startLine, entry.endLine)}
-                    text={entry.text}
-                    onCancel={() => removeAnnotationEntry(entry.id)}
-                    onComment={(text) => submitAnnotationEntry(entry.id, text)}
-                    onDelete={() => removeAnnotationEntry(entry.id)}
-                  />
-                ))}
-              </div>
-            )}
-            className="min-h-full"
-            contentEditable
-          />
-        </Virtualizer>
+                cacheKey: projectFileEditorCacheKey(
+                  environmentId,
+                  cwd,
+                  relativePath,
+                  contents,
+                  editor.getFile(),
+                ),
+              }}
+              options={{
+                disableFileHeader: true,
+                enableGutterUtility: !hasOpenCommentForm,
+                enableLineSelection: !hasOpenCommentForm,
+                onGutterUtilityClick: setSelectedRange,
+                onLineSelectionChange: setSelectedRange,
+                onLineSelectionEnd: handleLineSelectionEnd,
+                overflow: wordWrap ? "wrap" : "scroll",
+                theme: resolveDiffThemeName(resolvedTheme),
+                preferredHighlighter: PREFERRED_HIGHLIGHTER,
+                themeType: resolvedTheme,
+                unsafeCSS: FILE_LINK_REVEAL_UNSAFE_CSS,
+                onPostRender: handlePostRender,
+              }}
+              selectedLines={selectedRange}
+              lineAnnotations={lineAnnotations}
+              renderAnnotation={(annotation) => (
+                <div className="py-1">
+                  {annotation.metadata.entries.map((entry) => (
+                    <DiffCommentAnnotation
+                      key={entry.id}
+                      kind={entry.kind}
+                      rangeLabel={formatFileCommentRange(entry.startLine, entry.endLine)}
+                      text={entry.text}
+                      onCancel={() => removeAnnotationEntry(entry.id)}
+                      onComment={(text) => submitAnnotationEntry(entry.id, text)}
+                      onDelete={() => removeAnnotationEntry(entry.id)}
+                    />
+                  ))}
+                </div>
+              )}
+              className="min-h-full"
+              contentEditable
+            />
+          </Virtualizer>
+        </RestorableFileScroll>
       </div>
     </EditProvider>
   );
@@ -891,6 +922,8 @@ function RenderedMarkdownSurface({
   cwd,
   relativePath,
   contents,
+  scrollPositionKey,
+  restoreScrollPosition,
   threadRef,
   readOnly,
   onPendingChange,
@@ -914,27 +947,42 @@ function RenderedMarkdownSurface({
   });
 
   return (
-    <ScrollArea className="min-h-0 flex-1">
-      <FileMarkdownPreview
-        text={contents}
-        cwd={cwd}
-        relativePath={relativePath}
-        threadRef={threadRef}
-        onTaskListChange={
-          readOnly
-            ? undefined
-            : ({ markerOffset, checked }) => {
-                const currentContents =
-                  getOptimisticProjectFileQueryData(environmentId, cwd, relativePath)?.contents ??
-                  contents;
-                const nextContents = setMarkdownTaskChecked(currentContents, markerOffset, checked);
-                if (nextContents === currentContents) return;
-                setProjectFileQueryData(environmentId, cwd, relativePath, nextContents);
-                saveCoordinator.change(nextContents);
-              }
-        }
-      />
-    </ScrollArea>
+    <RestorableFileScroll
+      // Keyed by file so the old instance unmounts, and saves against its own viewport, before the
+      // next file's content commits into a reused one.
+      key={scrollPositionKey ?? relativePath}
+      positionKey={scrollPositionKey}
+      restorePosition={restoreScrollPosition}
+      sourceLineCount={fileSourceLineCount(contents)}
+      surface="markdown"
+      viewportSelector="[data-slot='scroll-area-viewport']"
+    >
+      <ScrollArea className="min-h-0 flex-1">
+        <FileMarkdownPreview
+          text={contents}
+          cwd={cwd}
+          relativePath={relativePath}
+          threadRef={threadRef}
+          onTaskListChange={
+            readOnly
+              ? undefined
+              : ({ markerOffset, checked }) => {
+                  const currentContents =
+                    getOptimisticProjectFileQueryData(environmentId, cwd, relativePath)?.contents ??
+                    contents;
+                  const nextContents = setMarkdownTaskChecked(
+                    currentContents,
+                    markerOffset,
+                    checked,
+                  );
+                  if (nextContents === currentContents) return;
+                  setProjectFileQueryData(environmentId, cwd, relativePath, nextContents);
+                  saveCoordinator.change(nextContents);
+                }
+          }
+        />
+      </ScrollArea>
+    </RestorableFileScroll>
   );
 }
 
@@ -1020,6 +1068,7 @@ export default function FilePreviewPanel({
     null,
   );
   const breadcrumbRef = useRef<HTMLDivElement>(null);
+  const previewSurfaceRef = useRef<HTMLDivElement>(null);
   const isMarkdown = relativePath ? isMarkdownPreviewFile(relativePath) : false;
   // A reveal still wins over the preference: the line only exists in the source.
   const revealHandled =
@@ -1040,7 +1089,35 @@ export default function FilePreviewPanel({
     isBrowserPreviewFile(relativePath);
   const absolutePath =
     relativePath && attachment === undefined ? resolvePathLinkTarget(relativePath, cwd) : null;
-  const onFilePostRender = useFileLineReveal(relativePath, revealLine, revealRequestId);
+  const scrollPositionKey =
+    relativePath === null
+      ? null
+      : fileScrollPositionKey({
+          threadKey: scopedThreadKey(threadRef),
+          cwd,
+          relativePath,
+        });
+  const rememberCurrentPreviewPosition = () => {
+    if (!isMarkdown || scrollPositionKey === null) return;
+    const selector = renderMarkdown
+      ? "[data-slot='scroll-area-viewport']"
+      : ".file-preview-virtualizer";
+    const viewport = previewSurfaceRef.current?.querySelector<HTMLElement>(selector);
+    if (!viewport) return;
+    rememberFileScrollPositionFromViewport({
+      positionKey: scrollPositionKey,
+      viewport,
+      surface: renderMarkdown ? "markdown" : "source",
+    });
+  };
+  const { onPostRender: onFilePostRender, revealPerformed } = useFileLineReveal(
+    relativePath,
+    scrollPositionKey,
+    revealLine,
+    revealRequestId,
+  );
+  // A pending reveal wins; once it has run, or when there is none, the saved position applies.
+  const restoreScrollPosition = revealHandled || revealPerformed;
   useWorkspaceMutationRefresh({
     enabled:
       attachment === undefined &&
@@ -1153,6 +1230,7 @@ export default function FilePreviewPanel({
                     className="shrink-0"
                     pressed={rendered}
                     onPressedChange={(pressed) => {
+                      rememberCurrentPreviewPosition();
                       setRenderedPreferred(pressed);
                       setHandledReveal(
                         pressed && relativePath !== null
@@ -1220,6 +1298,7 @@ export default function FilePreviewPanel({
       ) : null}
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <div
+          ref={previewSurfaceRef}
           className={cn(
             "min-w-0 flex-1 flex-col overflow-hidden",
             relativePath ? "flex" : "hidden",
@@ -1278,36 +1357,46 @@ export default function FilePreviewPanel({
                 threadRef={threadRef}
                 contents={file.data.contents}
                 readOnly={isHostFile}
+                scrollPositionKey={scrollPositionKey}
+                restoreScrollPosition={restoreScrollPosition}
                 onPendingChange={onPendingChange}
               />
             ) : file.data.truncated || isHostFile ? (
               <DiffWorkerPoolProvider>
-                <Virtualizer
+                <RestorableFileScroll
                   key={`${relativePath}:${resolvedTheme}:${file.data.byteLength}`}
-                  className="file-preview-virtualizer min-h-0 flex-1 overflow-auto"
-                  config={{
-                    overscrollSize: 600,
-                    intersectionObserverMargin: 1200,
-                  }}
+                  positionKey={scrollPositionKey}
+                  restorePosition={restoreScrollPosition}
+                  sourceLineCount={fileSourceLineCount(file.data.contents)}
+                  surface="source"
+                  viewportSelector=".file-preview-virtualizer"
                 >
-                  <File
-                    file={{
-                      name: relativePath,
-                      contents: file.data.contents,
-                      cacheKey: projectFileCacheKey(cwd, relativePath, file.data.contents),
+                  <Virtualizer
+                    className="file-preview-virtualizer min-h-0 flex-1 overflow-auto"
+                    config={{
+                      overscrollSize: 600,
+                      intersectionObserverMargin: 1200,
                     }}
-                    options={{
-                      disableFileHeader: true,
-                      overflow: wordWrap ? "wrap" : "scroll",
-                      theme: resolveDiffThemeName(resolvedTheme),
-                      preferredHighlighter: PREFERRED_HIGHLIGHTER,
-                      themeType: resolvedTheme,
-                      unsafeCSS: FILE_LINK_REVEAL_UNSAFE_CSS,
-                      onPostRender: onFilePostRender,
-                    }}
-                    className="min-h-full"
-                  />
-                </Virtualizer>
+                  >
+                    <File
+                      file={{
+                        name: relativePath,
+                        contents: file.data.contents,
+                        cacheKey: projectFileCacheKey(cwd, relativePath, file.data.contents),
+                      }}
+                      options={{
+                        disableFileHeader: true,
+                        overflow: wordWrap ? "wrap" : "scroll",
+                        theme: resolveDiffThemeName(resolvedTheme),
+                        preferredHighlighter: PREFERRED_HIGHLIGHTER,
+                        themeType: resolvedTheme,
+                        unsafeCSS: FILE_LINK_REVEAL_UNSAFE_CSS,
+                        onPostRender: onFilePostRender,
+                      }}
+                      className="min-h-full"
+                    />
+                  </Virtualizer>
+                </RestorableFileScroll>
               </DiffWorkerPoolProvider>
             ) : (
               <DiffWorkerPoolProvider>
@@ -1318,6 +1407,8 @@ export default function FilePreviewPanel({
                   relativePath={relativePath}
                   composerDraftTarget={composerDraftTarget}
                   contents={file.data.contents}
+                  scrollPositionKey={scrollPositionKey}
+                  restoreScrollPosition={restoreScrollPosition}
                   resolvedTheme={resolvedTheme}
                   revealRequestId={revealRequestId}
                   wordWrap={wordWrap}

--- a/apps/web/src/components/files/RestorableFileScroll.tsx
+++ b/apps/web/src/components/files/RestorableFileScroll.tsx
@@ -1,0 +1,221 @@
+import { type ReactNode, useEffect, useRef } from "react";
+
+import {
+  approximateSourceLineScrollTop,
+  type FileScrollSurface,
+  readFileScrollPosition,
+  rememberFileScrollPosition,
+  resolveRestoredFileScrollTop,
+} from "~/fileScrollState";
+import {
+  rememberFileScrollPositionFromViewport,
+  resolveFileScrollAnchorTop,
+} from "./fileScrollViewport";
+
+const FILE_SCROLL_RESTORE_MAX_ATTEMPTS = 30;
+
+function rememberFileScrollOffsetFromViewport(input: {
+  positionKey: string;
+  viewport: HTMLElement;
+  surface: FileScrollSurface;
+}): void {
+  rememberFileScrollPosition(
+    input.positionKey,
+    input.viewport.scrollTop,
+    Math.max(0, input.viewport.scrollHeight - input.viewport.clientHeight),
+    { surface: input.surface, anchorLine: null },
+  );
+}
+
+export function RestorableFileScroll({
+  positionKey,
+  restorePosition = true,
+  sourceLineCount,
+  surface,
+  viewportSelector,
+  children,
+}: {
+  positionKey: string | null;
+  restorePosition?: boolean;
+  sourceLineCount: number;
+  surface: FileScrollSurface;
+  viewportSelector: string;
+  children: ReactNode;
+}) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  // Read through a ref so content edits, which change the line count, do not restart restoration.
+  const sourceLineCountRef = useRef(sourceLineCount);
+  useEffect(() => {
+    sourceLineCountRef.current = sourceLineCount;
+  }, [sourceLineCount]);
+
+  useEffect(() => {
+    if (positionKey === null) return;
+    const viewport = rootRef.current?.querySelector<HTMLElement>(viewportSelector);
+    if (!viewport) return;
+
+    const savedPosition = restorePosition ? readFileScrollPosition(positionKey) : null;
+    let restoreFrame: number | null = null;
+    let rememberFrame: number | null = null;
+    let resizeObserver: ResizeObserver | null = null;
+    let mutationObserver: MutationObserver | null = null;
+    let restoring = restorePosition && savedPosition !== null;
+    let restoreAttempts = 0;
+
+    const rememberPosition = () => {
+      rememberFileScrollOffsetFromViewport({ positionKey, viewport, surface });
+    };
+    const scheduleRememberPosition = () => {
+      if (rememberFrame !== null) return;
+      rememberFrame = requestAnimationFrame(() => {
+        rememberFrame = null;
+        if (viewport.isConnected) rememberPosition();
+      });
+    };
+    const disconnectGeometryObservers = () => {
+      resizeObserver?.disconnect();
+      resizeObserver = null;
+      mutationObserver?.disconnect();
+      mutationObserver = null;
+    };
+    const stopRestore = () => {
+      restoring = false;
+      disconnectGeometryObservers();
+      if (restoreFrame !== null) {
+        cancelAnimationFrame(restoreFrame);
+        restoreFrame = null;
+      }
+    };
+    const cancelRestore = () => {
+      if (!restoring) return;
+      stopRestore();
+      scheduleRememberPosition();
+    };
+    const applySavedPosition = () => {
+      restoreFrame = null;
+      if (!restoring || !viewport.isConnected || savedPosition === null) return;
+      const scrollRange = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+      // Nothing scrollable yet: content is still mounting. Retry for a bounded number of frames
+      // so a file that stays empty still ends restoration.
+      if (savedPosition.scrollRange > 0 && scrollRange === 0) {
+        if (restoreAttempts < FILE_SCROLL_RESTORE_MAX_ATTEMPTS) {
+          restoreAttempts += 1;
+          restoreFrame = requestAnimationFrame(applySavedPosition);
+          return;
+        }
+        stopRestore();
+        return;
+      }
+      const crossesSurfaces =
+        savedPosition.surface !== surface && savedPosition.anchorLine !== null;
+      const anchorScrollTop =
+        crossesSurfaces && savedPosition.anchorLine !== null
+          ? resolveFileScrollAnchorTop(viewport, surface, savedPosition.anchorLine)
+          : null;
+      let target = resolveRestoredFileScrollTop(savedPosition, scrollRange, {
+        surface,
+        anchorScrollTop,
+      });
+      if (
+        crossesSurfaces &&
+        anchorScrollTop === null &&
+        surface === "source" &&
+        savedPosition.anchorLine !== null
+      ) {
+        target = approximateSourceLineScrollTop(
+          savedPosition.anchorLine,
+          sourceLineCountRef.current,
+          scrollRange,
+        );
+      }
+      if (target !== null && Math.abs(viewport.scrollTop - target) > 1) {
+        viewport.scrollTop = target;
+      }
+      if (
+        crossesSurfaces &&
+        anchorScrollTop === null &&
+        restoreAttempts < FILE_SCROLL_RESTORE_MAX_ATTEMPTS
+      ) {
+        restoreAttempts += 1;
+        restoreFrame = requestAnimationFrame(applySavedPosition);
+        return;
+      }
+      // Content still loading (images, deferred blocks) leaves the document shorter than when the
+      // position was saved. Retry for a bounded number of frames so late growth re-applies the
+      // target, then finish even if the file is now genuinely shorter.
+      if (
+        scrollRange < savedPosition.scrollRange &&
+        restoreAttempts < FILE_SCROLL_RESTORE_MAX_ATTEMPTS
+      ) {
+        restoreAttempts += 1;
+        restoreFrame = requestAnimationFrame(applySavedPosition);
+        return;
+      }
+      // Restore is done. Later scrolls, including programmatic ones, are the user's new position.
+      stopRestore();
+    };
+    // Observers and scroll events fire many times while the file content mounts. Each restore
+    // attempt reads scroll geometry, which forces layout, so coalesce them to one read per frame.
+    const scheduleApplySavedPosition = () => {
+      if (!restoring || restoreFrame !== null) return;
+      restoreFrame = requestAnimationFrame(applySavedPosition);
+    };
+    const handleScroll = () => {
+      if (restoring) {
+        scheduleApplySavedPosition();
+      } else {
+        scheduleRememberPosition();
+      }
+    };
+
+    viewport.addEventListener("scroll", handleScroll, { passive: true });
+    viewport.addEventListener("wheel", cancelRestore, { passive: true });
+    viewport.addEventListener("touchstart", cancelRestore, { passive: true });
+    viewport.addEventListener("pointerdown", cancelRestore, { passive: true });
+    viewport.addEventListener("keydown", cancelRestore);
+    if (restorePosition && savedPosition === null) {
+      viewport.scrollTop = 0;
+    } else if (savedPosition !== null) {
+      if (typeof ResizeObserver !== "undefined") {
+        resizeObserver = new ResizeObserver(scheduleApplySavedPosition);
+        resizeObserver.observe(viewport);
+        const content = viewport.firstElementChild;
+        if (content) resizeObserver.observe(content);
+      }
+      if (typeof MutationObserver !== "undefined") {
+        mutationObserver = new MutationObserver(scheduleApplySavedPosition);
+        mutationObserver.observe(viewport, {
+          attributes: true,
+          attributeFilter: ["style"],
+          childList: true,
+          subtree: true,
+        });
+      }
+      applySavedPosition();
+      scheduleApplySavedPosition();
+    }
+
+    return () => {
+      if (restoreFrame !== null) cancelAnimationFrame(restoreFrame);
+      if (rememberFrame !== null) {
+        cancelAnimationFrame(rememberFrame);
+        if (!restoring) {
+          rememberFileScrollPositionFromViewport({ positionKey, viewport, surface });
+        }
+      }
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
+      viewport.removeEventListener("scroll", handleScroll);
+      viewport.removeEventListener("wheel", cancelRestore);
+      viewport.removeEventListener("touchstart", cancelRestore);
+      viewport.removeEventListener("pointerdown", cancelRestore);
+      viewport.removeEventListener("keydown", cancelRestore);
+    };
+  }, [positionKey, restorePosition, surface, viewportSelector]);
+
+  return (
+    <div ref={rootRef} className="contents">
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/files/fileScrollViewport.ts
+++ b/apps/web/src/components/files/fileScrollViewport.ts
@@ -1,0 +1,102 @@
+import { type FileScrollSurface, rememberFileScrollPosition } from "~/fileScrollState";
+
+function fileScrollAnchorRoot(
+  viewport: HTMLElement,
+  surface: FileScrollSurface,
+): ParentNode | null {
+  if (surface === "markdown") return viewport;
+  const fileContainer = viewport.querySelector<HTMLElement>("diffs-container");
+  return fileContainer?.shadowRoot ?? fileContainer;
+}
+
+function fileScrollAnchorSelector(surface: FileScrollSurface): string {
+  return surface === "markdown" ? "[data-source-line]" : "[data-line]";
+}
+
+function fileScrollAnchorElements(
+  viewport: HTMLElement,
+  surface: FileScrollSurface,
+): HTMLElement[] {
+  const root = fileScrollAnchorRoot(viewport, surface);
+  if (!root) return [];
+  return Array.from(root.querySelectorAll<HTMLElement>(fileScrollAnchorSelector(surface)));
+}
+
+function fileScrollAnchorLine(element: HTMLElement, surface: FileScrollSurface): number | null {
+  const value = surface === "markdown" ? element.dataset.sourceLine : element.dataset.line;
+  const line = Number(value);
+  return Number.isSafeInteger(line) && line > 0 ? line : null;
+}
+
+function readFileScrollAnchorLine(
+  viewport: HTMLElement,
+  surface: FileScrollSurface,
+): number | null {
+  const anchorRoot = fileScrollAnchorRoot(viewport, surface);
+  if (!anchorRoot) return null;
+  const viewportRect = viewport.getBoundingClientRect();
+  const hitTestRoot = anchorRoot instanceof ShadowRoot ? anchorRoot : viewport.ownerDocument;
+  const horizontalInset = Math.min(24, viewportRect.width / 4);
+  const xCoordinates = [
+    viewportRect.left + horizontalInset,
+    viewportRect.left + viewportRect.width / 2,
+    viewportRect.right - horizontalInset,
+  ];
+  const selector = fileScrollAnchorSelector(surface);
+
+  for (let y = viewportRect.top + 1; y < viewportRect.bottom; y += 24) {
+    for (const x of xCoordinates) {
+      const hit = hitTestRoot.elementFromPoint(x, y);
+      const anchor = hit instanceof Element ? hit.closest<HTMLElement>(selector) : null;
+      if (!anchor || !anchorRoot.contains(anchor)) continue;
+      const line = fileScrollAnchorLine(anchor, surface);
+      if (line !== null) return line;
+    }
+  }
+  return null;
+}
+
+export function resolveFileScrollAnchorTop(
+  viewport: HTMLElement,
+  surface: FileScrollSurface,
+  anchorLine: number,
+): number | null {
+  let exact: HTMLElement | null = null;
+  let next: { element: HTMLElement; line: number } | null = null;
+  let previous: { element: HTMLElement; line: number } | null = null;
+  for (const element of fileScrollAnchorElements(viewport, surface)) {
+    const line = fileScrollAnchorLine(element, surface);
+    if (line === null) continue;
+    if (line === anchorLine) {
+      exact = element;
+      break;
+    }
+    if (line > anchorLine && (next === null || line < next.line)) next = { element, line };
+    if (line < anchorLine && (previous === null || line > previous.line)) {
+      previous = { element, line };
+    }
+  }
+  // The source view is virtualized, so a neighbouring mounted line says nothing about where the
+  // requested line is; report no anchor and let the caller fall back to a line estimate. Markdown
+  // mounts every block, so the nearest anchored block is the right answer there.
+  const element = surface === "source" ? exact : (exact ?? next?.element ?? previous?.element);
+  if (!element) return null;
+  const viewportRect = viewport.getBoundingClientRect();
+  return viewport.scrollTop + element.getBoundingClientRect().top - viewportRect.top;
+}
+
+export function rememberFileScrollPositionFromViewport(input: {
+  positionKey: string;
+  viewport: HTMLElement;
+  surface: FileScrollSurface;
+}): void {
+  rememberFileScrollPosition(
+    input.positionKey,
+    input.viewport.scrollTop,
+    Math.max(0, input.viewport.scrollHeight - input.viewport.clientHeight),
+    {
+      surface: input.surface,
+      anchorLine: readFileScrollAnchorLine(input.viewport, input.surface),
+    },
+  );
+}

--- a/apps/web/src/fileScrollState.test.ts
+++ b/apps/web/src/fileScrollState.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+
+import {
+  approximateSourceLineScrollTop,
+  readHandledFileReveal,
+  rememberHandledFileReveal,
+  clearFileScrollStateForTests,
+  fileScrollPositionKey,
+  readFileScrollPosition,
+  rememberFileScrollPosition,
+  resolveRestoredFileScrollTop,
+} from "./fileScrollState";
+
+describe("file scroll state", () => {
+  beforeEach(clearFileScrollStateForTests);
+
+  it("scopes positions to the thread, workspace, and path", () => {
+    expect(
+      fileScrollPositionKey({
+        threadKey: "environment:thread-a",
+        cwd: "/workspace",
+        relativePath: "README.md",
+      }),
+    ).not.toBe(
+      fileScrollPositionKey({
+        threadKey: "environment:thread-b",
+        cwd: "/workspace",
+        relativePath: "README.md",
+      }),
+    );
+  });
+
+  it("restores the exact offset when the surface geometry is unchanged", () => {
+    rememberFileScrollPosition("thread:file", 640, 2_000, {
+      surface: "source",
+      anchorLine: 34,
+    });
+
+    expect(
+      resolveRestoredFileScrollTop(readFileScrollPosition("thread:file"), 2_000, {
+        surface: "source",
+        anchorScrollTop: 900,
+      }),
+    ).toBe(640);
+  });
+
+  it("restores the same content anchor when Markdown and source layouts differ", () => {
+    rememberFileScrollPosition("thread:README.md", 500, 2_000, {
+      surface: "source",
+      anchorLine: 32,
+    });
+
+    expect(
+      resolveRestoredFileScrollTop(readFileScrollPosition("thread:README.md"), 4_000, {
+        surface: "markdown",
+        anchorScrollTop: 720,
+      }),
+    ).toBe(720);
+  });
+
+  it("falls back to document progress until the content anchor is rendered", () => {
+    rememberFileScrollPosition("thread:README.md", 500, 2_000, {
+      surface: "source",
+      anchorLine: 32,
+    });
+
+    expect(
+      resolveRestoredFileScrollTop(readFileScrollPosition("thread:README.md"), 4_000, {
+        surface: "markdown",
+        anchorScrollTop: null,
+      }),
+    ).toBe(1_000);
+  });
+
+  it("approximates an unrendered source anchor by line while the virtualizer catches up", () => {
+    expect(approximateSourceLineScrollTop(51, 101, 2_000)).toBe(1_000);
+  });
+
+  it("remembers which reveal request a file already consumed across panel mounts", () => {
+    expect(readHandledFileReveal("thread:README.md")).toBeNull();
+    rememberHandledFileReveal("thread:README.md", 7);
+    expect(readHandledFileReveal("thread:README.md")).toBe(7);
+    expect(readHandledFileReveal("thread:OTHER.md")).toBeNull();
+  });
+});

--- a/apps/web/src/fileScrollState.ts
+++ b/apps/web/src/fileScrollState.ts
@@ -1,0 +1,128 @@
+import { LRUCache } from "./lib/lruCache";
+
+const FILE_SCROLL_CACHE_SIZE = 500;
+const FILE_SCROLL_POSITION_BYTES = 32;
+
+export type FileScrollSurface = "markdown" | "source";
+
+interface FileScrollPosition {
+  readonly scrollTop: number;
+  readonly scrollRange: number;
+  readonly surface: FileScrollSurface;
+  readonly anchorLine: number | null;
+}
+
+const fileScrollPositions = new LRUCache<FileScrollPosition>(
+  FILE_SCROLL_CACHE_SIZE,
+  FILE_SCROLL_CACHE_SIZE * FILE_SCROLL_POSITION_BYTES,
+);
+
+// A citation reveal scrolls a file once. Remembering that per session, keyed like scroll
+// positions, lets a remounted panel restore the reader's later position instead of re-revealing.
+const handledFileReveals = new LRUCache<number>(
+  FILE_SCROLL_CACHE_SIZE,
+  FILE_SCROLL_CACHE_SIZE * FILE_SCROLL_POSITION_BYTES,
+);
+
+export function rememberHandledFileReveal(key: string, revealRequestId: number): void {
+  handledFileReveals.set(key, revealRequestId, FILE_SCROLL_POSITION_BYTES);
+}
+
+export function readHandledFileReveal(key: string): number | null {
+  return handledFileReveals.get(key);
+}
+
+export function fileScrollPositionKey(input: {
+  readonly threadKey: string;
+  readonly cwd: string;
+  readonly relativePath: string;
+}): string {
+  return `${input.threadKey}\u0000${input.cwd}\u0000${input.relativePath}`;
+}
+
+export function readFileScrollPosition(key: string): FileScrollPosition | null {
+  return fileScrollPositions.get(key);
+}
+
+export function rememberFileScrollPosition(
+  key: string,
+  scrollTop: number,
+  scrollRange: number,
+  anchor: {
+    readonly surface: FileScrollSurface;
+    readonly anchorLine: number | null;
+  },
+): void {
+  if (
+    !Number.isFinite(scrollTop) ||
+    !Number.isFinite(scrollRange) ||
+    scrollTop < 0 ||
+    scrollRange < 0
+  ) {
+    return;
+  }
+  fileScrollPositions.set(
+    key,
+    {
+      scrollTop: Math.min(scrollTop, scrollRange),
+      scrollRange,
+      surface: anchor.surface,
+      anchorLine:
+        anchor.anchorLine !== null &&
+        Number.isSafeInteger(anchor.anchorLine) &&
+        anchor.anchorLine > 0
+          ? anchor.anchorLine
+          : null,
+    },
+    FILE_SCROLL_POSITION_BYTES,
+  );
+}
+
+export function resolveRestoredFileScrollTop(
+  position: FileScrollPosition | null,
+  nextScrollRange: number,
+  target: {
+    readonly surface: FileScrollSurface;
+    readonly anchorScrollTop: number | null;
+  },
+): number | null {
+  if (!position || !Number.isFinite(nextScrollRange) || nextScrollRange < 0) return null;
+  if (
+    position.surface !== target.surface &&
+    target.anchorScrollTop !== null &&
+    Number.isFinite(target.anchorScrollTop)
+  ) {
+    return Math.min(nextScrollRange, Math.max(0, target.anchorScrollTop));
+  }
+  if (position.scrollRange === nextScrollRange || position.scrollRange === 0) {
+    return Math.min(position.scrollTop, nextScrollRange);
+  }
+  return Math.min(
+    nextScrollRange,
+    Math.max(0, (position.scrollTop / position.scrollRange) * nextScrollRange),
+  );
+}
+
+export function approximateSourceLineScrollTop(
+  line: number,
+  lineCount: number,
+  scrollRange: number,
+): number | null {
+  if (
+    !Number.isSafeInteger(line) ||
+    !Number.isSafeInteger(lineCount) ||
+    !Number.isFinite(scrollRange) ||
+    line < 1 ||
+    lineCount < 1 ||
+    scrollRange < 0
+  ) {
+    return null;
+  }
+  if (lineCount === 1) return 0;
+  return Math.min(scrollRange, ((line - 1) / (lineCount - 1)) * scrollRange);
+}
+
+export function clearFileScrollStateForTests(): void {
+  fileScrollPositions.clear();
+  handledFileReveals.clear();
+}

--- a/apps/web/src/markdown-source-line-anchors.test.tsx
+++ b/apps/web/src/markdown-source-line-anchors.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { remarkSourceLineAnchors } from "./markdown-source-line-anchors";
+
+describe("remarkSourceLineAnchors", () => {
+  it("marks block nodes with their Markdown source line", () => {
+    const heading = {
+      type: "heading",
+      position: { start: { line: 1 } },
+      data: undefined as { hProperties?: Record<string, unknown> } | undefined,
+    };
+    const paragraph = {
+      type: "paragraph",
+      position: { start: { line: 3 } },
+      data: { hProperties: { className: "lead" } },
+    };
+    const inlineText = { type: "text", position: { start: { line: 3 } } };
+    const tree = { type: "root", children: [heading, paragraph, inlineText] };
+
+    remarkSourceLineAnchors()(tree);
+
+    expect(heading.data).toEqual({ hProperties: { dataSourceLine: 1 } });
+    expect(paragraph.data).toEqual({
+      hProperties: { className: "lead", dataSourceLine: 3 },
+    });
+    expect(inlineText).not.toHaveProperty("data");
+  });
+});

--- a/apps/web/src/markdown-source-line-anchors.ts
+++ b/apps/web/src/markdown-source-line-anchors.ts
@@ -1,0 +1,44 @@
+type MarkdownNode = {
+  type?: string;
+  position?: {
+    start?: {
+      line?: number;
+    };
+  };
+  data?: {
+    hProperties?: Record<string, unknown>;
+  };
+  children?: MarkdownNode[];
+};
+
+const ANCHORED_BLOCK_TYPES = new Set([
+  "blockquote",
+  "code",
+  "heading",
+  "html",
+  "list",
+  "listItem",
+  "paragraph",
+  "table",
+  "thematicBreak",
+]);
+
+export function remarkSourceLineAnchors() {
+  return (tree: MarkdownNode) => {
+    const visit = (node: MarkdownNode) => {
+      const sourceLine = node.position?.start?.line;
+      if (ANCHORED_BLOCK_TYPES.has(node.type ?? "") && Number.isSafeInteger(sourceLine)) {
+        node.data = {
+          ...node.data,
+          hProperties: {
+            ...node.data?.hProperties,
+            dataSourceLine: sourceLine,
+          },
+        };
+      }
+      node.children?.forEach(visit);
+    };
+
+    visit(tree);
+  };
+}

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -91,6 +91,13 @@ offline environments and older servers keep their previous values. If connected
 environments disagree, **Apply to all** copies your current settings to those named
 in the warning. Changing a rule does not reopen already settled threads.
 
+## Returning to a file
+
+When you switch between threads or files on web or desktop, each open text or Markdown file
+keeps its reading position. Toggling a Markdown file between rendered and source keeps the same
+place in the document. Positions belong to the current client session and are not shared across
+devices.
+
 ## Link a pull request
 
 The server finds the PR for each unsettled thread's saved branch, even when your


### PR DESCRIPTION
## What Changed

Switching between files, or leaving a thread and coming back, now returns each text or Markdown file to where you were reading it. Positions are kept per client session, keyed by thread, working directory, and file path, in a bounded in-memory cache. Nothing is persisted or synced.

Markdown files also keep the same document position when you toggle between rendered and source, using per-block source line anchors. That is a deliberate addition beyond the original ask; happy to drop it if you'd rather keep the PR to plain offset restore.

Scope decisions:
- Web and desktop only. Mobile has its own file viewer and is consciously not covered.
- Media, HTML, and PDF previews don't go through the restore path; the user doc says so.
- No DOM test for the observer lifecycle, since the web unit suite runs without a DOM. The pure state and anchor helpers are tested.

## Why

Losing your place in a file every time you glance at another one is a constant small annoyance when driving agents all day. Provenance: #6195 (file half only; transcript scroll is separate).

Performance: restore attempts triggered by the mutation and resize observers and by scroll events coalesce into one pending animation frame, so mounting a file does at most one forced layout per frame instead of one per DOM mutation. Measured against main with the same fixture, switch time does not regress. The restore state also clears once the position is applied, so later programmatic scrolls are recorded rather than snapped back.

## UI Changes

https://github.com/user-attachments/assets/a1df56d0-1869-4efb-a684-79e4328731f8


_Video: switching between two scrolled files, then toggling a Markdown file between rendered and source. (attached below)_

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (motion change, video instead)
- [x] I included a video for animation/interaction changes

Written with Claude Fable 5.1 in Claude Code; performance captures by Codex GPT 5.6 Sol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore file scroll position for text and Markdown previews
> - Adds `RestorableFileScroll` and a shared LRU-backed scroll state in [fileScrollState.ts](https://github.com/pingdotgg/t3code/pull/9874/files#diff-dd239c8c81f0ed3595145210c5c9522d84cebb5ce067360b22fcccc649af1621) so file previews save and restore their scroll position per thread, workspace, and path across remounts.
> - Adds the `remarkSourceLineAnchors` remark plugin in [markdown-source-line-anchors.ts](https://github.com/pingdotgg/t3code/pull/9874/files#diff-b87afb1729082299dae0a7bc987423793e835de9cbcf642e2b3a22616d2d5369) to annotate Markdown block nodes with their source line; the sanitization schema in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/9874/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) allows this metadata through.
> - `FilePreviewPanel` captures viewport position before rendered/source toggles and restores it after, using exact offset, proportional progress, or source-line anchor resolution depending on what is available.
> - Citation reveals are persisted by position key so a completed reveal does not reapply on panel remount.
> - Behavioral Change: scroll positions are now stored client-side per session and are not shared across devices; invalid or out-of-range saved positions are discarded on restore.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1138b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only scroll cache and DOM attribute plumbing; the main caveat is widening markdown sanitization to allow `dataSourceLine`, which is a bounded, non-executable attribute.
> 
> **Overview**
> **File previews now remember where you were reading** when you change files or threads, using a session-scoped in-memory LRU keyed by thread, workspace, and path. Source and editable text views, read-only truncated previews, and rendered Markdown are wrapped in **`RestorableFileScroll`**, which saves scroll offset (and an optional **source-line anchor**) on scroll and restores it on return, with resize/mutation observers and rAF-coalesced retries until layout settles. User input cancels an in-flight restore so programmatic scroll is not fought.
> 
> **Toggling rendered Markdown vs source** keeps the same place in the document: file preview Markdown runs **`remarkSourceLineAnchors`**, **`ChatMarkdown`** allows and surfaces **`data-source-line`** on fenced code blocks and GitHub alert notes, and **`fileScrollViewport`** maps anchors between markdown (`data-source-line`) and Pierre source (`data-line`), with proportional line fallback when the virtualizer has not mounted the target line yet. The rendered/source toggle snapshots position via **`rememberFileScrollPositionFromViewport`** before switching modes.
> 
> User docs add a short **Returning to a file** section (session-local, not cross-device).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 832409c86985959cb861f388f9138d75691379e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File previews now remember and restore your reading position when switching between threads, files, or preview modes.
  * Rendered Markdown and source views preserve the same document location when switching between them.
  * Markdown content now maintains source-line anchors for code blocks, headings, alerts, and other sections.

* **Documentation**
  * Added guidance explaining file reading-position restoration, including session and device behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->