### PR TITLE
fix(mobile): keep usage tabs below the header when switching

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -11,7 +11,7 @@ import {
   formatUsd,
   makeWindow,
 } from "@t3tools/shared/usageFormat";
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { Platform, Pressable, RefreshControl, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -96,14 +96,6 @@ export function UsageRouteScreen() {
   // environment stays pending forever — neither may pin the spinner on.
   const refreshingUsage = environments.some((entry) => entry.isPending && entry.summary !== null);
   const showingLimits = tab === "limits";
-  // One ScrollView serves both tabs, so the offset would otherwise carry over
-  // and a short Limits list could open scrolled past its own content.
-  const scrollRef = useRef<ScrollView>(null);
-  const selectTab = (next: UsageTab) => {
-    if (next === tab) return;
-    setTab(next);
-    scrollRef.current?.scrollTo({ y: 0, animated: false });
-  };
   const selectWindow = (days: number) => {
     setWindowSelection({
       days,
@@ -133,7 +125,9 @@ export function UsageRouteScreen() {
         </>
       ) : null}
       <ScrollView
-        ref={scrollRef}
+        // Remount at each tab's native top. Scrolling to y: 0 ignores iOS's
+        // automatic header inset and hides the tab bar under the header.
+        key={tab}
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
         className="flex-1"
@@ -146,7 +140,7 @@ export function UsageRouteScreen() {
           />
         }
       >
-        <SegmentedControl options={TAB_OPTIONS} selected={tab} onSelect={selectTab} role="tab" />
+        <SegmentedControl options={TAB_OPTIONS} selected={tab} onSelect={setTab} role="tab" />
 
         {showingLimits ? (
           <UsageLimitsSection now={limits.now} failedLabels={limits.failedLabels} />


### PR DESCRIPTION
## What changed

Switching between Usage and Limits on iOS can scroll the tab selector behind the sheet header. Key the scroll view by the selected tab so each switch starts at the native top, with the automatic header inset applied. Keep the date range, metric, and refresh state in the parent screen.

## Why

The previous `scrollTo({ y: 0 })` ignored iOS's automatically adjusted top inset. On the base revision, returning from Limits to Usage moved the selector up by 71 points into the header.

## Verification

- Reproduced the bug on the base and verified the fix on an iPhone 17 Pro Max simulator running iOS 26.5, using the same disposable environment and synthetic usage data.
- Three Usage → Limits → Usage round trips kept both tabs at the same vertical position. The 7-day window and Tokens metric remained selected.
- Passed mobile typecheck, targeted lint, formatting, and `git diff --check`.
- Android was not exercised. This change is confined to the mobile screen and does not change shared contracts or provider behavior.

## UI changes

Same device, sheet size, data, and Limits → Usage sequence.

| Before | After |
| --- | --- |
| ![Before: Usage tabs scroll behind the header](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/2c99c26ddc7ba761/before.png) | ![After: Usage tabs stay below the header](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/ed16ea5fea060eca/after.png) |

[Before recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/b450ab220c863ec0/before-demo.mp4) · [After recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/c33e4945db5661d8/after-demo.mp4)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes
- [x] I included recordings of the interaction

Model: GPT-6. Harness: Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI scroll behavior on the mobile Usage screen with no API or shared-contract changes.
> 
> **Overview**
> Fixes **Usage ↔ Limits** tab switching on iOS where the segmented control could slide **under the sheet header** after returning from Limits.
> 
> The screen **stops resetting scroll with `scrollTo({ y: 0 })`** and the **`ScrollView` ref / `selectTab` wrapper**. Instead it **remounts the scroll view with `key={tab}`** so each tab starts at the native top with **`contentInsetAdjustmentBehavior="automatic"`** applied. Tab selection wires **`setTab` directly**; window, metric, and refresh behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d74cc22d68ded5004841cc04de53226af9f05b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Usage tabs to open at top by remounting `ScrollView` on tab switch
> Switching between Usage and Limits no longer leaves the shared scroll position in place. [UsageRouteScreen.tsx](https://github.com/pingdotgg/t3code/pull/9876/files#diff-488a6bd45cb7af1278effc53880b4af38118aedbf2b167549e1011124f850058) now keys the `ScrollView` on the selected tab so it remounts and starts at y: 0, removing the imperative `scrollTo` ref logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d74cc2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->