### PR TITLE
fix(web): prioritize open panel pull request when copying

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -222,6 +222,7 @@ import {
 import { useNowMinute } from "../hooks/useNowMinute";
 import { usePanelAnimationSettings, usePanelPresence } from "../panelAnimations";
 import { useNewThreadHandler } from "../hooks/useHandleNewThread";
+import { useOpenPanelPullRequestUrl } from "../hooks/useOpenPanelPullRequestUrl";
 import { useThreadActions } from "../hooks/useThreadActions";
 import { resolveAppModelSelectionForInstance } from "../modelSelection";
 import { confirmTerminalClose, isTerminalCloseConfirmPending } from "../lib/terminalCloseConfirm";
@@ -5077,16 +5078,24 @@ export default function ChatView(props: ChatViewProps) {
       threadRepository,
     ],
   );
+  const openPanelPullRequestUrl = useOpenPanelPullRequestUrl(activeThreadRef);
   const activeThreadReferenceCopyTarget = useMemo(
     () =>
       activeThreadId === null || !isServerThread
         ? null
         : resolveThreadReferenceCopyTarget({
             threadId: activeThreadId,
+            openPanelPullRequestUrl,
             linkedPullRequestUrl: linkedThreadPullRequest?.url ?? null,
             detectedPullRequestUrl: activeThreadPr?.url ?? null,
           }),
-    [activeThreadId, activeThreadPr?.url, isServerThread, linkedThreadPullRequest?.url],
+    [
+      activeThreadId,
+      activeThreadPr?.url,
+      isServerThread,
+      linkedThreadPullRequest?.url,
+      openPanelPullRequestUrl,
+    ],
   );
   const copyActiveThreadReference = useCallback(() => {
     const target = activeThreadReferenceCopyTarget;

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -71,6 +71,7 @@ import { useAtomValue } from "@effect/atom-react";
 import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
+import { useOpenPanelPullRequestUrl } from "../hooks/useOpenPanelPullRequestUrl";
 import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
 import { useClientSettings } from "../hooks/useSettings";
 import { useTheme } from "../hooks/useTheme";
@@ -633,11 +634,15 @@ function OpenCommandPaletteDialog(props: {
           ),
           retainTerminalOnBranchMismatch: activeThread.worktreePath === null,
         })?.url ?? null);
+  const openPanelPullRequestUrl = useOpenPanelPullRequestUrl(
+    activeThread ? scopeThreadRef(activeThread.environmentId, activeThread.id) : null,
+  );
   const activeThreadReferenceCopyTarget =
     activeThread == null
       ? null
       : resolveThreadReferenceCopyTarget({
           threadId: activeThread.id,
+          openPanelPullRequestUrl,
           linkedPullRequestUrl: activeThread.linkedPullRequest?.url ?? null,
           detectedPullRequestUrl,
         });

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2307,9 +2307,10 @@ function OpenCommandPaletteDialog(props: {
       }
       return;
     }
-    if (command === "thread.copyReference" && activeThreadReferenceCopyTarget !== null) {
+    if (command === "thread.copyReference") {
       event.preventDefault();
       event.stopPropagation();
+      if (activeThreadReferenceCopyTarget === null) return;
       setOpen(false);
       void copyActiveThreadReference();
       return;

--- a/apps/web/src/hooks/useOpenPanelPullRequestUrl.ts
+++ b/apps/web/src/hooks/useOpenPanelPullRequestUrl.ts
@@ -1,0 +1,43 @@
+import { scopeProjectRef } from "@t3tools/client-runtime/environment";
+import { EnvironmentId, ProjectId, type ScopedThreadRef } from "@t3tools/contracts";
+
+import { gitHubPullRequestBrowserUrl } from "../lib/openPullRequestLink";
+import { selectActiveRightPanelSurface, useRightPanelStore } from "../rightPanelStore";
+import { useProject } from "../state/entities";
+import { pullRequestEnvironment } from "../state/pullRequests";
+import { useEnvironmentQuery } from "../state/query";
+
+export function useOpenPanelPullRequestUrl(threadRef: ScopedThreadRef | null): string | null {
+  const surface = useRightPanelStore((state) =>
+    selectActiveRightPanelSurface(state.byThreadKey, threadRef),
+  );
+  const reference = surface?.kind === "pull-request" ? surface : null;
+  const environmentId = reference?.environmentId
+    ? EnvironmentId.make(reference.environmentId)
+    : threadRef?.environmentId;
+  const project = useProject(
+    reference && environmentId
+      ? scopeProjectRef(environmentId, ProjectId.make(reference.projectId))
+      : null,
+  );
+  const detail = useEnvironmentQuery(
+    reference && environmentId
+      ? pullRequestEnvironment.detail({
+          environmentId,
+          input: {
+            projectId: ProjectId.make(reference.projectId),
+            repository: reference.repository,
+            number: reference.number,
+          },
+        })
+      : null,
+  ).data;
+  return reference
+    ? (detail?.url ??
+        gitHubPullRequestBrowserUrl(
+          project?.repositoryIdentity,
+          reference.repository,
+          reference.number,
+        ))
+    : null;
+}

--- a/apps/web/src/hooks/useOpenPanelPullRequestUrl.ts
+++ b/apps/web/src/hooks/useOpenPanelPullRequestUrl.ts
@@ -1,6 +1,11 @@
 import { scopeProjectRef } from "@t3tools/client-runtime/environment";
 import { EnvironmentId, ProjectId, type ScopedThreadRef } from "@t3tools/contracts";
+import { useMemo } from "react";
 
+import {
+  readPullRequestDetailSnapshot,
+  resolveDisplayedPullRequestDetail,
+} from "../components/pullRequest/pullRequestDetail.logic";
 import { gitHubPullRequestBrowserUrl } from "../lib/openPullRequestLink";
 import { selectActiveRightPanelSurface, useRightPanelStore } from "../rightPanelStore";
 import { useProject } from "../state/entities";
@@ -32,8 +37,19 @@ export function useOpenPanelPullRequestUrl(threadRef: ScopedThreadRef | null): s
         })
       : null,
   ).data;
+  const cachedDetail = useMemo(
+    () =>
+      reference && environmentId
+        ? readPullRequestDetailSnapshot(
+            typeof window === "undefined" ? undefined : window.localStorage,
+            environmentId,
+            reference,
+          )
+        : null,
+    [environmentId, reference],
+  );
   return reference
-    ? (detail?.url ??
+    ? (resolveDisplayedPullRequestDetail({ live: detail, cached: cachedDetail, reference })?.url ??
         gitHubPullRequestBrowserUrl(
           project?.repositoryIdentity,
           reference.repository,

--- a/apps/web/src/hooks/useOpenPanelPullRequestUrl.ts
+++ b/apps/web/src/hooks/useOpenPanelPullRequestUrl.ts
@@ -12,7 +12,7 @@ import { useProject } from "../state/entities";
 import { pullRequestEnvironment } from "../state/pullRequests";
 import { useEnvironmentQuery } from "../state/query";
 
-export function useOpenPanelPullRequestUrl(threadRef: ScopedThreadRef | null): string | null {
+export function useOpenPanelPullRequestUrl(threadRef: ScopedThreadRef | null) {
   const surface = useRightPanelStore((state) =>
     selectActiveRightPanelSurface(state.byThreadKey, threadRef),
   );
@@ -55,5 +55,5 @@ export function useOpenPanelPullRequestUrl(threadRef: ScopedThreadRef | null): s
           reference.repository,
           reference.number,
         ))
-    : null;
+    : undefined;
 }

--- a/packages/shared/src/threadReference.test.ts
+++ b/packages/shared/src/threadReference.test.ts
@@ -3,6 +3,17 @@ import { describe, expect, it } from "vite-plus/test";
 import { resolveThreadReferenceCopyTarget } from "./threadReference.ts";
 
 describe("resolveThreadReferenceCopyTarget", () => {
+  it("does not copy another reference while the open panel URL is unavailable", () => {
+    expect(
+      resolveThreadReferenceCopyTarget({
+        threadId: "thread-1",
+        openPanelPullRequestUrl: null,
+        linkedPullRequestUrl: "https://github.com/t3/pr/12",
+        detectedPullRequestUrl: "https://github.com/t3/pr/13",
+      }),
+    ).toBeNull();
+  });
+
   it("prefers the open panel pull request over linked and detected pull requests", () => {
     expect(
       resolveThreadReferenceCopyTarget({

--- a/packages/shared/src/threadReference.test.ts
+++ b/packages/shared/src/threadReference.test.ts
@@ -3,6 +3,21 @@ import { describe, expect, it } from "vite-plus/test";
 import { resolveThreadReferenceCopyTarget } from "./threadReference.ts";
 
 describe("resolveThreadReferenceCopyTarget", () => {
+  it("prefers the open panel pull request over linked and detected pull requests", () => {
+    expect(
+      resolveThreadReferenceCopyTarget({
+        threadId: "thread-1",
+        openPanelPullRequestUrl: "https://github.com/t3/pr/14",
+        linkedPullRequestUrl: "https://github.com/t3/pr/12",
+        detectedPullRequestUrl: "https://github.com/t3/pr/13",
+      }),
+    ).toMatchObject({
+      kind: "pull-request",
+      value: "https://github.com/t3/pr/14",
+      successTitle: "PR link copied",
+    });
+  });
+
   it("prefers a durable linked pull request", () => {
     expect(
       resolveThreadReferenceCopyTarget({

--- a/packages/shared/src/threadReference.ts
+++ b/packages/shared/src/threadReference.ts
@@ -8,10 +8,12 @@ export interface ThreadReferenceCopyTarget {
 
 export function resolveThreadReferenceCopyTarget(input: {
   readonly threadId: string;
+  readonly openPanelPullRequestUrl?: string | null;
   readonly linkedPullRequestUrl?: string | null;
   readonly detectedPullRequestUrl?: string | null;
 }): ThreadReferenceCopyTarget {
-  const pullRequestUrl = input.linkedPullRequestUrl ?? input.detectedPullRequestUrl;
+  const pullRequestUrl =
+    input.openPanelPullRequestUrl ?? input.linkedPullRequestUrl ?? input.detectedPullRequestUrl;
   return pullRequestUrl
     ? {
         kind: "pull-request",

--- a/packages/shared/src/threadReference.ts
+++ b/packages/shared/src/threadReference.ts
@@ -8,10 +8,12 @@ export interface ThreadReferenceCopyTarget {
 
 export function resolveThreadReferenceCopyTarget(input: {
   readonly threadId: string;
-  readonly openPanelPullRequestUrl?: string | null;
+  /** Undefined means no PR panel; null means its URL is not available yet. */
+  readonly openPanelPullRequestUrl?: string | null | undefined;
   readonly linkedPullRequestUrl?: string | null;
   readonly detectedPullRequestUrl?: string | null;
-}): ThreadReferenceCopyTarget {
+}): ThreadReferenceCopyTarget | null {
+  if (input.openPanelPullRequestUrl === null) return null;
   const pullRequestUrl =
     input.openPanelPullRequestUrl ?? input.linkedPullRequestUrl ?? input.detectedPullRequestUrl;
   return pullRequestUrl


### PR DESCRIPTION
Cmd/Ctrl+Shift+C and the command palette now copy the pull request visible in the thread's right panel before the thread's linked or branch-detected pull request. Cached panel details supply the URL during refresh; an active panel with no available URL prevents copying an unrelated reference, and closing it restores the existing fallback.

Verified actual shortcut copy/paste with #9876 open beside a thread linked to #9877, the closed-panel fallback, and the command palette. 217 focused tests, web typecheck, and targeted lint passed; the recording below shows the verified transitions.

![Open panel PR priority, closed panel fallback, and command palette copy](https://uploads-production-47e4.up.railway.app/files/c68767bf-bf0e-4b81-b2b6-76815fe981a2/copy-pr-priority.gif)

Implemented with gpt-5.6-sol through Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized clipboard/copy-target logic with explicit null handling; return type change to `null` is wired at known call sites and covered by new unit tests.
> 
> **Overview**
> **Copy thread reference** (Cmd/Ctrl+Shift+C and the command palette) now prefers the pull request shown in the thread’s **right panel** over the thread’s linked or branch-detected PR.
> 
> A new `useOpenPanelPullRequestUrl` hook resolves that URL from the active panel surface (live detail, localStorage cache, or a GitHub browser fallback). `resolveThreadReferenceCopyTarget` takes an optional `openPanelPullRequestUrl`: when it is **`null`** (panel open but URL not ready), copying is blocked so an unrelated PR/thread ID is not copied; when **`undefined`**, behavior falls back to linked/detected PR, then thread ID. **ChatView** and **CommandPalette** pass the hook result into that resolver; the palette shortcut still runs but no-ops when there is no target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06c12d6ee232a34828394b6316c614662990cfa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prioritize open-panel pull request URL when copying thread references
> - Adds `useOpenPanelPullRequestUrl` hook in [useOpenPanelPullRequestUrl.ts](https://github.com/pingdotgg/t3code/pull/9877/files#diff-5155fe6333cb99a645edbf3afe4d067b1eec5fbdde9798f03b04c79fc587e669) to resolve the PR URL from the thread's active right-panel surface, using live detail data, cached snapshot, or a GitHub browser URL fallback
> - Updates `resolveThreadReferenceCopyTarget` in [threadReference.ts](https://github.com/pingdotgg/t3code/pull/9877/files#diff-c8ce6d92ecfd3374fe18ed8ced7b3f3d2e5ac854feb96eb7e256662741b538e6) to accept an optional open-panel URL with `undefined` (no panel, keep existing fallbacks) vs `null` (explicitly unavailable, return no target) semantics; a present URL takes precedence over linked and detected PRs
> - Wires the hook into [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/9877/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) and [CommandPalette.tsx](https://github.com/pingdotgg/t3code/pull/9877/files#diff-30c525d0ef54c6971e43ab0660a73ea227ef51e009f79e4083049d3349175a7a) so copy actions prefer the open-panel PR
> - Behavioral Change: when the open panel is explicitly unavailable (`null`), copying returns no target instead of falling back to linked/detected PRs; the command palette's `thread.copyReference` handler now always prevents the keyboard event even when no copy target exists
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06c12d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


