### PR TITLE
fix(web): keep file autosaves active after effect replay

### DIFF
--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -47,7 +47,6 @@ import { buildFileReviewComment } from "~/reviewCommentContext";
 import { assetEnvironment } from "~/state/assets";
 import { useEnvironmentHttpBaseUrl, usePrimaryEnvironmentId } from "~/state/environments";
 import { previewEnvironment } from "~/state/preview";
-import { projectEnvironment } from "~/state/projects";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { useAtomQueryRunner } from "~/state/use-atom-query-runner";
 
@@ -72,9 +71,8 @@ import {
   setMarkdownTaskChecked,
   shouldShowFileExplorer,
 } from "./filePreviewMode";
-import { FileSaveCoordinator } from "./fileSaveCoordinator";
+import { useFileSaveCoordinator } from "./useFileSaveCoordinator";
 import {
-  confirmProjectFileQueryData,
   getOptimisticProjectFileQueryData,
   setProjectFileQueryData,
   useProjectFileQuery,
@@ -101,7 +99,6 @@ interface FilePreviewPanelProps {
 const FILE_EXPLORER_STORAGE_KEY = "t3code.fileExplorerOpen";
 const RENDER_MARKDOWN_STORAGE_KEY = "t3code.renderMarkdown";
 const RENDER_BROWSER_FILE_STORAGE_KEY = "t3code.renderBrowserFile";
-const FILE_SAVE_DEBOUNCE_MS = 500;
 const FILE_LINK_REVEAL_ATTRIBUTE = "data-file-link-reveal";
 const FILE_LINK_REVEAL_UNSAFE_CSS = `
   ${DIFF_SURFACE_THEME_UNSAFE_CSS}
@@ -611,37 +608,6 @@ interface EditableFileSurfaceProps {
 interface FileSelectionOverride {
   revealRequestId: number;
   range: SelectedLineRange | null;
-}
-
-function useFileSaveCoordinator({
-  environmentId,
-  cwd,
-  relativePath,
-  onPendingChange,
-}: Pick<
-  EditableFileSurfaceProps,
-  "environmentId" | "cwd" | "relativePath" | "onPendingChange"
->): FileSaveCoordinator {
-  const writeFile = useAtomCommand(projectEnvironment.writeFile);
-  const coordinator = useMemo(
-    () =>
-      new FileSaveCoordinator({
-        debounceMs: FILE_SAVE_DEBOUNCE_MS,
-        onPendingChange: (pending) => onPendingChange(relativePath, pending),
-        persist: (nextContents) =>
-          writeFile({
-            environmentId,
-            input: { cwd, relativePath, contents: nextContents },
-          }),
-        onConfirmed: (confirmedContents) => {
-          confirmProjectFileQueryData(environmentId, cwd, relativePath, confirmedContents);
-        },
-      }),
-    [cwd, environmentId, onPendingChange, relativePath, writeFile],
-  );
-
-  useEffect(() => () => coordinator.dispose(), [coordinator]);
-  return coordinator;
 }
 
 function EditableFileSurface({

--- a/apps/web/src/components/files/useFileSaveCoordinator.test.tsx
+++ b/apps/web/src/components/files/useFileSaveCoordinator.test.tsx
@@ -1,0 +1,174 @@
+import { EnvironmentId } from "@t3tools/contracts";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { act, StrictMode } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { writeFile, confirmFile } = vi.hoisted(() => ({
+  writeFile: vi.fn(),
+  confirmFile: vi.fn(),
+}));
+vi.mock("~/state/projects", () => ({ projectEnvironment: { writeFile: {} } }));
+vi.mock("~/state/use-atom-command", () => ({ useAtomCommand: () => writeFile }));
+vi.mock("./projectFilesQueryState", () => ({ confirmProjectFileQueryData: confirmFile }));
+
+import { setMarkdownTaskChecked } from "./filePreviewMode";
+import { useFileSaveCoordinator } from "./useFileSaveCoordinator";
+
+const environmentId = EnvironmentId.make("save-lifecycle-audit");
+const onPendingChange = vi.fn();
+const defaultProps = {
+  environmentId,
+  cwd: "/workspace",
+  relativePath: "file.txt",
+  onPendingChange,
+};
+let renderer: ReactTestRenderer | null;
+
+function ChangeSource(_props: { onChange: (contents: string) => void }) {
+  return null;
+}
+
+function FileSurface(props: Parameters<typeof useFileSaveCoordinator>[0]) {
+  const coordinator = useFileSaveCoordinator(props);
+  return <ChangeSource onChange={(contents) => coordinator.change(contents)} />;
+}
+
+function mount(props = defaultProps) {
+  act(() => {
+    renderer = create(
+      <StrictMode>
+        <FileSurface {...props} />
+      </StrictMode>,
+    );
+  });
+}
+
+function changeHandler(): (contents: string) => void {
+  return renderer!.root.findByType(ChangeSource).props.onChange;
+}
+
+beforeEach(() => {
+  renderer = null;
+  vi.useFakeTimers();
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  writeFile.mockReset().mockResolvedValue(AsyncResult.success(undefined));
+  confirmFile.mockReset();
+  onPendingChange.mockReset();
+});
+
+afterEach(async () => {
+  await act(async () => renderer?.unmount());
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("file-save React lifecycle", () => {
+  it("persists editor model changes after StrictMode setup replay", async () => {
+    mount();
+    changeHandler()("AUDIT7907NATIVE\n");
+    expect(onPendingChange).toHaveBeenCalledWith("file.txt", true);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(writeFile).toHaveBeenCalledExactlyOnceWith({
+      environmentId,
+      input: { cwd: "/workspace", relativePath: "file.txt", contents: "AUDIT7907NATIVE\n" },
+    });
+    expect(confirmFile).toHaveBeenCalledExactlyOnceWith(
+      environmentId,
+      "/workspace",
+      "file.txt",
+      "AUDIT7907NATIVE\n",
+    );
+    expect(onPendingChange).toHaveBeenLastCalledWith("file.txt", false);
+  });
+
+  it("persists rendered Markdown task changes after StrictMode setup replay", async () => {
+    mount({ ...defaultProps, relativePath: "README.md" });
+    const nextContents = setMarkdownTaskChecked("- [ ] task\n", 2, true);
+    changeHandler()(nextContents);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(writeFile).toHaveBeenCalledExactlyOnceWith({
+      environmentId,
+      input: { cwd: "/workspace", relativePath: "README.md", contents: "- [x] task\n" },
+    });
+  });
+
+  it("keeps the debounce across rerenders of the same file", async () => {
+    mount();
+    changeHandler()("first");
+    await vi.advanceTimersByTimeAsync(300);
+    act(() =>
+      renderer!.update(
+        <StrictMode>
+          <FileSurface {...defaultProps} />
+        </StrictMode>,
+      ),
+    );
+    changeHandler()("latest");
+    await vi.advanceTimersByTimeAsync(499);
+    expect(writeFile).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(writeFile).toHaveBeenCalledTimes(1);
+    expect(writeFile.mock.calls[0]![0].input.contents).toBe("latest");
+  });
+
+  it("flushes on unmount and ignores a retired editor callback", async () => {
+    mount();
+    const retiredChange = changeHandler();
+    retiredChange("pending edit");
+    await act(async () => renderer!.unmount());
+    renderer = null;
+    retiredChange("stale editor contents");
+    await vi.runAllTimersAsync();
+    expect(writeFile).toHaveBeenCalledTimes(1);
+    expect(writeFile.mock.calls[0]![0].input.contents).toBe("pending edit");
+  });
+
+  it.each([
+    { relativePath: "other.txt" },
+    { cwd: "/other-workspace" },
+    { environmentId: EnvironmentId.make("other-environment") },
+  ])("retires callbacks when the file identity changes: %j", async (change) => {
+    mount();
+    const retiredChange = changeHandler();
+    retiredChange("old file edit");
+    const nextProps = { ...defaultProps, ...change };
+    act(() =>
+      renderer!.update(
+        <StrictMode>
+          <FileSurface {...nextProps} />
+        </StrictMode>,
+      ),
+    );
+    retiredChange("stale editor contents");
+    changeHandler()("new file edit");
+    await vi.runAllTimersAsync();
+    expect(writeFile.mock.calls.map(([request]) => request)).toEqual([
+      {
+        environmentId,
+        input: { cwd: "/workspace", relativePath: "file.txt", contents: "old file edit" },
+      },
+      {
+        environmentId: nextProps.environmentId,
+        input: {
+          cwd: nextProps.cwd,
+          relativePath: nextProps.relativePath,
+          contents: "new file edit",
+        },
+      },
+    ]);
+  });
+
+  it("does not reactivate a retired callback when the same file mounts again", async () => {
+    mount();
+    const retiredChange = changeHandler();
+    await act(async () => renderer!.unmount());
+    renderer = null;
+    mount();
+    retiredChange("stale contents");
+    changeHandler()("current contents");
+    await vi.runAllTimersAsync();
+    expect(writeFile).toHaveBeenCalledTimes(1);
+    expect(writeFile.mock.calls[0]![0].input.contents).toBe("current contents");
+  });
+});

--- a/apps/web/src/components/files/useFileSaveCoordinator.ts
+++ b/apps/web/src/components/files/useFileSaveCoordinator.ts
@@ -1,0 +1,56 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { createRef, useEffect, useMemo } from "react";
+
+import { projectEnvironment } from "~/state/projects";
+import { useAtomCommand } from "~/state/use-atom-command";
+
+import { FileSaveCoordinator } from "./fileSaveCoordinator";
+import { confirmProjectFileQueryData } from "./projectFilesQueryState";
+
+const FILE_SAVE_DEBOUNCE_MS = 500;
+
+interface FileSaveOptions {
+  environmentId: EnvironmentId;
+  cwd: string;
+  relativePath: string;
+  onPendingChange: (relativePath: string, pending: boolean) => void;
+}
+
+export function useFileSaveCoordinator({
+  environmentId,
+  cwd,
+  relativePath,
+  onPendingChange,
+}: FileSaveOptions): Pick<FileSaveCoordinator, "change"> {
+  const writeFile = useAtomCommand(projectEnvironment.writeFile);
+  const session = useMemo(() => {
+    const coordinatorRef = createRef<FileSaveCoordinator>();
+    return {
+      change: (contents: string) => coordinatorRef.current?.change(contents),
+      setup: () => {
+        const coordinator = new FileSaveCoordinator({
+          debounceMs: FILE_SAVE_DEBOUNCE_MS,
+          onPendingChange: (pending) => onPendingChange(relativePath, pending),
+          persist: (nextContents) =>
+            writeFile({
+              environmentId,
+              input: { cwd, relativePath, contents: nextContents },
+            }),
+          onConfirmed: (confirmedContents) => {
+            confirmProjectFileQueryData(environmentId, cwd, relativePath, confirmedContents);
+          },
+        });
+        coordinatorRef.current = coordinator;
+        return () => {
+          coordinatorRef.current = null;
+          coordinator.dispose();
+        };
+      },
+    };
+  }, [cwd, environmentId, onPendingChange, relativePath, writeFile]);
+
+  // StrictMode replays effect setup. Retired file sessions stay inert, while the
+  // replay gets a fresh coordinator instead of reusing a disposed one.
+  useEffect(session.setup, [session]);
+  return session;
+}


### PR DESCRIPTION
## Problem

React StrictMode replays effect setup in development. The file preview memoized a `FileSaveCoordinator` but disposed that same instance during the replay cleanup. Subsequent editor changes and rendered Markdown task changes never reached the write command.

This was discovered while auditing [#7907](https://github.com/pingdotgg/t3code/issues/7907). It is a separate save-lifecycle bug, not a demonstrated fix for that report's word-wrap focus jumps or "Line doesn't exist" error. That issue should remain open.

## Fix

Move the shared hook into its own module and create the coordinator in effect setup. The file-specific callback stays stable across effect replay, while cleanup detaches and disposes the old coordinator. A retired file callback cannot write into the next file or a later mount.

Both the source editor and rendered Markdown task list use the hook. The existing coordinator class, disposed guard, 500 ms debounce, write command, cache confirmation and close-flush behavior are unchanged. No dependency, server, contract, mobile or documentation changes.

## Verification

Base [363cde411](https://github.com/pingdotgg/t3code/commit/363cde4114c2186c496ed97cafba4a8737ea5585), committed September 4, 2026 at 20:12:04 PDT.

- With the original main-branch hook moved unchanged into the testable module, all eight actual React StrictMode lifecycle tests fail. The first editor change produces no pending notification; the Markdown task update produces zero write calls.
- The candidate passes all 25 focused tests. Coverage includes source-model changes, the real Markdown task transform, unchanged-file debounce, pending flush on close, path/cwd/environment switches, and ignored retired callbacks after unmount/remount.
- Web typecheck and three-file formatting pass. Targeted lint has no errors and one pre-existing effect-dependency warning in untouched FilePreviewPanel code.
- The three-file cumulative diff and both callers have been reviewed locally. The coordinator class is byte-identical to main.

```sh
cd apps/web
vp test run src/components/files/useFileSaveCoordinator.test.tsx src/components/files/fileSaveCoordinator.test.ts src/components/files/FilePreviewPanel.test.ts --project unit --maxWorkers 2
../../node_modules/.bin/tsgo --noEmit
```

The tests mount the real hook and coordinator under React StrictMode and assert the write/cache boundary. They do not simulate Pierre's native input handling or prove an actual disk write.

## Integrated client verification

On September 4, 2026 (PDT), the orchestrator tested Chromium 152 on Linux against the base above, then the exact production changes from [31c544f](https://github.com/pingdotgg/t3code/commit/31c544fe12101e32feed877d9024b2e5270d1191). Both runs used the same disposable local server, synthetic thread and owned Markdown file. Other independently reviewed UI patches were held constant between runs.

- Before: native pointer/keyboard input appended ` AUDIT-SAVE` and Enter in the real editor. Closing and reopening lost both edits; the actual file on disk was unchanged.
- After: the same input reached disk and survived closing/reopening. A rendered Markdown task toggle wrote `[x]`, remained checked after reopen, and unchecked successfully.
- A wrapped-line control sent 60 separate native Enter keypresses and a trailing marker. The file gained exactly 60 newline characters (6 → 66), retained the marker after reopen, and produced no captured window errors or unhandled rejections.
- These are actual editor/RPC/disk checks, not a projection-only fixture. No provider turn was sent. The reported CachyOS/Electron focus-jump/error path remains unverified; [#7907](https://github.com/pingdotgg/t3code/issues/7907) remains open.

Before — reopened file has lost the typed marker:

![Before: reopened Markdown file loses the native edit](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/998552d90fe48e67/9878-before-reopened.png)

After — reopened file retains the typed marker:

![After: reopened Markdown file retains the native edit](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/0d652cfca8847723/9878-after-reopened.png)

Before recording:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/de6de44b76f7a5c9/9878-before-save.webm

After recording:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/6369243b73a7020c/9878-after-save.webm

## Final audit

The orchestrator reviewed the whole three-file change and both callers. The coordinator class, debounce, command, cache and disposal guards remain unchanged. All current-head CI jobs that ran, Correctness, Approvability, UI Consistency, Effect Service Conventions and Bugbot pass; skipped jobs are not counted as executed tests. No unresolved review threads or active change requests remain.

This is a narrow lifecycle correctness repair within the requested simple-fix merge authority. No issue closure is implied.

Prepared by GPT 6 Astra via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the file-edit persistence path (debounced writes and query cache confirmation), but scope is limited to hook lifecycle wiring with regression tests; the coordinator implementation itself is unchanged.
> 
> **Overview**
> **Fixes file autosave stopping in development** when React StrictMode replays effect cleanup and disposed the memoized `FileSaveCoordinator` while the editor still called into that dead instance.
> 
> The inline `useFileSaveCoordinator` hook is **extracted** to `useFileSaveCoordinator.ts`. Coordinator creation moves into `useEffect` setup with a ref-backed `change` callback, so replay gets a **new** coordinator instead of reusing a disposed one. Retired callbacks are cleared on cleanup and cannot write after unmount, file switches, or remount. `FilePreviewPanel` now imports the shared hook; debounce, write command, and cache confirmation behavior on the coordinator class are unchanged.
> 
> Adds **StrictMode-focused unit tests** for editor saves, rendered Markdown task toggles, debounce across rerenders, unmount flush, and file identity changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31c544fe12101e32feed877d9024b2e5270d1191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix file autosave after effect replay in `FilePreviewPanel`
> - Extracts the save-coordinator hook from [FilePreviewPanel.tsx](https://github.com/pingdotgg/t3code/pull/9878/files#diff-776fa2f4352bbbf118206cfd39f4cf95c38e47b1629aa20a6c8c028cadf458ea) into [useFileSaveCoordinator.ts](https://github.com/pingdotgg/t3code/pull/9878/files#diff-7361efd1b3e36150ca35bed62aee40061044a124f6e16ad5cad39ca0593ee4b0), with a typed options contract and memoized session
> - `useFileSaveCoordinator` routes changes only to the active coordinator; effect replay and file-identity transitions create a fresh coordinator while stale callbacks from retired sessions become inert
> - Retains the existing 500 ms debounce, file-write persistence, pending-state reporting, and confirmed-query updates; cleanup clears the active coordinator reference before disposal
> - Adds StrictMode lifecycle tests in [useFileSaveCoordinator.test.tsx](https://github.com/pingdotgg/t3code/pull/9878/files#diff-d49b7530d7feb0d16a8ba0c7f6b1d1ac65a2c820fe66a8270cd5b4d1d2a88343) covering editor change persistence, Markdown task writes, rerender debounce, unmount/retired-callback, file-identity transitions, and same-file remount
> - Risk: callbacks retained after a session retires are silently dropped instead of writing; verify `useFileSaveCoordinator`'s session swap logic on relative path, working directory, and environment identity changes
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31c544f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


