### PR TITLE
fix(mobile): stream dictation with newer-model corrections

### DIFF
--- a/apps/mobile/modules/t3-native-controls/expo-module.config.json
+++ b/apps/mobile/modules/t3-native-controls/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "platforms": ["apple", "android"],
   "apple": {
-    "modules": ["T3NativeControlsModule", "T3KeyboardCommandsModule"]
+    "modules": ["T3NativeControlsModule", "T3KeyboardCommandsModule", "T3VoiceInputModule"]
   },
   "android": {
     "modules": [

--- a/apps/mobile/modules/t3-native-controls/ios/LiveVoiceSession.swift
+++ b/apps/mobile/modules/t3-native-controls/ios/LiveVoiceSession.swift
@@ -1,0 +1,160 @@
+import AVFoundation
+import Speech
+
+/// AVAudioConverter pulls each tap buffer synchronously, at most once.
+private final class VoiceConversionChunk: @unchecked Sendable {
+  private var buffer: AVAudioPCMBuffer?
+  init(_ buffer: AVAudioPCMBuffer) { self.buffer = buffer }
+  func take() -> AVAudioPCMBuffer? {
+    defer { buffer = nil }
+    return buffer
+  }
+}
+
+@available(iOS 26.0, *)
+@MainActor
+final class LiveVoiceSession {
+  let id: String
+  private let emit: ([String: Any]) -> Void
+  private let engine = AVAudioEngine()
+  private var transcription: VoiceTranscription?
+  private var input: AsyncStream<AnalyzerInput>.Continuation?
+  private var observers: [NSObjectProtocol] = []
+  private var tapInstalled = false
+  private var ending = false
+  private var startedAt: TimeInterval = 0
+  private var lastMeterAt: TimeInterval = 0
+
+  init(id: String, emit: @escaping ([String: Any]) -> Void) {
+    self.id = id
+    self.emit = emit
+  }
+
+  static func prepare(locale: String) async throws -> String? {
+    try await VoiceTranscription.prepare(locale: locale)
+  }
+
+  func start(locale: String, limit: Double) async throws {
+    let (sequence, continuation) = AsyncStream<AnalyzerInput>.makeStream()
+    input = continuation
+    let transcription = VoiceTranscription(emit: { [weak self] text in
+      guard let self else { return }
+      emit(["sessionId": id, "transcript": text])
+    }, interrupted: { [weak self] in self?.interrupted() })
+    self.transcription = transcription
+    let format = try await transcription.start(input: sequence, locale: locale)
+    let node = engine.inputNode
+    let sourceFormat = node.outputFormat(forBus: 0)
+    guard sourceFormat.sampleRate > 0, sourceFormat.channelCount > 0,
+      let converter = AVAudioConverter(from: sourceFormat, to: format)
+    else { throw LiveVoiceError.audioFormat }
+    converter.primeMethod = .none
+    let ratio = format.sampleRate / sourceFormat.sampleRate
+    node.installTap(onBus: 0, bufferSize: 4096, format: sourceFormat) { [weak self] buffer, _ in
+      let decibels = Self.decibels(for: buffer)
+      Task { @MainActor [weak self] in self?.meter(decibels, limit: limit) }
+      do {
+        if let converted = try Self.convert(buffer, using: converter, to: format, ratio: ratio) {
+          continuation.yield(AnalyzerInput(buffer: converted))
+        }
+      } catch {
+        Task { @MainActor [weak self] in self?.interrupted() }
+      }
+    }
+    tapInstalled = true
+    startedAt = ProcessInfo.processInfo.systemUptime
+    engine.prepare()
+    try engine.start()
+    for name in [AVAudioSession.interruptionNotification, AVAudioSession.mediaServicesWereResetNotification,
+                 NSNotification.Name.AVAudioEngineConfigurationChange] {
+      observers.append(NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+        Task { @MainActor [weak self] in self?.interrupted() }
+      })
+    }
+  }
+
+  private nonisolated static func decibels(for buffer: AVAudioPCMBuffer) -> Float {
+    var sum: Float = 0
+    if let samples = buffer.floatChannelData?[0] {
+      for frame in 0..<Int(buffer.frameLength) { sum += samples[frame] * samples[frame] }
+    }
+    let rms = (sum / Float(max(1, buffer.frameLength))).squareRoot()
+    return 20 * log10(max(rms, 0.000001))
+  }
+
+  private nonisolated static func convert(
+    _ buffer: AVAudioPCMBuffer,
+    using converter: AVAudioConverter,
+    to format: AVAudioFormat,
+    ratio: Double
+  ) throws -> AVAudioPCMBuffer? {
+    let capacity = AVAudioFrameCount((Double(buffer.frameLength) * ratio).rounded(.up) + 64)
+    guard let converted = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: capacity) else {
+      throw LiveVoiceError.audioFormat
+    }
+    var error: NSError?
+    let chunk = VoiceConversionChunk(buffer)
+    let status = converter.convert(to: converted, error: &error) { _, inputStatus in
+      guard let pending = chunk.take() else {
+        inputStatus.pointee = .noDataNow
+        return nil
+      }
+      inputStatus.pointee = .haveData
+      return pending
+    }
+    if status == .error || error != nil { throw LiveVoiceError.audioFormat }
+    return converted.frameLength > 0 ? converted : nil
+  }
+
+  private func meter(_ decibels: Float, limit: Double) {
+    guard !ending else { return }
+    let now = ProcessInfo.processInfo.systemUptime
+    let elapsed = now - startedAt
+    if now - lastMeterAt >= 0.08 {
+      lastMeterAt = now
+      emit(["sessionId": id, "durationMillis": elapsed * 1000, "metering": decibels])
+    }
+    if elapsed >= limit {
+      teardownCapture()
+      emit(["sessionId": id, "ended": true])
+    }
+  }
+
+  private func interrupted() {
+    guard !ending else { return }
+    teardownCapture()
+    emit(["sessionId": id, "error": "Voice recording was interrupted."])
+  }
+
+  func stop() async throws -> String {
+    teardownCapture()
+    do {
+      guard let transcription else { throw LiveVoiceError.unavailable }
+      let transcript = try await transcription.finish()
+      self.transcription = nil
+      return transcript
+    } catch {
+      await cancel()
+      throw error
+    }
+  }
+
+  func cancel() async {
+    teardownCapture()
+    await transcription?.cancel()
+    transcription = nil
+  }
+
+  private func teardownCapture() {
+    ending = true
+    observers.forEach(NotificationCenter.default.removeObserver)
+    observers.removeAll()
+    if tapInstalled {
+      engine.inputNode.removeTap(onBus: 0)
+      tapInstalled = false
+    }
+    engine.stop()
+    input?.finish()
+    input = nil
+  }
+}

--- a/apps/mobile/modules/t3-native-controls/ios/T3VoiceInputModule.swift
+++ b/apps/mobile/modules/t3-native-controls/ios/T3VoiceInputModule.swift
@@ -1,0 +1,107 @@
+import AVFoundation
+import ExpoModulesCore
+import Speech
+
+private final class VoiceUnavailableException: Exception {
+  override var code: String { "ERR_VOICE_UNAVAILABLE" }
+  override var reason: String { "Live voice transcription is unavailable." }
+}
+
+private final class VoiceBusyException: Exception {
+  override var code: String { "ERR_VOICE_BUSY" }
+  override var reason: String { "Another live voice transcription is already active." }
+}
+
+private final class VoiceAudioFormatException: Exception {
+  override var code: String { "ERR_VOICE_AUDIO_FORMAT" }
+  override var reason: String { "Live voice transcription could not configure audio capture." }
+}
+
+public final class T3VoiceInputModule: Module {
+  private var session: AnyObject?
+
+  public func definition() -> ModuleDefinition {
+    Name("T3VoiceInput")
+    Events("onVoiceInput")
+
+    Function("isAvailable") { () -> Bool in
+      if #available(iOS 26.0, *) { return SpeechTranscriber.isAvailable }
+      return false
+    }
+    AsyncFunction("prepare") { (locale: String) -> String? in
+      guard #available(iOS 26.0, *) else { throw VoiceUnavailableException() }
+      do {
+        return try await LiveVoiceSession.prepare(locale: locale)
+      } catch {
+        throw self.bridgeError(error)
+      }
+    }
+    AsyncFunction("start") { (id: String, locale: String, limit: Double) in
+      try await self.start(id: id, locale: locale, limit: limit)
+    }
+    AsyncFunction("stop") { (id: String) -> String in
+      try await self.stop(id: id)
+    }
+    AsyncFunction("cancel") { (id: String) in
+      await self.cancel(id: id)
+    }
+    OnDestroy {
+      Task { @MainActor in
+        if #available(iOS 26.0, *), let session = self.session as? LiveVoiceSession {
+          await session.cancel()
+          self.session = nil
+        }
+      }
+    }
+  }
+
+  @MainActor
+  private func start(id: String, locale: String, limit: Double) async throws {
+    guard #available(iOS 26.0, *) else { throw VoiceUnavailableException() }
+    guard session == nil else { throw VoiceBusyException() }
+    let voice = LiveVoiceSession(id: id) { [weak self] event in
+      self?.sendEvent("onVoiceInput", event)
+    }
+    session = voice
+    do {
+      try await voice.start(locale: locale, limit: limit)
+    } catch {
+      await voice.cancel()
+      session = nil
+      throw bridgeError(error)
+    }
+  }
+
+  @MainActor
+  private func stop(id: String) async throws -> String {
+    guard #available(iOS 26.0, *), let voice = session as? LiveVoiceSession,
+      voice.id == id else { throw VoiceUnavailableException() }
+    defer { if session === voice { session = nil } }
+    do {
+      return try await voice.stop()
+    } catch {
+      throw bridgeError(error)
+    }
+  }
+
+  @MainActor
+  private func cancel(id: String) async {
+    guard #available(iOS 26.0, *), let voice = session as? LiveVoiceSession,
+      voice.id == id else { return }
+    await voice.cancel()
+    if session === voice { session = nil }
+  }
+
+  private func bridgeError(_ error: Error) -> Error {
+    switch error {
+    case LiveVoiceError.unavailable:
+      return VoiceUnavailableException()
+    case LiveVoiceError.busy:
+      return VoiceBusyException()
+    case LiveVoiceError.audioFormat:
+      return VoiceAudioFormatException()
+    default:
+      return error
+    }
+  }
+}

--- a/apps/mobile/modules/t3-native-controls/ios/VoiceTranscript.swift
+++ b/apps/mobile/modules/t3-native-controls/ios/VoiceTranscript.swift
@@ -1,0 +1,177 @@
+import Foundation
+import NaturalLanguage
+import CoreMedia
+
+/// Replaces a recognizer's revisable passage without losing earlier passages.
+struct VoiceTranscript {
+  private struct Passage {
+    let range: CMTimeRange
+    let text: String
+  }
+  private var passages: [Passage] = []
+
+  mutating func update(text: String, range: CMTimeRange) {
+    passages.removeAll { $0.range.end > range.start || $0.range.start == range.start }
+    passages.append(Passage(range: range, text: text))
+  }
+
+  var text: String { passages.map(\.text).joined() }
+}
+
+/// The newer recognizer owns the prefix; fast dictation supplies the unfinished tail.
+enum VoiceDraft {
+  static func merge(corrected: String, provisional: String) -> String {
+    let correctedWords = words(in: corrected)
+    let provisionalWords = words(in: provisional)
+    guard !correctedWords.isEmpty else { return provisional }
+    guard !provisionalWords.isEmpty else { return corrected }
+
+    // Align to a prefix, leaving words the newer model hasn't reached on screen.
+    // Discarding a common prefix keeps the usual case small, even for long dictation.
+    var shared = 0
+    while shared < min(correctedWords.count, provisionalWords.count),
+      correctedWords[shared].value == provisionalWords[shared].value { shared += 1 }
+    let correctedTail = correctedWords.dropFirst(shared)
+    let provisionalTail = provisionalWords.dropFirst(shared)
+    // Normal suffix revisions leave a tiny tail, where the full matrix is cheaper.
+    if correctedTail.count >= 64, let alignedBoundary = smallAlignedBoundary(
+      corrected: correctedTail,
+      provisional: provisionalTail
+    ) {
+      let boundary = shared + alignedBoundary
+      guard boundary < provisionalWords.count else { return corrected }
+      let tailStart = provisionalWords[boundary].range.lowerBound
+      let previousEnd = boundary > 0
+        ? provisionalWords[boundary - 1].range.upperBound
+        : provisional.startIndex
+      let corrected = corrected.trimmingCharacters(in: .whitespacesAndNewlines)
+      let separator = separator(after: corrected, provisional[previousEnd..<tailStart])
+      return corrected + separator + provisional[tailStart...]
+    }
+    var costs = Array(0...provisionalTail.count)
+    var precedingCosts = costs
+    for (row, word) in correctedTail.enumerated() {
+      var next = [row + 1]
+      for (column, candidate) in provisionalTail.enumerated() {
+        var cost = min(costs[column + 1] + 1, next[column] + 1,
+                       costs[column] + (word.value == candidate.value ? 0 : 1))
+        // The engines can spell the same compound as one word or two ("timeout" / "time out").
+        if column > 0, word.value == provisionalWords[shared + column - 1].value + candidate.value {
+          cost = min(cost, costs[column - 1])
+        }
+        if row > 0, correctedWords[shared + row - 1].value + word.value == candidate.value {
+          cost = min(cost, precedingCosts[column])
+        }
+        next.append(cost)
+      }
+      precedingCosts = costs
+      costs = next
+    }
+    let minimum = costs.min() ?? 0
+    // On a tie, prefer replacing a mistaken word to inserting its correction beside it.
+    let boundary = shared + (costs.lastIndex(of: minimum) ?? 0)
+    guard boundary < provisionalWords.count else { return corrected }
+    let tailStart = provisionalWords[boundary].range.lowerBound
+    let previousEnd = boundary > 0 ? provisionalWords[boundary - 1].range.upperBound : provisional.startIndex
+    let corrected = corrected.trimmingCharacters(in: .whitespacesAndNewlines)
+    let separator = separator(after: corrected, provisional[previousEnd..<tailStart])
+    return corrected + separator + provisional[tailStart...]
+  }
+
+  private static func separator(after corrected: String, _ provisional: Substring) -> String {
+    guard corrected.last?.isLetter == true || corrected.last?.isNumber == true else {
+      return provisional.filter(\.isWhitespace)
+    }
+    return String(provisional)
+  }
+
+  /// Computes the same boundary as the full edit-distance matrix when the two
+  /// tails are already positionally aligned with only a few substitutions.
+  /// Keep this uncommon large-tail path out of the normal merge's instruction body.
+  @inline(never)
+  private static func smallAlignedBoundary(
+    corrected: ArraySlice<Word>,
+    provisional: ArraySlice<Word>
+  ) -> Int? {
+    guard provisional.count >= corrected.count else { return nil }
+    let corrected = Array(corrected)
+    let provisional = Array(provisional)
+
+    let maximumSubstitutions = 8
+    let substitutions = zip(corrected, provisional).filter { $0.0.value != $0.1.value }.count
+    guard substitutions <= maximumSubstitutions else { return nil }
+    guard !hasCompoundAlignment(corrected: corrected, provisional: provisional) else { return nil }
+
+    // The positional comparison gives an upper bound at corrected.count. With
+    // no compound transitions, a path of that cost cannot leave this band.
+    let infinity = substitutions + 1
+    var costs = Array(repeating: infinity, count: provisional.count + 1)
+    var next = costs
+    for column in 0...min(substitutions, provisional.count) { costs[column] = column }
+    var previousLower = 0
+    var previousUpper = min(substitutions, provisional.count)
+
+    for (rowIndex, word) in corrected.enumerated() {
+      let row = rowIndex + 1
+      let lower = max(0, row - substitutions)
+      let upper = min(provisional.count, row + substitutions)
+      for column in lower...upper { next[column] = infinity }
+      if lower == 0 { next[0] = row }
+
+      if upper >= max(1, lower) {
+        for column in max(1, lower)...upper {
+          let deletion = column >= previousLower && column <= previousUpper
+            ? costs[column] + 1
+            : infinity
+          let insertion = column - 1 >= lower ? next[column - 1] + 1 : infinity
+          let substitution = column - 1 >= previousLower && column - 1 <= previousUpper
+            ? costs[column - 1] + (word.value == provisional[column - 1].value ? 0 : 1)
+            : infinity
+          next[column] = min(deletion, insertion, substitution)
+        }
+      }
+      swap(&costs, &next)
+      previousLower = lower
+      previousUpper = upper
+    }
+
+    var minimum = infinity
+    var boundary = corrected.count
+    for column in previousLower...previousUpper where costs[column] <= minimum {
+      minimum = costs[column]
+      boundary = column
+    }
+    return boundary
+  }
+
+  private static func hasCompoundAlignment(
+    corrected: [Word],
+    provisional: [Word]
+  ) -> Bool {
+    let correctedValues = Set(corrected.map(\.value))
+    for index in provisional.indices.dropFirst()
+    where correctedValues.contains(provisional[index - 1].value + provisional[index].value) {
+      return true
+    }
+
+    let provisionalValues = Set(provisional.map(\.value))
+    for index in corrected.indices.dropFirst()
+    where provisionalValues.contains(corrected[index - 1].value + corrected[index].value) {
+      return true
+    }
+    return false
+  }
+
+  private struct Word {
+    let value: String
+    let range: Range<String.Index>
+  }
+
+  private static func words(in text: String) -> [Word] {
+    let tokenizer = NLTokenizer(unit: .word)
+    tokenizer.string = text
+    return tokenizer.tokens(for: text.startIndex..<text.endIndex).map {
+      Word(value: text[$0].lowercased(), range: $0)
+    }
+  }
+}

--- a/apps/mobile/modules/t3-native-controls/ios/VoiceTranscription.swift
+++ b/apps/mobile/modules/t3-native-controls/ios/VoiceTranscription.swift
@@ -1,0 +1,154 @@
+import AVFoundation
+import Speech
+
+enum LiveVoiceError: Error {
+  case unavailable, busy, audioFormat
+}
+
+/// Runs both on-device recognizers over the same audio, with no periodic forced finalization.
+@available(iOS 26.0, macOS 26.0, *)
+@MainActor
+final class VoiceTranscription {
+  private let emit: (String) -> Void
+  private let interrupted: () -> Void
+  private var analyzer: SpeechAnalyzer?
+  private var correctedTask: Task<Void, Error>?
+  private var provisionalTask: Task<Void, Error>?
+  private var corrected = VoiceTranscript()
+  private var provisional = VoiceTranscript()
+  private var lastEmission = ""
+  private var revision = 0
+  private var cancelled = false
+  private var ending = false
+
+  init(emit: @escaping (String) -> Void, interrupted: @escaping () -> Void) {
+    self.emit = emit
+    self.interrupted = interrupted
+  }
+
+  private static func modules(locale: Locale) async -> (SpeechTranscriber, DictationTranscriber?) {
+    let corrected = SpeechTranscriber(locale: locale, preset: .progressiveTranscription)
+    let fastLocale = await DictationTranscriber.supportedLocale(equivalentTo: locale)
+    let provisional = fastLocale.map { DictationTranscriber(locale: $0, preset: .progressiveLongDictation) }
+    return (corrected, provisional)
+  }
+
+  static func prepare(locale: String) async throws -> String? {
+    guard SpeechTranscriber.isAvailable,
+      let supported = await SpeechTranscriber.supportedLocale(equivalentTo: Locale(identifier: locale))
+    else { return nil }
+    let (corrected, provisional) = await modules(locale: supported)
+    var modules: [any SpeechModule] = [corrected]
+    if let provisional { modules.append(provisional) }
+    if let install = try await AssetInventory.assetInstallationRequest(supporting: modules) {
+      try await install.downloadAndInstall()
+    }
+    return supported.identifier
+  }
+
+  func start(input: AsyncStream<AnalyzerInput>, locale: String) async throws -> AVAudioFormat {
+    let (corrected, provisional) = await Self.modules(locale: Locale(identifier: locale))
+    try checkActive()
+    var modules: [any SpeechModule] = [corrected]
+    if let provisional { modules.append(provisional) }
+    let analyzer = SpeechAnalyzer(
+      modules: modules, options: .init(priority: .userInitiated, modelRetention: .lingering)
+    )
+    self.analyzer = analyzer
+    guard let format = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: modules)
+    else { throw LiveVoiceError.audioFormat }
+    try await analyzer.prepareToAnalyze(in: format)
+    try checkActive()
+    correctedTask = collect(
+      corrected.results, isCorrection: true, text: { String($0.text.characters) }
+    )
+    if let provisional {
+      provisionalTask = collect(
+        provisional.results, isCorrection: false, text: { String($0.text.characters) }
+      )
+    }
+    try await analyzer.start(inputSequence: input)
+    try checkActive()
+    return format
+  }
+
+  private func collect<Results: AsyncSequence & Sendable>(
+    _ results: Results, isCorrection: Bool, text: @escaping (Results.Element) -> String
+  ) -> Task<Void, Error> where Results.Element: SpeechModuleResult {
+    Task(priority: .userInitiated) { @MainActor [weak self] in
+      do {
+        for try await result in results {
+          guard let self else { return }
+          try checkActive()
+          let text = text(result)
+          if isCorrection {
+            corrected.update(text: text, range: result.range)
+          } else {
+            provisional.update(text: text, range: result.range)
+          }
+          revision += 1
+          let currentRevision = revision
+          let correctedText = corrected.text
+          let provisionalText = provisional.text
+          // Long recordings must not spend their alignment time on the UI thread.
+          let draft = await Task.detached(priority: .userInitiated) {
+            VoiceDraft.merge(corrected: correctedText, provisional: provisionalText)
+          }.value
+          try checkActive()
+          if currentRevision == revision { publish(draft) }
+        }
+      } catch {
+        guard isCorrection else { return }
+        if let self, !ending, !cancelled { interrupted() }
+        throw error
+      }
+    }
+  }
+
+  func finish() async throws -> String {
+    ending = true
+    try checkActive()
+    try await analyzer?.finalizeAndFinishThroughEndOfInput()
+    try await finishVoiceCollectors(corrected: correctedTask, provisional: provisionalTask)
+    try checkActive()
+    analyzer = nil
+    correctedTask = nil
+    provisionalTask = nil
+    // Once all audio is processed, only the newer model decides the final transcript.
+    let text = corrected.text
+    publish(text)
+    return text
+  }
+
+  func cancel() async {
+    cancelled = true
+    ending = true
+    correctedTask?.cancel()
+    provisionalTask?.cancel()
+    await analyzer?.cancelAndFinishNow()
+    _ = try? await correctedTask?.value
+    _ = try? await provisionalTask?.value
+    correctedTask = nil
+    provisionalTask = nil
+    analyzer = nil
+  }
+
+  private func checkActive() throws {
+    if cancelled { throw CancellationError() }
+    try Task.checkCancellation()
+  }
+
+  private func publish(_ text: String) {
+    guard text != lastEmission else { return }
+    lastEmission = text
+    emit(text)
+  }
+}
+
+/// The corrected recognizer owns final output. The faster provisional stream is optional.
+func finishVoiceCollectors(
+  corrected: Task<Void, Error>?, provisional: Task<Void, Error>?
+) async throws {
+  if let corrected { try await corrected.value }
+  if let provisional { _ = try? await provisional.value }
+}

--- a/apps/mobile/scripts/voice-transcription-tests.swift
+++ b/apps/mobile/scripts/voice-transcription-tests.swift
@@ -1,0 +1,350 @@
+import AVFoundation
+import Foundation
+import NaturalLanguage
+import Speech
+
+@main
+struct VoiceTranscriptionTests {
+  @MainActor
+  static func main() async throws {
+    testDrafts()
+    testDraftParity()
+    testPassages()
+    try await testCollectorFailures()
+    if CommandLine.arguments.count > 1 {
+      try await replay(URL(fileURLWithPath: CommandLine.arguments[1]))
+    }
+    print("PASS: native voice transcription tests")
+  }
+
+  static func testCollectorFailures() async throws {
+    enum CollectorFailure: Error { case failed }
+
+    try await finishVoiceCollectors(
+      corrected: Task {},
+      provisional: Task { throw CollectorFailure.failed }
+    )
+
+    do {
+      try await finishVoiceCollectors(
+        corrected: Task { throw CollectorFailure.failed },
+        provisional: Task {}
+      )
+      preconditionFailure("A corrected-recognizer failure must fail finalization")
+    } catch CollectorFailure.failed {}
+
+    print("PASS: provisional collector failure does not reject corrected finalization")
+  }
+
+  static func testDrafts() {
+    let cases = [
+      ("", "Please show", "Please show"),
+      ("Please show", "", "Please show"),
+      ("Please", "Please show the words", "Please show the words"),
+      ("Please show the words.", "Please show", "Please show the words."),
+      ("Use exponential backoff", "Use exponential backup and retry", "Use exponential backoff and retry"),
+      ("Use exponential backoff", "Use exponential backup and retry twice", "Use exponential backoff and retry twice"),
+      ("Change the timeout", "Change the time out to five seconds", "Change the timeout to five seconds"),
+      ("Use back off", "Use backoff and retry", "Use back off and retry"),
+      ("Please run tests", "Please run the tests now", "Please run tests now"),
+      ("Please run the tests", "Please run tests now", "Please run the tests now"),
+      ("I said go", "I said go go again", "I said go go again"),
+      ("Send it. Then wait", "Send it then wait for me", "Send it. Then wait for me"),
+      ("That works.", "That works. Keep going", "That works. Keep going"),
+      ("Hello, world!", "hello world and goodbye", "Hello, world! and goodbye"),
+      ("Hello", "Hello, world", "Hello, world"),
+      ("你好世界", "你好世界今天很好", "你好世界今天很好"),
+      ("Привет мир", "Привет мир сегодня", "Привет мир сегодня")
+    ]
+    for (corrected, provisional, expected) in cases {
+      let actual = VoiceDraft.merge(corrected: corrected, provisional: provisional)
+      precondition(actual == expected, "Merge: \(actual) != \(expected)")
+    }
+    let prefix = Array(repeating: "please run the tests", count: 250).joined(separator: " ")
+    let corrected = "Use backoff " + prefix
+    let provisional = "Use backup " + prefix + " and report the result"
+    let start = ProcessInfo.processInfo.systemUptime
+    precondition(VoiceDraft.merge(corrected: corrected, provisional: provisional) == corrected + " and report the result")
+    print("Long draft merge: \(ProcessInfo.processInfo.systemUptime - start)s")
+  }
+
+  static func testDraftParity() {
+    let retainedTail = VoiceDraft.merge(
+      corrected: "Repair the repeated go go command",
+      provisional: "Prepare the repeated go go command and keep the unfinished tail"
+    )
+    precondition(retainedTail == "Repair the repeated go go command and keep the unfinished tail")
+
+    let longWords = (0..<750).map { "token\($0)" }
+    var correctedLongWords = Array(longWords.dropLast(8))
+    var provisionalLongWords = longWords
+    correctedLongWords[0] = "repair0"
+    provisionalLongWords[0] = "prepare0"
+    let correctedLong = correctedLongWords.joined(separator: " ")
+    let provisionalLong = provisionalLongWords.joined(separator: " ")
+    precondition(
+      VoiceDraft.merge(corrected: correctedLong, provisional: provisionalLong) ==
+        OriginalVoiceDraft.merge(corrected: correctedLong, provisional: provisionalLong)
+    )
+
+    func requireLongParity(_ correctedWords: [String], _ provisionalWords: [String], name: String) {
+      let corrected = correctedWords.joined(separator: " ")
+      let provisional = provisionalWords.joined(separator: " ")
+      let expected = OriginalVoiceDraft.merge(corrected: corrected, provisional: provisional)
+      let actual = VoiceDraft.merge(corrected: corrected, provisional: provisional)
+      precondition(actual == expected, "Long \(name) merge: \(actual) != \(expected)")
+    }
+
+    // A repeated tail gives the final matrix row the same minimum at two
+    // boundaries. The merge must retain the original last-minimum choice.
+    requireLongParity(
+      ["stop"] + Array(repeating: "go", count: 79),
+      Array(repeating: "go", count: 88),
+      name: "repeated tie"
+    )
+
+    var balancedCorrected = (0..<80).map { "balanced\($0)" }
+    let balancedProvisional = balancedCorrected + (0..<8).map { "retained\($0)" }
+    balancedCorrected.remove(at: 1)
+    balancedCorrected.insert("replacement", at: 70)
+    requireLongParity(balancedCorrected, balancedProvisional, name: "balanced insert-delete")
+
+    let punctuatedCorrectedWords = ["repair0"] + (1..<80).map { "punctuated\($0)" }
+    let punctuatedProvisionalWords = ["prepare0"] + (1..<80).map { "punctuated\($0)" }
+    let punctuatedCorrected = punctuatedCorrectedWords.joined(separator: " ")
+    let punctuatedProvisional = punctuatedProvisionalWords.joined(separator: " ") + ", keep going"
+    precondition(
+      VoiceDraft.merge(corrected: punctuatedCorrected, provisional: punctuatedProvisional) ==
+        punctuatedCorrected + ", keep going",
+      "Long optimized merge must preserve tail punctuation"
+    )
+
+    let compoundCorrected = ["timeout"] + (1..<80).map { "compound\($0)" }
+    let compoundProvisional = ["time", "out"] + (1..<80).map { "compound\($0)" } +
+      (0..<8).map { "retainedCompound\($0)" }
+    requireLongParity(compoundCorrected, compoundProvisional, name: "compound fallback")
+
+    var random = DeterministicRandom(state: 0x9879_C0DE)
+    let vocabulary = ["go", "go", "time", "out", "timeout", "repair", "prepare", "the", "tail"]
+    for sample in 0..<2_000 {
+      let provisionalCount = random.integer(in: 1...40)
+      var provisional = (0..<provisionalCount).map { _ in random.element(vocabulary) }
+      var corrected = provisional
+      for _ in 0..<random.integer(in: 0...5) {
+        switch random.integer(in: 0...2) {
+        case 0 where !corrected.isEmpty:
+          corrected[random.integer(in: 0...(corrected.count - 1))] = random.element(vocabulary)
+        case 1 where corrected.count > 1:
+          corrected.remove(at: random.integer(in: 0...(corrected.count - 1)))
+        default:
+          corrected.insert(random.element(vocabulary), at: random.integer(in: 0...corrected.count))
+        }
+      }
+      if random.integer(in: 0...1) == 0, !provisional.isEmpty { provisional[0] = "prepare" }
+      let correctedText = corrected.joined(separator: sample.isMultiple(of: 3) ? "  " : " ")
+      let provisionalText = provisional.joined(separator: sample.isMultiple(of: 5) ? "  " : " ")
+      let expected = OriginalVoiceDraft.merge(
+        corrected: correctedText,
+        provisional: provisionalText
+      )
+      let actual = VoiceDraft.merge(corrected: correctedText, provisional: provisionalText)
+      precondition(actual == expected, "Random merge \(sample): \(actual) != \(expected)")
+    }
+
+    for sample in 0..<500 {
+      let correctedCount = random.integer(in: 64...220)
+      let provisionalCount = correctedCount + random.integer(in: 0...12)
+      var provisional = (0..<provisionalCount).map { "token\($0)" }
+      var corrected = Array(provisional.prefix(correctedCount))
+      for edit in 0..<random.integer(in: 1...8) {
+        corrected[random.integer(in: 0...(corrected.count - 1))] = "changed\(sample)_\(edit)"
+      }
+      if sample.isMultiple(of: 2) { provisional.append("retainedTail\(sample)") }
+      let correctedText = corrected.joined(separator: " ")
+      let provisionalText = provisional.joined(separator: " ")
+      let expected = OriginalVoiceDraft.merge(
+        corrected: correctedText,
+        provisional: provisionalText
+      )
+      let actual = VoiceDraft.merge(corrected: correctedText, provisional: provisionalText)
+      precondition(actual == expected, "Aligned random merge \(sample): \(actual) != \(expected)")
+    }
+    print("PASS: optimized draft merge matches 3 long and 2,500 randomized original outputs")
+  }
+
+  static func testPassages() {
+    var transcript = VoiceTranscript()
+    func range(_ start: Double, _ end: Double) -> CMTimeRange {
+      CMTimeRange(start: CMTime(seconds: start, preferredTimescale: 1000),
+                  end: CMTime(seconds: end, preferredTimescale: 1000))
+    }
+    transcript.update(text: "Please show", range: range(0, 1))
+    transcript.update(text: "Please show the words.", range: range(0, 2))
+    transcript.update(text: " Keep", range: range(2, 3))
+    // A subsequent passage can implicitly finalize the previous one without an isFinal event.
+    precondition(transcript.text == "Please show the words. Keep")
+    transcript.update(text: " Keep talking.", range: range(2, 4))
+    precondition(transcript.text == "Please show the words. Keep talking.")
+    transcript.update(text: "", range: range(2, 4))
+    precondition(transcript.text == "Please show the words.")
+  }
+
+  @MainActor
+  static func replay(_ url: URL) async throws {
+    let (input, continuation) = AsyncStream<AnalyzerInput>.makeStream()
+    var events: [[String: Any]] = []
+    var start = ProcessInfo.processInfo.systemUptime
+    var interrupted = false
+    let transcription = VoiceTranscription(emit: { text in
+      let event: [String: Any] = ["seconds": ProcessInfo.processInfo.systemUptime - start, "text": text]
+      events.append(event)
+      print(String(data: try! JSONSerialization.data(withJSONObject: event, options: [.sortedKeys]), encoding: .utf8)!)
+    }, interrupted: { interrupted = true })
+    let format = try await transcription.start(input: input, locale: "en-US")
+    let file = try AVAudioFile(forReading: url)
+    let source = file.processingFormat
+    let converter = AVAudioConverter(from: source, to: format)!
+    converter.primeMethod = .none
+    start = ProcessInfo.processInfo.systemUptime
+    let frames = AVAudioFrameCount(source.sampleRate * 0.0213333333)
+    while file.framePosition < file.length {
+      let buffer = AVAudioPCMBuffer(pcmFormat: source, frameCapacity: frames)!
+      try file.read(into: buffer)
+      let capacity = AVAudioFrameCount(ceil(Double(buffer.frameLength) * format.sampleRate / source.sampleRate) + 64)
+      let output = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: capacity)!
+      let chunk = InputChunk(buffer)
+      var error: NSError?
+      let status = converter.convert(to: output, error: &error) { _, status in
+        guard let buffer = chunk.take() else { status.pointee = .noDataNow; return nil }
+        status.pointee = .haveData
+        return buffer
+      }
+      precondition(status != .error && error == nil)
+      if output.frameLength > 0 { continuation.yield(AnalyzerInput(buffer: output)) }
+      let audioTime = Double(file.framePosition) / source.sampleRate
+      if CommandLine.arguments.contains("--cancel"), audioTime >= 1.5 {
+        continuation.finish()
+        let count = events.count
+        await transcription.cancel()
+        do {
+          _ = try await transcription.finish()
+          preconditionFailure("Cancelled live recording returned a transcript")
+        } catch is CancellationError {}
+        precondition(events.count == count && !interrupted)
+        print("PASS: cancellation during live recognition suppressed late text")
+        return
+      }
+      let remaining = audioTime - (ProcessInfo.processInfo.systemUptime - start)
+      if remaining > 0 { try await Task.sleep(for: .seconds(remaining)) }
+    }
+    let liveText = events.last?["text"] as? String ?? ""
+    continuation.finish()
+    let finishStarted = ProcessInfo.processInfo.systemUptime
+    let final = try await transcription.finish()
+    precondition(!interrupted)
+    if let index = CommandLine.arguments.firstIndex(of: "--expect") {
+      let expected = try String(contentsOfFile: CommandLine.arguments[index + 1], encoding: .utf8)
+      func words(_ text: String) -> [String] {
+        text.lowercased().components(separatedBy: CharacterSet.alphanumerics.inverted).filter { !$0.isEmpty }
+      }
+      let expectedWords = words(expected)
+      precondition(words(final) == expectedWords, "Final transcription differs from the spoken fixture")
+      let livePrefix = zip(words(liveText), expectedWords).prefix { $0 == $1 }.count
+      precondition(Double(livePrefix) / Double(expectedWords.count) >= 0.9,
+                   "Live text lost the spoken sentence before Finish")
+      print("PASS: live and final transcripts retain the spoken fixture")
+    }
+    let summary: [String: Any] = ["transcript": final, "firstResultSeconds": events.first?["seconds"] ?? NSNull(),
+                                  "updates": events.count, "liveTranscriptBeforeFinish": liveText, "finishSeconds": ProcessInfo.processInfo.systemUptime - finishStarted]
+    print("SUMMARY " + String(data: try JSONSerialization.data(withJSONObject: summary, options: [.sortedKeys]), encoding: .utf8)!)
+    let count = events.count
+    await transcription.cancel()
+    do {
+      _ = try await transcription.finish()
+      preconditionFailure("Finishing a cancelled transcription must fail")
+    } catch is CancellationError {}
+    precondition(events.count == count, "Cancelled transcription emitted text")
+    let empty = VoiceTranscription(emit: { _ in preconditionFailure("Cancelled startup emitted text") }, interrupted: {})
+    await empty.cancel()
+    do {
+      _ = try await empty.start(input: AsyncStream { $0.finish() }, locale: "en-US")
+      preconditionFailure("Starting a cancelled transcription must fail")
+    } catch is CancellationError {}
+  }
+}
+
+private enum OriginalVoiceDraft {
+  private struct Word {
+    let value: String
+    let range: Range<String.Index>
+  }
+
+  static func merge(corrected: String, provisional: String) -> String {
+    let correctedWords = words(in: corrected)
+    let provisionalWords = words(in: provisional)
+    guard !correctedWords.isEmpty else { return provisional }
+    guard !provisionalWords.isEmpty else { return corrected }
+
+    var shared = 0
+    while shared < min(correctedWords.count, provisionalWords.count),
+      correctedWords[shared].value == provisionalWords[shared].value { shared += 1 }
+    let correctedTail = correctedWords.dropFirst(shared)
+    let provisionalTail = provisionalWords.dropFirst(shared)
+    var costs = Array(0...provisionalTail.count)
+    var precedingCosts = costs
+    for (row, word) in correctedTail.enumerated() {
+      var next = [row + 1]
+      for (column, candidate) in provisionalTail.enumerated() {
+        var cost = min(costs[column + 1] + 1, next[column] + 1,
+                       costs[column] + (word.value == candidate.value ? 0 : 1))
+        if column > 0, word.value == provisionalWords[shared + column - 1].value + candidate.value {
+          cost = min(cost, costs[column - 1])
+        }
+        if row > 0, correctedWords[shared + row - 1].value + word.value == candidate.value {
+          cost = min(cost, precedingCosts[column])
+        }
+        next.append(cost)
+      }
+      precedingCosts = costs
+      costs = next
+    }
+    let minimum = costs.min() ?? 0
+    let boundary = shared + (costs.lastIndex(of: minimum) ?? 0)
+    guard boundary < provisionalWords.count else { return corrected }
+    let tailStart = provisionalWords[boundary].range.lowerBound
+    let previousEnd = boundary > 0 ? provisionalWords[boundary - 1].range.upperBound : provisional.startIndex
+    let corrected = corrected.trimmingCharacters(in: .whitespacesAndNewlines)
+    let provisionalSeparator = provisional[previousEnd..<tailStart]
+    let separator = corrected.last?.isLetter == true || corrected.last?.isNumber == true
+      ? String(provisionalSeparator)
+      : provisionalSeparator.filter(\.isWhitespace)
+    return corrected + separator + provisional[tailStart...]
+  }
+
+  private static func words(in text: String) -> [Word] {
+    let tokenizer = NLTokenizer(unit: .word)
+    tokenizer.string = text
+    return tokenizer.tokens(for: text.startIndex..<text.endIndex).map {
+      Word(value: text[$0].lowercased(), range: $0)
+    }
+  }
+}
+
+private struct DeterministicRandom {
+  var state: UInt64
+
+  mutating func integer(in range: ClosedRange<Int>) -> Int {
+    state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+    return range.lowerBound + Int(state % UInt64(range.count))
+  }
+
+  mutating func element(_ values: [String]) -> String {
+    values[integer(in: 0...(values.count - 1))]
+  }
+}
+
+private final class InputChunk: @unchecked Sendable {
+  private var buffer: AVAudioPCMBuffer?
+  init(_ buffer: AVAudioPCMBuffer) { self.buffer = buffer }
+  func take() -> AVAudioPCMBuffer? { defer { buffer = nil }; return buffer }
+}

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -372,8 +372,9 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     voiceInput.elapsedSeconds,
   );
   const isVoiceInputPresented = voicePresentation.statusLabel !== null;
-  // An open draft stays visible; only a collapsed composer becomes a voice strip.
-  const isExpanded = isFocused || settingsSheetPresentation.keepsComposerExpanded;
+  // Keep live speech visible even when dictation starts with the keyboard closed.
+  const isExpanded =
+    isFocused || settingsSheetPresentation.keepsComposerExpanded || voiceInput.isBusy;
   const showsCompactDictation = isVoiceInputPresented && !isExpanded;
   const isToolbarVisible = isExpanded || isVoiceInputPresented;
   const attachmentBlockReason = composerAttachmentUploadBlockReason({
@@ -429,11 +430,16 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
 
   const handleBlur = useCallback(() => {
     setIsFocused(false);
-    if (!settingsSheetPresentation.keepsComposerExpanded) {
+    if (!settingsSheetPresentation.keepsComposerExpanded && !voiceInput.isBusy) {
       onExpandedChange?.(false);
     }
     onEditorFocusChange?.(false);
-  }, [onEditorFocusChange, onExpandedChange, settingsSheetPresentation.keepsComposerExpanded]);
+  }, [
+    onEditorFocusChange,
+    onExpandedChange,
+    settingsSheetPresentation.keepsComposerExpanded,
+    voiceInput.isBusy,
+  ]);
   const handleSend = useCallback(async () => {
     // Typed out in full rather than picked from the menu. Attachments mean the
     // user is sending a prompt, so those go through as usual.

--- a/apps/mobile/src/features/voice-input/useVoiceInputController.ts
+++ b/apps/mobile/src/features/voice-input/useVoiceInputController.ts
@@ -23,6 +23,10 @@ import {
   type VoiceDraftSnapshot,
   type VoiceInputState,
 } from "@t3tools/client-runtime/voice-input";
+import {
+  reconcileVoiceDraftRender,
+  type VoiceDraftRenderSnapshot,
+} from "./voiceDraftRenderReconciliation";
 import { normalizeVoiceInputDecibels, VOICE_WAVEFORM_SAMPLE_COUNT } from "./voiceInputMetering";
 
 const INITIAL_STATE: VoiceInputState = { phase: "idle", error: null, errorAction: null };
@@ -75,17 +79,43 @@ export function useVoiceInputController(input: {
   const audioLevelsRef = useRef(Array<number>(VOICE_WAVEFORM_SAMPLE_COUNT).fill(0));
   const audioLevels = useSharedValue(audioLevelsRef.current);
   const controllerRef = useRef<VoiceInputController | null>(null);
-  const previousDraftRef = useRef({ ownerKey: input.ownerKey, text: input.draftMessage });
   const revisionRef = useRef(0);
-  if (
-    previousDraftRef.current.ownerKey !== input.ownerKey ||
-    previousDraftRef.current.text !== input.draftMessage
-  ) {
-    previousDraftRef.current = { ownerKey: input.ownerKey, text: input.draftMessage };
-    revisionRef.current += 1;
-  }
   const latestInputRef = useRef(input);
-  latestInputRef.current = input;
+  const acknowledgedDraftsRef = useRef<VoiceDraftRenderSnapshot[]>([]);
+  const renderedDraftRef = useRef<VoiceDraftRenderSnapshot>({
+    ownerKey: input.ownerKey,
+    text: input.draftMessage,
+    selection: input.selection,
+  });
+  const reconciledDraft = reconcileVoiceDraftRender(
+    renderedDraftRef.current,
+    {
+      ownerKey: latestInputRef.current.ownerKey,
+      text: latestInputRef.current.draftMessage,
+      selection: latestInputRef.current.selection,
+    },
+    {
+      ownerKey: input.ownerKey,
+      text: input.draftMessage,
+      selection: input.selection,
+    },
+    acknowledgedDraftsRef.current,
+  );
+  if (reconciledDraft.externalDraftChange) revisionRef.current += 1;
+  acknowledgedDraftsRef.current = reconciledDraft.externalDraftChange
+    ? []
+    : acknowledgedDraftsRef.current.slice(reconciledDraft.consumedAcknowledgements);
+  renderedDraftRef.current = {
+    ownerKey: input.ownerKey,
+    text: input.draftMessage,
+    selection: input.selection,
+  };
+  latestInputRef.current = {
+    ...input,
+    ownerKey: reconciledDraft.current.ownerKey,
+    draftMessage: reconciledDraft.current.text,
+    selection: reconciledDraft.current.selection,
+  };
 
   const handleRecorderStatus = useCallback((status: RecordingStatus) => {
     controllerRef.current?.handleRecorderStatus({
@@ -120,6 +150,11 @@ export function useVoiceInputController(input: {
       },
       commitDraft: (text, selection) => {
         const current = latestInputRef.current;
+        // Native hypotheses may arrive before React renders the previous one.
+        // Acknowledge our own write synchronously, preserving stale-edit detection.
+        revisionRef.current += 1;
+        acknowledgedDraftsRef.current.push({ ownerKey: current.ownerKey, text, selection });
+        latestInputRef.current = { ...current, draftMessage: text, selection };
         current.onChangeSelection(selection);
         current.onChangeDraftMessage(text);
       },
@@ -171,7 +206,7 @@ export function useVoiceInputController(input: {
 
     const sampleRecording = () => {
       if (controller.currentState.phase !== "recording") return;
-      const status = recorder.getStatus();
+      const status = controller.streamingStatus ?? recorder.getStatus();
       if (!status.isRecording) return;
 
       const level = normalizeVoiceInputDecibels(status.metering);

--- a/apps/mobile/src/features/voice-input/voiceDraftRenderReconciliation.test.ts
+++ b/apps/mobile/src/features/voice-input/voiceDraftRenderReconciliation.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  reconcileVoiceDraftRender,
+  type VoiceDraftRenderSnapshot,
+} from "./voiceDraftRenderReconciliation";
+
+const rendered: VoiceDraftRenderSnapshot = {
+  ownerKey: "environment:thread",
+  text: "before",
+  selection: { start: 6, end: 6 },
+};
+
+describe("reconcileVoiceDraftRender", () => {
+  it("keeps an acknowledged hypothesis through stale unrelated renders and its parent echo", () => {
+    const acknowledged: VoiceDraftRenderSnapshot = {
+      ...rendered,
+      text: "before spoken words",
+      selection: { start: 19, end: 19 },
+    };
+
+    const staleRender = reconcileVoiceDraftRender(rendered, acknowledged, rendered, [acknowledged]);
+    expect(staleRender).toEqual({
+      current: acknowledged,
+      externalDraftChange: false,
+      consumedAcknowledgements: 0,
+    });
+
+    const selectionEcho = reconcileVoiceDraftRender(
+      rendered,
+      acknowledged,
+      {
+        ...rendered,
+        selection: acknowledged.selection,
+      },
+      [acknowledged],
+    );
+    expect(selectionEcho).toEqual({
+      current: acknowledged,
+      externalDraftChange: false,
+      consumedAcknowledgements: 0,
+    });
+
+    const draftEcho = reconcileVoiceDraftRender(
+      rendered,
+      acknowledged,
+      {
+        ...acknowledged,
+        selection: rendered.selection,
+      },
+      [acknowledged],
+    );
+    expect(draftEcho).toEqual({
+      current: acknowledged,
+      externalDraftChange: false,
+      consumedAcknowledgements: 1,
+    });
+  });
+
+  it("does not mistake an older acknowledged hypothesis for an external edit", () => {
+    const first = { ...rendered, text: "before one" };
+    const second = { ...rendered, text: "before one two" };
+
+    expect(reconcileVoiceDraftRender(rendered, second, first, [first, second])).toEqual({
+      current: second,
+      externalDraftChange: false,
+      consumedAcknowledgements: 1,
+    });
+  });
+
+  it("accepts a real external draft edit", () => {
+    const reconciled = reconcileVoiceDraftRender(
+      rendered,
+      { ...rendered, text: "before spoken words" },
+      {
+        ...rendered,
+        text: "manual edit",
+        selection: { start: 11, end: 11 },
+      },
+      [{ ...rendered, text: "before spoken words" }],
+    );
+
+    expect(reconciled).toEqual({
+      current: {
+        ...rendered,
+        text: "manual edit",
+        selection: { start: 11, end: 11 },
+      },
+      externalDraftChange: true,
+      consumedAcknowledgements: 1,
+    });
+  });
+});

--- a/apps/mobile/src/features/voice-input/voiceDraftRenderReconciliation.ts
+++ b/apps/mobile/src/features/voice-input/voiceDraftRenderReconciliation.ts
@@ -1,0 +1,68 @@
+type Selection = {
+  readonly start: number;
+  readonly end: number;
+};
+
+export type VoiceDraftRenderSnapshot = {
+  readonly ownerKey: string | null;
+  readonly text: string;
+  readonly selection: Selection;
+};
+
+function sameDraft(left: VoiceDraftRenderSnapshot, right: VoiceDraftRenderSnapshot): boolean {
+  return left.ownerKey === right.ownerKey && left.text === right.text;
+}
+
+function sameSelection(left: Selection, right: Selection): boolean {
+  return left.start === right.start && left.end === right.end;
+}
+
+export function reconcileVoiceDraftRender(
+  rendered: VoiceDraftRenderSnapshot,
+  current: VoiceDraftRenderSnapshot,
+  incoming: VoiceDraftRenderSnapshot,
+  acknowledged: readonly VoiceDraftRenderSnapshot[],
+): {
+  readonly current: VoiceDraftRenderSnapshot;
+  readonly externalDraftChange: boolean;
+  readonly consumedAcknowledgements: number;
+} {
+  if (!sameDraft(rendered, incoming)) {
+    const acknowledgedIndex = acknowledged.findIndex((snapshot) => sameDraft(snapshot, incoming));
+    if (!sameDraft(current, incoming) && acknowledgedIndex === -1) {
+      return {
+        current: incoming,
+        externalDraftChange: true,
+        consumedAcknowledgements: acknowledged.length,
+      };
+    }
+    if (!sameDraft(current, incoming)) {
+      return {
+        current,
+        externalDraftChange: false,
+        consumedAcknowledgements: acknowledgedIndex + 1,
+      };
+    }
+    return {
+      current: {
+        ...incoming,
+        selection: sameSelection(rendered.selection, incoming.selection)
+          ? current.selection
+          : incoming.selection,
+      },
+      externalDraftChange: false,
+      consumedAcknowledgements: acknowledgedIndex + 1,
+    };
+  }
+
+  return {
+    current: {
+      ...current,
+      selection: sameSelection(rendered.selection, incoming.selection)
+        ? current.selection
+        : incoming.selection,
+    },
+    externalDraftChange: false,
+    consumedAcknowledgements: 0,
+  };
+}

--- a/apps/mobile/src/native/voiceNativeError.ios.ts
+++ b/apps/mobile/src/native/voiceNativeError.ios.ts
@@ -1,0 +1,39 @@
+import { VoiceTranscriptionError } from "@t3tools/client-runtime/voice-input";
+
+export function getNativeVoiceErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return undefined;
+  }
+
+  return typeof error.code === "string" ? error.code : undefined;
+}
+
+export function mapNativeVoiceError(
+  error: unknown,
+  phase: "preparation" | "transcription",
+): unknown {
+  if (error instanceof VoiceTranscriptionError) return error;
+
+  switch (getNativeVoiceErrorCode(error)) {
+    case "ERR_VOICE_UNAVAILABLE":
+      return new VoiceTranscriptionError(
+        "unavailable",
+        "Live voice transcription is unavailable.",
+        { cause: error },
+      );
+    case "ERR_VOICE_BUSY":
+      return new VoiceTranscriptionError(
+        phase === "preparation" ? "preparation-failed" : "transcription-failed",
+        "Another live voice transcription is already active.",
+        { cause: error },
+      );
+    case "ERR_VOICE_AUDIO_FORMAT":
+      return new VoiceTranscriptionError(
+        phase === "preparation" ? "preparation-failed" : "transcription-failed",
+        "Live voice transcription could not configure audio capture.",
+        { cause: error },
+      );
+    default:
+      return error;
+  }
+}

--- a/apps/mobile/src/native/voiceStreaming.ios.test.ts
+++ b/apps/mobile/src/native/voiceStreaming.ios.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  VoiceTranscriptionError,
+  type VoiceStreamingOptions,
+} from "@t3tools/client-runtime/voice-input";
+
+const native = vi.hoisted(() => ({
+  isAvailable: vi.fn(),
+  prepare: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+  cancel: vi.fn(),
+  addListener: vi.fn(),
+  remove: vi.fn(),
+}));
+vi.mock("expo", () => ({ requireOptionalNativeModule: () => native }));
+import {
+  startVoiceStreaming,
+  prepareVoiceStreaming,
+  isVoiceStreamingAvailable,
+} from "./voiceStreaming.ios";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  native.isAvailable.mockReturnValue(true);
+  native.prepare.mockResolvedValue("en-AU");
+  native.start.mockResolvedValue(undefined);
+  native.stop.mockResolvedValue("Final words.");
+  native.cancel.mockResolvedValue(undefined);
+  native.addListener.mockReturnValue({ remove: native.remove });
+});
+
+function options(): VoiceStreamingOptions {
+  return {
+    signal: new AbortController().signal,
+    onTranscript: vi.fn(),
+    onError: vi.fn(),
+    onEnd: vi.fn(),
+  };
+}
+
+it("delivers interim results before stop and ignores events belonging to another session", async () => {
+  const callbacks = options();
+  const session = await startVoiceStreaming("en-AU", 300, callbacks);
+  const id = native.start.mock.calls[0]![0];
+  const emit = native.addListener.mock.calls[0]![1];
+  emit({ sessionId: "old", transcript: "Old words" });
+  emit({ sessionId: id, transcript: "New words" });
+  expect(callbacks.onTranscript).toHaveBeenCalledExactlyOnceWith("New words");
+  expect(native.stop).not.toHaveBeenCalled();
+  await expect(session.stop()).resolves.toBe("Final words.");
+  emit({ sessionId: id, transcript: "Late words" });
+  expect(callbacks.onTranscript).toHaveBeenCalledTimes(1);
+  expect(native.remove).toHaveBeenCalled();
+});
+
+it("does not release cancellation during startup until native capture stops", async () => {
+  const started = deferred<void>();
+  const cancelled = deferred<void>();
+  native.start.mockReturnValue(started.promise);
+  native.cancel.mockReturnValue(cancelled.promise);
+  const abort = new AbortController();
+  const settled = vi.fn();
+  const result = startVoiceStreaming("en-AU", 300, { ...options(), signal: abort.signal }).then(
+    settled,
+    (error: unknown) => {
+      settled();
+      return error;
+    },
+  );
+  abort.abort();
+  expect(native.cancel).not.toHaveBeenCalled();
+  started.resolve();
+  // Drain promise reactions so the native cancellation boundary is reached.
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  expect(native.cancel).toHaveBeenCalledTimes(1);
+  expect(settled).not.toHaveBeenCalled();
+  cancelled.resolve();
+  await expect(result).resolves.toMatchObject({ code: "cancelled" });
+});
+
+it("cancels native capture before reporting a startup failure", async () => {
+  native.start.mockRejectedValueOnce(new Error("microphone unavailable"));
+
+  await expect(startVoiceStreaming("en-AU", 300, options())).rejects.toThrow(
+    "microphone unavailable",
+  );
+
+  expect(native.cancel).toHaveBeenCalledOnce();
+  expect(native.remove).toHaveBeenCalledOnce();
+});
+
+it.each([
+  ["ERR_VOICE_UNAVAILABLE", "unavailable", "unavailable"],
+  ["ERR_VOICE_BUSY", "transcription-failed", "already active"],
+  ["ERR_VOICE_AUDIO_FORMAT", "transcription-failed", "configure audio capture"],
+] as const)("maps native startup error %s", async (nativeCode, code, message) => {
+  native.start.mockRejectedValueOnce({ code: nativeCode });
+
+  const error = await startVoiceStreaming("en-AU", 300, options()).catch((cause: unknown) => cause);
+
+  expect(error).toBeInstanceOf(VoiceTranscriptionError);
+  expect(error).toMatchObject({ code });
+  expect(error).toHaveProperty("message", expect.stringContaining(message));
+  expect(native.cancel).toHaveBeenCalledOnce();
+});
+
+it("maps a native stop error after closing the streaming session", async () => {
+  native.stop.mockRejectedValueOnce({ code: "ERR_VOICE_AUDIO_FORMAT" });
+  const session = await startVoiceStreaming("en-AU", 300, options());
+
+  await expect(session.stop()).rejects.toMatchObject({
+    code: "transcription-failed",
+    message: expect.stringContaining("configure audio capture"),
+  });
+  expect(native.remove).toHaveBeenCalledOnce();
+});
+
+it("turns an error event during startup into a rejection after native cleanup", async () => {
+  const started = deferred<void>();
+  const cancellationEntered = deferred<void>();
+  const cancelled = deferred<void>();
+  native.start.mockReturnValue(started.promise);
+  native.cancel.mockImplementation(() => {
+    cancellationEntered.resolve();
+    return cancelled.promise;
+  });
+  const callbacks = options();
+  const settled = vi.fn();
+  const result = startVoiceStreaming("en-AU", 300, callbacks).then(settled, (error: unknown) => {
+    settled();
+    return error;
+  });
+  const emit = native.addListener.mock.calls[0]![1];
+  const sessionId = native.start.mock.calls[0]![0];
+
+  emit({ sessionId, error: "Live dictation was interrupted." });
+  expect(callbacks.onError).not.toHaveBeenCalled();
+  started.resolve();
+  await cancellationEntered.promise;
+  expect(native.cancel).toHaveBeenCalledOnce();
+  expect(settled).not.toHaveBeenCalled();
+  cancelled.resolve();
+
+  await expect(result).resolves.toMatchObject({ message: "Live dictation was interrupted." });
+});
+
+it("cancels native capture once and immediately suppresses late events", async () => {
+  const abort = new AbortController();
+  const callbacks = { ...options(), signal: abort.signal };
+  const session = await startVoiceStreaming("en-AU", 300, callbacks);
+  const emit = native.addListener.mock.calls[0]![1];
+  const sessionId = native.start.mock.calls[0]![0];
+  abort.abort();
+  emit({ sessionId, transcript: "Late" });
+  await session.cancel();
+  expect(native.cancel).toHaveBeenCalledTimes(1);
+  expect(callbacks.onTranscript).not.toHaveBeenCalled();
+});
+
+describe("capture events", () => {
+  it("reports real audio levels, recording limit, and interruptions", async () => {
+    const callbacks = options();
+    const session = await startVoiceStreaming("en-AU", 300, callbacks);
+    const emit = native.addListener.mock.calls[0]![1];
+    const sessionId = native.start.mock.calls[0]![0];
+    emit({ sessionId, durationMillis: 1800, metering: -20 });
+    expect(session.getStatus()).toEqual({ isRecording: true, durationMillis: 1800, metering: -20 });
+    emit({ sessionId, ended: true });
+    expect(callbacks.onEnd).toHaveBeenCalledOnce();
+    emit({ sessionId, error: "Interrupted" });
+    expect(callbacks.onError).toHaveBeenCalledWith("Interrupted");
+    await session.cancel();
+  });
+});
+
+it("prepares the streaming engine language and reports unsupported locales", async () => {
+  expect(isVoiceStreamingAvailable()).toBe(true);
+  await expect(prepareVoiceStreaming("en-AU", options())).resolves.toBe("en-AU");
+  native.prepare.mockResolvedValue(null);
+  await expect(prepareVoiceStreaming("unsupported", options())).rejects.toMatchObject({
+    code: "unsupported-locale",
+  });
+});
+
+it("rejects cancelled language preparation only after native work settles", async () => {
+  const prepared = deferred<string>();
+  native.prepare.mockReturnValue(prepared.promise);
+  const abort = new AbortController();
+  const settled = vi.fn();
+  const result = prepareVoiceStreaming("en-AU", { signal: abort.signal }).then(
+    settled,
+    (error: unknown) => {
+      settled();
+      return error;
+    },
+  );
+  abort.abort();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  expect(settled).not.toHaveBeenCalled();
+  prepared.resolve("en-AU");
+  await expect(result).resolves.toMatchObject({ code: "cancelled" });
+});

--- a/apps/mobile/src/native/voiceStreaming.ios.ts
+++ b/apps/mobile/src/native/voiceStreaming.ios.ts
@@ -1,0 +1,124 @@
+import { requireOptionalNativeModule } from "expo";
+import {
+  throwIfVoiceTranscriptionAborted,
+  VoiceTranscriptionError,
+  type VoiceTranscriptionOptions,
+  type VoiceStreamingOptions,
+  type VoiceStreamingSession,
+} from "@t3tools/client-runtime/voice-input";
+import { mapNativeVoiceError } from "./voiceNativeError.ios";
+
+type VoiceEvent = {
+  sessionId: string;
+  transcript?: string;
+  error?: string;
+  ended?: boolean;
+  durationMillis?: number;
+  metering?: number;
+};
+
+type NativeVoiceStreaming = {
+  isAvailable?: () => boolean;
+  prepare?: (locale: string) => Promise<string | null>;
+  start: (sessionId: string, locale: string, limitSeconds: number) => Promise<void>;
+  stop: (sessionId: string) => Promise<string>;
+  cancel: (sessionId: string) => Promise<void>;
+  addListener: (event: "onVoiceInput", listener: (event: VoiceEvent) => void) => { remove(): void };
+};
+
+const native = requireOptionalNativeModule<NativeVoiceStreaming>("T3VoiceInput");
+let sessionSequence = 0;
+
+export function isVoiceStreamingAvailable(): boolean {
+  return native?.isAvailable?.() === true;
+}
+
+export async function prepareVoiceStreaming(
+  locale: string,
+  { signal }: VoiceTranscriptionOptions,
+): Promise<string> {
+  throwIfVoiceTranscriptionAborted(signal);
+  if (!native?.prepare) throw new Error("Live dictation requires an updated app build.");
+  const supportedLocale = await native.prepare(locale);
+  throwIfVoiceTranscriptionAborted(signal);
+  if (!supportedLocale) {
+    throw new VoiceTranscriptionError(
+      "unsupported-locale",
+      "Dictation does not support this device language.",
+    );
+  }
+  return supportedLocale;
+}
+
+export async function startVoiceStreaming(
+  locale: string,
+  limitSeconds: number,
+  options: VoiceStreamingOptions,
+): Promise<VoiceStreamingSession> {
+  throwIfVoiceTranscriptionAborted(options.signal);
+  if (!native) throw new Error("Live dictation requires an updated app build.");
+  const module = native;
+  const sessionId = `voice-${++sessionSequence}`;
+  let status: ReturnType<VoiceStreamingSession["getStatus"]> = null;
+  let cancelPromise: Promise<void> | null = null;
+  let startupError: string | null = null;
+  let started = false;
+  let closed = false;
+  const subscription = module.addListener("onVoiceInput", (event) => {
+    if (closed || options.signal.aborted || event.sessionId !== sessionId) return;
+    if (event.transcript !== undefined) options.onTranscript(event.transcript);
+    if (event.durationMillis !== undefined) {
+      status = {
+        isRecording: true,
+        durationMillis: event.durationMillis,
+        metering: event.metering,
+      };
+    }
+    if (event.error) {
+      if (started) options.onError(event.error);
+      else startupError ??= event.error;
+    }
+    if (event.ended) options.onEnd();
+  });
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    status = null;
+    subscription.remove();
+    options.signal.removeEventListener("abort", onAbort);
+  };
+  const cancel = () => {
+    close();
+    cancelPromise ??= module.cancel(sessionId);
+    return cancelPromise;
+  };
+  const onAbort = () => {
+    void cancel().catch(() => undefined);
+  };
+  // Cancellation during startup settles only after the engine has finished starting.
+  try {
+    await module.start(sessionId, locale, limitSeconds);
+    throwIfVoiceTranscriptionAborted(options.signal);
+    if (startupError) throw new Error(startupError);
+    started = true;
+    options.signal.addEventListener("abort", onAbort, { once: true });
+    return {
+      getStatus: () => status,
+      cancel,
+      stop: async () => {
+        try {
+          const text = await module.stop(sessionId);
+          throwIfVoiceTranscriptionAborted(options.signal);
+          return text;
+        } catch (error) {
+          throw mapNativeVoiceError(error, "transcription");
+        } finally {
+          close();
+        }
+      },
+    };
+  } catch (error) {
+    await cancel().catch(() => undefined);
+    throw mapNativeVoiceError(error, "transcription");
+  }
+}

--- a/apps/mobile/src/native/voiceTranscription.ios.test.ts
+++ b/apps/mobile/src/native/voiceTranscription.ios.test.ts
@@ -4,8 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import { VoiceTranscriptionError } from "@t3tools/client-runtime/voice-input";
 
 const mocks = vi.hoisted(() => ({
+  streamingAvailable: true,
   isAvailable: vi.fn<(locale: string) => boolean>(),
   prepare: vi.fn<(locale: string) => Promise<string>>(),
+  prepareStreaming: vi.fn<(locale: string) => Promise<string>>(),
   transcribe: vi.fn<(audio: ArrayBufferLike, locale: string) => Promise<TranscriptionResult>>(),
   readAudio: vi.fn<() => Promise<ArrayBuffer>>(),
 }));
@@ -16,6 +18,12 @@ vi.mock("@react-native-ai/apple/src/NativeAppleTranscription", () => ({
     prepare: mocks.prepare,
     transcribe: mocks.transcribe,
   },
+}));
+
+vi.mock("./voiceStreaming.ios", () => ({
+  isVoiceStreamingAvailable: () => mocks.streamingAvailable,
+  prepareVoiceStreaming: (locale: string) => mocks.prepareStreaming(locale),
+  startVoiceStreaming: vi.fn(),
 }));
 
 vi.mock("expo-file-system", () => ({
@@ -45,8 +53,10 @@ function deferred<T>() {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  mocks.streamingAvailable = true;
   mocks.isAvailable.mockReturnValue(true);
   mocks.prepare.mockResolvedValue("sv-SE");
+  mocks.prepareStreaming.mockResolvedValue("sv-SE");
   mocks.readAudio.mockResolvedValue(audio);
   mocks.transcribe.mockResolvedValue(nativeTranscript);
 });
@@ -69,9 +79,51 @@ describe("getLocalVoiceTranscriber", () => {
     deviceLocale.mockReturnValue({ ...resolvedOptions, locale: "en-US" });
 
     await expect(prepared.transcribe("file:///voice.m4a", options)).resolves.toBe("Hej världen.");
-    expect(mocks.prepare).toHaveBeenCalledWith("sv-FI");
+    expect(mocks.prepareStreaming).toHaveBeenCalledWith("sv-FI");
     expect(prepared.locale).toBe("sv-SE");
     expect(mocks.transcribe).toHaveBeenCalledWith(audio, "sv-SE");
+  });
+
+  it("uses file transcription when live capture is unavailable", async () => {
+    mocks.streamingAvailable = false;
+    const options = { signal: new AbortController().signal };
+
+    const prepared = await getLocalVoiceTranscriber()!.prepare(options);
+
+    expect(mocks.prepare).toHaveBeenCalledWith(expect.any(String));
+    expect(mocks.prepareStreaming).not.toHaveBeenCalled();
+    expect(prepared.startStreaming).toBeUndefined();
+    await expect(prepared.transcribe("file:///voice.m4a", options)).resolves.toBe("Hej världen.");
+  });
+
+  it("uses file transcription when live preparation fails", async () => {
+    mocks.prepareStreaming.mockRejectedValueOnce(new Error("live unavailable"));
+    const options = { signal: new AbortController().signal };
+
+    const prepared = await getLocalVoiceTranscriber()!.prepare(options);
+
+    expect(mocks.prepare).toHaveBeenCalledWith(expect.any(String));
+    expect(prepared.startStreaming).toBeUndefined();
+  });
+
+  it("preserves the native unavailable classification when no fallback exists", async () => {
+    mocks.prepareStreaming.mockRejectedValueOnce({ code: "ERR_VOICE_UNAVAILABLE" });
+    mocks.isAvailable.mockReturnValue(false);
+    const options = { signal: new AbortController().signal };
+
+    const error = await getLocalVoiceTranscriber()!
+      .prepare(options)
+      .catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(VoiceTranscriptionError);
+    expect(error).toMatchObject({ code: "unavailable" });
+  });
+
+  it("does not advertise transcription when neither capture path is available", () => {
+    mocks.streamingAvailable = false;
+    mocks.isAvailable.mockReturnValue(false);
+
+    expect(getLocalVoiceTranscriber()).toBeNull();
   });
 
   it("does not start native transcription after cancellation during a file read", async () => {
@@ -98,12 +150,19 @@ describe("getLocalVoiceTranscriber", () => {
     expect(mocks.transcribe).not.toHaveBeenCalled();
   });
 
-  it.each(["prepare", "transcribe"] as const)(
+  it.each(["live prepare", "file prepare", "transcribe"] as const)(
     "waits for native %s to finish before settling cancellation",
     async (phase) => {
       const enteredNative = deferred<void>();
       const finishNative = deferred<void>();
-      if (phase === "prepare") {
+      if (phase === "live prepare") {
+        mocks.prepareStreaming.mockImplementation(async () => {
+          enteredNative.resolve();
+          await finishNative.promise;
+          return "sv-SE";
+        });
+      } else if (phase === "file prepare") {
+        mocks.streamingAvailable = false;
         mocks.prepare.mockImplementation(async () => {
           enteredNative.resolve();
           await finishNative.promise;
@@ -119,10 +178,9 @@ describe("getLocalVoiceTranscriber", () => {
       const controller = new AbortController();
       const options = { signal: controller.signal };
       const transcriber = getLocalVoiceTranscriber()!;
-      const operation =
-        phase === "prepare"
-          ? transcriber.prepare(options)
-          : (await transcriber.prepare(options)).transcribe("file:///voice.m4a", options);
+      const operation = phase.endsWith("prepare")
+        ? transcriber.prepare(options)
+        : (await transcriber.prepare(options)).transcribe("file:///voice.m4a", options);
       const settled = vi.fn((value: unknown) => value);
       const result = operation.then(settled, settled);
 

--- a/apps/mobile/src/native/voiceTranscription.ios.ts
+++ b/apps/mobile/src/native/voiceTranscription.ios.ts
@@ -1,8 +1,15 @@
+import {
+  isVoiceStreamingAvailable,
+  prepareVoiceStreaming,
+  startVoiceStreaming,
+} from "./voiceStreaming.ios";
+import { getNativeVoiceErrorCode, mapNativeVoiceError } from "./voiceNativeError.ios";
 import AppleTranscription from "@react-native-ai/apple/src/NativeAppleTranscription";
 import { File } from "expo-file-system";
 
 import {
   VoiceTranscriptionError,
+  VOICE_RECORDING_LIMIT_SECONDS,
   throwIfVoiceTranscriptionAborted,
   type PreparedVoiceTranscription,
   type VoiceTranscriber,
@@ -25,21 +32,40 @@ function wrapError(
   return new VoiceTranscriptionError(code, message, { cause });
 }
 
-function getNativeErrorCode(error: unknown): string | undefined {
-  if (typeof error !== "object" || error === null || !("code" in error)) {
-    return undefined;
-  }
-
-  return typeof error.code === "string" ? error.code : undefined;
-}
-
 export function getLocalVoiceTranscriber(): VoiceTranscriber | null {
   const locale = getDeviceLocale();
-  if (!AppleTranscription.isAvailable(locale)) return null;
+  if (!isVoiceStreamingAvailable() && !AppleTranscription.isAvailable(locale)) return null;
   return { prepare: (options) => prepareVoiceTranscription(locale, options) };
 }
 
 async function prepareVoiceTranscription(
+  locale: string,
+  { signal }: VoiceTranscriptionOptions,
+): Promise<PreparedVoiceTranscription> {
+  throwIfVoiceTranscriptionAborted(signal);
+  if (isVoiceStreamingAvailable()) {
+    try {
+      const supportedLocale = await prepareVoiceStreaming(locale, { signal });
+      throwIfVoiceTranscriptionAborted(signal);
+      return {
+        locale: supportedLocale,
+        prepareFileFallback: AppleTranscription.isAvailable(locale)
+          ? (options) => prepareFileVoiceTranscription(locale, options)
+          : undefined,
+        startStreaming: (options) =>
+          startVoiceStreaming(supportedLocale, VOICE_RECORDING_LIMIT_SECONDS, options),
+        transcribe: (uri, options) => transcribeVoiceRecording(uri, supportedLocale, options),
+      };
+    } catch (error) {
+      throwIfVoiceTranscriptionAborted(signal);
+      if (!AppleTranscription.isAvailable(locale)) throw mapPreparationError(error);
+    }
+  }
+
+  return prepareFileVoiceTranscription(locale, { signal });
+}
+
+async function prepareFileVoiceTranscription(
   locale: string,
   { signal }: VoiceTranscriptionOptions,
 ): Promise<PreparedVoiceTranscription> {
@@ -60,20 +86,28 @@ async function prepareVoiceTranscription(
     };
   } catch (error) {
     throwIfVoiceTranscriptionAborted(signal);
-    if (getNativeErrorCode(error) === "AppleTranscriptionUnsupportedLocale") {
-      throw new VoiceTranscriptionError(
-        "unsupported-locale",
-        "Voice transcription does not support this device language.",
-        { cause: error },
-      );
-    }
+    throw mapPreparationError(error);
+  }
+}
 
-    throw wrapError(
-      "preparation-failed",
-      "Voice transcription could not prepare this language.",
-      error,
+function mapPreparationError(error: unknown): VoiceTranscriptionError {
+  const nativeCode = getNativeVoiceErrorCode(error);
+  if (nativeCode === "AppleTranscriptionUnsupportedLocale") {
+    return new VoiceTranscriptionError(
+      "unsupported-locale",
+      "Voice transcription does not support this device language.",
+      { cause: error },
     );
   }
+
+  const nativeError = mapNativeVoiceError(error, "preparation");
+  if (nativeError instanceof VoiceTranscriptionError) return nativeError;
+
+  return wrapError(
+    "preparation-failed",
+    "Voice transcription could not prepare this language.",
+    error,
+  );
 }
 
 async function transcribeVoiceRecording(

--- a/docs/internals/voice-input.md
+++ b/docs/internals/voice-input.md
@@ -11,10 +11,50 @@ binds the transcriber and resolved locale for the whole recording. Draft ownersh
 text, and revision are captured before recording and checked before insertion, so
 a late transcript cannot overwrite a draft that was edited or replaced.
 
-Cancellation invalidates a result immediately, but resources stay owned until the
-underlying work settles. Apple's native transcription call cannot be interrupted
-once started. Releasing the session or deleting its recording when the abort signal
-fires would race that work. The [transcription contract](../../packages/client-runtime/src/voice-input/transcription.ts)
-therefore requires implementations to settle only after their work has stopped;
-the [Apple binding](../../apps/mobile/src/native/voiceTranscription.ios.ts) checks
-cancellation between native calls and discards late results.
+Live transcription owns microphone capture and streams complete hypotheses into
+the captured selection. Each hypothesis replaces the preceding one. The client
+acknowledges these writes synchronously because native events can arrive before
+React renders; unrelated text or ownership changes invalidate the session.
+
+React Native iOS feeds the same audio to two on-device modules in one
+`SpeechAnalyzer`: `DictationTranscriber` provides frequent provisional words and
+`SpeechTranscriber` provides newer-model corrections during recording. The newer
+transcript replaces the corresponding prefix while the fast recognizer supplies
+the remaining tail. Alignment handles spelling changes and compounds such as
+"time out" becoming "timeout". Results replace passages by audio range, including
+when the next passage implicitly finalizes the previous one.
+
+Preparation resolves and downloads both engines' language assets before microphone
+capture begins. Languages unsupported by the fast module use the newer module
+alone. Confirm drains both result streams and uses only the newer model's final
+transcript. There is no periodic forced finalization or second recording replay.
+
+Cancellation invalidates results immediately, but resources stay owned until
+native work settles. Preparation and finalization must finish or cancel before
+another composer can acquire the audio session. If live capture is unavailable or
+startup fails before producing text, the controller falls back to recording a
+temporary audio file, transcribing it on-device, and deleting it during cleanup.
+
+## Focused native verification
+
+On macOS 26 with Xcode 26, compile the production transcription and merge code
+with its standalone regression tests:
+
+```sh
+xcrun swiftc -O -parse-as-library \
+  apps/mobile/modules/t3-native-controls/ios/VoiceTranscript.swift \
+  apps/mobile/modules/t3-native-controls/ios/VoiceTranscription.swift \
+  apps/mobile/scripts/voice-transcription-tests.swift \
+  -o /tmp/t3-voice-transcription-tests
+/tmp/t3-voice-transcription-tests
+```
+
+Pass a local speech audio file to replay it at speaking speed through the actual
+production recognizers. The output includes composer updates, initial feedback
+time, finalization time, and the final transcript. Add `--expect <text-file>` for
+an assertion that the final words match the fixture and at least 90% of its prefix
+was visible before Finish. Add `--cancel` to verify that
+cancelling during recognition suppresses late text. Review the live transcript
+against the spoken fixture as well as the final output; fast first feedback alone
+does not establish usable dictation. Mac replay does not measure iPhone latency
+or verify its microphone capture.

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -82,17 +82,23 @@ and use **Attach again** or remove the missing file before sending.
 
 ## Voice input on iPhone
 
-On supported iPhones with iOS 26 or later, use the composer's microphone to record,
-then confirm to transcribe. Text is inserted where your selection was when
-recording started, ready for you to review and edit before sending.
+On supported iPhones with iOS 26 or later, tap the composer's microphone and speak.
+Your words appear in the draft as you speak and may be corrected as recognition
+continues. Confirm to finish dictation and apply the final corrections, then review
+or edit the text before sending.
+Text replaces the selection you had when dictation started.
 
 The first use may download Apple's speech model and needs a network connection.
-Later transcription works offline for that language. Recordings can be up to five
-minutes long. Canceling, leaving the screen, or an audio interruption discards the
-recording and preserves your existing draft.
+Later transcription works offline for that language. Dictation can last up to five
+minutes. Cancel removes the current dictation and restores your previous draft.
+Leaving the screen or an audio interruption stops capture and keeps words already
+shown in the draft.
 
-Transcription runs on your device. T3 Code deletes the temporary audio after
-transcription or cancellation; only the message text is sent when you submit.
+Live transcription runs on your device without saving an audio recording. If live
+dictation cannot start, T3 Code temporarily records audio for on-device
+transcription, then deletes the recording. In that fallback, words appear after
+you finish instead of while you speak. Only the message text is sent when you
+submit.
 
 ## Commands and skills
 

--- a/packages/client-runtime/src/voice-input/controller.test.ts
+++ b/packages/client-runtime/src/voice-input/controller.test.ts
@@ -10,7 +10,12 @@ import {
   type VoiceInputControllerDependencies,
   type VoiceRecorder,
 } from "./controller.ts";
-import type { PreparedVoiceTranscription, VoiceTranscriber } from "./transcription.ts";
+import type {
+  PreparedVoiceTranscription,
+  VoiceTranscriber,
+  VoiceStreamingOptions,
+  VoiceStreamingSession,
+} from "./transcription.ts";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -532,4 +537,298 @@ describe("VoiceInputController", () => {
     expect(harness.recorder.record).not.toHaveBeenCalled();
     expect(harness.controller.currentState.error).toContain("background");
   });
+});
+
+describe("live voice input", () => {
+  it("writes interim speech into the draft before stopping capture", async () => {
+    const stop = vi.fn(async () => "new words");
+    const transcribe = vi.fn(async () => "new words");
+    const harness = createHarness({
+      getTranscriber: () => ({
+        prepare: async () => ({
+          locale: "en-US",
+          transcribe,
+          startStreaming: async (options: { onTranscript: (text: string) => void }) => {
+            options.onTranscript("new");
+            return { stop, cancel: async () => undefined, getStatus: () => null };
+          },
+        }),
+      }),
+    });
+
+    await harness.controller.start();
+
+    expect(harness.controller.currentState.phase).toBe("recording");
+    expect(harness.commits.at(-1)?.text).toBe("hello new");
+    expect(stop).not.toHaveBeenCalled();
+    expect(transcribe).not.toHaveBeenCalled();
+    harness.controller.cancel();
+  });
+
+  it("falls back to file capture when live capture cannot start", async () => {
+    const transcribe = vi.fn(async () => "fallback words");
+    const prepareFileFallback = vi.fn(async () => preparedTranscription(transcribe));
+    const harness = createHarness({
+      getTranscriber: () => ({
+        prepare: async () => ({
+          locale: "en-US",
+          transcribe,
+          prepareFileFallback,
+          startStreaming: async (options) => {
+            options.onTranscript("   ");
+            throw new Error("live capture unavailable");
+          },
+        }),
+      }),
+    });
+
+    await harness.controller.start();
+
+    expect(prepareFileFallback).toHaveBeenCalledOnce();
+    expect(harness.recorder.record).toHaveBeenCalledWith({
+      forDuration: VOICE_RECORDING_LIMIT_SECONDS,
+    });
+    await harness.controller.stop();
+    expect(harness.commits.at(-1)?.text).toBe("hello fallback words");
+  });
+
+  it("keeps live words and does not start file capture when startup reports speech before failing", async () => {
+    let current = draft();
+    const prepareFileFallback = vi.fn(async () => preparedTranscription());
+    const harness = createHarness({
+      readDraft: () => current,
+      commitDraft: (text, selection) => {
+        current = { ...current, text, selection, revision: current.revision + 1 };
+      },
+      getTranscriber: () => ({
+        prepare: async () => ({
+          locale: "en-US",
+          transcribe: async () => "",
+          prepareFileFallback,
+          startStreaming: async (options) => {
+            options.onTranscript("recognized words");
+            throw new Error("live capture failed after speech");
+          },
+        }),
+      }),
+    });
+
+    await harness.controller.start();
+
+    expect(current.text).toBe("hello recognized words");
+    expect(harness.controller.currentState.phase).toBe("error");
+    expect(prepareFileFallback).not.toHaveBeenCalled();
+    expect(harness.recorder.record).not.toHaveBeenCalled();
+  });
+});
+
+function createLiveHarness() {
+  let callbacks!: VoiceStreamingOptions;
+  let current = draft();
+  const stop = vi.fn(async () => "new words.");
+  const cancel = vi.fn(async () => undefined);
+  const harness = createHarness({
+    readDraft: () => current,
+    commitDraft: (text, selection) => {
+      current = { ...current, text, selection, revision: current.revision + 1 };
+    },
+    getTranscriber: () => ({
+      prepare: async () => ({
+        locale: "en-US",
+        transcribe: async () => {
+          throw new Error("Must stream");
+        },
+        startStreaming: async (options) => {
+          callbacks = options;
+          return { stop, cancel, getStatus: () => null };
+        },
+      }),
+    }),
+  });
+  return {
+    ...harness,
+    stop,
+    cancel,
+    get text() {
+      return current.text;
+    },
+    emit: (text: string) => callbacks.onTranscript(text),
+    fail: () => callbacks.onError("Interrupted"),
+    end: () => callbacks.onEnd(),
+    edit: (text: string) => {
+      current = { ...current, text, revision: current.revision + 1 };
+    },
+    changeOwner: () => {
+      current = { ...draft(), ownerKey: "other" };
+    },
+  };
+}
+
+describe("streaming draft ownership", () => {
+  it("ignores idle file-recorder status while native streaming owns capture", async () => {
+    const h = createLiveHarness();
+    await h.controller.start();
+
+    await h.controller.handleRecorderStatus({
+      isFinished: false,
+      hasError: true,
+      error: "Idle recorder error",
+      url: null,
+    });
+    await h.controller.handleRecorderStatus({
+      isFinished: true,
+      hasError: false,
+      error: null,
+      url: "file:///idle-recorder.m4a",
+    });
+    h.emit("still speaking");
+
+    expect(h.controller.currentState.phase).toBe("recording");
+    expect(h.text).toBe("hello still speaking");
+    expect(h.stop).not.toHaveBeenCalled();
+    expect(h.cancel).not.toHaveBeenCalled();
+    h.controller.cancel();
+  });
+
+  it("revises interim words in place and flushes final punctuation once", async () => {
+    const h = createLiveHarness();
+    await h.controller.start();
+    h.emit("knew");
+    expect(h.text).toBe("hello knew");
+    h.emit("new words");
+    expect(h.text).toBe("hello new words");
+    expect(h.recorder.record).not.toHaveBeenCalled();
+    await h.controller.stop();
+    expect(h.text).toBe("hello new words.");
+    expect(h.controller.currentState.phase).toBe("idle");
+  });
+
+  it("keeps submission blocked until a correction replaces the whole provisional draft", async () => {
+    const h = createLiveHarness();
+    const correction = deferred<string>();
+    h.stop.mockReturnValue(correction.promise);
+    await h.controller.start();
+    h.emit("Please show that...");
+    const finishing = h.controller.stop();
+    expect(h.controller.currentState.phase).toBe("transcribing");
+    expect(voiceInputBlocksSubmission(h.controller.currentState)).toBe(true);
+    expect(h.text).toBe("hello Please show that...");
+    correction.resolve("Please show the words as I speak.");
+    await finishing;
+    expect(h.text).toBe("hello Please show the words as I speak.");
+    expect(voiceInputBlocksSubmission(h.controller.currentState)).toBe(false);
+  });
+
+  it("does not apply a delayed correction after a manual edit or owner change", async () => {
+    for (const change of ["edit", "owner"] as const) {
+      resetVoiceInputGlobalsForTests();
+      const h = createLiveHarness();
+      const correction = deferred<string>();
+      h.stop.mockReturnValue(correction.promise);
+      await h.controller.start();
+      h.emit("provisional...");
+      const finishing = h.controller.stop();
+      if (change === "edit") h.edit("my edit");
+      else h.changeOwner();
+      correction.resolve("corrected words");
+      await finishing;
+      expect(h.text).toBe(change === "edit" ? "my edit" : "hello world");
+    }
+  });
+
+  it("restores the original selection on cancellation and ignores late speech", async () => {
+    const h = createLiveHarness();
+    await h.controller.start();
+    h.emit("new");
+    h.controller.cancel();
+    h.emit("late text");
+    expect(h.text).toBe("hello world");
+    expect(h.cancel).toHaveBeenCalled();
+  });
+
+  it("never overwrites a manual edit or replacement owner", async () => {
+    for (const change of ["edit", "owner"] as const) {
+      resetVoiceInputGlobalsForTests();
+      const h = createLiveHarness();
+      await h.controller.start();
+      h.emit("new");
+      if (change === "edit") h.edit("my edit");
+      else h.changeOwner();
+      h.emit("late text");
+      expect(h.text).toBe(change === "edit" ? "my edit" : "hello world");
+      expect(h.controller.currentState.phase).toBe("error");
+    }
+  });
+
+  it("retains recognized words on interruption and rejects later callbacks", async () => {
+    const h = createLiveHarness();
+    await h.controller.start();
+    h.emit("new");
+    h.fail();
+    h.emit("late text");
+    expect(h.text).toBe("hello new");
+    expect(h.controller.currentState.phase).toBe("error");
+  });
+
+  it("restores the draft if the recognizer retracts all speech", async () => {
+    const h = createLiveHarness();
+    h.stop.mockResolvedValue("");
+    await h.controller.start();
+    h.emit("noise");
+    h.emit("");
+    expect(h.text).toBe("hello world");
+    await h.controller.stop();
+    expect(h.controller.currentState.error).toBe("No speech was detected.");
+  });
+
+  it("cancels finalization without adding the late final text", async () => {
+    const h = createLiveHarness();
+    const final = deferred<string>();
+    h.stop.mockReturnValue(final.promise);
+    await h.controller.start();
+    h.emit("new");
+    const finishing = h.controller.stop();
+    h.controller.cancel();
+    final.resolve("late final words");
+    await finishing;
+    expect(h.text).toBe("hello world");
+    expect(h.controller.currentState.phase).toBe("idle");
+  });
+});
+
+it("holds streaming ownership through cancellation during startup", async () => {
+  const entered = deferred<void>();
+  const start = deferred<VoiceStreamingSession>();
+  const released = deferred<void>();
+  const cancel = vi.fn(async () => undefined);
+  const h = createHarness({
+    getTranscriber: () => ({
+      prepare: async () => ({
+        locale: "en-US",
+        transcribe: async () => "",
+        startStreaming: () => {
+          entered.resolve();
+          return start.promise;
+        },
+      }),
+    }),
+    releaseRecording: async () => {
+      released.resolve();
+    },
+  });
+  const starting = h.controller.start();
+  await entered.promise;
+  h.controller.cancel();
+  const blocked = createHarness();
+  await blocked.controller.start();
+  expect(blocked.controller.currentState.error).toBe("Another voice recording is already active.");
+  start.resolve({ stop: async () => "", cancel, getStatus: () => null });
+  await starting;
+  await released.promise;
+  expect(cancel).toHaveBeenCalledOnce();
+  expect(h.controller.currentState.phase).toBe("idle");
+  const next = createHarness();
+  await next.controller.start();
+  expect(next.controller.currentState.phase).toBe("recording");
+  await next.controller.stop();
 });

--- a/packages/client-runtime/src/voice-input/controller.ts
+++ b/packages/client-runtime/src/voice-input/controller.ts
@@ -1,6 +1,10 @@
 import { replaceTextRange } from "@t3tools/shared/composerTrigger";
 
-import type { PreparedVoiceTranscription, VoiceTranscriber } from "./transcription.ts";
+import type {
+  PreparedVoiceTranscription,
+  VoiceTranscriber,
+  VoiceStreamingSession,
+} from "./transcription.ts";
 
 export const VOICE_RECORDING_LIMIT_SECONDS = 5 * 60;
 
@@ -181,6 +185,8 @@ export class VoiceInputController {
   private transcription: PreparedVoiceTranscription | null = null;
   private transcriptionAbortController: AbortController | null = null;
   private capturedDraft: VoiceDraftSnapshot | null = null;
+  private streaming: VoiceStreamingSession | null = null;
+  private expectedDraft: VoiceDraftSnapshot | null = null;
   private recordingUri: string | null = null;
   private readonly ownedRecordingUris = new Set<string>();
   private recordingConfigured = false;
@@ -192,6 +198,10 @@ export class VoiceInputController {
 
   get currentState(): VoiceInputState {
     return this.state;
+  }
+
+  get streamingStatus() {
+    return this.streaming?.getStatus() ?? null;
   }
 
   async start(): Promise<void> {
@@ -243,6 +253,63 @@ export class VoiceInputController {
       await this.dependencies.configureRecording();
       this.recordingConfigured = true;
       if (!this.isCurrent(operationToken)) return;
+      const streamingDraft = this.dependencies.readDraft();
+      if (this.transcription.startStreaming) {
+        const prepareFileFallback = this.transcription.prepareFileFallback;
+        if (!streamingDraft || streamingDraft.ownerKey !== initiatingDraft.ownerKey) {
+          this.setError("This draft is no longer available.", "retry");
+          return;
+        }
+        this.capturedDraft = streamingDraft;
+        this.expectedDraft = streamingDraft;
+        let receivedStreamingTranscript = false;
+        try {
+          this.streaming = await this.transcription.startStreaming({
+            signal: abortController.signal,
+            onTranscript: (text) => {
+              receivedStreamingTranscript ||= text.trim().length > 0;
+              if (this.isCurrent(operationToken)) this.updateLiveTranscript(text);
+            },
+            onError: (message) => {
+              if (this.isCurrent(operationToken)) this.failStreaming(message);
+            },
+            onEnd: () => {
+              if (this.isCurrent(operationToken)) void this.stop();
+            },
+          });
+          if (!this.isCurrent(operationToken)) return;
+          this.setState({ phase: "recording", error: null, errorAction: null });
+          return;
+        } catch (error) {
+          if (!this.isCurrent(operationToken)) return;
+          const currentDraft = this.dependencies.readDraft();
+          const expectedDraft = this.expectedDraft;
+          if (
+            receivedStreamingTranscript ||
+            !prepareFileFallback ||
+            !currentDraft ||
+            !expectedDraft ||
+            currentDraft.ownerKey !== expectedDraft.ownerKey ||
+            currentDraft.text !== expectedDraft.text ||
+            currentDraft.revision !== expectedDraft.revision
+          ) {
+            throw error;
+          }
+          this.capturedDraft = null;
+          this.expectedDraft = null;
+          try {
+            this.transcription = await runTranscriptionOperation(() =>
+              prepareFileFallback({ signal: abortController.signal }),
+            );
+          } catch (fallbackError) {
+            if (this.isCurrent(operationToken)) {
+              this.setError(preparationErrorMessage(fallbackError), "retry");
+            }
+            return;
+          }
+          if (!this.isCurrent(operationToken)) return;
+        }
+      }
       await this.dependencies.recorder.prepareToRecordAsync();
       if (!this.isCurrent(operationToken)) return;
       this.recordingUri = this.dependencies.recorder.uri;
@@ -281,13 +348,16 @@ export class VoiceInputController {
         this.setState(IDLE_STATE);
         return;
       case "preparing":
+        this.restoreBeforeDictation();
         this.invalidateOperation();
         this.setState(IDLE_STATE);
         return;
       case "recording":
+        this.restoreBeforeDictation();
         this.discardRecording(null);
         return;
       case "transcribing":
+        this.restoreBeforeDictation();
         this.invalidateOperation();
         this.setState(IDLE_STATE);
         return;
@@ -314,7 +384,7 @@ export class VoiceInputController {
   }
 
   handleRecorderStatus(status: VoiceRecorderStatus): Promise<void> | void {
-    if (this.state.phase !== "recording") return;
+    if (this.state.phase !== "recording" || this.streaming) return;
     if (status.hasError) {
       return this.interruptRecording(
         status.error ?? "Voice recording was interrupted.",
@@ -355,6 +425,18 @@ export class VoiceInputController {
     this.setState({ phase: "transcribing", error: null, errorAction: null });
 
     try {
+      if (this.streaming) {
+        const transcript = await this.streaming.stop();
+        if (!this.isCurrent(operationToken)) return;
+        this.updateLiveTranscript(transcript);
+        if (!this.isCurrent(operationToken)) return;
+        if (!transcript.trim()) {
+          this.setError("No speech was detected.", "retry");
+        } else {
+          this.setState(IDLE_STATE);
+        }
+        return;
+      }
       if (!alreadyStopped) await this.dependencies.recorder.stop();
       await this.releaseAudioSession();
       this.recordingUri = completedUri ?? this.dependencies.recorder.uri ?? this.recordingUri;
@@ -425,7 +507,8 @@ export class VoiceInputController {
         : { phase: "idle", error: null, errorAction: null },
     );
     try {
-      await this.dependencies.recorder.stop();
+      if (this.streaming) await this.streaming.cancel();
+      else await this.dependencies.recorder.stop();
       this.rememberRecordingUri(this.dependencies.recorder.uri);
     } catch {
       this.rememberRecordingUri(this.dependencies.recorder.uri);
@@ -434,7 +517,66 @@ export class VoiceInputController {
     }
   }
 
+  private failStreaming(message: string): void {
+    if (this.state.phase === "preparing" || this.finishing) {
+      // Startup/finalization owns cleanup until its native operation settles.
+      this.invalidateOperation();
+      this.setError(message, "retry");
+    } else {
+      void this.discardRecording(message);
+    }
+  }
+
+  private restoreBeforeDictation(): void {
+    const current = this.dependencies.readDraft();
+    const expected = this.expectedDraft;
+    const captured = this.capturedDraft;
+    if (
+      current &&
+      expected &&
+      captured &&
+      current.ownerKey === expected.ownerKey &&
+      current.text === expected.text &&
+      current.revision === expected.revision
+    ) {
+      this.dependencies.commitDraft(captured.text, captured.selection);
+    }
+  }
+
+  private updateLiveTranscript(transcript: string): void {
+    const captured = this.capturedDraft;
+    const expected = this.expectedDraft;
+    const current = this.dependencies.readDraft();
+    if (!captured || !expected || !this.transcription) return;
+    if (
+      !current ||
+      current.ownerKey !== expected.ownerKey ||
+      current.text !== expected.text ||
+      current.revision !== expected.revision
+    ) {
+      this.failStreaming("The draft changed while voice input was running. Dictation stopped.");
+      return;
+    }
+    // Always replace the original selection, never append successive hypotheses.
+    const result = resolveTranscriptCommit(
+      captured,
+      captured,
+      transcript,
+      this.transcription.locale,
+    );
+    if (result.kind === "stale") return;
+    const next = result.kind === "empty" ? captured : result;
+    if (next.text === current.text) return;
+    this.dependencies.commitDraft(next.text, next.selection);
+    this.expectedDraft = this.dependencies.readDraft();
+  }
+
   private async releaseResources(): Promise<void> {
+    if (this.streaming) {
+      await this.streaming.cancel().catch(() => undefined);
+      this.streaming = null;
+    }
+    this.expectedDraft = null;
     this.rememberRecordingUri(this.recordingUri);
     this.rememberRecordingUri(this.dependencies.recorder.uri);
     this.recordingUri = null;

--- a/packages/client-runtime/src/voice-input/index.ts
+++ b/packages/client-runtime/src/voice-input/index.ts
@@ -17,4 +17,6 @@ export {
   type VoiceTranscriber,
   type VoiceTranscriptionErrorCode,
   type VoiceTranscriptionOptions,
+  type VoiceStreamingOptions,
+  type VoiceStreamingSession,
 } from "./transcription.ts";

--- a/packages/client-runtime/src/voice-input/transcription.ts
+++ b/packages/client-runtime/src/voice-input/transcription.ts
@@ -3,9 +3,31 @@ export type VoiceTranscriptionOptions = {
   readonly signal: AbortSignal;
 };
 
+export type VoiceStreamingOptions = VoiceTranscriptionOptions & {
+  /** The complete transcript so far, including revisions to interim words. */
+  readonly onTranscript: (text: string) => void;
+  readonly onError: (message: string) => void;
+  readonly onEnd: () => void;
+};
+
+export type VoiceStreamingSession = {
+  readonly stop: () => Promise<string>;
+  readonly cancel: () => Promise<void>;
+  readonly getStatus: () => {
+    readonly isRecording: boolean;
+    readonly durationMillis: number;
+    readonly metering?: number;
+  } | null;
+};
+
 /** Binds a recording to its selected implementation and resolved locale. */
 export type PreparedVoiceTranscription = {
   readonly locale: string;
+  /** Prepares record-then-transcribe capture when live capture cannot start. */
+  readonly prepareFileFallback?: (
+    options: VoiceTranscriptionOptions,
+  ) => Promise<PreparedVoiceTranscription>;
+  readonly startStreaming?: (options: VoiceStreamingOptions) => Promise<VoiceStreamingSession>;
   readonly transcribe: (uri: string, options: VoiceTranscriptionOptions) => Promise<string>;
 };
 


### PR DESCRIPTION
## Problem

iOS dictation records first and transcribes only after Finish, so users see nothing while speaking. The newer on-device model alone also produces useful text later than Apple's progressive dictation.

## Fix

- One on-device `SpeechAnalyzer` feeds Apple's fast `DictationTranscriber` and the newer `SpeechTranscriber` concurrently. The newer transcript corrects the recognized prefix, fast dictation supplies the unfinished tail, and Finish returns the newer model's final transcript. Locales the fast recognizer doesn't support use the newer recognizer alone.
- Passages are merged by audio range. Draft alignment handles corrections, repeated words, compounds, and punctuation between the corrected prefix and provisional tail. Long, mostly aligned transcripts use a narrow edit-distance band so an early disagreement doesn't realign the whole growing transcript on every partial.
- The shared voice controller (`packages/client-runtime`) prefers live capture for existing-thread and New Task composers. Cancel restores the previous draft, text already shown survives an interruption, and live capture falls back to the existing record-then-transcribe path when it's unavailable or fails before producing any text.
- A provisional-recognizer failure no longer rejects Finish; a corrected-recognizer failure still does. Native errors cross the Expo boundary as `ERR_VOICE_UNAVAILABLE`, `ERR_VOICE_BUSY`, and `ERR_VOICE_AUDIO_FORMAT` and map to stable `VoiceTranscriptionError` codes.
- The mobile composer stays expanded while voice input is busy, so live words stay visible even when dictation starts with the keyboard closed. This combines with main's newer `keepsComposerExpanded` settings-sheet flag (#11127).

This needs a new native iOS binary; the native fingerprint gate covers that. Server, provider, wire contracts, Android, web, and the SwiftUI client are unchanged.

## UI evidence

These captures replay recognition events in the React Native composer. They were recorded for an earlier single-stream revision, so they show the composer while words stream in and after Finish. They don't show the final dual-model recognizer, native iPhone latency, or microphone behavior.

**Before (historical replay):** text stays hidden until Finish

![Before: dictated text stays hidden until Finish](https://github.com/saphid/t3code/releases/download/pr-evidence-mobile-live-dictation/before-clean.png)

**After (historical replay):** interim words appear above the waveform

![After: interim words remain visible above the waveform](https://github.com/saphid/t3code/releases/download/pr-evidence-mobile-live-dictation/after-clean.png)

<img src="https://github.com/saphid/t3code/releases/download/pr-evidence-mobile-live-dictation/after-animated.gif" width="400" alt="Controlled replay: dictated words and corrections appear in the composer while recording, then remain after Finish" />

[After video (25 s)](https://github.com/saphid/t3code/releases/download/pr-evidence-mobile-live-dictation/after-annotated.mp4) · [Before video (15 s)](https://github.com/saphid/t3code/releases/download/pr-evidence-mobile-live-dictation/before-annotated.mp4)

A signed iPhone build of an earlier dual-recognizer revision (`c3c578aa`) gave faster feedback in hands-on use. The current head hasn't had a physical-iPhone microphone pass.

## Verification (current head, rebased on main `211618fd`)

- `vp test run` on `voiceStreaming.ios.test.ts`, `voiceTranscription.ios.test.ts`, `controller.test.ts`, and `voiceDraftRenderReconciliation.test.ts`: 61 tests passed across 4 files.
- `vp run --filter @t3tools/mobile typecheck` and `vp run --filter @t3tools/client-runtime typecheck`: both exit 0.
- Changed-file `vp lint` exit 0 (only the existing advisory React compiler warnings in `ThreadComposer.tsx`), `vp fmt --check` exit 0, and `git diff --check` clean.
- `xcrun swiftc -O -parse-as-library VoiceTranscript.swift VoiceTranscription.swift voice-transcription-tests.swift`: compiled and ran with exit 0. The run checks the optimized merge against the original algorithm on 3 long and 2,500 randomized cases and covers collector-failure and punctuation regressions.
- `swiftlint lint --strict` on the four production Swift files: 0 violations.

A native-source benchmark of a five-minute draft (750 words, 1,200 partials) with a persistent first-word disagreement cut total merge time from about 20.1 s to 356 ms. The ordinary-suffix case moved from 190 ms to 210 ms. This measures the native merge only, not app or phone responsiveness.

**Still needed:** a React Native iOS app build and a physical-iPhone microphone pass covering live words and corrections, Finish, Cancel restore, startup fallback, interruptions, first-use model download, and both composers with the keyboard open and closed.

Rebased onto main as one commit; the old per-step history was interleaved with merge commits. Cross-provider review was skipped: Codex weekly quota was at 6%, below the 10% floor.

Coordination trace: T3 thread d72c6260-6435-4c0f-8328-e6125c8b8f38

Implemented with GPT-6/Sol in the Codex harness via T3 Code; rebased and verified with Claude Opus 5 in Claude Code via T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live iOS voice dictation with real-time draft updates and corrections.
  * Added automatic record-then-transcribe fallback when live dictation is unavailable.
  * Added cancellation, interruption handling, duration limits, language preparation, and clearer voice error reporting.
* **Bug Fixes**
  * Preserved the composer’s expanded state during dictation.
  * Improved draft reconciliation to prevent stale updates from overwriting voice input.
* **Documentation**
  * Updated user and internal documentation for live dictation, fallback behavior, cancellation, and interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->