### PR TITLE
fix(shared): validate cloudflared with the version subcommand

### DIFF
--- a/packages/shared/src/relayClient.test.ts
+++ b/packages/shared/src/relayClient.test.ts
@@ -61,7 +61,10 @@ const makeSpawnerLayer = (commands: Array<string>) =>
     ChildProcessSpawner.make((command) =>
       Effect.sync(() => {
         commands.push(ChildProcess.isStandardCommand(command) ? command.command : "piped-command");
-        return makeHandle();
+        // The pinned Windows executable rejects --version but accepts the version subcommand.
+        return makeHandle(
+          ChildProcess.isStandardCommand(command) && command.args.includes("--version") ? 1 : 0,
+        );
       }),
     ),
   );

--- a/packages/shared/src/relayClient.ts
+++ b/packages/shared/src/relayClient.ts
@@ -421,7 +421,7 @@ export const makeCloudflaredRelayClient = Effect.fn("cloudflared.make")(function
           .pipe(wrapInstallFailure("write_failed", "Could not make the relay client executable."));
       }
       yield* report("validating");
-      yield* runCommand(executablePath, ["--version"]).pipe(
+      yield* runCommand(executablePath, ["version"]).pipe(
         wrapInstallFailure("validation_failed", "The downloaded relay client binary did not run."),
       );
 


### PR DESCRIPTION
the pinned windows cloudflared executable can reject `--version`, preventing a valid relay download from activating. validation now uses the portable `version` subcommand; the existing installer tests model the rejected flag and verify activation completes.

verification: all 5 focused tests pass; reverting only the command reproduces `validation_failed` in both installation tests. targeted lint, shared typecheck and formatting pass, and the actual pinned linux binary reports `2026.5.2` with `version`; native windows execution remains unverified.

![cloudflared installer regression checks: 5 tests passed](https://uploads-production-47e4.up.railway.app/files/b9fead7e-3e37-435e-a636-e841bbd3ad1d/t3-9880-terminal.png)

fixes #8304.

implemented with gpt-6-astra via codex in t3 code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to post-install smoke check only; same failure path (`validation_failed`) if the binary cannot run `version`.
> 
> **Overview**
> **Fixes relay client install failing on Windows** when post-download validation runs `cloudflared --version`, which the pinned Windows binary rejects even though the binary is valid.
> 
> Managed install validation now runs the portable **`version` subcommand** instead of the `--version` flag. Installer tests mock a spawner that fails `--version` with exit code 1 so activation still completes with the new command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64e3daedde1557790d00454ac7cb896966c0a84e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate downloaded cloudflared with `version` subcommand in `makeCloudflaredRelayClient`
> The pinned Windows cloudflared executable rejects the `--version` argument but accepts the `version` subcommand. Changes the validation call in [relayClient.ts](https://github.com/pingdotgg/t3code/pull/9880/files#diff-6972338b30997b4e1c7b8f58b9fac32b1e1eaaa7dfb39f50588ddbb93e9f7ef5) from `--version` to `version`, and updates the mock spawner in [relayClient.test.ts](https://github.com/pingdotgg/t3code/pull/9880/files#diff-600cd56a354a18ad22e4f981d2c84b412734e99fc7ff511e5e5732d6e3d46b2c) to model `--version` as exit status 1. A failed validation still triggers the existing failure wrapper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64e3dae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
