### PR TITLE
fix(desktop): separate LAN and Tailscale pairing endpoints

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -194,7 +194,10 @@ const bootstrap = Effect.gen(function* () {
     yield* logBootstrapInfo("bootstrap enabled network access", {
       endpointUrl: serverExposureState.endpointUrl,
     });
-  } else if (settings.serverExposureMode === "network-accessible") {
+  } else if (
+    settings.serverExposureMode === "network-accessible" &&
+    serverExposureState.mode === "local-only"
+  ) {
     yield* logBootstrapWarning(
       "bootstrap fell back to local-only because no advertised network host was available",
     );

--- a/apps/desktop/src/backend/DesktopServerExposure.test.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.test.ts
@@ -324,32 +324,30 @@ describe("DesktopServerExposure", () => {
     ),
   );
 
-  it.effect(
-    "keeps a Tailscale-only host network-accessible without advertising a LAN endpoint",
-    () =>
-      withHarness(
-        tailnetNetworkInterfaces,
-        Effect.gen(function* () {
-          const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
-          const settings = yield* DesktopAppSettings.DesktopAppSettings;
-          yield* settings.setServerExposureMode("network-accessible");
+  it.effect("keeps Tailscale-only hosts network-accessible", () =>
+    withHarness(
+      tailnetNetworkInterfaces,
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        const settings = yield* DesktopAppSettings.DesktopAppSettings;
+        yield* settings.setServerExposureMode("network-accessible");
 
-          const state = yield* serverExposure.configureFromSettings({ port: 4173 });
-          assert.equal(state.mode, "network-accessible");
-          assert.equal(state.advertisedHost, null);
-          assert.equal(state.endpointUrl, null);
-          assert.equal((yield* serverExposure.backendConfig).bindHost, "0.0.0.0");
+        const state = yield* serverExposure.configureFromSettings({ port: 4173 });
+        assert.equal(state.mode, "network-accessible");
+        assert.equal(state.advertisedHost, null);
+        assert.equal(state.endpointUrl, null);
+        assert.equal((yield* serverExposure.backendConfig).bindHost, "0.0.0.0");
 
-          const endpoints = yield* serverExposure.getAdvertisedEndpoints;
-          assert.deepEqual(
-            endpoints.map((endpoint) => [endpoint.reachability, endpoint.httpBaseUrl]),
-            [
-              ["loopback", "http://127.0.0.1:4173/"],
-              ["private-network", "http://100.90.1.2:4173/"],
-            ],
-          );
-        }),
-      ),
+        const endpoints = yield* serverExposure.getAdvertisedEndpoints;
+        assert.deepEqual(
+          endpoints.map((endpoint) => [endpoint.reachability, endpoint.httpBaseUrl]),
+          [
+            ["loopback", "http://127.0.0.1:4173/"],
+            ["private-network", "http://100.90.1.2:4173/"],
+          ],
+        );
+      }),
+    ),
   );
 
   it.effect("does not spawn the tailscale CLI while server exposure is local-only", () =>
@@ -373,30 +371,28 @@ describe("DesktopServerExposure", () => {
     ),
   );
 
-  it.effect(
-    "honors an explicit Tailscale address in ConfigProvider desktop exposure overrides",
-    () =>
-      withHarness(
-        lanNetworkInterfaces,
-        Effect.gen(function* () {
-          const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
-          yield* serverExposure.configureFromSettings({ port: 4173 });
-          const change = yield* serverExposure.setMode("network-accessible");
+  it.effect("preserves explicit Tailscale exposure overrides", () =>
+    withHarness(
+      lanNetworkInterfaces,
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+        const change = yield* serverExposure.setMode("network-accessible");
 
-          assert.equal(change.state.advertisedHost, "100.90.1.2");
-          assert.equal(change.state.endpointUrl, "http://100.90.1.2:4173");
+        assert.equal(change.state.advertisedHost, "100.90.1.2");
+        assert.equal(change.state.endpointUrl, "http://100.90.1.2:4173");
 
-          const endpoints = yield* serverExposure.getAdvertisedEndpoints;
-          assert.deepEqual(
-            endpoints.map((endpoint) => endpoint.httpBaseUrl),
-            ["http://127.0.0.1:4173/", "http://100.90.1.2:4173/", "https://public.example.test/"],
-          );
-        }),
-        {
-          T3CODE_DESKTOP_LAN_HOST: "100.90.1.2",
-          T3CODE_DESKTOP_HTTPS_ENDPOINTS: "https://public.example.test",
-        },
-      ),
+        const endpoints = yield* serverExposure.getAdvertisedEndpoints;
+        assert.deepEqual(
+          endpoints.map((endpoint) => endpoint.httpBaseUrl),
+          ["http://127.0.0.1:4173/", "http://100.90.1.2:4173/", "https://public.example.test/"],
+        );
+      }),
+      {
+        T3CODE_DESKTOP_LAN_HOST: "100.90.1.2",
+        T3CODE_DESKTOP_HTTPS_ENDPOINTS: "https://public.example.test",
+      },
+    ),
   );
 
   it.effect("advertises loopback, LAN, and configured manual endpoints from runtime state", () =>

--- a/apps/desktop/src/backend/DesktopServerExposure.test.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.test.ts
@@ -307,9 +307,9 @@ describe("DesktopServerExposure", () => {
     );
   });
 
-  it.effect("resolves advertised endpoints from the scoped runtime state", () =>
+  it.effect("keeps LAN and Tailscale endpoints distinct when Tailscale is enumerated first", () =>
     withHarness(
-      { ...lanNetworkInterfaces, ...tailnetNetworkInterfaces },
+      { ...tailnetNetworkInterfaces, ...lanNetworkInterfaces },
       Effect.gen(function* () {
         const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
         yield* serverExposure.configureFromSettings({ port: 4173 });
@@ -322,6 +322,34 @@ describe("DesktopServerExposure", () => {
         );
       }),
     ),
+  );
+
+  it.effect(
+    "keeps a Tailscale-only host network-accessible without advertising a LAN endpoint",
+    () =>
+      withHarness(
+        tailnetNetworkInterfaces,
+        Effect.gen(function* () {
+          const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+          const settings = yield* DesktopAppSettings.DesktopAppSettings;
+          yield* settings.setServerExposureMode("network-accessible");
+
+          const state = yield* serverExposure.configureFromSettings({ port: 4173 });
+          assert.equal(state.mode, "network-accessible");
+          assert.equal(state.advertisedHost, null);
+          assert.equal(state.endpointUrl, null);
+          assert.equal((yield* serverExposure.backendConfig).bindHost, "0.0.0.0");
+
+          const endpoints = yield* serverExposure.getAdvertisedEndpoints;
+          assert.deepEqual(
+            endpoints.map((endpoint) => [endpoint.reachability, endpoint.httpBaseUrl]),
+            [
+              ["loopback", "http://127.0.0.1:4173/"],
+              ["private-network", "http://100.90.1.2:4173/"],
+            ],
+          );
+        }),
+      ),
   );
 
   it.effect("does not spawn the tailscale CLI while server exposure is local-only", () =>
@@ -345,28 +373,30 @@ describe("DesktopServerExposure", () => {
     ),
   );
 
-  it.effect("uses ConfigProvider desktop exposure overrides", () =>
-    withHarness(
-      lanNetworkInterfaces,
-      Effect.gen(function* () {
-        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
-        yield* serverExposure.configureFromSettings({ port: 4173 });
-        const change = yield* serverExposure.setMode("network-accessible");
+  it.effect(
+    "honors an explicit Tailscale address in ConfigProvider desktop exposure overrides",
+    () =>
+      withHarness(
+        lanNetworkInterfaces,
+        Effect.gen(function* () {
+          const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+          yield* serverExposure.configureFromSettings({ port: 4173 });
+          const change = yield* serverExposure.setMode("network-accessible");
 
-        assert.equal(change.state.advertisedHost, "10.0.0.7");
-        assert.equal(change.state.endpointUrl, "http://10.0.0.7:4173");
+          assert.equal(change.state.advertisedHost, "100.90.1.2");
+          assert.equal(change.state.endpointUrl, "http://100.90.1.2:4173");
 
-        const endpoints = yield* serverExposure.getAdvertisedEndpoints;
-        assert.deepEqual(
-          endpoints.map((endpoint) => endpoint.httpBaseUrl),
-          ["http://127.0.0.1:4173/", "http://10.0.0.7:4173/", "https://public.example.test/"],
-        );
-      }),
-      {
-        T3CODE_DESKTOP_LAN_HOST: "10.0.0.7",
-        T3CODE_DESKTOP_HTTPS_ENDPOINTS: "https://public.example.test",
-      },
-    ),
+          const endpoints = yield* serverExposure.getAdvertisedEndpoints;
+          assert.deepEqual(
+            endpoints.map((endpoint) => endpoint.httpBaseUrl),
+            ["http://127.0.0.1:4173/", "http://100.90.1.2:4173/", "https://public.example.test/"],
+          );
+        }),
+        {
+          T3CODE_DESKTOP_LAN_HOST: "100.90.1.2",
+          T3CODE_DESKTOP_HTTPS_ENDPOINTS: "https://public.example.test",
+        },
+      ),
   );
 
   it.effect("advertises loopback, LAN, and configured manual endpoints from runtime state", () =>

--- a/apps/desktop/src/backend/DesktopServerExposure.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.ts
@@ -9,7 +9,7 @@ import {
   type DesktopServerExposureMode,
   type DesktopServerExposureState,
 } from "@t3tools/contracts";
-import { readTailscaleStatus } from "@t3tools/tailscale";
+import { isTailscaleIpv4Address, readTailscaleStatus } from "@t3tools/tailscale";
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -65,7 +65,9 @@ const normalizeOptionalHost = (value: string | undefined): string | undefined =>
 };
 
 const isUsableLanIpv4Address = (address: string): boolean =>
-  !address.startsWith("127.") && !address.startsWith("169.254.");
+  !address.startsWith("127.") &&
+  !address.startsWith("169.254.") &&
+  !isTailscaleIpv4Address(address);
 
 const isHttpsEndpointUrl = (value: string): boolean => {
   try {
@@ -378,7 +380,14 @@ function resolveRuntimeState(input: {
     ...(advertisedHostOverride ? { advertisedHostOverride } : {}),
   });
   const unavailable =
-    input.requestedMode === "network-accessible" && requestedExposure.endpointUrl === null;
+    input.requestedMode === "network-accessible" &&
+    requestedExposure.endpointUrl === null &&
+    !Object.values(input.networkInterfaces).some((addresses) =>
+      addresses?.some(
+        (address) =>
+          !address.internal && address.family === "IPv4" && isTailscaleIpv4Address(address.address),
+      ),
+    );
   const exposure = unavailable
     ? resolveDesktopServerExposure({
         mode: "local-only",


### PR DESCRIPTION
When Tailscale is enumerated before Wi-Fi, desktop pairing advertises the tailnet address as both Local network and Tailscale IP. Automatic LAN discovery now skips tailnet addresses while preserving Tailscale-only connectivity and explicit host overrides.

Verified with 14 focused desktop exposure and Tailscale endpoint tests, targeted lint, and desktop typecheck. The updated tests fail against the original source for the two changed behaviors.

![lan and tailscale endpoint checks: 14 tests passed](https://uploads-production-47e4.up.railway.app/files/6d13e33b-092e-448b-a847-f9b8c6a3232e/t3-9882-terminal.png)

Fixes #7519.

Model: gpt-6-astra via Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes desktop network binding and advertised pairing endpoints; Tailscale-only machines that previously fell back to local-only now remain network-accessible.
> 
> **Overview**
> **Desktop pairing no longer treats Tailscale IPv4 addresses as the LAN host**, so advertised endpoints stay distinct when interface enumeration puts tailnet before Wi‑Fi.
> 
> `isUsableLanIpv4Address` excludes addresses recognized by `isTailscaleIpv4Address`, and **network-accessible mode no longer falls back to local-only** when there is no classic LAN host but a non-internal Tailscale IPv4 interface exists (bind stays on `0.0.0.0` with tailnet advertised separately). Bootstrap logging only warns about a local-only fallback when the user requested network access **and** runtime exposure actually resolved to local-only.
> 
> Tests cover Tailscale-before-LAN ordering, Tailscale-only hosts, and explicit `T3CODE_DESKTOP_LAN_HOST` overrides using tailnet addresses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30a4991322b69c6ddc5dcc7fc3373843a51ed08a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Separate LAN and Tailscale pairing endpoints in `DesktopServerExposure`
> - `isUsableLanIPv4Address` now excludes Tailscale IPv4 addresses, so LAN host resolution no longer picks a Tailscale address as the LAN endpoint.
> - `resolveRuntimeState` keeps network-accessible exposure when a Tailscale non-internal IPv4 address is present, even without a resolved endpoint URL. Previously it fell back to local-only in that case.
> - Desktop startup no longer emits the local-only fallback warning when the server remains network-accessible via Tailscale but has no single endpoint URL.
> - Tests in [DesktopServerExposure.test.ts](https://github.com/pingdotgg/t3code/pull/9882/files#diff-b697fab61000dcfcd9dc8f96c474398f400aa85d838e0c98e249235ec04f287d) are renamed and expanded to cover Tailscale-only exposure and explicit Tailscale overrides.
> - Behavioral Change: configurations that previously fell back to local-only now stay network-accessible when a qualifying Tailscale address exists; the fallback path is unchanged for configs lacking both an endpoint URL and a Tailscale address.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30a4991.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
