### PR TITLE
fix(web): sort equally merge-ready pull requests by diff size

### DIFF
--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -723,6 +723,7 @@ describe("default merge-readiness ranking", () => {
       number: 4,
       checksState: "passing",
       reviewDecision: "approved",
+      additions: 1_000,
       updatedAt: "2026-06-01T00:00:00Z",
     });
     const draft = entry({
@@ -747,7 +748,7 @@ describe("default merge-readiness ranking", () => {
     ).toEqual([4, 3, 5, 2, 6, 1]);
   });
 
-  it("uses recency inside one readiness tier", () => {
+  it("uses recency when readiness and diff size tie", () => {
     const older = entry({ number: 1, checksState: "passing" });
     const newer = entry({
       number: 2,
@@ -760,13 +761,13 @@ describe("default merge-readiness ranking", () => {
     ]);
   });
 
-  it("keeps readiness order stable when optional diff counts arrive", () => {
+  it("ranks smaller measured diffs first within a readiness tier as counts arrive", () => {
     const larger = entry({
       number: 1,
       checksState: "passing",
       reviewDecision: "approved",
-      additions: 40,
-      deletions: 10,
+      additions: 1,
+      deletions: 49,
       updatedAt: "2026-09-01T00:00:00Z",
     });
     const smaller = entry({
@@ -788,14 +789,30 @@ describe("default merge-readiness ranking", () => {
 
     expect(
       rankPullRequestsByMergeReadiness([larger, unknown, smaller]).map((row) => row.number),
-    ).toEqual([3, 1, 2]);
+    ).toEqual([2, 1, 3]);
     expect(
       rankPullRequestsByMergeReadiness([
         larger,
-        { ...unknown, additions: 500, deletions: 200 },
+        { ...unknown, additions: 1, deletions: 0 },
         smaller,
       ]).map((row) => row.number),
-    ).toEqual([3, 1, 2]);
+    ).toEqual([3, 2, 1]);
+  });
+
+  it("distinguishes measured empty diffs from missing counts when sorting groups", () => {
+    const unknown = entry({ number: 1, additions: 0, deletions: 0 });
+    const measured = entry({ number: 2 });
+    const empty = entry({ number: 3, additions: 0, deletions: 0 });
+    const groups = [
+      { key: "others", label: "Others", entries: [unknown, measured, empty] },
+    ] as const;
+
+    const sorted = sortPullRequestGroups(groups, "ready", "", (row) => row.number !== 1);
+
+    expect(sorted[0]!.entries.map((row) => row.number)).toEqual([3, 2, 1]);
+    expect(sortPullRequestGroups(groups, "ready", "sidebar", (row) => row.number !== 1)).toEqual(
+      groups,
+    );
   });
 
   it("keeps authored work first and ranks each group by readiness", () => {

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -1010,10 +1010,12 @@ export function rankPullRequestMatches<Entry extends PullRequestListEntry>(
  * verdict, then everything else still open. Drafts stay in that third tier because their author
  * has not made them mergeable yet. Finished work follows open work when all states are visible. A
  * known conflict is never ready, whatever its checks, review or state say, so it stays at the
- * bottom. Recency breaks ties, so optional diff counts never move the queue beneath the reader.
+ * bottom. Within each tier, smaller measured diffs come first, then unknown sizes. Recency
+ * breaks ties between equally sized diffs.
  */
 export function rankPullRequestsByMergeReadiness<Entry extends PullRequestListEntry>(
   entries: ReadonlyArray<Entry>,
+  hasMeasuredSize: (entry: Entry) => boolean = (entry) => entry.additions + entry.deletions > 0,
 ): ReadonlyArray<Entry> {
   const tier = (entry: Entry) => {
     if (entry.mergeability === "conflicting") return 4;
@@ -1026,7 +1028,9 @@ export function rankPullRequestsByMergeReadiness<Entry extends PullRequestListEn
   return entries.toSorted((left, right) => {
     const byTier = tier(left) - tier(right);
     if (byTier !== 0) return byTier;
-    return right.updatedAt.localeCompare(left.updatedAt);
+    const measured = Number(hasMeasuredSize(right)) - Number(hasMeasuredSize(left));
+    const sized = left.additions + left.deletions - (right.additions + right.deletions);
+    return measured || sized || right.updatedAt.localeCompare(left.updatedAt);
   });
 }
 
@@ -1042,7 +1046,7 @@ export function sortPullRequestGroups<Entry extends PullRequestListEntry>(
 
   if (sort === "ready") {
     return searchText.trim().length === 0
-      ? sortWithinGroups(rankPullRequestsByMergeReadiness)
+      ? sortWithinGroups((entries) => rankPullRequestsByMergeReadiness(entries, hasMeasuredSize))
       : groups;
   }
   if (sort === "updated") return groups;

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -292,7 +292,7 @@ function PullRequestsRouteView() {
   const search = Route.useSearch();
   const sort = search.sort ?? "ready";
   const statsPolicy: PullRequestStatsPolicy =
-    sort === "largest" || sort === "smallest" ? "eager" : "visible";
+    sort === "ready" || sort === "largest" || sort === "smallest" ? "eager" : "visible";
   const navigate = useNavigate({ from: Route.fullPath });
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const { environments } = useEnvironments();
@@ -1270,8 +1270,8 @@ function PullRequestsRouteView() {
     viewers,
   ]);
 
-  // Date sorts keep optional line-count reads near the viewport. Size sorts need every loaded
-  // count before their order is final. Received counts stay cached across both policies.
+  // Date sorts keep optional line-count reads near the viewport. Size and readiness sorts need
+  // every loaded count before their order is final. Counts stay cached across both policies.
   const entriesByStatsKey = useRef<ReadonlyMap<string, EnvironmentPullRequestEntry>>(new Map());
   entriesByStatsKey.current = new Map(
     groups.flatMap((group) =>

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -826,7 +826,7 @@ function PullRequestsRouteView() {
   // from the first moment rather than the second: a button that stays live through the slow half
   // of its own work is a button that gets pressed again, and buys the whole cascade twice.
   const [invalidating, setInvalidating] = useState(false);
-  const refreshFromHost = async () => {
+  const refreshFromHost = async (includeDetail = true) => {
     const requestedStatsScope = statsScopeRef.current;
     setInvalidating(true);
     try {
@@ -851,7 +851,7 @@ function PullRequestsRouteView() {
       setStatsTargetState({ key: requestedStatsScope.key, batches });
       statsQuery.refresh(batches.map(({ environmentId, input }) => ({ environmentId, input })));
     }
-    setDetailRefreshToken((token) => token + 1);
+    if (includeDetail) setDetailRefreshToken((token) => token + 1);
   };
   const refreshing = invalidating || listQuery.isPending;
 
@@ -1951,9 +1951,9 @@ function PullRequestsRouteView() {
               }
               refreshToken={detailRefreshToken}
               // Host actions can change both readiness and diff size, so refresh the counts
-              // alongside the list before ranking the updated row.
+              // alongside the list. The panel already refreshes itself after each action.
               onActed={() => {
-                void refreshFromHost();
+                void refreshFromHost(false);
               }}
             />
           </RightPanelTabs>

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1950,10 +1950,10 @@ function PullRequestsRouteView() {
                 ) ?? null
               }
               refreshToken={detailRefreshToken}
-              // Merging, closing or reopening changes the row this panel was opened from, so
-              // the list behind it is out of date the moment the host takes the action.
+              // Host actions can change both readiness and diff size, so refresh the counts
+              // alongside the list before ranking the updated row.
               onActed={() => {
-                refreshList(true);
+                void refreshFromHost();
               }}
             />
           </RightPanelTabs>


### PR DESCRIPTION
Merge readiness used recency alone within each readiness tier, leaving smaller diffs behind larger work. It now sorts by total additions plus deletions ascending within each tier, keeps unmeasured sizes last, and loads diff stats for every listed row in readiness mode. Host actions use the existing full refresh so branch updates refresh cached diff counts.

Verified with 118 focused pull-request list tests, web typecheck, scoped lint (no errors), and live sort switching in the web app at desktop and narrow widths in dark and light themes. Readiness tiers, involvement groups, search relevance, and other sort modes are preserved. The host-action callback change has focused refresh-logic coverage but remains unverified through a live branch update. Video capture succeeded on the remote browser machine, but the artifact could not be retrieved for playback or upload; video evidence remains unavailable.

![before: merge readiness puts the 93-line pr ahead of the 7-line pr](https://uploads-production-47e4.up.railway.app/files/2aaeec28-4289-45a6-8307-5d36038465fd/t3-pr-sort-before.png)

![after: merge readiness puts the 7-line pr ahead of the 93-line pr](https://uploads-production-47e4.up.railway.app/files/375d8b2d-ae90-4d0c-aed0-3959285c13b0/t3-pr-sort-after.png)

Implemented with gpt-5.6-sol in Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sort equally merge-ready pull requests by diff size in web UI
> - `rankPullRequestsByMergeReadiness` now orders by ascending total diff size within each readiness tier before falling back to recency, and accepts an optional measurement predicate so callers can define which PRs have measured counts
> - The pull-requests route eagerly requests diff statistics for the default ready sort so the new ordering has the counts it needs
> - `refreshFromHost` gains an optional flag to skip the detail-panel refresh token; panel actions now refresh only the list and stats, since the panel refreshes itself
> - Behavioral Change: measured entries sort ahead of unmeasured ones, and explicitly measured zero-line diffs rank before entries with missing counts; verify `sortPullRequestGroups` callers that previously relied on recency-only ordering in [pullRequestList.logic.ts](https://github.com/pingdotgg/t3code/pull/9887/files#diff-f8ca5dc8d0f0bac3b412ba2abaf7fca00497f36286660cfeb38242768c60e478)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ec7781.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> List UX and extra stats fetches for ready sort; no auth or data-model changes. Slightly more API load when browsing by merge readiness.
> 
> **Overview**
> **Merge readiness** ordering within each tier no longer uses recency alone. PRs at the same readiness level are ranked by **smaller measured diffs first**, then **unknown sizes**, then **recency** as a tie-breaker. An optional `hasMeasuredSize` hook lets the list treat fetched stats (including zero-line diffs) as measured instead of lumping them with missing counts.
> 
> The pull-requests page **eagerly loads diff stats** when sort is **Merge readiness** (same as largest/smallest), passes a custom `hasMeasuredSize` into `sortPullRequestGroups`, and after detail-panel host actions calls **`refreshFromHost(false)`** so list and diff counts refresh without re-bumping the detail refresh token the panel already handles.
> 
> Tests were updated for the new tier ordering and for measured vs unmeasured empty diffs in ready sort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ec778137c08d31dfb9a707de4e3819a15799886. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->