### PR TITLE
fix(web): copy provider update commands from compact rows

### DIFF
--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -598,15 +598,19 @@ export function ProviderInstanceCard({
           selected ? "bg-muted/45" : "hover:bg-muted/25",
         )}
       >
-        <button
-          type="button"
+        <div
           className={cn(
-            "flex min-w-0 flex-1 cursor-pointer items-start gap-3 rounded-md text-left outline-none transition-opacity focus-visible:ring-2 focus-visible:ring-ring",
+            "pointer-events-none relative flex min-w-0 flex-1 items-start gap-3 rounded-md text-left transition-opacity",
             !enabled && !selected && "opacity-60 group-hover:opacity-100",
           )}
-          onClick={onSelect}
-          aria-pressed={selected}
         >
+          <button
+            type="button"
+            className="pointer-events-auto absolute inset-0 cursor-pointer rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={onSelect}
+            aria-label={`Select ${displayName}`}
+            aria-pressed={selected}
+          />
           {titleIconNode}
           <span className="min-w-0 flex-1">
             <span className="flex min-w-0 items-center gap-2">
@@ -622,9 +626,31 @@ export function ProviderInstanceCard({
                 </code>
               ) : null}
               {versionAdvisory ? (
-                <span role="img" aria-label="Update available" className="inline-flex shrink-0">
-                  <ArrowUpCircleIcon className="size-3.5 text-muted-foreground" />
-                </span>
+                updateCommand ? (
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <Button
+                          type="button"
+                          size="icon-micro"
+                          variant="ghost-muted"
+                          className="pointer-events-auto relative shrink-0"
+                          aria-label={`Copy ${displayName} update command`}
+                          onClick={() =>
+                            copyToClipboard(updateCommand, { providerName: displayName })
+                          }
+                        >
+                          <ArrowUpCircleIcon className="size-3.5" />
+                        </Button>
+                      }
+                    />
+                    <TooltipPopup side="top">Copy update command</TooltipPopup>
+                  </Tooltip>
+                ) : (
+                  <span role="img" aria-label="Update available" className="inline-flex shrink-0">
+                    <ArrowUpCircleIcon className="size-3.5 text-muted-foreground" />
+                  </span>
+                )
               ) : null}
             </span>
             <span className="mt-0.5 flex items-start gap-1.5 text-[13px] leading-[1.45] text-muted-foreground/80">
@@ -637,7 +663,7 @@ export function ProviderInstanceCard({
               </span>
             </span>
           </span>
-        </button>
+        </div>
         <span className="flex h-5 shrink-0 items-center">
           <Switch
             checked={enabled}


### PR DESCRIPTION
## What Changed

Make each provider's compact update icon copy its advertised update command, with the existing clipboard success/error feedback. Keep row selection and the copy button as separate buttons so clicking the icon does not select the provider or nest interactive elements.

## Why

In narrow Settings → Providers layouts, the update icon was only an image inside the row selection button. Clicking it left the clipboard unchanged. This applies to every provider with an update command, including Codex, Claude, and OpenCode. Advisories without a command retain their informational icon.

## Validation

- 20 focused tests passed across ProviderInstanceCard, ProviderSettingsPanel environment behavior, and useCopyToClipboard.
- Web typecheck and targeted lint/format checks passed.
- Real browser with outdated-provider fixtures: verified exact copied command contents for all six drivers (Codex, Claude, Cursor, Grok, OpenCode, Antigravity), by click and Space at 360/600/1280px. Verified all six details-popover copy buttons and a custom Claude instance. These checks copy fixture commands without running installers. Also reproduced the unchanged clipboard before the fix and verified independent row selection.
- Shared web/desktop settings component; no mobile, provider adapter, or wire contract changes.

## UI Changes

| Before | After |
| --- | --- |
| ![Before](https://github.com/MatthewFeroz/t3code/releases/download/pr-evidence-compact-provider-copy/before.png) | ![After](https://github.com/MatthewFeroz/t3code/releases/download/pr-evidence-compact-provider-copy/after.png) |

[Browser interaction recording](https://github.com/MatthewFeroz/t3code/releases/download/pr-evidence-compact-provider-copy/compact-copy.mp4)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: GPT-6. Harness: Codex.
