### PR TITLE
fix(web): align provider header action sizes and spacing

### DIFF
--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -651,7 +651,7 @@ export function ProviderInstanceCard({
   }
 
   const editorHeaderAction = (
-    <div className="flex min-w-0 items-center gap-1.5">
+    <div className="flex shrink-0 items-center gap-1.5">
       {driverOption?.badgeLabel ? (
         <Badge variant="warning" size="sm" className="shrink-0">
           {driverOption.badgeLabel}
@@ -669,7 +669,7 @@ export function ProviderInstanceCard({
               render={
                 <Button
                   type="button"
-                  size="icon-micro"
+                  size="icon-xs"
                   variant="ghost"
                   className={cn(
                     "[--control-icon-color:currentColor]",
@@ -679,7 +679,7 @@ export function ProviderInstanceCard({
                   )}
                   aria-label="Update available — view details"
                 >
-                  <ArrowUpCircleIcon className="size-3.5" />
+                  <ArrowUpCircleIcon />
                 </Button>
               }
             />
@@ -758,14 +758,14 @@ export function ProviderInstanceCard({
         {onDelete ? (
           <Button
             type="button"
-            size="icon-micro"
+            size="icon-xs"
             variant="ghost-muted"
             disabled={readOnly}
             className="[--control-icon-color:currentColor] hover:text-destructive"
             onClick={onDelete}
             aria-label={`Delete instance ${instanceId}`}
           >
-            <Trash2Icon className="size-3" />
+            <Trash2Icon />
           </Button>
         ) : null}
       </span>


### PR DESCRIPTION
## What Changed

Use the standard `icon-xs` size for the provider details header's update and delete buttons, and let the button size set both icon sizes. Prevent the header action group from shrinking so long provider descriptions cannot push the icons into the card's right padding.

## Why

These section-header actions used 20px buttons with mismatched 14px and 12px icons. The settings convention calls for 24px buttons with 14px icons on desktop, increasing to 28px buttons with 16px icons at narrow widths. Long provider status text also squeezed the action group, overflowing its allotted width.

## Validation

- 12 focused ProviderInstanceCard and ProviderSettingsPanel environment tests passed.
- Web typecheck and targeted lint/format checks passed.
- Real browser with a custom Claude instance and a long version warning: verified button/icon dimensions, unobstructed click targets, opening update details, and copying the command at 360/600/1200px.
- Shared web/desktop provider settings; no mobile, provider adapter, wire contract, or documentation changes.

## UI Changes

| Before | After |
| --- | --- |
| ![Before](https://github.com/MatthewFeroz/t3code/releases/download/pr-evidence-provider-header-spacing/t3-provider-before-1200.png) | ![After](https://github.com/MatthewFeroz/t3code/releases/download/pr-evidence-provider-header-spacing/t3-provider-after-1200.png) |

[Narrow before](https://github.com/MatthewFeroz/t3code/releases/download/pr-evidence-provider-header-spacing/t3-provider-before-360.png) · [Narrow after](https://github.com/MatthewFeroz/t3code/releases/download/pr-evidence-provider-header-spacing/t3-provider-after-360.png)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- Static sizing/layout change; no animation or interaction changes.

Model: GPT-6. Harness: Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout and button sizing only in ProviderInstanceCard; no API, auth, or data-handling changes.
> 
> **Overview**
> The provider instance **editor header** now keeps its action cluster from compressing when status text is long, and its update/delete controls match the settings **icon button** convention.
> 
> The header action wrapper switches from `min-w-0` to **`shrink-0`** so badges, version label, update popover trigger, and delete button stay visible instead of being squeezed by long descriptions. The version-advisory and delete buttons move from **`icon-micro`** to **`icon-xs`**, with per-icon size classes removed so the button variant owns consistent hit targets and icon sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 289e10f1e0234e9b237894160934f80fb59dab05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix provider header action sizes and spacing in `ProviderInstanceCard`
> Updates the editor header action container in [ProviderInstanceCard.tsx](https://github.com/pingdotgg/t3code/pull/9890/files#diff-abfacda8242e42a51ed23d2b21b91d4822ff52c2dfb6650be36af9d8c82302e9) to use non-shrinking flex behavior. Switches the advisory and delete buttons from micro to extra-small icon size and removes explicit icon size classes so they use button defaults.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 289e10f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->