### PR TITLE
fix(web): stop hosted app from flashing Alpha in tab title

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -478,6 +478,12 @@
       }
     </style>
     <title>T3 Code (Alpha)</title>
+    <script>
+      try {
+        var branding = window.desktopBridge?.getAppBranding?.();
+        if (branding && branding.displayName) document.title = branding.displayName;
+      } catch {}
+    </script>
   </head>
   <body>
     <div id="root">

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -152,10 +152,31 @@ const configuredAllowedHosts = (process.env.T3CODE_DEV_ALLOWED_HOSTS ?? "")
   .filter((entry) => entry.length > 0);
 const allowedHosts = [".ts.net", ...configuredAllowedHosts];
 
-export default defineConfig(() => {
+function hostedHtmlTitlePlugin(channel: string, mode: string): Plugin {
+  return {
+    name: "t3code:hosted-html-title",
+    transformIndexHtml(html) {
+      const normalized = channel.trim().toLowerCase();
+      let title: string;
+      if (normalized === "latest") {
+        title = "T3 Code";
+      } else if (normalized === "nightly") {
+        title = "T3 Code (Nightly)";
+      } else if (mode === "development") {
+        title = "T3 Code (Dev)";
+      } else {
+        title = "T3 Code (Alpha)";
+      }
+      return html.replace(/<title>.*?<\/title>/, `<title>${title}</title>`);
+    },
+  };
+}
+
+export default defineConfig(({ mode }) => {
   return {
     assetsInclude: ["**/*.wasm"],
     plugins: [
+      hostedHtmlTitlePlugin(configuredHostedAppChannel, mode),
       devCompressionPlugin(),
       // Route components load as split chunks so settings, pull-request, and
       // usage code stay out of the cold-start payload; the router prefetches

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -152,7 +152,7 @@ const configuredAllowedHosts = (process.env.T3CODE_DEV_ALLOWED_HOSTS ?? "")
   .filter((entry) => entry.length > 0);
 const allowedHosts = [".ts.net", ...configuredAllowedHosts];
 
-function hostedHtmlTitlePlugin(channel: string, mode: string): Plugin {
+function hostedHtmlTitlePlugin(channel: string, isDev: boolean): Plugin {
   return {
     name: "t3code:hosted-html-title",
     transformIndexHtml(html) {
@@ -162,7 +162,7 @@ function hostedHtmlTitlePlugin(channel: string, mode: string): Plugin {
         title = "T3 Code";
       } else if (normalized === "nightly") {
         title = "T3 Code (Nightly)";
-      } else if (mode === "development") {
+      } else if (isDev) {
         title = "T3 Code (Dev)";
       } else {
         title = "T3 Code (Alpha)";
@@ -172,11 +172,11 @@ function hostedHtmlTitlePlugin(channel: string, mode: string): Plugin {
   };
 }
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ command }) => {
   return {
     assetsInclude: ["**/*.wasm"],
     plugins: [
-      hostedHtmlTitlePlugin(configuredHostedAppChannel, mode),
+      hostedHtmlTitlePlugin(configuredHostedAppChannel, command === "serve"),
       devCompressionPlugin(),
       // Route components load as split chunks so settings, pull-request, and
       // usage code stay out of the cold-start payload; the router prefetches


### PR DESCRIPTION
Loading app.t3.codes briefly showed "T3 Code (Alpha)" in the browser tab before React corrected it. The static index.html always said Alpha, while hosted builds for the latest channel should show just "T3 Code" and nightly should show "T3 Code (Nightly)".

This adds a Vite HTML transform that sets the title at build and dev serve time to match the logic in branding.ts, and adds a small synchronous script in the head so the desktop wrapper can apply its injected branding without waiting for React.

*This PR was generated with opencode via muse-spark-1.2-contributor on opencode go through T3Code*


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tab-title and static HTML only; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes a brief **“T3 Code (Alpha)”** flash in the browser tab on hosted loads by setting the correct title before React boots.
> 
> A new Vite **`hostedHtmlTitlePlugin`** rewrites `<title>` during dev serve and build from **`VITE_HOSTED_APP_CHANNEL`**: plain **T3 Code** for `latest`, **T3 Code (Nightly)** for `nightly`, **T3 Code (Dev)** when serving locally, otherwise **T3 Code (Alpha)**.
> 
> **`index.html`** also gets a small synchronous head script that applies **`window.desktopBridge.getAppBranding().displayName`** when present, so the desktop wrapper can override the title without waiting on the app bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7c63b8abb2079439cca59db0c7b840fc2f31129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop hosted web app from showing "Alpha" in tab title
> - Adds a Vite plugin `hostedHtmlTitlePlugin` that sets the built HTML title based on the configured channel: "T3 Code" for latest, "T3 Code (Nightly)" for nightly, "T3 Code (Dev)" for development, and "T3 Code (Alpha)" for other production channels.
> - Adds an inline bootstrap script in `index.html` that calls the optional desktop branding bridge and replaces the document title with the returned display name, if any. Bridge errors are ignored and the static title remains unchanged.
> - Behavioral Change: the Vite config now passes command context (build vs dev) and the application channel to the HTML title transform; out-of-tree Vite setups that reuse the config factory will see titles driven by these inputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7c63b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->