### PR TITLE
fix(chat): show hours for long runs

### DIFF
--- a/apps/mobile/src/features/threads/floating-working-control.tsx
+++ b/apps/mobile/src/features/threads/floating-working-control.tsx
@@ -1,3 +1,4 @@
+import { formatDuration } from "@t3tools/shared/orchestrationTiming";
 import { GlassContainer, GlassView } from "expo-glass-effect";
 import { useEffect, useState } from "react";
 import { ActivityIndicator, Text as SystemText, View } from "react-native";
@@ -234,6 +235,9 @@ function formatWorkingDuration(startedAt: string, nowMs: number): string {
   const totalSeconds = Math.floor((nowMs - startedAtMs) / 1_000);
   if (totalSeconds < 60) {
     return `${totalSeconds}s`;
+  }
+  if (totalSeconds >= 3_600) {
+    return formatDuration(totalSeconds * 1_000);
   }
 
   const minutes = Math.floor(totalSeconds / 60);

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -27,6 +27,7 @@ const NOOP_USE_ARTIFACT_TEMPLATE = () => {};
 const NOOP_OPEN_ATTACHMENT = (_attachment: ChatFileAttachment) => {};
 import { resolveChatListAnchoredEndSpace } from "@t3tools/shared/chatList";
 import { toolActivityFaviconUrl } from "@t3tools/shared/favicon";
+import { formatDuration } from "@t3tools/shared/orchestrationTiming";
 import { getProjectFaviconCacheKey } from "@t3tools/shared/projectFavicon";
 import { observeVisibleAnimation } from "../../lib/visibleAnimation";
 import {
@@ -1707,7 +1708,7 @@ function CompactingLabel() {
 // does not create a React commit every second while a response is streaming.
 // ---------------------------------------------------------------------------
 
-/** Live "Working for Xs" label. */
+/** Live elapsed time for the "Working for" label. */
 function WorkingTimer({ createdAt }: { createdAt: string }) {
   const textRef = useRef<HTMLSpanElement>(null);
   const initialText = formatWorkingTimerNow(createdAt);
@@ -2628,15 +2629,7 @@ function formatWorkingTimer(startIso: string, endIso: string): string | null {
     return `${elapsedSeconds}s`;
   }
 
-  const hours = Math.floor(elapsedSeconds / 3600);
-  const minutes = Math.floor((elapsedSeconds % 3600) / 60);
-  const seconds = elapsedSeconds % 60;
-
-  if (hours > 0) {
-    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
-  }
-
-  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  return formatDuration(elapsedSeconds * 1_000);
 }
 
 function formatWorkingTimerNow(startIso: string): string {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -36,6 +36,8 @@ import {
   type TurnDiffSummary,
 } from "./types";
 
+export { formatDuration, formatElapsed } from "@t3tools/shared/orchestrationTiming";
+
 export type ProviderPickerKind = ProviderDriverKind;
 
 export const PROVIDER_OPTIONS: Array<{
@@ -353,32 +355,6 @@ export function workEntryIndicatesToolNeutralStatus(entry: WorkLogEntry): boolea
     return false;
   }
   return true;
-}
-
-export function formatDuration(durationMs: number): string {
-  if (!Number.isFinite(durationMs) || durationMs < 0) return "0ms";
-  if (durationMs < 1_000) return `${Math.max(1, Math.round(durationMs))}ms`;
-  if (durationMs < 10_000) {
-    const tenths = Math.round(durationMs / 100) / 10;
-    // 9.95s+ rounds up to the next bucket — render "10s", not "10.0s".
-    return tenths >= 10 ? "10s" : `${tenths.toFixed(1)}s`;
-  }
-  if (durationMs < 60_000) return `${Math.round(durationMs / 1_000)}s`;
-  const minutes = Math.floor(durationMs / 60_000);
-  const seconds = Math.round((durationMs % 60_000) / 1_000);
-  if (seconds === 0) return `${minutes}m`;
-  if (seconds === 60) return `${minutes + 1}m`;
-  return `${minutes}m ${seconds}s`;
-}
-
-export function formatElapsed(startIso: string, endIso: string | undefined): string | null {
-  if (!endIso) return null;
-  const startedAt = Date.parse(startIso);
-  const endedAt = Date.parse(endIso);
-  if (Number.isNaN(startedAt) || Number.isNaN(endedAt) || endedAt < startedAt) {
-    return null;
-  }
-  return formatDuration(endedAt - startedAt);
 }
 
 type LatestTurnTiming = Pick<OrchestrationLatestTurn, "turnId" | "startedAt" | "completedAt">;

--- a/packages/shared/src/orchestrationTiming.test.ts
+++ b/packages/shared/src/orchestrationTiming.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { formatDuration, formatElapsed } from "./orchestrationTiming.ts";
+
+describe("formatDuration", () => {
+  it.each([
+    [0, "1ms"],
+    [250, "250ms"],
+    [1_500, "1.5s"],
+    [9_950, "10s"],
+    [22_000, "22s"],
+    [60_000, "1m"],
+    [65_000, "1m 5s"],
+    [119_500, "2m"],
+    [3_599_499, "59m 59s"],
+    [3_599_500, "1h"],
+    [3_600_000, "1h"],
+    [3_601_000, "1h 1s"],
+    [3_660_000, "1h 1m"],
+    [3_661_000, "1h 1m 1s"],
+    [7_199_500, "2h"],
+    [25_190_000, "6h 59m 50s"],
+    [90_061_000, "25h 1m 1s"],
+  ])("formats %d ms as %s", (durationMs, expected) => {
+    expect(formatDuration(durationMs)).toBe(expected);
+  });
+
+  it.each([-1, NaN, Infinity, -Infinity])("handles invalid durations: %s", (durationMs) => {
+    expect(formatDuration(durationMs)).toBe("0ms");
+  });
+});
+
+describe("formatElapsed", () => {
+  it("formats a long run across midnight", () => {
+    expect(formatElapsed("2026-09-03T22:00:00Z", "2026-09-04T04:59:50Z")).toBe("6h 59m 50s");
+  });
+});

--- a/packages/shared/src/orchestrationTiming.ts
+++ b/packages/shared/src/orchestrationTiming.ts
@@ -12,13 +12,20 @@ type SessionActivityState = {
 export function formatDuration(durationMs: number): string {
   if (!Number.isFinite(durationMs) || durationMs < 0) return "0ms";
   if (durationMs < 1_000) return `${Math.max(1, Math.round(durationMs))}ms`;
-  if (durationMs < 10_000) return `${(durationMs / 1_000).toFixed(1)}s`;
+  if (durationMs < 10_000) {
+    const tenths = Math.round(durationMs / 100) / 10;
+    return tenths >= 10 ? "10s" : `${tenths.toFixed(1)}s`;
+  }
   if (durationMs < 60_000) return `${Math.round(durationMs / 1_000)}s`;
-  const minutes = Math.floor(durationMs / 60_000);
-  const seconds = Math.round((durationMs % 60_000) / 1_000);
-  if (seconds === 0) return `${minutes}m`;
-  if (seconds === 60) return `${minutes + 1}m`;
-  return `${minutes}m ${seconds}s`;
+  const totalSeconds = Math.round(durationMs / 1_000);
+  const hours = Math.floor(totalSeconds / 3_600);
+  const minutes = Math.floor((totalSeconds % 3_600) / 60);
+  const seconds = totalSeconds % 60;
+  const parts: string[] = [];
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+  if (seconds > 0) parts.push(`${seconds}s`);
+  return parts.join(" ");
 }
 
 export function formatElapsed(startIso: string, endIso: string | undefined): string | null {


### PR DESCRIPTION
Long runs display total minutes, such as `419m 50s`, which is hard to read.

Show `6h 59m 50s` instead. Web, desktop, and mobile use the shared formatter for long live, completed, and stopped runs.

## Verification

- 210 tests pass with `vp test run packages/shared/src/orchestrationTiming.test.ts apps/web/src/components/chat/MessagesTimeline.logic.test.ts apps/mobile/src/lib/threadActivity.test.ts`.
- Shared, web, and mobile typechecks pass.
- Changed-file lint and formatting pass, with existing lint warnings.
- Browser verification and screenshots skipped at Theo's request.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only timing formatting with shared logic and tests; no auth, data, or orchestration behavior changes.
> 
> **Overview**
> Long agent runs no longer show unreadable minute totals like `419m 50s`. **Shared `formatDuration`** in `@t3tools/shared/orchestrationTiming` now includes **hours** (e.g. `6h 59m 50s`), tightens sub-10s rounding so `9.95s+` becomes `10s`, and gains **unit tests** for ms through multi-hour ranges.
> 
> **Web** drops duplicate `formatDuration` / `formatElapsed` from `session-logic.ts` (re-export from shared) and routes the chat timeline “Working for” / completed-run timers through the shared formatter. **Mobile** uses the same helper on the floating working pill when elapsed time is at least one hour, while keeping the existing `Xm YYs` style for shorter live timers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d07f1d075bbf4f6d62815189fb06f1199e9b268. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `formatDuration` to show hours for long runs in chat working timer
> - Updates `orchestrationTiming.formatDuration` to split durations of at least one minute into hours, minutes, and seconds, omitting zero-valued components. Sub-ten-second values now round to tenths.
> - Routes the mobile floating working control ([floating-working-control.tsx](https://github.com/pingdotgg/t3code/pull/9894/files#diff-9e62be699243ddedcfdadb394368aeeaa97cfbec534de679f14dd7fb27e5460c)) and the web `WorkingTimer` component ([MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/9894/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588)) through the shared formatter for hour-scale durations.
> - Removes local formatter implementations in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/9894/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) and re-exports the shared utilities instead.
> - Adds table-driven tests in [orchestrationTiming.test.ts](https://github.com/pingdotgg/t3code/pull/9894/files#diff-3427b78d344f13d3634f29dcecc7d1ebb26107d167e79a24176410d3a2bdd7bd) covering hour-scale formatting, rounding boundaries, invalid inputs, and midnight-spanning intervals.
> - Behavioral Change: completed working-time labels that previously showed only minutes and seconds now include hours (e.g. `1h 1s`) when the duration reaches an hour.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d07f1d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->