### PR TITLE
fix(mobile): show the provider account badge on thread rows

### DIFF
--- a/apps/mobile/src/components/ProviderIcon.tsx
+++ b/apps/mobile/src/components/ProviderIcon.tsx
@@ -1,6 +1,9 @@
 import { Image } from "expo-image";
 import { Path, Svg } from "react-native-svg";
+import { View } from "react-native";
+import { providerInstanceInitials } from "@t3tools/client-runtime/state/provider-instance-display";
 import { useAppearancePreferences } from "../features/settings/appearance/AppearancePreferencesProvider";
+import { AppText as Text } from "./AppText";
 
 type ProviderIconProps = {
   readonly provider: string | null | undefined;
@@ -78,5 +81,60 @@ export function ProviderIcon(props: ProviderIconProps) {
         d="M239.184 106.203a64.716 64.716 0 0 0-5.576-53.103C219.452 28.459 191 15.784 163.213 21.74A65.586 65.586 0 0 0 52.096 45.22a64.716 64.716 0 0 0-43.23 31.36c-14.31 24.602-11.061 55.634 8.033 76.74a64.665 64.665 0 0 0 5.525 53.102c14.174 24.65 42.644 37.324 70.446 31.36a64.72 64.72 0 0 0 48.754 21.744c28.481.025 53.714-18.361 62.414-45.481a64.767 64.767 0 0 0 43.229-31.36c14.137-24.558 10.875-55.423-8.083-76.483Zm-97.56 136.338a48.397 48.397 0 0 1-31.105-11.255l1.535-.87 51.67-29.825a8.595 8.595 0 0 0 4.247-7.367v-72.85l21.845 12.636c.218.111.37.32.409.563v60.367c-.056 26.818-21.783 48.545-48.601 48.601Zm-104.466-44.61a48.345 48.345 0 0 1-5.781-32.589l1.534.921 51.722 29.826a8.339 8.339 0 0 0 8.441 0l63.181-36.425v25.221a.87.87 0 0 1-.358.665l-52.335 30.184c-23.257 13.398-52.97 5.431-66.404-17.803ZM23.549 85.38a48.499 48.499 0 0 1 25.58-21.333v61.39a8.288 8.288 0 0 0 4.195 7.316l62.874 36.272-21.845 12.636a.819.819 0 0 1-.767 0L41.353 151.53c-23.211-13.454-31.171-43.144-17.804-66.405v.256Zm179.466 41.695-63.08-36.63L161.73 77.86a.819.819 0 0 1 .768 0l52.233 30.184a48.6 48.6 0 0 1-7.316 87.635v-61.391a8.544 8.544 0 0 0-4.4-7.213Zm21.742-32.69-1.535-.922-51.619-30.081a8.39 8.39 0 0 0-8.492 0L99.98 99.808V74.587a.716.716 0 0 1 .307-.665l52.233-30.133a48.652 48.652 0 0 1 72.236 50.391v.205ZM88.061 139.097l-21.845-12.585a.87.87 0 0 1-.41-.614V65.685a48.652 48.652 0 0 1 79.757-37.346l-1.535.87-51.67 29.825a8.595 8.595 0 0 0-4.246 7.367l-.051 72.697Zm11.868-25.58 28.138-16.217 28.188 16.218v32.434l-28.086 16.218-28.188-16.218-.052-32.434Z"
       />
     </Svg>
+  );
+}
+
+/**
+ * `ProviderIcon` plus the web sidebar's account badge: an accent-color
+ * initials bubble in the bottom-right corner, drawn when `showBadge` is set
+ * (accent color present, or several instances share this driver). The glyph
+ * dims to 60% opacity while the badge stays fully saturated, matching
+ * `apps/web/src/components/chat/ProviderInstanceIcon.tsx`.
+ */
+export function ProviderInstanceIcon(props: {
+  readonly provider: string | null | undefined;
+  readonly size?: number;
+  readonly displayName: string;
+  readonly accentColor?: string;
+  readonly showBadge?: boolean;
+  readonly surfaceColor: string;
+}) {
+  return (
+    <View style={{ position: "relative" }}>
+      <View style={{ opacity: 0.6 }}>
+        <ProviderIcon provider={props.provider} size={props.size} />
+      </View>
+      {props.showBadge ? (
+        <View
+          className={props.accentColor ? undefined : "bg-card"}
+          style={{
+            position: "absolute",
+            right: -3,
+            bottom: -3,
+            height: 12,
+            minWidth: 12,
+            paddingHorizontal: 2,
+            borderRadius: 999,
+            borderWidth: 1,
+            borderColor: props.surfaceColor,
+            backgroundColor: props.accentColor,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Text
+            className={props.accentColor ? undefined : "text-foreground-muted"}
+            style={{
+              fontSize: 7,
+              fontWeight: "600",
+              lineHeight: 9,
+              color: props.accentColor ? "#ffffff" : undefined,
+            }}
+          >
+            {providerInstanceInitials(props.displayName)}
+          </Text>
+        </View>
+      ) : null}
+    </View>
   );
 }

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -51,6 +51,7 @@ import {
   ThreadListV2SettledShelfHeader,
   ThreadListV2SnoozedShelfHeader,
 } from "../threads/thread-list-v2-items";
+import { resolveThreadProviderInstance } from "../threads/thread-provider-instance";
 import {
   buildThreadListV2Items,
   getThreadListV2OrderedSection,
@@ -840,15 +841,7 @@ export function HomeScreen(props: HomeScreenProps) {
           projectTitle={v2ProjectTitleByProjectKey.get(
             scopedProjectKey(thread.environmentId, thread.projectId),
           )}
-          providerDriver={
-            serverConfigs
-              .get(thread.environmentId)
-              ?.providers.find(
-                (provider) =>
-                  provider.instanceId ===
-                  (thread.session?.providerInstanceId ?? thread.modelSelection.instanceId),
-              )?.driver ?? null
-          }
+          providerInstance={resolveThreadProviderInstance(serverConfigs, thread)}
           environmentLabel={
             Object.keys(props.savedConnectionsById).length > 1
               ? (props.savedConnectionsById[thread.environmentId]?.environmentLabel ?? null)

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -78,6 +78,7 @@ import {
   ThreadListV2SettledShelfHeader,
   ThreadListV2SnoozedShelfHeader,
 } from "./thread-list-v2-items";
+import { resolveThreadProviderInstance } from "./thread-provider-instance";
 import {
   buildThreadListV2Items,
   getThreadListV2OrderedSection,
@@ -901,15 +902,7 @@ function ThreadNavigationSidebarPane(
               snoozeWakeLabelText={item.snoozeWakeLabelText}
               project={projectByKey.get(scopeKey) ?? null}
               projectTitle={projectTitleByProjectKey.get(scopeKey)}
-              providerDriver={
-                serverConfigs
-                  .get(thread.environmentId)
-                  ?.providers.find(
-                    (provider) =>
-                      provider.instanceId ===
-                      (thread.session?.providerInstanceId ?? thread.modelSelection.instanceId),
-                  )?.driver ?? null
-              }
+              providerInstance={resolveThreadProviderInstance(serverConfigs, thread)}
               environmentLabel={
                 Object.keys(savedConnectionsById).length > 1
                   ? (savedConnectionsById[thread.environmentId]?.environmentLabel ?? null)

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -16,7 +16,8 @@ import { AppText as Text } from "../../components/AppText";
 import { ControlPillMenu } from "../../components/ControlPill";
 import { EnvironmentMachineSymbol } from "../../components/EnvironmentMachineSymbol";
 import { ProjectFavicon } from "../../components/ProjectFavicon";
-import { ProviderIcon } from "../../components/ProviderIcon";
+import { ProviderInstanceIcon } from "../../components/ProviderIcon";
+import type { ThreadRowProviderInstance } from "./thread-provider-instance";
 import { cn } from "../../lib/cn";
 import { relativeTime } from "../../lib/time";
 import { useUniwindTheme } from "../../lib/useUniwindTheme";
@@ -349,7 +350,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
   readonly snoozePresetMinute: string;
   readonly project: EnvironmentProject | null;
   readonly projectTitle?: string;
-  readonly providerDriver: string | null;
+  readonly providerInstance: ThreadRowProviderInstance | null;
   /** Which machine hosts the thread. Null when only one environment is
       connected — repeating the same label on every row is noise. Mirrors
       the web sidebar's remote-environment cloud icon, but as text since
@@ -435,6 +436,15 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
   const selectedBackgroundColor = theme["--color-user-bubble"];
   const sidebarPane = props.pane === "sidebar";
   const selected = props.selected === true;
+  // The provider badge's border blends into the row's own surface, which
+  // differs by pane and (for the sidebar pane) selection: the sidebar row
+  // background becomes the selected fill or the drawer surface, while the
+  // flat "screen" pane rows always sit on the screen background.
+  const providerIconSurfaceColor = sidebarPane
+    ? selected
+      ? selectedBackgroundColor
+      : drawerColor
+    : screenColor;
 
   const status = resolveThreadListV2Status(thread);
   const statusLabel = STATUS_LABEL_BY_STATUS[status];
@@ -825,10 +835,15 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
             #{pr.label}
           </Text>
         ) : null}
-        {props.providerDriver ? (
-          <View className="opacity-60">
-            <ProviderIcon provider={props.providerDriver} size={14} />
-          </View>
+        {props.providerInstance ? (
+          <ProviderInstanceIcon
+            provider={props.providerInstance.driverKind}
+            size={14}
+            displayName={props.providerInstance.displayName}
+            accentColor={props.providerInstance.accentColor}
+            showBadge={props.providerInstance.showBadge}
+            surfaceColor={providerIconSurfaceColor}
+          />
         ) : null}
       </View>
     </>

--- a/apps/mobile/src/features/threads/thread-provider-instance.test.ts
+++ b/apps/mobile/src/features/threads/thread-provider-instance.test.ts
@@ -1,0 +1,98 @@
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import {
+  EnvironmentId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  type ServerConfig,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveThreadProviderInstance } from "./thread-provider-instance";
+
+function makeConfig(
+  providers: ReadonlyArray<{
+    readonly instanceId: string;
+    readonly driver: string;
+    readonly displayName?: string;
+    readonly accentColor?: string;
+  }>,
+): ServerConfig {
+  return { providers } as unknown as ServerConfig;
+}
+
+function makeThread(environmentId: EnvironmentId, instanceId: string): EnvironmentThreadShell {
+  return {
+    environmentId,
+    id: ThreadId.make("thread-1"),
+    projectId: ProjectId.make("project-1"),
+    title: "Thread",
+    modelSelection: { instanceId: ProviderInstanceId.make(instanceId), model: "gpt-5.4" },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    branch: null,
+    worktreePath: null,
+    latestTurn: null,
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+    archivedAt: null,
+    settledOverride: null,
+    settledAt: null,
+    session: null,
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+  } as unknown as EnvironmentThreadShell;
+}
+
+describe("resolveThreadProviderInstance", () => {
+  it("resolves two environments with the same default instance id independently", () => {
+    const environmentA = EnvironmentId.make("environment-a");
+    const environmentB = EnvironmentId.make("environment-b");
+    const serverConfigs = new Map<EnvironmentId, ServerConfig>([
+      [
+        environmentA,
+        makeConfig([{ instanceId: "codex", driver: "codex", accentColor: "#ff8800" }]),
+      ],
+      [environmentB, makeConfig([{ instanceId: "codex", driver: "codex" }])],
+    ]);
+
+    const threadA = makeThread(environmentA, "codex");
+    const threadB = makeThread(environmentB, "codex");
+
+    expect(resolveThreadProviderInstance(serverConfigs, threadA)?.accentColor).toBe("#ff8800");
+    expect(resolveThreadProviderInstance(serverConfigs, threadB)?.accentColor).toBeUndefined();
+  });
+
+  it("labels a custom instance by its id so its initials differ from the default", () => {
+    const environmentId = EnvironmentId.make("environment-a");
+    const serverConfigs = new Map<EnvironmentId, ServerConfig>([
+      [
+        environmentId,
+        makeConfig([
+          { instanceId: "codex", driver: "codex", displayName: "Codex" },
+          { instanceId: "codex_personal", driver: "codex", displayName: "Codex" },
+        ]),
+      ],
+    ]);
+
+    expect(
+      resolveThreadProviderInstance(serverConfigs, makeThread(environmentId, "codex"))?.displayName,
+    ).toBe("Codex");
+    expect(
+      resolveThreadProviderInstance(serverConfigs, makeThread(environmentId, "codex_personal"))
+        ?.displayName,
+    ).toBe("Codex Personal");
+  });
+
+  it("hides the badge for a single instance with no accent color", () => {
+    const environmentId = EnvironmentId.make("environment-a");
+    const serverConfigs = new Map<EnvironmentId, ServerConfig>([
+      [environmentId, makeConfig([{ instanceId: "codex", driver: "codex" }])],
+    ]);
+    const thread = makeThread(environmentId, "codex");
+
+    expect(resolveThreadProviderInstance(serverConfigs, thread)?.showBadge).toBe(false);
+  });
+});

--- a/apps/mobile/src/features/threads/thread-provider-instance.ts
+++ b/apps/mobile/src/features/threads/thread-provider-instance.ts
@@ -1,0 +1,42 @@
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import {
+  normalizeProviderAccentColor,
+  resolveProviderInstanceDisplayName,
+  shouldShowInstanceBadge,
+} from "@t3tools/client-runtime/state/provider-instance-display";
+import type { EnvironmentId, ProviderDriverKind, ServerConfig } from "@t3tools/contracts";
+
+/** What a thread row needs to draw the provider glyph and its account badge. */
+export interface ThreadRowProviderInstance {
+  readonly driverKind: ProviderDriverKind;
+  readonly displayName: string;
+  readonly accentColor?: string | undefined;
+  readonly showBadge: boolean;
+}
+
+/**
+ * Resolve the provider instance a thread runs on, scoped to the thread's own
+ * environment: default instance ids are the driver slug, so the same id
+ * names a different account on every server.
+ */
+export function resolveThreadProviderInstance(
+  serverConfigs: ReadonlyMap<EnvironmentId, ServerConfig>,
+  thread: EnvironmentThreadShell,
+): ThreadRowProviderInstance | null {
+  const providers = serverConfigs.get(thread.environmentId)?.providers ?? [];
+  const instanceId = thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
+  const snapshot = providers.find((provider) => provider.instanceId === instanceId);
+  if (!snapshot) return null;
+  const entry = {
+    driverKind: snapshot.driver,
+    displayName: resolveProviderInstanceDisplayName(snapshot),
+    accentColor: normalizeProviderAccentColor(snapshot.accentColor),
+  };
+  return {
+    ...entry,
+    showBadge: shouldShowInstanceBadge(
+      entry,
+      providers.map((provider) => ({ driverKind: provider.driver })),
+    ),
+  };
+}

--- a/apps/web/src/components/chat/ProviderInstanceIcon.tsx
+++ b/apps/web/src/components/chat/ProviderInstanceIcon.tsx
@@ -1,18 +1,11 @@
 import { type CSSProperties, memo } from "react";
 import { type ProviderDriverKind } from "@t3tools/contracts";
+import { providerInstanceInitials } from "@t3tools/client-runtime/state/provider-instance-display";
 
 import { PROVIDER_ICON_BY_PROVIDER } from "./providerIconUtils";
 import { cn } from "~/lib/utils";
 
-export function providerInstanceInitials(label: string): string {
-  const words = label.replace(/[_-]+/g, " ").split(/\s+/u).filter(Boolean);
-  if (words.length === 0) return "";
-  if (words.length === 1) return words[0]!.slice(0, 2).toUpperCase();
-  return words
-    .slice(0, 2)
-    .map((word) => word[0]?.toUpperCase() ?? "")
-    .join("");
-}
+export { providerInstanceInitials };
 
 export const ProviderInstanceIcon = memo(function ProviderInstanceIcon(props: {
   driverKind: ProviderDriverKind;

--- a/apps/web/src/providerInstances.ts
+++ b/apps/web/src/providerInstances.ts
@@ -15,7 +15,6 @@
 import {
   DEFAULT_MODEL_BY_PROVIDER,
   defaultInstanceIdForDriver,
-  PROVIDER_DISPLAY_NAMES,
   resolveProviderInstanceEnabled,
   type ModelSelection,
   type ProviderDriverKind,
@@ -25,8 +24,13 @@ import {
   type ServerSettings,
   type ServerProviderState,
 } from "@t3tools/contracts";
+import {
+  normalizeProviderAccentColor,
+  resolveProviderInstanceDisplayName,
+  shouldShowInstanceBadge,
+} from "@t3tools/client-runtime/state/provider-instance-display";
 
-import { formatProviderDriverKindLabel } from "./providerModels";
+export { normalizeProviderAccentColor, shouldShowInstanceBadge };
 
 /**
  * Local-only placeholder used while a draft has no provider it can safely
@@ -81,93 +85,6 @@ export function isProviderInstancePickerVisible(entry: ProviderInstanceEntry): b
 }
 
 /**
- * Turn an instance id slug into a human-readable label. Splits on `_` / `-`
- * and camelCase boundaries and title-cases each token, so `codex_personal`
- * becomes "Codex Personal" and `myCustomInstance` becomes "My Custom
- * Instance".
- *
- * This is a fallback used only when the wire snapshot's `displayName`
- * doesn't disambiguate a non-default instance from the default one of the
- * same driver (today every built-in driver hard-codes a single presentation
- * label per kind, so two instances of the same kind arrive with identical
- * display names). When a server/driver later plumbs the user's configured
- * `ProviderInstanceConfig.displayName` through to the snapshot, that value
- * will take precedence over this fallback.
- */
-function humanizeInstanceId(instanceId: ProviderInstanceId): string {
-  const words: string[] = [];
-  for (const token of instanceId
-    .replace(/[_-]+/g, " ")
-    .replace(/([a-z])([A-Z])/g, "$1 $2")
-    .split(" ")) {
-    if (token.length === 0) continue;
-    words.push(token.charAt(0).toUpperCase() + token.slice(1));
-  }
-  return words.join(" ");
-}
-
-function driverKindLabel(driverKind: ProviderDriverKind): string {
-  return PROVIDER_DISPLAY_NAMES[driverKind] ?? formatProviderDriverKindLabel(driverKind);
-}
-
-/**
- * Whether an instance's icon carries the account badge: accent color set, or
- * several instances sharing a driver so the brand glyph alone is ambiguous.
- * Shared by the composer trigger, the picker rail, and sidebar rows.
- */
-export function shouldShowInstanceBadge(
-  entry: ProviderInstanceEntry,
-  entries: Iterable<ProviderInstanceEntry>,
-): boolean {
-  if (entry.accentColor) return true;
-  let sharedDriverCount = 0;
-  for (const candidate of entries) {
-    if (candidate.driverKind === entry.driverKind && ++sharedDriverCount > 1) return true;
-  }
-  return false;
-}
-
-export function normalizeProviderAccentColor(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  if (!trimmed) return undefined;
-  return /^#[0-9a-fA-F]{6}$/u.test(trimmed) ? trimmed : undefined;
-}
-
-/**
- * Resolve an entry's displayName with a tiered priority:
- *
- *   1. A snapshot `displayName` that differs from the driver-kind label —
- *      the server has explicitly named this instance, trust it.
- *   2. For non-default instances, a humanized `instanceId` — the server
- *      fell back to the driver-level presentation constant (which is the
- *      same for every instance of that kind), so we differentiate at the
- *      UI layer by slug. This is what keeps "Codex" + "Codex Personal"
- *      distinguishable in tooltips and list labels today.
- *   3. The snapshot's `displayName` (if any) — default instance, trust
- *      whatever label the driver stamped.
- *   4. `driverKindLabel(driverKind)` — nothing else on hand, so use the
- *      canonical brand label from contracts (falling back to a generic
- *      title-case of the kind slug).
- */
-function resolveInstanceDisplayName(
-  snapshot: ServerProvider,
-  instanceId: ProviderInstanceId,
-  driverKind: ProviderDriverKind,
-  isDefault: boolean,
-): string {
-  const trimmedSnapshotName = snapshot.displayName?.trim();
-  const kindLabel = driverKindLabel(driverKind);
-  if (trimmedSnapshotName && trimmedSnapshotName !== kindLabel) {
-    return trimmedSnapshotName;
-  }
-  if (!isDefault) {
-    const humanized = humanizeInstanceId(instanceId);
-    if (humanized.length > 0) return humanized;
-  }
-  return trimmedSnapshotName || kindLabel;
-}
-
-/**
  * Project the wire `ServerProvider[]` into instance entries, one per
  * configured instance. Preserves the server's ordering (which sources
  * from `deriveProviderInstanceConfigMap` — explicit `providerInstances.*`
@@ -182,11 +99,10 @@ export function deriveProviderInstanceEntries(
     const driverKind = snapshot.driver;
     const defaultId = defaultInstanceIdForDriver(driverKind);
     const isDefault = instanceId === defaultId;
-    const displayName = resolveInstanceDisplayName(snapshot, instanceId, driverKind, isDefault);
     return {
       instanceId,
       driverKind,
-      displayName,
+      displayName: resolveProviderInstanceDisplayName(snapshot),
       accentColor: normalizeProviderAccentColor(snapshot.accentColor),
       continuationGroupKey: snapshot.continuation?.groupKey,
       enabled: snapshot.enabled,

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -139,6 +139,10 @@
       "types": "./src/state/projects.ts",
       "default": "./src/state/projects.ts"
     },
+    "./state/provider-instance-display": {
+      "types": "./src/state/providerInstanceDisplay.ts",
+      "default": "./src/state/providerInstanceDisplay.ts"
+    },
     "./state/pull-requests": {
       "types": "./src/state/pullRequests.ts",
       "default": "./src/state/pullRequests.ts"

--- a/packages/client-runtime/src/state/providerInstanceDisplay.test.ts
+++ b/packages/client-runtime/src/state/providerInstanceDisplay.test.ts
@@ -1,0 +1,108 @@
+import { ProviderDriverKind, ProviderInstanceId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  normalizeProviderAccentColor,
+  providerInstanceInitials,
+  resolveProviderInstanceDisplayName,
+  shouldShowInstanceBadge,
+} from "./providerInstanceDisplay.ts";
+
+const codex = ProviderDriverKind.make("codex");
+const claude = ProviderDriverKind.make("claudeAgent");
+
+describe("resolveProviderInstanceDisplayName", () => {
+  it("keeps a snapshot name that differs from the brand label", () => {
+    expect(
+      resolveProviderInstanceDisplayName({
+        instanceId: ProviderInstanceId.make("codex"),
+        driver: codex,
+        displayName: "Work",
+      }),
+    ).toBe("Work");
+  });
+
+  it("humanizes a custom instance id when the snapshot only carries the brand label", () => {
+    expect(
+      resolveProviderInstanceDisplayName({
+        instanceId: ProviderInstanceId.make("codex_personal"),
+        driver: codex,
+        displayName: "Codex",
+      }),
+    ).toBe("Codex Personal");
+  });
+
+  it("uses the brand label for the default instance", () => {
+    expect(
+      resolveProviderInstanceDisplayName({
+        instanceId: ProviderInstanceId.make("codex"),
+        driver: codex,
+      }),
+    ).toBe("Codex");
+  });
+});
+
+describe("providerInstanceInitials", () => {
+  it("takes the first two characters of a single word", () => {
+    expect(providerInstanceInitials("Codex")).toBe("CO");
+  });
+
+  it("takes the first character of each of the first two words", () => {
+    expect(providerInstanceInitials("Codex Personal")).toBe("CP");
+  });
+
+  it("ignores words past the first two", () => {
+    expect(providerInstanceInitials("Codex Personal Backup Account")).toBe("CP");
+  });
+
+  it("returns an empty string for an empty label", () => {
+    expect(providerInstanceInitials("")).toBe("");
+  });
+
+  it("keeps an emoji whole instead of splitting its surrogate pair", () => {
+    expect(providerInstanceInitials("😀 Work")).toBe("😀W");
+    expect(providerInstanceInitials("😀")).toBe("😀");
+  });
+});
+
+describe("normalizeProviderAccentColor", () => {
+  it("accepts a lowercase hex color", () => {
+    expect(normalizeProviderAccentColor("#ff8800")).toBe("#ff8800");
+  });
+
+  it("accepts an uppercase hex color", () => {
+    expect(normalizeProviderAccentColor("#FF8800")).toBe("#FF8800");
+  });
+
+  it("rejects a non-hex value", () => {
+    expect(normalizeProviderAccentColor("blue")).toBeUndefined();
+  });
+
+  it("rejects a short hex value", () => {
+    expect(normalizeProviderAccentColor("#fff")).toBeUndefined();
+  });
+
+  it("treats undefined and blank as unset", () => {
+    expect(normalizeProviderAccentColor(undefined)).toBeUndefined();
+    expect(normalizeProviderAccentColor("   ")).toBeUndefined();
+  });
+});
+
+describe("shouldShowInstanceBadge", () => {
+  it("shows the badge when the entry has an accent color", () => {
+    const entry = { driverKind: codex, accentColor: "#ff8800" };
+    expect(shouldShowInstanceBadge(entry, [entry])).toBe(true);
+  });
+
+  it("shows the badge when two entries share a driver, even without an accent", () => {
+    const first = { driverKind: codex, accentColor: undefined };
+    const second = { driverKind: codex, accentColor: undefined };
+    expect(shouldShowInstanceBadge(first, [first, second])).toBe(true);
+  });
+
+  it("hides the badge for a single instance of a driver with no accent", () => {
+    const entry = { driverKind: codex, accentColor: undefined };
+    const other = { driverKind: claude, accentColor: undefined };
+    expect(shouldShowInstanceBadge(entry, [entry, other])).toBe(false);
+  });
+});

--- a/packages/client-runtime/src/state/providerInstanceDisplay.ts
+++ b/packages/client-runtime/src/state/providerInstanceDisplay.ts
@@ -1,0 +1,88 @@
+/**
+ * How a configured provider instance presents itself in a client: its label,
+ * its accent color, and whether its icon carries the account badge. Shared by
+ * web and mobile so both clients name and badge the same instance identically.
+ *
+ * @module providerInstanceDisplay
+ */
+import {
+  defaultInstanceIdForDriver,
+  PROVIDER_DISPLAY_NAMES,
+  type ProviderDriverKind,
+  type ServerProvider,
+} from "@t3tools/contracts";
+
+/**
+ * Title-case a slug: splits on `_` / `-` and camelCase boundaries, so
+ * `codex_personal` becomes "Codex Personal" and `myCustomInstance` becomes
+ * "My Custom Instance".
+ */
+function humanizeSlug(slug: string): string {
+  return slug
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+/**
+ * Resolve an instance's label with a tiered priority:
+ *
+ *   1. A snapshot `displayName` that differs from the driver's brand label —
+ *      the server has explicitly named this instance, trust it.
+ *   2. For non-default instances, a humanized `instanceId` — the server fell
+ *      back to the driver-level label (the same for every instance of that
+ *      kind), so the slug is what keeps "Codex" and "Codex Personal" apart.
+ *   3. The snapshot's `displayName`, or the brand label from contracts.
+ */
+export function resolveProviderInstanceDisplayName(
+  snapshot: Pick<ServerProvider, "instanceId" | "driver" | "displayName">,
+): string {
+  const trimmedSnapshotName = snapshot.displayName?.trim();
+  const kindLabel = PROVIDER_DISPLAY_NAMES[snapshot.driver] ?? humanizeSlug(snapshot.driver);
+  if (trimmedSnapshotName && trimmedSnapshotName !== kindLabel) return trimmedSnapshotName;
+  if (snapshot.instanceId !== defaultInstanceIdForDriver(snapshot.driver)) {
+    const humanized = humanizeSlug(snapshot.instanceId);
+    if (humanized.length > 0) return humanized;
+  }
+  return trimmedSnapshotName || kindLabel;
+}
+
+/**
+ * Turn a display name into up to two initials for the badge: the first two
+ * characters of a single word, or the first character of each of the first
+ * two words. Iterates by code point so an emoji never splits into surrogates.
+ */
+export function providerInstanceInitials(label: string): string {
+  const words = label.replace(/[_-]+/g, " ").split(/\s+/u).filter(Boolean);
+  if (words.length === 0) return "";
+  if (words.length === 1) return Array.from(words[0]!).slice(0, 2).join("").toUpperCase();
+  return words
+    .slice(0, 2)
+    .map((word) => Array.from(word)[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+/** Only `#rrggbb` accent colors render; anything else is treated as unset. */
+export function normalizeProviderAccentColor(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return /^#[0-9a-fA-F]{6}$/u.test(trimmed) ? trimmed : undefined;
+}
+
+/**
+ * Whether an instance's icon carries the account badge: accent color set, or
+ * several instances sharing a driver so the brand glyph alone is ambiguous.
+ * Shared by the composer trigger, the picker rail, and sidebar/thread rows.
+ */
+export function shouldShowInstanceBadge(
+  entry: { readonly driverKind: ProviderDriverKind; readonly accentColor?: string | undefined },
+  entries: Iterable<{ readonly driverKind: ProviderDriverKind }>,
+): boolean {
+  if (entry.accentColor) return true;
+  let sharedDriverCount = 0;
+  for (const candidate of entries) {
+    if (candidate.driverKind === entry.driverKind && ++sharedDriverCount > 1) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## What Changed

Mobile thread rows now show which provider account a thread runs on, the way the web sidebar has since #5980. When an instance has an accent color, or several instances share one provider, the provider glyph carries the account's accent badge with its initials. Rows for a single plain instance look exactly as before.

The badge rule and the instance label rule move from the web app into `client-runtime`, so web and mobile name and badge an instance identically. Web keeps its call sites. Mobile replaces the inline provider lookup in the Home list and the iPad sidebar with one resolver that returns the driver, label, accent, and badge flag, scoped to the thread's own environment because default instance ids collide across servers. The legacy v1 list never drew a provider glyph and is left alone.

Fixes #9898.

## Why

With a work and a personal subscription on the same provider, the phone was the one client where you could not tell them apart. The row rendered a dimmed glyph, and an accent color set on the server never appeared on mobile. The data was already on the device; the row only received the driver and dropped the display name and accent on the way.

## Review guide

Eleven files, one concern. Read in this order:

- `packages/client-runtime/src/state/providerInstanceDisplay.ts` (new) — `shouldShowInstanceBadge`, `normalizeProviderAccentColor`, `providerInstanceInitials`, and the instance label rule, moved verbatim from `apps/web/src/providerInstances.ts` and `ProviderInstanceIcon.tsx`. Only two behavior changes: initials iterate by code point so an emoji name does not split, and the label fallback (humanize a non-default instance id when the server sent the brand label) is now shared instead of web-only. Exported as `@t3tools/client-runtime/state/provider-instance-display`.
- `apps/web/src/providerInstances.ts`, `apps/web/src/components/chat/ProviderInstanceIcon.tsx` — import from the shared module and re-export the old names. No web call site changes.
- `apps/mobile/src/features/threads/thread-provider-instance.ts` (new) — `resolveThreadProviderInstance(serverConfigs, thread)`, the one lookup both lists use.
- `apps/mobile/src/components/ProviderIcon.tsx` — `ProviderInstanceIcon`: the existing glyph at 60% opacity plus the corner badge, same geometry as web.
- `apps/mobile/src/features/threads/thread-list-v2-items.tsx`, `HomeScreen.tsx`, `ThreadNavigationSidebar.tsx` — the row takes the resolved instance instead of a driver string; each screen swaps its inline `.find(...)` for the resolver.

Risk is low: client-only, no contract or persistence change. The only web-visible effect is that `deriveProviderInstanceEntries` now calls the shared label resolver, which is the same code it called before.

## UI Changes

Same server, same threads, one Claude Code account with a green accent color.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/13a8d3bf-a573-410b-a6bb-5b059bcf3432" width="380" alt="Before: bare dimmed provider glyph on every row" /> | <img src="https://github.com/user-attachments/assets/e43053d0-0416-421d-9163-c8016a0d1266" width="380" alt="After: provider glyph with the green VI account badge; the Codex row stays badge-free" /> |
| <img src="https://github.com/user-attachments/assets/4e8bb320-8590-44fd-a834-267a098d3e8f" width="200" alt="Before, row icon at 4x" /> | <img src="https://github.com/user-attachments/assets/f437a37b-ba0a-49da-a36a-42df19a6c20e" width="200" alt="After, row icon at 4x: accent badge with initials hangs off the glyph corner" /> |

No motion changes, so no video.

## Verification

```sh
vp test run packages/client-runtime/src/state/providerInstanceDisplay.test.ts apps/mobile/src/features/threads/thread-provider-instance.test.ts apps/web/src/providerInstances.test.ts
```

- 53 tests pass, including two environments sharing a default instance id resolving to different accents, a custom instance labelled by its id so its initials differ from the default's, and emoji-safe initials.
- Client-runtime, mobile, and web typechecks pass. Changed-file lint and formatting pass, with pre-existing lint warnings in the sidebar file.
- Integrated pass on an Android 14 emulator against a copy of real data (screenshots above).
- Cursor Bugbot and Macroscope each raised one finding on the first revision (duplicate initials for two instances of one driver, and surrogate-splitting initials). Both are fixed in the current head with tests; Macroscope has approved.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (not applicable, no motion)

Written by Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added provider instance icons with display-name initials, accent colors, and optional badges.
  - Thread lists now show provider instance details more clearly.
  - Added a “New thread on branch” action to thread menus.
  - Improved provider instance display names, initials, accent colors, and badge visibility.
  - Updated working-status colors for better adaptive visibility.

- **Bug Fixes**
  - Improved provider resolution for threads across multiple environments.
  - Improved swipe-state handling when thread status or snooze details change.

- **Tests**
  - Added coverage for provider instance resolution and display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show provider account badge on mobile thread rows
> - Adds `ProviderInstanceIcon` to mobile, which dims the provider glyph and overlays an account badge with initials and accent color
> - Adds `resolveThreadProviderInstance` to resolve environment-scoped provider metadata (display name, accent color, badge visibility) for each thread row; [HomeScreen](https://github.com/pingdotgg/t3code/pull/9899/files#diff-b6e075b3065ae370669290cbaa8476a852399968002468571cd914d06a32fd40) and [ThreadNavigationSidebar](https://github.com/pingdotgg/t3code/pull/9899/files#diff-4431208d7dda139d19919302f332d6a63788b9d114b4b7a410d89a727b9ed455) now pass this metadata to rows
> - Moves provider display-name resolution, slug humanization, accent-color normalization, initials generation, and badge-visibility logic into shared [client-runtime](https://github.com/pingdotgg/t3code/pull/9899/files#diff-dd1531a01e3447b63bcbd3f8a7435191ae09445deaf707fa7a696e142f088fde) utilities; web now re-exports these instead of keeping local copies
> - Risk: `ThreadListV2Row` input changed from a driver string to `ThreadRowProviderInstance` metadata — any caller not updated via `HomeScreen` or `ThreadNavigationSidebar` will fail to compile
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1533e05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->