### PR TITLE
fix(mobile): respect notification permission when linking cloud environments

### DIFF
--- a/apps/mobile/src/features/cloud/linkEnvironment.test.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.test.ts
@@ -21,6 +21,15 @@ import {
   refreshCloudEnvironmentConnection,
 } from "./linkEnvironment";
 
+const { getPermissionsAsync, platform, supportsAgentAwarenessPush } = vi.hoisted(() => ({
+  platform: { OS: "ios" },
+  supportsAgentAwarenessPush: vi.fn(() => true),
+  getPermissionsAsync: vi.fn(async () => ({ granted: false })),
+}));
+
+vi.mock("expo-notifications", () => ({ getPermissionsAsync }));
+vi.mock("../agent-awareness/capabilities", () => ({ supportsAgentAwarenessPush }));
+
 vi.mock("expo-constants", () => ({
   default: {
     expoConfig: {
@@ -47,9 +56,7 @@ vi.mock("expo-device", () => ({
 }));
 
 vi.mock("react-native", () => ({
-  Platform: {
-    OS: "ios",
-  },
+  Platform: platform,
 }));
 
 vi.mock("expo-secure-store", () => ({
@@ -191,6 +198,9 @@ function listedEnvironment(environmentId: string) {
 describe("mobile cloud link environment client", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    getPermissionsAsync.mockReset();
+    supportsAgentAwarenessPush.mockReset();
+    platform.OS = "ios";
     createProofMock.mockClear();
     loadPreferences.mockClear();
   });
@@ -750,58 +760,87 @@ describe("mobile cloud link environment client", () => {
     }),
   );
 
-  it.effect("preserves disabled Live Activity preferences when linking an environment", () =>
-    Effect.gen(function* () {
-      loadPreferences.mockReturnValueOnce(Effect.succeed({ liveActivitiesEnabled: false }));
-      const bodies: Array<unknown> = [];
-      const fetchMock = vi.fn((url: string | URL, init?: RequestInit) => {
-        if (init?.body) {
-          // @effect-diagnostics-next-line preferSchemaOverJson:off
-          bodies.push(JSON.parse(requestBodyText(init.body)));
-        }
-        if (String(url).endsWith("/v1/client/environment-link-challenges")) {
-          return Promise.resolve(Response.json(validLinkChallengeResponse()));
-        }
-        if (String(url).endsWith("/api/connect/link-proof")) {
-          return Promise.resolve(Response.json(validLinkProof()));
-        }
-        if (String(url).endsWith("/v1/client/environment-links")) {
-          return Promise.resolve(Response.json(validLinkResponse()));
-        }
-        return Promise.resolve(
-          Response.json({ ok: true, endpointRuntimeStatus: { status: "configured" } }),
+  for (const { name, granted, os, pushSupported, enabled } of [
+    { name: "denied permission", granted: false, os: "ios", pushSupported: true, enabled: false },
+    { name: "granted permission", granted: true, os: "ios", pushSupported: true, enabled: true },
+    { name: "Android", granted: true, os: "android", pushSupported: true, enabled: false },
+    { name: "personal team build", granted: true, os: "ios", pushSupported: false, enabled: false },
+  ]) {
+    it.effect(`links with notifications ${enabled ? "enabled" : "disabled"} for ${name}`, () =>
+      Effect.gen(function* () {
+        platform.OS = os;
+        supportsAgentAwarenessPush.mockReturnValue(pushSupported);
+        getPermissionsAsync.mockResolvedValueOnce({ granted });
+        loadPreferences.mockReturnValueOnce(Effect.succeed({ liveActivitiesEnabled: false }));
+        const bodies: Array<unknown> = [];
+        const fetchMock = vi.fn((url: string | URL, init?: RequestInit) => {
+          if (init?.body) {
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            bodies.push(JSON.parse(requestBodyText(init.body)));
+          }
+          if (String(url).endsWith("/v1/client/environment-link-challenges")) {
+            return Promise.resolve(Response.json(validLinkChallengeResponse()));
+          }
+          if (String(url).endsWith("/api/connect/link-proof")) {
+            return Promise.resolve(Response.json(validLinkProof()));
+          }
+          if (String(url).endsWith("/v1/client/environment-links")) {
+            return Promise.resolve(Response.json(validLinkResponse()));
+          }
+          return Promise.resolve(
+            Response.json({ ok: true, endpointRuntimeStatus: { status: "configured" } }),
+          );
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        yield* withCloudServices(
+          linkEnvironmentToCloud({
+            clerkToken: "clerk-token",
+            connection: savedConnection,
+          }),
         );
-      });
+
+        expect(bodies[0]).toMatchObject({
+          notificationsEnabled: enabled,
+          liveActivitiesEnabled: false,
+        });
+        expect(bodies[1]).toMatchObject({
+          endpoint: {
+            httpBaseUrl: "https://desktop.example.test/",
+            wsBaseUrl: "wss://desktop.example.test/ws",
+            providerKind: "cloudflare_tunnel",
+          },
+          origin: {
+            localHttpHost: "127.0.0.1",
+            localHttpPort: 443,
+          },
+        });
+        expect(bodies[2]).toMatchObject({
+          deviceId: "device-1",
+          notificationsEnabled: enabled,
+          liveActivitiesEnabled: false,
+          managedTunnelsEnabled: true,
+        });
+        expect(bodies[3]).toMatchObject({
+          cloudUserId: "user_123",
+          environmentCredential: "environment-credential",
+        });
+      }),
+    );
+  }
+
+  it.effect("does not contact the relay when notification permission lookup fails", () =>
+    Effect.gen(function* () {
+      getPermissionsAsync.mockRejectedValueOnce(new Error("permission lookup failed"));
+      const fetchMock = vi.fn();
       vi.stubGlobal("fetch", fetchMock);
 
-      yield* withCloudServices(
-        linkEnvironmentToCloud({
-          clerkToken: "clerk-token",
-          connection: savedConnection,
-        }),
-      );
+      const error = yield* withCloudServices(
+        linkEnvironmentToCloud({ clerkToken: "clerk-token", connection: savedConnection }),
+      ).pipe(Effect.flip);
 
-      expect(bodies[1]).toMatchObject({
-        endpoint: {
-          httpBaseUrl: "https://desktop.example.test/",
-          wsBaseUrl: "wss://desktop.example.test/ws",
-          providerKind: "cloudflare_tunnel",
-        },
-        origin: {
-          localHttpHost: "127.0.0.1",
-          localHttpPort: 443,
-        },
-      });
-      expect(bodies[2]).toMatchObject({
-        deviceId: "device-1",
-        notificationsEnabled: true,
-        liveActivitiesEnabled: false,
-        managedTunnelsEnabled: true,
-      });
-      expect(bodies[3]).toMatchObject({
-        cloudUserId: "user_123",
-        environmentCredential: "environment-credential",
-      });
+      expect(error.message).toBe("Could not read notification permissions.");
+      expect(fetchMock).not.toHaveBeenCalled();
     }),
   );
 
@@ -838,8 +877,8 @@ describe("mobile cloud link environment client", () => {
       );
 
       expect(bodies.filter((body) => "liveActivitiesEnabled" in body)).toEqual([
-        expect.objectContaining({ liveActivitiesEnabled: true }),
-        expect.objectContaining({ liveActivitiesEnabled: true }),
+        expect.objectContaining({ notificationsEnabled: false, liveActivitiesEnabled: true }),
+        expect.objectContaining({ notificationsEnabled: false, liveActivitiesEnabled: true }),
       ]);
     }),
   );

--- a/apps/mobile/src/features/cloud/linkEnvironment.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.ts
@@ -1,3 +1,5 @@
+import * as Notifications from "expo-notifications";
+import { Platform } from "react-native";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
@@ -36,6 +38,7 @@ import { authClientMetadata } from "../../lib/authClientMetadata";
 import type { SavedRemoteConnection } from "../../lib/connection";
 import * as MobilePreferences from "../../persistence/mobile-preferences";
 import * as MobileStorage from "../../persistence/mobile-storage";
+import { supportsAgentAwarenessPush } from "../agent-awareness/capabilities";
 import { resolveCloudPublicConfig } from "./publicConfig";
 
 const RELAY_STATUS_AND_CONNECT_SCOPES = [
@@ -268,12 +271,19 @@ export function linkEnvironmentToCloudWithPreference(
     const deviceId = yield* storage.loadOrCreateAgentAwarenessDeviceId.pipe(
       Effect.mapError(cloudEnvironmentLinkError("Could not load the mobile device id.")),
     );
+    const notificationsEnabled =
+      Platform.OS === "ios" && supportsAgentAwarenessPush()
+        ? (yield* Effect.tryPromise({
+            try: () => Notifications.getPermissionsAsync(),
+            catch: cloudEnvironmentLinkError("Could not read notification permissions."),
+          })).granted
+        : false;
     const liveActivitiesEnabled = input.liveActivitiesEnabled;
     const challenge = yield* relayClient
       .createEnvironmentLinkChallenge({
         clerkToken: input.clerkToken,
         payload: {
-          notificationsEnabled: true,
+          notificationsEnabled,
           liveActivitiesEnabled,
           managedTunnelsEnabled: true,
         },
@@ -305,7 +315,7 @@ export function linkEnvironmentToCloudWithPreference(
         payload: {
           deviceId,
           proof,
-          notificationsEnabled: true,
+          notificationsEnabled,
           liveActivitiesEnabled,
           managedTunnelsEnabled: true,
         },


### PR DESCRIPTION
Mobile cloud linking sends `notificationsEnabled: true` even when notification permission is denied. Read the existing OS permission once and use it for both the link challenge and link request. Unsupported platforms and personal-team builds keep notifications disabled; permission lookup failures stop before contacting the relay.

Live Activities keep their existing preference. This applies when linking or relinking an environment; existing cloud links are not migrated.

Closes #9886.

## Verification

- Reproduced before the fix: the denied-permission regression received `notificationsEnabled: true` with Live Activities disabled.
- 61 focused tests pass across cloud linking, Live Activity preferences, and remote registration. Covers granted/denied permission, unsupported push, permission lookup failure, and both relay payloads.
- Mobile typecheck and changed-file lint/format checks pass.
- Native device verification was not run. No UI or wire-contract changes.

Created with GPT-6 in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes relay registration flags during cloud link/relink based on OS permission and capability checks; failures block linking but do not alter existing linked environments.
> 
> **Overview**
> Cloud environment linking no longer always sends **`notificationsEnabled: true`** to the relay. During link/relink, the client reads **`expo-notifications`** permission once (iOS only when agent-awareness push is supported) and uses that value for both the link-challenge and link payloads; **Live Activities** still follow the existing preference.
> 
> **Android**, builds without push support, and **denied** permission keep notifications disabled. If permission lookup fails, linking fails with *"Could not read notification permissions."* and **does not** call the relay. Tests were expanded with parameterized cases and a failure-path assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9131579c4672e80d9ef2c5500da010351b679e1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests for notification permission checks when linking cloud environments
> - Adds parameterized tests covering four cases: denied iOS permission, granted iOS permission, Android, and iOS without push support. Each verifies notification and Live Activity flags propagate correctly through challenge and link requests.
> - Adds a test that a notification permission lookup failure aborts linking before any relay request and returns the expected cloud-link error.
> - Updates the explicit Live Activity preference test to confirm that notifications are disabled while Live Activity remains enabled.
> - Behavioral Change: the test suite now asserts notifications are only enabled for the granted-iOS-with-push-support case; all other combinations disable notifications.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9131579.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->