### PR TITLE
fix(web): discard stale highlights after file edits

### DIFF
--- a/apps/web/src/components/files/fileEditorHighlight.test.ts
+++ b/apps/web/src/components/files/fileEditorHighlight.test.ts
@@ -1,0 +1,264 @@
+import {
+  FileRenderer,
+  getSharedHighlighter,
+  type BaseCodeOptions,
+  type DiffsHighlighter,
+  type FileContents,
+  type HighlightedToken,
+  type RenderRange,
+} from "@pierre/diffs";
+import { TextDocument } from "@pierre/diffs/editor";
+import { WorkerPoolManager, type WorkerRequest, type WorkerResponse } from "@pierre/diffs/worker";
+import * as NodeWorkerThreads from "node:worker_threads";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+type DocumentChange = NonNullable<ReturnType<TextDocument<unknown>["applyEdits"]>>;
+interface Tokenizer {
+  readonly themeType: "light" | "dark";
+  tokenize(change: DocumentChange, range: RenderRange): Map<number, HighlightedToken[]>;
+  cleanUp(): void;
+}
+
+// This dependency-internal tokenizer is the one used by Editor.#rerender.
+const tokenizerUrl = new URL("./editor/tokenizer.js", import.meta.resolve("@pierre/diffs"));
+const { EditorTokenizer } = (await import(/* @vite-ignore */ tokenizerUrl.href)) as {
+  EditorTokenizer: new (options: {
+    codeOptions: BaseCodeOptions;
+    highlighter: DiffsHighlighter;
+    textDocument: TextDocument<unknown>;
+    setStyle: (style: string) => void;
+    onDeferTokenize: (lines: Map<number, HighlightedToken[]>, theme: "light" | "dark") => void;
+  }) => Tokenizer;
+};
+
+const workerModule = import.meta.resolve("@pierre/diffs/worker/worker.js");
+const source = Array.from(
+  { length: 7_000 },
+  (_, index) =>
+    `export const section${index} = <p>Long wrapped source line ${index} for the file editor.</p>;`,
+).join("\n");
+const options = {
+  theme: "pierre-dark",
+  themeType: "dark",
+  preferredHighlighter: "shiki-wasm",
+  useTokenTransformer: true,
+  overflow: "wrap",
+  disableFileHeader: true,
+} as const;
+const range: RenderRange = {
+  startingLine: 6_950,
+  totalLines: 150,
+  bufferBefore: 0,
+  bufferAfter: 0,
+};
+
+interface HeldResponse {
+  data: WorkerResponse;
+  deliver: () => void;
+}
+let responses: HeldResponse[];
+let responseWaiters: ((response: HeldResponse) => void)[];
+let terminationPromises: Promise<number>[];
+let pool: WorkerPoolManager;
+let renderer: FileRenderer;
+let tokenizer: Tokenizer;
+let file: FileContents;
+let document: TextDocument<unknown>;
+
+function nextResponse(): Promise<HeldResponse> {
+  const response = responses.shift();
+  return response
+    ? Promise.resolve(response)
+    : new Promise((resolve) => responseWaiters.push(resolve));
+}
+
+class WorkerTransport {
+  private readonly worker = new NodeWorkerThreads.Worker(
+    `const { parentPort, workerData } = require("node:worker_threads");
+     globalThis.self = {
+       addEventListener(type, listener) {
+         if (type === "message") parentPort.on("message", data => listener({ data }));
+         if (type === "error") process.on("uncaughtException", listener);
+       }
+     };
+     globalThis.postMessage = data => parentPort.postMessage(data);
+     import(workerData.moduleUrl);`,
+    { eval: true, workerData: { moduleUrl: workerModule }, execArgv: [] },
+  );
+
+  addEventListener(
+    type: "message" | "error",
+    listener: (event: { data: WorkerResponse } | Error) => void,
+  ) {
+    if (type === "error") {
+      this.worker.on("error", listener);
+      return;
+    }
+    this.worker.on("message", (data: WorkerResponse) => {
+      const response = { data, deliver: () => listener({ data }) };
+      if (data.type !== "success" || data.requestType !== "file") {
+        response.deliver();
+        return;
+      }
+      const waiter = responseWaiters.shift();
+      if (waiter) waiter(response);
+      else responses.push(response);
+    });
+  }
+
+  postMessage(message: WorkerRequest) {
+    this.worker.postMessage(message, []);
+  }
+
+  terminate() {
+    terminationPromises.push(this.worker.terminate());
+  }
+}
+
+function applyChange(change: DocumentChange) {
+  // Keep the installed editor's non-DOM order, including the existing contents patch.
+  renderer.updateRenderCache(tokenizer.tokenize(change, range), tokenizer.themeType);
+  file.contents = document.getText();
+  if (change.lineDelta !== 0) renderer.applyDocumentChange(document);
+}
+
+function append(text: string) {
+  const position = document.positionAt(document.getText().length);
+  const change = document.applyEdits([
+    { range: { start: position, end: position }, newText: text },
+  ]);
+  expect(change).toBeDefined();
+  applyChange(change!);
+}
+
+function undo() {
+  const change = document.undo()?.[0];
+  expect(change).toBeDefined();
+  applyChange(change!);
+}
+
+function renderContents() {
+  const result = renderer.renderFile(file, range);
+  expect(result?.totalLines).toBe(document.lineCount);
+  return renderer.renderFullHTML(result!);
+}
+
+beforeEach(async () => {
+  responses = [];
+  responseWaiters = [];
+  terminationPromises = [];
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
+    setImmediate(() => callback(0)),
+  );
+  vi.stubGlobal("cancelAnimationFrame", clearImmediate);
+  vi.stubGlobal("window", { matchMedia: () => ({ matches: true }) });
+  pool = new WorkerPoolManager(
+    // Adapt browser transport only; Pierre's real worker produces each response.
+    { workerFactory: () => new WorkerTransport() as unknown as globalThis.Worker, poolSize: 1 },
+    options,
+  );
+  await pool.initialize(["tsx"]);
+  const highlighter = await getSharedHighlighter({
+    themes: ["pierre-dark"],
+    langs: ["tsx"],
+    preferredHighlighter: "shiki-wasm",
+  });
+  file = { name: "wrapped.tsx", contents: source, cacheKey: "editable-file" };
+  document = new TextDocument(file.name, source, "tsx");
+  renderer = new FileRenderer(options, () => {}, pool);
+  tokenizer = new EditorTokenizer({
+    codeOptions: options,
+    highlighter,
+    textDocument: document,
+    setStyle: () => {},
+    onDeferTokenize: (lines, theme) => renderer.updateRenderCache(lines, theme),
+  });
+  renderContents();
+});
+
+afterEach(async () => {
+  tokenizer?.cleanUp();
+  renderer?.cleanUp();
+  pool?.terminate();
+  await Promise.all(terminationPromises);
+  vi.unstubAllGlobals();
+});
+
+describe("editable file highlighting", () => {
+  it("still accepts an asynchronous highlight when the file has not changed", async () => {
+    expect(renderContents()).not.toContain('style="color:');
+    (await nextResponse()).deliver();
+    expect(renderContents()).toContain('style="color:');
+    expect(pool.getFileResultCache(file)).toBeDefined();
+  });
+
+  it.each([1, 60])(
+    "ignores a dispatched highlight after %i Enter edits and highlights the new version",
+    async (count) => {
+      const oldResponse = await nextResponse();
+      for (let index = 0; index < count; index += 1) append("\n");
+      append("export const EDITED_MARKER = 1;");
+      oldResponse.deliver();
+      expect(renderContents()).toContain("EDITED_MARKER");
+      const currentResponse = await nextResponse();
+      currentResponse.deliver();
+      expect(renderContents()).toContain("EDITED_MARKER");
+      const firstLines = renderer.renderFile(file, { ...range, startingLine: 0, totalLines: 20 });
+      expect(renderer.renderFullHTML(firstLines!)).toContain('style="color:');
+      expect(document.lineCount).toBe(7_000 + count);
+    },
+  );
+
+  it("does not replace a same-line edit with stale tokens", async () => {
+    const oldResponse = await nextResponse();
+    append(" EDITED_MARKER");
+    oldResponse.deliver();
+    expect(renderContents()).toContain("EDITED_MARKER");
+    expect(document.lineCount).toBe(7_000);
+    (await nextResponse()).deliver();
+    expect(renderContents()).toContain("EDITED_MARKER");
+  });
+
+  it("keeps undo edits after an older highlight arrives", async () => {
+    const oldResponse = await nextResponse();
+    append("\nexport const RETAINED_MARKER = 1;");
+    append("\nexport const UNDONE_MARKER = 2;");
+    undo();
+    oldResponse.deliver();
+    const html = renderContents();
+    expect(html).toContain("RETAINED_MARKER");
+    expect(html).not.toContain("UNDONE_MARKER");
+    (await nextResponse()).deliver();
+    expect(renderContents()).toContain("RETAINED_MARKER");
+    undo();
+    expect(document.getText()).toBe(source);
+    expect(renderContents()).not.toContain("RETAINED_MARKER");
+    const redone = document.redo()?.[0];
+    expect(redone).toBeDefined();
+    applyChange(redone!);
+    expect(renderContents()).toContain("RETAINED_MARKER");
+  });
+
+  it("evicts the pre-edit shared cache without losing already-highlighted lines", async () => {
+    (await nextResponse()).deliver();
+    expect(pool.getFileResultCache(file)).toBeDefined();
+    append("\nexport const EDITED_MARKER = 1;");
+    expect(pool.getFileResultCache(file)).toBeUndefined();
+    expect(renderContents()).toContain("EDITED_MARKER");
+    const firstLines = renderer.renderFile(file, { ...range, startingLine: 0, totalLines: 20 });
+    expect(renderer.renderFullHTML(firstLines!)).toContain('style="color:');
+  });
+
+  it("reopens the edited file with the same cache key while an old response is pending", async () => {
+    const oldResponse = await nextResponse();
+    append("\nexport const REOPENED_MARKER = 1;");
+    renderer.cleanUp();
+    renderer = new FileRenderer(options, () => {}, pool);
+    file = { ...file };
+    expect(renderContents()).toContain("REOPENED_MARKER");
+    oldResponse.deliver();
+    (await nextResponse()).deliver();
+    expect(renderContents()).toContain("REOPENED_MARKER");
+    expect(renderContents()).toContain('style="color:');
+  });
+});

--- a/patches/@pierre%2Fdiffs@1.3.0-beta.10.patch
+++ b/patches/@pierre%2Fdiffs@1.3.0-beta.10.patch
@@ -60,6 +60,18 @@ index e9f62f5..af82a46 100644
  	};
  	return merged;
  }
+diff --git a/dist/renderers/FileRenderer.js b/dist/renderers/FileRenderer.js
+--- a/dist/renderers/FileRenderer.js
++++ b/dist/renderers/FileRenderer.js
+@@ -163,6 +163,8 @@
+ 		if (this.renderCache == null) return;
+ 		const { file, result } = this.renderCache;
+ 		if (result == null) return;
++		this.workerManager?.cleanUpTasks(this);
++		if (file.cacheKey != null) this.workerManager?.evictFileFromCache(file.cacheKey);
+ 		const lineCache = this.lineCache != null && isLineCacheForFile(this.lineCache, file) ? this.lineCache : void 0;
+ 		for (const [line, tokens] of dirtyLines) {
+ 			if (lineCache != null && line < lineCache.lines.length) {
 diff --git a/package.json b/package.json
 index ff61c90..1e170e5 100644
 --- a/package.json

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,7 +92,7 @@ patchedDependencies:
   '@expo/metro-config@57.0.12': 96f1a75347e6ea02dc4b7034ace815d8ee39e18b8166ebfb573d9e58328f0dc2
   '@ff-labs/fff-node@0.9.4': ab9ff544009e1891cfe3930105862d3699007f38922a79f3c98d90018deca368
   '@legendapp/list@3.3.5': 03ec41339cd915ecb9a774a6b90cc2197c29038f7db67c4d2e55cd3971e5be43
-  '@pierre/diffs@1.3.0-beta.10': 7ef7cb0cbabb17c15cdb137554068b36f15f6f5265e73fb51452aa3380db91aa
+  '@pierre/diffs@1.3.0-beta.10': c087c47b657c44ddce2b0ec8237d675086414134e91829c4b4edd009ec86893e
   '@react-native-ai/apple@0.12.0': 2d09870c2848d185cb05b53ed823a46e12dba519324d8dd8e584e28731990f9d
   '@react-native-menu/menu@2.0.0': f63d256bf6a97a873b5e628eb595bd6ef0075ddd5bdd890fc920f7a6024290dd
   '@react-navigation/native-stack@7.17.6': e667c3cef8c78bb9ff4882ee5bd23a432247b843060a9499eb5f07e9e2295552
@@ -245,7 +245,7 @@ importers:
         version: 1.9.1
       '@pierre/diffs':
         specifier: 'catalog:'
-        version: 1.3.0-beta.10(patch_hash=7ef7cb0cbabb17c15cdb137554068b36f15f6f5265e73fb51452aa3380db91aa)(@shikijs/themes@4.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 1.3.0-beta.10(patch_hash=c087c47b657c44ddce2b0ec8237d675086414134e91829c4b4edd009ec86893e)(@shikijs/themes@4.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@react-native-ai/apple':
         specifier: 0.12.0
         version: 0.12.0(patch_hash=2d09870c2848d185cb05b53ed823a46e12dba519324d8dd8e584e28731990f9d)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
@@ -586,7 +586,7 @@ importers:
         version: 1.8.0
       '@pierre/diffs':
         specifier: 'catalog:'
-        version: 1.3.0-beta.10(patch_hash=7ef7cb0cbabb17c15cdb137554068b36f15f6f5265e73fb51452aa3380db91aa)(@shikijs/themes@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 1.3.0-beta.10(patch_hash=c087c47b657c44ddce2b0ec8237d675086414134e91829c4b4edd009ec86893e)(@shikijs/themes@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@pierre/trees':
         specifier: 1.0.0-beta.4
         version: 1.0.0-beta.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -13613,7 +13613,7 @@ snapshots:
       tslib: 2.8.1
       webcrypto-core: 1.9.2
 
-  '@pierre/diffs@1.3.0-beta.10(patch_hash=7ef7cb0cbabb17c15cdb137554068b36f15f6f5265e73fb51452aa3380db91aa)(@shikijs/themes@4.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@pierre/diffs@1.3.0-beta.10(patch_hash=c087c47b657c44ddce2b0ec8237d675086414134e91829c4b4edd009ec86893e)(@shikijs/themes@4.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@pierre/theme': 1.1.0
       '@pierre/theming': 0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(shiki@4.2.0)
@@ -13627,7 +13627,7 @@ snapshots:
     transitivePeerDependencies:
       - '@shikijs/themes'
 
-  '@pierre/diffs@1.3.0-beta.10(patch_hash=7ef7cb0cbabb17c15cdb137554068b36f15f6f5265e73fb51452aa3380db91aa)(@shikijs/themes@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@pierre/diffs@1.3.0-beta.10(patch_hash=c087c47b657c44ddce2b0ec8237d675086414134e91829c4b4edd009ec86893e)(@shikijs/themes@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@pierre/theme': 1.1.0
       '@pierre/theming': 0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(shiki@4.2.0)


### PR DESCRIPTION
Editing a large source file can race an older syntax-highlight response. The response replaces the editor's updated line data, losing same-line edits in the rendered view or throwing `FileRenderer.processFileResult: Line doesnt exist` after new lines are added.

Cancel the file renderer's pending highlight request and evict its shared AST before updating editor tokens. This reuses Pierre's existing cancellation and eviction methods. Later highlights still run. The dependency stays at `1.3.0-beta.10`; only its existing patch and lockfile patch hash change.

Related to [#7907](https://github.com/pingdotgg/t3code/issues/7907). This does not fix its separate wrapped-line scroll jump or establish a CachyOS/Electron retest. The issue should remain open for those remaining parts.

## Verification

- Real installed TextDocument, EditorTokenizer, FileRenderer and WASM worker, with only worker-message delivery controlled. No fabricated token results or browser geometry.
- Baseline: five of the initial six tests fail, including the exact renderer error after one or sixty Enter edits, lost same-line text, and undo. The no-edit asynchronous control passes.
- Candidate: seven editor-highlight controls pass, including fresh full-file highlighting, unchanged asynchronous output, same-line edits, Enter bursts, undo/redo, shared-cache eviction and reopening with the same key. Nineteen focused tests pass with the existing cache-identity and worker-lifecycle suites. The seven actual-worker tests passed again on the unchanged published head.
- Web typecheck, targeted lint, patch reverse-application check and Node syntax check pass. Base refreshed to [2fb99a7a](https://github.com/pingdotgg/t3code/commit/2fb99a7a664faf045f1884f38c620016b34874cb).
- Current-head CI has no pending or failing jobs. Cursor Bugbot passed. Macroscope approved eligibility; its separate correctness check was skipped and its approval explicitly did not review code objects.

## Actual browser before and after

Verified in Linux Chromium 152 with native pointer and keyboard input, word wrap enabled, and a 394px Files editor showing an owned copy of the public `ChatView.tsx`. No fabricated editor state, layout changes, provider turns or changes to shared installed packages were used.

Before, the main editor at [94cc8152](https://github.com/pingdotgg/t3code/commit/94cc8152fff5fd06baafd25964f54d7ec1a34f8d) displayed the exact renderer exception after repeated Enter edits and returning to EOF. That editor implementation is unchanged at the current base. This native race is intermittent: a later fresh 60-Enter baseline attempt did not fail. The controlled real-worker tests above establish the stale-response failure and repair without depending on browser timing.

Before: the large-file editor displays the reported exception.

![Before: FileRenderer.processFileResult reports Line doesnt exist in the narrow large-file editor](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/22eb1a184a9013cb/7907-large-editor-error.png)

After, the exact [d9e94bee](https://github.com/pingdotgg/t3code/commit/d9e94beec3a6cfaa1a6339bf6eb7f443f061aadd) package repair ran on main [2fb99a7a](https://github.com/pingdotgg/t3code/commit/2fb99a7a664faf045f1884f38c620016b34874cb). All Pierre imports resolved to the same isolated package. The live `FileRenderer.updateRenderCache` contained both repair calls, and `VirtualizedFile` remained unpatched.

- Starting at 8,255 lines, 60 native Enter presses persisted 8,315 lines and 317,716 bytes without a DOM renderer error.
- Undo, redo and a typed marker worked. Disk contents confirmed the marker, and closing/reopening the file retained it.
- After removing the marker, 61 further Enter presses reached 8,376 lines and 317,777 bytes, matching the large fixture size used for the earlier failure. Ctrl+End reached line 8,376 and the editor remained usable without the renderer exception.

After: the editor renders line 8,376 instead of the error.

![After: the repaired editor remains usable at line 8376 following repeated Enter edits](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/6de9f543d147bc4d/9902-candidate-8376.png)

After reopening: the saved marker remains present.

![After reopening: the saved AUDIT-9902 marker is retained in the file editor](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/7a150bc5e8eb2420/9902-candidate-reopened.png)

After recording: continued Enter editing and returning to EOF. The separate scroll jump is still visible; the renderer keeps working.

![After video: repeated native editing in the large wrapped file without the renderer exception](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/0ab2d0857762554a/9902-candidate-reopen.webm)

These captures use the same narrow editor and owned large-file fixture. The sidebar filter differs, and unrelated audit integrations were present in both runs. This is web verification, not a retest on the reporter's CachyOS/Electron setup. Interrupted baseline recordings are not included.

## Scope limit

The library's explicit `primeFileHighlightCache` API can retain a separately owned pending request for the same key. That unused-in-production T3 path is not changed here. Current T3 mounts one editable Files view per client, uses a separate prefix for read-only file caches, and does not call the priming API in production. Shared priming or concurrent same-key editor support needs a separate ownership decision. No new timer, loop, error suppression, save behavior or scroll policy is introduced.

GPT 6 Astra via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes edit-time rendering and worker/cache lifecycle in a patched dependency; wrong cancellation could regress highlighting or performance, but scope is limited to the editable file update path.
> 
> **Overview**
> Fixes a race where a late syntax-highlight worker response could overwrite the editor after typing in large files—dropping same-line edits, showing wrong tokens, or throwing when line counts diverge.
> 
> The **`@pierre/diffs` patch** extends **`FileRenderer.updateRenderCache`**: before merging new tokenizer output, it **cancels pending highlight tasks** for that renderer and **evicts the shared file cache** for the file’s `cacheKey`, so stale AST/results cannot be applied while newer edits are in flight. Later highlights still run normally.
> 
> Adds **`fileEditorHighlight.test.ts`**, an integration suite that drives real `TextDocument`, `EditorTokenizer`, `FileRenderer`, and the WASM worker while **deferring worker message delivery** to assert stale responses are ignored, undo/redo stays correct, cache eviction behaves, and reopening with the same key is safe. Lockfile updates reflect the revised patch hash only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9e94beec3a6cfaa1a6339bf6eb7f443f061aadd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `FileRenderer` to discard stale highlights after file edits
> - `FileRenderer` now cancels outstanding worker tasks and removes the edited file's keyed worker result cache before processing dirty rendered lines, so late async highlight responses no longer overwrite current edits.
> - Adds an integration test suite in [fileEditorHighlight.test.ts](https://github.com/pingdotgg/t3code/pull/9902/files#diff-76cf063dcc150cad3e96d75ac97cec76032ecf25b8c2f67cb4a5c47f2eb883db) covering stale responses after multiple edits, undo/redo ordering while a response is pending, shared-cache eviction, and reopening an edited file before pending responses complete.
> - Introduces a `WorkerTransport` adapter and helpers (`applyChange`, `append`, `undo`, `renderContents`) that let tests queue and release worker responses deterministically.
> - Risk: the patched `FileRenderer` cache-eviction path in [pnpm-lock.yaml](https://github.com/pingdotgg/t3code/pull/9902/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb)'s `@pierre/diffs` patch runs on every dirty-line update; verify that cache eviction does not drop highlights for files that were edited but not yet saved when a concurrent render occurs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9e94be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
