### PR TITLE
fix(server): keep old failures from waking snoozed V2 threads

### DIFF
--- a/apps/server/src/orchestration-v2/ThreadSettlementService.test.ts
+++ b/apps/server/src/orchestration-v2/ThreadSettlementService.test.ts
@@ -130,13 +130,36 @@ describe("isAutoSettlementCandidate", () => {
       snoozedAt: at(-60 * 60 * 1_000),
     });
     expect(isAutoSettlementCandidate(snoozed, NOW_MS)).toBe(false);
-    expect(isAutoSettlementCandidate(shell({ ...snoozed, status: "failed" }), NOW_MS)).toBe(true);
+    expect(
+      isAutoSettlementCandidate(
+        shell({ ...snoozed, status: "failed", latestRunCompletedAt: at(-30 * 60 * 1_000) }),
+        NOW_MS,
+      ),
+    ).toBe(true);
     expect(
       isAutoSettlementCandidate(
         shell({ ...snoozed, latestRunCompletedAt: at(-30 * 60 * 1_000) }),
         NOW_MS,
       ),
     ).toBe(true);
+    expect(
+      isAutoSettlementCandidate(
+        shell({ ...snoozed, status: "failed", latestRunCompletedAt: at(-2 * 60 * 60 * 1_000) }),
+        NOW_MS,
+      ),
+    ).toBe(false);
+    expect(
+      isAutoSettlementCandidate(
+        shell({ ...snoozed, status: "failed", latestRunCompletedAt: snoozed.snoozedAt }),
+        NOW_MS,
+      ),
+    ).toBe(false);
+    expect(
+      isAutoSettlementCandidate(
+        shell({ ...snoozed, status: "failed", latestRunCompletedAt: null }),
+        NOW_MS,
+      ),
+    ).toBe(false);
     // Expired snooze is no longer a park.
     expect(isAutoSettlementCandidate(shell({ ...snoozed, snoozedUntil: at(-1) }), NOW_MS)).toBe(
       true,

--- a/apps/server/src/orchestration-v2/ThreadSettlementService.ts
+++ b/apps/server/src/orchestration-v2/ThreadSettlementService.ts
@@ -112,7 +112,9 @@ export function isAutoSettlementCandidate(
   // one still parked on its wake time keeps its stronger statement.
   const snoozedAtMs = toMillis(thread.snoozedAt);
   const completedAtMs = toMillis(thread.latestRunCompletedAt);
-  const wokeOnError = thread.status === "failed";
+  const wokeOnError =
+    thread.status === "failed" &&
+    (snoozedAtMs === null || (completedAtMs !== null && completedAtMs > snoozedAtMs));
   const wokeOnCompletion =
     snoozedAtMs !== null && completedAtMs !== null && completedAtMs > snoozedAtMs;
   return wokeOnError || wokeOnCompletion;


### PR DESCRIPTION
A thread snoozed after a failed run can immediately become eligible for automatic settlement because V2 treats any failed status as a fresh wake-up.

Compare the failed run's completion timestamp with the snooze timestamp. Older failures, equal timestamps, and missing completion timestamps preserve the snooze; fresh failures and completed work can still wake it.

Validation: 11 focused settlement tests passed, including a regression that failed before the fix. Scoped typecheck and targeted lint passed. Cross-provider review was unavailable after the direct Claude Opus 5 high process failed OAuth authentication (exit 1, no model ran).

Targets the Orchestrator V2 branch in #2829. Implemented and reviewed by GPT-6 Astra in Codex/T3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eligibility for automatic thread settlement on snoozed threads, which can affect sidebar lifecycle timing but is scoped to one guard with new regression tests.
> 
> **Overview**
> **Snoozed Orchestrator V2 threads no longer become auto-settlement candidates just because `status` is `failed`.** The early-wake path in `isAutoSettlementCandidate` now treats a failure as waking the thread only when the latest run completed **after** snooze started (or when there is no `snoozedAt`). Pre-snooze failures, completion exactly at snooze time, and failed status with no completion timestamp keep the thread parked until `snoozedUntil`.
> 
> Fresh failures after snooze and completion-based early wake are unchanged. Tests in `ThreadSettlementService.test.ts` lock in those edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce9ecd9d1b3a3ffd64d5680cf5270166fba3f6a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Current-base verification

Updated to V2 base `26a48b007` at `669f993becd191d19d0e4923cdff47a602ec79f3`. Fresh focused regression runs pass (11 tests), along with targeted lint and affected package typechecks. The contribution files remain byte-for-byte identical to the previously reviewed PR head; this update incorporates the current target branch. Earlier verification above is retained with its original scope and limitations. Fresh independent Claude review is unavailable: `claude auth status` reports signed out. Refreshed by GPT-6 Astra in the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `isAutoSettlementCandidate` so old failures don't wake snoozed V2 threads
> Changes the failed-run early-wake condition in `isAutoSettlementCandidate` so a failed snoozed thread only qualifies for auto-settlement when it has no snooze-start timestamp or its latest run completed strictly after that timestamp. Threads completed before or exactly at snooze time remain ineligible. Tests in [ThreadSettlementService.test.ts](https://github.com/pingdotgg/t3code/pull/9903/files#diff-c76535085cbaafeb970717777da2e70b1d9630de84e94dad7c13529dcaad517b) cover the before, coincident, and absent-completion cases.
> - Behavioral Change: failed threads with an active snooze and a completion that predates snoozing are no longer auto-settlement candidates; previously they could wake the thread.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 669f993.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->