### PR TITLE
perf(web): keep timeline row reuse engaged while text streams

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1089,6 +1089,56 @@ describe("buildRevertTurnCountByUserMessageId", () => {
       }).size,
     ).toBe(0);
   });
+
+  it.each([true, false])(
+    "returns the previous map when contents are unchanged (rollback supported: %s)",
+    (supportsConversationRollback) => {
+      const input = {
+        supportsConversationRollback,
+        timelineEntries,
+        turnDiffSummaryByAssistantMessageId,
+        inferredCheckpointTurnCountByTurnId: {},
+      };
+      const previous = buildRevertTurnCountByUserMessageId(input);
+      const streamed = timelineEntries.map((entry) =>
+        entry.message.role === "assistant"
+          ? { ...entry, message: { ...entry.message, text: "Updated the file again" } }
+          : entry,
+      );
+
+      expect(
+        buildRevertTurnCountByUserMessageId({ ...input, timelineEntries: streamed }, previous),
+      ).toBe(previous);
+    },
+  );
+
+  it("returns a new map when a revert target changes", () => {
+    const input = {
+      supportsConversationRollback: true,
+      timelineEntries,
+      turnDiffSummaryByAssistantMessageId,
+      inferredCheckpointTurnCountByTurnId: {},
+    };
+    const previous = buildRevertTurnCountByUserMessageId(input);
+    const next = buildRevertTurnCountByUserMessageId(
+      {
+        ...input,
+        turnDiffSummaryByAssistantMessageId: new Map([
+          [
+            assistantMessageId,
+            {
+              ...turnDiffSummaryByAssistantMessageId.get(assistantMessageId)!,
+              checkpointTurnCount: 3,
+            },
+          ],
+        ]),
+      },
+      previous,
+    );
+
+    expect(next).not.toBe(previous);
+    expect(next).toEqual(new Map([[userMessageId, 2]]));
+  });
 });
 
 describe("deriveComposerSendState", () => {

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -38,6 +38,7 @@ import {
 } from "../types";
 import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
 import * as Schema from "effect/Schema";
+import { shallow } from "zustand/vanilla/shallow";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { environmentThreadDetails } from "../state/threads";
 import {
@@ -464,17 +465,24 @@ export function getAntigravitySendBlockReason(
   return null;
 }
 
-export function buildRevertTurnCountByUserMessageId(input: {
-  supportsConversationRollback: boolean;
-  timelineEntries: ReadonlyArray<TimelineEntry>;
-  turnDiffSummaryByAssistantMessageId: ReadonlyMap<MessageId, TurnDiffSummary>;
-  inferredCheckpointTurnCountByTurnId: Readonly<Record<string, number | undefined>>;
-}) {
+/**
+ * Maps each user message to the checkpoint turn count a revert should target.
+ * Returns `previous` when the result is unchanged: streaming text deltas
+ * rebuild `timelineEntries` per token, and the timeline row projection only
+ * reuses rows while this Map keeps its identity.
+ */
+export function buildRevertTurnCountByUserMessageId(
+  input: {
+    supportsConversationRollback: boolean;
+    timelineEntries: ReadonlyArray<TimelineEntry>;
+    turnDiffSummaryByAssistantMessageId: ReadonlyMap<MessageId, TurnDiffSummary>;
+    inferredCheckpointTurnCountByTurnId: Readonly<Record<string, number | undefined>>;
+  },
+  previous: Map<MessageId, number> | null = null,
+): Map<MessageId, number> {
   const byUserMessageId = new Map<MessageId, number>();
-  if (!input.supportsConversationRollback) {
-    return byUserMessageId;
-  }
-  for (let index = 0; index < input.timelineEntries.length; index += 1) {
+  const entryCount = input.supportsConversationRollback ? input.timelineEntries.length : 0;
+  for (let index = 0; index < entryCount; index += 1) {
     const entry = input.timelineEntries[index];
     if (!entry || entry.kind !== "message" || entry.message.role !== "user") {
       continue;
@@ -501,7 +509,7 @@ export function buildRevertTurnCountByUserMessageId(input: {
       break;
     }
   }
-  return byUserMessageId;
+  return previous !== null && shallow(previous, byUserMessageId) ? previous : byUserMessageId;
 }
 
 export function reconcileMountedTerminalThreadIds(input: {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2972,21 +2972,25 @@ export default function ChatView(props: ChatViewProps) {
     }
     return byMessageId;
   }, [turnDiffSummaries]);
-  const revertTurnCountByUserMessageId = useMemo(
-    () =>
-      buildRevertTurnCountByUserMessageId({
+  const lastRevertTurnCountRef = useRef<Map<MessageId, number> | null>(null);
+  const revertTurnCountByUserMessageId = useMemo(() => {
+    const next = buildRevertTurnCountByUserMessageId(
+      {
         supportsConversationRollback,
         timelineEntries,
         turnDiffSummaryByAssistantMessageId,
         inferredCheckpointTurnCountByTurnId,
-      }),
-    [
-      supportsConversationRollback,
-      inferredCheckpointTurnCountByTurnId,
-      timelineEntries,
-      turnDiffSummaryByAssistantMessageId,
-    ],
-  );
+      },
+      lastRevertTurnCountRef.current,
+    );
+    lastRevertTurnCountRef.current = next;
+    return next;
+  }, [
+    supportsConversationRollback,
+    inferredCheckpointTurnCountByTurnId,
+    timelineEntries,
+    turnDiffSummaryByAssistantMessageId,
+  ]);
 
   const gitCwd = activeProject
     ? projectScriptCwd({

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { MessageId, TurnId } from "@t3tools/contracts";
+import { CheckpointRef, MessageId, TurnId } from "@t3tools/contracts";
 import {
   computeStableMessagesTimelineRows,
   computeMessageDurationStart,
@@ -20,6 +20,7 @@ import {
   deriveTimelineEntriesWithState,
   type WorkLogEntry,
 } from "../../session-logic";
+import { buildRevertTurnCountByUserMessageId } from "../ChatView.logic";
 import { isImageAttachment, type ChatMessage, type TurnDiffSummary } from "../../types";
 
 describe("streaming row projection", () => {
@@ -241,6 +242,61 @@ describe("streaming row projection", () => {
       }
     },
   );
+
+  it("reuses rows when the revert map is rebuilt from the streamed entries", () => {
+    const initial = fixture("Partial");
+    const inferredCheckpointTurnCountByTurnId = { [initial.historyTurnId]: 1 };
+    const turnDiffSummaryByAssistantMessageId = new Map<MessageId, TurnDiffSummary>([
+      [
+        MessageId.make("history-assistant"),
+        {
+          turnId: initial.historyTurnId,
+          checkpointTurnCount: 1,
+          checkpointRef: CheckpointRef.make("refs/t3/checkpoints/history-turn"),
+          status: "ready",
+          files: [],
+          assistantMessageId: MessageId.make("history-assistant"),
+          completedAt: initial.time(4),
+        },
+      ],
+    ]);
+    let revertMap: Map<MessageId, number> | null = null;
+    // Mirrors ChatView: the map is derived from each delta's entries.
+    const build = (timelineEntries: typeof initial.timeline.entries) => {
+      revertMap = buildRevertTurnCountByUserMessageId(
+        {
+          supportsConversationRollback: true,
+          timelineEntries,
+          turnDiffSummaryByAssistantMessageId,
+          inferredCheckpointTurnCountByTurnId,
+        },
+        revertMap,
+      );
+      return {
+        ...initial.input,
+        timelineEntries,
+        turnDiffSummaryByAssistantMessageId,
+        revertTurnCountByUserMessageId: revertMap,
+      };
+    };
+    const previous = deriveMessagesTimelineRowsWithState(build(initial.timeline.entries));
+    expect(previous.rows.some((row) => row.kind === "message" && row.revertTurnCount === 0)).toBe(
+      true,
+    );
+    const last = initial.messages.at(-1)!;
+    const messages = [...initial.messages.slice(0, -1), { ...last, text: "Partial token" }];
+    const timeline = deriveTimelineEntriesWithState(messages, [], initial.work, initial.timeline);
+    const next = deriveMessagesTimelineRowsWithState(build(timeline.entries), previous);
+
+    expect(next.rows).toEqual(deriveMessagesTimelineRows(build(timeline.entries)));
+    for (const [index, row] of previous.rows.entries()) {
+      if ((row.kind === "message" || row.kind === "assistant-meta") && row.message === last) {
+        expect(next.rows[index]).toMatchObject({ message: { text: "Partial token" } });
+      } else {
+        expect(next.rows[index]).toBe(row);
+      }
+    }
+  });
 
   it.each(["completion", "turn", "role", "ordering"] as const)(
     "rebuilds row structure for a %s change with otherwise unchanged controls",


### PR DESCRIPTION
[#9725](https://github.com/pingdotgg/t3code/pull/9725) added a row-level fast path for streaming text: `deriveMessagesTimelineRowsWithState` reuses the previous rows when only a streaming message's text changed and every other input keeps its identity. In the app that path never engaged. `ChatView` rebuilt `revertTurnCountByUserMessageId` as a fresh `Map` on every streaming delta (its memo depends on `timelineEntries`, which changes per token), so the shallow context gate failed and `deriveMessagesTimelineRows` ran fully per token, followed by `computeStableMessagesTimelineRows` doing `Equal.equals` over every work row. The entries-level reuse from the same PR was real; the row-level half contributed nothing.

`buildRevertTurnCountByUserMessageId` now takes the previous `Map` and hands it back when the contents are unchanged, and `ChatView` threads the last result through a ref. Every other context input (`latestTurn`, `checkpoints`, `runningTurnId`, `expandedTurnIds`, `isWorking`, `activeTurnStartedAt`) was already identity-stable per token, so this was the only remaining churn.

## Verification

- `apps/web`: `vp test run src/components/ChatView.logic.test.ts src/components/chat/MessagesTimeline.logic.test.ts` passes (204 tests). The new projection test mirrors the `ChatView` wiring (map rebuilt from each delta's entries) and asserts row identity survives a text delta; it fails on `main` and passes here. Two `it.each` cases cover the builder returning the previous map with rollback supported and unsupported, plus a case where a changed revert target yields a new map.
- `tsgo --noEmit` in `apps/web` is clean.

No visual change; the row output is identical, only the identity of unchanged rows is preserved across streaming deltas.

Found by an audit of the perf PRs merged on 2026-09-04. Created with Claude Fable 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only referential stability for revert maps; rendered timeline data and revert targets are unchanged, with new unit/integration tests.
> 
> **Overview**
> Fixes a gap where **streaming text deltas** still forced a full messages timeline rebuild every token because `revertTurnCountByUserMessageId` was always a new `Map` (its memo depends on `timelineEntries`, which changes per delta). That broke the row-level identity gate in `deriveMessagesTimelineRowsWithState` even when revert targets were unchanged.
> 
> **`buildRevertTurnCountByUserMessageId`** now accepts an optional previous map and returns the same reference when entries are shallow-equal (via zustand `shallow`). **`ChatView`** keeps the last result in a ref and passes it into each rebuild. Rollback-disabled behavior is unchanged (empty map, still stable when contents match).
> 
> Tests cover map identity on simulated streaming assistant text, a new revert target producing a new map, and an integration case that unchanged timeline rows keep object identity across a text delta when wired like `ChatView`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4008479a24050c93a0bf1ee9dacad16e48eece0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve revert-target `Map` identity in `ChatView` during text streaming
> - `buildRevertTurnCountByUserMessageId` now accepts an optional previous `Map` and uses Zustand's shallow comparator to return the same `Map` instance when computed revert targets are unchanged, or a new `Map` when they differ
> - `ChatView` stores the last revert-target `Map` in a ref and feeds it into the memoized derivation so timeline rows keep stable identities while assistant text streams
> - Adds tests covering `Map` identity preservation on content-only updates, `Map` replacement when a checkpoint target changes, and unchanged row retention in timeline projections during streaming
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4008479.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->