### PR TITLE
fix(web): reset markdown widgets when the previewed file changes

### DIFF
--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -1266,7 +1266,11 @@ export default function FilePreviewPanel({
             </div>
           ) : relativePath && file.data ? (
             isMarkdown && renderMarkdown ? (
+              // Markdown reconciles in place across text updates, so a file
+              // switch needs a new key or the previous file's disclosure and
+              // wrap state carries into the next document.
               <RenderedMarkdownSurface
+                key={relativePath}
                 environmentId={environmentId}
                 cwd={cwd}
                 relativePath={relativePath}


### PR DESCRIPTION
[#9677](https://github.com/pingdotgg/t3code/pull/9677) hoisted the react-markdown component map to a module constant so streaming text reconciles in place instead of remounting the whole message. The Files panel rendered every markdown file through the same unkeyed `RenderedMarkdownSurface`, so a file switch now reconciled in place too: the previous document's open `<details>`, wrapped code fences, and pinned table header widths carried into the next file. Before #9677 the component map's memo depended on `text`, which forced a clean remount on every file change.

Key the rendered markdown surface by `relativePath`, matching the sibling code-view branches in the same ternary. Updates to the same file (agent edits, workspace refreshes) still reconcile in place, and the chat timeline is unaffected because it keys rows by message id.

## Verification

Reproduced in the web app against a two-file fixture project: open `README.md` rendered, open `CHANGELOG.md`, expand its `<details>`, switch back to `README.md`.

| | Before (main) | After |
| --- | --- | --- |
| Return to README after expanding CHANGELOG's details | ![README shows its details already expanded](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/940cc5f9e661efc3/markdown-before-crop.png) | ![README shows its details collapsed](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d8924c2790202c0a/markdown-after-crop.png) |

The `data-markdown-details-open` attribute read `true` on return with `main` and `false` with this change. There is no cheap unit-level regression guard for a `key` on this branch of `FilePreviewPanel` (the existing `ChatMarkdown` tests already cover in-place reconciliation with a stable key), so the proof is the browser check above. `tsgo --noEmit` in `apps/web` is clean.

Found by an audit of the perf PRs merged on 2026-09-04. Created with Claude Fable 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single React `key` on the file preview markdown branch; no auth, data, or API changes.
> 
> **Overview**
> **Fixes stale markdown UI state when switching files in the Files panel rendered preview.**
> 
> After in-place react-markdown reconciliation (#9677), an unkeyed `RenderedMarkdownSurface` kept the previous file’s widget state—open `<details>`, wrapped code fences, pinned table headers—when navigating to another markdown file. This PR adds `key={relativePath}` on that surface (aligned with other preview branches) so a path change forces a fresh mount while edits to the *same* file still reconcile in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 476f8f1fc4b94d6e5f0ca0279ac8f0c3edd136e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reset `RenderedMarkdownSurface` when previewed file changes in `FilePreviewPanel`
> Adds a `key` based on `relativePath` to the `RenderedMarkdownSurface` instance so React remounts it on file switch. This prevents disclosure and wrap state from the previously displayed file from persisting into the newly selected document.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 476f8f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->