### PR TITLE
fix(mobile): keep highlighting review diffs after a long line

### DIFF
--- a/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.test.ts
+++ b/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.test.ts
@@ -257,13 +257,13 @@ describe.each(["native", "javascript"] as const)("%s highlighting budgets", (eng
     expect(result.tokensByRowId["line-1"]?.some((token) => token.color !== null)).toBe(true);
   });
 
-  it("keeps long lines and unknown following syntax plain until the next hunk", async () => {
+  it("keeps only the long line plain and resumes highlighting after it", async () => {
     const longLine = `${"x".repeat(1_001)} /*`;
     const rows = [
       line(1, "export const before = 1;"),
       line(2, longLine),
       { kind: "comment", id: "note", commentText: "Check this", fileId: TYPESCRIPT_FILE.id },
-      line(3, "inside the comment */"),
+      line(3, "export const inside = 'x';"),
       makeHunk("next-hunk"),
       line(100, "export const after = 2;"),
     ] satisfies ReadonlyArray<NativeReviewDiffRow>;
@@ -274,12 +274,34 @@ describe.each(["native", "javascript"] as const)("%s highlighting budgets", (eng
     expect(result.tokensByRowId["line-2"]).toEqual([
       { content: longLine, color: null, fontStyle: null },
     ]);
-    expect(result.tokensByRowId["line-3"]).toEqual([
-      { content: "inside the comment */", color: null, fontStyle: null },
-    ]);
-    expect(result.tokensByRowId["line-1"]?.some((token) => token.color !== null)).toBe(true);
-    expect(result.tokensByRowId["line-100"]?.some((token) => token.color !== null)).toBe(true);
+    for (const id of ["line-1", "line-3", "line-100"]) {
+      expect(result.tokensByRowId[id]?.some((token) => token.color !== null)).toBe(true);
+    }
     expect(tokenization.calls.some((code) => code.includes(longLine))).toBe(false);
+  });
+
+  it("highlights the rows after a long line the same regardless of the first window", async () => {
+    const rows = [
+      line(1, "export const before = 1;"),
+      line(2, `const data = "${"x".repeat(1_050)}";`),
+      line(3, "export const inside = 'x';"),
+      line(4, "export const after = 2;"),
+    ];
+    const spanning = await highlightRows(rows);
+    const afterLongLine = await highlightNativeReviewDiffVisibleRows({
+      rows,
+      files: [TYPESCRIPT_FILE],
+      scheme: "dark",
+      engine,
+      firstRowIndex: 2,
+      lastRowIndex: 3,
+      overscanRows: 0,
+    });
+
+    for (const id of ["line-3", "line-4"]) {
+      expect(spanning.tokensByRowId[id]?.some((token) => token.color !== null)).toBe(true);
+      expect(afterLongLine.tokensByRowId[id]).toEqual(spanning.tokensByRowId[id]);
+    }
   });
 
   it("preserves multiline grammar and row mapping across character-limited batches", async () => {

--- a/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.ts
+++ b/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.ts
@@ -247,15 +247,16 @@ function createHighlighterHandle(
       while (start < lines.length) {
         if (signal?.aborted) return [];
 
-        // Skipping this line leaves its ending grammar state unknown. Keep the
-        // rest of this contiguous segment plain instead of guessing its syntax.
+        // Skipping this line leaves its ending grammar state unknown. Resume
+        // from a fresh state rather than leaving the rest of the segment plain:
+        // highlighted rows are cached for the sheet's lifetime, so a plain tail
+        // would stick, and which rows it covered would depend on where the
+        // first visible window happened to start.
         if (lines[start]!.length > NATIVE_REVIEW_DIFF_TOKENIZE_MAX_LINE_LENGTH) {
-          highlighted.push(
-            ...lines
-              .slice(start)
-              .map((content) => [{ content: content || " ", color: null, fontStyle: null }]),
-          );
-          break;
+          highlighted.push([{ content: lines[start] || " ", color: null, fontStyle: null }]);
+          grammarState = undefined;
+          start += 1;
+          continue;
         }
 
         let end = start;


### PR DESCRIPTION
[#9673](https://github.com/pingdotgg/t3code/pull/9673) bounded mobile review-diff highlighting by skipping lines over 1,000 characters. Because the ending grammar state of a skipped line is unknown, it also emitted the rest of the grammar segment as plain text and stopped. Two things compound that: `useNativeReviewDiffHighlighting` caches highlighted row ids for the sheet's lifetime, so the plain tail stuck permanently, and the segment is built from the visible window, so which rows went plain depended on where the first window happened to start. The same diff could render differently depending on scroll history.

Emit only the long line as plain text, reset the grammar state, and keep tokenizing. Worst case the first construct after the long line is mis-colored until the grammar resynchronizes, which the mobile source highlighter already accepts. Resetting rather than carrying the pre-long-line state is what makes a window that starts after the long line agree with one that spans it.

## Verification

- `apps/mobile`: `vp test run src/features/diffs/nativeReviewDiffHighlighter.test.ts` passes (16 tests, native and javascript engine suites). The existing long-line test now asserts the following rows are highlighted, and a new case asserts a window starting after the long line produces the same tokens as a spanning window. Both fail on `main` and pass here.
- `tsc --noEmit` in `apps/mobile` is clean.

No device run. The change is in the pure tokenize loop; the row-to-token mapping and the 8,000-character batching are unchanged.

Found by an audit of the perf PRs merged on 2026-09-04. Created with Claude Fable 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to the Shiki tokenize loop and test expectations; worst case is transient miscoloring after very long lines, which the product already tolerates.
> 
> **Overview**
> **Fixes mobile review-diff syntax highlighting stopping after lines over 1,000 characters.** Previously, when the tokenize loop skipped an oversized line, it marked the rest of that code segment plain and exited the loop—so rows below a long line stayed uncolored, and because highlights are cached for the sheet lifetime, that stuck. Which rows were affected could also vary with the first visible scroll window.
> 
> The loop now emits **only** the long line as a plain token, **clears grammar state**, and continues tokenizing following lines. Later rows get colors again; a window that starts after the long line should match one that includes it (at the cost of possible brief mis-highlighting until the grammar resyncs).
> 
> Tests are updated to expect highlighting on rows after a long line, plus a new case comparing spanning vs. post-long-line visible windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2941c0bebf2cb88aca62bb4d5f09d9ff87717b84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `nativeReviewDiffHighlighter` to resume highlighting after overlength lines
> Previously, when the tokenizer hit a line exceeding the budget, it marked the entire remaining input as plain text and stopped. Now it marks only the overlength line as plain, clears grammar state, advances one line, and continues tokenizing from a fresh state. This means rows after a long line are highlighted correctly rather than left uncolored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2941c0b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->