### PR TITLE
fix(marketing): align the endorsement carousel with its heading

### DIFF
--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -826,8 +826,11 @@ const screenshot = await getImage({
     gap: 12px;
     overflow-x: auto;
     overscroll-behavior-x: contain;
-    padding: 4px max(32px, calc((100vw - 1240px) / 2 + 32px));
-    scroll-padding-inline: max(32px, calc((100vw - 1240px) / 2 + 32px));
+    /* Percentages resolve against this element's own box rather than the
+       viewport, so the first card lines up with the heading's .container edge
+       even when a classic scrollbar makes 100vw wider than the layout. */
+    padding: 4px max(32px, calc((100% - 1240px) / 2 + 32px));
+    scroll-padding-inline: max(32px, calc((100% - 1240px) / 2 + 32px));
   }
 
   .endorsement-card {


### PR DESCRIPTION
[#9697](https://github.com/pingdotgg/t3code/pull/9697) padded the endorsement carousel with `calc((100vw - 1240px) / 2 + 32px)` so the first card would sit on the `.container` edge under the section heading. On platforms with a classic (non-overlay) scrollbar, `100vw` includes the scrollbar width, so the cards landed half a scrollbar to the right of the heading.

Use percentages, which resolve against the element's own box on every platform. The minified output becomes `max(32px, 50% - 588px)`, the same math against the right base.

## Verification

Measured in headless Chromium with native scrollbars enabled at a 1440px viewport (15px scrollbar). The red guide line marks the heading's left edge.

| | Before (main) | After |
| --- | --- | --- |
| First card vs heading | ![First card 7.5px right of the heading](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/6d3262cb720bed3a/carousel-before-crop.png) | ![First card aligned with the heading](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/34c6b2b6a35363b3/carousel-after-crop.png) |

`firstCardLeft - headingLeft` read `7.5` on `main` and `0` with this change. `astro check` and `astro build` pass; the `homeMotion` tests (the only JS touching this element) pass unchanged.

Found by an audit of the perf PRs merged on 2026-09-04. Created with Claude Fable 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing-only CSS tweak for carousel inset alignment; no logic, auth, or data changes.
> 
> **Overview**
> Fixes horizontal misalignment of the **endorsement carousel** on the marketing homepage when the browser uses a classic (non-overlay) scrollbar.
> 
> The carousel’s `padding` and `scroll-padding-inline` used `calc((100vw - 1240px) / 2 + 32px)` so the first card would line up with the endorsements heading inside `.container`. **`100vw` includes scrollbar width**, which shifted the cards slightly right of the heading.
> 
> The PR switches those calcs to **`100%`** (resolved against the carousel element’s box) and adds a short comment explaining why. Mobile breakpoints that set fixed `20px` padding are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b15884c0b358ef20d0844a552fa560c216329759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix endorsement carousel alignment with heading by using scroller width for padding
> The homepage endorsement-card scroller in [index.astro](https://github.com/pingdotgg/t3code/pull/9912/files#diff-44a2946e1eacc7096aee1ba8a172800aa7d94150585e21ff8486d94f4776677a) now calculates inline and scroll padding from the scroller's own width instead of the viewport width. This makes the first card align with the heading container edge when a classic scrollbar is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b15884c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->