### PR TITLE
fix(client): keep warm thread resumes live instead of flashing sync

### DIFF
--- a/packages/client-runtime/src/state/threads-atoms.test.ts
+++ b/packages/client-runtime/src/state/threads-atoms.test.ts
@@ -27,6 +27,7 @@ import {
   PrimaryConnectionTarget,
   type NetworkStatus,
   type PreparedConnection,
+  type SupervisorConnectionState,
 } from "../connection/model.ts";
 import { EnvironmentSupervisor } from "../connection/supervisor.ts";
 import { EnvironmentCacheStore } from "../platform/persistence.ts";
@@ -73,8 +74,18 @@ const THREAD: OrchestrationThread = {
 };
 const SNAPSHOT: OrchestrationThreadDetailSnapshot = { snapshotSequence: 7, thread: THREAD };
 
+const CONNECTED_STATE: SupervisorConnectionState = {
+  ...AVAILABLE_CONNECTION_STATE,
+  desired: true,
+  network: "online",
+  phase: "connected",
+  attempt: 1,
+  generation: 1,
+};
+
 const makeHarness = Effect.fn("TestThreadAtoms.makeHarness")(function* (options?: {
   readonly snapshot?: OrchestrationThreadDetailSnapshot;
+  readonly connected?: boolean;
 }) {
   const subscriptions = yield* Queue.unbounded<{
     readonly afterSequence: number | undefined;
@@ -123,10 +134,14 @@ const makeHarness = Effect.fn("TestThreadAtoms.makeHarness")(function* (options?
     probe: Effect.void,
     closed: Effect.never,
   };
+  const connectionState = yield* SubscriptionRef.make(
+    options?.connected ? CONNECTED_STATE : AVAILABLE_CONNECTION_STATE,
+  );
+  const sessionRef = yield* SubscriptionRef.make(Option.some(session));
   const supervisor = EnvironmentSupervisor.of({
     target: TARGET,
-    state: yield* SubscriptionRef.make(AVAILABLE_CONNECTION_STATE),
-    session: yield* SubscriptionRef.make(Option.some(session)),
+    state: connectionState,
+    session: sessionRef,
     prepared: yield* SubscriptionRef.make<Option.Option<PreparedConnection>>(
       Option.some({
         environmentId: TARGET.environmentId,
@@ -228,6 +243,9 @@ const makeHarness = Effect.fn("TestThreadAtoms.makeHarness")(function* (options?
     ref,
     subscriptions,
     olderLoads,
+    connectionState,
+    session,
+    sessionRef,
     counts: () => ({ httpLoads, diskLoads, opened, active }),
   };
 });
@@ -314,6 +332,75 @@ describe("createEnvironmentThreadStateAtoms", () => {
       const next = yield* Queue.take(h.subscriptions);
       expect(next.afterSequence).toBe(8);
       expect(h.counts()).toEqual({ httpLoads: 1, diskLoads: 1, opened: 2, active: 1 });
+      remount();
+      yield* Deferred.await(next.closed);
+    }),
+  );
+
+  it.effect.each([
+    { replayed: false, statuses: ["live"] },
+    { replayed: true, statuses: ["live", "synchronizing", "live"] },
+  ])(
+    "keeps a warm resume live until it replays events (replayed: $replayed)",
+    ({ replayed, statuses }) =>
+      Effect.gen(function* () {
+        const h = yield* makeHarness({ connected: true });
+        const unmount = h.registry.mount(h.stateAtom);
+        const first = yield* Queue.take(h.subscriptions);
+        yield* Queue.offer(first.events, { kind: "synchronized" });
+        yield* observeState(h.registry, h.stateAtom, (state) => state.status === "live");
+        unmount();
+        yield* Deferred.await(first.closed);
+
+        const observed: Array<EnvironmentThreadState["status"]> = [];
+        const stop = h.registry.subscribe(h.stateAtom, (state) => observed.push(state.status), {
+          immediate: true,
+        });
+        const remount = h.registry.mount(h.stateAtom);
+        const next = yield* Queue.take(h.subscriptions);
+        expect(next.afterSequence).toBe(7);
+        if (replayed) {
+          yield* Queue.offer(next.events, {
+            kind: "snapshot",
+            snapshot: { snapshotSequence: 9, thread: { ...THREAD, title: "Replayed" } },
+          });
+          yield* observeState(h.registry, h.stateAtom, (state) => state.status === "synchronizing");
+        }
+        yield* Queue.offer(next.events, { kind: "synchronized" });
+        yield* observeState(h.registry, h.stateAtom, (state) => state.status === "live");
+        expect(observed.filter((status, index) => observed[index - 1] !== status)).toEqual(
+          statuses,
+        );
+        stop();
+        remount();
+        yield* Deferred.await(next.closed);
+      }),
+  );
+
+  it.effect("downgrades a warm resume when the connection dropped while away", () =>
+    Effect.gen(function* () {
+      const h = yield* makeHarness({ connected: true });
+      const unmount = h.registry.mount(h.stateAtom);
+      const first = yield* Queue.take(h.subscriptions);
+      yield* Queue.offer(first.events, { kind: "synchronized" });
+      yield* observeState(h.registry, h.stateAtom, (state) => state.status === "live");
+      unmount();
+      yield* Deferred.await(first.closed);
+
+      yield* SubscriptionRef.set(h.sessionRef, Option.none());
+      yield* SubscriptionRef.set(h.connectionState, AVAILABLE_CONNECTION_STATE);
+      const remount = h.registry.mount(h.stateAtom);
+      yield* observeState(h.registry, h.stateAtom, (state) => state.status === "cached");
+      expect(currentThread(h.registry, h.stateAtom)).toBe(THREAD);
+      expect(h.counts().opened).toBe(1);
+
+      yield* SubscriptionRef.set(h.connectionState, CONNECTED_STATE);
+      yield* SubscriptionRef.set(h.sessionRef, Option.some(h.session));
+      const next = yield* Queue.take(h.subscriptions);
+      expect(next.afterSequence).toBe(7);
+      expect(h.registry.get(h.stateAtom).status).toBe("synchronizing");
+      yield* Queue.offer(next.events, { kind: "synchronized" });
+      yield* observeState(h.registry, h.stateAtom, (state) => state.status === "live");
       remount();
       yield* Deferred.await(next.closed);
     }),

--- a/packages/client-runtime/src/state/threads.ts
+++ b/packages/client-runtime/src/state/threads.ts
@@ -158,10 +158,18 @@ function matchesThreadSnapshot(
         currentPage.hasMore === page.hasMore;
 }
 
+// A retained "live" state stays live: the cursor resume that follows only
+// replays what the thread missed, and on servers that send the completion
+// marker the first replayed event moves the status to "synchronizing" on its
+// own. Downgrading here would flash a sync label on every return to a
+// recently viewed thread.
 function cachedThreadState(value: EnvironmentThreadState): EnvironmentThreadState {
   return {
     ...value,
-    status: value.status === "deleted" ? "deleted" : statusWithoutLiveData(value.data),
+    status:
+      value.status === "deleted" || (value.status === "live" && Option.isSome(value.data))
+        ? value.status
+        : statusWithoutLiveData(value.data),
     error: Option.none(),
     page: Option.map(value.page, (page) => ({ ...page, loadingOlder: false })),
   };
@@ -647,7 +655,16 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
       service.changes.pipe(Stream.filter(ConnectionWakeups.shouldResubscribeAfterWakeup)),
   });
 
-  yield* setSynchronizing;
+  // Only the first subscription after a warm live resume keeps the retained
+  // status. A replacement session or foreground resubscribe on the same scope
+  // may have missed events, so those show sync progress until confirmed.
+  const resumingLive = yield* Ref.make(initialState.status === "live");
+  const markSynchronizing = Effect.gen(function* () {
+    if (yield* Ref.get(resumingLive)) return;
+    yield* setSynchronizing;
+  });
+
+  yield* markSynchronizing;
   yield* Effect.forkScoped(
     subscribeDynamic(
       ORCHESTRATION_WS_METHODS.subscribeThread,
@@ -668,7 +685,8 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
         const supportsPagination = config.threadSnapshotPagination === true;
         yield* Ref.set(paginationSupported, supportsPagination);
         yield* Ref.set(awaitingCompletion, supportsCompletionMarker);
-        yield* setSynchronizing;
+        yield* markSynchronizing;
+        yield* Ref.set(resumingLive, false);
 
         let current = yield* SubscriptionRef.get(state);
         // A windowed cache resuming against a server without pagination is a


### PR DESCRIPTION
[#9740](https://github.com/pingdotgg/t3code/pull/9740) closes a thread's live stream when its last consumer leaves and resumes from a retained cursor for five idle minutes. The retained state was downgraded to `cached` and the resubscribe forced `synchronizing`, so every return to a recently viewed thread flashed "Syncing messages..." above the composer until the server's completion marker arrived. Before #9740 the atom stayed alive and live, so returning showed nothing. Thread switching is the hottest navigation in the app; on a relay or tunnel connection the flash is several frames.

Keep a retained live status through the first cursor resume. The rest of the state machine is unchanged:

- On servers that send the completion marker, a replayed event still moves the thread to `synchronizing` until the marker arrives, so a thread that actually missed events still shows sync progress.
- A dropped connection still downgrades to `cached` through the connection watcher, and the reconnect shows `synchronizing` again.
- A replacement session or app-foreground resubscribe still shows sync progress, since it may have missed events.

## Verification

- `packages/client-runtime`: `vp test run src/state` passes (31 files, 355 tests). Three new cases in `threads-atoms.test.ts` assert the observed status sequence on a warm return with nothing to replay (`live` only), with a replayed event (`live → synchronizing → live`), and after the connection dropped while away (`cached`, then `synchronizing` on reconnect). The first two fail on `main`.
- `tsgo --noEmit` in `packages/client-runtime` is clean.

Browser check against a copy of real data (two long threads), navigating A → B → A. To capture the moment the pill is decided, the `subscribeThread` frame was held in the browser so the resubscribe stays pending:

| | Before (main) | After |
| --- | --- | --- |
| Return to thread A within the resume window | ![Syncing messages pill above the composer](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/98923087fdcdb46f/warm-before-crop.png) | ![No pill above the composer](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/fcc047cfef4d20c9/warm-after-crop.png) |

Without holding the frame, a rendered-frame sampler on `main` observed the pill for about 2 s on localhost (two separate paints); with this change it never appeared. Pausing the server process while away and returning showed no pill and no stale label on this change, and the thread went live again once the server resumed.

This shared change applies to web, desktop, and mobile. No wire changes.

Found by an audit of the perf PRs merged on 2026-09-04. Created with Claude Fable 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core thread status transitions and subscription resume logic used on every thread navigation; behavior is well-covered by new tests but incorrect edge handling could hide real sync needs.
> 
> **Overview**
> Fixes a UX regression where returning to a recently viewed thread briefly showed **"Syncing messages..."** even when nothing was missed.
> 
> **Retained resume state** no longer downgrades `live` to `cached` in `cachedThreadState` when thread data is still present, so the UI can stay live across the idle resume window.
> 
> **First cursor resubscribe** after that warm resume skips the initial `synchronizing` transition via a `resumingLive` guard; later resubscribes (new session, foreground wakeup) still call `setSynchronizing` because they may have missed events. Replay with a completion marker still moves through `synchronizing` when events actually arrive; connection loss while away still downgrades to `cached` and reconnect shows sync again.
> 
> Tests extend the atom harness with controllable connection/session refs and add cases for warm return (no replay vs replayed snapshot) and disconnect-while-away behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b60ba9cab6e0013b7ee865a089a091478686d3a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix warm thread resume flashing `synchronizing` status instead of staying live
> - In `EnvironmentThreadState.make`, adds a `resuming-live` flag so the first subscription after a retained live resume skips the synchronizing transition; the flag clears after that input so later resubscriptions sync normally
> - In `cachedThreadState`, a retained thread with live status and available data now stays live when cached, instead of being downgraded to a non-live status
> - Adds test coverage for warm resumes with and without replayed events, plus connection-drop and remount scenarios that verify cached data is shown without a new stream and later resumes from the cached cursor
> - Risk: `cachedThreadState` status logic now depends on the retained state having a live status with present data; non-live or deleted states are unchanged, but any caller expecting cached threads to always report a non-live status will see different behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b60ba9c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->