### PR TITLE
fix(server): isolate Cursor metadata generation

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -14,6 +14,7 @@ import type * as AcpSchema from "effect-acp/schema";
 
 const requestLogPath = process.env.T3_ACP_REQUEST_LOG_PATH;
 const exitLogPath = process.env.T3_ACP_EXIT_LOG_PATH;
+const promptStartedPath = process.env.T3_ACP_PROMPT_STARTED_PATH;
 const antigravityProfile = process.env.T3_ACP_ANTIGRAVITY === "1";
 const emitToolCalls = process.env.T3_ACP_EMIT_TOOL_CALLS === "1";
 const emitInterleavedAssistantToolCalls =
@@ -615,6 +616,11 @@ const program = Effect.gen(function* () {
 
   yield* agent.handlePrompt((request) =>
     Effect.gen(function* () {
+      if (promptStartedPath) {
+        const pendingPromptStartedPath = `${promptStartedPath}.tmp`;
+        NodeFS.writeFileSync(pendingPromptStartedPath, process.cwd(), "utf8");
+        NodeFS.renameSync(pendingPromptStartedPath, promptStartedPath);
+      }
       const requestedSessionId = String(request.sessionId ?? sessionId);
       promptCount += 1;
 

--- a/apps/server/src/textGeneration/CursorTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/CursorTextGeneration.test.ts
@@ -7,9 +7,13 @@ import * as NodeFS from "node:fs";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
 import * as Clock from "effect/Clock";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as FileSystem from "effect/FileSystem";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { createModelSelection } from "@t3tools/shared/model";
@@ -68,10 +72,8 @@ function waitForFileContent(path: string): Effect.Effect<string> {
       if (Exit.isSuccess(result)) {
         return result.value;
       }
-      {
-        if ((yield* Clock.currentTimeMillis) >= deadline) {
-          return yield* Effect.die(result.cause);
-        }
+      if ((yield* Clock.currentTimeMillis) >= deadline) {
+        return yield* Effect.die(result.cause);
       }
       yield* Effect.sleep(25);
     }
@@ -79,102 +81,222 @@ function waitForFileContent(path: string): Effect.Effect<string> {
 }
 
 it.layer(CursorTextGenerationTestLayer)("CursorTextGeneration", (it) => {
-  it.effect("uses ACP model config options instead of raw CLI model ids", () => {
-    const requestLogDir = NodeFS.mkdtempSync(
-      NodePath.join(NodeOS.tmpdir(), "t3code-cursor-text-log-"),
-    );
-    const requestLogPath = NodePath.join(requestLogDir, "requests.ndjson");
-
-    return withFakeAcpAgent(
-      {
+  it.effect("isolates metadata generation while preserving relative Cursor binaries", () =>
+    Effect.gen(function* () {
+      const projectCwd = NodeFS.mkdtempSync(
+        NodePath.join(NodeOS.tmpdir(), "t3code-cursor-text-project-"),
+      );
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => NodeFS.rmSync(projectCwd, { recursive: true, force: true })),
+      );
+      const requestLogPath = NodePath.join(projectCwd, "requests.ndjson");
+      const agentPath = makeAcpAgentWrapper(projectCwd, {
         T3_ACP_REQUEST_LOG_PATH: requestLogPath,
+        // @effect-diagnostics-next-line preferSchemaOverJson:off - fixed mock-agent response fixture.
         T3_ACP_PROMPT_RESPONSE_TEXT: JSON.stringify({
           subject: "Add generated commit message",
           body: "- verify cursor acp model config path",
         }),
+      });
+      const relativeAgentPath = `.${NodePath.sep}${NodePath.relative(projectCwd, agentPath)}`;
+      const textGeneration = yield* makeCursorTextGeneration(
+        decodeCursorSettings({ binaryPath: relativeAgentPath }),
+      );
+
+      const generated = yield* textGeneration.generateCommitMessage({
+        cwd: projectCwd,
+        branch: "feature/cursor-text-generation",
+        stagedSummary: "M apps/server/src/textGeneration/CursorTextGeneration.ts",
+        stagedPatch:
+          "diff --git a/apps/server/src/textGeneration/CursorTextGeneration.ts b/apps/server/src/textGeneration/CursorTextGeneration.ts",
+        modelSelection: {
+          ...createModelSelection(ProviderInstanceId.make("cursor"), "gpt-5.4", [
+            { id: "reasoning", value: "xhigh" },
+            { id: "fastMode", value: true },
+            { id: "contextWindow", value: "1m" },
+          ]),
+        },
+      });
+
+      expect(generated.subject).toBe("Add generated commit message");
+      expect(generated.body).toBe("- verify cursor acp model config path");
+
+      const requests = NodeFS.readFileSync(requestLogPath, "utf8")
+        .trim()
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .map((line) => JSON.parse(line) as { method?: string; params?: Record<string, unknown> });
+
+      const sessionInput = requests.find((request) => request.method === "session/new")?.params;
+      const metadataWorkspace = sessionInput?.cwd;
+      expect(typeof metadataWorkspace).toBe("string");
+      expect(metadataWorkspace).not.toBe(projectCwd);
+      expect(metadataWorkspace).toContain("t3-cursor-metadata-");
+      expect(NodeFS.existsSync(String(metadataWorkspace))).toBe(false);
+
+      expect(
+        requests.find((request) => request.method === "initialize")?.params?.clientCapabilities,
+      ).toMatchObject({
+        _meta: {
+          parameterizedModelPicker: true,
+        },
+      });
+      expect(
+        requests.some(
+          (request) =>
+            request.method === "session/set_config_option" &&
+            request.params?.configId === "model" &&
+            request.params?.value === "gpt-5.4",
+        ),
+      ).toBe(true);
+      expect(
+        requests.some(
+          (request) =>
+            request.method === "session/set_config_option" &&
+            request.params?.configId === "reasoning" &&
+            request.params?.value === "extra-high",
+        ),
+      ).toBe(true);
+      expect(
+        requests.some(
+          (request) =>
+            request.method === "session/set_config_option" &&
+            request.params?.configId === "context" &&
+            request.params?.value === "1m",
+        ),
+      ).toBe(true);
+      expect(
+        requests.some(
+          (request) =>
+            request.method === "session/set_config_option" &&
+            request.params?.configId === "fast" &&
+            request.params?.value === "true",
+        ),
+      ).toBe(true);
+      expect(
+        requests.find((request) => request.method === "session/prompt")?.params?.prompt,
+      ).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "text",
+            text: expect.stringMatching(
+              /Do not use tools, read or write files, run commands[\s\S]*Staged patch:/,
+            ),
+          }),
+        ]),
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("removes the metadata workspace after caller cancellation", () => {
+    const requestLogDir = NodeFS.mkdtempSync(
+      NodePath.join(NodeOS.tmpdir(), "t3code-cursor-text-cancel-"),
+    );
+    const requestLogPath = NodePath.join(requestLogDir, "requests.ndjson");
+    const promptStartedPath = NodePath.join(requestLogDir, "prompt-started");
+
+    return withFakeAcpAgent(
+      {
+        T3_ACP_REQUEST_LOG_PATH: requestLogPath,
+        T3_ACP_PROMPT_STARTED_PATH: promptStartedPath,
+        T3_ACP_HANG_PROMPT_FOREVER: "1",
       },
       (textGeneration) =>
         Effect.gen(function* () {
-          const generated = yield* textGeneration.generateCommitMessage({
-            cwd: process.cwd(),
-            branch: "feature/cursor-text-generation",
-            stagedSummary: "M apps/server/src/textGeneration/CursorTextGeneration.ts",
-            stagedPatch:
-              "diff --git a/apps/server/src/textGeneration/CursorTextGeneration.ts b/apps/server/src/textGeneration/CursorTextGeneration.ts",
-            modelSelection: {
-              ...createModelSelection(ProviderInstanceId.make("cursor"), "gpt-5.4", [
-                { id: "reasoning", value: "xhigh" },
-                { id: "fastMode", value: true },
-                { id: "contextWindow", value: "1m" },
-              ]),
-            },
-          });
-
-          expect(generated.subject).toBe("Add generated commit message");
-          expect(generated.body).toBe("- verify cursor acp model config path");
-
-          const requests = NodeFS.readFileSync(requestLogPath, "utf8")
-            .trim()
-            .split("\n")
-            .filter((line) => line.length > 0)
-            .map(
-              (line) => JSON.parse(line) as { method?: string; params?: Record<string, unknown> },
-            );
-
-          expect(
-            requests.find((request) => request.method === "initialize")?.params?.clientCapabilities,
-          ).toMatchObject({
-            _meta: {
-              parameterizedModelPicker: true,
-            },
-          });
-          expect(
-            requests.some(
-              (request) =>
-                request.method === "session/set_config_option" &&
-                request.params?.configId === "model" &&
-                request.params?.value === "gpt-5.4",
-            ),
-          ).toBe(true);
-          expect(
-            requests.some(
-              (request) =>
-                request.method === "session/set_config_option" &&
-                request.params?.configId === "reasoning" &&
-                request.params?.value === "extra-high",
-            ),
-          ).toBe(true);
-          expect(
-            requests.some(
-              (request) =>
-                request.method === "session/set_config_option" &&
-                request.params?.configId === "context" &&
-                request.params?.value === "1m",
-            ),
-          ).toBe(true);
-          expect(
-            requests.some(
-              (request) =>
-                request.method === "session/set_config_option" &&
-                request.params?.configId === "fast" &&
-                request.params?.value === "true",
-            ),
-          ).toBe(true);
-          expect(
-            requests.find((request) => request.method === "session/prompt")?.params?.prompt,
-          ).toEqual(
-            expect.arrayContaining([
-              expect.objectContaining({
-                type: "text",
-                text: expect.stringContaining("Staged patch:"),
-              }),
-            ]),
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => NodeFS.rmSync(requestLogDir, { recursive: true, force: true })),
           );
+          const promptStarted = yield* Deferred.make<string>();
+          const watcher = NodeFS.watch(requestLogDir, (_event, filename) => {
+            if (
+              filename !== null &&
+              String(filename) !== NodePath.basename(promptStartedPath) &&
+              !NodeFS.existsSync(promptStartedPath)
+            ) {
+              return;
+            }
+            if (!NodeFS.existsSync(promptStartedPath)) return;
+            Deferred.doneUnsafe(
+              promptStarted,
+              Effect.sync(() => NodeFS.readFileSync(promptStartedPath, "utf8")),
+            );
+          });
+          yield* Effect.addFinalizer(() => Effect.sync(() => watcher.close()));
+          const request = yield* textGeneration
+            .generateCommitMessage({
+              cwd: process.cwd(),
+              branch: "feature/cursor-cancel",
+              stagedSummary: "M README.md",
+              stagedPatch: "diff --git a/README.md b/README.md",
+              modelSelection: {
+                instanceId: ProviderInstanceId.make("cursor"),
+                model: "composer-2",
+              },
+            })
+            .pipe(Effect.forkChild({ startImmediately: true }));
+          const metadataWorkspace = yield* Deferred.await(promptStarted);
+          expect(NodeFS.existsSync(metadataWorkspace)).toBe(true);
 
-          NodeFS.rmSync(requestLogDir, { recursive: true, force: true });
+          yield* Fiber.interrupt(request);
+
+          expect(NodeFS.existsSync(metadataWorkspace)).toBe(false);
         }),
     );
   });
+
+  it.effect("keeps generated metadata when workspace cleanup fails", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const tempDir = NodeFS.mkdtempSync(
+        NodePath.join(NodeOS.tmpdir(), "t3code-cursor-text-cleanup-"),
+      );
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => NodeFS.rmSync(tempDir, { recursive: true, force: true })),
+      );
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const agentPath = makeAcpAgentWrapper(tempDir, {
+        T3_ACP_REQUEST_LOG_PATH: requestLogPath,
+        T3_ACP_PROMPT_RESPONSE_TEXT: '{"title":"Cleanup must not replace this title"}',
+      });
+      let leakedWorkspace: string | undefined;
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          if (leakedWorkspace) NodeFS.rmSync(leakedWorkspace, { recursive: true, force: true });
+        }),
+      );
+      const failingFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        remove: (path, options) => {
+          if (!path.includes("t3-cursor-metadata-")) return fileSystem.remove(path, options);
+          leakedWorkspace = path;
+          return Effect.fail(
+            PlatformError.systemError({
+              _tag: "PermissionDenied",
+              module: "FileSystem",
+              method: "remove",
+              pathOrDescriptor: path,
+              description: "forced metadata workspace cleanup failure",
+            }),
+          );
+        },
+      });
+      const textGeneration = yield* makeCursorTextGeneration(
+        decodeCursorSettings({ binaryPath: agentPath }),
+      ).pipe(Effect.provideService(FileSystem.FileSystem, failingFileSystem));
+
+      const generated = yield* textGeneration.generateThreadTitle({
+        cwd: process.cwd(),
+        message: "Keep successful metadata despite cleanup failure.",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("cursor"),
+          model: "composer-2",
+        },
+      });
+
+      expect(generated.title).toBe("Cleanup must not replace this title");
+      expect(leakedWorkspace).toContain("t3-cursor-metadata-");
+    }).pipe(Effect.scoped),
+  );
 
   it.effect("accepts json objects with extra assistant text around them", () =>
     withFakeAcpAgent(

--- a/apps/server/src/textGeneration/CursorTextGeneration.ts
+++ b/apps/server/src/textGeneration/CursorTextGeneration.ts
@@ -1,6 +1,8 @@
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import { ChildProcessSpawner } from "effect/unstable/process";
@@ -28,6 +30,7 @@ import {
 } from "../provider/acp/CursorAcpSupport.ts";
 
 const CURSOR_TIMEOUT_MS = 180_000;
+const CURSOR_METADATA_WORKSPACE_PREFIX = "t3-cursor-metadata-";
 
 const isTextGenerationError = Schema.is(TextGenerationError);
 
@@ -41,11 +44,25 @@ export const makeCursorTextGeneration = Effect.fn("makeCursorTextGeneration")(fu
 ) {
   const crypto = yield* Crypto.Crypto;
   const commandSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
   const resolvedEnvironment = environment ?? process.env;
+
+  const settingsForMetadataWorkspace = (sourceCwd: string) => {
+    const binaryPath = cursorSettings.binaryPath;
+    if (
+      !binaryPath ||
+      path.isAbsolute(binaryPath) ||
+      (!binaryPath.includes("/") && !binaryPath.includes("\\"))
+    ) {
+      return cursorSettings;
+    }
+    return { ...cursorSettings, binaryPath: path.resolve(sourceCwd, binaryPath) };
+  };
 
   const runCursorJson = <S extends Schema.Top>({
     operation,
-    cwd,
+    sourceCwd,
     prompt,
     outputSchemaJson,
     modelSelection,
@@ -55,18 +72,35 @@ export const makeCursorTextGeneration = Effect.fn("makeCursorTextGeneration")(fu
       | "generatePrContent"
       | "generateBranchName"
       | "generateThreadTitle";
-    cwd: string;
+    sourceCwd: string;
     prompt: string;
     outputSchemaJson: S;
     modelSelection: ModelSelection;
   }): Effect.Effect<S["Type"], TextGenerationError, S["DecodingServices"]> =>
     Effect.gen(function* () {
+      const metadataWorkspace = yield* Effect.acquireRelease(
+        fileSystem.makeTempDirectory({ prefix: CURSOR_METADATA_WORKSPACE_PREFIX }).pipe(
+          Effect.mapError(
+            (cause) =>
+              new TextGenerationError({
+                operation,
+                detail: "Failed to create an isolated Cursor metadata workspace.",
+                cause,
+              }),
+          ),
+        ),
+        (workspace) =>
+          fileSystem.remove(workspace, { recursive: true, force: true }).pipe(
+            // Cleanup must not replace a successfully generated result.
+            Effect.ignore({ log: true }),
+          ),
+      );
       const outputRef = yield* Ref.make("");
       const runtime = yield* makeCursorAcpRuntime({
-        cursorSettings,
+        cursorSettings: settingsForMetadataWorkspace(sourceCwd),
         environment: resolvedEnvironment,
         childProcessSpawner: commandSpawner,
-        cwd,
+        cwd: metadataWorkspace,
         clientInfo: { name: "t3-code-git-text", version: "0.0.0" },
       }).pipe(Effect.provideService(Crypto.Crypto, crypto));
 
@@ -101,7 +135,17 @@ export const makeCursorTextGeneration = Effect.fn("makeCursorTextGeneration")(fu
         });
 
         return yield* runtime.prompt({
-          prompt: [{ type: "text", text: prompt }],
+          prompt: [
+            {
+              type: "text",
+              text: [
+                "Use only the input below. Do not use tools, read or write files, run commands, or ask questions.",
+                "Return only the requested JSON object.",
+                "",
+                prompt,
+              ].join("\n"),
+            },
+          ],
         });
       }).pipe(
         Effect.timeoutOption(CURSOR_TIMEOUT_MS),
@@ -177,7 +221,7 @@ export const makeCursorTextGeneration = Effect.fn("makeCursorTextGeneration")(fu
 
       const generated = yield* runCursorJson({
         operation: "generateCommitMessage",
-        cwd: input.cwd,
+        sourceCwd: input.cwd,
         prompt,
         outputSchemaJson: outputSchema,
         modelSelection: input.modelSelection,
@@ -206,7 +250,7 @@ export const makeCursorTextGeneration = Effect.fn("makeCursorTextGeneration")(fu
 
       const generated = yield* runCursorJson({
         operation: "generatePrContent",
-        cwd: input.cwd,
+        sourceCwd: input.cwd,
         prompt,
         outputSchemaJson: outputSchema,
         modelSelection: input.modelSelection,
@@ -227,7 +271,7 @@ export const makeCursorTextGeneration = Effect.fn("makeCursorTextGeneration")(fu
 
       const generated = yield* runCursorJson({
         operation: "generateBranchName",
-        cwd: input.cwd,
+        sourceCwd: input.cwd,
         prompt,
         outputSchemaJson: outputSchema,
         modelSelection: input.modelSelection,
@@ -248,7 +292,7 @@ export const makeCursorTextGeneration = Effect.fn("makeCursorTextGeneration")(fu
 
       const generated = yield* runCursorJson({
         operation: "generateThreadTitle",
-        cwd: input.cwd,
+        sourceCwd: input.cwd,
         prompt,
         outputSchemaJson: outputSchema,
         modelSelection: input.modelSelection,


### PR DESCRIPTION
Cursor generates titles, branch names, commit messages, and PR text from a prompt that already contains everything it needs. Starting those ACP requests in the real project directory exposes them to project files and instructions they do not need.

Each Cursor metadata request now starts in an empty temporary workspace, and the prompt tells Cursor to use only the supplied input. This follows #4169, which did the same for Claude. Relative configured binary paths still resolve from the original project. Endpoint, environment, and model settings are unchanged. The workspace is removed after the ACP child closes, on success, failure, or cancellation. Cleanup errors are logged and ignored so they don't discard generated output. This is also why the code uses an explicit `acquireRelease` instead of `makeTempDirectoryScoped`, whose finalizer calls `orDie`.

This isolates the workspace; it is not an OS sandbox. Only the Cursor implementation, its tests, and the mock ACP agent's prompt-started receipt change.

## Verification

Rebased onto `main` at `4d06156dd`; no conflicts.

- `vp test run src/textGeneration/CursorTextGeneration.test.ts`: 6 passed. Covers temp-workspace cwd, relative binary resolution, cleanup on success, failure, and cancellation, and output surviving a failed cleanup.
- `tsc --noEmit` for `apps/server`: passed.
- `vp lint` on the three touched files: passed.

Tests use the repo's mock ACP agent. No live Cursor run was done.

Coordination trace: T3 thread a837405b-3eae-403f-882c-f585e66419e5

Rebased and verified by Claude Opus 5 in Claude Code (via T3 Code).
