### PR TITLE
fix(desktop): preserve screenshot detail in scaled previews

### DIFF
--- a/apps/desktop/scripts/preview-capture-smoke.mjs
+++ b/apps/desktop/scripts/preview-capture-smoke.mjs
@@ -1,0 +1,167 @@
+// Run with Electron: electron apps/desktop/scripts/preview-capture-smoke.mjs
+import * as NodeAssert from "node:assert/strict";
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import { app, BrowserWindow, webContents } from "electron";
+import * as Effect from "effect/Effect";
+import { capturePreviewPage } from "../src/preview/PreviewCapture.ts";
+
+const directory = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-preview-capture-"));
+app.setPath("userData", directory);
+app.commandLine.appendSwitch("force-device-scale-factor", "2");
+const page = `<!doctype html><style>
+body { margin:48px; background:white; color:#171717; font:14px Arial }
+.lines { width:160px; height:64px; margin-top:24px;
+background:repeating-linear-gradient(90deg,#171717 0 1px,white 1px 2px) }
+</style><p>Search projects</p><p>Ready for review</p><div class="lines"></div>`;
+
+app.whenReady().then(async () => {
+  const window = new BrowserWindow({
+    width: 1500,
+    height: 1000,
+    webPreferences: { webviewTag: true, backgroundThrottling: false },
+  });
+  try {
+    const attached = new Promise((resolve) => {
+      window.webContents.once("did-attach-webview", (_event, guest) => {
+        guest.once("did-finish-load", () => resolve(guest.id));
+      });
+    });
+    await window.loadURL(
+      "data:text/html," +
+        encodeURIComponent(`<style>img { max-width:100%; height:auto }</style><body style="margin:0;background:black">
+<webview data-preview-tab="test" style="position:absolute;left:0;top:0;display:flex;width:1280px;height:800px;transform-origin:top left"
+src="data:text/html,${encodeURIComponent(page)}"></webview>`),
+    );
+    const guest = webContents.fromId(await attached);
+    guest.setBackgroundThrottling(false);
+    const capture = (rect) =>
+      Effect.runPromise(capturePreviewPage("test", guest, rect).pipe(Effect.timeout("5 seconds")));
+    const present = async (scale) => {
+      await window.webContents.executeJavaScript(`(() => {
+      document.querySelector("webview").style.transform = ${JSON.stringify(scale === 1 ? "none" : `scale(${scale})`)};
+      return new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    })()`);
+      await guest.executeJavaScript(
+        "new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))",
+      );
+    };
+    const viewport = () => guest.executeJavaScript("[innerWidth, innerHeight, devicePixelRatio]");
+    const assertRestored = async () => {
+      NodeAssert.equal(
+        await window.webContents.executeJavaScript(
+          'document.querySelectorAll("[id^=preview-capture-]").length',
+        ),
+        0,
+      );
+      NodeAssert.equal(
+        await window.webContents.executeJavaScript(
+          'getComputedStyle(document.querySelector("webview")).opacity',
+        ),
+        "1",
+      );
+    };
+
+    for (const zoom of [1, 1.25]) {
+      guest.setZoomFactor(zoom);
+      await present(1);
+      const baseline = await capture();
+      const dimensions = await viewport();
+      for (const scale of [0.4, 0.15]) {
+        await present(scale);
+        const before = await guest.capturePage();
+        NodeAssert.notDeepEqual(before.toBitmap(), baseline.toBitmap());
+        const after = await capture();
+        NodeAssert.deepEqual(after.toBitmap(), baseline.toBitmap());
+        for (const [name, image] of [
+          ["before", before],
+          ["after", after],
+        ]) {
+          NodeFS.writeFileSync(
+            NodePath.join(directory, `${name}-${zoom}-${scale}.png`),
+            image.resize({ width: 1280 }).toPNG(),
+          );
+        }
+        NodeAssert.deepEqual(await viewport(), dimensions);
+        await assertRestored();
+        console.log(`PASS: scale=${scale}, zoom=${zoom}, native pixels match wide preview`);
+      }
+    }
+
+    const [first, second] = await Promise.all([capture(), capture()]);
+    NodeAssert.deepEqual(first.toBitmap(), second.toBitmap());
+    await assertRestored();
+    const originalCapture = guest.capturePage.bind(guest);
+    let calls = 0;
+    guest.capturePage = async (...args) => {
+      if (++calls === 2) {
+        const frozenWidth = await window.webContents.executeJavaScript(
+          'document.querySelector("[id^=preview-capture-] img").getBoundingClientRect().width',
+        );
+        NodeAssert.equal(frozenWidth, 1280 * 0.15);
+        throw new Error("capture failed");
+      }
+      return originalCapture(...args);
+    };
+    await NodeAssert.rejects(capture(), (error) => error.cause?.message === "capture failed");
+    await assertRestored();
+    guest.capturePage = originalCapture;
+    await capture();
+    console.log("PASS: concurrent captures, failure cleanup, and subsequent capture");
+    calls = 0;
+    const started = Promise.withResolvers();
+    guest.capturePage = (...args) => {
+      if (++calls === 2) {
+        started.resolve();
+        return new Promise(() => {});
+      }
+      return originalCapture(...args);
+    };
+    const controller = new AbortController();
+    const interrupted = Effect.runPromise(capturePreviewPage("test", guest), {
+      signal: controller.signal,
+    });
+    await started.promise;
+    controller.abort();
+    await NodeAssert.rejects(interrupted);
+    await assertRestored();
+    guest.capturePage = originalCapture;
+    await capture();
+    console.log("PASS: interrupted capture restores the preview and releases its lock");
+
+    guest.setZoomFactor(1);
+    await present(1);
+    const rect = { x: 48, y: 110, width: 160, height: 64 };
+    const crop = await capture(rect);
+    await present(0.15);
+    NodeAssert.deepEqual((await capture(rect)).toBitmap(), crop.toBitmap());
+    console.log("PASS: annotation crop retains native pixels");
+    await present(1);
+    const visible = await capture();
+    await window.webContents.executeJavaScript(
+      'document.querySelector("webview").style.zIndex = "-1"',
+    );
+    NodeAssert.deepEqual((await capture()).toBitmap(), visible.toBitmap());
+    await guest.executeJavaScript(
+      'document.querySelector("p").textContent = "Changed in background"',
+    );
+    await guest.executeJavaScript(
+      "new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))",
+    );
+    const hidden = await capture();
+    NodeAssert.notDeepEqual(hidden.toBitmap(), visible.toBitmap());
+    await window.webContents.executeJavaScript(
+      'document.querySelector("webview").style.zIndex = "0"',
+    );
+    NodeAssert.deepEqual((await capture()).toBitmap(), hidden.toBitmap());
+    console.log("PASS: background capture sees current DOM changes");
+    console.log(`Evidence: ${directory}`);
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  } finally {
+    window.destroy();
+    app.exit(process.exitCode ?? 0);
+  }
+});

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -235,7 +235,9 @@ const makeTestHostWebContents = (): TestHostWebContents => {
   return {
     id: 7,
     mainFrame: { frameTreeNodeId: 7 },
-    executeJavaScript: vi.fn(async () => true),
+    executeJavaScript: vi.fn(async (expression: string) =>
+      expression.includes(DESKTOP_PREVIEW_RECORDING_CAPTURE_TRIGGER),
+    ),
     isDestroyed: () => false,
     session: {
       setDisplayMediaRequestHandler: vi.fn((next: TestDisplayMediaHandler) => {

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -67,6 +67,7 @@ import {
 import { isPreviewAnnotationPayload } from "./PickedElementPayload.ts";
 import { playwrightInjectedRuntimeInstallExpression } from "./PlaywrightInjectedRuntime.ts";
 import { makePreviewAutomationKeySequence } from "./PreviewKeyboard.ts";
+import { capturePreviewPage } from "./PreviewCapture.ts";
 import { captureFavicon, safeHttpOrigin, selectFaviconCandidates } from "./FaviconCapture.ts";
 
 export type PreviewNavStatus =
@@ -327,29 +328,16 @@ const captureAnnotationScreenshot = (
   wc: Electron.WebContents,
   cropRect: PreviewAnnotationRect | null,
 ): Effect.Effect<PreviewAnnotationPayload["screenshot"], PreviewManagerError> =>
-  Effect.tryPromise({
-    // The unused abort signal is what makes this interruptible, and therefore
-    // what lets the timeout below fire. Drop the parameter and a stalled
-    // capture strands the pick session again.
-    try: (_signal) =>
-      wc.capturePage(
-        cropRect
-          ? {
-              x: cropRect.x,
-              y: cropRect.y,
-              width: cropRect.width,
-              height: cropRect.height,
-            }
-          : undefined,
-      ),
-    catch: (cause) =>
-      new PreviewOperationError({
-        operation: "captureAnnotationScreenshot",
-        tabId,
-        webContentsId: wc.id,
-        cause,
-      }),
-  }).pipe(
+  capturePreviewPage(tabId, wc, cropRect ?? undefined).pipe(
+    Effect.mapError(
+      ({ cause }) =>
+        new PreviewOperationError({
+          operation: "captureAnnotationScreenshot",
+          tabId,
+          webContentsId: wc.id,
+          cause,
+        }),
+    ),
     Effect.map((image): PreviewAnnotationPayload["screenshot"] => {
       const size = image.getSize();
       return {
@@ -661,11 +649,8 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     const capture = Effect.gen(function* () {
       // Check after the retry delay, and again before accepting its result.
       yield* requireCurrentGuest;
-      const image = yield* Effect.tryPromise({
-        // An abort-signal parameter makes a stalled promise interruptible.
-        try: (_signal) => wc.capturePage(),
-        catch: (cause) => new PreviewOperationError({ ...errorContext, cause }),
-      }).pipe(
+      const image = yield* capturePreviewPage(tabId, wc).pipe(
+        Effect.mapError(({ cause }) => new PreviewOperationError({ ...errorContext, cause })),
         Effect.timeout(CAPTURE_PAGE_ATTEMPT_TIMEOUT_MS),
         Effect.catchTags({
           TimeoutError: (cause) =>

--- a/apps/desktop/src/preview/PreviewCapture.ts
+++ b/apps/desktop/src/preview/PreviewCapture.ts
@@ -1,0 +1,79 @@
+import * as NodeCrypto from "node:crypto";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
+
+const encodeString = Schema.encodeSync(Schema.fromJsonString(Schema.String));
+const captureLocks = new WeakMap<Electron.WebContents, Semaphore.Semaphore>();
+
+// Chromium rasterizes CSS-scaled guests at their displayed size, even for capturePage.
+// Freeze only that preview while capturing unscaled pixels; never change its viewport.
+export const capturePreviewPage = (
+  tabId: string,
+  wc: Electron.WebContents,
+  rect?: Electron.Rectangle,
+) => {
+  let lock = captureLocks.get(wc);
+  if (!lock) {
+    lock = Semaphore.makeUnsafe(1);
+    captureLocks.set(wc, lock);
+  }
+  const capture = Effect.tryPromise((_signal) => wc.capturePage(rect));
+  return lock.withPermit(
+    Effect.gen(function* () {
+      const host = wc.hostWebContents;
+      if (!host || host.isDestroyed()) return yield* capture;
+      const scaled = yield* Effect.tryPromise((_signal) =>
+        host.executeJavaScript(`(() => {
+          const view = document.querySelector("webview[data-preview-tab=" + CSS.escape(${encodeString(tabId)}) + "]");
+          return !!view && getComputedStyle(view).transform !== "none";
+        })()`),
+      );
+      if (scaled !== true) return yield* capture;
+      const frozen = yield* Effect.tryPromise((_signal) => wc.capturePage());
+      const token = `preview-capture-${NodeCrypto.randomUUID()}`;
+      return yield* Effect.tryPromise((_signal) =>
+        host.executeJavaScript(`(async () => {
+            const view = document.querySelector("webview[data-preview-tab=" + CSS.escape(${encodeString(tabId)}) + "]");
+            if (!view || view.getWebContentsId() !== ${wc.id}) throw new Error("Preview guest detached before capture");
+            const frozen = document.createElement("img");
+            frozen.src = ${encodeString(frozen.toDataURL())};
+            frozen.alt = "";
+            frozen.className = view.className;
+            frozen.style.cssText = view.style.cssText;
+            frozen.style.pointerEvents = "none";
+            frozen.style.maxWidth = "none";
+            const holder = document.createElement("span");
+            holder.id = ${encodeString(token)};
+            holder.style.display = "contents";
+            const style = document.createElement("style");
+            style.textContent = 'webview[data-preview-tab="' + CSS.escape(view.dataset.previewTab) + '"] { transform: none !important; opacity: 0 !important; pointer-events: none !important; }';
+            holder.append(frozen);
+            view.after(holder);
+            await frozen.decode();
+            if (holder.isConnected && view.isConnected) holder.append(style);
+          })()`),
+      ).pipe(
+        Effect.andThen(
+          Effect.tryPromise((_signal) =>
+            host.executeJavaScript(
+              "new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))",
+            ),
+          ),
+        ),
+        Effect.andThen(capture),
+        Effect.ensuring(
+          Effect.suspend(() =>
+            host.isDestroyed()
+              ? Effect.void
+              : Effect.tryPromise((_signal) =>
+                  host.executeJavaScript(
+                    `document.getElementById(${encodeString(token)})?.remove()`,
+                  ),
+                ).pipe(Effect.timeout("1 second"), Effect.ignore),
+          ),
+        ),
+      );
+    }),
+  );
+};


### PR DESCRIPTION
CSS-scaled previews rasterize at their displayed size, so `preview_snapshot` loses text and 1 px detail in narrow sidebars and mini previews despite keeping the same viewport and PNG dimensions.

Freeze the displayed preview while capturing native-scale guest pixels, then restore it on success, failure, or cancellation. The shared capture helper covers snapshots, saved screenshots, and annotation crops. Existing retries and stale-guest checks remain in place.

Verified on Linux with Electron 43.4.1 at 2× device scale:

- Before: narrow and mini captures differ from the wide preview. After: their pixels match it byte-for-byte at 100% and 125% zoom.
- Native Electron checks cover concurrent captures, failure/cancellation cleanup, annotation crops, and background DOM updates.
- All 84 preview manager tests, desktop typecheck, changed-file lint and formatting pass. macOS has not been tested.

Run the native check with `electron apps/desktop/scripts/preview-capture-smoke.mjs`; it writes before/after PNGs to the printed temporary directory.

## Before and after

Narrow preview, with the same 1280 × 800 page viewport:

![Before: narrow preview loses fine detail](https://github.com/user-attachments/assets/789a7d42-8992-4fc2-91aa-273fc3a55002)
![After: narrow preview preserves native detail](https://github.com/user-attachments/assets/2923430f-3bba-4054-8691-8ee1c741e590)

Mini preview, with the same page viewport:

![Before: mini preview loses the stripe pattern](https://github.com/user-attachments/assets/b48b0263-fe52-4950-a0e3-1808abde587b)
![After: mini preview preserves the stripe pattern](https://github.com/user-attachments/assets/f422599a-0d9c-4c6d-809d-9ceb876be5bc)

Native Electron capture check recording (isolated reproducer, not the full T3 client):

https://github.com/user-attachments/assets/3ad1069d-8be4-4370-ba25-3b93167edb79

Fixes #9872.

Created with GPT-6 Astra via Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live preview UI via injected host DOM/CSS during every scaled capture; bugs could cause stuck overlays or wrong screenshots, but scope is desktop preview capture only with cleanup and locking.
> 
> **Overview**
> **Fixes blurry or low-detail preview screenshots** when the embedded webview is shown smaller via CSS `transform` (narrow sidebars, mini previews). Chromium was rasterizing at the *displayed* size even though capture dimensions stayed the same.
> 
> Adds **`capturePreviewPage`** in `PreviewCapture.ts`: per-guest locking, detects a scaled host webview, briefly overlays a frozen frame and strips the transform for the actual `capturePage`, then **always tears down** the overlay on success, failure, or abort. **`Manager.ts`** routes annotation crops and automation/snapshot captures through this helper instead of calling `wc.capturePage()` directly; existing timeouts, retries, and stale-guest checks are unchanged.
> 
> Adds an **Electron smoke script** (`preview-capture-smoke.mjs`) that asserts pixel parity across zoom/scale, concurrent captures, error/interrupt cleanup, crops, and background DOM updates. **`Manager.test.ts`** adjusts the host `executeJavaScript` mock for recording-trigger detection used by the new host-side capture path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4790e8973f25ba15e9eac6391febaed9d66ac55f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix scaled preview screenshot detail by routing captures through `capturePreviewPage`
> - Adds `capturePreviewPage` in [PreviewCapture.ts](https://github.com/pingdotgg/t3code/pull/9916/files#diff-9c67687b48a57bfdf0e70d2058601c2b0a186e24a39361ebcb88b46bea665f23), a shared Effect utility that serializes captures per `WebContents` via a `WeakMap` semaphore. When the preview webview has a non-`none` CSS transform, it captures the guest once without crop, injects the unscaled image into a temporary host-side holder, hides the original webview, waits for render frames, then captures the requested rectangle from the holder.
> - Replaces direct `wc.capturePage` calls in both `captureAnnotationScreenshot` and `makeNativeOperations` in [Manager.ts](https://github.com/pingdotgg/t3code/pull/9916/files#diff-089eb443c0884e11dbe412c68c0a1b7b22e3f1d0b8672c79facba02399e3dc53) with `capturePreviewPage`, mapping errors into the existing `PreviewOperationError` context. Annotation timeout and native attempt timeout/guest-validation behavior remain unchanged.
> - Adds an Electron smoke test in [preview-capture-smoke.mjs](https://github.com/pingdotgg/t3code/pull/9916/files#diff-8cffe1c4723fb750b42a746528dcd8253b7e894d18e6efef4db984e41187dee8) that exercises preview capture across zoom levels, CSS scales, crop rectangles, concurrent requests, failures, aborts, and background DOM changes, writing PNG evidence and asserting viewport stability and DOM cleanup.
> - Updates the host mock in [Manager.test.ts](https://github.com/pingdotgg/t3code/pull/9916/files#diff-ebb5a62378521a03aed245fc2ed6968df6c2c9db6a709340dc336a924be4068b) so `executeJavaScript` returns true only for expressions containing `DESKTOP_PREVIEW_RECORDING_CAPTURE_TRIGGER`.
> - Risk: the temporary holder insertion and webview hiding in `capturePreviewPage` run on the host contents; if the bounded cleanup finalizer is interrupted, the injected style or holder element could remain on the host page.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4790e89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->