### PR TITLE
fix(antigravity): distinguish session initialization auth failures

### DIFF
--- a/apps/server/src/provider/AntigravityAuth.test.ts
+++ b/apps/server/src/provider/AntigravityAuth.test.ts
@@ -61,7 +61,7 @@ const makeHarness = Effect.fn("makeAuthTestHarness")(function* (
   } = {},
 ) {
   const authenticated = yield* Deferred.make<void, AcpErrors.AcpError>();
-  const discovered = yield* Deferred.make<void>();
+  const discovered = yield* Deferred.make<void, AcpErrors.AcpError>();
   const closed = yield* Deferred.make<void>();
   const events: string[] = [];
   let receiveAuthorizationUrl:
@@ -222,6 +222,33 @@ it.layer(NodeServices.layer)("AntigravityAuth", (it) => {
       assert.isNull(succeeded.expiresAt);
       assert.equal(harness.events.at(-1), "process-close");
     }),
+  );
+
+  it.effect(
+    "distinguishes a post-authentication session failure without exposing its payload",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* makeHarness();
+        yield* harness.auth.controller.start(owner);
+        yield* phase(harness.auth, "waiting");
+        yield* Deferred.succeed(harness.authenticated, undefined);
+        yield* Deferred.fail(
+          harness.discovered,
+          new AcpErrors.AcpRequestError({
+            code: -32603,
+            errorMessage: `Internal error ${callbackUrl}`,
+            method: "session/new",
+          }),
+        );
+        const failed = yield* phase(harness.auth, "failed");
+        assert.equal(
+          failed.message,
+          "Antigravity authenticated, but could not initialize a session or load models.",
+        );
+        assert.isNull(failed.authorizationUrl);
+        assert.deepEqual(harness.catalog(), ["previous-account-model"]);
+        yield* Deferred.await(harness.closed);
+      }),
   );
 
   it.effect("does not call callback HTTP success a successful Google sign-in", () =>

--- a/apps/server/src/provider/AntigravityAuth.ts
+++ b/apps/server/src/provider/AntigravityAuth.ts
@@ -114,6 +114,9 @@ function safeAuthFailure(cause: Cause.Cause<unknown>, usesBrowser: boolean): str
       if (/access_denied|denied access|cancelled/i.test(error.value.errorMessage)) {
         return "Google sign-in was not approved. Start sign-in again.";
       }
+      if (error.value.method === "session/new" && error.value.code === -32603) {
+        return "Antigravity authenticated, but could not initialize a session or load models.";
+      }
       if (!usesBrowser && error.value.code === -32602) {
         return "Antigravity rejected the configured credentials. Check the provider settings.";
       }


### PR DESCRIPTION
antigravity session initialization failures after authentication currently appear as generic sign-in failures. identify ACP session/new internal errors as a failure to initialize a session or load models, without exposing the provider error payload.

verified with 19 focused auth tests, server typecheck, and scoped lint and formatting checks. the focused auth test output is shown below. this improves diagnostics; it does not fix the upstream ACP failure.

![19 focused antigravity auth tests passing](https://uploads-production-47e4.up.railway.app/files/a180c5fd-b0b0-4e3e-83b5-f50452899e80/issue-9655-tests.png)

relates to #9655.

implemented with gpt-6-astra in codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing error strings only in Antigravity auth; no changes to sign-in, session, or credential handling logic.
> 
> **Overview**
> After Google sign-in succeeds, **Antigravity** failures during **`session/new`** (ACP internal error `-32603`) no longer surface as generic “Google sign-in failed” messages.
> 
> **`safeAuthFailure`** now maps that case to: *“Antigravity authenticated, but could not initialize a session or load models.”* The raw provider **`errorMessage`** (e.g. redirect URLs or other payload) is **not** shown to users.
> 
> A focused auth test simulates auth succeeding then **`session/new`** failing, and asserts the new copy, no leaked callback details, unchanged model catalog, and clean process shutdown. The test harness types the **`discovered`** deferred so it can fail with **`AcpRequestError`** like production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa71942a53befe4fd4e8178e98de58842bd2bf26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AntigravityAuth.safeAuthFailure` to distinguish `session/new` errors
> Maps ACP request errors from `session/new` with code `-32603` to the message "Antigravity authenticated, but could not initialize a session or load models." instead of the generic auth failure message. Updates `makeAuthTestHarness` to propagate discovery failures and adds a test covering the post-authentication session failure path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa71942.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->