### PR TITLE
fix(server): preserve project mutation fields across transports

### DIFF
--- a/apps/server/src/cli/project.ts
+++ b/apps/server/src/cli/project.ts
@@ -30,6 +30,7 @@ import * as ProjectEnrichmentService from "../project/ProjectEnrichmentService.t
 import * as ProjectFaviconResolver from "../project/ProjectFaviconResolver.ts";
 import * as RepositoryIdentityResolver from "../project/RepositoryIdentityResolver.ts";
 import * as ProjectService from "../project/ProjectService.ts";
+import { projectMutationOperation } from "../project/ProjectMutation.ts";
 import * as T3ProjectFileLoader from "../project/T3ProjectFileLoader.ts";
 import {
   clearPersistedServerRuntimeState,
@@ -425,42 +426,7 @@ const runProjectMutation = Effect.fn("runProjectMutation")(function* (
       const projects = yield* ProjectService.ProjectService;
       const output = yield* run({
         snapshot,
-        dispatch: (command) =>
-          command.type === "project.create"
-            ? projects
-                .create({
-                  commandId: command.commandId,
-                  projectId: command.projectId,
-                  title: command.title,
-                  workspaceRoot: command.workspaceRoot,
-                  ...(command.defaultModelSelection === undefined
-                    ? {}
-                    : { defaultModelSelection: command.defaultModelSelection }),
-                  ...(command.scripts === undefined ? {} : { scripts: command.scripts }),
-                })
-                .pipe(Effect.asVoid)
-            : command.type === "project.update"
-              ? projects
-                  .update({
-                    commandId: command.commandId,
-                    projectId: command.projectId,
-                    ...(command.title === undefined ? {} : { title: command.title }),
-                    ...(command.workspaceRoot === undefined
-                      ? {}
-                      : { workspaceRoot: command.workspaceRoot }),
-                    ...(command.defaultModelSelection === undefined
-                      ? {}
-                      : { defaultModelSelection: command.defaultModelSelection }),
-                    ...(command.scripts === undefined ? {} : { scripts: command.scripts }),
-                  })
-                  .pipe(Effect.asVoid)
-              : projects
-                  .delete({
-                    commandId: command.commandId,
-                    projectId: command.projectId,
-                    ...(command.force === undefined ? {} : { force: command.force }),
-                  })
-                  .pipe(Effect.asVoid),
+        dispatch: (command) => projectMutationOperation(projects, command).pipe(Effect.asVoid),
         mode: "offline",
       });
       yield* Console.log(output);

--- a/apps/server/src/project/ProjectMutation.test.ts
+++ b/apps/server/src/project/ProjectMutation.test.ts
@@ -1,0 +1,93 @@
+import { assert, it } from "@effect/vitest";
+import { CommandId, ProjectId, type Project } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Ref from "effect/Ref";
+
+import { projectMutationOperation } from "./ProjectMutation.ts";
+import { type ProjectService } from "./ProjectService.ts";
+
+const projectId = ProjectId.make("project:mutation-mapping");
+const project = {
+  id: projectId,
+  title: "Mapping",
+  workspaceRoot: "/work/mapping",
+  repositoryIdentity: null,
+  faviconPath: null,
+  projectIcon: null,
+  defaultModelSelection: null,
+  defaultThreadEnvMode: null,
+  autoPull: false,
+  scripts: [],
+  createdAt: "2026-09-05T00:00:00.000Z",
+  updatedAt: "2026-09-05T00:00:00.000Z",
+  deletedAt: null,
+} satisfies Project;
+
+it.effect("preserves every project mutation field", () =>
+  Effect.gen(function* () {
+    const calls = yield* Ref.make<ReadonlyArray<unknown>>([]);
+    const projects: Pick<ProjectService["Service"], "create" | "delete" | "update"> = {
+      create: (input) =>
+        Ref.update(calls, (entries) => [...entries, input]).pipe(Effect.as(project)),
+      update: (input) =>
+        Ref.update(calls, (entries) => [...entries, input]).pipe(Effect.as(project)),
+      delete: (input) =>
+        Ref.update(calls, (entries) => [...entries, input]).pipe(Effect.as(project)),
+    };
+
+    yield* projectMutationOperation(projects, {
+      type: "project.create",
+      commandId: CommandId.make("command:create"),
+      projectId,
+      title: "Created",
+      workspaceRoot: "/work/created",
+      createWorkspaceRootIfMissing: true,
+      defaultModelSelection: null,
+      scripts: [],
+    });
+    yield* projectMutationOperation(projects, {
+      type: "project.update",
+      commandId: CommandId.make("command:update"),
+      projectId,
+      title: "Updated",
+      workspaceRoot: "/work/updated",
+      defaultModelSelection: null,
+      autoPull: false,
+      projectIcon: null,
+      faviconPath: null,
+      defaultThreadEnvMode: null,
+      scripts: [],
+    });
+    yield* projectMutationOperation(projects, {
+      type: "project.delete",
+      commandId: CommandId.make("command:delete"),
+      projectId,
+      force: true,
+    });
+
+    assert.deepEqual(yield* Ref.get(calls), [
+      {
+        commandId: "command:create",
+        projectId,
+        title: "Created",
+        workspaceRoot: "/work/created",
+        createWorkspaceRootIfMissing: true,
+        defaultModelSelection: null,
+        scripts: [],
+      },
+      {
+        commandId: "command:update",
+        projectId,
+        title: "Updated",
+        workspaceRoot: "/work/updated",
+        defaultModelSelection: null,
+        autoPull: false,
+        projectIcon: null,
+        faviconPath: null,
+        defaultThreadEnvMode: null,
+        scripts: [],
+      },
+      { commandId: "command:delete", projectId, force: true },
+    ]);
+  }),
+);

--- a/apps/server/src/project/ProjectMutation.ts
+++ b/apps/server/src/project/ProjectMutation.ts
@@ -1,0 +1,53 @@
+import { type ProjectMutation } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+
+import { type ProjectService } from "./ProjectService.ts";
+
+type ProjectMutations = Pick<ProjectService["Service"], "create" | "delete" | "update">;
+
+export const projectMutationOperation = Effect.fn("projectMutationOperation")(function* (
+  projects: ProjectMutations,
+  mutation: ProjectMutation,
+) {
+  switch (mutation.type) {
+    case "project.create":
+      return yield* projects.create({
+        commandId: mutation.commandId,
+        projectId: mutation.projectId,
+        title: mutation.title,
+        workspaceRoot: mutation.workspaceRoot,
+        ...(mutation.createWorkspaceRootIfMissing === undefined
+          ? {}
+          : { createWorkspaceRootIfMissing: mutation.createWorkspaceRootIfMissing }),
+        ...(mutation.defaultModelSelection === undefined
+          ? {}
+          : { defaultModelSelection: mutation.defaultModelSelection }),
+        ...(mutation.scripts === undefined ? {} : { scripts: mutation.scripts }),
+      });
+
+    case "project.update":
+      return yield* projects.update({
+        commandId: mutation.commandId,
+        projectId: mutation.projectId,
+        ...(mutation.title === undefined ? {} : { title: mutation.title }),
+        ...(mutation.workspaceRoot === undefined ? {} : { workspaceRoot: mutation.workspaceRoot }),
+        ...(mutation.defaultModelSelection === undefined
+          ? {}
+          : { defaultModelSelection: mutation.defaultModelSelection }),
+        ...(mutation.autoPull === undefined ? {} : { autoPull: mutation.autoPull }),
+        ...(mutation.projectIcon === undefined ? {} : { projectIcon: mutation.projectIcon }),
+        ...(mutation.faviconPath === undefined ? {} : { faviconPath: mutation.faviconPath }),
+        ...(mutation.defaultThreadEnvMode === undefined
+          ? {}
+          : { defaultThreadEnvMode: mutation.defaultThreadEnvMode }),
+        ...(mutation.scripts === undefined ? {} : { scripts: mutation.scripts }),
+      });
+
+    case "project.delete":
+      return yield* projects.delete({
+        commandId: mutation.commandId,
+        projectId: mutation.projectId,
+        ...(mutation.force === undefined ? {} : { force: mutation.force }),
+      });
+  }
+});

--- a/apps/server/src/project/http.ts
+++ b/apps/server/src/project/http.ts
@@ -14,6 +14,7 @@ import {
 } from "../auth/http.ts";
 import * as ServerRuntimeStartup from "../serverRuntimeStartup.ts";
 import { ProjectService, type ProjectServiceError } from "./ProjectService.ts";
+import { projectMutationOperation } from "./ProjectMutation.ts";
 
 export const failProjectMutation = Effect.fn("environment.projects.failMutation")(function* (
   cause: ProjectServiceError | ServerRuntimeStartup.ServerRuntimeStartupError,
@@ -51,37 +52,7 @@ export const projectHttpApiLayer = HttpApiBuilder.group(
         Effect.fn("environment.projects.mutate")(function* (args) {
           yield* annotateEnvironmentRequest(args.endpoint.name);
           yield* requireEnvironmentScope(AuthOrchestrationOperateScope);
-          const mutation = args.payload;
-          const operation =
-            mutation.type === "project.create"
-              ? projects.create({
-                  commandId: mutation.commandId,
-                  projectId: mutation.projectId,
-                  title: mutation.title,
-                  workspaceRoot: mutation.workspaceRoot,
-                  ...(mutation.defaultModelSelection === undefined
-                    ? {}
-                    : { defaultModelSelection: mutation.defaultModelSelection }),
-                  ...(mutation.scripts === undefined ? {} : { scripts: mutation.scripts }),
-                })
-              : mutation.type === "project.update"
-                ? projects.update({
-                    commandId: mutation.commandId,
-                    projectId: mutation.projectId,
-                    ...(mutation.title === undefined ? {} : { title: mutation.title }),
-                    ...(mutation.workspaceRoot === undefined
-                      ? {}
-                      : { workspaceRoot: mutation.workspaceRoot }),
-                    ...(mutation.defaultModelSelection === undefined
-                      ? {}
-                      : { defaultModelSelection: mutation.defaultModelSelection }),
-                    ...(mutation.scripts === undefined ? {} : { scripts: mutation.scripts }),
-                  })
-                : projects.delete({
-                    commandId: mutation.commandId,
-                    projectId: mutation.projectId,
-                    ...(mutation.force === undefined ? {} : { force: mutation.force }),
-                  });
+          const operation = projectMutationOperation(projects, args.payload);
           return yield* startup.enqueueCommand(operation).pipe(Effect.catch(failProjectMutation));
         }),
       );

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -183,6 +183,7 @@ import { linkCreatedPullRequest } from "./git/linkCreatedPullRequest.ts";
 import * as ReviewService from "./review/ReviewService.ts";
 import * as ProjectEnrichmentService from "./project/ProjectEnrichmentService.ts";
 import * as ProjectService from "./project/ProjectService.ts";
+import { projectMutationOperation } from "./project/ProjectMutation.ts";
 import * as ServerEnvironment from "./environment/ServerEnvironment.ts";
 import * as RemoteOpenTargets from "./environment/RemoteOpenTargets.ts";
 import * as BackgroundPolicy from "./background/BackgroundPolicy.ts";
@@ -1672,48 +1673,7 @@ const makeWsRpcLayer = (
       });
 
       const mutateProject = Effect.fn("ws.projects.mutate")(function* (mutation: ProjectMutation) {
-        switch (mutation.type) {
-          case "project.create":
-            return yield* projectService.create({
-              commandId: mutation.commandId,
-              projectId: mutation.projectId,
-              title: mutation.title,
-              workspaceRoot: mutation.workspaceRoot,
-              ...(mutation.createWorkspaceRootIfMissing === undefined
-                ? {}
-                : { createWorkspaceRootIfMissing: mutation.createWorkspaceRootIfMissing }),
-              ...(mutation.defaultModelSelection === undefined
-                ? {}
-                : { defaultModelSelection: mutation.defaultModelSelection }),
-              ...(mutation.scripts === undefined ? {} : { scripts: mutation.scripts }),
-            });
-          case "project.update":
-            return yield* projectService.update({
-              commandId: mutation.commandId,
-              projectId: mutation.projectId,
-              ...(mutation.title === undefined ? {} : { title: mutation.title }),
-              ...(mutation.workspaceRoot === undefined
-                ? {}
-                : { workspaceRoot: mutation.workspaceRoot }),
-              ...(mutation.defaultModelSelection === undefined
-                ? {}
-                : { defaultModelSelection: mutation.defaultModelSelection }),
-              ...(mutation.autoPull === undefined ? {} : { autoPull: mutation.autoPull }),
-              ...(mutation.projectIcon === undefined ? {} : { projectIcon: mutation.projectIcon }),
-              ...(mutation.faviconPath === undefined ? {} : { faviconPath: mutation.faviconPath }),
-              ...(mutation.defaultThreadEnvMode === undefined
-                ? {}
-                : { defaultThreadEnvMode: mutation.defaultThreadEnvMode }),
-              ...(mutation.scripts === undefined ? {} : { scripts: mutation.scripts }),
-            });
-          case "project.delete": {
-            return yield* projectService.delete({
-              commandId: mutation.commandId,
-              projectId: mutation.projectId,
-              ...(mutation.force === undefined ? {} : { force: mutation.force }),
-            });
-          }
-        }
+        return yield* projectMutationOperation(projectService, mutation);
       });
 
       const handlers = ServerWsRpcGroup.of({


### PR DESCRIPTION
HTTP and offline CLI project mutations dropped options that the WebSocket path preserved, including auto-pull, icons, and the default thread environment. Share one mutation mapping across all three transports so the same command has the same behavior.

Reduced to the missing transport-parity fix after an independent audit. Seven focused project tests, server typecheck, scoped lint, and formatting pass.

Prepared with Codex GPT-6-Astra; independently reviewed by Claude Fable 5.1 in T3 Code.
