### PR TITLE
fix(codex): preserve qualified model ids in selection and generation

### DIFF
--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -184,7 +184,6 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
         environment: processEnv,
         ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
       });
-      const textGeneration = yield* makeCodexTextGeneration(effectiveConfig, processEnv);
 
       // Build a managed snapshot whose settings never change — mutations come
       // in as instance rebuilds from the registry rather than in-place
@@ -239,6 +238,11 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
               cause,
             }),
         ),
+      );
+      const textGeneration = yield* makeCodexTextGeneration(
+        effectiveConfig,
+        processEnv,
+        snapshot.getSnapshot.pipe(Effect.map((value) => value.models)),
       );
       const snapshotForCwd = (cwd: string) =>
         !effectiveConfig.enabled

--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -127,6 +127,23 @@ it("prefers sol over terra when both are available", () => {
   assert.deepStrictEqual(models.find((model) => model.isDefault)?.slug, "gpt-5.6-sol");
 });
 
+it("ranks qualified Codex models while preserving their wire ids", () => {
+  const models = applyPreferredCodexDefaultModel([
+    {
+      slug: "openai.gpt-5.6-luna",
+      name: "Luna",
+      isCustom: false,
+      isDefault: true,
+      capabilities: null,
+    },
+    { slug: "openai.gpt-5.6-sol", name: "Sol", isCustom: false, capabilities: null },
+  ]);
+  assert.deepStrictEqual(
+    models.filter((model) => model.isDefault).map((model) => model.slug),
+    ["openai.gpt-5.6-sol"],
+  );
+});
+
 it("keeps Codex's own default when no preferred model is available", () => {
   const models = applyPreferredCodexDefaultModel([
     { slug: "gpt-5.5", name: "GPT-5.5", isCustom: false, capabilities: null },

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -25,7 +25,11 @@ import type {
 } from "@t3tools/contracts";
 import { PREFERRED_DEFAULT_CODEX_MODELS, ServerSettingsError } from "@t3tools/contracts";
 
-import { createModelCapabilities, readCustomModelEntries } from "@t3tools/shared/model";
+import {
+  codexModelFamily,
+  createModelCapabilities,
+  readCustomModelEntries,
+} from "@t3tools/shared/model";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import { codexAppServerArgs, resolveCodexLaunchArgs } from "./codexLaunchArgs.ts";
 import {
@@ -227,9 +231,9 @@ function parseCodexModelListResponse(
 export function applyPreferredCodexDefaultModel(
   models: ReadonlyArray<ServerProviderModel>,
 ): ReadonlyArray<ServerProviderModel> {
-  const preferredSlug = PREFERRED_DEFAULT_CODEX_MODELS.find((slug) =>
-    models.some((model) => model.slug === slug && !model.isCustom),
-  );
+  const preferredSlug = PREFERRED_DEFAULT_CODEX_MODELS.flatMap((slug) =>
+    models.filter((model) => !model.isCustom && codexModelFamily(model.slug) === slug),
+  )[0]?.slug;
   if (!preferredSlug) {
     return models;
   }

--- a/apps/server/src/provider/ModelManifest.test.ts
+++ b/apps/server/src/provider/ModelManifest.test.ts
@@ -39,6 +39,20 @@ const model = (overrides: Partial<ServerProviderModel>): ServerProviderModel => 
 });
 
 describe("classifyModels", () => {
+  it("classifies qualified Codex families without changing their wire ids", () => {
+    const manifest: ModelManifestData = { version: 1, currentModels: { codex: ["gpt-test"] } };
+    const models = [
+      model({ slug: "openai.gpt-test", isLegacy: true }),
+      model({ slug: "openai.gpt-old" }),
+    ];
+    assert.deepStrictEqual(
+      classifyModels(models, manifest, CODEX).map((entry) => [entry.slug, entry.isLegacy ?? false]),
+      [
+        ["openai.gpt-test", false],
+        ["openai.gpt-old", true],
+      ],
+    );
+  });
   it("flags non-current models, clears stale flags, and skips custom models", () => {
     const manifest: ModelManifestData = {
       version: 1,
@@ -65,6 +79,21 @@ describe("classifyModels", () => {
 });
 
 describe("applyManifestDefault", () => {
+  it("resolves the manifest default to the qualified live model", () => {
+    const manifest: ModelManifestData = {
+      version: 1,
+      currentModels: {},
+      providers: { codex: { models: [], profiles: {}, defaults: { chat: "gpt-test" } } },
+    };
+    const models = [
+      model({ slug: "openai.gpt-old", isDefault: true }),
+      model({ slug: "openai.gpt-test" }),
+    ];
+    assert.strictEqual(
+      applyManifestDefault(models, manifest, CODEX).find((entry) => entry.isDefault)?.slug,
+      "openai.gpt-test",
+    );
+  });
   it("moves the default flag and its aliases to the manifest's chat default", () => {
     const driver = ProviderDriverKind.make("antigravity");
     const manifest: ModelManifestData = {

--- a/apps/server/src/provider/ModelManifest.ts
+++ b/apps/server/src/provider/ModelManifest.ts
@@ -19,6 +19,7 @@ import {
   type ProviderDriverKind,
   type ServerProviderModel,
 } from "@t3tools/contracts";
+import { codexModelFamily } from "@t3tools/shared/model";
 import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -212,13 +213,15 @@ export function isLegacyModel(
   driverKind: ProviderDriverKind,
   slug: string,
 ): boolean {
-  const catalogModel = manifest.providers?.[driverKind]?.models.find(
-    (model) => model.slug === slug,
-  );
+  const family = driverKind === "codex" ? codexModelFamily(slug) : slug;
+  const catalog = manifest.providers?.[driverKind]?.models;
+  const catalogModel =
+    catalog?.find((model) => model.slug === slug) ??
+    catalog?.find((model) => model.slug === family);
   if (catalogModel) return catalogModel.status === "legacy";
   const currentModels = manifest.currentModels[driverKind];
   if (!currentModels) return false;
-  return !currentModels.includes(slug);
+  return !currentModels.includes(slug) && !currentModels.includes(family);
 }
 
 /**
@@ -260,8 +263,17 @@ export function applyManifestDefault(
   manifest: ModelManifestData,
   driverKind: ProviderDriverKind,
 ): ReadonlyArray<ServerProviderModel> {
-  const slug = manifestDefaultModel(manifest, driverKind);
-  if (slug === undefined || !models.some((model) => model.slug === slug)) return models;
+  const requestedSlug = manifestDefaultModel(manifest, driverKind);
+  if (requestedSlug === undefined) return models;
+  const slug =
+    models.find((model) => model.slug === requestedSlug)?.slug ??
+    (driverKind === "codex"
+      ? models.find(
+          (model) =>
+            !model.isCustom && codexModelFamily(model.slug) === codexModelFamily(requestedSlug),
+        )?.slug
+      : undefined);
+  if (slug === undefined) return models;
   const previous = models.find((model) => model.isDefault && model.slug !== slug);
   if (!previous) return models;
   const movedAliases = previous.aliases ?? [];

--- a/apps/server/src/textGeneration/CodexTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/CodexTextGeneration.test.ts
@@ -134,6 +134,7 @@ function withFakeCodexEnv<A, E, R>(
   input: FakeCodexInput & {
     launchArgs?: string;
     environment?: NodeJS.ProcessEnv;
+    models?: ReadonlyArray<string>;
   },
   effectFn: (textGeneration: TextGeneration.TextGeneration["Service"]) => Effect.Effect<A, E, R>,
 ) {
@@ -142,12 +143,44 @@ function withFakeCodexEnv<A, E, R>(
     const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-codex-text-" });
     const codexPath = yield* makeFakeCodexBinary(tempDir, input);
     const config = decodeCodexSettings({ binaryPath: codexPath, launchArgs: input.launchArgs });
-    const textGeneration = yield* makeCodexTextGeneration(config, input.environment);
+    const textGeneration = yield* makeCodexTextGeneration(
+      config,
+      input.environment,
+      Effect.succeed(
+        (input.models ?? []).map((slug) => ({
+          slug,
+          name: slug,
+          isCustom: false,
+          capabilities: null,
+        })),
+      ),
+    );
     return yield* effectFn(textGeneration);
   }).pipe(Effect.scoped);
 }
 
 it.layer(CodexTextGenerationTestLayer)("CodexTextGeneration", (it) => {
+  for (const selectedModel of ["gpt-5.6-luna", "openai.gpt-5.6-luna"]) {
+    it.effect(`dispatches the qualified live model for ${selectedModel}`, () =>
+      withFakeCodexEnv(
+        {
+          output: JSON.stringify({ title: "Bedrock title" }),
+          models: ["openai.gpt-5.6-luna"],
+          requireArg: "--model openai.gpt-5.6-luna",
+          forbidArg: "--model gpt-5.6-luna",
+        },
+        (textGeneration) =>
+          Effect.gen(function* () {
+            const result = yield* textGeneration.generateThreadTitle({
+              cwd: process.cwd(),
+              message: "Describe this change",
+              modelSelection: createModelSelection(ProviderInstanceId.make("codex"), selectedModel),
+            });
+            expect(result.title).toBe("Bedrock title");
+          }),
+      ),
+    );
+  }
   it.effect("generates and sanitizes commit messages without branch by default", () =>
     withFakeCodexEnv(
       {

--- a/apps/server/src/textGeneration/CodexTextGeneration.ts
+++ b/apps/server/src/textGeneration/CodexTextGeneration.ts
@@ -11,6 +11,7 @@ import {
   type CodexSettings,
   DEFAULT_TEXT_GENERATION_REASONING_EFFORT,
   type ModelSelection,
+  type ServerProviderModel,
   TextGenerationError,
 } from "@t3tools/contracts";
 import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
@@ -34,7 +35,7 @@ import {
   sanitizeThreadTitle,
   toJsonSchemaObject,
 } from "./TextGenerationUtils.ts";
-import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
+import { codexModelFamily, getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 import { getCodexServiceTierOptionValue } from "../codexModelOptions.ts";
 
 const CODEX_TIMEOUT_MS = 180_000;
@@ -46,6 +47,7 @@ const encodeJsonString = Schema.encodeEffect(Schema.fromJsonString(Schema.Unknow
 export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(function* (
   codexConfig: CodexSettings,
   environment?: NodeJS.ProcessEnv,
+  getModels: Effect.Effect<ReadonlyArray<ServerProviderModel>> = Effect.succeed([]),
 ) {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -178,6 +180,14 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
     const outputPath = yield* writeTempFile(operation, "codex-output", "");
 
     const runCodexCommand = Effect.fn("runCodexJson.runCodexCommand")(function* () {
+      const models = yield* getModels;
+      const requestedModel = modelSelection.model;
+      const model =
+        models.find((candidate) => candidate.slug === requestedModel)?.slug ??
+        models.find(
+          (candidate) => !candidate.isCustom && codexModelFamily(candidate.slug) === requestedModel,
+        )?.slug ??
+        requestedModel;
       const launchArgs = resolveCodexLaunchArgs(codexConfig.launchArgs, resolvedEnvironment);
       const reasoningEffort =
         getModelSelectionStringOptionValue(modelSelection, "reasoningEffort") ??
@@ -193,7 +203,7 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
           "-s",
           "read-only",
           "--model",
-          modelSelection.model,
+          model,
           "--config",
           `model_reasoning_effort="${reasoningEffort}"`,
           ...(serviceTier ? ["--config", `service_tier="${serviceTier}"`] : []),

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -225,6 +225,11 @@ export function isClaudeUltrathinkPrompt(text: string | null | undefined): boole
   return typeof text === "string" && /\bultrathink\b/i.test(text);
 }
 
+/** Compare Codex model families without changing provider-owned dispatch identifiers. */
+export function codexModelFamily(slug: string): string {
+  return slug.startsWith("openai.gpt-") ? slug.slice("openai.".length) : slug;
+}
+
 export function normalizeModelSlug(
   model: string | null | undefined,
   provider: ProviderDriverKind = DEFAULT_PROVIDER_DRIVER_KIND,


### PR DESCRIPTION
qualified codex model ids were misclassified and auxiliary generation could dispatch an unqualified id. match known model families for defaults and classification while preserving live provider ids when dispatching.

verified with 37 focused tests, an 11-test manifest rerun, server typecheck, and scoped lint and formatting checks. fake-cli dispatch is covered; a native bedrock account was unavailable.

![qualified codex models: 37 tests passed](https://uploads-production-47e4.up.railway.app/files/97ed30e5-d0be-418d-ab60-a1f7498c2091/issue-9659-tests.png)

fixes #9659.

implemented with gpt-6-astra in codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model default, legacy classification, and CLI dispatch paths for Codex; wrong family matching could mis-label models or pass the wrong `--model`, though behavior is covered by focused tests.
> 
> **Overview**
> Adds **`codexModelFamily`** so Codex can compare model families (e.g. `gpt-5.6-luna` vs `openai.gpt-5.6-luna`) without rewriting the provider’s wire slugs.
> 
> **Default and manifest behavior** now family-match for Codex: preferred defaults, legacy/`currentModels` classification, and manifest chat defaults still flip flags on the **live catalog slug** (qualified when Bedrock returns it), not an unqualified manifest id.
> 
> **Auxiliary `codex exec` text generation** takes the instance snapshot’s models and resolves the user’s selection to an exact slug or a family match before passing **`--model`**, so commit/title/branch helpers don’t dispatch bare ids when only qualified models exist. **`CodexDriver`** wires text generation after the managed snapshot so that list is available.
> 
> Tests cover default ranking, manifest classification/defaults, and fake-CLI dispatch for both qualified and unqualified selections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a798389db9defc5599dfa07b3d45906abac9a7dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex model selection to preserve qualified live model IDs across manifest, provider, and text-generation layers
> - Adds `codexModelFamily` helper in [model.ts](https://github.com/pingdotgg/t3code/pull/9921/files#diff-6319cd97b4ed5842958c7fbc93b4ed733efa158c2b1ad15c1d54bcddea713505) to strip provider qualification from Codex GPT slugs so qualified and unqualified IDs can be compared by shared family.
> - `isLegacyModel` and `applyManifestDefault` in [ModelManifest.ts](https://github.com/pingdotgg/t3code/pull/9921/files#diff-90c8a7d2335de8efb8f559e4e63dfa1d33e525f9906c327988726c51bbaf750a) now classify and resolve Codex defaults by family, moving the default flag to the qualified live slug while transferring aliases from any prior default.
> - `applyPreferredCodexDefaultModel` in [CodexProvider.ts](https://github.com/pingdotgg/t3code/pull/9921/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53) matches preferred defaults by family instead of exact identifier, preserving the selected model's original wire slug.
> - `makeCodexTextGeneration` in [CodexTextGeneration.ts](https://github.com/pingdotgg/t3code/pull/9921/files#diff-203268bf51406720251f9faaf2c0c10f1764c3d78b0a3b539da7ef2a0a4c87ed) resolves the requested model by exact slug, then Codex family, then fallback, and passes the resolved qualified ID to the CLI.
> - [CodexDriver.ts](https://github.com/pingdotgg/t3code/pull/9921/files#diff-c705233bf69322a30e4a04be3428cd51dc6fa014d5a03b852da94c6ab9b6ae35) defers text-generation factory construction until after the managed Codex snapshot exists, so the factory reads the instance's current model list.
> - Behavioral Change: `makeCodexTextGeneration` and `applyManifestDefault` now dispatch or select a different model ID than the requested unqualified family name when a matching qualified live model exists; callers relying on the unqualified slug being passed through verbatim will see the qualified ID instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a798389.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->