### PR TITLE
fix(cursor): fall back to session models on older cli versions

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -1287,6 +1287,12 @@ const program = Effect.gen(function* () {
       });
     }
     if (method === "cursor/list_available_models") {
+      if (process.env.T3_ACP_CURSOR_MODELS_ERROR === "missing") {
+        return Effect.fail(AcpError.AcpRequestError.methodNotFound(method));
+      }
+      if (process.env.T3_ACP_CURSOR_MODELS_ERROR === "internal") {
+        return Effect.fail(AcpError.AcpRequestError.internalError("Mock model discovery failure"));
+      }
       return Effect.succeed({
         models: availableModels(),
       });

--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -350,6 +350,17 @@ const grokAcpModels: ReadonlyArray<AcpSchema.ModelInfo> = [
 ];
 
 function modelState(): AcpSchema.SessionModelState {
+  if (process.env.T3_ACP_CURSOR_MODELS_ERROR === "missing") {
+    return {
+      currentModelId: " grok-4.6 ",
+      availableModels: [
+        { modelId: " grok-4.6 ", name: " Grok 4.6 " },
+        { modelId: "grok-mock-alt", name: " Grok Mock Alt " },
+        { modelId: "blank-name", name: " " },
+        { modelId: " ", name: "Invalid" },
+      ],
+    };
+  }
   if (antigravityProfile) {
     return { currentModelId, availableModels: antigravityModels };
   }

--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -650,7 +650,10 @@ describe("discoverCursorModelsViaAcp", () => {
         customModels: [],
       }),
     );
-    expect(models.map((model) => model.slug)).toEqual(["grok-4.6", "grok-mock-alt"]);
+    expect(models.map((model) => [model.slug, model.name])).toEqual([
+      ["grok-4.6", "Grok 4.6"],
+      ["grok-mock-alt", "Grok Mock Alt"],
+    ]);
     expect(models.find((model) => model.isDefault)?.slug).toBe("grok-4.6");
     expect(models.every((model) => model.capabilities?.optionDescriptors?.length === 0)).toBe(true);
   });

--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -638,6 +638,38 @@ describe("checkCursorProviderStatus", () => {
 });
 
 describe("discoverCursorModelsViaAcp", () => {
+  it("uses the existing session catalog when the Cursor extension is unavailable", async () => {
+    const wrapperPath = await runNode(
+      makeMockAgentWrapper({ T3_ACP_CURSOR_MODELS_ERROR: "missing" }),
+    );
+    const models = await runNode(
+      discoverCursorModelsViaAcp({
+        enabled: true,
+        binaryPath: wrapperPath,
+        apiEndpoint: "",
+        customModels: [],
+      }),
+    );
+    expect(models.map((model) => model.slug)).toEqual(["grok-4.6", "grok-mock-alt"]);
+    expect(models.find((model) => model.isDefault)?.slug).toBe("grok-4.6");
+    expect(models.every((model) => model.capabilities?.optionDescriptors?.length === 0)).toBe(true);
+  });
+
+  it("does not hide failures from a supported model discovery extension", async () => {
+    const wrapperPath = await runNode(
+      makeMockAgentWrapper({ T3_ACP_CURSOR_MODELS_ERROR: "internal" }),
+    );
+    await expect(
+      runNode(
+        discoverCursorModelsViaAcp({
+          enabled: true,
+          binaryPath: wrapperPath,
+          apiEndpoint: "",
+          customModels: [],
+        }),
+      ),
+    ).rejects.toThrow("Mock model discovery failure");
+  });
   it("keeps the ACP probe runtime alive long enough to discover models", async () => {
     const wrapperPath = await runNode(makeMockAgentWrapper());
 

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -563,22 +563,34 @@ const discoverCursorModelsViaListAvailableModels = (
         return yield* acp.request("cursor/list_available_models", {}).pipe(
           Effect.flatMap(decodeCursorListAvailableModelsResponse),
           Effect.map(buildCursorDiscoveredModelsFromAvailableModelsResponse),
-          Effect.catchTag("AcpRequestError", (error) => {
-            const models = started.sessionSetupResult.models;
-            if (error.code !== -32601 || !models?.availableModels.length) {
-              return Effect.fail(error);
-            }
-            return Effect.succeed(
-              buildCursorDiscoveredModels(
-                models.availableModels.map((model) => ({
-                  slug: model.modelId,
-                  name: model.name,
-                  capabilities: EMPTY_CAPABILITIES,
-                })),
-              ).map((model) =>
-                model.slug === models.currentModelId ? { ...model, isDefault: true } : model,
-              ),
-            );
+          Effect.catchTags({
+            AcpRequestError: (error) => {
+              const models = started.sessionSetupResult.models;
+              if (error.code !== -32601 || !models?.availableModels.length) {
+                return Effect.fail(error);
+              }
+              return Effect.succeed(
+                buildCursorDiscoveredModels(
+                  models.availableModels.flatMap((model) => {
+                    const slug = model.modelId.trim();
+                    const name = model.name.trim();
+                    return slug && name
+                      ? [
+                          {
+                            slug,
+                            name,
+                            capabilities: EMPTY_CAPABILITIES,
+                          },
+                        ]
+                      : [];
+                  }),
+                ).map((model) =>
+                  model.slug === models.currentModelId.trim()
+                    ? { ...model, isDefault: true }
+                    : model,
+                ),
+              );
+            },
           }),
         );
       }),

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -559,10 +559,28 @@ const discoverCursorModelsViaListAvailableModels = (
     cursorSettings,
     (acp) =>
       Effect.gen(function* () {
-        yield* acp.start();
-        const response = yield* acp.request("cursor/list_available_models", {});
-        const decoded = yield* decodeCursorListAvailableModelsResponse(response);
-        return buildCursorDiscoveredModelsFromAvailableModelsResponse(decoded);
+        const started = yield* acp.start();
+        return yield* acp.request("cursor/list_available_models", {}).pipe(
+          Effect.flatMap(decodeCursorListAvailableModelsResponse),
+          Effect.map(buildCursorDiscoveredModelsFromAvailableModelsResponse),
+          Effect.catchTag("AcpRequestError", (error) => {
+            const models = started.sessionSetupResult.models;
+            if (error.code !== -32601 || !models?.availableModels.length) {
+              return Effect.fail(error);
+            }
+            return Effect.succeed(
+              buildCursorDiscoveredModels(
+                models.availableModels.map((model) => ({
+                  slug: model.modelId,
+                  name: model.name,
+                  capabilities: EMPTY_CAPABILITIES,
+                })),
+              ).map((model) =>
+                model.slug === models.currentModelId ? { ...model, isDefault: true } : model,
+              ),
+            );
+          }),
+        );
       }),
     environment,
   );
@@ -1120,8 +1138,8 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
  *
  * Used by `CursorDriver` as the `makeManagedServerProvider.enrichSnapshot`
  * hook: republishes update/version advisory metadata without performing any
- * model or capability discovery. Cursor model data comes exclusively from
- * `cursor/list_available_models` during provider status checks.
+ * model or capability discovery. Provider checks prefer
+ * `cursor/list_available_models`, falling back to the session catalog on older CLIs.
  */
 export const enrichCursorSnapshot = (input: {
   readonly settings: CursorSettings;


### PR DESCRIPTION
supported cursor versions without cursor/list_available_models lost their discovered model catalog. use the existing ACP session catalog only when that extension is missing, preserving errors from supported extensions. the existing minimum version and lab-channel requirements remain: the 2026.03.20 CLI reported in #8022 still requires an update, so this is a partial compatibility improvement.

verified with 31 focused cursor tests, a two-test final rerun, server typecheck, and scoped lint and formatting checks.

![cursor compatibility: 31 tests passed](https://uploads-production-47e4.up.railway.app/files/31a6098e-fa17-473d-95ba-8542ff4263b7/issue-8022-tests.png)

relates to #8022.

implemented with gpt-6-astra in codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider model discovery semantics for older Cursor CLIs; behavior is gated on a specific error code and session catalog presence, with focused tests, but callers that previously saw discovery fail may now get session-derived models.
> 
> **Overview**
> Restores Cursor model discovery on **older CLIs** that do not implement `cursor/list_available_models`. Discovery still uses that extension when present; if the call fails with **method not found** (`-32601`) and the ACP session already advertises models, the provider builds the catalog from that **session model state** instead of failing.
> 
> Fallback entries are **trimmed**, invalid slug/name pairs are dropped, capabilities are empty, and the model matching the session’s current ID is marked default. **Other ACP errors** (including internal failures from a CLI that does support the extension) still surface to callers.
> 
> The mock ACP agent adds `T3_ACP_CURSOR_MODELS_ERROR` toggles for the missing-extension and internal-error paths, with matching tests in `CursorProvider.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5f79e7aee84354c524612e4ded8361b91c18395. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to ACP session catalog when `cursor/list_available_models` is unavailable
> - `discoverCursorModelsViaListAvailableModels` now retains the ACP session setup result and, on a method-not-found error from `cursor/list_available_models`, falls back to the session model catalog when it contains entries.
> - Fallback models are trimmed of whitespace, entries with blank identifiers or names are discarded, capabilities are left empty, and the trimmed current session model is marked as default.
> - Other ACP request errors (including internal failures from a supported extension) are still propagated to the caller rather than triggering fallback.
> - The mock agent and `CursorProvider.test.ts` add fixtures and tests for both the missing-extension fallback and the internal-error propagation paths.
> - Risk: fallback only triggers on method-not-found with a non-empty session catalog; callers that relied on a hard failure in this scenario will now receive filtered session models instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d5f79e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->