### PR TITLE
fix(server): install pinned runtime when pnpm node lacks npm

### DIFF
--- a/apps/server/src/cloud/pinnedRuntime.test.ts
+++ b/apps/server/src/cloud/pinnedRuntime.test.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Fiber from "effect/Fiber";
 import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
 import * as ProcessRunner from "../processRunner.ts";
@@ -38,6 +39,84 @@ const successfulRunner = (fs: FileSystem.FileSystem, path: Path.Path) =>
   });
 
 it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
+  it.effect("installs through pnpm when its Node runtime has no npm executable", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-pinned-pnpm-" });
+      const commands: Array<ProcessRunner.ProcessRunInput> = [];
+      const install = successfulRunner(fs, path);
+      const paths = yield* ensurePinnedRuntimeInstalled({
+        baseDir,
+        version: "1.2.3",
+        fs,
+        path,
+        runner: ProcessRunner.ProcessRunner.of({
+          run: (input) => {
+            commands.push(input);
+            return input.command === "npm"
+              ? Effect.fail(
+                  new ProcessRunner.ProcessSpawnError({
+                    command: "npm",
+                    argumentCount: input.args.length,
+                    cause: PlatformError.systemError({
+                      _tag: "NotFound",
+                      module: "ChildProcess",
+                      method: "spawn",
+                    }),
+                  }),
+                )
+              : install.run(input);
+          },
+        }),
+        validate: (staging) =>
+          fs.exists(staging.entryPath).pipe(
+            Effect.flatMap((exists) => (exists ? Effect.void : Effect.die("missing runtime"))),
+            Effect.orDie,
+          ),
+      });
+      assert.deepEqual(
+        commands.map((command) => command.command),
+        ["npm", "pnpm"],
+      );
+      assert.deepEqual(commands[1]!.args, ["--package=npm@11", "dlx", "npm", ...commands[0]!.args]);
+      assert.equal(yield* fs.readFileString(paths.sentinelPath), "1.2.3\n");
+    }),
+  );
+
+  it.effect("does not try a different installer for npm permission failures", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-pinned-permission-" });
+      const commands: string[] = [];
+      yield* ensurePinnedRuntimeInstalled({
+        baseDir,
+        version: "1.2.3",
+        fs,
+        path,
+        runner: ProcessRunner.ProcessRunner.of({
+          run: (input) => {
+            commands.push(input.command);
+            return Effect.fail(
+              new ProcessRunner.ProcessSpawnError({
+                command: input.command,
+                argumentCount: input.args.length,
+                cause: PlatformError.systemError({
+                  _tag: "PermissionDenied",
+                  module: "ChildProcess",
+                  method: "spawn",
+                }),
+              }),
+            );
+          },
+        }),
+        validate: () => Effect.die("must not validate a failed install"),
+      }).pipe(Effect.flip);
+      assert.deepEqual(commands, ["npm"]);
+    }),
+  );
+
   it.effect("validates a staging tree before atomically publishing it", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/cloud/pinnedRuntime.ts
+++ b/apps/server/src/cloud/pinnedRuntime.ts
@@ -2,6 +2,7 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 import * as Option from "effect/Option";
 import * as Semaphore from "effect/Semaphore";
@@ -152,14 +153,34 @@ const installPinnedRuntime = Effect.fn("cloud.pinned_runtime.ensure_installed")(
 
   return yield* Effect.gen(function* () {
     const installStep = "installing the pinned t3 runtime (this can take a few minutes)";
+    const installArgs = [
+      "install",
+      "--prefix",
+      stagingDir,
+      "--no-fund",
+      "--no-audit",
+      `t3@${input.version}`,
+    ];
     yield* runner
       .run({
         command: "npm",
-        args: ["install", "--prefix", stagingDir, "--no-fund", "--no-audit", `t3@${input.version}`],
+        args: installArgs,
         // Native dependencies may compile from source on slower machines.
         timeout: PINNED_RUNTIME_INSTALL_TIMEOUT,
       })
       .pipe(
+        Effect.catchTag("ProcessSpawnError", (error) =>
+          error.cause instanceof PlatformError.PlatformError &&
+          error.cause.reason._tag === "NotFound"
+            ? // pnpm-managed Node installations do not include npm. Keep npm
+              // installation semantics for the pinned runtime and native builds.
+              runner.run({
+                command: "pnpm",
+                args: ["--package=npm@11", "dlx", "npm", ...installArgs],
+                timeout: PINNED_RUNTIME_INSTALL_TIMEOUT,
+              })
+            : Effect.fail(error),
+        ),
         Effect.mapError((cause) => new PinnedRuntimeInstallError({ step: installStep, cause })),
         Effect.filterOrFail(
           (result) => result.code === 0,

--- a/apps/server/src/cloud/pinnedRuntime.ts
+++ b/apps/server/src/cloud/pinnedRuntime.ts
@@ -169,18 +169,19 @@ const installPinnedRuntime = Effect.fn("cloud.pinned_runtime.ensure_installed")(
         timeout: PINNED_RUNTIME_INSTALL_TIMEOUT,
       })
       .pipe(
-        Effect.catchTag("ProcessSpawnError", (error) =>
-          error.cause instanceof PlatformError.PlatformError &&
-          error.cause.reason._tag === "NotFound"
-            ? // pnpm-managed Node installations do not include npm. Keep npm
-              // installation semantics for the pinned runtime and native builds.
-              runner.run({
-                command: "pnpm",
-                args: ["--package=npm@11", "dlx", "npm", ...installArgs],
-                timeout: PINNED_RUNTIME_INSTALL_TIMEOUT,
-              })
-            : Effect.fail(error),
-        ),
+        Effect.catchTags({
+          ProcessSpawnError: (error) =>
+            error.cause instanceof PlatformError.PlatformError &&
+            error.cause.reason._tag === "NotFound"
+              ? // pnpm-managed Node installations do not include npm. Keep npm
+                // installation semantics for the pinned runtime and native builds.
+                runner.run({
+                  command: "pnpm",
+                  args: ["--package=npm@11", "dlx", "npm", ...installArgs],
+                  timeout: PINNED_RUNTIME_INSTALL_TIMEOUT,
+                })
+              : Effect.fail(error),
+        }),
         Effect.mapError((cause) => new PinnedRuntimeInstallError({ step: installStep, cause })),
         Effect.filterOrFail(
           (result) => result.code === 0,


### PR DESCRIPTION
pnpm-managed node installations can lack npm, preventing pinned runtime installation. when npm is missing, run npm through pnpm dlx while retaining the existing install semantics and other failures.

verified with seven focused tests, server typecheck, scoped lint and formatting checks, and a real pnpm invocation returning npm 11.19.1. a full service install remains unverified;

![pinned runtime installation: 7 tests passed](https://uploads-production-47e4.up.railway.app/files/52bb7985-2a3d-46e3-bd06-f74e8d24f3c8/issue-5987-tests.png)

Fixes [#5987](https://github.com/pingdotgg/t3code/issues/5987).

Implemented with GPT 6 Astra in Codex.

## Additional maintainer verification

Reproduced the missing-npm failure on current main [cb9a6942](https://github.com/pingdotgg/t3code/commit/cb9a6942363ed7f097c7d1fb075bf3a265fbf5d2). Independently reviewed the complete change at [e8c08859](https://github.com/pingdotgg/t3code/commit/e8c08859dd41a49dbf9a8c7f7addbc05d36ec5a2), preserving Maria's implementation.

- Nine focused tests passed, including actual process-spawn ENOENT and nonzero-exit controls.
- A separate real-install test passed in 24.89 seconds with Node 24.20.0, pnpm 11.10.0 and npm 11.19.1, using empty disposable caches and no npm on PATH.
- Before: the current-main helper fails with `spawn npm ENOENT` and removes staging.
- After: this PR's unchanged helper installs real `t3@0.0.38` through pnpm, validates `t3 v0.0.38`, writes the exact completion sentinel and publishes the runtime with staging removed. npm's log confirms the msgpackr-extract and node-pty lifecycle scripts completed successfully.

No service, server or provider account was started. This verifies the installer mechanism, not the exact reported tool versions or a complete Debian/systemd service installation. Screenshots do not apply to this subprocess-only change.

Audit and verification by GPT 6 Astra via Codex in T3 Code.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches boot/self-update install path and subprocess spawning, but the fallback is narrowly scoped to missing `npm` and is covered by new tests.
> 
> **Overview**
> **Pinned runtime install** now retries when `npm` cannot be spawned because the executable is missing (typical on pnpm-managed Node), without changing behavior for other spawn failures.
> 
> `installPinnedRuntime` still runs `npm install` with the same args and timeout; on `ProcessSpawnError` with `PlatformError` `NotFound`, it runs `pnpm --package=npm@11 dlx npm` with those same install arguments. Permission and other spawn errors still fail immediately with no alternate installer.
> 
> Tests cover the npm→pnpm fallback command sequence and the case where only `npm` is attempted on permission denial.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8c08859dd41a49dbf9a8c7f7addbc05d36ec5a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `installPinnedRuntime` to fallback to pnpm when npm is not found
> - In [pinnedRuntime.ts](https://github.com/pingdotgg/t3code/pull/9923/files#diff-1db0e3a8605ae95c9cf7dba2fdf61ec1d60fad091e74453cf50e53da2b27fa03), spawning npm now falls back to running `npm 11` through `pnpm` if the `npm` executable is missing (`PlatformError` with `NotFound` reason)
> - The fallback preserves the original installation arguments and timeout
> - Other spawn errors, such as permission failures, continue through the existing error path without attempting a fallback
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8c0885.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->