### PR TITLE
fix(opencode): revert from the first removed assistant message

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -84,6 +84,7 @@ const runtimeMock = {
       | ((sessionID: string) => Promise<Array<{ id: string }>>)
       | null,
     closeCalls: [] as string[],
+    revertMessageID: undefined as string | undefined,
     revertCalls: [] as Array<{ sessionID: string; messageID?: string }>,
     messageCalls: [] as Array<{ sessionID: string; messageID: string }>,
     messageFailures: 0,
@@ -143,6 +144,7 @@ const runtimeMock = {
     this.state.sessionChildrenById.clear();
     this.state.sessionChildrenImplementation = null;
     this.state.closeCalls.length = 0;
+    this.state.revertMessageID = undefined;
     this.state.revertCalls.length = 0;
     this.state.messageCalls.length = 0;
     this.state.messageFailures = 0;
@@ -263,6 +265,9 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
           return {
             data: {
               id: sessionID,
+              ...(runtimeMock.state.revertMessageID
+                ? { revert: { messageID: runtimeMock.state.revertMessageID } }
+                : {}),
               ...(directory ? { directory } : {}),
               ...(parentID ? { parentID } : {}),
             },
@@ -374,6 +379,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
           if (!messageID) {
             throw new Error("Expected messageID");
           }
+          runtimeMock.state.revertMessageID = messageID;
         },
       },
       event: {
@@ -6329,6 +6335,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       ];
 
       for (const numTurns of [0, 1, 2, 3]) {
+        runtimeMock.state.revertMessageID = undefined;
         runtimeMock.state.revertCalls.length = 0;
         const snapshot = yield* adapter.rollbackThread(threadId, numTurns);
         NodeAssert.deepEqual(
@@ -6347,6 +6354,16 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
           ["assistant-1", "assistant-2"].slice(0, Math.max(0, 2 - numTurns)),
         );
       }
+      runtimeMock.state.revertMessageID = undefined;
+      for (const remaining of [1, 0]) {
+        const snapshot = yield* adapter.rollbackThread(threadId, 1);
+        NodeAssert.equal(snapshot.turns.length, remaining);
+        NodeAssert.deepEqual((yield* adapter.readThread(threadId)).turns, snapshot.turns);
+      }
+      NodeAssert.deepEqual(
+        runtimeMock.state.revertCalls.slice(-2).map((call) => call.messageID),
+        ["assistant-2", "assistant-1"],
+      );
       runtimeMock.state.messages = [];
       runtimeMock.state.revertCalls.length = 0;
       const emptySnapshot = yield* adapter.rollbackThread(threadId, 1);

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -379,7 +379,14 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
           if (!messageID) {
             throw new Error("Expected messageID");
           }
-          runtimeMock.state.revertMessageID = messageID;
+          let lastUserID: string | undefined;
+          for (const entry of runtimeMock.state.messages) {
+            if (entry.info.role === "user") lastUserID = entry.info.id;
+            if (entry.info.id === messageID && entry.parts.length > 0) {
+              runtimeMock.state.revertMessageID = lastUserID ?? messageID;
+              break;
+            }
+          }
         },
       },
       event: {
@@ -6324,13 +6331,15 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       });
 
       runtimeMock.state.messages = [
+        { info: { id: "user-1", role: "user" }, parts: [] },
         {
           info: { id: "assistant-1", role: "assistant" },
-          parts: [],
+          parts: [{ id: "part-1", type: "text", text: "first answer" }],
         },
+        { info: { id: "user-2", role: "user" }, parts: [] },
         {
           info: { id: "assistant-2", role: "assistant" },
-          parts: [],
+          parts: [{ id: "part-2", type: "text", text: "second answer" }],
         },
       ];
 
@@ -6364,6 +6373,15 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         runtimeMock.state.revertCalls.slice(-2).map((call) => call.messageID),
         ["assistant-2", "assistant-1"],
       );
+      runtimeMock.state.revertMessageID = undefined;
+      runtimeMock.state.messages = runtimeMock.state.messages.filter(
+        (entry) => entry.info.id !== "user-2",
+      );
+      const sharedUserSnapshot = yield* adapter.rollbackThread(threadId, 1);
+      NodeAssert.equal(runtimeMock.state.revertMessageID, "user-1");
+      NodeAssert.deepEqual(sharedUserSnapshot.turns, []);
+      NodeAssert.deepEqual((yield* adapter.readThread(threadId)).turns, []);
+
       runtimeMock.state.messages = [];
       runtimeMock.state.revertCalls.length = 0;
       const emptySnapshot = yield* adapter.rollbackThread(threadId, 1);

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -372,17 +372,8 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             ...(messageID ? { messageID } : {}),
           });
           if (!messageID) {
-            runtimeMock.state.messages = [];
-            return;
+            throw new Error("Expected messageID");
           }
-
-          const targetIndex = runtimeMock.state.messages.findIndex(
-            (entry) => entry.info.id === messageID,
-          );
-          runtimeMock.state.messages =
-            targetIndex >= 0
-              ? runtimeMock.state.messages.slice(0, targetIndex + 1)
-              : runtimeMock.state.messages;
         },
       },
       event: {
@@ -6316,7 +6307,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }).pipe(Effect.provide(adapterLayer));
   });
 
-  it.effect("reverts the full thread when rollback removes every assistant turn", () =>
+  it.effect("reverts the first removed assistant message and returns only retained turns", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
       const threadId = asThreadId("thread-rollback-all");
@@ -6337,12 +6328,30 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         },
       ];
 
-      const snapshot = yield* adapter.rollbackThread(threadId, 2);
-
-      NodeAssert.deepEqual(runtimeMock.state.revertCalls, [
-        { sessionID: "http://127.0.0.1:9999/session" },
-      ]);
-      NodeAssert.deepEqual(snapshot.turns, []);
+      for (const numTurns of [0, 1, 2, 3]) {
+        runtimeMock.state.revertCalls.length = 0;
+        const snapshot = yield* adapter.rollbackThread(threadId, numTurns);
+        NodeAssert.deepEqual(
+          runtimeMock.state.revertCalls,
+          numTurns === 0
+            ? []
+            : [
+                {
+                  sessionID: "http://127.0.0.1:9999/session",
+                  messageID: numTurns === 1 ? "assistant-2" : "assistant-1",
+                },
+              ],
+        );
+        NodeAssert.deepEqual(
+          snapshot.turns.map((turn) => turn.id),
+          ["assistant-1", "assistant-2"].slice(0, Math.max(0, 2 - numTurns)),
+        );
+      }
+      runtimeMock.state.messages = [];
+      runtimeMock.state.revertCalls.length = 0;
+      const emptySnapshot = yield* adapter.rollbackThread(threadId, 1);
+      NodeAssert.deepEqual(runtimeMock.state.revertCalls, []);
+      NodeAssert.deepEqual(emptySnapshot.turns, []);
     }),
   );
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -3750,6 +3750,9 @@ export function makeOpenCodeAdapter(
     const readThread: OpenCodeAdapterShape["readThread"] = Effect.fn("readThread")(
       function* (threadId) {
         const context = yield* ensureSessionContext(sessions, threadId);
+        const session = yield* runOpenCodeSdk("session.get", () =>
+          context.client.session.get({ sessionID: context.openCodeSessionId }),
+        ).pipe(Effect.mapError(toRequestError));
         const messages = yield* runOpenCodeSdk("session.messages", () =>
           context.client.session.messages({
             sessionID: context.openCodeSessionId,
@@ -3758,6 +3761,7 @@ export function makeOpenCodeAdapter(
 
         const turns: Array<OpenCodeTurnSnapshot> = [];
         for (const entry of messages.data ?? []) {
+          if (entry.info.id === session.data?.revert?.messageID) break;
           if (entry.info.role === "assistant") {
             turns.push({
               id: TurnId.make(entry.info.id),
@@ -3776,22 +3780,14 @@ export function makeOpenCodeAdapter(
     const rollbackThread: OpenCodeAdapterShape["rollbackThread"] = Effect.fn("rollbackThread")(
       function* (threadId, numTurns) {
         const context = yield* ensureSessionContext(sessions, threadId);
-        const messages = yield* runOpenCodeSdk("session.messages", () =>
-          context.client.session.messages({
-            sessionID: context.openCodeSessionId,
-          }),
-        ).pipe(Effect.mapError(toRequestError));
-
-        const assistantMessages = (messages.data ?? []).filter(
-          (entry) => entry.info.role === "assistant",
-        );
-        const targetIndex = Math.max(0, assistantMessages.length - numTurns);
-        const target = assistantMessages[targetIndex];
+        const snapshot = yield* readThread(threadId);
+        const targetIndex = Math.max(0, snapshot.turns.length - numTurns);
+        const target = snapshot.turns[targetIndex];
         if (target) {
           yield* runOpenCodeSdk("session.revert", () =>
             context.client.session.revert({
               sessionID: context.openCodeSessionId,
-              messageID: target.info.id,
+              messageID: target.id,
             }),
           ).pipe(Effect.mapError(toRequestError));
         }
@@ -3799,10 +3795,7 @@ export function makeOpenCodeAdapter(
         // OpenCode marks a revert boundary but retains the messages until the next prompt.
         return {
           threadId,
-          turns: assistantMessages.slice(0, targetIndex).map((entry) => ({
-            id: TurnId.make(entry.info.id),
-            items: [entry.info, ...entry.parts],
-          })),
+          turns: snapshot.turns.slice(0, targetIndex),
         };
       },
     );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -3790,13 +3790,11 @@ export function makeOpenCodeAdapter(
               messageID: target.id,
             }),
           ).pipe(Effect.mapError(toRequestError));
+          // Native revert can move the boundary to the preceding user message.
+          return yield* readThread(threadId);
         }
 
-        // OpenCode marks a revert boundary but retains the messages until the next prompt.
-        return {
-          threadId,
-          turns: snapshot.turns.slice(0, targetIndex),
-        };
+        return snapshot;
       },
     );
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -3785,16 +3785,25 @@ export function makeOpenCodeAdapter(
         const assistantMessages = (messages.data ?? []).filter(
           (entry) => entry.info.role === "assistant",
         );
-        const targetIndex = assistantMessages.length - numTurns - 1;
-        const target = targetIndex >= 0 ? assistantMessages[targetIndex] : null;
-        yield* runOpenCodeSdk("session.revert", () =>
-          context.client.session.revert({
-            sessionID: context.openCodeSessionId,
-            ...(target ? { messageID: target.info.id } : {}),
-          }),
-        ).pipe(Effect.mapError(toRequestError));
+        const targetIndex = Math.max(0, assistantMessages.length - numTurns);
+        const target = assistantMessages[targetIndex];
+        if (target) {
+          yield* runOpenCodeSdk("session.revert", () =>
+            context.client.session.revert({
+              sessionID: context.openCodeSessionId,
+              messageID: target.info.id,
+            }),
+          ).pipe(Effect.mapError(toRequestError));
+        }
 
-        return yield* readThread(threadId);
+        // OpenCode marks a revert boundary but retains the messages until the next prompt.
+        return {
+          threadId,
+          turns: assistantMessages.slice(0, targetIndex).map((entry) => ({
+            id: TurnId.make(entry.info.id),
+            items: [entry.info, ...entry.parts],
+          })),
+        };
       },
     );
 


### PR DESCRIPTION
opencode rollback used the last retained message and omitted the required id when removing all turns. target the first removed assistant message and read back the native revert boundary, including when multiple assistant messages share a preceding user message. opencode keeps its reverted history until the next prompt.

verified with all 108 opencode adapter tests, server typecheck, and scoped lint and formatting checks. the existing mock follows native inclusive revert semantics, including shared user-message boundaries and consecutive rollbacks.

![opencode adapter: 108 tests passed on the final head](https://uploads-production-47e4.up.railway.app/files/88275d1a-d3f1-4248-bab3-1555051e67dd/issue-2789-tests.png)

fixes #2789.

implemented with gpt-6-astra in codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollback/read semantics for OpenCode threads and adds a session.get on every readThread; callers that assumed pre-revert thread shape after rollback may see fewer turns.
> 
> **Overview**
> Fixes OpenCode thread rollback so it matches native revert semantics instead of slicing messages locally or reverting to the last *kept* assistant turn.
> 
> **`readThread`** now loads session metadata and stops listing assistant turns at `session.revert.messageID`, because OpenCode keeps reverted messages in the transcript until the next prompt.
> 
> **`rollbackThread`** derives the revert target from the current snapshot: the assistant turn at index `length - numTurns` (the first turn being removed). It always calls `session.revert` with that message ID, then re-reads the thread so a boundary that lands on the preceding user message is reflected. When there is nothing to revert, it returns the snapshot without calling revert.
> 
> Tests extend the runtime mock to expose `revert.messageID` on `session.get` and simulate inclusive revert behavior, with broader coverage for `numTurns`, consecutive rollbacks, and shared user-message boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c7358f56ba81e4bd76cd5032cddf15fe1f627c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `OpenCodeAdapter` rollback to revert from first removed assistant message
> - Updates the OpenCode runtime test double to model native revert as a persisted session boundary reported by `session.get`, instead of deleting messages immediately
> - Adds test cases covering zero through three requested turns, repeated rollback/readback, a shared user-message boundary, and an empty thread
> - Fixture now includes user messages and assistant parts so the mock can determine the native revert boundary
> - Risk: `session.revert` in the mock now requires a message ID and fails without one; calls without parts no longer truncate the mock message list directly
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c7358f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->