### PR TITLE
fix(server): keep mise-owned npm packages manual-only

### DIFF
--- a/apps/server/src/provider/Drivers/CodexDriver.test.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.test.ts
@@ -102,4 +102,120 @@ it.layer(testLayer)("CodexDriver", (it) => {
       expect((yield* instance.snapshot.resolveMaintenance()).update).toBeNull();
     }).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, noSpawn), Effect.scoped),
   );
+
+  for (const fixture of [
+    {
+      name: "leaves mise npm-backend installations manual-only",
+      installSegments: ["mise", "installs", "npm-openai-codex", "0.110.0"],
+      npmOwned: false,
+    },
+    {
+      name: "leaves mise tool aliases backed by npm manual-only",
+      installSegments: ["mise", "installs", "codex", "0.110.0"],
+      npmOwned: false,
+    },
+    {
+      name: "keeps npm updates for globals in a mise Node installation",
+      installSegments: ["mise", "installs", "node", "24.0.0"],
+      npmOwned: true,
+    },
+    {
+      name: "keeps npm updates for ordinary global installations",
+      installSegments: ["npm-global"],
+      npmOwned: true,
+    },
+  ] as const) {
+    it.effect.skipIf(windowsHost)(fixture.name, () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-codex-installer-" });
+        const installPath = NodePath.join(tempDir, ...fixture.installSegments);
+        const realBinaryPath = NodePath.join(
+          installPath,
+          "lib",
+          "node_modules",
+          "@openai",
+          "codex",
+          "bin",
+          "codex.js",
+        );
+        const binaryPath = NodePath.join(tempDir, "bin", "codex");
+        yield* fs.makeDirectory(NodePath.dirname(realBinaryPath), { recursive: true });
+        yield* fs.makeDirectory(NodePath.dirname(binaryPath), { recursive: true });
+        yield* fs.writeFileString(realBinaryPath, "#!/bin/sh\n");
+        yield* fs.chmod(realBinaryPath, 0o755);
+        yield* fs.symlink(realBinaryPath, binaryPath);
+
+        const instance = yield* CodexDriver.create({
+          instanceId: ProviderInstanceId.make("codex-installer"),
+          displayName: "Codex installer test",
+          enabled: false,
+          environment: [],
+          config: {
+            ...CodexDriver.defaultConfig(),
+            binaryPath,
+            homePath: NodePath.join(tempDir, "codex-home"),
+          },
+        });
+
+        const update = (yield* instance.snapshot.resolveMaintenance()).update;
+        if (fixture.npmOwned) {
+          expect(update).toMatchObject({
+            executable: "npm",
+            args: [
+              "install",
+              "-g",
+              "--prefix",
+              installPath,
+              "--allow-scripts=@openai/codex",
+              "@openai/codex@latest",
+            ],
+          });
+        } else {
+          expect(update).toBeNull();
+        }
+      }).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, noSpawn),
+        Effect.scoped,
+      ),
+    );
+  }
+
+  for (const layout of ["direct", "wrapper"] as const) {
+    it.effect.skipIf(windowsHost)(`leaves a mise ${layout} installation manual-only`, () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: `t3-codex-mise-${layout}-` });
+        const binaryPath =
+          layout === "direct"
+            ? NodePath.join(tempDir, "mise", "installs", "codex", "0.110.0", "codex")
+            : NodePath.join(tempDir, "omarchy", "bin", "codex");
+        yield* fs.makeDirectory(NodePath.dirname(binaryPath), { recursive: true });
+        yield* fs.writeFileString(
+          binaryPath,
+          layout === "direct"
+            ? "#!/bin/sh\n"
+            : '#!/bin/sh\nmise use -g --quiet "codex" || exit 1\nexec mise x "codex" -- "codex" "$@"\n',
+        );
+        yield* fs.chmod(binaryPath, 0o755);
+
+        const instance = yield* CodexDriver.create({
+          instanceId: ProviderInstanceId.make(`codex-mise-${layout}`),
+          displayName: "Codex mise test",
+          enabled: false,
+          environment: [],
+          config: {
+            ...CodexDriver.defaultConfig(),
+            binaryPath,
+            homePath: NodePath.join(tempDir, "codex-home"),
+          },
+        });
+
+        expect((yield* instance.snapshot.resolveMaintenance()).update).toBeNull();
+      }).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, noSpawn),
+        Effect.scoped,
+      ),
+    );
+  }
 });

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -240,6 +240,12 @@ export function npmGlobalPrefixFromCommandPath(
   if (packageIndex < 0 || normalized.slice(0, packageIndex).includes("/node_modules/")) {
     return null;
   }
+  // Mise's npm backend uses a global-looking layout inside a tool version.
+  // Globals under its Node installation still belong to npm.
+  const miseTool = /\/mise\/installs\/([^/]+)\/[^/]+$/.exec(normalized.slice(0, packageIndex))?.[1];
+  if (miseTool && miseTool !== "node") {
+    return null;
+  }
   return packageIndex === 0 ? "/" : slashPath.slice(0, packageIndex);
 }
 


### PR DESCRIPTION
## Problem

The Linux mise variant reported in [#8051](https://github.com/pingdotgg/t3code/issues/8051) still selects the wrong updater after [#9325](https://github.com/pingdotgg/t3code/pull/9325). Mise's npm backend places a package inside `mise/installs/<tool>/<version>/lib/node_modules/`, which T3 mistakes for an npm-owned global prefix. The offered command installs a newer package into that existing mise version directory.

## Change

Leave these mise-owned packages manual-only instead of offering npm. Ordinary npm globals, including globals under mise's `node` installation, retain their existing updater. Standalone Codex still uses its own updater and shared home.

This is a separate wrong-owner guard, not automatic mise support. Kristoffer's existing proposal [#9225](https://github.com/pingdotgg/t3code/pull/9225) identified the mise layouts and remains untouched. This change adds no mise invocation, wrapper parsing, cwd/configuration change, or installer execution.

## Before and after

Tested through the actual disabled `CodexDriver` resolver with disposable Linux files and executable symlinks. The process spawner and HTTP client fail if invoked.

On main [2fb99a7a](https://github.com/pingdotgg/t3code/commit/2fb99a7a664faf045f1884f38c620016b34874cb), the initial six-fixture probe produced one failure and five passes. The final eight-fixture regression suite produced two failures and six passes: both the explicit npm backend and an npm-backed tool alias incorrectly offered `npm install -g --prefix <mise-tool-version> ...`.

After the fix, all 32 focused driver and maintenance tests pass on latest main [df8e0eb4](https://github.com/pingdotgg/t3code/commit/df8e0eb46bca3dc01c17cc74a53b19aaacbe252b), committed September 5, 2026 at 04:52:21 UTC. Both mise npm fixtures now return `update: null`. Standalone/shared-home, ordinary npm, mise-managed Node globals, direct mise, wrapper, and missing-executable controls pass.

```sh
cd apps/server
vp test run src/provider/Drivers/CodexDriver.test.ts src/provider/providerMaintenance.test.ts --maxWorkers 2
```

Server typecheck, targeted lint, formatting, and diff checks pass on the final base. Typecheck emits existing suggestions in unrelated files but exits successfully. This is resolver behavior, so screenshots would not demonstrate the fix. No installer or provider command was run.

## Limits

This recognizes conventional paths containing `mise/installs`. Custom `MISE_DATA_DIR` roots with a different basename are not inferred. Native Windows, its separate shim/optional-package failures, and native macOS have not been tested. Native wrapper precedence is unchanged. This PR does not close the whole report or choose an automatic mise-update policy.

GPT 6 Astra via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes executable ownership detection for one-click provider updates; a mistake could suppress valid npm updates or still target the wrong install path, though the guard is narrowly scoped to conventional `mise/installs` paths.
> 
> **Overview**
> **Stops treating mise npm-backend installs as npm-owned globals** so provider maintenance no longer offers `npm install -g --prefix <mise-tool-version>` for Codex (and similar) living under `mise/installs/<tool>/<version>/lib/node_modules/`.
> 
> `npmGlobalPrefixFromCommandPath` now returns no prefix when the path sits under `mise/installs` for any tool **except** `node`, so globals under mise-managed Node still get the existing npm updater while ordinary npm prefixes are unchanged.
> 
> **CodexDriver maintenance tests** add disposable Linux fixtures (symlinked binaries, direct mise paths, wrapper scripts) asserting mise npm-backend and alias layouts stay manual-only (`update: null`) and that true npm-owned layouts still resolve the expected `npm install` command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3c62181be021529a08b63a5d98c0e78fa09a2c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `npmGlobalPrefixFromCommandPath` to skip mise-owned non-Node npm packages
> Previously, global-looking package paths under mise-managed non-Node tools (e.g. mise npm-backend, mise aliases) were incorrectly treated as npm-global, leading to unwanted npm update commands. The function now returns `null` when the prefix preceding `lib/node_modules` ends in a mise installation for a tool other than `node`, leaving those packages manual-only. Mise-managed Node installations and ordinary npm globals continue to resolve their npm prefix as before. Adds Unix-only tests in [CodexDriver.test.ts](https://github.com/pingdotgg/t3code/pull/9927/files#diff-5baf678b95e3ba8c59ea9ee8ec4fd22d9300615a985c9e58d67f09311813c59d) covering mise npm-backend, mise tool-alias, mise Node, ordinary npm-global, direct mise, and wrapper mise layouts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3c6218.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->