### PR TITLE
fix(web): preserve file attachments when editing queued runs

### DIFF
--- a/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
+++ b/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
@@ -898,7 +898,7 @@ describe("orchestrator MCP toolkit", () => {
                 text: "Rewrite the automatic delivery.",
               })
               .pipe(Effect.flip);
-            expect(completionEditError._tag).toBe("OrchestratorDispatchError");
+            expect(completionEditError._tag).toBe("OrchestratorCommandRejectedError");
             const completionReorderError = yield* orchestrator
               .dispatch({
                 type: "queued-run.reorder",

--- a/apps/server/src/orchestration-v2/Orchestrator.ts
+++ b/apps/server/src/orchestration-v2/Orchestrator.ts
@@ -96,6 +96,15 @@ export class OrchestratorDispatchError extends Schema.TaggedError<OrchestratorDi
   }
 }
 
+export class OrchestratorCommandRejectedError extends Schema.TaggedError<OrchestratorCommandRejectedError>()(
+  "OrchestratorCommandRejectedError",
+  { commandId: CommandId, commandType: Schema.String, cause: Schema.optional(Schema.Defect()) },
+) {
+  override get message(): string {
+    return `Orchestration command ${this.commandType} (${this.commandId}) was rejected before commit.`;
+  }
+}
+
 export class OrchestratorProjectionError extends Schema.TaggedError<OrchestratorProjectionError>()(
   "OrchestratorProjectionError",
   {
@@ -174,6 +183,7 @@ export function canReplayCommandReceipt(
 
 export const OrchestratorV2Error = Schema.Union([
   OrchestratorDispatchError,
+  OrchestratorCommandRejectedError,
   OrchestratorProjectionError,
   OrchestratorDomainEventStreamError,
   OrchestratorProviderAdapterError,
@@ -7825,7 +7835,7 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
       Effect.catch((cause) =>
         Effect.gen(function* () {
           const rejectedAt = yield* DateTime.now;
-          yield* eventSink
+          const receipt = yield* eventSink
             .commitRejectedCommand({
               commandId: command.commandId,
               threadId: commandThreadId(command),
@@ -7843,6 +7853,17 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
                   }),
               ),
             );
+          if (
+            command.type === "queued-run.edit" &&
+            receipt.status === "rejected" &&
+            cause._tag === "OrchestratorDispatchError"
+          ) {
+            return yield* new OrchestratorCommandRejectedError({
+              commandId: cause.commandId,
+              commandType: cause.commandType,
+              cause: cause.cause,
+            });
+          }
           return yield* cause;
         }),
       ),

--- a/apps/server/src/orchestration-v2/ThreadLaunchService.test.ts
+++ b/apps/server/src/orchestration-v2/ThreadLaunchService.test.ts
@@ -1549,6 +1549,66 @@ it.effect("shared intake preserves durable attachment bytes after a lost launch 
     });
     yield* dispatch;
     yield* dispatch;
+    const queuedProjection = yield* threads.getThreadProjection(input.threadId);
+    const queuedRun = queuedProjection.runs.find(
+      (run) => run.userMessageId === MessageId.make("intake-second"),
+    );
+    assert.isDefined(queuedRun);
+    assert.equal(queuedRun.status, "queued");
+    const queuedMessage = queuedProjection.messages.find(
+      (message) => message.id === queuedRun.userMessageId,
+    );
+    assert.isDefined(queuedMessage);
+    const file: ChatAttachment = {
+      type: "file",
+      id: ChatAttachmentId.make(createPendingAttachmentId("pdf")),
+      name: "queued.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 4,
+    };
+    const filePath = resolveAttachmentPath({
+      attachmentsDir: config.attachmentsDir,
+      attachment: file,
+    });
+    assert.isNotNull(filePath);
+    yield* fs.writeFile(filePath, new Uint8Array([5, 6, 7, 8]));
+    const edit = ThreadMessageIntake.dispatchCommand({
+      type: "queued-run.edit",
+      commandId: CommandId.make("intake-edit"),
+      threadId: input.threadId,
+      runId: queuedRun.id,
+      text: "Edited with a file",
+      attachments: [...queuedMessage.attachments, file],
+    });
+    yield* edit;
+    yield* edit;
+    const editedProjection = yield* threads.getThreadProjection(input.threadId);
+    const editedMessage = editedProjection.messages.find(
+      (message) => message.id === queuedRun.userMessageId,
+    );
+    assert.isDefined(editedMessage);
+    assert.equal(editedMessage.attachments.length, 2);
+    assert.deepEqual(editedMessage.attachments[0], queuedMessage.attachments[0]);
+    assert.notEqual(editedMessage.attachments[1]?.id, file.id);
+    const durableFilePath = resolveAttachmentPath({
+      attachmentsDir: config.attachmentsDir,
+      attachment: editedMessage.attachments[1]!,
+    });
+    assert.isNotNull(durableFilePath);
+    assert.deepEqual(yield* fs.readFile(durableFilePath), new Uint8Array([5, 6, 7, 8]));
+    assert.deepEqual(yield* fs.readFile(filePath), new Uint8Array([5, 6, 7, 8]));
+    const beforeRejectedEdit = (yield* claimedFiles).length;
+    const rejectedEdit = yield* ThreadMessageIntake.dispatchCommand({
+      type: "queued-run.edit",
+      commandId: CommandId.make("intake-edit-rejected"),
+      threadId: input.threadId,
+      runId: queuedRun.id,
+      text: "",
+      attachments: [file],
+    }).pipe(Effect.flip);
+    assert.equal(rejectedEdit._tag, "OrchestratorCommandRejectedError");
+    assert.equal((yield* claimedFiles).length, beforeRejectedEdit);
+    assert.deepEqual(yield* fs.readFile(filePath), new Uint8Array([5, 6, 7, 8]));
     const send = ThreadMessageIntake.sendToThread({
       commandId: CommandId.make("intake-send"),
       projectId,
@@ -1562,7 +1622,7 @@ it.effect("shared intake preserves durable attachment bytes after a lost launch 
     });
     yield* send;
     yield* send;
-    assert.equal((yield* claimedFiles).length, 3);
+    assert.equal((yield* claimedFiles).length, 4);
     const final = yield* threads.getThreadProjection(input.threadId);
     assert.equal(final.messages.length, 3);
     for (const message of final.messages) {

--- a/apps/server/src/orchestration-v2/ThreadMessageIntake.ts
+++ b/apps/server/src/orchestration-v2/ThreadMessageIntake.ts
@@ -16,6 +16,7 @@ function dispatchWasNotAccepted(
   error: Orchestrator.OrchestratorV2Error | ThreadManagement.ThreadManagementError,
 ) {
   switch (error._tag) {
+    case "OrchestratorCommandRejectedError":
     case "OrchestratorProjectionError":
     case "OrchestratorProviderAdapterError":
     case "OrchestratorCommandPreviouslyRejectedError":
@@ -74,10 +75,14 @@ export const dispatchCommand = Effect.fn("ThreadMessageIntake.dispatchCommand")(
     );
     return yield* threads.dispatch({ ...command, answers, attachmentsByQuestionId });
   }
-  if (command.type !== "message.dispatch") return yield* threads.dispatch(command);
+  if (
+    command.type !== "message.dispatch" &&
+    (command.type !== "queued-run.edit" || command.attachments === undefined)
+  )
+    return yield* threads.dispatch(command);
   const claimed = yield* AttachmentClaims.claimPendingAttachments({
     threadId: command.threadId,
-    attachments: command.attachments,
+    attachments: command.attachments ?? [],
   });
   return yield* threads.dispatch({ ...command, attachments: claimed.attachments }).pipe(
     Effect.tap((result) =>

--- a/apps/server/src/orchestration-v2/runtimeLayer.test.ts
+++ b/apps/server/src/orchestration-v2/runtimeLayer.test.ts
@@ -2375,7 +2375,7 @@ it.layer(TestLayer)("OrchestrationV2LayerLive lifecycle", (it) => {
           text: "   ",
         })
         .pipe(Effect.flip);
-      assert.equal(emptyEditError._tag, "OrchestratorDispatchError");
+      assert.equal(emptyEditError._tag, "OrchestratorCommandRejectedError");
 
       yield* orchestrator.dispatch({
         type: "queued-run.cancel",

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3890,6 +3890,7 @@ export default function ChatView(props: ChatViewProps) {
     reportFailure: false,
   });
   const queuedEditSaveInFlightRef = useRef(false);
+  const [isSavingQueuedEdit, setIsSavingQueuedEdit] = useState(false);
   const queuedEditImageResources = useMemo(
     () =>
       (editingQueuedRun?.existingAttachments ?? [])
@@ -7259,6 +7260,17 @@ export default function ChatView(props: ChatViewProps) {
       const editText = promptForSend.trim();
       const newEditImages = [...composerImages];
       const newEditFiles = [...composerFiles];
+      const newEditAttachments = [...newEditImages, ...newEditFiles];
+      if (
+        editingQueuedRun.existingAttachments.length + newEditAttachments.length >
+        PROVIDER_SEND_TURN_MAX_ATTACHMENTS
+      ) {
+        setThreadError(
+          editingQueuedRun.threadId,
+          `A message can have at most ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} attachments.`,
+        );
+        return;
+      }
       if (
         editText.length === 0 &&
         editingQueuedRun.existingAttachments.length === 0 &&
@@ -7268,6 +7280,7 @@ export default function ChatView(props: ChatViewProps) {
         return;
       }
       queuedEditSaveInFlightRef.current = true;
+      setIsSavingQueuedEdit(true);
       try {
         const uploads = await prepareQueuedEditAttachments({
           existingAttachments: editingQueuedRun.existingAttachments,
@@ -7319,6 +7332,7 @@ export default function ChatView(props: ChatViewProps) {
           return;
         }
         setThreadError(editingQueuedRun.threadId, null);
+        releaseDraftAttachments(newEditAttachments);
         promptRef.current = "";
         clearComposerDraftContent(queuedEditDraftTargetFor(editingQueuedRun.runId));
         composerRef.current?.resetCursorState();
@@ -7331,6 +7345,7 @@ export default function ChatView(props: ChatViewProps) {
         );
       } finally {
         queuedEditSaveInFlightRef.current = false;
+        setIsSavingQueuedEdit(false);
       }
       return;
     }
@@ -9145,7 +9160,10 @@ export default function ChatView(props: ChatViewProps) {
                     <ComposerSurface.Shell
                       contextStrip={showComposerContextStrip || showComposerModelStrip}
                     >
-                      <ComposerSurface.Host>
+                      <ComposerSurface.Host
+                        inert={isSavingQueuedEdit}
+                        aria-busy={isSavingQueuedEdit}
+                      >
                         <div className="relative z-10">
                           <ChatComposer
                             composerRef={composerRef}
@@ -9169,7 +9187,7 @@ export default function ChatView(props: ChatViewProps) {
                             projectSelectionRequired={isLocalDraftThread && activeProject === null}
                             phase={phase}
                             isConnecting={isConnecting}
-                            isSendBusy={isSendBusy}
+                            isSendBusy={isSendBusy || isSavingQueuedEdit}
                             isPreparingWorktree={isPreparingWorktree}
                             queuedRunsControl={
                               isServerThread && activeThread ? (


### PR DESCRIPTION
Queued-message edits must claim uploaded files into the thread attachment store before saving, so pending-upload cleanup cannot remove a saved attachment. Rejected edits release only claims known not to have committed; retries preserve accepted bytes.

Keeps the file-upload and draft-recovery helpers already on v2. Adds the missing claim path, a combined attachment-count guard, and a busy state that prevents edits during save.

Verification: 63 focused server, MCP, and queued-edit tests pass; the new durable-file regression fails on the base. Server and web typechecks pass. Browser verification passed on this head: the saved edit references a durable thread-owned file (87 bytes, contents checked), rather than a pending upload. A deliberately delayed dispatch confirmed that the composer stays inert while saving and re-enables after acceptance.

Prepared with Codex GPT-6-Astra; independently reviewed by Claude Fable 5.1 in T3 Code.

Before: queued edit before saving; baseline persisted a pending file ID.

![Before queued file edit](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/22dd43aca3fbfaad/9928-before-edit.png)

After: save in progress with the composer locked; acceptance persisted a durable file ID.

![After queued file save](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/8997d7c9f457f57d/9928-after-busy.png)

[Save recording (dispatch delayed 3 seconds for visibility)](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/6ea847d82800904a/9928-after-save.webm)
