### PR TITLE
fix(mobile): render generic message attachments

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -1517,9 +1517,7 @@ function renderFeedEntry(
     const renderedText = renderAssistantCitationsAsText(message.text);
     const styles = isUser ? markdownStyles.user : markdownStyles.assistant;
     const timestampLabel = formatMessageTime(isUser ? message.createdAt : message.updatedAt);
-    const attachments = (message.attachments ?? []).filter(
-      (attachment) => attachment.type === "image",
-    );
+    const attachments = message.attachments ?? [];
     const hasReviewCommentContext = message.text.includes("<review_comment");
     // A bubble that sizes itself from its content cannot lay out a block whose
     // intrinsic width overflows `maxWidth`: Android positions the bubble's


### PR DESCRIPTION
Non-image attachments disappeared from the React Native thread feed because an image-only filter removed them before renderer selection. Pass the complete attachment list to the existing image, PDF, video, and generic-file renderers.

Verified on an isolated iPhone 16 Pro simulator (iOS 26.5), using the same message, image and 53-byte text attachment against the same disposable V2 server. Before: `ThreadFeed.tsx` from `b9fa1399c`. After: #9929 head `2649ee3ca`, patch-identical in integration `fa6a1ab04`. The native Debug build succeeded (exit 0); only the Metro JavaScript bundle changed between captures. Generic text files and images were exercised; PDF/video opening and Android were not separately exercised.

| Before: text file missing | After: text file visible |
| --- | --- |
| ![Only the image is rendered](https://github.com/user-attachments/assets/70a91fca-f71c-4c68-b638-768f213655ad) | ![Image and release-notes.txt are rendered](https://github.com/user-attachments/assets/3b0eb602-98a6-4b2b-af22-6b5508cc47c5) |

<details><summary>Annotated evidence</summary>

![files-image-annotated.png](https://github.com/user-attachments/assets/dd615116-8119-4ae7-ab47-561ecc094d5c)

![files-image-annotated.png](https://github.com/user-attachments/assets/1e3cf841-fa59-4b02-9e49-b2f7bffb76d9)

</details>

Validation: React Native typecheck and targeted lint passed in the frozen integration run. The native snapshot exposes `Open release-notes.txt` after the fix and only `Open preview.png` before it. This changes React Native only; web/desktop and SwiftUI are separate clients.

Targets Julius’s Orchestrator V2 branch in #2829. A direct `claude --model claude-opus-5 --effort high --print --tools '' --no-session-persistence --output-format json` review attempt exited 1 because OAuth expired before model execution; no Claude review occurred.

Implemented and verified with GPT-6 Astra in Codex/T3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavioral fix in mobile UI; attachment routing was already implemented downstream.
> 
> **Overview**
> **Non-image message attachments were hidden** in the React Native thread feed because `ThreadFeed` filtered `message.attachments` to images only before rendering.
> 
> The feed now passes the **full attachment list** into the existing per-type UI: images, file chips (PDF preview, video tiles, generic files via share), and unknown types as inert rows. No new renderers—only removal of the image-only filter in the message entry path for user and assistant bubbles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2649ee3ca00aab43bf6c972cd6452441186e27a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `renderFeedEntry` to pass all message attachments, not just images
> The message-entry renderer in [ThreadFeed.tsx](https://github.com/pingdotgg/t3code/pull/9929/files#diff-97b9e47f1a8b00c4bb1a972e454769238aaceb538a03329f461e5c5d34cf7245) previously filtered `message.attachments` to image attachments only. It now uses the full `message.attachments` list (defaulting to empty when absent), so non-image attachments reach the feed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3c0750.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->