### PR TITLE
fix(mobile): use the archive eligibility guard when dispatching

### DIFF
--- a/apps/mobile/src/features/home/useThreadListActions.ts
+++ b/apps/mobile/src/features/home/useThreadListActions.ts
@@ -1,4 +1,3 @@
-import { threadRuntimeIsActive } from "@t3tools/client-runtime/state/shell";
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
 import { canSnooze } from "@t3tools/client-runtime/state/thread-settled";
 import * as Cause from "effect/Cause";
@@ -122,7 +121,7 @@ function useThreadActionExecutor(
         }
         // Archive keeps its original, narrower guard: never interrupt a
         // thread mid-turn.
-        if (action === "archive" && threadRuntimeIsActive(thread.runtime)) {
+        if (action === "archive" && !threadCanArchive(thread.runtime)) {
           Alert.alert(
             actionFailureTitle(action),
             "This thread is working. Interrupt it first, then try again.",


### PR DESCRIPTION
React Native could offer Archive and then reject it because the action handler used a broader “active” predicate than the menu. Reuse `threadCanArchive` at dispatch so queued/waiting states follow the existing archive policy while executing turns remain protected.

Verified the mounted native archive callback on an isolated iPhone 16 Pro simulator (iOS 26.5), using the Legacy Thread List and a disposable thread. Before: `useThreadListActions.ts` from `b9fa1399c`. After: #9930 head `9f7b9838b`, patch-identical in integration `fa6a1ab04`. Native Debug build: exit 0.

The callback received the same injected `runtime.status = "waiting"` fixture with a retained active-run ID on both bundles. Before, it showed the incorrect “working” alert. After, it sent the real archive command, the server persisted `archivedAt`, and the active-list count fell from 3 to 2. Restore through the mounted unarchive callback cleared `archivedAt`; a repeat archive succeeded.

| Before: archive rejected | After: archived thread removed |
| --- | --- |
| ![Waiting-state fixture rejected as working](https://github.com/user-attachments/assets/35b3b28a-5990-44f9-a75d-b4fe62f68aaf) | ![Archive succeeds and two active threads remain](https://github.com/user-attachments/assets/74c292f1-a93b-4362-86a1-919f04412a8d) |

<details><summary>Annotated screenshots</summary>

![archive-image-annotated.png](https://github.com/user-attachments/assets/d428f356-d967-4699-b98e-14779ed79afc)

![archive-image-annotated.png](https://github.com/user-attachments/assets/a7f80cd7-7a69-4507-ab80-8ff4f99bbb7b)

</details>

Automation limits: iOS did not expose thread rows as actionable accessibility targets, so the registered React callbacks were invoked through the development runtime. The physical row gesture was not exercised. A real Codex user-question turn still reports `running`, so the `waiting` state was explicitly injected at the callback boundary; this is a guard regression fixture, not a claim that that live provider state naturally becomes `waiting`. The initial direct deep-link entry to Archived Threads mounted a row without displaying it; that existing native presentation gap remains. A supplemental pass through the normal Settings → Archived Threads route displayed the row and exercised restoration as described below.

<details><summary>Supplemental normal Settings route and restoration proof</summary>

Normal Settings → Archived Threads shows the archived row (integration `fa6a1ab04`). On integrated candidate `860f3a6f5`, the public `Swipeable.openRight()` API exposed the row actions, then the actual semantic **Unarchive** button was tapped. The screen showed “No archived threads”; the server cleared `archivedAt` and the active-list count returned to 3. Both revisions contain the same #9930 archive hook. This supplements the waiting-state guard fixture above; it does not exercise the physical row swipe or establish that the initial direct deep-link presentation gap is fixed.

![Normal Settings route displays the archived thread](https://github.com/user-attachments/assets/186cc72d-2062-4b77-b932-64c411073e3c)

![Public Swipeable API exposes Unarchive and Delete actions](https://github.com/user-attachments/assets/b430c534-0415-436c-a4a7-e05db79460e9)

![After tapping Unarchive, no archived threads remain](https://github.com/user-attachments/assets/ef9865cf-13bb-4e14-ba14-8a4aee72bcf1)

</details>

Validation: all 3 archive-eligibility tests, React Native typecheck, and targeted lint passed in frozen verification. This changes only the React Native archive hook; Android was not separately exercised. Targets Julius’s Orchestrator V2 branch in #2829.

A direct Claude Opus 5 high review attempt exited 1 because OAuth expired before model execution; no Claude review occurred. Implemented and verified with GPT-6 Astra in Codex/T3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guard swap in the React Native archive path; behavior is narrowed to match existing archive policy and tests, with no auth or server contract changes.
> 
> **Overview**
> Fixes a mismatch where the thread list could show **Archive** but the action handler blocked it with a stricter “active runtime” check than the menu uses.
> 
> Archive dispatch in `useThreadListActions` now uses **`threadCanArchive`** (same as eligibility elsewhere) instead of **`threadRuntimeIsActive`**. Threads in **`waiting`** (and other non-executing states) can archive when policy allows; turns still in **`preparing`**, **`starting`**, or **`running`** keep the existing “working—interrupt first” alert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f7b9838b008c7ebfeb11a8cc632ba875196aab8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `threadCanArchive` guard instead of `threadRuntimeIsActive` in `useThreadActionExecutor`
> Replaces the direct `threadRuntimeIsActive` check with the existing `threadCanArchive` predicate when deciding whether to dispatch an archive action. The rejected case still shows the same alert and returns `false`. Risk: `threadCanArchive(thread.runtime)` may reject archive in states where `threadRuntimeIsActive` would have allowed it — verify the predicate's conditions in [useThreadListActions.ts](https://github.com/pingdotgg/t3code/pull/9930/files#diff-306460b1de597bc9d164b691fb0e4075061f7eb9246d316db687209ac8dec787) cover the intended runtime states.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1447ae0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->