### PR TITLE
fix(mobile): throttle streaming thread visit updates

### DIFF
--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -674,14 +674,16 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
 
   const visitThread = useAtomCommand(threadEnvironment.visit, { reportFailure: false });
   const lastDispatchedVisitRef = useRef<string | null>(null);
+  const lastVisitDispatchRef = useRef({ threadKey: selectedThreadKey, at: 0 });
   const selectedThreadId = props.selectedThread.id;
   const selectedThreadUpdatedAt = props.selectedThread.updatedAt;
   const selectedThreadLastVisitedAt = props.selectedThread.lastVisitedAt;
+  const selectedThreadCompletedAt = props.selectedThread.latestRun?.completedAt;
   useEffect(() => {
     // Records the server-side visited watermark while the thread is on
     // screen (mirror of web ChatView), so the "Done" marker clears on every
     // device. Field absent → the server predates visited tracking.
-    if (selectedThreadLastVisitedAt === undefined) return;
+    if (!showContent || selectedThreadLastVisitedAt === undefined) return;
     const threadUpdatedAtMs = Date.parse(selectedThreadUpdatedAt);
     if (Number.isNaN(threadUpdatedAtMs)) return;
     const lastVisitedAtMs = selectedThreadLastVisitedAt
@@ -691,17 +693,36 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
     // Dedupe per watermark — the effect re-runs before the command echo lands.
     const dispatchKey = `${selectedThreadKey}:${selectedThreadUpdatedAt}`;
     if (lastDispatchedVisitRef.current === dispatchKey) return;
-    lastDispatchedVisitRef.current = dispatchKey;
-    void visitThread({
-      environmentId: props.environmentId,
-      input: { threadId: selectedThreadId, visitedAt: selectedThreadUpdatedAt },
-    });
+    const dispatch = () => {
+      lastDispatchedVisitRef.current = dispatchKey;
+      lastVisitDispatchRef.current = { threadKey: selectedThreadKey, at: Date.now() };
+      void visitThread({
+        environmentId: props.environmentId,
+        input: { threadId: selectedThreadId, visitedAt: selectedThreadUpdatedAt },
+      });
+    };
+    // Completion clears unread state immediately; streaming watermarks use the
+    // same ten-second trailing throttle as web, keeping the newest update.
+    const completedAtMs = selectedThreadCompletedAt ? Date.parse(selectedThreadCompletedAt) : NaN;
+    const hasUnseenCompletion =
+      !Number.isNaN(completedAtMs) &&
+      (Number.isNaN(lastVisitedAtMs) || completedAtMs > lastVisitedAtMs);
+    const previous = lastVisitDispatchRef.current;
+    const elapsed = Date.now() - previous.at;
+    if (previous.threadKey !== selectedThreadKey || hasUnseenCompletion || elapsed >= 10_000) {
+      dispatch();
+      return;
+    }
+    const timer = setTimeout(dispatch, 10_000 - elapsed);
+    return () => clearTimeout(timer);
   }, [
     props.environmentId,
     selectedThreadId,
     selectedThreadKey,
     selectedThreadLastVisitedAt,
+    selectedThreadCompletedAt,
     selectedThreadUpdatedAt,
+    showContent,
     visitThread,
   ]);
 


### PR DESCRIPTION
Mobile sent a thread-visit command for every streaming update. Apply the existing web policy: send immediately on a newly opened thread or unseen completion, otherwise coalesce updates into a trailing visit at most once every ten seconds. Cancel pending timers when leaving the thread.

Verified in one fresh iOS simulator against an isolated server, with the web client on a draft so it could not send visits for the tested thread. Twenty metadata updates at 250 ms intervals produced 20 visit commands on the baseline and two on the patched client, 10.005 seconds apart. The final visited watermark equalled the latest thread update. Mobile typecheck and formatting pass.

[Measured command counts](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/6d0c2edfe151bec7/9931-measurement.json). The screenshots show the same live thread; the change is network traffic, not layout.

Before:

![Baseline mobile thread](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/bca04f24892fa395/9931-before.png)

After:

![Patched mobile thread](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/26665a17c01c5b85/9931-after.png)

[Patched live update recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/fc8ac071c82aefee/9931-after.mp4)

Prepared with Codex; independently reviewed by Claude Fable 5.1 in T3 Code.
