### PR TITLE
fix(web): hide sidebar search shortcut on mobile

### DIFF
--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -3598,11 +3598,9 @@ export default function LegacySidebar() {
     desktopUpdateState && showArm64IntelBuildWarning
       ? getArm64IntelBuildWarningDescription(desktopUpdateState)
       : null;
-  const commandPaletteShortcutLabel = shortcutLabelForCommand(
-    keybindings,
-    "commandPalette.toggle",
-    newThreadShortcutLabelOptions,
-  );
+  const commandPaletteShortcutLabel = isMobile
+    ? null
+    : shortcutLabelForCommand(keybindings, "commandPalette.toggle", newThreadShortcutLabelOptions);
   const handleDesktopUpdateButtonClick = useCallback(async () => {
     const bridge = window.desktopBridge;
     if (!bridge || !desktopUpdateState) return;


### PR DESCRIPTION
the mobile sidebar showed a keyboard shortcut beside search. hide the shortcut at the existing mobile breakpoint while preserving the control's action.

verified the before and after at 390 × 844, scoped lint and formatting, and the integrated evidence worktree's web typecheck. verified in the real app that the desktop shortcut remains visible and search opens its dialog.

![mobile sidebar search with keyboard shortcut before](https://uploads-production-47e4.up.railway.app/files/af384eec-6b16-4005-b5fa-c1a4abea881a/issue-4877-before.png)

![mobile sidebar search without keyboard shortcut after](https://uploads-production-47e4.up.railway.app/files/0ef91b49-6761-4799-9ff1-8e7932d70080/issue-4877-after.png)

fixes #4877.

implemented with gpt-6-astra in codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional in sidebar presentation logic; no changes to search/command-palette behavior or keybindings.
> 
> **Overview**
> Stops showing the **command palette keyboard hint** (`Kbd` next to **Search**) in the legacy sidebar when `isMobile` is true, by setting `commandPaletteShortcutLabel` to `null` instead of always resolving it via `shortcutLabelForCommand` for `commandPalette.toggle`.
> 
> Desktop behavior is unchanged: the Search row still opens the command palette and still displays the shortcut badge when a label exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa32fe192ec63bef5bbf43a0168bd14f9f16130a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide command-palette shortcut label in `LegacySidebar` on mobile
> The shortcut label computation now returns `null` when the sidebar is in mobile mode, so the keyboard shortcut hint is not shown on mobile. Desktop and other non-mobile layouts continue to use the existing `shortcutLabelForCommand` logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa32fe1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->