### PR TITLE
fix(settings): share restart continuation across environments

### DIFF
--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -44,6 +44,7 @@ import {
   type ServerSettingsPatch,
 } from "@t3tools/contracts";
 import {
+  filterSharedServerPatch,
   findSharedSettingsMismatches,
   pickSharedServerSettings,
   supportsSharedSettingsSync,
@@ -584,11 +585,13 @@ function AutoSettleSettingsRows() {
   const mismatches = findSharedSettingsMismatches({
     primaryEnvironmentId: reference.environmentId,
     primarySettings: referenceSettings,
+    primaryCapabilities: reference.serverConfig?.environment.capabilities,
     environments: environments.map((environment) => ({
       environmentId: environment.environmentId,
       label: environment.label,
       syncEligible: supportsSharedSettingsSync(environment),
       settings: environment.serverConfig?.settings ?? null,
+      capabilities: environment.serverConfig?.environment.capabilities,
     })),
   });
 
@@ -652,11 +655,22 @@ function AutoSettleSettingsRows() {
           <Pressable
             accessibilityRole="button"
             onPress={() => {
-              const patch = pickSharedServerSettings(referenceSettings);
+              const patch = pickSharedServerSettings(
+                referenceSettings,
+                reference.serverConfig?.environment.capabilities,
+              );
               for (const mismatch of mismatches) {
+                const target = environments.find(
+                  (candidate) => candidate.environmentId === mismatch.environmentId,
+                );
                 void updateSettings({
                   environmentId: mismatch.environmentId,
-                  input: { patch },
+                  input: {
+                    patch: filterSharedServerPatch(
+                      patch,
+                      target?.serverConfig?.environment.capabilities,
+                    ),
+                  },
                 });
               }
             }}

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -219,6 +219,7 @@ export const make = Effect.gen(function* () {
       pullRequests: true,
       threadSettlement: true,
       threadAutoSettlement: true,
+      threadRestartContinuation: true,
       threadSnooze: true,
       environmentThemes: true,
       usageLimitSources: true,

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -2439,7 +2439,7 @@ export function GeneralSettingsPanel() {
         <SettingsRow
           {...searchableSetting("continue-threads-after-server-update")}
           serverScoped
-          description="Automatically resume interrupted threads after an update, crash, or machine restart. Applies to this environment and all connected environments."
+          description="Automatically resume interrupted threads after an update, crash, or machine restart. Applies to this environment and all connected environments that support it. Update older servers first."
           resetAction={
             settings.continueThreadsAfterServerUpdate !==
             DEFAULT_UNIFIED_SETTINGS.continueThreadsAfterServerUpdate ? (

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -2439,7 +2439,7 @@ export function GeneralSettingsPanel() {
         <SettingsRow
           {...searchableSetting("continue-threads-after-server-update")}
           serverScoped
-          description="Automatically resume interrupted threads when this environment starts again after an update, crash, or machine restart."
+          description="Automatically resume interrupted threads after an update, crash, or machine restart. Applies to this environment and all connected environments."
           resetAction={
             settings.continueThreadsAfterServerUpdate !==
             DEFAULT_UNIFIED_SETTINGS.continueThreadsAfterServerUpdate ? (

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -26,6 +26,7 @@ import {
 } from "@t3tools/contracts/settings";
 import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
 import {
+  filterSharedServerPatch,
   findSharedSettingsMismatches,
   pickSharedServerSettings,
   splitSharedServerPatch,
@@ -368,18 +369,6 @@ export function usePrimarySettingsAvailable(): boolean {
   return primaryEnvironment !== null || !isHostedStaticApp();
 }
 
-/** Environments that can receive a shared settings write right now. */
-function useSharedSettingsSyncTargetIds(): ReadonlyArray<EnvironmentId> {
-  const { environments } = useEnvironments();
-  return useMemo(
-    () =>
-      environments
-        .filter(supportsSharedSettingsSync)
-        .map((environment) => environment.environmentId),
-    [environments],
-  );
-}
-
 /**
  * Returns an updater that routes each key to the correct backing store.
  *
@@ -394,7 +383,7 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
     serverEnvironment.updateSettings,
     "server settings update",
   );
-  const sharedSettingsSyncTargetIds = useSharedSettingsSyncTargetIds();
+  const { environments } = useEnvironments();
   const updateSettings = useCallback(
     (patch: UnifiedSettingsPatch) => {
       const { serverPatch, clientPatch } = splitPatch(patch);
@@ -419,7 +408,9 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
           }
         }
         if (Object.keys(sharedPatch).length > 0) {
-          const targets = new Set(sharedSettingsSyncTargetIds);
+          const targets = new Set(
+            environments.filter(supportsSharedSettingsSync).map((target) => target.environmentId),
+          );
           if (environmentId) {
             targets.add(environmentId);
           }
@@ -427,9 +418,15 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
             warnUnsaved();
           }
           for (const targetId of targets) {
+            const target = environments.find((candidate) => candidate.environmentId === targetId);
+            const targetPatch = filterSharedServerPatch(
+              sharedPatch,
+              target?.serverConfig?.environment.capabilities,
+            );
+            if (Object.keys(targetPatch).length === 0) continue;
             void persistServerSettings({
               environmentId: targetId,
-              input: { patch: sharedPatch },
+              input: { patch: targetPatch },
             });
           }
         }
@@ -438,7 +435,7 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
         persistClientSettingsPatch(clientPatch);
       }
     },
-    [environmentId, persistServerSettings, sharedSettingsSyncTargetIds],
+    [environmentId, environments, persistServerSettings],
   );
 
   return updateSettings;
@@ -453,6 +450,7 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
 export function useSharedSettingsSync() {
   const primaryEnvironment = usePrimaryEnvironment();
   const primaryEnvironmentId = primaryEnvironment?.environmentId ?? null;
+  const primaryCapabilities = primaryEnvironment?.serverConfig?.environment.capabilities;
   // Read the loaded config, not `primaryServerSettingsAtom`: that atom falls
   // back to defaults while the primary is disconnected, and "apply to all"
   // must never push defaults over real values. Same for a primary too old to
@@ -472,28 +470,35 @@ export function useSharedSettingsSync() {
       findSharedSettingsMismatches({
         primaryEnvironmentId,
         primarySettings,
+        primaryCapabilities,
         environments: environments.map((environment) => ({
           environmentId: environment.environmentId,
           label: environment.label,
           syncEligible: supportsSharedSettingsSync(environment),
           settings: environment.serverConfig?.settings ?? null,
+          capabilities: environment.serverConfig?.environment.capabilities,
         })),
       }),
-    [environments, primaryEnvironmentId, primarySettings],
+    [environments, primaryEnvironmentId, primarySettings, primaryCapabilities],
   );
 
   const applyToAll = useCallback(() => {
     if (primarySettings === null) {
       return;
     }
-    const patch = pickSharedServerSettings(primarySettings);
+    const patch = pickSharedServerSettings(primarySettings, primaryCapabilities);
     for (const mismatch of mismatches) {
+      const target = environments.find(
+        (candidate) => candidate.environmentId === mismatch.environmentId,
+      );
       void persistServerSettings({
         environmentId: mismatch.environmentId,
-        input: { patch },
+        input: {
+          patch: filterSharedServerPatch(patch, target?.serverConfig?.environment.capabilities),
+        },
       });
     }
-  }, [mismatches, persistServerSettings, primarySettings]);
+  }, [environments, mismatches, persistServerSettings, primarySettings, primaryCapabilities]);
 
   return { mismatches, applyToAll };
 }

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -391,11 +391,11 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
       if (Object.keys(serverPatch).length > 0) {
         const { sharedPatch, localPatch } = splitSharedServerPatch(serverPatch);
         // Dropping the write silently leaves the control looking saved.
-        const warnUnsaved = () =>
+        const warnUnsaved = (description = PRIMARY_SETTINGS_UNAVAILABLE_MESSAGE) =>
           toastManager.add({
             type: "warning",
             title: "Setting not saved",
-            description: PRIMARY_SETTINGS_UNAVAILABLE_MESSAGE,
+            description,
           });
         if (Object.keys(localPatch).length > 0) {
           if (environmentId) {
@@ -414,9 +414,7 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
           if (environmentId) {
             targets.add(environmentId);
           }
-          if (targets.size === 0) {
-            warnUnsaved();
-          }
+          let wroteToTarget = false;
           for (const targetId of targets) {
             const target = environments.find((candidate) => candidate.environmentId === targetId);
             const targetPatch = filterSharedServerPatch(
@@ -424,10 +422,16 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
               target?.serverConfig?.environment.capabilities,
             );
             if (Object.keys(targetPatch).length === 0) continue;
+            wroteToTarget = true;
             void persistServerSettings({
               environmentId: targetId,
               input: { patch: targetPatch },
             });
+          }
+          if (!wroteToTarget) {
+            warnUnsaved(
+              targets.size > 0 ? "Update older servers to save this setting." : undefined,
+            );
           }
         }
       }

--- a/docs/user/updating.md
+++ b/docs/user/updating.md
@@ -11,12 +11,14 @@ Server updates restart the connection and can interrupt active agents and
 terminal commands. Saved threads, settings, and project files remain.
 
 **Settings → General → Continue threads after restarts** is off by default.
-Enable it for each environment to resume supported active threads after an
-update, crash, or machine restart. T3 Code must start again on that machine;
+Enable it to resume supported active threads after an update, crash, or machine
+restart. Changes are saved to connected environments. If an environment was
+offline or has a different value, use **Apply to all** in Settings after it
+connects. T3 Code must start again on that machine;
 the setting does not enable automatic startup. Terminal commands may still be
 interrupted, and threads without saved provider resume state need a new message.
-If you previously enabled continuation for updates, enable this environment
-setting once to allow recovery without a connected client.
+If you previously enabled continuation for updates, enable this setting once
+to allow recovery without a connected client.
 
 ## Update a connected server
 

--- a/docs/user/updating.md
+++ b/docs/user/updating.md
@@ -12,9 +12,10 @@ terminal commands. Saved threads, settings, and project files remain.
 
 **Settings → General → Continue threads after restarts** is off by default.
 Enable it to resume supported active threads after an update, crash, or machine
-restart. Changes are saved to connected environments. If an environment was
-offline or has a different value, use **Apply to all** in Settings after it
-connects. T3 Code must start again on that machine;
+restart. Changes are saved to connected environments that support this setting;
+update older servers first. If a supported environment was offline or has a
+different value, use **Apply to all** in Settings after it connects.
+T3 Code must start again on that machine;
 the setting does not enable automatic startup. Terminal commands may still be
 interrupted, and threads without saved provider resume state need a new message.
 If you previously enabled continuation for updates, enable this setting once

--- a/packages/client-runtime/src/state/sharedSettings.test.ts
+++ b/packages/client-runtime/src/state/sharedSettings.test.ts
@@ -2,6 +2,7 @@ import { DEFAULT_SERVER_SETTINGS, EnvironmentId } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
 
 import {
+  filterSharedServerPatch,
   findSharedSettingsMismatches,
   pickSharedServerSettings,
   splitSharedServerPatch,
@@ -11,6 +12,7 @@ import {
 const primaryId = EnvironmentId.make("env-primary");
 const laptopId = EnvironmentId.make("env-laptop");
 const boxId = EnvironmentId.make("env-box");
+const restartCapabilities = { threadRestartContinuation: true };
 
 describe("supportsSharedSettingsSync", () => {
   it("accepts only connected servers that advertise the shared-settings capability", () => {
@@ -54,7 +56,9 @@ describe("splitSharedServerPatch", () => {
 
 describe("pickSharedServerSettings", () => {
   it("returns only the shared keys", () => {
-    expect(Object.keys(pickSharedServerSettings(DEFAULT_SERVER_SETTINGS)).sort()).toEqual([
+    expect(
+      Object.keys(pickSharedServerSettings(DEFAULT_SERVER_SETTINGS, restartCapabilities)).sort(),
+    ).toEqual([
       "continueThreadsAfterServerUpdate",
       "defaultThreadEnvMode",
       "newWorktreesStartFromOrigin",
@@ -63,6 +67,28 @@ describe("pickSharedServerSettings", () => {
       "sourceControlWritingStyle",
     ]);
   });
+});
+
+describe("filterSharedServerPatch", () => {
+  it.each([true, false])("preserves supported restart preference %s", (enabled) => {
+    const patch = { continueThreadsAfterServerUpdate: enabled, sidebarAutoSettleAfterDays: 7 };
+    expect(filterSharedServerPatch(patch, restartCapabilities)).toEqual(patch);
+  });
+
+  it.each([undefined, {}, { threadRestartContinuation: false }])(
+    "omits only the unsupported restart preference with capabilities %j",
+    (capabilities) => {
+      expect(
+        filterSharedServerPatch(
+          { continueThreadsAfterServerUpdate: true, sidebarAutoSettleAfterDays: 7 },
+          capabilities,
+        ),
+      ).toEqual({ sidebarAutoSettleAfterDays: 7 });
+      expect(pickSharedServerSettings(DEFAULT_SERVER_SETTINGS, capabilities)).not.toHaveProperty(
+        "continueThreadsAfterServerUpdate",
+      );
+    },
+  );
 });
 
 describe("findSharedSettingsMismatches", () => {
@@ -78,11 +104,13 @@ describe("findSharedSettingsMismatches", () => {
         label: "Remote Box",
         syncEligible: true,
         settings: remoteSettings,
+        capabilities: restartCapabilities,
       };
       expect(
         findSharedSettingsMismatches({
           primaryEnvironmentId: primaryId,
           primarySettings: settings,
+          primaryCapabilities: restartCapabilities,
           environments: [environment],
         }),
       ).toEqual([{ environmentId: boxId, label: "Remote Box" }]);
@@ -90,14 +118,54 @@ describe("findSharedSettingsMismatches", () => {
         findSharedSettingsMismatches({
           primaryEnvironmentId: primaryId,
           primarySettings: settings,
+          primaryCapabilities: restartCapabilities,
           environments: [
             {
               ...environment,
-              settings: Object.assign({}, remoteSettings, pickSharedServerSettings(settings)),
+              settings: Object.assign(
+                {},
+                remoteSettings,
+                pickSharedServerSettings(settings, restartCapabilities),
+              ),
             },
           ],
         }),
       ).toEqual([]);
+    },
+  );
+
+  it.each([
+    [undefined, restartCapabilities],
+    [restartCapabilities, undefined],
+    [undefined, undefined],
+  ])(
+    "ignores restart drift unless both servers support it (%j, %j)",
+    (primaryCapabilities, capabilities) => {
+      const environment = {
+        environmentId: boxId,
+        label: "Remote Box",
+        syncEligible: true,
+        capabilities,
+        settings: { ...primarySettings, continueThreadsAfterServerUpdate: true },
+      };
+      const input = {
+        primaryEnvironmentId: primaryId,
+        primarySettings,
+        primaryCapabilities,
+        environments: [environment],
+      };
+      expect(findSharedSettingsMismatches(input)).toEqual([]);
+      expect(
+        findSharedSettingsMismatches({
+          ...input,
+          environments: [
+            {
+              ...environment,
+              settings: { ...environment.settings, sidebarAutoSettleAfterDays: 14 },
+            },
+          ],
+        }),
+      ).toEqual([{ environmentId: boxId, label: "Remote Box" }]);
     },
   );
 

--- a/packages/client-runtime/src/state/sharedSettings.test.ts
+++ b/packages/client-runtime/src/state/sharedSettings.test.ts
@@ -40,9 +40,14 @@ describe("splitSharedServerPatch", () => {
     const { sharedPatch, localPatch } = splitSharedServerPatch({
       sidebarAutoSettleAfterDays: 7,
       sidebarAutoSettleOnMerge: false,
+      continueThreadsAfterServerUpdate: true,
       enableAgentBrowserAccess: false,
     });
-    expect(sharedPatch).toEqual({ sidebarAutoSettleAfterDays: 7, sidebarAutoSettleOnMerge: false });
+    expect(sharedPatch).toEqual({
+      sidebarAutoSettleAfterDays: 7,
+      sidebarAutoSettleOnMerge: false,
+      continueThreadsAfterServerUpdate: true,
+    });
     expect(localPatch).toEqual({ enableAgentBrowserAccess: false });
   });
 });
@@ -50,6 +55,7 @@ describe("splitSharedServerPatch", () => {
 describe("pickSharedServerSettings", () => {
   it("returns only the shared keys", () => {
     expect(Object.keys(pickSharedServerSettings(DEFAULT_SERVER_SETTINGS)).sort()).toEqual([
+      "continueThreadsAfterServerUpdate",
       "defaultThreadEnvMode",
       "newWorktreesStartFromOrigin",
       "sidebarAutoSettleAfterDays",
@@ -61,6 +67,39 @@ describe("pickSharedServerSettings", () => {
 
 describe("findSharedSettingsMismatches", () => {
   const primarySettings = { ...DEFAULT_SERVER_SETTINGS, sidebarAutoSettleAfterDays: 7 };
+
+  it.each([true, false])(
+    "detects remote restart continuation drift when the preference is %s",
+    (enabled) => {
+      const settings = { ...primarySettings, continueThreadsAfterServerUpdate: enabled };
+      const remoteSettings = { ...settings, continueThreadsAfterServerUpdate: !enabled };
+      const environment = {
+        environmentId: boxId,
+        label: "Remote Box",
+        syncEligible: true,
+        settings: remoteSettings,
+      };
+      expect(
+        findSharedSettingsMismatches({
+          primaryEnvironmentId: primaryId,
+          primarySettings: settings,
+          environments: [environment],
+        }),
+      ).toEqual([{ environmentId: boxId, label: "Remote Box" }]);
+      expect(
+        findSharedSettingsMismatches({
+          primaryEnvironmentId: primaryId,
+          primarySettings: settings,
+          environments: [
+            {
+              ...environment,
+              settings: Object.assign({}, remoteSettings, pickSharedServerSettings(settings)),
+            },
+          ],
+        }),
+      ).toEqual([]);
+    },
+  );
 
   it("lists sync-eligible environments whose shared settings differ", () => {
     const mismatches = findSharedSettingsMismatches({

--- a/packages/client-runtime/src/state/sharedSettings.ts
+++ b/packages/client-runtime/src/state/sharedSettings.ts
@@ -21,6 +21,7 @@ import type { EnvironmentConnectionPhase } from "../connection/presentation.ts";
 
 /** Server keys that hold a user preference rather than machine config. */
 export const SHARED_SERVER_SETTING_KEYS = [
+  "continueThreadsAfterServerUpdate",
   "sidebarAutoSettleAfterDays",
   "sidebarAutoSettleOnMerge",
   "defaultThreadEnvMode",

--- a/packages/client-runtime/src/state/sharedSettings.ts
+++ b/packages/client-runtime/src/state/sharedSettings.ts
@@ -53,15 +53,27 @@ export function splitSharedServerPatch(patch: ServerSettingsPatch): {
   };
 }
 
-/** The shared subset of one environment's settings, as a patch that can be written elsewhere. */
-export function pickSharedServerSettings(settings: ServerSettings): ServerSettingsPatch {
-  return Struct.pick(settings, SHARED_SERVER_SETTING_KEYS);
+/** Omit restart recovery on servers that cannot persist its preference. */
+export function filterSharedServerPatch(
+  patch: ServerSettingsPatch,
+  capabilities: Pick<ExecutionEnvironmentCapabilities, "threadRestartContinuation"> | undefined,
+): ServerSettingsPatch {
+  return capabilities?.threadRestartContinuation === true
+    ? patch
+    : Struct.omit(patch, ["continueThreadsAfterServerUpdate"]);
+}
+
+/** The shared subset supported by one environment. */
+export function pickSharedServerSettings(
+  settings: ServerSettings,
+  capabilities?: Pick<ExecutionEnvironmentCapabilities, "threadRestartContinuation">,
+): ServerSettingsPatch {
+  return filterSharedServerPatch(Struct.pick(settings, SHARED_SERVER_SETTING_KEYS), capabilities);
 }
 
 /**
  * Whether an environment can participate in shared-settings sync right now.
- * Auto-settlement is the newest feature backed by a shared key, so a server
- * advertising `threadAutoSettlement` can hold every shared key.
+ * Auto-settlement establishes baseline support; newer preferences are filtered separately.
  */
 export function supportsSharedSettingsSync(environment: {
   readonly connection: { readonly phase: EnvironmentConnectionPhase };
@@ -82,12 +94,15 @@ export interface SharedSettingsEnvironment {
   readonly label: string;
   readonly syncEligible: boolean;
   readonly settings: ServerSettings | null;
+  readonly capabilities?:
+    | Pick<ExecutionEnvironmentCapabilities, "threadRestartContinuation">
+    | undefined;
 }
 
 /**
  * Shared-settings sync targets whose values differ from the primary
  * environment's. Other environments are skipped: nothing can be read from or
- * written to them, or their server cannot hold every shared key. With no
+ * written to them, or their server lacks baseline shared-settings support. With no
  * primary settings loaded there is nothing to compare against, so nothing is
  * reported. Callers must pass the real loaded settings, never a default
  * fallback, or "apply to all" would push defaults over real values.
@@ -95,12 +110,18 @@ export interface SharedSettingsEnvironment {
 export function findSharedSettingsMismatches(input: {
   readonly primaryEnvironmentId: EnvironmentId | null;
   readonly primarySettings: ServerSettings | null;
+  readonly primaryCapabilities?:
+    | Pick<ExecutionEnvironmentCapabilities, "threadRestartContinuation">
+    | undefined;
   readonly environments: ReadonlyArray<SharedSettingsEnvironment>;
 }): ReadonlyArray<{ readonly environmentId: EnvironmentId; readonly label: string }> {
   if (input.primaryEnvironmentId === null || input.primarySettings === null) {
     return [];
   }
-  const expected = pickSharedServerSettings(input.primarySettings);
+  const primarySettings = pickSharedServerSettings(
+    input.primarySettings,
+    input.primaryCapabilities,
+  );
   return input.environments.flatMap((environment) => {
     if (
       environment.environmentId === input.primaryEnvironmentId ||
@@ -109,7 +130,11 @@ export function findSharedSettingsMismatches(input: {
     ) {
       return [];
     }
-    const actual = pickSharedServerSettings(environment.settings);
+    const expected = filterSharedServerPatch(primarySettings, environment.capabilities);
+    const actual = filterSharedServerPatch(
+      pickSharedServerSettings(environment.settings, environment.capabilities),
+      input.primaryCapabilities,
+    );
     return Equal.equals(actual, expected)
       ? []
       : [{ environmentId: environment.environmentId, label: environment.label }];

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -94,6 +94,8 @@ export const ExecutionEnvironmentCapabilities = Schema.Struct({
   threadSettlement: Schema.optionalKey(Schema.Boolean),
   /** Server evaluates merge and inactivity settlement without a client. */
   threadAutoSettlement: Schema.optionalKey(Schema.Boolean),
+  /** Server persists the opt-in for continuing interrupted threads after restarts. */
+  threadRestartContinuation: Schema.optionalKey(Schema.Boolean),
   /** Server understands thread.snooze / thread.unsnooze commands. Same
       version-skew contract as threadSettlement. */
   threadSnooze: Schema.optionalKey(Schema.Boolean),


### PR DESCRIPTION
Enabling "Continue threads after restarts" in desktop Settings saved only to the primary server, while remote updates read the remote server's disabled preference. The toggle now saves to local and connected supported servers, and existing mismatches use "Apply to all"; a capability check keeps older servers from receiving an unsupported key while preserving their other shared preferences.

Verified 141 focused tests, web/server/mobile/client-runtime typechecks, and scoped lint/format checks (existing lint warnings remain). In two isolated environments, toggling on/off persisted on both servers; disconnecting a remote, changing the preference, reconnecting, and applying to all resolved the mismatch. Native mobile runtime verification was not performed.

The 24-second capture samples actual preview frames while toggling off and on; both servers' persisted values were checked at each state.

![Restart continuation toggle off and on, verified on local and remote servers](https://uploads-production-47e4.up.railway.app/files/368482dd-3893-4c1f-a0a4-c88f35165ad5/restart-toggle.gif)

Unsupported-server warning verified without persisting a setting:

![Unsupported servers show setting not saved](https://uploads-production-47e4.up.railway.app/files/2ca9f04f-00ae-49b1-a11e-c45dae16a6b7/t3-restart-unsupported.png)

Model: `gpt-5.6-sol`; harness: Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-environment settings persistence and mismatch reconciliation; incorrect capability filtering could skip saves or hide drift, but scope is limited to one shared key with explicit version skew handling.
> 
> **Overview**
> **Continue threads after restarts** is now treated as a **shared server preference** like sidebar auto-settle, so toggling it propagates to all connected environments that support shared-settings sync instead of sticking on the primary only.
> 
> A new **`threadRestartContinuation`** environment capability gates whether `continueThreadsAfterServerUpdate` is included in sync, mismatch detection, and **Apply to all**. `filterSharedServerPatch` strips that key for older servers while other shared keys still sync; clients show a warning when no target can accept the restart preference. Web, mobile, settings copy, and user docs are updated to describe cross-environment behavior and upgrading older servers first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b71997160fc950ef21901fe2437e63c0cc19960e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter `continueThreadsAfterServerUpdate` by `threadRestartContinuation` capability in shared-settings sync
> - Adds `continueThreadsAfterServerUpdate` to `SHARED_SERVER_SETTING_KEYS` and introduces `filterSharedServerPatch` to omit the key when the target environment lacks `threadRestartContinuation` capability
> - Updates `findSharedSettingsMismatches` to compare restart-continuation values only when both primary and target advertise support, preventing false drift on mixed-capability setups
> - Propagates capability data through `useSharedSettingsSync`, `useUpdateSettingsTarget`, and `AutoSettleSettingsRows` so Apply-to-all sends a per-target filtered patch and surfaces an older-server warning when no target can accept the setting
> - Server advertises `threadRestartContinuation: true` via `ServerEnvironment.make`; docs and setting description text are updated accordingly
> - Risk: `pickSharedServerSettings` now takes an optional capability argument; callers that do not supply it will silently omit `continueThreadsAfterServerUpdate` from the selected shared settings — verify all callers in [sharedSettings.ts](https://github.com/pingdotgg/t3code/pull/9933/files#diff-38f5f180a1e6b08473997fcfd4ea833484eedc94dcfbe574949cee47cb522f70) and web/mobile hooks pass capabilities when the key is expected
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b719971.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

