### PR TITLE
fix(web): align tool disclosure chevrons with expanded state

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -3266,10 +3266,10 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
             )}
             aria-hidden
           >
-            <ChevronDownIcon
+            <ChevronRightIcon
               className={cn(
                 "size-3 shrink-0 text-icon-muted opacity-70 transition-transform duration-200",
-                expanded && "rotate-180",
+                expanded && "rotate-90",
               )}
             />
           </span>


### PR DESCRIPTION
collapsed tool rows pointed down and expanded rows pointed up. reuse the existing right chevron and rotate it down when expanded, preserving the control's action.

verified matching before and after views at 1280 × 800 and expanded an mcp row to confirm the down chevron and output. scoped lint, formatting, and the integrated evidence worktree's web typecheck passed; lint warnings are on unchanged lines.

![tool disclosure chevrons before](https://uploads-production-47e4.up.railway.app/files/aaafad6e-bf2b-476f-8406-e2006b0ea36d/issue-3584-before.png)

![tool disclosure chevrons after](https://uploads-production-47e4.up.railway.app/files/cd70131e-8e3f-47cd-b761-bcfc24c234c0/issue-3584-after.png)

![sampled live preview recording of tool output expanding and collapsing](https://uploads-production-47e4.up.railway.app/files/8ee847cc-3cdf-45de-a905-485e7dac66b1/issue-3584-interaction.gif)

fixes #3584.

implemented with `gpt-5.6-sol` in codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI/icon rotation in chat timeline tool rows with no logic or data changes.
> 
> **Overview**
> Expandable **tool/work log rows** in the chat timeline no longer use a down chevron that flips to up when open. They now use a **right chevron** that **rotates 90°** when expanded so collapsed reads as “closed” (→) and expanded as “open” (↓), matching the intended disclosure affordance.
> 
> Change is limited to the chevron icon and rotation class on those rows in `MessagesTimeline.tsx`; expand/collapse behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39657fdf2dfa9caa02593023c42e8d6b334aa830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix tool disclosure chevron direction in `PlainWorkEntryRow`
> Changes the expandable-entry indicator in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/9935/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) from a downward chevron with a 180° expanded rotation to a right-pointing chevron with a 90° expanded rotation. Collapsed rows now show a right arrow; expanded rows show a downward arrow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39657fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->