### PR TITLE
feat(desktop): open a configured local folder on startup

### DIFF
--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -721,16 +721,59 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
       }),
     );
 
-    it.effect("returns an empty listing when the OS denies directory access", () =>
+    for (const code of ["EACCES", "EPERM"]) {
+      it.effect(
+        `returns an empty picker listing for ${code} unless strict validation is enabled`,
+        () =>
+          Effect.gen(function* () {
+            const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+            const cwd = yield* makeTempDir({ prefix: "t3code-workspace-browse-denied-" });
+            const partialPath = yield* appendSeparator(cwd);
+            const denied = Object.assign(new Error(`${code}: permission denied`), { code });
+
+            vi.mocked(NodeFSP.readdir).mockRejectedValueOnce(denied);
+            const defaultResult = yield* workspaceEntries.browse({ partialPath });
+            expect(defaultResult).toEqual({ parentPath: cwd, entries: [] });
+
+            vi.mocked(NodeFSP.readdir).mockRejectedValueOnce(denied);
+            const nonStrictResult = yield* workspaceEntries.browse({
+              partialPath,
+              requireReadableDirectory: false,
+            });
+            expect(nonStrictResult).toEqual({ parentPath: cwd, entries: [] });
+          }),
+      );
+
+      it.effect(`rejects ${code} when directory readability is required`, () =>
+        Effect.gen(function* () {
+          const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+          const cwd = yield* makeTempDir({ prefix: "t3code-workspace-browse-strict-denied-" });
+          const partialPath = yield* appendSeparator(cwd);
+          const denied = Object.assign(new Error(`${code}: permission denied`), { code });
+          vi.mocked(NodeFSP.readdir).mockRejectedValueOnce(denied);
+
+          const error = yield* workspaceEntries
+            .browse({ partialPath, requireReadableDirectory: true })
+            .pipe(Effect.flip);
+
+          expect(error).toMatchObject({
+            _tag: "WorkspaceEntriesReadDirectoryError",
+            parentPath: cwd,
+            partialPath,
+            cause: denied,
+          });
+        }),
+      );
+    }
+
+    it.effect("accepts an empty readable directory when strict validation is enabled", () =>
       Effect.gen(function* () {
         const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
-        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-browse-eacces-" });
-
-        const denied = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
-        vi.mocked(NodeFSP.readdir).mockRejectedValueOnce(denied);
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-browse-strict-empty-" });
 
         const result = yield* workspaceEntries.browse({
           partialPath: yield* appendSeparator(cwd),
+          requireReadableDirectory: true,
         });
         expect(result).toEqual({ parentPath: cwd, entries: [] });
       }),

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -198,7 +198,9 @@ export const make = Effect.gen(function* () {
         Effect.catchIf(
           (error) => {
             const code = (error.cause as NodeJS.ErrnoException | undefined)?.code;
-            return code === "EACCES" || code === "EPERM";
+            return (
+              input.requireReadableDirectory !== true && (code === "EACCES" || code === "EPERM")
+            );
           },
           () => Effect.succeed([]),
         ),

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -574,6 +574,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin
         ? ["New worktrees start from origin"]
         : []),
+      ...(settings.openDefaultFolderOnStartup ? ["Open default folder on startup"] : []),
       ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
@@ -611,6 +612,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.composerCollapseOnBlur,
       settings.composerCollapseOnScroll,
       settings.addProjectBaseDirectory,
+      settings.openDefaultFolderOnStartup,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
       settings.diffIgnoreWhitespace,
@@ -733,6 +735,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       providerHealthRefreshInterval: DEFAULT_UNIFIED_SETTINGS.providerHealthRefreshInterval,
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+      openDefaultFolderOnStartup: DEFAULT_UNIFIED_SETTINGS.openDefaultFolderOnStartup,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
@@ -2627,6 +2630,28 @@ export function GeneralSettingsPanel() {
                 updateSettings({ newWorktreesStartFromOrigin: Boolean(checked) })
               }
               aria-label="Start new worktrees from origin by default"
+            />
+          }
+        />
+        <SettingsRow
+          serverScoped
+          {...searchableSetting("open-default-folder-on-startup")}
+          description="Open a local draft in the “Add project starts in” folder when this app starts. Saved only for this environment."
+          resetAction={
+            settings.openDefaultFolderOnStartup ? (
+              <SettingResetButton
+                label="open default folder on startup"
+                onClick={() => updateSettings({ openDefaultFolderOnStartup: false })}
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.openDefaultFolderOnStartup}
+              onCheckedChange={(checked) =>
+                updateSettings({ openDefaultFolderOnStartup: Boolean(checked) })
+              }
+              aria-label="Open default folder on startup"
             />
           }
         />

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -246,6 +246,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     searchTerms: ["new worktrees latest matching remote branch local"],
   },
   {
+    id: "open-default-folder-on-startup",
+    title: "Open default folder on startup",
+    to: "/settings/general",
+    searchTerms: ["launch restart reopen default local directory folder machine"],
+  },
+  {
     id: "add-project-starts-in",
     title: "Add project starts in",
     to: "/settings/general",

--- a/apps/web/src/lib/startupFolder.test.ts
+++ b/apps/web/src/lib/startupFolder.test.ts
@@ -1,0 +1,132 @@
+import type { EnvironmentProject } from "@t3tools/client-runtime/state/shell";
+import { EnvironmentId, ProjectId } from "@t3tools/contracts";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { resolveStartupFolderProject } from "./startupFolder";
+
+const primaryId = EnvironmentId.make("primary");
+const remoteId = EnvironmentId.make("remote");
+const folder = "/workspace/WIP";
+
+function project(
+  environmentId: EnvironmentId,
+  id: string,
+  workspaceRoot = folder,
+): EnvironmentProject {
+  return {
+    environmentId,
+    id: ProjectId.make(id),
+    title: "WIP",
+    workspaceRoot,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    repositoryIdentity: null,
+    defaultModelSelection: null,
+    scripts: [],
+  };
+}
+
+function dependencies(projects: EnvironmentProject[] = []) {
+  return {
+    environmentId: primaryId,
+    directory: folder,
+    browse: vi.fn(async (_partialPath: string) => ({ parentPath: folder })),
+    readProjects: () => projects,
+    createProject: vi.fn(async (_workspaceRoot: string) => ProjectId.make("created")),
+    waitForProject: vi.fn(async (): Promise<void> => undefined),
+  };
+}
+
+describe("resolveStartupFolderProject", () => {
+  it("reuses the primary environment project even when a remote project has the same path", async () => {
+    const deps = dependencies([project(remoteId, "remote-project"), project(primaryId, "local")]);
+
+    await expect(resolveStartupFolderProject(deps)).resolves.toEqual({
+      environmentId: primaryId,
+      projectId: "local",
+    });
+    expect(deps.createProject).not.toHaveBeenCalled();
+  });
+
+  it("matches a home-relative preference against the absolute path resolved by its server", async () => {
+    const deps = dependencies([project(primaryId, "local", "/home/developer/WIP/")]);
+    deps.directory = "  ~/WIP  ";
+    deps.browse.mockResolvedValue({ parentPath: "/home/developer/WIP" });
+
+    await expect(resolveStartupFolderProject(deps)).resolves.toEqual({
+      environmentId: primaryId,
+      projectId: "local",
+    });
+    expect(deps.browse).toHaveBeenCalledWith("~/WIP/");
+    expect(deps.createProject).not.toHaveBeenCalled();
+  });
+
+  it("uses the server's home directory when the configured folder is blank", async () => {
+    const deps = dependencies([project(primaryId, "home", "/home/developer")]);
+    deps.directory = "  ";
+    deps.browse.mockResolvedValue({ parentPath: "/home/developer" });
+
+    await expect(resolveStartupFolderProject(deps)).resolves.toEqual({
+      environmentId: primaryId,
+      projectId: "home",
+    });
+    expect(deps.browse).toHaveBeenCalledWith("~/");
+  });
+
+  it("creates an absent local project once and reuses it on the next startup", async () => {
+    const projects = [project(remoteId, "remote-project")];
+    const deps = dependencies(projects);
+    deps.waitForProject.mockImplementation(async () => {
+      if (!projects.some((entry) => entry.environmentId === primaryId)) {
+        projects.push(project(primaryId, "created"));
+      }
+    });
+
+    const first = await resolveStartupFolderProject(deps);
+    const second = await resolveStartupFolderProject(deps);
+
+    expect(first).toEqual({ environmentId: primaryId, projectId: "created" });
+    expect(second).toEqual(first);
+    expect(deps.createProject).toHaveBeenCalledExactlyOnceWith(folder);
+  });
+
+  it("does not create a project or return a navigation target when folder validation fails", async () => {
+    const deps = dependencies();
+    const failure = new Error("Directory does not exist");
+    deps.browse.mockRejectedValue(failure);
+    const navigate = vi.fn();
+
+    await expect(resolveStartupFolderProject(deps).then(navigate)).rejects.toBe(failure);
+    expect(deps.createProject).not.toHaveBeenCalled();
+    expect(deps.waitForProject).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("waits for the project to reach the client before returning its navigation target", async () => {
+    const deps = dependencies();
+    let releaseReceipt = () => {};
+    const receipt = new Promise<void>((resolve) => {
+      releaseReceipt = resolve;
+    });
+    let reportWaiting = () => {};
+    const waiting = new Promise<void>((resolve) => {
+      reportWaiting = resolve;
+    });
+    deps.waitForProject.mockImplementation(() => {
+      reportWaiting();
+      return receipt;
+    });
+    const navigate = vi.fn();
+    const result = resolveStartupFolderProject(deps).then(navigate);
+
+    await waiting;
+    expect(deps.createProject).toHaveBeenCalledExactlyOnceWith(folder);
+    expect(navigate).not.toHaveBeenCalled();
+    releaseReceipt();
+    await result;
+    expect(navigate).toHaveBeenCalledExactlyOnceWith({
+      environmentId: primaryId,
+      projectId: "created",
+    });
+  });
+});

--- a/apps/web/src/lib/startupFolder.test.ts
+++ b/apps/web/src/lib/startupFolder.test.ts
@@ -30,6 +30,7 @@ function dependencies(projects: EnvironmentProject[] = []) {
   return {
     environmentId: primaryId,
     directory: folder,
+    isCurrent: () => true,
     browse: vi.fn(async (_partialPath: string) => ({ parentPath: folder })),
     readProjects: () => projects,
     createProject: vi.fn(async (_workspaceRoot: string) => ProjectId.make("created")),
@@ -128,5 +129,61 @@ describe("resolveStartupFolderProject", () => {
       environmentId: primaryId,
       projectId: "created",
     });
+  });
+});
+
+describe("startup target changes", () => {
+  it("does not register the old folder when the primary changes during browsing", async () => {
+    const deps = dependencies();
+    let primary = primaryId;
+    deps.isCurrent = () => primary === primaryId;
+    let finishBrowse = (_value: { parentPath: string }) => {};
+    deps.browse.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishBrowse = resolve;
+        }),
+    );
+    const oldAttempt = resolveStartupFolderProject(deps);
+    primary = remoteId;
+    finishBrowse({ parentPath: folder });
+    await expect(oldAttempt).resolves.toBeNull();
+    expect(deps.createProject).not.toHaveBeenCalled();
+    expect(deps.waitForProject).not.toHaveBeenCalled();
+
+    const next = { ...dependencies([project(remoteId, "next")]), environmentId: remoteId };
+    await expect(resolveStartupFolderProject(next)).resolves.toEqual({
+      environmentId: remoteId,
+      projectId: "next",
+    });
+  });
+
+  it("does not return an old navigation target when the primary changes during projection", async () => {
+    const deps = dependencies([project(primaryId, "local")]);
+    let current = true;
+    deps.isCurrent = () => current;
+    let reportWaiting = () => {};
+    const waiting = new Promise<void>((resolve) => {
+      reportWaiting = resolve;
+    });
+    let finishProjection = () => {};
+    deps.waitForProject.mockImplementation(() => {
+      reportWaiting();
+      return new Promise<void>((resolve) => {
+        finishProjection = resolve;
+      });
+    });
+    const oldAttempt = resolveStartupFolderProject(deps);
+    await waiting;
+    current = false;
+    finishProjection();
+    await expect(oldAttempt).resolves.toBeNull();
+  });
+
+  it("skips work for an already superseded attempt", async () => {
+    const deps = { ...dependencies(), isCurrent: () => false };
+    await expect(resolveStartupFolderProject(deps)).resolves.toBeNull();
+    expect(deps.browse).not.toHaveBeenCalled();
+    expect(deps.createProject).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/startupFolder.ts
+++ b/apps/web/src/lib/startupFolder.ts
@@ -10,20 +10,24 @@ import type { EnvironmentId, ProjectId, ScopedProjectRef } from "@t3tools/contra
 export async function resolveStartupFolderProject(input: {
   environmentId: EnvironmentId;
   directory: string;
+  isCurrent: () => boolean;
   browse: (partialPath: string) => Promise<{ parentPath: string }>;
   readProjects: () => ReadonlyArray<EnvironmentProject>;
   createProject: (workspaceRoot: string) => Promise<ProjectId>;
   waitForProject: (projectRef: ScopedProjectRef) => Promise<unknown>;
-}): Promise<ScopedProjectRef> {
+}): Promise<ScopedProjectRef | null> {
+  if (!input.isCurrent()) return null;
   const { parentPath } = await input.browse(
     ensureBrowseDirectoryPath(input.directory.trim() || "~/"),
   );
+  if (!input.isCurrent()) return null;
   const existing = findProjectByPath(
     input.readProjects().filter((project) => project.environmentId === input.environmentId),
     parentPath,
   );
   const projectId = existing?.id ?? (await input.createProject(parentPath));
+  if (!input.isCurrent()) return null;
   const projectRef = scopeProjectRef(input.environmentId, projectId);
   await input.waitForProject(projectRef);
-  return projectRef;
+  return input.isCurrent() ? projectRef : null;
 }

--- a/apps/web/src/lib/startupFolder.ts
+++ b/apps/web/src/lib/startupFolder.ts
@@ -1,0 +1,29 @@
+import { scopeProjectRef } from "@t3tools/client-runtime/environment";
+import {
+  ensureBrowseDirectoryPath,
+  findProjectByPath,
+} from "@t3tools/client-runtime/state/projects";
+import type { EnvironmentProject } from "@t3tools/client-runtime/state/shell";
+import type { EnvironmentId, ProjectId, ScopedProjectRef } from "@t3tools/contracts";
+
+/** Resolve on the owning server before matching projects, including home-relative paths. */
+export async function resolveStartupFolderProject(input: {
+  environmentId: EnvironmentId;
+  directory: string;
+  browse: (partialPath: string) => Promise<{ parentPath: string }>;
+  readProjects: () => ReadonlyArray<EnvironmentProject>;
+  createProject: (workspaceRoot: string) => Promise<ProjectId>;
+  waitForProject: (projectRef: ScopedProjectRef) => Promise<unknown>;
+}): Promise<ScopedProjectRef> {
+  const { parentPath } = await input.browse(
+    ensureBrowseDirectoryPath(input.directory.trim() || "~/"),
+  );
+  const existing = findProjectByPath(
+    input.readProjects().filter((project) => project.environmentId === input.environmentId),
+    parentPath,
+  );
+  const projectId = existing?.id ?? (await input.createProject(parentPath));
+  const projectRef = scopeProjectRef(input.environmentId, projectId);
+  await input.waitForProject(projectRef);
+  return projectRef;
+}

--- a/apps/web/src/routes/_chat.index.tsx
+++ b/apps/web/src/routes/_chat.index.tsx
@@ -19,7 +19,10 @@ import {
   useProjects,
   useThreadShells,
 } from "../state/entities";
-import { useEnvironments, usePrimaryEnvironment } from "../state/environments";
+import { useEnvironments, useEnvironment, usePrimaryEnvironmentId } from "../state/environments";
+import type { EnvironmentId } from "@t3tools/contracts";
+import { appAtomRegistry } from "../rpc/atomRegistry";
+import { primaryEnvironmentIdAtom } from "../state/primaryEnvironment";
 import { APP_DISPLAY_NAME } from "~/branding";
 import { hasCloudPublicConfig } from "~/cloud/publicConfig";
 
@@ -47,19 +50,30 @@ function ChatIndexRouteView() {
 }
 
 function ConfiguredIndexLanding() {
+  const environmentId = usePrimaryEnvironmentId();
   const config = useAtomValue(primaryServerConfigAtom);
   // Schema defaults are not the saved preference. Wait for the owning server
   // before allowing the recent-project landing to navigate to another machine.
   if (!isHostedStaticApp() && config === null) return null;
-  return config?.settings.openDefaultFolderOnStartup ? (
-    <StartupFolderLanding directory={config.settings.addProjectBaseDirectory} />
+  return config?.settings.openDefaultFolderOnStartup && environmentId !== null ? (
+    <StartupFolderLanding
+      key={JSON.stringify([environmentId, config.settings.addProjectBaseDirectory])}
+      environmentId={environmentId}
+      directory={config.settings.addProjectBaseDirectory}
+    />
   ) : (
     <IndexDraftLanding />
   );
 }
 
-function StartupFolderLanding({ directory }: { directory: string }) {
-  const environment = usePrimaryEnvironment();
+function StartupFolderLanding({
+  directory,
+  environmentId,
+}: {
+  directory: string;
+  environmentId: EnvironmentId;
+}) {
+  const environment = useEnvironment(environmentId);
   const shell = useEnvironmentQuery(
     environment === null ? null : environmentShell.stateAtom(environment.environmentId),
   );
@@ -88,14 +102,21 @@ function StartupFolderLanding({ directory }: { directory: string }) {
 
   const start = useEffectEvent(async () => {
     if (!environment) return;
-    const environmentId = environment.environmentId;
     const requestingHref = router.state.location.href;
+    const isCurrent = () =>
+      mountedRef.current &&
+      appAtomRegistry.get(primaryEnvironmentIdAtom) === environmentId &&
+      router.state.location.href === requestingHref;
     try {
       const projectRef = await resolveStartupFolderProject({
         environmentId,
         directory,
+        isCurrent,
         browse: async (partialPath) => {
-          const result = await browse({ environmentId, input: { partialPath } });
+          const result = await browse({
+            environmentId,
+            input: { partialPath, requireReadableDirectory: true },
+          });
           if (result._tag === "Failure") throw squashAtomCommandFailure(result);
           return result.value;
         },
@@ -117,7 +138,7 @@ function StartupFolderLanding({ directory }: { directory: string }) {
         },
         waitForProject,
       });
-      if (!mountedRef.current || router.state.location.href !== requestingHref) return;
+      if (projectRef === null || !isCurrent()) return;
       await openThread(projectRef, {
         replace: true,
         envMode: "local",
@@ -126,7 +147,7 @@ function StartupFolderLanding({ directory }: { directory: string }) {
         startFromOrigin: false,
       });
     } catch {
-      if (mountedRef.current) setFailure(directory.trim() || "~/");
+      if (isCurrent()) setFailure(directory.trim() || "~/");
     }
   });
 

--- a/apps/web/src/routes/_chat.index.tsx
+++ b/apps/web/src/routes/_chat.index.tsx
@@ -1,7 +1,9 @@
+import { useAtomValue } from "@effect/atom-react";
+import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
 import { scopeProjectRef } from "@t3tools/client-runtime/environment";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
 import { LinkIcon, PlusIcon, RotateCcwIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 
 import { openCommandPalette } from "../commandPaletteBus";
 import { sortScopedProjectsForSidebar } from "../components/Sidebar.logic";
@@ -12,12 +14,26 @@ import { WorkspacePageHeader } from "../components/WorkspacePageHeader";
 import { useNewThreadHandler } from "../hooks/useHandleNewThread";
 import {
   useAllEnvironmentShellsBootstrapped,
+  readProjects,
+  waitForProject,
   useProjects,
   useThreadShells,
 } from "../state/entities";
-import { useEnvironments } from "../state/environments";
+import { useEnvironments, usePrimaryEnvironment } from "../state/environments";
 import { APP_DISPLAY_NAME } from "~/branding";
 import { hasCloudPublicConfig } from "~/cloud/publicConfig";
+
+import { isHostedStaticApp } from "../hostedPairing";
+import { primaryServerConfigAtom } from "../state/server";
+import { environmentShell } from "../state/shell";
+import { useEnvironmentQuery } from "../state/query";
+import { filesystemEnvironment } from "../state/filesystem";
+import { projectEnvironment } from "../state/projects";
+import { useAtomCommand } from "../state/use-atom-command";
+import { useAtomQueryRunner } from "../state/use-atom-query-runner";
+import { inferProjectTitleFromPath } from "../lib/projectPaths";
+import { newProjectId } from "../lib/utils";
+import { resolveStartupFolderProject } from "../lib/startupFolder";
 
 function ChatIndexRouteView() {
   const { authGateState } = Route.useRouteContext();
@@ -27,7 +43,127 @@ function ChatIndexRouteView() {
     return <HostedStaticOnboardingState />;
   }
 
-  return <IndexDraftLanding />;
+  return <ConfiguredIndexLanding />;
+}
+
+function ConfiguredIndexLanding() {
+  const config = useAtomValue(primaryServerConfigAtom);
+  // Schema defaults are not the saved preference. Wait for the owning server
+  // before allowing the recent-project landing to navigate to another machine.
+  if (!isHostedStaticApp() && config === null) return null;
+  return config?.settings.openDefaultFolderOnStartup ? (
+    <StartupFolderLanding directory={config.settings.addProjectBaseDirectory} />
+  ) : (
+    <IndexDraftLanding />
+  );
+}
+
+function StartupFolderLanding({ directory }: { directory: string }) {
+  const environment = usePrimaryEnvironment();
+  const shell = useEnvironmentQuery(
+    environment === null ? null : environmentShell.stateAtom(environment.environmentId),
+  );
+  const browse = useAtomQueryRunner(filesystemEnvironment.browse, {
+    reportFailure: false,
+    refresh: true,
+  });
+  const createProject = useAtomCommand(projectEnvironment.create, { reportFailure: false });
+  const openThread = useNewThreadHandler();
+  const router = useRouter();
+  const startedAttemptRef = useRef<number | null>(null);
+  const mountedRef = useRef(false);
+  const [failure, setFailure] = useState<string | null>(null);
+  const [retry, setRetry] = useState(0);
+  const ready =
+    environment?.connection.phase === "connected" &&
+    shell.data?.status === "live" &&
+    shell.data.snapshot._tag === "Some";
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const start = useEffectEvent(async () => {
+    if (!environment) return;
+    const environmentId = environment.environmentId;
+    const requestingHref = router.state.location.href;
+    try {
+      const projectRef = await resolveStartupFolderProject({
+        environmentId,
+        directory,
+        browse: async (partialPath) => {
+          const result = await browse({ environmentId, input: { partialPath } });
+          if (result._tag === "Failure") throw squashAtomCommandFailure(result);
+          return result.value;
+        },
+        readProjects,
+        createProject: async (workspaceRoot) => {
+          const projectId = newProjectId();
+          const result = await createProject({
+            environmentId,
+            input: {
+              projectId,
+              title: inferProjectTitleFromPath(workspaceRoot),
+              workspaceRoot,
+              createWorkspaceRootIfMissing: false,
+              defaultModelSelection: null,
+            },
+          });
+          if (result._tag === "Failure") throw squashAtomCommandFailure(result);
+          return projectId;
+        },
+        waitForProject,
+      });
+      if (!mountedRef.current || router.state.location.href !== requestingHref) return;
+      await openThread(projectRef, {
+        replace: true,
+        envMode: "local",
+        branch: null,
+        worktreePath: null,
+        startFromOrigin: false,
+      });
+    } catch {
+      if (mountedRef.current) setFailure(directory.trim() || "~/");
+    }
+  });
+
+  useEffect(() => {
+    if (!ready || startedAttemptRef.current === retry) return;
+    startedAttemptRef.current = retry;
+    void start();
+  }, [ready, retry]);
+
+  if (failure === null) return null;
+  return (
+    <SidebarInset className="h-dvh min-h-0 overflow-hidden bg-background text-foreground">
+      <Empty className="flex-1">
+        <EmptyHeader className="max-w-md">
+          <EmptyTitle>Couldn’t open the default folder</EmptyTitle>
+          <EmptyDescription>
+            Check that {failure} exists and is accessible on this environment, or change the startup
+            folder in General settings.
+          </EmptyDescription>
+          <div className="mt-5 flex justify-center gap-2">
+            <Button
+              size="sm"
+              onClick={() => {
+                setFailure(null);
+                setRetry((value) => value + 1);
+              }}
+            >
+              Try again
+            </Button>
+            <Button size="sm" variant="outline" render={<Link to="/settings/general" />}>
+              Open settings
+            </Button>
+          </div>
+        </EmptyHeader>
+      </Empty>
+    </SidebarInset>
+  );
 }
 
 /**

--- a/docs/user/project-settings.md
+++ b/docs/user/project-settings.md
@@ -16,3 +16,9 @@ upstream.
 T3 Code only pulls when it can fast-forward and the checkout has no changed files, untracked files,
 or local commits. It skips checkouts on another branch or without an upstream. If a checkout has
 local work, resolve it yourself before automatic pulls can resume.
+
+## Choose the folder opened at startup
+
+In **Settings → General → Projects & threads**, set **Add project starts in** to a folder on this environment and enable **Open default folder on startup**. The app opens a local draft in that folder when it starts, even if your most recent project was on another machine. An empty folder setting uses your home directory.
+
+The folder must already exist. If it becomes unavailable, you can retry or change the setting instead of opening a different project. The preference stays on the environment where you set it. Turn it off to return to opening the most recently active project. Explicit links to threads still open their requested destination.

--- a/packages/client-runtime/src/state/sharedSettings.test.ts
+++ b/packages/client-runtime/src/state/sharedSettings.test.ts
@@ -36,6 +36,14 @@ describe("supportsSharedSettingsSync", () => {
 });
 
 describe("splitSharedServerPatch", () => {
+  it("keeps startup folder preferences on their owning machine", () => {
+    const patch = { openDefaultFolderOnStartup: true, addProjectBaseDirectory: "~/WIP" };
+    expect(splitSharedServerPatch(patch)).toEqual({ sharedPatch: {}, localPatch: patch });
+    expect(pickSharedServerSettings({ ...DEFAULT_SERVER_SETTINGS, ...patch })).not.toHaveProperty(
+      "openDefaultFolderOnStartup",
+    );
+  });
+
   it("routes preference keys to the shared patch and machine keys to the local patch", () => {
     const { sharedPatch, localPatch } = splitSharedServerPatch({
       sidebarAutoSettleAfterDays: 7,
@@ -99,7 +107,12 @@ describe("findSharedSettingsMismatches", () => {
           environmentId: boxId,
           label: "Remote Box",
           syncEligible: true,
-          settings: { ...primarySettings, enableAgentBrowserAccess: false },
+          settings: {
+            ...primarySettings,
+            enableAgentBrowserAccess: false,
+            openDefaultFolderOnStartup: true,
+            addProjectBaseDirectory: "~/RemoteProjects",
+          },
         },
       ],
     });

--- a/packages/contracts/src/filesystem.test.ts
+++ b/packages/contracts/src/filesystem.test.ts
@@ -1,7 +1,29 @@
 import * as Schema from "effect/Schema";
 import { describe, expect, it } from "vite-plus/test";
 
-import { FilesystemBrowseError } from "./filesystem.ts";
+import { FilesystemBrowseError, FilesystemBrowseInput } from "./filesystem.ts";
+
+const decodeInput = Schema.decodeUnknownSync(FilesystemBrowseInput);
+const encodeInput = Schema.encodeSync(FilesystemBrowseInput);
+
+describe("FilesystemBrowseInput", () => {
+  it("keeps directory readability validation opt-in for existing clients", () => {
+    expect(decodeInput({ partialPath: "/workspace/" })).not.toHaveProperty(
+      "requireReadableDirectory",
+    );
+  });
+
+  it.each([true, false])("preserves readability validation mode %s across the wire", (required) => {
+    const input = { partialPath: "/workspace/", requireReadableDirectory: required };
+    expect(encodeInput(decodeInput(input))).toEqual(input);
+  });
+
+  it("rejects non-boolean readability validation modes", () => {
+    expect(() =>
+      decodeInput({ partialPath: "/workspace/", requireReadableDirectory: "true" }),
+    ).toThrow();
+  });
+});
 
 describe("FilesystemBrowseError", () => {
   it("derives a stable message from browse context while retaining the cause", () => {

--- a/packages/contracts/src/filesystem.ts
+++ b/packages/contracts/src/filesystem.ts
@@ -6,6 +6,8 @@ const FILESYSTEM_PATH_MAX_LENGTH = 512;
 export const FilesystemBrowseInput = Schema.Struct({
   partialPath: TrimmedNonEmptyString.check(Schema.isMaxLength(FILESYSTEM_PATH_MAX_LENGTH)),
   cwd: Schema.optional(TrimmedNonEmptyString.check(Schema.isMaxLength(FILESYSTEM_PATH_MAX_LENGTH))),
+  /** Fail on denied directory reads instead of returning an empty picker listing. */
+  requireReadableDirectory: Schema.optionalKey(Schema.Boolean),
 });
 export type FilesystemBrowseInput = typeof FilesystemBrowseInput.Type;
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -21,6 +21,32 @@ const decodeServerSettingsPatch = Schema.decodeUnknownSync(ServerSettingsPatch);
 const encodeServerSettings = Schema.encodeSync(ServerSettings);
 const decodeClaudeSettings = Schema.decodeUnknownSync(ClaudeSettings);
 
+describe("ServerSettings startup folder", () => {
+  it("preserves existing startup behavior when older settings omit the preference", () => {
+    expect(decodeServerSettings({}).openDefaultFolderOnStartup).toBe(false);
+    expect(DEFAULT_SERVER_SETTINGS.openDefaultFolderOnStartup).toBe(false);
+  });
+
+  it.each([true, false])("round-trips and patches the enabled state %s", (enabled) => {
+    const settings = decodeServerSettings({
+      openDefaultFolderOnStartup: enabled,
+      addProjectBaseDirectory: "~/WIP",
+    });
+    expect(decodeServerSettings(encodeServerSettings(settings))).toMatchObject({
+      openDefaultFolderOnStartup: enabled,
+      addProjectBaseDirectory: "~/WIP",
+    });
+    expect(decodeServerSettingsPatch({ openDefaultFolderOnStartup: enabled })).toEqual({
+      openDefaultFolderOnStartup: enabled,
+    });
+  });
+
+  it("leaves the preference unchanged for unrelated patches and rejects invalid values", () => {
+    expect(decodeServerSettingsPatch({})).not.toHaveProperty("openDefaultFolderOnStartup");
+    expect(() => decodeServerSettingsPatch({ openDefaultFolderOnStartup: "true" })).toThrow();
+  });
+});
+
 describe("ServerSettings usage price overrides", () => {
   const prices = { inputCostPerMillionTokens: 2, outputCostPerMillionTokens: 8 };
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -896,6 +896,9 @@ export const ServerSettings = Schema.Struct({
   newWorktreesStartFromOrigin: Schema.Boolean.pipe(
     Schema.withDecodingDefault(Effect.succeed(true)),
   ),
+  openDefaultFolderOnStartup: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(false)),
+  ),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   textGenerationModelSelection: ModelSelection.pipe(
     Schema.withDecodingDefault(
@@ -1125,6 +1128,7 @@ export const ServerSettingsPatch = Schema.Struct({
   environmentIcon: Schema.optionalKey(Schema.NullOr(EnvironmentMachineKind)),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
+  openDefaultFolderOnStartup: Schema.optionalKey(Schema.Boolean),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
   sourceControlWritingStyle: Schema.optionalKey(


### PR DESCRIPTION
## What Changed

Add an opt-in **Open default folder on startup** setting under General → Projects & threads. It uses **Add project starts in** to open a local draft on the primary environment, reusing the project or registering the existing directory. A missing directory shows Retry and Open settings without creating the folder or switching to another project. Disabling the setting restores the existing landing behavior, and explicit thread links retain their destination.

## Why

The landing page currently chooses the most recently active project across environments, so reopening the desktop app can land on a remote machine even when a preferred local folder is configured. The new preference stays on its owning environment and waits for its saved settings and live project snapshot before selecting a startup target.

Closes #9915.

## UI Changes

Before: “Add project starts in” only configures the folder browser. After: a separate startup toggle enables opening that folder when the app starts.

BEFORE:
<img width="878" height="217" alt="SCR-20260913-onld" src="https://github.com/user-attachments/assets/6a89e2ab-1592-473a-8587-8bab745d86ea" />

AFTER:
<img width="875" height="296" alt="SCR-20260913-oojp" src="https://github.com/user-attachments/assets/70b0ad8d-003c-40c3-b3bf-deb3e3fdf3ce" />

## Validation

- 150 focused tests passed for startup-folder resolution, primary-environment changes during in-flight work, strict directory-read failures, settings serialization, and machine-specific settings synchronization.
- Web and server package typechecks passed. Targeted lint completed with no errors; existing React warnings remain in the settings component and original index landing.
- Native macOS desktop checks covered missing-folder recovery, registration of an existing directory as a new project, enabled/disabled behavior, preference persistence, and full quit/relaunch into the configured folder.
- macOS ARM64 ZIP packaging passed. DMG packaging hit an existing `sips` SVG-background conversion failure; no packaging source changes were made.
- OpenClaw AutoReview loops 1 and 2 returned scoped-clean at P0/P1.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Implemented and verified with OpenAI GPT-6 Astra in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default chat index landing timing and navigation, and adds project creation on startup when the folder exists but has no project—bounded by strict browse validation and race guards.
> 
> **Overview**
> Adds an opt-in **Open default folder on startup** preference (machine-local, tied to **Add project starts in**) so the chat index can open a **local draft** in that folder on the primary environment instead of jumping to the most recently active project—often on another machine.
> 
> When enabled, the index waits for primary server settings and a live shell, then **`resolveStartupFolderProject`** resolves the path via browse, reuses or registers a project for the resolved directory, and navigates with history replace. Stale attempts are dropped if the primary environment or route changes mid-flight. Browse/validation failures surface **Try again** and a link to General settings without creating missing folders or falling back to another project.
> 
> Filesystem browse gains optional **`requireReadableDirectory`** so permission errors (`EACCES`/`EPERM`) fail strictly for startup validation while picker behavior stays unchanged by default. Settings UI, search, user docs, and contract/tests cover serialization and shared-settings routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f0aef1ebeb89edfacd751e0255060fd21f27cf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configured local folder opening on startup to desktop client
> - Adds `openDefaultFolderOnStartup` to the `ServerSettings` schema and a toggle in `GeneralSettingsPanel`, defaulting to `false`.
> - Introduces `StartupFolderLanding` and `resolveStartupFolderProject` to validate the configured folder, create or open a local project for it, and navigate to it.
> - Adds `requireReadableDirectory` to `FilesystemBrowseInput`. `WorkspaceEntries.browse` now returns errors for EACCES and EPERM when this flag is true instead of an empty listing.
> - Startup folder preferences are classified as local-only and excluded from shared server settings synchronization.
> - Risk: `WorkspaceEntries.browse` behavior changes for EACCES/EPERM when `requireReadableDirectory` is `true`; callers omitting this flag remain unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f0aef1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an “Open default folder on startup” setting under General → Projects & threads.
  - When enabled, the app opens the configured folder and creates a project when needed.
  - Added searchable settings support and improved onboarding and empty-project navigation.

- **Bug Fixes**
  - Folder access errors now surface when strict directory validation is enabled.

- **Documentation**
  - Documented startup folder behavior, unavailable folders, and project preference rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

