### PR TITLE
fix(web): keep chat media at a stable size while it loads

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1199,11 +1199,6 @@ function authoredImageSizeStyle(
   return undefined;
 }
 
-const CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME = cn(
-  CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME,
-  CHAT_MARKDOWN_MEDIA_LAYOUT_CLASS_NAME,
-  CHAT_MARKDOWN_MEDIA_FRAME_CLASS_NAME,
-);
 const MarkdownLinkContext = React.createContext(false);
 
 function expandableMarkdownImageProps(
@@ -1242,14 +1237,26 @@ function expandableMarkdownImageProps(
   };
 }
 
+function ChatMarkdownMediaUnavailableLabel(props: {
+  readonly alt: string;
+  readonly kind?: "image" | "video" | undefined;
+}) {
+  const label = props.kind === "video" ? "Video unavailable" : "Image unavailable";
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <TriangleAlertIcon aria-hidden className="size-3.5 shrink-0" />
+      {props.alt.length > 0 ? `${label} · ${props.alt}` : label}
+    </span>
+  );
+}
+
+/** Inline chip for sources that can never load, so nothing is waiting on a response. */
 function ChatMarkdownImageFallback(props: {
   readonly alt: string;
   readonly copyMarkdown?: string | undefined;
   readonly kind?: "image" | "video";
-  readonly actionsSource?: MediaActionSource;
 }) {
-  const label = props.kind === "video" ? "Video unavailable" : "Image unavailable";
-  const content = (
+  return (
     <span
       data-markdown-copy={props.copyMarkdown}
       className={cn(
@@ -1257,16 +1264,96 @@ function ChatMarkdownImageFallback(props: {
         "rounded-md border border-border/40 bg-muted/40 px-2 py-1 text-xs text-muted-foreground",
       )}
     >
-      <span className="inline-flex items-center gap-1.5">
-        <TriangleAlertIcon aria-hidden className="size-3.5 shrink-0" />
-        {props.alt.length > 0 ? `${label} · ${props.alt}` : label}
-      </span>
+      <ChatMarkdownMediaUnavailableLabel alt={props.alt} kind={props.kind} />
     </span>
   );
-  return props.actionsSource ? (
-    <MediaActions source={props.actionsSource}>{content}</MediaActions>
-  ) : (
-    content
+}
+
+const CHAT_MARKDOWN_IMAGE_FRAME_CLASS_NAME = cn(
+  "aspect-video w-full overflow-hidden bg-muted/60",
+  CHAT_MARKDOWN_MEDIA_MAX_WIDTH_CLASS_NAME,
+  CHAT_MARKDOWN_MEDIA_FRAME_CLASS_NAME,
+);
+
+/**
+ * Holds a 16:9 slot (or the authored size) until the image has decoded, and
+ * keeps that slot for the failure state, so a timeline row moves at most once:
+ * when the natural size arrives. A bare `<img>` is zero height until then.
+ */
+function ChatMarkdownImage(props: {
+  readonly src: string | null;
+  readonly sourceFailed?: boolean | undefined;
+  readonly alt: string;
+  readonly copyMarkdown: string | undefined;
+  readonly className?: string | undefined;
+  readonly style?: CSSProperties | undefined;
+  readonly actionsSource: MediaActionSource;
+  readonly originalUrl?: string | undefined;
+  readonly onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
+}) {
+  const [loaded, setLoaded] = useState(false);
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
+  const src = props.src;
+  const failed = props.sourceFailed === true || (src !== null && failedSrc === src);
+  // Once a size is known it stays; a re-signed URL for the same file must not
+  // drop the row back to the placeholder.
+  const settled = loaded && !failed;
+  // Cached images are complete before `onLoad` can fire.
+  const markLoadedIfComplete = useCallback((image: HTMLImageElement | null) => {
+    if (image?.complete && image.naturalWidth > 0) setLoaded(true);
+  }, []);
+
+  return (
+    <MediaActions source={props.actionsSource}>
+      <span
+        data-markdown-copy={props.copyMarkdown}
+        className={cn(
+          CHAT_MARKDOWN_MEDIA_LAYOUT_CLASS_NAME,
+          settled
+            ? props.onImageExpand && "cursor-zoom-in"
+            : cn(CHAT_MARKDOWN_IMAGE_FRAME_CLASS_NAME, "relative"),
+          props.className,
+        )}
+        style={settled ? undefined : props.style}
+        {...(failed
+          ? { role: "alert" as const }
+          : settled
+            ? expandableMarkdownImageProps(
+                props.onImageExpand,
+                src ?? "",
+                props.alt,
+                props.originalUrl,
+                props.actionsSource,
+              )
+            : { role: "status" as const, "aria-label": "Loading image" })}
+      >
+        {failed ? (
+          <span className="flex size-full items-center justify-center p-2 text-center text-xs text-muted-foreground">
+            <ChatMarkdownMediaUnavailableLabel alt={props.alt} />
+          </span>
+        ) : src !== null ? (
+          <img
+            ref={markLoadedIfComplete}
+            src={src}
+            alt={props.alt}
+            decoding="async"
+            draggable={false}
+            className={
+              settled
+                ? cn(
+                    "block!",
+                    CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME,
+                    CHAT_MARKDOWN_MEDIA_FRAME_CLASS_NAME,
+                  )
+                : "invisible absolute inset-0 size-full"
+            }
+            style={settled ? props.style : undefined}
+            onLoad={() => setLoaded(true)}
+            onError={() => setFailedSrc(src)}
+          />
+        ) : null}
+      </span>
+    </MediaActions>
   );
 }
 
@@ -1322,7 +1409,6 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
 }) {
   const assetUrl = useAssetUrlState(props.environmentId, props.resource);
   const refreshAssetUrl = useAssetUrlRefresh(props.environmentId, props.resource);
-  const [failedUrl, setFailedUrl] = useState<string | null>(null);
   const resource = props.resource;
   const path =
     resource._tag === "media-file"
@@ -1367,56 +1453,16 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
     );
   }
 
-  if (assetUrl._tag === "Failure" || (assetUrl._tag === "Success" && failedUrl === assetUrl.url)) {
-    return (
-      <ChatMarkdownImageFallback
-        alt={props.alt}
-        copyMarkdown={props.copyMarkdown}
-        kind={props.kind ?? "image"}
-        actionsSource={actionsSource}
-      />
-    );
-  }
-  if (assetUrl._tag !== "Success") {
-    return (
-      <MediaActions source={actionsSource}>
-        <span
-          data-markdown-copy={props.copyMarkdown}
-          role="status"
-          aria-label="Loading image"
-          className={cn(
-            CHAT_MARKDOWN_MEDIA_LAYOUT_CLASS_NAME,
-            "aspect-video w-64 max-w-full rounded-lg bg-muted/60",
-            CHAT_MARKDOWN_MEDIA_BOUNDS_CLASS_NAME,
-          )}
-          style={props.style}
-        />
-      </MediaActions>
-    );
-  }
   return (
-    <MediaActions source={actionsSource}>
-      <img
-        src={src ?? undefined}
-        alt={props.alt}
-        data-markdown-copy={props.copyMarkdown}
-        loading="lazy"
-        draggable={false}
-        className={cn(
-          CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME,
-          props.onImageExpand && "cursor-zoom-in",
-        )}
-        style={props.style}
-        {...expandableMarkdownImageProps(
-          props.onImageExpand,
-          src ?? assetUrl.url,
-          props.alt,
-          undefined,
-          actionsSource,
-        )}
-        onError={() => setFailedUrl(assetUrl.url)}
-      />
-    </MediaActions>
+    <ChatMarkdownImage
+      src={src}
+      sourceFailed={assetUrl._tag === "Failure"}
+      alt={props.alt}
+      copyMarkdown={props.copyMarkdown}
+      style={props.style}
+      actionsSource={actionsSource}
+      onImageExpand={props.onImageExpand}
+    />
   );
 });
 
@@ -2807,27 +2853,16 @@ const CHAT_MARKDOWN_COMPONENTS = {
         );
       }
       return (
-        <MediaActions source={actionsSource}>
-          <img
-            {...props}
-            src={mediaSrc}
-            alt={altText}
-            loading="lazy"
-            className={cn(
-              props.className,
-              CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME,
-              imageExpand && "cursor-zoom-in",
-            )}
-            style={authoredSizeStyle}
-            {...expandableMarkdownImageProps(
-              imageExpand,
-              mediaSrc,
-              altText,
-              originalUrl,
-              actionsSource,
-            )}
-          />
-        </MediaActions>
+        <ChatMarkdownImage
+          src={mediaSrc}
+          alt={altText}
+          copyMarkdown={copyMarkdown}
+          className={props.className}
+          style={authoredSizeStyle}
+          actionsSource={actionsSource}
+          originalUrl={originalUrl}
+          onImageExpand={imageExpand}
+        />
       );
     }
     if (imageSource._tag === "WorkspaceFile" && threadRef) {

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -372,7 +372,9 @@ function meaningfulHastChildren(node: MarkdownImageHastNode): MarkdownImageHastN
  */
 function markStandaloneImages(node: MarkdownImageHastNode) {
   const children = meaningfulHastChildren(node);
-  if (children.length === 1) {
+  // Only a block can make its image standalone; a link that wraps an image
+  // is still inline content of whatever block holds the link.
+  if (children.length === 1 && node.tagName !== "a") {
     let only = children[0];
     if (only?.type === "element" && only.tagName === "a") {
       const linkChildren = meaningfulHastChildren(only);

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -52,6 +52,7 @@ import React, {
   Children,
   Suspense,
   type CSSProperties,
+  type ComponentProps,
   type ClipboardEvent as ReactClipboardEvent,
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
@@ -1362,6 +1363,10 @@ function ChatMarkdownImage(props: {
   readonly standalone: boolean;
   readonly className?: string | undefined;
   readonly style?: CSSProperties | undefined;
+  /** Sanitized authored attributes (`id`, `align`, …) that fragment links and layout rely on. */
+  readonly imageProps?:
+    | Omit<ComponentProps<"img">, "src" | "alt" | "className" | "style">
+    | undefined;
   readonly actionsSource: MediaActionSource;
   readonly originalUrl?: string | undefined;
   readonly onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
@@ -1391,6 +1396,7 @@ function ChatMarkdownImage(props: {
     return (
       <MediaActions source={props.actionsSource}>
         <img
+          {...props.imageProps}
           ref={markLoadedIfComplete}
           src={src}
           alt={props.alt}
@@ -1424,6 +1430,7 @@ function ChatMarkdownImage(props: {
       />
     ) : (
       <span
+        id={props.imageProps?.id}
         data-markdown-copy={props.copyMarkdown}
         role="status"
         aria-label="Loading image"
@@ -1434,6 +1441,7 @@ function ChatMarkdownImage(props: {
   return (
     <MediaActions source={props.actionsSource}>
       <span
+        id={props.imageProps?.id}
         data-markdown-copy={props.copyMarkdown}
         className={cn(
           CHAT_MARKDOWN_MEDIA_LAYOUT_CLASS_NAME,
@@ -2940,7 +2948,8 @@ const CHAT_MARKDOWN_COMPONENTS = {
       typeof localSrc === "string" ? srcString.replaceAll("\\", "/") : srcString;
     const altText = alt ?? "";
     const copyMarkdown = markdownImageCopy(altText, srcString, authoredTitle);
-    const authoredSizeStyle = authoredImageSizeStyle(props.width, props.height);
+    const { className, style: _style, width, height, ...imageProps } = props;
+    const authoredSizeStyle = authoredImageSizeStyle(width, height);
     const imageSource = classifyMarkdownImageSource(classifiedSrc, imageBaseDir ?? cwd);
     const kind = mediaKindFromPath(classifiedSrc) ?? "image";
     if (imageSource._tag === "Direct") {
@@ -2973,8 +2982,9 @@ const CHAT_MARKDOWN_COMPONENTS = {
           alt={altText}
           copyMarkdown={copyMarkdown}
           standalone={standalone}
-          className={props.className}
+          className={className}
           style={authoredSizeStyle}
+          imageProps={imageProps}
           actionsSource={actionsSource}
           originalUrl={originalUrl}
           onImageExpand={imageExpand}

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -370,19 +370,36 @@ function meaningfulHastChildren(node: MarkdownImageHastNode): MarkdownImageHastN
  * in a sentence — stay inline at their natural size, since a placeholder taller
  * than the image would move the page more than the image itself does.
  */
-function markStandaloneImages(node: MarkdownImageHastNode) {
+/** Containers whose sole child image reads as a figure rather than part of a sentence. */
+const STANDALONE_IMAGE_BLOCKS = new Set([
+  "p",
+  "div",
+  "li",
+  "td",
+  "th",
+  "figure",
+  "center",
+  "blockquote",
+]);
+
+function soleImageDescendant(node: MarkdownImageHastNode): MarkdownImageHastNode | undefined {
   const children = meaningfulHastChildren(node);
-  // Only a block can make its image standalone; a link that wraps an image
-  // is still inline content of whatever block holds the link.
-  if (children.length === 1 && node.tagName !== "a") {
-    let only = children[0];
-    if (only?.type === "element" && only.tagName === "a") {
-      const linkChildren = meaningfulHastChildren(only);
-      only = linkChildren.length === 1 ? linkChildren[0] : undefined;
-    }
-    if (only?.type === "element" && only.tagName === "img") {
-      only.properties = { ...only.properties, dataStandalone: true };
-    }
+  if (children.length !== 1) return undefined;
+  const only = children[0];
+  if (only?.type !== "element") return undefined;
+  if (only.tagName === "img") return only;
+  // A link, emphasis, or similar inline wrapper around the image still counts
+  // as long as nothing else shares the block.
+  return only.tagName === "a" || only.tagName === "strong" || only.tagName === "em"
+    ? soleImageDescendant(only)
+    : undefined;
+}
+
+function markStandaloneImages(node: MarkdownImageHastNode) {
+  // A raw `<img>` on its own line reaches the root without a paragraph.
+  if (node.type === "root" || (node.tagName && STANDALONE_IMAGE_BLOCKS.has(node.tagName))) {
+    const image = soleImageDescendant(node);
+    if (image) image.properties = { ...image.properties, dataStandalone: true };
   }
   node.children?.forEach((child) => {
     if (child.type === "element") markStandaloneImages(child);

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -357,6 +357,36 @@ type MarkdownImageHastNode = {
   children?: MarkdownImageHastNode[];
 };
 
+function meaningfulHastChildren(node: MarkdownImageHastNode): MarkdownImageHastNode[] {
+  return (node.children ?? []).filter(
+    (child) => !(child.type === "text" && (child as { value?: string }).value?.trim() === ""),
+  );
+}
+
+/**
+ * An image that is the only content of its block (optionally wrapped in a
+ * link) is almost always a screenshot or figure, so it gets a reserved slot
+ * while it loads. Images mixed with text or other images — badge rows, icons
+ * in a sentence — stay inline at their natural size, since a placeholder taller
+ * than the image would move the page more than the image itself does.
+ */
+function markStandaloneImages(node: MarkdownImageHastNode) {
+  const children = meaningfulHastChildren(node);
+  if (children.length === 1) {
+    let only = children[0];
+    if (only?.type === "element" && only.tagName === "a") {
+      const linkChildren = meaningfulHastChildren(only);
+      only = linkChildren.length === 1 ? linkChildren[0] : undefined;
+    }
+    if (only?.type === "element" && only.tagName === "img") {
+      only.properties = { ...only.properties, dataStandalone: true };
+    }
+  }
+  node.children?.forEach((child) => {
+    if (child.type === "element") markStandaloneImages(child);
+  });
+}
+
 /** Carries authored image source metadata through the sanitizer to the image renderer. */
 function rehypePreserveImageSourceMeta() {
   return (tree: MarkdownImageHastNode) => {
@@ -374,6 +404,7 @@ function rehypePreserveImageSourceMeta() {
     };
 
     visit(tree);
+    markStandaloneImages(tree);
   };
 }
 
@@ -386,7 +417,12 @@ const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
     blockquote: [...(defaultSchema.attributes?.blockquote ?? []), "dataAlert"],
     div: [...(defaultSchema.attributes?.div ?? []), ...CODEX_ARTIFACT_TEMPLATE_HAST_PROPERTIES],
     a: [...(defaultSchema.attributes?.a ?? []), "dataPullRequestAutolink"],
-    img: [...(defaultSchema.attributes?.img ?? []), "dataLocalSrc", "dataMarkdownTitle"],
+    img: [
+      ...(defaultSchema.attributes?.img ?? []),
+      "dataLocalSrc",
+      "dataMarkdownTitle",
+      "dataStandalone",
+    ],
   },
   protocols: {
     ...defaultSchema.protocols,
@@ -1199,6 +1235,10 @@ function authoredImageSizeStyle(
   return undefined;
 }
 
+const CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME = cn(
+  CHAT_MARKDOWN_MEDIA_LAYOUT_CLASS_NAME,
+  CHAT_MARKDOWN_MEDIA_FRAME_CLASS_NAME,
+);
 const MarkdownLinkContext = React.createContext(false);
 
 function expandableMarkdownImageProps(
@@ -1250,13 +1290,14 @@ function ChatMarkdownMediaUnavailableLabel(props: {
   );
 }
 
-/** Inline chip for sources that can never load, so nothing is waiting on a response. */
+/** Inline chip for an image that sits in a line of text or can never load. */
 function ChatMarkdownImageFallback(props: {
   readonly alt: string;
   readonly copyMarkdown?: string | undefined;
   readonly kind?: "image" | "video";
+  readonly actionsSource?: MediaActionSource | undefined;
 }) {
-  return (
+  const content = (
     <span
       data-markdown-copy={props.copyMarkdown}
       className={cn(
@@ -1267,6 +1308,11 @@ function ChatMarkdownImageFallback(props: {
       <ChatMarkdownMediaUnavailableLabel alt={props.alt} kind={props.kind} />
     </span>
   );
+  return props.actionsSource ? (
+    <MediaActions source={props.actionsSource}>{content}</MediaActions>
+  ) : (
+    content
+  );
 }
 
 const CHAT_MARKDOWN_IMAGE_FRAME_CLASS_NAME = cn(
@@ -1276,15 +1322,20 @@ const CHAT_MARKDOWN_IMAGE_FRAME_CLASS_NAME = cn(
 );
 
 /**
- * Holds a 16:9 slot (or the authored size) until the image has decoded, and
- * keeps that slot for the failure state, so a timeline row moves at most once:
- * when the natural size arrives. A bare `<img>` is zero height until then.
+ * A standalone image holds a 16:9 slot (or its authored size) until it has
+ * decoded, and keeps that slot if it fails, so a timeline row moves at most
+ * once: when the natural size arrives. A bare `<img>` is zero height until
+ * then. Once decoded the image renders bare again so its box, hit area, and
+ * alignment are exactly the image's own. Inline images (badges, icons in a
+ * sentence) skip the slot: a placeholder taller than the image would move the
+ * page more than the image does.
  */
 function ChatMarkdownImage(props: {
   readonly src: string | null;
   readonly sourceFailed?: boolean | undefined;
   readonly alt: string;
   readonly copyMarkdown: string | undefined;
+  readonly standalone: boolean;
   readonly className?: string | undefined;
   readonly style?: CSSProperties | undefined;
   readonly actionsSource: MediaActionSource;
@@ -1295,37 +1346,77 @@ function ChatMarkdownImage(props: {
   const [failedSrc, setFailedSrc] = useState<string | null>(null);
   const src = props.src;
   const failed = props.sourceFailed === true || (src !== null && failedSrc === src);
-  // Once a size is known it stays; a re-signed URL for the same file must not
-  // drop the row back to the placeholder.
-  const settled = loaded && !failed;
+  // A decoded image keeps its box across a re-signed URL for the same file, so
+  // a periodic refresh never drops the row back to the placeholder; the browser
+  // keeps painting the old bitmap until the new one decodes. A failure clears
+  // that, so the next URL loads behind the slot again.
+  const settled = !failed && (!props.standalone || (loaded && failedSrc === null));
   // Cached images are complete before `onLoad` can fire.
   const markLoadedIfComplete = useCallback((image: HTMLImageElement | null) => {
     if (image?.complete && image.naturalWidth > 0) setLoaded(true);
   }, []);
 
+  if (src !== null && settled) {
+    return (
+      <MediaActions source={props.actionsSource}>
+        <img
+          ref={markLoadedIfComplete}
+          src={src}
+          alt={props.alt}
+          data-markdown-copy={props.copyMarkdown}
+          decoding="async"
+          draggable={false}
+          className={cn(
+            CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME,
+            props.className,
+            props.onImageExpand && "cursor-zoom-in",
+          )}
+          style={props.style}
+          {...expandableMarkdownImageProps(
+            props.onImageExpand,
+            src,
+            props.alt,
+            props.originalUrl,
+            props.actionsSource,
+          )}
+          onLoad={() => {
+            setLoaded(true);
+            setFailedSrc(null);
+          }}
+          onError={() => setFailedSrc(src)}
+        />
+      </MediaActions>
+    );
+  }
+  if (!props.standalone) {
+    return failed ? (
+      <ChatMarkdownImageFallback
+        alt={props.alt}
+        copyMarkdown={props.copyMarkdown}
+        actionsSource={props.actionsSource}
+      />
+    ) : (
+      <span
+        data-markdown-copy={props.copyMarkdown}
+        role="status"
+        aria-label="Loading image"
+        className={CHAT_MARKDOWN_MEDIA_LAYOUT_CLASS_NAME}
+      />
+    );
+  }
   return (
     <MediaActions source={props.actionsSource}>
       <span
         data-markdown-copy={props.copyMarkdown}
         className={cn(
           CHAT_MARKDOWN_MEDIA_LAYOUT_CLASS_NAME,
-          settled
-            ? props.onImageExpand && "cursor-zoom-in"
-            : cn(CHAT_MARKDOWN_IMAGE_FRAME_CLASS_NAME, "relative"),
-          props.className,
+          CHAT_MARKDOWN_IMAGE_FRAME_CLASS_NAME,
+          "relative",
         )}
-        style={settled ? undefined : props.style}
+        style={props.style}
         {...(failed
           ? { role: "alert" as const }
-          : settled
-            ? expandableMarkdownImageProps(
-                props.onImageExpand,
-                src ?? "",
-                props.alt,
-                props.originalUrl,
-                props.actionsSource,
-              )
-            : { role: "status" as const, "aria-label": "Loading image" })}
+          : { role: "status" as const, "aria-label": "Loading image" })}
       >
         {failed ? (
           <span className="flex size-full items-center justify-center p-2 text-center text-xs text-muted-foreground">
@@ -1338,17 +1429,11 @@ function ChatMarkdownImage(props: {
             alt={props.alt}
             decoding="async"
             draggable={false}
-            className={
-              settled
-                ? cn(
-                    "block!",
-                    CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME,
-                    CHAT_MARKDOWN_MEDIA_FRAME_CLASS_NAME,
-                  )
-                : "invisible absolute inset-0 size-full"
-            }
-            style={settled ? props.style : undefined}
-            onLoad={() => setLoaded(true)}
+            className="invisible absolute inset-0 size-full"
+            onLoad={() => {
+              setLoaded(true);
+              setFailedSrc(null);
+            }}
             onError={() => setFailedSrc(src)}
           />
         ) : null}
@@ -1403,6 +1488,8 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
   readonly alt: string;
   readonly copyMarkdown?: string;
   readonly srcFragment?: string;
+  /** Reserve a slot while loading; off for images that share a line with text. */
+  readonly standalone?: boolean | undefined;
   readonly style?: CSSProperties | undefined;
   readonly workspaceRoot?: string | undefined;
   readonly onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
@@ -1459,6 +1546,8 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
       sourceFailed={assetUrl._tag === "Failure"}
       alt={props.alt}
       copyMarkdown={props.copyMarkdown}
+      standalone={props.standalone ?? true}
+      className={CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME}
       style={props.style}
       actionsSource={actionsSource}
       onImageExpand={props.onImageExpand}
@@ -2818,6 +2907,7 @@ const CHAT_MARKDOWN_COMPONENTS = {
     const imageExpand = use(MarkdownLinkContext) ? undefined : expandMedia;
     const localSrc = node?.properties?.dataLocalSrc;
     const markdownTitle = node?.properties?.dataMarkdownTitle;
+    const standalone = node?.properties?.dataStandalone === true;
     const authoredSrc = typeof localSrc === "string" ? localSrc : src;
     const authoredTitle = typeof markdownTitle === "string" ? markdownTitle : title;
     const srcString =
@@ -2857,6 +2947,7 @@ const CHAT_MARKDOWN_COMPONENTS = {
           src={mediaSrc}
           alt={altText}
           copyMarkdown={copyMarkdown}
+          standalone={standalone}
           className={props.className}
           style={authoredSizeStyle}
           actionsSource={actionsSource}
@@ -2878,6 +2969,7 @@ const CHAT_MARKDOWN_COMPONENTS = {
           kind={kind}
           copyMarkdown={copyMarkdown}
           srcFragment={markdownImageSourceFragment(classifiedSrc)}
+          standalone={standalone}
           style={authoredSizeStyle}
           workspaceRoot={cwd}
           onImageExpand={imageExpand}

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1331,8 +1331,13 @@ const CHAT_MARKDOWN_IMAGE_FRAME_CLASS_NAME = cn(
  * alignment are exactly the image's own. Inline images (badges, icons in a
  * sentence) skip the slot: a placeholder taller than the image would move the
  * page more than the image does.
+ *
+ * Callers key this on the file's identity, not its URL: a re-signed URL for
+ * the same file keeps the decoded image on screen while the new bytes arrive,
+ * and a different file starts from the slot again.
  */
 function ChatMarkdownImage(props: {
+  /** Null while the URL is being resolved; the last decoded image stays up. */
   readonly src: string | null;
   readonly sourceFailed?: boolean | undefined;
   readonly alt: string;
@@ -1344,21 +1349,28 @@ function ChatMarkdownImage(props: {
   readonly originalUrl?: string | undefined;
   readonly onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
 }) {
-  const [loaded, setLoaded] = useState(false);
+  const [loadedSrc, setLoadedSrc] = useState<string | null>(null);
   const [failedSrc, setFailedSrc] = useState<string | null>(null);
-  const src = props.src;
+  const src = props.src ?? loadedSrc;
   const failed = props.sourceFailed === true || (src !== null && failedSrc === src);
-  // A decoded image keeps its box across a re-signed URL for the same file, so
-  // a periodic refresh never drops the row back to the placeholder; the browser
-  // keeps painting the old bitmap until the new one decodes. A failure clears
-  // that, so the next URL loads behind the slot again.
-  const settled = !failed && (!props.standalone || (loaded && failedSrc === null));
+  // A failure forgets the decoded image so the next URL loads behind the slot.
+  const settled = src !== null && !failed && (!props.standalone || loadedSrc !== null);
   // Cached images are complete before `onLoad` can fire.
   const markLoadedIfComplete = useCallback((image: HTMLImageElement | null) => {
-    if (image?.complete && image.naturalWidth > 0) setLoaded(true);
+    if (image?.complete && image.naturalWidth > 0) setLoadedSrc(image.currentSrc || image.src);
   }, []);
+  const imageEvents = (loadingSrc: string) => ({
+    onLoad: () => {
+      setLoadedSrc(loadingSrc);
+      setFailedSrc(null);
+    },
+    onError: () => {
+      setFailedSrc(loadingSrc);
+      setLoadedSrc(null);
+    },
+  });
 
-  if (src !== null && settled) {
+  if (settled) {
     return (
       <MediaActions source={props.actionsSource}>
         <img
@@ -1381,11 +1393,7 @@ function ChatMarkdownImage(props: {
             props.originalUrl,
             props.actionsSource,
           )}
-          onLoad={() => {
-            setLoaded(true);
-            setFailedSrc(null);
-          }}
-          onError={() => setFailedSrc(src)}
+          {...imageEvents(src)}
         />
       </MediaActions>
     );
@@ -1432,11 +1440,7 @@ function ChatMarkdownImage(props: {
             decoding="async"
             draggable={false}
             className="invisible absolute inset-0 size-full"
-            onLoad={() => {
-              setLoaded(true);
-              setFailedSrc(null);
-            }}
-            onError={() => setFailedSrc(src)}
+            {...imageEvents(src)}
           />
         ) : null}
       </span>
@@ -1544,6 +1548,7 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
 
   return (
     <ChatMarkdownImage
+      key={JSON.stringify([props.environmentId, props.resource, props.srcFragment])}
       src={src}
       sourceFailed={assetUrl._tag === "Failure"}
       alt={props.alt}
@@ -2946,6 +2951,7 @@ const CHAT_MARKDOWN_COMPONENTS = {
       }
       return (
         <ChatMarkdownImage
+          key={mediaSrc}
           src={mediaSrc}
           alt={altText}
           copyMarkdown={copyMarkdown}

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -238,6 +238,13 @@ describe("ChatMarkdown workspace images", () => {
     expect(render(markdown)).not.toContain("aspect-video");
   });
 
+  it("keeps an authored id on a remote image so fragment links resolve", () => {
+    const html = render('<img id="diagram" src="https://example.com/diagram.png" alt="diagram">');
+
+    // The sanitizer prefixes authored ids; the loading slot carries it too.
+    expect(html).toContain('<span id="user-content-diagram"');
+  });
+
   it("reserves a slot for an image that is alone in a list item", () => {
     expect(render("- ![shot](.t3/workspace-image.svg)")).toContain("aspect-video");
   });

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -231,10 +231,15 @@ describe("ChatMarkdown workspace images", () => {
     expect(html).toContain("aspect-video");
   });
 
-  it("keeps a linked image inline when text shares its line", () => {
-    const html = render("Figure: [![shot](.t3/workspace-image.svg)](https://example.com)");
+  it.each([
+    ["a link", "Figure: [![shot](.t3/workspace-image.svg)](https://example.com)"],
+    ["emphasis", "**![shot](.t3/workspace-image.svg)** caption"],
+  ])("keeps an image wrapped in %s inline when text shares its block", (_wrapper, markdown) => {
+    expect(render(markdown)).not.toContain("aspect-video");
+  });
 
-    expect(html).not.toContain("aspect-video");
+  it("reserves a slot for an image that is alone in a list item", () => {
+    expect(render("- ![shot](.t3/workspace-image.svg)")).toContain("aspect-video");
   });
 
   it("retains an authored SVG fragment on the signed URL", () => {

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -204,25 +204,31 @@ describe("ChatMarkdown workspace images", () => {
     expect(loadedStyle).toHaveProperty(constraint, expectedValue);
   });
 
-  it("keeps all images baseline-aligned and inline", () => {
+  it("keeps images that share a line inline and lets a standalone one reserve a slot", () => {
     const html = render(
       "![remote](https://example.com/badge.svg) ![workspace](.t3/workspace-image.svg)",
     );
-    const classNames = Array.from(
-      html.matchAll(/<span[^>]*class="([^"]*)"[^>]*role="status"/g),
-      (match) => match[1]?.split(" "),
-    );
 
-    expect(classNames).toHaveLength(2);
-    expect(classNames[0]).toContain("inline-block!");
-    expect(classNames[1]).toContain("inline-block!");
+    // Two images in one paragraph are badges: neither reserves a slot.
+    expect(html).not.toContain("aspect-video");
+    expect(html).toContain('src="https://example.com/badge.svg"');
+    expect(html).toContain('src="https://signed.test/workspace-image.svg"');
+    expect(html.match(/<img[^>]*class="[^"]*inline-block![^"]*"/g)).toHaveLength(1);
+    expect(html).not.toContain("invisible");
 
     const centeredHtml = render(
       '<p align="center"><img src=".t3/workspace-image.svg" alt="logo"></p>',
     );
-    const centeredClassName = /<span[^>]*class="([^"]*)"[^>]*role="status"/.exec(centeredHtml)?.[1];
+    const frame = /<span[^>]*role="status"[^>]*>/.exec(centeredHtml)?.[0];
 
-    expect(centeredClassName?.split(" ")).toContain("inline-block!");
+    expect(frame).toContain("inline-block!");
+    expect(frame).toContain("aspect-video");
+  });
+
+  it("reserves a slot for an image that is the only content of its link", () => {
+    const html = render("[![shot](.t3/workspace-image.svg)](https://example.com)");
+
+    expect(html).toContain("aspect-video");
   });
 
   it("retains an authored SVG fragment on the signed URL", () => {
@@ -282,8 +288,10 @@ describe("ChatMarkdown workspace images", () => {
   });
 
   it("reserves the same 16:9 frame while the URL, the bytes, and a failure resolve", () => {
-    const frameClassName = (html: string) =>
-      /<span[^>]*class="([^"]*)"[^>]*role="(?:status|alert)"/.exec(html)?.[1]?.split(" ") ?? [];
+    const frameClassName = (html: string) => {
+      const frame = /<span[^>]*role="(?:status|alert)"[^>]*>/.exec(html)?.[0] ?? "";
+      return /class="([^"]*)"/.exec(frame)?.[1]?.split(" ") ?? [];
+    };
     const markdown = "![shot](.t3/workspace-image.svg)";
 
     testState.assetState = "loading";
@@ -303,7 +311,7 @@ describe("ChatMarkdown workspace images", () => {
     expect(loadingBytes).not.toContain('loading="lazy"');
   });
 
-  it("gives remote images the same frame instead of a bare tag", () => {
+  it("gives a standalone remote image the same frame instead of a bare tag", () => {
     const html = render("![remote](https://example.com/shot.png)");
 
     expect(html).toContain('aria-label="Loading image"');

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -231,6 +231,12 @@ describe("ChatMarkdown workspace images", () => {
     expect(html).toContain("aspect-video");
   });
 
+  it("keeps a linked image inline when text shares its line", () => {
+    const html = render("Figure: [![shot](.t3/workspace-image.svg)](https://example.com)");
+
+    expect(html).not.toContain("aspect-video");
+  });
+
   it("retains an authored SVG fragment on the signed URL", () => {
     const html = render("![logo](icons.svg#logo)");
 

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -139,9 +139,10 @@ describe("ChatMarkdown workspace images", () => {
         path: "\\\\server\\share\\workspace-image.svg",
       },
     ]);
-    expect(html.match(/https:\/\/signed\.test\/workspace-image\.svg/g)).toHaveLength(4);
+    expect(html.match(/<img[^>]*src="https:\/\/signed\.test\/workspace-image\.svg"/g)).toHaveLength(
+      4,
+    );
     expect(html.match(/max-w-\[min\(100%,30rem\)\]/g)).toHaveLength(4);
-    expect(html.match(/max-h-\[30rem\]/g)).toHaveLength(4);
     expect(html).not.toContain("Image unavailable");
   });
 
@@ -203,21 +204,23 @@ describe("ChatMarkdown workspace images", () => {
     expect(loadedStyle).toHaveProperty(constraint, expectedValue);
   });
 
-  it("keeps all images baseline-aligned and workspace images inline", () => {
+  it("keeps all images baseline-aligned and inline", () => {
     const html = render(
       "![remote](https://example.com/badge.svg) ![workspace](.t3/workspace-image.svg)",
     );
-    const classNames = Array.from(html.matchAll(/<img[^>]*class="([^"]*)"/g), (match) =>
-      match[1]?.split(" "),
+    const classNames = Array.from(
+      html.matchAll(/<span[^>]*class="([^"]*)"[^>]*role="status"/g),
+      (match) => match[1]?.split(" "),
     );
 
     expect(classNames).toHaveLength(2);
+    expect(classNames[0]).toContain("inline-block!");
     expect(classNames[1]).toContain("inline-block!");
 
     const centeredHtml = render(
       '<p align="center"><img src=".t3/workspace-image.svg" alt="logo"></p>',
     );
-    const centeredClassName = /<img[^>]*class="([^"]*)"/.exec(centeredHtml)?.[1];
+    const centeredClassName = /<span[^>]*class="([^"]*)"[^>]*role="status"/.exec(centeredHtml)?.[1];
 
     expect(centeredClassName?.split(" ")).toContain("inline-block!");
   });
@@ -278,15 +281,33 @@ describe("ChatMarkdown workspace images", () => {
     );
   });
 
-  it("uses a static bounded-width placeholder while a signed asset URL loads", () => {
-    testState.assetState = "loading";
+  it("reserves the same 16:9 frame while the URL, the bytes, and a failure resolve", () => {
+    const frameClassName = (html: string) =>
+      /<span[^>]*class="([^"]*)"[^>]*role="(?:status|alert)"/.exec(html)?.[1]?.split(" ") ?? [];
+    const markdown = "![shot](.t3/workspace-image.svg)";
 
-    const html = render("![loading](.t3/workspace-image.svg)");
-    const className = /<span[^>]*aria-label="Loading image"[^>]*class="([^"]*)"/.exec(html)?.[1];
+    testState.assetState = "loading";
+    const loadingUrl = frameClassName(render(markdown));
+    testState.assetState = "success";
+    const loadingBytes = render(markdown);
+    testState.assetState = "failure";
+    const failure = render(markdown);
+
+    expect(loadingUrl).toEqual(expect.arrayContaining(["aspect-video", "w-full"]));
+    expect(loadingUrl).not.toContain("animate-pulse");
+    expect(frameClassName(loadingBytes)).toEqual(loadingUrl);
+    expect(frameClassName(failure)).toEqual(loadingUrl);
+    expect(failure).toContain("Image unavailable");
+    // The bytes are requested inside the frame but never paint at an unknown size.
+    expect(loadingBytes).toMatch(/<img[^>]*src="https:\/\/signed[^>]*class="invisible/);
+    expect(loadingBytes).not.toContain('loading="lazy"');
+  });
+
+  it("gives remote images the same frame instead of a bare tag", () => {
+    const html = render("![remote](https://example.com/shot.png)");
 
     expect(html).toContain('aria-label="Loading image"');
-    expect(html).not.toContain("animate-pulse");
-    expect(className?.split(" ")).toContain("w-64");
+    expect(html).toContain("aspect-video");
   });
 
   it("never passes a workspace source to a raw image when thread context is unavailable", () => {
@@ -313,7 +334,6 @@ describe("ChatMarkdown workspace images", () => {
     expect(testState.resources).toEqual([]);
     expect(html).toContain('src="https://example.com/image.png"');
     expect(html).toContain("max-w-[min(100%,30rem)]");
-    expect(html).toContain("max-h-[30rem]");
     expect(html).not.toContain("Image unavailable");
   });
 });

--- a/apps/web/src/components/media/MediaVideoPlayer.tsx
+++ b/apps/web/src/components/media/MediaVideoPlayer.tsx
@@ -129,7 +129,7 @@ export function MediaVideoPlayer({
           className={cn(
             // Same 16:9 slot as the loading and playing states, so a failed or
             // retried video does not move the rows below it.
-            "flex aspect-video min-h-28 w-full flex-col items-center justify-center gap-3 rounded-lg border border-border/40 bg-muted/40 p-4 text-center text-sm text-muted-foreground",
+            "flex aspect-video max-h-full min-h-28 w-full flex-col items-center justify-center gap-3 rounded-lg border border-border/40 bg-muted/40 p-4 text-center text-sm text-muted-foreground",
             stateClassName,
           )}
         >

--- a/apps/web/src/components/media/MediaVideoPlayer.tsx
+++ b/apps/web/src/components/media/MediaVideoPlayer.tsx
@@ -127,7 +127,9 @@ export function MediaVideoPlayer({
         <span
           role="alert"
           className={cn(
-            "flex min-h-28 flex-col items-center justify-center gap-3 rounded-lg border border-border/40 bg-muted/40 p-4 text-center text-sm text-muted-foreground",
+            // Same 16:9 slot as the loading and playing states, so a failed or
+            // retried video does not move the rows below it.
+            "flex aspect-video min-h-28 w-full flex-col items-center justify-center gap-3 rounded-lg border border-border/40 bg-muted/40 p-4 text-center text-sm text-muted-foreground",
             stateClassName,
           )}
         >


### PR DESCRIPTION
## Problem

Assistant markdown images in the chat timeline moved the rows below them two or three times while loading. Between the signed asset URL resolving and the bytes arriving, the `<img>` was zero height (the `w-64 aspect-video` placeholder only covered URL resolution), then it jumped to its natural size, and a failure swapped to a one-line chip. Remote `https://` images had no loading or error state at all. Both used `loading="lazy"`, which, since LegendList already virtualizes, deferred the fetch until the row was in the viewport, so the jump landed exactly where the user was looking rather than in the offscreen mount buffer. The video failure panel was `min-h-28` while its loading and playing states were 16:9.

## Fix

- A rehype pass marks an image **standalone** when it is the sole content of its block (paragraph, list item, cell, root), looking through inline wrappers like a link or emphasis. Standalone images are screenshots and figures; they reserve a 16:9 slot (or the authored `width`/`height`) through URL resolution *and* byte loading, host the `<img>` invisibly inside it until `onLoad`, and show the failure state in the same slot. Once decoded the image renders bare again, so its box, hit area, and alignment are exactly its own.
- Images that share a block with text or other images (badge rows, icons in a sentence) skip the slot and stay inline at natural size — a placeholder taller than a 20px badge would move the page more than the badge does.
- `decoding="async"` instead of `loading="lazy"`, so rows settle in LegendList's mount buffer before they scroll into view.
- The component tracks which URL decoded and callers key it on file identity: a re-signed URL for the same file swaps in behind the decoded bitmap, a null src during re-resolution keeps the last image up, a failure forgets it so the retry loads behind the slot, and a different file starts from the slot.
- `MediaVideoPlayer` failure panel takes the same `aspect-video` slot as its loading and playing states, capped at `max-h-full` so it cannot overflow the file preview pane.

Mobile's `ThreadMarkdownImage` already does fixed-frame-then-measure, so no change there.

## Evidence

Cold load of a seeded thread (3 badges, a linked figure beside text, landscape/portrait/wide workspace screenshots, a remote image, a missing file, a 404 remote image, a missing video) with image responses delayed 4 s, measured with a `layout-shift` PerformanceObserver armed before the timeline mounted.

| | Before | After |
|---|---|---|
| Content height while loading → loaded | 1448 → 2294 px | 2742 → 2953 px |
| Media layout-shift entries (CLS) | 6, total **0.497** | 1, total **0.013** |

The one remaining entry is the portrait screenshot growing past its 16:9 slot — the single shift the design accepts.

**While images load** — before: every image is a zero-height gap; after: standalone images hold their slot, the badge row and linked figure stay inline.

![Before/after while images load](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/dd50e0df20b849d2/t3-media-compare-loading.png)

**Settled** — badges and the linked figure are inline in both; failure states for a missing workspace file, a 404 remote image (previously a broken-image glyph), and a missing video now share the media slot.

![Before/after settled](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/419ac52581041551/t3-media-compare-settled.png)

**Recording** — side by side, same throttling.

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/968fc5e291327df4/t3-media-side-by-side.mp4

## Verification

- `vp test run` on `ChatMarkdown.workspace-images.test.tsx` (29 passed), `ChatMarkdown.test.tsx`, `MessagesTimeline.test.tsx`. New cases: slot classes identical across URL-loading, byte-loading, and failure; a standalone remote image gets the slot; two images in one paragraph stay inline; an image wrapped in a link or emphasis beside text stays inline; an image alone in a list item or a link gets the slot.
- `vp lint` and `vp run typecheck` clean for `apps/web`.
- In-browser: every decoded `<img>` is a direct child of its `<p>`/`<a>` with `vertical-align: middle`, no wrapper. A delayed URL swap on a decoded image held its box at 271 px for 272 consecutive frames before the new bytes decoded in place.

Model: Claude Fable 5 · Harness: Claude Code in T3 Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reserve stable 16:9 frames for `ChatMarkdown` images and `MediaVideoPlayer`
> - Adds HAST helpers in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/9938/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) to identify standalone Markdown images and marks them with a `dataStandalone` attribute.
> - Replaces direct image rendering with a stateful `ChatMarkdownImage` loader that reserves a 16:9 frame while loading or on failure.
> - Routes workspace-backed `ChatMarkdownAssetImage` through the shared loader so they use the same load-aware lifecycle.
> - Updates [MediaVideoPlayer.tsx](https://github.com/pingdotgg/t3code/pull/9938/files#diff-d9d57d4690c59dc19cf75a5391a407a03a2b3b9c4dec87cf593921fb70123c93) to use the same 16:9 layout for failed videos instead of a fixed minimum height.
> - Behavioral Change: Removes the old maximum-height class from workspace images; images sharing a block with text remain inline and keep their natural size.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d6472c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only markdown media rendering and layout; no auth, data, or API contract changes beyond allowed `dataStandalone` on sanitized images.
> 
> **Overview**
> Reduces **layout shift** in chat markdown by treating figure-like images differently from inline badges/icons.
> 
> A **rehype pass** tags images as `dataStandalone` when they are the only meaningful content in a block (paragraph, list item, cell, etc.), including when wrapped in a link or emphasis. **Standalone** images go through new **`ChatMarkdownImage`**, which holds a **16:9 frame** (or authored width/height) while the signed URL resolves, bytes decode, or load fails; the `<img>` loads invisibly inside the frame, then renders as a normal image once settled. **Inline** images in shared blocks skip the frame and keep natural sizing.
> 
> **`ChatMarkdownAssetImage`** and direct/remote image rendering delegate to **`ChatMarkdownImage`**, keyed on asset identity so re-signed URLs can swap without flashing; **`loading="lazy"`** is replaced with **`decoding="async"`**. **`MediaVideoPlayer`** failure UI uses the same **aspect-video** slot as loading/playback. Tests cover standalone vs inline heuristics and stable frames across loading and failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d6472c1c24411524483a8b3550c246d4bacaf6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->