### PR TITLE
refactor(shared): share changed-file parsing across activity consumers

### DIFF
--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -1,3 +1,4 @@
+import { extractActivityChangedFiles } from "@t3tools/shared/activityChangedFiles";
 import {
   ApprovalRequestId,
   isToolLifecycleItemType,
@@ -460,7 +461,7 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
       ? (activity.payload as Record<string, unknown>)
       : null;
   const commandPreview = extractToolCommand(payload);
-  const changedFiles = extractChangedFiles(payload);
+  const changedFiles = extractActivityChangedFiles(asRecord(payload?.data));
   const title = extractToolTitle(payload);
   const toolPresentation = extractToolActivityPresentation(payload);
   // Terminal task updates carry identity so they replace each child's progress row.
@@ -1195,70 +1196,6 @@ function extractWorkLogRequestKind(
     return payload.requestKind;
   }
   return requestKindFromRequestType(payload?.requestType) ?? undefined;
-}
-
-function pushChangedFile(target: string[], seen: Set<string>, value: unknown) {
-  const normalized = asTrimmedString(value);
-  if (!normalized || seen.has(normalized)) {
-    return;
-  }
-  seen.add(normalized);
-  target.push(normalized);
-}
-
-function collectChangedFiles(value: unknown, target: string[], seen: Set<string>, depth: number) {
-  if (depth > 4 || target.length >= 12) {
-    return;
-  }
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      collectChangedFiles(entry, target, seen, depth + 1);
-      if (target.length >= 12) {
-        return;
-      }
-    }
-    return;
-  }
-
-  const record = asRecord(value);
-  if (!record) {
-    return;
-  }
-
-  pushChangedFile(target, seen, record.path);
-  pushChangedFile(target, seen, record.filePath);
-  pushChangedFile(target, seen, record.relativePath);
-  pushChangedFile(target, seen, record.filename);
-  pushChangedFile(target, seen, record.newPath);
-  pushChangedFile(target, seen, record.oldPath);
-
-  for (const nestedKey of [
-    "item",
-    "result",
-    "input",
-    "data",
-    "changes",
-    "files",
-    "edits",
-    "patch",
-    "patches",
-    "operations",
-  ]) {
-    if (!(nestedKey in record)) {
-      continue;
-    }
-    collectChangedFiles(record[nestedKey], target, seen, depth + 1);
-    if (target.length >= 12) {
-      return;
-    }
-  }
-}
-
-function extractChangedFiles(payload: Record<string, unknown> | null): string[] {
-  const changedFiles: string[] = [];
-  const seen = new Set<string>();
-  collectChangedFiles(asRecord(payload?.data), changedFiles, seen, 0);
-  return changedFiles;
 }
 
 function compareActivityLifecycleRank(kind: string): number {

--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -1,3 +1,4 @@
+import { extractActivityChangedFiles } from "@t3tools/shared/activityChangedFiles";
 import type {
   OrchestrationEvent,
   OrchestrationThreadActivity,
@@ -17,68 +18,6 @@ function asTrimmedString(value: unknown): string | null {
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
-}
-
-function pushChangedFile(target: string[], seen: Set<string>, value: unknown): void {
-  const normalized = asTrimmedString(value);
-  if (!normalized || seen.has(normalized)) {
-    return;
-  }
-  seen.add(normalized);
-  target.push(normalized);
-}
-
-function collectChangedFiles(
-  value: unknown,
-  target: string[],
-  seen: Set<string>,
-  depth: number,
-): void {
-  if (depth > 4 || target.length >= 12) {
-    return;
-  }
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      collectChangedFiles(entry, target, seen, depth + 1);
-      if (target.length >= 12) {
-        return;
-      }
-    }
-    return;
-  }
-
-  const record = asRecord(value);
-  if (!record) {
-    return;
-  }
-
-  pushChangedFile(target, seen, record.path);
-  pushChangedFile(target, seen, record.filePath);
-  pushChangedFile(target, seen, record.relativePath);
-  pushChangedFile(target, seen, record.filename);
-  pushChangedFile(target, seen, record.newPath);
-  pushChangedFile(target, seen, record.oldPath);
-
-  for (const nestedKey of [
-    "item",
-    "result",
-    "input",
-    "data",
-    "changes",
-    "files",
-    "edits",
-    "patch",
-    "patches",
-    "operations",
-  ]) {
-    if (!(nestedKey in record)) {
-      continue;
-    }
-    collectChangedFiles(record[nestedKey], target, seen, depth + 1);
-    if (target.length >= 12) {
-      return;
-    }
-  }
 }
 
 function projectCommandData(data: Record<string, unknown>): Record<string, unknown> | undefined {
@@ -284,8 +223,7 @@ function projectMcpToolCallData(data: Record<string, unknown>): Record<string, u
     projectedData.kind = data.kind;
   }
 
-  const changedFiles: string[] = [];
-  collectChangedFiles(data, changedFiles, new Set<string>(), 0);
+  const changedFiles = extractActivityChangedFiles(data);
   if (changedFiles.length > 0) {
     projectedData.files = changedFiles.map((path) => ({ path }));
   }
@@ -395,8 +333,7 @@ export function projectActivityPayload(
     projectedData.imagePath = imagePath;
   }
 
-  const changedFiles: string[] = [];
-  collectChangedFiles(data, changedFiles, new Set<string>(), 0);
+  const changedFiles = extractActivityChangedFiles(data);
   if (changedFiles.length > 0) {
     // Both clients discover file names by walking objects with path-like keys.
     projectedData.files = changedFiles.map((path) => ({ path }));

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1,3 +1,4 @@
+import { extractActivityChangedFiles } from "@t3tools/shared/activityChangedFiles";
 import * as Option from "effect/Option";
 import * as Arr from "effect/Array";
 import * as Schema from "effect/Schema";
@@ -918,7 +919,7 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
       ? (activity.payload as Record<string, unknown>)
       : null;
   const commandPreview = extractToolCommand(payload);
-  const changedFiles = extractChangedFiles(payload);
+  const changedFiles = extractActivityChangedFiles(asRecord(payload?.data));
   const title = extractToolTitle(payload);
   const toolPresentation = extractToolActivityPresentation(payload);
   const isTaskActivity =
@@ -1678,70 +1679,6 @@ function extractWorkLogRequestKind(
     return payload.requestKind;
   }
   return requestKindFromRequestType(payload?.requestType) ?? undefined;
-}
-
-function pushChangedFile(target: string[], seen: Set<string>, value: unknown) {
-  const normalized = asTrimmedString(value);
-  if (!normalized || seen.has(normalized)) {
-    return;
-  }
-  seen.add(normalized);
-  target.push(normalized);
-}
-
-function collectChangedFiles(value: unknown, target: string[], seen: Set<string>, depth: number) {
-  if (depth > 4 || target.length >= 12) {
-    return;
-  }
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      collectChangedFiles(entry, target, seen, depth + 1);
-      if (target.length >= 12) {
-        return;
-      }
-    }
-    return;
-  }
-
-  const record = asRecord(value);
-  if (!record) {
-    return;
-  }
-
-  pushChangedFile(target, seen, record.path);
-  pushChangedFile(target, seen, record.filePath);
-  pushChangedFile(target, seen, record.relativePath);
-  pushChangedFile(target, seen, record.filename);
-  pushChangedFile(target, seen, record.newPath);
-  pushChangedFile(target, seen, record.oldPath);
-
-  for (const nestedKey of [
-    "item",
-    "result",
-    "input",
-    "data",
-    "changes",
-    "files",
-    "edits",
-    "patch",
-    "patches",
-    "operations",
-  ]) {
-    if (!(nestedKey in record)) {
-      continue;
-    }
-    collectChangedFiles(record[nestedKey], target, seen, depth + 1);
-    if (target.length >= 12) {
-      return;
-    }
-  }
-}
-
-function extractChangedFiles(payload: Record<string, unknown> | null): string[] {
-  const changedFiles: string[] = [];
-  const seen = new Set<string>();
-  collectChangedFiles(asRecord(payload?.data), changedFiles, seen, 0);
-  return changedFiles;
 }
 
 function compareActivitiesByOrder(

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./activityChangedFiles": {
+      "types": "./src/activityChangedFiles.ts",
+      "import": "./src/activityChangedFiles.ts"
+    },
     "./themePalettes": {
       "types": "./src/themePalettes.ts",
       "import": "./src/themePalettes.ts"

--- a/packages/shared/src/activityChangedFiles.ts
+++ b/packages/shared/src/activityChangedFiles.ts
@@ -1,0 +1,82 @@
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asTrimmedString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function pushChangedFile(target: string[], seen: Set<string>, value: unknown): void {
+  const normalized = asTrimmedString(value);
+  if (!normalized || seen.has(normalized)) {
+    return;
+  }
+  seen.add(normalized);
+  target.push(normalized);
+}
+
+function collectChangedFiles(
+  value: unknown,
+  target: string[],
+  seen: Set<string>,
+  depth: number,
+): void {
+  if (depth > 4 || target.length >= 12) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectChangedFiles(entry, target, seen, depth + 1);
+      if (target.length >= 12) {
+        return;
+      }
+    }
+    return;
+  }
+
+  const record = asRecord(value);
+  if (!record) {
+    return;
+  }
+
+  pushChangedFile(target, seen, record.path);
+  pushChangedFile(target, seen, record.filePath);
+  pushChangedFile(target, seen, record.relativePath);
+  pushChangedFile(target, seen, record.filename);
+  pushChangedFile(target, seen, record.newPath);
+  pushChangedFile(target, seen, record.oldPath);
+
+  for (const nestedKey of [
+    "item",
+    "result",
+    "input",
+    "data",
+    "changes",
+    "files",
+    "edits",
+    "patch",
+    "patches",
+    "operations",
+  ]) {
+    if (!(nestedKey in record)) {
+      continue;
+    }
+    collectChangedFiles(record[nestedKey], target, seen, depth + 1);
+    if (target.length >= 12) {
+      return;
+    }
+  }
+}
+
+/** Collects unique changed paths in payload order, with bounded recursion. */
+export function extractActivityChangedFiles(value: unknown): string[] {
+  const paths: string[] = [];
+  collectChangedFiles(value, paths, new Set<string>(), 0);
+  return paths;
+}


### PR DESCRIPTION
The server activity projection and the web and mobile work logs each maintain the same recursive changed-file parser. Any change to supported fields, traversal order, or limits currently needs three matching edits.

Move the parser into @t3tools/shared/activityChangedFiles and use it at all four call sites. Keep the existing trimming, deduplication, field order, recursion limits, and client payload guards. This removes about 100 lines overall without changing rendered output or wire contracts.

Validation: 197 existing tests passed across ActivityPayloadProjection, session-logic, and mobile threadActivity. Typechecks passed for shared, server, web, and mobile. Targeted lint and formatting passed. Checks used the repository's local Vite+ binary because the installed global CLI uses a different test runner version.

This covers server projection, web and desktop work logs, and mobile work logs. Provider adapters and connection modes continue using the same payloads.

Model: GPT-6. Harness: Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with existing test coverage; no API or wire contract changes, only deduplication of presentation logic.
> 
> **Overview**
> **Centralizes** recursive “changed file” path extraction in `@t3tools/shared/activityChangedFiles` as `extractActivityChangedFiles`, and **removes** the same ~80-line helpers from mobile `threadActivity`, web `session-logic`, and server `ActivityPayloadProjection`.
> 
> **Server** projection and **web/mobile** work logs now call the shared helper (clients still pass `payload.data`; projection passes tool `data` and maps results to `projectedData.files`). Parsing rules—path-like keys, nested field walk, dedup, depth cap, 12-file limit—are unchanged, so work-log display and slimmed activity payloads should match prior behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27d52481e928e488d8bd2858ea50116436876b8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract changed-file parsing into shared `activityChangedFiles` module
> - Adds `extractActivityChangedFiles` to a new shared package export, consolidating the recursive traversal, trimming, and deduplication logic that was duplicated across mobile, server, and web.
> - Removes the local `pushChangedFile`, `collectChangedFiles`, and `extractChangedFiles` helpers from [threadActivity.ts](https://github.com/pingdotgg/t3code/pull/9941/files#diff-a18e8ed6aa4a9d6b3d9e32ea2fa3034dfd7621b6af3d640ec1b95a8564c97eb5), [ActivityPayloadProjection.ts](https://github.com/pingdotgg/t3code/pull/9941/files#diff-debcaf6e868575f9d95bb6918b9983c3a8929d664039039b54e9e1c7ea3b4130), and [session-logic.ts](https://github.com/pingdotgg/t3code/pull/9941/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6); all three now call the shared extractor.
> - The shared traversal caps recursion at depth four and collects up to twelve unique paths, examining supported path fields and nested activity fields.
> - Risk: server-side projection in `projectMcpToolCallData` and `projectActivityPayload` previously used its own traversal; verify that the shared depth/count limits match the prior server behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 27d5248.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->