### PR TITLE
fix(web): avoid eager icon chunks in unbundled dev

### DIFF
--- a/apps/web/src/lucideOptimizer.test.ts
+++ b/apps/web/src/lucideOptimizer.test.ts
@@ -1,0 +1,138 @@
+// @effect-diagnostics nodeBuiltinImport:off - exercises real dependency optimization in disposable directories.
+import * as NodeChildProcess from "node:child_process";
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeURL from "node:url";
+import * as NodeUtil from "node:util";
+
+import { optimizeDeps, resolveConfig } from "vite-plus";
+import { expect, it } from "vite-plus/test";
+
+import webConfig from "../vite.config";
+
+const execFile = NodeUtil.promisify(NodeChildProcess.execFile);
+const webRoot = NodeURL.fileURLToPath(new URL("../", import.meta.url));
+
+async function optimizeIcons(withDynamic: boolean) {
+  const root = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3-lucide-optimizer-"));
+  try {
+    await NodeFSP.symlink(
+      NodePath.join(webRoot, "node_modules"),
+      NodePath.join(root, "node_modules"),
+      "junction",
+    );
+    await NodeFSP.writeFile(NodePath.join(root, "package.json"), '{"type":"module"}');
+    const entry = NodePath.join(root, "entry.ts");
+    await NodeFSP.writeFile(
+      entry,
+      'export { FolderCodeIcon } from "lucide-react";\n' +
+        (withDynamic ? 'export { DynamicIcon, iconNames } from "lucide-react/dynamic";\n' : ""),
+    );
+    const appConfig = await webConfig({ command: "serve", mode: "development" });
+    const config = await resolveConfig(
+      {
+        configFile: false,
+        envDir: false,
+        root,
+        cacheDir: NodePath.join(root, "cache"),
+        logLevel: "silent",
+        optimizeDeps: {
+          ...appConfig.optimizeDeps,
+          // Discover the real import combination without prebundling unrelated app dependencies.
+          include: [],
+          entries: [entry],
+        },
+      },
+      "serve",
+    );
+    const metadata = await optimizeDeps(config, true);
+    const iconEntry = metadata.optimized["lucide-react"]?.file;
+    if (!iconEntry) throw new Error("Lucide was not discovered by Vite");
+    const { stdout } = await execFile(process.execPath, [
+      "--input-type=module",
+      "-e",
+      `import { registerHooks } from "node:module";
+const entry = process.argv[1];
+const prefix = entry.slice(0, entry.lastIndexOf("/") + 1);
+const loaded = new Set();
+const hook = registerHooks({ load(url, context, nextLoad) {
+  if (url.startsWith(prefix)) loaded.add(url);
+  return nextLoad(url, context);
+} });
+const icons = await import(entry);
+hook.deregister();
+console.log(JSON.stringify({ modules: loaded.size, exports: Object.keys(icons).sort() }));`,
+      NodeURL.pathToFileURL(iconEntry).href,
+    ]);
+    return {
+      optimized: Object.keys(metadata.optimized),
+      ...(JSON.parse(stdout) as { modules: number; exports: string[] }),
+    };
+  } finally {
+    await NodeFSP.rm(root, { recursive: true, force: true });
+  }
+}
+
+it("does not split every static icon into an eager module when dynamic project icons are discovered", async () => {
+  const ordinary = await optimizeIcons(false);
+  const withDynamic = await optimizeIcons(true);
+
+  expect(withDynamic.modules).toBe(ordinary.modules);
+  expect(withDynamic.exports).toEqual(ordinary.exports);
+  expect(withDynamic.exports).toContain("FolderCodeIcon");
+  expect(withDynamic.optimized).toContain("lucide-react");
+  expect(withDynamic.optimized).not.toContain("lucide-react/dynamic");
+});
+
+it("keeps the unbundled dynamic registry lazy and resolves selected icons and aliases", async () => {
+  const dynamicEntry = NodeURL.fileURLToPath(
+    new URL("../node_modules/lucide-react/dynamic.mjs", import.meta.url),
+  );
+  const { stdout } = await execFile(process.execPath, [
+    "--input-type=module",
+    "-e",
+    `import { registerHooks } from "node:module";
+const iconLoads = new Set();
+const hook = registerHooks({ load(url, context, nextLoad) {
+  if (url.includes("/lucide-react/") && url.includes("/icons/")) iconLoads.add(url);
+  return nextLoad(url, context);
+} });
+const { DynamicIcon, iconNames, dynamicIconImports } = await import(process.argv[1]);
+const beforeSelection = iconLoads.size;
+const selected = [];
+for (const name of ["folder-code", "alarm-clock", "code-2"]) {
+  const icon = await dynamicIconImports[name]();
+  selected.push({ name, listed: iconNames.includes(name), displayName: icon.default.displayName,
+    nodeCount: icon.__iconNode.length });
+}
+hook.deregister();
+console.log(JSON.stringify({ beforeSelection, selected, iconLoads: [...iconLoads],
+  isForwardRef: DynamicIcon.$$typeof === Symbol.for("react.forward_ref"),
+  registryMatchesNames: JSON.stringify(iconNames) === JSON.stringify(Object.keys(dynamicIconImports)) }));`,
+    NodeURL.pathToFileURL(dynamicEntry).href,
+  ]);
+  const result = JSON.parse(stdout) as {
+    beforeSelection: number;
+    selected: { name: string; listed: boolean; displayName: string; nodeCount: number }[];
+    iconLoads: string[];
+    isForwardRef: boolean;
+    registryMatchesNames: boolean;
+  };
+
+  expect(result.beforeSelection).toBe(0);
+  expect(result.isForwardRef).toBe(true);
+  expect(result.registryMatchesNames).toBe(true);
+  expect(
+    result.selected.map(({ name, listed, displayName }) => ({ name, listed, displayName })),
+  ).toEqual([
+    { name: "folder-code", listed: true, displayName: "FolderCode" },
+    { name: "alarm-clock", listed: true, displayName: "AlarmClock" },
+    { name: "code-2", listed: true, displayName: "CodeXml" },
+  ]);
+  expect(result.selected.every(({ nodeCount }) => nodeCount > 0)).toBe(true);
+  expect(result.iconLoads.length).toBeGreaterThan(0);
+  expect(
+    result.iconLoads.every((url) => /\/(folder-code|alarm-clock|code-2|code-xml)\.js$/.test(url)),
+  ).toBe(true);
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -173,6 +173,9 @@ export default defineConfig(() => {
       tailwindPlugins(bundledDev),
     ],
     optimizeDeps: {
+      // Prebundling the dynamic registry splits the static icon barrel into
+      // thousands of eager chunks. Its native ESM imports can stay lazy.
+      exclude: ["lucide-react/dynamic"],
       include: [
         "@clerk/clerk-js",
         "@clerk/react/internal",


### PR DESCRIPTION
Closes [#9544](https://github.com/pingdotgg/t3code/issues/9544).

Discovering `lucide-react/dynamic` alongside ordinary Lucide imports makes the unbundled dev optimizer split the static icon barrel into thousands of eagerly imported modules. Exclude only that dynamic entry from prebundling so its existing native ESM imports stay lazy. This changes three config lines, with no dependency, icon API, UI, production-build, or bundled-dev changes.

## Verification

The regression test runs actual Vite dependency discovery and counts the emitted module graph with Node's ESM loader; it does not start a server or mock the optimizer.

| Check | Before | After |
| --- | --- | --- |
| Mandatory modules for the static Lucide entry in the isolated fixture | 1,674 | 1 |
| Full-app static Lucide import closure during an unbundled browser boot | 1,676 | 3 |
| Regression tests | Graph assertion fails (`1674` versus `1`); lazy-icon control passes | Both pass |

All 5,742 static export names are preserved. The dynamic registry loads no icon modules before selection; real `folder-code`, `alarm-clock`, and `code-2` alias imports resolve correctly. A focused production icon-build comparison produced byte-identical output before and after (1,671 chunks, 1,572,293 bytes); this was not a whole-app production build.

On head [307b29ec](https://github.com/pingdotgg/t3code/commit/307b29ec1ccd3b930f613200923b688346b18b54), based on [7a089b2b](https://github.com/pingdotgg/t3code/commit/7a089b2b2449c5c146e1a7d554a31e6d55924d3f):

- `vp test run src/lucideOptimizer.test.ts src/projectIconOptions.test.ts src/components/ProjectFavicon.test.tsx --maxWorkers=2`: 11 tests pass.
- Targeted lint, web `tsgo --noEmit`, and formatting checks pass.
- Chromium 152 on Linux, actual unbundled app: no raw icon modules before opening the picker; 24 default icons; searching `alarm clock` shows five matches; Violet selection saves; reopening and saving the Code2 alias works; resetting to Automatic works. The picker capture contained 47 successful requests, including 30 selected/matched raw icon modules and no optimizer icon chunks.

The browser used the same production exclusion and icon UI as this head; intervening main changes were outside the icon/Vite implementation. These are module-loading and behavior checks, not startup-speed measurements.

## Actual browser evidence

After: search and select a project icon.

![After: alarm clock search with five matching icons and a Violet selection](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/48e2d28268a53f6b/9544-after-alarm-selection.png)

After: the selected icon is saved on the disposable AuditProject.

![After: saved alarm-clock and Violet project icon](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d26ddd9852ce0435/9544-after-alarm-saved.png)

After: opening the icon picker and saving a project icon (14 seconds).

![After: actual project icon picker and save flow](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d102159a38b5e00a/9544-after-icon-flow.webm)

The before/after regression is the nonvisual import graph shown above; the UI is intentionally unchanged. No raw network captures are published.

## Limits

The original native Electron `ERR_INSUFFICIENT_RESOURCES` failure was not reproduced, so this does not close the issue or claim to fix every cause of it. Lucide 0.564.0's unbundled `dynamic.mjs` references a missing `dynamic.mjs.map`; Vite logs one source-map warning, while the actual picker requests and controls succeed. This PR does not alter that upstream packaging or suppress the warning.

## Human review required

All executed CI jobs, Bugbot, and Macroscope correctness/Effect checks passed on this head, with no unresolved code-review threads. Macroscope approvability is **NEUTRAL / not approved**, because the real-optimizer test adds an explained file-scoped `nodeBuiltinImport:off` diagnostic exemption. The repository's [approvability policy](https://github.com/pingdotgg/t3code/blob/307b29ec1ccd3b930f613200923b688346b18b54/.macroscope/approvability.md) requires human review for any new diagnostic suppression. This PR remains unmerged pending that decision; neutral is not treated as a passing approval.

GPT 6 Astra via Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only Vite `optimizeDeps` tuning plus regression tests; production builds and icon APIs are unchanged per PR verification.
> 
> **Overview**
> **Unbundled dev** was prebundling `lucide-react/dynamic` together with normal Lucide imports, which made Vite explode the static `lucide-react` barrel into ~1,600+ eagerly loaded modules. This PR **excludes only** `lucide-react/dynamic` from `optimizeDeps` so the dynamic registry keeps its native lazy ESM imports while static icons still prebundle as before.
> 
> Adds **`lucideOptimizer.test.ts`**, which runs real Vite dependency discovery in a disposable fixture and asserts the optimized module graph stays the same with or without dynamic imports, that `lucide-react/dynamic` is not prebundled, and that the unbundled dynamic entry loads icons lazily (including aliases like `code-2`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 307b29ec1ccd3b930f613200923b688346b18b54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude `lucide-react/dynamic` from Vite `optimizeDeps` prebundling
> - Prebundling `lucide-react/dynamic` forces Vite to create eager static-icon chunks; the subpath's native ESM imports stay lazy when excluded.
> - Adds [vite.config.ts](https://github.com/pingdotgg/t3code/pull/9943/files#diff-eea049695b0188b525a44f51269fe670485ed3e355f8cede185cafedec24d786) entry to `optimizeDeps.exclude` while keeping existing `optimizeDeps.include` entries.
> - Adds regression and behavior tests in [lucideOptimizer.test.ts](https://github.com/pingdotgg/t3code/pull/9943/files#diff-ac5bcec4335693da84f7a9ee4357eb15a44faf6d596bced1acaa3e0119c3a53d) that run isolated Vite optimization in a temp project and verify the dynamic registry loads no icon modules until icons are resolved.
> - Risk: removing `lucide-react/dynamic` from prebundling means dev servers must serve it as native ESM; browsers without native ESM import support in dev will fail to load the dynamic registry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 307b29e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
