### PR TITLE
feat(web): add an agent attention queue shortcut

### DIFF
--- a/apps/web/src/attentionQueue.test.ts
+++ b/apps/web/src/attentionQueue.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  resolveNextAttentionThreadKey,
+  resolveThreadAttention,
+  sortAttentionItems,
+} from "./attentionQueue";
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import { ThreadId, TurnId } from "@t3tools/contracts";
+
+function makeThread(overrides: Partial<EnvironmentThreadShell> = {}): EnvironmentThreadShell {
+  return {
+    id: ThreadId.make("thread-1"),
+    environmentId: "environment-1",
+    projectId: "project-1",
+    title: "Thread 1",
+    modelSelection: {} as EnvironmentThreadShell["modelSelection"],
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    branch: null,
+    worktreePath: null,
+    latestTurn: null,
+    createdAt: "2026-09-04T10:00:00.000Z",
+    updatedAt: "2026-09-04T10:00:00.000Z",
+    archivedAt: null,
+    settledOverride: null,
+    settledAt: null,
+    session: null,
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+    ...overrides,
+  } as EnvironmentThreadShell;
+}
+
+describe("thread attention queue", () => {
+  it("recognizes a completion newer than the last visit", () => {
+    const thread = makeThread({
+      latestTurn: {
+        turnId: TurnId.make("turn-1"),
+        state: "completed",
+        requestedAt: "2026-09-04T10:00:00.000Z",
+        startedAt: "2026-09-04T10:01:00.000Z",
+        completedAt: "2026-09-04T10:02:00.000Z",
+        assistantMessageId: null,
+      },
+      updatedAt: "2026-09-04T10:02:00.000Z",
+    });
+
+    expect(
+      resolveThreadAttention({
+        thread,
+        threadKey: "environment-1:thread-1",
+        lastVisitedAt: "2026-09-04T10:01:00.000Z",
+        acknowledgedAttentionKey: undefined,
+      })?.state,
+    ).toBe("ready");
+  });
+
+  it("keeps an acknowledged pending request out until its timestamp changes", () => {
+    const thread = makeThread({
+      hasPendingUserInput: true,
+      updatedAt: "2026-09-04T10:03:00.000Z",
+    });
+    const item = resolveThreadAttention({
+      thread,
+      threadKey: "environment-1:thread-1",
+      lastVisitedAt: undefined,
+      acknowledgedAttentionKey: "input:2026-09-04T10:03:00.000Z",
+    });
+
+    expect(item).toBeNull();
+  });
+
+  it("orders newest attention first and advances with wraparound", () => {
+    const items = sortAttentionItems(
+      [
+        resolveThreadAttention({
+          thread: makeThread({
+            id: ThreadId.make("old"),
+            updatedAt: "2026-09-04T10:01:00.000Z",
+            hasPendingUserInput: true,
+          }),
+          threadKey: "environment-1:old",
+          lastVisitedAt: undefined,
+          acknowledgedAttentionKey: undefined,
+        })!,
+        resolveThreadAttention({
+          thread: makeThread({
+            id: ThreadId.make("new"),
+            updatedAt: "2026-09-04T10:02:00.000Z",
+            hasPendingUserInput: true,
+          }),
+          threadKey: "environment-1:new",
+          lastVisitedAt: undefined,
+          acknowledgedAttentionKey: undefined,
+        })!,
+      ].filter(Boolean),
+    );
+
+    expect(items.map((item) => item.threadKey)).toEqual(["environment-1:new", "environment-1:old"]);
+    expect(resolveNextAttentionThreadKey({ items, currentThreadKey: "environment-1:old" })).toBe(
+      "environment-1:new",
+    );
+  });
+});

--- a/apps/web/src/attentionQueue.ts
+++ b/apps/web/src/attentionQueue.ts
@@ -1,0 +1,86 @@
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+
+export type ThreadAttentionState = "ready" | "input" | "approval" | "failed";
+
+export interface ThreadAttentionItem {
+  readonly thread: EnvironmentThreadShell;
+  readonly threadKey: string;
+  readonly state: ThreadAttentionState;
+  readonly occurredAt: string;
+  readonly attentionKey: string;
+}
+
+type AttentionInput = {
+  readonly thread: EnvironmentThreadShell;
+  readonly threadKey: string;
+  readonly lastVisitedAt: string | undefined;
+  readonly acknowledgedAttentionKey: string | undefined;
+};
+
+function isNewerTimestamp(candidate: string, reference: string | undefined): boolean {
+  if (!reference) return true;
+  const candidateMs = Date.parse(candidate);
+  const referenceMs = Date.parse(reference);
+  return Number.isNaN(referenceMs) || candidateMs > referenceMs;
+}
+
+function resolveAttentionState(thread: EnvironmentThreadShell): ThreadAttentionState | null {
+  if (thread.hasPendingApprovals) return "approval";
+  if (thread.hasPendingUserInput) return "input";
+  if (thread.session?.status === "error" || thread.latestTurn?.state === "error") {
+    return "failed";
+  }
+  if (thread.hasActionableProposedPlan || thread.latestTurn?.state === "completed") {
+    return "ready";
+  }
+  return null;
+}
+
+function resolveOccurredAt(thread: EnvironmentThreadShell, state: ThreadAttentionState): string {
+  if (state === "ready" && thread.latestTurn?.completedAt) {
+    return thread.latestTurn.completedAt;
+  }
+  return thread.updatedAt;
+}
+
+export function resolveThreadAttention(input: AttentionInput): ThreadAttentionItem | null {
+  const { thread, threadKey, lastVisitedAt, acknowledgedAttentionKey } = input;
+  if (thread.archivedAt !== null) return null;
+
+  const state = resolveAttentionState(thread);
+  if (!state) return null;
+
+  const occurredAt = resolveOccurredAt(thread, state);
+  const attentionKey = `${state}:${occurredAt}`;
+  if (attentionKey === acknowledgedAttentionKey) return null;
+
+  if (state === "ready" && !isNewerTimestamp(occurredAt, lastVisitedAt)) {
+    return null;
+  }
+
+  return { thread, threadKey, state, occurredAt, attentionKey };
+}
+
+export function sortAttentionItems(items: readonly ThreadAttentionItem[]): ThreadAttentionItem[] {
+  return [...items].toSorted(
+    (left, right) =>
+      Date.parse(right.occurredAt) - Date.parse(left.occurredAt) ||
+      left.threadKey.localeCompare(right.threadKey),
+  );
+}
+
+export function resolveNextAttentionThreadKey(input: {
+  readonly items: readonly ThreadAttentionItem[];
+  readonly currentThreadKey: string | null;
+}): string | null {
+  if (input.items.length === 0) return null;
+  if (input.currentThreadKey === null) return input.items[0]?.threadKey ?? null;
+
+  const currentIndex = input.items.findIndex((item) => item.threadKey === input.currentThreadKey);
+  if (currentIndex === -1) return input.items[0]?.threadKey ?? null;
+  return input.items[(currentIndex + 1) % input.items.length]?.threadKey ?? null;
+}
+
+export function attentionNotificationTitle(item: ThreadAttentionItem): string {
+  return `${item.state}: ${item.thread.title}`;
+}

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -45,6 +45,7 @@ import {
   useSidebarVisibility,
 } from "./ui/sidebar";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
+import { ThreadAttentionQueue } from "./ThreadAttentionQueue";
 
 const MACOS_TRAFFIC_LIGHTS_LEFT_INSET = "90px";
 
@@ -220,6 +221,7 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
 
   return (
     <PanelAnimationSuppressionProvider value={panelAnimationsSuppressed}>
+      <ThreadAttentionQueue />
       <SidebarProvider
         className="h-dvh! min-h-0!"
         data-panel-animations={routePanelAnimationsActive ? "true" : "false"}

--- a/apps/web/src/components/ThreadAttentionQueue.tsx
+++ b/apps/web/src/components/ThreadAttentionQueue.tsx
@@ -1,0 +1,205 @@
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { useAtomValue } from "@effect/atom-react";
+import { useNavigate, useLocation, useParams } from "@tanstack/react-router";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+
+import { useThreadShells } from "../state/entities";
+import { useUiStateStore } from "../uiStateStore";
+import { buildThreadRouteParams, resolveThreadRouteTarget } from "../threadRoutes";
+import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
+import { isTerminalFocused } from "../lib/terminalFocus";
+import { isCommandPaletteOpen } from "../commandPaletteBus";
+import {
+  attentionNotificationTitle,
+  resolveNextAttentionThreadKey,
+  resolveThreadAttention,
+  sortAttentionItems,
+  type ThreadAttentionItem,
+} from "../attentionQueue";
+import { primaryServerKeybindingsAtom } from "~/state/server";
+import { stackedThreadToast, toastManager } from "./ui/toast";
+
+function isTextEntryTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  return target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement;
+}
+
+function threadKeyFor(shell: EnvironmentThreadShell): string {
+  return scopedThreadKey(scopeThreadRef(shell.environmentId, shell.id));
+}
+
+function attentionItemsForThreads(
+  threads: readonly EnvironmentThreadShell[],
+  lastVisitedAtById: Readonly<Record<string, string>>,
+  acknowledgedById: Readonly<Record<string, string>>,
+): ThreadAttentionItem[] {
+  return sortAttentionItems(
+    threads.flatMap((thread) => {
+      const threadKey = threadKeyFor(thread);
+      const item = resolveThreadAttention({
+        thread,
+        threadKey,
+        lastVisitedAt: lastVisitedAtById[threadKey],
+        acknowledgedAttentionKey: acknowledgedById[threadKey],
+      });
+      return item ? [item] : [];
+    }),
+  );
+}
+
+function toastTypeForAttention(item: ThreadAttentionItem): "error" | "info" | "success" {
+  if (item.state === "failed") return "error";
+  if (item.state === "ready") return "success";
+  return "info";
+}
+
+export function ThreadAttentionQueue() {
+  const pathname = useLocation({ select: (location) => location.pathname });
+  const routeTarget = useParams({
+    strict: false,
+    select: (params) => resolveThreadRouteTarget(params),
+  });
+  const navigate = useNavigate();
+  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const threads = useThreadShells();
+  const lastVisitedAtById = useUiStateStore((state) => state.threadLastVisitedAtById);
+  const acknowledgedById = useUiStateStore((state) => state.threadAttentionAcknowledgedById);
+  const acknowledgeThreadAttention = useUiStateStore((state) => state.acknowledgeThreadAttention);
+  const currentThreadKey =
+    routeTarget?.kind === "server" ? scopedThreadKey(routeTarget.threadRef) : null;
+  const attentionItems = useMemo(
+    () => attentionItemsForThreads(threads, lastVisitedAtById, acknowledgedById),
+    [acknowledgedById, lastVisitedAtById, threads],
+  );
+  const attentionItemsByKey = useMemo(
+    () => new Map(attentionItems.map((item) => [item.threadKey, item] as const)),
+    [attentionItems],
+  );
+  const shortcutLabel = shortcutLabelForCommand(keybindings, "thread.nextAttention") ?? "⌥L";
+  const toastIdsByThreadKey = useRef(new Map<string, ReturnType<typeof toastManager.add>>());
+  const initializedRef = useRef(false);
+  const previousAttentionKeysRef = useRef(new Map<string, string>());
+
+  const openAttentionItem = useCallback(
+    (item: ThreadAttentionItem) => {
+      acknowledgeThreadAttention(item.threadKey, item.attentionKey);
+      void navigate({
+        to: "/$environmentId/$threadId",
+        params: buildThreadRouteParams(scopeThreadRef(item.thread.environmentId, item.thread.id)),
+      });
+    },
+    [acknowledgeThreadAttention, navigate],
+  );
+
+  useEffect(() => {
+    if (pathname.startsWith("/settings") || routeTarget?.kind !== "server") return;
+    const item = attentionItemsByKey.get(currentThreadKey ?? "");
+    if (item) acknowledgeThreadAttention(item.threadKey, item.attentionKey);
+  }, [
+    acknowledgeThreadAttention,
+    attentionItemsByKey,
+    currentThreadKey,
+    pathname,
+    routeTarget?.kind,
+  ]);
+
+  useEffect(() => {
+    const currentKeys = new Set(attentionItemsByKey.keys());
+    for (const [threadKey, toastId] of toastIdsByThreadKey.current) {
+      if (!currentKeys.has(threadKey)) {
+        toastManager.close(toastId);
+        toastIdsByThreadKey.current.delete(threadKey);
+      }
+    }
+
+    const previousAttentionKeys = previousAttentionKeysRef.current;
+    if (initializedRef.current) {
+      for (const item of attentionItems) {
+        const previousKey = previousAttentionKeys.get(item.threadKey);
+        if (previousKey === item.attentionKey || item.threadKey === currentThreadKey) continue;
+
+        const toast = stackedThreadToast({
+          type: toastTypeForAttention(item),
+          title: attentionNotificationTitle(item),
+          description: `${shortcutLabel} to review next`,
+          timeout: 0,
+          data: {
+            onClose: () => acknowledgeThreadAttention(item.threadKey, item.attentionKey),
+          },
+          actionProps: {
+            children: "Open",
+            onClick: () => openAttentionItem(item),
+          },
+        });
+        const existingToastId = toastIdsByThreadKey.current.get(item.threadKey);
+        if (existingToastId) {
+          toastManager.update(existingToastId, toast);
+        } else {
+          toastIdsByThreadKey.current.set(item.threadKey, toastManager.add(toast));
+        }
+      }
+    }
+
+    previousAttentionKeysRef.current = new Map(
+      attentionItems.map((item) => [item.threadKey, item.attentionKey]),
+    );
+    initializedRef.current = true;
+  }, [
+    acknowledgeThreadAttention,
+    attentionItems,
+    attentionItemsByKey,
+    currentThreadKey,
+    openAttentionItem,
+    shortcutLabel,
+  ]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.defaultPrevented ||
+        event.repeat ||
+        event.key === "Unidentified" ||
+        isCommandPaletteOpen() ||
+        isTerminalFocused() ||
+        isTextEntryTarget(event.target) ||
+        pathname.startsWith("/settings") ||
+        routeTarget?.kind !== "server"
+      ) {
+        return;
+      }
+      if (
+        resolveShortcutCommand(event, keybindings, {
+          context: { terminalFocus: false, terminalOpen: false },
+        }) !== "thread.nextAttention"
+      ) {
+        return;
+      }
+
+      const targetKey = resolveNextAttentionThreadKey({
+        items: attentionItems,
+        currentThreadKey,
+      });
+      const target = targetKey ? attentionItemsByKey.get(targetKey) : undefined;
+      if (!target) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      openAttentionItem(target);
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [
+    attentionItems,
+    attentionItemsByKey,
+    currentThreadKey,
+    keybindings,
+    openAttentionItem,
+    pathname,
+    routeTarget?.kind,
+  ]);
+
+  return null;
+}

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -24,6 +24,7 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
     projectOrder: [],
     sidebarProjectScopeKey: null,
     threadLastVisitedAtById: {},
+    threadAttentionAcknowledgedById: {},
     threadChangedFilesExpandedById: {},
     defaultAdvertisedEndpointKey: null,
     ...overrides,
@@ -187,6 +188,7 @@ describe("parsePersistedState", () => {
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },
+      threadAttentionAcknowledgedById: {},
       defaultAdvertisedEndpointKey: "desktop-core:lan:http",
       sidebarProjectScopeKey: null,
       threadChangedFilesExpandedById: {
@@ -308,6 +310,7 @@ describe("uiStateStore persistence", () => {
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },
+      threadAttentionAcknowledgedById: {},
       defaultAdvertisedEndpointKey: "desktop-core:lan:http",
       sidebarProjectScopeKey: null,
       threadChangedFilesExpansionVersion: 2,

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -22,6 +22,7 @@ export interface PersistedUiState {
   projectExpandedById?: Record<string, boolean>;
   projectOrder?: string[];
   threadLastVisitedAtById?: Record<string, string>;
+  threadAttentionAcknowledgedById?: Record<string, string>;
   collapsedProjectCwds?: string[];
   expandedProjectCwds?: string[];
   projectOrderCwds?: string[];
@@ -42,6 +43,7 @@ export interface UiProjectState {
 
 export interface UiThreadState {
   threadLastVisitedAtById: Record<string, string>;
+  threadAttentionAcknowledgedById: Record<string, string>;
   threadChangedFilesExpandedById: Record<string, Record<string, boolean>>;
 }
 
@@ -56,6 +58,7 @@ const initialState: UiState = {
   projectOrder: [],
   sidebarProjectScopeKey: null,
   threadLastVisitedAtById: {},
+  threadAttentionAcknowledgedById: {},
   threadChangedFilesExpandedById: {},
   defaultAdvertisedEndpointKey: null,
 };
@@ -109,6 +112,18 @@ function sanitizeTimestampRecord(value: unknown): Record<string, string> {
   );
 }
 
+function sanitizeStringRecord(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] =>
+        entry[0].length > 0 && typeof entry[1] === "string" && entry[1].length > 0,
+    ),
+  );
+}
+
 export function parsePersistedState(parsed: PersistedUiState): UiState {
   const projectExpandedById =
     parsed.projectExpandedById === undefined
@@ -137,6 +152,7 @@ export function parsePersistedState(parsed: PersistedUiState): UiState {
     projectExpandedById,
     projectOrder,
     threadLastVisitedAtById: sanitizeTimestampRecord(parsed.threadLastVisitedAtById),
+    threadAttentionAcknowledgedById: sanitizeStringRecord(parsed.threadAttentionAcknowledgedById),
     threadChangedFilesExpandedById:
       parsed.threadChangedFilesExpansionVersion === THREAD_CHANGED_FILES_EXPANSION_VERSION
         ? sanitizePersistedThreadChangedFilesExpanded(parsed.threadChangedFilesExpandedById)
@@ -212,6 +228,7 @@ export function persistState(state: UiState): void {
         projectExpandedById,
         projectOrder: state.projectOrder,
         threadLastVisitedAtById: state.threadLastVisitedAtById,
+        threadAttentionAcknowledgedById: state.threadAttentionAcknowledgedById,
         defaultAdvertisedEndpointKey: state.defaultAdvertisedEndpointKey,
         sidebarProjectScopeKey: state.sidebarProjectScopeKey,
         threadChangedFilesExpansionVersion: THREAD_CHANGED_FILES_EXPANSION_VERSION,
@@ -250,6 +267,23 @@ export function markThreadVisited(state: UiState, threadId: string, visitedAt: s
     threadLastVisitedAtById: {
       ...state.threadLastVisitedAtById,
       [threadId]: visitedAt,
+    },
+  };
+}
+
+export function acknowledgeThreadAttention(
+  state: UiState,
+  threadId: string,
+  attentionKey: string,
+): UiState {
+  if (!attentionKey || state.threadAttentionAcknowledgedById[threadId] === attentionKey) {
+    return state;
+  }
+  return {
+    ...state,
+    threadAttentionAcknowledgedById: {
+      ...state.threadAttentionAcknowledgedById,
+      [threadId]: attentionKey,
     },
   };
 }
@@ -403,6 +437,7 @@ export function reorderProjects(
 
 interface UiStateStore extends UiState {
   markThreadVisited: (threadId: string, visitedAt: string) => void;
+  acknowledgeThreadAttention: (threadId: string, attentionKey: string) => void;
   markThreadUnread: (threadId: string, latestTurnCompletedAt: string | null | undefined) => void;
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
   setDefaultAdvertisedEndpointKey: (key: string | null) => void;
@@ -419,6 +454,8 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
   ...readPersistedState(),
   markThreadVisited: (threadId, visitedAt) =>
     set((state) => markThreadVisited(state, threadId, visitedAt)),
+  acknowledgeThreadAttention: (threadId, attentionKey) =>
+    set((state) => acknowledgeThreadAttention(state, threadId, attentionKey)),
   markThreadUnread: (threadId, latestTurnCompletedAt) =>
     set((state) => markThreadUnread(state, threadId, latestTurnCompletedAt)),
   setThreadChangedFilesExpanded: (threadId, turnId, expanded) =>
@@ -434,6 +471,17 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
       reorderProjects(state, currentProjectOrder, draggedProjectIds, targetProjectIds),
     ),
 }));
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key !== PERSISTED_STATE_KEY || event.newValue === null) return;
+    try {
+      useUiStateStore.setState(parsePersistedState(JSON.parse(event.newValue) as PersistedUiState));
+    } catch {
+      // Ignore malformed cross-tab state to keep the active tab usable.
+    }
+  });
+}
 
 useUiStateStore.subscribe((state) => debouncedPersistState.maybeExecute(state));
 

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -57,6 +57,13 @@ a shortcut.
 `chat.newLocal` skips that chooser. Both use your
 [new-thread defaults](./thread-sidebar.md#start-a-thread).
 
+`thread.nextAttention` opens the newest conversation awaiting review. When
+already viewing an attention item, it advances through the remaining items and
+wraps around. Its default shortcut is `alt+l` (`⌥L` on macOS). The queue
+includes completed, failed, input-required, and approval-required agents; it
+ignores running agents and removes an item when you open or dismiss its
+notification. Repeated updates from the same agent update its existing item.
+
 ## Reserved shortcuts
 
 In the desktop app, `mod+w` closes the focused terminal or the active right-panel

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -37,6 +37,7 @@ export type ModelPickerJumpKeybindingCommand =
 export const THREAD_KEYBINDING_COMMANDS = [
   "thread.previous",
   "thread.next",
+  "thread.nextAttention",
   "thread.copyReference",
   "thread.settle",
   "thread.pin",

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -47,6 +47,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+o", command: "editor.openFavorite" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
+  { key: "alt+l", command: "thread.nextAttention", when: "!terminalFocus" },
   { key: "mod+shift+c", command: "thread.copyReference", when: "!terminalFocus" },
   { key: "mod+shift+s", command: "thread.settle", when: "!terminalFocus" },
   { key: "mod+shift+p", command: "thread.pin", when: "!terminalFocus" },


### PR DESCRIPTION
## Summary

Adds a focused review queue for agents that have reached an actionable state, with `Alt+L` (`⌥L` on macOS) as the default shortcut.

## Behavior

- Includes one queue item per agent for completed/ready, failed, needs input, and needs approval states.
- Orders items by the most recent actionable event.
- From another conversation, `Alt+L` opens the newest item; from a queued conversation, it advances through the queue and wraps around.
- Opening a conversation from the sidebar, toast, or shortcut acknowledges that agent’s current event. New events from the same agent re-enter the queue.
- Shows one persistent in-app toast per agent with the conversation title, state, and the active shortcut label. Explicit dismissal also acknowledges the item.
- Ignores text entry, terminal focus, command palette, settings, non-conversation routes, repeats, and empty queues.
- Persists acknowledgments and synchronizes them across same-device tabs/windows.
- Keeps mobile and native OS notifications out of this first phase.

## Implementation notes

- Uses the existing keybinding resolver and settings surface, so `thread.nextAttention` can be remapped like other commands.
- Derives attention from the existing `EnvironmentThreadShell` state; no server protocol or persistence changes are required.
- Keeps queue derivation pure and covered with unit tests.
- Uses the canonical scoped thread key to avoid collisions between environments.

## Verification

- `pnpm --filter @t3tools/web typecheck`
- `pnpm --filter @t3tools/web exec vp test run --project unit src/attentionQueue.test.ts src/keybindings.test.ts src/uiStateStore.test.ts`
- `pnpm exec vp fmt --check ...` on all changed files
- `git diff --check`
- Targeted `vp lint`; only the pre-existing `set-state-in-effect` warning at `apps/web/src/components/AppSidebarLayout.tsx:198` remains.

Documentation is included in `docs/user/keybindings.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Web-only navigation, toasts, and localStorage; no server or auth changes. Main risk is shortcut/toast interaction edge cases (terminal, settings, multi-tab).
> 
> **Overview**
> Adds a **client-side agent attention queue** so conversations that need review (completed/ready, failed, pending input, pending approval) surface as persistent toasts and can be stepped through with **`thread.nextAttention`** (default **`alt+l`** / ⌥L).
> 
> Pure queue logic in `attentionQueue.ts` derives items from `EnvironmentThreadShell`, orders by newest actionable timestamp, respects **last-visit** for ready completions, and skips items matching a persisted **acknowledgment key** (`state:timestamp`). `ThreadAttentionQueue` mounts from `AppSidebarLayout`, auto-acknowledges when you land on a queued thread, shows/updates one toast per thread (Open / dismiss acknowledges), and navigates on shortcut with wraparound cycling.
> 
> **UI state** gains `threadAttentionAcknowledgedById` (localStorage + **cross-tab** `storage` sync). Contracts/shared defaults register the new command; user docs describe behavior and remapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7fd193173ad63c5a5d8dae44086850015a5f317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent attention queue with notifications and `alt+l` navigation shortcut
> - Adds an attention queue that classifies threads into pending-approval, pending-input, failed, and ready states, then sorts them newest-first and surfaces them as toast notifications in [ThreadAttentionQueue.tsx](https://github.com/pingdotgg/t3code/pull/9944/files#diff-930448a6228cb7b3457c07aa98fb3aa5b8151a4c71ae88335aa5b5ffe3b7f106)
> - Viewing a thread acknowledges its current attention item; repeated updates replace the existing notification rather than stacking duplicates
> - Adds the `thread.nextAttention` command bound to `alt+l` (terminal-focus excluded) to cycle through the sorted queue with wraparound; the shortcut is ignored on settings routes, command-palette state, and text-entry focus
> - Persists acknowledged attention keys per thread in [uiStateStore.ts](https://github.com/pingdotgg/t3code/pull/9944/files#diff-605fd32a90753e51ac329e924c51be2b2ce46a7ce8b6d02117aee02489c8acd8) with sanitization on hydration and a cross-tab storage listener that applies valid incoming state
> - Behavioral Change: persisted UI state now includes a `threadAttentionAcknowledgements` record; older persisted state missing this field hydrates as an empty record
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e7fd193. 7 files reviewed, 3 issues evaluated, 1 issue filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/components/ThreadAttentionQueue.tsx — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 26](https://github.com/pingdotgg/t3code/blob/e7fd193173ad63c5a5d8dae44086850015a5f317/apps/web/src/components/ThreadAttentionQueue.tsx#L26): `isTextEntryTarget` treats every `HTMLInputElement` as text entry, including non-text controls. For example, a focused Markdown task-list checkbox in a conversation makes the `Alt+L` handler return early, so the attention shortcut is unavailable even though the target accepts no text input. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->