### PR TITLE
fix(desktop): keep Linux AppImage filename stable across updates

### DIFF
--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -51,6 +51,7 @@ import {
   resolveDesktopProductName,
   resolveDesktopUpdateChannel,
   resolveDesktopWebAssetBrand,
+  resolveLinuxArtifactName,
   resolveResourceMonitorRustTargets,
   resolveWindowsServerAsarIgnoreGlobs,
   resourceMonitorExecutableName,
@@ -262,6 +263,14 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
   it("switches desktop packaging product names to nightly for nightly builds", () => {
     assert.equal(resolveDesktopProductName("0.0.17"), "T3 Code (Alpha)");
     assert.equal(resolveDesktopProductName("0.0.17-nightly.20260413.42"), "T3 Code (Nightly)");
+  });
+
+  it("keeps Linux artifact names version-free so updates preserve dock pins", () => {
+    assert.equal(resolveLinuxArtifactName("0.0.17"), "T3-Code-${arch}.${ext}");
+    assert.equal(
+      resolveLinuxArtifactName("0.0.17-nightly.20260413.42"),
+      "T3-Code-Nightly-${arch}.${ext}",
+    );
   });
 
   it("switches desktop packaging icons to the nightly artwork for nightly versions", () => {

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -2562,6 +2562,18 @@ export function resolveDesktopProductName(version: string): string {
     : (desktopPackageJson.productName ?? "T3 Code");
 }
 
+// Linux AppImages auto-update in place, so the artifact filename must not
+// contain the version: electron-updater keeps the existing file when the
+// published name carries no version, and a stable path keeps dock pins,
+// .desktop entries, shortcuts, and file associations working across updates
+// (electron-userland/electron-builder#5810). Nightly and stable need distinct
+// names because both can live side by side in ~/Applications.
+export function resolveLinuxArtifactName(version: string): string {
+  return resolveDesktopUpdateChannel(version) === "nightly"
+    ? "T3-Code-Nightly-${arch}.${ext}"
+    : "T3-Code-${arch}.${ext}";
+}
+
 export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
   platform: typeof BuildPlatform.Type,
   target: string,
@@ -2668,6 +2680,9 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
   if (platform === "linux") {
     buildConfig.linux = {
       target: [target],
+      // Stable filename without the version: AppImages update in place and a
+      // versioned name orphans dock pins and .desktop entries every release.
+      artifactName: resolveLinuxArtifactName(version),
       executableName: "t3code",
       icon: "icons",
       category: "Development",


### PR DESCRIPTION
Every release ships a differently-named AppImage (`T3-Code-<version>-<arch>.AppImage`), orphaning dock pins, .desktop entries, shortcuts, and file associations on each update — and leaving deleted-but-running processes behind to wedge the next launch's SingletonLock.

This sets a Linux-only `artifactName` without the version (`T3-Code-${arch}.AppImage`, `T3-Code-Nightly-${arch}.AppImage` for nightlies since both channels can live in `~/Applications`). Follows the recommended practice from electron-userland/electron-builder#5810 (omit the version from the auto-updating artifact itself, like the mac .app; the versioned dmg/nsis names are untouched), so electron-updater replaces one stable file in place.

Fixes #9945. Tests: new case asserting both channel names; full build-desktop-artifact suite (69 tests) green, lint/fmt clean.

Built and verified with OpenCode + Muse Spark.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Linux packaging filename only; no runtime auth or data-path changes. Main risk is updater or release consumers expecting versioned Linux artifact names.
> 
> **Overview**
> Linux AppImage builds now use **version-free** output names so auto-updates replace the same file instead of shipping a new filename every release.
> 
> `resolveLinuxArtifactName` picks `T3-Code-${arch}.${ext}` for stable releases and `T3-Code-Nightly-${arch}.${ext}` for nightly builds (so both channels can coexist). The Linux electron-builder config sets `linux.artifactName` from that helper; macOS/Windows default versioned naming is unchanged.
> 
> A unit test locks in both channel patterns. This is meant to keep dock pins, `.desktop` entries, shortcuts, and file associations valid across updates and avoid orphaned AppImages blocking the next launch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05f38d6cb4eb99d50237ed71ccb90ac0c1f37690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Linux AppImage filename to stay stable across updates
> - Adds `resolveLinuxArtifactName` in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/9946/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d) to return version-free artifact name templates: one for stable, one for nightly
> - Wires the resolver into `createBuildConfig` via electron-builder's `artifactName` so Linux builds emit channel-specific filenames without the build version
> - Adds tests in [build-desktop-artifact.test.ts](https://github.com/pingdotgg/t3code/pull/9946/files#diff-a199d37af35c35dd3b48cf71436cb06b23acccd6857a9fe74db6d48cb73c7663) covering both stable and nightly inputs
> - Risk: Linux artifact filenames now drop the version string; any existing tooling or update flows that parse the version from the filename will need to read it elsewhere
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 05f38d6. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->