### PR TITLE
fix(web): load file grammar before enabling edits

### DIFF
--- a/apps/web/src/components/files/fileEditorLanguageReadiness.test.ts
+++ b/apps/web/src/components/files/fileEditorLanguageReadiness.test.ts
@@ -1,0 +1,186 @@
+import {
+  FileRenderer,
+  disposeHighlighter,
+  getSharedHighlighter,
+  type BaseCodeOptions,
+  type DiffsHighlighter,
+  type FileContents,
+  type HighlightedToken,
+} from "@pierre/diffs";
+import { TextDocument } from "@pierre/diffs/editor";
+import { WorkerPoolManager, type WorkerRequest, type WorkerResponse } from "@pierre/diffs/worker";
+import * as NodeWorkerThreads from "node:worker_threads";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+type DocumentChange = NonNullable<ReturnType<TextDocument<unknown>["applyEdits"]>>;
+interface Tokenizer {
+  tokenize(change: DocumentChange): Map<number, HighlightedToken[]>;
+  cleanUp(): void;
+}
+
+const tokenizerUrl = new URL("./editor/tokenizer.js", import.meta.resolve("@pierre/diffs"));
+const { EditorTokenizer } = (await import(/* @vite-ignore */ tokenizerUrl.href)) as {
+  EditorTokenizer: new (options: {
+    codeOptions: BaseCodeOptions;
+    highlighter: DiffsHighlighter;
+    textDocument: TextDocument<unknown>;
+    setStyle: (style: string) => void;
+    onDeferTokenize: () => void;
+  }) => Tokenizer;
+};
+
+const workerModule = import.meta.resolve("@pierre/diffs/worker/worker.js");
+const options = {
+  theme: "pierre-dark",
+  themeType: "dark",
+  preferredHighlighter: "shiki-wasm",
+  useTokenTransformer: true,
+} as const;
+const source = "export const View = () => <div>Ready</div>;";
+let pool: WorkerPoolManager;
+let renderer: FileRenderer;
+let terminationPromises: Promise<number>[];
+
+class WorkerTransport {
+  private readonly worker = new NodeWorkerThreads.Worker(
+    `const { parentPort, workerData } = require("node:worker_threads");
+     globalThis.self = {
+       addEventListener(type, listener) {
+         if (type === "message") parentPort.on("message", data => listener({ data }));
+         if (type === "error") process.on("uncaughtException", listener);
+       }
+     };
+     globalThis.postMessage = data => parentPort.postMessage(data);
+     import(workerData.moduleUrl);`,
+    { eval: true, workerData: { moduleUrl: workerModule }, execArgv: [] },
+  );
+
+  addEventListener(
+    type: "message" | "error",
+    listener: (event: { data: WorkerResponse } | Error) => void,
+  ) {
+    if (type === "error") this.worker.on("error", listener);
+    else this.worker.on("message", (data: WorkerResponse) => listener({ data }));
+  }
+
+  postMessage(message: WorkerRequest) {
+    this.worker.postMessage(message, []);
+  }
+
+  terminate() {
+    terminationPromises.push(this.worker.terminate());
+  }
+}
+
+function firstEnter(highlighter: DiffsHighlighter, file: FileContents, language: string) {
+  const document = new TextDocument(file.name, file.contents, language);
+  const tokenizer = new EditorTokenizer({
+    codeOptions: options,
+    highlighter,
+    textDocument: document,
+    setStyle: () => {},
+    onDeferTokenize: () => {},
+  });
+  try {
+    const end = document.positionAt(file.contents.length);
+    const change = document.applyEdits([{ range: { start: end, end }, newText: "\n" }]);
+    expect(change).toBeDefined();
+    // This is the synchronous first edit, before the tokenizer's debounced prebuild.
+    const dirtyLines = tokenizer.tokenize(change!);
+    expect([...dirtyLines.keys()]).toEqual([0, 1]);
+    expect(document.getText()).toBe(`${file.contents}\n`);
+  } finally {
+    tokenizer.cleanUp();
+  }
+}
+
+beforeEach(async () => {
+  terminationPromises = [];
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
+    setImmediate(() => callback(0)),
+  );
+  vi.stubGlobal("cancelAnimationFrame", clearImmediate);
+  vi.stubGlobal("window", { matchMedia: () => ({ matches: true }) });
+  await disposeHighlighter();
+  pool = new WorkerPoolManager(
+    // Adapt transport only. The installed Pierre worker resolves and highlights the file.
+    { workerFactory: () => new WorkerTransport() as unknown as globalThis.Worker, poolSize: 1 },
+    options,
+  );
+  await pool.initialize();
+  renderer = new FileRenderer(options, undefined, pool);
+});
+
+afterEach(async () => {
+  renderer?.cleanUp();
+  pool?.terminate();
+  await Promise.all(terminationPromises);
+  await disposeHighlighter();
+  vi.unstubAllGlobals();
+});
+
+describe("editable file language readiness", () => {
+  it.each(["hydrate", "renderFile"] as const)(
+    "%s prepares the inferred language before the first edit of a worker-highlighted file",
+    async (method) => {
+      const file = { name: "cold.tsx", contents: source, cacheKey: "cold-tsx" };
+      await pool.primeFileHighlightCache(file);
+      expect(pool.getFileResultCache(file)).toBeDefined();
+      const mainHighlighter = await getSharedHighlighter({
+        themes: ["pierre-dark"],
+        langs: ["text"],
+      });
+      expect(mainHighlighter.getLoadedLanguages()).not.toContain("tsx");
+      renderer[method](file);
+      // Read-only worker rendering must not load editor grammars on the main thread.
+      expect(mainHighlighter.getLoadedLanguages()).not.toContain("tsx");
+      const highlighter = await renderer.initializeHighlighter();
+      firstEnter(highlighter, file, "tsx");
+    },
+  );
+
+  it.each(["hydrate", "renderFile"] as const)(
+    "%s respects an explicit language when the filename suggests plain text",
+    async (method) => {
+      const file: FileContents = {
+        name: "source.txt",
+        lang: "tsx",
+        contents: source,
+        cacheKey: "explicit-tsx",
+      };
+      await pool.primeFileHighlightCache(file);
+      renderer[method](file);
+      firstEnter(await renderer.initializeHighlighter(), file, "tsx");
+    },
+  );
+
+  it("loads a newly opened language after reusing a worker-backed renderer", async () => {
+    const previousFile: FileContents = {
+      name: "previous.ts",
+      contents: "export const value = 1;",
+      cacheKey: "previous-ts",
+    };
+    await getSharedHighlighter({ themes: ["pierre-dark"], langs: ["typescript"] });
+    renderer.renderFile(previousFile);
+    firstEnter(await renderer.initializeHighlighter(), previousFile, "typescript");
+    const nextFile = { name: "next.tsx", contents: source, cacheKey: "next-tsx" };
+    renderer.renderFile(nextFile);
+    firstEnter(await renderer.initializeHighlighter(), nextFile, "tsx");
+  });
+
+  it("prepares a hydrated non-worker file even when its theme was already loaded", async () => {
+    renderer.cleanUp();
+    renderer = new FileRenderer(options);
+    const file = { name: "local.tsx", contents: source, cacheKey: "local-tsx" };
+    renderer.hydrate(file);
+    firstEnter(await renderer.initializeHighlighter(), file, "tsx");
+  });
+
+  it("keeps plain text editable without loading an unrelated grammar", async () => {
+    const file = { name: "notes.txt", contents: "Plain text", cacheKey: "plain-text" };
+    renderer.renderFile(file);
+    const highlighter = await renderer.initializeHighlighter();
+    firstEnter(highlighter, file, "text");
+    expect(highlighter.getLoadedLanguages()).not.toContain("tsx");
+  });
+});

--- a/patches/@pierre%2Fdiffs@1.3.0-beta.10.patch
+++ b/patches/@pierre%2Fdiffs@1.3.0-beta.10.patch
@@ -63,6 +63,18 @@ index e9f62f5..af82a46 100644
 diff --git a/dist/renderers/FileRenderer.js b/dist/renderers/FileRenderer.js
 --- a/dist/renderers/FileRenderer.js
 +++ b/dist/renderers/FileRenderer.js
+@@ -107,10 +107,10 @@
+ 			result: massiveFile ? void 0 : cache?.result,
+ 			renderRange: void 0
+ 		};
++		this.computedLang = file.lang ?? getFiletypeFromFileName(file.name);
+ 		if (this.workerManager?.isWorkingPool() === true) {
+ 			if (this.renderCache.result == null && !massiveFile) this.workerManager.highlightFileAST(this, file);
+ 		} else if (this.highlighter == null) {
+-			this.computedLang = file.lang ?? getFiletypeFromFileName(file.name);
+ 			this.initializeHighlighter();
+ 		}
+ 	}
 @@ -163,6 +163,8 @@
  		if (this.renderCache == null) return;
  		const { file, result } = this.renderCache;
@@ -72,6 +84,22 @@ diff --git a/dist/renderers/FileRenderer.js b/dist/renderers/FileRenderer.js
  		const lineCache = this.lineCache != null && isLineCacheForFile(this.lineCache, file) ? this.lineCache : void 0;
  		for (const [line, tokens] of dirtyLines) {
  			if (lineCache != null && line < lineCache.lines.length) {
+@@ -268,6 +270,7 @@
+ 		const forcePlainText = !hasContent || isFilePlainText(file) || isFileMassive(lines.length, this.getTokenizeMaxLength());
+ 		const newContent = !areFilesEqual(file, this.renderCache.file);
+ 		const newRenderRange = !areRenderRangesEqual(this.renderCache.renderRange, renderRange);
++		this.computedLang = file.lang ?? getFiletypeFromFileName(file.name);
+ 		if (this.workerManager?.isWorkingPool() === true) {
+ 			if (forcePlainText || this.renderCache.result == null || !this.renderCache.highlighted && (newContent || newRenderRange)) {
+ 				this.renderCache.file = file;
+@@ -278,7 +281,6 @@
+ 			}
+ 			if (!forcePlainText && hasContent && (!this.renderCache.highlighted || forceHighlight)) this.workerManager.highlightFileAST(this, file);
+ 		} else {
+-			this.computedLang = file.lang ?? getFiletypeFromFileName(file.name);
+ 			const hasThemes = this.highlighter != null && areThemesAttached(options.theme);
+ 			const hasLangs = this.highlighter != null && areLanguagesAttached(this.computedLang);
+ 			const canHighlight = !forcePlainText && hasLangs;
 diff --git a/package.json b/package.json
 index ff61c90..1e170e5 100644
 --- a/package.json

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,7 +92,7 @@ patchedDependencies:
   '@expo/metro-config@57.0.12': 96f1a75347e6ea02dc4b7034ace815d8ee39e18b8166ebfb573d9e58328f0dc2
   '@ff-labs/fff-node@0.9.4': ab9ff544009e1891cfe3930105862d3699007f38922a79f3c98d90018deca368
   '@legendapp/list@3.3.5': 03ec41339cd915ecb9a774a6b90cc2197c29038f7db67c4d2e55cd3971e5be43
-  '@pierre/diffs@1.3.0-beta.10': c087c47b657c44ddce2b0ec8237d675086414134e91829c4b4edd009ec86893e
+  '@pierre/diffs@1.3.0-beta.10': c2ea3a9821addf19641e88074a6d8896c62b0f7cfa762899b0e9e80ff5e8add4
   '@react-native-ai/apple@0.12.0': 2d09870c2848d185cb05b53ed823a46e12dba519324d8dd8e584e28731990f9d
   '@react-native-menu/menu@2.0.0': f63d256bf6a97a873b5e628eb595bd6ef0075ddd5bdd890fc920f7a6024290dd
   '@react-navigation/native-stack@7.17.6': e667c3cef8c78bb9ff4882ee5bd23a432247b843060a9499eb5f07e9e2295552
@@ -245,7 +245,7 @@ importers:
         version: 1.9.1
       '@pierre/diffs':
         specifier: 'catalog:'
-        version: 1.3.0-beta.10(patch_hash=c087c47b657c44ddce2b0ec8237d675086414134e91829c4b4edd009ec86893e)(@shikijs/themes@4.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 1.3.0-beta.10(patch_hash=c2ea3a9821addf19641e88074a6d8896c62b0f7cfa762899b0e9e80ff5e8add4)(@shikijs/themes@4.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@react-native-ai/apple':
         specifier: 0.12.0
         version: 0.12.0(patch_hash=2d09870c2848d185cb05b53ed823a46e12dba519324d8dd8e584e28731990f9d)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
@@ -586,7 +586,7 @@ importers:
         version: 1.8.0
       '@pierre/diffs':
         specifier: 'catalog:'
-        version: 1.3.0-beta.10(patch_hash=c087c47b657c44ddce2b0ec8237d675086414134e91829c4b4edd009ec86893e)(@shikijs/themes@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 1.3.0-beta.10(patch_hash=c2ea3a9821addf19641e88074a6d8896c62b0f7cfa762899b0e9e80ff5e8add4)(@shikijs/themes@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@pierre/trees':
         specifier: 1.0.0-beta.4
         version: 1.0.0-beta.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -13613,7 +13613,7 @@ snapshots:
       tslib: 2.8.1
       webcrypto-core: 1.9.2
 
-  '@pierre/diffs@1.3.0-beta.10(patch_hash=c087c47b657c44ddce2b0ec8237d675086414134e91829c4b4edd009ec86893e)(@shikijs/themes@4.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@pierre/diffs@1.3.0-beta.10(patch_hash=c2ea3a9821addf19641e88074a6d8896c62b0f7cfa762899b0e9e80ff5e8add4)(@shikijs/themes@4.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@pierre/theme': 1.1.0
       '@pierre/theming': 0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.2.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(shiki@4.2.0)
@@ -13627,7 +13627,7 @@ snapshots:
     transitivePeerDependencies:
       - '@shikijs/themes'
 
-  '@pierre/diffs@1.3.0-beta.10(patch_hash=c087c47b657c44ddce2b0ec8237d675086414134e91829c4b4edd009ec86893e)(@shikijs/themes@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@pierre/diffs@1.3.0-beta.10(patch_hash=c2ea3a9821addf19641e88074a6d8896c62b0f7cfa762899b0e9e80ff5e8add4)(@shikijs/themes@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@pierre/theme': 1.1.0
       '@pierre/theming': 0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(shiki@4.2.0)


### PR DESCRIPTION
Opening a worker-highlighted TSX file could leave the editor's main-thread highlighter without its grammar. The first edit then threw `Grammar for language "tsx" not loaded`, after emitting the changed contents but before completing the incremental render.

Move the existing file-language assignment before the worker branch in `FileRenderer.hydrate` and `FileRenderer.renderFile`. The editor already awaits highlighter initialization before enabling edits; that initialization now loads the actual file language. Read-only worker highlighting still does not load editor grammars on the main thread.

### Native before and after

Both runs used a fresh Linux Chromium client, the same 8,323-line TSX fixture, and the app at [f47a3fe9](https://github.com/pingdotgg/t3code/commit/f47a3fe90354a3dfa14276e3699541d552426276). The after run changed only this grammar patch. The existing stale-highlight fix was present in both; neither run included the separate viewport candidate. Read-only inspection captured actual editor state, without replacing methods or mocking the highlighter.

| At the first native Enter | Before | After |
| --- | --- | --- |
| Worker ready | `true` | `true` |
| Renderer language | `text` | `tsx` |
| Main-thread loaded languages | `[]` | `["tsx"]` |
| New page errors | 1, missing TSX grammar | 0 |

The after run also completed native undo/redo without new exceptions. A typed marker persisted on disk after closing the file and remained visible on reopening it.

After save and reopen, showing persistence rather than a layout fix:

![After: the saved TSX marker remains visible when the file is reopened](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/8034d64baaed2b35/7907-cold-candidate-reopened.png)

[Short native reopen recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/a8a3e52e989be9b5/7907-cold-candidate-reopen.mp4)

The first-edit screenshots look alike because the separate viewport jump remains. The runtime observations above and the regression tests establish the grammar repair; the screenshot and clip establish the saved-file result.

### Verification

```sh
vp test run apps/web/src/components/files/fileEditorLanguageReadiness.test.ts apps/web/src/components/files/fileEditorHighlight.test.ts apps/web/src/components/files/fileContentRevision.test.ts apps/web/src/components/files/FilePreviewPanel.test.ts --maxWorkers=2
```

The tests use the installed Pierre worker and actual renderer, tokenizer and document classes. Worker-highlighted cases await the completed highlight, then apply the first edit without waiting for the tokenizer's delayed prebuild. On the unpatched main implementation at [c7dc3cbd](https://github.com/pingdotgg/t3code/commit/c7dc3cbd068a93c9fb5027df7bea719d16e4ffbe), six readiness cases fail with the exact missing-grammar exception and plain text passes. After the fix, all seven readiness cases pass, covering both rendering entry points, explicit language overrides, language switches and non-worker hydration.

All 26 focused tests, targeted lint and web typecheck pass on [61d8322a](https://github.com/pingdotgg/t3code/commit/61d8322a4332f527afab8ea45b9587d535a57c25), refreshed onto [7a089b2b](https://github.com/pingdotgg/t3code/commit/7a089b2b2449c5c146e1a7d554a31e6d55924d3f). The intervening main changes do not touch the editor. Independent review and reruns of the unchanged fix also pass.

This addresses a separate cold-language failure found while investigating [#7907](https://github.com/pingdotgg/t3code/issues/7907). It does not include the wrapped-row height-cache change or fix intermittent caret positioning on redo. Keep that report open.

GPT 6 Astra via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes vendored renderer/highlighter lifecycle and worker cache eviction on edit; behavior is covered by new integration tests but touches core editing and highlighting paths.
> 
> **Overview**
> Fixes a crash on the **first edit** of worker-highlighted files (e.g. TSX) where the main-thread highlighter had not loaded the file’s grammar (`Grammar for language "tsx" not loaded`), even though read-only highlighting already ran in a worker.
> 
> The **`@pierre/diffs` patch** moves **`computedLang`** (explicit `file.lang` or inferred from the filename) to run **before** the worker vs main-thread branches in **`FileRenderer.hydrate`** and **`renderFile`**, so **`initializeHighlighter()`** (already awaited before edits) loads the correct language instead of staying on plain text. Read-only worker AST highlighting still does not pull editor grammars onto the main thread until the editor initializes. Incremental tokenization also **cleans worker tasks** and **evicts the file highlight cache** when applying dirty lines, and default editor options in the patch drop forced gutter/selection overrides while keeping **`useTokenTransformer: true`**.
> 
> Adds **`fileEditorLanguageReadiness.test.ts`**, which drives the real Pierre worker (via a Node worker transport), **`FileRenderer`**, tokenizer, and a synchronous “first Enter” edit to lock in hydrate/render paths, explicit language overrides, language switches, non-worker hydration, and plain-text files. **`pnpm-lock.yaml`** updates the patched **`@pierre/diffs`** hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61d8322a4332f527afab8ea45b9587d535a57c25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Compute file language before worker branch in `FileRenderer.hydrate` and `renderFile`
> - Moves the explicit-or-filename-inferred language computation ahead of the worker-manager branch in both `FileRenderer.hydrate` and `FileRenderer.renderFile`, so worker-backed rendering records the correct language before highlighting
> - Previously the language was only set in the local-highlighter path, so the first edit on a worker-backed file could lack the right grammar
> - Adds a Node `WorkerTransport` adapter and a suite of readiness tests in [fileEditorLanguageReadiness.test.ts](https://github.com/pingdotgg/t3code/pull/9947/files#diff-872c8caae790829772c6c06b013a5a8a2645e4b16521ee416bd32c42893bb73f) covering worker-backed hydrate/renderFile, explicit language, renderer reuse, and plain-text edits
> - **Risk:** `renderFile` now updates `computedLang` for every rendered file rather than only local-highlighted files; consumers relying on `computedLang` being unset for worker-backed renders should verify behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61d8322.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->