### PR TITLE
fix(web): deduplicate PR project filter choices

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
@@ -8,7 +8,6 @@ import type {
   SourceControlProviderKind,
 } from "@t3tools/contracts";
 import {
-  CheckIcon,
   CircleCheckIcon,
   CircleDashedIcon,
   CircleSlashIcon,
@@ -38,6 +37,7 @@ import {
   MenuPopup,
   MenuRadioGroup,
   MenuRadioItem,
+  MenuRadioItemIndicator,
   MenuSeparator,
   MenuSub,
   MenuSubPopup,
@@ -206,7 +206,7 @@ function PullRequestFilterRadioGroup<Value extends string>({
               <PullRequestFilterOptionIcon option={option} />
               <span className="min-w-0 flex-1 truncate">{option.label}</span>
               {option.unavailable ? <span className="shrink-0">· Unavailable</span> : null}
-              {option.value === value ? <CheckIcon aria-hidden className="size-3.5" /> : null}
+              <MenuRadioItemIndicator />
             </span>
           </MenuRadioItem>
         );

--- a/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
@@ -8,6 +8,7 @@ import type {
   SourceControlProviderKind,
 } from "@t3tools/contracts";
 import {
+  CheckIcon,
   CircleCheckIcon,
   CircleDashedIcon,
   CircleSlashIcon,
@@ -205,6 +206,7 @@ function PullRequestFilterRadioGroup<Value extends string>({
               <PullRequestFilterOptionIcon option={option} />
               <span className="min-w-0 flex-1 truncate">{option.label}</span>
               {option.unavailable ? <span className="shrink-0">· Unavailable</span> : null}
+              {option.value === value ? <CheckIcon aria-hidden className="size-3.5" /> : null}
             </span>
           </MenuRadioItem>
         );
@@ -455,8 +457,8 @@ export function PullRequestFiltersMenu({
     readonly environmentId: EnvironmentId;
     readonly title: string;
     readonly workspaceRoot: string;
-    readonly faviconPath?: string | null;
-    readonly projectIcon?: ProjectIconOverride | null;
+    readonly faviconPath?: string | null | undefined;
+    readonly projectIcon?: ProjectIconOverride | null | undefined;
   }>;
   projectId: ProjectId | undefined;
   /**

--- a/apps/web/src/components/pullRequest/pullRequestProjectFilter.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestProjectFilter.logic.test.ts
@@ -1,0 +1,158 @@
+import { EnvironmentId, ProjectId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { findScopedProject } from "./pullRequestList.logic";
+import { pullRequestFilterProjects } from "./pullRequestProjectFilter.logic";
+
+const cups = EnvironmentId.make("env-cups");
+const nucbox = EnvironmentId.make("env-nucbox");
+const labels = new Map([
+  [cups, "cups"],
+  [nucbox, "nucbox-1"],
+]);
+
+function project(
+  id: string,
+  environmentId = nucbox,
+  canonicalKey: string | null = "github.com/pingdotgg/t3code",
+) {
+  return {
+    id: ProjectId.make(id),
+    environmentId,
+    title: "t3code",
+    workspaceRoot: `/work/${id}`,
+    repositoryIdentity: canonicalKey === null ? null : { canonicalKey },
+    faviconPath: `${id}/favicon.png`,
+  };
+}
+
+describe("pull request project filter choices", () => {
+  it("collapses three checkouts on one server without dropping another server's copy", () => {
+    const projects = [
+      project("main"),
+      project("worktree-1"),
+      project("worktree-2"),
+      project("main", cups),
+    ];
+
+    const choices = pullRequestFilterProjects(projects, labels);
+
+    expect(choices.map(({ id, environmentId, title }) => ({ id, environmentId, title }))).toEqual([
+      { id: "main", environmentId: cups, title: "t3code · cups" },
+      { id: "main", environmentId: nucbox, title: "t3code · nucbox-1" },
+    ]);
+    expect(choices[1]?.workspaceRoot).toBe("/work/main");
+    expect(choices[1]?.faviconPath).toBe("main/favicon.png");
+  });
+
+  it("keeps a saved worktree selection as the repository's only choice", () => {
+    const projects = [project("main"), project("worktree"), project("worktree", cups)];
+    const selected = findScopedProject(projects, nucbox, "worktree");
+
+    const choices = pullRequestFilterProjects(projects, labels, selected);
+
+    expect(choices.filter((choice) => choice.environmentId === nucbox)).toEqual([
+      { ...projects[1], title: "t3code · nucbox-1" },
+    ]);
+    expect(findScopedProject(choices, nucbox, "worktree")).toBeDefined();
+    expect(findScopedProject(choices, nucbox, "main")).toBeUndefined();
+    expect(findScopedProject(choices, cups, "worktree")).toBeDefined();
+  });
+
+  it("matches canonical repositories regardless of casing", () => {
+    const main = project("main");
+    const worktree = project("worktree", nucbox, "GitHub.com/PingDotGG/T3Code");
+
+    expect(pullRequestFilterProjects([main, worktree], labels)).toEqual([main]);
+  });
+
+  it("does not add a server suffix after duplicate checkouts have collapsed", () => {
+    const main = project("main");
+
+    expect(pullRequestFilterProjects([main, project("worktree")], labels)).toEqual([main]);
+    expect(main.title).toBe("t3code");
+  });
+
+  it("distinguishes same-named repositories on one server by checkout path", () => {
+    const projects = [
+      project("upstream"),
+      project("fork", nucbox, "github.com/juliusmarminge/t3code"),
+    ];
+
+    const choices = pullRequestFilterProjects(projects, labels);
+
+    expect(choices.map((choice) => choice.title)).toEqual([
+      "t3code · nucbox-1 · /work/fork",
+      "t3code · nucbox-1 · /work/upstream",
+    ]);
+  });
+
+  it("keeps repositories on different hosts separate", () => {
+    const choices = pullRequestFilterProjects(
+      [project("github"), project("enterprise", nucbox, "git.example.com/pingdotgg/t3code")],
+      labels,
+    );
+
+    expect(choices.map((choice) => choice.id)).toEqual(["enterprise", "github"]);
+  });
+
+  it("does not merge projects whose repository identity is unknown", () => {
+    const choices = pullRequestFilterProjects(
+      [project("first", nucbox, null), project("second", nucbox, null)],
+      labels,
+    );
+
+    expect(choices.map((choice) => choice.title)).toEqual([
+      "t3code · nucbox-1 · /work/first",
+      "t3code · nucbox-1 · /work/second",
+    ]);
+  });
+
+  it("distinguishes servers with the same display name and checkout path", () => {
+    const first = project("main");
+    const second = project("main", cups);
+    const repeatedLabels = new Map([
+      [cups, "nucbox-1"],
+      [nucbox, "nucbox-1"],
+    ]);
+
+    const choices = pullRequestFilterProjects([first, second], repeatedLabels);
+
+    expect(choices.map((choice) => choice.title)).toEqual([
+      "t3code · nucbox-1 · /work/main · env-cups",
+      "t3code · nucbox-1 · /work/main · env-nucbox",
+    ]);
+  });
+
+  it("uses the environment id when its label is unavailable", () => {
+    const choices = pullRequestFilterProjects(
+      [project("main"), project("remote", cups)],
+      new Map(),
+    );
+
+    expect(choices.map((choice) => choice.title)).toEqual([
+      "t3code · env-cups",
+      "t3code · env-nucbox",
+    ]);
+  });
+
+  it("can distinguish unresolved project records that also share a checkout path", () => {
+    const first = project("first", nucbox, null);
+    const second = { ...project("second", nucbox, null), workspaceRoot: first.workspaceRoot };
+
+    const choices = pullRequestFilterProjects([first, second], labels);
+
+    expect(choices.map((choice) => choice.title)).toEqual([
+      "t3code · nucbox-1 · /work/first · env-nucbox · first",
+      "t3code · nucbox-1 · /work/first · env-nucbox · second",
+    ]);
+  });
+
+  it("leaves unrelated names unchanged and orders them alphabetically", () => {
+    const app = { ...project("app"), title: "Zebra" };
+    const tools = { ...project("tools", nucbox, "github.com/acme/tools"), title: "Alpha" };
+
+    expect(pullRequestFilterProjects([app, tools], labels)).toEqual([tools, app]);
+    expect(pullRequestFilterProjects([], labels)).toEqual([]);
+  });
+});

--- a/apps/web/src/components/pullRequest/pullRequestProjectFilter.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestProjectFilter.logic.ts
@@ -1,0 +1,53 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+
+import type { AssignableProject } from "./pullRequestProjectAssignment.logic";
+
+interface FilterProject extends AssignableProject {
+  readonly title: string;
+  readonly workspaceRoot: string;
+}
+
+function distinguishTitles<Project extends FilterProject>(
+  projects: ReadonlyArray<Project>,
+  suffix: (project: Project) => string,
+) {
+  const counts = new Map<string, number>();
+  for (const project of projects) {
+    counts.set(project.title, (counts.get(project.title) ?? 0) + 1);
+  }
+  return projects.map((project) =>
+    (counts.get(project.title) ?? 0) > 1
+      ? { ...project, title: `${project.title} · ${suffix(project)}` }
+      : project,
+  );
+}
+
+/** One choice per repository per server, retaining the selected checkout for saved scopes. */
+export function pullRequestFilterProjects<Project extends FilterProject>(
+  projects: ReadonlyArray<Project>,
+  environmentLabels: ReadonlyMap<EnvironmentId, string>,
+  selectedProject?: Pick<AssignableProject, "id" | "environmentId">,
+) {
+  const byRepository = new Map<string, Project>();
+  for (const project of projects) {
+    const repository = project.repositoryIdentity?.canonicalKey?.toLowerCase();
+    const key = JSON.stringify([
+      project.environmentId,
+      repository ? ["repository", repository] : ["project", project.id],
+    ]);
+    const selected =
+      project.id === selectedProject?.id && project.environmentId === selectedProject.environmentId;
+    if (!byRepository.has(key) || selected) byRepository.set(key, project);
+  }
+
+  const byServer = distinguishTitles(
+    [...byRepository.values()],
+    (project) => environmentLabels.get(project.environmentId) ?? project.environmentId,
+  );
+  const byPath = distinguishTitles(byServer, (project) => project.workspaceRoot);
+  // Separate environments can share both their display name and their checkout path.
+  const byEnvironment = distinguishTitles(byPath, (project) => project.environmentId);
+  return distinguishTitles(byEnvironment, (project) => project.id).toSorted((left, right) =>
+    left.title.localeCompare(right.title),
+  );
+}

--- a/apps/web/src/components/ui/menu.tsx
+++ b/apps/web/src/components/ui/menu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Menu as MenuPrimitive } from "@base-ui/react/menu";
-import { ChevronRightIcon } from "lucide-react";
+import { CheckIcon, ChevronRightIcon } from "lucide-react";
 import type * as React from "react";
 
 import { cn } from "~/lib/utils";
@@ -177,6 +177,23 @@ function MenuRadioItem({
   );
 }
 
+function MenuRadioItemIndicator({
+  className,
+  children,
+  ...props
+}: MenuPrimitive.RadioItemIndicator.Props) {
+  return (
+    <MenuPrimitive.RadioItemIndicator
+      aria-hidden
+      className={cn("flex shrink-0", className)}
+      data-slot="menu-radio-item-indicator"
+      {...props}
+    >
+      {children ?? <CheckIcon className="size-3.5" />}
+    </MenuPrimitive.RadioItemIndicator>
+  );
+}
+
 function MenuGroupLabel({
   className,
   inset,
@@ -300,6 +317,7 @@ export {
   MenuRadioGroup as DropdownMenuRadioGroup,
   MenuRadioItem,
   MenuRadioItem as DropdownMenuRadioItem,
+  MenuRadioItemIndicator,
   MenuGroupLabel,
   MenuGroupLabel as DropdownMenuLabel,
   MenuSeparator,

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -86,6 +86,7 @@ import {
   writePullRequestListPreferences,
 } from "../components/pullRequest/pullRequestListPreferences";
 import { assignProjectsToEnvironments } from "../components/pullRequest/pullRequestProjectAssignment.logic";
+import { pullRequestFilterProjects } from "../components/pullRequest/pullRequestProjectFilter.logic";
 import { environmentMachineIcon } from "../components/EnvironmentMachineIcon";
 import { PullRequestDetailPanel } from "../components/pullRequest/PullRequestDetailPanel";
 import {
@@ -356,27 +357,6 @@ function PullRequestsRouteView() {
       ),
     [environments],
   );
-  const scopedProjects = useMemo(() => {
-    // Two machines can hold the same repository, so a title the workspace carries twice is told
-    // apart by the environment it lives on rather than left as two identical rows.
-    const titleCounts = new Map<string, number>();
-    for (const project of projects) {
-      titleCounts.set(project.title, (titleCounts.get(project.title) ?? 0) + 1);
-    }
-    return projects
-      .map((project) => ({
-        id: project.id,
-        environmentId: project.environmentId,
-        title:
-          (titleCounts.get(project.title) ?? 0) > 1
-            ? `${project.title} · ${environmentLabels.get(project.environmentId) ?? project.environmentId}`
-            : project.title,
-        workspaceRoot: project.workspaceRoot,
-        faviconPath: project.faviconPath ?? null,
-        projectIcon: project.projectIcon ?? null,
-      }))
-      .toSorted((left, right) => left.title.localeCompare(right.title));
-  }, [environmentLabels, projects]);
   // The scope the URL asks for, once the environments have had their say about whether it exists.
   const scopedProjectId = useMemo(
     () => resolveProjectScope(search.projectId, projects, projectsKnown),
@@ -385,6 +365,10 @@ function PullRequestsRouteView() {
   const scopedProject = useMemo(
     () => findScopedProject(projects, scopedEnvironmentId, scopedProjectId),
     [projects, scopedEnvironmentId, scopedProjectId],
+  );
+  const scopedProjects = useMemo(
+    () => pullRequestFilterProjects(projects, environmentLabels, scopedProject),
+    [environmentLabels, projects, scopedProject],
   );
 
   // A link from a thread or the sidebar only knows the repository, so the owning project is


### PR DESCRIPTION
The PR Project filter listed every checkout independently, so several checkouts of the same repository on one server appeared as identical choices.

Show one choice per repository per server, preserve saved checkout selections, and distinguish remaining name collisions. Selected options use a shared, opt-in radio indicator. Other menus and merge-readiness sorting/fetching are unchanged.

## Verification

- 152 focused PR list, filter, and assignment tests pass, including 11 project-choice regressions.
- Web typecheck passes; scoped lint has no errors (existing warnings only).
- Browser verified duplicate collapse, selecting/clearing, and a saved URL naming an alternate checkout. Clearing retains the existing server scope.
- Fresh whole-PR audit found no remaining blockers. CI jobs that ran pass, configured skips remain skipped, and the bot finding is fixed and resolved.
- Web and desktop share this route; browser verification used web. Multi-environment cases have unit coverage. No mobile, provider, wire-contract, or documentation changes were needed.

## Before / after

Actual base [7a089b2](https://github.com/pingdotgg/t3code/commit/7a089b2b2449c5c146e1a7d554a31e6d55924d3f) and head [fa907505](https://github.com/pingdotgg/t3code/commit/fa9075053602e8b7285c83aeec4380e094fd2b5e), with the same disposable three-project fixture, query, 1440×1000 viewport, and scroll position.

| Before | After |
| --- | --- |
| ![Before: three identical repository choices](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/259b47682c7557ef/before-project.png) | ![After: one repository choice and a selection checkmark](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/18a497b04e4133d9/after-project-final.png) |

<details>
<summary>Full-page screenshots</summary>

Before:

![Before: PR Project filter with duplicate choices](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4979e3df32185e81/before-final.png)

After:

![After: deduplicated PR Project filter](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4b89cce26be2923f/after-final.png)

</details>

Select and clear, on the final head (light theme):

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/fe03ecfbef2c98bc/project-filter-demo-final.mp4

Implemented with vega-alpha in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Filter scope now collapses multiple checkouts of the same repo on one server to a single row, which can change which project a user picks unless the saved-selection and suffix logic matches expectations.
> 
> **Overview**
> The PR **Project** filter no longer lists every worktree separately. It now shows **one choice per canonical repository per server**, while still honoring a saved scope when the user had picked a specific checkout.
> 
> A new `pullRequestFilterProjects` helper replaces the inline “duplicate title → append server label” logic on the pull-requests route. It keys rows by environment plus repository identity (case-insensitive), keeps the explicitly selected project when collapsing duplicates, and only adds disambiguating title suffixes (server label, path, environment id, project id) when names would still collide.
> 
> Filter radio menus also show a **checkmark** on the active option via a new `MenuRadioItemIndicator` in the shared menu component, wired into `PullRequestFilterRadioGroup`. Regression tests cover collapse, saved worktree selection, unknown identities, and edge-case naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa9075053602e8b7285c83aeec4380e094fd2b5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate pull-request project filter choices by repository and environment
> - Adds `pullRequestFilterProjects` in [pullRequestProjectFilter.logic.ts](https://github.com/pingdotgg/t3code/pull/9948/files#diff-da2110bab4d1769f666c7a3d99b7c8320b105915f6ecc20377bf91240625a4a7) that groups projects per environment and lowercased canonical repository identity, collapses duplicate checkouts (retaining the selected one), and disambiguates titles by environment label, checkout path, environment id, then project id
> - Adds `distinguishTitles` utility that appends a suffix only to titles appearing more than once, and a reusable `MenuRadioItemIndicator` in [menu.tsx](https://github.com/pingdotgg/t3code/pull/9948/files#diff-e0c9f33f4f308eae4b7e310785187bc81767e547539de6fcd955fa42aaccc621) so radio options show a check mark on the selected item
> - Updates [PullRequestsRouteView](https://github.com/pingdotgg/t3code/pull/9948/files#diff-514a5b26d9687035b089d834742d874da174aa0a8a0c7c2fd47c61d11795afa5) to call the new utility, replacing route-local title-counting logic, and updates `PullRequestFiltersMenu` input types so optional favicon/icon fields accept `undefined`
> - Adds extensive tests in [pullRequestProjectFilter.logic.test.ts](https://github.com/pingdotgg/t3code/pull/9948/files#diff-8c00ea6804fe15861a507ac6802dc9908b77d4200c74c71039608047efe73de9) covering case-insensitive matching, cross-host distinction, unknown-identity retention, and ordering
> - Behavioral Change: filter choices now show one entry per repository per environment instead of one per project checkout; previously distinct duplicate checkouts are collapsed into a single choice
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa90750.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
