### PR TITLE
fix(web): show readable messages for structured thread errors

### DIFF
--- a/apps/web/src/components/chat/ThreadErrorBanner.test.tsx
+++ b/apps/web/src/components/chat/ThreadErrorBanner.test.tsx
@@ -4,12 +4,93 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   dismissThreadErrorBannerForSession,
   getThreadErrorBannerKey,
+  getThreadErrorBannerMessage,
   isThreadErrorBannerDismissedForSession,
   shouldShowThreadErrorBanner,
   ThreadErrorBanner,
 } from "./ThreadErrorBanner";
 
+describe("getThreadErrorBannerMessage", () => {
+  it("shows the message from the reported unsupported-model error", () => {
+    const error =
+      '{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The \'gpt-5.3-codex\' model is not supported when using Codex with a ChatGPT account."}}';
+
+    expect(getThreadErrorBannerMessage(error)).toBe(
+      "The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.",
+    );
+  });
+
+  it("shows the message from the reported multiline error", () => {
+    const error = `{
+  "error": {
+    "message": "X-OpenAI-Internal-Codex-Responses-Lite only supports function tools, custom tools, and client-executed tool search.",
+    "type": "invalid_request_error",
+    "param": "tools",
+    "code": "unsupported_value"
+  }
+}`;
+
+    expect(getThreadErrorBannerMessage(error)).toBe(
+      "X-OpenAI-Internal-Codex-Responses-Lite only supports function tools, custom tools, and client-executed tool search.",
+    );
+  });
+
+  it("preserves whitespace in a recognized message", () => {
+    const message = "  First line\n\tSecond line  ";
+    const error = ` \n${JSON.stringify({ error: { message } })}\t `;
+
+    expect(getThreadErrorBannerMessage(error)).toBe(message);
+  });
+
+  it("does not recursively unwrap a selected message", () => {
+    const message = JSON.stringify({ error: { message: "Inner message" } });
+
+    expect(getThreadErrorBannerMessage(JSON.stringify({ error: { message } }))).toBe(message);
+  });
+
+  it.each([
+    ["plain text and its whitespace", "  Could not start the turn.\nTry again.  "],
+    ["empty text", ""],
+    ["whitespace-only text", " \n\t "],
+    ["invalid JSON", '{"error":{"message":"Cut off"'],
+    ["JSON null", "null"],
+    ["a JSON string", '"Could not start the turn."'],
+    ["a JSON number", "400"],
+    ["an array", '[{"error":{"message":"Array entry"}}]'],
+    ["a top-level message", '{"message":"Top-level message"}'],
+    ["an unknown object", '{"status":400,"code":"unsupported_value"}'],
+    ["a null error", '{"error":null}'],
+    ["a string-valued error", '{"error":"Could not start the turn."}'],
+    ["an array-valued error", '{"error":[{"message":"Array entry"}]}'],
+    ["an absent message", '{"error":{"code":"unsupported_value"}}'],
+    ["an empty message", '{"error":{"message":""}}'],
+    ["a whitespace-only message", JSON.stringify({ error: { message: " \n\t " } })],
+    ["a non-string message", '{"error":{"message":400}}'],
+    ["a deeper error object", '{"error":{"error":{"message":"Deeper message"}}}'],
+    ["double-encoded JSON", JSON.stringify('{"error":{"message":"Encoded message"}}')],
+  ])("leaves %s unchanged", (_description, error) => {
+    expect(getThreadErrorBannerMessage(error)).toBe(error);
+  });
+});
+
 describe("ThreadErrorBanner", () => {
+  it("does not dismiss different diagnostics that share the same headline", () => {
+    const firstError = JSON.stringify({ error: { message: "Turn failed", code: "first" } });
+    const secondError = JSON.stringify({ error: { message: "Turn failed", code: "second" } });
+    const threadKey = "env:thread-same-headline";
+    dismissThreadErrorBannerForSession(getThreadErrorBannerKey(threadKey, firstError));
+
+    expect(getThreadErrorBannerMessage(firstError)).toBe("Turn failed");
+    expect(getThreadErrorBannerMessage(secondError)).toBe("Turn failed");
+    expect(
+      shouldShowThreadErrorBanner(
+        threadKey,
+        secondError,
+        isThreadErrorBannerDismissedForSession(getThreadErrorBannerKey(threadKey, secondError)),
+      ),
+    ).toBe(true);
+  });
+
   it("stays hidden after its current error is dismissed", () => {
     const bannerKey = getThreadErrorBannerKey("env:thread-a", "Aborted");
     dismissThreadErrorBannerForSession(bannerKey);

--- a/apps/web/src/components/chat/ThreadErrorBanner.tsx
+++ b/apps/web/src/components/chat/ThreadErrorBanner.tsx
@@ -4,6 +4,25 @@ import { Button } from "../ui/button";
 import { CircleAlertIcon, XIcon } from "lucide-react";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
+export function getThreadErrorBannerMessage(error: string): string {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(error);
+  } catch {
+    return error;
+  }
+  if (typeof payload !== "object" || payload === null || !("error" in payload)) {
+    return error;
+  }
+  const nestedError = payload.error;
+  if (typeof nestedError !== "object" || nestedError === null || !("message" in nestedError)) {
+    return error;
+  }
+  return typeof nestedError.message === "string" && nestedError.message.trim().length > 0
+    ? nestedError.message
+    : error;
+}
+
 export function getThreadErrorBannerKey(threadKey: string, error: string | null): string | null {
   return error === null ? null : `${threadKey}\u0000${error}`;
 }
@@ -52,7 +71,9 @@ export const ThreadErrorBanner = memo(function ThreadErrorBanner({
         <CircleAlertIcon />
         <AlertDescription>
           <Tooltip>
-            <TooltipTrigger render={<div className="line-clamp-3" />}>{error}</TooltipTrigger>
+            <TooltipTrigger render={<div className="line-clamp-3" />}>
+              {getThreadErrorBannerMessage(error)}
+            </TooltipTrigger>
             <TooltipPopup side="top" className="max-w-96 whitespace-pre-wrap">
               {error}
             </TooltipPopup>


### PR DESCRIPTION
Related to [#3747](https://github.com/pingdotgg/t3code/issues/3747). Keep that issue open.

The chat error banner still displays raw JSON even when the response contains a useful `error.message`. Show that nonempty string in the headline, while retaining the exact original payload in the existing tooltip. Plain text, invalid JSON and unrecognized shapes keep their current display. Dismissal keys still use the raw payload, so different diagnostics with the same headline remain distinct.

HUMAN-HOLD: this is a proposed presentation choice. Diagnostic fields move out of the collapsed headline into the existing tooltip. Keep this PR unmerged pending human approval. It changes only the shared web/desktop banner, not mobile error details, server normalization, transport contracts, layout or word wrapping. It does not address the underlying provider errors.

Earlier message-extraction work was proposed by xxashxx-svg in [#3830](https://github.com/pingdotgg/t3code/pull/3830), which closed when orchestration V2 replaced its server paths. This narrower implementation leaves that broader normalization out. The original tiny-width layout defect did not reproduce on current main and was already addressed by [#3899](https://github.com/pingdotgg/t3code/pull/3899); the remaining raw-JSON headline did reproduce.

## Verification

Both exact public JSON examples were rendered in an isolated Linux Chromium 152 client using a disposable thread. No provider or account request was made. Main [7a089b2b](https://github.com/pingdotgg/t3code/commit/7a089b2b2449c5c146e1a7d554a31e6d55924d3f) displayed the raw payloads. The exact candidate banner patch was then tested on [2fa5ef4c](https://github.com/pingdotgg/t3code/commit/2fa5ef4c7bf3aafabe98392d25be7eb86847ce8f), whose intervening changes did not touch the banner.

- At the same 366px text width, the 166-character payload becomes its complete 83-character message in two lines. The 245-character payload becomes its complete 115-character message in three lines.
- The tooltip retains the exact original 166/245 characters without horizontal overflow. The wide-view control and native dismiss interaction pass.
- All 30 focused banner tests pass, including both public payloads, whitespace preservation, unchanged fallbacks, one-pass extraction and raw-payload dismissal identity. Fallback shapes were verified in unit tests, not separately in the browser. No new static-markup assertions were added.
- Focused lint, web typecheck and diff checks pass after merging current main. CI and configured reviews are tracked on the current PR head.

The original Arch/Qtile Electron and macOS desktop environments were not available. Mobile is unchanged. These limits are why this PR does not close the whole report.

## Before

The multiline public payload appears as JSON in the clamped headline.

![Before: raw JSON occupies the thread error banner](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/309f8873c465102b/3747-main-pretty.png)

## After

The same error shows its message at the same viewport and thread position.

![After: the full nested message appears in the thread error banner](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/7ec91f2170fdac4b/3747-candidate-pretty.png)

The existing tooltip still exposes the complete original diagnostic.

![After: the tooltip preserves the exact original JSON payload](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/159b5a2101ebc26e/3747-candidate-pretty-tooltip.png)

GPT 6 Astra via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in the web chat error banner with conservative parsing fallbacks and no changes to dismissal or transport behavior.
> 
> **Overview**
> Structured API error payloads no longer fill the thread error banner headline with raw JSON. A new **`getThreadErrorBannerMessage`** helper parses JSON when possible and shows a non-empty **`error.message`** string in the clamped headline; plain text, invalid JSON, and unrecognized shapes are unchanged.
> 
> The **tooltip still shows the full original error string**, so diagnostics stay available without cluttering the visible line. **Dismissal keys remain tied to the raw payload**, so two errors with the same extracted headline (e.g. same message, different `code`) stay independently dismissable—covered by a new test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05a247c51fd26318a4fd697b357301853fb1af48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract nested `error.message` from JSON payloads in `ThreadErrorBanner` headline
> - Adds `getThreadErrorBannerMessage` utility that parses a JSON error string and returns the nested `error.message` when it is a non-empty string; all other inputs fall back to the original error string without recursive unwrapping
> - `ThreadErrorBanner` now shows the extracted message as the alert headline while the tooltip keeps the full original error string
> - Adds test coverage for single-line and multiline JSON, malformed payloads, missing fields, and dismissal-key isolation for diagnostics with the same nested message but different codes
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05a247c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->