### PR TITLE
fix(web): reveal reselected diff files

### DIFF
--- a/apps/web/src/components/diffs/DiffFileTree.test.tsx
+++ b/apps/web/src/components/diffs/DiffFileTree.test.tsx
@@ -1,0 +1,193 @@
+import type { CodeViewScrollTarget } from "@pierre/diffs";
+import type { FileTree as FileTreeModel } from "@pierre/trees";
+import { FileTree } from "@pierre/trees/react";
+import { act, type MouseEvent, type ReactNode } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { DiffFileTree, type DiffFileTreeEntry } from "./DiffFileTree";
+import { useCodeViewFileReveal } from "./useCodeViewFileReveal";
+
+vi.mock("../../hooks/useTheme", () => ({ useTheme: () => ({ resolvedTheme: "dark" }) }));
+// Tooltip positioning is unrelated to the tree's actual model and activation path.
+vi.mock("../ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+  TooltipTrigger: ({ render }: { render: ReactNode }) => render,
+  TooltipPopup: () => null,
+}));
+
+const entries: DiffFileTreeEntry[] = [
+  { path: "01-tall.ts", status: "modified" },
+  { path: "02-short.ts", status: "modified" },
+  { path: "03-medium.ts", status: "modified" },
+];
+
+class TreeRow {
+  constructor(readonly path: string) {}
+
+  getAttribute(name: string) {
+    return name === "data-item-path" ? this.path : null;
+  }
+}
+
+describe("diff tree file activation", () => {
+  let renderer: ReactTestRenderer | undefined;
+  const targets: CodeViewScrollTarget[] = [];
+  const viewer = {
+    getInstance: () => viewer,
+    scrollTo: (target: CodeViewScrollTarget) => targets.push(target),
+  };
+
+  function Panel({
+    files = entries,
+    selectedPath = null,
+  }: {
+    files?: DiffFileTreeEntry[];
+    selectedPath?: string | null;
+  }) {
+    const reveal = useCodeViewFileReveal(viewer, "working-tree");
+    return (
+      <DiffFileTree
+        entries={files}
+        ariaLabel="Working tree files"
+        selectedPath={selectedPath}
+        onSelectFile={(path) => reveal(`${path}\0${path}`)}
+      />
+    );
+  }
+
+  const model = (): FileTreeModel => renderer!.root.findByType(FileTree).props.model;
+
+  async function mount(props: Parameters<typeof Panel>[0] = {}) {
+    await act(async () => {
+      renderer = create(<Panel {...props} />);
+    });
+  }
+
+  // Exercise T3's capture handler before the real Pierre model's selection transition.
+  // Only DOM hit testing is represented here; native pointer/keyboard dispatch and diff
+  // geometry are verified separately in the integrated client.
+  async function activate(path: string, modifiers: Partial<MouseEvent<HTMLElement>> = {}) {
+    const event = {
+      button: 0,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      altKey: false,
+      defaultPrevented: false,
+      nativeEvent: { composedPath: () => [{}, new TreeRow(path), {}] },
+      ...modifiers,
+    } as MouseEvent<HTMLElement>;
+    await act(async () => {
+      renderer!.root
+        .find((node) => String(node.type) === "file-tree-container")
+        .props.onClickCapture?.(event);
+      const tree = model();
+      const item = tree.getItem(path)!;
+      if (event.ctrlKey || event.metaKey) {
+        item.toggleSelect();
+      } else {
+        for (const selected of tree.getSelectedPaths()) {
+          if (selected !== path) tree.getItem(selected)?.deselect();
+        }
+        item.select();
+      }
+      item.focus();
+      if ("toggle" in item && !event.ctrlKey && !event.metaKey && !event.shiftKey) item.toggle();
+    });
+  }
+
+  beforeEach(() => {
+    targets.length = 0;
+    vi.useFakeTimers();
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal("HTMLElement", TreeRow);
+  });
+
+  afterEach(async () => {
+    await act(async () => renderer?.unmount());
+    renderer = undefined;
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("reissues the reveal when the sole selected file is activated again", async () => {
+    await mount();
+    await activate("02-short.ts");
+    expect(model().getSelectedPaths()).toEqual(["02-short.ts"]);
+    await activate("02-short.ts");
+    expect(targets).toEqual([
+      { type: "item", id: "02-short.ts\u000002-short.ts", align: "start" },
+      { type: "item", id: "02-short.ts\u000002-short.ts", align: "start" },
+    ]);
+  });
+
+  it("reveals newly selected files once in either direction", async () => {
+    await mount();
+    await activate("02-short.ts");
+    await activate("01-tall.ts");
+    await activate("03-medium.ts");
+    expect(targets.map((target) => ("id" in target ? target.id : null))).toEqual(
+      ["02-short.ts", "01-tall.ts", "03-medium.ts"].map((path) => `${path}\0${path}`),
+    );
+  });
+
+  it("keeps focus-only navigation separate from button activation", async () => {
+    await mount();
+    await activate("02-short.ts");
+    await act(async () => model().getItem("01-tall.ts")!.focus());
+    expect(model().getSelectedPaths()).toEqual(["02-short.ts"]);
+    expect(targets).toHaveLength(1);
+    await activate("01-tall.ts", { detail: 0 });
+    await activate("01-tall.ts", { detail: 0 });
+    expect(targets).toHaveLength(3);
+  });
+
+  it.each(["ctrlKey", "metaKey"] as const)(
+    "does not reveal a selected file that a %s click deselects",
+    async (modifier) => {
+      await mount();
+      await activate("02-short.ts");
+      await activate("02-short.ts", { [modifier]: true });
+      expect(model().getSelectedPaths()).toEqual([]);
+      expect(targets).toHaveLength(1);
+    },
+  );
+
+  it("lets a click narrow multiple selected files without a second reveal", async () => {
+    await mount();
+    await activate("02-short.ts");
+    await act(async () => model().getItem("01-tall.ts")!.select());
+    expect(model().getSelectedPaths()).toHaveLength(2);
+    targets.length = 0;
+    await activate("02-short.ts");
+    expect(model().getSelectedPaths()).toEqual(["02-short.ts"]);
+    expect(targets).toHaveLength(1);
+  });
+
+  it("leaves directory selection and expansion to the tree", async () => {
+    await mount({ files: [{ path: "src/app.ts", status: "modified" }] });
+    const directory = model().getItem("src/")!;
+    if (!("isExpanded" in directory)) throw new Error("Expected the directory handle");
+    expect(directory.isExpanded()).toBe(true);
+    await activate("src/");
+    expect(directory.isExpanded()).toBe(false);
+    await activate("src/");
+    expect(directory.isExpanded()).toBe(true);
+    expect(targets).toEqual([]);
+  });
+
+  it("does not echo controlled selection, but lets the reader activate it", async () => {
+    await mount({ selectedPath: "02-short.ts" });
+    expect(model().getSelectedPaths()).toEqual(["02-short.ts"]);
+    expect(targets).toEqual([]);
+    await activate("02-short.ts");
+    expect(targets).toHaveLength(1);
+    await act(async () => {
+      renderer!.update(<Panel selectedPath="03-medium.ts" />);
+    });
+    expect(model().getSelectedPaths()).toEqual(["03-medium.ts"]);
+    expect(targets).toHaveLength(1);
+  });
+});

--- a/apps/web/src/components/diffs/DiffFileTree.tsx
+++ b/apps/web/src/components/diffs/DiffFileTree.tsx
@@ -177,6 +177,29 @@ export function DiffFileTree({
       <FileTree
         model={model}
         aria-label={ariaLabel}
+        onClickCapture={(event) => {
+          if (
+            event.defaultPrevented ||
+            event.button !== 0 ||
+            event.ctrlKey ||
+            event.metaKey ||
+            event.shiftKey ||
+            event.altKey
+          ) {
+            return;
+          }
+          // Pierre does not emit a selection change for its sole selected row.
+          // Read selection before the row handles the click so new selections reveal only once.
+          const selected = model.getSelectedPaths();
+          const path = selected.length === 1 ? selected[0] : undefined;
+          if (!path || !filePathsRef.current.has(path)) return;
+          const clickedSelectedRow = event.nativeEvent
+            .composedPath()
+            .some(
+              (node) => node instanceof HTMLElement && node.getAttribute("data-item-path") === path,
+            );
+          if (clickedSelectedRow) onSelectFileRef.current(path);
+        }}
         className="min-h-0 flex-1 overflow-hidden"
         style={pierreTreeStyle(resolvedTheme)}
       />


### PR DESCRIPTION
Clicking an already-selected diff file does not emit a Pierre selection change. After scrolling away, another click therefore leaves the viewer on the preceding file.

Handle a plain activation of the sole selected file at the tree host's capture phase and send the existing reveal request. New selections, modifier selection, directory toggling, and controlled selection updates retain their existing paths. This changes no collapse or viewport policy.

Related to [#5113](https://github.com/pingdotgg/t3code/issues/5113). Keep that report open: the original Ubuntu/i3 setup and every possible preceding-file case have not been verified.

## Verification

- Actual T3 component, Pierre FileTree model, and existing reveal hook: three regressions fail on main; all eight cases pass with the fix. Six existing tree mapping/update controls also pass.
- Web typecheck, focused lint, and formatting pass. Lint retains one pre-existing effect-dependency warning outside this diff.
- Linux Chromium152,1280x900, the same owned three-file Git fixture, and main [e5a87e8b](https://github.com/pingdotgg/t3code/commit/e5a87e8b9ca9db21e0291ddbd54438c5fe56b277) plus this exact production change. Repeated selection restores the short file's header to the top in stacked and split views: scrollTop1904→3904 and1084→1984 respectively.
- Native Enter on the selected row restores its file. ArrowDown moves focus without changing the diff; Enter then selects and reveals the next file. Selecting a file after Collapse all expands only that file.
- The shared component's PR-code-tab caller was reviewed and the common tree/reveal path is covered by tests; native integration was verified in the workspace Diff panel only. Mobile is unchanged. No provider turn or native Ubuntu/i3 desktop test was run.

## Before and after

Before, the short file is selected but clicking it again leaves the preceding tall file visible.

![Before: selected short file leaves the preceding tall file visible](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/81b77d96b2705c88/5113-main-same-row.png)

After, activating that same selected row reveals the short file.

![After: activating the selected short file reveals its own header](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/f52a05bc28874d63/5113-candidate-same-row.png)

## Rapid outcome/control recordings

Each 1.2-second clip is native-speed outcome/control footage, not a paced full-sequence recording or a latency benchmark. The complete pointer and keyboard sequences and scroll measurements were verified separately in the client.

Before: the selected short file leaves the tall file visible; selecting another row and returning is the working control.

![Before: rapid same-row failure and alternate-selection control](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/67f619a6a232fd1b/5113-before-rapid-activation.webm)

After: reactivating the selected short file restores its own diff.

![After: rapid selected-file reveal](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/8e1b68bb798f21ac/5113-after-rapid-activation.webm)

GPT 6 Astra via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only diff panel behavior with a narrow capture handler and regression tests; no auth, data, or API changes.
> 
> **Overview**
> Fixes diff file tree clicks on an **already-selected** file not scrolling the viewer back to that file, because Pierre’s `FileTree` does not fire a selection change when the sole selected row is activated again.
> 
> `DiffFileTree` adds a capture-phase `onClickCapture` on the tree host: for a plain left click, if exactly one file is selected and the click hits that row (`data-item-path`), it calls the existing `onSelectFile` reveal path. Modifier clicks, directories, multi-select narrowing, and controlled `selectedPath` sync are unchanged.
> 
> Adds **`DiffFileTree.test.tsx`** with eight cases around re-activation, new selection, focus vs click, ctrl/meta deselect, multi-select, folders, and controlled selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62841b3458b2cdbe6302ac375ca58ed704164ba3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-reveal already-selected diff file when its row is clicked again
> - Adds a capture-phase click handler in `DiffFileTree` that checks the pre-click model selection; when exactly one file is selected and the click hits that file's row, it invokes the file-selection callback before Pierre processes the click.
> - Ignores prevented, non-primary, modified, shifted, or alternate clicks, and does nothing for directory rows or clicks that miss the selected row.
> - Adds a test suite in `DiffFileTree.test.tsx` covering repeated single-file activation, new-file selection order, focus-only navigation, ctrl/meta deselection, multi-selection narrowing, directory toggling, and controlled-selection synchronization.
> - Risk: the capture handler calls the selection callback during `event.capture` in [DiffFileTree.tsx](https://github.com/pingdotgg/t3code/pull/9951/files#diff-a7a76025df6544ac5c8a9309377e32a612c38e304efcf040fcd0b12544626cac); consumers that rely on the callback firing only after Pierre's selection processing may see it fire earlier on re-clicks of an already sole-selected file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 62841b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->