### PR TITLE
test(web): keep provider field readers private

### DIFF
--- a/apps/web/src/components/settings/ProviderSettingsForm.test.ts
+++ b/apps/web/src/components/settings/ProviderSettingsForm.test.ts
@@ -5,8 +5,6 @@ import { DRIVER_OPTION_BY_VALUE } from "./providerDriverMeta";
 import {
   deriveProviderSettingsFields,
   nextProviderConfigWithFieldValue,
-  readProviderConfigBoolean,
-  readProviderConfigString,
 } from "./ProviderSettingsForm";
 
 describe("ProviderSettingsForm helpers", () => {
@@ -90,10 +88,6 @@ describe("ProviderSettingsForm helpers", () => {
     expect(next).toEqual({ forkOwned: 1 });
   });
 
-  it("reads non-string config values as blank strings", () => {
-    expect(readProviderConfigString({ binaryPath: 123 }, "binaryPath")).toBe("");
-  });
-
   it("omits false boolean fields when clearWhenEmpty is omit", () => {
     const next = nextProviderConfigWithFieldValue(
       { forkOwned: 1, experimental: true },
@@ -155,13 +149,5 @@ describe("ProviderSettingsForm helpers", () => {
     );
 
     expect(next).toEqual({ experimental: false });
-  });
-
-  it("reads non-boolean config values as false booleans", () => {
-    expect(readProviderConfigBoolean({ experimental: "true" }, "experimental")).toBe(false);
-  });
-
-  it("reads missing boolean config values from the supplied default", () => {
-    expect(readProviderConfigBoolean({}, "experimental", true)).toBe(true);
   });
 });

--- a/apps/web/src/components/settings/ProviderSettingsForm.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsForm.tsx
@@ -119,17 +119,13 @@ export function deriveProviderSettingsFields(
     });
 }
 
-export function readProviderConfigString(config: unknown, key: string): string {
+function readProviderConfigString(config: unknown, key: string): string {
   if (config === null || typeof config !== "object") return "";
   const value = (config as Record<string, unknown>)[key];
   return typeof value === "string" ? value : "";
 }
 
-export function readProviderConfigBoolean(
-  config: unknown,
-  key: string,
-  defaultValue = false,
-): boolean {
+function readProviderConfigBoolean(config: unknown, key: string, defaultValue = false): boolean {
   if (config === null || typeof config !== "object") return defaultValue;
   const value = (config as Record<string, unknown>)[key];
   return typeof value === "boolean" ? value : defaultValue;


### PR DESCRIPTION
Two private provider-field readers were exported solely so tests could exercise primitive type checks and fallback values.

Make the readers private and remove those three direct tests. Keep the tests for schema-derived controls, unknown-key preservation, default-value persistence, and environment selection. Runtime function bodies are unchanged.

Verification: 18 focused tests passed across ProviderSettingsForm, ProviderSettingsPanel.environment, and AddProviderInstanceDialog.environment. Web typecheck, targeted lint, and formatting passed. No visual behavior changed, so screenshots do not apply.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only API tightening and test cleanup with no runtime logic changes.
> 
> **Overview**
> **Encapsulates** provider config parsing helpers by making `readProviderConfigString` and `readProviderConfigBoolean` module-private instead of exported. Their behavior is unchanged; they still back form controls and `nextProviderConfigWithFieldValue`.
> 
> **Tests** drop three cases that called those helpers directly (wrong-type and default-value coercion). Coverage stays on schema-derived fields, `clearWhenEmpty` / boolean omit rules, and unknown-key preservation via the public `nextProviderConfigWithFieldValue` API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42a1d356637e46a16fc0d2a8bc1c8e3ae24de37b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `readProviderConfigString` and `readProviderConfigBoolean` private in `ProviderSettingsForm`
> Removes the export on the two provider config field readers so they stay module-private. Updates [ProviderSettingsForm.test.ts](https://github.com/pingdotgg/t3code/pull/9952/files#diff-74adfd414c4f4450eccf651438131a37e10e8e2f37d77d55852953423278c960) to stop importing them directly; tests now exercise behavior through the component rather than the readers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42a1d35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->