### PR TITLE
test(mobile): keep composer selection helper private

### DIFF
--- a/apps/mobile/src/features/threads/use-composer-command-menu.test.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.test.ts
@@ -13,15 +13,8 @@ vi.mock("../../state/use-atom-command", () => ({
 
 import {
   buildComposerSlashCommandItems,
-  composerSelectionAtEnd,
   resolveComposerCommandSelection,
 } from "./use-composer-command-menu";
-
-describe("composerSelectionAtEnd", () => {
-  it("resets a changed draft owner to the new draft end", () => {
-    expect(composerSelectionAtEnd("queued task 🧪")).toEqual({ start: 14, end: 14 });
-  });
-});
 
 describe("mobile slash commands", () => {
   const antigravity = {

--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -27,7 +27,7 @@ import { matchesSlashSkillQuery } from "./composerSlashSkillSearch";
 
 const WORKSPACE_SNAPSHOT_RETRY_COOLDOWN_MS = 10_000;
 
-export function composerSelectionAtEnd(draftMessage: string): ComposerEditorSelection {
+function composerSelectionAtEnd(draftMessage: string): ComposerEditorSelection {
   return { start: draftMessage.length, end: draftMessage.length };
 }
 


### PR DESCRIPTION
The mobile composer exported its one-line cursor-at-end helper only for a test of the string length.

Keep the helper private and remove that direct test. The four slash-command cases remain, covering native provider commands, supported T3 plan commands, mid-message filtering, and a provider switch invalidating a selection. Runtime code is unchanged for both existing-thread and new-task composers.

Verification: all four focused tests, the mobile package typecheck, and targeted formatting passed. Targeted lint passed with two warnings on unchanged hook code. No visual behavior changed, so screenshots do not apply.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and export-surface cleanup only; composer runtime behavior is unchanged.
> 
> **Overview**
> Makes **`composerSelectionAtEnd`** an internal helper in the mobile composer command menu hook instead of a public export, so cursor-at-end logic stays tied to hook usage rather than the module API.
> 
> Removes the dedicated unit test that imported and asserted on that helper directly. **Slash-command** coverage is unchanged: native provider commands, T3 plan behavior, mid-message filtering, and provider-switch selection handling still run through **`buildComposerSlashCommandItems`** and **`resolveComposerCommandSelection`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3403e0d3935b00200a9963c7d29fd2e01fa6dbc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `composerSelectionAtEnd` private in composer command menu
> Changes `composerSelectionAtEnd` from an exported function to a module-private function in [use-composer-command-menu.ts](https://github.com/pingdotgg/t3code/pull/9953/files#diff-765bb6c8049500163389336a7a5e0c83873e041f5b14c72e5f5804359e6492d9). Removes the direct import and the dedicated test suite for this helper in [use-composer-command-menu.test.ts](https://github.com/pingdotgg/t3code/pull/9953/files#diff-0c511098f5fa8c4c202c9980650b87ea793d5cf71d22c8ccd0c5a61701ae2385). The remaining slash-command tests and the selection calculation are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3403e0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->