### PR TITLE
fix(terminal): identify T3 Code terminal sessions

### DIFF
--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -27,6 +27,7 @@ import * as TestClock from "effect/testing/TestClock";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { expect } from "vite-plus/test";
 
+import packageJson from "../../package.json" with { type: "json" };
 import * as ProcessRunner from "../processRunner.ts";
 import * as TerminalManager from "./Manager.ts";
 import * as PtyAdapter from "./PtyAdapter.ts";
@@ -1712,6 +1713,39 @@ it.layer(
       }),
   );
 
+  it.effect.each([
+    { name: "the parent has no identity", env: {} },
+    {
+      name: "the parent identifies a different terminal",
+      env: { TERM_PROGRAM: "Apple_Terminal", TERM_PROGRAM_VERSION: "2.14" },
+    },
+  ] as const)("sets T3 Code terminal identity when $name", ({ env: parentEnv }) =>
+    Effect.gen(function* () {
+      const env = Object.freeze({ ...parentEnv });
+      const { manager, ptyAdapter } = yield* createManager(5, { env });
+      yield* manager.open(openInput());
+
+      expect(ptyAdapter.spawnInputs[0]?.env.TERM_PROGRAM).toBe("t3code");
+      expect(ptyAdapter.spawnInputs[0]?.env.TERM_PROGRAM_VERSION).toBe(packageJson.version);
+      expect(env).toEqual(parentEnv);
+    }),
+  );
+
+  it.effect("preserves partial and blank terminal identity overrides on restart", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        env: { TERM_PROGRAM: "Apple_Terminal", TERM_PROGRAM_VERSION: "2.14" },
+      });
+      yield* manager.open(openInput({ env: { TERM_PROGRAM_VERSION: "custom-version" } }));
+      expect(ptyAdapter.spawnInputs[0]?.env.TERM_PROGRAM).toBe("t3code");
+      expect(ptyAdapter.spawnInputs[0]?.env.TERM_PROGRAM_VERSION).toBe("custom-version");
+
+      yield* manager.restart(restartInput({ env: { TERM_PROGRAM: "" } }));
+      expect(ptyAdapter.spawnInputs[1]?.env.TERM_PROGRAM).toBe("");
+      expect(ptyAdapter.spawnInputs[1]?.env.TERM_PROGRAM_VERSION).toBe(packageJson.version);
+    }),
+  );
+
   it.effect("filters app runtime env variables from terminal sessions", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager(5, {
@@ -1809,6 +1843,8 @@ it.layer(
             T3CODE_PROJECT_ROOT: "/repo",
             T3CODE_WORKTREE_PATH: "/repo/worktree-a",
             CUSTOM_FLAG: "1",
+            TERM_PROGRAM: "custom-terminal",
+            TERM_PROGRAM_VERSION: "custom-version",
           },
         }),
       );
@@ -1819,6 +1855,8 @@ it.layer(
       assert.equal(spawnInput.env.T3CODE_PROJECT_ROOT, "/repo");
       assert.equal(spawnInput.env.T3CODE_WORKTREE_PATH, "/repo/worktree-a");
       assert.equal(spawnInput.env.CUSTOM_FLAG, "1");
+      assert.equal(spawnInput.env.TERM_PROGRAM, "custom-terminal");
+      assert.equal(spawnInput.env.TERM_PROGRAM_VERSION, "custom-version");
     }),
   );
 

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -51,6 +51,7 @@ import * as Scope from "effect/Scope";
 import * as Semaphore from "effect/Semaphore";
 import * as SynchronizedRef from "effect/SynchronizedRef";
 
+import packageJson from "../../package.json" with { type: "json" };
 import * as ServerConfig from "../config.ts";
 import {
   increment,
@@ -1265,6 +1266,8 @@ function createTerminalSpawnEnv(
     if (shouldExcludeTerminalEnvKey(key)) continue;
     spawnEnv[key] = value;
   }
+  spawnEnv.TERM_PROGRAM = "t3code";
+  spawnEnv.TERM_PROGRAM_VERSION = packageJson.version;
   if (runtimeEnv) {
     for (const [key, value] of Object.entries(runtimeEnv)) {
       spawnEnv[key] = value;


### PR DESCRIPTION
Closes #8450.

## Problem and fix

New T3 Code terminal shells have no `TERM_PROGRAM` or `TERM_PROGRAM_VERSION` when those variables are absent from the server environment. If the server inherits `Apple_Terminal`, that launcher identity reaches the T3 terminal instead.

Set `TERM_PROGRAM=t3code` and `TERM_PROGRAM_VERSION` to the server package version when constructing the PTY environment. Explicit per-terminal overrides still win, including empty strings. The change applies to newly started and restarted shells; it does not alter an already-running shell.

Closes [#8450](https://github.com/pingdotgg/t3code/issues/8450). Credit to [lavindeep](https://github.com/lavindeep) for the original implementation in [#8473](https://github.com/pingdotgg/t3code/pull/8473). This adapts that three-line production change to current main and adds partial-override and restart coverage. The original PR remains closed and untouched.

## Human hold

Do not merge automatically. The [earlier closure](https://github.com/pingdotgg/t3code/pull/8473#issuecomment-5453030813) considered this behavior correct but low priority. This PR is a prepared option for a maintainer to revisit that priority and approve the `t3code` identity and server-version choice. A remote client's version can differ from its server's version.

There are no changes to `TERM`, `COLORTERM`, terminal rendering, DEC queries, provider processes, contracts, or client code. The separate color fix in [#7680](https://github.com/pingdotgg/t3code/pull/7680) is preserved.

## Before and after

On September 5, 2026 UTC, tested fresh main [e5a87e8b9](https://github.com/pingdotgg/t3code/commit/e5a87e8b9ca9db21e0291ddbd54438c5fe56b277) and this candidate through the real `TerminalManager` and `NodePtyAdapter`, spawning `/bin/sh` on Linux. Each test used a disposable log directory and explicit parent environment. The shell printed:

```sh
printf 'AUDIT8450:[%s][%s][%s]\n' "$TERM_PROGRAM" "$TERM_PROGRAM_VERSION" "$COLORTERM"
```

| Environment | Before | After |
| --- | --- | --- |
| Empty parent environment | `AUDIT8450:[][][truecolor]` | `AUDIT8450:[t3code][0.0.38][truecolor]` |
| Parent identifies Apple Terminal | `AUDIT8450:[Apple_Terminal][2.14][truecolor]` | `AUDIT8450:[t3code][0.0.38][truecolor]` |
| Explicit per-terminal identity and color | `AUDIT8450:[custom-terminal][custom-version][24bit]` | Unchanged |

The fixture waited for output and native exit receipts; all six captured before/after child PIDs were confirmed gone. No full server, browser, provider, account, or installer was started. These textual receipts exercise the child environment directly; there is no visual change requiring screenshots.

## Verification and limits

- Regression tests before the production change: three failures and one passing explicit-override control.
- Candidate: all 72 tests in `Manager.test.ts`, `NodePtyAdapter.test.ts`, and `BunPtyAdapter.test.ts` pass with `--maxWorkers=2`.
- Targeted lint and formatting pass. The existing `prefer-array-find` warning in untouched test code remains.
- Server typecheck passes with existing nonblocking Effect suggestions. Independent review reran the four identity/override tests successfully.
- Tests cover absent and inherited identity, unchanged parent values, explicit full and partial overrides, and an empty program override on restart. Existing color and AppImage behavior remain covered.

Web, desktop, mobile, and project setup terminals use the same server-side spawn path; their explicit environment values retain precedence. This was inspected in source, not verified in each client. The original macOS 15.7.4 report, packaged desktop, Windows/ConPTY, and native Bun PTY have not been exercised here. This PR does not auto-close the issue or claim those native results.

Prepared with GPT 6 Astra via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small env-default change at PTY spawn with override precedence preserved; no auth, contracts, or terminal rendering changes.
> 
> **Overview**
> PTY spawn env now sets **`TERM_PROGRAM=t3code`** and **`TERM_PROGRAM_VERSION`** from the server package version in `createTerminalSpawnEnv`, so integrated shells no longer inherit a parent launcher identity (e.g. Apple Terminal) when those vars are missing or wrong upstream.
> 
> Per-terminal **`open` / `restart` env overrides** still apply afterward, including partial updates and empty-string clears. **`COLORTERM`**, **`TERM`**, and rendering behavior are unchanged.
> 
> **`Manager.test.ts`** adds coverage for default identity, explicit overrides, and restart behavior; the runtime-env injection test now asserts `TERM_PROGRAM` / `TERM_PROGRAM_VERSION` pass through when set explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4884259a48677193e091701622293f9e341c5f7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `TERM_PROGRAM` to `t3code` in `createTerminalSpawnEnv`
> - Terminals spawned through the server now identify themselves as `t3code` at the current server package version by default, by setting `TERM_PROGRAM` and `TERM_PROGRAM_VERSION` after filtering the base process environment in [Manager.ts](https://github.com/pingdotgg/t3code/pull/9954/files#diff-9b98fe5056129db24d311ed1bd8f66a72127cf90fa7529da47e0725f2813532e).
> - Explicit runtime overrides for `TERM_PROGRAM` and `TERM_PROGRAM_VERSION` still take precedence, including blank values, because runtime entries are applied after the defaults.
> - Adds test coverage in [Manager.test.ts](https://github.com/pingdotgg/t3code/pull/9954/files#diff-24940c1a981597b3ff69612842e726ca0dc8f341aa4e716769b52c3166749bf9) for default identity, partial and blank overrides, and pass-through of explicit runtime values.
> - Behavioral Change: spawned terminals that previously inherited the parent shell's `TERM_PROGRAM` now report `t3code` unless a runtime override is supplied; review consumers that branch on `TERM_PROGRAM`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4884259.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->