### PR TITLE
test(client-runtime): keep scoped key implementation private

### DIFF
--- a/packages/client-runtime/src/environment/knownEnvironment.test.ts
+++ b/packages/client-runtime/src/environment/knownEnvironment.test.ts
@@ -6,7 +6,6 @@ import {
   parseScopedProjectKey,
   parseScopedThreadKey,
   scopedProjectKey,
-  scopedRefKey,
   scopedThreadKey,
   scopeProjectRef,
   scopeThreadRef,
@@ -40,8 +39,6 @@ describe("scoped refs", () => {
   const threadRef = scopeThreadRef(environmentId, ThreadId.make("thread-1"));
 
   it("builds stable scoped project and thread keys", () => {
-    expect(scopedRefKey(projectRef)).toBe("environment-test:project-1");
-    expect(scopedRefKey(threadRef)).toBe("environment-test:thread-1");
     expect(scopedProjectKey(projectRef)).toBe("environment-test:project-1");
     expect(scopedThreadKey(threadRef)).toBe("environment-test:thread-1");
   });

--- a/packages/client-runtime/src/environment/scoped.ts
+++ b/packages/client-runtime/src/environment/scoped.ts
@@ -22,7 +22,7 @@ export function scopeThreadRef(
   return { environmentId, threadId };
 }
 
-export function scopedRefKey(ref: ScopedProjectRef | ScopedThreadRef): string {
+function scopedRefKey(ref: ScopedProjectRef | ScopedThreadRef): string {
   const localId = "projectId" in ref ? ref.projectId : ref.threadId;
   return `${ref.environmentId}:${localId}`;
 }


### PR DESCRIPTION
The shared scoped-key implementation was exported only so a test could repeat the assertions already made through the project-key and thread-key APIs.

Make `scopedRefKey` private and remove those two duplicate assertions. Keep the four tests covering public key generation, typed references, parsing, and malformed keys. Runtime behavior is unchanged.

Verification: all four known-environment tests, client-runtime typecheck, targeted lint, and formatting passed. No visual behavior changed, so screenshots do not apply.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export visibility and test cleanup only; public scoped key APIs and behavior are unchanged.
> 
> **Overview**
> **Encapsulates** the shared scoped-key helper by making `scopedRefKey` a module-private function in `scoped.ts` instead of a public export.
> 
> **Tests** no longer import or assert against `scopedRefKey` directly; stable key behavior is still covered through the public `scopedProjectKey` and `scopedThreadKey` APIs. No change to key format or runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58437dde9ab85dbd31de5a2549c529874652c13c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `scopedRefKey` private in `scoped.ts` module
> Changes `scopedRefKey` from an exported function to a module-private function in [scoped.ts](https://github.com/pingdotgg/t3code/pull/9955/files#diff-be780ade140f7c49877b0834740fe375708a25e3e5b60faca7d132c7dbfceac5). Removes the direct import and assertions for `scopedRefKey` from [knownEnvironment.test.ts](https://github.com/pingdotgg/t3code/pull/9955/files#diff-7e73251b23d1f206b917d83f8f83ae1bffb0fea769b639e1827cd4fbe8f05e9f); tests now only validate the public project- and thread-specific key helpers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58437dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->