### PR TITLE
fix(codex): prefer GPT-6 Astra by default

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -127,6 +127,21 @@ it("prefers sol over terra when both are available", () => {
   assert.deepStrictEqual(models.find((model) => model.isDefault)?.slug, "gpt-5.6-sol");
 });
 
+it("prefers astra over previous current models", () => {
+  const models = applyPreferredCodexDefaultModel([
+    {
+      slug: "gpt-5.6-sol",
+      name: "GPT-5.6-Sol",
+      isCustom: false,
+      isDefault: true,
+      capabilities: null,
+    },
+    { slug: "gpt-6-astra", name: "GPT-6-Astra", isCustom: false, capabilities: null },
+  ]);
+
+  assert.deepStrictEqual(models.find((model) => model.isDefault)?.slug, "gpt-6-astra");
+});
+
 it("keeps Codex's own default when no preferred model is available", () => {
   const models = applyPreferredCodexDefaultModel([
     { slug: "gpt-5.5", name: "GPT-5.5", isCustom: false, capabilities: null },

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -149,7 +149,7 @@ const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 const GROK_DRIVER_KIND = ProviderDriverKind.make("grok");
 const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
 
-export const DEFAULT_MODEL = "gpt-5.6-sol";
+export const DEFAULT_MODEL = "gpt-6-astra";
 
 /**
  * Codex default-model preference, most preferred first. The provider snapshot
@@ -157,6 +157,7 @@ export const DEFAULT_MODEL = "gpt-5.6-sol";
  * default; when none are available, Codex's own `isDefault` flag wins.
  */
 export const PREFERRED_DEFAULT_CODEX_MODELS: ReadonlyArray<string> = [
+  "gpt-6-astra",
   "gpt-5.6-sol",
   "gpt-5.6-terra",
 ];


### PR DESCRIPTION
Codex 0.153.4 makes GPT-6 Astra its bundled default, but T3's preferred-model ranking still reassigns the default flag to GPT-5.6 Sol whenever both appear in `model/list`. New Codex drafts therefore keep selecting the previous model after Astra is discovered.

## Fix

- Put `gpt-6-astra` first in the live Codex model preference order.
- Use Astra as the static fallback when no live catalog is available.
- Add a regression test proving Astra wins over the previous current models.
- Keep GPT-5.6 Luna as the separate low-cost text-generation default.

## Verification

- `corepack pnpm exec vp fmt --check packages/contracts/src/model.ts apps/server/src/provider/Layers/CodexProvider.test.ts`
- `corepack pnpm exec vp lint packages/contracts/src/model.ts apps/server/src/provider/Layers/CodexProvider.test.ts --report-unused-disable-directives`
- `corepack pnpm exec vp test run apps/server/src/provider/Layers/CodexProvider.test.ts apps/server/src/provider/Layers/CodexSessionRuntime.test.ts apps/server/src/serverRuntimeStartup.test.ts apps/web/src/modelSelection.test.ts apps/web/src/composerDraftStore.test.ts` (197 tests)
- `corepack pnpm exec vp run --filter @t3tools/contracts typecheck`
- `corepack pnpm exec vp run --filter t3 typecheck`

Prepared with GPT-5.6-Sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to Codex model preference ordering; no auth, data, or session-runtime logic changes in this diff.
> 
> **Overview**
> Aligns T3’s Codex defaults with Codex 0.153.4 by making **GPT-6 Astra** the top choice when the live `model/list` includes it.
> 
> `DEFAULT_MODEL` and the head of `PREFERRED_DEFAULT_CODEX_MODELS` in `@t3tools/contracts` now use `gpt-6-astra` instead of `gpt-5.6-sol`, so preferred-default logic and static fallbacks pick Astra over Sol/Terra. **GPT-5.6 Luna** stays the separate text-generation default.
> 
> Adds a regression test in `CodexProvider.test.ts` that `applyPreferredCodexDefaultModel` marks Astra default when both Astra and Sol are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29ea1d4da01f87ead7eed0f441e6fdf8f5e6633b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prefer GPT-6 Astra as default Codex model
> Changes `DEFAULT_MODEL` from Sol to Astra and inserts Astra at the front of `PREFERRED_DEFAULT_CODEX_MODELS`, ahead of Sol and Terra. Adds a test in [CodexProvider.test.ts](https://github.com/pingdotgg/t3code/pull/9957/files#diff-e4480f09a7643d1d20e19242d87524b912b0f1c6c1c6fd12cc64cc644219643d) verifying Astra wins over a previous current-model default when both are present.
> - Risk: any caller relying on `DEFAULT_MODEL` being Sol now gets Astra; consumers importing `DEFAULT_MODEL` or depending on the previous Sol default need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29ea1d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->