### PR TITLE
chore: remove redundant root tooling dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,7 @@
     "sync:repos": "node scripts/sync-reference-repos.ts"
   },
   "devDependencies": {
-    "@babel/plugin-transform-react-jsx": "7.28.6",
     "@effect/tsgo": "catalog:",
-    "@oxlint/plugins": "^1.63.0",
     "@types/node": "catalog:",
     "@typescript/native-preview": "catalog:",
     "knip": "6.34.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,15 +109,9 @@ importers:
 
   .:
     devDependencies:
-      '@babel/plugin-transform-react-jsx':
-        specifier: 7.28.6
-        version: 7.28.6(@babel/core@7.29.7)
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.13.2
-      '@oxlint/plugins':
-        specifier: ^1.63.0
-        version: 1.68.0
       '@types/node':
         specifier: 24.12.4
         version: 24.12.4
@@ -14304,7 +14298,7 @@ snapshots:
       '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-regenerator': 7.29.7(@babel/core@7.29.7)


### PR DESCRIPTION
Knip found two redundant root development dependencies: the unused direct Babel JSX transform and a second declaration of @oxlint/plugins.

Remove those root declarations. The lint-plugin workspace keeps its own @oxlint/plugins dependency, and Expo retains its transitive JSX transform dependency.

Verification: dependency installation and the complete Knip file/dependency gate pass. Twenty focused JSX and lint-plugin tests passed; actual lint plugin loading passed. The web production build passed in 57.62 seconds. No runtime or visual behavior changed, so screenshots do not apply.

Leave this stack unmerged for maintainer review.

Model: gpt-6 astra. Harness: Codex in T3 Code.
