### PR TITLE
ci: reject unused files and dependencies with Knip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
       - name: Ensure Electron runtime is installed
         run: vp run --filter @t3tools/desktop ensure:electron
 
+      # Export cleanup is still a manual audit; files and dependencies have no baseline.
+      - name: Check unused files and dependencies
+        run: vp run knip:check
+
       - name: Check
         run: vp check
 

--- a/docs/operations/development.md
+++ b/docs/operations/development.md
@@ -69,6 +69,15 @@ Use `vp run lint:mobile` for native mobile changes. CI owns the full suite; see
 The [manual Windows lane](../../.github/workflows/windows-tests.yml) is available for focused
 Windows investigation while that suite is not a required gate.
 
+### Unused code
+
+`vp run knip:check` runs the unused-file and dependency check enforced by CI.
+Use `vp run knip --workspace apps/web` to audit one workspace, including exports,
+or `vp run knip:production --workspace apps/web` to find code kept alive only by tests.
+The full export audit still has findings and is not a CI gate. Review callers before
+deleting code; production mode can also report development scripts and test fixtures.
+Runtime-discovered entrypoints and dependency exceptions belong in [knip.jsonc](../../knip.jsonc).
+
 ## Desktop artifacts
 
 Local artifact builds are unsigned by default and write to `release/`:

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "tc": "vp run -r --concurrency-limit 2 typecheck",
     "lint": "vp lint --report-unused-disable-directives",
     "knip": "knip",
+    "knip:check": "knip --include files,dependencies --no-config-hints",
     "knip:production": "knip --production",
     "lint:mobile": "node scripts/mobile-native-static-check.ts",
     "test": "vp run -r test",


### PR DESCRIPTION
Unused files and dependency declarations can otherwise accumulate again after this cleanup.

Run knip:check in the existing CI Check job. It enforces zero unused files and dependencies, including development dependencies. Add concise workspace and production-audit instructions to the development runbook.

The export/type backlog remains visible through the full audit but is not yet a CI gate. This does not introduce an issue-count baseline or suppress the remaining exports.

Verification: the exact CI command passes. Temporarily adding an orphan TypeScript file made it exit 1 and identify that file; removing the probe restored a passing result. Formatting and diff checks passed. No runtime or visual behavior changed, so screenshots do not apply.

Leave this stack unmerged for maintainer review.

Model: gpt-6 astra. Harness: Codex in T3 Code.

## Closes discussions
- https://github.com/pingdotgg/t3code/discussions/7042
