### PR TITLE
fix(web): give the browser keybinding notice breathing room

### DIFF
--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -1324,7 +1324,7 @@ function KeybindingsList(props: KeybindingsListProps) {
 /** Shown in the browser build only; the desktop app receives every shortcut. */
 function BrowserKeybindingNotice() {
   return (
-    <div className="flex items-center gap-1.5 px-3 pb-2 text-[12px] text-muted-foreground sm:px-4">
+    <div className="flex items-center gap-2 px-3 py-2.5 text-[12px] leading-[1.45] text-muted-foreground sm:px-4">
       <TriangleAlertIcon className="size-3.5 shrink-0 text-warning" aria-hidden />
       <span>
         Some shortcuts may be claimed by the browser before T3 Code sees them. Use the desktop app


### PR DESCRIPTION
The browser-only warning at the top of Settings → Keybindings only had bottom padding, so the icon and text sat cramped against the section's top border and the icon didn't line up with the row titles below it.

Gave the notice symmetric vertical padding, widened the icon/text gap to match the rest of the settings rows, and set the same line height the section descriptions use so the icon centers on the text.

Web only; the notice is not rendered in the desktop app and mobile has no keybindings settings.

## Before

![Before: warning text flush against the section's top border, icon slightly inset from the row titles](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/a26b1509d386ea85/keybindings-notice-before.png)

## After

![After: warning row has even space above and below, icon aligned with the row titles](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/aa059fb0b9ca2673/keybindings-notice-after.png)

## Verification

- `vp lint` on the touched file and `vp run typecheck` in `apps/web` pass.
- Screenshots taken from the same worktree dev server (base vs head), dark mode, 1440×900 @2x.

Written by Claude Fable 5 via Claude Code in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only tweak to a browser-only notice; no logic, data, or security impact.
> 
> **Overview**
> Updates **`BrowserKeybindingNotice`** styling in Settings → Keybindings (web only) so the warning row matches neighboring settings layout.
> 
> The notice container now uses **symmetric vertical padding** (`py-2.5` instead of bottom-only `pb-2`), **`gap-2`** between icon and text (aligned with `SettingsRow` titles), and **`leading-[1.45]`** so the warning icon lines up with the text like section descriptions. Copy and behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60af871bb724e5a9388b4cc332d90f73b50c3709. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add vertical padding and spacing to `BrowserKeybindingNotice`
> Adjusts the styling of the notice container in [KeybindingsSettings.tsx](https://github.com/pingdotgg/t3code/pull/9964/files#diff-12068495a79a13f54503fa3061aafb91f05537621626906b290ed059e660d4d4) to increase flex gap, add uniform vertical padding, and set an explicit line height. Small-screen bottom padding is replaced with consistent vertical padding while horizontal padding and typography remain unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60af871.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->