### PR TITLE
fix(web): keep the composer expanded until the thread can scroll

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -111,6 +111,7 @@ import { type LegendListRef } from "@legendapp/list/react";
 import {
   CHAT_TIMELINE_ANCHOR_OFFSET,
   getAnchoredTurnMetrics,
+  timelineContentOverflowsViewport,
   type TimelineScrollMode,
 } from "./chat/timelineScrollAnchoring";
 import {
@@ -1646,6 +1647,9 @@ export default function ChatView(props: ChatViewProps) {
   const [scrollToEndClearance, setScrollToEndClearance] = useState(0);
   const isAtEndRef = useRef(true);
   const isTimelineAtLogicalEnd = useCallback(() => isAtEndRef.current, []);
+  // Whether the timeline's rows extend past the viewport above the composer.
+  // The composer only rests when there is reading space to give back.
+  const [timelineOverflows, setTimelineOverflows] = useState(false);
   const attachmentPreviewHandoffByMessageIdRef = useRef<Record<string, string[]>>({});
   const attachmentPreviewPromotionInFlightByMessageIdRef = useRef<Record<string, true>>({});
   const sendInFlightRef = useRef(false);
@@ -4485,32 +4489,11 @@ export default function ChatView(props: ChatViewProps) {
     [composerTimelineInset],
   );
   const timelineRealContentOverflowsViewport = useCallback(
-    (list?: LegendListRef | null) => {
-      const resolvedList = list ?? legendListRef.current;
-      const state = resolvedList?.getState();
-      if (!resolvedList || !state || state.data.length === 0) {
-        return false;
-      }
-
-      const lastRowIndex = state.data.length - 1;
-      const lastRowTop = state.positionAtIndex(lastRowIndex);
-      const lastRowHeight = state.sizeAtIndex(lastRowIndex);
-      if (
-        typeof lastRowTop !== "number" ||
-        typeof lastRowHeight !== "number" ||
-        !Number.isFinite(lastRowTop) ||
-        !Number.isFinite(lastRowHeight)
-      ) {
-        return false;
-      }
-
-      const realContentBottom = lastRowTop + Math.max(1, lastRowHeight);
-      const visibleScrollLength = Math.max(
-        0,
-        (state.scrollLength ?? 0) - composerTimelineInset - CHAT_TIMELINE_ANCHOR_OFFSET,
-      );
-      return realContentBottom > visibleScrollLength;
-    },
+    (list?: LegendListRef | null) =>
+      timelineContentOverflowsViewport((list ?? legendListRef.current)?.getState(), {
+        composerInset: composerTimelineInset,
+        anchorOffset: CHAT_TIMELINE_ANCHOR_OFFSET,
+      }),
     [composerTimelineInset],
   );
   const pageScrollControllerRef = useRef<ReturnType<typeof createPageScrollController> | null>(
@@ -7840,6 +7823,7 @@ export default function ChatView(props: ChatViewProps) {
                 contentInsetEndAdjustment={composerTimelineInset}
                 liveFollowEnabled={timelineLiveFollowEnabled}
                 onIsAtEndChange={onIsAtEndChange}
+                onContentOverflowChange={setTimelineOverflows}
                 onToolOutputCollapsedAtEnd={onToolOutputCollapsedAtEnd}
                 onManualNavigation={cancelTimelineLiveFollowForUserNavigation}
                 hideEmptyPlaceholder={isDraftHeroState || threadDetailLoading}
@@ -7986,6 +7970,7 @@ export default function ChatView(props: ChatViewProps) {
                             onRestingControlsVisibilityChange={setRestingComposerControlsVisible}
                             getTimelineScrollableNode={getTimelineScrollableNode}
                             isTimelineAtLogicalEnd={isTimelineAtLogicalEnd}
+                            timelineOverflows={timelineOverflows}
                             onComposerOverlayHeightChange={publishComposerOverlayHeight}
                             onRestingChange={onComposerRestingChange}
                             promptRef={promptRef}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1251,6 +1251,8 @@ export interface ChatComposerProps {
   onRestingControlsVisibilityChange: (visible: boolean) => void;
   getTimelineScrollableNode: () => HTMLElement | null;
   isTimelineAtLogicalEnd: () => boolean;
+  /** Whether the timeline has more content than fits above the composer. */
+  timelineOverflows: boolean;
   onComposerOverlayHeightChange: (height: number) => void;
   /**
    * Whether the desktop resting layout is active. Reported from a layout
@@ -1361,6 +1363,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     onRestingControlsVisibilityChange,
     getTimelineScrollableNode,
     isTimelineAtLogicalEnd,
+    timelineOverflows,
     onComposerOverlayHeightChange,
     onRestingChange,
     promptRef,
@@ -3699,6 +3702,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     isScrollCollapsed: isComposerScrollCollapsed,
     hasExpandedChrome: composerHasExpandedChrome,
     collapseOnBlur: settings.composerCollapseOnBlur,
+    timelineOverflows,
   });
   // The relocated controls live in the context strip whenever the composer is
   // collapsed for any reason, the desktop resting layout or the phone

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -279,6 +279,7 @@ describe("MessagesTimeline", () => {
             isScrollCollapsed: composer.isComposerScrollCollapsed,
             hasExpandedChrome: false,
             collapseOnBlur: true,
+            timelineOverflows: true,
           });
         });
         return (

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -623,6 +623,12 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   // sees the settled positions. One frame is shared across bursts of size
   // changes.
   const contentOverflowFrameRef = useRef<number | null>(null);
+  const cancelContentOverflowFrame = useCallback(() => {
+    if (contentOverflowFrameRef.current !== null) {
+      cancelAnimationFrame(contentOverflowFrameRef.current);
+      contentOverflowFrameRef.current = null;
+    }
+  }, []);
   const reportContentOverflow = useCallback(() => {
     if (!onContentOverflowChange || contentOverflowFrameRef.current !== null) return;
     contentOverflowFrameRef.current = requestAnimationFrame(() => {
@@ -630,19 +636,16 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onContentOverflowChange(measureContentOverflow());
     });
   }, [measureContentOverflow, onContentOverflowChange]);
-  useEffect(() => {
-    return () => {
-      if (contentOverflowFrameRef.current !== null) {
-        cancelAnimationFrame(contentOverflowFrameRef.current);
-      }
-    };
-  }, []);
+  useEffect(() => cancelContentOverflowFrame, [cancelContentOverflowFrame]);
   // The list's own layout effects have already run here, so estimated row
   // positions are in place. Reporting before the first paint lets a thread
   // open in its final composer layout instead of correcting it a frame later.
+  // A frame scheduled with the previous inset would overwrite this read, so
+  // it is dropped first.
   useLayoutEffect(() => {
+    cancelContentOverflowFrame();
     onContentOverflowChange?.(measureContentOverflow());
-  }, [measureContentOverflow, onContentOverflowChange, rows.length]);
+  }, [cancelContentOverflowFrame, measureContentOverflow, onContentOverflowChange, rows.length]);
 
   const handleScroll = useCallback(() => {
     const state = listRef.current?.getState?.();

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -113,7 +113,10 @@ import {
 } from "./ExpandedImagePreview";
 import { ProposedPlanCard } from "./ProposedPlanCard";
 import { ChangedFilesCard } from "./ChangedFilesTree";
-import { CHAT_TIMELINE_ANCHOR_OFFSET } from "./timelineScrollAnchoring";
+import {
+  CHAT_TIMELINE_ANCHOR_OFFSET,
+  timelineContentOverflowsViewport,
+} from "./timelineScrollAnchoring";
 import { MessageCopyButton } from "./MessageCopyButton";
 import { PierreEntryIcon } from "./PierreEntryIcon";
 import { AssistantSelectionToolbar } from "./AssistantSelectionToolbar";
@@ -335,6 +338,11 @@ interface MessagesTimelineProps {
    */
   liveFollowEnabled: boolean;
   onIsAtEndChange: (isAtEnd: boolean) => void;
+  /**
+   * Whether the real rows extend past the viewport above the composer.
+   * Reported after scrolls, row size changes, and viewport resizes.
+   */
+  onContentOverflowChange?: (overflows: boolean) => void;
   onToolOutputCollapsedAtEnd?: () => void;
   onManualNavigation: () => void;
   hideEmptyPlaceholder?: boolean;
@@ -382,6 +390,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   contentInsetEndAdjustment,
   liveFollowEnabled,
   onIsAtEndChange,
+  onContentOverflowChange,
   onToolOutputCollapsedAtEnd,
   onManualNavigation,
   hideEmptyPlaceholder = false,
@@ -602,12 +611,46 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     [anchoredEndSpace, contentInsetEndAdjustment],
   );
 
+  const measureContentOverflow = useCallback(
+    () =>
+      timelineContentOverflowsViewport(listRef.current?.getState?.(), {
+        composerInset: contentInsetEndAdjustment,
+        anchorOffset: CHAT_TIMELINE_ANCHOR_OFFSET,
+      }),
+    [contentInsetEndAdjustment, listRef],
+  );
+  // LegendList lays rows out from layout effects, so a read on the next frame
+  // sees the settled positions. One frame is shared across bursts of size
+  // changes.
+  const contentOverflowFrameRef = useRef<number | null>(null);
+  const reportContentOverflow = useCallback(() => {
+    if (!onContentOverflowChange || contentOverflowFrameRef.current !== null) return;
+    contentOverflowFrameRef.current = requestAnimationFrame(() => {
+      contentOverflowFrameRef.current = null;
+      onContentOverflowChange(measureContentOverflow());
+    });
+  }, [measureContentOverflow, onContentOverflowChange]);
+  useEffect(() => {
+    return () => {
+      if (contentOverflowFrameRef.current !== null) {
+        cancelAnimationFrame(contentOverflowFrameRef.current);
+      }
+    };
+  }, []);
+  // The list's own layout effects have already run here, so estimated row
+  // positions are in place. Reporting before the first paint lets a thread
+  // open in its final composer layout instead of correcting it a frame later.
+  useLayoutEffect(() => {
+    onContentOverflowChange?.(measureContentOverflow());
+  }, [measureContentOverflow, onContentOverflowChange, rows.length]);
+
   const handleScroll = useCallback(() => {
     const state = listRef.current?.getState?.();
     const isAtEnd = resolveTimelineIsAtEnd(state);
     if (isAtEnd !== undefined && !citationPositioning) {
       onIsAtEndChange(isAtEnd);
     }
+    reportContentOverflow();
     if (!state || minimapItems.length === 0) {
       return;
     }
@@ -630,7 +673,14 @@ export const MessagesTimeline = memo(function MessagesTimeline({
 
       strip.dataset.inView = inView ? "true" : "false";
     }
-  }, [citationPositioning, listRef, minimapItems, minimapStripMap, onIsAtEndChange]);
+  }, [
+    citationPositioning,
+    listRef,
+    minimapItems,
+    minimapStripMap,
+    onIsAtEndChange,
+    reportContentOverflow,
+  ]);
 
   useEffect(() => {
     const frame = requestAnimationFrame(handleScroll);
@@ -649,6 +699,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
         current === nextHasPersistentGutter ? current : nextHasPersistentGutter,
       );
       setMinimapHitStripWidth(resolveTimelineMinimapHitStripWidth(viewportWidth));
+      reportContentOverflow();
     };
 
     const frame = requestAnimationFrame(measure);
@@ -660,7 +711,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       cancelAnimationFrame(frame);
       observer.disconnect();
     };
-  }, [timelineViewportElement, rows.length]);
+  }, [timelineViewportElement, rows.length, reportContentOverflow]);
 
   const sharedState = useMemo<TimelineRowSharedState>(
     () => ({
@@ -789,6 +840,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
             }
             maintainScrollAtEndThreshold={1}
             onScroll={handleScroll}
+            onItemSizeChanged={reportContentOverflow}
             className={cn(
               "scrollbar-gutter-both h-full min-h-0 overflow-x-hidden overscroll-y-contain px-3 [overflow-anchor:none] sm:px-5",
               topFadeEnabled && "topbar-scroll-fade",

--- a/apps/web/src/components/chat/timelineScrollAnchoring.test.tsx
+++ b/apps/web/src/components/chat/timelineScrollAnchoring.test.tsx
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
-import { getAnchoredTurnMetrics, getRowBottom } from "./timelineScrollAnchoring";
+import {
+  getAnchoredTurnMetrics,
+  getRowBottom,
+  timelineContentOverflowsViewport,
+} from "./timelineScrollAnchoring";
 
 function buildState({
   positions,
@@ -20,6 +24,31 @@ function buildState({
     sizeAtIndex: (index: number) => sizes[index],
   };
 }
+
+describe("timelineContentOverflowsViewport", () => {
+  const inset = { composerInset: 100, anchorOffset: 24 };
+
+  it("reports overflow from the last row, not the inset spacer", () => {
+    const fits = buildState({ positions: [0, 200], sizes: [200, 300], scrollLength: 700 });
+    expect(timelineContentOverflowsViewport(fits, inset)).toBe(false);
+
+    const overflows = buildState({ positions: [0, 200], sizes: [200, 400], scrollLength: 700 });
+    expect(timelineContentOverflowsViewport(overflows, inset)).toBe(true);
+  });
+
+  it("treats an empty or unmeasured list as fitting", () => {
+    expect(timelineContentOverflowsViewport(undefined, inset)).toBe(false);
+    expect(timelineContentOverflowsViewport(buildState({ positions: [], sizes: [] }), inset)).toBe(
+      false,
+    );
+    expect(
+      timelineContentOverflowsViewport(
+        buildState({ positions: [0, 200], sizes: [200, Number.NaN] }),
+        inset,
+      ),
+    ).toBe(false);
+  });
+});
 
 describe("timeline scroll anchoring", () => {
   it("measures row bottoms from LegendList row position and size", () => {

--- a/apps/web/src/components/chat/timelineScrollAnchoring.test.tsx
+++ b/apps/web/src/components/chat/timelineScrollAnchoring.test.tsx
@@ -38,6 +38,12 @@ describe("timelineContentOverflowsViewport", () => {
 
   it("treats an empty or unmeasured list as fitting", () => {
     expect(timelineContentOverflowsViewport(undefined, inset)).toBe(false);
+    expect(
+      timelineContentOverflowsViewport(
+        buildState({ positions: [0, 200], sizes: [200, 400], scrollLength: 0 }),
+        inset,
+      ),
+    ).toBe(false);
     expect(timelineContentOverflowsViewport(buildState({ positions: [], sizes: [] }), inset)).toBe(
       false,
     );

--- a/apps/web/src/components/chat/timelineScrollAnchoring.ts
+++ b/apps/web/src/components/chat/timelineScrollAnchoring.ts
@@ -37,6 +37,30 @@ export function getRowBottom(state: TimelineListMeasurementState, index: number)
   return top + Math.max(1, height);
 }
 
+/**
+ * Whether the timeline's real rows extend past the viewport left above the
+ * composer. The list's own content length includes the composer inset
+ * spacer, so this measures from the last row instead. Unknown row geometry
+ * counts as fitting.
+ */
+export function timelineContentOverflowsViewport(
+  state: TimelineListMeasurementState | undefined,
+  input: { readonly composerInset: number; readonly anchorOffset: number },
+): boolean {
+  if (!state || !state.data || state.data.length === 0) {
+    return false;
+  }
+  const lastBottom = getRowBottom(state, state.data.length - 1);
+  if (lastBottom === null) {
+    return false;
+  }
+  const visibleScrollLength = Math.max(
+    0,
+    (state.scrollLength ?? 0) - input.composerInset - input.anchorOffset,
+  );
+  return lastBottom > visibleScrollLength;
+}
+
 export function getAnchoredTurnMetrics({
   state,
   anchorIndex,

--- a/apps/web/src/components/chat/timelineScrollAnchoring.ts
+++ b/apps/web/src/components/chat/timelineScrollAnchoring.ts
@@ -41,7 +41,7 @@ export function getRowBottom(state: TimelineListMeasurementState, index: number)
  * Whether the timeline's real rows extend past the viewport left above the
  * composer. The list's own content length includes the composer inset
  * spacer, so this measures from the last row instead. Unknown row geometry
- * counts as fitting.
+ * or an unmeasured viewport counts as fitting.
  */
 export function timelineContentOverflowsViewport(
   state: TimelineListMeasurementState | undefined,
@@ -50,14 +50,15 @@ export function timelineContentOverflowsViewport(
   if (!state || !state.data || state.data.length === 0) {
     return false;
   }
+  const scrollLength = state.scrollLength;
+  if (typeof scrollLength !== "number" || !Number.isFinite(scrollLength) || scrollLength <= 0) {
+    return false;
+  }
   const lastBottom = getRowBottom(state, state.data.length - 1);
   if (lastBottom === null) {
     return false;
   }
-  const visibleScrollLength = Math.max(
-    0,
-    (state.scrollLength ?? 0) - input.composerInset - input.anchorOffset,
-  );
+  const visibleScrollLength = Math.max(0, scrollLength - input.composerInset - input.anchorOffset);
   return lastBottom > visibleScrollLength;
 }
 

--- a/apps/web/src/components/chat/useComposerFocusState.test.tsx
+++ b/apps/web/src/components/chat/useComposerFocusState.test.tsx
@@ -20,6 +20,7 @@ function ComposerProbe({ isMobileViewport = false }: { isMobileViewport?: boolea
       isScrollCollapsed: state.isComposerScrollCollapsed,
       hasExpandedChrome: false,
       collapseOnBlur: true,
+      timelineOverflows: true,
     });
   });
   return null;

--- a/apps/web/src/components/composerFooterLayout.test.ts
+++ b/apps/web/src/components/composerFooterLayout.test.ts
@@ -104,6 +104,7 @@ describe("shouldUseRestingComposerLayout", () => {
     isScrollCollapsed: false,
     hasExpandedChrome: false,
     collapseOnBlur: true,
+    timelineOverflows: true,
   };
 
   it("uses the resting layout for an unfocused desktop composer", () => {
@@ -129,6 +130,17 @@ describe("shouldUseRestingComposerLayout", () => {
         collapseOnBlur: false,
       }),
     ).toBe(true);
+  });
+
+  it("keeps the composer expanded while the timeline fits above it", () => {
+    expect(shouldUseRestingComposerLayout({ ...resting, timelineOverflows: false })).toBe(false);
+    expect(
+      shouldUseRestingComposerLayout({
+        ...resting,
+        isScrollCollapsed: true,
+        timelineOverflows: false,
+      }),
+    ).toBe(false);
   });
 
   it("keeps new-thread composers expanded", () => {

--- a/apps/web/src/components/composerFooterLayout.ts
+++ b/apps/web/src/components/composerFooterLayout.ts
@@ -30,6 +30,8 @@ export function shouldUseRestingComposerLayout(input: {
   isScrollCollapsed: boolean;
   hasExpandedChrome: boolean;
   collapseOnBlur: boolean;
+  /** Whether the timeline has more content than fits above the composer. */
+  timelineOverflows: boolean;
 }): boolean {
   // Passive draft content is deliberately absent here. Resting only clamps
   // the prompt row and overlays its actions; non-image attachment and context
@@ -44,8 +46,18 @@ export function shouldUseRestingComposerLayout(input: {
   // the user asked for it with the gesture, and it lifts on the next
   // composer interaction. With blur collapse off, losing focus alone never
   // rests the composer.
+  //
+  // Resting exists to give reading space back to the timeline. A thread that
+  // fits above the composer has nothing to reclaim, so it stays expanded and
+  // never shows the collapsed row that a fresh thread would otherwise open on.
   const collapsed = input.isScrollCollapsed || (input.collapseOnBlur && !input.isFocused);
-  return input.isExistingThread && !input.isMobileViewport && collapsed && !input.hasExpandedChrome;
+  return (
+    input.isExistingThread &&
+    !input.isMobileViewport &&
+    input.timelineOverflows &&
+    collapsed &&
+    !input.hasExpandedChrome
+  );
 }
 
 /**


### PR DESCRIPTION
Opening a new thread showed the composer already collapsed into its single-line resting row, even when the thread had one short exchange and nothing above it could scroll. The collapsed row gave no space back and it was not obvious how to reopen the composer without clicking into it.

The timeline now reports whether its rows extend past the viewport above the composer, and the resting rule requires that overflow. A thread that fits stays expanded. A thread that can scroll rests on blur and scroll exactly as before, and it still opens at rest on its first paint.

## Verification

- `vp test run` on `composerFooterLayout.test.ts`, `timelineScrollAnchoring.test.tsx`, `useComposerFocusState.test.tsx`, and `MessagesTimeline.test.tsx` (88 passing), including new cases for the overflow helper and the resting rule.
- Web typecheck and formatting pass. The two lint warnings on the timeline file are the same ones main already has.
- No browser pass.

Created with Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop composer layout behavior changes for short threads; overflow state depends on LegendList measurements and may lag until the next layout or scroll event in edge cases.
> 
> **Overview**
> Short threads no longer open with the desktop composer collapsed into its resting row when the message list still fits above it. **Timeline overflow** is now measured from the last real row (ignoring the composer inset spacer) via shared `timelineContentOverflowsViewport`, and `MessagesTimeline` publishes that flag through `onContentOverflowChange` after layout, scroll, row resize, and viewport changes.
> 
> `shouldUseRestingComposerLayout` **requires `timelineOverflows`** before blur- or scroll-driven collapse applies, so resting only reclaims space when there is scrollable history. `ChatView` wires the signal into `ChatComposer`; callers and tests pass the new required field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d4fa73260e08004c8ee4c1595de87173f1ab03f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep desktop composer expanded until timeline overflows viewport
> - Adds shared `timelineContentOverflowsViewport` helper in [timelineScrollAnchoring.ts](https://github.com/pingdotgg/t3code/pull/9965/files#diff-7d5bb365d2e39e9337a3a31436884ed0c0df1127c2033e30a6c027826c46de67) that measures the real last row against usable viewport height (scroll length minus composer inset and anchor offset), returning false for empty/invalid state.
> - `MessagesTimeline` reports overflow via a new `onContentOverflowChange` callback after initial layout, scroll, resize, row-size, row-count, or inset changes; `ChatView` tracks this state and passes it to `ChatComposer`.
> - `shouldUseRestingComposerLayout` now requires a `timelineOverflows` boolean, so the desktop resting (collapsed) layout is only selected when the timeline actually overflows the area above the composer.
> - Behavioral Change: desktop existing-thread composers that previously collapsed (even when content fit) now stay expanded until overflow is measured; callers of `shouldUseRestingComposerLayout` and `ChatComposer` must supply the new required `timelineOverflows` prop.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d4fa73.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->