### PR TITLE
feat(web): customize thread list rows with saved layouts

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -55,6 +55,22 @@ const clientSettings: ClientSettings = {
   showSkillsInSlashMenu: false,
   providerModelPreferences: {},
   sidebarCompactThreadRows: false,
+  sidebarThreadRowLayoutMode: "custom",
+  sidebarActiveThreadLayoutId: "daily",
+  sidebarSavedThreadLayouts: [
+    {
+      id: "daily",
+      name: "Daily",
+      layout: [
+        { component: "title", row: 1, alignment: "left" },
+        { component: "status", row: 2, alignment: "right" },
+      ],
+    },
+  ],
+  sidebarThreadRowLayout: [
+    { component: "title", row: 1, alignment: "left" },
+    { component: "status", row: 2, alignment: "right" },
+  ],
   sidebarProjectGroupingMode: "repository_path",
   sidebarProjectGroupingOverrides: {
     "environment-1:/tmp/project-a": "separate",

--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -54,6 +54,7 @@ const clientSettings: ClientSettings = {
   proactivePanelsEnabled: true,
   showSkillsInSlashMenu: false,
   providerModelPreferences: {},
+  sidebarCompactThreadRows: false,
   sidebarProjectGroupingMode: "repository_path",
   sidebarProjectGroupingOverrides: {
     "environment-1:/tmp/project-a": "separate",

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -22,6 +22,8 @@ import {
 } from "../panelAnimations";
 import LegacyThreadSidebar from "./LegacySidebar";
 import ThreadSidebar from "./Sidebar";
+import { ThreadListPreviewContext } from "./settings/ThreadListPreviewContext";
+import { Button } from "./ui/button";
 import { SettingsSidebarNav } from "./settings/SettingsSidebarNav";
 import { SidebarChromeHeader } from "./sidebar/SidebarChrome";
 import {
@@ -45,6 +47,26 @@ import {
   useSidebarVisibility,
 } from "./ui/sidebar";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
+
+function ThreadListPreviewNavigation({ onClose }: { onClose: () => void }) {
+  const { isMobile, setOpenMobile } = useSidebar();
+  return (
+    <div className="border-b border-sidebar-border p-3">
+      <p className="mb-2 text-xs text-muted-foreground">Your threads · layout preview</p>
+      <Button
+        className="w-full"
+        size="sm"
+        variant="outline"
+        onClick={() => {
+          onClose();
+          if (isMobile) setOpenMobile(false);
+        }}
+      >
+        Back to settings navigation
+      </Button>
+    </div>
+  );
+}
 
 const MACOS_TRAFFIC_LIGHTS_LEFT_INSET = "90px";
 
@@ -153,6 +175,11 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const routePanelAnimationsActive = panelAnimationsActive && !panelAnimationsSuppressed;
   const isOnSettings = pathname === "/settings" || pathname.startsWith("/settings/");
   const isMacosDesktop = isElectron && isMacPlatform(navigator.platform);
+  const [showThreadListPreview, setShowThreadListPreview] = useState(false);
+  const previewing = isOnSettings && showThreadListPreview;
+  useEffect(() => {
+    setShowThreadListPreview(false);
+  }, [pathname]);
   const [sidebarWidth, setSidebarWidth] = useState(readInitialThreadSidebarWidth);
   // Subscribed rather than read once: the clamp must track live window size,
   // and a clamped drag ends with an unchanged width, which skips the re-render
@@ -219,44 +246,51 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   }, [navigate, pathname]);
 
   return (
-    <PanelAnimationSuppressionProvider value={panelAnimationsSuppressed}>
-      <SidebarProvider
-        className="h-dvh! min-h-0!"
-        data-panel-animations={routePanelAnimationsActive ? "true" : "false"}
-        defaultOpen
-        style={sidebarProviderStyle}
-      >
-        <ProjectProjectionRetention />
-        <Sidebar
-          side="left"
-          collapsible="offcanvas"
-          data-app-sidebar=""
-          className="border-r border-sidebar-border bg-sidebar text-sidebar-foreground"
-          resizable={{
-            maxWidth: sidebarMaximumWidth,
-            minWidth: THREAD_SIDEBAR_MIN_WIDTH,
-            shouldAcceptWidth: ({ currentWidth, nextWidth, wrapper }) =>
-              nextWidth <= currentWidth ||
-              wrapper.clientWidth - nextWidth >= THREAD_MAIN_CONTENT_MIN_WIDTH,
-            storageKey: THREAD_SIDEBAR_WIDTH_STORAGE_KEY,
-            onResize: setSidebarWidth,
-          }}
+    <ThreadListPreviewContext value={{ showing: previewing, setShowing: setShowThreadListPreview }}>
+      <PanelAnimationSuppressionProvider value={panelAnimationsSuppressed}>
+        <SidebarProvider
+          className="h-dvh! min-h-0!"
+          data-panel-animations={routePanelAnimationsActive ? "true" : "false"}
+          defaultOpen
+          style={sidebarProviderStyle}
         >
-          {isOnSettings ? (
-            <>
-              <SidebarChromeHeader isElectron={isElectron} />
-              <SettingsSidebarNav pathname={pathname} />
-            </>
-          ) : legacySidebarEnabled ? (
-            <LegacyThreadSidebar />
-          ) : (
-            <ThreadSidebar />
-          )}
-          <SidebarRail onDoubleClick={resetSidebarWidth} />
-        </Sidebar>
-        {children}
-        <SidebarControl />
-      </SidebarProvider>
-    </PanelAnimationSuppressionProvider>
+          <ProjectProjectionRetention />
+          <Sidebar
+            side="left"
+            collapsible="offcanvas"
+            data-app-sidebar=""
+            className="border-r border-sidebar-border bg-sidebar text-sidebar-foreground"
+            resizable={{
+              maxWidth: sidebarMaximumWidth,
+              minWidth: THREAD_SIDEBAR_MIN_WIDTH,
+              shouldAcceptWidth: ({ currentWidth, nextWidth, wrapper }) =>
+                nextWidth <= currentWidth ||
+                wrapper.clientWidth - nextWidth >= THREAD_MAIN_CONTENT_MIN_WIDTH,
+              storageKey: THREAD_SIDEBAR_WIDTH_STORAGE_KEY,
+              onResize: setSidebarWidth,
+            }}
+          >
+            {previewing ? (
+              <>
+                <ThreadListPreviewNavigation onClose={() => setShowThreadListPreview(false)} />
+                <ThreadSidebar />
+              </>
+            ) : isOnSettings ? (
+              <>
+                <SidebarChromeHeader isElectron={isElectron} />
+                <SettingsSidebarNav pathname={pathname} />
+              </>
+            ) : legacySidebarEnabled ? (
+              <LegacyThreadSidebar />
+            ) : (
+              <ThreadSidebar />
+            )}
+            <SidebarRail onDoubleClick={resetSidebarWidth} />
+          </Sidebar>
+          {children}
+          <SidebarControl />
+        </SidebarProvider>
+      </PanelAnimationSuppressionProvider>
+    </ThreadListPreviewContext>
   );
 }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -118,6 +118,7 @@ import { startNewThreadFromContext } from "../lib/chatThreadActions";
 import { useClientSettings } from "../hooks/useSettings";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useLocalStorage } from "../hooks/useLocalStorage";
+import { SidebarCompletedTime } from "./sidebar/SidebarCompletedTime";
 import { useNowMinute } from "../hooks/useNowMinute";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
 import {
@@ -945,6 +946,7 @@ const dropVerbBadge: Record<SidebarDropVerb, ReactNode> = {
 const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   thread: SidebarThreadSummary;
   variant: "card" | "slim";
+  compact: boolean;
   // Slim rows are either settled (action: un-settle) or merely quiet
   // (seen Ready threads — action: settle).
   variantAction: "settle" | "unsettle" | "unsnooze";
@@ -1712,6 +1714,11 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     );
   }
 
+  const compact = props.compact;
+  const compactCompletedAt =
+    compact && status === "ready" && !isWokeStatus
+      ? (thread.latestTurn?.completedAt ?? null)
+      : null;
   const diff = latestTurnDiff(thread);
 
   return (
@@ -1720,8 +1727,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       {...sortableRootProps}
       {...(fileDropHandlers ?? {})}
       className={cn(
-        // Matches the h-[4.875rem] content box; the py-0.5 padding is added on top.
-        "list-none py-0.5 [content-visibility:auto] [contain-intrinsic-size:auto_78px]",
+        "list-none [content-visibility:auto]",
+        compact
+          ? "[contain-intrinsic-size:auto_36px]"
+          : "py-0.5 [contain-intrinsic-size:auto_78px]",
         sortable?.isDragging && "relative z-20",
       )}
     >
@@ -1732,7 +1741,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
               ref={rowRef}
               role="button"
               tabIndex={0}
-              data-testid="sidebar-row-card"
+              data-testid={compact ? "sidebar-row-compact" : "sidebar-row-card"}
               aria-busy={isRegeneratingTitle || undefined}
               className={rowSurfaceClassName}
               onClick={handleClick}
@@ -1742,13 +1751,22 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
             />
           }
         >
-          <div className="relative z-10 h-[4.875rem] px-[var(--sidebar-row-content-inset)] py-[var(--sidebar-content-inset)]">
-            <div className="flex h-5 min-w-0 items-center gap-1.5">
+          <div
+            className={cn(
+              "relative z-10",
+              compact
+                ? "flex h-9 items-center px-2.5"
+                : "h-[4.875rem] px-[var(--sidebar-row-content-inset)] py-[var(--sidebar-content-inset)]",
+            )}
+          >
+            <div className="flex h-5 w-full min-w-0 items-center gap-1.5">
               {draftIndicator}
               {props.project ? (
                 <ProjectFavicon project={props.project} className="size-4 shrink-0" />
               ) : null}
-              {props.projectDisplayName ? (
+              {compact ? (
+                title
+              ) : props.projectDisplayName ? (
                 <span
                   className={cn(
                     "min-w-0 flex-1 truncate text-secondary-label text-xs",
@@ -1781,7 +1799,9 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                       snoozeMenuOpen && "pointer-events-none absolute right-0 opacity-0",
                     )}
                   >
-                    {topStatus ? (
+                    {compactCompletedAt ? (
+                      <SidebarCompletedTime completedAt={compactCompletedAt} />
+                    ) : topStatus ? (
                       isWokeStatus ? (
                         <Tooltip>
                           <TooltipTrigger
@@ -1817,7 +1837,12 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                           {/* The label alone is the live region: a role="status"
                             wrapper around the ticking duration would make
                             screen readers announce every second. */}
-                          <span role="status">{topStatus.label}</span>
+                          <span
+                            role="status"
+                            className={compact && status === "working" ? "sr-only" : undefined}
+                          >
+                            {topStatus.label}
+                          </span>
                           {status === "working" ? (
                             <span aria-hidden>
                               <WorkingDuration startedAt={resolveWorkingStartedAt(thread)} />
@@ -1829,7 +1854,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                       threadTimeLabel(thread)
                     )}
                   </span>
-                  {props.settlementSupported || showSnoozeButton || hasUnsentDraft ? (
+                  {props.settlementSupported ||
+                  showSnoozeButton ||
+                  hasUnsentDraft ||
+                  (compact && prBadge) ? (
                     <span
                       className={cn(
                         // focus-visible, not focus-within: a mouse click leaves
@@ -1841,6 +1869,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                         snoozeMenuOpen && "pointer-events-auto static opacity-100",
                       )}
                     >
+                      {compact ? prBadge : null}
                       {hasUnsentDraft ? (
                         <Tooltip>
                           <TooltipTrigger
@@ -1879,7 +1908,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                             }
                           >
                             <CheckIcon className="size-3.5" />
-                            Settle
+                            {compact ? null : "Settle"}
                           </TooltipTrigger>
                           <TooltipPopup>Settle thread</TooltipPopup>
                         </Tooltip>
@@ -1889,68 +1918,70 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                 </span>
               )}
             </div>
-            <div className="mt-1 flex min-w-0">
-              {title}
-              {isRegeneratingTitle ? (
-                <span role="status" className="sr-only">
-                  Regenerating title
-                </span>
-              ) : null}
-            </div>
-            <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-secondary-label text-xs">
-              {/* Always the branch. The plan step used to take this slot while
+            {isRegeneratingTitle ? (
+              <span role="status" className="sr-only">
+                Regenerating title
+              </span>
+            ) : null}
+            {compact ? null : (
+              <>
+                <div className="mt-1 flex min-w-0">{title}</div>
+                <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-secondary-label text-xs">
+                  {/* Always the branch. The plan step used to take this slot while
                   working, but it truncated to a half-sentence and dropped the
                   branch, so the row lost its most stable identifier. */}
-              {thread.branch ? (
-                <>
-                  <ThreadWorktreeIndicator thread={thread} />
-                  <span className="min-w-0 flex-1 truncate whitespace-nowrap text-muted-foreground/40">
-                    {thread.branch}
+                  {thread.branch ? (
+                    <>
+                      <ThreadWorktreeIndicator thread={thread} />
+                      <span className="min-w-0 flex-1 truncate whitespace-nowrap text-muted-foreground/40">
+                        {thread.branch}
+                      </span>
+                    </>
+                  ) : (
+                    <span className="flex-1" />
+                  )}
+                  {terminalStatusIcon}
+                  {prBadge}
+                  {diff ? (
+                    <span className="shrink-0 font-mono">
+                      <span className="text-diff-addition-foreground">+{diff.insertions}</span>{" "}
+                      <span className="text-diff-deletion-foreground">−{diff.deletions}</span>
+                    </span>
+                  ) : null}
+                  <span
+                    aria-hidden
+                    className="pointer-events-none ml-auto inline-flex shrink-0 items-center gap-1"
+                  >
+                    {isRemote ? (
+                      <span className="inline-flex shrink-0 items-center text-sidebar-muted-foreground/70">
+                        <EnvironmentMachineIcon
+                          aria-hidden
+                          kind={props.environmentMachine}
+                          className="size-3.5"
+                        />
+                      </span>
+                    ) : null}
+                    {driverKind ? (
+                      <span className="inline-flex shrink-0 items-center">
+                        <ProviderInstanceIcon
+                          driverKind={driverKind}
+                          displayName={
+                            providerEntry?.displayName ??
+                            thread.session?.providerName ??
+                            modelInstanceId
+                          }
+                          accentColor={providerEntry?.accentColor}
+                          showBadge={showInstanceBadge}
+                          // Glyph dims, badge stays saturated; offset matches the composer trigger.
+                          iconClassName="size-3.5 opacity-60"
+                          badgeClassName="right-[-0.1875rem] bottom-[-0.1875rem] h-3 min-w-3 px-0.5 text-[7px]"
+                        />
+                      </span>
+                    ) : null}
                   </span>
-                </>
-              ) : (
-                <span className="flex-1" />
-              )}
-              {terminalStatusIcon}
-              {prBadge}
-              {diff ? (
-                <span className="shrink-0 font-mono">
-                  <span className="text-diff-addition-foreground">+{diff.insertions}</span>{" "}
-                  <span className="text-diff-deletion-foreground">−{diff.deletions}</span>
-                </span>
-              ) : null}
-              <span
-                aria-hidden
-                className="pointer-events-none ml-auto inline-flex shrink-0 items-center gap-1"
-              >
-                {isRemote ? (
-                  <span className="inline-flex shrink-0 items-center text-sidebar-muted-foreground/70">
-                    <EnvironmentMachineIcon
-                      aria-hidden
-                      kind={props.environmentMachine}
-                      className="size-3.5"
-                    />
-                  </span>
-                ) : null}
-                {driverKind ? (
-                  <span className="inline-flex shrink-0 items-center">
-                    <ProviderInstanceIcon
-                      driverKind={driverKind}
-                      displayName={
-                        providerEntry?.displayName ??
-                        thread.session?.providerName ??
-                        modelInstanceId
-                      }
-                      accentColor={providerEntry?.accentColor}
-                      showBadge={showInstanceBadge}
-                      // Glyph dims, badge stays saturated; offset matches the composer trigger.
-                      iconClassName="size-3.5 opacity-60"
-                      badgeClassName="right-[-0.1875rem] bottom-[-0.1875rem] h-3 min-w-3 px-0.5 text-[7px]"
-                    />
-                  </span>
-                ) : null}
-              </span>
-            </div>
+                </div>
+              </>
+            )}
           </div>
           {props.jumpLabel ? <JumpHintBadge label={props.jumpLabel} /> : null}
         </TooltipTrigger>
@@ -2112,6 +2143,7 @@ export default function Sidebar() {
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const compactThreadRows = useClientSettings((s) => s.sidebarCompactThreadRows);
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const confirmThreadArchive = useClientSettings((s) => s.confirmThreadArchive);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
@@ -4645,10 +4677,9 @@ export default function Sidebar() {
                         const threadKey = scopedThreadKey(
                           scopeThreadRef(thread.environmentId, thread.id),
                         );
-                        // Settled and snoozed are the ONLY things that collapse a
-                        // row: every other thread is a full card. Density comes
-                        // from users (or the auto rules) actually parking work,
-                        // not from the sidebar second-guessing what still matters.
+                        // Settled and snoozed always use slim rows. Active and
+                        // pinned threads use cards unless the user has explicitly
+                        // enabled the compact thread-list preference.
                         const isCard = section === "active" || section === "pinned";
                         const rowVariant = isCard ? "card" : "slim";
                         return (
@@ -4658,6 +4689,7 @@ export default function Sidebar() {
                             key={`${threadKey}:${rowVariant}`}
                             thread={thread}
                             variant={rowVariant}
+                            compact={compactThreadRows}
                             // Snoozed rows wake, settled rows un-settle, and cards settle.
                             variantAction={
                               section === "snoozed"

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -34,7 +34,13 @@ import {
   type ScopedThreadRef,
   type ThreadId,
 } from "@t3tools/contracts";
-import type { TimestampFormat } from "@t3tools/contracts/settings";
+import {
+  type SidebarThreadRowLayoutMode,
+  type SidebarThreadRowPlacement,
+  type TimestampFormat,
+} from "@t3tools/contracts/settings";
+import { ThreadRowLayout } from "./ThreadRowLayout";
+import { threadRowLayoutForMode } from "./settings/savedThreadLayouts";
 import {
   AlarmClockIcon,
   AlarmClockOffIcon,
@@ -946,7 +952,8 @@ const dropVerbBadge: Record<SidebarDropVerb, ReactNode> = {
 const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   thread: SidebarThreadSummary;
   variant: "card" | "slim";
-  compact: boolean;
+  layoutMode: SidebarThreadRowLayoutMode;
+  customLayout: ReadonlyArray<SidebarThreadRowPlacement>;
   // Slim rows are either settled (action: un-settle) or merely quiet
   // (seen Ready threads — action: settle).
   variantAction: "settle" | "unsettle" | "unsnooze";
@@ -1562,6 +1569,225 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     )
   ) : null;
 
+  if (props.layoutMode !== "standard") {
+    const rowActivity =
+      status === "working" ? (
+        <span
+          role="status"
+          aria-label="Working"
+          className="inline-flex shrink-0 items-center gap-1 text-sky-600 tabular-nums dark:text-sky-400"
+        >
+          <CircleDashedIcon aria-hidden className="size-4" />
+          <span aria-hidden>
+            <WorkingDuration startedAt={resolveWorkingStartedAt(thread)} />
+          </span>
+        </span>
+      ) : isWokeStatus ? (
+        <Tooltip disabled={snoozeMenuOpen}>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                aria-label="Dismiss Woke notification"
+                onClick={handleAcknowledgeWokeClick}
+                className={cn(
+                  "inline-flex shrink-0 cursor-pointer items-center gap-1 rounded-sm text-xs font-medium outline-none hover:underline focus-visible:ring-2 focus-visible:ring-ring",
+                  topStatus.className,
+                )}
+              />
+            }
+          >
+            <AlarmClockIcon aria-hidden className="size-3" />
+            <span role="status">{topStatus.label}</span>
+          </TooltipTrigger>
+          <TooltipPopup side="top">Dismiss Woke notification</TooltipPopup>
+        </Tooltip>
+      ) : variantAction === "unsettle" ? (
+        <span className="shrink-0 text-xs text-secondary-label tabular-nums">
+          {settledTimeLabel(thread)}
+        </span>
+      ) : status === "ready" && thread.latestTurn?.completedAt != null ? (
+        <SidebarCompletedTime completedAt={thread.latestTurn.completedAt} />
+      ) : topStatus ? (
+        <span role="status" className={cn("shrink-0 text-xs font-medium", topStatus.className)}>
+          {topStatus.label}
+        </span>
+      ) : (
+        <span className="shrink-0 text-xs text-secondary-label tabular-nums">
+          {threadTimeLabel(thread)}
+        </span>
+      );
+
+    const statusIndicator = isWokeStatus ? (
+      rowActivity
+    ) : (
+      <span role="status" className={cn("truncate", topStatus?.className)}>
+        {topStatus?.label ??
+          (variantAction === "unsnooze"
+            ? "Snoozed"
+            : variantAction === "unsettle"
+              ? "Settled"
+              : "Ready")}
+      </span>
+    );
+    const snoozeLabel =
+      variantAction === "unsnooze" && props.snoozeWakeLabelText ? (
+        <span className="truncate text-blue-600 dark:text-blue-400">
+          {props.snoozeWakeLabelText}
+        </span>
+      ) : null;
+    const components = {
+      projectIcon: props.project ? (
+        <ProjectFavicon project={props.project} className="size-4 shrink-0" />
+      ) : null,
+      title,
+      pin: pinIndicator,
+      activity: snoozeLabel ?? rowActivity,
+      status: statusIndicator,
+      duration:
+        status === "working" ? (
+          <span aria-label="Working duration" className="tabular-nums">
+            <WorkingDuration startedAt={resolveWorkingStartedAt(thread)} />
+          </span>
+        ) : null,
+      project: props.projectDisplayName ? (
+        <span className="truncate">{props.projectDisplayName}</span>
+      ) : null,
+      environment: props.environmentLabel ? (
+        <span className="truncate">{props.environmentLabel}</span>
+      ) : null,
+      provider: driverKind ? (
+        <ProviderInstanceIcon
+          driverKind={driverKind}
+          displayName={thread.session?.providerName ?? modelInstanceId}
+          iconClassName="size-3.5"
+        />
+      ) : null,
+      model: <span className="truncate">{modelLabel}</span>,
+      branch: thread.branch ? (
+        <span className="inline-flex min-w-0 items-center gap-1">
+          <GitBranchIcon className="size-3 shrink-0" />
+          <span className="truncate">{thread.branch}</span>
+        </span>
+      ) : null,
+      worktree: thread.worktreePath?.trim() ? <ThreadWorktreeIndicator thread={thread} /> : null,
+      pullRequest: prBadge,
+      terminal: terminalStatusIcon,
+      updated: <span className="truncate tabular-nums">{threadTimeLabel(thread)}</span>,
+      created: (
+        <span className="truncate tabular-nums">
+          {compactSidebarTimeLabel(formatRelativeTimeLabel(thread.createdAt))}
+        </span>
+      ),
+      completed: thread.latestTurn?.completedAt ? (
+        <SidebarCompletedTime completedAt={thread.latestTurn.completedAt} />
+      ) : null,
+      snooze: snoozeLabel,
+    };
+    const chosenLayout = threadRowLayoutForMode(props.layoutMode, props.customLayout);
+    // A hidden title must still be editable from the context menu or double-click.
+    const layout =
+      isRenaming && !chosenLayout.some((item) => item.component === "title")
+        ? [
+            { component: "title" as const, row: 1 as const, alignment: "left" as const },
+            ...chosenLayout,
+          ]
+        : chosenLayout;
+    return (
+      <li
+        data-thread-item
+        {...sortableRootProps}
+        {...(fileDropHandlers ?? {})}
+        className={cn(
+          "list-none [content-visibility:auto] [contain-intrinsic-size:auto_36px]",
+          sortable?.isDragging && "relative z-20",
+        )}
+      >
+        <Tooltip disabled={snoozeMenuOpen || props.sortable?.isDragging}>
+          <TooltipTrigger
+            render={
+              <div
+                ref={rowRef}
+                role="button"
+                tabIndex={0}
+                aria-label={thread.title}
+                data-testid={`sidebar-row-${props.layoutMode}`}
+                aria-busy={isRegeneratingTitle || undefined}
+                className={cn(
+                  rowSurfaceClassName,
+                  "flex min-h-9 items-center px-2.5 py-1.5 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+                )}
+                onClick={handleClick}
+                onDoubleClick={handleDoubleClick}
+                onKeyDown={handleKeyDown}
+                onContextMenu={handleContextMenu}
+              />
+            }
+          >
+            {draftIndicator}
+            <ThreadRowLayout layout={layout} components={components} />
+            {dragDestination}
+            {isRegeneratingTitle ? (
+              <span className="sr-only" role="status">
+                Regenerating title
+              </span>
+            ) : null}
+            <span
+              className={cn(
+                "pointer-events-none flex w-0 shrink-0 items-center overflow-hidden opacity-0 has-[:focus-visible]:pointer-events-auto has-[:focus-visible]:ml-1 has-[:focus-visible]:w-auto has-[:focus-visible]:overflow-visible has-[:focus-visible]:opacity-100 group-hover/sidebar-row:pointer-events-auto group-hover/sidebar-row:ml-1 group-hover/sidebar-row:w-auto group-hover/sidebar-row:overflow-visible group-hover/sidebar-row:opacity-100",
+                snoozeMenuOpen && "pointer-events-auto ml-1 w-auto overflow-visible opacity-100",
+              )}
+            >
+              {hasUnsentDraft ? (
+                <Button
+                  size="icon-xs"
+                  variant="ghost-muted"
+                  aria-label="Discard draft"
+                  onClick={handleDiscardDraftClick}
+                >
+                  <XIcon className="size-3.5" />
+                </Button>
+              ) : null}
+              {variantAction === "unsnooze" && props.snoozeSupported ? (
+                <Button
+                  size="icon-xs"
+                  variant="ghost-muted"
+                  aria-label="Wake thread now"
+                  onClick={handleUnsnoozeClick}
+                >
+                  <AlarmClockOffIcon className="size-3.5" />
+                </Button>
+              ) : showSnoozeButton ? (
+                <SnoozePopoverButton
+                  open={snoozeMenuOpen}
+                  onOpenChange={setSnoozeMenuOpen}
+                  onSnooze={handleSnoozePreset}
+                  timestampFormat={props.timestampFormat}
+                />
+              ) : null}
+              {props.settlementSupported && variantAction !== "unsnooze" ? (
+                <Button
+                  size="icon-xs"
+                  variant="ghost-muted"
+                  aria-label={variantAction === "unsettle" ? "Un-settle thread" : "Settle thread"}
+                  onClick={variantAction === "unsettle" ? handleUnsettleClick : handleSettleClick}
+                >
+                  {variantAction === "unsettle" ? (
+                    <Undo2Icon className="size-3.5" />
+                  ) : (
+                    <CheckIcon className="size-3.5" />
+                  )}
+                </Button>
+              ) : null}
+            </span>
+            {props.jumpLabel ? <JumpHintBadge label={props.jumpLabel} /> : null}
+          </TooltipTrigger>
+          {detailsTooltip}
+        </Tooltip>
+      </li>
+    );
+  }
+
   if (variant === "slim") {
     return (
       <li
@@ -1714,11 +1940,6 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     );
   }
 
-  const compact = props.compact;
-  const compactCompletedAt =
-    compact && status === "ready" && !isWokeStatus
-      ? (thread.latestTurn?.completedAt ?? null)
-      : null;
   const diff = latestTurnDiff(thread);
 
   return (
@@ -1727,10 +1948,8 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       {...sortableRootProps}
       {...(fileDropHandlers ?? {})}
       className={cn(
-        "list-none [content-visibility:auto]",
-        compact
-          ? "[contain-intrinsic-size:auto_36px]"
-          : "py-0.5 [contain-intrinsic-size:auto_78px]",
+        // Matches the h-[4.875rem] content box; the py-0.5 padding is added on top.
+        "list-none py-0.5 [content-visibility:auto] [contain-intrinsic-size:auto_78px]",
         sortable?.isDragging && "relative z-20",
       )}
     >
@@ -1741,7 +1960,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
               ref={rowRef}
               role="button"
               tabIndex={0}
-              data-testid={compact ? "sidebar-row-compact" : "sidebar-row-card"}
+              data-testid="sidebar-row-card"
               aria-busy={isRegeneratingTitle || undefined}
               className={rowSurfaceClassName}
               onClick={handleClick}
@@ -1751,22 +1970,13 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
             />
           }
         >
-          <div
-            className={cn(
-              "relative z-10",
-              compact
-                ? "flex h-9 items-center px-2.5"
-                : "h-[4.875rem] px-[var(--sidebar-row-content-inset)] py-[var(--sidebar-content-inset)]",
-            )}
-          >
-            <div className="flex h-5 w-full min-w-0 items-center gap-1.5">
+          <div className="relative z-10 h-[4.875rem] px-[var(--sidebar-row-content-inset)] py-[var(--sidebar-content-inset)]">
+            <div className="flex h-5 min-w-0 items-center gap-1.5">
               {draftIndicator}
               {props.project ? (
                 <ProjectFavicon project={props.project} className="size-4 shrink-0" />
               ) : null}
-              {compact ? (
-                title
-              ) : props.projectDisplayName ? (
+              {props.projectDisplayName ? (
                 <span
                   className={cn(
                     "min-w-0 flex-1 truncate text-secondary-label text-xs",
@@ -1799,9 +2009,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                       snoozeMenuOpen && "pointer-events-none absolute right-0 opacity-0",
                     )}
                   >
-                    {compactCompletedAt ? (
-                      <SidebarCompletedTime completedAt={compactCompletedAt} />
-                    ) : topStatus ? (
+                    {topStatus ? (
                       isWokeStatus ? (
                         <Tooltip>
                           <TooltipTrigger
@@ -1837,12 +2045,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                           {/* The label alone is the live region: a role="status"
                             wrapper around the ticking duration would make
                             screen readers announce every second. */}
-                          <span
-                            role="status"
-                            className={compact && status === "working" ? "sr-only" : undefined}
-                          >
-                            {topStatus.label}
-                          </span>
+                          <span role="status">{topStatus.label}</span>
                           {status === "working" ? (
                             <span aria-hidden>
                               <WorkingDuration startedAt={resolveWorkingStartedAt(thread)} />
@@ -1854,10 +2057,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                       threadTimeLabel(thread)
                     )}
                   </span>
-                  {props.settlementSupported ||
-                  showSnoozeButton ||
-                  hasUnsentDraft ||
-                  (compact && prBadge) ? (
+                  {props.settlementSupported || showSnoozeButton || hasUnsentDraft ? (
                     <span
                       className={cn(
                         // focus-visible, not focus-within: a mouse click leaves
@@ -1869,7 +2069,6 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                         snoozeMenuOpen && "pointer-events-auto static opacity-100",
                       )}
                     >
-                      {compact ? prBadge : null}
                       {hasUnsentDraft ? (
                         <Tooltip>
                           <TooltipTrigger
@@ -1908,7 +2107,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                             }
                           >
                             <CheckIcon className="size-3.5" />
-                            {compact ? null : "Settle"}
+                            Settle
                           </TooltipTrigger>
                           <TooltipPopup>Settle thread</TooltipPopup>
                         </Tooltip>
@@ -1918,70 +2117,68 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                 </span>
               )}
             </div>
-            {isRegeneratingTitle ? (
-              <span role="status" className="sr-only">
-                Regenerating title
-              </span>
-            ) : null}
-            {compact ? null : (
-              <>
-                <div className="mt-1 flex min-w-0">{title}</div>
-                <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-secondary-label text-xs">
-                  {/* Always the branch. The plan step used to take this slot while
+            <div className="mt-1 flex min-w-0">
+              {title}
+              {isRegeneratingTitle ? (
+                <span role="status" className="sr-only">
+                  Regenerating title
+                </span>
+              ) : null}
+            </div>
+            <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-secondary-label text-xs">
+              {/* Always the branch. The plan step used to take this slot while
                   working, but it truncated to a half-sentence and dropped the
                   branch, so the row lost its most stable identifier. */}
-                  {thread.branch ? (
-                    <>
-                      <ThreadWorktreeIndicator thread={thread} />
-                      <span className="min-w-0 flex-1 truncate whitespace-nowrap text-muted-foreground/40">
-                        {thread.branch}
-                      </span>
-                    </>
-                  ) : (
-                    <span className="flex-1" />
-                  )}
-                  {terminalStatusIcon}
-                  {prBadge}
-                  {diff ? (
-                    <span className="shrink-0 font-mono">
-                      <span className="text-diff-addition-foreground">+{diff.insertions}</span>{" "}
-                      <span className="text-diff-deletion-foreground">−{diff.deletions}</span>
-                    </span>
-                  ) : null}
-                  <span
-                    aria-hidden
-                    className="pointer-events-none ml-auto inline-flex shrink-0 items-center gap-1"
-                  >
-                    {isRemote ? (
-                      <span className="inline-flex shrink-0 items-center text-sidebar-muted-foreground/70">
-                        <EnvironmentMachineIcon
-                          aria-hidden
-                          kind={props.environmentMachine}
-                          className="size-3.5"
-                        />
-                      </span>
-                    ) : null}
-                    {driverKind ? (
-                      <span className="inline-flex shrink-0 items-center">
-                        <ProviderInstanceIcon
-                          driverKind={driverKind}
-                          displayName={
-                            providerEntry?.displayName ??
-                            thread.session?.providerName ??
-                            modelInstanceId
-                          }
-                          accentColor={providerEntry?.accentColor}
-                          showBadge={showInstanceBadge}
-                          // Glyph dims, badge stays saturated; offset matches the composer trigger.
-                          iconClassName="size-3.5 opacity-60"
-                          badgeClassName="right-[-0.1875rem] bottom-[-0.1875rem] h-3 min-w-3 px-0.5 text-[7px]"
-                        />
-                      </span>
-                    ) : null}
+              {thread.branch ? (
+                <>
+                  <ThreadWorktreeIndicator thread={thread} />
+                  <span className="min-w-0 flex-1 truncate whitespace-nowrap text-muted-foreground/40">
+                    {thread.branch}
                   </span>
-                </div>
-              </>
-            )}
+                </>
+              ) : (
+                <span className="flex-1" />
+              )}
+              {terminalStatusIcon}
+              {prBadge}
+              {diff ? (
+                <span className="shrink-0 font-mono">
+                  <span className="text-diff-addition-foreground">+{diff.insertions}</span>{" "}
+                  <span className="text-diff-deletion-foreground">−{diff.deletions}</span>
+                </span>
+              ) : null}
+              <span
+                aria-hidden
+                className="pointer-events-none ml-auto inline-flex shrink-0 items-center gap-1"
+              >
+                {isRemote ? (
+                  <span className="inline-flex shrink-0 items-center text-sidebar-muted-foreground/70">
+                    <EnvironmentMachineIcon
+                      aria-hidden
+                      kind={props.environmentMachine}
+                      className="size-3.5"
+                    />
+                  </span>
+                ) : null}
+                {driverKind ? (
+                  <span className="inline-flex shrink-0 items-center">
+                    <ProviderInstanceIcon
+                      driverKind={driverKind}
+                      displayName={
+                        providerEntry?.displayName ??
+                        thread.session?.providerName ??
+                        modelInstanceId
+                      }
+                      accentColor={providerEntry?.accentColor}
+                      showBadge={showInstanceBadge}
+                      // Glyph dims, badge stays saturated; offset matches the composer trigger.
+                      iconClassName="size-3.5 opacity-60"
+                      badgeClassName="right-[-0.1875rem] bottom-[-0.1875rem] h-3 min-w-3 px-0.5 text-[7px]"
+                    />
+                  </span>
+                ) : null}
+              </span>
+            </div>
           </div>
           {props.jumpLabel ? <JumpHintBadge label={props.jumpLabel} /> : null}
         </TooltipTrigger>
@@ -2143,7 +2340,12 @@ export default function Sidebar() {
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
-  const compactThreadRows = useClientSettings((s) => s.sidebarCompactThreadRows);
+  const layoutMode = useClientSettings((s) =>
+    s.sidebarThreadRowLayoutMode === "standard" && s.sidebarCompactThreadRows
+      ? "compact"
+      : s.sidebarThreadRowLayoutMode,
+  );
+  const customLayout = useClientSettings((s) => s.sidebarThreadRowLayout);
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const confirmThreadArchive = useClientSettings((s) => s.confirmThreadArchive);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
@@ -4677,19 +4879,21 @@ export default function Sidebar() {
                         const threadKey = scopedThreadKey(
                           scopeThreadRef(thread.environmentId, thread.id),
                         );
-                        // Settled and snoozed always use slim rows. Active and
-                        // pinned threads use cards unless the user has explicitly
-                        // enabled the compact thread-list preference.
+                        // Standard active and pinned threads use cards while
+                        // settled and snoozed threads use slim rows. Compact and
+                        // custom modes take the shared layout-row branch in every
+                        // section.
                         const isCard = section === "active" || section === "pinned";
                         const rowVariant = isCard ? "card" : "slim";
                         return (
                           <SidebarThreadRow
-                            // Fade between card and compact rows while the outer
-                            // sortable wrapper keeps its identity during a drag.
+                            // Keep the outer sortable wrapper's identity as the
+                            // selected row layout changes.
                             key={`${threadKey}:${rowVariant}`}
                             thread={thread}
                             variant={rowVariant}
-                            compact={compactThreadRows}
+                            layoutMode={layoutMode}
+                            customLayout={customLayout}
                             // Snoozed rows wake, settled rows un-settle, and cards settle.
                             variantAction={
                               section === "snoozed"

--- a/apps/web/src/components/ThreadRowLayout.tsx
+++ b/apps/web/src/components/ThreadRowLayout.tsx
@@ -1,0 +1,105 @@
+import { Fragment, type ReactNode } from "react";
+import type {
+  SidebarThreadRowComponent,
+  SidebarThreadRowPlacement,
+} from "@t3tools/contracts/settings";
+import { cn } from "../lib/utils";
+
+export const THREAD_ROW_COMPONENT_LABELS = {
+  projectIcon: "Project icon",
+  title: "Thread title",
+  pin: "Pin",
+  activity: "Activity (status and time)",
+  status: "Status",
+  duration: "Working duration",
+  project: "Project name",
+  environment: "Environment",
+  provider: "Provider",
+  model: "Model",
+  branch: "Branch",
+  worktree: "Worktree indicator",
+  pullRequest: "Pull request",
+  terminal: "Terminal activity",
+  updated: "Last message time",
+  created: "Created time",
+  completed: "Completed time",
+  snooze: "Snooze wake time",
+} satisfies Record<SidebarThreadRowComponent, string>;
+
+export type ThreadRowLayoutSideProps = {
+  row: SidebarThreadRowPlacement["row"];
+  alignment: SidebarThreadRowPlacement["alignment"];
+  className: string;
+  children: ReactNode;
+  empty: boolean;
+};
+
+export type ThreadRowLayoutRowProps = {
+  row: SidebarThreadRowPlacement["row"];
+  className: string;
+  children: ReactNode;
+};
+
+/** Shared geometry for the real list and settings preview. Missing details take no space. */
+export function ThreadRowLayout({
+  layout,
+  components,
+  renderSide,
+  renderRow,
+  showEmptyRows = false,
+}: {
+  layout: ReadonlyArray<SidebarThreadRowPlacement>;
+  components: Partial<Record<SidebarThreadRowComponent, ReactNode>>;
+  /** Editor-only wrapper; receives empty sides so details can be placed directly in the sample. */
+  renderSide?: (props: ThreadRowLayoutSideProps) => ReactNode;
+  renderRow?: (props: ThreadRowLayoutRowProps) => ReactNode;
+  showEmptyRows?: boolean;
+}) {
+  return (
+    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+      {([1, 2, 3] as const).map((row) => {
+        const items = layout.filter(
+          (item) => item.row === row && components[item.component] != null,
+        );
+        if (items.length === 0 && !showEmptyRows) return null;
+        const className = "flex min-h-5 w-full min-w-0 items-center gap-2";
+        const children = (["left", "right"] as const).map((alignment) => {
+          const group = items.filter((item) => item.alignment === alignment);
+          if (!group.length && !renderSide) return null;
+          const className = cn(
+            "flex min-w-0 basis-auto items-center gap-1.5 overflow-hidden",
+            alignment === "left" ? "flex-1" : "ml-auto justify-end text-right",
+          );
+          const children = group.map((item) => (
+            <div
+              key={item.component}
+              className={cn(
+                "flex min-w-0 items-center overflow-hidden text-xs text-secondary-label",
+                item.component === "title" ? "flex-1" : "shrink",
+                alignment === "right" && "justify-end text-right [&>span]:text-right",
+              )}
+            >
+              {components[item.component]}
+            </div>
+          ));
+          return renderSide ? (
+            <Fragment key={alignment}>
+              {renderSide({ row, alignment, className, children, empty: !group.length })}
+            </Fragment>
+          ) : (
+            <div key={alignment} className={className}>
+              {children}
+            </div>
+          );
+        });
+        return renderRow ? (
+          <Fragment key={row}>{renderRow({ row, className, children })}</Fragment>
+        ) : (
+          <div key={row} className={className}>
+            {children}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -22,6 +22,7 @@ import {
   DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE,
   DEFAULT_UNIFIED_SETTINGS,
   type DiffLayout,
+  DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT,
   type EnvironmentIdentificationMode,
   MAX_APPEARANCE_CONTRAST,
   MAX_CODE_FONT_SIZE,
@@ -159,6 +160,7 @@ import {
   useSettingsSearchTargetId,
 } from "./settingsLayout";
 import { searchableSetting } from "./settingsSearch";
+import { ThreadRowLayoutSettings } from "./ThreadRowLayoutSettings";
 import { ProjectFavicon } from "../ProjectFavicon";
 import { PanelAnimationsPreview } from "./PanelAnimationsPreview";
 
@@ -526,15 +528,20 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode
         ? ["Project Grouping"]
         : []),
-      ...(settings.sidebarCompactThreadRows !== DEFAULT_UNIFIED_SETTINGS.sidebarCompactThreadRows
-        ? ["Compact thread list"]
-        : []),
       ...(settings.sidebarAutoSettleAfterDays !==
       DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays
         ? ["Auto-settle inactive threads"]
         : []),
       ...(settings.sidebarAutoSettleOnMerge !== DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleOnMerge
         ? ["Auto-settle merged threads"]
+        : []),
+      ...(settings.sidebarCompactThreadRows ||
+      settings.sidebarThreadRowLayoutMode !== "standard" ||
+      settings.sidebarSavedThreadLayouts.length > 0 ||
+      settings.sidebarActiveThreadLayoutId !== null ||
+      JSON.stringify(settings.sidebarThreadRowLayout) !==
+        JSON.stringify(DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT)
+        ? ["Thread list layout"]
         : []),
       ...(settings.wordWrap !== DEFAULT_UNIFIED_SETTINGS.wordWrap ? ["Word wrap"] : []),
       ...getChangedTypographySettingLabels(settings),
@@ -633,10 +640,14 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.continueThreadsAfterServerUpdate,
       settings.sidebarAutoSettleAfterDays,
       settings.sidebarAutoSettleOnMerge,
-      settings.sidebarCompactThreadRows,
       settings.sidebarProjectGroupingMode,
       settings.sidebarThreadPreviewCount,
       settings.showSkillsInSlashMenu,
+      settings.sidebarCompactThreadRows,
+      settings.sidebarThreadRowLayoutMode,
+      settings.sidebarThreadRowLayout,
+      settings.sidebarSavedThreadLayouts,
+      settings.sidebarActiveThreadLayoutId,
       settings.timestampFormat,
       settings.wordWrap,
       followSystem,
@@ -712,6 +723,11 @@ export function useSettingsRestore(onRestored?: () => void) {
       diffColorScheme: DEFAULT_UNIFIED_SETTINGS.diffColorScheme,
       timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
       wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
+      sidebarCompactThreadRows: DEFAULT_UNIFIED_SETTINGS.sidebarCompactThreadRows,
+      sidebarThreadRowLayoutMode: DEFAULT_UNIFIED_SETTINGS.sidebarThreadRowLayoutMode,
+      sidebarThreadRowLayout: DEFAULT_UNIFIED_SETTINGS.sidebarThreadRowLayout,
+      sidebarSavedThreadLayouts: DEFAULT_UNIFIED_SETTINGS.sidebarSavedThreadLayouts,
+      sidebarActiveThreadLayoutId: DEFAULT_UNIFIED_SETTINGS.sidebarActiveThreadLayoutId,
       diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
       diffLayout: DEFAULT_UNIFIED_SETTINGS.diffLayout,
       proactivePanelsEnabled: DEFAULT_UNIFIED_SETTINGS.proactivePanelsEnabled,
@@ -723,7 +739,6 @@ export function useSettingsRestore(onRestored?: () => void) {
       panelAnimationDurationMs: DEFAULT_UNIFIED_SETTINGS.panelAnimationDurationMs,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
       sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
-      sidebarCompactThreadRows: DEFAULT_UNIFIED_SETTINGS.sidebarCompactThreadRows,
       sidebarAutoSettleAfterDays: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
       sidebarAutoSettleOnMerge: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleOnMerge,
       enableLegacyTokenStreaming: DEFAULT_UNIFIED_SETTINGS.enableLegacyTokenStreaming,
@@ -2168,6 +2183,8 @@ export function GeneralSettingsPanel() {
           }
         />
 
+        <ThreadRowLayoutSettings settings={settings} onChange={updateSettings} />
+
         {supportsAutoSettlement ? (
           <>
             <SettingsRow
@@ -2246,33 +2263,6 @@ export function GeneralSettingsPanel() {
       </SettingsSection>
 
       <SettingsSection id="behavior" title="Behavior">
-        <SettingsRow
-          {...searchableSetting("compact-thread-list")}
-          description="Show active and pinned threads on one line. Hover a thread to see its full details."
-          resetAction={
-            settings.sidebarCompactThreadRows !==
-            DEFAULT_UNIFIED_SETTINGS.sidebarCompactThreadRows ? (
-              <SettingResetButton
-                label="compact thread list"
-                onClick={() =>
-                  updateSettings({
-                    sidebarCompactThreadRows: DEFAULT_UNIFIED_SETTINGS.sidebarCompactThreadRows,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <Switch
-              checked={settings.sidebarCompactThreadRows}
-              onCheckedChange={(checked) =>
-                updateSettings({ sidebarCompactThreadRows: Boolean(checked) })
-              }
-              aria-label="Compact thread list"
-            />
-          }
-        />
-
         <SettingsRow
           {...searchableSetting("time-format")}
           description="System default follows your browser or OS clock preference."

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -526,6 +526,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode
         ? ["Project Grouping"]
         : []),
+      ...(settings.sidebarCompactThreadRows !== DEFAULT_UNIFIED_SETTINGS.sidebarCompactThreadRows
+        ? ["Compact thread list"]
+        : []),
       ...(settings.sidebarAutoSettleAfterDays !==
       DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays
         ? ["Auto-settle inactive threads"]
@@ -630,6 +633,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.continueThreadsAfterServerUpdate,
       settings.sidebarAutoSettleAfterDays,
       settings.sidebarAutoSettleOnMerge,
+      settings.sidebarCompactThreadRows,
       settings.sidebarProjectGroupingMode,
       settings.sidebarThreadPreviewCount,
       settings.showSkillsInSlashMenu,
@@ -719,6 +723,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       panelAnimationDurationMs: DEFAULT_UNIFIED_SETTINGS.panelAnimationDurationMs,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
       sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
+      sidebarCompactThreadRows: DEFAULT_UNIFIED_SETTINGS.sidebarCompactThreadRows,
       sidebarAutoSettleAfterDays: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
       sidebarAutoSettleOnMerge: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleOnMerge,
       enableLegacyTokenStreaming: DEFAULT_UNIFIED_SETTINGS.enableLegacyTokenStreaming,
@@ -2241,6 +2246,33 @@ export function GeneralSettingsPanel() {
       </SettingsSection>
 
       <SettingsSection id="behavior" title="Behavior">
+        <SettingsRow
+          {...searchableSetting("compact-thread-list")}
+          description="Show active and pinned threads on one line. Hover a thread to see its full details."
+          resetAction={
+            settings.sidebarCompactThreadRows !==
+            DEFAULT_UNIFIED_SETTINGS.sidebarCompactThreadRows ? (
+              <SettingResetButton
+                label="compact thread list"
+                onClick={() =>
+                  updateSettings({
+                    sidebarCompactThreadRows: DEFAULT_UNIFIED_SETTINGS.sidebarCompactThreadRows,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.sidebarCompactThreadRows}
+              onCheckedChange={(checked) =>
+                updateSettings({ sidebarCompactThreadRows: Boolean(checked) })
+              }
+              aria-label="Compact thread list"
+            />
+          }
+        />
+
         <SettingsRow
           {...searchableSetting("time-format")}
           description="System default follows your browser or OS clock preference."

--- a/apps/web/src/components/settings/ThreadListPreviewContext.tsx
+++ b/apps/web/src/components/settings/ThreadListPreviewContext.tsx
@@ -1,0 +1,12 @@
+import { createContext, useContext } from "react";
+
+export const ThreadListPreviewContext = createContext<{
+  showing: boolean;
+  setShowing: (showing: boolean) => void;
+} | null>(null);
+
+export function useThreadListPreview() {
+  const context = useContext(ThreadListPreviewContext);
+  if (!context) throw new Error("Thread list preview requires AppSidebarLayout");
+  return context;
+}

--- a/apps/web/src/components/settings/ThreadRowLayoutEditor.logic.test.ts
+++ b/apps/web/src/components/settings/ThreadRowLayoutEditor.logic.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { SidebarThreadRowPlacement } from "@t3tools/contracts/settings";
+import { dropThreadDetail, threadRowBlankSpace } from "./ThreadRowLayoutEditor.logic";
+
+const layout: ReadonlyArray<SidebarThreadRowPlacement> = [
+  { component: "projectIcon", row: 1, alignment: "left" },
+  { component: "title", row: 1, alignment: "left" },
+  { component: "activity", row: 1, alignment: "right" },
+];
+
+describe("dropping thread details", () => {
+  it("adds a hidden detail to an empty row side", () => {
+    expect(
+      dropThreadDetail(layout, "model", { kind: "place", row: 2, alignment: "right" }),
+    ).toEqual([...layout, { component: "model", row: 2, alignment: "right" }]);
+  });
+
+  it("moves an existing detail between rows without duplicating it", () => {
+    const next = dropThreadDetail(layout, "title", { kind: "place", row: 3, alignment: "right" });
+    expect(next).toEqual([
+      layout[0],
+      layout[2],
+      { component: "title", row: 3, alignment: "right" },
+    ]);
+    expect(layout[1]?.row).toBe(1);
+  });
+
+  it("reorders before and after a peer in the same row", () => {
+    const next = dropThreadDetail(layout, "title", {
+      kind: "place",
+      row: 1,
+      alignment: "left",
+      relativeTo: "projectIcon",
+      edge: "before",
+    });
+    expect(next.map((item) => item.component)).toEqual(["title", "projectIcon", "activity"]);
+    expect(
+      dropThreadDetail(next, "title", {
+        kind: "place",
+        row: 1,
+        alignment: "left",
+        relativeTo: "projectIcon",
+        edge: "after",
+      }),
+    ).toEqual(layout);
+  });
+
+  it("moves across sides next to another detail", () => {
+    expect(
+      dropThreadDetail(layout, "title", {
+        kind: "place",
+        row: 1,
+        alignment: "right",
+        relativeTo: "activity",
+        edge: "after",
+      }),
+    ).toEqual([layout[0], layout[2], { component: "title", row: 1, alignment: "right" }]);
+  });
+
+  it("appends when dropped into the empty space of an occupied side", () => {
+    expect(
+      dropThreadDetail(layout, "projectIcon", { kind: "place", row: 1, alignment: "left" })
+        .filter((item) => item.alignment === "left")
+        .map((item) => item.component),
+    ).toEqual(["title", "projectIcon"]);
+  });
+
+  it("hides a detail but never removes the final visible detail", () => {
+    expect(dropThreadDetail(layout, "title", { kind: "hide" })).toEqual([layout[0], layout[2]]);
+    const onlyTitle = [{ component: "title", row: 1, alignment: "left" }] as const;
+    expect(dropThreadDetail(onlyTitle, "title", { kind: "hide" })).toBe(onlyTitle);
+    expect(dropThreadDetail(layout, "model", { kind: "hide" })).toBe(layout);
+  });
+
+  it("preserves saved settings on cancellation, outside drops and self-drops", () => {
+    expect(dropThreadDetail(layout, "title", null)).toBe(layout);
+    expect(
+      dropThreadDetail(layout, "title", {
+        kind: "place",
+        row: 1,
+        alignment: "left",
+        relativeTo: "title",
+        edge: "before",
+      }),
+    ).toBe(layout);
+    expect(
+      dropThreadDetail(layout, "title", {
+        kind: "place",
+        row: 1,
+        alignment: "left",
+        relativeTo: "projectIcon",
+        edge: "after",
+      }),
+    ).toBe(layout);
+  });
+});
+
+describe("blank-space drop targets", () => {
+  const row = { left: 100, right: 460 };
+
+  it("uses the full width for an empty row or an unoccupied side", () => {
+    expect(threadRowBlankSpace(row, [], [])).toEqual({ left: 0, width: 360 });
+    expect(threadRowBlankSpace(row, [{ right: 180 }], [])).toEqual({ left: 80, width: 280 });
+    expect(threadRowBlankSpace(row, [], [{ left: 420 }])).toEqual({ left: 0, width: 320 });
+  });
+
+  it("splits the actual gap between visible details rather than the flex container", () => {
+    const gap = threadRowBlankSpace(
+      row,
+      [{ right: 130 }, { right: 210 }],
+      [{ left: 430 }, { left: 410 }],
+    );
+    expect(gap).toEqual({ left: 110, width: 200 });
+    // The right target starts halfway through the visible gap, well before the right group.
+    expect(row.left + gap.left + gap.width / 2).toBe(310);
+  });
+
+  it("does not expose a gap when details fill or overflow the row", () => {
+    expect(threadRowBlankSpace(row, [{ right: 420 }], [{ left: 410 }]).width).toBe(0);
+    expect(threadRowBlankSpace(row, [{ right: 480 }], []).width).toBe(0);
+  });
+});

--- a/apps/web/src/components/settings/ThreadRowLayoutEditor.logic.ts
+++ b/apps/web/src/components/settings/ThreadRowLayoutEditor.logic.ts
@@ -1,0 +1,60 @@
+import type {
+  SidebarThreadRowComponent,
+  SidebarThreadRowPlacement,
+} from "@t3tools/contracts/settings";
+
+export type ThreadDetailDropTarget =
+  | { kind: "hide" }
+  | {
+      kind: "place";
+      row: SidebarThreadRowPlacement["row"];
+      alignment: SidebarThreadRowPlacement["alignment"];
+      relativeTo?: SidebarThreadRowComponent;
+      edge?: "before" | "after";
+    };
+
+/** Apply a drop once, preserving other details and preventing an empty saved layout. */
+export function dropThreadDetail(
+  layout: ReadonlyArray<SidebarThreadRowPlacement>,
+  component: SidebarThreadRowComponent,
+  target: ThreadDetailDropTarget | null,
+) {
+  if (!target) return layout;
+  const remaining = layout.filter((item) => item.component !== component);
+  if (target.kind === "hide")
+    return remaining.length && remaining.length !== layout.length ? remaining : layout;
+  if (target.relativeTo === component) return layout;
+  const placement = { component, row: target.row, alignment: target.alignment };
+  const relativeIndex = remaining.findIndex(
+    (item) =>
+      item.component === target.relativeTo &&
+      item.row === target.row &&
+      item.alignment === target.alignment,
+  );
+  const next = [...remaining];
+  next.splice(
+    relativeIndex < 0 ? remaining.length : relativeIndex + (target.edge === "after" ? 1 : 0),
+    0,
+    placement,
+  );
+  return next.length === layout.length &&
+    next.every(
+      (item, i) =>
+        item.component === layout[i]?.component &&
+        item.row === layout[i]?.row &&
+        item.alignment === layout[i]?.alignment,
+    )
+    ? layout
+    : next;
+}
+
+/** The visible space between the two groups, including unused width inside a flexed title. */
+export function threadRowBlankSpace(
+  row: { left: number; right: number },
+  leftDetails: ReadonlyArray<{ right: number }>,
+  rightDetails: ReadonlyArray<{ left: number }>,
+) {
+  const start = Math.max(row.left, ...leftDetails.map((detail) => detail.right));
+  const end = Math.min(row.right, ...rightDetails.map((detail) => detail.left));
+  return { left: start - row.left, width: Math.max(0, end - start) };
+}

--- a/apps/web/src/components/settings/ThreadRowLayoutEditor.tsx
+++ b/apps/web/src/components/settings/ThreadRowLayoutEditor.tsx
@@ -1,0 +1,641 @@
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  pointerWithin,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type CollisionDetection,
+  type Modifier,
+} from "@dnd-kit/core";
+import { getEventCoordinates } from "@dnd-kit/utilities";
+import {
+  CircleDashedIcon,
+  GitBranchIcon,
+  GripVerticalIcon,
+  PinIcon,
+  TerminalIcon,
+} from "lucide-react";
+import {
+  DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT,
+  SidebarThreadRowComponent,
+  type SidebarThreadRowPlacement,
+} from "@t3tools/contracts/settings";
+import { cn } from "../../lib/utils";
+import { Button } from "../ui/button";
+import {
+  THREAD_ROW_COMPONENT_LABELS,
+  ThreadRowLayout,
+  type ThreadRowLayoutSideProps,
+  type ThreadRowLayoutRowProps,
+} from "../ThreadRowLayout";
+import {
+  dropThreadDetail,
+  threadRowBlankSpace,
+  type ThreadDetailDropTarget,
+} from "./ThreadRowLayoutEditor.logic";
+
+const SAMPLE_COMPONENTS = {
+  projectIcon: (
+    <span className="rounded bg-foreground px-0.5 text-[10px] font-bold text-background">T3</span>
+  ),
+  title: (
+    <span className="truncate text-sm font-medium text-foreground">Build a custom thread list</span>
+  ),
+  pin: <PinIcon className="size-3" />,
+  activity: (
+    <span className="inline-flex items-center gap-1 text-sky-600 dark:text-sky-400">
+      <CircleDashedIcon className="size-4" />
+      6s
+    </span>
+  ),
+  status: <span className="text-sky-600 dark:text-sky-400">Working</span>,
+  duration: "6s",
+  project: "T3 Code",
+  environment: "MacBook Pro",
+  provider: "Codex",
+  model: "GPT-5.6",
+  branch: (
+    <span className="inline-flex min-w-0 items-center gap-1">
+      <GitBranchIcon className="size-3 shrink-0" />
+      <span className="truncate">feat/thread-layout</span>
+    </span>
+  ),
+  worktree: "Worktree",
+  pullRequest: <span className="text-emerald-600 dark:text-emerald-400">#9835</span>,
+  terminal: <TerminalIcon className="size-3.5" />,
+  updated: "now",
+  created: "2h",
+  completed: "5m",
+  snooze: "Tomorrow, 9 AM",
+} satisfies Record<SidebarThreadRowComponent, ReactNode>;
+
+const ROWS = [1, 2, 3] as const;
+const SIDES = ["left", "right"] as const;
+const rowId = (row: number, side: string) => `row:${row}:${side}`;
+const edgeId = (component: SidebarThreadRowComponent, edge: "before" | "after") =>
+  `edge:${component}:${edge}`;
+
+const detectDrop: CollisionDetection = (args) => {
+  const collisions = pointerWithin(args);
+  const edge = collisions.find((collision) => String(collision.id).startsWith("edge:"));
+  const gap = collisions.find((collision) => String(collision.id).startsWith("gap:"));
+  return edge ? [edge] : gap ? [gap] : collisions;
+};
+
+// Offset only the floating copy; hit testing stays at the pointer.
+const offsetDragPreview: Modifier = ({ activatorEvent, activeNodeRect, transform }) => {
+  const pointer = activatorEvent ? getEventCoordinates(activatorEvent) : null;
+  if (!pointer || !activeNodeRect) return transform;
+  return {
+    ...transform,
+    x: transform.x + pointer.x - activeNodeRect.left + 12,
+    y: transform.y + pointer.y - activeNodeRect.top + 20,
+  };
+};
+
+function InsertionMarker({ side }: { side: "left" | "right" }) {
+  return (
+    <span
+      aria-hidden
+      data-layout-insertion
+      className={cn(
+        "pointer-events-none absolute inset-y-0 z-20 w-1 rounded-full bg-sky-500 ring-1 ring-background dark:bg-sky-400",
+        side === "left" ? "left-0" : "right-0",
+      )}
+    />
+  );
+}
+
+function DetailFace({
+  component,
+  placed,
+}: {
+  component: SidebarThreadRowComponent;
+  placed: boolean;
+}) {
+  return placed ? (
+    SAMPLE_COMPONENTS[component]
+  ) : (
+    <>
+      <GripVerticalIcon aria-hidden className="size-3 shrink-0 text-muted-foreground/60" />
+      <span className="flex min-w-0 flex-col items-start gap-1 text-left">
+        <span className="flex min-h-5 max-w-full items-center text-xs text-secondary-label">
+          {SAMPLE_COMPONENTS[component]}
+        </span>
+        <span className="text-[10px] text-muted-foreground">
+          {THREAD_ROW_COMPONENT_LABELS[component]}
+        </span>
+      </span>
+    </>
+  );
+}
+
+function DetailChip({
+  component,
+  placed,
+  selected,
+  onSelect,
+  onRemove,
+  canRemove,
+}: {
+  component: SidebarThreadRowComponent;
+  placed: boolean;
+  selected: boolean;
+  onSelect: () => void;
+  onRemove: () => void;
+  canRemove: boolean;
+}) {
+  const drag = useDraggable({ id: component });
+  const before = useDroppable({
+    id: edgeId(component, "before"),
+    disabled: !placed || drag.isDragging,
+  });
+  const after = useDroppable({
+    id: edgeId(component, "after"),
+    disabled: !placed || drag.isDragging,
+  });
+  return (
+    <div
+      className={cn(
+        "relative flex min-w-0 max-w-full items-stretch rounded-sm",
+        !placed && "border border-border bg-background",
+        selected && "ring-1 ring-inset ring-primary",
+        drag.isDragging && "opacity-30",
+      )}
+    >
+      <div
+        ref={before.setNodeRef}
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute inset-y-0 left-0 w-1/2",
+          before.isOver && "z-10 bg-sky-500/15",
+        )}
+      >
+        {before.isOver && <InsertionMarker side="left" />}
+      </div>
+      <button
+        ref={drag.setNodeRef}
+        {...drag.listeners}
+        {...drag.attributes}
+        type="button"
+        data-layout-detail={component}
+        aria-label={`Move ${THREAD_ROW_COMPONENT_LABELS[component]}`}
+        aria-pressed={selected}
+        onClick={onSelect}
+        onKeyDown={(event) => {
+          if (placed && canRemove && (event.key === "Delete" || event.key === "Backspace")) {
+            event.preventDefault();
+            event.stopPropagation();
+            onRemove();
+          }
+        }}
+        className={cn(
+          "flex min-w-0 flex-1 touch-none items-center gap-1 rounded-sm outline-none select-none hover:bg-primary/10 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring cursor-default",
+          placed ? "min-h-5 whitespace-nowrap" : "px-2 py-1.5",
+        )}
+      >
+        <DetailFace component={component} placed={placed} />
+      </button>
+      <div
+        ref={after.setNodeRef}
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute inset-y-0 right-0 w-1/2",
+          after.isOver && "z-10 bg-sky-500/15",
+        )}
+      >
+        {after.isOver && <InsertionMarker side="right" />}
+      </div>
+    </div>
+  );
+}
+
+function GapTarget({ row, alignment }: Pick<ThreadRowLayoutSideProps, "row" | "alignment">) {
+  const { setNodeRef, isOver } = useDroppable({ id: `gap:${row}:${alignment}` });
+  return (
+    <div
+      ref={setNodeRef}
+      data-layout-gap={`${row}:${alignment}`}
+      className={cn(
+        "relative flex h-full min-w-0 flex-1 items-center justify-center rounded-sm",
+        isOver && "bg-sky-500/15",
+      )}
+    >
+      {isOver && <InsertionMarker side={alignment} />}
+    </div>
+  );
+}
+
+function PreviewRow({
+  row,
+  className,
+  children,
+  editing,
+}: ThreadRowLayoutRowProps & { editing: boolean }) {
+  const root = useRef<HTMLDivElement>(null);
+  const [gap, setGap] = useState({ left: 0, width: 0 });
+  useLayoutEffect(() => {
+    const node = root.current;
+    if (!editing || !node) return;
+    const measure = () => {
+      const details = (side: string) =>
+        Array.from(
+          node.querySelectorAll(`[data-layout-drop="${rowId(row, side)}"] [data-layout-detail]`),
+          (detail) => detail.getBoundingClientRect(),
+        );
+      const next = threadRowBlankSpace(
+        node.getBoundingClientRect(),
+        details("left"),
+        details("right"),
+      );
+      setGap((previous) =>
+        previous.left === next.left && previous.width === next.width ? previous : next,
+      );
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [editing, row, children]);
+  return (
+    <div ref={root} className={cn(className, "relative")}>
+      {children}
+      {editing && gap.width > 0 && (
+        <div className="pointer-events-none absolute inset-y-0 z-10 flex" style={gap}>
+          <GapTarget row={row} alignment="left" />
+          <GapTarget row={row} alignment="right" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PreviewSide({
+  row,
+  alignment,
+  className,
+  children,
+  empty,
+  picking,
+  editing,
+  onPlace,
+}: ThreadRowLayoutSideProps & {
+  picking: boolean;
+  editing: boolean;
+  onPlace: () => void;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: rowId(row, alignment) });
+  if (empty && !editing && !picking) return null;
+  return (
+    <div
+      ref={setNodeRef}
+      data-layout-drop={rowId(row, alignment)}
+      className={cn(
+        className,
+        "relative min-h-5 rounded-sm",
+        empty && editing && "min-w-12",
+        isOver && "bg-sky-500/15",
+      )}
+    >
+      {children}
+      {isOver && <InsertionMarker side={empty ? alignment : "right"} />}
+      {empty && editing ? (
+        <button
+          type="button"
+          disabled={!picking}
+          onClick={onPlace}
+          aria-label={`Place selected detail in row ${row}, ${alignment}`}
+          className="w-full border-b border-dashed border-muted-foreground/30 text-[10px] text-muted-foreground/60 focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          {alignment === "left" ? `Row ${row}` : "Right"}
+        </button>
+      ) : picking ? (
+        <button
+          type="button"
+          onClick={onPlace}
+          aria-label={`Place selected detail in row ${row}, ${alignment}`}
+          className="sr-only focus:not-sr-only focus:absolute focus:inset-0 focus:bg-sidebar focus:text-xs"
+        >
+          Place here
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function AvailableDetails({
+  children,
+  picking,
+  onHide,
+}: {
+  children: ReactNode;
+  picking: boolean;
+  onHide: () => void;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: "available" });
+  return (
+    <div
+      ref={setNodeRef}
+      data-layout-drop="available"
+      className={cn("min-w-0 space-y-2 rounded-lg", isOver && "bg-primary/10 ring-1 ring-primary")}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-xs font-medium text-muted-foreground">Available details</h3>
+        {picking ? (
+          <Button variant="outline" size="sm" onClick={onHide}>
+            Hide selected detail
+          </Button>
+        ) : null}
+      </div>
+      <div className="flex flex-wrap gap-2">{children}</div>
+    </div>
+  );
+}
+
+export function ThreadRowLayoutEditor({
+  layoutId,
+  layout,
+  disabled = false,
+  onChange,
+  footer,
+  renderHeader,
+  showResetLayout = true,
+  resetLayout = DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT,
+  showAvailableDetails = true,
+}: {
+  layoutId: string;
+  layout: ReadonlyArray<SidebarThreadRowPlacement>;
+  disabled?: boolean;
+  onChange: (layout: ReadonlyArray<SidebarThreadRowPlacement>) => void;
+  footer?: ReactNode;
+  renderHeader: (preview: ReactNode) => ReactNode;
+  showResetLayout?: boolean;
+  resetLayout?: ReadonlyArray<SidebarThreadRowPlacement>;
+  showAvailableDetails?: boolean;
+}) {
+  const [dragging, setDragging] = useState<SidebarThreadRowComponent | null>(null);
+  const [selection, setSelection] = useState<{
+    layoutId: string;
+    component: SidebarThreadRowComponent;
+  } | null>(null);
+  const picked = selection?.layoutId === layoutId ? selection.component : null;
+  const setPicked = (component: SidebarThreadRowComponent | null) =>
+    setSelection(component ? { layoutId, component } : null);
+  const [message, setMessage] = useState("");
+  const root = useRef<HTMLDivElement>(null);
+  const focusAfterChange = useRef<SidebarThreadRowComponent | null>(null);
+  useLayoutEffect(() => {
+    const component = focusAfterChange.current;
+    if (!component) return;
+    root.current?.querySelector<HTMLButtonElement>(`[data-layout-detail="${component}"]`)?.focus();
+    focusAfterChange.current = null;
+  }, [layout]);
+  useEffect(() => {
+    if (!dragging) return;
+    // Let the drag sensor cancel before Settings handles Escape as navigation.
+    const keepInEditor = (event: KeyboardEvent) => {
+      if (event.key === "Escape") event.preventDefault();
+    };
+    window.addEventListener("keydown", keepInEditor, true);
+    return () => window.removeEventListener("keydown", keepInEditor, true);
+  }, [dragging]);
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
+  const targets = new Map<string, ThreadDetailDropTarget>([["available", { kind: "hide" }]]);
+  for (const row of ROWS)
+    for (const alignment of SIDES) {
+      targets.set(rowId(row, alignment), { kind: "place", row, alignment });
+      const first = layout.find(
+        (item) => item.row === row && item.alignment === alignment && item.component !== dragging,
+      );
+      targets.set(`gap:${row}:${alignment}`, {
+        kind: "place",
+        row,
+        alignment,
+        ...(alignment === "right" && first ? { relativeTo: first.component, edge: "before" } : {}),
+      });
+    }
+  for (const item of layout)
+    for (const edge of ["before", "after"] as const)
+      targets.set(edgeId(item.component, edge), {
+        kind: "place",
+        row: item.row,
+        alignment: item.alignment,
+        relativeTo: item.component,
+        edge,
+      });
+
+  const place = (
+    component: SidebarThreadRowComponent,
+    target: ThreadDetailDropTarget | null,
+    restoreFocus = false,
+  ) => {
+    const next = dropThreadDetail(layout, component, target);
+    if (next !== layout) {
+      if (restoreFocus) focusAfterChange.current = component;
+      onChange(next);
+    }
+    setPicked(null);
+    setMessage(
+      target?.kind === "hide"
+        ? layout.some((item) => item.component === component)
+          ? next === layout
+            ? "Keep at least one detail visible."
+            : `${THREAD_ROW_COMPONENT_LABELS[component]} hidden.`
+          : "Move cancelled."
+        : target
+          ? `${THREAD_ROW_COMPONENT_LABELS[component]} placed in row ${target.row}, ${target.alignment}.`
+          : "Move cancelled.",
+    );
+    if (restoreFocus && next === layout)
+      root.current
+        ?.querySelector<HTMLButtonElement>(`[data-layout-detail="${component}"]`)
+        ?.focus();
+  };
+  const chip = (component: SidebarThreadRowComponent, placed: boolean) => (
+    <DetailChip
+      key={component}
+      component={component}
+      placed={placed}
+      selected={picked === component}
+      canRemove={layout.length > 1}
+      onSelect={() => {
+        if (picked && picked !== component && placed) {
+          place(picked, targets.get(edgeId(component, "before")) ?? null, true);
+        } else {
+          setPicked(picked === component ? null : component);
+          setMessage(
+            picked === component
+              ? "Move cancelled."
+              : `${THREAD_ROW_COMPONENT_LABELS[component]} selected. Choose a row side or another detail to place it.`,
+          );
+        }
+      }}
+      onRemove={() => place(component, { kind: "hide" }, true)}
+    />
+  );
+
+  const preview = (
+    <div className="w-fit min-w-0 max-w-full overflow-x-auto">
+      <div
+        className="w-[calc(var(--sidebar-width)-2*var(--sidebar-content-inset)-2px)] rounded-md bg-sidebar px-2.5 py-1.5 ring-1 ring-inset ring-border"
+        aria-label="Thread layout preview"
+      >
+        <ThreadRowLayout
+          layout={layout}
+          showEmptyRows={dragging !== null}
+          components={Object.fromEntries(
+            layout.map(({ component }) => [component, chip(component, true)]),
+          )}
+          renderRow={(props) => <PreviewRow {...props} editing={dragging !== null} />}
+          renderSide={(props) => (
+            <PreviewSide
+              {...props}
+              editing={dragging !== null}
+              picking={picked !== null}
+              onPlace={() => {
+                if (picked)
+                  place(
+                    picked,
+                    { kind: "place", row: props.row, alignment: props.alignment },
+                    true,
+                  );
+              }}
+            />
+          )}
+        />
+      </div>
+    </div>
+  );
+
+  return (
+    <DndContext
+      sensors={disabled ? [] : sensors}
+      autoScroll={{ layoutShiftCompensation: false }}
+      collisionDetection={detectDrop}
+      accessibility={{
+        screenReaderInstructions: {
+          draggable:
+            "Press Enter or Space to select a detail. Use arrow keys to change its row or side, or select another detail to insert before it. Escape cancels.",
+        },
+      }}
+      onDragStart={({ active }) => {
+        setPicked(null);
+        setDragging(SidebarThreadRowComponent.literals.find((id) => id === active.id) ?? null);
+      }}
+      onDragCancel={() => {
+        setDragging(null);
+        setMessage("Move cancelled.");
+      }}
+      onDragEnd={({ active, over }) => {
+        setDragging(null);
+        const component = SidebarThreadRowComponent.literals.find((id) => id === active.id);
+        if (component) place(component, over ? (targets.get(String(over.id)) ?? null) : null);
+      }}
+    >
+      <div
+        ref={root}
+        inert={disabled || undefined}
+        aria-disabled={disabled || undefined}
+        className="space-y-4 rounded-xl px-3 pt-3 pb-1 sm:px-4 cursor-default [&_*]:cursor-default"
+        onKeyDown={(event) => {
+          if (
+            picked &&
+            event.target instanceof Element &&
+            event.target.closest("[data-layout-detail]") &&
+            ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(event.key)
+          ) {
+            event.preventDefault();
+            event.stopPropagation();
+            const current = layout.find((item) => item.component === picked);
+            const row = current?.row ?? 1;
+            const alignment = current?.alignment ?? "left";
+            place(
+              picked,
+              {
+                kind: "place",
+                row:
+                  event.key === "ArrowUp"
+                    ? row === 3
+                      ? 2
+                      : 1
+                    : event.key === "ArrowDown"
+                      ? row === 1
+                        ? 2
+                        : 3
+                      : row,
+                alignment:
+                  event.key === "ArrowLeft"
+                    ? "left"
+                    : event.key === "ArrowRight"
+                      ? "right"
+                      : alignment,
+              },
+              true,
+            );
+          }
+          if (event.key === "Escape" && dragging) event.preventDefault();
+          if (event.key === "Escape" && picked) {
+            event.preventDefault();
+            event.stopPropagation();
+            setPicked(null);
+            setMessage("Move cancelled.");
+          }
+        }}
+      >
+        <div className="space-y-4">
+          {renderHeader(preview)}
+          {showAvailableDetails && (
+            <AvailableDetails
+              picking={layout.length > 1 && layout.some((item) => item.component === picked)}
+              onHide={() => {
+                if (picked) place(picked, { kind: "hide" }, true);
+              }}
+            >
+              {SidebarThreadRowComponent.literals
+                .filter((component) => !layout.some((item) => item.component === component))
+                .map((component) => chip(component, false))}
+            </AvailableDetails>
+          )}
+        </div>
+        {(showResetLayout || footer) && (
+          <div className="flex flex-wrap items-center gap-2">
+            {showResetLayout && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setPicked(null);
+                  onChange(resetLayout);
+                }}
+              >
+                Reset layout
+              </Button>
+            )}
+            {footer}
+          </div>
+        )}
+        <span className="sr-only" role="status">
+          {message}
+        </span>
+      </div>
+      <DragOverlay
+        dropAnimation={null}
+        modifiers={[offsetDragPreview]}
+        className="pointer-events-none"
+      >
+        {dragging ? (
+          <div
+            data-layout-drag-preview
+            className="flex w-max max-w-64 items-center gap-1.5 rounded-md border border-primary bg-background px-2 py-1.5 text-xs whitespace-nowrap shadow-lg"
+          >
+            <DetailFace component={dragging} placed />
+          </div>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
+  );
+}

--- a/apps/web/src/components/settings/ThreadRowLayoutSettings.test.tsx
+++ b/apps/web/src/components/settings/ThreadRowLayoutSettings.test.tsx
@@ -1,0 +1,110 @@
+import { DEFAULT_CLIENT_SETTINGS, type SavedThreadRowLayout } from "@t3tools/contracts/settings";
+import { act, type ReactNode } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const setup = vi.hoisted(() => ({ hydrated: false, setShowing: vi.fn() }));
+
+vi.mock("../../hooks/useSettings", () => ({
+  useClientSettingsHydrated: () => setup.hydrated,
+  usePrimarySettingsAvailable: () => true,
+}));
+
+vi.mock("../ui/sidebar", () => ({
+  useSidebar: () => ({ isMobile: false, setOpenMobile: vi.fn(), setOpen: vi.fn() }),
+}));
+
+vi.mock("./ThreadListPreviewContext", () => ({
+  useThreadListPreview: () => ({ showing: false, setShowing: setup.setShowing }),
+}));
+
+vi.mock("./ThreadRowLayoutEditor", () => ({
+  ThreadRowLayoutEditor: ({
+    renderHeader,
+    footer,
+  }: {
+    renderHeader: (preview: ReactNode) => ReactNode;
+    footer: ReactNode;
+  }) => (
+    <>
+      {renderHeader(<div>Preview</div>)}
+      {footer}
+    </>
+  ),
+}));
+
+import { ThreadRowLayoutSettings } from "./ThreadRowLayoutSettings";
+
+let renderer: ReactTestRenderer | undefined;
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  setup.hydrated = false;
+  setup.setShowing.mockClear();
+});
+
+afterEach(async () => {
+  await act(() => renderer?.unmount());
+  renderer = undefined;
+  vi.unstubAllGlobals();
+});
+
+function duplicateButton() {
+  return renderer!.root.find(
+    (node) => node.type === "button" && node.children.includes("Duplicate"),
+  );
+}
+
+describe("thread row layout settings hydration", () => {
+  it("does not build a saved-layout patch from the pre-hydration defaults", async () => {
+    const onChange = vi.fn();
+    await act(() => {
+      renderer = create(
+        <ThreadRowLayoutSettings settings={DEFAULT_CLIENT_SETTINGS} onChange={onChange} />,
+      );
+    });
+
+    const preview = () =>
+      renderer!.root.find(
+        (node) => node.type === "button" && node.children.includes("Preview my threads"),
+      );
+    expect(preview().props.disabled).toBe(true);
+    await act(() => preview().props.onClick());
+    expect(setup.setShowing).not.toHaveBeenCalled();
+
+    const duplicateBeforeHydration = duplicateButton();
+    await act(() => duplicateBeforeHydration.props.onClick());
+    expect(onChange).not.toHaveBeenCalled();
+    expect(duplicateBeforeHydration.props.disabled).toBe(true);
+
+    const existing: SavedThreadRowLayout = {
+      id: "saved-review",
+      name: "Review",
+      layout: DEFAULT_CLIENT_SETTINGS.sidebarThreadRowLayout,
+    };
+    setup.hydrated = true;
+    await act(() => {
+      renderer!.update(
+        <ThreadRowLayoutSettings
+          settings={{
+            ...DEFAULT_CLIENT_SETTINGS,
+            sidebarSavedThreadLayouts: [existing],
+          }}
+          onChange={onChange}
+        />,
+      );
+    });
+
+    expect(preview().props.disabled).toBe(false);
+    await act(() => preview().props.onClick());
+    expect(setup.setShowing).toHaveBeenCalledWith(true);
+
+    expect(duplicateButton().props.disabled).toBe(false);
+    await act(() => duplicateButton().props.onClick());
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange.mock.calls[0]?.[0].sidebarSavedThreadLayouts).toEqual([
+      existing,
+      expect.objectContaining({ name: "Standard copy" }),
+    ]);
+  });
+});

--- a/apps/web/src/components/settings/ThreadRowLayoutSettings.tsx
+++ b/apps/web/src/components/settings/ThreadRowLayoutSettings.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useId, useRef, useState } from "react";
+import { type ClientSettings, type ClientSettingsPatch } from "@t3tools/contracts/settings";
+import { CheckIcon, XIcon } from "lucide-react";
+import { randomUUID } from "../../lib/utils";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectPopup,
+  SelectItem,
+  SelectSeparator,
+} from "../ui/select";
+import { SettingsRow, SettingResetButton } from "./settingsLayout";
+import { searchableSetting } from "./settingsSearch";
+import { useSidebar } from "../ui/sidebar";
+import { ThreadRowLayoutEditor } from "./ThreadRowLayoutEditor";
+import {
+  changeSavedThreadLayout,
+  resolveSavedThreadLayouts,
+  COMPACT_THREAD_LAYOUT,
+} from "./savedThreadLayouts";
+import { useThreadListPreview } from "./ThreadListPreviewContext";
+import { useClientSettingsHydrated } from "../../hooks/useSettings";
+
+export function ThreadRowLayoutSettings({
+  settings,
+  onChange,
+}: {
+  settings: ClientSettings;
+  onChange: (patch: ClientSettingsPatch) => void;
+}) {
+  const { layouts, current, preset } = resolveSavedThreadLayouts(settings);
+  const settingsHydrated = useClientSettingsHydrated();
+  const [rename, setRename] = useState<string | null>(null);
+  const [renameError, setRenameError] = useState<string | null>(null);
+  const renameErrorId = useId();
+  const pickerRef = useRef<HTMLButtonElement>(null);
+  const wasRenaming = useRef(false);
+  useEffect(() => {
+    if (rename === null && wasRenaming.current) pickerRef.current?.focus();
+    wasRenaming.current = rename !== null;
+  }, [rename]);
+  const { showing, setShowing } = useThreadListPreview();
+  const { isMobile, setOpenMobile, setOpen } = useSidebar();
+  useEffect(() => () => setShowing(false), [setShowing]);
+  const change = (action: Parameters<typeof changeSavedThreadLayout>[1]) => {
+    if (!settingsHydrated) return false;
+    const patch = changeSavedThreadLayout(settings, action);
+    if (patch) onChange(patch);
+    return patch !== null;
+  };
+  return (
+    <ThreadRowLayoutEditor
+      renderHeader={(preview) => (
+        <SettingsRow
+          {...searchableSetting("compact-thread-list")}
+          title="Thread list layout"
+          resetAction={
+            preset === null ? (
+              <SettingResetButton
+                label="thread list layout"
+                disabled={!settingsHydrated}
+                onClick={() => {
+                  setRename(null);
+                  change({ type: "select", id: "preset:standard" });
+                }}
+              />
+            ) : null
+          }
+          className="px-0 pt-0 pb-0 sm:px-0"
+        >
+          <div className="flex flex-wrap items-start gap-4 pt-3">
+            <div className="min-w-0 max-w-full shrink-0">{preview}</div>
+            <div className="ml-auto flex w-48 max-w-full shrink-0 flex-col items-end gap-2">
+              {rename !== null ? (
+                <form
+                  className="flex w-full min-w-0 flex-wrap items-center gap-2"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    const name = rename.trim();
+                    if (!name) return;
+                    if (
+                      name === current.name ||
+                      change({ type: "rename", id: randomUUID(), name })
+                    ) {
+                      setRename(null);
+                    } else {
+                      setRenameError("A layout with that name already exists.");
+                    }
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Escape") {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      setRename(null);
+                    }
+                  }}
+                >
+                  <Input
+                    autoFocus
+                    aria-label="Layout name"
+                    aria-invalid={renameError !== null || undefined}
+                    aria-describedby={renameError ? renameErrorId : undefined}
+                    className="min-w-0 flex-1"
+                    onFocus={(event) => event.currentTarget.select()}
+                    maxLength={80}
+                    value={rename}
+                    disabled={!settingsHydrated}
+                    onChange={(event) => {
+                      setRename(event.target.value);
+                      setRenameError(null);
+                    }}
+                  />
+                  <Button
+                    type="submit"
+                    size="icon-sm"
+                    aria-label="Accept layout name"
+                    disabled={!settingsHydrated || !rename.trim()}
+                  >
+                    <CheckIcon />
+                  </Button>
+                  <Button
+                    type="button"
+                    size="icon-sm"
+                    variant="ghost"
+                    aria-label="Cancel rename"
+                    disabled={!settingsHydrated}
+                    onClick={() => setRename(null)}
+                  >
+                    <XIcon />
+                  </Button>
+                  {renameError ? (
+                    <p id={renameErrorId} role="alert" className="text-destructive w-full text-xs">
+                      {renameError}
+                    </p>
+                  ) : null}
+                </form>
+              ) : (
+                <>
+                  <Select
+                    value={current.id}
+                    disabled={!settingsHydrated}
+                    onValueChange={(id) => {
+                      if (id) {
+                        setRename(null);
+                        if (id === "action:new-layout") {
+                          change({ type: "create", id: randomUUID(), duplicate: false });
+                        } else {
+                          change({ type: "select", id });
+                        }
+                      }
+                    }}
+                  >
+                    <SelectTrigger
+                      ref={pickerRef}
+                      aria-label="Saved thread layout"
+                      className="w-full"
+                    >
+                      <SelectValue>{current.name}</SelectValue>
+                    </SelectTrigger>
+                    <SelectPopup>
+                      {layouts.map((item) => (
+                        <SelectItem key={item.id} value={item.id}>
+                          {item.name}
+                        </SelectItem>
+                      ))}
+                      <SelectSeparator />
+                      <SelectItem value="action:new-layout">New layout…</SelectItem>
+                    </SelectPopup>
+                  </Select>
+                </>
+              )}
+              <div className="flex items-center gap-2">
+                {rename === null && preset === null && (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="w-16"
+                    disabled={!settingsHydrated}
+                    onClick={() => {
+                      setRenameError(null);
+                      setRename(current.name);
+                    }}
+                  >
+                    Rename
+                  </Button>
+                )}
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={!settingsHydrated}
+                  onClick={() => {
+                    setRename(null);
+                    change({ type: "create", id: randomUUID(), duplicate: true });
+                  }}
+                >
+                  Duplicate
+                </Button>
+              </div>
+            </div>
+          </div>
+        </SettingsRow>
+      )}
+      layoutId={current.id}
+      layout={current.layout}
+      disabled={!settingsHydrated}
+      showAvailableDetails={preset === null}
+      showResetLayout={preset === null}
+      resetLayout={preset ? current.layout : COMPACT_THREAD_LAYOUT.layout}
+      onChange={(layout) => change({ type: "edit", id: randomUUID(), layout })}
+      footer={
+        <>
+          <Button
+            size="sm"
+            variant={showing ? "default" : "outline"}
+            disabled={!settingsHydrated}
+            onClick={() => {
+              if (!settingsHydrated) return;
+              setShowing(!showing);
+              if (!showing) {
+                if (isMobile) setOpenMobile(true);
+                else setOpen(true);
+              }
+            }}
+          >
+            {showing ? "Close thread list preview" : "Preview my threads"}
+          </Button>
+          {preset === null ? (
+            <Button
+              size="sm"
+              variant="destructive"
+              className="sm:ml-auto"
+              disabled={!settingsHydrated}
+              onClick={() => {
+                setRename(null);
+                change({ type: "delete" });
+              }}
+            >
+              Delete layout
+            </Button>
+          ) : null}
+        </>
+      }
+    />
+  );
+}

--- a/apps/web/src/components/settings/savedThreadLayouts.test.ts
+++ b/apps/web/src/components/settings/savedThreadLayouts.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  DEFAULT_CLIENT_SETTINGS,
+  DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT,
+} from "@t3tools/contracts/settings";
+import {
+  changeSavedThreadLayout,
+  resolveSavedThreadLayouts,
+  STANDARD_THREAD_LAYOUT,
+  COMPACT_THREAD_LAYOUT,
+  threadRowLayoutForMode,
+} from "./savedThreadLayouts";
+
+const original = {
+  ...DEFAULT_CLIENT_SETTINGS,
+  sidebarThreadRowLayoutMode: "custom" as const,
+  sidebarThreadRowLayout: [{ component: "title", row: 2, alignment: "right" }] as const,
+};
+
+describe("saved thread layouts", () => {
+  it("rejects renaming to another saved or built-in layout name", () => {
+    const first = changeSavedThreadLayout(original, {
+      type: "create",
+      id: "one",
+      duplicate: false,
+    })!;
+    const second = changeSavedThreadLayout(first, { type: "create", id: "two", duplicate: false })!;
+    for (const name of ["Layout", "Standard", "Compact"]) {
+      expect(changeSavedThreadLayout(second, { type: "rename", id: "unused", name })).toBeNull();
+    }
+  });
+  it("preserves the pre-existing arrangement when creating a fresh layout", () => {
+    const next = changeSavedThreadLayout(original, {
+      type: "create",
+      id: "new",
+      duplicate: false,
+    })!;
+    expect(next.sidebarThreadRowLayout).toEqual(DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT);
+    expect(next.sidebarSavedThreadLayouts[0]?.layout).toEqual(original.sidebarThreadRowLayout);
+    const restored = changeSavedThreadLayout(next, { type: "select", id: "current" });
+    expect(restored?.sidebarThreadRowLayout).toEqual(original.sidebarThreadRowLayout);
+  });
+
+  it("edits a duplicate independently and restores both arrangements when switching", () => {
+    const copy = changeSavedThreadLayout(original, {
+      type: "create",
+      id: "copy",
+      duplicate: true,
+    })!;
+    const edited = changeSavedThreadLayout(copy, {
+      type: "edit",
+      id: "unused",
+      layout: DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT,
+    })!;
+    const first = changeSavedThreadLayout(edited, { type: "select", id: "current" })!;
+    expect(first.sidebarThreadRowLayout).toEqual(original.sidebarThreadRowLayout);
+    expect(
+      changeSavedThreadLayout(first, { type: "select", id: "copy" })?.sidebarThreadRowLayout,
+    ).toEqual(DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT);
+    expect(original.sidebarThreadRowLayout[0]?.row).toBe(2);
+  });
+
+  it("renames, deletes and selects a surviving layout, and falls back to Standard after deleting the last custom layout", () => {
+    const copy = changeSavedThreadLayout(original, {
+      type: "create",
+      id: "copy",
+      duplicate: true,
+    })!;
+    const renamed = changeSavedThreadLayout(copy, {
+      type: "rename",
+      id: "renamed",
+      name: "  Focus  ",
+    })!;
+    expect(resolveSavedThreadLayouts(renamed).current.name).toBe("Focus");
+    const remaining = changeSavedThreadLayout(renamed, { type: "delete" })!;
+    expect(remaining.sidebarActiveThreadLayoutId).toBe("current");
+    expect(remaining.sidebarThreadRowLayout).toEqual(original.sidebarThreadRowLayout);
+    const empty = changeSavedThreadLayout(remaining, { type: "delete" })!;
+    expect(empty.sidebarSavedThreadLayouts).toEqual([]);
+    expect(resolveSavedThreadLayouts(empty).current.name).toBe("Standard");
+    expect(changeSavedThreadLayout(empty, { type: "delete" })).toBeNull();
+    expect(
+      changeSavedThreadLayout(remaining, { type: "rename", id: "renamed", name: " " }),
+    ).toBeNull();
+    expect(changeSavedThreadLayout(remaining, { type: "select", id: "missing" })).toBeNull();
+  });
+
+  it("gives new layouts distinct names and retains saved layouts when selection is missing", () => {
+    const first = changeSavedThreadLayout(original, {
+      type: "create",
+      id: "one",
+      duplicate: false,
+    })!;
+    const second = changeSavedThreadLayout(first, { type: "create", id: "two", duplicate: false })!;
+    expect(resolveSavedThreadLayouts(second).current.name).toBe("Layout 2");
+    const orphaned = resolveSavedThreadLayouts({ ...second, sidebarActiveThreadLayoutId: null });
+    expect(orphaned.layouts.map((item) => item.id)).toEqual([
+      "preset:standard",
+      "preset:compact",
+      "current",
+      "one",
+      "two",
+    ]);
+    expect(
+      changeSavedThreadLayout(second, { type: "create", id: "one", duplicate: false }),
+    ).toBeNull();
+  });
+});
+
+describe("built-in thread layouts", () => {
+  it("maps each persisted mode to the layout rendered by the sidebar", () => {
+    expect(threadRowLayoutForMode("standard", original.sidebarThreadRowLayout)).toBe(
+      STANDARD_THREAD_LAYOUT.layout,
+    );
+    expect(threadRowLayoutForMode("compact", original.sidebarThreadRowLayout)).toBe(
+      COMPACT_THREAD_LAYOUT.layout,
+    );
+    expect(threadRowLayoutForMode("custom", original.sidebarThreadRowLayout)).toBe(
+      original.sidebarThreadRowLayout,
+    );
+  });
+
+  it("offers both presets without creating a custom layout, including legacy compact settings", () => {
+    const initial = resolveSavedThreadLayouts(DEFAULT_CLIENT_SETTINGS);
+    expect(initial.layouts).toEqual([STANDARD_THREAD_LAYOUT, COMPACT_THREAD_LAYOUT]);
+    expect(initial.current).toBe(STANDARD_THREAD_LAYOUT);
+    expect(
+      resolveSavedThreadLayouts({ ...DEFAULT_CLIENT_SETTINGS, sidebarCompactThreadRows: true })
+        .current,
+    ).toBe(COMPACT_THREAD_LAYOUT);
+  });
+
+  it.each([STANDARD_THREAD_LAYOUT, COMPACT_THREAD_LAYOUT])(
+    "forks $name on its first edit and keeps subsequent edits in that copy",
+    (preset) => {
+      const selected = changeSavedThreadLayout(original, { type: "select", id: preset.id })!;
+      const layout = [
+        ...preset.layout,
+        { component: "model", row: 2, alignment: "right" } as const,
+      ];
+      const edited = changeSavedThreadLayout(selected, { type: "edit", id: "fork", layout })!;
+      expect(edited.sidebarThreadRowLayoutMode).toBe("custom");
+      expect(edited.sidebarActiveThreadLayoutId).toBe("fork");
+      expect(resolveSavedThreadLayouts(edited).current.name).toBe(`${preset.name} copy`);
+      expect(edited.sidebarThreadRowLayout).toEqual(layout);
+      expect(edited.sidebarSavedThreadLayouts.map((item) => item.id)).toEqual(["current", "fork"]);
+      const again = changeSavedThreadLayout(edited, {
+        type: "edit",
+        id: "unused",
+        layout: [{ component: "title", row: 1, alignment: "left" }],
+      })!;
+      expect(again.sidebarActiveThreadLayoutId).toBe("fork");
+      expect(again.sidebarSavedThreadLayouts).toHaveLength(2);
+      const restored = changeSavedThreadLayout(again, { type: "select", id: preset.id })!;
+      expect(resolveSavedThreadLayouts(restored).current).toEqual(preset);
+      expect(restored.sidebarThreadRowLayoutMode).toBe(
+        preset === STANDARD_THREAD_LAYOUT ? "standard" : "compact",
+      );
+      expect(
+        changeSavedThreadLayout(restored, { type: "select", id: "current" })
+          ?.sidebarThreadRowLayout,
+      ).toEqual(original.sidebarThreadRowLayout);
+    },
+  );
+
+  it("does not fork a preset for a no-op edit or cancelled drag", () => {
+    expect(
+      changeSavedThreadLayout(DEFAULT_CLIENT_SETTINGS, {
+        type: "edit",
+        id: "fork",
+        layout: STANDARD_THREAD_LAYOUT.layout.map((item) => ({ ...item })),
+      }),
+    ).toBeNull();
+  });
+
+  it("creates distinct names when editing the same preset again", () => {
+    const layout = [{ component: "title", row: 1, alignment: "left" }] as const;
+    const first = changeSavedThreadLayout(DEFAULT_CLIENT_SETTINGS, {
+      type: "edit",
+      id: "one",
+      layout,
+    })!;
+    const selected = changeSavedThreadLayout(first, {
+      type: "select",
+      id: STANDARD_THREAD_LAYOUT.id,
+    })!;
+    const second = changeSavedThreadLayout(selected, { type: "edit", id: "two", layout })!;
+    expect(resolveSavedThreadLayouts(second).current.name).toBe("Standard copy 2");
+    expect(second.sidebarSavedThreadLayouts).toHaveLength(2);
+  });
+
+  it("copies a preset when renaming or duplicating it and never deletes a built-in", () => {
+    const renamed = changeSavedThreadLayout(DEFAULT_CLIENT_SETTINGS, {
+      type: "rename",
+      id: "named",
+      name: "Focus",
+    })!;
+    expect(resolveSavedThreadLayouts(renamed).current).toEqual({
+      id: "named",
+      name: "Focus",
+      layout: STANDARD_THREAD_LAYOUT.layout,
+    });
+    const copy = changeSavedThreadLayout(DEFAULT_CLIENT_SETTINGS, {
+      type: "create",
+      id: "copy",
+      duplicate: true,
+    })!;
+    expect(copy.sidebarThreadRowLayout).toEqual(STANDARD_THREAD_LAYOUT.layout);
+    expect(changeSavedThreadLayout(DEFAULT_CLIENT_SETTINGS, { type: "delete" })).toBeNull();
+    expect(
+      changeSavedThreadLayout(DEFAULT_CLIENT_SETTINGS, {
+        type: "edit",
+        id: STANDARD_THREAD_LAYOUT.id,
+        layout: COMPACT_THREAD_LAYOUT.layout,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/components/settings/savedThreadLayouts.ts
+++ b/apps/web/src/components/settings/savedThreadLayouts.ts
@@ -1,0 +1,199 @@
+import {
+  DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT,
+  type ClientSettings,
+  type SavedThreadRowLayout,
+  type SidebarThreadRowLayoutMode,
+  type SidebarThreadRowPlacement,
+} from "@t3tools/contracts/settings";
+
+type LayoutSettings = Pick<
+  ClientSettings,
+  | "sidebarThreadRowLayout"
+  | "sidebarSavedThreadLayouts"
+  | "sidebarActiveThreadLayoutId"
+  | "sidebarThreadRowLayoutMode"
+  | "sidebarCompactThreadRows"
+>;
+
+export const STANDARD_THREAD_LAYOUT: SavedThreadRowLayout = {
+  id: "preset:standard",
+  name: "Standard",
+  layout: [
+    { component: "projectIcon", row: 1, alignment: "left" },
+    { component: "project", row: 1, alignment: "left" },
+    { component: "pin", row: 1, alignment: "right" },
+    { component: "status", row: 1, alignment: "right" },
+    { component: "duration", row: 1, alignment: "right" },
+    { component: "title", row: 2, alignment: "left" },
+    { component: "worktree", row: 3, alignment: "left" },
+    { component: "branch", row: 3, alignment: "left" },
+    { component: "terminal", row: 3, alignment: "right" },
+    { component: "pullRequest", row: 3, alignment: "right" },
+    { component: "provider", row: 3, alignment: "right" },
+  ],
+};
+export const COMPACT_THREAD_LAYOUT: SavedThreadRowLayout = {
+  id: "preset:compact",
+  name: "Compact",
+  layout: DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT,
+};
+const BUILT_IN_THREAD_LAYOUTS = [STANDARD_THREAD_LAYOUT, COMPACT_THREAD_LAYOUT];
+
+export function threadRowLayoutForMode(
+  mode: SidebarThreadRowLayoutMode,
+  customLayout: ReadonlyArray<SidebarThreadRowPlacement>,
+): ReadonlyArray<SidebarThreadRowPlacement> {
+  switch (mode) {
+    case "standard":
+      return STANDARD_THREAD_LAYOUT.layout;
+    case "compact":
+      return COMPACT_THREAD_LAYOUT.layout;
+    case "custom":
+      return customLayout;
+  }
+}
+
+const isPreset = (id: string) => BUILT_IN_THREAD_LAYOUTS.some((item) => item.id === id);
+const sameLayout = (
+  left: ReadonlyArray<SidebarThreadRowPlacement>,
+  right: ReadonlyArray<SidebarThreadRowPlacement>,
+) =>
+  left.length === right.length &&
+  left.every(
+    (item, i) =>
+      item.component === right[i]?.component &&
+      item.row === right[i]?.row &&
+      item.alignment === right[i]?.alignment,
+  );
+
+/** Keep built-ins out of saved state and preserve arrangements from before the layout library. */
+export function resolveSavedThreadLayouts(settings: LayoutSettings) {
+  const mode =
+    settings.sidebarThreadRowLayoutMode === "standard" && settings.sidebarCompactThreadRows
+      ? "compact"
+      : settings.sidebarThreadRowLayoutMode;
+  const saved = settings.sidebarSavedThreadLayouts.filter((item) => !isPreset(item.id));
+  const active = saved.find((item) => item.id === settings.sidebarActiveThreadLayoutId);
+  const custom = {
+    id: "current",
+    name: "My layout",
+    ...active,
+    layout: settings.sidebarThreadRowLayout,
+  };
+  const hasCustom =
+    !!active || mode === "custom" || !sameLayout(custom.layout, DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT);
+  const customLayouts = !hasCustom
+    ? saved
+    : active
+      ? saved.map((item) => (item.id === active.id ? custom : item))
+      : [custom, ...saved.filter((item) => item.id !== custom.id)];
+  const preset = mode === "custom" ? null : mode;
+  const current =
+    preset === "standard"
+      ? STANDARD_THREAD_LAYOUT
+      : preset === "compact"
+        ? COMPACT_THREAD_LAYOUT
+        : custom;
+  return { layouts: [...BUILT_IN_THREAD_LAYOUTS, ...customLayouts], current, preset };
+}
+
+type LayoutAction =
+  | { type: "edit"; id: string; layout: ReadonlyArray<SidebarThreadRowPlacement> }
+  | { type: "select"; id: string }
+  | { type: "create"; id: string; duplicate: boolean }
+  | { type: "rename"; id: string; name: string }
+  | { type: "delete" };
+
+export function changeSavedThreadLayout(
+  settings: LayoutSettings,
+  action: LayoutAction,
+): LayoutSettings | null {
+  const resolved = resolveSavedThreadLayouts(settings);
+  let { current } = resolved;
+  let saved = resolved.layouts.filter((item) => !isPreset(item.id));
+  const create = (id: string, base: string, layout: ReadonlyArray<SidebarThreadRowPlacement>) => {
+    if (resolved.layouts.some((item) => item.id === id)) return null;
+    let name = base;
+    for (let n = 2; resolved.layouts.some((item) => item.name === name); n++) name = `${base} ${n}`;
+    return { id, name, layout };
+  };
+  switch (action.type) {
+    case "edit": {
+      if (sameLayout(current.layout, action.layout)) return null;
+      const edited = resolved.preset
+        ? create(action.id, `${current.name} copy`, action.layout)
+        : { ...current, layout: action.layout };
+      if (!edited) return null;
+      current = edited;
+      break;
+    }
+    case "select": {
+      const selected = resolved.layouts.find((item) => item.id === action.id);
+      if (!selected) return null;
+      if (isPreset(selected.id)) {
+        return {
+          sidebarThreadRowLayout: settings.sidebarThreadRowLayout,
+          sidebarThreadRowLayoutMode:
+            selected.id === STANDARD_THREAD_LAYOUT.id ? "standard" : "compact",
+          sidebarCompactThreadRows: false,
+          sidebarActiveThreadLayoutId: resolved.preset
+            ? settings.sidebarActiveThreadLayoutId
+            : current.id,
+          sidebarSavedThreadLayouts: saved,
+        };
+      }
+      current = selected;
+      break;
+    }
+    case "create": {
+      const created = create(
+        action.id,
+        action.duplicate ? `${current.name.slice(0, 65)} copy` : "Layout",
+        action.duplicate ? current.layout : DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT,
+      );
+      if (!created) return null;
+      current = created;
+      break;
+    }
+    case "rename": {
+      const name = action.name.trim();
+      if (
+        !name ||
+        name.length > 80 ||
+        name === current.name ||
+        resolved.layouts.some((item) => item.id !== current.id && item.name === name)
+      )
+        return null;
+      const renamed = resolved.preset
+        ? create(action.id, name, current.layout)
+        : { ...current, name };
+      if (!renamed) return null;
+      current = renamed;
+      break;
+    }
+    case "delete": {
+      if (resolved.preset) return null;
+      saved = saved.filter((item) => item.id !== current.id);
+      const next = saved[0];
+      if (!next)
+        return {
+          sidebarThreadRowLayoutMode: "standard",
+          sidebarCompactThreadRows: false,
+          sidebarThreadRowLayout: DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT,
+          sidebarActiveThreadLayoutId: null,
+          sidebarSavedThreadLayouts: [],
+        };
+      current = next;
+      break;
+    }
+  }
+  return {
+    sidebarThreadRowLayoutMode: "custom",
+    sidebarCompactThreadRows: false,
+    sidebarThreadRowLayout: current.layout,
+    sidebarActiveThreadLayoutId: current.id,
+    sidebarSavedThreadLayouts: saved.some((item) => item.id === current.id)
+      ? saved.map((item) => (item.id === current.id ? current : item))
+      : [...saved, current],
+  };
+}

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -169,6 +169,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     searchTerms: ["combine matching repositories environments sidebar"],
   },
   {
+    id: "compact-thread-list",
+    title: "Compact thread list",
+    to: "/settings/general",
+  },
+  {
     id: "auto-settle-inactive-threads",
     title: "Auto-settle inactive threads",
     to: "/settings/general",

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -170,7 +170,8 @@ export const SETTINGS_SEARCH_ITEMS = [
   },
   {
     id: "compact-thread-list",
-    title: "Compact thread list",
+    title: "Thread list layout",
+    searchTerms: ["standard compact custom rows saved layouts preview my threads"],
     to: "/settings/general",
   },
   {

--- a/apps/web/src/components/sidebar/SidebarCompletedTime.test.tsx
+++ b/apps/web/src/components/sidebar/SidebarCompletedTime.test.tsx
@@ -1,0 +1,56 @@
+import { act, memo } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, expect, it, vi } from "vite-plus/test";
+
+import { SidebarCompletedTime } from "./SidebarCompletedTime";
+
+let renderer: ReactTestRenderer | undefined;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-09-07T01:01:00Z"));
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("window", {
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+  });
+});
+
+afterEach(async () => {
+  await act(() => renderer?.unmount());
+  renderer = undefined;
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+it("advances visible and accessible completion times without rerendering its memoized row", async () => {
+  const rowRender = vi.fn();
+  const Row = memo(function Row() {
+    rowRender();
+    return <SidebarCompletedTime completedAt="2026-09-07T01:00:00Z" />;
+  });
+  await act(() => {
+    renderer = create(<Row />);
+  });
+  expect(renderer!.root.findByType("time").props.dateTime).toBe("2026-09-07T01:00:00Z");
+  expect(renderer!.root.findByProps({ className: "sr-only" }).children).toEqual(["Completed "]);
+  expect(
+    renderer!.root.findAll((node) => node.props.role === "status" || node.props["aria-live"]),
+  ).toHaveLength(0);
+  expect(renderer!.root.findByProps({ className: "text-secondary-label" }).children).toEqual([
+    "1m",
+  ]);
+
+  await act(() => vi.advanceTimersByTime(60_000));
+
+  expect(renderer!.root.findByProps({ className: "sr-only" }).children).toEqual(["Completed "]);
+  expect(renderer!.root.findByProps({ className: "text-secondary-label" }).children).toEqual([
+    "2m",
+  ]);
+  expect(rowRender).toHaveBeenCalledTimes(1);
+  await act(() => renderer!.unmount());
+  renderer = undefined;
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/apps/web/src/components/sidebar/SidebarCompletedTime.tsx
+++ b/apps/web/src/components/sidebar/SidebarCompletedTime.tsx
@@ -1,0 +1,22 @@
+import { CircleCheckIcon } from "lucide-react";
+
+import { useNowMinute } from "../../hooks/useNowMinute";
+import { formatRelativeTimeLabel } from "../../timestampFormat";
+
+export function SidebarCompletedTime({ completedAt }: { completedAt: string }) {
+  // Subscribe inside the label so time advances even when the row is memoized.
+  const nowMinute = useNowMinute();
+  const relativeTime = formatRelativeTimeLabel(completedAt, Date.parse(`${nowMinute}:00Z`));
+  const label = relativeTime === "just now" ? "now" : relativeTime.replace(/ ago$/, "");
+
+  return (
+    <time
+      dateTime={completedAt}
+      className="inline-flex items-center gap-1 text-emerald-700 dark:text-emerald-300"
+    >
+      <CircleCheckIcon aria-hidden className="size-4 shrink-0" />
+      <span className="sr-only">Completed </span>
+      <span className="text-secondary-label">{label}</span>
+    </time>
+  );
+}

--- a/apps/web/src/timestampFormat.test.ts
+++ b/apps/web/src/timestampFormat.test.ts
@@ -228,3 +228,15 @@ describe("formatElapsedDurationLabel", () => {
     expect(formatElapsedDurationLabel("2026-04-03T12:00:00.000Z")).toBe("4d");
   });
 });
+
+describe("explicit relative-time clock", () => {
+  it("uses the supplied minute instead of the wall clock", () => {
+    const completedAt = "2026-09-07T01:00:00Z";
+    expect(formatRelativeTimeLabel(completedAt, Date.parse("2026-09-07T01:01:00Z"))).toBe("1m ago");
+    expect(formatRelativeTimeLabel(completedAt, Date.parse("2026-09-07T01:02:00Z"))).toBe("2m ago");
+    expect(formatRelativeTime(completedAt, Date.parse("2026-09-07T01:02:00Z"))).toEqual({
+      value: "2m",
+      suffix: "ago",
+    });
+  });
+});

--- a/apps/web/src/timestampFormat.ts
+++ b/apps/web/src/timestampFormat.ts
@@ -196,10 +196,10 @@ export type RelativeTimeState =
   | { status: "invalid" }
   | { status: "relative"; value: string; suffix: string | null };
 
-export function formatRelativeTime(isoDate: string): RelativeTimeParts | null {
+export function formatRelativeTime(isoDate: string, nowMs = Date.now()): RelativeTimeParts | null {
   const date = parseTimestampDate(isoDate);
   if (!date) return null;
-  const diffMs = Date.now() - date.getTime();
+  const diffMs = nowMs - date.getTime();
   if (diffMs < 0) return { value: "just now", suffix: null };
   const seconds = Math.floor(diffMs / 1000);
   if (seconds < 60) return { value: "just now", suffix: null };
@@ -211,8 +211,8 @@ export function formatRelativeTime(isoDate: string): RelativeTimeParts | null {
   return { value: `${days}d`, suffix: "ago" };
 }
 
-export function formatRelativeTimeLabel(isoDate: string) {
-  const relative = formatRelativeTime(isoDate);
+export function formatRelativeTimeLabel(isoDate: string, nowMs = Date.now()) {
+  const relative = formatRelativeTime(isoDate, nowMs);
   if (!relative) return "";
   return relative.suffix ? `${relative.value} ${relative.suffix}` : relative.value;
 }

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -1,5 +1,16 @@
 # Working with threads
 
+## Custom thread layouts
+
+In **Settings → General → Thread list layout**, choose Standard, Compact, or
+**New layout…**. Drag sample details into the preview to choose their order, row,
+and alignment. Drag a placed detail back to Available details to hide it.
+
+Edits save automatically. Editing Standard or Compact creates a separate custom
+layout; the built-ins stay available. Duplicate a layout to try a variation, and
+use **Preview my threads** to see it across your actual sidebar before returning
+to Settings. Named layouts and the selection are saved on this client.
+
 Use a new thread for a separate task. Choose **New worktree** when its code changes
 need a separate branch and working directory.
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -7,6 +7,7 @@ import {
   ClientSettingsPatch,
   ClaudeSettings,
   DEFAULT_SERVER_SETTINGS,
+  DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT,
   resolveProviderInstanceEnabled,
   ServerSettings,
   ServerSettingsPatch,
@@ -782,4 +783,83 @@ it("validates remote device hosts and rejects ambiguous host ids", () => {
     decodeDeviceHostSettings({ deviceHosts: [{ ...host, target: "-oProxyCommand=bad" }] }),
   ).toThrow();
   expect(() => decodeDeviceHostSettings({ deviceHosts: [{ ...host, port: 0 }] })).toThrow();
+});
+
+describe("ClientSettings thread row layout", () => {
+  it("keeps existing installs standard and preserves the earlier compact preference", () => {
+    const defaults = decodeClientSettings({});
+    expect(defaults.sidebarThreadRowLayoutMode).toBe("standard");
+    expect(defaults.sidebarThreadRowLayout).toEqual(DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT);
+    expect(defaults.sidebarSavedThreadLayouts).toEqual([]);
+    expect(defaults.sidebarActiveThreadLayoutId).toBeNull();
+    expect(decodeClientSettings({ sidebarCompactThreadRows: true }).sidebarCompactThreadRows).toBe(
+      true,
+    );
+  });
+
+  it("round-trips custom order, rows and alignment through persisted settings", () => {
+    const patch = decodeClientSettingsPatch({
+      sidebarThreadRowLayoutMode: "custom",
+      sidebarThreadRowLayout: [
+        { component: "model", row: 2, alignment: "left" },
+        { component: "title", row: 1, alignment: "right" },
+        { component: "project", row: 2, alignment: "left" },
+      ],
+    });
+    const settings = decodeClientSettings(patch);
+    const reloaded = decodeClientSettings(
+      JSON.parse(JSON.stringify(encodeClientSettings(settings))),
+    );
+    expect(reloaded.sidebarThreadRowLayoutMode).toBe("custom");
+    expect(reloaded.sidebarThreadRowLayout).toEqual(patch.sidebarThreadRowLayout);
+  });
+
+  it.each(
+    [
+      [],
+      [{ component: "title", row: 0, alignment: "left" }],
+      [{ component: "title", row: 1, alignment: "center" }],
+      [{ component: "unknown", row: 1, alignment: "left" }],
+      [
+        { component: "title", row: 1, alignment: "left" },
+        { component: "title", row: 2, alignment: "right" },
+      ],
+    ].map((layout) => ({ layout })),
+  )("rejects malformed or ambiguous layouts: $layout", ({ layout }) => {
+    expect(() => decodeClientSettings({ sidebarThreadRowLayout: layout })).toThrow();
+    expect(() => decodeClientSettingsPatch({ sidebarThreadRowLayout: layout })).toThrow();
+  });
+
+  it("allows hiding the title and keeps the custom arrangement when changing modes", () => {
+    const settings = decodeClientSettings({
+      sidebarThreadRowLayoutMode: "custom",
+      sidebarThreadRowLayout: [{ component: "projectIcon", row: 1, alignment: "right" }],
+    });
+    const standard = decodeClientSettings({
+      ...settings,
+      ...decodeClientSettingsPatch({ sidebarThreadRowLayoutMode: "standard" }),
+    });
+    expect(standard.sidebarThreadRowLayout).toEqual(settings.sidebarThreadRowLayout);
+    expect(() => decodeClientSettingsPatch({ sidebarThreadRowLayoutMode: "invalid" })).toThrow();
+  });
+});
+
+describe("saved thread layout settings", () => {
+  const saved = { id: "daily", name: "Daily", layout: DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT };
+  it("round-trips the library and active selection through persistence and patches", () => {
+    const patch = decodeClientSettingsPatch({
+      sidebarSavedThreadLayouts: [saved],
+      sidebarActiveThreadLayoutId: "daily",
+    });
+    const reloaded = decodeClientSettings(
+      JSON.parse(JSON.stringify(encodeClientSettings(decodeClientSettings(patch)))),
+    );
+    expect(reloaded.sidebarSavedThreadLayouts).toEqual([saved]);
+    expect(reloaded.sidebarActiveThreadLayoutId).toBe("daily");
+  });
+  it("rejects duplicate IDs, blank names and invalid nested arrangements", () => {
+    for (const layouts of [[saved, saved], [{ ...saved, name: " " }], [{ ...saved, layout: [] }]]) {
+      expect(() => decodeClientSettingsPatch({ sidebarSavedThreadLayouts: layouts })).toThrow();
+    }
+  });
 });

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -390,7 +390,18 @@ describe("ClientSettings environment identification", () => {
 
 describe("ClientSettings sidebar", () => {
   it("defaults to the current sidebar", () => {
-    expect(decodeClientSettings({}).legacySidebarEnabled).toBe(false);
+    const settings = decodeClientSettings({});
+    expect(settings.legacySidebarEnabled).toBe(false);
+    expect(settings.sidebarCompactThreadRows).toBe(false);
+  });
+
+  it("preserves an explicit compact thread row preference", () => {
+    expect(decodeClientSettings({ sidebarCompactThreadRows: true }).sidebarCompactThreadRows).toBe(
+      true,
+    );
+    expect(
+      decodeClientSettingsPatch({ sidebarCompactThreadRows: true }).sidebarCompactThreadRows,
+    ).toBe(true);
   });
 
   it("drops the retired sidebar v2 beta keys, resetting everyone to the default", () => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -53,6 +53,63 @@ export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at
 export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
 export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
 
+export const SidebarThreadRowLayoutMode = Schema.Literals(["standard", "compact", "custom"]);
+export type SidebarThreadRowLayoutMode = typeof SidebarThreadRowLayoutMode.Type;
+export const SidebarThreadRowComponent = Schema.Literals([
+  "projectIcon",
+  "title",
+  "pin",
+  "activity",
+  "status",
+  "duration",
+  "project",
+  "environment",
+  "provider",
+  "model",
+  "branch",
+  "worktree",
+  "pullRequest",
+  "terminal",
+  "updated",
+  "created",
+  "completed",
+  "snooze",
+]);
+export type SidebarThreadRowComponent = typeof SidebarThreadRowComponent.Type;
+export const SidebarThreadRowPlacement = Schema.Struct({
+  component: SidebarThreadRowComponent,
+  row: Schema.Literals([1, 2, 3]),
+  alignment: Schema.Literals(["left", "right"]),
+});
+export type SidebarThreadRowPlacement = typeof SidebarThreadRowPlacement.Type;
+export const SidebarThreadRowLayout = Schema.Array(SidebarThreadRowPlacement).check(
+  Schema.isMinLength(1),
+  Schema.makeFilter(
+    (items) =>
+      new Set(items.map((item) => item.component)).size === items.length ||
+      "Each thread detail can appear only once",
+  ),
+);
+export const SavedThreadRowLayout = Schema.Struct({
+  id: TrimmedNonEmptyString,
+  name: TrimmedNonEmptyString.check(Schema.isMaxLength(80)),
+  layout: SidebarThreadRowLayout,
+});
+export type SavedThreadRowLayout = typeof SavedThreadRowLayout.Type;
+export const SavedThreadRowLayouts = Schema.Array(SavedThreadRowLayout).check(
+  Schema.makeFilter(
+    (items) =>
+      new Set(items.map((item) => item.id)).size === items.length || "Layout IDs must be unique",
+  ),
+);
+export const DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT: ReadonlyArray<SidebarThreadRowPlacement> = [
+  { component: "projectIcon", row: 1, alignment: "left" },
+  { component: "title", row: 1, alignment: "left" },
+  { component: "pin", row: 1, alignment: "right" },
+  { component: "pullRequest", row: 1, alignment: "right" },
+  { component: "activity", row: 1, alignment: "right" },
+];
+
 export const SidebarProjectGroupingMode = Schema.Literals([
   "repository",
   "repository_path",
@@ -435,6 +492,18 @@ export const ClientSettingsSchema = Schema.Struct({
   sidebarCompactThreadRows: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   sidebarThreadPreviewCount: SidebarThreadPreviewCount.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT)),
+  ),
+  sidebarThreadRowLayoutMode: SidebarThreadRowLayoutMode.pipe(
+    Schema.withDecodingDefault(Effect.succeed("standard")),
+  ),
+  sidebarThreadRowLayout: SidebarThreadRowLayout.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_ROW_LAYOUT)),
+  ),
+  sidebarSavedThreadLayouts: SavedThreadRowLayouts.pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+  ),
+  sidebarActiveThreadLayoutId: Schema.NullOr(TrimmedNonEmptyString).pipe(
+    Schema.withDecodingDefault(Effect.succeed(null)),
   ),
   timestampFormat: TimestampFormat.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_TIMESTAMP_FORMAT)),
@@ -1392,6 +1461,10 @@ export const ClientSettingsPatch = Schema.Struct({
   sidebarThreadSortOrder: Schema.optionalKey(SidebarThreadSortOrder),
   sidebarCompactThreadRows: Schema.optionalKey(Schema.Boolean),
   sidebarThreadPreviewCount: Schema.optionalKey(SidebarThreadPreviewCount),
+  sidebarThreadRowLayoutMode: Schema.optionalKey(SidebarThreadRowLayoutMode),
+  sidebarThreadRowLayout: Schema.optionalKey(SidebarThreadRowLayout),
+  sidebarSavedThreadLayouts: Schema.optionalKey(SavedThreadRowLayouts),
+  sidebarActiveThreadLayoutId: Schema.optionalKey(Schema.NullOr(TrimmedNonEmptyString)),
   timestampFormat: Schema.optionalKey(TimestampFormat),
   snapShotEnabled: Schema.optionalKey(Schema.Boolean),
   snapShotIncludeAccessibility: Schema.optionalKey(Schema.Boolean),

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -432,6 +432,7 @@ export const ClientSettingsSchema = Schema.Struct({
   sidebarThreadSortOrder: SidebarThreadSortOrder.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_SORT_ORDER)),
   ),
+  sidebarCompactThreadRows: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   sidebarThreadPreviewCount: SidebarThreadPreviewCount.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT)),
   ),
@@ -1389,6 +1390,7 @@ export const ClientSettingsPatch = Schema.Struct({
   ),
   sidebarProjectSortOrder: Schema.optionalKey(SidebarProjectSortOrder),
   sidebarThreadSortOrder: Schema.optionalKey(SidebarThreadSortOrder),
+  sidebarCompactThreadRows: Schema.optionalKey(Schema.Boolean),
   sidebarThreadPreviewCount: Schema.optionalKey(SidebarThreadPreviewCount),
   timestampFormat: Schema.optionalKey(TimestampFormat),
   snapShotEnabled: Schema.optionalKey(Schema.Boolean),


### PR DESCRIPTION
Thread rows had two fixed shapes (the full card and, with #9417, a one-line compact row), so users couldn't choose which details a row shows or where. This adds a **Thread list layout** control in Settings → General (web and desktop). Pick Standard or Compact, or arrange row details into named custom layouts with up to three rows.

## How it works

- **Contracts:** `ClientSettings` gains `sidebarThreadRowLayoutMode`, `sidebarThreadRowLayout`, `sidebarSavedThreadLayouts` and `sidebarActiveThreadLayoutId`. These are validated schemas that reject duplicate details, duplicate IDs, and blank names.
- **Sidebar:** Standard keeps main's card unchanged. Compact and custom layouts render through one shared `ThreadRowLayout` renderer in every section. The Settings preview and the real sidebar therefore can't drift apart.
- **Settings:** the layout picker replaces #9417's standalone "Compact thread list" switch, so there's one control. An existing `sidebarCompactThreadRows: true` still opens as the Compact preset. Editing a built-in creates a custom copy. Layouts support duplicate, rename (a rejected name shows an inline error), reset and delete, with keyboard and pointer editing. **Preview my threads** shows the layout on your actual sidebar. Every control stays disabled until settings hydrate, so a patch can't be built from defaults and overwrite saved layouts.
- **Docs:** `docs/user/thread-sidebar.md` has a short "Custom thread layouts" section.

Web and desktop only. Mobile has its own native thread list and isn't affected. Client settings are per-client, so connection mode doesn't matter.

## Stack

Stacked on **#9417** (`07ffd755c`, rebased on current `main`). Land #9417 first. This branch is now one commit on top of it, rebuilt from the previous merge-heavy history.

## Verification (head `07db5c9cf`)

- `vp test run`: web layout editor, saved layouts, layout settings (hydration gate), completed-time, timestamp, settings search, and sidebar logic tests passed (7 files / 231 tests). Contracts `settings.test.ts` passed (115). Desktop `DesktopClientSettings.test.ts` passed (11).
- `tsc --noEmit` passed for `packages/contracts`, `apps/web` and `apps/desktop`. Targeted `vp lint` reported no errors; the only warnings are in existing Sidebar code. `vp fmt --check` passed.

## Media

[Recording](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9967-8c4fbcf-exact-head.mp4) · [contact sheet](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9967-8c4fbcf-exact-head-contact-sheet.png)

![Layout editor contact sheet](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9967-8c4fbcf-exact-head-contact-sheet.png)

This was recorded on `8c4fbcf`. It shows Compact selected (36 px sidebar rows), a Standard duplicate edited by keyboard and pointer, and the edits surviving a reload. The row renderer and editor are unchanged since then. What changed is the rebase and dropping #9417's duplicate switch. A fresh capture on this head is still pending.

Coordination trace: T3 thread 9ea1927f-51fd-4673-bd8f-0d274ec59207

Rebased and updated by Claude Opus 5 (1M context) in Claude Code (T3 Code harness). Earlier iterations were by GPT-5.6 Sol and GPT-6 in Codex/T3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
