### PR TITLE
test(contracts): keep driver default lookup private

### DIFF
--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -7,7 +7,6 @@ import {
   ClientSettingsPatch,
   ClaudeSettings,
   DEFAULT_SERVER_SETTINGS,
-  defaultEnabledForDriver,
   resolveProviderInstanceEnabled,
   ServerSettings,
   ServerSettingsPatch,
@@ -432,14 +431,6 @@ describe("provider enabled defaults", () => {
     expect(decoded.providers.opencode.enabled).toBe(false);
   });
 
-  it("derives per-driver defaults from the settings schemas", () => {
-    expect(defaultEnabledForDriver(ProviderDriverKind.make("codex"))).toBe(true);
-    expect(defaultEnabledForDriver(ProviderDriverKind.make("cursor"))).toBe(false);
-    expect(defaultEnabledForDriver(ProviderDriverKind.make("grok"))).toBe(false);
-    // Unknown fork drivers stay enabled; their own build decides otherwise.
-    expect(defaultEnabledForDriver(ProviderDriverKind.make("ollama"))).toBe(true);
-  });
-
   it("keeps Cursor enabled when an existing user explicitly opted in", () => {
     const cursor = ProviderDriverKind.make("cursor");
     const cursorId = ProviderInstanceId.make("cursor");
@@ -460,6 +451,10 @@ describe("provider enabled defaults", () => {
     // No flags anywhere: driver default applies.
     expect(resolveProviderInstanceEnabled({ driver: grok, config: {} })).toBe(false);
     expect(resolveProviderInstanceEnabled({ driver: codex, config: {} })).toBe(true);
+    // Unknown fork drivers stay enabled.
+    expect(
+      resolveProviderInstanceEnabled({ driver: ProviderDriverKind.make("ollama"), config: {} }),
+    ).toBe(true);
     // Envelope flag wins over the driver default.
     expect(resolveProviderInstanceEnabled({ driver: grok, enabled: true, config: {} })).toBe(true);
     expect(resolveProviderInstanceEnabled({ driver: codex, enabled: false, config: {} })).toBe(

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -975,7 +975,7 @@ export const providerInstanceConfigEnabledFlag = (config: unknown): boolean | un
  * through `DEFAULT_SERVER_SETTINGS`, so the schema's decoding default stays
  * the single source of truth. Unknown (fork) drivers default to enabled.
  */
-export const defaultEnabledForDriver = (driver: ProviderDriverKind): boolean => {
+const defaultEnabledForDriver = (driver: ProviderDriverKind): boolean => {
   const legacyDefaults = DEFAULT_SERVER_SETTINGS.providers as Record<
     string,
     { readonly enabled?: boolean } | undefined


### PR DESCRIPTION
The provider-default lookup was exported only for direct assertions that duplicated the settings and provider-instance tests.

Keep the lookup private and remove its direct test. Preserve unknown fork-driver defaults through the public instance resolver, alongside the existing flag-precedence and opt-in cases. Runtime implementation and settings schemas are unchanged.

Verification: all 88 remaining settings tests pass, including after rebasing onto the landed Knip stack. Contracts typecheck, targeted lint, formatting, and diff checks pass. No visual behavior changes, so screenshots do not apply.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Encapsulation and test-only changes; enabled-state resolution logic is unchanged.
> 
> **Overview**
> Makes **`defaultEnabledForDriver`** module-private in `settings.ts` so driver default lookup is no longer part of the contracts public API. **`resolveProviderInstanceEnabled`** remains the supported way to read whether an instance is enabled.
> 
> Tests drop direct calls to **`defaultEnabledForDriver`** and the standalone “derives per-driver defaults” case. The unknown fork-driver default (e.g. **ollama** enabled when no flags are set) is asserted through **`resolveProviderInstanceEnabled`** alongside the existing precedence and opt-in coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2bdb4ef5a9b6d2b2c619d516191a7ebe994cd08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `defaultEnabledForDriver` private in `settings.ts`
> Removes the module export of the internal `defaultEnabledForDriver` helper so it stays private to [settings.ts](https://github.com/pingdotgg/t3code/pull/9968/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c). Moves the unknown-driver default assertion into the `resolveProviderInstanceEnabled` test in [settings.test.ts](https://github.com/pingdotgg/t3code/pull/9968/files#diff-fd1303724b757882ea800308c3e9f426c66a71a81c2c80fae2b7f125749a4012), covering the behavior through the public resolver instead of direct helper access.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2bdb4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->