### PR TITLE
add viewed button in PR reviews

### DIFF
--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -69,6 +69,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.pullRequestsSummary]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsDetail]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsActivity]: AuthOrchestrationReadScope,
+  [WS_METHODS.pullRequestsFileViewedStates]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsThreadComments]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsDiffFileContents]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsRunAction]: AuthOrchestrationOperateScope,
@@ -79,6 +80,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.pullRequestsReplyToThread]: AuthOrchestrationOperateScope,
   [WS_METHODS.pullRequestsSetThreadResolution]: AuthOrchestrationOperateScope,
   [WS_METHODS.pullRequestsSetReaction]: AuthOrchestrationOperateScope,
+  [WS_METHODS.pullRequestsSetFileViewed]: AuthOrchestrationOperateScope,
   // Read scope like the reads it un-caches: refreshing is part of reading, and a read-only
   // client pressing refresh must not be told it may not look again.
   [WS_METHODS.pullRequestsInvalidate]: AuthOrchestrationReadScope,

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, assert, expect, it, vi } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 import * as TestClock from "effect/testing/TestClock";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
@@ -3089,6 +3090,149 @@ layer("GitHubPullRequestCli.layer", (it) => {
       expect(callAt(0).args).toContain("repos/acme/web/issues/7/labels/good%20first%20issue");
       expect(callAt(0).args).toContain("DELETE");
       expect(callAt(1).args).toContain("repos/acme/web/issues/7/labels/area%2Fweb");
+    }),
+  );
+});
+
+const decodeViewedMutation = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(
+    Schema.Struct({
+      query: Schema.String,
+      variables: Schema.Struct({ pullRequestId: Schema.String, path: Schema.String }),
+    }),
+  ),
+);
+
+layer("GitHub file viewed state", (it) => {
+  const encodeJson = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
+  const reference = { cwd: "/w", repository: "acme/web", host: "github.acme.test", number: 7 };
+  const filePage = (
+    nodes: ReadonlyArray<{ path: string; viewerViewedState: string }>,
+    hasNextPage = false,
+    endCursor: string | null = null,
+  ) =>
+    output(
+      encodeJson({
+        data: {
+          repository: { pullRequest: { files: { nodes, pageInfo: { hasNextPage, endCursor } } } },
+        },
+      }),
+    );
+
+  it.effect("loads every page and treats dismissed files as unviewed", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(
+          filePage(
+            [
+              { path: "src/renamed.ts", viewerViewedState: "VIEWED" },
+              { path: "src/deleted.ts", viewerViewedState: "UNVIEWED" },
+            ],
+            true,
+            "next-files",
+          ),
+        ),
+      );
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(filePage([{ path: " space ü.ts ", viewerViewedState: "DISMISSED" }])),
+      );
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+      assert.deepStrictEqual(yield* cli.getFileViewedStates(reference), {
+        files: [
+          { path: "src/renamed.ts", viewed: true },
+          { path: "src/deleted.ts", viewed: false },
+          { path: " space ü.ts ", viewed: false },
+        ],
+      });
+      expect(callAt(0).args).toContain("github.acme.test");
+      expect(callAt(0).args).toContain("owner=acme");
+      expect(callAt(0).args).toContain("name=web");
+      expect(callAt(0).args).toContain("number=7");
+      expect(callAt(0).args).not.toContain("cursor=next-files");
+      expect(callAt(1).args).toContain("cursor=next-files");
+    }),
+  );
+
+  for (const viewed of [true, false]) {
+    it.effect(`writes viewed=${viewed} to the resolved PR with the exact path`, () =>
+      Effect.gen(function* () {
+        mockedExecute.mockReturnValueOnce(
+          Effect.succeed(
+            output(
+              encodeJson({
+                data: { repository: { pullRequest: { id: "PR_7" } } },
+              }),
+            ),
+          ),
+        );
+        mockedExecute.mockReturnValueOnce(Effect.succeed(output("{}")));
+        const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+        const path = ' src/"renamed" ü.ts ';
+        yield* cli.setFileViewed({ ...reference, path, viewed });
+        expect(callAt(0).args).toContain("number=7");
+        const request = callAt(1);
+        assert.deepStrictEqual(request.args, [
+          "api",
+          "graphql",
+          "--hostname",
+          "github.acme.test",
+          "--input",
+          "-",
+        ]);
+        const body = yield* decodeViewedMutation(request.stdin ?? "{}");
+        assert.deepStrictEqual(body.variables, { pullRequestId: "PR_7", path });
+        expect(body.query).toContain(viewed ? "markFileAsViewed(" : "unmarkFileAsViewed(");
+      }),
+    );
+  }
+
+  it.effect("rejects a repeated pagination cursor", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValue(Effect.succeed(filePage([], true, "same")));
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+      const error = yield* Effect.flip(cli.getFileViewedStates(reference));
+      assert.strictEqual(error._tag, "GitHubPullRequestReadError");
+      assert.strictEqual(mockedExecute.mock.calls.length, 2);
+    }),
+  );
+
+  it.effect("does not return partial viewed state after a later page fails", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(filePage([{ path: "a.ts", viewerViewedState: "VIEWED" }], true, "next")),
+      );
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output('{"data":{"repository":null}}')));
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+      const error = yield* Effect.flip(cli.getFileViewedStates(reference));
+      assert.strictEqual(error._tag, "GitHubPullRequestReadError");
+    }),
+  );
+
+  it.effect("propagates a rejected viewed mutation", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(
+          output(
+            encodeJson({
+              data: { repository: { pullRequest: { id: "PR_7" } } },
+            }),
+          ),
+        ),
+      );
+      mockedExecute.mockReturnValueOnce(
+        Effect.fail(
+          new GitHubCli.GitHubCliAuthenticationError({
+            command: "gh",
+            cwd: "/w",
+            cause: "authentication expired",
+          }),
+        ),
+      );
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+      const error = yield* Effect.flip(
+        cli.setFileViewed({ ...reference, path: "a.ts", viewed: true }),
+      );
+      assert.strictEqual(error._tag, "GitHubCliAuthenticationError");
     }),
   );
 });

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -6,6 +6,7 @@ import * as Schema from "effect/Schema";
 import {
   resolvePullRequestAuthorFilter,
   type PullRequestAction,
+  type PullRequestFileViewedStates,
   type PullRequestActor,
   type PullRequestInvolvement,
   type PullRequestListFilters,
@@ -28,6 +29,11 @@ import * as GitHubGraphQlBudget from "../sourceControl/githubGraphQlBudget.ts";
 import * as SourceControlRateLimit from "../sourceControl/SourceControlRateLimit.ts";
 import {
   ACTOR_AVATARS_GRAPHQL_QUERY,
+  FILE_VIEWED_STATES_GRAPHQL_QUERY,
+  type GitHubFileViewedStatesPage,
+  MARK_FILE_VIEWED_GRAPHQL_MUTATION,
+  UNMARK_FILE_VIEWED_GRAPHQL_MUTATION,
+  decodeFileViewedStatesJson,
   ADD_REACTION_GRAPHQL_MUTATION,
   buildReviewSubmissionJson,
   buildReviewerRequestJson,
@@ -662,6 +668,22 @@ export class GitHubPullRequestCli extends Context.Service<
       readonly host: string;
       readonly threadId: string;
       readonly resolved: boolean;
+    }) => Effect.Effect<void, GitHubPullRequestCliError>;
+
+    readonly getFileViewedStates: (input: {
+      readonly cwd: string;
+      readonly repository: string;
+      readonly host: string;
+      readonly number: number;
+    }) => Effect.Effect<PullRequestFileViewedStates, GitHubPullRequestCliError>;
+
+    readonly setFileViewed: (input: {
+      readonly cwd: string;
+      readonly repository: string;
+      readonly host: string;
+      readonly number: number;
+      readonly path: string;
+      readonly viewed: boolean;
     }) => Effect.Effect<void, GitHubPullRequestCliError>;
 
     /**
@@ -2227,6 +2249,56 @@ export const make = Effect.gen(function* () {
           : UNRESOLVE_REVIEW_THREAD_GRAPHQL_MUTATION,
         variables: { threadId: input.threadId },
       }),
+
+    getFileViewedStates: Effect.fn("GitHubPullRequestCli.getFileViewedStates")(function* (input) {
+      const { owner, name } = parseRepositorySelector(input.repository);
+      const files: Array<PullRequestFileViewedStates["files"][number]> = [];
+      const cursors = new Set<string>();
+      const readPage = (cursor: string | null) =>
+        graphqlRead({
+          cwd: input.cwd,
+          host: input.host,
+          operation: "getFileViewedStates",
+          variables: [
+            ["-f", `owner=${owner}`],
+            ["-f", `name=${name}`],
+            ["-F", `number=${input.number}`],
+            ...(cursor === null ? [] : [["-f", `cursor=${cursor}`] as const]),
+          ],
+          query: FILE_VIEWED_STATES_GRAPHQL_QUERY,
+          decode: decodeFileViewedStatesJson,
+        });
+      let cursor: string | null = null;
+      while (true) {
+        const page: GitHubFileViewedStatesPage = yield* readPage(cursor);
+        files.push(...page.files);
+        if (!page.pageInfo.hasNextPage) return { files };
+        cursor = page.pageInfo.endCursor;
+        if (cursor === null || cursors.has(cursor)) {
+          return yield* new GitHubPullRequestReadError({
+            command: "gh",
+            cwd: input.cwd,
+            operation: "getFileViewedStates",
+            cause: "GitHub returned an invalid file cursor.",
+          });
+        }
+        cursors.add(cursor);
+      }
+    }),
+
+    setFileViewed: (input) =>
+      pullRequestNodeId({ ...input, operation: "setFileViewed" }).pipe(
+        Effect.flatMap((pullRequestId) =>
+          graphql({
+            cwd: input.cwd,
+            host: input.host,
+            query: input.viewed
+              ? MARK_FILE_VIEWED_GRAPHQL_MUTATION
+              : UNMARK_FILE_VIEWED_GRAPHQL_MUTATION,
+            variables: { pullRequestId, path: input.path },
+          }),
+        ),
+      ),
 
     setReaction: (input) => {
       const givenSubjectId = input.subjectId;

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
@@ -39,6 +39,7 @@ const CAPABILITIES: PullRequestCapabilities = {
   updateMethods: ["merge", "rebase"],
   search: true,
   reactions: true,
+  fileViewedState: true,
   review: {
     inlineComment: true,
     reply: true,
@@ -588,6 +589,10 @@ export const make = Effect.gen(function* () {
           body: input.body,
         })
         .pipe(Effect.mapError(fail("replyToThread"))),
+
+    getFileViewedStates: (input) =>
+      cli.getFileViewedStates(input).pipe(Effect.mapError(fail("getFileViewedStates"))),
+    setFileViewed: (input) => cli.setFileViewed(input).pipe(Effect.mapError(fail("setFileViewed"))),
 
     setReaction: (input) =>
       cli

--- a/apps/server/src/pullRequest/PullRequestProvider.ts
+++ b/apps/server/src/pullRequest/PullRequestProvider.ts
@@ -2,6 +2,7 @@ import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import type {
   PullRequestAction,
+  PullRequestFileViewedStates,
   PullRequestActor,
   PullRequestBaseComparison,
   PullRequestCapabilities,
@@ -495,6 +496,18 @@ export interface PullRequestProviderApi {
       readonly number: number;
       readonly threadId: string;
       readonly body: string;
+    },
+  ) => Effect.Effect<void, PullRequestProviderError>;
+
+  readonly getFileViewedStates?: (
+    input: ProviderRepositoryRef & { readonly number: number },
+  ) => Effect.Effect<PullRequestFileViewedStates, PullRequestProviderError>;
+
+  readonly setFileViewed?: (
+    input: ProviderRepositoryRef & {
+      readonly number: number;
+      readonly path: string;
+      readonly viewed: boolean;
     },
   ) => Effect.Effect<void, PullRequestProviderError>;
 

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -3994,3 +3994,82 @@ it.effect("names the signed-in account in the detail, and says nothing where the
     assert.strictEqual(unnamed.viewer, undefined);
   }),
 );
+
+it.effect("shares viewed-state reads and invalidates them after marking and unmarking", () =>
+  Effect.gen(function* () {
+    let viewed = false;
+    let reads = 0;
+    const writes: Array<{ path: string; viewed: boolean; repository: string; number: number }> = [];
+    const base = fakeProvider("github");
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "t3code", workspaceRoot: "/a", repository: "pingdotgg/t3code" }),
+      ],
+      providers: [
+        fakeProvider("github", {
+          capabilities: { ...base.capabilities, fileViewedState: true },
+          getFileViewedStates: () =>
+            Effect.sync(() => {
+              reads++;
+              return { files: [{ path: " renamed.ts ", viewed }] };
+            }),
+          setFileViewed: (input) =>
+            Effect.sync(() => {
+              writes.push(input);
+              viewed = input.viewed;
+            }),
+        }),
+      ],
+    });
+    const reference = { projectId: "p1" as ProjectId, repository: "pingdotgg/t3code", number: 7 };
+    const initial = yield* Effect.all(
+      [service.fileViewedStates(reference), service.fileViewedStates(reference)],
+      { concurrency: "unbounded" },
+    );
+    assert.strictEqual(reads, 1);
+    assert.deepStrictEqual(initial[0], { files: [{ path: " renamed.ts ", viewed: false }] });
+    for (const next of [true, false]) {
+      yield* service.setFileViewed({ ...reference, path: " renamed.ts ", viewed: next });
+      assert.deepStrictEqual(yield* service.fileViewedStates(reference), {
+        files: [{ path: " renamed.ts ", viewed: next }],
+      });
+    }
+    assert.strictEqual(reads, 3);
+    assert.deepStrictEqual(
+      writes.map(({ path, viewed, repository, number }) => ({ path, viewed, repository, number })),
+      [
+        { path: " renamed.ts ", viewed: true, repository: "pingdotgg/t3code", number: 7 },
+        { path: " renamed.ts ", viewed: false, repository: "pingdotgg/t3code", number: 7 },
+      ],
+    );
+    yield* service.invalidate({ reference });
+    yield* service.fileViewedStates(reference);
+    assert.strictEqual(reads, 4);
+  }),
+);
+
+it.effect("refuses viewed state on a host without the capability", () =>
+  Effect.gen(function* () {
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "t3code", workspaceRoot: "/a", repository: "pingdotgg/t3code" }),
+      ],
+      providers: [
+        fakeProvider("github", {
+          getFileViewedStates: () => Effect.die("must not read"),
+          setFileViewed: () => Effect.die("must not write"),
+        }),
+      ],
+    });
+    const reference = { projectId: "p1" as ProjectId, repository: "pingdotgg/t3code", number: 7 };
+    assert.strictEqual(
+      (yield* Effect.flip(service.fileViewedStates(reference)))._tag,
+      "PullRequestOperationError",
+    );
+    assert.strictEqual(
+      (yield* Effect.flip(service.setFileViewed({ ...reference, path: "a.ts", viewed: true })))
+        ._tag,
+      "PullRequestOperationError",
+    );
+  }),
+);

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -39,6 +39,8 @@ import {
   type PullRequestListStatsResult,
   type PullRequestProviderSummary,
   type PullRequestReactionInput,
+  type PullRequestFileViewedStates,
+  type PullRequestSetFileViewedInput,
   type PullRequestRef,
   type PullRequestReviewVerdict,
   type PullRequestReviewerCandidateList,
@@ -178,6 +180,12 @@ export class PullRequestService extends Context.Service<
     ) => Effect.Effect<void, PullRequestError>;
     readonly setThreadResolution: (
       input: PullRequestThreadResolutionInput,
+    ) => Effect.Effect<void, PullRequestError>;
+    readonly fileViewedStates: (
+      input: PullRequestRef,
+    ) => Effect.Effect<PullRequestFileViewedStates, PullRequestError>;
+    readonly setFileViewed: (
+      input: PullRequestSetFileViewedInput,
     ) => Effect.Effect<void, PullRequestError>;
     readonly setReaction: (
       input: PullRequestReactionInput,
@@ -503,6 +511,16 @@ function withRateLimitBackoff(
       : { listLabelCandidates: interactive("listLabelCandidates", api.listLabelCandidates) }),
     ...(api.setLabels === undefined ? {} : { setLabels: interactive("setLabels", api.setLabels) }),
     replyToThread: interactive("replyToThread", api.replyToThread),
+    ...(api.getFileViewedStates === undefined
+      ? {}
+      : {
+          getFileViewedStates: wrap("getFileViewedStates", api.getFileViewedStates),
+        }),
+    ...(api.setFileViewed === undefined
+      ? {}
+      : {
+          setFileViewed: interactive("setFileViewed", api.setFileViewed),
+        }),
     setReaction: interactive("setReaction", api.setReaction),
     setThreadResolution: interactive("setThreadResolution", api.setThreadResolution),
   };
@@ -1763,6 +1781,54 @@ export const make = Effect.gen(function* () {
       }),
     );
 
+  const fileViewedStatesUncached = Effect.fn("PullRequestService.fileViewedStates")(function* (
+    input: PullRequestRef,
+  ) {
+    const project = yield* requireProject(input);
+    if (
+      project.api.capabilities.fileViewedState !== true ||
+      project.api.getFileViewedStates === undefined
+    ) {
+      return yield* new PullRequestOperationError({
+        operation: "fileViewedStates",
+        detail: "This host does not support viewed files.",
+      });
+    }
+    return yield* project.api
+      .getFileViewedStates({
+        cwd: project.project.workspaceRoot,
+        repository: project.repository,
+        host: project.host,
+        number: input.number,
+      })
+      .pipe(Effect.mapError(toPullRequestError("fileViewedStates")));
+  });
+
+  const setFileViewed: PullRequestService["Service"]["setFileViewed"] = Effect.fn(
+    "PullRequestService.setFileViewed",
+  )(function* (input) {
+    const project = yield* requireProject(input);
+    if (
+      project.api.capabilities.fileViewedState !== true ||
+      project.api.setFileViewed === undefined
+    ) {
+      return yield* new PullRequestOperationError({
+        operation: "setFileViewed",
+        detail: "This host does not support viewed files.",
+      });
+    }
+    yield* project.api
+      .setFileViewed({
+        cwd: project.project.workspaceRoot,
+        repository: project.repository,
+        host: project.host,
+        number: input.number,
+        path: input.path,
+        viewed: input.viewed,
+      })
+      .pipe(Effect.mapError(toPullRequestError("setFileViewed")));
+  });
+
   /**
    * Reacting is gated on the host alone. Every host with reactions takes one from whoever can read
    * the change request, so there is no access left to check that reading it has not already
@@ -2162,6 +2228,19 @@ export const make = Effect.gen(function* () {
     };
   };
 
+  const fileViewedStatesCache = yield* Cache.makeWith(
+    (key: string) => {
+      const [, projectId, repository, number] = JSON.parse(key) as [number, string, string, number];
+      return fileViewedStatesUncached({ projectId, repository, number } as PullRequestRef);
+    },
+    {
+      capacity: DETAIL_CACHE_CAPACITY,
+      timeToLive: (exit) => (Exit.isSuccess(exit) ? DETAIL_CACHE_TTL : Duration.zero),
+    },
+  );
+  const fileViewedStates: PullRequestService["Service"]["fileViewedStates"] = (input) =>
+    Cache.get(fileViewedStatesCache, refCacheKey(input));
+
   const summaryCache = yield* Cache.makeWith(
     (key: string) => {
       const [, projectId, repository, number] = JSON.parse(key) as [number, string, string, number];
@@ -2464,6 +2543,11 @@ export const make = Effect.gen(function* () {
     submitReview: invalidatedByMutation(submitReview),
     replyToThread: invalidatedByMutation(replyToThread),
     setThreadResolution: invalidatedByMutation(setThreadResolution),
+    fileViewedStates,
+    setFileViewed: (input) =>
+      setFileViewed(input).pipe(
+        Effect.tap(() => Cache.invalidate(fileViewedStatesCache, refCacheKey(input))),
+      ),
     setReaction: invalidatedByMutation(setReaction),
     // The candidate list is deliberately read fresh per menu-open, so it stays uncached.
     reviewerCandidates,

--- a/apps/server/src/pullRequest/gitHubPullRequestJson.ts
+++ b/apps/server/src/pullRequest/gitHubPullRequestJson.ts
@@ -2445,3 +2445,58 @@ export function decodePullRequestFilesJson(
     omittedFileStats,
   });
 }
+
+export const FILE_VIEWED_STATES_GRAPHQL_QUERY = `query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      files(first: 100, after: $cursor) {
+        nodes { path viewerViewedState }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`;
+
+const decodeFileViewedStates = decodeJsonResult(
+  Schema.Struct({
+    data: Schema.Struct({
+      repository: Schema.Struct({
+        pullRequest: Schema.Struct({
+          files: Schema.Struct({
+            nodes: Schema.Array(
+              Schema.Struct({
+                path: Schema.String,
+                viewerViewedState: Schema.Literals(["VIEWED", "UNVIEWED", "DISMISSED"]),
+              }),
+            ),
+            pageInfo: Schema.Struct({
+              hasNextPage: Schema.Boolean,
+              endCursor: Schema.NullOr(Schema.String),
+            }),
+          }),
+        }),
+      }),
+    }),
+  }),
+);
+
+export function decodeFileViewedStatesJson(raw: string) {
+  return Result.map(decodeFileViewedStates(raw), ({ data }) => ({
+    files: data.repository.pullRequest.files.nodes.map((file) => ({
+      path: file.path,
+      viewed: file.viewerViewedState === "VIEWED",
+    })),
+    pageInfo: data.repository.pullRequest.files.pageInfo,
+  }));
+}
+
+export const MARK_FILE_VIEWED_GRAPHQL_MUTATION = `mutation($pullRequestId: ID!, $path: String!) {
+  markFileAsViewed(input: {pullRequestId: $pullRequestId, path: $path}) { clientMutationId }
+}`;
+export const UNMARK_FILE_VIEWED_GRAPHQL_MUTATION = `mutation($pullRequestId: ID!, $path: String!) {
+  unmarkFileAsViewed(input: {pullRequestId: $pullRequestId, path: $path}) { clientMutationId }
+}`;
+
+export type GitHubFileViewedStatesPage = Result.Result.Success<
+  ReturnType<typeof decodeFileViewedStatesJson>
+>;

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -2145,6 +2145,22 @@ const makeWsRpcLayer = (
             pullRequests.setThreadResolution(input),
             { "rpc.aggregate": "pull-requests" },
           ),
+        [WS_METHODS.pullRequestsFileViewedStates]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.pullRequestsFileViewedStates,
+            pullRequests.fileViewedStates(input),
+            {
+              "rpc.aggregate": "pull-requests",
+            },
+          ),
+        [WS_METHODS.pullRequestsSetFileViewed]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.pullRequestsSetFileViewed,
+            pullRequests.setFileViewed(input),
+            {
+              "rpc.aggregate": "pull-requests",
+            },
+          ),
         [WS_METHODS.pullRequestsSetReaction]: (input) =>
           observeRpcEffect(WS_METHODS.pullRequestsSetReaction, pullRequests.setReaction(input), {
             "rpc.aggregate": "pull-requests",

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -827,7 +827,12 @@ export function PullRequestCodeTab({
               reference={reference}
               path={resolveFileDiffPath(item.fileDiff)}
               viewed={viewedFiles.get(resolveFileDiffPath(item.fileDiff))}
-              onOptimisticChange={setOptimisticFileViewed}
+              onOptimisticChange={(path, viewed) => {
+                setOptimisticFileViewed(path, viewed);
+                // A checkbox click is a new fold choice. On failure, restore the fold state
+                // captured by the callback that started the request.
+                setFileCollapsed(item.id, viewed ?? item.collapsed === true);
+              }}
               onRefresh={refreshViewedFiles}
             />
           )}
@@ -842,6 +847,7 @@ export function PullRequestCodeTab({
       reference,
       viewedFiles,
       setOptimisticFileViewed,
+      setFileCollapsed,
       refreshViewedFiles,
     ],
   );

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -4,6 +4,7 @@ import type {
   EnvironmentId,
   PullRequestDetailView,
   PullRequestDiffSide,
+  PullRequestFileViewedStates,
   PullRequestOmittedFileStat,
   PullRequestRef,
   PullRequestReviewPosition,
@@ -75,6 +76,7 @@ import { toastManager } from "../ui/toast";
 import { Toggle, ToggleGroup } from "../ui/toggle-group";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { PendingReviewCommentCard, ReviewThreadCard } from "./PullRequestReviewAnnotation";
+import { PullRequestFileViewedCheckbox } from "./PullRequestFileViewedCheckbox";
 import { PullRequestReviewBar } from "./PullRequestReviewBar";
 import {
   isFileDiffCollapsed,
@@ -218,7 +220,12 @@ export function PullRequestCodeTab({
 }) {
   const { resolvedTheme } = useTheme();
   const settings = useClientSettings();
-  const [toggledFiles, setToggledFiles] = useState<ReadonlySet<string>>(() => new Set());
+  const [fileFoldOverrides, setFileFoldOverrides] = useState<ReadonlyMap<string, boolean>>(
+    () => new Map(),
+  );
+  const [optimisticViewedFiles, setOptimisticViewedFiles] = useState<
+    ReadonlyMap<string, { snapshot: PullRequestFileViewedStates | null; viewed: boolean }>
+  >(() => new Map());
   // A change of any size can carry hundreds of commits, and a menu that long is a scroll rather
   // than a choice. The rest arrive ten at a time, on request.
   const [visibleCommitCount, setVisibleCommitCount] = useState(COMMIT_PAGE_SIZE);
@@ -262,13 +269,66 @@ export function PullRequestCodeTab({
   useEffect(() => {
     setDraft(null);
     setSelectedLines(null);
-    setToggledFiles(new Set());
+    setFileFoldOverrides(new Map());
+    setOptimisticViewedFiles(new Map());
     setFoldOverride(null);
     setVisibleCommitCount(COMMIT_PAGE_SIZE);
     setOrphansOpen(false);
     setSliceState({ key: scopeKey, cursor: null, slices: NO_SLICES });
     parseCache.current.clear();
   }, [scopeKey]);
+
+  // GitHub records viewed state for the whole PR, not for an individual commit.
+  const canViewFiles = detail.capabilities.fileViewedState === true && commit === null;
+  const viewedQuery = useEnvironmentQuery(
+    canViewFiles
+      ? pullRequestEnvironment.fileViewedStates({ environmentId, input: reference })
+      : null,
+  );
+  const refreshViewedFiles = viewedQuery.refresh;
+  const viewedSnapshot = viewedQuery.data;
+  const viewedFileKey = useCallback(
+    (path: string) => JSON.stringify([environmentId, referenceKey, path]),
+    [environmentId, referenceKey],
+  );
+  // The checkbox and the diff share the same optimistic value, so neither waits for GitHub.
+  const viewedFiles = useMemo(
+    () =>
+      new Map(
+        viewedSnapshot?.files.map((file) => {
+          const optimistic = optimisticViewedFiles.get(viewedFileKey(file.path));
+          return [
+            file.path,
+            optimistic?.snapshot === viewedSnapshot ? optimistic.viewed : file.viewed,
+          ];
+        }),
+      ),
+    [viewedSnapshot, optimisticViewedFiles, viewedFileKey],
+  );
+  const setOptimisticFileViewed = useCallback(
+    (path: string, viewed: boolean | null) => {
+      const key = viewedFileKey(path);
+      setOptimisticViewedFiles((current) => {
+        const next = new Map(current);
+        if (viewed === null) next.delete(key);
+        else next.set(key, { snapshot: viewedSnapshot, viewed });
+        return next;
+      });
+    },
+    [viewedFileKey, viewedSnapshot],
+  );
+  const viewedRefreshKey = JSON.stringify([
+    environmentId,
+    referenceKey,
+    refreshToken,
+    detail.updatedAt,
+  ]);
+  const appliedViewedRefreshKey = useRef(viewedRefreshKey);
+  useEffect(() => {
+    if (!canViewFiles || appliedViewedRefreshKey.current === viewedRefreshKey) return;
+    appliedViewedRefreshKey.current = viewedRefreshKey;
+    refreshViewedFiles();
+  }, [canViewFiles, refreshViewedFiles, viewedRefreshKey]);
 
   const loadedSlices = sliceState.key === scopeKey ? sliceState.slices : NO_SLICES;
   const cursor = sliceState.key === scopeKey ? sliceState.cursor : null;
@@ -485,7 +545,12 @@ export function PullRequestCodeTab({
           groupAt(anchor.side, anchor.line).draft = true;
         }
 
-        const collapsed = isFileDiffCollapsed(fileKey, foldOverride, toggledFiles);
+        const collapsed = isFileDiffCollapsed(
+          fileKey,
+          foldOverride,
+          fileFoldOverrides,
+          canViewFiles && viewedFiles.get(path) === true,
+        );
 
         const annotations: ReviewAnnotation[] = [...groups.values()].map((group) => ({
           side: toViewerSide(group.side),
@@ -538,7 +603,9 @@ export function PullRequestCodeTab({
       foldOverride,
       pendingComments,
       placedThreadIds,
-      toggledFiles,
+      fileFoldOverrides,
+      canViewFiles,
+      viewedFiles,
     ],
   );
   const lineStat = useMemo(() => getDiffLineStat(files), [files]);
@@ -590,16 +657,9 @@ export function PullRequestCodeTab({
   // A stable identity: the viewer's SlotPortals memoizes each file's header/annotation portal on
   // these render props, so a fresh function here would recreate every visible file's portal on
   // every tab re-render (a line-selection drag, a keystroke in the draft, a review-store update).
-  const toggleFile = useCallback(
-    (fileKey: string) =>
-      setToggledFiles((current) => {
-        // The override becomes this file's new default the moment it is folded into the set below,
-        // so nothing has to be re-derived when the reader goes back to choosing one at a time.
-        const next = new Set(current);
-        if (next.has(fileKey)) next.delete(fileKey);
-        else next.add(fileKey);
-        return next;
-      }),
+  const setFileCollapsed = useCallback(
+    (fileKey: string, collapsed: boolean) =>
+      setFileFoldOverrides((current) => new Map(current).set(fileKey, collapsed)),
     [],
   );
 
@@ -608,10 +668,10 @@ export function PullRequestCodeTab({
     (path: string) => {
       const item = items.find((candidate) => resolveFileDiffPath(candidate.fileDiff) === path);
       if (item === undefined) return;
-      if (item.collapsed === true) toggleFile(item.id);
+      if (item.collapsed === true) setFileCollapsed(item.id, false);
       requestTreeReveal(item.id);
     },
-    [items, requestTreeReveal, toggleFile],
+    [items, requestTreeReveal, setFileCollapsed],
   );
 
   const toggleAllFiles = () => {
@@ -619,7 +679,7 @@ export function PullRequestCodeTab({
     // still paging would otherwise bring its next slice in folded, moments after the reader
     // asked for everything to be open.
     setFoldOverride(areAllDiffFilesCollapsed(fileKeys, collapsedFileKeys) ? "expanded" : "folded");
-    setToggledFiles(new Set());
+    setFileFoldOverrides(new Map());
   };
 
   // Newest first: the last commit is the one a reader coming back to a change is looking for.
@@ -726,7 +786,7 @@ export function PullRequestCodeTab({
           className="mr-1 rounded hover:bg-transparent"
           onClick={(event) => {
             event.stopPropagation();
-            toggleFile(item.id);
+            setFileCollapsed(item.id, item.collapsed !== true);
           }}
         >
           {collapsed ? (
@@ -737,7 +797,7 @@ export function PullRequestCodeTab({
         </Button>
       );
     },
-    [toggleFile],
+    [setFileCollapsed],
   );
 
   const renderHeaderMetadata = useCallback(
@@ -754,14 +814,36 @@ export function PullRequestCodeTab({
         if (withheld) ({ additions, deletions } = withheld);
       }
       return (
-        <PullRequestDiffStat
-          additions={additions}
-          deletions={deletions}
-          className="font-mono text-[11px]"
-        />
+        <div className="flex items-center gap-3">
+          <PullRequestDiffStat
+            additions={additions}
+            deletions={deletions}
+            className="font-mono text-[11px]"
+          />
+          {canViewFiles && (
+            <PullRequestFileViewedCheckbox
+              key={`${environmentId}:${referenceKey}:${resolveFileDiffPath(item.fileDiff)}`}
+              environmentId={environmentId}
+              reference={reference}
+              path={resolveFileDiffPath(item.fileDiff)}
+              viewed={viewedFiles.get(resolveFileDiffPath(item.fileDiff))}
+              onOptimisticChange={setOptimisticFileViewed}
+              onRefresh={refreshViewedFiles}
+            />
+          )}
+        </div>
       );
     },
-    [omittedFileStats],
+    [
+      omittedFileStats,
+      canViewFiles,
+      environmentId,
+      referenceKey,
+      reference,
+      viewedFiles,
+      setOptimisticFileViewed,
+      refreshViewedFiles,
+    ],
   );
 
   const diffViewOptions = useMemo(
@@ -1347,6 +1429,17 @@ export function PullRequestCodeTab({
           </CollapsiblePanel>
         </Collapsible>
       ) : null}
+      {canViewFiles && viewedQuery.error !== null && (
+        <div
+          role="alert"
+          className="flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground"
+        >
+          Viewed status could not be loaded from GitHub.
+          <Button size="xs" variant="ghost" onClick={refreshViewedFiles}>
+            Retry
+          </Button>
+        </div>
+      )}
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Relative wrapper so the review overlay floats over the diff rather than pushing it
             up; the viewer inside still owns its own scrolling. */}
@@ -1362,7 +1455,11 @@ export function PullRequestCodeTab({
               // A control inside the header — the collapse chevron — handles itself, and
               // this capture listener fires before its own click does. Leave it alone or
               // the two toggles cancel out.
-              if (node instanceof HTMLButtonElement || node instanceof HTMLAnchorElement) {
+              if (
+                node instanceof HTMLButtonElement ||
+                node instanceof HTMLAnchorElement ||
+                node.hasAttribute("data-file-viewed-control")
+              ) {
                 return;
               }
               if (node.hasAttribute("data-diffs-header")) {
@@ -1371,7 +1468,7 @@ export function PullRequestCodeTab({
                 const item = items.find(
                   (candidate) => resolveFileDiffPath(candidate.fileDiff) === filePath,
                 );
-                if (item !== undefined) toggleFile(item.id);
+                if (item !== undefined) setFileCollapsed(item.id, item.collapsed !== true);
                 return;
               }
             }

--- a/apps/web/src/components/pullRequest/PullRequestFileViewedCheckbox.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestFileViewedCheckbox.tsx
@@ -1,0 +1,70 @@
+import type { EnvironmentId, PullRequestRef } from "@t3tools/contracts";
+import { useState } from "react";
+
+import { pullRequestEnvironment } from "~/state/pullRequests";
+import { useAtomCommand } from "~/state/use-atom-command";
+import { Checkbox } from "../ui/checkbox";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { toastManager } from "../ui/toast";
+
+/** Shows the pending toggle while GitHub saves the file’s viewed state. */
+export function PullRequestFileViewedCheckbox({
+  environmentId,
+  reference,
+  path,
+  viewed,
+  onOptimisticChange,
+  onRefresh,
+}: {
+  environmentId: EnvironmentId;
+  reference: PullRequestRef;
+  path: string;
+  viewed: boolean | undefined;
+  onOptimisticChange: (path: string, viewed: boolean | null) => void;
+  onRefresh: () => void;
+}) {
+  const setFileViewed = useAtomCommand(pullRequestEnvironment.setFileViewed, {
+    reportFailure: false,
+  });
+  const [pending, setPending] = useState(false);
+
+  const toggle = async (next: boolean) => {
+    if (pending || viewed === undefined) return;
+    setPending(true);
+    onOptimisticChange(path, next);
+    const result = await setFileViewed({
+      environmentId,
+      input: { ...reference, path, viewed: next },
+    });
+    setPending(false);
+    if (result._tag === "Failure") {
+      onOptimisticChange(path, null);
+      toastManager.add({ type: "error", title: "Viewed status could not be saved to GitHub" });
+      return;
+    }
+    onRefresh();
+  };
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <label
+            data-file-viewed-control
+            className="flex shrink-0 cursor-pointer items-center gap-1.5 text-xs text-muted-foreground"
+            onClick={(event) => event.stopPropagation()}
+          />
+        }
+      >
+        <Checkbox
+          checked={viewed === true}
+          disabled={pending || viewed === undefined}
+          aria-label={`Mark ${path} as viewed on GitHub`}
+          onCheckedChange={(next) => void toggle(next)}
+        />
+        Viewed
+      </TooltipTrigger>
+      <TooltipPopup>Viewed on GitHub</TooltipPopup>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/components/pullRequest/pullRequestDiff.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDiff.logic.test.ts
@@ -48,34 +48,58 @@ describe("isLineInFileDiff", () => {
 });
 
 describe("isFileDiffCollapsed", () => {
-  const NO_TOGGLES: ReadonlySet<string> = new Set();
+  const NO_OVERRIDES: ReadonlyMap<string, boolean> = new Map();
 
-  it("opens every file before the reader has touched anything", () => {
-    expect(isFileDiffCollapsed("a.ts", null, NO_TOGGLES)).toBe(false);
-    expect(isFileDiffCollapsed("b.ts", null, NO_TOGGLES)).toBe(false);
+  it("opens unviewed files before the reader has touched anything", () => {
+    expect(isFileDiffCollapsed("a.ts", null, NO_OVERRIDES)).toBe(false);
+    expect(isFileDiffCollapsed("b.ts", null, NO_OVERRIDES)).toBe(false);
+  });
+
+  it("collapses viewed files, including files loaded in a later slice", () => {
+    expect(isFileDiffCollapsed("a.ts", null, NO_OVERRIDES, true)).toBe(true);
+    expect(isFileDiffCollapsed("later.ts", null, NO_OVERRIDES, true)).toBe(true);
+    expect(isFileDiffCollapsed("unviewed.ts", null, NO_OVERRIDES, false)).toBe(false);
+  });
+
+  it("follows viewed and unviewed changes until the reader overrides the default", () => {
+    expect(isFileDiffCollapsed("a.ts", null, NO_OVERRIDES, false)).toBe(false);
+    expect(isFileDiffCollapsed("a.ts", null, NO_OVERRIDES, true)).toBe(true);
+    expect(isFileDiffCollapsed("a.ts", null, NO_OVERRIDES, false)).toBe(false);
+  });
+
+  it("keeps manual choices when viewed state refreshes", () => {
+    for (const viewed of [true, false]) {
+      expect(isFileDiffCollapsed("a.ts", null, new Map([["a.ts", false]]), viewed)).toBe(false);
+      expect(isFileDiffCollapsed("a.ts", null, new Map([["a.ts", true]]), viewed)).toBe(true);
+    }
+  });
+
+  it("lets the toolbar expand viewed files and collapse unviewed files", () => {
+    expect(isFileDiffCollapsed("a.ts", "expanded", NO_OVERRIDES, true)).toBe(false);
+    expect(isFileDiffCollapsed("b.ts", "folded", NO_OVERRIDES, false)).toBe(true);
   });
 
   it("opens every file once the toolbar has asked for it", () => {
-    // Pressing the toolbar clears the reader's own toggles, which is why the set is empty here.
-    expect(isFileDiffCollapsed("a.ts", "expanded", NO_TOGGLES)).toBe(false);
-    expect(isFileDiffCollapsed("b.ts", "expanded", NO_TOGGLES)).toBe(false);
+    // Pressing the toolbar clears the reader's per-file overrides.
+    expect(isFileDiffCollapsed("a.ts", "expanded", NO_OVERRIDES)).toBe(false);
+    expect(isFileDiffCollapsed("b.ts", "expanded", NO_OVERRIDES)).toBe(false);
   });
 
   it("folds every file again on the second press", () => {
-    expect(isFileDiffCollapsed("a.ts", "folded", NO_TOGGLES)).toBe(true);
-    expect(isFileDiffCollapsed("b.ts", "folded", NO_TOGGLES)).toBe(true);
+    expect(isFileDiffCollapsed("a.ts", "folded", NO_OVERRIDES)).toBe(true);
+    expect(isFileDiffCollapsed("b.ts", "folded", NO_OVERRIDES)).toBe(true);
   });
 
   it("keeps a file the reader folded closed as the next slice arrives", () => {
     // The file keys grow with every slice, so the answer for one already folded must not depend
     // on how many of them there are by then.
-    const toggled = new Set(["b.ts"]);
-    expect(isFileDiffCollapsed("b.ts", null, toggled)).toBe(true);
-    expect(isFileDiffCollapsed("c.ts", null, toggled)).toBe(false);
+    const overrides = new Map([["b.ts", true]]);
+    expect(isFileDiffCollapsed("b.ts", null, overrides)).toBe(true);
+    expect(isFileDiffCollapsed("c.ts", null, overrides)).toBe(false);
   });
 
   it("still answers to a toggle after either toolbar press", () => {
-    expect(isFileDiffCollapsed("a.ts", "expanded", new Set(["a.ts"]))).toBe(true);
-    expect(isFileDiffCollapsed("a.ts", "folded", new Set(["a.ts"]))).toBe(false);
+    expect(isFileDiffCollapsed("a.ts", "expanded", new Map([["a.ts", true]]))).toBe(true);
+    expect(isFileDiffCollapsed("a.ts", "folded", new Map([["a.ts", false]]))).toBe(false);
   });
 });

--- a/apps/web/src/components/pullRequest/pullRequestDiff.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDiff.logic.ts
@@ -25,19 +25,17 @@ export function isLineInFileDiff(
 export type DiffFoldOverride = "expanded" | "folded" | null;
 
 /**
- * Whether a file is drawn folded.
- *
- * A diff arrives a slice at a time, so the reader's own choices are kept as the difference from
- * what the toolbar last said rather than as the set of folded files: a file that has not loaded
- * yet cannot be in a set, and would otherwise land expanded moments after the reader folded
- * everything. Files start expanded so opening the Code tab immediately shows the change; the
- * reader can still fold individual files or the whole diff from the toolbar.
+ * Viewed files start folded. Toolbar and per-file choices override that default, including for
+ * files arriving in later slices. Keep per-file choices as explicit states so a viewed-state
+ * refresh cannot invert a file the reader already opened or closed.
  */
 export function isFileDiffCollapsed(
   fileKey: string,
   foldOverride: DiffFoldOverride,
-  toggledFileKeys: ReadonlySet<string>,
+  fileFoldOverrides: ReadonlyMap<string, boolean>,
+  viewed = false,
 ): boolean {
-  const foldedByDefault = foldOverride === "folded";
-  return toggledFileKeys.has(fileKey) ? !foldedByDefault : foldedByDefault;
+  return (
+    fileFoldOverrides.get(fileKey) ?? (foldOverride === null ? viewed : foldOverride === "folded")
+  );
 }

--- a/packages/client-runtime/src/state/pullRequests.ts
+++ b/packages/client-runtime/src/state/pullRequests.ts
@@ -242,6 +242,17 @@ export function createPullRequestEnvironmentAtoms<R, E>(
       scheduler: commandScheduler,
       concurrency: serialPerEnvironment,
     }),
+    fileViewedStates: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:pull-requests:file-viewed-states",
+      tag: WS_METHODS.pullRequestsFileViewedStates,
+      staleTimeMs: 15_000,
+    }),
+    setFileViewed: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:pull-requests:set-file-viewed",
+      tag: WS_METHODS.pullRequestsSetFileViewed,
+      scheduler: commandScheduler,
+      concurrency: serialPerEnvironment,
+    }),
     setReaction: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:set-reaction",
       tag: WS_METHODS.pullRequestsSetReaction,

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -418,6 +418,8 @@ export const PullRequestCapabilities = Schema.Struct({
    * to change them, which is what every server before this field was.
    */
   labels: Schema.optional(Schema.Boolean),
+  /** The signed-in account can mark changed files as viewed on the host. */
+  fileViewedState: Schema.optional(Schema.Boolean),
 });
 export type PullRequestCapabilities = typeof PullRequestCapabilities.Type;
 
@@ -991,6 +993,20 @@ export const PullRequestThreadResolutionInput = Schema.Struct({
   resolved: Schema.Boolean,
 });
 export type PullRequestThreadResolutionInput = typeof PullRequestThreadResolutionInput.Type;
+
+/** Viewed state belongs to the account signed in on the environment's host CLI. */
+export const PullRequestFileViewedStates = Schema.Struct({
+  files: Schema.Array(Schema.Struct({ path: Schema.String, viewed: Schema.Boolean })),
+});
+export type PullRequestFileViewedStates = typeof PullRequestFileViewedStates.Type;
+
+export const PullRequestSetFileViewedInput = Schema.Struct({
+  ...PullRequestRef.fields,
+  // Preserve spaces in Git paths, including leading and trailing spaces.
+  path: Schema.String.check(Schema.isNonEmpty(), Schema.isMaxLength(4096)),
+  viewed: Schema.Boolean,
+});
+export type PullRequestSetFileViewedInput = typeof PullRequestSetFileViewedInput.Type;
 
 /**
  * Reacting and taking the reaction back are one operation with `reacted` turned around, which is

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -105,6 +105,8 @@ import {
   PullRequestListStatsResult,
   PullRequestOperationError,
   PullRequestReactionInput,
+  PullRequestFileViewedStates,
+  PullRequestSetFileViewedInput,
   PullRequestRef,
   PullRequestSummary,
   PullRequestReviewerCandidateList,
@@ -341,6 +343,8 @@ export const WS_METHODS = {
   pullRequestsSubmitReview: "pullRequests.submitReview",
   pullRequestsReplyToThread: "pullRequests.replyToThread",
   pullRequestsSetThreadResolution: "pullRequests.setThreadResolution",
+  pullRequestsFileViewedStates: "pullRequests.fileViewedStates",
+  pullRequestsSetFileViewed: "pullRequests.setFileViewed",
   pullRequestsSetReaction: "pullRequests.setReaction",
   pullRequestsInvalidate: "pullRequests.invalidate",
   pullRequestsSubscribeRefreshes: "pullRequests.subscribeRefreshes",
@@ -702,6 +706,18 @@ export const WsPullRequestsSetThreadResolutionRpc = Rpc.make(
     error: PullRequestRpcError,
   },
 );
+
+export const WsPullRequestsFileViewedStatesRpc = Rpc.make(WS_METHODS.pullRequestsFileViewedStates, {
+  payload: PullRequestRef,
+  success: PullRequestFileViewedStates,
+  error: PullRequestRpcError,
+});
+
+export const WsPullRequestsSetFileViewedRpc = Rpc.make(WS_METHODS.pullRequestsSetFileViewed, {
+  payload: PullRequestSetFileViewedInput,
+  success: Schema.Void,
+  error: PullRequestRpcError,
+});
 
 export const WsPullRequestsSetReactionRpc = Rpc.make(WS_METHODS.pullRequestsSetReaction, {
   payload: PullRequestReactionInput,
@@ -1224,6 +1240,8 @@ export const WsRpcGroup = RpcGroup.make(
   WsPullRequestsSubmitReviewRpc,
   WsPullRequestsReplyToThreadRpc,
   WsPullRequestsSetThreadResolutionRpc,
+  WsPullRequestsFileViewedStatesRpc,
+  WsPullRequestsSetFileViewedRpc,
   WsPullRequestsSetReactionRpc,
   WsPullRequestsInvalidateRpc,
   WsPullRequestsSubscribeRefreshesRpc,


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

> New features will most likely just annoy us

Hopefully it's a small enough feature: https://github.com/pingdotgg/t3code/discussions/8269

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

Added a "viewed" button in the PR review tab.
When clicked, it changes the "viewed" button in GitHub as well.


## Why

<!-- Explain the problem being solved and why this approach is the right one. -->
I want to review PRs inside t3code.
## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

https://github.com/user-attachments/assets/b818b508-09b7-435a-ba41-14760d4b5c6c
## Checklist

- [ ] This PR is small and focused (I will review the PR and work on this)
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-file `Viewed` checkbox to pull request reviews
> - Adds end-to-end file viewed-state support: new RPC methods `pullRequests.fileViewedStates` and `pullRequests.setFileViewed`, schema-validated contracts, and WebSocket handlers in [ws.ts](https://github.com/pingdotgg/t3code/pull/9969/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125)
> - Implements the GitHub adapter in [GitHubPullRequestCli.ts](https://github.com/pingdotgg/t3code/pull/9969/files#diff-5f996ba58ab5dee2c62090f97591f9434b30c9db0025bf3f8212b5732391e966) using paginated GraphQL reads (VIEWED → true, DISMISSED/UNVIEWED → false) and mark/unmark mutations via the resolved pull-request node ID
> - The service layer in [PullRequestService.ts](https://github.com/pingdotgg/t3code/pull/9969/files#diff-6dc74968ebcf535ce84fea9f44369080aa5246f4a8c9d10824bf988651c4f0bf) caches successful reads (15s stale time on the client), invalidates on successful writes, and returns `PullRequestOperationError` when the provider lacks the `fileViewedState` capability
> - The frontend in [PullRequestCodeTab.tsx](https://github.com/pingdotgg/t3code/pull/9969/files#diff-9b2044cf0a11cf3fc9a01b507ffcdb8f5fef43cdbf0c1ee6c00dfedd8ae796a0) shows a checkbox per file header with optimistic state, toast-on-failure rollback, and auto-collapse for files marked VIEWED; manual and toolbar fold overrides take precedence over viewed defaults
> - Behavioral Change: `isFileDiffCollapsed` in [pullRequestDiff.logic.ts](https://github.com/pingdotgg/t3code/pull/9969/files#diff-649a5e91c117152116822343399c96a121e95252ae1887b2378f0ebeaed7cdd9) now takes a boolean map instead of a toggle set; any caller still passing a `Set<string>` will break
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized cff7339. 13 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/pullRequest/PullRequestService.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 2549](https://github.com/pingdotgg/t3code/blob/cff73394c5c6847a1638890abfb75a4a4ac8922c/apps/server/src/pullRequest/PullRequestService.ts#L2549): `setFileViewed` invalidates only the cache key built from the mutation's raw `repository` string. `requireProject` deliberately accepts repository names case-insensitively, while `refCacheKey` preserves their casing. Thus a viewed-state read using `Owner/Repo` caches the canonical repository's state, then a successful toggle submitted as `owner/repo` invalidates a different key; subsequent `Owner/Repo` reads return the stale status until the TTL expires. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->