### PR TITLE
refactor(shared): remove unused viewport formatters

### DIFF
--- a/packages/shared/src/previewViewport.test.ts
+++ b/packages/shared/src/previewViewport.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import {
-  PREVIEW_VIEWPORT_PRESETS,
-  previewViewportLabel,
-  previewViewportPresetOrientation,
-  resolvePreviewViewport,
-} from "./previewViewport.ts";
+import { PREVIEW_VIEWPORT_PRESETS, resolvePreviewViewport } from "./previewViewport.ts";
 
 describe("previewViewport", () => {
   it("resolves fill and exact freeform viewports", () => {
@@ -58,13 +53,5 @@ describe("previewViewport", () => {
       "Nest Hub",
       "Nest Hub Max",
     ]);
-  });
-
-  it("formats settings for compact UI", () => {
-    expect(previewViewportLabel({ _tag: "fill" })).toBe("Fill panel");
-    expect(previewViewportLabel({ _tag: "freeform", width: 393, height: 852 })).toBe("393 × 852");
-    expect(previewViewportPresetOrientation({ _tag: "freeform", width: 852, height: 393 })).toBe(
-      "landscape",
-    );
   });
 });

--- a/packages/shared/src/previewViewport.ts
+++ b/packages/shared/src/previewViewport.ts
@@ -173,14 +173,3 @@ export function resolvePreviewViewport(
     height: input.height,
   };
 }
-
-export function previewViewportLabel(viewport: PreviewViewportSetting): string {
-  return viewport._tag === "fill" ? "Fill panel" : `${viewport.width} × ${viewport.height}`;
-}
-
-export function previewViewportPresetOrientation(
-  viewport: PreviewViewportSetting,
-): "portrait" | "landscape" | null {
-  if (viewport._tag === "fill" || viewport.width === viewport.height) return null;
-  return viewport.width > viewport.height ? "landscape" : "portrait";
-}


### PR DESCRIPTION
The viewport label and orientation helpers have no callers outside their own unit test. They no longer contribute to preview behavior.

Remove both helpers and their orphaned assertions. Keep viewport resolution and preset coverage.

Verification: focused suite passed before (4 tests) and after (3 tests); shared-package typecheck, targeted lint/format checks, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only cleanup of unused exports with no callers; preview behavior is unchanged.
> 
> **Overview**
> Removes dead code from `previewViewport.ts`: **`previewViewportLabel`** (compact UI strings like "Fill panel" or "393 × 852") and **`previewViewportPresetOrientation`** (portrait/landscape for freeform sizes).
> 
> The test file drops the spec that only exercised those helpers and narrows imports to **`resolvePreviewViewport`** and **`PREVIEW_VIEWPORT_PRESETS`**. **Viewport resolution**, preset catalog, and the remaining three tests are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65bd20fa9889419464998f46267e6327270e393a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused viewport label and preset orientation helpers
> - Removes the `previewViewportLabel` and `previewViewportPresetOrientation` exported helpers from [previewViewport.ts](https://github.com/pingdotgg/t3code/pull/9970/files#diff-b36c58d5cb961b36dcce7ba0ec1562beea5fd05aef80d12c01afdd2c5edccd49)
> - Deletes the corresponding test case and imports from [previewViewport.test.ts](https://github.com/pingdotgg/t3code/pull/9970/files#diff-2e924d9969e3cfad90cdf579a8b7229e864e5b7f8598386c1cc0d7d6572d37f3)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65bd20f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->