### PR TITLE
refactor(mobile): remove unused provider option summary

### DIFF
--- a/apps/mobile/src/lib/providerOptions.test.ts
+++ b/apps/mobile/src/lib/providerOptions.test.ts
@@ -2,11 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import type { ModelCapabilities } from "@t3tools/contracts";
 
-import {
-  applyProviderOptionSelection,
-  providerOptionValueLabels,
-  resolveProviderOptionDescriptors,
-} from "./providerOptions";
+import { applyProviderOptionSelection, resolveProviderOptionDescriptors } from "./providerOptions";
 
 const CODEX_CAPABILITIES: ModelCapabilities = {
   optionDescriptors: [
@@ -34,15 +30,6 @@ const CODEX_CAPABILITIES: ModelCapabilities = {
 };
 
 describe("mobile provider options", () => {
-  it("summarizes the option values currently in effect", () => {
-    const descriptors = resolveProviderOptionDescriptors({
-      capabilities: CODEX_CAPABILITIES,
-      selections: undefined,
-    });
-
-    expect(providerOptionValueLabels(descriptors)).toEqual(["Medium", "Standard"]);
-  });
-
   it("updates generic select options without knowing provider-specific ids", () => {
     const descriptors = resolveProviderOptionDescriptors({
       capabilities: CODEX_CAPABILITIES,
@@ -62,7 +49,7 @@ describe("mobile provider options", () => {
     expect(applyProviderOptionSelection(descriptors, { id: "unknown", value: "high" })).toBeNull();
   });
 
-  it("treats an unspecified boolean capability as off", () => {
+  it("updates generic boolean options", () => {
     const descriptors = resolveProviderOptionDescriptors({
       capabilities: {
         optionDescriptors: [{ id: "fastMode", label: "Fast Mode", type: "boolean" }],
@@ -70,7 +57,6 @@ describe("mobile provider options", () => {
       selections: undefined,
     });
 
-    expect(providerOptionValueLabels(descriptors)).toEqual([]);
     expect(applyProviderOptionSelection(descriptors, { id: "fastMode", value: true })).toEqual([
       { id: "fastMode", value: true },
     ]);

--- a/apps/mobile/src/lib/providerOptions.ts
+++ b/apps/mobile/src/lib/providerOptions.ts
@@ -5,7 +5,6 @@ import type {
 } from "@t3tools/contracts";
 import {
   buildProviderOptionSelectionsFromDescriptors,
-  getProviderOptionCurrentLabel,
   getProviderOptionDescriptors,
 } from "@t3tools/shared/model";
 
@@ -19,23 +18,6 @@ export function resolveProviderOptionDescriptors(input: {
   return getProviderOptionDescriptors({
     caps: input.capabilities,
     selections: input.selections,
-  });
-}
-
-/**
- * Labels for the option values currently in effect (select values plus
- * enabled booleans), used to summarize the thread configuration in the
- * composer trigger pill.
- */
-export function providerOptionValueLabels(
-  descriptors: ReadonlyArray<ProviderOptionDescriptor>,
-): ReadonlyArray<string> {
-  return descriptors.flatMap((descriptor) => {
-    if (descriptor.type === "boolean") {
-      return descriptor.currentValue ? [descriptor.label] : [];
-    }
-    const label = getProviderOptionCurrentLabel(descriptor);
-    return label ? [label] : [];
   });
 }
 


### PR DESCRIPTION
The mobile provider-option summary formatter is only called by its own tests; the composer no longer uses it.

Remove the formatter and those assertions. Keep the tests for selecting provider options, including unknown IDs and boolean updates.

Verification: focused suite passed before (3 tests) and after (2 tests); mobile typecheck, targeted lint/format checks, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and dead-code removal only; selection behavior in `applyProviderOptionSelection` is unchanged.
> 
> **Overview**
> Removes dead code from mobile provider options: **`providerOptionValueLabels`** and its **`getProviderOptionCurrentLabel`** import, which formatted labels for the composer trigger pill but are no longer used in the app.
> 
> Tests drop the summary-focused case and the boolean “unspecified = off” label assertion; the suite still covers **`applyProviderOptionSelection`** for select updates, invalid choices, unknown IDs, and boolean toggles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 505983583e9a9c736d7931890527cb79a8599b35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `providerOptionValueLabels` utility from mobile provider options
> Deletes the exported `providerOptionValueLabels` utility and its dependency on `getProviderOptionCurrentLabel` in [providerOptions.ts](https://github.com/pingdotgg/t3code/pull/9971/files#diff-ef880aa6b8fc7a821a06d204e1aaca62956ae062d1821a7d3571b369112ad0a6). Removes the corresponding test in [providerOptions.test.ts](https://github.com/pingdotgg/t3code/pull/9971/files#diff-5d5baa0f5a3522cafee56776c2daf0de2236acf5853425eec21e1ae902dbd843) and adjusts the boolean-option test to verify that selecting `true` produces the expected selection.
> - Risk: any caller importing `providerOptionValueLabels` will break at compile time, since the export is removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5059835.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->