### PR TITLE
refactor(client-runtime): remove unused connection phase message

### DIFF
--- a/packages/client-runtime/src/connection/presentation.test.ts
+++ b/packages/client-runtime/src/connection/presentation.test.ts
@@ -10,7 +10,6 @@ import {
 } from "./model.ts";
 import {
   connectionCatalogDisplayUrl,
-  connectionPhaseMessage,
   connectionStatusText,
   connectionStatusTitle,
   presentEnvironmentConnection,
@@ -117,10 +116,6 @@ describe("connection presentation", () => {
       error: "Relay connection timed out.",
       traceId: "trace-retry",
     });
-  });
-
-  it("gives offline status precedence in global messaging", () => {
-    expect(connectionPhaseMessage("connected", TARGET.label, "offline")).toBe("You are offline");
   });
 
   it("combines reconnect progress with the latest failure", () => {

--- a/packages/client-runtime/src/connection/presentation.ts
+++ b/packages/client-runtime/src/connection/presentation.ts
@@ -2,7 +2,7 @@ import type { ServerConfig } from "@t3tools/contracts";
 import * as Option from "effect/Option";
 
 import type { ConnectionCatalogEntry } from "./catalog.ts";
-import type { NetworkStatus, SupervisorConnectionState } from "./model.ts";
+import type { SupervisorConnectionState } from "./model.ts";
 
 export type EnvironmentConnectionPhase =
   | "available"
@@ -103,27 +103,5 @@ export function connectionCatalogDisplayUrl(entry: ConnectionCatalogEntry): stri
       return Option.isSome(entry.profile) && entry.profile.value._tag === "SshConnectionProfile"
         ? `${entry.profile.value.target.username}@${entry.profile.value.target.hostname}`
         : null;
-  }
-}
-
-export function connectionPhaseMessage(
-  phase: EnvironmentConnectionPhase,
-  label: string,
-  networkStatus: NetworkStatus,
-): string {
-  if (networkStatus === "offline" || phase === "offline") {
-    return "You are offline";
-  }
-  switch (phase) {
-    case "available":
-      return "Available";
-    case "connecting":
-      return `Connecting to ${label}...`;
-    case "reconnecting":
-      return `Reconnecting to ${label}...`;
-    case "connected":
-      return "Connected";
-    case "error":
-      return "Connection failed";
   }
 }


### PR DESCRIPTION
The old connection-phase message formatter has no production callers. Its only caller is a unit test for an offline string.

Remove the formatter, its unused type import, and that test. Keep the tests for the connection presentation APIs used by clients.

Verification: focused suite passed before (8 tests) and after (7 tests); client-runtime typecheck, targeted lint/format checks, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal only; no behavior change for APIs still used by clients.
> 
> **Overview**
> Removes the dead **`connectionPhaseMessage`** helper from `presentation.ts`, which formatted phase/network strings (including offline precedence) but had **no production callers**.
> 
> Also drops the unused **`NetworkStatus`** import tied to that helper, removes the import and unit test that only asserted offline global messaging, and leaves **`connectionStatusText`**, **`connectionStatusTitle`**, and **`presentEnvironmentConnection`** coverage unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba414149e6b48f18ee1941e2a87797d71d0e6728. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `connectionPhaseMessage` helper from client-runtime connection presentation
> Deletes the exported `connectionPhaseMessage` helper and its test in [presentation.ts](https://github.com/pingdotgg/t3code/pull/9972/files#diff-696aa7c2bcbe229bb02c6650bd93c240a3bf10020da226e64d7158f5dd4da6b3) and [presentation.test.ts](https://github.com/pingdotgg/t3code/pull/9972/files#diff-64852ef9953bb33a1e0ecb4c89451474d26ab7cc4bd3cbc8b7a97172c2e2e60a). Also removes the now-unused `NetworkStatus` type import.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba41414.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->