### PR TITLE
refactor(mobile): remove unused layout calculations

### DIFF
--- a/apps/mobile/src/lib/layout.test.ts
+++ b/apps/mobile/src/lib/layout.test.ts
@@ -2,11 +2,9 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   constrainAuxiliaryPaneWidth,
-  constrainPrimarySidebarWidth,
   deriveCenteredContentHorizontalPadding,
   deriveFileInspectorPaneLayout,
   deriveLayout,
-  deriveStableFormSheetDetent,
   deriveThreadFeedInitialContentInset,
   deriveThreadWorkLogSizing,
   deriveWorkspacePaneLayout,
@@ -75,12 +73,6 @@ describe("deriveThreadFeedInitialContentInset", () => {
 });
 
 describe("resizable pane constraints", () => {
-  it("keeps a preferred sidebar width across large windows and clamps it in a narrow split view", () => {
-    expect(constrainPrimarySidebarWidth(430, 1_366)).toBe(430);
-    expect(constrainPrimarySidebarWidth(430, 744)).toBe(384);
-    expect(constrainPrimarySidebarWidth(100, 1_366)).toBe(280);
-  });
-
   it("preserves a useful main pane while constraining a trailing pane", () => {
     expect(constrainAuxiliaryPaneWidth({ preferredWidth: 440, availableWidth: 1_100 })).toBe(440);
     expect(constrainAuxiliaryPaneWidth({ preferredWidth: 440, availableWidth: 900 })).toBe(340);
@@ -390,16 +382,5 @@ describe("deriveWorkspacePaneLayout", () => {
       auxiliaryPaneVisible: false,
       auxiliaryPaneWidth: null,
     });
-  });
-});
-
-describe("deriveStableFormSheetDetent", () => {
-  it.each([
-    { height: 1_194, expected: 0.62 },
-    { height: 834, expected: 0.863 },
-    { height: 600, expected: 0.893 },
-    { height: 0, expected: 0.92 },
-  ])("derives a stable sheet detent for height $height", ({ height, expected }) => {
-    expect(deriveStableFormSheetDetent(height)).toBe(expected);
   });
 });

--- a/apps/mobile/src/lib/layout.ts
+++ b/apps/mobile/src/lib/layout.ts
@@ -16,7 +16,6 @@ export const SPLIT_LAYOUT_MIN_WIDTH = 720;
 export const SPLIT_LAYOUT_MIN_HEIGHT = 600;
 
 export const SPLIT_SIDEBAR_MIN_WIDTH = 280;
-export const SPLIT_SIDEBAR_MAX_WIDTH = 460;
 const SPLIT_SIDEBAR_DEFAULT_MAX_WIDTH = 380;
 
 export const AUXILIARY_PANE_MIN_CONTENT_WIDTH = 960;
@@ -50,10 +49,6 @@ export const AUXILIARY_PANE_MAX_WIDTH = 480;
 const AUXILIARY_PANE_DEFAULT_MAX_WIDTH = 320;
 const FILE_INSPECTOR_MIN_VIEWPORT_WIDTH = 820;
 const FILE_INSPECTOR_MIN_MAIN_WIDTH = 560;
-const STABLE_FORM_SHEET_MAX_HEIGHT = 720;
-const STABLE_FORM_SHEET_VERTICAL_MARGIN = 64;
-const STABLE_FORM_SHEET_MIN_DETENT = 0.62;
-const STABLE_FORM_SHEET_MAX_DETENT = 0.92;
 
 export type LayoutVariant = "compact" | "split";
 
@@ -218,22 +213,6 @@ export function deriveFileInspectorPaneLayout(input: {
   };
 }
 
-/** Keep a user-selected sidebar width useful as a window is resized. */
-export function constrainPrimarySidebarWidth(
-  preferredWidth: number,
-  viewportWidth = Number.POSITIVE_INFINITY,
-): number {
-  const safeWidth = Number.isFinite(preferredWidth) ? preferredWidth : SPLIT_SIDEBAR_MIN_WIDTH;
-  const viewportMax = Number.isFinite(viewportWidth)
-    ? Math.max(SPLIT_SIDEBAR_MIN_WIDTH, viewportWidth - 360)
-    : SPLIT_SIDEBAR_MAX_WIDTH;
-  return clamp(
-    Math.round(safeWidth),
-    SPLIT_SIDEBAR_MIN_WIDTH,
-    Math.min(SPLIT_SIDEBAR_MAX_WIDTH, viewportMax),
-  );
-}
-
 /**
  * Keep an auxiliary pane within native-feeling bounds without squeezing its
  * neighboring content below a usable reading/editor width.
@@ -274,21 +253,4 @@ export function deriveCenteredContentHorizontalPadding(input: {
   }
 
   return minimumPadding + Math.max(0, (viewportWidth - input.maxContentWidth) / 2);
-}
-
-export function deriveStableFormSheetDetent(containerHeight: number): number {
-  if (!Number.isFinite(containerHeight) || containerHeight <= 0) {
-    return STABLE_FORM_SHEET_MAX_DETENT;
-  }
-
-  const targetHeight = Math.min(
-    STABLE_FORM_SHEET_MAX_HEIGHT,
-    Math.max(0, containerHeight - STABLE_FORM_SHEET_VERTICAL_MARGIN),
-  );
-  const detent = clamp(
-    targetHeight / containerHeight,
-    STABLE_FORM_SHEET_MIN_DETENT,
-    STABLE_FORM_SHEET_MAX_DETENT,
-  );
-  return Math.round(detent * 1_000) / 1_000;
 }


### PR DESCRIPTION
The primary-sidebar width and stable form-sheet detent calculations are only called by their own tests.

Remove those calculations, their exclusively owned constants, and the orphaned cases. Keep the live pane sizing, padding, and layout behavior unchanged.

Verification: Focused layout suite: 42 tests before, 37 after. Mobile typecheck, targeted lint/format checks, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deletions with no production call sites; no behavior change to live pane or shell layout.
> 
> **Overview**
> Removes **dead layout helpers** from `layout.ts` that were only exercised by their own unit tests: `constrainPrimarySidebarWidth` (and `SPLIT_SIDEBAR_MAX_WIDTH`) and `deriveStableFormSheetDetent` (plus its form-sheet detent constants).
> 
> The matching tests in `layout.test.ts` are dropped as well. **Runtime layout behavior is unchanged**—`deriveLayout`, auxiliary pane sizing, padding, and workspace pane logic stay as they are.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01a1d53745e25aa84a3330c300070eff9101de1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `constrainPrimarySidebarWidth` and `deriveStableFormSheetDetent` from mobile layout module
> Removes the primary-sidebar width constraint helper, the stable form-sheet detent helper, and their associated constants and tests from [layout.ts](https://github.com/pingdotgg/t3code/pull/9974/files#diff-3ec9d5e0285c42e8cc3bb4d432f83eb9ebfe2be1f270c01367d25528afc76cac) and [layout.test.ts](https://github.com/pingdotgg/t3code/pull/9974/files#diff-19718b0285c219e25c6f247db47409a386b594fa8b9a34b0a8e82f672dec9633). These helpers were no longer used by any runtime code. Risk: any out-of-tree consumers importing `constrainPrimarySidebarWidth` or the maximum split-sidebar width constant will break, as these exports are removed without deprecation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01a1d53.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->