### PR TITLE
refactor(mobile): remove unused font size steppers

### DIFF
--- a/apps/mobile/src/lib/appearancePreferences.test.ts
+++ b/apps/mobile/src/lib/appearancePreferences.test.ts
@@ -13,8 +13,6 @@ import {
   resolveMobileCodeSurface,
   resolveNativeMarkdownTypography,
   resolveTextScaleVariables,
-  stepBaseFontSize,
-  stepCodeFontSize,
   stepTerminalFontSize,
 } from "./appearancePreferences";
 
@@ -73,11 +71,8 @@ describe("appearancePreferences", () => {
     expect(normalizeCodeFontSize(30)).toBe(18);
   });
 
-  it("steps font sizes within bounds", () => {
+  it("steps terminal font size within bounds", () => {
     expect(stepTerminalFontSize(6, -1)).toBe(6);
-    expect(stepBaseFontSize(11, -1)).toBe(11);
-    expect(stepCodeFontSize(8, -1)).toBe(8);
-    expect(stepBaseFontSize(15, 1)).toBe(16);
   });
 
   it("scales markdown typography from the base size", () => {

--- a/apps/mobile/src/lib/appearancePreferences.ts
+++ b/apps/mobile/src/lib/appearancePreferences.ts
@@ -235,20 +235,10 @@ export function resolveNativeMarkdownTypography(baseFontSize: number): NativeMar
   };
 }
 
-export function stepBaseFontSize(current: number, direction: -1 | 1): number {
-  const next = direction === -1 ? current - BASE_FONT_SIZE_STEP : current + BASE_FONT_SIZE_STEP;
-  return normalizeBaseFontSize(next);
-}
-
 export function stepTerminalFontSize(current: number, direction: -1 | 1): number {
   const next =
     direction === -1 ? current - TERMINAL_FONT_SIZE_STEP : current + TERMINAL_FONT_SIZE_STEP;
   return normalizeTerminalFontSize(next);
-}
-
-export function stepCodeFontSize(current: number, direction: -1 | 1): number {
-  const next = direction === -1 ? current - CODE_FONT_SIZE_STEP : current + CODE_FONT_SIZE_STEP;
-  return normalizeCodeFontSize(next);
 }
 
 export {


### PR DESCRIPTION
The base- and code-font stepping wrappers have no production callers.

Remove them and their direct assertions. Keep font normalization, migrations, typography coverage, and the terminal stepper. Settings still uses the step constants, so those remain.

Verification: Focused appearance suite: 13 tests before and after. Mobile typecheck, targeted lint/format checks, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal in appearance helpers with no behavior change to live settings or terminal UI stepping.
> 
> **Overview**
> Removes **`stepBaseFontSize`** and **`stepCodeFontSize`** from `appearancePreferences.ts` because nothing in mobile calls them anymore. **Terminal font stepping** (`stepTerminalFontSize`) and all **normalization, derivation, and typography** helpers stay unchanged.
> 
> Tests drop imports and assertions for the removed steppers and narrow the stepping case to **terminal bounds only** (e.g. stepping down at the minimum stays clamped).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1f71e6cfb13567673f8372e619b914c3a626f47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `stepBaseFontSize` and `stepCodeFontSize` helpers from mobile appearance preferences
> Deletes the two unused font-size stepping helpers and their bound-normalization logic from [appearancePreferences.ts](https://github.com/pingdotgg/t3code/pull/9975/files#diff-05cdfd018ad160c909feeb2b14b13a6dd68a52dc1ab8074445001c53457ecac6), keeping the terminal font-size stepper unchanged. Updates the test suite in [appearancePreferences.test.ts](https://github.com/pingdotgg/t3code/pull/9975/files#diff-3ca6dbeb64857eb94381ca9551467cb238c62ba3604df1e194192b5730cf66fb) to remove the deleted imports and assertions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f1f71e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->