### PR TITLE
refactor(client-runtime): remove unused file position predicate

### DIFF
--- a/packages/client-runtime/src/markdownLinks.test.ts
+++ b/packages/client-runtime/src/markdownLinks.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   fileBasename,
   inlineCodeFilePathCandidate,
-  isConventionalFilePosition,
   parseFileUrlHref,
   parseMarkdownFileLink,
   splitFilePathPosition,
@@ -25,15 +24,6 @@ describe("inlineCodeFilePathCandidate", () => {
     ["example.pl/index.html", null],
   ])("distinguishes file paths from code and hostnames in %s", (source, candidate) => {
     expect(inlineCodeFilePathCandidate(source)).toBe(candidate);
-  });
-});
-
-describe("isConventionalFilePosition", () => {
-  it("distinguishes extensionless file locations from labels and ports", () => {
-    expect(isConventionalFilePosition("Dockerfile:8:2")).toBe(true);
-    expect(isConventionalFilePosition("Makefile")).toBe(false);
-    expect(isConventionalFilePosition("TODO:12")).toBe(false);
-    expect(isConventionalFilePosition("port:3000")).toBe(false);
   });
 });
 

--- a/packages/client-runtime/src/markdownLinks.ts
+++ b/packages/client-runtime/src/markdownLinks.ts
@@ -15,7 +15,6 @@ const INLINE_CODE_DISQUALIFIER_PATTERN = /[\s`]/;
 const PATH_SEPARATOR_PATTERN = /[\\/]/;
 const FILE_EXTENSION_PATTERN = /\.[A-Za-z0-9_-]+$/;
 const NUMERIC_DOTTED_PATTERN = /^\d+(?:\.\d+)+$/;
-const BARE_EXTENSIONLESS_POSITION_PATTERN = /^[A-Za-z0-9_-]+(?::\d+){1,2}$/;
 // Standard OS and dev-container roots; deliberately excludes app-route-ish
 // prefixes like /app/ or /chat/ so SPA routes never read as files.
 const POSIX_FILE_ROOT_PREFIXES = [
@@ -150,14 +149,6 @@ function looksLikeHostname(segment: string, hasPosition: boolean): boolean {
   if (labels.length < 2 || lastLabel === undefined) return false;
   if (GENERIC_HOSTNAME_TLDS.has(lastLabel)) return true;
   return !hasPosition && COUNTRY_HOSTNAME_TLDS.has(lastLabel);
-}
-
-/** Recognizes conventional extensionless filenames with an explicit line position. */
-export function isConventionalFilePosition(path: string): boolean {
-  return (
-    BARE_EXTENSIONLESS_POSITION_PATTERN.test(path) &&
-    EXTENSIONLESS_FILE_NAMES.has(path.replace(POSITION_SUFFIX_PATTERN, ""))
-  );
 }
 
 /**


### PR DESCRIPTION
The conventional-file-position predicate is only called by its own test; the active markdown parser does not use it.

Remove the predicate, its private regular expression, and that test. Keep the active path and URL parsing coverage.

Verification: Focused markdown-link suite: 84 tests before, 83 after. Client-runtime typecheck, targeted lint/format checks, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletes unused exports and tests only; markdown link parsing behavior and its coverage are unchanged.
> 
> **Overview**
> Removes dead code from the markdown file-link helpers: the exported **`isConventionalFilePosition`** helper, its **`BARE_EXTENSIONLESS_POSITION_PATTERN`** regex, and the dedicated test block.
> 
> Nothing in the client runtime called that predicate; extensionless names with line suffixes (e.g. **`Dockerfile:8`**) are still recognized through **`parseMarkdownFileLink`** and existing tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fa6ef680289c036c88d0463262b4b8979499fb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `isConventionalFilePosition` from `markdownLinks` module
> Deletes the `isConventionalFilePosition` helper and its associated regex constant from [markdownLinks.ts](https://github.com/pingdotgg/t3code/pull/9976/files#diff-61bfbb3d21cf76210b9a3622411fbb27acab9e95f653467b9af1a46f7d02df91), along with the matching test suite in [markdownLinks.test.ts](https://github.com/pingdotgg/t3code/pull/9976/files#diff-311bb5a7be1286b39d5c29211daf4f22888a0d6ec48125f3c5ce37b1faf9388c). The helper checked for extensionless filenames like `Dockerfile:8:2` with one or two numeric position components but was no longer used.
> - Risk: any code importing `isConventionalFilePosition` from this module will fail to compile or load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7fa6ef6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->