### PR TITLE
test(server): cover raw OpenCode deltas through the adapter

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -43,7 +43,6 @@ import {
   type OpenCodeRuntimeShape,
 } from "../opencodeRuntime.ts";
 import {
-  appendOpenCodeAssistantTextDelta,
   isOpenCodeNotFound,
   isSameOpenCodeDirectory,
   makeOpenCodeAdapter,
@@ -6430,20 +6429,17 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       }).pipe(Effect.scoped),
   );
 
-  it.effect("appends raw assistant text deltas and reconciles part update snapshots", () =>
+  it.effect("reconciles assistant text snapshots", () =>
     Effect.sync(() => {
       const firstUpdate = mergeOpenCodeAssistantText(undefined, "Hello");
-      const overlapDelta = appendOpenCodeAssistantTextDelta(firstUpdate.latestText, "lo world");
-      const secondUpdate = mergeOpenCodeAssistantText(overlapDelta.nextText, "Hellolo world");
       const appendedUpdate = mergeOpenCodeAssistantText("Hello", "Hello world");
       const changedUpdate = mergeOpenCodeAssistantText("Hello world", "Hello there");
       const staleUpdate = mergeOpenCodeAssistantText("Hello world", "Hello");
 
-      NodeAssert.deepEqual(
-        [firstUpdate.deltaToEmit, overlapDelta.deltaToEmit, secondUpdate.deltaToEmit],
-        ["Hello", "lo world", ""],
-      );
-      NodeAssert.equal(secondUpdate.latestText, "Hellolo world");
+      NodeAssert.deepEqual(firstUpdate, {
+        latestText: "Hello",
+        deltaToEmit: "Hello",
+      });
       NodeAssert.deepEqual(appendedUpdate, {
         latestText: "Hello world",
         deltaToEmit: " world",

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -626,7 +626,7 @@ export function mergeOpenCodeAssistantText(
   };
 }
 
-export function appendOpenCodeAssistantTextDelta(
+function appendOpenCodeAssistantTextDelta(
   previousText: string,
   delta: string,
 ): {


### PR DESCRIPTION
The string-concatenation helper is exported only for direct unit-test assertions.

Make it private and remove those assertions. Keep snapshot reconciliation cases and the existing adapter-level delta regression.

Verification: Both focused snapshot/delta regression tests passed before and after. Targeted lint and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and visibility-only change; adapter streaming behavior is unchanged and still covered indirectly.
> 
> **Overview**
> **Encapsulates** `appendOpenCodeAssistantTextDelta` by removing its export in `OpenCodeAdapter.ts`; the adapter still uses it for streaming assistant text.
> 
> **Tests** no longer import or assert on raw delta concatenation. The effect test is renamed to focus on **`mergeOpenCodeAssistantText`** snapshot reconciliation (initial emit, append suffix, replacement, stale snapshot).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec01c6c9dd743e5af897db72cf019fc3dc560e61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `appendOpenCodeAssistantTextDelta` file-local and test deltas via adapter
> Changes `appendOpenCodeAssistantTextDelta` from an exported function to a file-local helper in [OpenCodeAdapter.ts](https://github.com/pingdotgg/t3code/pull/9977/files#diff-a4267388b15e5043ae1899beded972cbee9e52533ca3d9d65d438a91a9f7fbe7). Refactors the reconciliation test in [OpenCodeAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/9977/files#diff-2d1ef28752ab2f1ec0f021e6723508dc18e6a9294ebd20255ec3767afe34cf5f) to verify assistant-text snapshots through `mergeOpenCodeAssistantText` instead of testing the helper directly. Removes the overlap-delta scenario and keeps assertions for initial, appended, changed, and stale snapshots.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec01c6c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->