### PR TITLE
test(server): cover thread lookup through command invariants

### DIFF
--- a/apps/server/src/orchestration/commandInvariants.test.ts
+++ b/apps/server/src/orchestration/commandInvariants.test.ts
@@ -11,12 +11,7 @@ import {
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 
-import {
-  findThreadById,
-  listThreadsByProjectId,
-  requireThread,
-  requireThreadAbsent,
-} from "./commandInvariants.ts";
+import { listThreadsByProjectId, requireThread, requireThreadAbsent } from "./commandInvariants.ts";
 
 const now = "2026-01-01T00:00:00.000Z";
 
@@ -121,9 +116,7 @@ const messageSendCommand: OrchestrationCommand = {
 };
 
 describe("commandInvariants", () => {
-  it("finds threads by id and project", () => {
-    expect(findThreadById(readModel, ThreadId.make("thread-1"))?.projectId).toBe("project-a");
-    expect(findThreadById(readModel, ThreadId.make("missing"))).toBeUndefined();
+  it("lists threads by project", () => {
     expect(
       listThreadsByProjectId(readModel, ProjectId.make("project-b")).map((thread) => thread.id),
     ).toEqual([ThreadId.make("thread-2")]);

--- a/apps/server/src/orchestration/commandInvariants.ts
+++ b/apps/server/src/orchestration/commandInvariants.ts
@@ -18,7 +18,7 @@ function invariantError(commandType: string, detail: string): OrchestrationComma
   });
 }
 
-export function findThreadById(
+function findThreadById(
   readModel: OrchestrationReadModel,
   threadId: ThreadId,
 ): OrchestrationThread | undefined {


### PR DESCRIPTION
The Array.find wrapper is exported only for two assertions that repeat coverage in the command-invariant tests.

Make the lookup private and remove those assertions. Keep existing/missing-thread, project filtering, create, and soft-delete coverage.

Verification: All 4 command-invariant tests passed before and after. Targeted lint and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No behavior change—only export visibility and redundant test removal in orchestration invariants.
> 
> **Overview**
> **Encapsulates** orchestration thread lookup by making `findThreadById` module-private instead of exported; it remains the internal helper for `requireThread` and `requireThreadAbsent`.
> 
> **Tests** drop direct `findThreadById` assertions and rename the case to focus on `listThreadsByProjectId`, on the grounds that existing/missing-thread behavior is already covered by `requireThread` and related invariant tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7f41c1d60d45eceb0ab18633cd66fe81a0b0020. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `findThreadById` module-private and test thread lookup via `listThreadsByProjectId`
> - Removes direct test coverage of `findThreadById` in [commandInvariants.test.ts](https://github.com/pingdotgg/t3code/pull/9978/files#diff-c46c2a56fef5b8a955031d5a2def26445396842bb753c7dcd9eca2515f60d7be) and replaces it with thread-presence checks through `listThreadsByProjectId`.
> - Changes `findThreadById` in [commandInvariants.ts](https://github.com/pingdotgg/t3code/pull/9978/files#diff-426dec65d7876b98b993600840e4b58dcca662d84f3a23e884ea72cc2783e6a0) from an exported function to a module-private function without altering its lookup logic.
> - Behavioral Change: `findThreadById` is no longer exported from `commandInvariants.ts`; any external consumers importing it will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7f41c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->