### PR TITLE
test(server): assert the dispatched welcome thread model

### DIFF
--- a/apps/server/src/serverRuntimeStartup.test.ts
+++ b/apps/server/src/serverRuntimeStartup.test.ts
@@ -17,13 +17,6 @@ import * as AnalyticsService from "./telemetry/AnalyticsService.ts";
 import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
 import * as GitVcsDriver from "./vcs/GitVcsDriver.ts";
 
-it("uses the canonical Codex default for the auto-bootstrapped welcome thread", () => {
-  assert.deepStrictEqual(ServerRuntimeStartup.getAutoBootstrapThreadModelSelection(), {
-    instanceId: ProviderInstanceId.make("codex"),
-    model: DEFAULT_MODEL,
-  });
-});
-
 it.effect("automatic pull only updates enabled, behind, clean default-branch checkouts", () =>
   Effect.gen(function* () {
     const pulled: string[] = [];
@@ -201,7 +194,10 @@ it.effect("resolveAutoBootstrapWelcomeTargets returns existing project and threa
               id: bootstrapProjectId,
               title: "Startup Project",
               workspaceRoot: "/tmp/startup-project",
-              defaultModelSelection: ServerRuntimeStartup.getAutoBootstrapThreadModelSelection(),
+              defaultModelSelection: {
+                instanceId: ProviderInstanceId.make("codex"),
+                model: DEFAULT_MODEL,
+              },
               scripts: [],
               createdAt: "2026-01-01T00:00:00.000Z",
               updatedAt: "2026-01-01T00:00:00.000Z",
@@ -298,10 +294,10 @@ it.effect("resolveAutoBootstrapWelcomeTargets creates a project and thread when 
       ["project.create", "thread.create"],
     );
     assert.equal("defaultModelSelection" in commands[0]!, false);
-    assert.deepStrictEqual(
-      commands[1]?.modelSelection,
-      ServerRuntimeStartup.getAutoBootstrapThreadModelSelection(),
-    );
+    assert.deepStrictEqual(commands[1]?.modelSelection, {
+      instanceId: ProviderInstanceId.make("codex"),
+      model: DEFAULT_MODEL,
+    });
   }),
 );
 

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -176,7 +176,7 @@ export const launchStartupHeartbeat = recordStartupHeartbeat.pipe(
   Effect.asVoid,
 );
 
-export const getAutoBootstrapThreadModelSelection = (): ModelSelection => ({
+const getAutoBootstrapThreadModelSelection = (): ModelSelection => ({
   instanceId: ProviderInstanceId.make("codex"),
   model: DEFAULT_MODEL,
 });


### PR DESCRIPTION
The welcome-model getter is exported for a literal-only test, and another test computes its expected result with the same getter.

Make the getter private. Assert the canonical model on the actual dispatched thread.create command and remove the redundant direct test.

Verification: Full focused startup suite: 9 tests before, 8 after. Targeted lint and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and export-scope cleanup only; runtime bootstrap logic is unchanged.
> 
> **Overview**
> Makes **`getAutoBootstrapThreadModelSelection`** module-private in `serverRuntimeStartup.ts` so it is no longer part of the public startup API.
> 
> Startup tests no longer call that helper or keep a dedicated test that only mirrored its return value. They now assert the canonical Codex default (`codex` + `DEFAULT_MODEL`) inline on the **`thread.create`** dispatch and on fixture `defaultModelSelection`, so expectations are checked against real bootstrap behavior instead of the same getter under test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f888e80226e7f9ad08d6e60c41f3ba35f5313afa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `getAutoBootstrapThreadModelSelection` module-private and update welcome thread tests
> Removes the export of `getAutoBootstrapThreadModelSelection` in [serverRuntimeStartup.ts](https://github.com/pingdotgg/t3code/pull/9980/files#diff-1930335d6e319fc5766e0578303e19f9d788e9990f87604b77f9f768e61d7118) so the helper stays internal. Tests in [serverRuntimeStartup.test.ts](https://github.com/pingdotgg/t3code/pull/9980/files#diff-19fa17f560ffd7127a3d2620af09e534b2f23f31c7760e5f6c2b780cf121e27c) now inline the Codex provider instance and default model instead of importing the helper, and the standalone test that asserted the helper's return value is deleted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f888e80.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->