### PR TITLE
refactor(desktop): remove unused keyring remediation text

### DIFF
--- a/apps/desktop/src/linuxSecretStorage.test.ts
+++ b/apps/desktop/src/linuxSecretStorage.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   normalizeLinuxPasswordStorePreference,
   resolveLinuxPasswordStoreSwitch,
-  resolveLinuxSecretStorageUnavailableMessage,
 } from "./linuxSecretStorage.ts";
 
 const autoSwitch = (env: NodeJS.ProcessEnv) =>
@@ -123,81 +122,5 @@ describe("linuxSecretStorage", () => {
         KDE_SESSION_VERSION: "6",
       }),
     ).toBe("gnome-libsecret");
-  });
-
-  it("uses GNOME Keyring remediation for libsecret and unknown backends", () => {
-    expect(
-      resolveLinuxSecretStorageUnavailableMessage({
-        configuredPreference: "auto",
-        selectedBackend: "gnome_libsecret",
-        env: { XDG_CURRENT_DESKTOP: "niri" },
-      }),
-    ).toContain("GNOME Keyring");
-  });
-
-  it("prefers explicit libsecret selection over KDE desktop heuristics", () => {
-    expect(
-      resolveLinuxSecretStorageUnavailableMessage({
-        configuredPreference: "gnome-libsecret",
-        selectedBackend: "unknown",
-        env: { XDG_CURRENT_DESKTOP: "KDE" },
-      }),
-    ).toContain("GNOME Keyring");
-    expect(
-      resolveLinuxSecretStorageUnavailableMessage({
-        configuredPreference: "auto",
-        selectedBackend: "gnome_libsecret",
-        env: { XDG_CURRENT_DESKTOP: "KDE" },
-      }),
-    ).toContain("GNOME Keyring");
-  });
-
-  it("prefers explicit KWallet preference over selected gnome-libsecret backend", () => {
-    expect(
-      resolveLinuxSecretStorageUnavailableMessage({
-        configuredPreference: "kwallet6",
-        selectedBackend: "gnome_libsecret",
-        env: { XDG_CURRENT_DESKTOP: "niri" },
-      }),
-    ).toContain("KWallet");
-    expect(
-      resolveLinuxSecretStorageUnavailableMessage({
-        configuredPreference: "kwallet",
-        selectedBackend: "gnome-libsecret",
-        env: {},
-      }),
-    ).toContain("KWallet");
-  });
-
-  it("uses KWallet remediation wording for KDE-looking sessions", () => {
-    expect(
-      resolveLinuxSecretStorageUnavailableMessage({
-        configuredPreference: "auto",
-        selectedBackend: "kwallet6",
-        env: {},
-      }),
-    ).toContain("KWallet");
-    expect(
-      resolveLinuxSecretStorageUnavailableMessage({
-        configuredPreference: "auto",
-        selectedBackend: "unknown",
-        env: { XDG_CURRENT_DESKTOP: "KDE" },
-      }),
-    ).toContain("KWallet");
-    expect(
-      resolveLinuxSecretStorageUnavailableMessage({
-        configuredPreference: "auto",
-        selectedBackend: "unknown",
-        env: { DESKTOP_SESSION: "plasmawayland" },
-      }),
-    ).toContain("KWallet");
-    // A desktop name outranks a bare KDE marker when choosing the wording.
-    expect(
-      resolveLinuxSecretStorageUnavailableMessage({
-        configuredPreference: "auto",
-        selectedBackend: "unknown",
-        env: { GDMSESSION: "gnome", KDE_FULL_SESSION: "true" },
-      }),
-    ).toContain("GNOME Keyring");
   });
 });

--- a/apps/desktop/src/linuxSecretStorage.ts
+++ b/apps/desktop/src/linuxSecretStorage.ts
@@ -25,9 +25,6 @@ const ELECTRON_KDE_DESKTOP = "KDE";
 // Chromium recognizes LXQt and still selects basic text for it, so it does need a forced backend.
 const ELECTRON_UNPROTECTED_DESKTOPS = new Set(["LXQt"]);
 
-const KDE_NAME_PREFIXES = ["kde", "plasma"];
-const NEGATIVE_FLAG_VALUES = new Set(["0", "false", "no", "off"]);
-
 export function normalizeLinuxPasswordStorePreference(
   value: unknown,
 ): LinuxPasswordStorePreference {
@@ -77,102 +74,6 @@ function electronSelectsProtectedBackend(env: NodeJS.ProcessEnv): boolean {
   return false;
 }
 
-export function resolveLinuxSecretStorageUnavailableMessage(input: {
-  readonly configuredPreference: LinuxPasswordStorePreference;
-  readonly selectedBackend: string | null;
-  readonly env: NodeJS.ProcessEnv;
-}): string {
-  if (input.configuredPreference === "gnome-libsecret") {
-    return getGnomeKeyringRemediationMessage();
-  }
-
-  if (
-    input.configuredPreference === "kwallet" ||
-    input.configuredPreference === "kwallet5" ||
-    input.configuredPreference === "kwallet6"
-  ) {
-    return getKWalletRemediationMessage();
-  }
-
-  const backend = normalizeSelectedStorageBackend(input.selectedBackend);
-  if (backend === "gnome-libsecret") {
-    return getGnomeKeyringRemediationMessage();
-  }
-
-  if (
-    backend === "kwallet" ||
-    backend === "kwallet5" ||
-    backend === "kwallet6" ||
-    looksLikeKdeSession(input.env)
-  ) {
-    return getKWalletRemediationMessage();
-  }
-
-  return getGnomeKeyringRemediationMessage();
-}
-
-function getGnomeKeyringRemediationMessage(): string {
-  return "T3 Code could not access GNOME Keyring to save this environment credential. Install and start GNOME Keyring, then restart T3 Code.";
-}
-
-function getKWalletRemediationMessage(): string {
-  return "T3 Code could not access KWallet to save this environment credential. Enable the KDE wallet subsystem in System Settings, then restart T3 Code.";
-}
-
-// Advisory only: this picks between the GNOME Keyring and KWallet wording in the failure notice. It
-// never decides which backend to select, so a loose match costs a user slightly wrong instructions
-// rather than an unprotected credential store.
-function looksLikeKdeSession(env: NodeJS.ProcessEnv): boolean {
-  const currentDesktopNames = nonEmptyDesktopNames(env.XDG_CURRENT_DESKTOP);
-  if (currentDesktopNames.length > 0) {
-    return currentDesktopNames.some(isKdeDesktopName);
-  }
-
-  const legacyNames = legacyDesktopNames(env);
-  if (legacyNames.length > 0) {
-    return legacyNames.some(isKdeDesktopName);
-  }
-
-  return isSet(env.KDE_SESSION_VERSION) || isAffirmativeFlag(env.KDE_FULL_SESSION);
-}
-
-function isKdeDesktopName(name: string): boolean {
-  return KDE_NAME_PREFIXES.some((prefix) => name.startsWith(prefix));
-}
-
-function legacyDesktopNames(env: NodeJS.ProcessEnv): string[] {
-  return [env.XDG_SESSION_DESKTOP, env.DESKTOP_SESSION, env.GDMSESSION].flatMap((entry) => {
-    const normalized = normalizeDesktopName(entry);
-    return normalized ? [normalized] : [];
-  });
-}
-
-function nonEmptyDesktopNames(value: string | undefined): string[] {
-  return splitDesktopNameList(value).flatMap((entry) => {
-    const normalized = normalizeDesktopName(entry);
-    return normalized ? [normalized] : [];
-  });
-}
-
-function isSet(value: string | undefined): boolean {
-  return Boolean(value?.trim());
-}
-
-function isAffirmativeFlag(value: string | undefined): boolean {
-  const normalized = value?.trim().toLowerCase();
-  return normalized ? !NEGATIVE_FLAG_VALUES.has(normalized) : false;
-}
-
 function splitDesktopNameList(value: string | undefined): string[] {
   return value?.split(":") ?? [];
-}
-
-function normalizeDesktopName(value: string | undefined): string | null {
-  const normalized = value?.trim().toLowerCase();
-  return normalized && normalized.length > 0 ? normalized : null;
-}
-
-function normalizeSelectedStorageBackend(value: string | null): string | null {
-  const normalized = value?.trim().toLowerCase().replace(/_/gu, "-");
-  return normalized && normalized.length > 0 ? normalized : null;
 }


### PR DESCRIPTION
The old Linux keyring remediation formatter and its private detection helpers have no production callers.

Remove that dead code and its four wording tests. Leave live password-store selection and its coverage unchanged.

Verification: Selected desktop baseline: 32 tests passed, including all 15 Linux tests. After cleanup: all 11 remaining Linux tests passed. Desktop typecheck, targeted lint/format checks, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deletion of unused code with no production callers; live Linux password-store behavior and tests for selection logic remain intact.
> 
> **Overview**
> Removes dead Linux secret-storage **user-facing error text** and the KDE/GNOME heuristics that only existed to pick between GNOME Keyring vs KWallet wording in failure notices.
> 
> **`resolveLinuxSecretStorageUnavailableMessage`** and its private helpers (`looksLikeKdeSession`, desktop-name normalization, remediation string builders) are deleted from `linuxSecretStorage.ts`, along with the four tests that asserted that messaging. **Password-store auto-selection** (`resolveLinuxPasswordStoreSwitch`, `normalizeLinuxPasswordStorePreference`) and their existing test suite are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7930abc870feddec5c806572d0329287cb6742e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused keyring remediation text from `linuxSecretStorage`
> - Deletes the exported `resolveLinuxSecretStorageUnavailableMessage` resolver and its GNOME Keyring/KWallet remediation-message constructors from [linuxSecretStorage.ts](https://github.com/pingdotgg/t3code/pull/9981/files#diff-1d0b3955426bdce5a8352d981b77ad48c3254c13c7b17fbb964a346242ee8226).
> - Removes KDE desktop-name constants, session-detection helpers, and the selected-backend normalization helper that supported the deleted resolver.
> - Drops four test cases for remediation-message selection from [linuxSecretStorage.test.ts](https://github.com/pingdotgg/t3code/pull/9981/files#diff-d8941ab64bfb3ae27ec1bf9e75d61b90e16341854b224f48233e212a8619d8bd); password-store normalization and backend-switch tests remain.
> - Risk: any out-of-tree code importing `resolveLinuxSecretStorageUnavailableMessage` will break, since the export is removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7930ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->