### PR TITLE
refactor(desktop): remove test-only Electron error predicates

### DIFF
--- a/apps/desktop/src/electron/ElectronDialog.test.ts
+++ b/apps/desktop/src/electron/ElectronDialog.test.ts
@@ -43,7 +43,6 @@ describe("ElectronDialog", () => {
       );
 
       assert.instanceOf(error, ElectronDialog.ElectronDialogPickFolderError);
-      assert.isTrue(ElectronDialog.isElectronDialogError(error));
       assert.strictEqual(error.ownerWindowId, 7);
       assert.strictEqual(error.defaultPath, "/workspace");
       assert.strictEqual(error.cause, cause);

--- a/apps/desktop/src/electron/ElectronDialog.ts
+++ b/apps/desktop/src/electron/ElectronDialog.ts
@@ -73,7 +73,6 @@ export const ElectronDialogError = Schema.Union([
   ElectronDialogShowErrorBoxError,
 ]);
 export type ElectronDialogError = typeof ElectronDialogError.Type;
-export const isElectronDialogError = Schema.is(ElectronDialogError);
 
 export interface ElectronDialogPickFolderInput {
   readonly owner: Option.Option<Electron.BrowserWindow>;

--- a/apps/desktop/src/electron/ElectronTheme.test.ts
+++ b/apps/desktop/src/electron/ElectronTheme.test.ts
@@ -64,7 +64,6 @@ describe("ElectronTheme", () => {
       const error = yield* Effect.flip(electronTheme.setSource("dark"));
 
       assert.instanceOf(error, ElectronTheme.ElectronThemeSetSourceError);
-      assert.isTrue(ElectronTheme.isElectronThemeSetSourceError(error));
       assert.strictEqual(error.source, "dark");
       assert.strictEqual(error.cause, cause);
       assert.include(error.message, "dark");

--- a/apps/desktop/src/electron/ElectronTheme.ts
+++ b/apps/desktop/src/electron/ElectronTheme.ts
@@ -19,8 +19,6 @@ export class ElectronThemeSetSourceError extends Schema.TaggedErrorClass<Electro
   }
 }
 
-export const isElectronThemeSetSourceError = Schema.is(ElectronThemeSetSourceError);
-
 export class ElectronTheme extends Context.Service<
   ElectronTheme,
   {

--- a/apps/desktop/src/electron/ElectronUpdater.test.ts
+++ b/apps/desktop/src/electron/ElectronUpdater.test.ts
@@ -71,7 +71,6 @@ describe("ElectronUpdater", () => {
       const error = yield* updater.checkForUpdates.pipe(Effect.flip);
 
       assert.instanceOf(error, ElectronUpdater.ElectronUpdaterCheckForUpdatesError);
-      assert.isTrue(ElectronUpdater.isElectronUpdaterError(error));
       assert.equal(error.channel, "beta");
       assert.strictEqual(error.cause, cause);
       assert.equal(error.message, "Electron updater failed to check for updates on channel beta.");
@@ -89,7 +88,6 @@ describe("ElectronUpdater", () => {
       const error = yield* updater.downloadUpdate.pipe(Effect.flip);
 
       assert.instanceOf(error, ElectronUpdater.ElectronUpdaterDownloadUpdateError);
-      assert.isTrue(ElectronUpdater.isElectronUpdaterError(error));
       assert.equal(error.channel, "nightly");
       assert.strictEqual(error.cause, cause);
       assert.equal(
@@ -126,7 +124,6 @@ describe("ElectronUpdater", () => {
         .pipe(Effect.flip);
 
       assert.instanceOf(error, ElectronUpdater.ElectronUpdaterQuitAndInstallError);
-      assert.isTrue(ElectronUpdater.isElectronUpdaterError(error));
       assert.equal(error.channel, "alpha");
       assert.equal(error.isSilent, true);
       assert.equal(error.isForceRunAfter, false);

--- a/apps/desktop/src/electron/ElectronUpdater.ts
+++ b/apps/desktop/src/electron/ElectronUpdater.ts
@@ -54,7 +54,6 @@ export const ElectronUpdaterError = Schema.Union([
   ElectronUpdaterQuitAndInstallError,
 ]);
 export type ElectronUpdaterError = typeof ElectronUpdaterError.Type;
-export const isElectronUpdaterError = Schema.is(ElectronUpdaterError);
 
 export class ElectronUpdater extends Context.Service<
   ElectronUpdater,

--- a/apps/desktop/src/electron/ElectronWindow.test.ts
+++ b/apps/desktop/src/electron/ElectronWindow.test.ts
@@ -79,7 +79,6 @@ describe("ElectronWindow", () => {
       const error = yield* electronWindow.create(options).pipe(Effect.flip);
 
       assert.instanceOf(error, ElectronWindow.ElectronWindowCreateError);
-      assert.isTrue(ElectronWindow.isElectronWindowCreateError(error));
       assert.deepEqual(error.options, {
         title: "T3 Code",
         width: 1100,

--- a/apps/desktop/src/electron/ElectronWindow.ts
+++ b/apps/desktop/src/electron/ElectronWindow.ts
@@ -58,8 +58,6 @@ export class ElectronWindowCreateError extends Schema.TaggedErrorClass<ElectronW
   }
 }
 
-export const isElectronWindowCreateError = Schema.is(ElectronWindowCreateError);
-
 export class ElectronWindowOperationError extends Schema.TaggedErrorClass<ElectronWindowOperationError>()(
   "ElectronWindowOperationError",
   {


### PR DESCRIPTION
Four Electron error predicates are only used by tests immediately after assertions for the same error classes.

Remove the predicates and six duplicate assertions. Keep error schemas, unions, and all behavior, lifecycle, and error-detail tests.

Verification: All 17 focused Electron tests passed before and after. Desktop typecheck, targeted lint/format checks, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code and test-only assertion cleanup with no runtime behavior changes.
> 
> **Overview**
> Removes **Schema.is**-based error predicate helpers from desktop Electron modules (`ElectronDialog`, `ElectronTheme`, `ElectronUpdater`, `ElectronWindow`) that were only exercised in tests immediately after `instanceOf` checks on the same error classes.
> 
> Matching **redundant test assertions** are dropped; **tagged error classes**, **union schemas** (e.g. `ElectronDialogError`, `ElectronUpdaterError`), and the rest of the error-detail and lifecycle tests are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b747cb883747d6c0cb45dfd31202249715d96339. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove test-only Electron error type guards from desktop app
> - Removes exported schema-based error predicates from `ElectronDialog`, `ElectronTheme`, `ElectronUpdater`, and `ElectronWindow` modules. The aggregate error schemas and type aliases remain.
> - Updates corresponding test files to drop assertions that checked errors against the module-level error guards. Tests still validate concrete error classes, causes, and contextual metadata.
> - Behavioral Change: removes the exported predicates (e.g. `isElectronDialogError`) from each module; any out-of-tree consumers relying on them will need to use the retained schema or type alias instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b747cb8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->