### PR TITLE
refactor(web): remove obsolete pull request link opener

### DIFF
--- a/apps/web/src/lib/openPullRequestLink.test.ts
+++ b/apps/web/src/lib/openPullRequestLink.test.ts
@@ -1,14 +1,12 @@
-import { describe, expect, it, vi } from "vite-plus/test";
+import { describe, expect, it } from "vite-plus/test";
 
 import {
   changeRequestRepositoryUrl,
   findProjectForChangeRequest,
   gitHubPullRequestBrowserUrl,
   matchesLinkedPullRequestUrl,
-  openPullRequestLink,
   parseChangeRequestUrl,
   pullRequestCandidateUrlFromReferenceAutolink,
-  PullRequestLinkOpenError,
   shouldOpenPullRequestExternally,
 } from "./openPullRequestLink";
 import { ProjectId, type RepositoryIdentity } from "@t3tools/contracts";
@@ -181,33 +179,6 @@ describe("matchesLinkedPullRequestUrl", () => {
         "https://github.example.com/pingdotgg/t3code/pull/42",
       ),
     ).toBe(false);
-  });
-});
-
-describe("openPullRequestLink", () => {
-  it("opens the requested pull request URL", async () => {
-    const openExternal = vi.fn(async () => undefined);
-    const targetUrl = "https://github.com/pingdotgg/t3code/pull/123";
-
-    await openPullRequestLink({ openExternal }, targetUrl);
-
-    expect(openExternal).toHaveBeenCalledExactlyOnceWith(targetUrl);
-  });
-
-  it("reports bridge failures with a safe target origin", async () => {
-    const cause = new Error("desktop shell unavailable");
-    const targetUrl = "https://github.com/pingdotgg/t3code/pull/123?token=secret";
-    const openExternal = vi.fn(async () => Promise.reject(cause));
-
-    const result = openPullRequestLink({ openExternal }, targetUrl);
-
-    await expect(result).rejects.toEqual(
-      new PullRequestLinkOpenError({
-        targetOrigin: "https://github.com",
-        cause,
-      }),
-    );
-    await expect(result).rejects.not.toHaveProperty("message", expect.stringContaining("secret"));
   });
 });
 

--- a/apps/web/src/lib/openPullRequestLink.ts
+++ b/apps/web/src/lib/openPullRequestLink.ts
@@ -1,12 +1,10 @@
 import type {
   EnvironmentId,
-  LocalApi,
   RepositoryIdentity,
   ScopedThreadRef,
   ThreadLinkedPullRequest,
 } from "@t3tools/contracts";
 import { useNavigate } from "@tanstack/react-router";
-import * as Schema from "effect/Schema";
 import { type MouseEvent, useCallback } from "react";
 
 import { pullRequestHostOf, type SourceControlProviderKind } from "@t3tools/contracts";
@@ -18,41 +16,6 @@ import type { EnvironmentProject } from "@t3tools/client-runtime/state/shell";
 
 import { useProjects, useServerConfigs } from "../state/entities";
 import { usePrimaryEnvironmentId } from "../state/environments";
-
-export class PullRequestLinkOpenError extends Schema.TaggedErrorClass<PullRequestLinkOpenError>()(
-  "PullRequestLinkOpenError",
-  {
-    targetOrigin: Schema.NullOr(Schema.String),
-    cause: Schema.Defect(),
-  },
-) {
-  static fromCause(targetUrl: string, cause: unknown): PullRequestLinkOpenError {
-    let targetOrigin: string | null = null;
-    try {
-      targetOrigin = new URL(targetUrl).origin;
-    } catch {
-      // Keep malformed URLs out of diagnostics while preserving the open failure below.
-    }
-    return new PullRequestLinkOpenError({ targetOrigin, cause });
-  }
-
-  override get message(): string {
-    return this.targetOrigin === null
-      ? "Unable to open pull request link."
-      : `Unable to open pull request link at ${this.targetOrigin}.`;
-  }
-}
-
-export async function openPullRequestLink(
-  shell: Pick<LocalApi["shell"], "openExternal">,
-  targetUrl: string,
-): Promise<void> {
-  try {
-    await shell.openExternal(targetUrl);
-  } catch (cause) {
-    throw PullRequestLinkOpenError.fromCause(targetUrl, cause);
-  }
-}
 
 /** Builds a GitHub URL that remains available when the pull request API cannot be read. */
 export function gitHubPullRequestBrowserUrl(


### PR DESCRIPTION
The old direct pull-request link opener and its error class are only called by their own tests. The app uses useOpenPrLink and the shared link-opening path.

Remove the obsolete wrapper, error class, and two tests. Keep the active hook and URL routing/parsing coverage unchanged.

Verification: Focused link suite: 30 tests before, 28 after. Web typecheck, targeted lint/format checks, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only cleanup of unused exports and tests; no change to the active link-opening path.
> 
> **Overview**
> Removes dead code from `openPullRequestLink.ts`: the **`openPullRequestLink`** helper that wrapped `shell.openExternal`, and the **`PullRequestLinkOpenError`** Effect Schema error type (including origin sanitization for failed opens).
> 
> Pull request links are already opened via **`useOpenPrLink`** → **`useOpenLink`**, with failures surfaced through toasts. URL parsing, in-app routing, and **`shouldOpenPullRequestExternally`** behavior are unchanged.
> 
> The test file drops the **`openPullRequestLink`** describe block (two cases) and the unused **`vi`** import; remaining URL/matching tests stay as-is.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e21bfd6bb7437825ffed397a8e0b8e309634eda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove obsolete `openPullRequestLink` helper and `PullRequestLinkOpenError` class
> Deletes the async `openPullRequestLink` helper that opened URLs via `shell.openExternal` and its tagged `PullRequestLinkOpenError` class. Removes the corresponding test suite in [openPullRequestLink.test.ts](https://github.com/pingdotgg/t3code/pull/9983/files#diff-459189e562f39dbb78ad2b7d874903b62832e9e686c2c128b6b9de1d11c392d2) and unused imports in both modules. Risk: any remaining out-of-tree callers referencing `openPullRequestLink` or `PullRequestLinkOpenError` from [openPullRequestLink.ts](https://github.com/pingdotgg/t3code/pull/9983/files#diff-953140e01f1329a36fe8f5606c9027215b588e76537644ab9819a9a618d000ae) will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e21bfd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->