### PR TITLE
refactor(web): remove unused pull request state label

### DIFF
--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -38,7 +38,6 @@ import {
   shouldRefreshPullRequestActivity,
   resolveBaseFreshness,
   buildPullRequestTimeline,
-  describePullRequestState,
   editPullRequestThreadComment,
   writePullRequestDetailSnapshot,
 } from "./pullRequestDetail.logic";
@@ -196,15 +195,6 @@ describe("pull request primary control", () => {
       "resolve",
     );
     expect(resolvePullRequestPrimaryControl({ ...open, isDraft: true })).toBe("ready");
-  });
-});
-
-describe("pull request state description", () => {
-  it("keeps draft and conflicts orthogonal to the terminal states", () => {
-    expect(describePullRequestState("open", true)).toBe("Draft");
-    expect(describePullRequestState("open", false)).toBe("Ready for review");
-    expect(describePullRequestState("merged", true)).toBe("Merged");
-    expect(describePullRequestState("closed", false)).toBe("Closed");
   });
 });
 

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -189,13 +189,6 @@ export function isStackedPullRequestBase(
   return defaultBranch !== baseBranch;
 }
 
-/** Plain-language state, shown beside the author. Conflicts are a merge signal, not a state. */
-export function describePullRequestState(state: PullRequestState, isDraft: boolean): string {
-  if (state === "merged") return "Merged";
-  if (state === "closed") return "Closed";
-  return isDraft ? "Draft" : "Ready for review";
-}
-
 /** Chronological ascending, oldest to newest — reversed for the "newest" reading order. */
 export function orderPullRequestComments<T extends { readonly createdAt: string }>(
   comments: ReadonlyArray<T>,


### PR DESCRIPTION
The pull-request state label formatter has no callers outside its own test.

Remove the formatter and its orphaned assertions. The live pull-request controls and detail logic are unchanged.

Verification: Focused detail-logic suite: 93 tests before, 92 after. Web typecheck, targeted lint/format checks, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and unused helper removal with no runtime behavior change.
> 
> **Overview**
> Removes dead code from pull request detail logic: the **`describePullRequestState`** helper that mapped `PullRequestState` and draft flag to strings like "Draft", "Ready for review", "Merged", and "Closed".
> 
> That helper is deleted from `pullRequestDetail.logic.ts`, along with its dedicated test block and import in `pullRequestDetail.logic.test.ts`. **No production callers** are affected; primary controls, timeline, and other detail behavior stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 346a2d7b5112b5549449618d6fb97dd16d92c14c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `describePullRequestState` helper and tests
> Deletes the exported helper that converted pull request state and draft flag into labels like `Draft` and `Ready for review`, along with its test suite in [pullRequestDetail.logic.test.ts](https://github.com/pingdotgg/t3code/pull/9984/files#diff-e60dcca9528657e439208537290f4173177d2ce18d6e73b42339275341bc3bcd). Risk: `describePullRequestState` export is removed; any out-of-tree callers will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 346a2d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->