### PR TITLE
test(server): remove authorization prompt snapshots

### DIFF
--- a/apps/server/src/cli/connect.test.ts
+++ b/apps/server/src/cli/connect.test.ts
@@ -13,30 +13,11 @@ import * as Terminal from "effect/Terminal";
 import * as BootService from "../cloud/bootService.ts";
 import {
   acquireRelayClientForLink,
-  formatHeadlessAuthorizationPrompt,
-  formatRelayClientReady,
   headlessSessionConfig,
   isPublishAgentActivityEnabledValue,
   reportCloudDisconnectResults,
 } from "./connect.ts";
 import { recoverServiceOnboardingOffer } from "./service.ts";
-
-it("explains how to complete headless authorization", () => {
-  assert.equal(
-    formatHeadlessAuthorizationPrompt("https://example.test/connect"),
-    [
-      "Headless authorization",
-      "Open this URL on a device with a browser:",
-      "  https://example.test/connect",
-      "",
-      "After signing in, return here and enter the code shown in your browser.",
-    ].join("\n"),
-  );
-});
-
-it("formats relay readiness without printing its installation path", () => {
-  assert.equal(formatRelayClientReady("2026.5.2"), "✓ Relay client ready · cloudflared 2026.5.2");
-});
 
 const readHeadlessSessionConfig = (env: Record<string, string>) =>
   headlessSessionConfig.pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env }))));

--- a/apps/server/src/cli/connect.ts
+++ b/apps/server/src/cli/connect.ts
@@ -86,7 +86,7 @@ const promptForOutOfBandOAuthCode = Effect.fn("cloud.cli.prompt_for_out_of_band_
   },
 );
 
-export function formatHeadlessAuthorizationPrompt(authorizeUrl: string): string {
+function formatHeadlessAuthorizationPrompt(authorizeUrl: string): string {
   return [
     "Headless authorization",
     "Open this URL on a device with a browser:",
@@ -464,7 +464,7 @@ const runCloudCommand = Effect.fn("cloud.cli.run_cloud_command")(function* <A, E
 
 const connectedAs = (identity: string | null): string => (identity ? ` as ${identity}` : "");
 
-export function formatRelayClientReady(version: string): string {
+function formatRelayClientReady(version: string): string {
   return `✓ Relay client ready · cloudflared ${version}`;
 }
 

--- a/apps/server/src/cloud/CliTokenManager.test.ts
+++ b/apps/server/src/cloud/CliTokenManager.test.ts
@@ -93,19 +93,6 @@ class PromptRejectedError extends Schema.TaggedErrorClass<PromptRejectedError>()
   { message: Schema.String },
 ) {}
 
-it("formats loopback authorization with a headless-host fallback", () => {
-  assert.equal(
-    CliTokenManager.formatLoopbackAuthorizationPrompt("https://clerk.example.test/authorize"),
-    [
-      "Open this URL to authorize T3 Connect:",
-      "  https://clerk.example.test/authorize",
-      "",
-      "Press \u001b[1mEnter\u001b[22m to open it in your browser.",
-      "No browser on this device? Press \u001b[1mH\u001b[22m to switch to headless mode.",
-    ].join("\n"),
-  );
-});
-
 const makeTestTerminal = (queue: Queue.Queue<Terminal.UserInput>) =>
   Terminal.make({
     columns: Effect.succeed(80),

--- a/apps/server/src/cloud/CliTokenManager.ts
+++ b/apps/server/src/cloud/CliTokenManager.ts
@@ -44,7 +44,7 @@ const CLOUD_CLI_OAUTH_CALLBACK_TIMEOUT = Duration.minutes(10);
 const CLOUD_CLI_OAUTH_REFRESH_EARLY_MS = Duration.toMillis(Duration.minutes(5));
 const boldTerminalText = (value: string): string => `\u001b[1m${value}\u001b[22m`;
 
-export function formatLoopbackAuthorizationPrompt(authorizationUrl: string): string {
+function formatLoopbackAuthorizationPrompt(authorizationUrl: string): string {
   return [
     "Open this URL to authorize T3 Connect:",
     `  ${authorizationUrl}`,


### PR DESCRIPTION
Three prompt formatters are exported only so tests can repeat their exact strings.

Make the formatters private and remove those snapshots. Runtime text is unchanged; the real terminal interaction, headless fallback, callback, and PKCE exchange tests remain.

Verification: Both focused CLI/token suites passed: 17 tests before, 14 after. Targeted lint and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and export-surface cleanup only; no logic or runtime prompt text changes.
> 
> **Overview**
> Stops exporting three CLI authorization message helpers that existed mainly so tests could assert full prompt strings.
> 
> `formatHeadlessAuthorizationPrompt` and `formatRelayClientReady` in `connect.ts`, plus `formatLoopbackAuthorizationPrompt` in `CliTokenManager.ts`, are now module-private. The corresponding snapshot-style unit tests in `connect.test.ts` and `CliTokenManager.test.ts` are removed (17 → 14 tests in those suites). **User-facing copy and flows are unchanged**; behavioral coverage for loopback/headless interaction, OAuth callbacks, and PKCE exchange remains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e730ec988c1fba2bfa2d3c0a74315a6992b8791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove authorization prompt snapshot tests and make formatting helpers module-private
> - Deletes direct tests for the headless, relay-client, and loopback authorization prompt formatting helpers across [connect.test.ts](https://github.com/pingdotgg/t3code/pull/9985/files#diff-be26bd4d15fbb004ca1964b67bcfc21328a54c13acc983450031aa8b8d92ef84) and [CliTokenManager.test.ts](https://github.com/pingdotgg/t3code/pull/9985/files#diff-c5f4a3c1e2413ba94b2b59b0182cfc1dd5f1cfce75fc6920c072af3604a3c3f0)
> - Changes `formatHeadlessAuthorizationPrompt`, `formatRelayClientReady`, and `formatLoopbackAuthorizationPrompt` from exported functions to module-private; prompt construction logic is unchanged
> - Behavioral Change: these helpers are no longer accessible to external callers or tests
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e730ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->