### PR TITLE
test(server): remove provider label identity assertion

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -61,7 +61,6 @@ import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQu
 import * as ThreadBackgroundLiveness from "../ThreadBackgroundLiveness.ts";
 import * as ThreadPlanProgress from "../ThreadPlanProgress.ts";
 import {
-  providerErrorLabel,
   providerErrorLabelFromInstanceHint,
   ProviderCommandReactorLive,
 } from "./ProviderCommandReactor.ts";
@@ -163,10 +162,6 @@ describe("ProviderCommandReactor", () => {
           instanceId: "claude_openrouter",
         }),
       ).toBe("claude_openrouter");
-    });
-
-    it("uses the unknown driver kind when the resolved driver is not registered locally", () => {
-      expect(providerErrorLabel("third_party_driver")).toBe("third_party_driver");
     });
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -228,7 +228,7 @@ function formatThreadTitleContext(messages: ReadonlyArray<ThreadTitleMessage>): 
   };
 }
 
-export function providerErrorLabel(value: string | undefined): string {
+function providerErrorLabel(value: string | undefined): string {
   const normalized = value?.trim();
   return normalized && normalized.length > 0 ? normalized : "unknown";
 }


### PR DESCRIPTION
The provider label helper is exported for a test that only checks an ordinary string is returned unchanged.

Make it private and remove that assertion. Keep the tests for the outer instance-attribution behavior.

Verification: Focused attribution cases passed: 3 before, 2 after. Targeted lint passed with existing warnings on untouched lines; diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Encapsulation and test-only change with no runtime behavior change; public API remains `providerErrorLabelFromInstanceHint`.
> 
> **Overview**
> **Makes `providerErrorLabel` an internal helper** in `ProviderCommandReactor.ts` by dropping its `export`, since it was only exported to support a unit test that asserted trivial string passthrough.
> 
> **Test cleanup:** Removes the direct `providerErrorLabel` import and the case that checked an unknown driver kind string is returned unchanged. **Provider error attribution** is still covered via `providerErrorLabelFromInstanceHint` (current vs desired instance slugs when lookup fails).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b2c73c2a1b3e17a3bf2be7ffc996e4dd5672826. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `providerErrorLabel` module-private in `ProviderCommandReactor`
> Changes `providerErrorLabel` from an exported function to a module-private function in [ProviderCommandReactor.ts](https://github.com/pingdotgg/t3code/pull/9987/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d) and removes the direct fallback-behavior test from [ProviderCommandReactor.test.ts](https://github.com/pingdotgg/t3code/pull/9987/files#diff-24590cda9b5d40bcb845f474304592ddf62ae6d252d40be60e19435aa75347c4). The function implementation and fallback behavior are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b2c73c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->