### PR TITLE
test(server): consolidate agent activity opt-in coverage

### DIFF
--- a/apps/server/src/cli/connect.test.ts
+++ b/apps/server/src/cli/connect.test.ts
@@ -16,7 +16,6 @@ import {
   formatHeadlessAuthorizationPrompt,
   formatRelayClientReady,
   headlessSessionConfig,
-  isPublishAgentActivityEnabledValue,
   reportCloudDisconnectResults,
 } from "./connect.ts";
 import { recoverServiceOnboardingOffer } from "./service.ts";
@@ -208,11 +207,4 @@ it.effect("keeps disconnect causes in structured logs and out of console warning
       }),
     ),
   );
-});
-
-it("treats only the literal 'true' as publish-enabled", () => {
-  assert.equal(isPublishAgentActivityEnabledValue("true"), true);
-  assert.equal(isPublishAgentActivityEnabledValue("false"), false);
-  assert.equal(isPublishAgentActivityEnabledValue(null), false);
-  assert.equal(isPublishAgentActivityEnabledValue("TRUE"), false);
 });

--- a/apps/server/src/cli/connect.ts
+++ b/apps/server/src/cli/connect.ts
@@ -144,10 +144,6 @@ function stringToBytes(value: string): Uint8Array {
   return new TextEncoder().encode(value);
 }
 
-export function isPublishAgentActivityEnabledValue(value: string | null): boolean {
-  return isAgentActivityPublishingEnabledValue(value);
-}
-
 interface CloudCliStatus {
   readonly desired: boolean;
   readonly authenticated: boolean;
@@ -573,7 +569,7 @@ const connectStatusCommand = Command.make("status", {
           linked: Option.isSome(cloudUserId),
           cloudUserId: Option.isSome(cloudUserId) ? bytesToString(cloudUserId.value) : null,
           relayUrl: Option.isSome(relayUrl) ? bytesToString(relayUrl.value) : null,
-          publishAgentActivity: isPublishAgentActivityEnabledValue(
+          publishAgentActivity: isAgentActivityPublishingEnabledValue(
             Option.isSome(publishAgentActivity) ? bytesToString(publishAgentActivity.value) : null,
           ),
           relayClient: executable,

--- a/apps/server/src/relay/AgentAwarenessRelay.test.ts
+++ b/apps/server/src/relay/AgentAwarenessRelay.test.ts
@@ -39,6 +39,7 @@ import {
   type ProjectionSnapshotQueryShape,
 } from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import {
+  isAgentActivityPublishingEnabledValue,
   RELAY_ENVIRONMENT_CREDENTIAL_SECRET,
   RELAY_ISSUER_SECRET,
   RELAY_URL_SECRET,
@@ -220,9 +221,10 @@ describe.sequential("signRelayAgentActivityPublishProof", () => {
   });
 
   it("requires an explicit opt-in before publishing agent activity", () => {
-    expect(AgentAwarenessRelay.isAgentActivityPublishingEnabled(null)).toBe(false);
-    expect(AgentAwarenessRelay.isAgentActivityPublishingEnabled("false")).toBe(false);
-    expect(AgentAwarenessRelay.isAgentActivityPublishingEnabled("true")).toBe(true);
+    expect(isAgentActivityPublishingEnabledValue(null)).toBe(false);
+    expect(isAgentActivityPublishingEnabledValue("false")).toBe(false);
+    expect(isAgentActivityPublishingEnabledValue("TRUE")).toBe(false);
+    expect(isAgentActivityPublishingEnabledValue("true")).toBe(true);
   });
 
   it("redacts failed activity details and caps other relay detail", () => {

--- a/apps/server/src/relay/AgentAwarenessRelay.ts
+++ b/apps/server/src/relay/AgentAwarenessRelay.ts
@@ -102,10 +102,6 @@ export function agentAwarenessPublishIdentity(state: RelayAgentActivityState | n
   return JSON.stringify(meaningfulState);
 }
 
-export function isAgentActivityPublishingEnabled(value: string | null): boolean {
-  return isAgentActivityPublishingEnabledValue(value);
-}
-
 export function resolveAgentActivityPublishingStartupState(input: {
   readonly relayConfigured: boolean;
   readonly publishEnabled: boolean;
@@ -322,7 +318,7 @@ export const make = Effect.gen(function* () {
   });
 
   const readPublishAgentActivityEnabled = readSecretString(PUBLISH_AGENT_ACTIVITY_SECRET).pipe(
-    Effect.map(isAgentActivityPublishingEnabled),
+    Effect.map(isAgentActivityPublishingEnabledValue),
   );
 
   const makeRelayClient = (relayConfig: {


### PR DESCRIPTION
The CLI and awareness relay each wrap the same activity-publishing predicate just to expose another test target.

Call the canonical predicate directly and remove both wrappers. Keep one explicit privacy-default test covering null, false, uppercase TRUE, and literal true.

Verification: Both focused suites passed: 21 tests before, 20 after. Targeted lint and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with no behavior change beyond consolidating call sites and test location; opt-in still requires the literal string `true`.
> 
> **Overview**
> Removes thin wrapper exports around **`isAgentActivityPublishingEnabledValue`** in the CLI (`connect.ts`) and **`AgentAwarenessRelay`**, so both call the shared predicate in **`cloud/config.ts`** directly.
> 
> The duplicate CLI unit test for publish opt-in parsing is dropped; **`AgentAwarenessRelay.test.ts`** keeps a single privacy-default test (null, `false`, uppercase `TRUE`, literal `true`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fc0cdf59dcc16c7fd2614cd08b16b92b01fafe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate agent activity opt-in tests and remove wrapper re-exports
> - Removes the connect-module and relay-module wrappers that re-exported the shared publish-agent-activity value parser; [connect.ts](https://github.com/pingdotgg/t3code/pull/9988/files#diff-369ea07c1ac5b161aaf3838766eade272006cee25413a596386e01aa6d2b9aa0) and [AgentAwarenessRelay.ts](https://github.com/pingdotgg/t3code/pull/9988/files#diff-46d7033397b4a9b5846cacda38ebc024554005dcf6e10f8369546c0dcd1b6573) now call the shared `isAgentActivityPublishingEnabledValue` helper directly.
> - Updates tests in [connect.test.ts](https://github.com/pingdotgg/t3code/pull/9988/files#diff-be26bd4d15fbb004ca1964b67bcfc21328a54c13acc983450031aa8b8d92ef84) and [AgentAwarenessRelay.test.ts](https://github.com/pingdotgg/t3code/pull/9988/files#diff-fada49bb6ae8c31e4b1a1a75ddb12265e32d005d5d495e20d431fbd6a58c4c3d) to import and exercise the shared cloud-config parser directly, including an assertion that uppercase `TRUE` is disabled while `false`, null, and lowercase `true` remain covered.
> - Risk: callers that imported `isPublishAgentActivityEnabledValue` from the connect or relay modules must switch to the shared helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4fc0cdf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->