### PR TITLE
refactor(shared): remove unused preview URL predicate

### DIFF
--- a/packages/shared/src/preview.test.ts
+++ b/packages/shared/src/preview.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   isLoopbackHost,
-  isPreviewableUrl,
   newPreviewTabId,
   normalizePreviewUrl,
   PreviewUrlNormalizationError,
@@ -25,24 +24,6 @@ describe("isLoopbackHost", () => {
   it.each(["example.com", "192.168.1.10", "10.0.0.1", ""])("%s is not loopback", (host) => {
     expect(isLoopbackHost(host)).toBe(false);
   });
-});
-
-describe("isPreviewableUrl", () => {
-  it.each([
-    "http://localhost:5173",
-    "http://127.0.0.1:3000/path",
-    "http://0.0.0.0:8080",
-    "http://[::1]:5173",
-  ])("%s is previewable", (url) => {
-    expect(isPreviewableUrl(url)).toBe(true);
-  });
-
-  it.each(["https://example.com", "ws://localhost:5173", "file:///etc/passwd", "not-a-url", ""])(
-    "%s is not previewable",
-    (url) => {
-      expect(isPreviewableUrl(url)).toBe(false);
-    },
-  );
 });
 
 describe("normalizePreviewUrl", () => {

--- a/packages/shared/src/preview.ts
+++ b/packages/shared/src/preview.ts
@@ -36,17 +36,6 @@ export function isLoopbackHost(host: string): boolean {
   return false;
 }
 
-/** True when a raw URL string looks like a loopback dev URL we can preview. */
-export function isPreviewableUrl(rawUrl: string): boolean {
-  try {
-    const parsed = new URL(rawUrl);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
-    return isLoopbackHost(parsed.hostname);
-  } catch {
-    return false;
-  }
-}
-
 export class PreviewUrlNormalizationError extends Schema.TaggedErrorClass<PreviewUrlNormalizationError>()(
   "PreviewUrlNormalizationError",
   {


### PR DESCRIPTION
The old loopback-only previewability predicate has no production callers.

Remove it and its nine orphaned cases. Keep live preview normalization, loopback-host checks, and validation/redaction coverage unchanged.

Verification: Focused preview suite: 25 tests before, 16 after. Shared-package typecheck, targeted lint/format checks, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal with no production callers; preview normalization and loopback checks stay in place.
> 
> **Overview**
> Removes the unused **`isPreviewableUrl`** export from `packages/shared/src/preview.ts`, which previously parsed a string and returned true only for `http:`/`https:` URLs on loopback hostnames.
> 
> The dedicated **`isPreviewableUrl`** test block (nine cases) is deleted from `preview.test.ts`. **`isLoopbackHost`**, **`normalizePreviewUrl`**, and the rest of the preview URL normalization and error handling are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ef7295271b2b291fb4757b6ddf9c45f7a914890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `isPreviewableUrl` previewability predicate
> Deletes the exported `isPreviewableUrl` function from [preview.ts](https://github.com/pingdotgg/t3code/pull/9989/files#diff-fb6a2f1ea150bd83474c4f0454daa856c96132e57d75b425efde45840e2f4143) and its associated test suite in [preview.test.ts](https://github.com/pingdotgg/t3code/pull/9989/files#diff-13eac8ba73c22452ee61a51074f3f5a00f8244931d76e23eb1e0bd2b0c196343). Risk: consumers importing this named export will break; verify no remaining references to `isPreviewableUrl` exist outside this package.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ef7295.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->