### PR TITLE
refactor(shared): remove unused mention path serializer

### DIFF
--- a/packages/shared/src/composerTrigger.test.ts
+++ b/packages/shared/src/composerTrigger.test.ts
@@ -1,20 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { serializeComposerFileLink, serializeComposerMentionPath } from "./composerTrigger.ts";
-
-describe("serializeComposerMentionPath", () => {
-  it("keeps simple mention paths unquoted", () => {
-    expect(serializeComposerMentionPath("src/index.ts")).toBe("src/index.ts");
-  });
-
-  it("quotes mention paths containing whitespace", () => {
-    expect(serializeComposerMentionPath("docs/My File.md")).toBe('"docs/My File.md"');
-  });
-
-  it("escapes quoted mention path content", () => {
-    expect(serializeComposerMentionPath('docs/My "File".md')).toBe('"docs/My \\"File\\".md"');
-  });
-});
+import { serializeComposerFileLink } from "./composerTrigger.ts";
 
 describe("serializeComposerFileLink", () => {
   it("uses the basename as the markdown label", () => {

--- a/packages/shared/src/composerTrigger.ts
+++ b/packages/shared/src/composerTrigger.ts
@@ -8,15 +8,6 @@ export interface ComposerTrigger {
   rangeEnd: number;
 }
 
-const SIMPLE_MENTION_PATH_REGEX = /^[^\s@"\\]+$/;
-
-export function serializeComposerMentionPath(path: string): string {
-  if (SIMPLE_MENTION_PATH_REGEX.test(path)) {
-    return path;
-  }
-  return `"${path.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
-}
-
 function composerFileLinkBasename(path: string): string {
   const separatorIndex = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
   return separatorIndex >= 0 ? path.slice(separatorIndex + 1) : path;


### PR DESCRIPTION
The old quoted-mention serializer is used only by its own tests; current clients insert markdown file links.

Remove it, its private regular expression, and the three quoting tests. Keep the active markdown serializer and its escaping coverage.

Verification: Focused composer-trigger suite: 7 tests before, 4 after. Shared-package typecheck, targeted lint/format checks, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal with no remaining call sites; active composer serialization behavior is unchanged.
> 
> **Overview**
> Removes the legacy **`serializeComposerMentionPath`** helper and its **`SIMPLE_MENTION_PATH_REGEX`** from `composerTrigger.ts`, along with the three tests that only exercised quoted `@` mention paths.
> 
> Composer path insertion now relies solely on **`serializeComposerFileLink`** (markdown links with basename labels and encoded destinations); the test file import and suite are trimmed accordingly while **`serializeComposerFileLink`** coverage stays in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38600c24f69b4ee5a771e5e96d36acf8f7cbb150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `serializeComposerMentionPath` from shared composer module
> Deletes the `serializeComposerMentionPath` function and its `SIMPLE_MENTION_PATH_REGEX` constant from [composerTrigger.ts](https://github.com/pingdotgg/t3code/pull/9990/files#diff-b4159167bd9a29da87e9151654616f69eb910aa170ac2d930c07130f06f93cb9), along with the matching tests in [composerTrigger.test.ts](https://github.com/pingdotgg/t3code/pull/9990/files#diff-77b1c49f44e4499af61ef5439edc194be2e6fd19f048f74889a605f3e3e6c39c). The `serializeComposerFileLink` export and its tests remain. Risk: any out-of-tree code importing `serializeComposerMentionPath` will no longer compile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38600c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->