### PR TITLE
refactor(shared): remove retired PATH capture parser

### DIFF
--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -8,7 +8,6 @@ import * as TestClock from "effect/testing/TestClock";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
-  extractPathFromShellOutput,
   CommandAvailability,
   CommandResolutionCache,
   type CommandAvailabilityChecker,
@@ -38,28 +37,6 @@ const withWindowsEnvironmentMocks = <A, E, R>(
     Effect.provideService(WindowsShellEnvironment, readEnvironment),
     Effect.provideService(CommandAvailability, commandAvailable),
   );
-
-describe("extractPathFromShellOutput", () => {
-  it("extracts the path between capture markers", () => {
-    expect(
-      extractPathFromShellOutput(
-        "__T3CODE_PATH_START__\n/opt/homebrew/bin:/usr/bin\n__T3CODE_PATH_END__\n",
-      ),
-    ).toBe("/opt/homebrew/bin:/usr/bin");
-  });
-
-  it("ignores shell startup noise around the capture markers", () => {
-    expect(
-      extractPathFromShellOutput(
-        "Welcome to fish\n__T3CODE_PATH_START__\n/opt/homebrew/bin:/usr/bin\n__T3CODE_PATH_END__\nBye\n",
-      ),
-    ).toBe("/opt/homebrew/bin:/usr/bin");
-  });
-
-  it("returns null when the markers are missing", () => {
-    expect(extractPathFromShellOutput("/opt/homebrew/bin /usr/bin")).toBeNull();
-  });
-});
 
 describe("readPathFromLoginShell", () => {
   it("uses a shell-agnostic printenv PATH probe", () => {

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -12,8 +12,6 @@ import * as Path from "effect/Path";
 import { HostProcessEnvironment, HostProcessPlatform } from "./hostProcess.ts";
 import * as Context from "effect/Context";
 
-const PATH_CAPTURE_START = "__T3CODE_PATH_START__";
-const PATH_CAPTURE_END = "__T3CODE_PATH_END__";
 const SHELL_ENV_NAME_PATTERN = /^[A-Z0-9_]+$/;
 const WINDOWS_PATH_DELIMITER = ";";
 const POSIX_PATH_DELIMITER = ":";
@@ -177,18 +175,6 @@ export function listLoginShellCandidates(
   }
 
   return candidates;
-}
-
-export function extractPathFromShellOutput(output: string): string | null {
-  const startIndex = output.indexOf(PATH_CAPTURE_START);
-  if (startIndex === -1) return null;
-
-  const valueStartIndex = startIndex + PATH_CAPTURE_START.length;
-  const endIndex = output.indexOf(PATH_CAPTURE_END, valueStartIndex);
-  if (endIndex === -1) return null;
-
-  const pathValue = output.slice(valueStartIndex, endIndex).trim();
-  return pathValue.length > 0 ? pathValue : null;
 }
 
 export function readPathFromLoginShell(


### PR DESCRIPTION
The marker-based PATH parser has no production callers. Login-shell PATH reading now uses the environment reader.

Remove the retired parser, its markers, and three orphaned tests. Keep shell environment, escaping, Windows probing, and executable-resolution coverage.

Verification: Focused shell suite: 36 tests before, 33 after. Shared-package typecheck, targeted lint/format checks, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal only; PATH behavior stays on the existing environment reader with no production call sites removed.
> 
> **Overview**
> Removes the legacy **marker-based PATH parser** (`extractPathFromShellOutput` and `__T3CODE_PATH_*` markers) from `shell.ts`. Login-shell PATH already comes from `readEnvironmentFromLoginShell` via the per-variable `__T3CODE_ENV_*` capture flow, so this helper had no callers.
> 
> The matching unit tests for the old parser are deleted; remaining shell tests still cover login-shell PATH probing, environment capture, Windows probing, and command resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 267bdbd5b83670aa9f84602e154bfdca8f44e6fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove retired `extractPathFromShellOutput` helper and marker constants
> Deletes the unused shell-output path extraction helper, its start/end marker constants, and the associated test suite from [shell.ts](https://github.com/pingdotgg/t3code/pull/9991/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce) and [shell.test.ts](https://github.com/pingdotgg/t3code/pull/9991/files#diff-024b87c2c05ce19f7366c156ab261b505a48c5dcc47f564611041c74af49c9f4).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 267bdbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->