### PR TITLE
refactor(web): test the live usage column builder

### DIFF
--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { buildDayColumns, niceScale } from "./UsageProviderChart";
+import { buildPeriodColumns, niceScale } from "./UsageProviderChart";
 import { providersWithUsage } from "./usageProviders";
 
 describe("niceScale", () => {
@@ -41,7 +41,7 @@ describe("niceScale", () => {
   });
 });
 
-describe("buildDayColumns", () => {
+describe("buildPeriodColumns", () => {
   const days = ["2026-08-01", "2026-08-02", "2026-08-03"];
   const byDay = new Map([
     [
@@ -69,11 +69,13 @@ describe("buildDayColumns", () => {
   ]);
 
   it("plots each day on its own", () => {
-    expect(buildDayColumns(days, byDay, "cost").map((column) => column.total)).toEqual([30, 0, 5]);
+    expect(buildPeriodColumns(days, byDay, "cost").map((column) => column.total)).toEqual([
+      30, 0, 5,
+    ]);
   });
 
   it("reads the requested metric", () => {
-    expect(buildDayColumns(days, byDay, "tokens").map((column) => column.total)).toEqual([
+    expect(buildPeriodColumns(days, byDay, "tokens").map((column) => column.total)).toEqual([
       300, 0, 50,
     ]);
   });
@@ -81,7 +83,7 @@ describe("buildDayColumns", () => {
   it("keeps band values absolute rather than cumulative", () => {
     // Regression: the bands were once stack offsets, which drew Claude Code
     // permanently above Codex regardless of which provider spent more.
-    const [first] = buildDayColumns(days, byDay, "cost");
+    const [first] = buildPeriodColumns(days, byDay, "cost");
 
     expect(first?.bands).toEqual([
       { provider: "codex", value: 10 },
@@ -91,7 +93,7 @@ describe("buildDayColumns", () => {
   });
 
   it("reports the total as the sum of its bands", () => {
-    for (const column of buildDayColumns(days, byDay, "cost")) {
+    for (const column of buildPeriodColumns(days, byDay, "cost")) {
       const sum = column.bands.reduce((running, band) => running + band.value, 0);
       expect(column.total).toBeCloseTo(sum, 9);
     }
@@ -125,7 +127,7 @@ describe("hourly chart columns", () => {
     ]);
 
     expect(
-      buildDayColumns(
+      buildPeriodColumns(
         ["2026-08-11T08:37:00.000Z", "2026-08-11T09:37:00.000Z", "2026-08-11T10:37:00.000Z"],
         byHour,
         "cost",

--- a/apps/web/src/components/usage/UsageProviderChart.tsx
+++ b/apps/web/src/components/usage/UsageProviderChart.tsx
@@ -54,7 +54,7 @@ function valueFor(
   return metric === "tokens" ? entry.totalTokens : entry.costUsd;
 }
 
-function buildPeriodColumns(
+export function buildPeriodColumns(
   periods: readonly string[],
   byPeriod: ReadonlyMap<string, DailyTotals | HourlyTotals>,
   metric: UsageChartMetric,
@@ -167,24 +167,6 @@ export function niceScale(peak: number, count: number): { max: number; ticks: re
   const ticks: number[] = [];
   for (let value = 0; value <= max + step * 1e-6; value += step) ticks.push(value);
   return { max, ticks };
-}
-
-/**
- * Turns the merged daily totals into one column per day.
- *
- * Values are absolute, not cumulative: each provider is drawn from the same
- * zero baseline so the chart never implies that one provider is always larger.
- *
- * The chart paths and the hover readout both consume this, so the number under
- * the cursor is by construction the number that was plotted rather than a
- * second derivation that can drift from it.
- */
-export function buildDayColumns(
-  days: readonly string[],
-  byDay: ReadonlyMap<string, DailyTotals>,
-  metric: UsageChartMetric,
-): readonly DayColumn[] {
-  return buildPeriodColumns(days, byDay, metric);
 }
 
 export function UsageProviderChart({


### PR DESCRIPTION
The usage-chart tests go through a forwarding wrapper that the chart itself never calls.

Remove that wrapper and point the same tests at the actual period-column builder. Keep all numeric, ordering, and band-value regressions; chart behavior is unchanged.

Verification: All 11 focused tests passed before and after. Web typecheck, targeted lint/format checks, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and export cleanup only; no changes to chart logic or data paths.
> 
> **Overview**
> Usage chart tests no longer go through a **daily-only wrapper** that the component never called. **`buildDayColumns` is removed**; **`buildPeriodColumns` is exported** and the same regression tests (totals, metrics, absolute band values, hourly zero-fill) now target that function directly.
> 
> Chart rendering still builds columns with **`buildPeriodColumns`**; only the public test surface and exports change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1adc8a20a7493425c505e3be123ea834b7072469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Export `buildPeriodColumns` and remove `buildDayColumns` wrapper in usage chart
> Renames the column-builder tests and calls from `buildDayColumns` to `buildPeriodColumns` in [UsageProviderChart.test.ts](https://github.com/pingdotgg/t3code/pull/9993/files#diff-d99d57a044a74f07ecab557801b7fd12fb1f67bae8ad9ced3250e94a252bae18). Exports `buildPeriodColumns` directly in [UsageProviderChart.tsx](https://github.com/pingdotgg/t3code/pull/9993/files#diff-52c28becdc9ddcf01c41d61d218f83687038f2efea310911245393fc696d5c56) and removes the `buildDayColumns` compatibility wrapper.
> - Risk: any external callers importing `buildDayColumns` will break; no in-tree callers remain after this change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1adc8a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->