### PR TITLE
refactor(web): remove unused aspect ratio reconciler

### DIFF
--- a/apps/web/src/browser/BrowserDeviceToolbar.test.ts
+++ b/apps/web/src/browser/BrowserDeviceToolbar.test.ts
@@ -1,10 +1,7 @@
 import type { PreviewViewportSetting } from "@t3tools/contracts";
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import {
-  commitViewportAndAspectRatio,
-  reconcileLockedAspectRatio,
-} from "./browserDeviceToolbarState";
+import { commitViewportAndAspectRatio } from "./browserDeviceToolbarState";
 
 describe("commitViewportAndAspectRatio", () => {
   it("commits the aspect ratio only after the viewport succeeds", async () => {
@@ -37,13 +34,5 @@ describe("commitViewportAndAspectRatio", () => {
       ),
     ).rejects.toThrow("resize failed");
     expect(onAspectRatioChange).not.toHaveBeenCalled();
-  });
-});
-
-describe("reconcileLockedAspectRatio", () => {
-  it("tracks external viewport ratios only while the lock remains active", () => {
-    expect(reconcileLockedAspectRatio(1.5, 16 / 9)).toBe(16 / 9);
-    expect(reconcileLockedAspectRatio(null, 16 / 9)).toBeNull();
-    expect(reconcileLockedAspectRatio(1.5, null)).toBeNull();
   });
 });

--- a/apps/web/src/browser/browserDeviceToolbarState.ts
+++ b/apps/web/src/browser/browserDeviceToolbarState.ts
@@ -1,12 +1,5 @@
 import type { PreviewViewportSetting } from "@t3tools/contracts";
 
-export function reconcileLockedAspectRatio(
-  current: number | null,
-  viewportAspectRatio: number | null,
-): number | null {
-  return current === null || viewportAspectRatio === null ? null : viewportAspectRatio;
-}
-
 export async function commitViewportAndAspectRatio(
   setting: PreviewViewportSetting,
   aspectRatio: number | null,


### PR DESCRIPTION
The aspect-ratio reconciliation helper is only called by its own test.

Remove it and that test. Keep the live viewport commit path and both success/failure ordering tests.

Verification: Focused toolbar suite: 3 tests before, 2 after. Web typecheck, targeted lint/format checks, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal with no changes to the live viewport commit path or its tests.
> 
> **Overview**
> Removes **`reconcileLockedAspectRatio`** from `browserDeviceToolbarState.ts` and drops its unit tests in `BrowserDeviceToolbar.test.ts`. The helper was unused outside its own test suite.
> 
> **`commitViewportAndAspectRatio`** and its two tests (success ordering and no aspect-ratio update on viewport failure) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e6a566e8f2df2e10fa3302a36795fc346382db3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `reconcileLockedAspectRatio` from `browserDeviceToolbarState`
> Deletes the exported `reconcileLockedAspectRatio` utility and its test suite from [browserDeviceToolbarState.ts](https://github.com/pingdotgg/t3code/pull/9994/files#diff-1449b95a509360028fdec651228644465391fe6682309210168aa193864ead7d) and [BrowserDeviceToolbar.test.ts](https://github.com/pingdotgg/t3code/pull/9994/files#diff-c61a760e24b26bdfdb2605916287dd13c766d8fbc0f99013decc7a387ed96077). The function returned the viewport aspect ratio when both locked and viewport ratios were non-null but was no longer used.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e6a566.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->