### PR TITLE
test(web): keep the preview profile label helper private

### DIFF
--- a/apps/web/src/components/preview/PreviewView.test.tsx
+++ b/apps/web/src/components/preview/PreviewView.test.tsx
@@ -251,7 +251,7 @@ vi.mock("./AgentBrowserCursor", () => ({ AgentBrowserCursor: () => null }));
 vi.mock("~/browser/BrowserSurfaceSlot", () => ({ BrowserSurfaceSlot: () => null }));
 vi.mock("./usePreviewSession", () => ({ usePreviewSession: vi.fn() }));
 
-import { PreviewView, previewProfileName } from "./PreviewView";
+import { PreviewView } from "./PreviewView";
 import { toastManager } from "~/components/ui/toast";
 import { previewRuntimeTabId } from "~/browser/previewRuntimeTabId";
 
@@ -350,12 +350,6 @@ describe("PreviewView navigation", () => {
     mocks.showEmptyState = false;
     mocks.loading = false;
     mocks.recordVisitForThread.mockClear();
-  });
-
-  it("labels a tab whose saved profile was removed", () => {
-    expect(previewProfileName(BUILT_IN_BROWSER_PROFILES, "profile-removed")).toBe(
-      "Removed profile",
-    );
   });
 
   it("does not rerender while loading time passes", async () => {

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -76,7 +76,7 @@ interface Props {
   ) => void;
 }
 
-export function previewProfileName(
+function previewProfileName(
   profiles: ReadonlyArray<{ readonly id: string; readonly name: string }>,
   profileId: string,
 ): string {


### PR DESCRIPTION
The preview profile-name lookup is exported only for a direct wording assertion.

Make the helper private and remove that test. Keep the preview navigation and rendering-behavior suite; the component and fallback label are unchanged.

Verification: Focused preview suite: 11 tests before, 10 after. Web typecheck and format/diff checks passed; targeted lint passed with existing warnings on untouched lines.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only surface-area change with no production logic changes; profile labeling in the UI is unchanged.
> 
> **Overview**
> **Makes `previewProfileName` a module-private helper** in `PreviewView.tsx` instead of a public export. Runtime behavior is unchanged: tabs still show profile names with the same **"Removed profile"** fallback when the saved profile id is missing.
> 
> **Drops the unit test** that imported the helper only to assert that fallback string. The rest of the `PreviewView` navigation and rendering tests stay as-is (suite goes from 11 to 10 tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 754e81d9b959ba64b3e9022c46e22ee4162932e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `previewProfileName` helper module-local in `PreviewView`
> Changes `previewProfileName` in `PreviewView.tsx` from an exported function to a module-local function. Removes the test that asserted a missing saved profile is labeled "Removed profile", which relied on the now-private helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 754e81d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->