### PR TITLE
test(relay): keep the stage slug helper private

### DIFF
--- a/infra/relay/src/deploymentConfig.test.ts
+++ b/infra/relay/src/deploymentConfig.test.ts
@@ -11,16 +11,9 @@ import {
   RelayPublicDomainLabelTooLongError,
   relayPublicDomainForStage,
   relayResourceNameForStage,
-  relayStageSlug,
 } from "./deploymentConfig.ts";
 
 const isRelayPublicDomainLabelTooLongError = Schema.is(RelayPublicDomainLabelTooLongError);
-
-describe("relayStageSlug", () => {
-  it("matches Alchemy physical-name sanitization for default developer stages", () => {
-    expect(relayStageSlug("dev_julius")).toBe("dev-julius");
-  });
-});
 
 describe("relayPublicDomainForStage", () => {
   it("uses the canonical relay hostname for production", () => {

--- a/infra/relay/src/deploymentConfig.ts
+++ b/infra/relay/src/deploymentConfig.ts
@@ -56,7 +56,7 @@ function appendDnsSafeSuffix(prefix: string, suffix: string): string {
  * Alchemy's physical-name helper sanitizes resource names after adding the
  * stage. Keep custom domains and runtime-created resources aligned with it.
  */
-export function relayStageSlug(stage: string): string {
+function relayStageSlug(stage: string): string {
   return stage
     .toLowerCase()
     .replaceAll(/[^a-z0-9-]/g, "-")


### PR DESCRIPTION
The relay stage-slug helper is exported only for a direct assertion already covered by the public hostname and resource-name tests.

Make it private and remove that duplicate test. Resource names, hostname validation, production zone ownership, and DNS length checks are unchanged.

Verification: focused deployment-config suite passed before (10 tests) and after (9 tests); relay typecheck, targeted lint/format checks, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export visibility and test-only cleanup with no logic changes; no other packages import `relayStageSlug`.
> 
> **Overview**
> **Makes `relayStageSlug` an internal helper** in `deploymentConfig.ts` instead of a public export, since stage sanitization is already exercised through the public APIs.
> 
> **Removes the dedicated `relayStageSlug` unit test** and its import from `deploymentConfig.test.ts`; behavior coverage stays on `relayPublicDomainForStage`, `relayResourceNameForStage`, and managed-endpoint hostname/tunnel tests (e.g. `dev_julius` → `dev-julius`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b0512e3bd8f49d58b3094d0405add1d7fed1a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `relayStageSlug` helper module-private in `deploymentConfig.ts`
> Changes `relayStageSlug` from an exported function to a module-private function. Removes the direct import of `relayStageSlug` and its dedicated test suite from [deploymentConfig.test.ts](https://github.com/pingdotgg/t3code/pull/9998/files#diff-700465a6e627409193f5b0170abdce58f88443c98fdab599a55dda6ada3a030f). The sanitization logic is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30b0512.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->