### PR TITLE
refactor(mobile): keep project selection helper private

### DIFF
--- a/apps/mobile/src/features/threads/new-task-project-selection.test.ts
+++ b/apps/mobile/src/features/threads/new-task-project-selection.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from "vite-plus/test";
 import type { EnvironmentProject } from "@t3tools/client-runtime/state/shell";
 import type { HomeProjectScope } from "../home/homeThreadList";
 import {
-  getOnlySelectableProject,
   getProjectScopeSelectionTarget,
   resolveDraftProjectSelection,
 } from "./new-task-project-selection";
@@ -35,18 +34,6 @@ function makeScope(projects: ReadonlyArray<EnvironmentProject>): HomeProjectScop
     })),
   };
 }
-
-describe("getOnlySelectableProject", () => {
-  it("auto-selects when there is exactly one physical project", () => {
-    const project = makeProject("t3code");
-    expect(getOnlySelectableProject([makeScope([project])])).toBe(project);
-  });
-
-  it("selects the representative when one logical project has multiple workspaces", () => {
-    const projects = [makeProject("t3code"), makeProject("t3code-2"), makeProject("t3code-3")];
-    expect(getOnlySelectableProject([makeScope(projects)])).toBe(projects[0]);
-  });
-});
 
 describe("getProjectScopeSelectionTarget", () => {
   it("keeps the current environment when it hosts the selected logical project", () => {

--- a/apps/mobile/src/features/threads/new-task-project-selection.ts
+++ b/apps/mobile/src/features/threads/new-task-project-selection.ts
@@ -19,7 +19,7 @@ export function getProjectScopeSelectionTarget(
   );
 }
 
-export function getOnlySelectableProject(
+function getOnlySelectableProject(
   projectScopes: ReadonlyArray<HomeProjectScope>,
 ): EnvironmentProject | null {
   const onlyScope = projectScopes.length === 1 ? projectScopes[0] : null;


### PR DESCRIPTION
getOnlySelectableProject is used by the public resolver in its own module; its only external callers were two tests that repeated the resolver's existing physical/logical project cases.

Make the helper private and remove those duplicates. Keep explicit-selection preservation, removed-project fallback, environment preference, and physical/logical project resolution coverage.

Focused new-task project-selection tests: 8 before, 6 after. Mobile package typecheck, targeted lint/format checks, and git diff --check pass.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Module boundary and test cleanup only; resolver behavior and exported API are unchanged.
> 
> **Overview**
> **`getOnlySelectableProject`** is no longer part of the module’s public API—it stays as an internal helper used only by **`resolveDraftProjectSelection`**.
> 
> The dedicated **`getOnlySelectableProject`** test block is removed because the same single-scope / representative behavior is already asserted through **`resolveDraftProjectSelection`** (only physical project and multi-workspace logical project cases). Remaining tests still cover environment preference, explicit selection, and removed-project fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14df0e1914bdd06e9bdf5329c8cdda25a8eb5a9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `getOnlySelectableProject` private in project selection helper
> Removes the export of `getOnlySelectableProject` in [new-task-project-selection.ts](https://github.com/pingdotgg/t3code/pull/9999/files#diff-8d009f9633c651c528c5597c97d1fede4cef7b05ff69dd719364cd55d5c6555c), making it module-private. Drops the function's direct unit tests in [new-task-project-selection.test.ts](https://github.com/pingdotgg/t3code/pull/9999/files#diff-d59b40c9575cc55144b5e65b0f2a80f5ccae50ddfcba1314d4a31a9f65669580); coverage now relies on higher-level tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14df0e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->