### PR TITLE
refactor(mobile): keep review default ID helper private

### DIFF
--- a/apps/mobile/src/features/review/reviewFileVisibility.test.ts
+++ b/apps/mobile/src/features/review/reviewFileVisibility.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
-  getDefaultReviewExpandedFileIds,
   getValidExplicitReviewFileIds,
   getValidReviewFileIds,
   removeReviewFileId,
@@ -29,7 +28,6 @@ describe("review file visibility", () => {
   const files = [makeFile("a.ts"), makeFile("b.ts")];
 
   it("defaults expanded files to every renderable file", () => {
-    expect(getDefaultReviewExpandedFileIds(files)).toEqual(["a.ts", "b.ts"]);
     expect(getValidReviewFileIds(files, undefined)).toEqual(["a.ts", "b.ts"]);
   });
 

--- a/apps/mobile/src/features/review/reviewFileVisibility.ts
+++ b/apps/mobile/src/features/review/reviewFileVisibility.ts
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from "react";
 import { updateReviewExpandedFileIds, updateReviewViewedFileIds } from "./reviewState";
 import type { ReviewRenderableFile } from "./reviewModel";
 
-export function getDefaultReviewExpandedFileIds(
+function getDefaultReviewExpandedFileIds(
   files: ReadonlyArray<ReviewRenderableFile>,
 ): ReadonlyArray<string> {
   return files.map((file) => file.id);


### PR DESCRIPTION
getDefaultReviewExpandedFileIds is only called by getValidReviewFileIds and its direct test. That test immediately repeats the same expected IDs through the public function.

Make the mapper private and remove the duplicate assertion. Keep default expansion, stale-ID filtering, explicit viewed defaults, and non-mutating toggle/removal checks.

Focused review-visibility tests: 3 before and after. Mobile package typecheck, targeted lint/format checks, and git diff --check pass.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal visibility and test cleanup only; no change to review expansion or caching behavior.
> 
> **Overview**
> **Encapsulates** default expanded-file ID mapping by making `getDefaultReviewExpandedFileIds` module-private instead of exported. Behavior is unchanged: `getValidReviewFileIds(files, undefined)` still expands to every renderable file ID via that helper.
> 
> **Tests** drop the redundant direct call to the private helper and keep asserting default expansion through the public `getValidReviewFileIds` API, along with existing stale-ID filtering, explicit viewed defaults, and toggle/remove immutability checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad4a09a92c6dc1758974c6e24e066da836c6dccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `getDefaultReviewExpandedFileIds` file-local in review visibility module
> Removes `getDefaultReviewExpandedFileIds` from the module's public API by dropping its export. The test in [reviewFileVisibility.test.ts](https://github.com/pingdotgg/t3code/pull/10000/files#diff-fd468f5b3e63ec2703880d877b86153f1e24d75fb1f65a4798f82e0196d1ee8d) now derives the default-expansion IDs via the existing valid-review-file helper instead of importing the function.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad4a09a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->