### PR TITLE
refactor(mobile): remove unused native style constants

### DIFF
--- a/apps/mobile/src/features/files/nativeSourceFileAdapter.test.ts
+++ b/apps/mobile/src/features/files/nativeSourceFileAdapter.test.ts
@@ -3,30 +3,10 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   buildNativeSourceRows,
   buildNativeSourceTokens,
-  NATIVE_SOURCE_ROW_HEIGHT,
-  NATIVE_SOURCE_STYLE,
   nativeSourceRowId,
 } from "./nativeSourceFileAdapter";
-import {
-  NATIVE_REVIEW_DIFF_ROW_HEIGHT,
-  NATIVE_REVIEW_DIFF_STYLE,
-} from "../review/nativeReviewDiffAdapter";
 
 describe("nativeSourceFileAdapter", () => {
-  it("uses the same compact code typography as the diff viewer", () => {
-    expect(NATIVE_SOURCE_ROW_HEIGHT).toBe(NATIVE_REVIEW_DIFF_ROW_HEIGHT);
-    expect(NATIVE_SOURCE_STYLE).toMatchObject({
-      rowHeight: NATIVE_REVIEW_DIFF_STYLE.rowHeight,
-      gutterWidth: NATIVE_REVIEW_DIFF_STYLE.gutterWidth,
-      codePadding: NATIVE_REVIEW_DIFF_STYLE.codePadding,
-      textVerticalInset: NATIVE_REVIEW_DIFF_STYLE.textVerticalInset,
-      codeFontSize: NATIVE_REVIEW_DIFF_STYLE.codeFontSize,
-      codeFontWeight: NATIVE_REVIEW_DIFF_STYLE.codeFontWeight,
-      lineNumberFontSize: NATIVE_REVIEW_DIFF_STYLE.lineNumberFontSize,
-      lineNumberFontWeight: NATIVE_REVIEW_DIFF_STYLE.lineNumberFontWeight,
-    });
-  });
-
   it("maps plain source lines onto context rows with stable line numbers", () => {
     expect(buildNativeSourceRows(["const value = 1;", "\treturn value;"])).toEqual([
       {

--- a/apps/mobile/src/features/files/nativeSourceFileAdapter.ts
+++ b/apps/mobile/src/features/files/nativeSourceFileAdapter.ts
@@ -4,16 +4,10 @@ import type {
   NativeReviewDiffToken,
 } from "../diffs/nativeReviewDiffSurface";
 import type { ResolvedMobileCodeSurface } from "../../lib/appearancePreferences";
-import { resolveMobileCodeSurface } from "../../lib/appearancePreferences";
 import { MOBILE_CODE_SURFACE, MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import type { SourceHighlightTokens } from "./sourceHighlightingState";
 
-export const NATIVE_SOURCE_ROW_HEIGHT = MOBILE_CODE_SURFACE.rowHeight;
 export const NATIVE_SOURCE_CONTENT_WIDTH = 32_000;
-
-export const NATIVE_SOURCE_STYLE: NativeReviewDiffStyle = createNativeSourceStyle(
-  resolveMobileCodeSurface(MOBILE_CODE_SURFACE.fontSize),
-);
 
 export function createNativeSourceStyle(
   codeSurface: ResolvedMobileCodeSurface,

--- a/apps/mobile/src/features/review/nativeReviewDiffAdapter.ts
+++ b/apps/mobile/src/features/review/nativeReviewDiffAdapter.ts
@@ -6,8 +6,6 @@ import type {
 import * as Arr from "effect/Array";
 import { pipe } from "effect/Function";
 import type { ResolvedMobileCodeSurface } from "../../lib/appearancePreferences";
-import { resolveMobileCodeSurface } from "../../lib/appearancePreferences";
-import { MOBILE_CODE_SURFACE } from "../../lib/typography";
 import { type MobileThemeId, type MobileThemeVariables } from "../../lib/mobileTheme";
 import { getMobileTerminalTheme, type TerminalAppearanceScheme } from "../terminal/terminalTheme";
 import { computeWordAltDiffRanges } from "./reviewWordDiffs";
@@ -25,12 +23,7 @@ const NATIVE_HEX_COLOR = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i;
 const NATIVE_RGBA_COLOR =
   /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)$/;
 
-export const NATIVE_REVIEW_DIFF_ROW_HEIGHT = MOBILE_CODE_SURFACE.rowHeight;
 export const NATIVE_REVIEW_DIFF_CONTENT_WIDTH = 2_800;
-
-export const NATIVE_REVIEW_DIFF_STYLE = createNativeReviewDiffStyle(
-  resolveMobileCodeSurface(MOBILE_CODE_SURFACE.fontSize),
-);
 
 function opaqueNativeHexColor(color: string, background: string): string {
   const hex = NATIVE_HEX_COLOR.exec(color);


### PR DESCRIPTION
The source/diff default row-height and style constants have no production callers; only a test compares them. Both viewers use appearance-aware style factories instead.

Remove the four unused constants, their owned imports, and the equality-only test. Keep the live style factories and source-row, token-mapping, and native diff adapter coverage unchanged.

Focused source/diff adapter tests: 11 before, 10 after. Mobile package typecheck, targeted lint/format checks, and git diff --check pass.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal with no production callers; runtime styling paths are unchanged.
> 
> **Overview**
> Removes **four default native code-view constants** (`NATIVE_SOURCE_ROW_HEIGHT`, `NATIVE_SOURCE_STYLE`, `NATIVE_REVIEW_DIFF_ROW_HEIGHT`, `NATIVE_REVIEW_DIFF_STYLE`) from the source and review diff adapters, along with imports that existed only to build those defaults.
> 
> **`createNativeSourceStyle`** and **`createNativeReviewDiffStyle`** stay as the live APIs; callers (e.g. appearance settings) already derive styles from **`ResolvedMobileCodeSurface`**. The deleted test only asserted that the removed source constants matched the diff constants—behavioral tests for row/token mapping are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 711843f279d395418a49046a04d9c402d6a53ef7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused native source and review diff style constants
> - Removes unused module-level row-height and style constants from [nativeSourceFileAdapter.ts](https://github.com/pingdotgg/t3code/pull/10001/files#diff-fbd74d72dc5cf4821bda1fece2c39a0d1bb55bf593f05db5ceb8ab5bbe5823ac) and [nativeReviewDiffAdapter.ts](https://github.com/pingdotgg/t3code/pull/10001/files#diff-6614ec9d7a7d681c251dea272795b05d9a910b6607687e308a73350d2ac5d9eb).
> - Drops the test in [nativeSourceFileAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/10001/files#diff-27a7698fd189b61aa797df39c3cb552c0b4d1c9f28f675ac6ed1b66ef5b762c0) that verified these constants matched between adapters.
> - The underlying style factories and adapter logic remain unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 711843f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->