### PR TITLE
refactor(mobile): test terminal palettes through public theme API

### DIFF
--- a/apps/mobile/src/features/terminal/terminalTheme.test.ts
+++ b/apps/mobile/src/features/terminal/terminalTheme.test.ts
@@ -3,15 +3,11 @@ import { BUILT_IN_THEMES, getThemeColorsForAppearance } from "@t3tools/shared/th
 
 import { themeColorToNativeColor } from "../../lib/mobileTheme";
 
-import {
-  buildGhosttyThemeConfig,
-  getMobileTerminalTheme,
-  getPierreTerminalTheme,
-} from "./terminalTheme";
+import { buildGhosttyThemeConfig, getMobileTerminalTheme } from "./terminalTheme";
 
-describe("getPierreTerminalTheme", () => {
-  it("returns the Pierre light terminal palette", () => {
-    expect(getPierreTerminalTheme("light")).toMatchObject({
+describe("getMobileTerminalTheme", () => {
+  it("preserves the default light terminal palette", () => {
+    expect(getMobileTerminalTheme("t3-code", "light")).toMatchObject({
       background: "#f2f2f7",
       foreground: "#6C6C71",
       cursorForeground: "#009fff",
@@ -19,23 +15,14 @@ describe("getPierreTerminalTheme", () => {
     });
   });
 
-  it("returns the Pierre dark terminal palette", () => {
-    expect(getPierreTerminalTheme("dark")).toMatchObject({
+  it("preserves the default dark terminal palette", () => {
+    expect(getMobileTerminalTheme("t3-code", "dark")).toMatchObject({
       background: "#0a0a0a",
       foreground: "#adadb1",
       cursorForeground: "#009fff",
       cursorBackground: "#0a0a0a",
     });
   });
-});
-
-describe("getMobileTerminalTheme", () => {
-  it("preserves the Pierre terminal for the default theme", () => {
-    for (const scheme of ["light", "dark"] as const) {
-      expect(getMobileTerminalTheme("t3-code", scheme)).toEqual(getPierreTerminalTheme(scheme));
-    }
-  });
-
   it("applies the selected palette without replacing ANSI status colors", () => {
     const standard = getMobileTerminalTheme("t3-code", "dark");
     const ocean = getMobileTerminalTheme("ocean", "dark");
@@ -58,7 +45,7 @@ describe("getMobileTerminalTheme", () => {
 
 describe("buildGhosttyThemeConfig", () => {
   it("serializes theme colors into a ghostty config file", () => {
-    const config = buildGhosttyThemeConfig(getPierreTerminalTheme("dark"));
+    const config = buildGhosttyThemeConfig(getMobileTerminalTheme("t3-code", "dark"));
 
     expect(config).toContain("background = #0a0a0a");
     expect(config).toContain("foreground = #adadb1");

--- a/apps/mobile/src/features/terminal/terminalTheme.ts
+++ b/apps/mobile/src/features/terminal/terminalTheme.ts
@@ -74,7 +74,7 @@ const PIERRE_DARK_THEME: TerminalTheme = {
   ],
 };
 
-export function getPierreTerminalTheme(scheme: TerminalAppearanceScheme): TerminalTheme {
+function getPierreTerminalTheme(scheme: TerminalAppearanceScheme): TerminalTheme {
   return scheme === "light" ? PIERRE_LIGHT_THEME : PIERRE_DARK_THEME;
 }
 


### PR DESCRIPTION
getPierreTerminalTheme is only used internally by getMobileTerminalTheme and directly by tests. A separate test merely compares that public function to its helper.

Make the helper private and test explicit light/dark palette values through getMobileTerminalTheme. Keep custom-palette/ANSI behavior and Ghostty serialization checks, also using the public API.

Focused terminal-theme tests: 6 before, 5 after. Mobile package typecheck, targeted lint/format checks, and git diff --check pass.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and export-surface cleanup only; no change to how `getMobileTerminalTheme` builds themes for app code.
> 
> **Overview**
> **Makes `getPierreTerminalTheme` module-private** so mobile terminal styling is exercised only through **`getMobileTerminalTheme`**.
> 
> **Updates terminal theme tests** to assert default `t3-code` light/dark palette values on the public API, drops the redundant “public equals helper” case, and keeps custom palette / ANSI palette and Ghostty serialization checks—**Ghostty tests now build config from `getMobileTerminalTheme("t3-code", "dark")`** instead of the former exported helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc6761d45442092cadacd48d501794b9cd434d1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `getPierreTerminalTheme` private and test terminal palettes via public `getMobileTerminalTheme` API
> Removes the export of `getPierreTerminalTheme` in [terminalTheme.ts](https://github.com/pingdotgg/t3code/pull/10002/files#diff-33e4897ec97176de2d7850f55123686d6ab2e2f06b293996defb50974628dcef), making it module-private. Updates tests in [terminalTheme.test.ts](https://github.com/pingdotgg/t3code/pull/10002/files#diff-712bad5a6ca6e9869fee1210f1676bdffb0529ad884f941b67966a7a9dde4146) to import only the public `getMobileTerminalTheme` builder, passing the `t3-code` identifier for default palette assertions and Ghostty config fixture generation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc6761d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->