### PR TITLE
refactor(mobile): remove unused file tree walkers

### DIFF
--- a/apps/mobile/src/features/files/fileTree.test.ts
+++ b/apps/mobile/src/features/files/fileTree.test.ts
@@ -1,13 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import type { ProjectEntry } from "@t3tools/contracts";
 
-import {
-  buildFileTree,
-  countFileNodes,
-  defaultExpandedTreePaths,
-  firstFilePath,
-  flattenFileTree,
-} from "./fileTree";
+import { buildFileTree, defaultExpandedTreePaths, flattenFileTree } from "./fileTree";
 
 const entries = [
   { kind: "file", path: "README.md" },
@@ -30,8 +24,6 @@ describe("mobile file tree helpers", () => {
       "directory:src/components",
       "file:src/index.ts",
     ]);
-    expect(countFileNodes(tree)).toBe(4);
-    expect(firstFilePath(tree)).toBe("src/components/App.tsx");
   });
 
   it("flattens expanded directories and hides collapsed descendants", () => {

--- a/apps/mobile/src/features/files/fileTree.ts
+++ b/apps/mobile/src/features/files/fileTree.ts
@@ -117,18 +117,6 @@ export function buildFileTree(entries: ReadonlyArray<ProjectEntry>): ReadonlyArr
   return [...root.children.values()].sort(compareNodes).map(freezeNode);
 }
 
-export function countFileNodes(nodes: ReadonlyArray<FileTreeNode>): number {
-  let count = 0;
-  for (const node of nodes) {
-    if (node.kind === "file") {
-      count += 1;
-    } else {
-      count += countFileNodes(node.children);
-    }
-  }
-  return count;
-}
-
 export function defaultExpandedTreePaths(nodes: ReadonlyArray<FileTreeNode>): ReadonlySet<string> {
   const expanded = new Set<string>();
   for (const node of nodes) {
@@ -204,17 +192,4 @@ export function flattenFileTree(input: {
     flattenNode(output, node, 0, input.expanded, searchTokens);
   }
   return output;
-}
-
-export function firstFilePath(nodes: ReadonlyArray<FileTreeNode>): string | null {
-  for (const node of nodes) {
-    if (node.kind === "file") {
-      return node.path;
-    }
-    const child = firstFilePath(node.children);
-    if (child !== null) {
-      return child;
-    }
-  }
-  return null;
 }


### PR DESCRIPTION
countFileNodes and firstFilePath have no production callers; repository references are limited to their own recursion and direct test assertions.

Remove both walkers and those assertions. Keep hierarchy ordering, expanded/collapsed visibility, ancestor matching, fuzzy path search, and default expansion tests unchanged.

Focused file-tree tests: 5 before and after. Mobile package typecheck, targeted lint/format checks, and git diff --check pass.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure removal of unused helpers and test-only assertions; no behavior change to exported APIs still in use.
> 
> **Overview**
> Removes dead code from the mobile file tree helpers: **`countFileNodes`** and **`firstFilePath`** are deleted from `fileTree.ts` because nothing in production used them.
> 
> The file tree test suite drops imports and assertions that only exercised those two walkers. **Hierarchy building, flattening with expand/collapse, search/ancestor matching, fuzzy queries, and default expansion** tests are unchanged (still five cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76b49a799ddc12c1e8d270b5ea0fa5205d69f6d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `countFileNodes` and `firstFilePath` from mobile file tree helpers
> Deletes the two recursive utilities and their test assertions from [fileTree.ts](https://github.com/pingdotgg/t3code/pull/10003/files#diff-a426e27c1f37249856061a16c0178f7ecc596f91ace03cbe96fa81352aafdc67) and [fileTree.test.ts](https://github.com/pingdotgg/t3code/pull/10003/files#diff-68f83d46b19be72ebb8f7e46c980b4cff90476304bb1a531de093518350a2ec4). Remaining tests still cover tree construction, flattening, and default expansion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76b49a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->