### PR TITLE
refactor(shared): keep persisted settings helpers private

### DIFF
--- a/packages/shared/src/serverSettings.test.ts
+++ b/packages/shared/src/serverSettings.test.ts
@@ -11,43 +11,34 @@ import { resolveServerBackgroundActivitySettings } from "./backgroundActivitySet
 import { createModelSelection } from "./model.ts";
 import {
   applyServerSettingsPatch,
-  extractPersistedServerObservabilitySettings,
   isModelSelectionProviderEnabled,
-  normalizePersistedServerSettingString,
   parsePersistedServerObservabilitySettings,
   resolveSourceControlWriterModelSelection,
 } from "./serverSettings.ts";
 
 describe("serverSettings helpers", () => {
-  it("normalizes optional persisted strings", () => {
-    expect(normalizePersistedServerSettingString(undefined)).toBeUndefined();
-    expect(normalizePersistedServerSettingString("   ")).toBeUndefined();
-    expect(normalizePersistedServerSettingString("  http://localhost:4318/v1/traces  ")).toBe(
-      "http://localhost:4318/v1/traces",
-    );
-  });
-
-  it("extracts persisted observability settings", () => {
+  it("ignores missing and blank persisted observability URLs", () => {
+    expect(parsePersistedServerObservabilitySettings("{}")).toEqual({
+      otlpTracesUrl: undefined,
+      otlpMetricsUrl: undefined,
+    });
     expect(
-      extractPersistedServerObservabilitySettings({
-        observability: {
-          otlpTracesUrl: "  http://localhost:4318/v1/traces  ",
-          otlpMetricsUrl: "  http://localhost:4318/v1/metrics  ",
-        },
-      }),
+      parsePersistedServerObservabilitySettings(
+        JSON.stringify({ observability: { otlpTracesUrl: "   ", otlpMetricsUrl: "" } }),
+      ),
     ).toEqual({
-      otlpTracesUrl: "http://localhost:4318/v1/traces",
-      otlpMetricsUrl: "http://localhost:4318/v1/metrics",
+      otlpTracesUrl: undefined,
+      otlpMetricsUrl: undefined,
     });
   });
 
-  it("parses lenient persisted settings JSON", () => {
+  it("parses lenient persisted settings JSON and trims observability URLs", () => {
     expect(
       parsePersistedServerObservabilitySettings(
         JSON.stringify({
           observability: {
-            otlpTracesUrl: "http://localhost:4318/v1/traces",
-            otlpMetricsUrl: "http://localhost:4318/v1/metrics",
+            otlpTracesUrl: "  http://localhost:4318/v1/traces  ",
+            otlpMetricsUrl: "  http://localhost:4318/v1/metrics  ",
           },
         }),
       ),

--- a/packages/shared/src/serverSettings.ts
+++ b/packages/shared/src/serverSettings.ts
@@ -69,14 +69,14 @@ export interface PersistedServerObservabilitySettings {
   readonly otlpMetricsUrl: string | undefined;
 }
 
-export function normalizePersistedServerSettingString(
+function normalizePersistedServerSettingString(
   value: string | null | undefined,
 ): string | undefined {
   const trimmed = value?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : undefined;
 }
 
-export function extractPersistedServerObservabilitySettings(input: {
+function extractPersistedServerObservabilitySettings(input: {
   readonly observability?: {
     readonly otlpTracesUrl?: string;
     readonly otlpMetricsUrl?: string;


### PR DESCRIPTION
The persisted-string normalizer and observability extractor are used only inside their module and by direct tests.

Make them private and test their outcomes through parsePersistedServerObservabilitySettings. Keep explicit missing/blank/trimmed URL expectations and malformed-JSON fallback, plus the existing settings merge/provider-selection coverage.

Focused server-settings tests: 25 before, 24 after. Shared package typecheck, targeted lint/format checks, and git diff --check pass.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with no API or runtime behavior change beyond hiding two helpers; risk is limited to test coverage alignment.
> 
> **Overview**
> **`normalizePersistedServerSettingString` and `extractPersistedServerObservabilitySettings` are no longer part of the shared package’s public API**—they stay module-private and are only used when building results from **`parsePersistedServerObservabilitySettings`**.
> 
> Tests were reshaped to match: direct helper coverage was removed in favor of **`parsePersistedServerObservabilitySettings`**, still asserting that missing/blank OTLP URLs become `undefined`, valid URLs are trimmed, and invalid JSON falls back safely. Observability parsing behavior is unchanged; only encapsulation and how it’s verified moved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a53956869db552658c4bdb16ceef56eda20aec09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `normalizePersistedServerSettingString` and `extractPersistedServerObservabilitySettings` private in `serverSettings`
> Converts two exported helpers in [serverSettings.ts](https://github.com/pingdotgg/t3code/pull/10004/files#diff-043ca428f05b5295b6161cdcb2c48bd97c3985f21faa3a8214057decca51518f) to file-private functions. Their trimming and blank-value handling are unchanged. Tests in [serverSettings.test.ts](https://github.com/pingdotgg/t3code/pull/10004/files#diff-7e40ca4f652952527cffdd29ffa9e492fa97dfacff250aa1889c5b7aaa1b235e) now exercise behavior through the public persisted-settings parser instead of calling the helpers directly, adding coverage for absent, blank, and whitespace-only URLs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a539568.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->