### PR TITLE
refactor(shared): test favicon selection through public API

### DIFF
--- a/packages/shared/src/favicon.test.ts
+++ b/packages/shared/src/favicon.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 
-import {
-  explicitFaviconUrl,
-  faviconUrlForOrigin,
-  faviconUrlForPage,
-  toolActivityFaviconUrl,
-} from "./favicon.ts";
+import { faviconUrlForOrigin, toolActivityFaviconUrl } from "./favicon.ts";
 
 describe("faviconUrlForOrigin", () => {
   it.each([
@@ -46,12 +41,12 @@ describe("faviconUrlForOrigin", () => {
   );
 });
 
-describe("faviconUrlForPage", () => {
+describe("toolActivityFaviconUrl", () => {
   it("uses the page origin instead of a third-party favicon service", () => {
-    expect(faviconUrlForPage("https://example.com/docs/page?q=1")).toBe(
+    expect(toolActivityFaviconUrl({ pageUrl: "https://example.com/docs/page?q=1" }, "light")).toBe(
       "https://example.com/favicon.ico",
     );
-    expect(faviconUrlForPage("http://localhost:5173/app")).toBe(
+    expect(toolActivityFaviconUrl({ pageUrl: "http://localhost:5173/app" }, "light")).toBe(
       "http://localhost:5173/favicon.ico",
     );
   });
@@ -86,7 +81,17 @@ describe("faviconUrlForPage", () => {
   });
 
   it("accepts provider-supplied image URLs but rejects extension URLs", () => {
-    expect(explicitFaviconUrl("https://example.com/icon.png")).toBe("https://example.com/icon.png");
-    expect(explicitFaviconUrl("chrome-extension://example/_favicon/")).toBeNull();
+    expect(
+      toolActivityFaviconUrl(
+        { pageUrl: "https://example.com/docs", faviconUrl: "https://example.com/icon.png" },
+        "light",
+      ),
+    ).toBe("https://example.com/icon.png");
+    expect(
+      toolActivityFaviconUrl(
+        { pageUrl: "https://example.com/docs", faviconUrl: "chrome-extension://example/_favicon/" },
+        "light",
+      ),
+    ).toBe("https://example.com/favicon.ico");
   });
 });

--- a/packages/shared/src/favicon.ts
+++ b/packages/shared/src/favicon.ts
@@ -5,7 +5,7 @@ import { isPublicFaviconHost } from "./hostClassification.ts";
  * conventional favicon and let the image element fall back to a browser glyph.
  * Chrome-backed tools can pass their tab's explicit favicon URL separately.
  */
-export function faviconUrlForPage(rawUrl: string | null | undefined, _size = 32): string | null {
+function faviconUrlForPage(rawUrl: string | null | undefined, _size = 32): string | null {
   if (!rawUrl || rawUrl.length > 4096) return null;
   try {
     const pageUrl = new URL(rawUrl);
@@ -40,7 +40,7 @@ function themedFaviconUrlForPage(
 }
 
 /** Accepts image URLs supplied by a trusted provider event. */
-export function explicitFaviconUrl(rawUrl: string | null | undefined): string | null {
+function explicitFaviconUrl(rawUrl: string | null | undefined): string | null {
   if (!rawUrl || rawUrl.length > 4096) return null;
   try {
     const url = new URL(rawUrl);


### PR DESCRIPTION
faviconUrlForPage and explicitFaviconUrl are only used inside toolActivityFaviconUrl and directly by tests.

Make them private and assert conventional/local favicon selection and provider-image/extension fallback through the public selector. Keep themed-icon precedence and all private-host, malformed-origin, and unsupported-protocol coverage unchanged.

Focused favicon tests: 30 before and after. Shared package typecheck, targeted lint/format checks, and git diff --check pass.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only refactor and test realignment with no changes to favicon resolution logic in production code.
> 
> **Overview**
> **Encapsulates** favicon helpers by making `faviconUrlForPage` and `explicitFaviconUrl` module-private; selection behavior stays routed through **`toolActivityFaviconUrl`**.
> 
> **Tests** stop importing those helpers and instead exercise conventional `/favicon.ico` fallback, themed GitHub icons, provider light/dark URLs, and trusted vs rejected favicon URLs via the public selector. The extension-URL case now asserts fallback to the page origin’s **`/favicon.ico`** (matching the full resolution chain) rather than a bare **`null`** from `explicitFaviconUrl` alone.
> 
> **`faviconUrlForOrigin`** tests are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49c1c45639fcce0fadfe333c97c7bed31e8b1555. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Test favicon selection through public API in `shared` package
> Removes the exports of `faviconUrlForPage` and `explicitFaviconUrl` from [favicon.ts](https://github.com/pingdotgg/t3code/pull/10005/files#diff-130df2363f611bc7aaf20f8d7bf716468b18436af9824e0d7a41b5afca6337b8), making them module-private. Updates [favicon.test.ts](https://github.com/pingdotgg/t3code/pull/10005/files#diff-670cec8ad89d7763ef57423188b834c80e2382f87e6cfcc072530ce660d4f8ed) to exercise origin fallback and explicit favicon validation through the public `toolActivityFaviconUrl` helper instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49c1c45.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->