### PR TITLE
refactor(mobile): test final connection status presentation

### DIFF
--- a/apps/mobile/src/features/home/workspace-connection-status.test.ts
+++ b/apps/mobile/src/features/home/workspace-connection-status.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import type { WorkspaceState } from "../../state/workspaceModel";
-import {
-  shouldShowWorkspaceConnectionStatus,
-  workspaceConnectionStatusLabel,
-  workspaceConnectionStatusPresentation,
-} from "./workspace-connection-status";
+import { workspaceConnectionStatusPresentation } from "./workspace-connection-status";
 
 function workspaceState(overrides: Partial<WorkspaceState> = {}): WorkspaceState {
   return {
@@ -27,14 +23,16 @@ function workspaceState(overrides: Partial<WorkspaceState> = {}): WorkspaceState
 
 describe("workspace connection status", () => {
   it("stays hidden while a ready environment is connected", () => {
-    expect(shouldShowWorkspaceConnectionStatus(workspaceState())).toBe(false);
+    expect(workspaceConnectionStatusPresentation(workspaceState())).toBeNull();
   });
 
   it("surfaces offline snapshots", () => {
     const state = workspaceState({ networkStatus: "offline", hasReadyEnvironment: false });
 
-    expect(shouldShowWorkspaceConnectionStatus(state)).toBe(true);
-    expect(workspaceConnectionStatusLabel(state)).toBe("You are offline");
+    expect(workspaceConnectionStatusPresentation(state)).toEqual({
+      label: "You are offline",
+      showsProgress: false,
+    });
   });
 
   it("names the environment while reconnecting", () => {
@@ -54,8 +52,10 @@ describe("workspace connection status", () => {
       ],
     });
 
-    expect(shouldShowWorkspaceConnectionStatus(state)).toBe(true);
-    expect(workspaceConnectionStatusLabel(state)).toBe("Reconnecting to Julius’s Mac mini");
+    expect(workspaceConnectionStatusPresentation(state)).toEqual({
+      label: "Reconnecting to Julius’s Mac mini",
+      showsProgress: true,
+    });
   });
 
   it("surfaces connection errors before the generic disconnected fallback", () => {
@@ -65,15 +65,19 @@ describe("workspace connection status", () => {
       hasReadyEnvironment: false,
     });
 
-    expect(shouldShowWorkspaceConnectionStatus(state)).toBe(true);
-    expect(workspaceConnectionStatusLabel(state)).toBe("Could not reach Julius’s Mac mini");
+    expect(workspaceConnectionStatusPresentation(state)).toEqual({
+      label: "Could not reach Julius’s Mac mini",
+      showsProgress: false,
+    });
   });
 
   it("shows shell catch-up while cached threads remain visible", () => {
     const state = workspaceState({ hasPendingShellSnapshot: true });
 
-    expect(shouldShowWorkspaceConnectionStatus(state)).toBe(true);
-    expect(workspaceConnectionStatusLabel(state)).toBe("Syncing threads...");
+    expect(workspaceConnectionStatusPresentation(state)).toEqual({
+      label: "Syncing threads...",
+      showsProgress: true,
+    });
   });
 
   it("distinguishes initial shell loading from cached catch-up", () => {
@@ -82,39 +86,9 @@ describe("workspace connection status", () => {
       hasPendingShellSnapshot: true,
     });
 
-    expect(shouldShowWorkspaceConnectionStatus(state)).toBe(true);
-    expect(workspaceConnectionStatusLabel(state)).toBe("Loading threads...");
-  });
-
-  it("presents nothing while connected", () => {
-    expect(workspaceConnectionStatusPresentation(workspaceState())).toBeNull();
-  });
-
-  it("presents progress while reconnecting but not while offline", () => {
-    const reconnecting = workspaceState({
-      hasConnectingEnvironment: true,
-      hasReadyEnvironment: false,
-      connectingEnvironments: [
-        {
-          environmentId: "environment-1" as never,
-          environmentLabel: "Julius’s Mac mini",
-          displayUrl: "",
-          isRelayManaged: false,
-          connectionState: "reconnecting",
-          connectionError: null,
-          connectionErrorTraceId: null,
-        },
-      ],
-    });
-    expect(workspaceConnectionStatusPresentation(reconnecting)).toEqual({
-      label: "Reconnecting to Julius’s Mac mini",
+    expect(workspaceConnectionStatusPresentation(state)).toEqual({
+      label: "Loading threads...",
       showsProgress: true,
-    });
-
-    const offline = workspaceState({ networkStatus: "offline", hasReadyEnvironment: false });
-    expect(workspaceConnectionStatusPresentation(offline)).toEqual({
-      label: "You are offline",
-      showsProgress: false,
     });
   });
 });

--- a/apps/mobile/src/features/home/workspace-connection-status.ts
+++ b/apps/mobile/src/features/home/workspace-connection-status.ts
@@ -6,7 +6,7 @@ export interface WorkspaceConnectionStatusPresentation {
   readonly showsProgress: boolean;
 }
 
-export function shouldShowWorkspaceConnectionStatus(state: WorkspaceState): boolean {
+function shouldShowWorkspaceConnectionStatus(state: WorkspaceState): boolean {
   return (
     state.networkStatus === "offline" ||
     state.connectionError !== null ||
@@ -16,7 +16,7 @@ export function shouldShowWorkspaceConnectionStatus(state: WorkspaceState): bool
   );
 }
 
-export function workspaceConnectionStatusLabel(state: WorkspaceState): string {
+function workspaceConnectionStatusLabel(state: WorkspaceState): string {
   if (state.networkStatus === "offline") return "You are offline";
   if (state.connectingEnvironments.length === 1) {
     return `Reconnecting to ${state.connectingEnvironments[0]!.environmentLabel}`;


### PR DESCRIPTION
The visibility and label helpers are only called by workspaceConnectionStatusPresentation and directly by tests. Several tests repeat the same connected/offline/reconnecting scenarios at both levels.

Make the helpers private and assert the final label/progress object. Preserve connected, offline, named reconnect, connection error, cached syncing, and initial loading cases while consolidating duplicate scenarios.

Focused connection-status tests: 8 before, 6 after. Mobile package typecheck, targeted lint/format checks, and git diff --check pass.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor and test-only surface-area change with no change to the exported presentation API or runtime behavior.
> 
> **Overview**
> **Encapsulates** workspace connection status helpers by making `shouldShowWorkspaceConnectionStatus` and `workspaceConnectionStatusLabel` module-private; callers and tests now go through **`workspaceConnectionStatusPresentation`** only.
> 
> **Tests** were tightened from eight to six cases by dropping duplicate low-level visibility/label/progress checks and asserting the full `{ label, showsProgress }` object (or `null` when connected) for offline, reconnect, errors, syncing, and initial loading scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f74133b2e53ee91f590d2f4f4e47940e1b51095b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `workspaceConnectionStatusLabel` and `shouldShowWorkspaceConnectionStatus` private and refactor their tests
> Changes the two helpers in [workspace-connection-status.ts](https://github.com/pingdotgg/t3code/pull/10007/files#diff-4f0c34a8068b1744e0acbb5b3cd033202189b7ade5067bcfe667df3ad3a762e1) from exported to module-private. Updates the test suite in [workspace-connection-status.test.ts](https://github.com/pingdotgg/t3code/pull/10007/files#diff-4ecdff5f0a1c30cd54ffa47ef211205524059e2a7c94587237f155d03f881ae3) to test only the exported presentation function, removing direct imports and assertions for the now-private helpers.
> - Risk: consumers importing `shouldShowWorkspaceConnectionStatus` or `workspaceConnectionStatusLabel` will break
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f74133b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->