### PR TITLE
refactor(shared): remove unused Clerk hostname predicate

### DIFF
--- a/packages/shared/src/relayAuth.test.ts
+++ b/packages/shared/src/relayAuth.test.ts
@@ -5,7 +5,6 @@ import {
   ClerkPublishableKeyFrontendApiError,
   clerkFrontendApiHostnameFromPublishableKey,
   clerkFrontendApiUrlFromPublishableKey,
-  isAllowedClerkFrontendApiHostname,
 } from "./relayAuth.ts";
 
 const clerkPublishableKey = (hostname: string): string => `pk_test_${btoa(`${hostname}$`)}`;
@@ -74,15 +73,5 @@ describe("Clerk relay auth", () => {
       reason: "invalid-url",
     });
     expect((error as ClerkPublishableKeyFrontendApiError).cause).toBeInstanceOf(Error);
-  });
-
-  it("allows standard Clerk hosts and an exact configured custom hostname", () => {
-    expect(isAllowedClerkFrontendApiHostname("example.clerk.accounts.dev", null)).toBe(true);
-    expect(isAllowedClerkFrontendApiHostname("example.clerk.accounts.com", null)).toBe(true);
-    expect(isAllowedClerkFrontendApiHostname("clerk.t3.codes", "clerk.t3.codes")).toBe(true);
-    expect(isAllowedClerkFrontendApiHostname("attacker.example", "clerk.t3.codes")).toBe(false);
-    expect(isAllowedClerkFrontendApiHostname("nested.clerk.t3.codes", "clerk.t3.codes")).toBe(
-      false,
-    );
   });
 });

--- a/packages/shared/src/relayAuth.ts
+++ b/packages/shared/src/relayAuth.ts
@@ -81,17 +81,6 @@ export function clerkFrontendApiHostnameFromPublishableKey(publishableKey: strin
   return parseClerkFrontendApi(publishableKey).hostname;
 }
 
-export function isAllowedClerkFrontendApiHostname(
-  hostname: string,
-  configuredHostname: string | null,
-): boolean {
-  return (
-    hostname.endsWith(".clerk.accounts.dev") ||
-    hostname.endsWith(".clerk.accounts.com") ||
-    hostname === configuredHostname
-  );
-}
-
 export function relayClerkTokenOptions(template: string) {
   return {
     template,


### PR DESCRIPTION
isAllowedClerkFrontendApiHostname has no production callers; only its direct hostname test references it. It is not part of the active relay-auth validation path.

Remove the orphan predicate and its test. Keep publishable-key hostname/URL derivation and decoding, empty/path, and URL-parser error coverage unchanged.

Focused relay-auth tests: 5 before, 4 after. Shared package typecheck, targeted lint/format checks, and git diff --check pass.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal with no callers; relay-auth behavior and exports used in production are unchanged.
> 
> **Overview**
> Removes the unused **`isAllowedClerkFrontendApiHostname`** helper from `relayAuth.ts` and drops its dedicated test case from `relayAuth.test.ts`.
> 
> **Publishable-key** hostname/URL derivation, decoding errors, and the rest of the relay-auth test suite are unchanged—this only deletes dead code that was not on the active validation path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9106ee1aa8a43ba7e0b367e1c20bbcb2ea8cd4ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `isAllowedClerkFrontendApiHostname` helper
> Deletes the exported Clerk hostname allowlist helper from [relayAuth.ts](https://github.com/pingdotgg/t3code/pull/10008/files#diff-410af5027d54ec0d2b400533989d5d3988ccde98d119e45a7996b1b548a957d5) and its test suite in [relayAuth.test.ts](https://github.com/pingdotgg/t3code/pull/10008/files#diff-636c0ea0bddaee829b1fefdc2c40f90b49969c8d2a610b6c56094910ba2f4791). The helper checked for standard Clerk Accounts suffixes or exact configured custom hostnames and rejected others. It is no longer referenced, so removing it is a pure cleanup with no runtime impact.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9106ee1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->