### PR TITLE
refactor(web): remove unused terminal context preview formatter

### DIFF
--- a/apps/web/src/lib/terminalContext.test.ts
+++ b/apps/web/src/lib/terminalContext.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   appendTerminalContextsToPrompt,
-  buildTerminalContextPreviewTitle,
   buildTerminalContextBlock,
   countInlineTerminalContextPlaceholders,
   deriveDisplayedUserMessageState,
@@ -133,20 +132,6 @@ describe("terminalContext", () => {
       previewTitle: null,
       contexts: [],
     });
-  });
-
-  it("returns null preview title when every context is invalid", () => {
-    expect(
-      buildTerminalContextPreviewTitle([
-        makeContext({
-          terminalId: "   ",
-        }),
-        makeContext({
-          id: "context-2",
-          text: "\n\n",
-        }),
-      ]),
-    ).toBeNull();
   });
 
   it("tracks inline terminal context placeholders in prompt text", () => {

--- a/apps/web/src/lib/terminalContext.ts
+++ b/apps/web/src/lib/terminalContext.ts
@@ -65,20 +65,6 @@ export function filterTerminalContextsWithText<T extends { text: string }>(
   return contexts.filter((context) => hasTerminalContextText(context));
 }
 
-function previewTerminalContextText(text: string): string {
-  const normalized = normalizeTerminalContextText(text);
-  if (normalized.length === 0) {
-    return "";
-  }
-  const lines = normalized.split("\n");
-  const visibleLines = lines.slice(0, 3);
-  if (lines.length > 3) {
-    visibleLines.push("...");
-  }
-  const preview = visibleLines.join("\n");
-  return preview.length > 180 ? `${preview.slice(0, 177)}...` : preview;
-}
-
 export function normalizeTerminalContextSelection(
   selection: TerminalContextSelection,
 ): TerminalContextSelection | null {
@@ -127,27 +113,6 @@ export function formatInlineTerminalContextLabel(selection: {
       ? `${selection.lineStart}`
       : `${selection.lineStart}-${selection.lineEnd}`;
   return `@${terminalLabel}:${range}`;
-}
-
-export function buildTerminalContextPreviewTitle(
-  contexts: ReadonlyArray<TerminalContextSelection>,
-): string | null {
-  if (contexts.length === 0) {
-    return null;
-  }
-  const previewParts: string[] = [];
-  for (const context of contexts) {
-    const normalized = normalizeTerminalContextSelection(context);
-    if (!normalized) continue;
-    const preview = previewTerminalContextText(normalized.text);
-    previewParts.push(
-      preview.length > 0
-        ? `${formatTerminalContextLabel(normalized)}\n${preview}`
-        : formatTerminalContextLabel(normalized),
-    );
-  }
-  const previews = previewParts.join("\n\n");
-  return previews.length > 0 ? previews : null;
 }
 
 function buildTerminalContextBodyLines(selection: TerminalContextSelection): string[] {


### PR DESCRIPTION
`buildTerminalContextPreviewTitle` has no production caller. Repository-wide caller searches found only its definition and a direct test. Remove that obsolete formatter, its exclusive private `previewTerminalContextText` helper, and the test.

The live terminal-context parsing, prompt materialization, selection validation, placeholder handling, and displayed-message paths stay unchanged.

Verification: the focused terminal-context suite passed before with 13 tests and after with 12. Web typecheck, changed-file lint and formatting, and `git diff --check` passed. This is a nonvisual deletion; no browser or repo-wide checks were run.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deletion of unused exports and tests; no changes to live prompt or display logic.
> 
> **Overview**
> Removes dead terminal-context preview formatting code that nothing in production called anymore.
> 
> **`buildTerminalContextPreviewTitle`** and its private **`previewTerminalContextText`** helper are deleted from `terminalContext.ts`, along with the unit test that only exercised that export. Imports in the test file are updated accordingly.
> 
> Trailing-context parsing, **`previewTitle`** on **`extractTrailingTerminalContexts`** / **`deriveDisplayedUserMessageState`**, and all other terminal-context behavior are unchanged—those paths still build previews from parsed `<terminal_context>` blocks, not the removed formatter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7ed2fc9f68b4397719b9d58aa52f01a83f4ed38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `buildTerminalContextPreviewTitle` from terminal context
> Removes the unused `buildTerminalContextPreviewTitle` export and private `previewTerminalContextText` utility from [terminalContext.ts](https://github.com/pingdotgg/t3code/pull/10009/files#diff-9fd625a57d1198538542525433c2f56f4611d0d627f56733d34cf7a9e197d322). Deletes the associated tests in [terminalContext.test.ts](https://github.com/pingdotgg/t3code/pull/10009/files#diff-143ad7a78879452ce49b31520e70c5b3309af6295a021ada2712142063781934). Risk: `buildTerminalContextPreviewTitle` is no longer exported from `terminalContext`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7ed2fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->