### PR TITLE
ci: reject unused tailscale exports with Knip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Ensure Electron runtime is installed
         run: vp run --filter @t3tools/desktop ensure:electron
 
-      # Export cleanup is still a manual audit; files and dependencies have no baseline.
-      - name: Check unused files and dependencies
+      # Files/dependencies are repo-wide; export checks cover clean workspaces only.
+      - name: Check unused code
         run: vp run knip:check
 
       - name: Check

--- a/docs/operations/development.md
+++ b/docs/operations/development.md
@@ -71,10 +71,12 @@ Windows investigation while that suite is not a required gate.
 
 ### Unused code
 
-`vp run knip:check` runs the unused-file and dependency check enforced by CI.
+`vp run knip:check` checks unused files and dependencies across the repo, then
+unused exports and types in `packages/tailscale`. CI enforces both checks.
 Use `vp run knip --workspace apps/web` to audit one workspace, including exports,
 or `vp run knip:production --workspace apps/web` to find code kept alive only by tests.
-The full export audit still has findings and is not a CI gate. Review callers before
+The full export audit still has findings and is not a repo-wide CI gate. Extend the
+export check's workspace selectors as more workspaces become clean. Review callers before
 deleting code; production mode can also report development scripts and test fixtures.
 Runtime-discovered entrypoints and dependency exceptions belong in [knip.jsonc](../../knip.jsonc).
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "tc": "vp run -r --concurrency-limit 2 typecheck",
     "lint": "vp lint --report-unused-disable-directives",
     "knip": "knip",
-    "knip:check": "knip --include files,dependencies --no-config-hints",
+    "knip:check": "knip --include files,dependencies --no-config-hints && knip --workspace packages/tailscale --exports --no-config-hints",
     "knip:production": "knip --production",
     "lint:mobile": "node scripts/mobile-native-static-check.ts",
     "test": "vp run -r test",


### PR DESCRIPTION
CI currently rejects unused files and dependencies but does not reject unused exports. The Tailscale package is export-clean after the preceding layer, so it can now enforce those checks without a backlog baseline.

Extend the existing knip:check command with a Tailscale export/type audit. Keep the repository-wide file/dependency gate and existing entrypoint handling. Add no dependencies, suppressions, or baseline. Update the existing maintainer instructions so the checked scope is explicit and can grow workspace by workspace. The full repository export audit remains available and still reports the backlog.

Verification: the exact CI command passes. Temporarily re-exporting one unused value and type makes it exit 1 and name both findings; restoring the cleanup makes it pass again. Formatting and diff checks pass. No product behavior changes.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and CI script changes only; no runtime or product behavior is modified.
> 
> **Overview**
> **CI now fails on unused exports and types in `packages/tailscale`**, in addition to the existing repo-wide unused-file and dependency checks.
> 
> The root `knip:check` script chains a second Knip run (`--workspace packages/tailscale --exports`). The CI step is renamed to **Check unused code** with comments/docs that spell out the split: repo-wide files/deps vs export gates only for workspaces that are clean enough to enforce.
> 
> Maintainer docs note the full export audit is still optional and can grow workspace-by-workspace as backlogs shrink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ccaaf0727aa68ed029b847f28b4730a981e7241. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject unused `tailscale` exports in `knip:check` CI script
> - Extends the `knip:check` script in [package.json](https://github.com/pingdotgg/t3code/pull/10012/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to run an export check scoped to `packages/tailscale` after the repo-wide files and dependencies check passes.
> - Updates [docs/operations/development.md](https://github.com/pingdotgg/t3code/pull/10012/files#diff-d4193c695085935050d7dd7572ae2c767e26244ca27f5ae7fd015ff4c97c8ba2) and renames the CI step in [ci.yml](https://github.com/pingdotgg/t3code/pull/10012/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) to reflect the new check.
> - Behavioral Change: CI now fails if `packages/tailscale` contains unused exports or types.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ccaaf0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->