### PR TITLE
refactor(web): remove unused desktop update visibility helper

### DIFF
--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -12,7 +12,6 @@ import {
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
   shouldShowArm64IntelBuildWarning,
-  shouldShowDesktopUpdateButton,
   shouldToastDesktopUpdateActionResult,
 } from "./desktopUpdate.logic";
 
@@ -42,7 +41,6 @@ describe("desktop update button state", () => {
       status: "available",
       availableVersion: "1.1.0",
     };
-    expect(shouldShowDesktopUpdateButton(state)).toBe(true);
     expect(resolveDesktopUpdateButtonAction(state)).toBe("download");
   });
 
@@ -55,7 +53,6 @@ describe("desktop update button state", () => {
       errorContext: "download",
       canRetry: true,
     };
-    expect(shouldShowDesktopUpdateButton(state)).toBe(true);
     expect(resolveDesktopUpdateButtonAction(state)).toBe("download");
     expect(getDesktopUpdateButtonTooltip(state)).toContain("Click to retry");
   });
@@ -70,7 +67,6 @@ describe("desktop update button state", () => {
       errorContext: "install",
       canRetry: true,
     };
-    expect(shouldShowDesktopUpdateButton(state)).toBe(true);
     expect(resolveDesktopUpdateButtonAction(state)).toBe("install");
     expect(getDesktopUpdateButtonTooltip(state)).toContain("Click to retry");
   });
@@ -85,7 +81,6 @@ describe("desktop update button state", () => {
       errorContext: null,
       canRetry: true,
     };
-    expect(shouldShowDesktopUpdateButton(state)).toBe(true);
     expect(resolveDesktopUpdateButtonAction(state)).toBe("install");
     expect(getDesktopUpdateButtonTooltip(state)).toContain("Click to restart and install");
   });
@@ -111,7 +106,7 @@ describe("desktop update button state", () => {
     expect(resolveDesktopUpdateButtonAction(state)).toBe("none");
   });
 
-  it("hides the button for non-actionable check errors", () => {
+  it("has no action for non-actionable check errors", () => {
     const state: DesktopUpdateState = {
       ...baseState,
       status: "error",
@@ -119,7 +114,6 @@ describe("desktop update button state", () => {
       errorContext: "check",
       canRetry: true,
     };
-    expect(shouldShowDesktopUpdateButton(state)).toBe(false);
     expect(resolveDesktopUpdateButtonAction(state)).toBe("none");
   });
 
@@ -130,7 +124,6 @@ describe("desktop update button state", () => {
       availableVersion: "1.1.0",
       downloadPercent: 42.5,
     };
-    expect(shouldShowDesktopUpdateButton(state)).toBe(true);
     expect(isDesktopUpdateButtonDisabled(state)).toBe(true);
     expect(getDesktopUpdateButtonTooltip(state)).toContain("42%");
   });

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -47,16 +47,6 @@ export function resolveDesktopUpdateButtonAction(
   return "none";
 }
 
-export function shouldShowDesktopUpdateButton(state: DesktopUpdateState | null): boolean {
-  if (!state || !state.enabled) {
-    return false;
-  }
-  if (state.status === "downloading") {
-    return true;
-  }
-  return resolveDesktopUpdateButtonAction(state) !== "none";
-}
-
 export function shouldShowArm64IntelBuildWarning(state: DesktopUpdateState | null): boolean {
   return state?.hostArch === "arm64" && state.appArch === "x64";
 }


### PR DESCRIPTION
`shouldShowDesktopUpdateButton` is referenced only by its definition and test assertions. Remove the dead helper and those assertions. The current desktop-update UI uses the adjacent action, disabled-state, and tooltip logic, which stays unchanged.

Every existing scenario remains, including retry, downloading, unavailable/error states, architecture warnings, release notes, and confirmation behavior.

Verification: the focused desktop-update UI logic suite passed with 31 tests before and after. Web typecheck, changed-file lint and formatting, and `git diff --check` passed. This is a nonvisual deletion; no browser or repo-wide checks were run.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal with no production call sites; behavior covered by unchanged action/disabled/tooltip logic and existing tests.
> 
> **Overview**
> Removes **`shouldShowDesktopUpdateButton`** from `desktopUpdate.logic.ts` because nothing in the app calls it anymore—the desktop update UI already keys off **`resolveDesktopUpdateButtonAction`**, **`isDesktopUpdateButtonDisabled`**, and tooltip helpers instead.
> 
> Tests drop the redundant visibility assertions and keep the same scenarios via action resolution (including renaming one case to describe “no action” rather than “hides the button”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a7068b772f28920e2f1b0f19a77b35e3f3a5fae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `shouldShowDesktopUpdateButton` helper from desktop update logic
> Deletes the exported visibility helper in [desktopUpdate.logic.ts](https://github.com/pingdotgg/t3code/pull/10014/files#diff-ad19260d118b0d961892078ed35b67240d359da2ae4b4c8bd33e258537c503af) that determined whether the desktop update button should show based on enabled state, download status, and resolved action. Updates tests in [desktopUpdate.logic.test.ts](https://github.com/pingdotgg/t3code/pull/10014/files#diff-96a4905c89d54ee90b7a7248f4cb0f60cfa640f6ff13da50864ae5dc47c0b028) to stop importing the helper and assert only the resolved action, disabled state, and tooltip.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a7068b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->