### PR TITLE
refactor(web): remove obsolete provider update helpers

### DIFF
--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
@@ -18,17 +18,14 @@ import {
   environmentGroupsWithUpdates,
   firstFailedProviderUpdateMessage,
   firstRejectedProviderUpdateMessage,
-  firstUnsuccessfulSecondaryProviderOutcome,
   getProviderUpdateInitialToastView,
   getProviderUpdateProgressToastView,
   getProviderUpdateRejectedToastView,
   getProviderUpdateSidebarPillView,
-  getSingleProviderUpdateProgressToastView,
   hasOneClickUpdateProviderCandidate,
   isProviderUpdateCandidate,
   isTerminalProviderUpdatePhase,
   localEnvironmentUpdateNotificationKey,
-  parseWslDistroFromInstanceId,
   providerUpdateNotificationKey,
   resolveEnvironmentUpdateRowStatus,
   shouldShowPrimaryProviderUpdateToast,
@@ -368,28 +365,6 @@ describe("provider update launch notification logic", () => {
     });
   });
 
-  it("resolves a single-provider completion view from the returned provider snapshot", () => {
-    const view = getSingleProviderUpdateProgressToastView(
-      provider({
-        driver: driver("codex"),
-        updateState: {
-          status: "failed",
-          startedAt: checkedAt,
-          finishedAt: checkedAt,
-          message: "command failed",
-          output: "stderr",
-        },
-      }),
-    );
-
-    expect(view).toMatchObject({
-      phase: "failed",
-      type: "error",
-      title: "Codex v1.1.0 update failed",
-      description: "command failed",
-    });
-  });
-
   it("keeps unchanged providers actionable from settings", () => {
     const view = getProviderUpdateProgressToastView({
       providers: [
@@ -441,31 +416,6 @@ describe("provider update launch notification logic", () => {
       title: "Provider updated",
       description: "New sessions will use the updated provider.",
       dismissAfterVisibleMs: 3_000,
-    });
-  });
-
-  it("uses the updated version in the single-provider success toast title", () => {
-    const view = getSingleProviderUpdateProgressToastView(
-      provider({
-        driver: driver("codex"),
-        version: "1.1.0",
-        latestVersion: "1.1.0",
-        advisoryStatus: "current",
-        updateState: {
-          status: "succeeded",
-          startedAt: checkedAt,
-          finishedAt: checkedAt,
-          message: "Provider updated.",
-          output: null,
-        },
-      }),
-    );
-
-    expect(view).toMatchObject({
-      phase: "succeeded",
-      type: "success",
-      title: "Codex updated: v1.1.0",
-      description: "New sessions will use the updated provider.",
     });
   });
 
@@ -814,39 +764,6 @@ describe("provider update launch notification logic", () => {
       expect(snapshots).toEqual([primary]);
     });
 
-    it("flags the first unsuccessful secondary outcome, skipping the primary and successes", () => {
-      const primaryFailed = provider({
-        driver: driver("codex"),
-        updateState: terminalState("failed", "primary boom"),
-      });
-
-      expect(
-        firstUnsuccessfulSecondaryProviderOutcome([
-          fulfilledOutcome(true, primaryFailed),
-          fulfilledOutcome(
-            false,
-            provider({
-              driver: driver("codex"),
-              updateState: terminalState("succeeded", "ok"),
-            }),
-          ),
-        ]),
-      ).toBeNull();
-
-      expect(
-        firstUnsuccessfulSecondaryProviderOutcome([
-          fulfilledOutcome(true, primaryFailed),
-          fulfilledOutcome(
-            false,
-            provider({
-              driver: driver("codex"),
-              updateState: terminalState("failed", "wsl boom"),
-            }),
-          ),
-        ]),
-      ).toMatchObject({ status: "failed", provider: { updateState: { message: "wsl boom" } } });
-    });
-
     it("treats a rejected dispatch as not contributing a snapshot", () => {
       const primary = provider({
         driver: driver("codex"),
@@ -994,14 +911,6 @@ describe("provider update launch notification logic", () => {
           fallbackLabel: "My Device",
         }),
       ).toBe("My Device");
-    });
-
-    it("parses the WSL distro from the backend instance id", () => {
-      expect(parseWslDistroFromInstanceId("wsl:ubuntu")).toBe("ubuntu");
-      expect(parseWslDistroFromInstanceId("wsl:default")).toBeNull();
-      expect(parseWslDistroFromInstanceId("wsl:")).toBeNull();
-      expect(parseWslDistroFromInstanceId("ssh:host")).toBeNull();
-      expect(parseWslDistroFromInstanceId(undefined)).toBeNull();
     });
   });
 

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
@@ -326,41 +326,6 @@ export function getProviderUpdateProgressToastView(input: {
   return getProviderUpdateRunningToastView(input.providerCount);
 }
 
-export function getSingleProviderUpdateProgressToastView(
-  provider: ServerProvider,
-): ProviderUpdateToastView {
-  const view = getProviderUpdateProgressToastView({
-    providers: [provider],
-    providerCount: 1,
-  });
-  const providerName = PROVIDER_DISPLAY_NAMES[provider.driver] ?? provider.driver;
-
-  switch (view.phase) {
-    case "running":
-      return {
-        ...view,
-        title: `Updating ${providerName}`,
-      };
-    case "failed":
-      return {
-        ...view,
-        title: getProviderFailedUpdateTitle(provider),
-      };
-    case "unchanged":
-      return {
-        ...view,
-        title: `${providerName} still needs an update`,
-      };
-    case "succeeded":
-      return {
-        ...view,
-        title: getProviderUpdatedTitle(provider),
-      };
-    default:
-      return view;
-  }
-}
-
 export function collectUpdatedProviderSnapshots(input: {
   readonly results: ReadonlyArray<
     AtomCommandResult<{ readonly providers: ReadonlyArray<ServerProvider> }, unknown>
@@ -647,42 +612,6 @@ export function collectProviderUpdateOutcomeSnapshots(
     }
   }
   return [...worstByDriver.values()];
-}
-
-/**
- * The first secondary (non-primary) backend whose update resolved without
- * succeeding. The primary's own failed/unchanged state is already surfaced
- * inline in settings, so only secondaries (which have no inline row) need an
- * explicit callout.
- */
-export function firstUnsuccessfulSecondaryProviderOutcome(
-  results: ReadonlyArray<PromiseSettledResult<LocalProviderUpdateOutcome>>,
-): { readonly provider: ServerProvider; readonly status: "failed" | "unchanged" } | null {
-  for (const result of results) {
-    if (result.status !== "fulfilled") {
-      continue;
-    }
-    const outcome = result.value;
-    if (outcome.isPrimary || outcome.provider === null) {
-      continue;
-    }
-    const status = outcome.provider.updateState?.status;
-    if (status === "failed" || status === "unchanged") {
-      return { provider: outcome.provider, status };
-    }
-  }
-  return null;
-}
-
-const WSL_INSTANCE_ID_PREFIX = "wsl:";
-
-/** The distro name from a WSL backend instance id ("wsl:ubuntu" -> "ubuntu"), or null for the default. */
-export function parseWslDistroFromInstanceId(instanceId: string | undefined): string | null {
-  if (!instanceId || !instanceId.startsWith(WSL_INSTANCE_ID_PREFIX)) {
-    return null;
-  }
-  const distro = instanceId.slice(WSL_INSTANCE_ID_PREFIX.length).trim();
-  return distro.length === 0 || distro === "default" ? null : distro;
 }
 
 /**


### PR DESCRIPTION
Caller searches found no production use of `getSingleProviderUpdateProgressToastView`, `firstUnsuccessfulSecondaryProviderOutcome`, or `parseWslDistroFromInstanceId`. Remove those old presentation paths, the parser's exclusive prefix constant, and four tests that exercise only those paths.

Keep the live update eligibility, progress, terminal-state persistence, cross-environment aggregation, and display-label logic and tests. Current environment labels already receive the WSL metadata directly.

Verification: the focused provider-update logic suite passed before with 47 tests and after with 43. Web typecheck, changed-file lint and formatting, and `git diff --check` passed. This is a nonvisual deletion; no browser or repo-wide checks were run.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code deletion only; active update toasts, sidebar pills, and environment labeling paths are unchanged.
> 
> **Overview**
> Removes three unused helpers from **ProviderUpdateLaunchNotification.logic** and their dedicated tests, shrinking the provider-update logic suite from 47 to 43 cases.
> 
> **Deleted APIs:** `getSingleProviderUpdateProgressToastView` (per-provider toast titles), `firstUnsuccessfulSecondaryProviderOutcome` (secondary-backend failure callouts), and `parseWslDistroFromInstanceId` plus its `wsl:` prefix constant. Multi-backend outcomes still flow through `collectProviderUpdateOutcomeSnapshots` and `getProviderUpdateProgressToastView`; WSL labels still use `deriveEnvironmentDisplayLabel` with `wslDistro` passed in by callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cfd52de79b9e3928bfcabb1b9f297707739c343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove obsolete provider update helpers from `ProviderUpdateLaunchNotification`
> - Deletes three exported helpers in [ProviderUpdateLaunchNotification.logic.ts](https://github.com/pingdotgg/t3code/pull/10015/files#diff-08d466d51f5e8ebb0d9c876490ddfc4c8bd21ca893ad398bc7460c8cb85ee05f): `getSingleProviderUpdateProgressToastView`, `firstUnsuccessfulSecondaryProviderOutcome`, and `parseWslDistroFromInstanceId`.
> - Removes the corresponding unit tests in [ProviderUpdateLaunchNotification.logic.test.ts](https://github.com/pingdotgg/t3code/pull/10015/files#diff-a983a86d309f324ce50f42aac45db69b658f292d9553bc1b2008720ac721fec2), including tests for single-provider completion/success views, secondary outcome selection, and WSL distro parsing.
> - Risk: any out-of-tree callers importing the removed helpers will fail to build; confirm no other modules reference these exports.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6cfd52d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->