### PR TITLE
test(web): keep pull request menu items private

### DIFF
--- a/apps/web/src/components/pullRequest/pullRequestLinkContextMenu.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestLinkContextMenu.test.ts
@@ -1,15 +1,8 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { openOnHostLabel, pullRequestLinkContextMenuItems } from "./pullRequestLinkContextMenu";
+import { openOnHostLabel } from "./pullRequestLinkContextMenu";
 
 describe("pull request link context menu", () => {
-  it("offers the copy first and the host's own page after it", () => {
-    expect(pullRequestLinkContextMenuItems("Open on GitHub")).toEqual([
-      { id: "copy-link", label: "Copy link", icon: "copy" },
-      { id: "open-external", label: "Open on GitHub" },
-    ]);
-  });
-
   it("names every host it knows, and says nothing false about one it does not", () => {
     expect(openOnHostLabel("github")).toBe("Open on GitHub");
     expect(openOnHostLabel("gitlab")).toBe("Open on GitLab");

--- a/apps/web/src/components/pullRequest/pullRequestLinkContextMenu.ts
+++ b/apps/web/src/components/pullRequest/pullRequestLinkContextMenu.ts
@@ -19,7 +19,7 @@ export const openOnHostLabel = (provider: string): string =>
   OPEN_ON_HOST_LABELS[provider] ?? "Open on host";
 
 /** Copy first: it is the reason to right-click a number rather than click it. */
-export function pullRequestLinkContextMenuItems(
+function pullRequestLinkContextMenuItems(
   openLabel: string,
 ): readonly ContextMenuItem<PullRequestLinkContextMenuAction>[] {
   return [


### PR DESCRIPTION
`pullRequestLinkContextMenuItems` is a fixed two-item array factory. Its only external consumer is a test that repeats the array; the real context-menu handler calls it within the same file. Make the helper private and remove that direct test.

The menu items and callbacks do not change. `openOnHostLabel` remains exported for its production consumers, and its host-fallback test stays.

Verification: the focused pull-request context-menu suite passed before with 2 tests and after with 1. Web typecheck, changed-file lint and formatting, and `git diff --check` passed. This is a nonvisual export/test cleanup; no browser or repo-wide checks were run.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Non-behavioral refactor: drops a redundant export and test with no production API or menu logic changes.
> 
> **Overview**
> **`pullRequestLinkContextMenuItems`** is no longer exported from `pullRequestLinkContextMenu.ts`; it stays a file-local helper used only by **`showPullRequestLinkContextMenu`**.
> 
> The test that imported it and asserted the fixed two-item menu order (**Copy link**, then the host open label) is removed. **`openOnHostLabel`** remains public, and its host-name / fallback coverage test is unchanged. **Runtime menu behavior is unchanged**—this is export visibility and test cleanup only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30f90b26e544929210d47993177dba58f694218f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `pullRequestLinkContextMenuItems` private in pull request context menu
> - Changes `pullRequestLinkContextMenuItems` from an exported function to a module-private function in [pullRequestLinkContextMenu.ts](https://github.com/pingdotgg/t3code/pull/10016/files#diff-0dcb54d998927dd237536ebfb10e037dd60c34007b125949a071a70b66f0e662). Parameters, menu-item ordering, labels, and return values are unchanged.
> - Removes the test case and import that directly inspected `pullRequestLinkContextMenuItems` in [pullRequestLinkContextMenu.test.ts](https://github.com/pingdotgg/t3code/pull/10016/files#diff-63bbee6989005c8065dcdcd8f5a1455584307dc8d0cb7b46990da57fc8ec0f18). The suite now only verifies host-specific labels via `openOnHostLabel`.
> - Risk: any out-of-tree consumers importing `pullRequestLinkContextMenuItems` from `pullRequestLinkContextMenu.ts` will break at compile time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30f90b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->