### PR TITLE
refactor(server): remove test-only pricing normalizer

### DIFF
--- a/apps/server/src/usage/usagePricing.test.ts
+++ b/apps/server/src/usage/usagePricing.test.ts
@@ -4,7 +4,6 @@ import {
   cacheSavingsUsd,
   createOverrideRateTable,
   lookupRate,
-  normalizeModelName,
   parseRateTable,
   priceUsage,
 } from "./usagePricing.ts";
@@ -81,10 +80,6 @@ describe("usage pricing", () => {
         costSource: "providerReported",
       });
     }
-  });
-
-  it("keeps the existing model-name normalization contract", () => {
-    expect(normalizeModelName(" Anthropic/Claude-Opus-5 ")).toBe("claude-opus-5");
   });
 
   it("keeps the canonical Fable rate separate from DeepInfra in either order", () => {

--- a/apps/server/src/usage/usagePricing.ts
+++ b/apps/server/src/usage/usagePricing.ts
@@ -127,16 +127,6 @@ function normalizeRateKey(model: string): string {
   return model.trim().toLowerCase();
 }
 
-/**
- * Canonicalises a model name for lookup.
- *
- * Strips a `provider/` prefix and lowercases, since transcripts are
- * inconsistent about casing.
- */
-export function normalizeModelName(model: string): string {
-  return bareModelName(normalizeRateKey(model));
-}
-
 function bareModelName(key: string): string {
   const slash = key.lastIndexOf("/");
   return slash === -1 ? key : key.slice(slash + 1);


### PR DESCRIPTION
normalizeModelName has no production callers; its only caller is a direct normalization test. Remove that unused wrapper and test. The active rate lookup still uses normalizeRateKey and bareModelName unchanged.

Keep provider-qualified rates, aliases, overrides, cached-token pricing, and total-price coverage. The focused usage pricing suite passed with 8 tests before and 7 after. Targeted lint, formatting, and git diff --check passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal with no production callers; pricing logic paths are untouched.
> 
> **Overview**
> Removes the exported **`normalizeModelName`** helper from `usagePricing.ts` and drops the test that only asserted its behavior (trim, lowercase, strip `provider/` prefix).
> 
> **Rate lookup and pricing are unchanged:** `lookupRate` still uses **`normalizeRateKey`** and **`bareModelName`** internally; overrides, aliases, bracket variants, and the rest of the usage pricing tests stay as they were.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97248a9a27f07010a4c331a1264303c0d8ff8de3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `normalizeModelName` helper and its test from usage pricing
> Deletes the exported model-name normalization utility from the pricing module and removes the corresponding import and contract test from the test suite. This clears out test-only code from [usagePricing.ts](https://github.com/pingdotgg/t3code/pull/10017/files#diff-fe836a76687342f066ff2679d4edcb42b28156a016ba013085092c27fc826c66).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97248a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->