### PR TITLE
fix(web): restore settled PR colors on hover

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1468,9 +1468,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
           // number from reflowing as PR states stream in.
           "shrink-0 text-xs tabular-nums hover:underline",
           variant === "slim" && variantAction === "unsettle"
-            ? props.isActive
-              ? "text-secondary-label"
-              : cn("text-secondary-label transition-colors", settledPrHoverClass)
+            ? cn("text-secondary-label transition-colors", settledPrHoverClass)
             : prStatus.colorClass,
         )}
         aria-label={prStatus.tooltip}

--- a/apps/web/src/components/ThreadStatusIndicators.test.ts
+++ b/apps/web/src/components/ThreadStatusIndicators.test.ts
@@ -125,10 +125,12 @@ describe("settledPrHoverColorClass", () => {
     ["merged", "text-violet-600"],
     ["closed", "text-red-600"],
   ] as const)("restores the %s pull request color on row hover", (state, colorClass) => {
-    expect(settledPrHoverColorClass(state)).toContain(`group-hover/v2-row:${colorClass}`);
+    expect(settledPrHoverColorClass(state)).toContain(`group-hover/sidebar-row:${colorClass}`);
   });
 
   it("keeps draft pull requests gray on row hover", () => {
-    expect(settledPrHoverColorClass("open", true)).toContain("group-hover/v2-row:text-zinc-500");
+    expect(settledPrHoverColorClass("open", true)).toContain(
+      "group-hover/sidebar-row:text-zinc-500",
+    );
   });
 });

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -86,13 +86,13 @@ export function settledPrHoverColorClass(
   switch (state) {
     case "open":
       if (isDraft) {
-        return "group-hover/v2-row:text-zinc-500 dark:group-hover/v2-row:text-zinc-400/80";
+        return "group-hover/sidebar-row:text-zinc-500 dark:group-hover/sidebar-row:text-zinc-400/80";
       }
-      return "group-hover/v2-row:text-emerald-600 dark:group-hover/v2-row:text-emerald-300/90";
+      return "group-hover/sidebar-row:text-emerald-600 dark:group-hover/sidebar-row:text-emerald-300/90";
     case "merged":
-      return "group-hover/v2-row:text-violet-600 dark:group-hover/v2-row:text-violet-300/90";
+      return "group-hover/sidebar-row:text-violet-600 dark:group-hover/sidebar-row:text-violet-300/90";
     case "closed":
-      return "group-hover/v2-row:text-red-600 dark:group-hover/v2-row:text-red-300/90";
+      return "group-hover/sidebar-row:text-red-600 dark:group-hover/sidebar-row:text-red-300/90";
   }
 }
 


### PR DESCRIPTION
> [!NOTE]
> 🤖 **GPT-6 Astra on behalf of Oliver**

## ELI5
Hovering a settled thread shows its PR number in the PR state's color again, including the selected thread.

## Problem
The sidebar rename left the hover selectors targeting `v2-row` instead of `sidebar-row`, breaking the behavior introduced in #4451. Selected settled rows also skipped the hover classes.

## Fix
Use the current row group and apply the hover classes to selected settled rows. Open, merged, closed, and draft colors remain consistent with other PR badges.

Validation: 41 focused tests passed, web typecheck passed, targeted lint completed with existing sidebar warnings. Verified the selected settled row in the local web client. Code review found no actionable issues.

## UI Changes
### Before
Screenshot supplied by Oliver.

<img width="634" alt="Before: settled PR number stays gray on hover" src="https://github.com/user-attachments/assets/76a4153f-93c0-42fa-8a36-518c2f958141" />

### After
Matching row captured in the isolated web client with the default dark theme.

<img width="634" alt="After: settled open PR number turns green on hover" src="https://github.com/user-attachments/assets/aaaf5305-591c-4537-8a52-c46d68d83b24" />

Changes made by GPT-6 Astra in Codex.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore settled PR hover colors in `SidebarThreadRow`
> - Changes `settledPrHoverColorClass` in [ThreadStatusIndicators.tsx](https://github.com/pingdotgg/t3code/pull/10023/files#diff-91746549eb55de0a3ac6a473f89804fbe3db8852968122b4b12cebad10625189) to target the `sidebar-row` group-hover variant instead of `v2-row`.
> - Updates `SidebarThreadRow` in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/10023/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) so active slim rows include the transition and hover color classes instead of suppressing them.
> - Risk: Callers still using the `v2-row` group namespace will no longer receive the hover color classes.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6aab96.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated pull request status badge hover colors in sidebar rows for draft, open, merged, and closed states.
  - Standardized badge styling so hover behavior remains consistent regardless of the row’s active state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->