### PR TITLE
fix(server): wait for native Codex start before Stop

### DIFF
--- a/apps/server/src/orchestration-v2/Adapters/CodexAdapterV2.test.ts
+++ b/apps/server/src/orchestration-v2/Adapters/CodexAdapterV2.test.ts
@@ -1266,6 +1266,7 @@ describe("CodexAdapterV2 post-settle continuation", () => {
   const makeCodexReplayHarness = (
     transcript: CodexReplay.CodexAppServerReplayTranscript,
     onEvent: (event: ProviderAdapterV2Event) => Effect.Effect<unknown> = () => Effect.void,
+    onRequest: (method: string) => Effect.Effect<void> = () => Effect.void,
   ) =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
@@ -1284,7 +1285,17 @@ describe("CodexAdapterV2 post-settle continuation", () => {
                 }),
             ),
             Effect.flatMap((context) =>
-              Effect.service(CodexClient.CodexAppServerClient).pipe(Effect.provide(context)),
+              Effect.service(CodexClient.CodexAppServerClient).pipe(
+                Effect.map(
+                  (client) =>
+                    ({
+                      ...client,
+                      request: (method, params) =>
+                        onRequest(method).pipe(Effect.andThen(client.request(method, params))),
+                    }) satisfies CodexClient.CodexAppServerClient["Service"],
+                ),
+                Effect.provide(context),
+              ),
             ),
           ),
       };
@@ -1358,6 +1369,182 @@ describe("CodexAdapterV2 post-settle continuation", () => {
         firstTerminal: Deferred.await(firstTerminal),
       };
     });
+
+  it.effect("waits for native start before interrupting an acknowledged queued turn", () =>
+    Effect.gen(function* () {
+      const nativeThreadId = "early-stop-thread";
+      const nativeTurnId = "early-stop-turn";
+      const prompt = "Run a command.";
+      const preamble = codexReplayPreamble({ nativeThreadId, nativeTurnId, prompt });
+      const transcript = makeCodexReplayTranscript({
+        scenario: "early-stop-await-native-start",
+        entries: [
+          ...preamble.slice(0, -2),
+          {
+            type: "emit_inbound",
+            label: "turn/start/queued",
+            frame: {
+              id: 3,
+              result: {
+                turn: {
+                  ...makeCodexReplayTurn({ id: nativeTurnId, status: "inProgress" }),
+                  startedAt: null,
+                },
+              },
+            },
+          },
+          {
+            type: "emit_inbound",
+            label: "turn/started",
+            afterMs: 1000,
+            frame: {
+              method: "turn/started",
+              params: {
+                threadId: nativeThreadId,
+                turn: makeCodexReplayTurn({ id: nativeTurnId, status: "inProgress" }),
+              },
+            },
+          },
+          {
+            type: "expect_outbound",
+            label: "turn/interrupt",
+            frame: {
+              id: 4,
+              method: "turn/interrupt",
+              params: { threadId: nativeThreadId, turnId: nativeTurnId },
+            },
+          },
+          { type: "emit_inbound", label: "turn/interrupt", frame: { id: 4, result: {} } },
+          {
+            type: "emit_inbound",
+            label: "turn/completed",
+            frame: {
+              method: "turn/completed",
+              params: {
+                threadId: nativeThreadId,
+                turn: makeCodexReplayTurn({ id: nativeTurnId, status: "interrupted" }),
+              },
+            },
+          },
+        ],
+      });
+      let interruptSent = false;
+      const harness = yield* makeCodexReplayHarness(
+        transcript,
+        () => Effect.void,
+        (method) =>
+          Effect.sync(() => {
+            if (method === "turn/interrupt") interruptSent = true;
+          }),
+      );
+      yield* harness.runtime.startTurn(
+        makeCodexTestTurnInput({
+          threadId: harness.threadId,
+          providerThread: harness.providerThread,
+          now: yield* DateTime.now,
+          attemptId: RunAttemptId.make("early-stop-attempt"),
+          text: prompt,
+        }),
+      );
+      const providerTurnId = (yield* IdAllocatorV2).derive.providerTurn({
+        driver: CODEX_DRIVER_KIND,
+        nativeTurnId,
+      });
+      const interrupt = yield* harness.runtime
+        .interruptTurn({ providerThread: harness.providerThread, providerTurnId })
+        .pipe(Effect.forkScoped);
+      yield* TestClock.adjust("500 millis");
+      assert.isFalse(interruptSent, "Stop must not reach Codex before native turn/started");
+      yield* TestClock.adjust("500 millis");
+      yield* Fiber.join(interrupt);
+      yield* harness.firstTerminal;
+      assert.equal(harness.terminalEvents()[0]?.status, "interrupted");
+      assert.lengthOf(harness.terminalEvents(), 1);
+      assert.isFalse(yield* harness.hasPendingBackgroundWork);
+    }).pipe(Effect.scoped, Effect.provide(Layer.merge(idAllocatorLayer, NodeServices.layer))),
+  );
+
+  it.effect("settles Stop when a queued native turn fails before starting", () =>
+    Effect.gen(function* () {
+      const nativeThreadId = "early-stop-thread";
+      const nativeTurnId = "early-stop-turn";
+      const prompt = "Run a command.";
+      const preamble = codexReplayPreamble({ nativeThreadId, nativeTurnId, prompt });
+      const transcript = makeCodexReplayTranscript({
+        scenario: "early-stop-failed-before-native-start",
+        entries: [
+          ...preamble.slice(0, -2),
+          {
+            type: "emit_inbound",
+            label: "turn/start/queued",
+            frame: {
+              id: 3,
+              result: {
+                turn: {
+                  ...makeCodexReplayTurn({ id: nativeTurnId, status: "inProgress" }),
+                  startedAt: null,
+                },
+              },
+            },
+          },
+          {
+            type: "emit_inbound",
+            label: "turn/failed",
+            afterMs: 1000,
+            frame: {
+              method: "turn/completed",
+              params: {
+                threadId: nativeThreadId,
+                turn: {
+                  ...makeCodexReplayTurn({ id: nativeTurnId, status: "failed" }),
+                  startedAt: null,
+                  error: {
+                    message: "Failed before native start",
+                    codexErrorInfo: null,
+                    additionalDetails: null,
+                  },
+                },
+              },
+            },
+          },
+        ],
+      });
+      let interruptSent = false;
+      const harness = yield* makeCodexReplayHarness(
+        transcript,
+        () => Effect.void,
+        (method) =>
+          Effect.sync(() => {
+            if (method === "turn/interrupt") interruptSent = true;
+          }),
+      );
+      yield* harness.runtime.startTurn(
+        makeCodexTestTurnInput({
+          threadId: harness.threadId,
+          providerThread: harness.providerThread,
+          now: yield* DateTime.now,
+          attemptId: RunAttemptId.make("early-stop-attempt"),
+          text: prompt,
+        }),
+      );
+      const providerTurnId = (yield* IdAllocatorV2).derive.providerTurn({
+        driver: CODEX_DRIVER_KIND,
+        nativeTurnId,
+      });
+      const interrupt = yield* harness.runtime
+        .interruptTurn({ providerThread: harness.providerThread, providerTurnId })
+        .pipe(Effect.forkScoped);
+      yield* TestClock.adjust("500 millis");
+      assert.isFalse(interruptSent, "Stop must not reach Codex before native turn/started");
+      yield* TestClock.adjust("500 millis");
+      yield* Fiber.join(interrupt);
+      yield* harness.firstTerminal;
+      assert.equal(harness.terminalEvents()[0]?.status, "failed");
+      assert.lengthOf(harness.terminalEvents(), 1);
+      assert.isFalse(interruptSent, "A terminal native turn must not receive turn/interrupt");
+      assert.isFalse(yield* harness.hasPendingBackgroundWork);
+    }).pipe(Effect.scoped, Effect.provide(Layer.merge(idAllocatorLayer, NodeServices.layer))),
+  );
 
   const assistantMessages = (events: ReadonlyArray<ProviderAdapterV2Event>) =>
     events.filter(

--- a/apps/server/src/orchestration-v2/Adapters/CodexAdapterV2.test.ts
+++ b/apps/server/src/orchestration-v2/Adapters/CodexAdapterV2.test.ts
@@ -1546,6 +1546,66 @@ describe("CodexAdapterV2 post-settle continuation", () => {
     }).pipe(Effect.scoped, Effect.provide(Layer.merge(idAllocatorLayer, NodeServices.layer))),
   );
 
+  it.effect("bounds Stop when a queued native turn never starts", () =>
+    Effect.gen(function* () {
+      const nativeThreadId = "early-stop-thread";
+      const nativeTurnId = "early-stop-turn";
+      const prompt = "Run a command.";
+      const preamble = codexReplayPreamble({ nativeThreadId, nativeTurnId, prompt });
+      const transcript = makeCodexReplayTranscript({
+        scenario: "early-stop-never-starts",
+        entries: [
+          ...preamble.slice(0, -2),
+          {
+            type: "emit_inbound",
+            label: "turn/start/queued",
+            frame: {
+              id: 3,
+              result: {
+                turn: {
+                  ...makeCodexReplayTurn({ id: nativeTurnId, status: "inProgress" }),
+                  startedAt: null,
+                },
+              },
+            },
+          },
+        ],
+      });
+      let interruptSent = false;
+      const harness = yield* makeCodexReplayHarness(
+        transcript,
+        () => Effect.void,
+        (method) =>
+          Effect.sync(() => {
+            if (method === "turn/interrupt") interruptSent = true;
+          }),
+      );
+      yield* harness.runtime.startTurn(
+        makeCodexTestTurnInput({
+          threadId: harness.threadId,
+          providerThread: harness.providerThread,
+          now: yield* DateTime.now,
+          attemptId: RunAttemptId.make("early-stop-attempt"),
+          text: prompt,
+        }),
+      );
+      const providerTurnId = (yield* IdAllocatorV2).derive.providerTurn({
+        driver: CODEX_DRIVER_KIND,
+        nativeTurnId,
+      });
+      const interrupt = yield* harness.runtime
+        .interruptTurn({ providerThread: harness.providerThread, providerTurnId })
+        .pipe(Effect.exit, Effect.forkScoped);
+      yield* TestClock.adjust("10 seconds");
+      assert.equal((yield* Fiber.join(interrupt))._tag, "Failure");
+      yield* harness.firstTerminal;
+      assert.equal(harness.terminalEvents()[0]?.status, "interrupted");
+      assert.lengthOf(harness.terminalEvents(), 1);
+      assert.isFalse(interruptSent, "An unstarted native turn must not receive turn/interrupt");
+      assert.isFalse(yield* harness.hasPendingBackgroundWork);
+    }).pipe(Effect.scoped, Effect.provide(Layer.merge(idAllocatorLayer, NodeServices.layer))),
+  );
+
   const assistantMessages = (events: ReadonlyArray<ProviderAdapterV2Event>) =>
     events.filter(
       (event): event is Extract<ProviderAdapterV2Event, { type: "message.updated" }> =>

--- a/apps/server/src/orchestration-v2/Adapters/CodexAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/CodexAdapterV2.ts
@@ -890,6 +890,7 @@ function codexErrorInfoCode(value: unknown): string | null {
 }
 
 interface ActiveCodexTurnContext {
+  readonly nativeStartReady?: Deferred.Deferred<void>;
   readonly input: ProviderAdapterV2TurnInput;
   readonly projectionAppThread: OrchestrationV2AppThread;
   readonly projectionThreadId: ThreadId;
@@ -1671,6 +1672,7 @@ export function makeCodexAdapterV2(adapterOptions: CodexAdapterV2Options): Provi
           readonly turnInput: ProviderAdapterV2TurnInput;
           readonly nativeTurnId: string;
           readonly startedAt: DateTime.Utc;
+          readonly waitForNativeStart?: boolean;
         }) =>
           Effect.gen(function* () {
             const existing = (yield* Ref.get(activeTurns)).get(input.nativeTurnId);
@@ -1682,6 +1684,9 @@ export function makeCodexAdapterV2(adapterOptions: CodexAdapterV2Options): Provi
               nativeTurnId: input.nativeTurnId,
             });
             const context: ActiveCodexTurnContext = {
+              ...(input.waitForNativeStart
+                ? { nativeStartReady: yield* Deferred.make<void>() }
+                : {}),
               input: input.turnInput,
               projectionAppThread: input.turnInput.appThread,
               projectionThreadId: input.turnInput.threadId,
@@ -3549,6 +3554,9 @@ export function makeCodexAdapterV2(adapterOptions: CodexAdapterV2Options): Provi
           Effect.gen(function* () {
             const context = (yield* Ref.get(activeTurns)).get(payload.turn.id);
             if (context !== undefined) {
+              if (context.nativeStartReady !== undefined) {
+                yield* Deferred.succeed(context.nativeStartReady, undefined);
+              }
               return;
             }
             const pendingRootTurn = (yield* Ref.get(pendingRootTurns)).get(payload.threadId);
@@ -4798,6 +4806,9 @@ export function makeCodexAdapterV2(adapterOptions: CodexAdapterV2Options): Provi
                 updated.delete(input.nativeTurnId);
                 return updated;
               });
+              if (input.context.nativeStartReady !== undefined) {
+                yield* Deferred.succeed(input.context.nativeStartReady, undefined);
+              }
               yield* flushReadyRootTerminals();
               if (!retainSettledContext && !interruptInProgress) {
                 yield* Ref.update(runningCommandItemsByTurn, (current) => {
@@ -5022,7 +5033,12 @@ export function makeCodexAdapterV2(adapterOptions: CodexAdapterV2Options): Provi
               const started = yield* client.request("turn/start", turnStartParams);
               const nativeTurnId = started.turn.id;
               const startedAt = codexTimestamp(started.turn.startedAt);
-              yield* registerRootTurn({ turnInput, nativeTurnId, startedAt });
+              yield* registerRootTurn({
+                turnInput,
+                nativeTurnId,
+                startedAt,
+                waitForNativeStart: started.turn.startedAt === null,
+              });
               yield* Ref.update(pendingRootTurns, (current) => {
                 const updated = new Map(current);
                 updated.delete(threadId);
@@ -5282,6 +5298,11 @@ export function makeCodexAdapterV2(adapterOptions: CodexAdapterV2Options): Provi
               yield* Effect.gen(function* () {
                 for (const target of interruptTargets) {
                   const context = target.context;
+                  // A null start timestamp acknowledges a queued turn; Codex cannot interrupt it
+                  // until turn/started confirms that the native task exists.
+                  if (context.nativeStartReady !== undefined) {
+                    yield* Deferred.await(context.nativeStartReady);
+                  }
                   if ((yield* Ref.get(activeTurns)).get(context.nativeTurnId) !== context) {
                     continue;
                   }

--- a/apps/server/src/orchestration-v2/Adapters/CodexAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/CodexAdapterV2.ts
@@ -5301,7 +5301,14 @@ export function makeCodexAdapterV2(adapterOptions: CodexAdapterV2Options): Provi
                   // A null start timestamp acknowledges a queued turn; Codex cannot interrupt it
                   // until turn/started confirms that the native task exists.
                   if (context.nativeStartReady !== undefined) {
-                    yield* Deferred.await(context.nativeStartReady);
+                    const ready = yield* Deferred.await(context.nativeStartReady).pipe(
+                      Effect.timeoutOption("10 seconds"),
+                    );
+                    if (Option.isNone(ready)) {
+                      return yield* toProtocolError(
+                        "Codex did not start the queued turn within 10 seconds; Stop could not be delivered.",
+                      );
+                    }
                   }
                   if ((yield* Ref.get(activeTurns)).get(context.nativeTurnId) !== context) {
                     continue;


### PR DESCRIPTION
Stop waits for native Codex turn/started when turn/start acknowledges a queued turn with a null start timestamp. If the turn fails before starting, Stop finishes without sending an invalid interrupt.

Rebased onto current v2, preserving the original feature commit. The prerequisite redaction assertion is already in v2.

Validation: both new regression cases fail with the base adapter and pass with this patch; all 61 Codex adapter tests pass. Server typecheck and scoped formatting pass. CI and the requested Claude Fable 5.1 review are being checked before merge.

Prepared by GPT-6 Astra in the Codex/T3 harness.

Review follow-up: the native-start wait now has a ten-second deadline. If Codex never starts or terminalizes the turn, Stop reports an error and executes the existing lineage finalization and interrupt-state cleanup. The added timeout regression hangs on the previous head and passes with the fix.
