### PR TITLE
fix(server): keep the native Grok default model

### DIFF
--- a/apps/server/src/orchestration-v2/Adapters/AcpAdapterV2.test.ts
+++ b/apps/server/src/orchestration-v2/Adapters/AcpAdapterV2.test.ts
@@ -12,6 +12,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
 import {
   CheckpointId,
+  GrokSettings,
   EnvironmentId,
   MessageId,
   type ModelSelection,
@@ -87,6 +88,10 @@ import {
   type AcpAdapterV2RuntimeInput,
   type AcpAdapterV2SubagentUpdate,
 } from "./AcpAdapterV2.ts";
+
+import { makeGrokAdapterV2 } from "./GrokAdapterV2.ts";
+
+const DEFAULT_GROK_SETTINGS = Schema.decodeSync(GrokSettings)({});
 
 const serverConfigLayer = ServerConfig.layerTest(process.cwd(), {
   prefix: "t3-acp-v2-adapter-",
@@ -2688,6 +2693,50 @@ describe("AcpAdapterV2", () => {
       assert.equal(finalizerMethods.filter((method) => method === "session/close").length, 1);
     }).pipe(Effect.provide(testLayer)),
   );
+
+  for (const model of ["grok-build", "grok-mock-alt"]) {
+    it.effect(`Grok configures the native session for ${model}`, () =>
+      Effect.gen(function* () {
+        const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const idAllocator = yield* IdAllocatorV2;
+        const path = yield* Path.Path;
+        const serverConfig = yield* ServerConfig;
+        const mockAgentPath = yield* path.fromFileUrl(
+          new URL("../../../scripts/acp-mock-agent.ts", import.meta.url),
+        );
+        const protocolEvents = yield* Queue.unbounded<EffectAcpProtocol.AcpProtocolLogEvent>();
+        const instanceId = ProviderInstanceId.make("grok-test");
+        const adapter = makeGrokAdapterV2({
+          instanceId,
+          settings: DEFAULT_GROK_SETTINGS,
+          environment: {},
+          hostPlatform: yield* HostProcessPlatform,
+          childProcessSpawner,
+          crypto: yield* Crypto.Crypto,
+          fileSystem,
+          idAllocator,
+          serverConfig,
+          makeRuntime: makeMockRuntime({ childProcessSpawner, mockAgentPath, protocolEvents }),
+        });
+        yield* adapter.openSession({
+          threadId: ThreadId.make(`grok-model-${model}`),
+          providerSessionId: ProviderSessionId.make(`grok-model-${model}`),
+          modelSelection: { instanceId, model },
+          runtimePolicy: ProviderAdapterV2RuntimePolicy.make({
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            cwd: process.cwd(),
+          }),
+        });
+        const methods = yield* pollProtocolMethods(protocolEvents);
+        assert.equal(
+          methods.filter((method) => method === "session/set_model").length,
+          model === "grok-build" ? 0 : 1,
+        );
+      }).pipe(Effect.provide(testLayer), Effect.scoped),
+    );
+  }
 
   it.effect("skips requested options that the active ACP session does not expose", () =>
     Effect.gen(function* () {

--- a/apps/server/src/orchestration-v2/Adapters/AcpAdapterV2.test.ts
+++ b/apps/server/src/orchestration-v2/Adapters/AcpAdapterV2.test.ts
@@ -2738,6 +2738,71 @@ describe("AcpAdapterV2", () => {
     );
   }
 
+  it.live("Grok reapplies an explicit return to the session's setup-time model", () =>
+    Effect.gen(function* () {
+      const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const idAllocator = yield* IdAllocatorV2;
+      const path = yield* Path.Path;
+      const serverConfig = yield* ServerConfig;
+      const mockAgentPath = yield* path.fromFileUrl(
+        new URL("../../../scripts/acp-mock-agent.ts", import.meta.url),
+      );
+      const protocolEvents = yield* Queue.unbounded<EffectAcpProtocol.AcpProtocolLogEvent>();
+      const instanceId = ProviderInstanceId.make("grok-test-switch-back");
+      const adapter = makeGrokAdapterV2({
+        instanceId,
+        settings: DEFAULT_GROK_SETTINGS,
+        environment: {},
+        hostPlatform: yield* HostProcessPlatform,
+        childProcessSpawner,
+        crypto: yield* Crypto.Crypto,
+        fileSystem,
+        idAllocator,
+        serverConfig,
+        makeRuntime: makeMockRuntime({ childProcessSpawner, mockAgentPath, protocolEvents }),
+      });
+      const threadId = ThreadId.make("grok-model-switch-back");
+      const runtimePolicy = ProviderAdapterV2RuntimePolicy.make({
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        cwd: process.cwd(),
+      });
+      const runtime = yield* adapter.openSession({
+        threadId,
+        providerSessionId: ProviderSessionId.make("grok-model-switch-back"),
+        modelSelection: { instanceId, model: "grok-mock-alt" },
+        runtimePolicy,
+      });
+      const providerThread = yield* runtime.ensureThread({
+        threadId,
+        modelSelection: { instanceId, model: "grok-mock-alt" },
+        runtimePolicy,
+      });
+      // The mock session starts on grok-4.6. Switching away and explicitly
+      // back must re-send session/set_model; stale setup metadata used to make
+      // the return trip a silent no-op that left the session on the alt model.
+      for (const model of ["grok-4.6", "grok-mock-alt"]) {
+        yield* runtime.startTurn(
+          makeTurnInput({
+            threadId,
+            providerThread,
+            instanceId,
+            runtimePolicy,
+            now: yield* DateTime.now,
+            modelSelection: { instanceId, model },
+          }),
+        );
+        yield* runtime.events.pipe(
+          Stream.filter((event) => event.type === "turn.terminal"),
+          Stream.runHead,
+        );
+      }
+      const methods = yield* pollProtocolMethods(protocolEvents);
+      assert.equal(methods.filter((method) => method === "session/set_model").length, 3);
+    }).pipe(Effect.provide(testLayer), Effect.scoped),
+  );
+
   it.effect("skips requested options that the active ACP session does not expose", () =>
     Effect.gen(function* () {
       const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;

--- a/apps/server/src/orchestration-v2/Adapters/AcpAdapterV2.test.ts
+++ b/apps/server/src/orchestration-v2/Adapters/AcpAdapterV2.test.ts
@@ -2694,7 +2694,7 @@ describe("AcpAdapterV2", () => {
     }).pipe(Effect.provide(testLayer)),
   );
 
-  for (const model of ["grok-build", "grok-mock-alt"]) {
+  for (const model of ["grok-build", "composer-2"]) {
     it.effect(`Grok configures the native session for ${model}`, () =>
       Effect.gen(function* () {
         const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
@@ -2729,9 +2729,16 @@ describe("AcpAdapterV2", () => {
             cwd: process.cwd(),
           }),
         });
-        const methods = yield* pollProtocolMethods(protocolEvents);
+        const requests = (yield* Queue.takeAll(protocolEvents)).map(rawProtocolRequest);
         assert.equal(
-          methods.filter((method) => method === "session/set_model").length,
+          requests.filter(
+            (request) =>
+              request?.method === "session/set_config_option" &&
+              typeof request.params === "object" &&
+              request.params !== null &&
+              "configId" in request.params &&
+              request.params.configId === "model",
+          ).length,
           model === "grok-build" ? 0 : 1,
         );
       }).pipe(Effect.provide(testLayer), Effect.scoped),
@@ -2771,18 +2778,18 @@ describe("AcpAdapterV2", () => {
       const runtime = yield* adapter.openSession({
         threadId,
         providerSessionId: ProviderSessionId.make("grok-model-switch-back"),
-        modelSelection: { instanceId, model: "grok-mock-alt" },
+        modelSelection: { instanceId, model: "composer-2" },
         runtimePolicy,
       });
       const providerThread = yield* runtime.ensureThread({
         threadId,
-        modelSelection: { instanceId, model: "grok-mock-alt" },
+        modelSelection: { instanceId, model: "composer-2" },
         runtimePolicy,
       });
-      // The mock session starts on grok-4.6. Switching away and explicitly
-      // back must re-send session/set_model; stale setup metadata used to make
+      // The mock session starts on default. Switching away and explicitly
+      // back must send the model configuration change; stale metadata can make
       // the return trip a silent no-op that left the session on the alt model.
-      for (const model of ["grok-4.6", "grok-mock-alt"]) {
+      for (const model of ["default", "composer-2"]) {
         yield* runtime.startTurn(
           makeTurnInput({
             threadId,
@@ -2798,8 +2805,18 @@ describe("AcpAdapterV2", () => {
           Stream.runHead,
         );
       }
-      const methods = yield* pollProtocolMethods(protocolEvents);
-      assert.equal(methods.filter((method) => method === "session/set_model").length, 3);
+      const requests = (yield* Queue.takeAll(protocolEvents)).map(rawProtocolRequest);
+      assert.equal(
+        requests.filter(
+          (request) =>
+            request?.method === "session/set_config_option" &&
+            typeof request.params === "object" &&
+            request.params !== null &&
+            "configId" in request.params &&
+            request.params.configId === "model",
+        ).length,
+        3,
+      );
     }).pipe(Effect.provide(testLayer), Effect.scoped),
   );
 

--- a/apps/server/src/orchestration-v2/Adapters/AcpAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/AcpAdapterV2.ts
@@ -5768,8 +5768,13 @@ export function makeAcpAdapterV2(options: AcpAdapterV2Options): ProviderAdapterV
           runtimePolicy: ProviderAdapterV2RuntimePolicy,
         ) {
           const requestedModel = flavor.resolveModelId?.(modelSelection) ?? modelSelection.model;
+          let appliedModel: string | undefined;
           if (flavor.applyModelSelection !== undefined) {
-            yield* flavor.applyModelSelection({ runtime, startResult, modelSelection });
+            appliedModel = yield* flavor.applyModelSelection({
+              runtime,
+              startResult,
+              modelSelection,
+            });
           } else if (
             requestedModel.length > 0 &&
             requestedModel !== "auto" &&
@@ -5782,6 +5787,29 @@ export function makeAcpAdapterV2(options: AcpAdapterV2Options): ProviderAdapterV
             if (hasModelConfig) {
               yield* runtime.setModel(requestedModel);
             }
+          }
+          // Same-runtime switches compare against this stored setup, so keep
+          // its model metadata in sync with what the session now runs on;
+          // otherwise switching A -> B -> A would see the stale setup-time A
+          // and skip the final switch.
+          if (appliedModel !== undefined) {
+            const applied = appliedModel;
+            yield* Ref.update(activeSessionSetup, (setup) => {
+              if (setup === null) {
+                return setup;
+              }
+              const models = setup.sessionSetupResult.models;
+              if (models == null || models.currentModelId === applied) {
+                return setup;
+              }
+              return {
+                ...setup,
+                sessionSetupResult: {
+                  ...setup.sessionSetupResult,
+                  models: { ...models, currentModelId: applied },
+                },
+              };
+            });
           }
           const optionSelections = modelSelection.options ?? [];
           const configOptions = yield* runtime.getConfigOptions;

--- a/apps/server/src/orchestration-v2/Adapters/GrokAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/GrokAdapterV2.ts
@@ -226,11 +226,22 @@ export function makeGrokAcpAdapterFlavor(options: GrokAdapterV2Options): AcpAdap
     supportsCompaction: true,
     resolveModelId: (selection) => resolveGrokAcpBaseModelId(selection.model),
     applyModelSelection: ({ runtime, startResult, modelSelection }) =>
-      applyGrokAcpModelSelection({
-        runtime,
-        currentModelId: currentGrokModelIdFromSessionSetup(startResult.sessionSetupResult),
-        requestedModelId: resolveGrokAcpBaseModelId(modelSelection.model),
-        mapError: (cause) => cause,
+      Effect.gen(function* () {
+        const legacy = startResult.initializeResult.protocolVersion === 1;
+        const options = legacy ? [] : yield* runtime.getConfigOptions;
+        const configuredModel = options.find((option) => option.category === "model")?.currentValue;
+        return yield* applyGrokAcpModelSelection({
+          runtime: legacy
+            ? runtime
+            : { setSessionModel: (model) => runtime.setModel(model).pipe(Effect.as({})) },
+          currentModelId: legacy
+            ? currentGrokModelIdFromSessionSetup(startResult.sessionSetupResult)
+            : typeof configuredModel === "string"
+              ? configuredModel
+              : undefined,
+          requestedModelId: resolveGrokAcpBaseModelId(modelSelection.model),
+          mapError: (cause) => cause,
+        });
       }),
     makeRuntime:
       options.makeRuntime ??

--- a/apps/server/src/orchestration-v2/Adapters/GrokAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/GrokAdapterV2.ts
@@ -17,6 +17,8 @@ import type * as EffectAcpErrors from "effect-acp/errors";
 import { ServerConfig } from "../../config.ts";
 import { makeAcpNativeLoggerFactory } from "../../provider/acp/AcpNativeLogging.ts";
 import {
+  applyGrokAcpModelSelection,
+  currentGrokModelIdFromSessionSetup,
   makeGrokAcpRuntime,
   resolveGrokAcpBaseModelId,
 } from "../../provider/acp/GrokAcpSupport.ts";
@@ -223,6 +225,13 @@ export function makeGrokAcpAdapterFlavor(options: GrokAdapterV2Options): AcpAdap
     supportsImagePrompts: true,
     supportsCompaction: true,
     resolveModelId: (selection) => resolveGrokAcpBaseModelId(selection.model),
+    applyModelSelection: ({ runtime, startResult, modelSelection }) =>
+      applyGrokAcpModelSelection({
+        runtime,
+        currentModelId: currentGrokModelIdFromSessionSetup(startResult.sessionSetupResult),
+        requestedModelId: resolveGrokAcpBaseModelId(modelSelection.model),
+        mapError: (cause) => cause,
+      }),
     makeRuntime:
       options.makeRuntime ??
       ((input) =>


### PR DESCRIPTION
Treat Grok's product slug as “keep the native session model,” and keep model selection current when switching away and back within one runtime.

Rebased the original two commits onto v2. Adapted model selection to use ACP v1 session/set_model or ACP v2 model configuration according to the negotiated protocol. Preserved the current generic ACP option handling.

Validation: default selection and switching-back regression cases fail on the base and pass with this change. All 124 ACP adapter/Grok support tests pass, alongside server typechecking and scoped formatting/lint. CI and Claude Fable 5.1 review are checked before merge.

Prepared with Codex/T3; independent review requested from Claude Fable 5.1.
