### PR TITLE
fix(server): name the missing project folder instead of a provider spawn error

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -887,6 +887,46 @@ describe("ProviderCommandReactor", () => {
     expect(harness.sendTurn).not.toHaveBeenCalled();
   });
 
+  it("starts a worktree thread in its worktree after the project folder disappears", async () => {
+    const harness = await createHarness();
+    const worktreePath = NodePath.join(harness.stateDir, "provider-project-worktree");
+    NodeFS.mkdirSync(worktreePath, { recursive: true });
+
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.make("cmd-thread-worktree-survives"),
+        threadId: ThreadId.make("thread-1"),
+        worktreePath,
+      }),
+    );
+    NodeFS.rmSync(harness.projectRoot, { recursive: true, force: true });
+
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-worktree-survives"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-worktree-survives"),
+          role: "user",
+          text: "hello",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({ cwd: worktreePath });
+    const thread = (await harness.readModel()).threads.find(
+      (entry) => entry.id === ThreadId.make("thread-1"),
+    );
+    expect(thread?.session?.status).not.toBe("error");
+  });
+
   effectIt.effect("retains a turn dispatched immediately after start until activation", () =>
     Effect.gen(function* () {
       const activation = yield* Deferred.make<void>();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -186,6 +186,9 @@ describe("ProviderCommandReactor", () => {
     createdBaseDirs.add(baseDir);
     const { stateDir } = deriveServerPathsSync(baseDir, undefined);
     createdStateDirs.add(stateDir);
+    // Session start checks that the project root exists on disk.
+    const projectRoot = NodePath.join(stateDir, "provider-project");
+    NodeFS.mkdirSync(projectRoot, { recursive: true });
     const runtimeEventPubSub = Effect.runSync(PubSub.unbounded<ProviderRuntimeEvent>());
     const tryHandlePromptCommand = vi.fn<ProviderAuthService["Service"]["tryHandlePromptCommand"]>(
       input?.tryHandlePromptCommandEffect ?? (() => Effect.succeed(false)),
@@ -480,7 +483,7 @@ describe("ProviderCommandReactor", () => {
         commandId: CommandId.make("cmd-project-create"),
         projectId: asProjectId("project-1"),
         title: "Provider Project",
-        workspaceRoot: "/tmp/provider-project",
+        workspaceRoot: projectRoot,
         defaultModelSelection: modelSelection,
         createdAt: now,
       }),
@@ -576,6 +579,7 @@ describe("ProviderCommandReactor", () => {
       generateThreadTitle,
       runtimeSessions,
       stateDir,
+      projectRoot,
       drain,
       runEffect,
       get titleRegenerationCompletionDispatchAttempts() {
@@ -823,7 +827,7 @@ describe("ProviderCommandReactor", () => {
     await waitFor(() => harness.sendTurn.mock.calls.length === 1);
     expect(harness.startSession.mock.calls[0]?.[0]).toEqual(ThreadId.make("thread-1"));
     expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
-      cwd: "/tmp/provider-project",
+      cwd: harness.projectRoot,
       modelSelection: {
         instanceId: ProviderInstanceId.make("codex"),
         model: "gpt-5-codex",
@@ -836,6 +840,51 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.threadId).toBe("thread-1");
     expect(thread?.session?.status).toBe("starting");
     expect(thread?.session?.runtimeMode).toBe("approval-required");
+  });
+
+  it("reports a missing project folder instead of starting a provider session", async () => {
+    const harness = await createHarness();
+    NodeFS.rmSync(harness.projectRoot, { recursive: true, force: true });
+
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-missing-project"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-missing-project"),
+          role: "user",
+          text: "hello",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+    await waitFor(async () => {
+      const readModel = await harness.readModel();
+      return (
+        readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"))?.session
+          ?.status === "error"
+      );
+    });
+    await harness.drain();
+
+    const thread = (await harness.readModel()).threads.find(
+      (entry) => entry.id === ThreadId.make("thread-1"),
+    );
+    const detail = `This project's folder no longer exists: ${harness.projectRoot}`;
+    expect(thread?.session).toMatchObject({ status: "error", lastError: detail });
+    expect(thread?.activities).toContainEqual(
+      expect.objectContaining({
+        kind: "provider.turn.start.failed",
+        tone: "error",
+        payload: expect.objectContaining({ detail }),
+      }),
+    );
+    expect(harness.startSession).not.toHaveBeenCalled();
+    expect(harness.sendTurn).not.toHaveBeenCalled();
   });
 
   effectIt.effect("retains a turn dispatched immediately after start until activation", () =>
@@ -1114,7 +1163,7 @@ describe("ProviderCommandReactor", () => {
 
     expect(harness.generateThreadTitle).toHaveBeenCalledTimes(1);
     expect(harness.generateThreadTitle.mock.calls[0]?.[0]).toMatchObject({
-      cwd: "/tmp/provider-project",
+      cwd: harness.projectRoot,
       previousTitle: "Investigate reconnect regressions",
       message: [
         "USER:",
@@ -1926,9 +1975,9 @@ describe("ProviderCommandReactor", () => {
     );
 
     await waitFor(() => harness.startSession.mock.calls.length === 1);
-    expect(harness.pruneWorktrees).toHaveBeenCalledWith({ cwd: "/tmp/provider-project" });
+    expect(harness.pruneWorktrees).toHaveBeenCalledWith({ cwd: harness.projectRoot });
     expect(harness.createWorktree).toHaveBeenCalledWith({
-      cwd: "/tmp/provider-project",
+      cwd: harness.projectRoot,
       refName: "feature/restore",
       path: worktreePath,
     });
@@ -2427,7 +2476,7 @@ describe("ProviderCommandReactor", () => {
     await waitFor(() => harness.startSession.mock.calls.length === 1);
     await waitFor(() => harness.sendTurn.mock.calls.length === 1);
     expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
-      cwd: "/tmp/provider-project",
+      cwd: harness.projectRoot,
     });
 
     await Effect.runPromise(
@@ -3206,7 +3255,7 @@ describe("ProviderCommandReactor", () => {
       status: "ready",
       runtimeMode: "approval-required",
       threadId: ThreadId.make("thread-1"),
-      cwd: "/tmp/provider-project",
+      cwd: harness.projectRoot,
       resumeCursor: { opaque: "resume-without-instance" },
       createdAt: now,
       updatedAt: now,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -655,6 +655,19 @@ const make = Effect.gen(function* () {
       }
     }
     const project = yield* resolveProject(thread.projectId);
+    // A project root that was moved or deleted after it was added would
+    // otherwise surface as a provider spawn failure that never names the
+    // folder. Check it here so every provider reports the same cause.
+    const projectRootExists = project
+      ? yield* fileSystem.exists(project.workspaceRoot).pipe(Effect.orElseSucceed(() => true))
+      : true;
+    if (project && !projectRootExists) {
+      return yield* new ProviderAdapterRequestError({
+        provider: preferredProvider,
+        method: "thread.turn.start",
+        detail: `This project's folder no longer exists: ${project.workspaceRoot}`,
+      });
+    }
     const effectiveCwd = resolveThreadWorkspaceCwd({
       thread,
       projects: project ? [project] : [],

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -655,19 +655,6 @@ const make = Effect.gen(function* () {
       }
     }
     const project = yield* resolveProject(thread.projectId);
-    // A project root that was moved or deleted after it was added would
-    // otherwise surface as a provider spawn failure that never names the
-    // folder. Check it here so every provider reports the same cause.
-    const projectRootExists = project
-      ? yield* fileSystem.exists(project.workspaceRoot).pipe(Effect.orElseSucceed(() => true))
-      : true;
-    if (project && !projectRootExists) {
-      return yield* new ProviderAdapterRequestError({
-        provider: preferredProvider,
-        method: "thread.turn.start",
-        detail: `This project's folder no longer exists: ${project.workspaceRoot}`,
-      });
-    }
     const effectiveCwd = resolveThreadWorkspaceCwd({
       thread,
       projects: project ? [project] : [],
@@ -678,22 +665,46 @@ const make = Effect.gen(function* () {
           .pipe(Effect.forkDetach)
       : Effect.void;
 
+    // A project folder that was moved or deleted after it was added would
+    // otherwise surface as a provider spawn failure that never names the
+    // path. Only a fresh session on the project root is checked: a running
+    // session keeps its cwd, and worktree threads are handled by
+    // ensureThreadWorktree.
+    const ensureProjectRootExists = Effect.gen(function* () {
+      if (!project || thread.worktreePath) {
+        return;
+      }
+      const exists = yield* fileSystem
+        .exists(project.workspaceRoot)
+        .pipe(Effect.orElseSucceed(() => true));
+      if (!exists) {
+        return yield* new ProviderAdapterRequestError({
+          provider: preferredProvider,
+          method: "thread.turn.start",
+          detail: `This project's folder no longer exists: ${project.workspaceRoot}`,
+        });
+      }
+    });
+
     const startProviderSession = (input?: {
       readonly resumeCursor?: unknown;
       readonly provider?: ProviderDriverKind;
     }) =>
-      providerService
-        .startSession(threadId, {
-          threadId,
-          ...(preferredProvider ? { provider: preferredProvider } : {}),
-          providerInstanceId: desiredInstanceId,
-          ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
-          ...(thread.title ? { title: thread.title } : {}),
-          modelSelection: desiredModelSelection,
-          ...(input?.resumeCursor !== undefined ? { resumeCursor: input.resumeCursor } : {}),
-          runtimeMode: desiredRuntimeMode,
-        })
-        .pipe(Effect.tap(() => refreshWorkspaceSnapshot));
+      ensureProjectRootExists.pipe(
+        Effect.flatMap(() =>
+          providerService.startSession(threadId, {
+            threadId,
+            ...(preferredProvider ? { provider: preferredProvider } : {}),
+            providerInstanceId: desiredInstanceId,
+            ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
+            ...(thread.title ? { title: thread.title } : {}),
+            modelSelection: desiredModelSelection,
+            ...(input?.resumeCursor !== undefined ? { resumeCursor: input.resumeCursor } : {}),
+            runtimeMode: desiredRuntimeMode,
+          }),
+        ),
+        Effect.tap(() => refreshWorkspaceSnapshot),
+      );
 
     const bindSessionToThread = (session: ProviderSession) =>
       Effect.gen(function* () {


### PR DESCRIPTION
Fixes #4940

## Problem

If a project's folder is moved or deleted after it was added to T3 Code, the next turn fails with a raw provider spawn error (`spawn ... ENOENT` for Codex, and equivalents for the other providers) plus a stack trace in the toast. Nothing tells the user which folder went missing, so it reads like a broken provider install rather than a moved project.

## Fix

`ProviderCommandReactor` now checks that the project's `workspaceRoot` still exists right before it spawns a new provider session. The check is skipped for threads that have a worktree, since their provider runs in the worktree under T3 home and `ensureThreadWorktree` already recreates a missing one. If the folder is gone, the turn fails with a `ProviderAdapterRequestError` whose detail is shown verbatim:

    This project's folder no longer exists: /path/to/the/project

The check lives in the reactor, ahead of provider selection, so Codex, Claude, Cursor, Grok, OpenCode, and Antigravity all report the same cause instead of six different spawn failures. The session lands in the usual `error` state with `lastError` set and a `provider.turn.start.failed` activity, so the existing UI paths surface it with no client changes.

Re-linking a moved project to its new location, as the issue also suggests, is a separate feature and out of scope for this PR.

## Tests

- Two new tests in `ProviderCommandReactor.test.ts`:
  - Deletes the project root, dispatches a turn start, and asserts the session error, the failure activity with the exact message, and that neither `startSession` nor `sendTurn` was called.
  - A worktree thread whose project folder was deleted still starts its provider in the worktree and sends the turn.
- The harness now creates a real project directory under the test state dir instead of the placeholder `/tmp/provider-project` path, so the existing tests keep passing the new check.
- Verified locally: `vp test run` on the reactor test file (60/60), `vp lint`, `vp fmt --check`, and the server typecheck.

Model: Claude Fable 5.1. Harness: Claude Code.