### PR TITLE
refactor(server): keep manifest age parsing private

### DIFF
--- a/apps/server/src/provider/ModelManifest.test.ts
+++ b/apps/server/src/provider/ModelManifest.test.ts
@@ -17,7 +17,6 @@ import {
   make,
   resolveProviderCatalog,
   type ModelManifestData,
-  manifestUpdatedAtMs,
   encodeManifestCache,
 } from "./ModelManifest.ts";
 
@@ -382,7 +381,6 @@ describe("ModelManifest service", () => {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const config = yield* ServerConfig.ServerConfig;
-      assert.isAbove(manifestUpdatedAtMs(BUNDLED_MODEL_MANIFEST), 0);
       const cachePath = path.join(config.stateDir, "model-manifest.json");
       // A cache of the manifest as it was before the release edited it. The
       // fetch time is irrelevant: the remote may be unreachable now, so

--- a/apps/server/src/provider/ModelManifest.ts
+++ b/apps/server/src/provider/ModelManifest.ts
@@ -138,7 +138,7 @@ export const BUNDLED_MODEL_MANIFEST: ModelManifestData =
   Schema.decodeUnknownSync(ModelManifestSchema)(bundledManifestJson);
 
 /** Epoch millis of the manifest's `updatedAt`, or 0 when absent or unparsable. */
-export function manifestUpdatedAtMs(manifest: ModelManifestData): number {
+function manifestUpdatedAtMs(manifest: ModelManifestData): number {
   if (manifest.updatedAt === undefined) return 0;
   const parsed = Date.parse(manifest.updatedAt);
   return Number.isNaN(parsed) ? 0 : parsed;


### PR DESCRIPTION
The manifest timestamp parser was exported only for a preliminary assertion in the cache-selection test. That assertion repeated a condition already required by the undated-cache case.

Make the parser private and remove the preliminary assertion. The service test still verifies that undated and older caches lose to the bundle and a newer cache wins. Runtime logic is unchanged.

Verification: the four targeted baseline suites passed all 48 tests. The manifest suite still passes all 9 tests after this change. Server-only typecheck, targeted lint, formatting, and diff checks passed. No visual behavior changed.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `manifestUpdatedAtMs` helper private in `ModelManifest`
> Changes `manifestUpdatedAtMs` from an exported function to a module-private function in [ModelManifest.ts](https://github.com/pingdotgg/t3code/pull/10028/files#diff-90c8a7d2335de8efb8f559e4e63dfa1d33e525f9906c327988726c51bbaf750a). Removes the corresponding test import and timestamp assertion in [ModelManifest.test.ts](https://github.com/pingdotgg/t3code/pull/10028/files#diff-6c2f59aceb04c442bc4e6cba801e7fa4ca415305c4b422091753a1283ad11567). Parsing behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35a1751.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->