### PR TITLE
refactor(mobile): remove unused awareness relay URL normalizer

### DIFF
--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -33,7 +33,6 @@ import {
   mergeAgentAwarenessRegistrationPreferences,
   refreshActiveLiveActivityRemoteRegistration,
   refreshAgentAwarenessRegistration,
-  normalizeAgentAwarenessRelayBaseUrl,
   registerAgentAwarenessConnection,
   registerLiveActivityPushToken,
   releaseAgentAwarenessRelayTokenProvider,
@@ -361,13 +360,6 @@ describe("makeRelayDeviceRegistrationRequest", () => {
         notifyOnFailure: true,
       },
     });
-  });
-
-  it("normalizes relay base URLs for APNs registration requests", () => {
-    expect(normalizeAgentAwarenessRelayBaseUrl(" https://relay.example.test/// ")).toBe(
-      "https://relay.example.test",
-    );
-    expect(normalizeAgentAwarenessRelayBaseUrl("   ")).toBeNull();
   });
 
   it("overrides persisted preferences for an in-flight registration", () => {

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -139,16 +139,6 @@ export function mergeAgentAwarenessRegistrationPreferences(
   return { ...stored, ...override };
 }
 
-export function normalizeAgentAwarenessRelayBaseUrl(
-  value: string | null | undefined,
-): string | null {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    return null;
-  }
-  return trimmed.replace(/\/+$/g, "");
-}
-
 function readRelayConfig(): { readonly url: string } | null {
   const relayUrl = resolveCloudPublicConfig().relay.url;
   if (!relayUrl) {


### PR DESCRIPTION
The Live Activity relay URL normalizer had no production callers. Its dedicated test was the only consumer, while registration reads the resolved cloud config directly.

Remove the orphan helper and its test. Active configuration and registration behavior stay unchanged.

Verification: 41 focused tests passed before, 40 after across remote registration, Live Activity preferences, and cloud public config. Mobile typecheck, targeted lint/format, and diff checks passed. No visual change.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `normalizeAgentAwarenessRelayBaseUrl` normalizer from mobile agent-awareness
> Deletes the relay-base-URL normalization utility that trimmed whitespace, removed trailing slashes, and converted blank values to null, along with its test. The helper was unused as part of a cross-file refactor in the agent-awareness registration flow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ccd132.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->