### PR TITLE
refactor(server): remove unused startup heartbeat launcher

### DIFF
--- a/apps/server/src/serverRuntimeStartup.test.ts
+++ b/apps/server/src/serverRuntimeStartup.test.ts
@@ -13,7 +13,6 @@ import * as Stream from "effect/Stream";
 import * as ServerConfig from "./config.ts";
 import * as OrchestrationEngine from "./orchestration/Services/OrchestrationEngine.ts";
 import * as ProjectionSnapshotQuery from "./orchestration/Services/ProjectionSnapshotQuery.ts";
-import * as AnalyticsService from "./telemetry/AnalyticsService.ts";
 import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
 import * as GitVcsDriver from "./vcs/GitVcsDriver.ts";
 
@@ -99,56 +98,6 @@ it.effect("enqueueCommand fails queued work when readiness fails", () =>
 
       const error = yield* Effect.flip(Fiber.join(queuedCommandFiber));
       assert.equal(error.message, "Server runtime startup failed before command readiness.");
-    }),
-  ),
-);
-
-it.effect("launchStartupHeartbeat does not block the caller while counts are loading", () =>
-  Effect.scoped(
-    Effect.gen(function* () {
-      const releaseCounts = yield* Deferred.make<void, never>();
-      const countsStarted = yield* Deferred.make<void, never>();
-
-      yield* ServerRuntimeStartup.launchStartupHeartbeat.pipe(
-        Effect.provideService(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {
-          getUserInputActivity: () => Effect.die("unused"),
-          getCommandReadModel: () => Effect.die("unused"),
-          getSnapshot: () => Effect.die("unused"),
-          getShellSnapshot: () => Effect.die("unused"),
-          getArchivedShellSnapshot: () => Effect.die("unused"),
-          getSnapshotSequence: () => Effect.die("unused"),
-          getEventReplayStats: () => Effect.die("unused"),
-          getCounts: () =>
-            Deferred.succeed(countsStarted, undefined).pipe(
-              Effect.andThen(Deferred.await(releaseCounts)),
-              Effect.as({
-                projectCount: 2,
-                threadCount: 3,
-              }),
-            ),
-          getActiveProjectByWorkspaceRoot: () => Effect.succeed(Option.none()),
-          getProjectShellById: () => Effect.succeed(Option.none()),
-          getFirstActiveThreadIdByProjectId: () => Effect.succeed(Option.none()),
-          getThreadCheckpointContext: () => Effect.succeed(Option.none()),
-          getFullThreadDiffContext: () => Effect.succeed(Option.none()),
-          getThreadRuntimeContext: () => Effect.die("unused"),
-          getThreadShellById: () => Effect.succeed(Option.none()),
-          getThreadDetailById: () => Effect.succeed(Option.none()),
-          getThreadDetailSnapshot: () => Effect.succeed(Option.none()),
-          searchThreads: () => Effect.succeed({ matches: [] }),
-        }),
-        Effect.provideService(AnalyticsService.AnalyticsService, {
-          record: () => Effect.void,
-          flush: Effect.void,
-        }),
-      );
-
-      // The heartbeat is forked, so the caller is already back here while
-      // getCounts is still parked. Awaiting countsStarted proves the forked
-      // work really ran; releaseCounts staying incomplete proves the caller
-      // never waited for it.
-      yield* Deferred.await(countsStarted);
-      assert.equal(yield* Deferred.isDone(releaseCounts), false);
     }),
   ),
 );

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -168,14 +168,6 @@ export const recordStartupHeartbeat = Effect.gen(function* () {
   });
 });
 
-export const launchStartupHeartbeat = recordStartupHeartbeat.pipe(
-  Effect.annotateSpans({ "startup.phase": "heartbeat.record" }),
-  Effect.withSpan("server.startup.heartbeat.record"),
-  Effect.ignoreCause({ log: true }),
-  Effect.forkScoped,
-  Effect.asVoid,
-);
-
 const getAutoBootstrapThreadModelSelection = (): ModelSelection => ({
   instanceId: ProviderInstanceId.make("codex"),
   model: DEFAULT_MODEL,


### PR DESCRIPTION
The exported startup heartbeat launcher had no runtime callers. Only its unit test used it, while real startup already schedules the heartbeat through forkParked.

Delete the unused launcher and its orphan test. Keep recordStartupHeartbeat, the live startup pipeline, and all command readiness and startup reconciliation coverage unchanged. The removed test exercised the orphan wrapper, not the live heartbeat's scheduling.

Verification: the four targeted baseline suites passed all 48 tests. After removal, startup and reconciliation suites pass all 31 tests. Server-only typecheck, targeted lint, formatting, and diff checks passed. No visual behavior changed.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `launchStartupHeartbeat` from `serverRuntimeStartup`
> Deletes the exported `launchStartupHeartbeat` effect and its associated test from [serverRuntimeStartup.ts](https://github.com/pingdotgg/t3code/pull/10030/files#diff-1930335d6e319fc5766e0578303e19f9d788e9990f87604b77f9f768e61d7118). The effect previously forked startup heartbeat recording into a background scope. Risk: any out-of-tree callers importing `launchStartupHeartbeat` will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f2d932.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->