### PR TITLE
refactor(shared): keep search ranking comparator private

### DIFF
--- a/packages/shared/src/searchRanking.test.ts
+++ b/packages/shared/src/searchRanking.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
-  compareRankedSearchResults,
   insertRankedSearchResult,
   normalizeSearchQuery,
   scoreQueryMatch,
@@ -90,6 +89,5 @@ describe("insertRankedSearchResult", () => {
     insertRankedSearchResult(ranked, { item: "c", score: 30, tieBreaker: "c" }, 2);
 
     expect(ranked.map((entry) => entry.item)).toEqual(["a", "b"]);
-    expect(compareRankedSearchResults(ranked[0]!, ranked[1]!)).toBeLessThan(0);
   });
 });

--- a/packages/shared/src/searchRanking.ts
+++ b/packages/shared/src/searchRanking.ts
@@ -135,7 +135,7 @@ export function scoreQueryMatch(input: {
   return null;
 }
 
-export function compareRankedSearchResults<T>(
+function compareRankedSearchResults<T>(
   left: RankedSearchResult<T>,
   right: RankedSearchResult<T>,
 ): number {


### PR DESCRIPTION
The search ranking comparator was exported only for an assertion that repeated the ordering already checked through insertRankedSearchResult.

Keep the comparator private and remove that duplicate assertion. The insertion algorithm and expected ranked output are unchanged.

Verification: 31 focused tests passed before and after across shared ranking, mobile file search, and web command/model/skill search. Shared-package typecheck, targeted lint/format, and diff checks passed. No visual change.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `compareRankedSearchResults` comparator private in `searchRanking`
> Removes the export of the ranking comparator from [searchRanking.ts](https://github.com/pingdotgg/t3code/pull/10031/files#diff-6f3a72c8d432e8ebe3f4edf96d0454da65a4388a344154257e7a6244b2647c60); the comparison logic is unchanged. Updates [searchRanking.test.ts](https://github.com/pingdotgg/t3code/pull/10031/files#diff-479ecacd16585aacb79cc97af7291a7ec693dd324a7c4f0e753c4627b2743aba) to stop importing the comparator directly, while still asserting ranked items are ordered and limited correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bce6f2b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->