### PR TITLE
refactor(server): keep telemetry identity errors private

### DIFF
--- a/apps/server/src/telemetry/Identify.test.ts
+++ b/apps/server/src/telemetry/Identify.test.ts
@@ -33,26 +33,6 @@ const findIdentityLog = (
   errorTag: string,
 ) => logs.find((log) => log.annotations.source === source && log.annotations.errorTag === errorTag);
 
-it("preserves exact telemetry identity causes without deriving messages from them", () => {
-  const decodeCause = new Error("private nested decode details");
-  const decodeError = new Identify.TelemetryIdentityDecodeError({
-    source: "codex",
-    filePath: "/tmp/auth.json",
-    cause: decodeCause,
-  });
-  const readCause = new Error("private nested read details");
-  const readError = new Identify.TelemetryIdentityReadError({
-    source: "anonymous",
-    filePath: "/tmp/anonymous-id",
-    cause: readCause,
-  });
-
-  assert.strictEqual(decodeError.cause, decodeCause);
-  assert.strictEqual(readError.cause, readCause);
-  assert.notInclude(decodeError.message, decodeCause.message);
-  assert.notInclude(readError.message, readCause.message);
-});
-
 it.layer(NodeServices.layer)("telemetry identity", (it) => {
   it.effect("uses the persisted anonymous id when provider identities are absent", () =>
     Effect.gen(function* () {

--- a/apps/server/src/telemetry/Identify.ts
+++ b/apps/server/src/telemetry/Identify.ts
@@ -23,7 +23,7 @@ const ClaudeJsonSchema = Schema.Struct({
 export const TelemetryIdentitySource = Schema.Literals(["codex", "claude", "anonymous"]);
 export type TelemetryIdentitySource = typeof TelemetryIdentitySource.Type;
 
-export class TelemetryIdentityReadError extends Schema.TaggedErrorClass<TelemetryIdentityReadError>()(
+class TelemetryIdentityReadError extends Schema.TaggedErrorClass<TelemetryIdentityReadError>()(
   "TelemetryIdentityReadError",
   {
     source: TelemetryIdentitySource,
@@ -36,7 +36,7 @@ export class TelemetryIdentityReadError extends Schema.TaggedErrorClass<Telemetr
   }
 }
 
-export class TelemetryIdentityDecodeError extends Schema.TaggedErrorClass<TelemetryIdentityDecodeError>()(
+class TelemetryIdentityDecodeError extends Schema.TaggedErrorClass<TelemetryIdentityDecodeError>()(
   "TelemetryIdentityDecodeError",
   {
     source: Schema.Literals(["codex", "claude"]),


### PR DESCRIPTION
Two telemetry identity errors were exported only so a test could construct them and inspect their supplied causes. Real failure tests already exercise identity fallback and safe logging through getTelemetryIdentifierForHome.

Make those error classes private and remove the constructor-only test. Keep their messages, causes, error handling, and all three behavior tests unchanged, including the malformed-auth token-redaction test and the unreadable anonymous-ID case.

Verification: the four targeted baseline suites passed all 48 tests. All 3 retained identity behavior tests pass after this change. Server-only typecheck, targeted lint, formatting, and diff checks passed. No visual behavior changed.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make telemetry identity error classes private in `Identify.ts`
> - Removes the module export from `TelemetryIdentityReadError` and `TelemetryIdentityDecodeError` in [Identify.ts](https://github.com/pingdotgg/t3code/pull/10032/files#diff-a50c9348071512e0bea296dca3a49a3f8fe4e903cf32378d3d94c5341161b174). The error fields and message logic are unchanged.
> - Drops the test in [Identify.test.ts](https://github.com/pingdotgg/t3code/pull/10032/files#diff-bb593f6aef27f4b63614bebfeeb20abe393153f50247081075a2b9946e9ecdf3) that asserted cause preservation and message formatting for these errors.
> - Behavioral Change: `TelemetryIdentityReadError` and `TelemetryIdentityDecodeError` are no longer importable outside the `telemetry/Identify` module; any external consumers will fail to compile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8b204b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->