### PR TITLE
refactor(mobile): test composer persistence through the live decoder

### DIFF
--- a/apps/mobile/src/state/use-composer-drafts.test.ts
+++ b/apps/mobile/src/state/use-composer-drafts.test.ts
@@ -159,7 +159,6 @@ import {
   copyComposerDraftContentIfEmpty,
   copyComposerDraftContentState,
   decodePersistedComposerState,
-  decodePersistedComposerDrafts,
   ensureComposerDraftsLoaded,
   type ComposerDraft,
   flushComposerDrafts,
@@ -252,12 +251,12 @@ describe("mobile composer drafts", () => {
     };
 
     expect(
-      decodePersistedComposerDrafts({
+      decodePersistedComposerState({
         schemaVersion: 1,
         drafts: {
           "environment-1:thread-1": { text: "Review this file", attachments: [file] },
         },
-      }),
+      }).drafts,
     ).toEqual({
       "environment-1:thread-1": { text: "Review this file", attachments: [file] },
     });
@@ -987,7 +986,7 @@ describe("mobile composer drafts", () => {
 
   it("rejects persisted images without image bytes or a file URI", () => {
     expect(() =>
-      decodePersistedComposerDrafts({
+      decodePersistedComposerState({
         schemaVersion: 1,
         drafts: {
           "environment-1:thread-1": {
@@ -1010,7 +1009,7 @@ describe("mobile composer drafts", () => {
 
   it("hydrates selector state even when the message content is empty", () => {
     expect(
-      decodePersistedComposerDrafts({
+      decodePersistedComposerState({
         schemaVersion: 1,
         drafts: {
           "new-task:environment-1:project-1": {
@@ -1030,7 +1029,7 @@ describe("mobile composer drafts", () => {
             },
           },
         },
-      }),
+      }).drafts,
     ).toEqual({
       "new-task:environment-1:project-1": {
         text: "",
@@ -1053,18 +1052,18 @@ describe("mobile composer drafts", () => {
 
   it("keeps legacy content-only drafts and rejects invalid selector state", () => {
     expect(
-      decodePersistedComposerDrafts({
+      decodePersistedComposerState({
         schemaVersion: 1,
         drafts: {
           "environment-1:thread-1": DRAFT,
         },
-      }),
+      }).drafts,
     ).toEqual({
       "environment-1:thread-1": DRAFT,
     });
 
     expect(() =>
-      decodePersistedComposerDrafts({
+      decodePersistedComposerState({
         schemaVersion: 1,
         drafts: {
           "environment-1:thread-1": {

--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -238,10 +238,6 @@ export function decodePersistedComposerState(value: unknown): {
   };
 }
 
-export function decodePersistedComposerDrafts(value: unknown): Record<string, ComposerDraft> {
-  return decodePersistedComposerState(value).drafts;
-}
-
 async function getComposerDraftsFile() {
   const { Directory, File, Paths } = await import("expo-file-system");
   const directory = new Directory(Paths.document, COMPOSER_DRAFTS_DIRECTORY);


### PR DESCRIPTION
An old draft decoder wrapper only projected .drafts from decodePersistedComposerState and had no production callers. Five test calls kept it exported.

Remove the wrapper and exercise the live full-state decoder instead. Every attachment, migration, selector-state, and validation assertion is preserved. The persisted schema and loader are unchanged.

Verification: all 56 composer persistence tests passed before and after. Mobile typecheck, targeted lint/format, and diff checks passed. No visual change.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `decodePersistedComposerDrafts` wrapper and test via state decoder
> Removes the exported thin wrapper `decodePersistedComposerDrafts` in [use-composer-drafts.ts](https://github.com/pingdotgg/t3code/pull/10033/files#diff-6acb6f89d59b03b7738cacfb4cec712073b5d8c6b8d2abcd3cde1acee04f818e) that delegated to the persisted-state decoder and returned only its drafts collection. Updates all calls in [use-composer-drafts.test.ts](https://github.com/pingdotgg/t3code/pull/10033/files#diff-ddae2bf2d99d04cca326a03b063c38cf94809bc34aee7a8fe319ccb85ae837b7) to invoke the state decoder directly and read its drafts collection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38cccdd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->