### PR TITLE
refactor(codex): keep app-server client internals private

### DIFF
--- a/packages/effect-codex-app-server/src/_internal/shared.ts
+++ b/packages/effect-codex-app-server/src/_internal/shared.ts
@@ -5,7 +5,7 @@ import * as CodexError from "../errors.ts";
 
 export const JsonRpcId = Schema.Union([Schema.Number, Schema.String]);
 
-export const JsonRpcError = Schema.Struct({
+const JsonRpcError = Schema.Struct({
   code: Schema.Number,
   message: Schema.String,
   data: Schema.optional(Schema.Unknown),

--- a/packages/effect-codex-app-server/src/client.ts
+++ b/packages/effect-codex-app-server/src/client.ts
@@ -84,7 +84,7 @@ type ServerNotificationHandler = (
   payload: unknown,
 ) => Effect.Effect<void, CodexError.CodexAppServerError>;
 
-export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make")(function* (
+const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make")(function* (
   stdio: Stdio.Stdio,
   options: CodexAppServerClientOptions = {},
   terminationError?: Effect.Effect<CodexError.CodexAppServerError>,
@@ -249,11 +249,6 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
       }),
   });
 });
-
-export const layer = (
-  stdio: Stdio.Stdio,
-  options: CodexAppServerClientOptions = {},
-): Layer.Layer<CodexAppServerClient> => Layer.effect(CodexAppServerClient, make(stdio, options));
 
 export const layerChildProcess = (
   handle: ChildProcessSpawner.ChildProcessHandle,

--- a/packages/effect-codex-app-server/src/errors.ts
+++ b/packages/effect-codex-app-server/src/errors.ts
@@ -1,15 +1,15 @@
 import * as Schema from "effect/Schema";
 import type * as SchemaIssue from "effect/SchemaIssue";
 
-export const CodexAppServerRequestOperation = Schema.Literals([
+const CodexAppServerRequestOperation = Schema.Literals([
   "decode-payload",
   "encode-payload",
   "handle-request",
   "receive-response",
 ]);
-export type CodexAppServerRequestOperation = typeof CodexAppServerRequestOperation.Type;
+type CodexAppServerRequestOperation = typeof CodexAppServerRequestOperation.Type;
 
-export const CodexAppServerSchemaIssueKind = Schema.Literals([
+const CodexAppServerSchemaIssueKind = Schema.Literals([
   "Filter",
   "Encoding",
   "Pointer",
@@ -22,9 +22,9 @@ export const CodexAppServerSchemaIssueKind = Schema.Literals([
   "Forbidden",
   "OneOf",
 ]);
-export type CodexAppServerSchemaIssueKind = typeof CodexAppServerSchemaIssueKind.Type;
+type CodexAppServerSchemaIssueKind = typeof CodexAppServerSchemaIssueKind.Type;
 
-export interface CodexAppServerSchemaIssueDiagnostics {
+interface CodexAppServerSchemaIssueDiagnostics {
   readonly issueCount: number;
   readonly issueKinds: ReadonlyArray<CodexAppServerSchemaIssueKind>;
   readonly maximumPathDepth: number;
@@ -62,7 +62,7 @@ const schemaIssueDiagnostics = (root: SchemaIssue.Issue): CodexAppServerSchemaIs
   };
 };
 
-export const CodexAppServerPayloadKind = Schema.Literals([
+const CodexAppServerPayloadKind = Schema.Literals([
   "null",
   "array",
   "string",
@@ -74,7 +74,7 @@ export const CodexAppServerPayloadKind = Schema.Literals([
   "function",
   "undefined",
 ]);
-export type CodexAppServerPayloadKind = typeof CodexAppServerPayloadKind.Type;
+type CodexAppServerPayloadKind = typeof CodexAppServerPayloadKind.Type;
 
 const payloadKind = (payload: unknown): CodexAppServerPayloadKind => {
   if (payload === null) return "null";
@@ -84,8 +84,7 @@ const payloadKind = (payload: unknown): CodexAppServerPayloadKind => {
 
 const protocolMessageFields = ["id", "method", "params", "result", "error"] as const;
 
-export const CodexAppServerProtocolMessageField = Schema.Literals(protocolMessageFields);
-export type CodexAppServerProtocolMessageField = typeof CodexAppServerProtocolMessageField.Type;
+const CodexAppServerProtocolMessageField = Schema.Literals(protocolMessageFields);
 
 export interface CodexAppServerRequestDiagnostics {
   readonly method?: string;


### PR DESCRIPTION
Knip reports seven unused values and one unused type in the private Codex app-server package. The plain-stdio layer has no callers; production providers, the probe script and client tests use the child-process layer.

Remove that unused layer and an unused type alias. Make the client constructor, internal error schemas/types and JSON-RPC error schema private. Keep the active child-process layer, wire behavior, error diagnostics and generated upstream definitions unchanged. No tests are removed.

Verification: the package export audit goes from eight findings to zero. All 35 package tests pass before and after; 79 tests pass when including the server Codex provider and session runtime suites. Package typecheck, targeted lint, formatting and diff checks pass. The retained tests exercise real mock-peer requests, notifications, stderr draining and error diagnostics. No visual change.

This is the cleanup layer beneath the new CI export gate. Left unmerged for maintainer review.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused exports from `effect-codex-app-server` client internals
> - Removes named exports for `JsonRpcError` schema in [shared.ts](https://github.com/pingdotgg/t3code/pull/10035/files#diff-082b3e69a506286c6688439b14dd2ee72dffcd995aeb34fd03f517ac162e4d5a) and `CodexAppServerClient.make`/`CodexAppServerClient.layer` in [client.ts](https://github.com/pingdotgg/t3code/pull/10035/files#diff-3d60ac4e051da962d4a1e6f4bd881857f81b3f5ead25e9cf52ac0be96924b717)
> - Removes named exports for several schemas, types, and an interface in [errors.ts](https://github.com/pingdotgg/t3code/pull/10035/files#diff-15f2438678486824c3e9f879f76d63b1a379a3d8ed1df47fac0fdd40b9c6de0c): `CodexAppServerRequestOperation`, `CodexAppServerSchemaIssueKind`, `CodexAppServerSchemaIssueDiagnostics`, `CodexAppServerPayloadKind`, and `CodexAppServerProtocolMessageField`
> - All definitions remain unchanged within their modules; only the export keyword is removed
> - Risk: any out-of-tree consumers importing these symbols by name will fail to compile until updated
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6c854d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->