### PR TITLE
ci: reject unused Codex client exports with Knip

### DIFF
--- a/docs/operations/development.md
+++ b/docs/operations/development.md
@@ -72,7 +72,8 @@ Windows investigation while that suite is not a required gate.
 ### Unused code
 
 `vp run knip:check` checks unused files and dependencies across the repo, then
-unused exports and types in `packages/tailscale`. CI enforces both checks.
+unused exports and types in `packages/tailscale` and `packages/effect-codex-app-server`.
+CI enforces both checks.
 Use `vp run knip --workspace apps/web` to audit one workspace, including exports,
 or `vp run knip:production --workspace apps/web` to find code kept alive only by tests.
 The full export audit still has findings and is not a repo-wide CI gate. Extend the

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "tc": "vp run -r --concurrency-limit 2 typecheck",
     "lint": "vp lint --report-unused-disable-directives",
     "knip": "knip",
-    "knip:check": "knip --include files,dependencies --no-config-hints && knip --workspace packages/tailscale --exports --no-config-hints",
+    "knip:check": "knip --include files,dependencies --no-config-hints && knip --workspace packages/tailscale --workspace packages/effect-codex-app-server --exports --no-config-hints",
     "knip:production": "knip --production",
     "lint:mobile": "node scripts/mobile-native-static-check.ts",
     "test": "vp run -r test",


### PR DESCRIPTION
The Codex app-server workspace is now free of unused export findings, but CI currently enforces exports only in the Tailscale workspace.

Add the Codex app-server workspace to the existing export check and update the development command guidance. Keep the repository-wide file/dependency gate and generated-protocol exceptions unchanged. No dependencies, suppressions or issue baseline are added.

Verification: the exact `vp run knip:check` command passes. Temporarily restoring the unused `JsonRpcError` value and `CodexAppServerSchemaIssueDiagnostics` type makes that command exit 1 and name both violations. Removing them again restores a passing result. Formatting and diff checks pass.

Depends on the cleanup layer immediately below. Left unmerged for maintainer review.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend `knip:check` to reject unused exports in `effect-codex-app-server`
> The `knip:check` script in [package.json](https://github.com/pingdotgg/t3code/pull/10036/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) now runs the unused-exports audit for `packages/effect-codex-app-server` alongside the existing `packages/tailscale` audit, while preserving the repo-wide files and dependencies audit. [docs/operations/development.md](https://github.com/pingdotgg/t3code/pull/10036/files#diff-d4193c695085935050d7dd7572ae2c767e26244ca27f5ae7fd015ff4c97c8ba2) is updated to document the expanded scope.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e502a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->