### PR TITLE
refactor(server): keep Cursor fallback models private

### DIFF
--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -16,7 +16,6 @@ import {
   buildCursorCapabilitiesFromConfigOptions,
   checkCursorProviderStatus,
   discoverCursorModelsViaAcp,
-  getCursorFallbackModels,
   getCursorParameterizedModelPickerUnsupportedMessage,
   parseCursorAboutOutput,
   parseCursorCliConfigChannel,
@@ -472,16 +471,6 @@ describe("Cursor skills", () => {
       expect(hasCursorSkillMention(text)).toBe(false);
       expect(rewriteCursorSkillMentions(text, names)).toBe(text);
     }
-  });
-});
-
-describe("getCursorFallbackModels", () => {
-  it("does not publish any built-in cursor models before ACP discovery", () => {
-    expect(
-      getCursorFallbackModels({
-        customModels: ["internal/cursor-model"],
-      }).map((model) => model.slug),
-    ).toEqual(["internal/cursor-model"]);
   });
 });
 

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -572,7 +572,7 @@ export const discoverCursorModelsViaAcp = (
   environment?: NodeJS.ProcessEnv,
 ) => discoverCursorModelsViaListAvailableModels(cursorSettings, environment);
 
-export function getCursorFallbackModels(
+function getCursorFallbackModels(
   cursorSettings: Pick<CursorSettings, "customModels">,
 ): ReadonlyArray<ServerProviderModel> {
   return providerModelsFromSettings([], cursorSettings.customModels, EMPTY_CAPABILITIES);


### PR DESCRIPTION
Cursor's fallback-model helper was exported only for a direct wrapper test. The provider snapshot tests already check the empty and custom-only model policy when discovery is unavailable.

Keep the helper private and remove the direct test. Retain the snapshot tests and the full discovery, capabilities, skills, and status coverage. Runtime fallback logic is unchanged.

Verification: the four targeted baseline suites passed all 48 tests. All 26 retained Cursor provider tests pass after this change. Server-only typecheck, targeted lint, formatting, and diff checks passed. No visual behavior changed.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `getCursorFallbackModels` a module-private function in `CursorProvider`
> Removes the export of `getCursorFallbackModels` in [CursorProvider.ts](https://github.com/pingdotgg/t3code/pull/10038/files#diff-da40152ecdcfcea481b905f726c4401fa8cfa0b5c6d4aa9f70ef5bcbfe23fb38) so it is no longer part of the module's public API. The implementation and inputs are unchanged. Deletes the dedicated test suite for the helper in [CursorProvider.test.ts](https://github.com/pingdotgg/t3code/pull/10038/files#diff-5d4e43078b6cc1220d1a70c97c171118d5ee124ae17ac8d3d620432f9c402c36) and its now-unneeded import.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c6a1c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->