### PR TITLE
refactor(mobile): remove obsolete review list builder

### DIFF
--- a/apps/mobile/src/features/review/reviewModel.test.ts
+++ b/apps/mobile/src/features/review/reviewModel.test.ts
@@ -8,7 +8,6 @@ import {
 } from "@t3tools/contracts";
 
 import {
-  buildReviewListItems,
   buildReviewParsedDiff,
   buildReviewSectionItems,
   getDefaultReviewSectionId,
@@ -270,85 +269,5 @@ describe("buildReviewParsedDiff", () => {
       title: "Large diff",
       actionLabel: "Load diff",
     });
-  });
-
-  it("flattens expanded file rows into virtualized review items", () => {
-    const file = makeRenderableFile({
-      path: "apps/mobile/src/a.ts",
-      rows: [
-        {
-          kind: "hunk",
-          id: "hunk-1",
-          header: "@@ -1,1 +1,2 @@",
-          context: null,
-        },
-        {
-          kind: "line",
-          id: "line-1",
-          change: "add",
-          oldLineNumber: null,
-          newLineNumber: 1,
-          content: "const after = 2;",
-          additionTokenIndex: 0,
-          deletionTokenIndex: null,
-          comparison: null,
-        },
-      ],
-    });
-
-    const items = buildReviewListItems({
-      files: [file],
-      expandedFileIds: [file.id],
-      revealedLargeFileIds: [],
-    });
-
-    expect(items).toEqual([
-      expect.objectContaining({ kind: "file-header", fileId: file.id, expanded: true }),
-      expect.objectContaining({
-        kind: "hunk",
-        fileId: file.id,
-        file,
-        row: file.rows[0],
-      }),
-      expect.objectContaining({
-        kind: "line",
-        fileId: file.id,
-        file,
-        row: file.rows[1],
-        lineIndex: 0,
-      }),
-    ]);
-  });
-
-  it("keeps large diffs collapsed into a placeholder item until revealed", () => {
-    const file = makeRenderableFile({
-      path: "apps/mobile/src/big.ts",
-      rows: Array.from({ length: 401 }, (_, index) => ({
-        kind: "line" as const,
-        id: `line-${index}`,
-        change: "add" as const,
-        oldLineNumber: null,
-        newLineNumber: index + 1,
-        content: `const line${index} = ${index};`,
-        additionTokenIndex: index,
-        deletionTokenIndex: null,
-        comparison: null,
-      })),
-    });
-
-    const items = buildReviewListItems({
-      files: [file],
-      expandedFileIds: [file.id],
-      revealedLargeFileIds: [],
-    });
-
-    expect(items).toEqual([
-      expect.objectContaining({ kind: "file-header", fileId: file.id, expanded: true }),
-      expect.objectContaining({
-        kind: "file-suppressed",
-        fileId: file.id,
-        actionLabel: "Load diff",
-      }),
-    ]);
   });
 });

--- a/apps/mobile/src/features/review/reviewModel.ts
+++ b/apps/mobile/src/features/review/reviewModel.ts
@@ -58,45 +58,6 @@ export interface ReviewRenderableFile {
   readonly rows: ReadonlyArray<ReviewRenderableRow>;
 }
 
-export interface ReviewFileHeaderListItem {
-  readonly kind: "file-header";
-  readonly id: string;
-  readonly fileId: string;
-  readonly file: ReviewRenderableFile;
-  readonly expanded: boolean;
-}
-
-export interface ReviewFileSuppressedListItem {
-  readonly kind: "file-suppressed";
-  readonly id: string;
-  readonly fileId: string;
-  readonly message: string;
-  readonly actionLabel: string | null;
-}
-
-export interface ReviewHunkListItem {
-  readonly kind: "hunk";
-  readonly id: string;
-  readonly fileId: string;
-  readonly file: ReviewRenderableFile;
-  readonly row: ReviewRenderableHunkRow;
-}
-
-export interface ReviewLineListItem {
-  readonly kind: "line";
-  readonly id: string;
-  readonly fileId: string;
-  readonly file: ReviewRenderableFile;
-  readonly row: ReviewRenderableLineRow;
-  readonly lineIndex: number;
-}
-
-export type ReviewListItem =
-  | ReviewFileHeaderListItem
-  | ReviewFileSuppressedListItem
-  | ReviewHunkListItem
-  | ReviewLineListItem;
-
 export type ReviewFilePreviewState =
   | {
       readonly kind: "render";
@@ -314,77 +275,6 @@ export function getReviewFilePreviewState(file: ReviewRenderableFile): ReviewFil
   }
 
   return { kind: "render" };
-}
-
-// The flattened review list item model is inspired by pierre/diffs' iterator-first
-// virtualization architecture, adapted here for React Native virtualization.
-// Original project: https://github.com/pingdotgg/pierre/tree/main/packages/diffs
-// Reference files:
-// - src/utils/iterateOverDiff.ts
-// - src/components/VirtualizedFileDiff.ts
-export function buildReviewListItems(input: {
-  readonly files: ReadonlyArray<ReviewRenderableFile>;
-  readonly expandedFileIds: ReadonlyArray<string>;
-  readonly revealedLargeFileIds: ReadonlyArray<string>;
-}): ReadonlyArray<ReviewListItem> {
-  const expandedFileIds = new Set(input.expandedFileIds);
-  const revealedLargeFileIds = new Set(input.revealedLargeFileIds);
-  const items: ReviewListItem[] = [];
-
-  input.files.forEach((file) => {
-    const expanded = expandedFileIds.has(file.id);
-    items.push({
-      kind: "file-header",
-      id: `${file.id}:header`,
-      fileId: file.id,
-      file,
-      expanded,
-    });
-
-    if (!expanded) {
-      return;
-    }
-
-    const previewState = getReviewFilePreviewState(file);
-    if (previewState.kind === "suppressed") {
-      if (previewState.reason !== "large" || !revealedLargeFileIds.has(file.id)) {
-        items.push({
-          kind: "file-suppressed",
-          id: `${file.id}:suppressed`,
-          fileId: file.id,
-          message: previewState.message,
-          actionLabel: previewState.actionLabel,
-        });
-        return;
-      }
-    }
-
-    let lineIndex = 0;
-    file.rows.forEach((row, rowIndex) => {
-      if (row.kind === "hunk") {
-        items.push({
-          kind: "hunk",
-          id: `${file.id}:row:${rowIndex}:${row.id}`,
-          fileId: file.id,
-          file,
-          row,
-        });
-        return;
-      }
-
-      items.push({
-        kind: "line",
-        id: `${file.id}:row:${rowIndex}:${row.id}`,
-        fileId: file.id,
-        file,
-        row,
-        lineIndex,
-      });
-      lineIndex += 1;
-    });
-  });
-
-  return items;
 }
 
 function fallbackHunkHeader(hunk: FileDiffMetadata["hunks"][number]): string {


### PR DESCRIPTION
The old virtualized review-list builder had no production callers. Only two tests used its file-header/hunk/line representation; current review views use the native diff adapter.

Remove the builder, its exclusively owned item types, and those two tests. Keep live patch parsing, preview suppression, and native rendering data unchanged.

Verification: 25 focused tests passed before, 23 after across review models, native adapters, cached state, and file visibility. Mobile typecheck, targeted lint/format, and diff checks passed. No visual change.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove obsolete `buildReviewListItems` helper and `ReviewListItem` types from mobile review model
> - Deletes the `ReviewListItem` union and its member interfaces (file-header, file-suppressed, hunk, line) plus the `buildReviewListItems` helper from [reviewModel.ts](https://github.com/pingdotgg/t3code/pull/10039/files#diff-076213075b0d2241f667e75479ded37ea3bfd368aa02a9f5830f0af69549a37b). These types flattened review files into headers, placeholders, hunks, and line items.
> - Removes the corresponding tests for flattened file rows and large-file placeholders in [reviewModel.test.ts](https://github.com/pingdotgg/t3code/pull/10039/files#diff-321b7cd70151438d23a19e0388a5c76f89bde3e125be0f40a2bdde34a7d327a1). Remaining tests still cover parsed diffs and preview state.
> - Risk: any out-of-tree consumer importing `buildReviewListItems` or `ReviewListItem` from `reviewModel` will fail to compile; in-tree callers should be checked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9cb1827.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->