### PR TITLE
refactor(web): remove unused xterm link range helpers

### DIFF
--- a/apps/web/src/terminal-links.test.ts
+++ b/apps/web/src/terminal-links.test.ts
@@ -6,8 +6,6 @@ import {
   isTerminalLinkActivation,
   isTerminalUrl,
   resolvePathLinkTarget,
-  resolveWrappedTerminalLinkRange,
-  wrappedTerminalLinkRangeIntersectsBufferLine,
   type TerminalBufferLineLike,
 } from "./terminal-links";
 
@@ -151,46 +149,6 @@ describe("collectWrappedTerminalLinkLine", () => {
         end: firstSegment.length + secondSegment.length,
       },
     ]);
-  });
-});
-
-describe("resolveWrappedTerminalLinkRange", () => {
-  it("maps wrapped URL matches back to the correct buffer rows", () => {
-    const prefix = "see ";
-    const firstSegment = `${prefix}https://example.com/a`;
-    const secondSegment = "/bc?x=1";
-    const lines = [
-      createBufferLine("prompt> "),
-      createBufferLine(firstSegment),
-      createBufferLine(secondSegment, true),
-    ];
-    const wrappedLine = collectWrappedTerminalLinkLine(2, (index) => lines[index]);
-
-    expect(wrappedLine).not.toBeNull();
-    if (!wrappedLine) {
-      throw new Error("Expected wrapped terminal line to be present.");
-    }
-
-    const [match] = extractTerminalLinks(wrappedLine.text);
-    expect(match).toEqual({
-      kind: "url",
-      text: "https://example.com/a/bc?x=1",
-      start: prefix.length,
-      end: firstSegment.length + secondSegment.length,
-    });
-    if (!match) {
-      throw new Error("Expected wrapped URL match to be present.");
-    }
-
-    const range = resolveWrappedTerminalLinkRange(wrappedLine, match);
-
-    expect(range).toEqual({
-      start: { x: prefix.length + 1, y: 2 },
-      end: { x: secondSegment.length, y: 3 },
-    });
-    expect(wrappedTerminalLinkRangeIntersectsBufferLine(range, 2)).toBe(true);
-    expect(wrappedTerminalLinkRangeIntersectsBufferLine(range, 3)).toBe(true);
-    expect(wrappedTerminalLinkRangeIntersectsBufferLine(range, 4)).toBe(false);
   });
 });
 

--- a/apps/web/src/terminal-links.ts
+++ b/apps/web/src/terminal-links.ts
@@ -14,16 +14,6 @@ export interface TerminalLinkMatch {
   end: number;
 }
 
-export interface TerminalLinkBufferPosition {
-  x: number;
-  y: number;
-}
-
-export interface TerminalLinkBufferRange {
-  start: TerminalLinkBufferPosition;
-  end: TerminalLinkBufferPosition;
-}
-
 export interface TerminalBufferLineLike {
   readonly isWrapped?: boolean;
   translateToString(trimRight?: boolean): string;
@@ -197,43 +187,6 @@ export function collectWrappedTerminalLinkLine(
     text: segments.map((segment) => segment.text).join(""),
     segments,
   };
-}
-
-function resolveCharacterPosition(
-  segments: ReadonlyArray<WrappedTerminalLinkLineSegment>,
-  characterIndex: number,
-): TerminalLinkBufferPosition {
-  for (const segment of segments) {
-    if (characterIndex < segment.endIndex) {
-      return {
-        x: characterIndex - segment.startIndex + 1,
-        y: segment.bufferLineNumber,
-      };
-    }
-  }
-
-  const lastSegment = segments[segments.length - 1];
-  return {
-    x: Math.max(lastSegment?.text.length ?? 0, 1),
-    y: lastSegment?.bufferLineNumber ?? 1,
-  };
-}
-
-export function resolveWrappedTerminalLinkRange(
-  wrappedLine: WrappedTerminalLinkLine,
-  match: Pick<TerminalLinkMatch, "start" | "end">,
-): TerminalLinkBufferRange {
-  return {
-    start: resolveCharacterPosition(wrappedLine.segments, match.start),
-    end: resolveCharacterPosition(wrappedLine.segments, match.end - 1),
-  };
-}
-
-export function wrappedTerminalLinkRangeIntersectsBufferLine(
-  range: TerminalLinkBufferRange,
-  bufferLineNumber: number,
-): boolean {
-  return range.start.y <= bufferLineNumber && bufferLineNumber <= range.end.y;
 }
 
 export function isTerminalLinkActivation(


### PR DESCRIPTION
The old one-based xterm link-coordinate helpers have no runtime callers. Their dedicated test is the only consumer, while Ghostty computes ranges from its actual cell widths.

Remove the old range resolver, intersection predicate, private coordinate helper, owned range types and one orphan test. Keep shared link extraction, wrapped-line reconstruction and the current Ghostty range and viewport-truncation coverage unchanged.

Verification: exact-symbol and import-path searches confirmed the removed subtree is unused. Terminal-link and Ghostty surface suites passed before and after, 62 to 61 cases. Web package typecheck, targeted lint, formatting and git diff --check passed. No screenshots apply to removal of unused code.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused terminal-link buffer range helpers in `apps/web`
> Deletes the exported buffer-position and buffer-range interfaces, the `resolveWrappedTerminalLinkRange` function, and the `wrappedTerminalLinkRangeIntersectsBufferLine` predicate from [terminal-links.ts](https://github.com/pingdotgg/t3code/pull/10040/files#diff-5f57eb38e8e99e705308a736729815ef1ec005cf2f20cca912a9f7abcf28c110). Also removes the corresponding wrapped-range test case and its imports from [terminal-links.test.ts](https://github.com/pingdotgg/t3code/pull/10040/files#diff-51db27efd5a7baf72fc030985f4b0bbf820c58837db0b26c2909b4d0bb9a36c4). These helpers were unused.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 46c84d3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->