### PR TITLE
refactor(web): test live Ghostty link resolution directly

### DIFF
--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -23,8 +23,6 @@ import {
   terminalGridCellAt,
   terminalScrollbarGeometry,
   terminalScrollbarOffsetAtPointer,
-  terminalLinkAtColumn,
-  terminalLinkAtPosition,
   terminalLinkAtPositionWithRange,
   terminalContentOriginY,
   terminalFontFamily,
@@ -433,7 +431,7 @@ describe("shouldBlinkTerminalCursor", () => {
   });
 });
 
-describe("terminalLinkAtColumn", () => {
+describe("terminalLinkAtPositionWithRange", () => {
   it("maps terminal cells to UTF-16 offsets after a wide emoji", () => {
     const cells = [
       cell("🙂"),
@@ -450,9 +448,11 @@ describe("terminalLinkAtColumn", () => {
       wrapsToNext: false,
     };
 
-    expect(terminalLinkAtColumn(row, 2)).toBe("https://t3.codes");
-    expect(terminalLinkAtColumn(row, cells.length - 1)).toBe("https://t3.codes");
-    expect(terminalLinkAtColumn(row, 0)).toBeNull();
+    expect(terminalLinkAtPositionWithRange([row], 0, 2)?.text).toBe("https://t3.codes");
+    expect(terminalLinkAtPositionWithRange([row], 0, cells.length - 1)?.text).toBe(
+      "https://t3.codes",
+    );
+    expect(terminalLinkAtPositionWithRange([row], 0, 0)).toBeNull();
     expect(terminalLinkAtPositionWithRange([row], 0, 8)?.range).toEqual({
       start: { x: 2, y: 0 },
       end: { x: cells.length - 1, y: 0 },
@@ -473,10 +473,10 @@ describe("terminalLinkAtColumn", () => {
       row("C:\\repo\\file.ts", false),
     ];
 
-    expect(terminalLinkAtPosition(rows, 0, 8)).toBe("https://example.com/reference");
-    expect(terminalLinkAtPosition(rows, 1, 4)).toBe("https://example.com/reference");
-    expect(terminalLinkAtPosition(rows, 2, 2)).toBe("~/project/file");
-    expect(terminalLinkAtPosition(rows, 3, 4)).toBe("C:\\repo\\file.ts");
+    expect(terminalLinkAtPositionWithRange(rows, 0, 8)?.text).toBe("https://example.com/reference");
+    expect(terminalLinkAtPositionWithRange(rows, 1, 4)?.text).toBe("https://example.com/reference");
+    expect(terminalLinkAtPositionWithRange(rows, 2, 2)?.text).toBe("~/project/file");
+    expect(terminalLinkAtPositionWithRange(rows, 3, 4)?.text).toBe("C:\\repo\\file.ts");
     expect(terminalLinkAtPositionWithRange(rows, 1, 4)).toEqual({
       text: "https://example.com/reference",
       range: {
@@ -495,13 +495,13 @@ describe("terminalLinkAtColumn", () => {
     });
     // The head of the wrapped line scrolled above the viewport.
     const headCut = [row("ple.com/missing", true), row("head", true)];
-    expect(terminalLinkAtPosition(headCut, 0, 4)).toBeNull();
+    expect(terminalLinkAtPositionWithRange(headCut, 0, 4)).toBeNull();
     // The bottom row soft-wraps on below the viewport.
     const tailCut = [row("https://t3.codes", false, true)];
-    expect(terminalLinkAtPosition(tailCut, 0, 8)).toBeNull();
+    expect(terminalLinkAtPositionWithRange(tailCut, 0, 8)).toBeNull();
     // A partial bottom row is provably complete and still resolves.
     const complete = [row("https://t3.codes", false), row("", false)];
-    expect(terminalLinkAtPosition(complete, 0, 8)).toBe("https://t3.codes");
+    expect(terminalLinkAtPositionWithRange(complete, 0, 8)?.text).toBe("https://t3.codes");
     // A wide grapheme earlier in the row must not break truncation detection:
     // the soft-wrap flag decides, not string-length-versus-cell-count.
     const wideFull: GhosttyRow = {
@@ -514,7 +514,7 @@ describe("terminalLinkAtColumn", () => {
       isWrapContinuation: false,
       wrapsToNext: true,
     };
-    expect(terminalLinkAtPosition([wideFull], 0, 8)).toBeNull();
+    expect(terminalLinkAtPositionWithRange([wideFull], 0, 8)).toBeNull();
     // Unwritten trailing cells prove the bottom row is complete.
     const unwrittenTail: GhosttyRow = {
       cells: [
@@ -526,7 +526,7 @@ describe("terminalLinkAtColumn", () => {
       isWrapContinuation: false,
       wrapsToNext: false,
     };
-    expect(terminalLinkAtPosition([unwrittenTail], 0, 8)).toBe("https://t3.codes");
+    expect(terminalLinkAtPositionWithRange([unwrittenTail], 0, 8)?.text).toBe("https://t3.codes");
   });
 });
 

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -244,14 +244,6 @@ function terminalColumnOffset(row: GhosttySnapshot["rowData"][number], column: n
   return offset;
 }
 
-export function terminalLinkAtPosition(
-  rows: GhosttySnapshot["rowData"],
-  rowIndex: number,
-  column: number,
-): string | null {
-  return terminalLinkAtPositionWithRange(rows, rowIndex, column)?.text ?? null;
-}
-
 export interface TerminalLinkWithRange {
   readonly text: string;
   readonly range: GhosttyCellRange;
@@ -323,10 +315,6 @@ export function terminalLinkAtPositionWithRange(
     }
   }
   return null;
-}
-
-export function terminalLinkAtColumn(row: GhosttySnapshot["rowData"][number], column: number) {
-  return terminalLinkAtPosition([row], 0, column);
 }
 
 export function isTerminalCopyShortcut(


### PR DESCRIPTION
Two Ghostty link helpers only delegated to the real range resolver and survived solely as test entry points. The terminal itself already calls terminalLinkAtPositionWithRange.

Remove terminalLinkAtColumn and terminalLinkAtPosition, then run every existing link scenario against the live resolver. Preserve emoji offsets, wrapped URL and POSIX/Windows paths, exact returned ranges, viewport truncation and unwritten-cell behavior. No test cases or runtime behavior are removed.

Verification: exact-symbol and import-path searches found no runtime consumers of either wrapper. Terminal-link and Ghostty surface suites passed before and after, all 62 cases. Web package typecheck, targeted lint, formatting and git diff --check passed. No screenshots apply to this internal test-entry cleanup.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove Ghostty link-resolution convenience helpers and test range-aware resolver directly
> - Removes `terminalLinkAtPosition` and `terminalLinkAtColumn` convenience wrappers from [surface.ts](https://github.com/pingdotgg/t3code/pull/10041/files#diff-036d64ffe3b3b3d167137e8ea29edae7af74a9e0323fc798c4f291992235d267) that converted the range-aware resolver into a string-or-null or column-based result.
> - Updates tests in [surface.test.ts](https://github.com/pingdotgg/t3code/pull/10041/files#diff-4739505f766bda541a0cf14a163fb5321204b64183ba45ffcc1a0026ad6e8029) to call the range-returning resolver directly and inspect its `text` property, while still verifying cell ranges and null results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be2bd7b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->