### PR TITLE
test(server): remove duplicate VCS error constructor checks

### DIFF
--- a/apps/server/src/vcs/VcsProjectConfig.test.ts
+++ b/apps/server/src/vcs/VcsProjectConfig.test.ts
@@ -14,22 +14,6 @@ const TestLayer = VcsProjectConfig.layer.pipe(
 );
 
 describe("VcsProjectConfig", () => {
-  it("keeps operation context and the original cause on config errors", () => {
-    const cause = new Error("permission denied");
-    const error = new VcsProjectConfig.VcsProjectConfigError({
-      operation: "read",
-      cwd: "/repo/packages/app",
-      configPath: "/repo/.t3code/vcs.json",
-      cause,
-    });
-
-    assert.equal(error.operation, "read");
-    assert.equal(error.cwd, "/repo/packages/app");
-    assert.equal(error.configPath, "/repo/.t3code/vcs.json");
-    assert.strictEqual(error.cause, cause);
-    assert.equal(error.message, "Failed to read VCS project config at /repo/.t3code/vcs.json.");
-  });
-
   it.layer(TestLayer)("uses an explicit requested VCS kind before config", (it) => {
     it.effect("returns the requested kind", () =>
       Effect.gen(function* () {


### PR DESCRIPTION
The VCS config suite checked fields supplied directly to an error constructor even though its failure tests already inspect errors emitted by real config operations.

Remove only that constructor fixture. Keep the inspect, malformed-JSON, and unreadable-path cases, including their operation, path, message, and cause checks. Production code and its error export are unchanged.

Verification: the VCS config and Codex session baseline suites passed all 46 tests. All 7 retained VCS config tests pass after this change. Server-only typecheck, targeted lint, formatting, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove duplicate `VcsProjectConfigError` constructor checks from VCS test suite
> Removes the test case in [VcsProjectConfig.test.ts](https://github.com/pingdotgg/t3code/pull/10042/files#diff-b3ae3446988fbc49c10a4ebf96fef9073080375a2933513c22d6b9e6e8be134c) that constructed a `VcsProjectConfigError` and asserted its operation, working directory, config path, original cause, and error message. The remaining VCS-kind resolution tests are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79487db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->