### PR TITLE
refactor(mobile): keep appearance calculations private

### DIFF
--- a/apps/mobile/src/lib/appearancePreferences.test.ts
+++ b/apps/mobile/src/lib/appearancePreferences.test.ts
@@ -2,11 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   DEFAULT_BASE_FONT_SIZE,
-  deriveCodeFontSize,
-  deriveTerminalFontSize,
   normalizeBaseFontSize,
-  normalizeCodeFontSize,
-  normalizeCodeWordBreak,
   resolveAppearance,
   resolveAppearancePreferences,
   resolveMarkdownFontSizes,
@@ -48,10 +44,8 @@ describe("appearancePreferences", () => {
     expect(appearance.isCodeFontSizeCustom).toBe(false);
 
     const scaled = resolveAppearance(resolveAppearancePreferences({ baseFontSize: 22 }));
-    expect(scaled.terminalFontSize).toBe(deriveTerminalFontSize(22));
-    expect(scaled.codeFontSize).toBe(deriveCodeFontSize(22));
-    expect(scaled.terminalFontSize).toBeGreaterThan(10);
-    expect(scaled.codeFontSize).toBeGreaterThan(11);
+    expect(scaled.terminalFontSize).toBe(14);
+    expect(scaled.codeFontSize).toBe(17);
   });
 
   it("applies explicit overrides over derived values", () => {
@@ -67,8 +61,8 @@ describe("appearancePreferences", () => {
   it("clamps base and code font sizes", () => {
     expect(normalizeBaseFontSize(4)).toBe(11);
     expect(normalizeBaseFontSize(30)).toBe(22);
-    expect(normalizeCodeFontSize(4)).toBe(8);
-    expect(normalizeCodeFontSize(30)).toBe(18);
+    expect(resolveAppearancePreferences({ codeFontSize: 4 }).codeFontSize).toBe(8);
+    expect(resolveAppearancePreferences({ codeFontSize: 30 }).codeFontSize).toBe(18);
   });
 
   it("steps terminal font size within bounds", () => {
@@ -92,9 +86,8 @@ describe("appearancePreferences", () => {
     });
   });
 
-  it("defaults code word break to false", () => {
-    expect(normalizeCodeWordBreak(undefined)).toBe(false);
-    expect(normalizeCodeWordBreak(true)).toBe(true);
+  it("keeps explicit code word break enabled", () => {
+    expect(resolveAppearancePreferences({ codeWordBreak: true }).codeWordBreak).toBe(true);
   });
 
   it("returns the authored text scale at the 16pt default", () => {

--- a/apps/mobile/src/lib/appearancePreferences.ts
+++ b/apps/mobile/src/lib/appearancePreferences.ts
@@ -75,7 +75,7 @@ export function normalizeBaseFontSize(value: number | null | undefined): number 
   return Math.min(MAX_BASE_FONT_SIZE, Math.max(MIN_BASE_FONT_SIZE, Math.round(value)));
 }
 
-export function normalizeCodeFontSize(value: number | null | undefined): number {
+function normalizeCodeFontSize(value: number | null | undefined): number {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return DEFAULT_CODE_FONT_SIZE;
   }
@@ -83,18 +83,18 @@ export function normalizeCodeFontSize(value: number | null | undefined): number 
   return Math.min(MAX_CODE_FONT_SIZE, Math.max(MIN_CODE_FONT_SIZE, Math.round(value)));
 }
 
-export function normalizeCodeWordBreak(value: boolean | null | undefined): boolean {
+function normalizeCodeWordBreak(value: boolean | null | undefined): boolean {
   return value === true;
 }
 
 /** Terminal size derived from base: 10.5pt at base 16, snapped to 0.5pt steps. */
-export function deriveTerminalFontSize(baseFontSize: number): number {
+function deriveTerminalFontSize(baseFontSize: number): number {
   const scale = normalizeBaseFontSize(baseFontSize) / DEFAULT_BASE_FONT_SIZE;
   return normalizeTerminalFontSize(Math.round(DEFAULT_TERMINAL_FONT_SIZE * scale * 2) / 2);
 }
 
 /** Code/diff size derived from base: 12pt at base 16. */
-export function deriveCodeFontSize(baseFontSize: number): number {
+function deriveCodeFontSize(baseFontSize: number): number {
   const scale = normalizeBaseFontSize(baseFontSize) / DEFAULT_BASE_FONT_SIZE;
   return normalizeCodeFontSize(Math.round(DEFAULT_CODE_FONT_SIZE * scale));
 }


### PR DESCRIPTION
Four appearance helpers were exported only for direct tests, including comparisons between resolved sizes and the same helpers used to produce them.

Keep those helpers private. Assert the actual resolved sizes, font-size limits, and enabled word break through the active appearance APIs. Defaults and all existing typography cases remain covered. No font calculations change.

Verification: 27 focused appearance, terminal-preference, and native adapter tests passed before and after. Mobile typecheck, targeted lint/format, and diff checks passed. No visual change.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make appearance preference calculation helpers private in `appearancePreferences`
> Converts `normalizeCodeFontSize`, `normalizeCodeWordBreak`, `deriveTerminalFontSize`, and `deriveCodeFontSize` from exported functions to module-private functions in [appearancePreferences.ts](https://github.com/pingdotgg/t3code/pull/10043/files#diff-05cdfd018ad160c909feeb2b14b13a6dd68a52dc1ab8074445001c53457ecac6). The helper logic is unchanged; tests now exercise these behaviors through the public `resolveAppearancePreferences` resolver instead of calling the helpers directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 34979f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->