### PR TITLE
refactor(shared): remove unused elapsed-time adapter

### DIFF
--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -35,7 +35,7 @@ import {
   type TurnDiffSummary,
 } from "./types";
 
-export { formatDuration, formatElapsed } from "@t3tools/shared/orchestrationTiming";
+export { formatDuration } from "@t3tools/shared/orchestrationTiming";
 
 export type WorkLogToolLifecycleStatus =
   | "inProgress"

--- a/packages/shared/src/orchestrationTiming.test.ts
+++ b/packages/shared/src/orchestrationTiming.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { formatDuration, formatElapsed } from "./orchestrationTiming.ts";
+import { formatDuration } from "./orchestrationTiming.ts";
 
 describe("formatDuration", () => {
   it.each([
@@ -27,11 +27,5 @@ describe("formatDuration", () => {
 
   it.each([-1, NaN, Infinity, -Infinity])("handles invalid durations: %s", (durationMs) => {
     expect(formatDuration(durationMs)).toBe("0ms");
-  });
-});
-
-describe("formatElapsed", () => {
-  it("formats a long run across midnight", () => {
-    expect(formatElapsed("2026-09-03T22:00:00Z", "2026-09-04T04:59:50Z")).toBe("6h 59m 50s");
   });
 });

--- a/packages/shared/src/orchestrationTiming.ts
+++ b/packages/shared/src/orchestrationTiming.ts
@@ -28,16 +28,6 @@ export function formatDuration(durationMs: number): string {
   return parts.join(" ");
 }
 
-export function formatElapsed(startIso: string, endIso: string | undefined): string | null {
-  if (!endIso) return null;
-  const startedAt = Date.parse(startIso);
-  const endedAt = Date.parse(endIso);
-  if (Number.isNaN(startedAt) || Number.isNaN(endedAt) || endedAt < startedAt) {
-    return null;
-  }
-  return formatDuration(endedAt - startedAt);
-}
-
 export function isLatestTurnSettled(
   latestTurn: LatestTurnTiming | null,
   session: SessionActivityState | null,


### PR DESCRIPTION
The shared elapsed-time adapter had no production callers. Its web re-export was unused, and one direct test kept the adapter alive.

Remove the adapter, unused re-export, and dedicated test. Keep formatDuration and its rounding, hour-boundary, and invalid-input tests unchanged. The unrelated server diagnostics formatter is untouched.

Verification: 210 focused shared-timing, web-session, and mobile-activity tests passed before, 209 after. Shared and web typechecks, targeted lint/format, and diff checks passed. No visual change.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `formatElapsed` from shared orchestration-timing module
> Deletes the `formatElapsed` utility, its test suite, and the re-export from the session-logic module. `formatDuration` remains available and tested.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6894ff3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->