### PR TITLE
refactor(desktop): remove test-only error predicates

### DIFF
--- a/apps/desktop/src/backend/DesktopServerExposure.test.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.test.ts
@@ -272,8 +272,6 @@ describe("DesktopServerExposure", () => {
           modeError,
           DesktopServerExposure.DesktopServerExposureModePersistenceError,
         );
-        assert.isTrue(DesktopServerExposure.isDesktopServerExposureSetModeError(modeError));
-        assert.isTrue(DesktopServerExposure.isDesktopServerExposureError(modeError));
         assert.equal(modeError.mode, "network-accessible");
         assert.strictEqual(modeError.cause, settingsFailure);
         assert.strictEqual(modeError.cause.cause, diskFailure);
@@ -290,7 +288,6 @@ describe("DesktopServerExposure", () => {
           tailscaleError,
           DesktopServerExposure.DesktopTailscaleServePersistenceError,
         );
-        assert.isTrue(DesktopServerExposure.isDesktopServerExposureError(tailscaleError));
         assert.equal(tailscaleError.enabled, true);
         assert.equal(tailscaleError.port, 8443);
         assert.strictEqual(tailscaleError.cause, settingsFailure);

--- a/apps/desktop/src/backend/DesktopServerExposure.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.ts
@@ -244,7 +244,6 @@ export const DesktopServerExposureSetModeError = Schema.Union([
   DesktopServerExposureModePersistenceError,
 ]);
 export type DesktopServerExposureSetModeError = typeof DesktopServerExposureSetModeError.Type;
-export const isDesktopServerExposureSetModeError = Schema.is(DesktopServerExposureSetModeError);
 
 export const DesktopServerExposureError = Schema.Union([
   DesktopServerExposureNoNetworkAddressError,
@@ -252,7 +251,6 @@ export const DesktopServerExposureError = Schema.Union([
   DesktopTailscaleServePersistenceError,
 ]);
 export type DesktopServerExposureError = typeof DesktopServerExposureError.Type;
-export const isDesktopServerExposureError = Schema.is(DesktopServerExposureError);
 
 export interface DesktopServerExposureBackendConfig {
   readonly port: number;

--- a/apps/desktop/src/ipc/DesktopIpc.test.ts
+++ b/apps/desktop/src/ipc/DesktopIpc.test.ts
@@ -41,7 +41,6 @@ describe("DesktopIpc", () => {
       const error = yield* Effect.flip(Effect.scoped(ipc.handle(invokeMethod)));
 
       assert.instanceOf(error, DesktopIpc.DesktopIpcRegistrationError);
-      assert.isTrue(DesktopIpc.isDesktopIpcError(error));
       assert.strictEqual(error.handlerKind, "invoke");
       assert.strictEqual(error.channel, invokeMethod.channel);
       assert.strictEqual(error.cause, cause);
@@ -69,7 +68,6 @@ describe("DesktopIpc", () => {
       if (exit._tag === "Success") return;
       const error = Cause.squash(exit.cause);
       assert.instanceOf(error, DesktopIpc.DesktopIpcUnregistrationError);
-      assert.isTrue(DesktopIpc.isDesktopIpcError(error));
       assert.strictEqual(error.handlerKind, "sync");
       assert.strictEqual(error.channel, syncMethod.channel);
       assert.strictEqual(error.cause, cause);

--- a/apps/desktop/src/ipc/DesktopIpc.ts
+++ b/apps/desktop/src/ipc/DesktopIpc.ts
@@ -55,7 +55,6 @@ export const DesktopIpcError = Schema.Union([
   DesktopIpcUnregistrationError,
 ]);
 export type DesktopIpcError = typeof DesktopIpcError.Type;
-export const isDesktopIpcError = Schema.is(DesktopIpcError);
 
 export interface DesktopIpcMethod<E, R> {
   readonly channel: string;

--- a/apps/desktop/src/preview/BrowserSession.test.ts
+++ b/apps/desktop/src/preview/BrowserSession.test.ts
@@ -172,8 +172,6 @@ describe("BrowserSession", () => {
       const error = yield* browserSessions.getPartition("environment-a").pipe(Effect.flip);
 
       assert.instanceOf(error, BrowserSession.BrowserSessionPartitionDerivationError);
-      assert.isTrue(BrowserSession.isBrowserSessionGetSessionError(error));
-      assert.isTrue(BrowserSession.isBrowserSessionError(error));
       assert.equal(error.scope, "environment-a");
       assert.strictEqual(error.cause, platformCause);
       assert.strictEqual(error.cause.reason.cause, nativeCause);
@@ -196,8 +194,6 @@ describe("BrowserSession", () => {
       const error = yield* browserSessions.getSession("environment-b").pipe(Effect.flip);
 
       assert.instanceOf(error, BrowserSession.BrowserSessionCreationError);
-      assert.isTrue(BrowserSession.isBrowserSessionGetSessionError(error));
-      assert.isTrue(BrowserSession.isBrowserSessionError(error));
       assert.equal(error.scope, "environment-b");
       assert.equal(error.partition, partition);
       assert.strictEqual(error.cause, cause);
@@ -270,7 +266,6 @@ describe("BrowserSession", () => {
       const storageError = yield* browserSessions.clearCookies().pipe(Effect.flip);
 
       assert.instanceOf(storageError, BrowserSession.BrowserSessionStorageClearError);
-      assert.isTrue(BrowserSession.isBrowserSessionError(storageError));
       assert.equal(storageError.partition, secondPartition);
       assert.strictEqual(storageError.cause, storageCause);
       assert.equal(
@@ -287,7 +282,6 @@ describe("BrowserSession", () => {
       const cacheError = yield* browserSessions.clearCache().pipe(Effect.flip);
 
       assert.instanceOf(cacheError, BrowserSession.BrowserSessionCacheClearError);
-      assert.isTrue(BrowserSession.isBrowserSessionError(cacheError));
       assert.equal(cacheError.partition, firstPartition);
       assert.strictEqual(cacheError.cause, cacheCause);
       assert.equal(

--- a/apps/desktop/src/preview/BrowserSession.ts
+++ b/apps/desktop/src/preview/BrowserSession.ts
@@ -93,7 +93,6 @@ export const BrowserSessionGetSessionError = Schema.Union([
   BrowserSessionCreationError,
 ]);
 export type BrowserSessionGetSessionError = typeof BrowserSessionGetSessionError.Type;
-export const isBrowserSessionGetSessionError = Schema.is(BrowserSessionGetSessionError);
 
 export const BrowserSessionError = Schema.Union([
   BrowserSessionPartitionDerivationError,
@@ -102,7 +101,6 @@ export const BrowserSessionError = Schema.Union([
   BrowserSessionCacheClearError,
 ]);
 export type BrowserSessionError = typeof BrowserSessionError.Type;
-export const isBrowserSessionError = Schema.is(BrowserSessionError);
 
 export class BrowserSession extends Context.Service<
   BrowserSession,

--- a/apps/desktop/src/updates/DesktopUpdates.test.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.test.ts
@@ -794,7 +794,6 @@ describe("DesktopUpdates", () => {
         const error = yield* updates.setChannel("nightly").pipe(Effect.flip);
 
         assert.instanceOf(error, DesktopUpdates.DesktopUpdateChannelPersistenceError);
-        assert.isTrue(DesktopUpdates.isDesktopUpdateSetChannelError(error));
         assert.equal(error.channel, "nightly");
         assert.strictEqual(error.cause, settingsFailure);
         assert.strictEqual(error.cause.cause, diskFailure);

--- a/apps/desktop/src/updates/DesktopUpdates.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.ts
@@ -155,7 +155,6 @@ export const DesktopUpdateSetChannelError = Schema.Union([
   DesktopUpdateChannelPersistenceError,
 ]);
 export type DesktopUpdateSetChannelError = typeof DesktopUpdateSetChannelError.Type;
-export const isDesktopUpdateSetChannelError = Schema.is(DesktopUpdateSetChannelError);
 
 export class DesktopUpdates extends Context.Service<
   DesktopUpdates,


### PR DESCRIPTION
Six desktop error predicates have no production callers. Tests call them immediately after checking the concrete error class, duplicating that assertion without exercising additional behavior.

Remove the predicate exports and twelve redundant assertions. Preserve every test, error class and schema, including failure context, nested causes, secret redaction, recovery after persistence failure and attempts to clear every browser session.

Verification: tracked symbol searches found only definitions and the removed assertions. All 45 focused IPC, updates, browser-session and server-exposure tests passed before and after. Desktop package typecheck, targeted lint, formatting and git diff --check passed. Typecheck reports existing non-blocking Effect suggestions. No screenshots apply to unused predicates and duplicate assertions.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove test-only `is*Error` schema predicates from desktop modules
> - Deletes exported error-predicate functions across `DesktopServerExposure`, `DesktopIpc`, `BrowserSession`, and `DesktopUpdates`; the underlying error schemas and type aliases remain.
> - Updates each module's tests to drop schema-predicate assertions, relying instead on field-level checks (cause, message, scope, channel, etc.).
> - Risk: external consumers importing the removed `is*Error` predicates (e.g. `isDesktopIpcError`, `isBrowserSessionError`, `isDesktopServerExposureSetModeError`, `isDesktopUpdateSetChannelError`) will break; in-tree usages are updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae4ce6b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->