### PR TITLE
refactor(mobile): keep review reset hashing private

### DIFF
--- a/apps/mobile/src/features/review/reviewDiffBridgeKeys.test.ts
+++ b/apps/mobile/src/features/review/reviewDiffBridgeKeys.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { buildNativeReviewTokensResetKey, hashReviewDiffKey } from "./reviewDiffBridgeKeys";
+import { buildNativeReviewTokensResetKey } from "./reviewDiffBridgeKeys";
 
 describe("native review diff bridge", () => {
-  it("builds stable reset keys from the rendered diff identity", () => {
+  it("changes reset keys when the rendered diff identity changes", () => {
     const input = {
       threadKey: "env:thread",
       sectionId: "turn:2",
@@ -13,15 +13,12 @@ describe("native review diff bridge", () => {
       rowCount: 4,
     };
 
-    expect(buildNativeReviewTokensResetKey(input)).toBe(buildNativeReviewTokensResetKey(input));
-    expect(buildNativeReviewTokensResetKey({ ...input, rowCount: 5 })).not.toBe(
-      buildNativeReviewTokensResetKey(input),
-    );
-    expect(buildNativeReviewTokensResetKey({ ...input, diff: null })).toContain(":empty:");
-  });
+    const resetKey = buildNativeReviewTokensResetKey(input);
 
-  it("includes diff length in the hash key to reduce accidental collisions", () => {
-    expect(hashReviewDiffKey("abc")).toMatch(/^3:/);
-    expect(hashReviewDiffKey("abcd")).toMatch(/^4:/);
+    expect(
+      buildNativeReviewTokensResetKey({ ...input, diff: "diff --git a/b.ts b/b.ts" }),
+    ).not.toBe(resetKey);
+    expect(buildNativeReviewTokensResetKey({ ...input, rowCount: 5 })).not.toBe(resetKey);
+    expect(buildNativeReviewTokensResetKey({ ...input, diff: null })).not.toBe(resetKey);
   });
 });

--- a/apps/mobile/src/features/review/reviewDiffBridgeKeys.ts
+++ b/apps/mobile/src/features/review/reviewDiffBridgeKeys.ts
@@ -3,7 +3,7 @@ import type { NativeReviewDiffHighlightScheme } from "../diffs/nativeReviewDiffH
 // Pure key-derivation helpers for the native review diff bridge. Kept free of
 // react-native / hook imports so they stay unit-testable in node.
 
-export function hashReviewDiffKey(diff: string | null | undefined): string {
+function hashReviewDiffKey(diff: string | null | undefined): string {
   if (!diff) {
     return "empty";
   }

--- a/apps/mobile/src/features/review/useNativeReviewDiffBridge.ts
+++ b/apps/mobile/src/features/review/useNativeReviewDiffBridge.ts
@@ -8,7 +8,7 @@ import { useNativeReviewDiffHighlighting } from "./useNativeReviewDiffHighlighti
 import { buildNativeReviewTokensResetKey } from "./reviewDiffBridgeKeys";
 import { useUniwindTheme } from "../../lib/useUniwindTheme";
 
-export { buildNativeReviewTokensResetKey, hashReviewDiffKey } from "./reviewDiffBridgeKeys";
+export { buildNativeReviewTokensResetKey } from "./reviewDiffBridgeKeys";
 
 export function useNativeReviewDiffBridge(input: {
   readonly threadKey: string | null;


### PR DESCRIPTION
The native review reset hash was exported and re-exported only for tests of its string format. Those assertions did not verify token invalidation when diff content changes.

Keep the hash private and remove its unused hook re-export. Test reset-key changes through the live builder for same-length content changes, different row counts, and cleared diffs. The hash algorithm and key representation are unchanged.

Verification: 7 focused reset-key and native-view tests passed before, 6 after. Mobile typecheck, targeted lint/format, and diff checks passed. No visual change.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `hashReviewDiffKey` private in `reviewDiffBridgeKeys` module
> Removes `hashReviewDiffKey` from the public API by dropping its export and the re-export in [useNativeReviewDiffBridge.ts](https://github.com/pingdotgg/t3code/pull/10048/files#diff-1f2c956d5c5addc0bfb1f51c0127435149cd5ad4ef101907bdf27709710d9b69). The function itself stays unchanged. Tests in [reviewDiffBridgeKeys.test.ts](https://github.com/pingdotgg/t3code/pull/10048/files#diff-73884c30bd9d0af7b0eed43f9477c67aef2f9d8bab774e0ff0dfbdb1ccd5d4dc) no longer import or test the hash directly; instead they verify that `buildNativeReviewTokensResetKey` returns a different key when diff contents, row count, or a null diff change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb9fe60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->