### PR TITLE
refactor(web): remove unused preview thread reset helper

### DIFF
--- a/apps/web/src/previewStateStore.test.ts
+++ b/apps/web/src/previewStateStore.test.ts
@@ -18,7 +18,6 @@ import {
   readThreadPreviewState,
   reconcilePreviewServerSessions,
   rememberPreviewUrl,
-  removePreviewThread,
   resetPreviewStateForTests,
   subscribeThreadPreviewState,
   setActivePreviewTab,
@@ -608,13 +607,5 @@ describe("previewStateStore (single-tab)", () => {
     expect(state.recentlySeenUrls[0]).toBe(
       `http://localhost:${5000 + __testing.RECENT_URL_LIMIT + 4}/`,
     );
-  });
-
-  it("removeThread strips the entry", () => {
-    const snapshot = makeSnapshot();
-    applyPreviewServerSnapshot(ref, snapshot);
-    removePreviewThread(ref);
-    const state = readThreadPreviewState(ref);
-    expect(state).toEqual(__testing.EMPTY_THREAD_PREVIEW_STATE);
   });
 });

--- a/apps/web/src/previewStateStore.ts
+++ b/apps/web/src/previewStateStore.ts
@@ -472,13 +472,6 @@ export function rememberPreviewUrl(ref: ScopedThreadRef, url: string): void {
   }));
 }
 
-export function removePreviewThread(ref: ScopedThreadRef): void {
-  const threadKey = scopedThreadKey(ref);
-  appAtomRegistry.set(previewStateAtom(threadKey), EMPTY_THREAD_PREVIEW_STATE);
-  syncActivePreviewThread(threadKey, EMPTY_THREAD_PREVIEW_STATE);
-  changedPreviewThreadKeys.delete(threadKey);
-}
-
 export function isPreviewSupportedInRuntime(): boolean {
   if (typeof window === "undefined") return false;
   return Boolean(window.desktopBridge?.preview);


### PR DESCRIPTION
removePreviewThread has no runtime callers and is exercised only by its own direct test. Real preview closing uses the optimistic close and recovery path, while test setup uses resetPreviewStateForTests.

Remove the unused helper and its one orphan test. Keep the real close workflow, stale-response suppression, failed-close recovery, multi-tab state, restart/revision ordering and test reset support unchanged.

Verification: tracked symbol and import-path searches found no production consumer or reexport. Preview-state and close-session suites passed before and after, 29 to 28 cases. Web package typecheck, targeted lint, formatting and git diff --check passed. No screenshots apply to removal of unused code.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `removePreviewThread` helper from `previewStateStore`
> Deletes the exported `removePreviewThread` utility and its test in [previewStateStore.test.ts](https://github.com/pingdotgg/t3code/pull/10049/files#diff-d1f3eda54052bd094d4a4c338b826a2c12dabd1ca92c48ecbb6e780b88700a0c). The helper reset a scoped thread's preview atom and cleared related state, but was no longer called anywhere.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f4333c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->