### PR TITLE
fix(server): preserve inline sensitive env values on save

### DIFF
--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -1039,6 +1039,37 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
+  it.effect("preserves inline sensitive provider environment values on a redacted save", () =>
+    Effect.gen(function* () {
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const instanceId = ProviderInstanceId.make("codex_personal");
+      yield* fileSystem.writeFileString(
+        serverConfig.settingsPath,
+        '{"providerInstances":{"codex_personal":{"driver":"codex","environment":[{"name":"OPENROUTER_API_KEY","value":"inline-secret","sensitive":true}],"config":{}}}}',
+      );
+      const clientSettings = ServerSettingsModule.redactServerSettingsForClient(
+        yield* serverSettings.getSettings,
+      );
+      assert.equal(clientSettings.providerInstances[instanceId]?.environment?.[0]?.value, "");
+
+      const saved = yield* serverSettings.updateSettings({
+        providerInstances: clientSettings.providerInstances,
+      });
+
+      assert.equal(saved.providerInstances[instanceId]?.environment?.[0]?.value, "inline-secret");
+      assert.notInclude(
+        yield* fileSystem.readFileString(serverConfig.settingsPath),
+        "inline-secret",
+      );
+      assert.equal(
+        (yield* serverSettings.getSettings).providerInstances[instanceId]?.environment?.[0]?.value,
+        "inline-secret",
+      );
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
   it.effect("stores sensitive provider instance environment values outside settings.json", () =>
     Effect.gen(function* () {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -609,9 +609,22 @@ const make = Effect.gen(function* () {
           }
 
           nextSecretKeys.add(secretName);
-          if (!variable.valueRedacted) {
-            if (variable.value.length > 0) {
-              yield* secretStore.set(secretName, textEncoder.encode(variable.value)).pipe(
+          let valueToPersist = variable.valueRedacted ? undefined : variable.value;
+          if (variable.valueRedacted) {
+            const currentVariable = current.providerInstances[
+              ProviderInstanceId.make(instanceId)
+            ]?.environment?.findLast((entry) => entry.name === variable.name);
+            if (
+              currentVariable?.sensitive &&
+              !currentVariable.valueRedacted &&
+              currentVariable.value.length > 0
+            ) {
+              valueToPersist = currentVariable.value;
+            }
+          }
+          if (valueToPersist !== undefined) {
+            if (valueToPersist.length > 0) {
+              yield* secretStore.set(secretName, textEncoder.encode(valueToPersist)).pipe(
                 Effect.mapError(
                   (cause) =>
                     new ServerSettingsError({


### PR DESCRIPTION
## What Changed

Saving a provider with a sensitive environment value stored inline could replace that value with an empty redacted placeholder. Preserve the current inline value through the existing secret writer before saving the placeholder.

Adds one regression test for the redacted read/save round trip.

## Why

Clients only receive the redacted value, so saving an unchanged credential must preserve the server's current value. This fixes the data loss without changing the settings schema or clients.

Fixes #10022.

## Validation

- `vp test run apps/server/src/serverSettings.test.ts`: 34 tests passed. The new regression test failed before the fix.
- `vp exec tsgo --noEmit -p apps/server/tsconfig.json`: passed.
- `vp lint apps/server/src/serverSettings.ts apps/server/src/serverSettings.test.ts`: passed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- UI screenshots and video are not applicable.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve inline sensitive env values on save in server settings
> Fixes the server settings update flow so that redacted inline sensitive environment values are not overwritten with empty strings when the client submits a redacted copy. The update service now retains the existing secret on save while the settings file stays redacted. Added an integration test in [serverSettings.test.ts](https://github.com/pingdotgg/t3code/pull/10053/files#diff-511d9a6e2ded44cb61547a93c6a9e5b08e51a068ea0c2ccc0fba26e09a96810f) that writes a provider instance with an inline secret, submits the redacted form, and asserts the secret is preserved in memory but absent from the file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d69162.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->