### PR TITLE
feat(mobile): add subscription usage home screen widgets

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -131,6 +131,12 @@ const widgetsPlugin: NonNullable<ExpoConfig["plugins"]>[number] = [
     frequentUpdates: true,
     widgets: [
       {
+        name: "SubscriptionUsage",
+        displayName: "Subscription usage",
+        description: "Subscription quotas from your connected T3 Code environments.",
+        supportedFamilies: ["systemSmall", "systemMedium", "systemLarge"],
+      },
+      {
         name: "AgentActivity",
         displayName: "Agent Activity",
         description: "Shows the current state of active T3 Code agents.",

--- a/apps/mobile/modules/t3-subscription-widget/android/build.gradle
+++ b/apps/mobile/modules/t3-subscription-widget/android/build.gradle
@@ -1,0 +1,18 @@
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
+
+group = 'com.t3tools.subscriptionwidget'
+version = '0.0.0'
+
+android {
+  namespace 'expo.modules.t3subscriptionwidget'
+  compileSdk rootProject.ext.compileSdkVersion
+  defaultConfig {
+    minSdkVersion rootProject.ext.minSdkVersion
+    targetSdkVersion rootProject.ext.targetSdkVersion
+  }
+}
+
+dependencies {
+  implementation project(':expo-modules-core')
+}

--- a/apps/mobile/modules/t3-subscription-widget/android/src/main/AndroidManifest.xml
+++ b/apps/mobile/modules/t3-subscription-widget/android/src/main/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application>
+    <receiver android:name="expo.modules.t3subscriptionwidget.SubscriptionUsageWidget" android:exported="false" android:label="@string/t3_subscription_widget_name">
+      <intent-filter><action android:name="android.appwidget.action.APPWIDGET_UPDATE" /></intent-filter>
+      <meta-data android:name="android.appwidget.provider" android:resource="@xml/t3_subscription_widget_info" />
+    </receiver>
+  </application>
+</manifest>

--- a/apps/mobile/modules/t3-subscription-widget/android/src/main/java/expo/modules/t3subscriptionwidget/SubscriptionUsageWidget.kt
+++ b/apps/mobile/modules/t3-subscription-widget/android/src/main/java/expo/modules/t3subscriptionwidget/SubscriptionUsageWidget.kt
@@ -73,7 +73,13 @@ class SubscriptionUsageWidget : AppWidgetProvider() {
         }
         views.setTextViewText(
           R.id.t3_widget_footer,
-          context.getString(R.string.t3_subscription_widget_as_of, formatted) + more
+          (
+            if (oldest > 0) {
+              context.getString(R.string.t3_subscription_widget_as_of, formatted)
+            } else {
+              context.getString(R.string.t3_subscription_widget_unknown_check)
+            }
+            ) + more
         )
       }
       manager.updateAppWidget(id, views)

--- a/apps/mobile/modules/t3-subscription-widget/android/src/main/java/expo/modules/t3subscriptionwidget/SubscriptionUsageWidget.kt
+++ b/apps/mobile/modules/t3-subscription-widget/android/src/main/java/expo/modules/t3subscriptionwidget/SubscriptionUsageWidget.kt
@@ -1,0 +1,79 @@
+package expo.modules.t3subscriptionwidget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.View
+import android.widget.RemoteViews
+import org.json.JSONObject
+import java.text.DateFormat
+import java.util.Date
+
+class SubscriptionUsageWidget : AppWidgetProvider() {
+  override fun onUpdate(context: Context, manager: AppWidgetManager, ids: IntArray) {
+    ids.forEach { update(context, manager, it) }
+  }
+
+  override fun onAppWidgetOptionsChanged(context: Context, manager: AppWidgetManager, id: Int, options: Bundle) {
+    update(context, manager, id)
+  }
+
+  companion object {
+    const val PREFERENCES = "t3_subscription_widget"
+
+    fun updateAll(context: Context) {
+      val manager = AppWidgetManager.getInstance(context)
+      manager.getAppWidgetIds(ComponentName(context, SubscriptionUsageWidget::class.java))
+        .forEach { update(context, manager, it) }
+    }
+
+    private fun update(context: Context, manager: AppWidgetManager, id: Int) {
+      val saved = context.getSharedPreferences(PREFERENCES, 0).getString("snapshot", null)
+      val snapshot = try { saved?.let { JSONObject(it) } } catch (_: Exception) { null }
+      val views = RemoteViews(context.packageName, R.layout.t3_subscription_widget)
+      // Explicitly target this variant's launcher so co-installed builds cannot steal the tap.
+      val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)?.apply {
+        action = Intent.ACTION_VIEW
+        data = Uri.parse(snapshot?.optString("deepLink")?.takeIf { it.isNotBlank() }
+          ?: "t3code://settings/usage?tab=limits")
+        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+      }
+      if (intent != null) {
+        views.setOnClickPendingIntent(R.id.t3_widget_root, PendingIntent.getActivity(
+          context, id, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE))
+      }
+      val rows = snapshot?.optJSONArray("rows")
+      if (rows != null && rows.length() > 0) {
+        views.removeAllViews(R.id.t3_widget_rows)
+        val height = manager.getAppWidgetOptions(id).getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT, 180)
+        val count = ((height - 64) / 66).coerceIn(1, 8).coerceAtMost(rows.length())
+        var oldest = Long.MAX_VALUE
+        for (index in 0 until count) {
+          val row = rows.optJSONObject(index) ?: continue
+          val child = RemoteViews(context.packageName, R.layout.t3_subscription_widget_row)
+          val used = if (row.isNull("usedPercent")) null else row.optInt("usedPercent").coerceIn(0, 100)
+          child.setTextViewText(R.id.t3_widget_label, row.optString("label"))
+          child.setTextViewText(R.id.t3_widget_window, row.optString("window"))
+          child.setTextViewText(R.id.t3_widget_percent, used?.let { context.getString(R.string.t3_subscription_widget_used, it) } ?: "—")
+          child.setViewVisibility(R.id.t3_widget_progress, if (used == null) View.GONE else View.VISIBLE)
+          if (used != null) child.setProgressBar(R.id.t3_widget_progress, 100, used, false)
+          child.setTextViewText(R.id.t3_widget_reset,
+            if (row.optLong("expiresAt") <= System.currentTimeMillis()) context.getString(R.string.t3_subscription_widget_refresh)
+            else row.optString("resetLabel"))
+          oldest = minOf(oldest, row.optLong("checkedAt"))
+          views.addView(R.id.t3_widget_rows, child)
+        }
+        val remaining = (snapshot?.optInt("totalRows", rows.length()) ?: rows.length()) - count
+        val formatted = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT).format(Date(oldest))
+        views.setTextViewText(R.id.t3_widget_footer, context.getString(R.string.t3_subscription_widget_as_of, formatted) +
+          if (remaining > 0) context.getString(R.string.t3_subscription_widget_more, remaining) else "")
+      }
+      manager.updateAppWidget(id, views)
+    }
+  }
+}

--- a/apps/mobile/modules/t3-subscription-widget/android/src/main/java/expo/modules/t3subscriptionwidget/SubscriptionUsageWidget.kt
+++ b/apps/mobile/modules/t3-subscription-widget/android/src/main/java/expo/modules/t3subscriptionwidget/SubscriptionUsageWidget.kt
@@ -19,7 +19,12 @@ class SubscriptionUsageWidget : AppWidgetProvider() {
     ids.forEach { update(context, manager, it) }
   }
 
-  override fun onAppWidgetOptionsChanged(context: Context, manager: AppWidgetManager, id: Int, options: Bundle) {
+  override fun onAppWidgetOptionsChanged(
+    context: Context,
+    manager: AppWidgetManager,
+    id: Int,
+    options: Bundle
+  ) {
     update(context, manager, id)
   }
 
@@ -34,46 +39,80 @@ class SubscriptionUsageWidget : AppWidgetProvider() {
 
     private fun update(context: Context, manager: AppWidgetManager, id: Int) {
       val saved = context.getSharedPreferences(PREFERENCES, 0).getString("snapshot", null)
-      val snapshot = try { saved?.let { JSONObject(it) } } catch (_: Exception) { null }
-      val views = RemoteViews(context.packageName, R.layout.t3_subscription_widget)
-      // Explicitly target this variant's launcher so co-installed builds cannot steal the tap.
-      val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)?.apply {
-        action = Intent.ACTION_VIEW
-        data = Uri.parse(snapshot?.optString("deepLink")?.takeIf { it.isNotBlank() }
-          ?: "t3code://settings/usage?tab=limits")
-        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+      val snapshot = try {
+        saved?.let { JSONObject(it) }
+      } catch (_: Exception) {
+        null
       }
-      if (intent != null) {
-        views.setOnClickPendingIntent(R.id.t3_widget_root, PendingIntent.getActivity(
-          context, id, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE))
+      val views = RemoteViews(context.packageName, R.layout.t3_subscription_widget)
+      openAppIntent(context, id, snapshot)?.let {
+        views.setOnClickPendingIntent(R.id.t3_widget_root, it)
       }
       val rows = snapshot?.optJSONArray("rows")
       if (rows != null && rows.length() > 0) {
         views.removeAllViews(R.id.t3_widget_rows)
-        val height = manager.getAppWidgetOptions(id).getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT, 180)
+        val options = manager.getAppWidgetOptions(id)
+        val height = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT, 180)
         val count = ((height - 64) / 66).coerceIn(1, 8).coerceAtMost(rows.length())
         var oldest = Long.MAX_VALUE
         for (index in 0 until count) {
           val row = rows.optJSONObject(index) ?: continue
-          val child = RemoteViews(context.packageName, R.layout.t3_subscription_widget_row)
-          val used = if (row.isNull("usedPercent")) null else row.optInt("usedPercent").coerceIn(0, 100)
-          child.setTextViewText(R.id.t3_widget_label, row.optString("label"))
-          child.setTextViewText(R.id.t3_widget_window, row.optString("window"))
-          child.setTextViewText(R.id.t3_widget_percent, used?.let { context.getString(R.string.t3_subscription_widget_used, it) } ?: "—")
-          child.setViewVisibility(R.id.t3_widget_progress, if (used == null) View.GONE else View.VISIBLE)
-          if (used != null) child.setProgressBar(R.id.t3_widget_progress, 100, used, false)
-          child.setTextViewText(R.id.t3_widget_reset,
-            if (row.optLong("expiresAt") <= System.currentTimeMillis()) context.getString(R.string.t3_subscription_widget_refresh)
-            else row.optString("resetLabel"))
+          val child = rowView(context, row)
           oldest = minOf(oldest, row.optLong("checkedAt"))
           views.addView(R.id.t3_widget_rows, child)
         }
         val remaining = (snapshot?.optInt("totalRows", rows.length()) ?: rows.length()) - count
-        val formatted = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT).format(Date(oldest))
-        views.setTextViewText(R.id.t3_widget_footer, context.getString(R.string.t3_subscription_widget_as_of, formatted) +
-          if (remaining > 0) context.getString(R.string.t3_subscription_widget_more, remaining) else "")
+        val formatted = DateFormat.getDateTimeInstance(
+          DateFormat.SHORT,
+          DateFormat.SHORT
+        ).format(Date(oldest))
+        val more = if (remaining > 0) {
+          context.getString(R.string.t3_subscription_widget_more, remaining)
+        } else {
+          ""
+        }
+        views.setTextViewText(
+          R.id.t3_widget_footer,
+          context.getString(R.string.t3_subscription_widget_as_of, formatted) + more
+        )
       }
       manager.updateAppWidget(id, views)
+    }
+
+    private fun openAppIntent(context: Context, id: Int, snapshot: JSONObject?): PendingIntent? {
+      // Target this variant's launcher so co-installed builds cannot steal the tap.
+      val intent =
+        context.packageManager.getLaunchIntentForPackage(context.packageName) ?: return null
+      intent.action = Intent.ACTION_VIEW
+      val deepLink = snapshot?.optString("deepLink")?.takeIf { it.isNotBlank() }
+        ?: "t3code://settings/usage?tab=limits"
+      intent.data = Uri.parse(deepLink)
+      intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+      return PendingIntent.getActivity(
+        context,
+        id,
+        intent,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+      )
+    }
+
+    private fun rowView(context: Context, row: JSONObject): RemoteViews {
+      val child = RemoteViews(context.packageName, R.layout.t3_subscription_widget_row)
+      val used = if (row.isNull("usedPercent")) null else row.optInt("usedPercent").coerceIn(0, 100)
+      child.setTextViewText(R.id.t3_widget_label, row.optString("label"))
+      child.setTextViewText(R.id.t3_widget_window, row.optString("window"))
+      val percent = used?.let { context.getString(R.string.t3_subscription_widget_used, it) } ?: "—"
+      child.setTextViewText(R.id.t3_widget_percent, percent)
+      val visibility = if (used == null) View.GONE else View.VISIBLE
+      child.setViewVisibility(R.id.t3_widget_progress, visibility)
+      if (used != null) child.setProgressBar(R.id.t3_widget_progress, 100, used, false)
+      val reset = if (row.optLong("expiresAt") <= System.currentTimeMillis()) {
+        context.getString(R.string.t3_subscription_widget_refresh)
+      } else {
+        row.optString("resetLabel")
+      }
+      child.setTextViewText(R.id.t3_widget_reset, reset)
+      return child
     }
   }
 }

--- a/apps/mobile/modules/t3-subscription-widget/android/src/main/java/expo/modules/t3subscriptionwidget/T3SubscriptionWidgetModule.kt
+++ b/apps/mobile/modules/t3-subscription-widget/android/src/main/java/expo/modules/t3subscriptionwidget/T3SubscriptionWidgetModule.kt
@@ -1,0 +1,18 @@
+package expo.modules.t3subscriptionwidget
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import org.json.JSONObject
+
+class T3SubscriptionWidgetModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("T3SubscriptionWidget")
+    Function("updateSnapshot") { snapshot: String ->
+      val context = appContext.reactContext ?: return@Function
+      JSONObject(snapshot) // Reject malformed writes before replacing the saved snapshot.
+      context.getSharedPreferences(SubscriptionUsageWidget.PREFERENCES, 0)
+        .edit().putString("snapshot", snapshot).apply()
+      SubscriptionUsageWidget.updateAll(context)
+    }
+  }
+}

--- a/apps/mobile/modules/t3-subscription-widget/android/src/main/res/drawable/t3_subscription_widget_background.xml
+++ b/apps/mobile/modules/t3-subscription-widget/android/src/main/res/drawable/t3_subscription_widget_background.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+  <solid android:color="@color/t3_widget_background" />
+  <corners android:radius="20dp" />
+</shape>

--- a/apps/mobile/modules/t3-subscription-widget/android/src/main/res/layout/t3_subscription_widget.xml
+++ b/apps/mobile/modules/t3-subscription-widget/android/src/main/res/layout/t3_subscription_widget.xml
@@ -1,0 +1,9 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:id="@+id/t3_widget_root" android:layout_width="match_parent" android:layout_height="match_parent"
+  android:orientation="vertical" android:padding="16dp" android:background="@drawable/t3_subscription_widget_background">
+  <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:text="@string/t3_subscription_widget_name" android:textStyle="bold" android:textSize="16sp" android:textColor="@color/t3_widget_foreground" android:maxLines="1" android:ellipsize="end" />
+  <LinearLayout android:id="@+id/t3_widget_rows" android:layout_width="match_parent" android:layout_height="0dp" android:layout_weight="1" android:orientation="vertical">
+    <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="8dp" android:text="@string/t3_subscription_widget_empty" android:textSize="13sp" android:textColor="@color/t3_widget_secondary" />
+  </LinearLayout>
+  <TextView android:id="@+id/t3_widget_footer" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="@string/t3_subscription_widget_open" android:textSize="10sp" android:textColor="@color/t3_widget_secondary" android:maxLines="1" android:ellipsize="end" />
+</LinearLayout>

--- a/apps/mobile/modules/t3-subscription-widget/android/src/main/res/layout/t3_subscription_widget_row.xml
+++ b/apps/mobile/modules/t3-subscription-widget/android/src/main/res/layout/t3_subscription_widget_row.xml
@@ -1,0 +1,10 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="vertical" android:paddingTop="8dp">
+  <LinearLayout android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="horizontal">
+    <TextView android:id="@+id/t3_widget_label" android:layout_width="0dp" android:layout_weight="1" android:layout_height="wrap_content" android:textSize="12sp" android:textStyle="bold" android:textColor="@color/t3_widget_foreground" android:maxLines="1" android:ellipsize="end" />
+    <TextView android:id="@+id/t3_widget_percent" android:layout_width="wrap_content" android:layout_height="wrap_content" android:paddingStart="8dp" android:textSize="12sp" android:textColor="@color/t3_widget_foreground" />
+  </LinearLayout>
+  <TextView android:id="@+id/t3_widget_window" android:layout_width="match_parent" android:layout_height="wrap_content" android:textSize="10sp" android:textColor="@color/t3_widget_secondary" android:maxLines="1" android:ellipsize="end" />
+  <ProgressBar android:id="@+id/t3_widget_progress" style="?android:attr/progressBarStyleHorizontal" android:layout_width="match_parent" android:layout_height="6dp" android:max="100" android:progressTint="#0284c7" />
+  <TextView android:id="@+id/t3_widget_reset" android:layout_width="match_parent" android:layout_height="wrap_content" android:textSize="10sp" android:textColor="@color/t3_widget_secondary" android:maxLines="1" android:ellipsize="end" />
+</LinearLayout>

--- a/apps/mobile/modules/t3-subscription-widget/android/src/main/res/values-night/colors.xml
+++ b/apps/mobile/modules/t3-subscription-widget/android/src/main/res/values-night/colors.xml
@@ -1,0 +1,5 @@
+<resources>
+  <color name="t3_widget_background">#18181B</color>
+  <color name="t3_widget_foreground">#FAFAFA</color>
+  <color name="t3_widget_secondary">#A1A1AA</color>
+</resources>

--- a/apps/mobile/modules/t3-subscription-widget/android/src/main/res/values/colors.xml
+++ b/apps/mobile/modules/t3-subscription-widget/android/src/main/res/values/colors.xml
@@ -1,0 +1,5 @@
+<resources>
+  <color name="t3_widget_background">#FAFAFA</color>
+  <color name="t3_widget_foreground">#18181B</color>
+  <color name="t3_widget_secondary">#52525B</color>
+</resources>

--- a/apps/mobile/modules/t3-subscription-widget/android/src/main/res/values/strings.xml
+++ b/apps/mobile/modules/t3-subscription-widget/android/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
+  <string name="t3_subscription_widget_unknown_check">Last checked unavailable</string>
   <string name="t3_subscription_widget_name">Subscription usage</string>
   <string name="t3_subscription_widget_description">Saved subscription quotas from your T3 Code environments. Tap to refresh in the app.</string>
   <string name="t3_subscription_widget_empty">Open T3 Code and connect an environment to see limits.</string>

--- a/apps/mobile/modules/t3-subscription-widget/android/src/main/res/values/strings.xml
+++ b/apps/mobile/modules/t3-subscription-widget/android/src/main/res/values/strings.xml
@@ -1,0 +1,10 @@
+<resources>
+  <string name="t3_subscription_widget_name">Subscription usage</string>
+  <string name="t3_subscription_widget_description">Saved subscription quotas from your T3 Code environments. Tap to refresh in the app.</string>
+  <string name="t3_subscription_widget_empty">Open T3 Code and connect an environment to see limits.</string>
+  <string name="t3_subscription_widget_open">Tap to open Usage</string>
+  <string name="t3_subscription_widget_refresh">Open app to refresh</string>
+  <string name="t3_subscription_widget_used">%1$d%% used</string>
+  <string name="t3_subscription_widget_as_of">As of %1$s</string>
+  <string name="t3_subscription_widget_more"> · +%1$d more</string>
+</resources>

--- a/apps/mobile/modules/t3-subscription-widget/android/src/main/res/xml/t3_subscription_widget_info.xml
+++ b/apps/mobile/modules/t3-subscription-widget/android/src/main/res/xml/t3_subscription_widget_info.xml
@@ -1,0 +1,9 @@
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+  android:minWidth="250dp" android:minHeight="180dp"
+  android:minResizeWidth="180dp" android:minResizeHeight="130dp"
+  android:targetCellWidth="4" android:targetCellHeight="3"
+  android:resizeMode="horizontal|vertical" android:widgetCategory="home_screen"
+  android:updatePeriodMillis="1800000"
+  android:description="@string/t3_subscription_widget_description"
+  android:initialLayout="@layout/t3_subscription_widget"
+  android:previewLayout="@layout/t3_subscription_widget" />

--- a/apps/mobile/modules/t3-subscription-widget/expo-module.config.json
+++ b/apps/mobile/modules/t3-subscription-widget/expo-module.config.json
@@ -1,0 +1,4 @@
+{
+  "platforms": ["android"],
+  "android": { "modules": ["expo.modules.t3subscriptionwidget.T3SubscriptionWidgetModule"] }
+}

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -24,6 +24,8 @@ import { OverlayPortalHost } from "./components/OverlayPortal";
 import { appBlurTargetRef } from "./lib/appBlurTarget";
 import { useMobileNavigationTheme } from "./lib/useMobileNavigationTheme";
 
+import { SubscriptionUsageCoordinator } from "./widgets/SubscriptionUsageCoordinator";
+
 import "../global.css";
 
 if (process.env.EXPO_PUBLIC_SHOWCASE === "1") {
@@ -77,6 +79,7 @@ function AppContent() {
   return (
     <>
       <SplashScreenCoordinator />
+      <SubscriptionUsageCoordinator />
       <GestureHandlerRootView className="flex-1">
         <KeyboardProvider statusBarTranslucent>
           <SafeAreaProvider>

--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -1,5 +1,5 @@
 import { EnvironmentId, USAGE_CONTRACT_VERSION } from "@t3tools/contracts";
-import { useNavigation } from "@react-navigation/native";
+import { type RouteProp, useNavigation, useRoute } from "@react-navigation/native";
 import {
   isCompatibleUsageContractVersion,
   isModelCostUnknown,
@@ -65,11 +65,21 @@ const CHART_HEIGHT = 180;
  * pull to refresh, each refreshing its own data.
  */
 export function UsageRouteScreen() {
+  const route = useRoute<RouteProp<{ Usage: { tab?: string } | undefined }, "Usage">>();
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
-  // Limits first: remaining quota and reset time are what most people open
-  // the screen for.
-  const [tab, setTab] = useState<UsageTab>("limits");
+  const [selection, setSelection] = useState(() => ({
+    params: route.params,
+    tab: (route.params?.tab === "usage" ? "usage" : "limits") as UsageTab,
+  }));
+  if (selection.params !== route.params) {
+    setSelection({
+      params: route.params,
+      tab: route.params?.tab === "usage" ? "usage" : "limits",
+    });
+  }
+  const { tab } = selection;
+  const setTab = (tab: UsageTab) => setSelection({ params: route.params, tab });
   const [windowSelection, setWindowSelection] = useState(() => ({
     days: 30,
     window: makeWindow(30),

--- a/apps/mobile/src/widgets/SubscriptionUsage.test.ts
+++ b/apps/mobile/src/widgets/SubscriptionUsage.test.ts
@@ -77,7 +77,7 @@ describe("iOS subscription widget", () => {
               label: "Claude",
               window: "No subscription limits",
               resetLabel: "Open app for details",
-              checkedAt: now,
+              checkedAt: 0,
               expiresAt: 0,
             },
           ],
@@ -88,6 +88,8 @@ describe("iOS subscription widget", () => {
     );
     expect(tree).toContain("—");
     expect(tree).toContain("No subscription limits");
+    expect(tree).toContain("Last checked unavailable");
+    expect(tree).not.toContain("1970");
     expect(tree).not.toContain("ProgressView");
     expect(tree).not.toContain("0% used");
   });

--- a/apps/mobile/src/widgets/SubscriptionUsage.test.ts
+++ b/apps/mobile/src/widgets/SubscriptionUsage.test.ts
@@ -67,4 +67,28 @@ describe("iOS subscription widget", () => {
     expect(tree).not.toContain("Resets tomorrow");
     expect(tree).toContain("90% used");
   });
+  it("renders an omitted quota as unavailable rather than zero", () => {
+    const tree = JSON.stringify(
+      SubscriptionUsage(
+        {
+          ...snapshot,
+          rows: [
+            {
+              label: "Claude",
+              window: "No subscription limits",
+              resetLabel: "Open app for details",
+              checkedAt: now,
+              expiresAt: 0,
+            },
+          ],
+          totalRows: 1,
+        },
+        { date: new Date(now), widgetFamily: "systemSmall", configuration: undefined },
+      ),
+    );
+    expect(tree).toContain("—");
+    expect(tree).toContain("No subscription limits");
+    expect(tree).not.toContain("ProgressView");
+    expect(tree).not.toContain("0% used");
+  });
 });

--- a/apps/mobile/src/widgets/SubscriptionUsage.test.ts
+++ b/apps/mobile/src/widgets/SubscriptionUsage.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+vi.mock("@expo/ui/swift-ui", () =>
+  Object.fromEntries(
+    ["HStack", "ProgressView", "Spacer", "Text", "VStack"].map((name) => [name, name]),
+  ),
+);
+vi.mock("@expo/ui/swift-ui/modifiers", () =>
+  Object.fromEntries(
+    ["font", "foregroundStyle", "lineLimit", "tint", "widgetURL"].map((name) => [
+      name,
+      (value: unknown) => ({ [name]: value }),
+    ]),
+  ),
+);
+vi.mock("expo-widgets", () => ({ createWidget: (name: string) => ({ name }) }));
+import { SubscriptionUsage } from "./SubscriptionUsage";
+import type { SubscriptionUsageSnapshot } from "./subscriptionUsageSnapshot";
+
+const now = Date.parse("2026-09-05T12:00:00Z");
+const snapshot: SubscriptionUsageSnapshot = {
+  deepLink: "t3code-dev://settings/usage?tab=limits",
+  totalRows: 8,
+  rows: Array.from({ length: 8 }, (_, index) => ({
+    label: `Provider ${index}`,
+    window: "Weekly",
+    usedPercent: 90,
+    resetLabel: "Resets tomorrow",
+    checkedAt: now,
+    expiresAt: now + 600_000,
+  })),
+};
+
+describe("iOS subscription widget", () => {
+  it.each([
+    ["systemSmall", 1],
+    ["systemMedium", 2],
+    ["systemLarge", 4],
+  ] as const)("bounds %s content and reports omitted windows", (widgetFamily, count) => {
+    const tree = JSON.stringify(
+      SubscriptionUsage(snapshot, { date: new Date(now), widgetFamily, configuration: undefined }),
+    );
+    expect(tree).toContain(`Provider ${count - 1}`);
+    expect(tree).not.toContain(`Provider ${count}`);
+    expect(tree).toContain(`+${8 - count} more`);
+    expect(tree).toContain(snapshot.deepLink);
+  });
+  it("renders gallery props without account data", () => {
+    const tree = JSON.stringify(
+      SubscriptionUsage({} as SubscriptionUsageSnapshot, {
+        date: new Date(now),
+        widgetFamily: "systemSmall",
+        configuration: undefined,
+      }),
+    );
+    expect(tree).toContain("connect an environment");
+    expect(tree).not.toContain("Invalid Date");
+  });
+  it("replaces reset copy when the snapshot expires", () => {
+    const tree = JSON.stringify(
+      SubscriptionUsage(snapshot, {
+        date: new Date(now + 600_000),
+        widgetFamily: "systemSmall",
+        configuration: undefined,
+      }),
+    );
+    expect(tree).toContain("Open app to refresh");
+    expect(tree).not.toContain("Resets tomorrow");
+    expect(tree).toContain("90% used");
+  });
+});

--- a/apps/mobile/src/widgets/SubscriptionUsage.tsx
+++ b/apps/mobile/src/widgets/SubscriptionUsage.tsx
@@ -31,13 +31,13 @@ export function SubscriptionUsage(
         </Text>
         <Spacer />
         <Text modifiers={[font({ size: 12 }), foregroundStyle("primary")]}>
-          {row.usedPercent === null ? "—" : `${row.usedPercent}% used`}
+          {typeof row.usedPercent !== "number" ? "—" : `${row.usedPercent}% used`}
         </Text>
       </HStack>
       <Text modifiers={[font({ size: 10 }), foregroundStyle("secondary"), lineLimit(1)]}>
         {row.window}
       </Text>
-      {row.usedPercent !== null ? (
+      {typeof row.usedPercent === "number" ? (
         <ProgressView
           value={row.usedPercent / 100}
           modifiers={[
@@ -60,7 +60,7 @@ export function SubscriptionUsage(
       <Text
         modifiers={[font({ size: 14, weight: "bold" }), foregroundStyle("primary"), lineLimit(1)]}
       >
-        Subscription usage
+        {environment.widgetFamily === "systemSmall" ? "Usage limits" : "Subscription usage"}
       </Text>
       {visible.length === 0 ? (
         <Text modifiers={[font({ size: 12 }), foregroundStyle("secondary")]}>
@@ -77,9 +77,14 @@ export function SubscriptionUsage(
       <Spacer minLength={0} />
       <Text modifiers={[font({ size: 10 }), foregroundStyle("secondary"), lineLimit(1)]}>
         {visible.length > 0
-          ? `As of ${new Date(Math.min(...visible.map((row) => row.checkedAt))).toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}${props.totalRows > visible.length ? ` · +${props.totalRows - visible.length} more` : ""}`
+          ? `As of ${new Date(Math.min(...visible.map((row) => row.checkedAt))).toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}`
           : "Tap to open Usage"}
       </Text>
+      {props.totalRows > visible.length ? (
+        <Text modifiers={[font({ size: 10 }), foregroundStyle("secondary"), lineLimit(1)]}>
+          {`+${props.totalRows - visible.length} more`}
+        </Text>
+      ) : null}
     </VStack>
   );
 }

--- a/apps/mobile/src/widgets/SubscriptionUsage.tsx
+++ b/apps/mobile/src/widgets/SubscriptionUsage.tsx
@@ -16,6 +16,7 @@ export function SubscriptionUsage(
         ? 2
         : 1;
   const visible = rows.slice(0, count);
+  const oldest = Math.min(...visible.map((row) => row.checkedAt));
   const now = environment.date.getTime();
   const renderRow = (row: SubscriptionUsageSnapshot["rows"][number], index: number) => (
     <VStack key={index} alignment="leading" spacing={3}>
@@ -77,7 +78,9 @@ export function SubscriptionUsage(
       <Spacer minLength={0} />
       <Text modifiers={[font({ size: 10 }), foregroundStyle("secondary"), lineLimit(1)]}>
         {visible.length > 0
-          ? `As of ${new Date(Math.min(...visible.map((row) => row.checkedAt))).toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}`
+          ? oldest > 0
+            ? `As of ${new Date(oldest).toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}`
+            : "Last checked unavailable"
           : "Tap to open Usage"}
       </Text>
       {props.totalRows > visible.length ? (

--- a/apps/mobile/src/widgets/SubscriptionUsage.tsx
+++ b/apps/mobile/src/widgets/SubscriptionUsage.tsx
@@ -1,0 +1,87 @@
+import { HStack, ProgressView, Spacer, Text, VStack } from "@expo/ui/swift-ui";
+import { font, foregroundStyle, lineLimit, tint, widgetURL } from "@expo/ui/swift-ui/modifiers";
+import { createWidget, type WidgetEnvironment } from "expo-widgets";
+import type { SubscriptionUsageSnapshot } from "./subscriptionUsageSnapshot";
+
+export function SubscriptionUsage(
+  props: SubscriptionUsageSnapshot,
+  environment: WidgetEnvironment,
+) {
+  "widget";
+  const rows = props.rows ?? [];
+  const count =
+    environment.widgetFamily === "systemLarge"
+      ? 4
+      : environment.widgetFamily === "systemMedium"
+        ? 2
+        : 1;
+  const visible = rows.slice(0, count);
+  const now = environment.date.getTime();
+  const renderRow = (row: SubscriptionUsageSnapshot["rows"][number], index: number) => (
+    <VStack key={index} alignment="leading" spacing={3}>
+      <HStack>
+        <Text
+          modifiers={[
+            font({ size: 12, weight: "semibold" }),
+            foregroundStyle("primary"),
+            lineLimit(1),
+          ]}
+        >
+          {row.label}
+        </Text>
+        <Spacer />
+        <Text modifiers={[font({ size: 12 }), foregroundStyle("primary")]}>
+          {row.usedPercent === null ? "—" : `${row.usedPercent}% used`}
+        </Text>
+      </HStack>
+      <Text modifiers={[font({ size: 10 }), foregroundStyle("secondary"), lineLimit(1)]}>
+        {row.window}
+      </Text>
+      {row.usedPercent !== null ? (
+        <ProgressView
+          value={row.usedPercent / 100}
+          modifiers={[
+            tint(row.usedPercent >= 90 ? "#dc2626" : row.usedPercent >= 70 ? "#d97706" : "#0284c7"),
+          ]}
+        />
+      ) : null}
+      <Text modifiers={[font({ size: 10 }), foregroundStyle("secondary"), lineLimit(1)]}>
+        {row.expiresAt <= now ? "Open app to refresh" : row.resetLabel}
+      </Text>
+    </VStack>
+  );
+
+  return (
+    <VStack
+      alignment="leading"
+      spacing={8}
+      modifiers={[widgetURL(props.deepLink ?? "t3code://settings/usage?tab=limits")]}
+    >
+      <Text
+        modifiers={[font({ size: 14, weight: "bold" }), foregroundStyle("primary"), lineLimit(1)]}
+      >
+        Subscription usage
+      </Text>
+      {visible.length === 0 ? (
+        <Text modifiers={[font({ size: 12 }), foregroundStyle("secondary")]}>
+          Open T3 Code and connect an environment to see limits.
+        </Text>
+      ) : null}
+      {environment.widgetFamily === "systemMedium" ? (
+        <HStack alignment="top" spacing={16}>
+          {visible.map(renderRow)}
+        </HStack>
+      ) : (
+        visible.map(renderRow)
+      )}
+      <Spacer minLength={0} />
+      <Text modifiers={[font({ size: 10 }), foregroundStyle("secondary"), lineLimit(1)]}>
+        {visible.length > 0
+          ? `As of ${new Date(Math.min(...visible.map((row) => row.checkedAt))).toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}${props.totalRows > visible.length ? ` · +${props.totalRows - visible.length} more` : ""}`
+          : "Tap to open Usage"}
+      </Text>
+    </VStack>
+  );
+}
+
+export default createWidget("SubscriptionUsage", SubscriptionUsage);

--- a/apps/mobile/src/widgets/SubscriptionUsageCoordinator.tsx
+++ b/apps/mobile/src/widgets/SubscriptionUsageCoordinator.tsx
@@ -1,0 +1,30 @@
+import { useAtomValue } from "@effect/atom-react";
+import { Atom } from "effect/unstable/reactivity";
+import * as Linking from "expo-linking";
+import { useEffect } from "react";
+import { environmentCatalog } from "../connection/catalog";
+import { environmentPresentations } from "../state/presentation";
+import { publishSubscriptionUsage } from "./publishSubscriptionUsage";
+import { buildSubscriptionUsageSnapshot } from "./subscriptionUsageSnapshot";
+
+// Isolate quota changes from the much busier thread/config presentation stream.
+const snapshotAtom = Atom.make((get) =>
+  buildSubscriptionUsageSnapshot(
+    get(environmentPresentations.presentationsAtom),
+    Linking.createURL("settings/usage", { queryParams: { tab: "limits" } }),
+  ),
+).pipe(Atom.withEquality((a, b) => JSON.stringify(a) === JSON.stringify(b)));
+
+export function SubscriptionUsageCoordinator() {
+  const catalog = useAtomValue(environmentCatalog.catalogValueAtom);
+  const snapshot = useAtomValue(snapshotAtom);
+  useEffect(() => {
+    if (!catalog.isReady) return;
+    void Promise.resolve()
+      .then(() => publishSubscriptionUsage(snapshot))
+      .catch((error: unknown) => {
+        console.warn("Could not update subscription usage widget", error);
+      });
+  }, [catalog.isReady, snapshot]);
+  return null;
+}

--- a/apps/mobile/src/widgets/publishSubscriptionUsage.android.ts
+++ b/apps/mobile/src/widgets/publishSubscriptionUsage.android.ts
@@ -1,0 +1,8 @@
+import { requireOptionalNativeModule } from "expo";
+import type { SubscriptionUsageSnapshot } from "./subscriptionUsageSnapshot";
+
+export function publishSubscriptionUsage(snapshot: SubscriptionUsageSnapshot) {
+  requireOptionalNativeModule<{ updateSnapshot: (snapshot: string) => void }>(
+    "T3SubscriptionWidget",
+  )?.updateSnapshot(JSON.stringify(snapshot));
+}

--- a/apps/mobile/src/widgets/publishSubscriptionUsage.ios.ts
+++ b/apps/mobile/src/widgets/publishSubscriptionUsage.ios.ts
@@ -1,0 +1,11 @@
+import { requireOptionalNativeModule } from "expo";
+import {
+  subscriptionUsageTimeline,
+  type SubscriptionUsageSnapshot,
+} from "./subscriptionUsageSnapshot";
+
+export async function publishSubscriptionUsage(snapshot: SubscriptionUsageSnapshot) {
+  if (!requireOptionalNativeModule("ExpoWidgets")) return;
+  const { default: widget } = await import("./SubscriptionUsage");
+  widget.updateTimeline(subscriptionUsageTimeline(snapshot, Date.now()));
+}

--- a/apps/mobile/src/widgets/publishSubscriptionUsage.ts
+++ b/apps/mobile/src/widgets/publishSubscriptionUsage.ts
@@ -1,0 +1,3 @@
+import type { SubscriptionUsageSnapshot } from "./subscriptionUsageSnapshot";
+
+export function publishSubscriptionUsage(_snapshot: SubscriptionUsageSnapshot) {}

--- a/apps/mobile/src/widgets/subscriptionUsageSnapshot.test.ts
+++ b/apps/mobile/src/widgets/subscriptionUsageSnapshot.test.ts
@@ -1,0 +1,157 @@
+import {
+  EnvironmentId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  UsageLimitSourceId,
+  type ServerProvider,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+import {
+  buildSubscriptionUsageSnapshot,
+  subscriptionUsageTimeline,
+} from "./subscriptionUsageSnapshot";
+
+const checkedAt = "2026-09-05T12:00:00.000Z";
+const now = Date.parse(checkedAt);
+const window = {
+  id: "session",
+  kind: "session",
+  label: "5 hours",
+  usedPercent: 40,
+  resetsAt: "2026-09-05T12:10:00.000Z",
+} as const;
+const limits = { checkedAt, windows: [window] };
+const deepLink = "t3code-dev://settings/usage?tab=limits";
+function provider(overrides: Partial<ServerProvider> = {}): ServerProvider {
+  return {
+    instanceId: ProviderInstanceId.make("codex"),
+    driver: ProviderDriverKind.make("codex"),
+    enabled: true,
+    installed: true,
+    version: null,
+    status: "ready",
+    auth: { status: "authenticated", email: "private@example.com" },
+    checkedAt,
+    models: [],
+    slashCommands: [],
+    skills: [],
+    usageLimits: limits,
+    ...overrides,
+  };
+}
+function presentations(providers: readonly ServerProvider[] = [provider()]) {
+  return new Map([
+    [
+      EnvironmentId.make("env"),
+      { entry: { target: { label: "Remote" } }, serverConfig: { providers } },
+    ],
+  ]);
+}
+
+describe("subscription widget snapshots", () => {
+  it("uses provider data and its observation time without exposing account emails", () => {
+    const snapshot = buildSubscriptionUsageSnapshot(presentations(), deepLink);
+    expect(snapshot.rows[0]).toMatchObject({
+      label: "Codex",
+      usedPercent: 40,
+      checkedAt: now,
+      expiresAt: now + 10 * 60_000,
+    });
+    expect(snapshot.deepLink).toBe(deepLink);
+    expect(JSON.stringify(snapshot)).not.toContain("private@example.com");
+  });
+  it("clears data after removing environments and hides disabled providers", () => {
+    expect(buildSubscriptionUsageSnapshot(new Map(), deepLink).rows).toEqual([]);
+    expect(
+      buildSubscriptionUsageSnapshot(presentations([provider({ enabled: false })]), deepLink).rows,
+    ).toEqual([]);
+  });
+  it("uses upstream deduplication for a native account also present in a proxy hub", () => {
+    const input = new Map([
+      [
+        EnvironmentId.make("env"),
+        {
+          entry: { target: { label: "Remote" } },
+          serverConfig: {
+            providers: [provider()],
+            usageLimitSources: [
+              {
+                id: UsageLimitSourceId.make("hub"),
+                kind: "cliproxy" as const,
+                label: "Hub",
+                checkedAt,
+                accounts: [
+                  {
+                    id: "account",
+                    driver: ProviderDriverKind.make("codex"),
+                    email: " PRIVATE@example.com ",
+                    usageLimits: limits,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    ]);
+    expect(buildSubscriptionUsageSnapshot(input, deepLink).rows).toHaveLength(1);
+    input.get(EnvironmentId.make("env"))!.serverConfig.providers = [];
+    const snapshot = buildSubscriptionUsageSnapshot(input, deepLink);
+    expect(snapshot.rows[0]?.label).toBe("Hub · Codex 1");
+    expect(JSON.stringify(snapshot)).not.toContain("example.com");
+  });
+  it("keeps unavailable quotas distinct from zero usage and omits provider error messages", () => {
+    const snapshot = buildSubscriptionUsageSnapshot(
+      presentations([
+        provider({
+          usageLimits: {
+            ...limits,
+            unavailable: { reason: "probeFailed", message: "token secret" },
+          },
+        }),
+      ]),
+      deepLink,
+    );
+    expect(snapshot.rows[0]).toMatchObject({ usedPercent: null, window: "Limits unavailable" });
+    expect(JSON.stringify(snapshot)).not.toContain("token secret");
+    expect(
+      buildSubscriptionUsageSnapshot(
+        presentations([
+          provider({ usageLimits: { checkedAt, windows: [{ ...window, usedPercent: 0 }] } }),
+        ]),
+        deepLink,
+      ).rows[0]?.usedPercent,
+    ).toBe(0);
+  });
+  it("bounds OS storage and puts the most constrained windows first", () => {
+    const windows = Array.from({ length: 20 }, (_, index) => ({
+      ...window,
+      id: `${index}`,
+      usedPercent: index * 5,
+    }));
+    const snapshot = buildSubscriptionUsageSnapshot(
+      presentations([provider({ usageLimits: { checkedAt, windows } })]),
+      deepLink,
+    );
+    expect(snapshot.rows).toHaveLength(8);
+    expect(snapshot.totalRows).toBe(20);
+    expect(snapshot.rows[0]?.usedPercent).toBe(95);
+  });
+  it("marks unknown or distant reset times stale after thirty minutes", () => {
+    const snapshot = buildSubscriptionUsageSnapshot(
+      presentations([
+        provider({ usageLimits: { checkedAt, windows: [{ ...window, resetsAt: undefined }] } }),
+      ]),
+      deepLink,
+    );
+    expect(snapshot.rows[0]?.expiresAt).toBe(now + 30 * 60_000);
+    expect(snapshot.rows[0]?.resetLabel).toBe("Reset time unavailable");
+  });
+  it("schedules a reset boundary without inventing a zero quota", () => {
+    const snapshot = buildSubscriptionUsageSnapshot(presentations(), deepLink);
+    const timeline = subscriptionUsageTimeline(snapshot, now);
+    expect(timeline.map((entry) => entry.date.getTime())).toEqual([now, now + 10 * 60_000]);
+    expect(timeline[1]?.props.rows[0]?.usedPercent).toBe(40);
+    expect(subscriptionUsageTimeline(snapshot, now + 60 * 60_000)).toHaveLength(1);
+  });
+});

--- a/apps/mobile/src/widgets/subscriptionUsageSnapshot.test.ts
+++ b/apps/mobile/src/widgets/subscriptionUsageSnapshot.test.ts
@@ -155,4 +155,13 @@ describe("subscription widget snapshots", () => {
     expect(timeline[1]?.props.rows[0]?.usedPercent).toBe(40);
     expect(subscriptionUsageTimeline(snapshot, now + 60 * 60_000)).toHaveLength(1);
   });
+  it("marks a malformed check time immediately stale without changing the quota", () => {
+    const snapshot = buildSubscriptionUsageSnapshot(
+      presentations([provider({ usageLimits: { ...limits, checkedAt: "invalid" } })]),
+      deepLink,
+    );
+    expect(snapshot.rows[0]).toMatchObject({ checkedAt: 0, expiresAt: 0, usedPercent: 40 });
+    expect(subscriptionUsageTimeline(snapshot, now)).toHaveLength(1);
+    expect(JSON.stringify(snapshot)).not.toContain("null");
+  });
 });

--- a/apps/mobile/src/widgets/subscriptionUsageSnapshot.test.ts
+++ b/apps/mobile/src/widgets/subscriptionUsageSnapshot.test.ts
@@ -112,7 +112,8 @@ describe("subscription widget snapshots", () => {
       ]),
       deepLink,
     );
-    expect(snapshot.rows[0]).toMatchObject({ usedPercent: null, window: "Limits unavailable" });
+    expect(snapshot.rows[0]).toMatchObject({ window: "Limits unavailable" });
+    expect(snapshot.rows[0]).not.toHaveProperty("usedPercent");
     expect(JSON.stringify(snapshot)).not.toContain("token secret");
     expect(
       buildSubscriptionUsageSnapshot(

--- a/apps/mobile/src/widgets/subscriptionUsageSnapshot.test.ts
+++ b/apps/mobile/src/widgets/subscriptionUsageSnapshot.test.ts
@@ -60,6 +60,14 @@ describe("subscription widget snapshots", () => {
     expect(snapshot.deepLink).toBe(deepLink);
     expect(JSON.stringify(snapshot)).not.toContain("private@example.com");
   });
+  it("never shows an email-bearing instance name on the home screen", () => {
+    const snapshot = buildSubscriptionUsageSnapshot(
+      presentations([provider({ displayName: "work@example.com" })]),
+      deepLink,
+    );
+    expect(snapshot.rows[0]?.label).toBe("Codex");
+    expect(JSON.stringify(snapshot)).not.toContain("example.com");
+  });
   it("clears data after removing environments and hides disabled providers", () => {
     expect(buildSubscriptionUsageSnapshot(new Map(), deepLink).rows).toEqual([]);
     expect(

--- a/apps/mobile/src/widgets/subscriptionUsageSnapshot.test.ts
+++ b/apps/mobile/src/widgets/subscriptionUsageSnapshot.test.ts
@@ -108,6 +108,69 @@ describe("subscription widget snapshots", () => {
     expect(snapshot.rows[0]?.label).toBe("Hub · Codex 1");
     expect(JSON.stringify(snapshot)).not.toContain("example.com");
   });
+  it.each(["hub", "environment"] as const)(
+    "uses the freshest reading for the same account reported by another %s",
+    (origin) => {
+      const newerLimits = {
+        checkedAt: "2026-09-05T12:05:00.000Z",
+        windows: [{ ...window, usedPercent: 10 }],
+      };
+      const input = new Map([
+        [
+          EnvironmentId.make("native"),
+          {
+            entry: { target: { label: "Laptop" } },
+            serverConfig: {
+              providers: [
+                provider({ usageLimits: { ...limits, windows: [{ ...window, usedPercent: 90 }] } }),
+              ],
+              usageLimitSources: [],
+            },
+          },
+        ],
+        [
+          EnvironmentId.make("other"),
+          {
+            entry: { target: { label: "Desktop" } },
+            serverConfig: {
+              providers: origin === "environment" ? [provider({ usageLimits: newerLimits })] : [],
+              usageLimitSources:
+                origin === "hub"
+                  ? [
+                      {
+                        id: UsageLimitSourceId.make("hub"),
+                        kind: "cliproxy" as const,
+                        label: "Hub",
+                        checkedAt: newerLimits.checkedAt,
+                        accounts: [
+                          {
+                            id: "account",
+                            driver: ProviderDriverKind.make("codex"),
+                            email: " PRIVATE@example.com ",
+                            usageLimits: newerLimits,
+                          },
+                        ],
+                      },
+                    ]
+                  : [],
+            },
+          },
+        ],
+      ]);
+      for (const entries of [input, new Map([...input].toReversed())]) {
+        const snapshot = buildSubscriptionUsageSnapshot(entries, deepLink);
+        expect(snapshot.totalRows).toBe(1);
+        expect(snapshot.rows).toMatchObject([
+          { usedPercent: 10, checkedAt: Date.parse(newerLimits.checkedAt) },
+        ]);
+        expect(JSON.stringify(snapshot)).not.toContain("example.com");
+      }
+      input.delete(EnvironmentId.make("other"));
+      expect(buildSubscriptionUsageSnapshot(input, deepLink).rows).toMatchObject([
+        { usedPercent: 90 },
+      ]);
+    },
+  );
   it("keeps unavailable quotas distinct from zero usage and omits provider error messages", () => {
     const snapshot = buildSubscriptionUsageSnapshot(
       presentations([

--- a/apps/mobile/src/widgets/subscriptionUsageSnapshot.ts
+++ b/apps/mobile/src/widgets/subscriptionUsageSnapshot.ts
@@ -1,0 +1,97 @@
+import type { ServerProvider, ServerProviderUsageLimits } from "@t3tools/contracts";
+import { collectLimitSources, collectLimitsGroups } from "@t3tools/shared/usageLimits";
+
+export interface SubscriptionUsageRow {
+  readonly label: string;
+  readonly window: string;
+  readonly usedPercent: number | null;
+  readonly resetLabel: string;
+  readonly expiresAt: number;
+  readonly checkedAt: number;
+}
+
+export interface SubscriptionUsageSnapshot {
+  readonly rows: readonly SubscriptionUsageRow[];
+  readonly totalRows: number;
+  readonly deepLink: string;
+}
+
+type Presentations = Parameters<typeof collectLimitsGroups>[0] &
+  Parameters<typeof collectLimitSources>[0];
+const MAX_AGE = 30 * 60_000;
+
+/** Only display data crosses into OS storage; credentials and emails stay in the app. */
+export function buildSubscriptionUsageSnapshot(
+  presentations: Presentations,
+  deepLink: string,
+): SubscriptionUsageSnapshot {
+  const rows: SubscriptionUsageRow[] = [];
+  const add = (label: string, limits: ServerProviderUsageLimits, sourceFailed = false) => {
+    const checkedAt = Date.parse(limits.checkedAt);
+    if (limits.unavailable || sourceFailed || limits.windows.length === 0) {
+      rows.push({
+        label,
+        window:
+          limits.unavailable?.reason === "unsupported"
+            ? "No subscription limits"
+            : "Limits unavailable",
+        usedPercent: null,
+        resetLabel: "Open app for details",
+        checkedAt,
+        expiresAt: 0,
+      });
+      return;
+    }
+    for (const window of limits.windows) {
+      const reset = window.resetsAt ? Date.parse(window.resetsAt) : NaN;
+      rows.push({
+        label,
+        window: window.label,
+        usedPercent: Math.round(Math.max(0, Math.min(100, window.usedPercent))),
+        resetLabel: Number.isFinite(reset)
+          ? `Resets ${new Date(reset).toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}`
+          : "Reset time unavailable",
+        checkedAt,
+        expiresAt: Math.min(checkedAt + MAX_AGE, Number.isFinite(reset) ? reset : Infinity),
+      });
+    }
+  };
+  const driverLabel = (driver: string) => ({ codex: "Codex", claudeAgent: "Claude" })[driver];
+  const providerLimitsLabel = (provider: ServerProvider) =>
+    provider.displayName?.trim() || driverLabel(provider.driver) || String(provider.driver);
+  for (const group of collectLimitsGroups(presentations)) {
+    for (const provider of group.providers) {
+      if (!provider.usageLimits) continue;
+      const label = providerLimitsLabel(provider);
+      add(
+        group.environmentLabel ? `${group.environmentLabel} · ${label}` : label,
+        provider.usageLimits,
+      );
+    }
+  }
+  for (const source of collectLimitSources(presentations)) {
+    for (const [index, account] of source.accounts.entries()) {
+      add(
+        `${source.label} · ${driverLabel(account.driver) ?? account.driver} ${index + 1}`,
+        account.usageLimits,
+        Boolean(source.error),
+      );
+    }
+    if (source.error && source.accounts.length === 0) {
+      add(source.label, { checkedAt: source.checkedAt, windows: [] });
+    }
+  }
+  // Most constrained windows stay visible in the smallest families. Stable
+  // sorting preserves account order when two windows have the same quota.
+  rows.sort((a, b) => (b.usedPercent ?? -1) - (a.usedPercent ?? -1));
+  return { rows: rows.slice(0, 8), totalRows: rows.length, deepLink };
+}
+
+/** Schedule expiry without pretending that a reset supplies a fresh quota reading. */
+export function subscriptionUsageTimeline(snapshot: SubscriptionUsageSnapshot, now: number) {
+  const dates = [
+    now,
+    ...new Set(snapshot.rows.map((row) => row.expiresAt).filter((at) => at > now)),
+  ];
+  return dates.sort((a, b) => a - b).map((at) => ({ date: new Date(at), props: snapshot }));
+}

--- a/apps/mobile/src/widgets/subscriptionUsageSnapshot.ts
+++ b/apps/mobile/src/widgets/subscriptionUsageSnapshot.ts
@@ -4,7 +4,8 @@ import { collectLimitSources, collectLimitsGroups } from "@t3tools/shared/usageL
 export interface SubscriptionUsageRow {
   readonly label: string;
   readonly window: string;
-  readonly usedPercent: number | null;
+  // Omit unavailable values: iOS widget storage accepts property lists, not null.
+  readonly usedPercent?: number;
   readonly resetLabel: string;
   readonly expiresAt: number;
   readonly checkedAt: number;
@@ -35,7 +36,6 @@ export function buildSubscriptionUsageSnapshot(
           limits.unavailable?.reason === "unsupported"
             ? "No subscription limits"
             : "Limits unavailable",
-        usedPercent: null,
         resetLabel: "Open app for details",
         checkedAt,
         expiresAt: 0,

--- a/apps/mobile/src/widgets/subscriptionUsageSnapshot.ts
+++ b/apps/mobile/src/widgets/subscriptionUsageSnapshot.ts
@@ -28,7 +28,8 @@ export function buildSubscriptionUsageSnapshot(
 ): SubscriptionUsageSnapshot {
   const rows: SubscriptionUsageRow[] = [];
   const add = (label: string, limits: ServerProviderUsageLimits, sourceFailed = false) => {
-    const checkedAt = Date.parse(limits.checkedAt);
+    const parsedCheckedAt = Date.parse(limits.checkedAt);
+    const checkedAt = Number.isFinite(parsedCheckedAt) ? parsedCheckedAt : 0;
     if (limits.unavailable || sourceFailed || limits.windows.length === 0) {
       rows.push({
         label,
@@ -52,7 +53,10 @@ export function buildSubscriptionUsageSnapshot(
           ? `Resets ${new Date(reset).toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}`
           : "Reset time unavailable",
         checkedAt,
-        expiresAt: Math.min(checkedAt + MAX_AGE, Number.isFinite(reset) ? reset : Infinity),
+        expiresAt:
+          checkedAt === 0
+            ? 0
+            : Math.min(checkedAt + MAX_AGE, Number.isFinite(reset) ? reset : Infinity),
       });
     }
   };

--- a/apps/mobile/src/widgets/subscriptionUsageSnapshot.ts
+++ b/apps/mobile/src/widgets/subscriptionUsageSnapshot.ts
@@ -1,5 +1,10 @@
-import type { ServerProvider, ServerProviderUsageLimits } from "@t3tools/contracts";
-import { collectLimitSources, collectLimitsGroups } from "@t3tools/shared/usageLimits";
+import type { ServerProviderUsageLimits } from "@t3tools/contracts";
+import {
+  collectLimitAccounts,
+  limitsNotice,
+  providersWithLimits,
+  type LimitPresentations,
+} from "@t3tools/shared/usageLimits";
 
 export interface SubscriptionUsageRow {
   readonly label: string;
@@ -17,20 +22,18 @@ export interface SubscriptionUsageSnapshot {
   readonly deepLink: string;
 }
 
-type Presentations = Parameters<typeof collectLimitsGroups>[0] &
-  Parameters<typeof collectLimitSources>[0];
 const MAX_AGE = 30 * 60_000;
 
 /** Only display data crosses into OS storage; credentials and emails stay in the app. */
 export function buildSubscriptionUsageSnapshot(
-  presentations: Presentations,
+  presentations: LimitPresentations,
   deepLink: string,
 ): SubscriptionUsageSnapshot {
   const rows: SubscriptionUsageRow[] = [];
-  const add = (label: string, limits: ServerProviderUsageLimits, sourceFailed = false) => {
+  const add = (label: string, limits: ServerProviderUsageLimits) => {
     const parsedCheckedAt = Date.parse(limits.checkedAt);
     const checkedAt = Number.isFinite(parsedCheckedAt) ? parsedCheckedAt : 0;
-    if (limits.unavailable || sourceFailed || limits.windows.length === 0) {
+    if (limits.unavailable || limits.windows.length === 0) {
       rows.push({
         label,
         window:
@@ -60,36 +63,51 @@ export function buildSubscriptionUsageSnapshot(
       });
     }
   };
-  const driverLabel = (driver: string) => ({ codex: "Codex", claudeAgent: "Claude" })[driver];
-  // Home screens have no reveal control, so email-bearing names fall back to the driver.
-  const providerLimitsLabel = (provider: ServerProvider) => {
-    const displayName = provider.displayName?.trim();
-    return (
-      (displayName && !displayName.includes("@") ? displayName : undefined) ||
-      driverLabel(provider.driver) ||
-      String(provider.driver)
+  const driverLabels: Readonly<Record<string, string>> = { codex: "Codex", claudeAgent: "Claude" };
+  // Home screens have no reveal control, so email-bearing names use a generic label.
+  const safeLabel = (value: string | null | undefined, fallback: string) =>
+    value?.trim() && !value.includes("@") ? value.trim() : fallback;
+  for (const [index, account] of collectLimitAccounts(presentations).entries()) {
+    const driver = driverLabels[account.driver] ?? String(account.driver);
+    const name = safeLabel(account.displayName, driver);
+    const origin = account.sourceLabel
+      ? safeLabel(account.sourceLabel, "Hub")
+      : presentations.size > 1
+        ? account.environments.map((entry) => safeLabel(entry.label, "Environment")).join(", ")
+        : "";
+    add(
+      origin ? `${origin} · ${name}${account.sourceLabel ? ` ${index + 1}` : ""}` : name,
+      account.limits,
     );
-  };
-  for (const group of collectLimitsGroups(presentations)) {
-    for (const provider of group.providers) {
-      if (!provider.usageLimits) continue;
-      const label = providerLimitsLabel(provider);
+  }
+  // Usable quotas come exclusively from the shared account selection. Keep
+  // unavailable readings visible without copying private probe errors to OS storage.
+  for (const presentation of presentations.values()) {
+    const label = (name: string) =>
+      presentations.size > 1
+        ? `${safeLabel(presentation.entry.target.label, "Environment")} · ${name}`
+        : name;
+    for (const provider of providersWithLimits(presentation.serverConfig?.providers ?? [])) {
+      if (!provider.usageLimits || limitsNotice(provider.usageLimits) === null) continue;
       add(
-        group.environmentLabel ? `${group.environmentLabel} · ${label}` : label,
+        label(
+          safeLabel(provider.displayName, driverLabels[provider.driver] ?? String(provider.driver)),
+        ),
         provider.usageLimits,
       );
     }
-  }
-  for (const source of collectLimitSources(presentations)) {
-    for (const [index, account] of source.accounts.entries()) {
-      add(
-        `${source.label} · ${driverLabel(account.driver) ?? account.driver} ${index + 1}`,
-        account.usageLimits,
-        Boolean(source.error),
-      );
-    }
-    if (source.error && source.accounts.length === 0) {
-      add(source.label, { checkedAt: source.checkedAt, windows: [] });
+    for (const source of presentation.serverConfig?.usageLimitSources ?? []) {
+      const name = label(safeLabel(source.label, "Hub"));
+      for (const [index, account] of source.accounts.entries()) {
+        if (limitsNotice(account.usageLimits) === null) continue;
+        add(
+          `${name} · ${driverLabels[account.driver] ?? account.driver} ${index + 1}`,
+          account.usageLimits,
+        );
+      }
+      if (source.error && source.accounts.length === 0) {
+        add(name, { checkedAt: source.checkedAt, windows: [] });
+      }
     }
   }
   // Most constrained windows stay visible in the smallest families. Stable

--- a/apps/mobile/src/widgets/subscriptionUsageSnapshot.ts
+++ b/apps/mobile/src/widgets/subscriptionUsageSnapshot.ts
@@ -61,8 +61,15 @@ export function buildSubscriptionUsageSnapshot(
     }
   };
   const driverLabel = (driver: string) => ({ codex: "Codex", claudeAgent: "Claude" })[driver];
-  const providerLimitsLabel = (provider: ServerProvider) =>
-    provider.displayName?.trim() || driverLabel(provider.driver) || String(provider.driver);
+  // Home screens have no reveal control, so email-bearing names fall back to the driver.
+  const providerLimitsLabel = (provider: ServerProvider) => {
+    const displayName = provider.displayName?.trim();
+    return (
+      (displayName && !displayName.includes("@") ? displayName : undefined) ||
+      driverLabel(provider.driver) ||
+      String(provider.driver)
+    );
+  };
   for (const group of collectLimitsGroups(presentations)) {
     for (const provider of group.providers) {
       if (!provider.usageLimits) continue;

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -81,3 +81,22 @@ account and choose **Use reset** to redeem one. No hub plugin is required.
 This connection supplies usage information; configure
 the provider separately to send agent requests through the hub. Remove the hub from the same
 settings section when you no longer need it.
+
+## Add subscription usage to your home screen
+
+On iOS or Android, open T3 Code and connect your environments, then add the **Subscription usage**
+widget from your phone's widget gallery. On iOS, choose small, medium, or large. On Android,
+resize the widget to show more quota windows. Tap it to open **Usage → Limits**.
+
+The widget shows saved quota percentages, reset times, and when the displayed data was checked.
+The most-used quota windows appear first; a “more” count indicates additional windows in the app.
+Account email addresses are omitted. Providers without subscription usage data do not appear.
+
+Data updates while the app receives information from connected environments. The widget does
+not fetch quotas while the app is closed. After thirty minutes or a reported reset time, it asks
+you to open the app to refresh; Android may show this notice at its next system widget update.
+Pull to refresh on **Limits** to request a new reading. A reset never makes the saved percentage
+zero automatically. Removing an environment in the app removes its data from the widget.
+
+If the widget is missing from the gallery, update the installed app and open it once. Widgets
+require an app build that includes them; iOS builds without widget extensions do not offer them.

--- a/packages/shared/src/usageLimits.test.ts
+++ b/packages/shared/src/usageLimits.test.ts
@@ -3,7 +3,6 @@ import {
   ProviderDriverKind,
   ProviderInstanceId,
   type ServerProvider,
-  type UsageLimitSourceAccount,
   UsageLimitSourceId,
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
@@ -17,8 +16,6 @@ import {
   collectLimitAccounts,
   collectLimitNotices,
   collectLimitPools,
-  collectLimitSources,
-  collectLimitsGroups,
   elapsedShare,
   formatResetsIn,
   limitsNotice,
@@ -126,191 +123,6 @@ describe("providersWithLimits", () => {
         }),
       ]),
     ).toEqual([codex]);
-  });
-});
-
-describe("collectLimitsGroups", () => {
-  it("labels environments only when more than one reports limits", () => {
-    const limits = { checkedAt: "2026-09-03T11:00:00.000Z", windows: [window] };
-    const codex = provider({ usageLimits: limits });
-    const one = new Map([
-      ["env-a", { entry: { target: { label: "Laptop" } }, serverConfig: { providers: [codex] } }],
-      [
-        "env-b",
-        { entry: { target: { label: "Desktop" } }, serverConfig: { providers: [provider({})] } },
-      ],
-    ] as const);
-    expect(collectLimitsGroups(one as never).map((group) => group.environmentLabel)).toEqual([
-      null,
-    ]);
-
-    const two = new Map([
-      ["env-a", { entry: { target: { label: "Laptop" } }, serverConfig: { providers: [codex] } }],
-      ["env-b", { entry: { target: { label: "Desktop" } }, serverConfig: { providers: [codex] } }],
-    ] as const);
-    expect(collectLimitsGroups(two as never).map((group) => group.environmentLabel)).toEqual([
-      "Laptop",
-      "Desktop",
-    ]);
-  });
-});
-
-describe("collectLimitSources", () => {
-  const source = {
-    id: UsageLimitSourceId.make("cliproxy-hub"),
-    kind: "cliproxy" as const,
-    label: "hub",
-    checkedAt: "2026-09-03T11:00:00.000Z",
-    accounts: [],
-  };
-  const limits = { checkedAt: source.checkedAt, windows: [window] };
-  const account: UsageLimitSourceAccount = {
-    id: "codex-personal",
-    driver: ProviderDriverKind.make("codex"),
-    email: "person@example.com",
-    plan: "ChatGPT Pro Subscription",
-    usageLimits: limits,
-  };
-  const native = provider({
-    displayName: "Personal",
-    auth: { status: "authenticated", email: account.email },
-    usageLimits: { ...limits, resetCredits: { availableCount: 2 } },
-  });
-
-  function presentations(
-    providers: readonly ServerProvider[],
-    accounts: readonly UsageLimitSourceAccount[] = [account],
-  ) {
-    return new Map([
-      [
-        EnvironmentId.make("env-a"),
-        {
-          entry: { target: { label: "Laptop" } },
-          serverConfig: { providers, usageLimitSources: [{ ...source, accounts }] },
-        },
-      ],
-    ]);
-  }
-
-  it.each(["codex", "claudeAgent"])(
-    "prefers native %s limits by email without changing provider rows or source snapshots",
-    (kind) => {
-      const driver = ProviderDriverKind.make(kind);
-      const first = { ...native, driver };
-      const second = { ...first, instanceId: ProviderInstanceId.make("work") };
-      const accounts = [{ ...account, driver, email: " Person@Example.COM " }];
-      const input = presentations([first, second], accounts);
-
-      expect(collectLimitSources(input)).toMatchObject([{ accounts: [], hiddenAccountCount: 1 }]);
-      expect(collectLimitsGroups(input)[0]?.providers).toEqual([first, second]);
-      expect(accounts).toHaveLength(1);
-      expect(first.usageLimits?.resetCredits?.availableCount).toBe(2);
-    },
-  );
-
-  it("matches across environments even when the hub is visited before the native provider", () => {
-    const input = presentations([]);
-    input.set(EnvironmentId.make("env-b"), {
-      entry: { target: { label: "Desktop" } },
-      serverConfig: { providers: [native], usageLimitSources: [] },
-    });
-
-    expect(collectLimitSources(input)).toMatchObject([
-      { accounts: [], hiddenAccountCount: 1, environmentId: "env-a" },
-    ]);
-  });
-
-  it("keeps other providers, other emails, and unidentified accounts with the same plan", () => {
-    const accounts = [
-      account,
-      { ...account, id: "other-provider", driver: ProviderDriverKind.make("claudeAgent") },
-      { ...account, id: "other-email", email: "other@example.com" },
-      { ...account, id: "unknown-email", email: undefined },
-    ];
-
-    expect(collectLimitSources(presentations([native], accounts))).toMatchObject([
-      { accounts: accounts.slice(1), hiddenAccountCount: 1 },
-    ]);
-    expect(
-      collectLimitSources(
-        presentations([{ ...native, auth: { status: "authenticated" } }], accounts),
-      )[0]?.accounts,
-    ).toEqual(accounts);
-  });
-
-  it.each([
-    { enabled: false },
-    { installed: false },
-    { availability: "unavailable" },
-    { usageLimits: undefined },
-    { usageLimits: { ...limits, windows: [] } },
-    { usageLimits: { ...limits, unavailable: { reason: "probeFailed" } } },
-    { usageLimits: { ...limits, unavailable: { reason: "unsupported" } } },
-  ] satisfies Partial<ServerProvider>[])(
-    "retains hub limits when the native provider cannot show them: %j",
-    (overrides) => {
-      expect(collectLimitSources(presentations([{ ...native, ...overrides }]))).toMatchObject([
-        { accounts: [account], hiddenAccountCount: 0 },
-      ]);
-    },
-  );
-
-  it("restores the hub account when the matching provider disappears", () => {
-    const input = presentations([native]);
-    expect(collectLimitSources(input)[0]?.accounts).toEqual([]);
-    input.delete(EnvironmentId.make("env-a"));
-    for (const [id, entry] of presentations([])) input.set(id, entry);
-
-    expect(collectLimitSources(input)[0]?.accounts).toEqual([account]);
-  });
-
-  it("keeps source errors and genuinely empty sources distinguishable from hidden accounts", () => {
-    const input = new Map([
-      [
-        EnvironmentId.make("env-a"),
-        {
-          entry: { target: { label: "Laptop" } },
-          serverConfig: {
-            providers: [native],
-            usageLimitSources: [{ ...source, error: "Hub unavailable" }],
-          },
-        },
-      ],
-    ]);
-    expect(collectLimitSources(input)).toMatchObject([
-      { accounts: [], hiddenAccountCount: 0, error: "Hub unavailable" },
-    ]);
-  });
-
-  it("keys sources per environment and names the environment only when several have some", () => {
-    const one = new Map([
-      [
-        "env-a",
-        { entry: { target: { label: "Laptop" } }, serverConfig: { usageLimitSources: [source] } },
-      ],
-      [
-        "env-b",
-        { entry: { target: { label: "Desktop" } }, serverConfig: { usageLimitSources: [] } },
-      ],
-    ] as const);
-    expect(collectLimitSources(one as never).map((entry) => [entry.key, entry.label])).toEqual([
-      ["env-a:cliproxy-hub", "hub"],
-    ]);
-
-    const two = new Map([
-      [
-        "env-a",
-        { entry: { target: { label: "Laptop" } }, serverConfig: { usageLimitSources: [source] } },
-      ],
-      [
-        "env-b",
-        { entry: { target: { label: "Desktop" } }, serverConfig: { usageLimitSources: [source] } },
-      ],
-    ] as const);
-    expect(collectLimitSources(two as never).map((entry) => entry.label)).toEqual([
-      "Laptop · hub",
-      "Desktop · hub",
-    ]);
   });
 });
 

--- a/packages/shared/src/usageLimits.ts
+++ b/packages/shared/src/usageLimits.ts
@@ -15,7 +15,6 @@ import {
   type ServerProvider,
   type ServerProviderUsageLimits,
   type ServerProviderUsageWindow,
-  type UsageLimitSourceSnapshot,
   type UsageLimitSourceSnapshots,
 } from "@t3tools/contracts";
 
@@ -42,108 +41,16 @@ export function providersWithLimits(
   );
 }
 
-export interface LimitsGroup {
-  readonly environmentId: EnvironmentId;
-  /** Null while only one environment is connected; there is nothing to tell apart. */
-  readonly environmentLabel: string | null;
-  readonly providers: readonly ServerProvider[];
-}
-
-/**
- * One group per connected environment with a provider reporting limits.
- * Provider snapshots come from the config stream every client already holds,
- * so opening the view costs no extra request.
- */
-export function collectLimitsGroups(
-  presentations: ReadonlyMap<
-    EnvironmentId,
-    {
-      readonly entry: { readonly target: { readonly label: string } };
-      readonly serverConfig: {
-        readonly providers?: readonly ServerProvider[] | undefined;
-      } | null;
-    }
-  >,
-): readonly LimitsGroup[] {
-  const groups: LimitsGroup[] = [];
-  for (const [environmentId, presentation] of presentations) {
-    const providers = providersWithLimits(presentation.serverConfig?.providers ?? []);
-    if (providers.length === 0) continue;
-    groups.push({ environmentId, environmentLabel: presentation.entry.target.label, providers });
+export type LimitPresentations = ReadonlyMap<
+  EnvironmentId,
+  {
+    readonly entry: { readonly target: { readonly label: string } };
+    readonly serverConfig: {
+      readonly providers?: readonly ServerProvider[] | undefined;
+      readonly usageLimitSources?: UsageLimitSourceSnapshots | undefined;
+    } | null;
   }
-  return groups.length > 1 ? groups : groups.map((group) => ({ ...group, environmentLabel: null }));
-}
-
-/**
- * Every usage-limit source across connected environments, keyed so two
- * environments pointing at the same hub still get their own rows. The label
- * carries the environment only when more than one environment has sources.
- * A native provider with usable limits takes precedence over the same account
- * in a source, even when it belongs to another connected environment.
- */
-export function collectLimitSources(
-  presentations: ReadonlyMap<
-    EnvironmentId,
-    {
-      readonly entry: { readonly target: { readonly label: string } };
-      readonly serverConfig: {
-        readonly providers?: readonly ServerProvider[] | undefined;
-        readonly usageLimitSources?: UsageLimitSourceSnapshots | undefined;
-      } | null;
-    }
-  >,
-): ReadonlyArray<
-  UsageLimitSourceSnapshot & {
-    readonly key: string;
-    readonly environmentId: EnvironmentId;
-    readonly hiddenAccountCount: number;
-  }
-> {
-  const nativeAccounts = new Set<string>();
-  for (const presentation of presentations.values()) {
-    for (const provider of providersWithLimits(presentation.serverConfig?.providers ?? [])) {
-      const key = accountKey(provider.driver, provider.auth.email);
-      if (
-        key !== null &&
-        provider.usageLimits?.windows.length &&
-        !provider.usageLimits.unavailable
-      ) {
-        nativeAccounts.add(key);
-      }
-    }
-  }
-  const perEnvironment: Array<{
-    readonly environmentId: EnvironmentId;
-    readonly environmentLabel: string;
-    readonly sources: UsageLimitSourceSnapshots;
-  }> = [];
-  for (const [environmentId, presentation] of presentations) {
-    const sources = presentation.serverConfig?.usageLimitSources ?? [];
-    if (sources.length === 0) continue;
-    perEnvironment.push({
-      environmentId,
-      environmentLabel: presentation.entry.target.label,
-      sources,
-    });
-  }
-  const labelEnvironment = perEnvironment.length > 1;
-  return perEnvironment.flatMap(({ environmentId, environmentLabel, sources }) =>
-    sources.map((source) => {
-      const accounts = source.accounts.filter((account) => {
-        const key = accountKey(account.driver, account.email);
-        return key === null || !nativeAccounts.has(key);
-      });
-      return {
-        ...source,
-        accounts,
-        hiddenAccountCount: source.accounts.length - accounts.length,
-        environmentId,
-        key: `${environmentId}:${source.id}`,
-        label: labelEnvironment ? `${environmentLabel} · ${source.label}` : source.label,
-      };
-    }),
-  );
-}
+>;
 
 function accountKey(driver: ServerProvider["driver"], email: string | undefined): string | null {
   const normalizedEmail = email?.trim().toLowerCase();
@@ -184,9 +91,7 @@ export interface LimitAccount {
  * entry per distinct account. The freshest reads supply windows and credits;
  * native instances supply names and environment labels.
  */
-export function collectLimitAccounts(
-  presentations: Parameters<typeof collectLimitSources>[0],
-): readonly LimitAccount[] {
+export function collectLimitAccounts(presentations: LimitPresentations): readonly LimitAccount[] {
   const accounts = new Map<string, LimitAccount>();
   const creditSources = new Map<string, LimitAccount>();
   const hubRedeems = new Map<string, LimitAccount>();
@@ -315,9 +220,7 @@ export function collectLimitAccounts(
  * are left out; there is nothing for the user to act on. The environment
  * is named only when more than one is connected.
  */
-export function collectLimitNotices(
-  presentations: Parameters<typeof collectLimitSources>[0],
-): readonly string[] {
+export function collectLimitNotices(presentations: LimitPresentations): readonly string[] {
   const label = (environmentLabel: string, subject: string) =>
     presentations.size > 1 ? `${environmentLabel} · ${subject}` : subject;
   const notices: string[] = [];


### PR DESCRIPTION
## Problem

Checking subscription headroom means opening the app. There is no home screen view of the quotas shown in **Usage → Limits**.

## Fix

Adds a **Subscription usage** home screen widget to React Native mobile on iOS and Android. It uses the same provider and CLIProxyAPI account selection as **Usage → Limits**, via `collectLimitsGroups` and `collectLimitSources` in `@t3tools/shared/usageLimits`, and shows saved quota percentages, reset times, and when each reading was checked. Tapping it opens the Limits tab.

- iOS offers small, medium, and large layouts through `expo-widgets`. Android is a local Expo module with a resizable RemoteViews widget.
- The most-used windows come first, followed by a count of any others.
- Only display data reaches OS storage: no credentials, no account emails, and no provider error messages. Instance names that contain an email fall back to the driver name, matching the masking from #10668, because a home screen has no reveal control.
- Updates arrive through the existing config stream. The widget makes no extra server requests and does not fetch while the app is closed. After thirty minutes, or once a reported reset time passes, it asks the user to open the app to refresh. A reset never produces an invented 0% reading.
- If a check time is invalid, the reading is marked stale immediately and shows "Last checked unavailable".

No backend, wire-contract, web/desktop, or SwiftUI client changes. `docs/user/usage.md` gets a short section on adding the widget.

## Media

This widget is new. Before this PR, the widget gallery has no **Subscription usage** entry. The media below comes from an iPhone 16 Pro simulator on iOS 26.5, using real provider limits from a disposable localhost environment. It was recorded before the rebase and the email-masking commit, neither of which changes the layout. Percentages differ between shots because the readings are live.

| Small | Medium | Large |
| --- | --- | --- |
| <img width="250" alt="Small widget shows saved Codex quota, check time and additional-window count" src="https://github.com/user-attachments/assets/94f164d4-4827-4c0c-ac12-ba5b00f0ee57" /> | <img width="250" alt="Medium widget shows Codex quota beside unavailable Claude limits" src="https://github.com/user-attachments/assets/60bdbc25-57ee-48d0-8445-3c7972bd7b9c" /> | <img width="250" alt="Large widget shows the same saved provider readings" src="https://github.com/user-attachments/assets/cfea0e3e-d539-46e5-bf30-faa802f24953" /> |

**Tap into Limits.** The widget and the Limits screen show the same 67% quota. Idle time was trimmed from the recording, so it shows navigation, not latency.

https://github.com/user-attachments/assets/12cbdf98-a61f-4f73-b2c2-f443f86532ba

<details>
<summary>Annotated version</summary>

https://github.com/user-attachments/assets/190da250-9aa2-4462-aa8b-21287b5f8fb2

</details>

Android has build verification, not emulator interaction proof. Expo's iOS widget data sharing needs an App Groups-capable signing team, so Personal Team builds that disable extensions do not offer the widget.

## Verification

Checks on the rebased head:

- `vp test run src/widgets` (apps/mobile): 27 tests passed. They cover snapshot selection, upstream account deduplication, unavailable versus zero quotas, email-free labels, expiry timelines, and iOS layout bounds.
- `tsc --noEmit` for apps/mobile, `vp lint` and `vp fmt --check` on the touched files: all passed.

Checks from before the rebase: iOS and Android Metro exports, both native prebuilds, `:t3-subscription-widget:assembleDebug`, Swift lint, and ktlint/detekt passed, and the simulator run above was completed.

Cross-provider review was skipped because Codex weekly quota headroom was below the threshold.

Coordination trace: T3 thread 00cff86a-f9c1-41a2-973c-e5f5ee7581d8

Authored with GPT-6 via the Codex harness in T3 Code; rebased and updated with Claude Opus 5 via Claude Code in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Subscription usage” home-screen widgets for iOS and Android.
  - View usage percentages, progress indicators, reset times, unavailable limits, timestamps, and additional-item counts.
  - Widgets support multiple sizes and adapt displayed usage limits.
  - Tapping a widget opens the app’s Usage or Limits view.
  - Widget data refreshes automatically and stays synchronized with in-app usage information.
  - Added support for empty states, expired usage data, and unavailable quotas.

- **Documentation**
  - Added setup, behavior, supported sizes, and troubleshooting guidance for subscription usage widgets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->