### PR TITLE
refactor(server): simplify native telemetry error internals

### DIFF
--- a/apps/server/src/resourceTelemetry/NativeTelemetryClient.test.ts
+++ b/apps/server/src/resourceTelemetry/NativeTelemetryClient.test.ts
@@ -1,6 +1,5 @@
 import type { HostPowerSnapshot } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
-import * as Cause from "effect/Cause";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
@@ -9,12 +8,9 @@ import * as Ref from "effect/Ref";
 import * as Semaphore from "effect/Semaphore";
 
 import {
-  NativeTelemetryRequestTimedOut,
-  NativeTelemetryStreamClosed,
   canCommandNativeTelemetrySidecar,
   canRequestNativeTelemetryRetry,
   commitCollectionControlUpdate,
-  nativeTelemetrySupervisorFailureMessage,
   retainRecentNativeTelemetryFailures,
   resolveNativeSampleIntervalMs,
   synchronizeCollectionControlOnStart,
@@ -79,44 +75,6 @@ describe("canCommandNativeTelemetrySidecar", () => {
     expect(canCommandNativeTelemetrySidecar("degraded", true)).toBe(true);
     expect(canCommandNativeTelemetrySidecar("unavailable", true)).toBe(false);
     expect(canCommandNativeTelemetrySidecar("degraded", false)).toBe(false);
-  });
-});
-
-describe("NativeTelemetryRequestTimedOut", () => {
-  it("models history and sample request deadlines without a fabricated cause", () => {
-    const historyTimeout = new NativeTelemetryRequestTimedOut({
-      operation: "readHistory",
-      timeoutMs: 15_000,
-    });
-    const sampleTimeout = new NativeTelemetryRequestTimedOut({
-      operation: "sampleNow",
-      timeoutMs: 5_000,
-    });
-
-    expect(historyTimeout.message).toBe(
-      "Resource monitor 'readHistory' request timed out after 15000ms.",
-    );
-    expect(sampleTimeout.message).toBe(
-      "Resource monitor 'sampleNow' request timed out after 5000ms.",
-    );
-    expect("cause" in historyTimeout).toBe(false);
-    expect("cause" in sampleTimeout).toBe(false);
-  });
-});
-
-describe("native telemetry supervisor failures", () => {
-  it("distinguishes a closed event stream from a process exit", () => {
-    expect(new NativeTelemetryStreamClosed().message).toBe(
-      "Resource monitor event stream closed unexpectedly.",
-    );
-  });
-
-  it("keeps defect details out of the caller-visible health message", () => {
-    const secret = "credential=do-not-expose";
-    const message = nativeTelemetrySupervisorFailureMessage(Cause.die(new Error(secret)));
-
-    expect(message).toBe("Resource monitor supervisor stopped unexpectedly.");
-    expect(message).not.toContain(secret);
   });
 });
 

--- a/apps/server/src/resourceTelemetry/NativeTelemetryClient.ts
+++ b/apps/server/src/resourceTelemetry/NativeTelemetryClient.ts
@@ -73,7 +73,7 @@ export class NativeTelemetryHandshakeTimedOut extends Schema.TaggedErrorClass<Na
   }
 }
 
-export class NativeTelemetryRequestTimedOut extends Schema.TaggedErrorClass<NativeTelemetryRequestTimedOut>()(
+class NativeTelemetryRequestTimedOut extends Schema.TaggedErrorClass<NativeTelemetryRequestTimedOut>()(
   "NativeTelemetryRequestTimedOut",
   {
     operation: Schema.Literals(["readHistory", "sampleNow"]),
@@ -131,7 +131,7 @@ export class NativeTelemetryExited extends Schema.TaggedErrorClass<NativeTelemet
   }
 }
 
-export class NativeTelemetryStreamClosed extends Schema.TaggedErrorClass<NativeTelemetryStreamClosed>()(
+class NativeTelemetryStreamClosed extends Schema.TaggedErrorClass<NativeTelemetryStreamClosed>()(
   "NativeTelemetryStreamClosed",
   {},
 ) {
@@ -338,10 +338,6 @@ export function retainRecentNativeTelemetryFailures(
 
 function errorMessage(error: NativeTelemetryClientError): string {
   return error.message;
-}
-
-export function nativeTelemetrySupervisorFailureMessage(_cause: Cause.Cause<unknown>): string {
-  return "Resource monitor supervisor stopped unexpectedly.";
 }
 
 export function canRequestNativeTelemetryRetry(
@@ -734,7 +730,7 @@ export const make = Effect.fn("resourceTelemetry.nativeTelemetryClient.make")(fu
             ...current,
             status: "unavailable" as const,
             hello: Option.none(),
-            lastError: Option.some(nativeTelemetrySupervisorFailureMessage(cause)),
+            lastError: Option.some("Resource monitor supervisor stopped unexpectedly."),
           })).pipe(
             Effect.andThen(publishHealth),
             Effect.andThen(


### PR DESCRIPTION
Two native telemetry errors were exported only for constructor-message tests. A supervisor-message helper ignored its cause argument and returned a fixed string.

Keep the error classes private, put the same supervisor message at its sole runtime call site, and remove the three message-only tests. Deadline handling, event-stream handling, the public error union, and structured cause logging are unchanged.

Verification: seven focused baseline suites passed 80 tests. After this change, the native client and resource telemetry suites pass all 14 retained tests. Server-only typecheck, targeted lint, formatting, and diff checks passed. The retained integration suite uses a mocked native client; it does not prove native deadline/stream transitions, which the removed constructor tests did not exercise either.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `NativeTelemetryRequestTimedOut`, `NativeTelemetryStreamClosed`, and `nativeTelemetrySupervisorFailureMessage` module-private
> Simplifies native telemetry error internals in [NativeTelemetryClient.ts](https://github.com/pingdotgg/t3code/pull/10057/files#diff-07d549e2af53646fca411242cbc28a89c7549d587bca378956346b2335909d6c) by removing three public exports: the `NativeTelemetryRequestTimedOut` and `NativeTelemetryStreamClosed` error classes and the `nativeTelemetrySupervisorFailureMessage` helper. The supervisor failure handler now inlines the fixed failure string directly; cause logging remains in the warning branch. Tests that validated the removed exports' messages and cause properties are deleted.
> - Risk: out-of-tree consumers importing `NativeTelemetryRequestTimedOut`, `NativeTelemetryStreamClosed`, or `nativeTelemetrySupervisorFailureMessage` from this module will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0b1687.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->