### PR TITLE
refactor(mobile): remove write-only terminal font cache

### DIFF
--- a/apps/mobile/src/features/settings/appearance/AppearancePreferencesProvider.tsx
+++ b/apps/mobile/src/features/settings/appearance/AppearancePreferencesProvider.tsx
@@ -37,7 +37,6 @@ import {
   getMobileUniwindThemeName,
   type MobileThemeRuntimeState,
 } from "../../../lib/mobileThemeRuntime";
-import { cacheTerminalFontSize } from "../../terminal/terminalUiState";
 
 interface AppearancePreferencesContextValue {
   /** Effective values with base-size derivation applied. Use this for rendering. */
@@ -143,8 +142,7 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
   useLayoutEffect(() => {
     selectedThemeIdsRef.current = themeIds;
     syncThemeRuntime(runtimeState);
-    cacheTerminalFontSize(appearance.terminalFontSize);
-  }, [appearance.terminalFontSize, runtimeState, syncThemeRuntime, themeIds]);
+  }, [runtimeState, syncThemeRuntime, themeIds]);
 
   const setThemeIdForAppearance = useCallback(
     (appearance: MobileThemeAppearance, value: MobileThemeId) => {

--- a/apps/mobile/src/features/terminal/terminalUiState.test.ts
+++ b/apps/mobile/src/features/terminal/terminalUiState.test.ts
@@ -2,9 +2,7 @@ import { beforeEach, describe, expect, it } from "vite-plus/test";
 import { EnvironmentId, ThreadId } from "@t3tools/contracts";
 
 import {
-  cacheTerminalFontSize,
   cacheTerminalGridSize,
-  getCachedTerminalFontSize,
   getCachedTerminalGridSize,
   resetTerminalUiStateCaches,
 } from "./terminalUiState";
@@ -12,14 +10,6 @@ import {
 describe("terminalUiState", () => {
   beforeEach(() => {
     resetTerminalUiStateCaches();
-  });
-
-  it("caches terminal font size using the shared normalization rules", () => {
-    expect(getCachedTerminalFontSize()).toBeNull();
-    expect(cacheTerminalFontSize(8.5)).toBe(8.5);
-    expect(getCachedTerminalFontSize()).toBe(8.5);
-    expect(cacheTerminalFontSize(100)).toBe(14);
-    expect(getCachedTerminalFontSize()).toBe(14);
   });
 
   it("stores terminal grid sizes per terminal target", () => {

--- a/apps/mobile/src/features/terminal/terminalUiState.ts
+++ b/apps/mobile/src/features/terminal/terminalUiState.ts
@@ -1,7 +1,5 @@
 import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
 
-import { DEFAULT_TERMINAL_FONT_SIZE, normalizeTerminalFontSize } from "./terminalPreferences";
-
 export interface TerminalGridSize {
   readonly cols: number;
   readonly rows: number;
@@ -14,20 +12,9 @@ export interface TerminalUiStateTarget {
 }
 
 const terminalGridSizeCache = new Map<string, TerminalGridSize>();
-let cachedTerminalFontSize: number | null = null;
 
 function terminalUiStateKey(target: TerminalUiStateTarget): string {
   return `${target.environmentId}:${target.threadId}:${target.terminalId}`;
-}
-
-export function getCachedTerminalFontSize(): number | null {
-  return cachedTerminalFontSize;
-}
-
-export function cacheTerminalFontSize(value: number | null | undefined): number {
-  const normalized = normalizeTerminalFontSize(value ?? DEFAULT_TERMINAL_FONT_SIZE);
-  cachedTerminalFontSize = normalized;
-  return normalized;
 }
 
 export function getCachedTerminalGridSize(target: TerminalUiStateTarget): TerminalGridSize | null {
@@ -47,6 +34,5 @@ export function cacheTerminalGridSize(
 }
 
 export function resetTerminalUiStateCaches() {
-  cachedTerminalFontSize = null;
   terminalGridSizeCache.clear();
 }


### PR DESCRIPTION
Appearance changes wrote a second terminal font-size cache that production never read. Only a direct cache test used the getter.

Remove the unused cache, its writer/getter, and its test. The appearance provider still owns the resolved size and synchronizes theme state; terminal grid caching is unchanged.

Verification: 19 focused terminal-state, appearance, and terminal-preference tests passed before, 18 after. Mobile typecheck, targeted lint/format, and diff checks passed. No visual change.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove write-only terminal font cache from `terminalUiState` and `AppearancePreferencesProvider`
> Deletes the terminal font-size cache state, its getter/setter APIs, reset logic, and normalization dependency in `terminalUiState.ts`. Stops writing the resolved terminal font size from the layout effect in `AppearancePreferencesProvider.tsx`, which now synchronizes only theme IDs and mobile theme runtime state. Updates the test suite in `terminalUiState.test.ts` to cover terminal grid-size caching only. Terminal grid-size caching and its reset behavior remain unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc0ce40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->