### PR TITLE
test(server): remove repeated runtime prompt interpolation cases

### DIFF
--- a/apps/server/src/provider/RuntimeInstructions.test.ts
+++ b/apps/server/src/provider/RuntimeInstructions.test.ts
@@ -2,17 +2,6 @@ import { describe, expect, it } from "vite-plus/test";
 import { buildRuntimeInstructions } from "./RuntimeInstructions.ts";
 
 describe("buildRuntimeInstructions", () => {
-  it.each(["Codex", "Claude Code", "Cursor", "Grok", "OpenCode", "Antigravity"])(
-    "identifies the %s harness and describes media embedding",
-    (harness) => {
-      const instructions = buildRuntimeInstructions({ harness });
-      expect(instructions).toContain(`running in T3 Code through the ${harness} harness.`);
-      expect(instructions).toContain("embed images and videos");
-      expect(instructions).toContain("Markdown with absolute file paths");
-      expect(instructions).not.toContain("undefined");
-    },
-  );
-
   it("keeps known model and effort metadata on one line", () => {
     expect(
       buildRuntimeInstructions({


### PR DESCRIPTION
Six harness-name cases repeated the same string interpolation and static media instructions without exercising different logic.

Remove that repeated table. Keep whitespace normalization, unresolved-model omission, and the Codex session tests that check assembled runtime metadata and media instructions. Production code and provider integrations are unchanged.

Verification: seven baseline suites passed 80 tests. The runtime instruction and Codex session suites pass all 43 retained tests. Server-only typecheck, targeted lint, formatting, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove repeated runtime prompt interpolation test cases from `buildRuntimeInstructions` suite
> Removes the parameterized tests that asserted runtime instructions identify the selected harness and describe image/video embedding behavior for Codex, Claude Code, Cursor, Grok, OpenCode, and Antigravity. Tests for model and reasoning-effort metadata remain unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7ab6be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->