### PR TITLE
refactor(mobile): remove obsolete native diff token stream

### DIFF
--- a/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.test.ts
+++ b/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.test.ts
@@ -2,11 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import type { NativeReviewDiffRow } from "./nativeReviewDiffSurface";
 import type { NativeReviewDiffFile } from "./nativeReviewDiffTypes";
-import {
-  highlightNativeReviewDiffVisibleRows,
-  streamNativeReviewDiffTokens,
-  type NativeReviewDiffTokenChunk,
-} from "./nativeReviewDiffHighlighter";
+import { highlightNativeReviewDiffVisibleRows } from "./nativeReviewDiffHighlighter";
 
 const tokenization = vi.hoisted(() => ({
   calls: [] as string[],
@@ -339,22 +335,5 @@ describe.each(["native", "javascript"] as const)("%s highlighting budgets", (eng
     expect(tokenization.calls).toHaveLength(1);
     expect(result.rowCount).toBe(0);
     expect(result.tokensByRowId).toEqual({});
-  });
-
-  it("applies the same long-line guard to streamed token chunks", async () => {
-    const content = "x".repeat(10_000);
-    const chunks: NativeReviewDiffTokenChunk[] = [];
-
-    await streamNativeReviewDiffTokens({
-      rows: [line(1, content)],
-      files: [TYPESCRIPT_FILE],
-      scheme: "dark",
-      engine,
-      onChunk: (chunk) => chunks.push(chunk),
-    });
-
-    expect(chunks).toHaveLength(1);
-    expect(chunks[0]?.tokensByRowId["line-1"]).toEqual([{ content, color: null, fontStyle: null }]);
-    expect(tokenization.calls).toHaveLength(0);
   });
 });

--- a/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.ts
+++ b/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.ts
@@ -65,26 +65,6 @@ interface IndexedNativeReviewDiffLineRow {
   readonly rowIndex: number;
 }
 
-export interface NativeReviewDiffTokenChunk {
-  readonly chunkIndex: number;
-  readonly fileId: string;
-  readonly filePath: string;
-  readonly language: NativeReviewDiffLanguage;
-  readonly lineCount: number;
-  readonly durationMs: number;
-  readonly tokensByRowId: Record<string, ReadonlyArray<NativeReviewDiffToken>>;
-}
-
-export interface StreamNativeReviewDiffTokenInput {
-  readonly rows: ReadonlyArray<NativeReviewDiffRow>;
-  readonly files: ReadonlyArray<NativeReviewDiffFile>;
-  readonly scheme: NativeReviewDiffHighlightScheme;
-  readonly engine?: NativeReviewDiffHighlightEngine;
-  readonly chunkSize?: number;
-  readonly signal?: AbortSignal;
-  readonly onChunk: (chunk: NativeReviewDiffTokenChunk) => void;
-}
-
 export interface HighlightNativeReviewDiffVisibleRowsInput {
   readonly rows: ReadonlyArray<NativeReviewDiffRow>;
   readonly files: ReadonlyArray<NativeReviewDiffFile>;
@@ -98,7 +78,6 @@ export interface HighlightNativeReviewDiffVisibleRowsInput {
   readonly signal?: AbortSignal;
 }
 
-const NATIVE_REVIEW_DIFF_HIGHLIGHT_CHUNK_SIZE = 500;
 const NATIVE_REVIEW_DIFF_VISIBLE_OVERSCAN_ROWS = 160;
 const NATIVE_REVIEW_DIFF_VISIBLE_MAX_ROWS = 360;
 const NATIVE_REVIEW_DIFF_TOKENIZE_MAX_LINE_LENGTH = 1_000;
@@ -423,20 +402,6 @@ function canShareGrammarContext(
   );
 }
 
-function groupLineRowsByFileId(rows: ReadonlyArray<NativeReviewDiffRow>) {
-  const rowsByFileId = new Map<string, NativeReviewDiffLineRow[]>();
-  for (const row of rows) {
-    if (!isHighlightableLineRow(row)) {
-      continue;
-    }
-
-    const fileRows = rowsByFileId.get(row.fileId) ?? [];
-    fileRows.push(row);
-    rowsByFileId.set(row.fileId, fileRows);
-  }
-  return rowsByFileId;
-}
-
 function createFileMap(files: ReadonlyArray<NativeReviewDiffFile>) {
   return new Map(files.map((file) => [file.id, file]));
 }
@@ -560,53 +525,4 @@ export async function highlightNativeReviewDiffVisibleRows(
     rowCount: selectedRows.length,
     durationMs: Math.round(performance.now() - startedAt),
   };
-}
-
-export async function streamNativeReviewDiffTokens(
-  input: StreamNativeReviewDiffTokenInput,
-): Promise<NativeReviewDiffHighlightEngine> {
-  const highlighter = await getNativeReviewDiffHighlighter(input.engine ?? "native");
-  const rowsByFileId = groupLineRowsByFileId(input.rows);
-  const theme = NATIVE_REVIEW_DIFF_THEME_NAME_BY_SCHEME[input.scheme];
-  const chunkSize = input.chunkSize ?? NATIVE_REVIEW_DIFF_HIGHLIGHT_CHUNK_SIZE;
-  let chunkIndex = 0;
-
-  for (const file of input.files) {
-    const fileRows = rowsByFileId.get(file.id) ?? [];
-    for (let startIndex = 0; startIndex < fileRows.length; startIndex += chunkSize) {
-      if (input.signal?.aborted) {
-        return highlighter.engine;
-      }
-
-      const startedAt = performance.now();
-      const chunkRows = fileRows.slice(startIndex, startIndex + chunkSize);
-      const code = chunkRows.map((row) => row.content).join("\n");
-      const tokenLines = await highlighter.tokenize(code, {
-        lang: file.language,
-        theme,
-        signal: input.signal,
-      });
-      if (input.signal?.aborted) return highlighter.engine;
-      const tokensByRowId: Record<string, ReadonlyArray<NativeReviewDiffToken>> = {};
-
-      chunkRows.forEach((row, rowIndex) => {
-        tokensByRowId[row.id] = tokenLines[rowIndex] ?? makePlainTokenFallback(row);
-      });
-
-      input.onChunk({
-        chunkIndex,
-        fileId: file.id,
-        filePath: file.path,
-        language: file.language,
-        lineCount: chunkRows.length,
-        durationMs: Math.round(performance.now() - startedAt),
-        tokensByRowId,
-      });
-
-      chunkIndex += 1;
-      await waitForNextFrame();
-    }
-  }
-
-  return highlighter.engine;
 }


### PR DESCRIPTION
The old native diff token-stream entrypoint had no production callers. Current review views request visible rows through highlightNativeReviewDiffVisibleRows.

Remove the stream API, its exclusively owned types/grouping helper/chunk limit, and the stream-specific test. Shared tokenization and the active visible-row API are unchanged.

Verification: 16 native/JavaScript highlighter tests passed before, 14 after. Mobile typecheck, targeted lint/format, and diff checks passed. No visual change.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove obsolete native diff token stream from `nativeReviewDiffHighlighter`
> - Deletes the streaming tokenization API: `streamNativeReviewDiffTokens`, its input/chunk types, the `NATIVE_REVIEW_DIFF_HIGHLIGHT_CHUNK_SIZE` constant, and the `groupLineRowsByFileId` helper
> - Removes the corresponding test for chunked tokenization behavior, leaving only visible-row highlighting tests
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 74a06e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->