### PR TITLE
test(server): remove title prompt editorial snapshots

### DIFF
--- a/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
@@ -146,7 +146,7 @@ describe("buildBranchNamePrompt", () => {
 });
 
 describe("buildThreadTitlePrompt", () => {
-  it("includes the user message and the title guidance rules", () => {
+  it("includes the user message without absent attachment metadata", () => {
     const result = buildThreadTitlePrompt({
       message: "Investigate reconnect regressions after session restore",
     });
@@ -154,18 +154,6 @@ describe("buildThreadTitlePrompt", () => {
     expect(result.prompt).toContain("User message:");
     expect(result.prompt).toContain("Investigate reconnect regressions after session restore");
     expect(result.prompt).not.toContain("Attachment metadata:");
-    expect(result.prompt).toContain(
-      "Generate a title that will help the user recognize this T3 Code thread weeks later.",
-    );
-    expect(result.prompt).toContain(
-      "Title the subject and outcome. Discard incidental instructions.",
-    );
-    expect(result.prompt).toContain(
-      "Name the product change, not the mock, plan, report, branch, or PR used to produce it.",
-    );
-    expect(result.prompt).not.toContain(
-      "Title should summarize the user's request, not restate it verbatim.",
-    );
   });
 
   it("includes attachment metadata when attachments are provided", () => {
@@ -188,24 +176,6 @@ describe("buildThreadTitlePrompt", () => {
     expect(result.prompt).toContain("67890 bytes");
   });
 
-  it.each([
-    { mode: "initial", previousTitle: undefined },
-    { mode: "regeneration", previousTitle: "Open Projects in Desktop App" },
-  ])(
-    "tells the $mode prompt not to title linked PRs from local git history",
-    ({ previousTitle }) => {
-      const result = buildThreadTitlePrompt({
-        message: "$takeover https://github.com/pingdotgg/t3code/pull/8588",
-        ...(previousTitle === undefined ? {} : { previousTitle }),
-      });
-
-      expect(result.prompt).toContain(
-        "Local git history is not evidence of what a linked PR or issue is about.",
-      );
-      expect(result.prompt).toContain('such as "Take Over PR 8588"');
-    },
-  );
-
   it("regenerates from recent thread contents and identifies the previous title", () => {
     const result = buildThreadTitlePrompt({
       message: `USER:\nInvestigate reconnect regressions\n\nASSISTANT:\nThe remaining issue is stale session state`,
@@ -216,15 +186,6 @@ describe("buildThreadTitlePrompt", () => {
       "Regenerate the title for an existing T3 Code thread so the user can recognize it weeks later.",
     );
     expect(result.prompt).toContain('The previous title was "Investigate reconnect regressions".');
-    expect(result.prompt).toContain(
-      "Read the USER messages first. Identify the latest explicit durable goal.",
-    );
-    expect(result.prompt).toContain(
-      "Do not promote one assistant finding into the thread subject unless the user adopts it as a new goal.",
-    );
-    expect(result.prompt).toContain(
-      'A subagent-monitoring review that finds a Codex roster bug remains "Review Subagent Monitoring Risks,"',
-    );
     expect(result.prompt).toContain("Thread contents:");
     expect(result.prompt).toContain("The remaining issue is stale session state");
   });


### PR DESCRIPTION
The title prompt tests copied editorial sentences and examples that were returned unchanged for every input.

Remove those wording snapshots while keeping dynamic message and attachment content, previous-title handling, regeneration selection, truncation, and template/policy coverage. All production prompts and exports are unchanged.

Verification: seven baseline suites passed 80 tests. All 19 retained text-generation prompt/utility tests pass. Server-only typecheck, targeted lint, formatting, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove title prompt editorial snapshot assertions from `TextGenerationPrompts` tests
> Updates the `buildThreadTitlePrompt` test suite to drop assertions for detailed title-guidance strings. The suite now checks user message handling, attachment metadata, regeneration context, previous title, thread contents, and truncation. Removes the parameterized test that asserted guidance for titling linked PRs from local git history.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7bc9b74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->