### PR TITLE
refactor(web): observe preview tests through the live registry

### DIFF
--- a/apps/web/src/previewStateStore.test.ts
+++ b/apps/web/src/previewStateStore.test.ts
@@ -19,10 +19,10 @@ import {
   reconcilePreviewServerSessions,
   rememberPreviewUrl,
   resetPreviewStateForTests,
-  subscribeThreadPreviewState,
   setActivePreviewTab,
   updatePreviewServerSnapshot,
 } from "./previewStateStore";
+import { appAtomRegistry } from "./rpc/atomRegistry";
 
 const environmentId = "env-1" as EnvironmentId;
 const ref = scopeThreadRef(environmentId, ThreadId.make("thread-1"));
@@ -352,7 +352,7 @@ describe("previewStateStore (single-tab)", () => {
       },
     };
     let updateCount = 0;
-    const unsubscribe = subscribeThreadPreviewState(ref, () => {
+    const unsubscribe = appAtomRegistry.subscribe(previewStateAtom(scopedThreadKey(ref)), () => {
       updateCount += 1;
     });
 

--- a/apps/web/src/previewStateStore.ts
+++ b/apps/web/src/previewStateStore.ts
@@ -173,19 +173,6 @@ export function readThreadPreviewState(ref: ScopedThreadRef): ThreadPreviewState
   return appAtomRegistry.get(previewStateAtom(scopedThreadKey(ref)));
 }
 
-export function subscribeThreadPreviewState(
-  ref: ScopedThreadRef,
-  listener: (state: ThreadPreviewState, previous: ThreadPreviewState) => void,
-): () => void {
-  const atom = previewStateAtom(scopedThreadKey(ref));
-  let previous = appAtomRegistry.get(atom);
-  return appAtomRegistry.subscribe(atom, (state) => {
-    const prior = previous;
-    previous = state;
-    listener(state, prior);
-  });
-}
-
 export function applyPreviewServerEvent(ref: ScopedThreadRef, event: PreviewEvent): void {
   updateThreadPreviewState(ref, (current) => {
     if (current.serverEpoch !== null && event.serverEpoch !== current.serverEpoch) return current;


### PR DESCRIPTION
A preview-state subscription wrapper exists only for one regression test and maintains previous-state bookkeeping that the test never uses.

Subscribe that test directly to the existing application registry and preview atom, then remove the unused wrapper. Keep the regression asserting that two equal desktop overlays publish only one update. No production state updates or test scenarios change.

Verification: tracked searches found only the wrapper definition and this test call. Preview-state and close-session suites pass all 28 cases before and after. Web package typecheck, targeted lint, formatting and git diff --check pass. No screenshots apply to an internal test-entry cleanup.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `subscribeThreadPreviewState` and observe preview tests through `appAtomRegistry`
> The preview state subscription helper in [previewStateStore.ts](https://github.com/pingdotgg/t3code/pull/10064/files#diff-19016f363ca68fddd6b79d0f335f7f9326088012252aa66466c2fd609178851d) is removed; tests now subscribe directly to the preview state atom via `appAtomRegistry`. This aligns test observation with the live atom registry rather than a custom wrapper. The test in [previewStateStore.test.ts](https://github.com/pingdotgg/t3code/pull/10064/files#diff-d1f3eda54052bd094d4a4c338b826a2c12dabd1ca92c48ecbb6e780b88700a0c) still tracks notification counts and unsubscribes before asserting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61e0ed1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->