### PR TITLE
test(server): remove keybinding default assignment snapshot

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -188,33 +188,6 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
-  it.effect("ships configurable thread navigation defaults", () =>
-    Effect.sync(() => {
-      const defaultsByCommand = new Map(
-        Keybindings.DEFAULT_KEYBINDINGS.map((binding) => [binding.command, binding.key] as const),
-      );
-
-      assert.equal(defaultsByCommand.get("thread.previous"), "mod+shift+[");
-      assert.equal(defaultsByCommand.get("thread.next"), "mod+shift+]");
-      assert.equal(defaultsByCommand.get("thread.copyReference"), "mod+shift+c");
-      assert.equal(defaultsByCommand.get("thread.settle"), "mod+shift+s");
-      assert.equal(defaultsByCommand.get("thread.pin"), "mod+shift+p");
-      assert.equal(defaultsByCommand.get("thread.jump.1"), "mod+1");
-      assert.equal(defaultsByCommand.get("thread.jump.9"), "mod+9");
-      assert.equal(defaultsByCommand.get("modelPicker.toggle"), "mod+shift+m");
-      assert.equal(defaultsByCommand.get("themeEditor.toggle"), "mod+alt+shift+t");
-      assert.equal(defaultsByCommand.get("filePicker.toggle"), "mod+p");
-      assert.equal(defaultsByCommand.get("projectSearch.toggle"), "mod+shift+f");
-      assert.equal(defaultsByCommand.get("sidebar.toggle"), "mod+b");
-      assert.equal(defaultsByCommand.get("rightPanel.toggle"), "mod+alt+b");
-      assert.isFalse(defaultsByCommand.has("rightPanel.toggleMaximized"));
-      assert.equal(defaultsByCommand.get("rightPanel.close"), "mod+w");
-      assert.equal(defaultsByCommand.get("terminal.splitVertical"), "mod+shift+d");
-      assert.equal(defaultsByCommand.get("modelPicker.jump.1"), "mod+1");
-      assert.equal(defaultsByCommand.get("modelPicker.jump.9"), "mod+9");
-    }),
-  );
-
   it.effect("uses defaults in runtime when config is malformed without overriding file", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;


### PR DESCRIPTION
One keybinding test repeated the default shortcut table without exercising loading, matching, or persistence.

Remove that static assignment snapshot. Keep all parser/compiler tests and the service tests for bootstrapping defaults, malformed configs, edits, caching, and concurrent writes. Production defaults and server exports are unchanged.

Verification: seven baseline suites passed 80 tests. All 21 retained keybinding tests pass. Server-only typecheck, targeted lint, formatting, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove keybinding default assignment snapshot test
> Removes the `ships configurable thread navigation defaults` test in [keybindings.test.ts](https://github.com/pingdotgg/t3code/pull/10065/files#diff-7cdcaa91f266fd337d189836ac52dd8f055d807b8309bb3b551dedc118740a3a). That test built a command-to-key map from default keybindings and asserted shortcuts for thread navigation, model picker, theme editor, file picker, project search, sidebar, right panel, terminal splitting, and numeric model-picker jumps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 04a2c1e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->