### PR TITLE
test(server): cover CLI runner detection through command suggestions

### DIFF
--- a/apps/server/src/cli/invocation.test.ts
+++ b/apps/server/src/cli/invocation.test.ts
@@ -1,49 +1,62 @@
 import { assert, it } from "@effect/vitest";
 
-import { detectCliRunner, formatCliCommand, suggestedPackageSpec } from "./invocation.ts";
+import { formatCliCommand } from "./invocation.ts";
 
-it("detects package runners from their cache entry paths", () => {
-  assert.equal(detectCliRunner("/home/theo/.npm/_npx/abc123/node_modules/t3/dist/bin.mjs"), "npx");
-  assert.equal(
-    detectCliRunner(
+it("formats package runner commands from their cache entry paths", () => {
+  for (const [entryPath, expected] of [
+    ["/home/theo/.npm/_npx/abc123/node_modules/t3/dist/bin.mjs", "npx t3 serve"],
+    [
       "C:\\Users\\theo\\AppData\\Local\\npm-cache\\_npx\\abc\\node_modules\\t3\\dist\\bin.mjs",
-    ),
-    "npx",
-  );
-  assert.equal(
-    detectCliRunner("/home/theo/.cache/pnpm/dlx/abc/node_modules/t3/dist/bin.mjs"),
-    "pnpm dlx",
-  );
-  assert.equal(
-    detectCliRunner("/home/theo/.local/share/pnpm/.pnpm/dlx/abc/node_modules/t3/dist/bin.mjs"),
-    "pnpm dlx",
-  );
-  assert.equal(
-    detectCliRunner(
+      "npx t3 serve",
+    ],
+    ["/home/theo/.cache/pnpm/dlx/abc/node_modules/t3/dist/bin.mjs", "pnpm dlx t3 serve"],
+    [
+      "/home/theo/.local/share/pnpm/.pnpm/dlx/abc/node_modules/t3/dist/bin.mjs",
+      "pnpm dlx t3 serve",
+    ],
+    [
       "C:\\Users\\theo\\AppData\\Local\\pnpm-cache\\dlx\\abc\\node_modules\\t3\\dist\\bin.mjs",
-    ),
-    "pnpm dlx",
-  );
-  assert.equal(detectCliRunner("/home/theo/.bun/install/cache/t3@0.0.31/dist/bin.mjs"), "bunx");
-  assert.equal(detectCliRunner("/tmp/bunx-1000-t3@latest/node_modules/t3/dist/bin.mjs"), "bunx");
-  assert.equal(
-    detectCliRunner(
+      "pnpm dlx t3 serve",
+    ],
+    ["/home/theo/.bun/install/cache/t3@0.0.31/dist/bin.mjs", "bunx t3 serve"],
+    ["/tmp/bunx-1000-t3@latest/node_modules/t3/dist/bin.mjs", "bunx t3 serve"],
+    [
       "C:\\Users\\theo\\AppData\\Local\\Temp\\bunx-0-t3@latest\\node_modules\\t3\\dist\\bin.mjs",
-    ),
-    "bunx",
-  );
+      "bunx t3 serve",
+    ],
+  ] as const) {
+    assert.equal(formatCliCommand({ subcommand: "serve", entryPath, version: "0.0.31" }), expected);
+  }
 });
 
 it("treats stable installs as direct invocations", () => {
-  assert.isNull(detectCliRunner("/usr/local/lib/node_modules/t3/dist/bin.mjs"));
-  assert.isNull(detectCliRunner("/home/theo/Code/work/t3code/apps/server/dist/bin.mjs"));
-  assert.isNull(detectCliRunner("/home/theo/.t3/runtime/0.0.31/node_modules/t3/dist/bin.mjs"));
-  assert.isNull(detectCliRunner(""));
+  for (const entryPath of [
+    "/usr/local/lib/node_modules/t3/dist/bin.mjs",
+    "/home/theo/Code/work/t3code/apps/server/dist/bin.mjs",
+    "/home/theo/.t3/runtime/0.0.31/node_modules/t3/dist/bin.mjs",
+    "",
+  ]) {
+    assert.equal(
+      formatCliCommand({ subcommand: "serve", entryPath, version: "0.0.31" }),
+      "t3 serve",
+    );
+  }
 });
 
 it("re-suggests the nightly channel only for nightly builds", () => {
-  assert.equal(suggestedPackageSpec("0.0.31-nightly.20260729"), "t3@nightly");
-  assert.equal(suggestedPackageSpec("0.0.31"), "t3");
+  for (const [version, expected] of [
+    ["0.0.31-nightly.20260729", "npx t3@nightly serve"],
+    ["0.0.31", "npx t3 serve"],
+  ] as const) {
+    assert.equal(
+      formatCliCommand({
+        subcommand: "serve",
+        entryPath: "/home/theo/.npm/_npx/abc123/node_modules/t3/dist/bin.mjs",
+        version,
+      }),
+      expected,
+    );
+  }
 });
 
 it("formats serve suggestions to match the launching command", () => {

--- a/apps/server/src/cli/invocation.ts
+++ b/apps/server/src/cli/invocation.ts
@@ -18,7 +18,7 @@ export type CliRunner = "npx" | "pnpm dlx" | "bunx";
  * Global installs and repo checkouts match none of these and return null.
  * Detection is best-effort; callers must fail closed to a plain `t3` command.
  */
-export function detectCliRunner(entryPath: string): CliRunner | null {
+function detectCliRunner(entryPath: string): CliRunner | null {
   const path = entryPath.replaceAll("\\", "/");
   if (path.includes("/_npx/")) {
     return "npx";
@@ -42,7 +42,7 @@ export function detectCliRunner(entryPath: string): CliRunner | null {
  * from the running version: nightly builds re-suggest the nightly channel,
  * anything else suggests the bare package.
  */
-export function suggestedPackageSpec(version: string): string {
+function suggestedPackageSpec(version: string): string {
   return version.includes("-nightly.") ? "t3@nightly" : "t3";
 }
 


### PR DESCRIPTION
CLI runner detection and package-channel selection were exported only so tests could call those internal helpers.

Make both helpers private and check the same inputs through formatCliCommand. Preserve every Linux/Windows cache path, direct-install fallback, stable/nightly version, and existing serve-suggestion case. Production command formatting is unchanged.

Verification: seven baseline suites passed 80 tests. All 4 invocation tests pass with their original scenarios preserved. Server-only typecheck, targeted lint, formatting, and diff checks passed.

Model: gpt-6 astra. Harness: Codex in T3 Code.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route CLI runner detection tests through `formatCliCommand` and privatize helpers
> Replaces direct assertions against `detectCliRunner` and `suggestedPackageSpec` with table-driven tests that verify the full command output of `formatCliCommand`. Covers npx, pnpm dlx, and bunx cache paths on Unix and Windows, stable vs nightly channel selection, and stable installs that resolve to the direct `t3 serve` command.
>
> - Makes `detectCliRunner` and `suggestedPackageSpec` module-private in [invocation.ts](https://github.com/pingdotgg/t3code/pull/10066/files#diff-f66315c334f5c48011ca39453770f9f79309c92830faf9f19f96bf162b7ae089) since tests now exercise them only through the public formatter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4d286e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->