### PR TITLE
refactor(mobile): remove unused cloud relay URL normalizer

### DIFF
--- a/apps/mobile/src/features/cloud/linkEnvironment.test.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.test.ts
@@ -17,7 +17,6 @@ import {
   connectCloudEnvironment,
   listCloudEnvironments,
   listCloudEnvironmentsWithStatus,
-  normalizeRelayBaseUrl,
   refreshCloudEnvironmentConnection,
 } from "./linkEnvironment";
 
@@ -193,13 +192,6 @@ describe("mobile cloud link environment client", () => {
     vi.restoreAllMocks();
     createProofMock.mockClear();
     loadPreferences.mockClear();
-  });
-
-  it("normalizes configured relay base URLs before building DPoP-bound requests", () => {
-    expect(normalizeRelayBaseUrl(" https://relay.example.test/// ")).toBe(
-      "https://relay.example.test",
-    );
-    expect(normalizeRelayBaseUrl("   ")).toBeNull();
   });
 
   it("makes linked environments visible while their status is still loading", () => {

--- a/apps/mobile/src/features/cloud/linkEnvironment.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.ts
@@ -43,14 +43,6 @@ const RELAY_STATUS_AND_CONNECT_SCOPES = [
   RelayEnvironmentConnectScope,
 ] satisfies ReadonlyArray<RelayDpopAccessTokenScope>;
 
-export function normalizeRelayBaseUrl(value: string | null | undefined): string | null {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    return null;
-  }
-  return trimmed.replace(/\/+$/g, "");
-}
-
 function readRelayUrl(): string | null {
   return resolveCloudPublicConfig().relay.url;
 }


### PR DESCRIPTION
The mobile cloud relay URL normalizer had no production callers. Its test claimed request normalization but only exercised the orphan helper.

Remove the helper and dedicated test. The active URL reader still uses resolveCloudPublicConfig().relay.url, and request/authentication code is unchanged.

Verification: 28 focused cloud-link and public-config tests passed before, 27 after. Mobile typecheck, targeted lint/format, and diff checks passed. No visual change.

Model: gpt-6 astra. Harness: Codex in T3 Code.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `normalizeRelayBaseUrl` helper from mobile cloud link environment
> Deletes the `normalizeRelayBaseUrl` utility and its test suite. The helper previously trimmed whitespace, removed trailing slashes, and converted blank values to null for relay URLs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dea7fca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->