### PR TITLE
test(server): cover Grok skill parsing through discovery

### DIFF
--- a/apps/server/src/provider/Drivers/GrokSkills.test.ts
+++ b/apps/server/src/provider/Drivers/GrokSkills.test.ts
@@ -1,141 +1,172 @@
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
-import { discoverGrokSkills, parseGrokInspectSkills } from "./GrokSkills.ts";
+import { discoverGrokSkills } from "./GrokSkills.ts";
 
 const inspectPayload = (skills: ReadonlyArray<unknown>) => JSON.stringify({ skills });
 
-describe("parseGrokInspectSkills", () => {
-  it("maps inspect entries onto provider skills, sorted by name", () => {
-    const skills = parseGrokInspectSkills(
-      inspectPayload([
-        {
-          name: "writing-docs",
-          description: "Write user docs.",
-          source: { type: "user", path: "/home/dev/.grok/skills/writing-docs/SKILL.md" },
-          userInvocable: true,
-        },
+const makeInspectSpawner = (stdout: string, exitCode = 0, spawnCwds?: Array<string | undefined>) =>
+  ChildProcessSpawner.make((command) => {
+    spawnCwds?.push(command._tag === "StandardCommand" ? command.options.cwd : undefined);
+    return Effect.succeed(
+      ChildProcessSpawner.makeHandle({
+        pid: ChildProcessSpawner.ProcessId(1),
+        exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(exitCode)),
+        isRunning: Effect.succeed(false),
+        kill: () => Effect.void,
+        unref: Effect.succeed(Effect.void),
+        stdin: Sink.drain,
+        stdout: Stream.encodeText(Stream.make(stdout)),
+        stderr: Stream.empty,
+        all: Stream.empty,
+        getInputFd: () => Sink.drain,
+        getOutputFd: () => Stream.empty,
+      }),
+    );
+  });
+
+describe("discoverGrokSkills", () => {
+  it.effect("maps inspect entries onto provider skills, sorted by name", () =>
+    Effect.gen(function* () {
+      const skills = yield* discoverGrokSkills({ binaryPath: "grok" }, {});
+
+      expect(skills).toEqual([
         {
           name: "deploy",
           description: "Deploy the app.",
-          source: {
-            type: "plugin",
-            path: "/home/dev/.grok/installed-plugins/pkg/plug/skills/deploy/SKILL.md",
-          },
-          userInvocable: true,
+          path: "/home/dev/.grok/installed-plugins/pkg/plug/skills/deploy/SKILL.md",
+          scope: "plugin",
+          enabled: true,
         },
-      ]),
-    );
+        {
+          name: "writing-docs",
+          description: "Write user docs.",
+          path: "/home/dev/.grok/skills/writing-docs/SKILL.md",
+          scope: "user",
+          enabled: true,
+        },
+      ]);
+    }).pipe(
+      Effect.provideService(
+        ChildProcessSpawner.ChildProcessSpawner,
+        makeInspectSpawner(
+          inspectPayload([
+            {
+              name: "writing-docs",
+              description: "Write user docs.",
+              source: { type: "user", path: "/home/dev/.grok/skills/writing-docs/SKILL.md" },
+              userInvocable: true,
+            },
+            {
+              name: "deploy",
+              description: "Deploy the app.",
+              source: {
+                type: "plugin",
+                path: "/home/dev/.grok/installed-plugins/pkg/plug/skills/deploy/SKILL.md",
+              },
+              userInvocable: true,
+            },
+          ]),
+        ),
+      ),
+    ),
+  );
 
-    expect(skills).toEqual([
-      {
-        name: "deploy",
-        description: "Deploy the app.",
-        path: "/home/dev/.grok/installed-plugins/pkg/plug/skills/deploy/SKILL.md",
-        scope: "plugin",
-        enabled: true,
-      },
-      {
-        name: "writing-docs",
-        description: "Write user docs.",
-        path: "/home/dev/.grok/skills/writing-docs/SKILL.md",
-        scope: "user",
-        enabled: true,
-      },
-    ]);
-  });
+  it.effect("disables skills the CLI marks as not user-invocable", () =>
+    Effect.gen(function* () {
+      const skills = yield* discoverGrokSkills({ binaryPath: "grok" }, {});
 
-  it("disables skills the CLI marks as not user-invocable", () => {
-    const skills = parseGrokInspectSkills(
-      inspectPayload([
+      expect(skills).toEqual([
         {
           name: "internal-helper",
-          source: { type: "bundled", path: "/opt/grok/bundled/skills/internal-helper/SKILL.md" },
-          userInvocable: false,
+          path: "/opt/grok/bundled/skills/internal-helper/SKILL.md",
+          scope: "bundled",
+          enabled: false,
         },
-      ]),
-    );
+      ]);
+    }).pipe(
+      Effect.provideService(
+        ChildProcessSpawner.ChildProcessSpawner,
+        makeInspectSpawner(
+          inspectPayload([
+            {
+              name: "internal-helper",
+              source: {
+                type: "bundled",
+                path: "/opt/grok/bundled/skills/internal-helper/SKILL.md",
+              },
+              userInvocable: false,
+            },
+          ]),
+        ),
+      ),
+    ),
+  );
 
-    expect(skills).toEqual([
-      {
-        name: "internal-helper",
-        path: "/opt/grok/bundled/skills/internal-helper/SKILL.md",
-        scope: "bundled",
-        enabled: false,
-      },
-    ]);
-  });
+  it.effect("skips entries without a name or a filesystem path", () =>
+    Effect.gen(function* () {
+      const skills = yield* discoverGrokSkills({ binaryPath: "grok" }, {});
+      expect(skills.map((skill) => skill.name)).toEqual(["kept"]);
+    }).pipe(
+      Effect.provideService(
+        ChildProcessSpawner.ChildProcessSpawner,
+        makeInspectSpawner(
+          inspectPayload([
+            { name: "  ", source: { type: "user", path: "/tmp/skills/a/SKILL.md" } },
+            { name: "no-path", source: { type: "user" } },
+            { name: "no-source" },
+            "not-an-object",
+            { name: "kept", source: { type: "project", path: "/repo/.grok/skills/kept/SKILL.md" } },
+          ]),
+        ),
+      ),
+    ),
+  );
 
-  it("skips entries without a name or a filesystem path", () => {
-    const skills = parseGrokInspectSkills(
-      inspectPayload([
-        { name: "  ", source: { type: "user", path: "/tmp/skills/a/SKILL.md" } },
-        { name: "no-path", source: { type: "user" } },
-        { name: "no-source" },
-        "not-an-object",
-        { name: "kept", source: { type: "project", path: "/repo/.grok/skills/kept/SKILL.md" } },
-      ]),
-    );
+  it.effect("rejects malformed or unexpected output as a decode failure", () =>
+    Effect.gen(function* () {
+      for (const stdout of ["not json", "null", '{"skills":"nope"}', "{}"]) {
+        const error = yield* discoverGrokSkills({ binaryPath: "grok" }, {}).pipe(
+          Effect.flip,
+          Effect.provideService(
+            ChildProcessSpawner.ChildProcessSpawner,
+            makeInspectSpawner(stdout),
+          ),
+        );
+        expect(error).toMatchObject({ _tag: "GrokSkillsProbeError", stage: "decode" });
+      }
+    }),
+  );
 
-    expect(skills.map((skill) => skill.name)).toEqual(["kept"]);
-  });
-
-  it("returns an empty list for malformed or unexpected output", () => {
-    expect(parseGrokInspectSkills("not json")).toEqual([]);
-    expect(parseGrokInspectSkills("null")).toEqual([]);
-    expect(parseGrokInspectSkills(JSON.stringify({ skills: "nope" }))).toEqual([]);
-    expect(parseGrokInspectSkills(JSON.stringify({}))).toEqual([]);
-  });
-});
-
-describe("discoverGrokSkills", () => {
   it.effect("spawns in the configured cwd and rejects a failed probe", () => {
     const spawnCwds: Array<string | undefined> = [];
-    let exitCode = 0;
-    const spawner = ChildProcessSpawner.make((command) => {
-      spawnCwds.push(command._tag === "StandardCommand" ? command.options.cwd : undefined);
-      return Effect.succeed(
-        ChildProcessSpawner.makeHandle({
-          pid: ChildProcessSpawner.ProcessId(1),
-          exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(exitCode)),
-          isRunning: Effect.succeed(false),
-          kill: () => Effect.void,
-          unref: Effect.succeed(Effect.void),
-          stdin: Sink.drain,
-          stdout: Stream.encodeText(
-            Stream.make(
-              inspectPayload([
-                {
-                  name: "kept",
-                  source: { type: "project", path: "/workspaces/demo/.grok/skills/kept/SKILL.md" },
-                },
-              ]),
-            ),
-          ),
-          stderr: Stream.empty,
-          all: Stream.empty,
-          getInputFd: () => Sink.drain,
-          getOutputFd: () => Stream.empty,
-        }),
-      );
-    });
+    const stdout = inspectPayload([
+      {
+        name: "kept",
+        source: { type: "project", path: "/workspaces/demo/.grok/skills/kept/SKILL.md" },
+      },
+    ]);
 
     return Effect.gen(function* () {
       const skills = yield* discoverGrokSkills({ binaryPath: "grok" }, {}, "/workspaces/demo").pipe(
-        Effect.provide(Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner)),
+        Effect.provideService(
+          ChildProcessSpawner.ChildProcessSpawner,
+          makeInspectSpawner(stdout, 0, spawnCwds),
+        ),
       );
 
       expect(spawnCwds).toEqual(["/workspaces/demo"]);
       expect(skills.map((skill) => skill.name)).toEqual(["kept"]);
 
-      exitCode = 1;
       const failed = yield* discoverGrokSkills({ binaryPath: "grok" }).pipe(
         Effect.result,
-        Effect.provide(Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner)),
+        Effect.provideService(
+          ChildProcessSpawner.ChildProcessSpawner,
+          makeInspectSpawner(stdout, 1),
+        ),
       );
       expect(failed._tag).toBe("Failure");
     });

--- a/apps/server/src/provider/Drivers/GrokSkills.ts
+++ b/apps/server/src/provider/Drivers/GrokSkills.ts
@@ -91,10 +91,6 @@ function decodeGrokInspectSkills(stdout: string): ReadonlyArray<ServerProviderSk
   return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
 }
 
-export function parseGrokInspectSkills(stdout: string): ReadonlyArray<ServerProviderSkill> {
-  return decodeGrokInspectSkills(stdout) ?? [];
-}
-
 /**
  * Run `grok inspect --json` and map the reported catalog onto provider
  * skills. Callers that need best-effort discovery can recover this effect to


### PR DESCRIPTION
The exported Grok parser wrapper had no runtime callers and silently returned an empty list for malformed output. Real skill discovery calls the decoder directly and reports a typed failure.

Delete the obsolete wrapper and run its meaningful mapping/filtering cases through discoverGrokSkills using the existing process-spawner fixture. Preserve sorting, descriptions, source scopes, disabled skills, invalid entries, configured cwd, and failed-exit coverage. Malformed-output cases now assert the real decode failure instead of the unused wrapper's empty-list policy.

Verification: seven baseline suites passed 80 tests. All 5 Grok skill tests pass through discovery. Server-only typecheck, targeted lint, formatting, and diff checks passed. The live decoder and discovery implementation are unchanged.

Model: gpt-6 astra. Harness: Codex in T3 Code.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cover Grok skill parsing through `discoverGrokSkills` instead of parser unit tests
> - Replaces direct tests of the removed `parseGrokInspectSkills` with Effect-based tests that run `discoverGrokSkills` against a mockable `makeInspectSpawner` test helper controlling stdout, exit code, and cwd.
> - Adds tests for malformed stdout (now raises `GrokSkillsProbeError` at the decode stage instead of returning an empty list), invalid entry omission, `userInvocable: false` mapping to disabled, sorting, and nonzero-exit failure.
> - Removes the exported `parseGrokInspectSkills` from [GrokSkills.ts](https://github.com/pingdotgg/t3code/pull/10070/files#diff-b9a91917429e16fdadd1583ee3bb784e862cc270fd9ffa70002cf175bbef35ab); callers must use the discovery effect.
> - Risk: removal of the `parseGrokInspectSkills` export breaks any out-of-tree caller importing that function.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8932553.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->