### PR TITLE
refactor(mobile): remove unused cloud pending-status mapper

### DIFF
--- a/apps/mobile/src/features/cloud/linkEnvironment.test.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.test.ts
@@ -11,7 +11,6 @@ import { MobilePreferencesStore } from "../../persistence/mobile-preferences";
 import { MobileStorage } from "../../persistence/mobile-storage";
 
 import {
-  cloudEnvironmentsPendingStatus,
   linkEnvironmentToCloud,
   linkEnvironmentToCloudWithPreference,
   connectCloudEnvironment,
@@ -192,16 +191,6 @@ describe("mobile cloud link environment client", () => {
     vi.restoreAllMocks();
     createProofMock.mockClear();
     loadPreferences.mockClear();
-  });
-
-  it("makes linked environments visible while their status is still loading", () => {
-    expect(cloudEnvironmentsPendingStatus([listedEnvironment("env-1")])).toMatchObject([
-      {
-        environment: { environmentId: "env-1", label: "Desktop" },
-        status: null,
-        statusError: "Checking status...",
-      },
-    ]);
   });
 
   it.effect("decodes relay environment list responses before returning records", () =>

--- a/apps/mobile/src/features/cloud/linkEnvironment.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.ts
@@ -397,16 +397,6 @@ export function getCloudEnvironmentStatus(input: {
   });
 }
 
-export function cloudEnvironmentsPendingStatus(
-  environments: ReadonlyArray<RelayClientEnvironmentRecord>,
-): ReadonlyArray<CloudEnvironmentRecordWithStatus> {
-  return environments.map((environment) => ({
-    environment,
-    status: null,
-    statusError: "Checking status...",
-  }));
-}
-
 export function loadCloudEnvironmentStatuses(input: {
   readonly clerkToken: string;
   readonly environments: ReadonlyArray<RelayClientEnvironmentRecord>;


### PR DESCRIPTION
An old cloud pending-status mapper had no production callers. Its single test asserted a loading object that the current client never used.

Remove the mapper and its dedicated test. Cloud discovery, linking, identity validation, and current loading behavior stay unchanged.

Verification: 27 focused cloud-link and public-config tests passed on the updated main base, 26 after. Mobile typecheck, targeted lint/format, and diff checks passed. The rebase preserves the previously merged URL-normalizer cleanup and changes no patch content. No visual change.

Model: gpt-6 astra. Harness: Codex in T3 Code.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `cloudEnvironmentsPendingStatus` mapper
> Deletes the exported helper in [linkEnvironment.ts](https://github.com/pingdotgg/t3code/pull/10071/files#diff-14699cfea77b0136e19c830618d4732f12baf0fadf700dee05707865269277e1) that mapped relay environment records into pending cloud status records, along with its dedicated test in [linkEnvironment.test.ts](https://github.com/pingdotgg/t3code/pull/10071/files#diff-6052f7af4e540e26d12ca218c671779ccdc6314f065af11a63403d0d1385c8b9). The helper and its assertions were unused.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2c8b16.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
