### PR TITLE
refactor(web): remove unused model picker hint helpers

### DIFF
--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -19,7 +19,6 @@ import {
   isTerminalSplitVerticalShortcut,
   isTerminalToggleShortcut,
   resolveShortcutCommand,
-  shouldShowModelPickerJumpHints,
   shouldShowThreadJumpHintsForModifiers,
   shortcutLabelForCommand,
   terminalDeleteShortcutData,
@@ -540,21 +539,6 @@ describe("model picker navigation helpers", () => {
     assert.strictEqual(modelPickerJumpIndexFromCommand("modelPicker.jump.1"), 0);
     assert.strictEqual(modelPickerJumpIndexFromCommand("modelPicker.jump.3"), 2);
     assert.isNull(modelPickerJumpIndexFromCommand("thread.jump.1"));
-  });
-
-  it("shows jump hints only while the model picker context is active", () => {
-    assert.isFalse(
-      shouldShowModelPickerJumpHints(event({ metaKey: true }), DEFAULT_BINDINGS, {
-        platform: "MacIntel",
-        context: { modelPickerOpen: false },
-      }),
-    );
-    assert.isTrue(
-      shouldShowModelPickerJumpHints(event({ metaKey: true }), DEFAULT_BINDINGS, {
-        platform: "MacIntel",
-        context: { modelPickerOpen: true },
-      }),
-    );
   });
 });
 

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -329,32 +329,6 @@ export function modelPickerJumpIndexFromCommand(command: string): number | null 
   return index === -1 ? null : index;
 }
 
-export function shouldShowModelPickerJumpHints(
-  event: ShortcutEventLike,
-  keybindings: ResolvedKeybindingsConfig,
-  options?: ShortcutMatchOptions,
-): boolean {
-  return shouldShowModelPickerJumpHintsForModifiers(event, keybindings, options);
-}
-
-export function shouldShowModelPickerJumpHintsForModifiers(
-  modifiers: ShortcutModifierStateLike,
-  keybindings: ResolvedKeybindingsConfig,
-  options?: ShortcutMatchOptions,
-): boolean {
-  const platform = resolvePlatform(options);
-
-  for (const command of MODEL_PICKER_JUMP_KEYBINDING_COMMANDS) {
-    const shortcut = findEffectiveShortcutForCommand(keybindings, command, options);
-    if (!shortcut) continue;
-    if (matchesShortcutModifiers(modifiers, shortcut, platform)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 export function isTerminalToggleShortcut(
   event: ShortcutEventLike,
   keybindings: ResolvedKeybindingsConfig,


### PR DESCRIPTION
Two model-picker modifier-hint helpers survive only through one direct test. The active picker already renders shortcut labels from the configured bindings and resolves keyboard commands directly.

Remove the unused helpers and their sole obsolete modifier-gating test. Keep jump-command mapping, shortcut labels, command context and the model-selection tests. The actual picker is unchanged.

Rebased after the live keybinding resolver cleanup landed. The only conflict was its adjacent test import; keep the live thread-modifier resolver while deleting the unused model-picker import. Range-diff shows only that context rename, and the zero-context deletion patch is identical to the original change.

Verification: fresh tracked caller searches found no production consumer. Keybinding and model-picker suites pass on the exact new base and rebased head, 68 to 67 tests. Web package typecheck, targeted lint, formatting and git diff --check pass. The sole removed case is unchanged and all model-picker selection tests are untouched. No screenshots apply to this dead-code removal.

Model: gpt-6 astra. Harness: Codex in T3 Code.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused model picker jump-hint helpers from `keybindings`
> Deletes the exported `shouldShowModelPickerJumpHints` and `shouldShowModelPickerJumpHintsForModifiers` helpers from [keybindings.ts](https://github.com/pingdotgg/t3code/pull/10072/files#diff-0c56a39781768a3ed42f3d306e35b87e9d2426ccb4a81010bc2c4fe735001385), along with the test that validated hint visibility in [keybindings.test.ts](https://github.com/pingdotgg/t3code/pull/10072/files#diff-3e7e2d1443a6ef65804eb664f29494497397949e2f3a8252f07d8dbac6d54c76). These helpers were no longer used.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf495d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
