### PR TITLE
test(web): remove mocked diff view prop snapshot

### DIFF
--- a/apps/web/src/components/diffs/StyledDiffCodeView.test.tsx
+++ b/apps/web/src/components/diffs/StyledDiffCodeView.test.tsx
@@ -18,13 +18,10 @@ import {
   useState,
   type Ref,
 } from "react";
-import { renderToStaticMarkup } from "react-dom/server";
 import { create, type ReactTestRenderer } from "react-test-renderer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const testState = vi.hoisted(() => ({
-  codeViewClassName: null as string | null,
-  codeViewOptions: null as Record<string, unknown> | null,
   workers: [] as NodeWorkerThreads.Worker[],
   terminations: [] as Promise<number>[],
   requests: [] as WorkerRequest[],
@@ -102,8 +99,6 @@ vi.mock("@pierre/diffs/worker/worker.js?worker", async () => {
 vi.mock("@pierre/diffs/react", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@pierre/diffs/react")>()),
   CodeView: (props: CodeViewProps) => {
-    testState.codeViewClassName = props.className ?? null;
-    testState.codeViewOptions = props.options ? { ...props.options } : null;
     return props.items?.map((item) =>
       item.type === "file" ? <FileOutput key={item.id} file={item.file} /> : null,
     );
@@ -157,49 +152,6 @@ function renderViews(count: number) {
     </StrictMode>
   );
 }
-
-describe("StyledDiffCodeView", () => {
-  beforeEach(() => {
-    testState.codeViewClassName = null;
-    testState.codeViewOptions = null;
-  });
-
-  it("always pairs the shared diff styling with its virtualized geometry", () => {
-    const loadDiffFiles = vi.fn(async () => ({
-      oldFile: { name: "before.ts", contents: "before\n" },
-      newFile: { name: "after.ts", contents: "after\n" },
-    }));
-    renderToStaticMarkup(
-      <StyledDiffCodeView
-        className="min-h-0"
-        items={[]}
-        options={{ theme: "pierre-dark", stickyHeaders: true, loadDiffFiles }}
-      />,
-    );
-
-    expect(testState.codeViewClassName).toBe(
-      "diff-render-surface [--code-background:var(--background)] outline-none min-h-0",
-    );
-    expect(testState.codeViewOptions).toMatchObject({
-      theme: "pierre-dark",
-      stickyHeaders: true,
-      loadDiffFiles,
-      itemMetrics: {
-        diffHeaderHeight: 32,
-        hunkSeparatorHeight: 24,
-        paddingTop: 0,
-        paddingBottom: 8,
-      },
-      layout: { paddingTop: 0, paddingBottom: 0, gap: 0 },
-    });
-    expect(testState.codeViewOptions?.unsafeCSS).toEqual(
-      expect.stringContaining("[data-unmodified-lines]::before"),
-    );
-    expect(testState.codeViewOptions?.unsafeCSS).toEqual(
-      expect.stringContaining(")[data-expand-index]\n  [data-unmodified-lines]"),
-    );
-  });
-});
 
 describe("code-view worker lifecycle", () => {
   let renderer: ReactTestRenderer | undefined;


### PR DESCRIPTION
The diff wrapper's styling test captures props from a mocked CodeView and repeats class names, numeric options and CSS strings. It does not measure virtualized layout.

Remove that single snapshot-style case and its exclusive capture state. Keep all three real-worker lifecycle tests and all four file-reveal tests unchanged. Production components and worker behavior are untouched.

Verification: StyledDiffCodeView and AnnotatableCodeView suites pass before and after, 9 to 8 tests. The seven retained StyledDiffCodeView cases exercise real worker startup/fallback/cleanup and file-reveal ordering. Web package typecheck, targeted lint, formatting and git diff --check pass. No screenshots apply to this test-only removal.

Model: gpt-6 astra. Harness: Codex in T3 Code.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove mocked diff view prop snapshot from `StyledDiffCodeView` tests
> - Deletes the styling contract test suite that asserted `StyledDiffCodeView`'s className, theme/sticky-header options, virtualized item metrics, layout padding, and unsafe CSS selectors in [StyledDiffCodeView.test.tsx](https://github.com/pingdotgg/t3code/pull/10073/files#diff-a1ec77ef6e0506d2849234cafdc508c495543ac9ec35800f08f29aab4af0876d)
> - Stops the `CodeView` mock from copying and storing received `className` and `options` props into `testState`; the mock still renders items from `props.items`
> - Behavioral Change: tests no longer expose or verify `CodeView` received `className` or `options` values via `testState`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1355fc9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->