### PR TITLE
fix(web): let authorized clients scrolling reach settings

### DIFF
--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -3222,6 +3222,7 @@ export function ConnectionsSettings() {
             >
               <ScrollArea
                 scrollFade
+                chainVerticalScroll
                 className="max-h-[22.5rem]"
                 data-testid="authorized-clients-scroll-area"
               >


### PR DESCRIPTION
> [!NOTE]
> 🤖 **GPT-6 on behalf of Oliver**

## ELI5
Scrolling over Authorized clients now lets the Settings page keep moving when the list cannot scroll further.

## Problem
The nested list contains vertical scrolling even when all clients fit.

## Fix
Enable the existing `chainVerticalScroll` option, consistent with other Settings lists. Applies to web and desktop.

## UI Changes
Before: scrolling stops over the list, including when it has no overflow.

https://github.com/user-attachments/assets/df593298-4dc9-4481-9730-ca79c8de12b1

After: scrolling reaches the Settings page when the list fits or reaches either edge. Long lists retain their internal scrolling.



## Validation
Web typecheck and targeted formatting pass. Targeted lint passes with an existing memoization warning at ConnectionsSettings.tsx:2095. Code review found no actionable issues. Browser behavior was not verified.

Made with GPT-6 in the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable `chainVerticalScroll` on authorized-clients `ScrollArea` in `ConnectionsSettings`
> Adds the `chainVerticalScroll` prop to the authorized-clients scroll area in [ConnectionsSettings.tsx](https://github.com/pingdotgg/t3code/pull/10080/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9) so scroll events chain properly. Existing fade behavior, height limit, and rendered client content are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 767c595.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->