### PR TITLE
fix(server): recognize Tailscale Serve in auth policy

### DIFF
--- a/apps/server/src/auth/EnvironmentAuthPolicy.test.ts
+++ b/apps/server/src/auth/EnvironmentAuthPolicy.test.ts
@@ -139,6 +139,26 @@ it.layer(NodeServices.layer)("EnvironmentAuthPolicy.layer", (it) => {
     ),
   );
 
+  it.effect(
+    "uses remote-reachable policy for loopback web hosts when tailscale-serve is enabled",
+    () =>
+      Effect.gen(function* () {
+        const policy = yield* EnvironmentAuthPolicy.EnvironmentAuthPolicy;
+        const descriptor = yield* policy.getDescriptor();
+
+        expect(descriptor.policy).toBe("remote-reachable");
+        expect(descriptor.bootstrapMethods).toEqual(["one-time-token"]);
+      }).pipe(
+        Effect.provide(
+          makeEnvironmentAuthPolicyLayer({
+            mode: "web",
+            host: "127.0.0.1",
+            tailscaleServeEnabled: true,
+          }),
+        ),
+      ),
+  );
+
   it.effect("uses remote-reachable policy for non-loopback web hosts", () =>
     Effect.gen(function* () {
       const policy = yield* EnvironmentAuthPolicy.EnvironmentAuthPolicy;

--- a/apps/server/src/auth/EnvironmentAuthPolicy.test.ts
+++ b/apps/server/src/auth/EnvironmentAuthPolicy.test.ts
@@ -83,24 +83,27 @@ it.layer(NodeServices.layer)("EnvironmentAuthPolicy.layer", (it) => {
     ),
   );
 
-  it.effect("uses loopback-browser policy for loopback web hosts", () =>
-    Effect.gen(function* () {
-      const policy = yield* EnvironmentAuthPolicy.EnvironmentAuthPolicy;
-      const descriptor = yield* policy.getDescriptor();
+  for (const host of ["127.0.0.1", "::1"]) {
+    it.effect(`uses loopback-browser policy for web host ${host} without Serve`, () =>
+      Effect.gen(function* () {
+        const policy = yield* EnvironmentAuthPolicy.EnvironmentAuthPolicy;
+        const descriptor = yield* policy.getDescriptor();
 
-      expect(descriptor.policy).toBe("loopback-browser");
-      expect(descriptor.bootstrapMethods).toEqual(["one-time-token"]);
-      expect(descriptor.sessionCookieName).toMatch(/^t3_session_3773_[a-f0-9]{12}$/);
-    }).pipe(
-      Effect.provide(
-        makeEnvironmentAuthPolicyLayer({
-          mode: "web",
-          host: "127.0.0.1",
-          port: 3773,
-        }),
+        expect(descriptor.policy).toBe("loopback-browser");
+        expect(descriptor.bootstrapMethods).toEqual(["one-time-token"]);
+        expect(descriptor.sessionCookieName).toMatch(/^t3_session_3773_[a-f0-9]{12}$/);
+      }).pipe(
+        Effect.provide(
+          makeEnvironmentAuthPolicyLayer({
+            mode: "web",
+            host,
+            port: 3773,
+            tailscaleServeEnabled: false,
+          }),
+        ),
       ),
-    ),
-  );
+    );
+  }
 
   it.effect("uses remote-reachable policy for wildcard web hosts", () =>
     Effect.gen(function* () {
@@ -139,9 +142,8 @@ it.layer(NodeServices.layer)("EnvironmentAuthPolicy.layer", (it) => {
     ),
   );
 
-  it.effect(
-    "uses remote-reachable policy for loopback web hosts when tailscale-serve is enabled",
-    () =>
+  for (const host of ["127.0.0.1", "::1"]) {
+    it.effect(`uses remote-reachable policy for web host ${host} with Serve enabled`, () =>
       Effect.gen(function* () {
         const policy = yield* EnvironmentAuthPolicy.EnvironmentAuthPolicy;
         const descriptor = yield* policy.getDescriptor();
@@ -152,12 +154,59 @@ it.layer(NodeServices.layer)("EnvironmentAuthPolicy.layer", (it) => {
         Effect.provide(
           makeEnvironmentAuthPolicyLayer({
             mode: "web",
-            host: "127.0.0.1",
+            host,
             tailscaleServeEnabled: true,
           }),
         ),
       ),
-  );
+    );
+  }
+
+  for (const mode of ["web", "desktop"] as const) {
+    it.effect(`preserves ${mode} session descriptors when Serve is enabled and disabled`, () =>
+      Effect.gen(function* () {
+        const config = yield* ServerConfig.ServerConfig;
+        const descriptorForServe = (tailscaleServeEnabled: boolean) =>
+          EnvironmentAuthPolicy.make.pipe(
+            Effect.provideService(ServerConfig.ServerConfig, {
+              ...config,
+              mode,
+              host: "127.0.0.1",
+              port: 3773,
+              tailscaleServeEnabled,
+            }),
+            Effect.flatMap((policy) => policy.getDescriptor()),
+          );
+        const disabled = yield* descriptorForServe(false);
+        const enabled = yield* descriptorForServe(true);
+        const disabledAgain = yield* descriptorForServe(false);
+
+        expect(enabled).toEqual({
+          ...disabled,
+          policy: "remote-reachable",
+          bootstrapMethods:
+            mode === "desktop" ? ["desktop-bootstrap", "one-time-token"] : ["one-time-token"],
+        });
+        expect(enabled.sessionMethods).toEqual([
+          "browser-session-cookie",
+          "bearer-access-token",
+          "dpop-access-token",
+        ]);
+        expect(disabledAgain).toEqual(disabled);
+        expect(disabled.policy).toBe(
+          mode === "desktop" ? "desktop-managed-local" : "loopback-browser",
+        );
+      }).pipe(
+        Effect.provide(
+          ServerEnvironment.identityLayer.pipe(
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), { prefix: "t3-auth-serve-policy-" }),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 
   it.effect("uses remote-reachable policy for non-loopback web hosts", () =>
     Effect.gen(function* () {

--- a/apps/server/src/auth/EnvironmentAuthPolicy.ts
+++ b/apps/server/src/auth/EnvironmentAuthPolicy.ts
@@ -17,8 +17,7 @@ export class EnvironmentAuthPolicy extends Context.Service<
 export const make = Effect.gen(function* () {
   const config = yield* ServerConfig.ServerConfig;
   const serverEnvironment = yield* ServerEnvironment.ServerEnvironmentIdentity;
-  const isRemoteReachable =
-    config.tailscaleServeEnabled || isRemoteReachableHost(config.host);
+  const isRemoteReachable = config.tailscaleServeEnabled || isRemoteReachableHost(config.host);
 
   const policy =
     config.mode === "desktop"

--- a/apps/server/src/auth/EnvironmentAuthPolicy.ts
+++ b/apps/server/src/auth/EnvironmentAuthPolicy.ts
@@ -17,7 +17,8 @@ export class EnvironmentAuthPolicy extends Context.Service<
 export const make = Effect.gen(function* () {
   const config = yield* ServerConfig.ServerConfig;
   const serverEnvironment = yield* ServerEnvironment.ServerEnvironmentIdentity;
-  const isRemoteReachable = isRemoteReachableHost(config.host);
+  const isRemoteReachable =
+    config.tailscaleServeEnabled || isRemoteReachableHost(config.host);
 
   const policy =
     config.mode === "desktop"


### PR DESCRIPTION
Closes #4462.

Tailscale Serve can expose a loopback-bound server, but its auth descriptor still says `loopback-browser`. The ordinary web Connections settings use that policy to decide whether remote client management is available.

Include the existing `tailscaleServeEnabled` flag in the host classification. Listener binding, credential validation, grant scopes, session methods and cookie naming remain unchanged. Desktop keeps `desktop-bootstrap` and advertises `one-time-token` alongside it when configured for Serve.

Closes [#4462](https://github.com/pingdotgg/t3code/issues/4462). This ports the clean first commit [e703892](https://github.com/pingdotgg/t3code/commit/e703892dd4e4112fc169a2efa2de6a97e1972bf6) from [#4509](https://github.com/pingdotgg/t3code/pull/4509), retaining psalmsdove's original author identity. The original PR also contains an unrelated Claude permission change, which is excluded. Neither original PR nor its author's branch is modified.

## Human decision required

Keep this unmerged until the intended-reachability and bootstrap classification is approved. The contract describes intended access, not transport health. If Serve setup fails, the configured flag still causes this descriptor to advertise remote intent. This does not introduce a liveness probe or claim that Serve setup succeeded, and does not close the issue automatically.

## Before and after evidence

Actual production `EnvironmentAuthPolicy`, configuration, environment identity and Node services reproduce the underlying descriptor failure on main [09aac715](https://github.com/pingdotgg/t3code/commit/09aac71563c66a4f65f6fbe701aa9596cb677767), committed September 5, 2026 at 09:22:30 UTC. No Tailscale process or mocked policy result is involved.

| Control | Main | Candidate |
| --- | --- | --- |
| Web loopback `127.0.0.1` or `::1`, Serve enabled | `loopback-browser` | `remote-reachable` |
| Same web identity, Serve disabled → enabled → disabled | Enabled descriptor incorrectly remains local | Remote while configured; cookie/session methods unchanged; disabling returns the original descriptor |
| Same desktop identity, Serve disabled → enabled → disabled | Enabled descriptor remains desktop-local | Remote while configured; desktop bootstrap retained with one-time token; cookie/session methods unchanged; disabling returns the original descriptor |

The permanent policy suite fails four controls and passes eight with the exact main production expression. It passes all twelve with this change. The sequential configuration cases construct actual policy services with the same disposable identity; they test descriptors, not a live server restart or browser session migration.

On [ce943bd6](https://github.com/pingdotgg/t3code/commit/ce943bd60a2e6ff34cae4a430b90c6236d9a9007):

- All 30 focused policy/auth/helper tests pass, including Serve off, ordinary loopback, wildcard, LAN, desktop bootstrap and cookie isolation. An independent orchestrator run also passes all 30.
- Server typecheck, scoped lint, formatting and whitespace checks pass.
- All descriptor consumers were checked. HTTP session state and WebSocket config retain the existing schema; web access management still requires its existing access scope. Native desktop endpoint discovery and provider behavior are unchanged.

```sh
cd apps/server
vp test run --maxWorkers 1 src/auth/EnvironmentAuthPolicy.test.ts src/auth/EnvironmentAuth.test.ts src/auth/utils.test.ts
```

No UI component changes, so the evidence is the production descriptor before/after control rather than screenshots. Original NixOS, remote HTTPS, Tailscale setup, endpoint advertisement and native desktop flows were not exercised. The IPv6 test proves classification only; existing Serve forwarding still targets `127.0.0.1`, so it does not validate an IPv6-only listener through Serve.

At September 5, 2026, 09:57 UTC, all executed CI jobs and Macroscope correctness/service-convention checks pass on this head. Macroscope Approvability is neutral, with eligibility explicitly withheld for the auth/reachability/bootstrap decision above. No current-head Cursor or CodeRabbit review result is present. There are no unresolved review threads or active review requests, but the human hold remains; this is not an all-green or merge-ready verdict.

GPT 6 Astra via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Recognize Tailscale Serve flag as remote-reachable in `EnvironmentAuthPolicy`
> - `EnvironmentAuthPolicy.make` now treats an enabled Tailscale Serve configuration as sufficient for remote reachability, in addition to the existing host-based check
> - When Serve is enabled on a loopback host, the policy switches to remote-reachable and desktop configs gain the one-time-token bootstrap alongside the existing desktop bootstrap
> - Tests in [EnvironmentAuthPolicy.test.ts](https://github.com/pingdotgg/t3code/pull/10083/files#diff-810ae635809965b98acb0c57073d684bc6450edd080650df9b18258d64cc3ff1) cover IPv4/IPv6 loopback with and without Serve, plus toggle behavior for web and desktop session descriptors
> - Behavioral Change: toggling Serve off restores the original descriptor; toggling on changes only policy and desktop bootstrap fields while preserving session methods
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce943bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->