### PR TITLE
fix(server): keep Homebrew mise shims manual-only

### DIFF
--- a/apps/server/src/provider/Drivers/CodexDriver.test.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.test.ts
@@ -8,7 +8,10 @@ import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
 import { HttpClient } from "effect/unstable/http";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
 import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
@@ -17,6 +20,11 @@ import { ServerSettingsService } from "../../serverSettings.ts";
 import { layerTest as codexResetCreditLayerTest } from "../Layers/codexResetCredit.ts";
 import { NoOpProviderEventLoggers, ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
 import * as ModelManifest from "../ModelManifest.ts";
+import {
+  createProviderVersionAdvisory,
+  ProviderVersionCache,
+  resolveLatestProviderVersion,
+} from "../providerMaintenance.ts";
 import { CodexDriver } from "./CodexDriver.ts";
 
 const testLayer = ServerConfig.layerTest(process.cwd(), {
@@ -218,4 +226,147 @@ it.layer(testLayer)("CodexDriver", (it) => {
       ),
     );
   }
+
+  it.effect.each([
+    {
+      name: "conventional shim",
+      dataRoot: "mise",
+      commandName: "codex",
+      version: "0.153.4",
+      nodeFirst: false,
+    },
+    {
+      name: "custom data directory",
+      dataRoot: "custom-tool-data",
+      commandName: "codex",
+      version: "0.153.4",
+      nodeFirst: false,
+    },
+    {
+      name: "renamed configured command",
+      dataRoot: "mise",
+      commandName: "custom-codex",
+      version: "0.153.4",
+      nodeFirst: false,
+    },
+    {
+      name: "outdated provider",
+      dataRoot: "mise",
+      commandName: "codex",
+      version: "0.153.3",
+      nodeFirst: false,
+    },
+    {
+      name: "npm before shim",
+      dataRoot: "mise",
+      commandName: "codex",
+      version: "0.153.4",
+      nodeFirst: true,
+    },
+  ])(
+    "does not mistake Homebrew mise for Codex's installer: $name",
+    (fixture) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-codex-mise-shim-" });
+        const brewPrefix = NodePath.join(tempDir, "homebrew");
+        const brewPath = NodePath.join(brewPrefix, "bin", "brew");
+        const misePath = NodePath.join(brewPrefix, "Cellar", "mise", "2026.9.1", "bin", "mise");
+        const shimDir = NodePath.join(tempDir, fixture.dataRoot, "shims");
+        const npmPrefix = NodePath.join(tempDir, "mise", "installs", "node", "24.13.0");
+        const npmBin = NodePath.join(npmPrefix, "bin");
+        const npmEntry = NodePath.join(
+          npmPrefix,
+          "lib",
+          "node_modules",
+          "@openai",
+          "codex",
+          "bin",
+          "codex.js",
+        );
+        for (const file of [brewPath, misePath, npmEntry]) {
+          yield* fs.makeDirectory(NodePath.dirname(file), { recursive: true });
+          yield* fs.writeFileString(file, "#!/bin/sh\n");
+          yield* fs.chmod(file, 0o755);
+        }
+        yield* fs.makeDirectory(shimDir, { recursive: true });
+        yield* fs.makeDirectory(npmBin, { recursive: true });
+        yield* fs.symlink(misePath, NodePath.join(shimDir, fixture.commandName));
+        yield* fs.symlink(npmEntry, NodePath.join(npmBin, fixture.commandName));
+        const lookupPath = [
+          ...(fixture.nodeFirst ? [npmBin, shimDir] : [shimDir, npmBin]),
+          NodePath.dirname(brewPath),
+        ].join(NodePath.delimiter);
+        const probes: Array<ReadonlyArray<string>> = [];
+        const metadataSpawner = ChildProcessSpawner.make((command) => {
+          if (!ChildProcess.isStandardCommand(command) || command.command !== brewPath) {
+            return Effect.die("Provider resolution must not execute a provider or updater");
+          }
+          probes.push(command.args);
+          const stdout =
+            command.args[0] === "--prefix"
+              ? brewPrefix
+              : JSON.stringify({ formulae: [{ versions: { stable: "2026.9.1" } }] });
+          return Effect.succeed(
+            ChildProcessSpawner.makeHandle({
+              pid: ChildProcessSpawner.ProcessId(1),
+              exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+              isRunning: Effect.succeed(false),
+              kill: () => Effect.void,
+              unref: Effect.succeed(Effect.void),
+              stdin: Sink.drain,
+              stdout: Stream.encodeText(Stream.make(stdout)),
+              stderr: Stream.empty,
+              all: Stream.empty,
+              getInputFd: () => Sink.drain,
+              getOutputFd: () => Stream.empty,
+            }),
+          );
+        });
+        const instance = yield* CodexDriver.create({
+          instanceId: ProviderInstanceId.make("codex-mise-shim"),
+          displayName: "Codex shim test",
+          enabled: false,
+          environment: [{ name: "PATH", value: lookupPath, sensitive: false }],
+          config: {
+            ...CodexDriver.defaultConfig(),
+            binaryPath: fixture.commandName,
+            homePath: NodePath.join(tempDir, "codex-home"),
+          },
+        }).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, metadataSpawner));
+        const capabilities = yield* instance.snapshot.resolveMaintenance();
+        const latestVersion = yield* resolveLatestProviderVersion(capabilities).pipe(
+          Effect.provideService(
+            ProviderVersionCache,
+            new Map([
+              ["@openai/codex", { expiresAt: Number.MAX_SAFE_INTEGER, version: "0.153.4" }],
+            ]),
+          ),
+        );
+        expect(probes).toEqual([]);
+        expect(latestVersion).toBe("0.153.4");
+        expect(
+          createProviderVersionAdvisory({
+            driver: CodexDriver.driverKind,
+            currentVersion: fixture.version,
+            latestVersion,
+            maintenanceCapabilities: capabilities,
+          }),
+        ).toMatchObject({
+          status: fixture.version === "0.153.4" ? "current" : "behind_latest",
+          currentVersion: fixture.version,
+          latestVersion: "0.153.4",
+          canUpdate: fixture.nodeFirst,
+        });
+        if (fixture.nodeFirst) {
+          expect(capabilities.update).toMatchObject({
+            executable: "npm",
+            args: expect.arrayContaining(["--prefix", npmPrefix, "@openai/codex@latest"]),
+          });
+        } else {
+          expect(capabilities.update).toBeNull();
+        }
+      }).pipe(Effect.scoped),
+    { skip: windowsHost },
+  );
 });

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -595,25 +595,29 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       }),
   );
 
-  it.effect.skipIf(!symlinksSupported)(
-    "upgrades the Homebrew cask that owns the binary and compares against its version",
-    () =>
+  it.effect.each([
+    { directory: "Caskroom", name: "package-tool", kind: "cask" },
+    { directory: "Cellar", name: "package-tool", kind: "formula" },
+    { directory: "Cellar", name: "package-tool@latest", kind: "formula" },
+  ] as const)(
+    "upgrades the owning Homebrew $kind $name through an executable alias",
+    (fixture) =>
       Effect.gen(function* () {
         const tempDir = yield* makeTempDir("t3-homebrew-capabilities");
         const brewBinDir = NodePath.join(tempDir, "brew-bin");
         const brewPath = NodePath.join(brewBinDir, "brew");
         writeExecutable(brewPath);
-        const caskBinary = NodePath.join(
+        const ownedBinary = NodePath.join(
           tempDir,
-          "Caskroom",
-          "package-tool",
+          fixture.directory,
+          fixture.name,
           "0.148.0",
-          "package-tool",
+          "package-tool-0.148.0",
         );
-        writeExecutable(caskBinary);
-        const link = NodePath.join(tempDir, "bin", "package-tool");
+        writeExecutable(ownedBinary);
+        const link = NodePath.join(tempDir, "bin", "custom-package-tool");
         NodeFS.mkdirSync(NodePath.dirname(link), { recursive: true });
-        NodeFS.symlinkSync(caskBinary, link);
+        NodeFS.symlinkSync(ownedBinary, link);
         const spawned: Array<ReadonlyArray<string>> = [];
 
         const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
@@ -630,27 +634,38 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
               spawned.push([command, ...args]);
               return args[0] === "--prefix"
                 ? `${tempDir}\n`
-                : JSON.stringify({ casks: [{ version: "0.148.0,42" }] });
+                : JSON.stringify(
+                    fixture.kind === "cask"
+                      ? { casks: [{ version: "0.148.0,42" }] }
+                      : { formulae: [{ versions: { stable: "0.148.0" } }] },
+                  );
             }),
           ),
         );
 
         expect(spawned).toEqual([
           [brewPath, "--prefix"],
-          [brewPath, "info", "--json=v2", "package-tool"],
+          [brewPath, "info", "--json=v2", fixture.name],
         ]);
         expect(capabilities).toEqual({
           provider: driver("packageTool"),
           packageName: "@example/package-tool",
           latestVersion: "0.148.0",
           update: {
-            command: "brew upgrade --cask package-tool",
+            command:
+              fixture.kind === "cask"
+                ? `brew upgrade --cask ${fixture.name}`
+                : `brew upgrade ${fixture.name}`,
             executable: brewPath,
-            args: ["upgrade", "--cask", "package-tool"],
+            args:
+              fixture.kind === "cask"
+                ? ["upgrade", "--cask", fixture.name]
+                : ["upgrade", fixture.name],
             lockKey: "homebrew",
           },
         });
       }),
+    { skip: !symlinksSupported },
   );
 
   it.effect.skipIf(windowsHost)(

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -432,6 +432,10 @@ export const resolvePackageManagedProviderMaintenance = Effect.fn(
 
   const homebrew = homebrewOwnershipFromCommandPath(context.realCommandPath);
   if (homebrew) {
+    // Mise shims resolve to the version manager, not the provider.
+    if (homebrew.kind === "formula" && homebrew.name.toLowerCase() === "mise") {
+      return manual;
+    }
     const brewPath = yield* resolveCommandPath("brew", { env: context.env }).pipe(
       Effect.catchTags({ CommandResolutionError: () => Effect.succeed(null) }),
     );


### PR DESCRIPTION
Mise shims can resolve to Homebrew's mise executable. T3 then mistakes the version manager for the provider's installer, offers `brew upgrade mise`, and compares Codex against mise's version.

Return the existing manual-only capabilities for the known Homebrew `mise` formula before any Homebrew lookup or probe. The earlier native and package-manager ownership proofs remain unchanged. This also keeps mise's release number out of the provider's latest-version advisory.

Related [#10050](https://github.com/pingdotgg/t3code/issues/10050) and [#8051](https://github.com/pingdotgg/t3code/issues/8051). This does not implement automatic mise updates or replace [#9225](https://github.com/pingdotgg/t3code/pull/9225).

## Before and after

Reproduced using the actual `CodexDriver`, real owned Linux executable files, symlinks and PATH resolution, plus synthetic Homebrew metadata. Provider HTTP calls were disabled and the npm version cache was seeded. No provider, mise, Homebrew or updater process ran.

Baseline [09aac7156](https://github.com/pingdotgg/t3code/commit/09aac71563c66a4f65f6fbe701aa9596cb677767), September 5, 2026 at 09:22:30 UTC, was still latest `origin/main` at the final pre-push fetch. The two tracked test files produced 4 failures and 35 passes before the guard, then 39 passes at [eb8354d46](https://github.com/pingdotgg/t3code/commit/eb8354d46390572a108adb31d44835fd7d20724a).

| Fixture | Before | After |
| --- | --- | --- |
| Conventional or custom-data-root shim to `Cellar/mise/2026.9.1/bin/mise` | `brew upgrade mise`, latest `2026.9.1`, false outdated advisory | Manual-only, cached Codex latest `0.153.4`, current advisory, no Homebrew probes |
| Renamed configured shim command | Same wrong Homebrew owner | Same manual-only result |
| Installed Codex `0.153.3`, latest `0.153.4` | Compared against mise's release | Still outdated, but manual-only |
| npm global under mise-managed Node, Node bin first | npm update at the owning prefix | Unchanged |
| Genuine Homebrew formula, versioned formula, or cask through an executable alias | Correct owner and installer version | Unchanged |

Versions above are fixture data. Existing native, ordinary npm and direct mise controls also pass. The five original diagnostic cases passed against the final formatted candidate, for 44 tests including the 39 tracked tests. An independent review reran all 39 tracked tests successfully.

## Verification and limits

From `apps/server` in a normally installed worktree:

```sh
vp test run src/provider/Drivers/CodexDriver.test.ts src/provider/providerMaintenance.test.ts --maxWorkers=2
```

Scoped lint, formatting and server typechecking pass. Local verification reused existing dependencies with private aliases to this worktree's current contracts/shared sources. No production configuration or dependency changed.

This is resolver/advisory proof, not native macOS desktop reproduction or an Update-button test. Claude and OpenCode share the resolver but were source-inspected only. Other managers, native-wrapper precedence, broader Windows cases and the separate stderr-display complaint are outside this fix. There is no client layout change, so screenshots are not applicable. No issue is automatically closed.

GPT 6 Astra via Codex in T3 Code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return manual-only maintenance for Homebrew `mise` shim paths in `resolvePackageManagedProviderMaintenance`
> - Adds an early return in [providerMaintenance.ts](https://github.com/pingdotgg/t3code/pull/10085/files#diff-e29fae218a488cafd27faaeea37f0b7c1dccd03ba4a994975736ddf89e3bde14) when the resolved real executable path belongs to the Homebrew formula named `mise`, before brew-based resolution runs.
> - Expands the Homebrew ownership test in [providerMaintenance.test.ts](https://github.com/pingdotgg/t3code/pull/10085/files#diff-40e44f8465f8c4e465f1d73d81229b1ff72980f8fa6e6711363d9ef9c1fb54ad) to cover casks, standard formulas, and versioned formulas via a parameterized fixture.
> - Adds a parameterized test in [CodexDriver.test.ts](https://github.com/pingdotgg/t3code/pull/10085/files#diff-5baf678b95e3ba8c59ea9ee8ec4fd22d9300615a985c9e58d67f09311813c59d) verifying that a Codex path through a Homebrew mise shim stays manual-only while an npm-installed path still uses the npm updater.
> - Behavioral Change: executables whose real path is owned by the Homebrew `mise` formula now get manual-only capabilities instead of being treated as a Homebrew installation of the provider.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb8354d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->