### PR TITLE
fix(web): prevent sidebar tooltip title clipping

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -326,7 +326,7 @@ function SidebarThreadTooltip({
       className="max-w-80 text-left whitespace-normal [&_[data-slot=tooltip-viewport]]:p-0"
     >
       <div className="flex min-w-0 max-w-80 flex-col gap-2 p-[var(--floating-content-inset)]">
-        <div className="min-w-0 truncate text-xs leading-none font-medium text-foreground">
+        <div className="min-w-0 truncate text-xs leading-tight font-medium text-foreground">
           {thread.title}
         </div>
         <div className="grid gap-1.5 pl-0.5 text-xs text-muted-foreground">


### PR DESCRIPTION
## What Changed

Adjusted the sidebar thread tooltip title from `leading-none` to `leading-tight` so glyph descenders render fully.

## Why

The previous line height clipped the lower portion of title text such as `g` in the hover card.

## UI Changes

Before:
<img width="487" height="201" alt="image" src="https://github.com/user-attachments/assets/fc38eb2c-d9be-43a0-ba12-814d9c9e0993" />

After:
<img width="472" height="175" alt="image" src="https://github.com/user-attachments/assets/ae54fad7-cc43-466a-9d0e-9abdce79e615" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

## Testing

- vp run --filter @t3tools/web typecheck

Model: GPT-5.6 Terra
Harness: Codex