### PR TITLE
fix(server): retain bounded runtime diagnostic details

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3245,6 +3245,151 @@ describe("ProviderRuntimeIngestion", () => {
     expect(activityPayload?.message).toBe("runtime activity exploded");
   });
 
+  it.each(
+    (["runtime.error", "runtime.warning"] as const).flatMap((type) =>
+      [
+        {
+          fixture: "reported",
+          message:
+            "2026-03-14T16:11:12.550224Z ERROR codex_core::codex: failed to load skill /home/sebherrerabe/repos/devsuite/.agent/skills/monorepo-scaffolding/SKILL.md: invalid YAML: mapping values are not allowed in this context at line 2 column 50",
+        },
+        {
+          fixture: "fictional",
+          message:
+            "2026-09-05T09:00:00.000000Z ERROR codex_core::codex: failed to load skill /workspace/example/.agent/skills/application-project-scaffolding/SKILL.md: invalid YAML: mapping values are not allowed in this context at line 2 column 50",
+        },
+      ].map((fixture) => ({ type, ...fixture })),
+    ),
+  )(
+    "retains the $fixture malformed-skill diagnostic tail in $type work-log detail",
+    async ({ type, message }) => {
+      const harness = await createHarness();
+      await harness.emitAndDrain([
+        {
+          type,
+          eventId: asEventId("malformed-skill-diagnostic"),
+          provider: ProviderDriverKind.make("codex"),
+          createdAt: "2026-01-01T00:00:01.000Z",
+          threadId: asThreadId("thread-1"),
+          turnId: asTurnId("turn-1"),
+          payload: { message },
+        },
+      ]);
+
+      const thread = (await harness.readModel()).threads[0];
+      const activity = thread?.activities.find(
+        (entry) => entry.id === "malformed-skill-diagnostic",
+      );
+      expect(activity?.payload).toEqual({
+        message: message.slice(0, 177) + "...",
+        detail: message,
+      });
+      expect(activity?.summary).toBe(
+        type === "runtime.error" ? "Runtime error" : message.slice(0, 117) + "...",
+      );
+      expect(thread?.session?.lastError).toBe(type === "runtime.error" ? message : null);
+    },
+  );
+
+  it.each(
+    (["runtime.error", "runtime.warning"] as const).flatMap((type) =>
+      [
+        { name: "compact boundary", message: "a".repeat(180), detail: undefined },
+        { name: "first expanded character", message: "a".repeat(181), detail: "a".repeat(181) },
+        { name: "detail boundary", message: "a".repeat(2_048), detail: "a".repeat(2_048) },
+        {
+          name: "oversized message",
+          message: "a".repeat(2_049),
+          detail: "a".repeat(2_045) + "...",
+        },
+        {
+          name: "multiline Unicode",
+          message: "診断エラー 🐛\n".repeat(30) + "at line 2 column 50",
+          detail: "診断エラー 🐛\n".repeat(30) + "at line 2 column 50",
+        },
+      ].map((testCase) => ({ type, ...testCase })),
+    ),
+  )(
+    "bounds $name in $type detail without changing compact fields",
+    async ({ type, message, detail }) => {
+      const harness = await createHarness();
+      await harness.emitAndDrain([
+        {
+          type,
+          eventId: asEventId("bounded-diagnostic"),
+          provider: ProviderDriverKind.make("codex"),
+          createdAt: "2026-01-01T00:00:01.000Z",
+          threadId: asThreadId("thread-1"),
+          payload: { message },
+        },
+      ]);
+
+      const thread = (await harness.readModel()).threads[0];
+      const activity = thread?.activities.find((entry) => entry.id === "bounded-diagnostic");
+      expect(activity?.payload).toEqual({
+        message: message.length <= 180 ? message : message.slice(0, 177) + "...",
+        ...(detail === undefined ? {} : { detail }),
+      });
+      expect(thread?.session?.lastError).toBe(type === "runtime.error" ? message : null);
+    },
+  );
+
+  it.each(["existing detail", "", null, { latencyMs: 1_500 }, 0, false])(
+    "preserves explicit warning detail %j instead of replacing it with the message",
+    async (detail) => {
+      const harness = await createHarness();
+      const message = "warning ".repeat(300);
+      await harness.emitAndDrain([
+        {
+          type: "runtime.warning",
+          eventId: asEventId("explicit-warning-detail"),
+          provider: ProviderDriverKind.make("codex"),
+          createdAt: "2026-01-01T00:00:01.000Z",
+          threadId: asThreadId("thread-1"),
+          payload: { message, detail },
+        },
+      ]);
+
+      const activity = (await harness.readModel()).threads[0]?.activities.find(
+        (entry) => entry.id === "explicit-warning-detail",
+      );
+      expect(activity?.payload).toEqual({ message: message.slice(0, 177) + "...", detail });
+    },
+  );
+
+  it("does not expand non-runtime details or retain arbitrary runtime error detail", async () => {
+    const harness = await createHarness();
+    const reason = "denied ".repeat(400);
+    const base = {
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:01.000Z",
+      threadId: asThreadId("thread-1"),
+    };
+    await harness.emitAndDrain([
+      {
+        ...base,
+        type: "tool.denied",
+        eventId: asEventId("unchanged-tool-detail"),
+        payload: { toolName: "Read", reason },
+      },
+      {
+        ...base,
+        type: "runtime.error",
+        eventId: asEventId("short-runtime-error"),
+        payload: { message: "Short error", detail: { nativePayload: "not retained" } },
+      },
+    ]);
+
+    const activities = (await harness.readModel()).threads[0]?.activities;
+    expect(activities?.find((entry) => entry.id === "unchanged-tool-detail")?.payload).toEqual({
+      toolName: "Read",
+      detail: reason.slice(0, 177) + "...",
+    });
+    expect(activities?.find((entry) => entry.id === "short-runtime-error")?.payload).toEqual({
+      message: "Short error",
+    });
+  });
+
   it("keeps the session running when a runtime.warning arrives during an active turn", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -218,6 +218,8 @@ function truncateDetail(value: string, limit = 180): string {
   return value.length > limit ? `${value.slice(0, limit - 3)}...` : value;
 }
 
+const RUNTIME_DIAGNOSTIC_DETAIL_LIMIT = 2_048;
+
 function normalizeProposedPlanMarkdown(planMarkdown: string | undefined): string | undefined {
   const trimmed = planMarkdown?.trim();
   if (!trimmed) {
@@ -481,6 +483,9 @@ export function runtimeEventToActivities(
           summary: "Runtime error",
           payload: {
             message: truncateDetail(event.payload.message),
+            ...(event.payload.message.length > 180
+              ? { detail: truncateDetail(event.payload.message, RUNTIME_DIAGNOSTIC_DETAIL_LIMIT) }
+              : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,
@@ -520,7 +525,13 @@ export function runtimeEventToActivities(
           summary: truncateDetail(event.payload.message, 120),
           payload: {
             message: truncateDetail(event.payload.message),
-            ...(event.payload.detail !== undefined ? { detail: event.payload.detail } : {}),
+            ...(event.payload.detail !== undefined
+              ? { detail: event.payload.detail }
+              : event.payload.message.length > 180
+                ? {
+                    detail: truncateDetail(event.payload.message, RUNTIME_DIAGNOSTIC_DETAIL_LIMIT),
+                  }
+                : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -93,6 +93,9 @@ const decodeTransferShellSnapshot = Schema.decodeUnknownEffect(
   Schema.fromJsonString(OrchestrationShellSnapshot),
 );
 const encodeTestJson = Schema.encodeUnknownSync(Schema.fromJsonString(Schema.Unknown));
+const decodeRuntimeDiagnosticPayload = Schema.decodeUnknownSync(
+  Schema.Struct({ message: Schema.String, detail: Schema.optional(Schema.String) }),
+);
 
 import * as BackgroundPolicy from "./background/BackgroundPolicy.ts";
 import * as ServerConfig from "./config.ts";
@@ -11097,6 +11100,172 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 });
+
+it.live(
+  "measures a 500-row runtime diagnostic window over HTTP and WebSocket",
+  () =>
+    Effect.gen(function* () {
+      const provider = ProviderDriverKind.make("codex");
+      const reportedMessage =
+        "2026-03-14T16:11:12.550224Z ERROR codex_core::codex: failed to load skill /home/sebherrerabe/repos/devsuite/.agent/skills/monorepo-scaffolding/SKILL.md: invalid YAML: mapping values are not allowed in this context at line 2 column 50";
+      const variants = [
+        { name: "reported-233", message: () => reportedMessage },
+        { name: "saturated-repeated", message: () => "diagnostic ".repeat(300) },
+        {
+          name: "saturated-varied",
+          message: (row: number) =>
+            Array.from({ length: 80 }, (_, block) =>
+              NodeCrypto.createHash("sha256").update(`${row}:${block}`).digest("base64"),
+            ).join(""),
+        },
+        {
+          name: "saturated-json-escapes",
+          message: (row: number) =>
+            `diagnostic ${row}: ` +
+            Array.from({ length: 3_072 }, (_, index) =>
+              String.fromCharCode((row + index) % 8),
+            ).join(""),
+        },
+      ];
+      const results = yield* Effect.forEach(
+        variants,
+        (variant) =>
+          Effect.acquireUseRelease(
+            makeOrchestrationIntegrationHarness({ provider }),
+            (harness) =>
+              Effect.scoped(
+                Effect.gen(function* () {
+                  assert.isNotNull(harness.adapterHarness);
+                  const adapter = harness.adapterHarness!;
+                  const modelSelection = transferModelSelection(provider);
+                  const projectId = ProjectId.make("runtime-diagnostic-project");
+                  const createdAt = "2026-06-01T00:00:00.000Z";
+                  yield* harness.engine.dispatch({
+                    type: "project.create",
+                    commandId: CommandId.make("diagnostics-project"),
+                    projectId,
+                    title: "Runtime diagnostics",
+                    workspaceRoot: harness.workspaceDir,
+                    defaultModelSelection: modelSelection,
+                    createdAt,
+                  });
+                  yield* harness.engine.dispatch({
+                    type: "thread.create",
+                    commandId: CommandId.make("diagnostics-thread"),
+                    threadId: TRANSFER_THREAD_ID,
+                    projectId,
+                    title: "Runtime diagnostics",
+                    modelSelection,
+                    runtimeMode: "approval-required",
+                    interactionMode: "default",
+                    branch: "main",
+                    worktreePath: harness.workspaceDir,
+                    createdAt,
+                  });
+                  yield* harness.providerService.startSession(TRANSFER_THREAD_ID, {
+                    threadId: TRANSFER_THREAD_ID,
+                    provider,
+                    providerInstanceId: modelSelection.instanceId,
+                    modelSelection,
+                    runtimeMode: "approval-required",
+                    cwd: harness.workspaceDir,
+                  });
+                  yield* adapter.queueTurnResponse(TRANSFER_THREAD_ID, {
+                    events: Array.from({ length: 500 }, (_, row) => ({
+                      type: "runtime.warning",
+                      eventId: EventId.make(`diagnostic-${row}`),
+                      provider,
+                      threadId: TRANSFER_THREAD_ID,
+                      createdAt,
+                      payload: { message: variant.message(row) },
+                    })),
+                  });
+                  yield* buildAppUnderTest({
+                    layers: {
+                      orchestrationEngine: harness.engine,
+                      projectionSnapshotQuery: harness.snapshotQuery,
+                    },
+                  });
+                  const baseUrl = yield* getHttpServerUrl();
+                  const cookie = yield* getAuthenticatedSessionCookieHeader();
+                  const wsUrl = baseUrl.replace(/^http:/, "ws:") + "/ws";
+                  const client = yield* openMeasuredWsClient({ url: wsUrl, cookie });
+                  assert.include(client.recorder.negotiatedExtensions(), "permessage-deflate");
+                  const items = yield* subscribeThreadItems(
+                    client,
+                    yield* harness.engine.latestSequence,
+                  );
+                  yield* awaitSubscriptionSynchronized(items, "diagnostic subscription ready");
+                  const start = client.recorder.totals();
+                  yield* harness.providerService.sendTurn({
+                    threadId: TRANSFER_THREAD_ID,
+                    input: "Replay the owned diagnostic fixture.",
+                    modelSelection,
+                  });
+
+                  const delivered: OrchestrationThreadActivity[] = [];
+                  while (delivered.length < 500) {
+                    const item = yield* Queue.take(items);
+                    if (
+                      item.kind === "event" &&
+                      item.event.type === "thread.activity-appended" &&
+                      item.event.payload.activity.kind === "runtime.warning"
+                    ) {
+                      delivered.push(item.event.payload.activity);
+                    }
+                  }
+                  yield* harness.drainProviderRuntime;
+                  const webSocket = transferDelta(start, client.recorder.totals());
+                  const response = yield* measureHttpGet({
+                    url: `${baseUrl}/api/orchestration/threads/${TRANSFER_THREAD_ID}`,
+                    headers: { cookie },
+                  });
+                  assert.equal(response.status, 200);
+                  assert.equal(response.contentEncoding, "gzip");
+                  const snapshot = yield* decodeTransferThreadSnapshot(
+                    Buffer.from(response.decodedBody).toString("utf8"),
+                  );
+                  const activities = snapshot.thread.activities.filter(
+                    (activity) => activity.kind === "runtime.warning",
+                  );
+                  assert.equal(activities.length, 500);
+                  const deliveredById = new Map(
+                    delivered.map((activity) => [activity.id, activity.payload]),
+                  );
+                  for (const activity of activities) {
+                    assert.deepEqual(activity.payload, deliveredById.get(activity.id));
+                  }
+                  const payloads = activities.map((activity) =>
+                    decodeRuntimeDiagnosticPayload(activity.payload),
+                  );
+                  assert.isTrue(payloads.every((payload) => payload.message.length === 180));
+                  assert.isTrue(
+                    payloads.every((payload) => (payload.detail?.length ?? 0) <= 2_048),
+                  );
+                  return {
+                    variant: variant.name,
+                    rows: activities.length,
+                    retainedDetailCharacters: payloads.reduce(
+                      (total, payload) => total + (payload.detail?.length ?? 0),
+                      0,
+                    ),
+                    http: {
+                      jsonBytes: response.decodedBodyBytes,
+                      gzipBytes: response.encodedBodyBytes,
+                      wireBytes: response.wireBytes,
+                    },
+                    webSocket,
+                  };
+                }),
+              ),
+            (harness) => harness.dispose,
+          ).pipe(Effect.provide(NodeHttpServerTestWithWsDeflate)),
+        { concurrency: 1 },
+      );
+      yield* Effect.logInfo(`RUNTIME_DIAGNOSTIC_TRANSFER ${encodeTestJson(results)}`);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  120_000,
+);
 
 it.live(
   "reports thread HTTP and WebSocket transfer budgets",

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -11109,10 +11109,15 @@ it.live(
       const reportedMessage =
         "2026-03-14T16:11:12.550224Z ERROR codex_core::codex: failed to load skill /home/sebherrerabe/repos/devsuite/.agent/skills/monorepo-scaffolding/SKILL.md: invalid YAML: mapping values are not allowed in this context at line 2 column 50";
       const variants = [
-        { name: "reported-233", message: () => reportedMessage },
-        { name: "saturated-repeated", message: () => "diagnostic ".repeat(300) },
+        { name: "reported-233", expectedDetailLength: 233, message: () => reportedMessage },
+        {
+          name: "saturated-repeated",
+          expectedDetailLength: 2_048,
+          message: () => "diagnostic ".repeat(300),
+        },
         {
           name: "saturated-varied",
+          expectedDetailLength: 2_048,
           message: (row: number) =>
             Array.from({ length: 80 }, (_, block) =>
               NodeCrypto.createHash("sha256").update(`${row}:${block}`).digest("base64"),
@@ -11120,6 +11125,7 @@ it.live(
         },
         {
           name: "saturated-json-escapes",
+          expectedDetailLength: 2_048,
           message: (row: number) =>
             `diagnostic ${row}: ` +
             Array.from({ length: 3_072 }, (_, index) =>
@@ -11240,7 +11246,9 @@ it.live(
                   );
                   assert.isTrue(payloads.every((payload) => payload.message.length === 180));
                   assert.isTrue(
-                    payloads.every((payload) => (payload.detail?.length ?? 0) <= 2_048),
+                    payloads.every(
+                      (payload) => payload.detail?.length === variant.expectedDetailLength,
+                    ),
                   );
                   return {
                     variant: variant.name,


### PR DESCRIPTION
Runtime diagnostics can lose their line and column when the durable work-log message is shortened to 180 characters.

Keep that compact message and the existing warning summary. For longer runtime error/warning messages, retain plain-text detail up to 2,048 JavaScript string code units including the truncation marker. Preserve an existing warning detail, banners and session errors unchanged.

### Evidence

- The report's 233-character message and a fictional counterpart fail four receipt-driven SQLite readback assertions on main; all pass with this change.
- All 92 ingestion/projection tests and the strengthened 500-row transport case passed, covering boundaries, Unicode, explicit warning details and unchanged compact fields. Server types and targeted lint passed.
- An inert adapter sends a 500-row window through real production HTTP/gzip and WebSocket/deflate transports. Both client production functions consume the actual resulting activities, including mobile expanded/copy text.
- Independent root runs pass all 92 ingestion/projection tests, the strengthened transport case and 12 both-client checks.
- The matching actual-client captures below replay the exact fictional before/after ingestion records through the unchanged diagnostic renderer. Same viewport, expanded row and scroll position. No native WSL2/provider collection is claimed.

Before:

![Before: the retained diagnostic ends before its line and column](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/2ad10e9fd49ae8da/1084-native-before-visible.png)

After:

![After: the expanded diagnostic retains line 2 column 50](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d3f06bc757000ebf/1084-native-after-visible.png)

### Human decision required

The new retention limit increases transfer size. With 500 varied cap-sized diagnostics, the snapshot grows from 244,276 to 1,274,276 JSON bytes, or 73,616 to 784,783 gzip bytes. Highly escaped text reaches about 7 MB decoded JSON. Confirm the 2,048-code-unit tradeoff before merging.

Related to [#1084](https://github.com/pingdotgg/t3code/issues/1084), which stays open. Text beyond the cap can still lose its tail. Explicit warning details keep their existing precedence and are not newly capped, so this is not a universal payload limit. This does not revive the banner changes proposed by ecatuogno1 in [#1202](https://github.com/pingdotgg/t3code/pull/1202).

Prepared by GPT 6 Astra via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retain bounded runtime diagnostic details in `runtimeEventToActivities`
> - Long runtime error and warning messages now keep a compact `message` field capped at 180 characters plus a derived `detail` field capped at 2,048 characters when no explicit detail is supplied.
> - Explicit warning detail values are preserved unchanged; short runtime messages do not gain a derived detail.
> - Other event branches (e.g. tool-denied) are unchanged.
> - Risk: consumers that previously saw only the truncated compact message now receive an additional `detail` field on long runtime error/warning activities — check any activity readers in `apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts` and downstream transports for unexpected payload growth.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e67db5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->