### PR TITLE
fix(ssh): report remote package installation failures accurately

### DIFF
--- a/packages/ssh/src/runnerProcess.test.ts
+++ b/packages/ssh/src/runnerProcess.test.ts
@@ -165,3 +165,143 @@ if (args.includes("--package")) {
     );
   },
 );
+
+describe.skipIf(HostProcessPlatform.defaultValue() === "win32")(
+  "remote runner install diagnostics",
+  () => {
+    const decodeArguments = Schema.decodeUnknownSync(
+      Schema.fromJsonString(Schema.Array(Schema.String)),
+    );
+    const cases = (["npx", "npm"] as const).flatMap((packageManager) =>
+      (
+        [
+          "etarget",
+          "network",
+          "empty-success",
+          "success",
+          "failed-with-path",
+          "existing-cli",
+          "node-override",
+        ] as const
+      ).map((mode) => ({ packageManager, mode })),
+    );
+
+    it.live.each(cases)("handles $packageManager/$mode", ({ packageManager, mode }) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+        const fixture = yield* fs.makeTempDirectoryScoped({ prefix: "t3-runner-install-" });
+        const bin = path.join(fixture, "bin");
+        const cliPath = path.join(fixture, "installed cli.mjs");
+        const callsPath = path.join(fixture, "installer-calls.jsonl");
+        const packageSpec = "t3@0.0.39-nightly.20260905.1286";
+        const args = ["serve", "a path with spaces"];
+        yield* fs.makeDirectory(bin);
+        yield* fs.symlink(process.execPath, path.join(bin, "node"));
+        yield* fs.writeFileString(
+          cliPath,
+          `#!/usr/bin/env node
+process.stdout.write(JSON.stringify(process.argv.slice(2)) + "\\n");
+`,
+        );
+        yield* fs.chmod(cliPath, 0o700);
+        yield* fs.writeFileString(callsPath, "");
+        yield* fs.writeFileString(
+          path.join(bin, packageManager),
+          `#!/usr/bin/env node
+const fs = require("node:fs");
+fs.appendFileSync(process.env.T3_TEST_CALLS, JSON.stringify(process.argv.slice(2)) + "\\n");
+const mode = process.env.T3_TEST_MODE;
+if (mode === "success" || mode === "failed-with-path") {
+  process.stdout.write(process.env.T3_TEST_CLI + "\\n");
+}
+if (mode === "etarget" || mode === "failed-with-path") {
+  process.stderr.write("npm error code ETARGET\\nnpm error notarget No matching version found.\\n");
+  process.exitCode = 42;
+} else if (mode === "network") {
+  process.stderr.write("npm error code ENETUNREACH\\n");
+  process.exitCode = 43;
+}
+`,
+        );
+        yield* fs.chmod(path.join(bin, packageManager), 0o700);
+        if (mode === "existing-cli") yield* fs.symlink(cliPath, path.join(bin, "t3"));
+
+        const child = yield* spawner.spawn(
+          ChildProcess.make("/bin/sh", ["-s", "--", ...args], {
+            cwd: fixture,
+            extendEnv: false,
+            env: {
+              PATH: bin,
+              T3_TEST_MODE: mode,
+              T3_TEST_CLI: cliPath,
+              T3_TEST_CALLS: callsPath,
+            },
+            stdin: Stream.make(
+              new TextEncoder().encode(
+                buildRemoteT3RunnerScript({
+                  packageSpec,
+                  ...(mode === "node-override" ? { nodeScriptPath: cliPath } : {}),
+                }),
+              ),
+            ),
+          }),
+        );
+        const { stdout, stderr, exitCode } = yield* Effect.all(
+          {
+            stdout: child.stdout.pipe(Stream.decodeText(), Stream.mkString),
+            stderr: child.stderr.pipe(Stream.decodeText(), Stream.mkString),
+            exitCode: child.exitCode,
+          },
+          { concurrency: "unbounded" },
+        );
+        const installFailed =
+          mode === "etarget" || mode === "network" || mode === "failed-with-path";
+        const missingExecutable = mode === "empty-success";
+        assert.equal(exitCode, installFailed || missingExecutable ? 1 : 0);
+        if (installFailed || missingExecutable) {
+          assert.equal(stdout, "");
+        } else {
+          assert.deepEqual(decodeArguments(stdout), args);
+        }
+        if (installFailed) {
+          const npmError = mode === "network" ? "ENETUNREACH" : "ETARGET";
+          assert.include(stderr, `npm error code ${npmError}\n`);
+          assert.include(stderr, `Remote host could not install ${packageSpec}.`);
+          assert.notInclude(stderr, "Remote host installed");
+          assert.notInclude(stderr, "Install a C toolchain");
+        } else if (missingExecutable) {
+          assert.include(stderr, `Remote host installed ${packageSpec}`);
+          assert.include(stderr, "npm produced no t3 executable");
+          assert.include(stderr, "Install a C toolchain");
+        } else {
+          assert.equal(stderr, "");
+        }
+        const expectedCall = [
+          ...(packageManager === "npm" ? ["exec"] : []),
+          "--yes",
+          "--package",
+          packageSpec,
+          "--",
+          "sh",
+          "-c",
+          "command -v t3",
+        ];
+        const usesInstaller = mode !== "existing-cli" && mode !== "node-override";
+        const calls = yield* fs.readFileString(callsPath);
+        if (usesInstaller) {
+          assert.deepEqual(
+            calls
+              .trim()
+              .split("\n")
+              .map((line) => decodeArguments(line)),
+            [expectedCall],
+          );
+        } else {
+          assert.equal(calls, "");
+        }
+      }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+    );
+  },
+);

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -433,7 +433,10 @@ fi
 # never becomes ready. Resolve the CLI once up front so that install failure is
 # reported here, with npm's own output on stderr.
 require_installed_t3_cli() {
-  T3_CLI_PATH="$("$@" -- sh -c 'command -v t3' || true)"
+  if ! T3_CLI_PATH="$("$@" -- sh -c 'command -v t3')"; then
+    printf 'Remote host could not install %s. See npm output above for the cause.\\n' @@T3_PACKAGE_SPEC@@ >&2
+    return 1
+  fi
   if [ -n "$T3_CLI_PATH" ]; then
     return 0
   fi


### PR DESCRIPTION
Related [#10084](https://github.com/pingdotgg/t3code/issues/10084).

When a remote package installation failed with `ETARGET`, the SSH runner discarded its exit status and claimed that installation succeeded but needed a C compiler. A failed installer that printed an executable path could even proceed to launch it.

Check the installer's exit status before accepting its stdout. Keep npm's original stderr and report installation failure without guessing its cause. The existing zero-exit/no-executable compiler advice remains intact, as do package versions, installer arguments, retries, timeouts, Node overrides and direct CLI execution.

## Verification

- Before the fix, six actual shell-process controls failed and ten passed. Afterward, all sixteen pass. The complete focused runner, tunnel and command run passes all 36 tests; an independent orchestrator run also passed all 36.
- Both `npx` and `npm exec` paths cover ETARGET, another nonzero error, failure with a valid path on stdout, zero-exit/no-executable, successful install, an existing CLI and a Node script override. Existing PID, graceful shutdown and restart controls pass.
- SSH package typechecking, targeted formatting and lint pass.

The tests execute the production-generated script through real `/bin/sh`, using owned synthetic installer executables and no registry access. They reproduce the diagnostic boundary, not the original package-publication timing, remote Node22/npm11 environment, SSH desktop dialog or successful reconnect. No version fallback or publication change is included. Screenshots do not apply to this shell-only fix. All current-head executed CI, Macroscope correctness, Effect Service Conventions and approvability checks pass. No unresolved review threads remain. Cursor review is paused at the team spending limit; CodeRabbit automatic reviews are disabled. Final merge review is pending.

Prepared by GPT 6 Astra via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `require_installed_t3_cli` to report package-manager failures in SSH runner
> - The `require_installed_t3_cli` shell helper in [tunnel.ts](https://github.com/pingdotgg/t3code/pull/10088/files#diff-7338be65675ab0699d0c8c6426e54f3421747885231f9bbb0ace4ec129cb2072) now checks the installer command's exit status. When the package-manager command fails, it prints an installation failure message with the package spec and exits with status 1 instead of silently proceeding.
> - When the installer succeeds but emits no executable path, the existing native-dependency/toolchain diagnostic is unchanged.
> - Adds a live parameterized test suite in [runnerProcess.test.ts](https://github.com/pingdotgg/t3code/pull/10088/files#diff-9d41ea955be50fe778ec775e7ddec1c03fd09d338f6134222b3d20bfe4ff198d) covering npx and npm across seven scenarios (resolution failure, network failure, empty output, success, failed install with stdout path, existing CLI, node-script override).
> - Risk: the helper now exits immediately on installer failure rather than falling through to the missing-executable diagnostic, so any remote environment where the package manager exits non-zero for non-installation reasons will surface a different error message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e1843e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->