### PR TITLE
fix(claude): keep MCP credentials out of process arguments

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.mcp.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.mcp.test.ts
@@ -1,0 +1,259 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeChildProcess from "node:child_process";
+import * as NodeURL from "node:url";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import { query, type Options as ClaudeQueryOptions } from "@anthropic-ai/claude-agent-sdk";
+import { ClaudeSettings, EnvironmentId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+
+import { ServerConfig } from "../../config.ts";
+import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import { SYNTHETIC_CLAUDE_MODEL_CATALOG } from "../ClaudeModelCatalog.testFixtures.ts";
+import { makeClaudeAdapter } from "./ClaudeAdapter.ts";
+
+const decodeSettings = Schema.decodeUnknownSync(ClaudeSettings);
+const decodeReceipt = Schema.decodeUnknownSync(
+  Schema.Union([
+    Schema.Struct({
+      type: Schema.Literal("spawn"),
+      args: Schema.Array(Schema.String),
+      authorization: Schema.NullOr(Schema.String),
+    }),
+    Schema.Struct({ type: Schema.Literal("state"), prompts: Schema.Number }),
+  ]),
+);
+const decodeMcpConfig = Schema.decodeUnknownSync(
+  Schema.fromJsonString(
+    Schema.Struct({
+      mcpServers: Schema.Struct({
+        "t3-code": Schema.Struct({
+          type: Schema.Literal("http"),
+          url: Schema.String,
+          headers: Schema.Struct({ Authorization: Schema.String }),
+        }),
+      }),
+    }),
+  ),
+);
+type SpawnReceipt = Extract<ReturnType<typeof decodeReceipt>, { type: "spawn" }>;
+
+const FIRST_HEADER = "Bearer AUDIT_MCP_FIRST_NOT_A_CREDENTIAL";
+const SECOND_HEADER = "Bearer AUDIT_MCP_SECOND_NOT_A_CREDENTIAL";
+const ENDPOINT = "http://127.0.0.1:1/mcp";
+const fixturePath = NodeURL.fileURLToPath(
+  new URL("../testFixtures/claudeMcpArgv.mjs", import.meta.url),
+);
+const instanceId = ProviderInstanceId.make("claudeAgent");
+
+const makeHarness = Effect.fn("makeClaudeMcpSdkHarness")(function* (launchArgs = "") {
+  const fs = yield* FileSystem.FileSystem;
+  const directory = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-mcp-sdk-" });
+  const environment = Object.freeze({
+    AUDIT_PARENT_VALUE: "unchanged",
+    T3_MCP_AUTHORIZATION: "inherited-value",
+  });
+  const registeredThreads: ThreadId[] = [];
+  const captures: Array<{
+    runtime: ReturnType<typeof query>;
+    options: ClaudeQueryOptions;
+    child: NodeChildProcess.ChildProcess;
+    spawned: Promise<SpawnReceipt>;
+    state: Promise<number>;
+    exited: Promise<void>;
+  }> = [];
+  yield* Effect.addFinalizer(() =>
+    Effect.promise(async () => {
+      for (const threadId of registeredThreads)
+        McpProviderSession.clearMcpProviderSession(threadId);
+      await Promise.all(
+        captures.map(async ({ runtime, exited }) => {
+          runtime.close();
+          await exited;
+        }),
+      );
+    }),
+  );
+  const adapter = yield* makeClaudeAdapter(
+    decodeSettings({
+      binaryPath: "inert-claude-never-executed",
+      launchArgs,
+    }),
+    {
+      instanceId,
+      environment,
+      modelCatalog: Effect.succeed(SYNTHETIC_CLAUDE_MODEL_CATALOG),
+      createQuery: ({ prompt, options }) => {
+        const spawned = Promise.withResolvers<SpawnReceipt>();
+        const state = Promise.withResolvers<number>();
+        const exited = Promise.withResolvers<void>();
+        let child: NodeChildProcess.ChildProcess | undefined;
+        const runtime = query({
+          prompt,
+          options: {
+            ...options,
+            settingSources: [],
+            settings: { disableAllHooks: true },
+            persistSession: false,
+            tools: [],
+            spawnClaudeCodeProcess: (invocation) => {
+              // Preserve the real SDK's arguments and environment; only replace the executable.
+              const spawnedChild = NodeChildProcess.spawn(
+                process.execPath,
+                [fixturePath, ...invocation.args],
+                { cwd: directory, env: invocation.env, stdio: ["pipe", "pipe", "pipe", "ipc"] },
+              ) as NodeChildProcess.ChildProcessWithoutNullStreams;
+              child = spawnedChild;
+              spawnedChild.stderr.resume();
+              spawnedChild.once("exit", () => exited.resolve());
+              spawnedChild.once("error", (error) => {
+                spawned.reject(error);
+                exited.resolve();
+              });
+              spawnedChild.on("message", (message) => {
+                const receipt = decodeReceipt(message);
+                if (receipt.type === "spawn") spawned.resolve(receipt);
+                else state.resolve(receipt.prompts);
+              });
+              return spawnedChild;
+            },
+          },
+        });
+        assert.isDefined(child);
+        captures.push({
+          runtime,
+          options,
+          child,
+          spawned: spawned.promise,
+          state: state.promise,
+          exited: exited.promise,
+        });
+        return runtime;
+      },
+    },
+  ).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        ServerConfig.layerTest(directory, directory),
+        ServerSettingsService.layerTest(),
+      ),
+    ),
+  );
+
+  const register = (threadId: ThreadId, authorizationHeader: string) => {
+    registeredThreads.push(threadId);
+    McpProviderSession.setMcpProviderSession({
+      threadId,
+      providerInstanceId: instanceId,
+      environmentId: EnvironmentId.make("00000000-0000-4000-8000-000000010020"),
+      providerSessionId: "00000000-0000-4000-8000-000000010020",
+      endpoint: ENDPOINT,
+      authorizationHeader,
+    });
+  };
+  const start = Effect.fn("startClaudeMcpSdkSession")(function* (threadId: ThreadId) {
+    yield* adapter.startSession({
+      threadId,
+      providerInstanceId: instanceId,
+      runtimeMode: "approval-required",
+      cwd: directory,
+    });
+    const capture = captures.at(-1)!;
+    const receipt = yield* Effect.promise(() => capture.spawned);
+    yield* Effect.promise(() => capture.runtime.initializationResult());
+    capture.child.send!("inspect");
+    assert.equal(yield* Effect.promise(() => capture.state), 0);
+    return { ...capture, receipt };
+  });
+  return { adapter, environment, captures, register, start };
+});
+
+function mcpArguments(args: readonly string[]) {
+  return args.flatMap((arg, index) => (arg === "--mcp-config" ? [args[index + 1]!] : []));
+}
+
+describe("Claude built-in MCP credentials through the actual SDK", () => {
+  it.effect.each(["", "--mcp-config /workspace/example/user-mcp.json"])(
+    "keeps the bearer out of child argv with launch arguments %j",
+    (launchArgs) =>
+      Effect.gen(function* () {
+        const harness = yield* makeHarness(launchArgs);
+        const threadId = ThreadId.make("claude-mcp-argv");
+        harness.register(threadId, FIRST_HEADER);
+        const { receipt } = yield* harness.start(threadId);
+        assert.notInclude(receipt.args.join("\0"), FIRST_HEADER);
+        assert.equal(receipt.authorization, FIRST_HEADER);
+        const configs = mcpArguments(receipt.args);
+        assert.equal(configs.length, launchArgs === "" ? 1 : 2);
+        const inline = configs.find((value) => value.startsWith("{"));
+        assert.isDefined(inline);
+        assert.deepStrictEqual(decodeMcpConfig(inline), {
+          mcpServers: {
+            "t3-code": {
+              type: "http",
+              url: ENDPOINT,
+              headers: { Authorization: "${T3_MCP_AUTHORIZATION}" },
+            },
+          },
+        });
+        if (launchArgs !== "") assert.include(configs, "/workspace/example/user-mcp.json");
+        assert.deepStrictEqual(harness.environment, {
+          AUDIT_PARENT_VALUE: "unchanged",
+          T3_MCP_AUTHORIZATION: "inherited-value",
+        });
+        yield* harness.adapter.stopSession(threadId);
+      }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect.each(["none", "another-thread"] as const)(
+    "leaves the environment unchanged when MCP belongs to %s",
+    (mcp) =>
+      Effect.gen(function* () {
+        const harness = yield* makeHarness();
+        const threadId = ThreadId.make(`claude-mcp-${mcp}`);
+        if (mcp === "another-thread")
+          harness.register(ThreadId.make(`${threadId}-other`), FIRST_HEADER);
+        const { receipt, options } = yield* harness.start(threadId);
+        assert.deepStrictEqual(mcpArguments(receipt.args), []);
+        assert.strictEqual(options.env, harness.environment);
+        assert.equal(receipt.authorization, "inherited-value");
+        assert.notInclude(receipt.args.join("\0"), FIRST_HEADER);
+        yield* harness.adapter.stopSession(threadId);
+      }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect(
+    "keeps simultaneous thread credentials separate without mutating the parent environment",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* makeHarness();
+        const firstId = ThreadId.make("claude-mcp-first");
+        const secondId = ThreadId.make("claude-mcp-second");
+        harness.register(firstId, FIRST_HEADER);
+        harness.register(secondId, SECOND_HEADER);
+        const first = yield* harness.start(firstId);
+        const second = yield* harness.start(secondId);
+        assert.notStrictEqual(first.options.env, harness.environment);
+        assert.notStrictEqual(first.options.env, second.options.env);
+        assert.equal(first.options.env?.T3_MCP_AUTHORIZATION, FIRST_HEADER);
+        assert.equal(second.options.env?.T3_MCP_AUTHORIZATION, SECOND_HEADER);
+        assert.equal(first.receipt.authorization, FIRST_HEADER);
+        assert.equal(second.receipt.authorization, SECOND_HEADER);
+        for (const { receipt } of [first, second]) {
+          assert.notInclude(receipt.args.join("\0"), FIRST_HEADER);
+          assert.notInclude(receipt.args.join("\0"), SECOND_HEADER);
+        }
+        assert.deepStrictEqual(harness.environment, {
+          AUDIT_PARENT_VALUE: "unchanged",
+          T3_MCP_AUTHORIZATION: "inherited-value",
+        });
+        yield* harness.adapter.stopSession(firstId);
+        yield* harness.adapter.stopSession(secondId);
+      }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+});

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -4681,7 +4681,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         canUseTool,
         onUserDialog,
         supportedDialogKinds: ["resume_return"],
-        env: claudeEnvironment,
+        env: mcpSession
+          ? {
+              ...claudeEnvironment,
+              T3_MCP_AUTHORIZATION: mcpSession.authorizationHeader,
+            }
+          : claudeEnvironment,
         additionalDirectories,
         ...(Object.keys(extraArgs).length > 0 ? { extraArgs } : {}),
         ...(mcpSession
@@ -4691,7 +4696,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
                   type: "http",
                   url: mcpSession.endpoint,
                   headers: {
-                    Authorization: mcpSession.authorizationHeader,
+                    // Claude expands this after the SDK serializes MCP config into argv.
+                    Authorization: "${T3_MCP_AUTHORIZATION}",
                   },
                 },
               },

--- a/apps/server/src/provider/testFixtures/claudeMcpArgv.mjs
+++ b/apps/server/src/provider/testFixtures/claudeMcpArgv.mjs
@@ -1,0 +1,36 @@
+import * as NodeReadline from "node:readline";
+
+// Inert SDK protocol peer. Tests supply only synthetic credentials.
+process.send?.({
+  type: "spawn",
+  args: process.argv.slice(2),
+  authorization: process.env.T3_MCP_AUTHORIZATION ?? null,
+});
+
+let prompts = 0;
+const input = NodeReadline.createInterface({ input: process.stdin });
+input.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.type === "user") {
+    prompts += 1;
+    return;
+  }
+  if (message.type !== "control_request") return;
+  process.stdout.write(
+    JSON.stringify({
+      type: "control_response",
+      response: {
+        subtype: "success",
+        request_id: message.request_id,
+        response:
+          message.request.subtype === "initialize"
+            ? { commands: [], models: [], agents: [], account: {}, output_style: "default" }
+            : {},
+      },
+    }) + "\n",
+  );
+});
+process.on("message", (message) => {
+  if (message === "inspect") process.send?.({ type: "state", prompts });
+});
+input.on("close", () => process.exit(0));


### PR DESCRIPTION
Closes #10020.

The Claude Agent SDK serializes the built-in MCP configuration into process arguments, exposing its thread-scoped bearer to argv inspection and argv-based diagnostics.

Pass the authorization header in a per-session environment clone and use Claude's `${T3_MCP_AUTHORIZATION}` expansion in the existing MCP header. User MCP launch arguments, endpoints, and session/token lifetimes stay unchanged. No credential files are added.

Closes [#10020](https://github.com/pingdotgg/t3code/issues/10020).

### Verification

- Actual production adapter → SDK → inert Node process: three regression cases fail and two controls pass on main; all five pass with the fix. Covers argv, child environment, concurrent-session isolation, immutable parent environment, missing/other-thread sessions, and an existing user MCP flag.
- 98 focused adapter tests, server typecheck, and targeted lint pass.
- Actual modified adapter → SDK 0.3.260 → native CLI 2.1.236: MCP connects and every observed request carries the correct synthetic header, while actual process arguments contain the reference and no bearer. Zero prompts, clean child exit. This used disposable config and an isolated network namespace with loopback only, without an account or provider call.
- Independent verification repeated all 98 tests and the complete modified-adapter native probe, with the same results. The three-file diff and relevant callers were independently reviewed.

Claude documents [HTTP-header environment expansion](https://code.claude.com/docs/en/mcp#environment-variable-expansion-in-mcpjson); the native probe also verifies the SDK's inline-config path. Other native versions were not exercised. The credential remains in the child environment and memory; this fixes argv exposure, not OS-level isolation.

Human approval required; do not merge automatically. All executed CI jobs pass on [e47b6f09a](https://github.com/pingdotgg/t3code/commit/e47b6f09a62075ee92e535cb8ea7e74f655549cf): 15 successful check runs, four skipped, and one neutral Approvability check. Correctness and Effect checks pass. The repository's [approval policy](https://github.com/pingdotgg/t3code/blob/39802c06117fae0b3da43624b0d54309c5437c72/.macroscope/approvability.md) requires human review for the new test-only `nodeBuiltinImport` diagnostic suppression; the credential-boundary change also needs that review. The suppression matches existing adapter-test conventions but is not exempt from the policy. No screenshots apply to this process-boundary change.

Prepared by GPT 6 Astra via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass MCP credentials via child environment instead of process arguments in `makeClaudeAdapter`
> - Changes `makeClaudeAdapter` so that queries with a matching MCP provider session receive a copied environment containing that session's authorization value, instead of serializing it into SDK launch arguments.
> - The generated built-in MCP server configuration now references the environment value indirectly rather than placing the authorization header directly in the config arguments.
> - Queries without a matching MCP session retain the prior environment and omit the built-in MCP configuration.
> - Adds an integration-test harness and inert protocol fixture (`claudeMcpArgv.mjs`) that exercises the real Claude SDK launch path, verifying credentials stay out of argv, concurrent threads don't leak credentials, and the parent environment is not mutated.
> - Risk: the child process now receives MCP authorization via environment variable (`CLAUDE_MCP_AUTH` or similar) instead of argv; any out-of-tree code or logging that previously read the credential from generated MCP config arguments will no longer find it there.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e47b6f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
