### PR TITLE
fix(web): scale agent spawn rows with interface font

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -3069,7 +3069,7 @@ const AgentSpawnCtaRow = memo(function AgentSpawnCtaRow(props: { workEntry: Time
     <button
       type="button"
       onClick={onOpenAgents}
-      className="flex w-full items-center gap-2 rounded-md border border-border/60 bg-card/50 px-2.5 py-1.5 text-left text-[13px] transition hover:bg-accent/50"
+      className="flex w-full items-center gap-2 rounded-md border border-border/60 bg-card/50 px-2.5 py-1.5 text-left text-[.8125rem] transition hover:bg-accent/50"
     >
       <span aria-hidden className={cn("size-1.5 shrink-0 rounded-full", dotClass)} />
       <WorkEntryIcon name="bot" className="size-3.5 shrink-0 text-muted-foreground" />


### PR DESCRIPTION
The agent-spawn row's lead text stayed at 13px when the Interface font size increased, even though its status text and neighboring tool headers scaled.

Use `.8125rem` for that row. It remains 13px at the default Interface size of 16 and follows the existing preference. Status text, counters, icons, spacing and expanded Code output are unchanged.

Related [#7438](https://github.com/pingdotgg/t3code/issues/7438). This does not add a separate tool-font setting or claim to resolve the full macOS/high-DPI report.

In the actual client at Interface 20, the label now grows from 13px to 16.25px. Restoring Interface 16 returns it to 13px. Code output and status text are unchanged. Normal settings changes, reload, and opening/closing the Agents panel passed. Both captures use the same synthetic data, 1280×900 viewport, scroll position and Interface20/Code13 preferences. The relevant before paths match main; the after uses this exact change.

Before:

![Before: the subagent label remains 13px at Interface 20](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/216fc4807ad7817f/7438-before-interface20.png)

After:

![After: the subagent label scales to 16.25px at Interface 20](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4fefaa2dd7833dd9/7438-after-interface20-matched.png)

Verification: 13 existing appearance tests, web typecheck, targeted lint and formatting pass. An independent reviewer repeated all 13 tests and reviewed the complete change and callers. No static style assertion or diagnostic suppression was added.

GPT 6 Astra via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scale `AgentSpawnCtaRow` text size with interface font
> Changes the CTA row's Tailwind text-size utility in `AgentSpawnCtaRow` from an explicit 13px to 0.8125rem so it scales with the interface font setting. No other component logic or markup changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d16399a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->