### PR TITLE
feat(web): show advisory daily usage budget alerts

### DIFF
--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -6,6 +6,7 @@ import {
   type UsageProviderKind,
 } from "@t3tools/contracts";
 import {
+  AlertTriangleIcon,
   CircleAlertIcon,
   ChevronDownIcon,
   CircleDashedIcon,
@@ -37,6 +38,7 @@ import {
   formatUsd,
   makeWindow,
 } from "@t3tools/shared/usageFormat";
+import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
 import { Button } from "../ui/button";
 import {
   Menu,
@@ -67,6 +69,7 @@ import {
   saveUsagePagePreferences,
   type UsagePagePreferences,
 } from "./usagePagePreferences";
+import { evaluateDailyUsageBudget } from "./usageBudget";
 
 type UsageMetric = UsageChartMetric | "limits";
 const METRIC_OPTIONS = [
@@ -135,6 +138,11 @@ export function UsagePage() {
     () => (isPast24Hours ? merged.hourly : merged.daily).toReversed(),
     [isPast24Hours, merged.daily, merged.hourly],
   );
+  const budgetAlert = useMemo(
+    () => evaluateDailyUsageBudget(merged.daily, window.untilDay),
+    [merged.daily, window.untilDay],
+  );
+
   const breakdownModels = useMemo(
     () =>
       breakdown === "model" && metric === "tokens"
@@ -354,6 +362,28 @@ export function UsagePage() {
               <UsageSkeleton />
             ) : (
               <>
+                {budgetAlert !== null ? (
+                  <Alert variant="warning" controlAlignment="first-line">
+                    <AlertTriangleIcon aria-hidden />
+                    <AlertTitle>
+                      {budgetAlert.level === "pause"
+                        ? "Usage pause level reached"
+                        : budgetAlert.level === "approval"
+                          ? "Usage approval level reached"
+                          : "Usage warning level reached"}
+                    </AlertTitle>
+                    <AlertDescription>
+                      {budgetAlert.kind === "claude"
+                        ? `Claude reached ${formatUsd(budgetAlert.valueUsd)} on ${formatDayShort(budgetAlert.day)}, at or above the ${formatUsd(budgetAlert.thresholdUsd)} ${budgetAlert.level} level.`
+                        : `API-equivalent usage reached ${formatUsd(budgetAlert.valueUsd)} on ${formatDayShort(budgetAlert.day)}, at or above the ${formatUsd(budgetAlert.thresholdUsd)} ${budgetAlert.level} level. This includes hypothetical subscription usage.`}
+                      {budgetAlert.level === "pause"
+                        ? " Pause new agent work and review the usage breakdown."
+                        : budgetAlert.level === "approval"
+                          ? " Get approval before launching more work."
+                          : " Review the usage breakdown before expanding the workload."}
+                    </AlertDescription>
+                  </Alert>
+                ) : null}
                 <section className="grid gap-6 lg:grid-cols-[minmax(0,18rem)_minmax(0,1fr)]">
                   <div className="flex min-w-0 flex-col gap-5">
                     <div className="flex flex-col gap-1">

--- a/apps/web/src/components/usage/usageBudget.test.ts
+++ b/apps/web/src/components/usage/usageBudget.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { DailyTotals } from "@t3tools/shared/usageMerge";
+
+import { evaluateDailyUsageBudget } from "./usageBudget";
+
+function day(day: string, claudeUsd: number, codexUsd: number): DailyTotals {
+  return {
+    day,
+    costUsd: claudeUsd + codexUsd,
+    totalTokens: 0,
+    byProvider: new Map([
+      ["claude", { costUsd: claudeUsd, totalTokens: 0 }],
+      ["codex", { costUsd: codexUsd, totalTokens: 0 }],
+    ]),
+  };
+}
+
+describe("evaluateDailyUsageBudget", () => {
+  it("returns the strongest crossing in the visible window", () => {
+    expect(
+      evaluateDailyUsageBudget(
+        [day("2026-08-30", 600, 0), day("2026-08-31", 2_100, 0)],
+        "2026-08-31",
+      ),
+    ).toEqual({
+      day: "2026-08-31",
+      kind: "claude",
+      level: "pause",
+      thresholdUsd: 2_000,
+      valueUsd: 2_100,
+    });
+  });
+
+  it("warns on API-equivalent cost even when Claude remains below its limit", () => {
+    expect(evaluateDailyUsageBudget([day("2026-08-31", 100, 950)], "2026-08-31")).toMatchObject({
+      kind: "apiEquivalent",
+      level: "warn",
+      valueUsd: 1_050,
+    });
+  });
+
+  it("returns null below every threshold", () => {
+    expect(evaluateDailyUsageBudget([day("2026-08-31", 100, 100)], "2026-08-31")).toBeNull();
+  });
+
+  it("does not keep warning about an older day", () => {
+    expect(
+      evaluateDailyUsageBudget(
+        [day("2026-08-30", 2_100, 0), day("2026-08-31", 100, 100)],
+        "2026-08-31",
+      ),
+    ).toBeNull();
+  });
+
+  it("does not show yesterday's alert when today has no usage bucket", () => {
+    expect(evaluateDailyUsageBudget([day("2026-08-30", 2_100, 0)], "2026-08-31")).toBeNull();
+  });
+});

--- a/apps/web/src/components/usage/usageBudget.ts
+++ b/apps/web/src/components/usage/usageBudget.ts
@@ -1,0 +1,70 @@
+import type { DailyTotals } from "@t3tools/shared/usageMerge";
+
+export const DAILY_USAGE_BUDGET = {
+  claudeUsd: { warn: 500, approval: 1_000, pause: 2_000 },
+  apiEquivalentUsd: { warn: 1_000, approval: 1_500, pause: 2_000 },
+} as const;
+
+export type UsageBudgetLevel = "warn" | "approval" | "pause";
+
+export interface UsageBudgetAlert {
+  readonly day: string;
+  readonly level: UsageBudgetLevel;
+  readonly kind: "claude" | "apiEquivalent";
+  readonly valueUsd: number;
+  readonly thresholdUsd: number;
+}
+
+const LEVELS = ["warn", "approval", "pause"] as const;
+const LEVEL_RANK: Record<UsageBudgetLevel, number> = { warn: 0, approval: 1, pause: 2 };
+
+function crossed(
+  valueUsd: number,
+  thresholds: Readonly<Record<UsageBudgetLevel, number>>,
+): { readonly level: UsageBudgetLevel; readonly thresholdUsd: number } | null {
+  let result: { readonly level: UsageBudgetLevel; readonly thresholdUsd: number } | null = null;
+  for (const level of LEVELS) {
+    if (valueUsd >= thresholds[level]) result = { level, thresholdUsd: thresholds[level] };
+  }
+  return result;
+}
+
+/** Returns the strongest deterministic budget crossing on the requested day. */
+export function evaluateDailyUsageBudget(
+  daily: readonly DailyTotals[],
+  requestedDay: string,
+): UsageBudgetAlert | null {
+  const alerts: UsageBudgetAlert[] = [];
+  for (const period of daily) {
+    if (period.day !== requestedDay) continue;
+    const claudeUsd = period.byProvider.get("claude")?.costUsd ?? 0;
+    const claude = crossed(claudeUsd, DAILY_USAGE_BUDGET.claudeUsd);
+    if (claude !== null) {
+      alerts.push({
+        day: period.day,
+        kind: "claude",
+        valueUsd: claudeUsd,
+        ...claude,
+      });
+    }
+
+    const apiEquivalent = crossed(period.costUsd, DAILY_USAGE_BUDGET.apiEquivalentUsd);
+    if (apiEquivalent !== null) {
+      alerts.push({
+        day: period.day,
+        kind: "apiEquivalent",
+        valueUsd: period.costUsd,
+        ...apiEquivalent,
+      });
+    }
+  }
+
+  return (
+    alerts.toSorted(
+      (left, right) =>
+        LEVEL_RANK[right.level] - LEVEL_RANK[left.level] ||
+        right.valueUsd / right.thresholdUsd - left.valueUsd / left.thresholdUsd ||
+        right.day.localeCompare(left.day),
+    )[0] ?? null
+  );
+}

--- a/apps/web/src/components/usage/usageBudget.ts
+++ b/apps/web/src/components/usage/usageBudget.ts
@@ -1,6 +1,6 @@
 import type { DailyTotals } from "@t3tools/shared/usageMerge";
 
-export const DAILY_USAGE_BUDGET = {
+const DAILY_USAGE_BUDGET = {
   claudeUsd: { warn: 500, approval: 1_000, pause: 2_000 },
   apiEquivalentUsd: { warn: 1_000, approval: 1_500, pause: 2_000 },
 } as const;

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -73,3 +73,7 @@ account and choose **Use reset** to redeem one. No hub plugin is required.
 This connection supplies usage information; configure
 the provider separately to send agent requests through the hub. Remove the hub from the same
 settings section when you no longer need it.
+
+## Daily budget alerts
+
+The latest calendar day's usage shows advisory budget levels. Claude warnings use API-rate estimates; API-equivalent warnings include subscription traffic such as Codex. Warning starts at $500 Claude or $1,000 API-equivalent, approval at $1,000 or $1,500, and pause at $2,000 for either measure. These alerts do not automatically block provider work.


### PR DESCRIPTION
The Usage page now shows advisory daily budget levels for Claude API-rate estimates and total API-equivalent usage. These warnings make the existing daily spend visible without blocking provider work.

Split from #8857 at the author's request so handovers and work admission controls remain separate reviews. Budget thresholds and calculations are preserved from the original feature.

Validation at `121268db4`: all five focused budget tests pass; scoped web-workspace export analysis (`vp exec knip --workspace apps/web --exports --preprocessor ./scripts/knip-schemas.ts --no-config-hints`), targeted lint, and diff checks pass. The export check reproduced the CI failure before the fix; the thresholds are now module-local. Earlier feature validation reported a passing web typecheck; it was not rerun for this export-only repair. The real web Usage page shows the warning for synthetic Claude usage of $600 on Sep 5 against its $500 level. The same provider logs produce the same $662 range total on the baseline without the warning. These levels are advisory; no provider pausing is claimed.

Before: the same usage has no daily warning.

![Before: $662 usage without a warning](https://github.com/saphid/t3code/releases/download/pr-evidence-limits-20260905/budget-before-detail.png)

After: daily Claude usage crosses its warning level.

![After: Claude $600 exceeds the $500 warning level](https://github.com/saphid/t3code/releases/download/pr-evidence-limits-20260905/budget-after-detail.png)

Matched content crops omit differing sidebar fixtures and an unrelated update notification on the far right.

Web evidence uses disposable synthetic data: baseline `39802c0`, integrated candidate `0cb918039d4f0f220470673e2252acf28eda8d71` (tree `f56dc89e078c9ad43ef049202bbb0b428fca2ca4`) containing #8857, #10095, #10097 and #10094. This is integrated web proof, not a standalone or native-client capture. It predates the current rebased head; the export-only repair does not alter the shown UI, but these captures are not a fresh current-head interaction run. The prior integration passed 330 focused tests and server/web/React Native typechecks; the candidate differs only in the corrected hard-limit setting description, which passed scoped lint. No unpublished integration glue is required.

Direct Claude Opus 5 high review attempt exited 1 on expired OAuth before a model ran. A fresh direct Claude Opus 5 high review attempt for the export-only repair also exited 1 on expired OAuth; no model ran. Parent source review of that one-line repair found no actionable findings.

Implemented and verified with GPT-6 Astra in the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add advisory daily usage budget alerts to `UsagePage`
> - Evaluates the selected usage window against daily budget thresholds and renders the strongest returned level (warning, approval, or pause) as an alert in the regular usage view
> - Uses separate messaging for Claude and API-equivalent usage, displaying the measured value, threshold, and day along with level-specific review guidance
> - Suppresses the alert in the limits view, while usage is pending, or when no threshold is crossed
> - Risk: alert rendering depends on the budget evaluator contract; mismatched threshold or level shapes from the evaluator will cause the alert to silently not render or display incomplete guidance in [UsagePage.tsx](https://github.com/pingdotgg/t3code/pull/10094/files#diff-e076db2611ea0a07e1c8ec8571cc21103a2a4c7fc0feb865192fc12c8a18dead)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 121268d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added daily usage budget alerts for Claude and API-equivalent costs.
  - Alerts indicate warning, approval, or pause thresholds and include the affected usage date and value.
  - The strongest applicable alert is shown above the usage breakdown.
  - Alerts provide guidance without automatically blocking provider activity.

- **Documentation**
  - Added user documentation describing daily budget thresholds, alert levels, and advisory behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->