### PR TITLE
fix(web): explain what enabling network access means in its confirmation

### DIFF
--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -3249,7 +3249,9 @@ export function ConnectionsSettings() {
                 <AlertDialogDescription>
                   {pendingDesktopServerExposureMode === "network-accessible"
                     ? "Other devices on your network can pair with this environment, and anyone with a valid pairing credential can run commands here until it expires or is revoked. T3 Code will restart."
-                    : "Only this machine can reach this environment again. Devices that already paired will disconnect. T3 Code will restart."}
+                    : tailscaleHttpsEndpoint?.status === "available"
+                      ? "Only this machine and your tailnet can reach this environment again. Tailscale HTTPS stays on; devices that paired over the local network will disconnect. T3 Code will restart."
+                      : "Only this machine can reach this environment again. Devices that paired over the local network will disconnect. T3 Code will restart."}
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -3248,8 +3248,8 @@ export function ConnectionsSettings() {
                 </AlertDialogTitle>
                 <AlertDialogDescription>
                   {pendingDesktopServerExposureMode === "network-accessible"
-                    ? "T3 Code will restart to expose this environment over the network."
-                    : "T3 Code will restart and limit this environment back to this machine."}
+                    ? "Other devices on your network can pair with this environment, and anyone with a valid pairing credential can run commands here until it expires or is revoked. T3 Code will restart."
+                    : "Only this machine can reach this environment again. Devices that already paired will disconnect. T3 Code will restart."}
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
@@ -3261,7 +3261,9 @@ export function ConnectionsSettings() {
                 </AlertDialogClose>
                 <Button
                   variant={
-                    pendingDesktopServerExposureMode === "local-only" ? "destructive" : "default"
+                    pendingDesktopServerExposureMode === "network-accessible"
+                      ? "destructive"
+                      : "default"
                   }
                   onClick={handleConfirmDesktopServerExposureChange}
                   disabled={

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -3249,9 +3249,7 @@ export function ConnectionsSettings() {
                 <AlertDialogDescription>
                   {pendingDesktopServerExposureMode === "network-accessible"
                     ? "Other devices on your network can pair with this environment, and anyone with a valid pairing credential can run commands here until it expires or is revoked. T3 Code will restart."
-                    : tailscaleHttpsEndpoint?.status === "available"
-                      ? "Only this machine and your tailnet can reach this environment again. Tailscale HTTPS stays on; devices that paired over the local network will disconnect. T3 Code will restart."
-                      : "Only this machine can reach this environment again. Devices that paired over the local network will disconnect. T3 Code will restart."}
+                    : "This environment stops listening on your local network, so devices that paired over it will disconnect. Tunnels you have set up, such as T3 Connect or Tailscale HTTPS, keep their own access. T3 Code will restart."}
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>


### PR DESCRIPTION
The confirmation for **Settings → Connections → Network access** only warned about the restart, and styled *disabling* as the destructive choice. Widening an environment from this machine to the whole network is the consequential decision, so the dialog now says what that opens up (other devices can pair, and anyone holding a valid pairing credential can run commands until it expires or is revoked) and carries the destructive styling on that branch. Disabling explains that the environment stops listening on the local network, so devices that paired over it disconnect, while tunnels such as T3 Connect or Tailscale HTTPS keep their own access (switching to `local-only` only changes the bind address to loopback).

Copy-only change plus the swapped button variant; no logic or contract changes. The dialog exists only on desktop, so mobile is unaffected.

### Before
<img width="544" height="204" alt="image" src="https://github.com/user-attachments/assets/a625b73b-f9ec-4dee-857c-d6e2389b8339" />

### After
<img width="544" height="242" alt="image" src="https://github.com/user-attachments/assets/6648b347-f225-4450-99c3-73ce76bbd427" />


Fixes #9883.

Implemented with Claude Code (Claude Fable 5).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify network access confirmation dialog copy in `ConnectionsSettings`
> - Updates the enable-network-access confirmation to state that other devices on the network can pair and that valid pairing credentials allow command execution until expiry or revocation
> - When disabling, shows a Tailscale-specific local-only message when the Tailscale HTTPS endpoint is available, otherwise states only the local machine can reach the environment
> - Both disable messages note that paired local-network devices will disconnect and that T3 Code will restart
> - Changes the confirmation button to destructive styling when enabling network access and default styling when disabling
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ed78d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
