### PR TITLE
fix(web): preserve original mention text in the composer

### DIFF
--- a/apps/web/src/components/ComposerPromptEditor.serialization.test.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.serialization.test.tsx
@@ -6,10 +6,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import { collapseExpandedComposerCursor } from "../composer-logic";
 import { ComposerPromptEditor, type ComposerPromptEditorHandle } from "./ComposerPromptEditor";
-import {
-  buildComposerPromptHistoryEntries,
-  stepComposerPromptHistory,
-} from "./chat/composerPromptHistory";
 
 vi.mock("./chat/FileTagChip", () => ({
   FILE_TAG_CHIP_CLASS_NAME: "",
@@ -102,42 +98,17 @@ describe("composer mention serialization", () => {
     expect(editorRef.current?.readSnapshot().value).toBe(prompt);
   });
 
-  it("keeps history navigation active after replacing the controlled prompt", async () => {
-    const entries = buildComposerPromptHistoryEntries([
-      { id: "older", role: "user", text: "Older plain control" },
-      { id: "newer", role: "user", text: "@README.md control" },
-    ]);
-    await renderPrompt("");
-    const first = stepComposerPromptHistory({
-      direction: "backward",
-      entries,
-      position: null,
-      currentPrompt: "",
-    });
-    expect(first?.prompt).toBe(entries[1]?.prompt);
-    await renderPrompt(first!.prompt);
-    expect(editorRef.current?.readSnapshot().expandedCursor).toBe(first!.prompt.length);
-
-    const second = stepComposerPromptHistory({
-      direction: "backward",
-      entries,
-      position: first!.position,
-      currentPrompt: editorRef.current!.readSnapshot().value,
-    });
-    expect(second?.prompt).toBe(entries[0]?.prompt);
-    expect(lexicalEditor.getEditorState().read(() => $firstMention().isInline())).toBe(true);
-    await renderPrompt(second!.prompt);
-    expect(editorRef.current?.readSnapshot().value).toBe(entries[0]?.prompt);
-
-    const forward = stepComposerPromptHistory({
-      direction: "forward",
-      entries,
-      position: second!.position,
-      currentPrompt: editorRef.current!.readSnapshot().value,
-    });
-    expect(forward?.prompt).toBe(first!.prompt);
-    await renderPrompt(forward!.prompt);
-    expect(editorRef.current?.readSnapshot().value).toBe(first!.prompt);
+  it("preserves original source when replacing the controlled prompt", async () => {
+    for (const prompt of ["", "@README.md control", "Older plain control", "@README.md control"]) {
+      await renderPrompt(prompt);
+      expect(editorRef.current?.readSnapshot()).toMatchObject({
+        value: prompt,
+        expandedCursor: prompt.length,
+      });
+      if (prompt === "@README.md control") {
+        expect(lexicalEditor.getEditorState().read(() => $firstMention().isInline())).toBe(true);
+      }
+    }
   });
 
   it("preserves source when Lexical clones the mention and reloads exported state", async () => {

--- a/apps/web/src/components/ComposerPromptEditor.serialization.test.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.serialization.test.tsx
@@ -1,0 +1,213 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $copyNode, $getRoot, $isElementNode, PASTE_COMMAND, type LexicalEditor } from "lexical";
+import { act, createRef } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { collapseExpandedComposerCursor } from "../composer-logic";
+import { ComposerPromptEditor, type ComposerPromptEditorHandle } from "./ComposerPromptEditor";
+import {
+  buildComposerPromptHistoryEntries,
+  stepComposerPromptHistory,
+} from "./chat/composerPromptHistory";
+
+vi.mock("./chat/FileTagChip", () => ({
+  FILE_TAG_CHIP_CLASS_NAME: "",
+  FileTagChipContent: () => null,
+}));
+vi.mock("./chat/ComposerPendingTerminalContexts", () => ({
+  ComposerPendingTerminalContextChip: () => null,
+}));
+vi.mock("./chat/AssistantCitationChip", () => ({ AssistantCitationChip: () => null }));
+
+let lexicalEditor: LexicalEditor;
+// Keep the real composer, registered nodes, updates, and snapshot API. Only the
+// DOM view is omitted so Lexical runs headlessly in this component test.
+vi.mock("@lexical/react/LexicalPlainTextPlugin", () => ({
+  PlainTextPlugin: function HeadlessEditor() {
+    [lexicalEditor] = useLexicalComposerContext();
+    return null;
+  },
+}));
+
+let renderer: ReactTestRenderer | undefined;
+const editorRef = createRef<ComposerPromptEditorHandle>();
+
+function composer(value: string) {
+  return (
+    <ComposerPromptEditor
+      value={value}
+      cursor={collapseExpandedComposerCursor(value, value.length)}
+      terminalContexts={[]}
+      skills={[]}
+      disabled={false}
+      placeholder="Write a prompt"
+      onRemoveTerminalContext={() => {}}
+      onChange={() => {}}
+      onPaste={() => {}}
+      editorRef={editorRef}
+    />
+  );
+}
+
+async function renderPrompt(value: string) {
+  await act(() => {
+    if (renderer) renderer.update(composer(value));
+    else renderer = create(composer(value));
+  });
+}
+
+function $firstMention() {
+  const paragraph = $getRoot().getFirstChildOrThrow();
+  if (!$isElementNode(paragraph)) throw new Error("Expected a composer paragraph");
+  const mention = paragraph.getFirstChildOrThrow();
+  if (mention.getType() !== "composer-mention") throw new Error("Expected a mention");
+  return mention;
+}
+
+class TestClipboardEvent extends Event {
+  readonly clipboardData: DataTransfer;
+
+  constructor(text: string) {
+    super("paste", { cancelable: true });
+    this.clipboardData = {
+      files: [],
+      getData: (type: string) => (type === "text/plain" ? text : ""),
+    } as unknown as DataTransfer;
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("document", { activeElement: null });
+});
+
+afterEach(async () => {
+  await act(() => renderer?.unmount());
+  renderer = undefined;
+  vi.unstubAllGlobals();
+});
+
+describe("composer mention serialization", () => {
+  it.each([
+    "@README.md control",
+    "@terminal-1:3 Explain this output\n\n<terminal_context>\n- Terminal 1 line 3:\n  3 | output\n</terminal_context>",
+    '@"docs/My \\"File\\".md" please',
+    '@"docs/雪 👋.md" please',
+    "[README.md](README.md) control",
+    "[config#draft?.json](config%23draft%3f.json) control",
+    "Plain text\n  Keep indentation 👋",
+  ])("preserves the initial prompt %s", async (prompt) => {
+    await renderPrompt(prompt);
+    expect(editorRef.current?.readSnapshot().value).toBe(prompt);
+  });
+
+  it("keeps history navigation active after replacing the controlled prompt", async () => {
+    const entries = buildComposerPromptHistoryEntries([
+      { id: "older", role: "user", text: "Older plain control" },
+      { id: "newer", role: "user", text: "@README.md control" },
+    ]);
+    await renderPrompt("");
+    const first = stepComposerPromptHistory({
+      direction: "backward",
+      entries,
+      position: null,
+      currentPrompt: "",
+    });
+    expect(first?.prompt).toBe(entries[1]?.prompt);
+    await renderPrompt(first!.prompt);
+    expect(editorRef.current?.readSnapshot().expandedCursor).toBe(first!.prompt.length);
+
+    const second = stepComposerPromptHistory({
+      direction: "backward",
+      entries,
+      position: first!.position,
+      currentPrompt: editorRef.current!.readSnapshot().value,
+    });
+    expect(second?.prompt).toBe(entries[0]?.prompt);
+    expect(lexicalEditor.getEditorState().read(() => $firstMention().isInline())).toBe(true);
+    await renderPrompt(second!.prompt);
+    expect(editorRef.current?.readSnapshot().value).toBe(entries[0]?.prompt);
+
+    const forward = stepComposerPromptHistory({
+      direction: "forward",
+      entries,
+      position: second!.position,
+      currentPrompt: editorRef.current!.readSnapshot().value,
+    });
+    expect(forward?.prompt).toBe(first!.prompt);
+    await renderPrompt(forward!.prompt);
+    expect(editorRef.current?.readSnapshot().value).toBe(first!.prompt);
+  });
+
+  it("preserves source when Lexical clones the mention and reloads exported state", async () => {
+    const prompt = '@"docs/雪 👋.md" remains a chip';
+    await renderPrompt(prompt);
+    const originalKey = lexicalEditor.getEditorState().read(() => $firstMention().getKey());
+
+    await act(() => {
+      lexicalEditor.update(
+        () => {
+          const mention = $firstMention();
+          mention.replace($copyNode(mention));
+        },
+        { discrete: true },
+      );
+    });
+    expect(lexicalEditor.getEditorState().read(() => $firstMention().getKey())).not.toBe(
+      originalKey,
+    );
+    expect(editorRef.current?.readSnapshot().value).toBe(prompt);
+    const exportedState = lexicalEditor.getEditorState().toJSON();
+
+    await renderPrompt("");
+    await act(() => {
+      lexicalEditor.setEditorState(lexicalEditor.parseEditorState(exportedState));
+    });
+    expect(editorRef.current?.readSnapshot().value).toBe(prompt);
+    expect(lexicalEditor.getEditorState().read(() => $firstMention().isInline())).toBe(true);
+  });
+
+  it("keeps canonical serialization when importing legacy mention JSON without source", async () => {
+    await renderPrompt("");
+    await act(() => {
+      lexicalEditor.setEditorState(
+        lexicalEditor.parseEditorState(
+          JSON.stringify({
+            root: {
+              type: "root",
+              version: 1,
+              children: [
+                {
+                  type: "paragraph",
+                  version: 1,
+                  children: [{ type: "composer-mention", version: 1, path: "README.md" }],
+                },
+              ],
+            },
+          }),
+        ),
+      );
+    });
+    expect(editorRef.current?.readSnapshot().value).toBe("[README.md](README.md)");
+    expect(lexicalEditor.getEditorState().read(() => $firstMention().isInline())).toBe(true);
+  });
+
+  it("still serializes a newly inserted mention canonically", async () => {
+    vi.stubGlobal("ClipboardEvent", TestClipboardEvent);
+    await renderPrompt("");
+    const event = new TestClipboardEvent("@README.md ");
+    await act(() => {
+      lexicalEditor.update(
+        () => {
+          $getRoot().selectEnd();
+          lexicalEditor.dispatchCommand(PASTE_COMMAND, event as ClipboardEvent);
+        },
+        { discrete: true },
+      );
+    });
+    expect(event.defaultPrevented).toBe(true);
+    expect(editorRef.current?.readSnapshot().value).toBe("[README.md](README.md) ");
+    expect(lexicalEditor.getEditorState().read(() => $firstMention().isInline())).toBe(true);
+  });
+});

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -117,6 +117,7 @@ const BACKTICK_SURROUND_CLOSE_SYMBOL = SURROUND_SYMBOLS_MAP.get("`") ?? null;
 type SerializedComposerMentionNode = Spread<
   {
     path: string;
+    source?: string;
     type: "composer-mention";
     version: 1;
   },
@@ -174,28 +175,33 @@ function ComposerMentionDecorator(props: { path: string }) {
 
 class ComposerMentionNode extends DecoratorNode<React.ReactElement> {
   __path: string;
+  __source: string;
 
   static override getType(): string {
     return "composer-mention";
   }
 
   static override clone(node: ComposerMentionNode): ComposerMentionNode {
-    return new ComposerMentionNode(node.__path, node.__key);
+    return new ComposerMentionNode(node.__path, node.__source, node.__key);
   }
 
   static override importJSON(serializedNode: SerializedComposerMentionNode): ComposerMentionNode {
-    return $createComposerMentionNode(serializedNode.path).updateFromJSON(serializedNode);
+    return $createComposerMentionNode(serializedNode.path, serializedNode.source).updateFromJSON(
+      serializedNode,
+    );
   }
 
-  constructor(path: string, key?: NodeKey) {
+  constructor(path: string, source = serializeComposerFileLink(path), key?: NodeKey) {
     super(key);
     this.__path = path;
+    this.__source = source;
   }
 
   override exportJSON(): SerializedComposerMentionNode {
     return {
       ...super.exportJSON(),
       path: this.__path,
+      source: this.__source,
       type: "composer-mention",
       version: 1,
     };
@@ -212,7 +218,7 @@ class ComposerMentionNode extends DecoratorNode<React.ReactElement> {
   }
 
   override getTextContent(): string {
-    return serializeComposerFileLink(this.__path);
+    return this.__source;
   }
 
   override isInline(): true {
@@ -224,8 +230,8 @@ class ComposerMentionNode extends DecoratorNode<React.ReactElement> {
   }
 }
 
-function $createComposerMentionNode(path: string): ComposerMentionNode {
-  return $applyNodeReplacement(new ComposerMentionNode(path));
+function $createComposerMentionNode(path: string, source?: string): ComposerMentionNode {
+  return $applyNodeReplacement(new ComposerMentionNode(path, source));
 }
 
 function resolveSkillDescription(
@@ -851,7 +857,7 @@ function $setComposerEditorPrompt(
       continue;
     }
     if (segment.type === "mention") {
-      paragraph.append($createComposerMentionNode(segment.path));
+      paragraph.append($createComposerMentionNode(segment.path, segment.source));
       continue;
     }
     if (segment.type === "skill") {


### PR DESCRIPTION
Recalling `@README.md control` rewrites its 18 characters into the 30-character `[README.md](README.md) control`. Moving the caret then clears the active history position, so ArrowUp no longer reaches the older prompt.

Preserve the parser's original source in the existing mention node, including Lexical clones and JSON round trips. New mentions and legacy JSON without source keep their canonical serialization. Visual chips are unchanged.

Related [#10056](https://github.com/pingdotgg/t3code/issues/10056). This fixes mention serialization only, not the separate send-time provenance problem.

Verified on September 5, 2026 against latest fetched main [485782b2](https://github.com/pingdotgg/t3code/commit/485782b2aab7d7aee57bacba841e11ac24d9cc63), with candidate [885cc01a](https://github.com/pingdotgg/t3code/commit/885cc01a80e4a4346906fad39ba264a97c141695):

- In the actual browser client, empty composer → ArrowUp → Control+Home → ArrowUp gets stuck on main and reaches `Older plain control` with the fix. Direct ArrowUp → ArrowUp works on main; that is not the failing sequence.
- The candidate keeps the original 18 characters and the visual file chip. Forward history, return to empty, and a recalled draft surviving reload also pass.
- 125 focused tests pass, including actual React/Lexical serialization, quoted and Unicode paths, encoded spelling, controlled prompt replacement and cursor offsets, clone/JSON reload, and legacy/new-mention defaults. Web typechecking, scoped lint, and formatting pass. The orchestrator independently repeated the 125 tests and reviewed both complete changed files and their callers.

The browser comparison uses the same isolated mock backend and stored messages at 1280×900. This proves client recall behavior, not real-provider turn completion. Web and Electron share the changed editor; the separate mobile composer, provider adapters, and wire contracts are unchanged.

Before, after the caret-move/history sequence:

![Before: composer remains stuck on the recalled README mention](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/8086ac48946d9fd9/mention-source-before-stuck.png)

After, the same sequence reaches the older prompt:

![After: composer reaches Older plain control](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/15abf2596b0c2789/mention-source-after-older-settled.png)

[Before recording, 4.8 seconds](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/2ec515886d4b6f7a/mention-source-before-visible.webm) · [After recording, 3.7 seconds](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/2c6304c975c05e69/mention-source-after-visible.webm). Only startup time was trimmed. No UI reconstruction or timing changes.

GPT 6 Astra via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve original mention text in the `ComposerPromptEditor`
> Fixes mention serialization so the original source survives editor reconstruction, Lexical cloning, and JSON export/import.
>
> - Adds a headless test suite in [ComposerPromptEditor.serialization.test.tsx](https://github.com/pingdotgg/t3code/pull/10100/files#diff-5f368e84e89f4f62fcaa8a87d556eaa8c4a70088e61277bfe57259dbf5f08813) covering plain text, file mentions, terminal contexts, quoted and Unicode paths, and Markdown citations.
> - Tests assert controlled prompt replacement, legacy mention JSON fallback (missing `source` field), and canonical serialization of newly pasted mentions.
> - Runtime change: preserve the parser's original mention source during editor reconstruction, cloning, and JSON round trips. New pasted mentions and legacy JSON retain canonical serialization.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 885cc01.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->