### PR TITLE
fix(composer): preserve authored text in prompt recall

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -987,7 +987,7 @@ export function NewTaskDraftScreen(props: {
       startFromOrigin,
       runtimeMode,
       interactionMode,
-      initialMessageText,
+      initialMessageText: draft.text,
       initialAttachments: draft.attachments,
       onAttachmentsUploaded: async (attachments) => {
         flow.replaceAttachments(attachments);

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -1,3 +1,4 @@
+import { createComposerRecall, recallComposerText } from "@t3tools/shared/composerRecall";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type {
@@ -841,7 +842,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     const draftKey = pendingTaskDraftKey(message.messageId);
     // Only hydrate a fresh editing draft; reopening mid-edit keeps newer edits.
     if (isComposerDraftEmpty(getComposerDraftSnapshot(draftKey))) {
-      setComposerDraftText(draftKey, message.text);
+      setComposerDraftText(draftKey, recallComposerText(message));
       replaceComposerDraftAttachments(draftKey, message.attachments);
       updateComposerDraftSettings(draftKey, {
         modelSelection: message.modelSelection,
@@ -904,6 +905,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
         messageId: MessageId.make(metadata.messageId),
         commandId: CommandId.make(metadata.commandId),
         text,
+        composerRecall: createComposerRecall(draft.text),
         attachments: draft.attachments,
         modelSelection: draftModelSelection,
         runtimeMode: draft.runtimeMode ?? DEFAULT_RUNTIME_MODE,

--- a/apps/mobile/src/features/threads/use-project-actions.ts
+++ b/apps/mobile/src/features/threads/use-project-actions.ts
@@ -10,6 +10,7 @@ import {
   type RuntimeMode,
 } from "@t3tools/contracts";
 import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
+import { createComposerRecall } from "@t3tools/shared/composerRecall";
 import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
 
@@ -138,6 +139,9 @@ export function useCreateProjectThread() {
           messageId: metadata.messageId,
           createdAt: metadata.createdAt,
           text: initialMessageText,
+          ...(serverConfig.environment.capabilities.composerRecall === true
+            ? { composerRecall: createComposerRecall(input.initialMessageText) }
+            : {}),
           uploadedAttachments: prepared.attachments,
           modelSelection: input.modelSelection,
           runtimeMode: input.runtimeMode,

--- a/apps/mobile/src/features/threads/use-project-actions.ts
+++ b/apps/mobile/src/features/threads/use-project-actions.ts
@@ -139,7 +139,7 @@ export function useCreateProjectThread() {
           messageId: metadata.messageId,
           createdAt: metadata.createdAt,
           text: initialMessageText,
-          ...(serverConfig.environment.capabilities.composerRecall === true
+          ...(serverConfig?.environment.capabilities.composerRecall === true
             ? { composerRecall: createComposerRecall(input.initialMessageText) }
             : {}),
           uploadedAttachments: prepared.attachments,

--- a/apps/mobile/src/lib/projectThreadStartTurn.test.ts
+++ b/apps/mobile/src/lib/projectThreadStartTurn.test.ts
@@ -1,11 +1,14 @@
 import {
   EnvironmentId,
+  ClientOrchestrationCommand,
   MessageId,
   ProjectId,
   ProviderInstanceId,
   ThreadId,
 } from "@t3tools/contracts";
 import { serializeAssistantCitation } from "@t3tools/shared/assistantCitations";
+import { createComposerRecall, recallComposerText } from "@t3tools/shared/composerRecall";
+import * as Schema from "effect/Schema";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
@@ -13,7 +16,50 @@ import {
   deriveThreadTitleFromPrompt,
 } from "./projectThreadStartTurn";
 
+const decodeClientCommand = Schema.decodeUnknownSync(ClientOrchestrationCommand);
+
 describe("project thread title", () => {
+  it("round trips a project send through the wire without changing provider text", () => {
+    const raw = "  Ultrathink:\nLiteral mobile example 😀\n";
+    const spec = {
+      projectId: ProjectId.make("project"),
+      projectCwd: "/workspace",
+      threadId: "thread",
+      commandId: "command",
+      messageId: "message",
+      createdAt: "2026-09-05T00:00:00Z",
+      text: raw.trim(),
+      uploadedAttachments: [],
+      modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "test-model" },
+      runtimeMode: "full-access",
+      interactionMode: "default",
+      workspaceMode: "local",
+      branch: null,
+      worktreePath: null,
+      startFromOrigin: false,
+      worktreeBranchName: "unused",
+    } as const;
+    const input = buildProjectThreadStartTurnInput({
+      ...spec,
+      composerRecall: createComposerRecall(raw),
+    });
+    const command = decodeClientCommand(
+      JSON.parse(JSON.stringify({ type: "thread.turn.start", ...input })),
+    );
+    expect(command.type).toBe("thread.turn.start");
+    if (command.type !== "thread.turn.start") throw new Error("Unexpected command");
+    expect(command.message.text).toBe(raw.trim());
+    expect(recallComposerText(command.message)).toBe(raw);
+    const legacy = buildProjectThreadStartTurnInput(spec);
+    expect(legacy.message).toEqual({
+      messageId: "message",
+      role: "user",
+      text: raw.trim(),
+      attachments: [],
+    });
+    expect(input.titleSeed).toBe(legacy.titleSeed);
+    expect(input.bootstrap).toEqual(legacy.bootstrap);
+  });
   it("keeps ordinary titles and the empty-prompt fallback", () => {
     expect(deriveThreadTitleFromPrompt("  Fix\n the parser  ")).toBe("Fix the parser");
     expect(deriveThreadTitleFromPrompt(" \n ")).toBe("New thread");

--- a/apps/mobile/src/lib/projectThreadStartTurn.ts
+++ b/apps/mobile/src/lib/projectThreadStartTurn.ts
@@ -3,6 +3,7 @@ import {
   MessageId,
   ThreadId,
   type ModelSelection,
+  type ComposerRecall,
   type ProjectId,
   type ProviderInteractionMode,
   type RuntimeMode,
@@ -29,6 +30,7 @@ export interface ProjectThreadStartTurnSpec {
   readonly messageId: string;
   readonly createdAt: string;
   readonly text: string;
+  readonly composerRecall?: ComposerRecall;
   /** Wire attachments from `prepareTurnAttachments`, in composer order. */
   readonly uploadedAttachments: ReadonlyArray<UploadedMobileAttachment>;
   readonly modelSelection: ModelSelection;
@@ -57,6 +59,7 @@ export function buildProjectThreadStartTurnInput(spec: ProjectThreadStartTurnSpe
       messageId: MessageId.make(spec.messageId),
       role: "user" as const,
       text: spec.text,
+      ...(spec.composerRecall !== undefined ? { composerRecall: spec.composerRecall } : {}),
       attachments: spec.uploadedAttachments,
     },
     modelSelection: spec.modelSelection,

--- a/apps/mobile/src/state/thread-outbox-model.ts
+++ b/apps/mobile/src/state/thread-outbox-model.ts
@@ -6,6 +6,7 @@ import {
 import type { EnvironmentShellStatus } from "@t3tools/client-runtime/state/shell";
 import {
   CommandId,
+  ComposerRecall,
   EnvironmentId,
   IsoDateTime,
   MessageId,
@@ -50,6 +51,7 @@ export const QueuedThreadMessageSchema = Schema.Struct({
   messageId: MessageId,
   commandId: CommandId,
   text: Schema.String,
+  composerRecall: Schema.optional(ComposerRecall),
   attachments: Schema.Array(DraftComposerAttachmentSchema),
   modelSelection: Schema.optional(ModelSelection),
   runtimeMode: Schema.optional(RuntimeMode),
@@ -79,6 +81,7 @@ export interface QueuedThreadMessage {
   readonly messageId: MessageId;
   readonly commandId: CommandId;
   readonly text: string;
+  readonly composerRecall?: ComposerRecall;
   readonly attachments: ReadonlyArray<DraftComposerAttachment>;
   readonly modelSelection?: ModelSelectionType;
   readonly runtimeMode?: RuntimeModeType;

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@t3tools/contracts";
 import { AtomRegistry } from "effect/unstable/reactivity";
 import { onTestFinished, vi } from "vite-plus/test";
+import { createComposerRecall, recallComposerText } from "@t3tools/shared/composerRecall";
 
 const outboxFiles = vi.hoisted(() => new Map<string, string | Error>());
 
@@ -107,6 +108,75 @@ function queuedMessage(input: {
 }
 
 describe("thread outbox", () => {
+  it("preserves recall through durable queue restart, attachment rewrite and edit", async () => {
+    onTestFinished(() => outboxFiles.clear());
+    const registry = AtomRegistry.make();
+    onTestFinished(() => registry.dispose());
+    const manager = createThreadOutboxManager({ registry, storage: expoThreadOutboxStorage });
+    const raw = "  Ultrathink:\nKeep this literal 😀\n";
+    const message = {
+      ...queuedMessage({ messageId: "recall", createdAt: "2026-09-05T00:00:00Z" }),
+      text: raw.trim(),
+      composerRecall: createComposerRecall(raw),
+    };
+    await manager.enqueue(message);
+    expect(JSON.parse(String(outboxFiles.get("recall.json"))).schemaVersion).toBe(3);
+    const restartedRegistry = AtomRegistry.make();
+    onTestFinished(() => restartedRegistry.dispose());
+    const restarted = createThreadOutboxManager({
+      registry: restartedRegistry,
+      storage: expoThreadOutboxStorage,
+    });
+    await restarted.load();
+    const restored = Object.values(
+      restartedRegistry.get(restarted.queuedMessagesByThreadKeyAtom),
+    ).flat()[0]!;
+    expect(restored.composerRecall).toEqual(message.composerRecall);
+    expect(recallComposerText(restored)).toBe(raw);
+    const revision = restarted.revisionOf(restored.messageId);
+    const uploaded = {
+      ...restored,
+      attachments: [
+        {
+          id: "image",
+          type: "image" as const,
+          name: "photo.png",
+          mimeType: "image/png",
+          sizeBytes: 3,
+          fileUri: "file:///documents/photo.png",
+          previewUri: "file:///documents/photo.png",
+          uploadedAttachmentId: "pending-photo",
+          uploadEnvironmentId: message.environmentId,
+        },
+      ],
+    };
+    expect(await restarted.update(uploaded, revision)).toBe(true);
+    const uploadedRecord = (await expoThreadOutboxStorage.load()).messages[0]!;
+    expect(uploadedRecord.attachments).toEqual(uploaded.attachments);
+    expect(recallComposerText(uploadedRecord)).toBe(raw);
+    const editedRaw = "\tA different edited literal\n";
+    const edited = {
+      ...restored,
+      text: editedRaw.trim(),
+      composerRecall: createComposerRecall(editedRaw),
+    };
+    expect(await restarted.update(edited, restarted.revisionOf(restored.messageId))).toBe(true);
+    expect(await restarted.update(restored, revision)).toBe(false);
+    const persisted = (await expoThreadOutboxStorage.load()).messages[0]!;
+    expect(recallComposerText(persisted)).toBe(editedRaw);
+    const legacy = decodeQueuedThreadMessage({
+      ...(encodeQueuedThreadMessage(
+        queuedMessage({
+          messageId: "legacy",
+          createdAt: "2026-09-05T00:00:00Z",
+        }),
+      ) as object),
+      text: raw,
+      schemaVersion: 3,
+    });
+    expect(legacy.composerRecall).toBeUndefined();
+    expect(recallComposerText(legacy)).toBe(raw);
+  });
   it.each(["read", "json", "schema"] as const)(
     "recovers usable messages without permitting cleanup after a record %s failure",
     async (failure) => {

--- a/apps/mobile/src/state/use-thread-composer-state.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.ts
@@ -56,6 +56,7 @@ import { setPendingConnectionError } from "../state/use-remote-environment-regis
 import { useSelectedThreadDetail } from "../state/use-thread-detail";
 import { useThreadSelection } from "../state/use-thread-selection";
 import { enqueueThreadOutboxMessage } from "./thread-outbox";
+import { createComposerRecall } from "@t3tools/shared/composerRecall";
 import { dispatchingQueuedMessageIdAtom, useThreadOutboxMessages } from "./use-thread-outbox";
 import { threadEnvironment } from "./threads";
 import { useAtomCommand } from "./use-atom-command";
@@ -358,6 +359,7 @@ export function useThreadComposerState() {
       commandId: CommandId.make(metadata.commandId),
       text,
       attachments,
+      composerRecall: createComposerRecall(draft.text),
       modelSelection,
       runtimeMode: draft.runtimeMode ?? thread.runtimeMode,
       interactionMode: resolveProviderInteractionMode(
@@ -379,7 +381,7 @@ export function useThreadComposerState() {
         // append: the merge path slots existing attachments first and truncates
         // at the send limit, which would silently drop this message's images if
         // the user attached new ones while the write was in flight.
-        void mergeComposerDraftContent(threadKey, { text, attachments: [] });
+        void mergeComposerDraftContent(threadKey, { text: draft.text, attachments: [] });
         appendComposerDraftAttachments(threadKey, attachments, { allowOverflow: true });
         setPendingConnectionError(
           error instanceof Error ? error.message : "Failed to save the queued message.",

--- a/apps/mobile/src/state/use-thread-outbox-drain.test.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.test.ts
@@ -1,3 +1,4 @@
+import { createComposerRecall } from "@t3tools/shared/composerRecall";
 import {
   CommandId,
   EnvironmentId,
@@ -582,6 +583,23 @@ describe("thread outbox delivered creation recovery", () => {
 });
 
 describe("thread outbox recovery rollback", () => {
+  it("restores authored recall whitespace without losing a concurrent draft", async () => {
+    const raw = "  Ultrathink:\nKeep this example\n";
+    const message = {
+      ...queuedMessage({ messageId: "recall-restore", text: raw.trim() }),
+      composerRecall: createComposerRecall(raw),
+    };
+    const draftKey = `${message.environmentId}:${message.threadId}`;
+    appAtomRegistry.set(composerDrafts.composerDraftsAtom, {
+      [draftKey]: { text: "typed while queued", attachments: [] },
+    });
+    await harness.manager.enqueue(message);
+    await expect(restoreRejectedQueuedMessage(message, "rejected")).resolves.toBe("restored");
+    expect(composerDrafts.getComposerDraftSnapshot(draftKey).text).toBe(
+      `typed while queued\n\n${raw}`,
+    );
+    expect(remainingMessages()).toEqual([]);
+  });
   it("restores a rejected new task into its durable project draft", async () => {
     const message: QueuedThreadMessage = {
       ...queuedMessage({ messageId: "message-creation-restore", text: "new task text" }),

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -1,3 +1,4 @@
+import { recallComposerText } from "@t3tools/shared/composerRecall";
 import { useAtomValue } from "@effect/atom-react";
 import type {
   EnvironmentProject,
@@ -280,7 +281,7 @@ export async function recoverEditedCreationAfterDelivery(
     // from deleting the attachment files. allowOverflow mirrors the
     // send-failure restore; the send path refuses over-cap drafts, so the
     // state stays recoverable.
-    await mergeComposerDraftContent(draftKey, { text: kept.text, attachments: [] });
+    await mergeComposerDraftContent(draftKey, { text: recallComposerText(kept), attachments: [] });
     if (appAtomRegistry.get(editingQueuedMessageIdsAtom)[kept.messageId]) {
       return true;
     }
@@ -370,7 +371,7 @@ export async function restoreRejectedQueuedMessage(
     let mergedDraft: ComposerDraft;
     try {
       await mergeComposerDraftContent(draftKey, {
-        text: queuedMessage.text,
+        text: recallComposerText(queuedMessage),
         attachments: queuedMessage.attachments,
       });
     } finally {
@@ -759,6 +760,10 @@ export function useThreadOutboxDrain(): void {
             messageId: queuedMessage.messageId,
             role: "user",
             text: queuedMessage.text,
+            ...(currentConfig.environment.capabilities.composerRecall === true &&
+            queuedMessage.composerRecall !== undefined
+              ? { composerRecall: queuedMessage.composerRecall }
+              : {}),
             attachments: prepared.attachments,
           },
           modelSelection: sendSettings.modelSelection,
@@ -880,6 +885,10 @@ export function useThreadOutboxDrain(): void {
           messageId: queuedMessage.messageId,
           createdAt: queuedMessage.createdAt,
           text: queuedMessage.text.trim(),
+          ...(currentConfig.environment.capabilities.composerRecall === true &&
+          queuedMessage.composerRecall !== undefined
+            ? { composerRecall: queuedMessage.composerRecall }
+            : {}),
           uploadedAttachments: prepared.attachments,
           modelSelection: sendSettings.modelSelection,
           runtimeMode: sendSettings.runtimeMode,

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -226,6 +226,7 @@ export const make = Effect.gen(function* () {
       usagePriceOverrides: true,
       threadPinning: true,
       threadPinReorder: true,
+      composerRecall: true,
       threadTitleRegeneration: true,
       threadPullRequestLinking: true,
       environmentIcon: true,

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -236,7 +236,7 @@ describe("OrchestrationEngine", () => {
       }
       const events = await system.run(Stream.runCollect(system.engine.readEvents(0)));
       let replay = createEmptyReadModel(now());
-      for (const event of events) replay = await Effect.runPromise(projectEvent(replay, event));
+      for (const event of events) replay = await system.run(projectEvent(replay, event));
       for (const entry of cases) {
         expect(
           replay.threads.find((thread) => thread.id === `recall-${entry.id}`)?.messages[0]

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -2,6 +2,7 @@
 import * as NodeFSP from "node:fs/promises";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
+import * as NodeSqlite from "node:sqlite";
 
 import {
   ApprovalRequestId,
@@ -53,6 +54,7 @@ import {
 } from "../Services/ProjectionPipeline.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
 import { ServerConfig } from "../../config.ts";
+import { createEmptyReadModel, projectEvent } from "../projector.ts";
 
 const asProjectId = (value: string): ProjectId => ProjectId.make(value);
 const asMessageId = (value: string): MessageId => MessageId.make(value);
@@ -93,6 +95,8 @@ async function createOrchestrationSystem(databasePath?: string) {
     readModel: () => runtime.runPromise(snapshotQuery.getSnapshot()),
     readThread: (threadId: ThreadId) =>
       runtime.runPromise(snapshotQuery.getThreadDetailById(threadId)),
+    readWindow: (threadId: ThreadId) =>
+      runtime.runPromise(snapshotQuery.getThreadDetailSnapshot(threadId, { turnLimit: 10 })),
     run: <A, E>(effect: Effect.Effect<A, E>) => runtime.runPromise(effect),
     dispose: () => runtime.dispose(),
   };
@@ -114,6 +118,141 @@ const hasMetricSnapshot = (
   );
 
 describe("OrchestrationEngine", () => {
+  it("persists composer recall through committed events, SQLite, window reads and restart", async () => {
+    const directory = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3-composer-recall-"));
+    const databasePath = NodePath.join(directory, "state.sqlite");
+    let system = await createOrchestrationSystem(databasePath);
+    const projectId = ProjectId.make("recall-project");
+    const text = "Ultrathink:\nKeep this prefix in my example";
+    const cases = [
+      { id: "literal", composerRecall: { ranges: [[0, text.length]] } },
+      { id: "generated", composerRecall: { ranges: [[12, text.length]] } },
+      { id: "none", composerRecall: { ranges: [] } },
+      { id: "legacy" },
+      { id: "invalid", composerRecall: { ranges: [[0, text.length + 1]] } },
+      { id: "large", text: "x".repeat(50_000), composerRecall: { ranges: [[0, 50_000]] } },
+    ] as const;
+    try {
+      await system.run(
+        system.engine.dispatch({
+          type: "project.create",
+          commandId: CommandId.make("recall-project"),
+          projectId,
+          title: "Recall",
+          workspaceRoot: directory,
+          createdAt: now(),
+        }),
+      );
+      for (const entry of cases) {
+        const messageText = "text" in entry ? entry.text : text;
+        const threadId = ThreadId.make(`recall-${entry.id}`);
+        await system.run(
+          system.engine.dispatch({
+            type: "thread.create",
+            commandId: CommandId.make(`create-${entry.id}`),
+            threadId,
+            projectId,
+            title: entry.id,
+            modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "test-model" },
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            branch: null,
+            worktreePath: null,
+            createdAt: now(),
+          }),
+        );
+        const message = {
+          messageId: MessageId.make(entry.id),
+          role: "user" as const,
+          text: messageText,
+          attachments: [],
+          ...("composerRecall" in entry ? { composerRecall: entry.composerRecall } : {}),
+        };
+        const receipt = await system.run(
+          system.engine.dispatch({
+            type: "thread.turn.start",
+            commandId: CommandId.make(`send-${entry.id}`),
+            threadId,
+            message,
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            createdAt: now(),
+          }),
+        );
+        const events = await system.run(
+          Stream.runCollect(system.engine.readEvents(receipt.sequence - 2)),
+        );
+        const sent = events.find((event) => event.type === "thread.message-sent");
+        expect(sent?.payload.text).toBe(messageText);
+        expect(sent?.payload.composerRecall).toEqual(
+          entry.id !== "invalid" && "composerRecall" in entry ? entry.composerRecall : undefined,
+        );
+      }
+      const assertSnapshot = async () => {
+        const snapshot = await system.readModel();
+        for (const entry of cases) {
+          const threadId = ThreadId.make(`recall-${entry.id}`);
+          const expected =
+            entry.id !== "invalid" && "composerRecall" in entry ? entry.composerRecall : undefined;
+          const snapshotMessage = snapshot.threads.find((thread) => thread.id === threadId)
+            ?.messages[0];
+          expect(snapshotMessage?.text).toBe("text" in entry ? entry.text : text);
+          expect(snapshotMessage).toHaveProperty("id", entry.id);
+          expect(snapshotMessage?.composerRecall).toEqual(expected);
+          const detail = Option.getOrThrow(await system.readThread(threadId));
+          expect(detail.messages[0]?.composerRecall).toEqual(expected);
+          const window = Option.getOrThrow(await system.readWindow(threadId));
+          expect(window.thread.messages[0]?.composerRecall).toEqual(expected);
+        }
+      };
+      await assertSnapshot();
+      const db = new NodeSqlite.DatabaseSync(databasePath, { readOnly: true });
+      try {
+        const rows = db
+          .prepare(
+            "SELECT message_id, text, composer_recall_json FROM projection_thread_messages ORDER BY message_id",
+          )
+          .all();
+        expect(rows.map((row) => [row.message_id, row.text, row.composer_recall_json])).toEqual([
+          ["generated", text, JSON.stringify({ ranges: [[12, text.length]] })],
+          ["invalid", text, null],
+          ["large", "x".repeat(50_000), JSON.stringify({ ranges: [[0, 50_000]] })],
+          ["legacy", text, null],
+          ["literal", text, JSON.stringify({ ranges: [[0, text.length]] })],
+          ["none", text, JSON.stringify({ ranges: [] })],
+        ]);
+        const large = rows.find((row) => row.message_id === "large")!;
+        expect(Buffer.byteLength(String(large.composer_recall_json))).toBe(22);
+        expect(
+          Buffer.byteLength(
+            JSON.stringify({
+              text: large.text,
+              composerRecall: JSON.parse(String(large.composer_recall_json)),
+            }),
+          ) - Buffer.byteLength(JSON.stringify({ text: large.text })),
+        ).toBe(40);
+      } finally {
+        db.close();
+      }
+      const events = await system.run(Stream.runCollect(system.engine.readEvents(0)));
+      let replay = createEmptyReadModel(now());
+      for (const event of events) replay = await Effect.runPromise(projectEvent(replay, event));
+      for (const entry of cases) {
+        expect(
+          replay.threads.find((thread) => thread.id === `recall-${entry.id}`)?.messages[0]
+            ?.composerRecall,
+        ).toEqual(
+          entry.id !== "invalid" && "composerRecall" in entry ? entry.composerRecall : undefined,
+        );
+      }
+      await system.dispose();
+      system = await createOrchestrationSystem(databasePath);
+      await assertSnapshot();
+    } finally {
+      await system.dispose();
+      await NodeFSP.rm(directory, { recursive: true, force: true });
+    }
+  });
   it.each(["running", "stopped"] as const)(
     "sends async answers with a %s session and rejects old duplicate replies",
     async (status) => {

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1064,12 +1064,16 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
                   attachments: event.payload.attachments,
                 })
               : previousMessage?.attachments;
+          const composerRecall =
+            event.payload.composerRecall ??
+            (previousMessage?.text === nextText ? previousMessage.composerRecall : undefined);
           yield* projectionThreadMessageRepository.upsert({
             messageId: event.payload.messageId,
             threadId: event.payload.threadId,
             turnId: event.payload.turnId,
             role: event.payload.role,
             text: nextText,
+            ...(composerRecall !== undefined ? { composerRecall } : {}),
             ...(nextAttachments !== undefined ? { attachments: [...nextAttachments] } : {}),
             isStreaming: false,
             createdAt: previousMessage?.createdAt ?? event.payload.createdAt,

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -1,3 +1,4 @@
+import { ComposerRecall } from "@t3tools/contracts";
 import {
   AgentSessionImportSource,
   ApprovalRequestId,
@@ -103,6 +104,7 @@ const ProjectionThreadMessageDbRowSchema = ProjectionThreadMessage.mapFields(
   Struct.assign({
     isStreaming: Schema.Number,
     attachments: Schema.NullOr(Schema.fromJsonString(Schema.Array(ChatAttachment))),
+    composerRecall: Schema.NullOr(Schema.fromJsonString(ComposerRecall)),
   }),
 );
 const ProjectionThreadProposedPlanDbRowSchema = ProjectionThreadProposedPlan;
@@ -605,6 +607,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           role,
           text,
           attachments_json AS "attachments",
+          composer_recall_json AS "composerRecall",
           is_streaming AS "isStreaming",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
@@ -1129,6 +1132,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           role,
           text,
           attachments_json AS "attachments",
+          composer_recall_json AS "composerRecall",
           is_streaming AS "isStreaming",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
@@ -1486,6 +1490,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           role,
           text,
           attachments_json AS "attachments",
+          composer_recall_json AS "composerRecall",
           is_streaming AS "isStreaming",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
@@ -1884,6 +1889,7 @@ pending_approval_requests AS (
                   id: row.messageId,
                   role: row.role,
                   text: row.text,
+                  ...(row.composerRecall !== null ? { composerRecall: row.composerRecall } : {}),
                   ...(row.attachments !== null ? { attachments: row.attachments } : {}),
                   turnId: row.turnId,
                   streaming: row.isStreaming === 1,
@@ -3119,6 +3125,7 @@ pending_approval_requests AS (
             id: row.messageId,
             role: row.role,
             text: row.text,
+            ...(row.composerRecall !== null ? { composerRecall: row.composerRecall } : {}),
             turnId: row.turnId,
             streaming: row.isStreaming === 1,
             createdAt: row.createdAt,

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -10,6 +10,7 @@ import {
   type OrchestrationThreadActivity,
 } from "@t3tools/contracts";
 import { compareDateTimeStrings } from "@t3tools/shared/dateTime";
+import { validComposerRecall } from "@t3tools/shared/composerRecall";
 import * as DateTime from "effect/DateTime";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
@@ -956,6 +957,14 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           messageId: command.message.messageId,
           role: "user",
           text: command.message.text,
+          ...(command.message.composerRecall !== undefined
+            ? {
+                composerRecall: validComposerRecall(
+                  command.message.text,
+                  command.message.composerRecall,
+                ),
+              }
+            : {}),
           attachments: command.message.attachments,
           turnId: null,
           streaming: false,

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -561,6 +561,9 @@ export function projectEvent(
             id: payload.messageId,
             role: payload.role,
             text: payload.text,
+            ...(payload.composerRecall !== undefined
+              ? { composerRecall: payload.composerRecall }
+              : {}),
             ...(payload.attachments !== undefined ? { attachments: payload.attachments } : {}),
             turnId: payload.turnId,
             streaming: payload.streaming,
@@ -583,6 +586,12 @@ export function projectEvent(
                         ? message.text
                         : entry.text,
                     streaming: message.streaming,
+                    composerRecall:
+                      message.composerRecall ??
+                      (message.text.length === 0 ||
+                      (!message.streaming && message.text === entry.text)
+                        ? entry.composerRecall
+                        : undefined),
                     updatedAt: message.updatedAt,
                     turnId: message.turnId,
                     ...(message.attachments !== undefined

--- a/apps/server/src/persistence/Layers/ProjectionThreadMessages.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadMessages.test.ts
@@ -12,6 +12,42 @@ const layer = it.layer(
 );
 
 layer("ProjectionThreadMessageRepository", (it) => {
+  it.effect("keeps recall for empty updates and discards it when text changes", () =>
+    Effect.gen(function* () {
+      const repository = yield* ProjectionThreadMessageRepository;
+      const message = {
+        messageId: MessageId.make("recall-update"),
+        threadId: ThreadId.make("recall-thread"),
+        turnId: null,
+        role: "user" as const,
+        text: "literal",
+        isStreaming: false,
+        createdAt: "2026-09-05T00:00:00Z",
+        updatedAt: "2026-09-05T00:00:00Z",
+        composerRecall: { ranges: [[0, 7]] } as const,
+      };
+      yield* repository.upsert(message);
+      yield* repository.appendStreaming({ ...message, text: "" });
+      assert.deepEqual(
+        (yield* repository.listByThreadId(message))[0]?.composerRecall,
+        message.composerRecall,
+      );
+      yield* repository.appendStreaming({
+        ...message,
+        text: " changed",
+        composerRecall: undefined,
+      });
+      const appended = (yield* repository.listByThreadId(message))[0];
+      assert.strictEqual(appended?.text, "literal changed");
+      assert.strictEqual(appended?.composerRecall, undefined);
+      yield* repository.upsert(message);
+      yield* repository.upsert({ ...message, text: "replacement", composerRecall: undefined });
+      const replaced = (yield* repository.listByThreadId(message))[0];
+      assert.strictEqual(replaced?.text, "replacement");
+      assert.strictEqual(replaced?.composerRecall, undefined);
+    }),
+  );
+
   it.effect("finds the latest live user-message time within one thread", () =>
     Effect.gen(function* () {
       const repository = yield* ProjectionThreadMessageRepository;

--- a/apps/server/src/persistence/Layers/ProjectionThreadMessages.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadMessages.ts
@@ -5,7 +5,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import * as Struct from "effect/Struct";
-import { ChatAttachment } from "@t3tools/contracts";
+import { ChatAttachment, ComposerRecall } from "@t3tools/contracts";
 
 import { toPersistenceSqlError } from "../Errors.ts";
 import {
@@ -22,6 +22,7 @@ const ProjectionThreadMessageDbRowSchema = ProjectionThreadMessage.mapFields(
   Struct.assign({
     isStreaming: Schema.Number,
     attachments: Schema.NullOr(Schema.fromJsonString(Schema.Array(ChatAttachment))),
+    composerRecall: Schema.NullOr(Schema.fromJsonString(ComposerRecall)),
   }),
 );
 
@@ -34,6 +35,7 @@ function toProjectionThreadMessage(
     turnId: row.turnId,
     role: row.role,
     text: row.text,
+    ...(row.composerRecall !== null ? { composerRecall: row.composerRecall } : {}),
     isStreaming: row.isStreaming === 1,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
@@ -57,6 +59,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           role,
           text,
           attachments_json,
+          composer_recall_json,
           is_streaming,
           created_at,
           updated_at
@@ -75,6 +78,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
               WHERE message_id = ${row.messageId}
             )
           ),
+          ${row.composerRecall !== undefined ? JSON.stringify(row.composerRecall) : null},
           ${row.isStreaming ? 1 : 0},
           ${row.createdAt},
           ${row.updatedAt}
@@ -85,6 +89,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           turn_id = excluded.turn_id,
           role = excluded.role,
           text = excluded.text,
+          composer_recall_json = excluded.composer_recall_json,
           attachments_json = COALESCE(
             excluded.attachments_json,
             projection_thread_messages.attachments_json
@@ -109,6 +114,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           role,
           text,
           attachments_json,
+          composer_recall_json,
           is_streaming,
           created_at,
           updated_at
@@ -120,6 +126,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           ${row.role},
           ${row.text},
           ${nextAttachmentsJson},
+          ${row.composerRecall !== undefined ? JSON.stringify(row.composerRecall) : null},
           1,
           ${row.createdAt},
           ${row.updatedAt}
@@ -130,6 +137,8 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           turn_id = excluded.turn_id,
           role = excluded.role,
           text = projection_thread_messages.text || excluded.text,
+          composer_recall_json = CASE WHEN excluded.text = ''
+            THEN projection_thread_messages.composer_recall_json ELSE NULL END,
           attachments_json = COALESCE(
             excluded.attachments_json,
             projection_thread_messages.attachments_json
@@ -152,6 +161,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           role,
           text,
           attachments_json AS "attachments",
+          composer_recall_json AS "composerRecall",
           is_streaming AS "isStreaming",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
@@ -173,6 +183,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           role,
           text,
           attachments_json AS "attachments",
+          composer_recall_json AS "composerRecall",
           is_streaming AS "isStreaming",
           created_at AS "createdAt",
           updated_at AS "updatedAt"

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -59,6 +59,7 @@ import Migration0044 from "./Migrations/044_ClearAutomaticProjectModelDefaults.t
 import Migration0045 from "./Migrations/045_ProjectionProjectsAutoPull.ts";
 import Migration0046 from "./Migrations/046_RepairAutomaticSettlementTimestamps.ts";
 import Migration0047 from "./Migrations/047_ProjectionProjectIcon.ts";
+import Migration0048 from "./Migrations/048_ProjectionMessageComposerRecall.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -118,6 +119,7 @@ export const migrationEntries = [
   [45, "ProjectionProjectsAutoPull", Migration0045],
   [46, "RepairAutomaticSettlementTimestamps", Migration0046],
   [47, "ProjectionProjectIcon", Migration0047],
+  [48, "ProjectionMessageComposerRecall", Migration0048],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);

--- a/apps/server/src/persistence/Migrations/048_ProjectionMessageComposerRecall.test.ts
+++ b/apps/server/src/persistence/Migrations/048_ProjectionMessageComposerRecall.test.ts
@@ -1,0 +1,28 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as NodeSqliteClient from "@t3tools/shared/nodeSqliteClient";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+
+it.layer(NodeSqliteClient.layerMemory())("048_ProjectionMessageComposerRecall", (it) => {
+  it.effect("leaves existing message text unchanged and its origin unknown", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations({ toMigrationInclusive: 47 });
+      const text = "Ultrathink:\nKeep this prefix in my example";
+      yield* sql`INSERT INTO projection_thread_messages
+        (message_id, thread_id, role, text, is_streaming, created_at, updated_at)
+        VALUES ('legacy', 'thread', 'user', ${text}, 0, '2026-09-05T00:00:00Z', '2026-09-05T00:00:00Z')`;
+      yield* runMigrations({ toMigrationInclusive: 48 });
+      yield* runMigrations({ toMigrationInclusive: 48 });
+      const rows = yield* sql<{
+        readonly text: string;
+        readonly composer_recall_json: string | null;
+      }>`
+        SELECT text, composer_recall_json FROM projection_thread_messages WHERE message_id = 'legacy'
+      `;
+      assert.deepEqual(rows, [{ text, composer_recall_json: null }]);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/048_ProjectionMessageComposerRecall.ts
+++ b/apps/server/src/persistence/Migrations/048_ProjectionMessageComposerRecall.ts
@@ -1,0 +1,7 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  yield* sql`ALTER TABLE projection_thread_messages ADD COLUMN composer_recall_json TEXT`;
+});

--- a/apps/server/src/persistence/Services/ProjectionThreadMessages.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadMessages.ts
@@ -8,6 +8,7 @@
  */
 import {
   ChatAttachment,
+  ComposerRecall,
   MessageId,
   OrchestrationMessageRole,
   ThreadId,
@@ -28,6 +29,7 @@ export const ProjectionThreadMessage = Schema.Struct({
   turnId: Schema.NullOr(TurnId),
   role: OrchestrationMessageRole,
   text: Schema.String,
+  composerRecall: Schema.optional(ComposerRecall),
   attachments: Schema.optional(Schema.Array(ChatAttachment)),
   isStreaming: Schema.Boolean,
   createdAt: IsoDateTime,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1,4 +1,4 @@
-import { offsetComposerRecall } from "@t3tools/shared/composerRecall";
+import { createComposerRecall, offsetComposerRecall } from "@t3tools/shared/composerRecall";
 import {
   type AssistantCitation,
   type ApprovalRequestId,
@@ -256,7 +256,7 @@ import {
 } from "../composerDraftStore";
 import {
   composeTerminalContextPrompt,
-  createDraftComposerRecall,
+  stripInlineTerminalContextPlaceholders,
   formatTerminalContextLabel,
   type TerminalContextDraft,
   type TerminalContextSelection,
@@ -6329,7 +6329,9 @@ export default function ChatView(props: ChatViewProps) {
       await onSubmitPlanFollowUp({
         text: followUp.text,
         composerRecall:
-          trimmed.length > 0 ? createDraftComposerRecall(promptForSend) : { ranges: [] },
+          trimmed.length > 0
+            ? createComposerRecall(stripInlineTerminalContextPlaceholders(promptForSend))
+            : { ranges: [] },
         interactionMode: followUp.interactionMode,
       });
       return;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1,7 +1,9 @@
+import { offsetComposerRecall } from "@t3tools/shared/composerRecall";
 import {
   type AssistantCitation,
   type ApprovalRequestId,
   type ChatFileAttachment,
+  type ComposerRecall,
   DEFAULT_MODEL,
   type EnvironmentId,
   type MessageId,
@@ -253,7 +255,8 @@ import {
   type DraftId,
 } from "../composerDraftStore";
 import {
-  appendTerminalContextsToPrompt,
+  composeTerminalContextPrompt,
+  createDraftComposerRecall,
   formatTerminalContextLabel,
   type TerminalContextDraft,
   type TerminalContextSelection,
@@ -6325,6 +6328,8 @@ export default function ChatView(props: ChatViewProps) {
       composerRef.current?.resetCursorState();
       await onSubmitPlanFollowUp({
         text: followUp.text,
+        composerRecall:
+          trimmed.length > 0 ? createDraftComposerRecall(promptForSend) : { ranges: [] },
         interactionMode: followUp.interactionMode,
       });
       return;
@@ -6396,8 +6401,12 @@ export default function ChatView(props: ChatViewProps) {
     const composerElementContextsSnapshot = [...composerElementContexts];
     const composerPreviewAnnotationsSnapshot = [...composerPreviewAnnotations];
     const composerReviewCommentsSnapshot: ReviewCommentContext[] = [...composerReviewComments];
+    const terminalPrompt = composeTerminalContextPrompt(
+      promptForSend,
+      composerTerminalContextsSnapshot,
+    );
     const messageTextWithContexts = appendElementContextsToPrompt(
-      appendTerminalContextsToPrompt(promptForSend, composerTerminalContextsSnapshot),
+      terminalPrompt.text,
       composerElementContextsSnapshot,
     );
     const messageTextWithPreviewAnnotations = composerPreviewAnnotationsSnapshot.reduce(
@@ -6415,6 +6424,15 @@ export default function ChatView(props: ChatViewProps) {
       effort: ctxSelectedPromptEffort,
       text: messageTextForSend || ATTACHMENT_ONLY_BOOTSTRAP_PROMPT,
     });
+    const outgoingComposerRecall =
+      appAtomRegistry.get(environmentServerConfigsAtom).get(environmentId)?.environment.capabilities
+        .composerRecall === true
+        ? offsetComposerRecall(
+            terminalPrompt.composerRecall,
+            outgoingMessageText.length -
+              (messageTextForSend || ATTACHMENT_ONLY_BOOTSTRAP_PROMPT).trim().length,
+          )
+        : undefined;
     if (composerRef.current?.validateProviderInput(outgoingMessageText) === false) {
       return;
     }
@@ -6574,6 +6592,7 @@ export default function ChatView(props: ChatViewProps) {
         id: messageIdForSend,
         role: "user",
         text: outgoingMessageText,
+        ...(outgoingComposerRecall !== undefined ? { composerRecall: outgoingComposerRecall } : {}),
         ...(optimisticAttachments.length > 0 ? { attachments: optimisticAttachments } : {}),
         turnId: null,
         createdAt: messageCreatedAt,
@@ -6717,6 +6736,9 @@ export default function ChatView(props: ChatViewProps) {
             messageId: messageIdForSend,
             role: "user",
             text: outgoingMessageText,
+            ...(outgoingComposerRecall !== undefined
+              ? { composerRecall: outgoingComposerRecall }
+              : {}),
             attachments: turnAttachmentsResult.value,
           },
           modelSelection: ctxSelectedModelSelection,
@@ -7042,9 +7064,11 @@ export default function ChatView(props: ChatViewProps) {
   const onSubmitPlanFollowUp = useCallback(
     async ({
       text,
+      composerRecall,
       interactionMode: nextInteractionMode,
     }: {
       text: string;
+      composerRecall: ComposerRecall;
       interactionMode: "default" | "plan";
     }) => {
       if (
@@ -7084,6 +7108,11 @@ export default function ChatView(props: ChatViewProps) {
         effort: ctxSelectedPromptEffort,
         text: trimmed,
       });
+      const outgoingComposerRecall =
+        appAtomRegistry.get(environmentServerConfigsAtom).get(environmentId)?.environment
+          .capabilities.composerRecall === true
+          ? offsetComposerRecall(composerRecall, outgoingMessageText.length - trimmed.length)
+          : undefined;
 
       sendInFlightRef.current = true;
       beginLocalDispatch({ preparingWorktree: false });
@@ -7097,6 +7126,9 @@ export default function ChatView(props: ChatViewProps) {
           id: messageIdForSend,
           role: "user",
           text: outgoingMessageText,
+          ...(outgoingComposerRecall !== undefined
+            ? { composerRecall: outgoingComposerRecall }
+            : {}),
           turnId: null,
           createdAt: messageCreatedAt,
           updatedAt: messageCreatedAt,
@@ -7133,6 +7165,9 @@ export default function ChatView(props: ChatViewProps) {
               messageId: messageIdForSend,
               role: "user",
               text: outgoingMessageText,
+              ...(outgoingComposerRecall !== undefined
+                ? { composerRecall: outgoingComposerRecall }
+                : {}),
               attachments: [],
             },
             modelSelection: ctxSelectedModelSelection,
@@ -7269,6 +7304,10 @@ export default function ChatView(props: ChatViewProps) {
             messageId: newMessageId(),
             role: "user",
             text: outgoingImplementationPrompt,
+            ...(appAtomRegistry.get(environmentServerConfigsAtom).get(environmentId)?.environment
+              .capabilities.composerRecall === true
+              ? { composerRecall: { ranges: [] } }
+              : {}),
             attachments: [],
           },
           modelSelection: ctxSelectedModelSelection,

--- a/apps/web/src/components/chat/composerPromptHistory.test.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.test.ts
@@ -1,16 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { appendElementContextsToPrompt } from "../../lib/elementContext";
 import {
-  appendTerminalContextsToPrompt,
-  materializeInlineTerminalContextPrompt,
-} from "../../lib/terminalContext";
-import { appendReviewCommentsToPrompt, buildFileReviewComment } from "../../reviewCommentContext";
-import { buildPlanImplementationPrompt } from "../../proposedPlan";
-import {
-  ATTACHMENT_ONLY_BOOTSTRAP_PROMPT,
   buildComposerPromptHistoryEntries,
-  recallableComposerPrompt,
   stepComposerPromptHistory,
   type ComposerPromptHistoryPosition,
 } from "./composerPromptHistory";
@@ -29,97 +20,6 @@ function backward(position: ComposerPromptHistoryPosition | null, currentPrompt:
 function forward(position: ComposerPromptHistoryPosition | null, currentPrompt: string) {
   return stepComposerPromptHistory({ direction: "forward", entries, position, currentPrompt });
 }
-
-describe("recallableComposerPrompt", () => {
-  it("strips send-time context blocks and the ultrathink prefix", () => {
-    const withTerminal = appendTerminalContextsToPrompt("Investigate this", [
-      {
-        terminalId: "default",
-        terminalLabel: "Terminal 1",
-        lineStart: 12,
-        lineEnd: 13,
-        text: "git status\nOn branch main",
-      },
-    ]);
-    const withElement = appendElementContextsToPrompt(withTerminal, [
-      {
-        pageUrl: "https://example.com",
-        pageTitle: "Example",
-        tagName: "button",
-        selector: "button.submit",
-        htmlPreview: "<button>Save</button>",
-        componentName: null,
-        source: null,
-        styles: "",
-      },
-    ]);
-    expect(recallableComposerPrompt(`Ultrathink:\n${withElement}`)).toBe("Investigate this");
-  });
-
-  it("removes inline terminal labels along with their trailing block", () => {
-    const context = {
-      terminalId: "default",
-      terminalLabel: "Terminal 1",
-      lineStart: 12,
-      lineEnd: 13,
-      text: "git status",
-    };
-    const typed = materializeInlineTerminalContextPrompt("Look at \uFFFC please", [context]);
-    expect(typed).toBe("Look at @terminal-1:12-13 please");
-    const sent = appendTerminalContextsToPrompt(typed, [context]);
-    expect(recallableComposerPrompt(sent)).toBe("Look at please");
-  });
-
-  it("removes one label per chip and leaves other whitespace alone", () => {
-    const context = {
-      terminalId: "default",
-      terminalLabel: "Terminal 1",
-      lineStart: 4,
-      lineEnd: 4,
-      text: "ls",
-    };
-    const typed = "@terminal-1:4 typed twice: @terminal-1:4\n    indented  code";
-    const sent = appendTerminalContextsToPrompt(typed, [context]);
-    expect(recallableComposerPrompt(sent)).toBe("typed twice: @terminal-1:4\n    indented  code");
-  });
-
-  it("does not strip a typed label that only starts with the chip label", () => {
-    const context = {
-      terminalId: "default",
-      terminalLabel: "Terminal 1",
-      lineStart: 4,
-      lineEnd: 4,
-      text: "ls",
-    };
-    const typed = "see @terminal-1:40 and @terminal-1:4-12 then @terminal-1:4";
-    const sent = appendTerminalContextsToPrompt(typed, [context]);
-    expect(recallableComposerPrompt(sent)).toBe("see @terminal-1:40 and @terminal-1:4-12 then");
-  });
-
-  it("strips only the review comments appended at the end", () => {
-    const comment = buildFileReviewComment({
-      id: "comment-1",
-      filePath: "src/app.ts",
-      startLine: 2,
-      endLine: 3,
-      text: "Keep this configurable.",
-      contents: "one\ntwo\nthree",
-    });
-    const sent = appendReviewCommentsToPrompt("Please update this.", [comment]);
-    expect(recallableComposerPrompt(sent)).toBe("Please update this.");
-    const midPrompt = appendReviewCommentsToPrompt("Before", [comment]) + "\n\nAfter";
-    expect(recallableComposerPrompt(midPrompt)).toBe(midPrompt);
-    // A typed block earlier in the prompt survives when the trailing one goes.
-    const both = appendReviewCommentsToPrompt(midPrompt, [comment]);
-    expect(recallableComposerPrompt(both)).toBe(midPrompt);
-  });
-
-  it("returns an empty string for app-composed sends", () => {
-    expect(recallableComposerPrompt("   ")).toBe("");
-    expect(recallableComposerPrompt(ATTACHMENT_ONLY_BOOTSTRAP_PROMPT)).toBe("");
-    expect(recallableComposerPrompt(buildPlanImplementationPrompt("# Plan\n1. do it"))).toBe("");
-  });
-});
 
 describe("buildComposerPromptHistoryEntries", () => {
   it("keeps user messages with text, oldest first", () => {

--- a/apps/web/src/components/chat/composerPromptHistory.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.ts
@@ -1,7 +1,5 @@
-import { extractTrailingElementContexts } from "../../lib/elementContext";
-import { extractTrailingPreviewAnnotation } from "../../lib/previewAnnotation";
-import { extractTrailingTerminalContexts } from "../../lib/terminalContext";
-import { PLAN_IMPLEMENTATION_PROMPT_PREFIX } from "../../proposedPlan";
+import type { ComposerRecall } from "@t3tools/contracts";
+import { recallComposerText } from "@t3tools/shared/composerRecall";
 
 /**
  * Terminal-style prompt recall for the composer. ArrowUp on an empty
@@ -12,9 +10,6 @@ import { PLAN_IMPLEMENTATION_PROMPT_PREFIX } from "../../proposedPlan";
  * messages on every keypress, so there is no store to persist or sync.
  */
 
-const CLAUDE_ULTRATHINK_PREFIX = "Ultrathink:\n";
-const REVIEW_COMMENT_BLOCK_PATTERN = /<review_comment\b[^>]*>[\s\S]*?<\/review_comment>/g;
-
 /** Text sent in place of an empty prompt when a message is attachments only. */
 export const ATTACHMENT_ONLY_BOOTSTRAP_PROMPT =
   "[User attached one or more files without additional text. Respond using the conversation context and the attached files.]";
@@ -23,6 +18,7 @@ export interface ComposerPromptHistoryMessage {
   readonly id: string;
   readonly role: string;
   readonly text: string;
+  readonly composerRecall?: ComposerRecall | undefined;
 }
 
 export interface ComposerPromptHistoryEntry {
@@ -62,103 +58,6 @@ export interface ComposerPromptHistoryStep {
 }
 
 /**
- * Drop only the review comments appended at send time, which sit at the
- * end. Cuts the original string at the start of the trailing run of blocks
- * so any review comment block the user typed earlier stays byte-for-byte.
- */
-function stripTrailingReviewComments(prompt: string): string {
-  let cut = prompt.length;
-  for (const match of [...prompt.matchAll(REVIEW_COMMENT_BLOCK_PATTERN)].toReversed()) {
-    const blockEnd = match.index + match[0].length;
-    if (prompt.slice(blockEnd, cut).trim().length > 0) break;
-    cut = match.index;
-  }
-  return cut === prompt.length ? prompt : prompt.slice(0, cut).trimEnd();
-}
-
-/**
- * Inline terminal chips are sent as `@terminal-1:12-13` labels in the text
- * with their content in the trailing block. Once the block is stripped the
- * label points at nothing, so remove it too. Each block entry removes one
- * label (the first match) and the single space beside it. Nothing else in
- * the prompt is touched, so indented code and typed labels survive. Block
- * headers look like `Terminal 1 lines 12-13`.
- */
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function stripInlineTerminalLabels(prompt: string, headers: ReadonlyArray<string>): string {
-  let result = prompt;
-  for (const header of headers) {
-    const match = /^(.+?) lines? (\d+(?:-\d+)?)$/.exec(header);
-    if (!match) continue;
-    const label = `@${match[1]!.trim().toLowerCase().replace(/\s+/g, "-")}:${match[2]}`;
-    // Whole label only: `@terminal-1:4` must not match inside `@terminal-1:40`
-    // or `@terminal-1:4-12`.
-    const labelPattern = new RegExp(`${escapeRegExp(label)}(?![\\d-])`);
-    const index = result.search(labelPattern);
-    if (index < 0) continue;
-    let end = index + label.length;
-    let start = index;
-    if (result[end] === " ") end += 1;
-    else if (result[start - 1] === " ") start -= 1;
-    result = result.slice(0, start) + result.slice(end);
-  }
-  return result;
-}
-
-/**
- * Reduce a sent message to the text the user typed. Send-time appends
- * (terminal and element context blocks, preview annotations, review
- * comments, the Claude ultrathink prefix) are stripped so a recalled prompt
- * never carries stale context from another turn.
- */
-export function recallableComposerPrompt(messageText: string): string {
-  let prompt = messageText.trim();
-  if (prompt.startsWith(CLAUDE_ULTRATHINK_PREFIX)) {
-    prompt = prompt.slice(CLAUDE_ULTRATHINK_PREFIX.length);
-  }
-
-  while (prompt.length > 0) {
-    const withoutReviewComments = stripTrailingReviewComments(prompt);
-    if (withoutReviewComments !== prompt) {
-      prompt = withoutReviewComments;
-      continue;
-    }
-    const previewAnnotation = extractTrailingPreviewAnnotation(prompt);
-    if (previewAnnotation.annotation) {
-      prompt = previewAnnotation.promptText;
-      continue;
-    }
-    const elementContexts = extractTrailingElementContexts(prompt);
-    if (elementContexts.contextCount > 0) {
-      prompt = elementContexts.promptText;
-      continue;
-    }
-    const terminalContexts = extractTrailingTerminalContexts(prompt);
-    if (terminalContexts.contextCount > 0) {
-      prompt = stripInlineTerminalLabels(
-        terminalContexts.promptText,
-        terminalContexts.contexts.map((context) => context.header),
-      );
-      continue;
-    }
-    break;
-  }
-
-  // App-composed sends are not text the user typed, so they are not history.
-  const trimmed = prompt.trim();
-  if (
-    trimmed === ATTACHMENT_ONLY_BOOTSTRAP_PROMPT ||
-    trimmed.startsWith(PLAN_IMPLEMENTATION_PROMPT_PREFIX)
-  ) {
-    return "";
-  }
-  return trimmed;
-}
-
-/**
  * Oldest first. Consecutive identical prompts collapse into the newest one,
  * matching shell `HISTCONTROL=ignoredups`. Image-only sends have no text and
  * are skipped.
@@ -169,8 +68,8 @@ export function buildComposerPromptHistoryEntries(
   const entries: ComposerPromptHistoryEntry[] = [];
   for (const message of messages) {
     if (message.role !== "user") continue;
-    const prompt = recallableComposerPrompt(message.text);
-    if (prompt.length === 0) continue;
+    const prompt = recallComposerText(message);
+    if (prompt.trim().length === 0) continue;
     const previous = entries[entries.length - 1];
     if (previous && previous.prompt === prompt) {
       entries[entries.length - 1] = { id: message.id, prompt };

--- a/apps/web/src/components/chat/composerPromptRecall.test.ts
+++ b/apps/web/src/components/chat/composerPromptRecall.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  createComposerRecall,
+  offsetComposerRecall,
+  recallComposerText,
+} from "@t3tools/shared/composerRecall";
+import { applyClaudePromptEffortPrefix } from "@t3tools/shared/model";
+import {
+  composeTerminalContextPrompt,
+  materializeInlineTerminalContextPrompt,
+  buildTerminalContextBlock,
+  createDraftComposerRecall,
+} from "../../lib/terminalContext";
+import { appendElementContextsToPrompt } from "../../lib/elementContext";
+import { appendPreviewAnnotationPrompt } from "../../lib/previewAnnotation";
+import { appendReviewCommentsToPrompt, buildFileReviewComment } from "../../reviewCommentContext";
+import { buildPlanImplementationPrompt } from "../../proposedPlan";
+
+import {
+  ATTACHMENT_ONLY_BOOTSTRAP_PROMPT,
+  buildComposerPromptHistoryEntries,
+} from "./composerPromptHistory";
+
+describe("durable composer recall", () => {
+  it("excludes known chip placeholders on the unmaterialized plan-follow-up path", () => {
+    const raw = "  Keep @terminal-1:4 literal \uFFFC\ntext\uFFFC  ";
+    expect(
+      recallComposerText({ text: raw.trim(), composerRecall: createDraftComposerRecall(raw) }),
+    ).toBe("  Keep @terminal-1:4 literal \ntext  ");
+  });
+  it.each([
+    "Ultrathink:\nKeep this prefix in my example",
+    "Example:\n<review_comment>Keep this literal</review_comment>",
+    "PLEASE IMPLEMENT THIS PLAN:\nThis is an example, not an action",
+  ])("preserves unknown authored text unchanged: %s", (text) => {
+    expect(buildComposerPromptHistoryEntries([{ id: "literal", role: "user", text }])).toEqual([
+      { id: "literal", prompt: text },
+    ]);
+  });
+
+  it("distinguishes identical text with recorded different origins", () => {
+    const text = "Ultrathink:\nKeep this prefix in my example";
+    const messages = [
+      { id: "literal", role: "user", text, composerRecall: { ranges: [[0, text.length]] } },
+      { id: "generated", role: "user", text, composerRecall: { ranges: [[12, text.length]] } },
+    ] as const;
+    expect(buildComposerPromptHistoryEntries(messages)).toEqual([
+      { id: "literal", prompt: text },
+      { id: "generated", prompt: "Keep this prefix in my example" },
+    ]);
+  });
+
+  it.each([
+    ATTACHMENT_ONLY_BOOTSTRAP_PROMPT,
+    buildPlanImplementationPrompt("Implement the example"),
+  ])("keeps a typed bootstrap message but skips the same generated message", (text) => {
+    expect(
+      buildComposerPromptHistoryEntries([
+        { id: "authored", role: "user", text, composerRecall: createComposerRecall(text) },
+        { id: "generated", role: "user", text, composerRecall: { ranges: [] } },
+        { id: "unknown", role: "user", text: `${text}\nlegacy` },
+      ]),
+    ).toEqual([
+      { id: "authored", prompt: text },
+      { id: "unknown", prompt: `${text}\nlegacy` },
+    ]);
+  });
+
+  it.each([
+    "  Ultrathink:\nAlready editable\n",
+    "  /compact keep recent errors  ",
+    "  Ordinary 😀 prompt\n",
+  ])("preserves authored text when effort adds no prefix or a known prefix: %j", (raw) => {
+    const composed = composeTerminalContextPrompt(raw, []);
+    const text = applyClaudePromptEffortPrefix(composed.text, "ultrathink");
+    expect(
+      recallComposerText({
+        text,
+        composerRecall: offsetComposerRecall(
+          composed.composerRecall,
+          text.length - composed.text.length,
+        ),
+      }),
+    ).toBe(raw);
+  });
+
+  it("keeps literal labels and markup while excluding actual appended context", () => {
+    const raw = "  @terminal-1:4 literal\n<review_comment>example</review_comment>\n\uFFFC done  ";
+    const contexts = [
+      { terminalId: "default", terminalLabel: "Terminal 1", lineStart: 4, lineEnd: 4, text: "pwd" },
+    ];
+    const composed = composeTerminalContextPrompt(raw, contexts);
+    expect(composed.text).toBe(
+      `${materializeInlineTerminalContextPrompt(raw, contexts).trim()}\n\n${buildTerminalContextBlock(contexts)}`,
+    );
+    const withElement = appendElementContextsToPrompt(composed.text, [
+      {
+        pageUrl: "https://example.com",
+        pageTitle: "Example",
+        tagName: "button",
+        selector: "button",
+        htmlPreview: "<button>Save</button>",
+        componentName: null,
+        source: null,
+        styles: "",
+      },
+    ]);
+    const withPreview = appendPreviewAnnotationPrompt(withElement, {
+      id: "preview",
+      pageUrl: "https://example.com",
+      pageTitle: "Example",
+      comment: "Change this",
+      elements: [],
+      regions: [],
+      strokes: [],
+      styleChanges: [],
+      screenshot: null,
+      createdAt: "2026-09-05T00:00:00Z",
+    });
+    const withReview = appendReviewCommentsToPrompt(withPreview, [
+      buildFileReviewComment({
+        id: "review",
+        filePath: "file.ts",
+        startLine: 1,
+        endLine: 1,
+        text: "Check this",
+        contents: "one",
+      }),
+    ]);
+    const text = applyClaudePromptEffortPrefix(withReview, "ultrathink");
+    const composerRecall = offsetComposerRecall(
+      composed.composerRecall,
+      text.length - withReview.length,
+    );
+    expect(recallComposerText({ text, composerRecall })).toBe(raw.replace("\uFFFC", ""));
+    expect(
+      buildComposerPromptHistoryEntries([{ id: "sent", role: "user", text, composerRecall }]),
+    ).toEqual([{ id: "sent", prompt: raw.replace("\uFFFC", "") }]);
+  });
+});

--- a/apps/web/src/components/chat/composerPromptRecall.test.ts
+++ b/apps/web/src/components/chat/composerPromptRecall.test.ts
@@ -9,12 +9,13 @@ import {
   composeTerminalContextPrompt,
   materializeInlineTerminalContextPrompt,
   buildTerminalContextBlock,
-  createDraftComposerRecall,
+  stripInlineTerminalContextPlaceholders,
 } from "../../lib/terminalContext";
 import { appendElementContextsToPrompt } from "../../lib/elementContext";
 import { appendPreviewAnnotationPrompt } from "../../lib/previewAnnotation";
 import { appendReviewCommentsToPrompt, buildFileReviewComment } from "../../reviewCommentContext";
-import { buildPlanImplementationPrompt } from "../../proposedPlan";
+import { buildPlanImplementationPrompt, resolvePlanFollowUpSubmission } from "../../proposedPlan";
+import { deriveComposerSendState } from "../ChatView.logic";
 
 import {
   ATTACHMENT_ONLY_BOOTSTRAP_PROMPT,
@@ -22,12 +23,32 @@ import {
 } from "./composerPromptHistory";
 
 describe("durable composer recall", () => {
-  it("excludes known chip placeholders on the unmaterialized plan-follow-up path", () => {
-    const raw = "  Keep @terminal-1:4 literal \uFFFC\ntext\uFFFC  ";
-    expect(
-      recallComposerText({ text: raw.trim(), composerRecall: createDraftComposerRecall(raw) }),
-    ).toBe("  Keep @terminal-1:4 literal \ntext  ");
-  });
+  it.each([null, "ultrathink"])(
+    "recalls the actual plan-follow-up send with effort %s",
+    (effort) => {
+      const raw = " \ta\uFFFCb\n    text\uFFFC \n";
+      const sendState = deriveComposerSendState({
+        prompt: raw,
+        imageCount: 0,
+        terminalContexts: [],
+      });
+      const followUp = resolvePlanFollowUpSubmission({
+        draftText: sendState.trimmedPrompt,
+        planMarkdown: "# Plan",
+      });
+      const text = applyClaudePromptEffortPrefix(followUp.text, effort);
+      expect(followUp.text).toBe("ab\n    text");
+      expect(
+        recallComposerText({
+          text,
+          composerRecall: offsetComposerRecall(
+            createComposerRecall(stripInlineTerminalContextPlaceholders(raw)),
+            text.length - followUp.text.length,
+          ),
+        }),
+      ).toBe(" \tab\n    text \n");
+    },
+  );
   it.each([
     "Ultrathink:\nKeep this prefix in my example",
     "Example:\n<review_comment>Keep this literal</review_comment>",

--- a/apps/web/src/lib/terminalContext.ts
+++ b/apps/web/src/lib/terminalContext.ts
@@ -181,17 +181,6 @@ export function appendTerminalContextsToPrompt(
   return composeTerminalContextPrompt(prompt, contexts).text;
 }
 
-/** Plan follow-ups keep placeholders in provider text but do not recall the chip nodes. */
-export function createDraftComposerRecall(prompt: string) {
-  let offset = 0;
-  const ranges: Array<[number, number]> = [];
-  for (const part of prompt.split(INLINE_TERMINAL_CONTEXT_PLACEHOLDER)) {
-    if (part.length > 0) ranges.push([offset, offset + part.length]);
-    offset += part.length + INLINE_TERMINAL_CONTEXT_PLACEHOLDER.length;
-  }
-  return createComposerRecall(prompt, ranges);
-}
-
 /** Keep origin while expanding chips; a typed identical label remains authored text. */
 export function composeTerminalContextPrompt(
   prompt: string,

--- a/apps/web/src/lib/terminalContext.ts
+++ b/apps/web/src/lib/terminalContext.ts
@@ -1,4 +1,5 @@
 import { type ThreadId } from "@t3tools/contracts";
+import { createComposerRecall } from "@t3tools/shared/composerRecall";
 
 import { extractTrailingElementContexts, type ParsedElementContextEntry } from "./elementContext";
 
@@ -177,12 +178,49 @@ export function appendTerminalContextsToPrompt(
   prompt: string,
   contexts: ReadonlyArray<TerminalContextSelection>,
 ): string {
-  const trimmedPrompt = materializeInlineTerminalContextPrompt(prompt, contexts).trim();
-  const contextBlock = buildTerminalContextBlock(contexts);
-  if (contextBlock.length === 0) {
-    return trimmedPrompt;
+  return composeTerminalContextPrompt(prompt, contexts).text;
+}
+
+/** Plan follow-ups keep placeholders in provider text but do not recall the chip nodes. */
+export function createDraftComposerRecall(prompt: string) {
+  let offset = 0;
+  const ranges: Array<[number, number]> = [];
+  for (const part of prompt.split(INLINE_TERMINAL_CONTEXT_PLACEHOLDER)) {
+    if (part.length > 0) ranges.push([offset, offset + part.length]);
+    offset += part.length + INLINE_TERMINAL_CONTEXT_PLACEHOLDER.length;
   }
-  return trimmedPrompt.length > 0 ? `${trimmedPrompt}\n\n${contextBlock}` : contextBlock;
+  return createComposerRecall(prompt, ranges);
+}
+
+/** Keep origin while expanding chips; a typed identical label remains authored text. */
+export function composeTerminalContextPrompt(
+  prompt: string,
+  contexts: ReadonlyArray<TerminalContextSelection>,
+) {
+  const parts = prompt.split(INLINE_TERMINAL_CONTEXT_PLACEHOLDER);
+  const ranges: Array<[number, number]> = [];
+  let materialized = "";
+  for (const [index, part] of parts.entries()) {
+    const start = materialized.length;
+    materialized += part;
+    if (part.length > 0) ranges.push([start, materialized.length]);
+    const context = contexts[index];
+    if (index < parts.length - 1 && context) {
+      materialized += formatInlineTerminalContextLabel(context);
+    }
+  }
+  const composerRecall = createComposerRecall(materialized, ranges);
+  const trimmedPrompt = materialized.trim();
+  const contextBlock = buildTerminalContextBlock(contexts);
+  return {
+    text:
+      contextBlock.length === 0
+        ? trimmedPrompt
+        : trimmedPrompt.length > 0
+          ? `${trimmedPrompt}\n\n${contextBlock}`
+          : contextBlock,
+    composerRecall,
+  };
 }
 
 export function extractTrailingTerminalContexts(prompt: string): ExtractedTerminalContexts {

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -60,9 +60,10 @@ navigate to their sources.
 
 Press `ArrowUp` in an empty composer to bring back the last prompt you sent in this thread. Press
 `ArrowUp` again to go further back, and `ArrowDown` to come forward. Moving forward past the newest
-prompt clears the composer. Recall walks the prompts loaded in the thread. Attachments, terminal
-context, and other extras from the original message are not restored, only the text you typed. A
-composer that holds an attachment or a picked element does not count as empty.
+prompt clears the composer. Recall walks the prompts loaded in the thread. Messages sent with
+updated apps and servers recall the editable prompt without added context; attachments are not
+reattached. Older messages may recall their full saved text, including generated context. A composer
+that holds an attachment or a picked element does not count as empty.
 
 When the composer has text, the arrow keys move the caret as usual. Recall takes over only while
 the text is an unedited recalled prompt, with the caret on the first visual line for `ArrowUp` or

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -13,6 +13,7 @@ import {
 import type { OrchestrationThread } from "@t3tools/contracts";
 
 import { applyThreadDetailEvent } from "./threadReducer.ts";
+import { recallComposerText } from "@t3tools/shared/composerRecall";
 
 const baseEventFields = {
   eventId: EventId.make("event-1"),
@@ -46,6 +47,94 @@ const baseThread: OrchestrationThread = {
 };
 
 describe("applyThreadDetailEvent", () => {
+  it("preserves recall on acknowledgement but invalidates it when message text is replaced", () => {
+    const text = "Ultrathink:\nKeep this prefix";
+    const composerRecall = { ranges: [[12, text.length]] } as const;
+    const message = {
+      id: MessageId.make("recall"),
+      role: "user" as const,
+      text,
+      composerRecall,
+      turnId: null,
+      streaming: false,
+      createdAt: baseThread.createdAt,
+      updatedAt: baseThread.updatedAt,
+    };
+    const event = {
+      ...baseEventFields,
+      sequence: 1,
+      occurredAt: baseThread.updatedAt,
+      aggregateKind: "thread" as const,
+      aggregateId: baseThread.id,
+      type: "thread.message-sent" as const,
+      payload: {
+        threadId: baseThread.id,
+        messageId: message.id,
+        role: message.role,
+        text,
+        turnId: null,
+        streaming: false,
+        createdAt: message.createdAt,
+        updatedAt: message.updatedAt,
+      },
+    };
+    const ack = applyThreadDetailEvent({ ...baseThread, messages: [message] }, event);
+    if (ack.kind !== "updated") throw new Error("Expected acknowledgement");
+    expect(ack.thread.messages).toHaveLength(1);
+    expect(recallComposerText(ack.thread.messages[0]!)).toBe("Keep this prefix");
+    const replacement = applyThreadDetailEvent(ack.thread, {
+      ...event,
+      payload: { ...event.payload, text: "An unrelated longer replacement" },
+    });
+    if (replacement.kind !== "updated") throw new Error("Expected replacement");
+    expect(replacement.thread.messages[0]?.composerRecall).toBeUndefined();
+    expect(recallComposerText(replacement.thread.messages[0]!)).toBe(
+      "An unrelated longer replacement",
+    );
+    const streamed = applyThreadDetailEvent(ack.thread, {
+      ...event,
+      payload: { ...event.payload, text: "extra", streaming: true },
+    });
+    if (streamed.kind !== "updated") throw new Error("Expected append");
+    expect(streamed.thread.messages[0]?.composerRecall).toBeUndefined();
+    const empty = applyThreadDetailEvent(ack.thread, {
+      ...event,
+      payload: { ...event.payload, text: "" },
+    });
+    if (empty.kind !== "updated") throw new Error("Expected empty completion");
+    expect(empty.thread.messages[0]?.composerRecall).toEqual(composerRecall);
+  });
+
+  it("retains distinct literal and generated recall from live events", () => {
+    const text = "Ultrathink:\nKeep this prefix";
+    for (const [ranges, expected] of [
+      [[[0, text.length]], text],
+      [[[12, text.length]], "Keep this prefix"],
+      [[], ""],
+    ] as const) {
+      const result = applyThreadDetailEvent(baseThread, {
+        ...baseEventFields,
+        sequence: 1,
+        occurredAt: baseThread.updatedAt,
+        aggregateKind: "thread",
+        aggregateId: baseThread.id,
+        type: "thread.message-sent",
+        payload: {
+          threadId: baseThread.id,
+          messageId: MessageId.make("recall"),
+          role: "user",
+          text,
+          composerRecall: { ranges },
+          turnId: null,
+          streaming: false,
+          createdAt: baseThread.createdAt,
+          updatedAt: baseThread.updatedAt,
+        },
+      });
+      if (result.kind !== "updated") throw new Error("Expected message");
+      expect(recallComposerText(result.thread.messages[0]!)).toBe(expected);
+    }
+  });
   describe("project events", () => {
     it("returns unchanged for project.created", () => {
       const result = applyThreadDetailEvent(baseThread, {

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -308,6 +308,9 @@ export function applyThreadDetailEvent(
         id: event.payload.messageId,
         role: event.payload.role,
         text: event.payload.text,
+        ...(event.payload.composerRecall !== undefined
+          ? { composerRecall: event.payload.composerRecall }
+          : {}),
         ...(event.payload.attachments !== undefined
           ? { attachments: event.payload.attachments }
           : {}),
@@ -330,6 +333,12 @@ export function applyThreadDetailEvent(
                       ? message.text
                       : entry.text,
                   streaming: message.streaming,
+                  composerRecall:
+                    message.composerRecall ??
+                    (message.text.length === 0 ||
+                    (!message.streaming && message.text === entry.text)
+                      ? entry.composerRecall
+                      : undefined),
                   ...(message.turnId !== undefined ? { turnId: message.turnId } : {}),
                   ...(message.streaming ? {} : { updatedAt: message.updatedAt }),
                   ...(message.attachments !== undefined

--- a/packages/contracts/src/composerRecall.ts
+++ b/packages/contracts/src/composerRecall.ts
@@ -1,0 +1,13 @@
+import * as Schema from "effect/Schema";
+
+import { NonNegativeInt } from "./baseSchemas.ts";
+
+const Whitespace = Schema.String.check(Schema.isPattern(/^\s*$/u));
+
+/** Kept UTF-16 slices of message text. Absent means unknown; empty means no prompt. */
+export const ComposerRecall = Schema.Struct({
+  ranges: Schema.Array(Schema.Tuple([NonNegativeInt, NonNegativeInt])),
+  leadingWhitespace: Schema.optional(Whitespace),
+  trailingWhitespace: Schema.optional(Whitespace),
+});
+export type ComposerRecall = typeof ComposerRecall.Type;

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -115,6 +115,8 @@ export const ExecutionEnvironmentCapabilities = Schema.Struct({
   /** Server understands thread.pin.reorder (and orderKey on thread.pin).
       Same version-skew contract as threadSettlement. */
   threadPinReorder: Schema.optionalKey(Schema.Boolean),
+  /** Server persists send-time composer recall slices on user messages. */
+  composerRecall: Schema.optionalKey(Schema.Boolean),
   /** Server understands regenerateTitle on thread.meta.update. Absent on
       older servers, so clients hide the action instead of sending it. */
   threadTitleRegeneration: Schema.optionalKey(Schema.Boolean),

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./baseSchemas.ts";
+export * from "./composerRecall.ts";
 export * from "./assistantCitations.ts";
 export * from "./background.ts";
 export * from "./auth.ts";

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -41,6 +41,10 @@ const decodeProjectCreatedPayload = Schema.decodeUnknownEffect(ProjectCreatedPay
 const decodeProjectMetaUpdatedPayload = Schema.decodeUnknownEffect(ProjectMetaUpdatedPayload);
 const decodeThreadTurnStartCommand = Schema.decodeUnknownEffect(ThreadTurnStartCommand);
 const decodeClientOrchestrationCommand = Schema.decodeUnknownEffect(ClientOrchestrationCommand);
+const encodeUnknownJson = Schema.encodeEffect(Schema.fromJsonString(Schema.Unknown));
+const decodeClientOrchestrationCommandJson = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(ClientOrchestrationCommand),
+);
 const decodeOrchestrationMessage = Schema.decodeUnknownEffect(OrchestrationMessage);
 const decodeThreadMessageSentPayload = Schema.decodeUnknownEffect(ThreadMessageSentPayload);
 const decodeThreadTurnStartRequestedPayload = Schema.decodeUnknownEffect(
@@ -235,7 +239,7 @@ it.effect("preserves optional composer provenance across client and internal com
       undefined,
       { ranges: [] },
       { ranges: [[0, 5]], leadingWhitespace: " \n" },
-    ]) {
+    ] as const) {
       const command = {
         type: "thread.turn.start",
         commandId: "recall-command",
@@ -251,7 +255,8 @@ it.effect("preserves optional composer provenance across client and internal com
         },
         createdAt: "2026-09-05T00:00:00Z",
       };
-      const client = yield* decodeClientOrchestrationCommand(JSON.parse(JSON.stringify(command)));
+      const json = yield* encodeUnknownJson(command);
+      const client = yield* decodeClientOrchestrationCommandJson(json);
       assert.strictEqual(client.type, "thread.turn.start");
       if (client.type !== "thread.turn.start") return;
       const persisted = yield* decodeThreadTurnStartCommand(client);

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -229,6 +229,54 @@ it.effect("rejects command fields that become empty after trim", () =>
   }),
 );
 
+it.effect("preserves optional composer provenance across client and internal command codecs", () =>
+  Effect.gen(function* () {
+    for (const composerRecall of [
+      undefined,
+      { ranges: [] },
+      { ranges: [[0, 5]], leadingWhitespace: " \n" },
+    ]) {
+      const command = {
+        type: "thread.turn.start",
+        commandId: "recall-command",
+        threadId: "recall-thread",
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        message: {
+          messageId: "recall-message",
+          role: "user",
+          text: "hello",
+          attachments: [],
+          ...(composerRecall === undefined ? {} : { composerRecall }),
+        },
+        createdAt: "2026-09-05T00:00:00Z",
+      };
+      const client = yield* decodeClientOrchestrationCommand(JSON.parse(JSON.stringify(command)));
+      assert.strictEqual(client.type, "thread.turn.start");
+      if (client.type !== "thread.turn.start") return;
+      const persisted = yield* decodeThreadTurnStartCommand(client);
+      assert.strictEqual(persisted.message.text, "hello");
+      assert.deepEqual(persisted.message.composerRecall, composerRecall);
+    }
+    const invalid = yield* Effect.exit(
+      decodeThreadTurnStartCommand({
+        type: "thread.turn.start",
+        commandId: "invalid",
+        threadId: "recall-thread",
+        message: {
+          messageId: "invalid",
+          role: "user",
+          text: "hello",
+          attachments: [],
+          composerRecall: { ranges: [[-1, 5]] },
+        },
+        createdAt: "2026-09-05T00:00:00Z",
+      }),
+    );
+    assert.strictEqual(invalid._tag, "Failure");
+  }),
+);
+
 it.effect("decodes thread.turn.start defaults for provider and runtime mode", () =>
   Effect.gen(function* () {
     const parsed = yield* decodeThreadTurnStartCommand({

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -23,6 +23,7 @@ import {
   TurnId,
 } from "./baseSchemas.ts";
 import { ProviderInstanceId } from "./providerInstance.ts";
+import { ComposerRecall } from "./composerRecall.ts";
 
 export const ORCHESTRATION_WS_METHODS = {
   dispatchCommand: "orchestration.dispatchCommand",
@@ -355,6 +356,7 @@ export const OrchestrationMessage = Schema.Struct({
   id: MessageId,
   role: OrchestrationMessageRole,
   text: Schema.String,
+  composerRecall: Schema.optional(ComposerRecall),
   attachments: Schema.optional(Schema.Array(ChatAttachment)),
   turnId: Schema.NullOr(TurnId),
   streaming: Schema.Boolean,
@@ -962,6 +964,7 @@ export const ThreadTurnStartCommand = Schema.Struct({
     messageId: MessageId,
     role: Schema.Literal("user"),
     text: Schema.String,
+    composerRecall: Schema.optional(ComposerRecall),
     attachments: Schema.Array(ChatAttachment),
   }),
   modelSelection: Schema.optional(ModelSelection),
@@ -983,6 +986,7 @@ const ClientThreadTurnStartCommand = Schema.Struct({
     messageId: MessageId,
     role: Schema.Literal("user"),
     text: Schema.String,
+    composerRecall: Schema.optional(ComposerRecall),
     attachments: Schema.Array(Schema.Union([UploadChatAttachment, ChatAttachment])),
   }),
   modelSelection: Schema.optional(ModelSelection),
@@ -1389,6 +1393,7 @@ export const ThreadMessageSentPayload = Schema.Struct({
   messageId: MessageId,
   role: OrchestrationMessageRole,
   text: Schema.String,
+  composerRecall: Schema.optional(ComposerRecall),
   attachments: Schema.optional(Schema.Array(ChatAttachment)),
   turnId: Schema.NullOr(TurnId),
   streaming: Schema.Boolean,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./composerRecall": {
+      "types": "./src/composerRecall.ts",
+      "import": "./src/composerRecall.ts"
+    },
     "./themePalettes": {
       "types": "./src/themePalettes.ts",
       "import": "./src/themePalettes.ts"

--- a/packages/shared/src/composerRecall.test.ts
+++ b/packages/shared/src/composerRecall.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vite-plus/test";
+import * as Schema from "effect/Schema";
+import { ComposerRecall } from "@t3tools/contracts";
+
+import {
+  createComposerRecall,
+  offsetComposerRecall,
+  recallComposerText,
+} from "./composerRecall.ts";
+
+const decodeComposerRecall = Schema.decodeUnknownSync(ComposerRecall);
+
+describe("composer recall", () => {
+  it.each(["  😀\r\n    indented\t\n", "Ultrathink:\nLiteral", "", " \t\r\n"])(
+    "round trips authored text without changing trimmed input: %j",
+    (raw) => {
+      const composerRecall = createComposerRecall(raw);
+      expect(decodeComposerRecall(composerRecall)).toEqual(composerRecall);
+      expect(recallComposerText({ text: raw.trim(), composerRecall })).toBe(raw);
+    },
+  );
+
+  it("keeps authored slices around a generated inline span and prefix", () => {
+    const expanded = "  typed @same then @same end  ";
+    const second = expanded.lastIndexOf("@same");
+    const recall = createComposerRecall(expanded, [
+      [0, second],
+      [second + 5, expanded.length],
+    ]);
+    const text = `PREFIX\n${expanded.trim()}\nCONTEXT`;
+    expect(recallComposerText({ text, composerRecall: offsetComposerRecall(recall, 7) })).toBe(
+      "  typed @same then  end  ",
+    );
+  });
+
+  it.each([
+    { ranges: [[-1, 3]] },
+    { ranges: [[0, 500]] },
+    { ranges: [[2, 1]] },
+    {
+      ranges: [
+        [0, 3],
+        [2, 4],
+      ],
+    },
+    { ranges: [[0.5, 3]] },
+    { ranges: [], leadingWhitespace: "not whitespace" },
+  ] as const)("keeps full text when slice metadata is invalid: %j", (composerRecall) => {
+    expect(recallComposerText({ text: "literal", composerRecall })).toBe("literal");
+  });
+
+  it("distinguishes no authored text from unknown origin", () => {
+    expect(recallComposerText({ text: "generated", composerRecall: { ranges: [] } })).toBe("");
+    expect(recallComposerText({ text: "generated" })).toBe("generated");
+  });
+
+  it("keeps metadata independent of a large prompt's length", () => {
+    const raw = "x".repeat(50_000);
+    const metadata = createComposerRecall(raw);
+    expect(metadata).toEqual({ ranges: [[0, 50_000]] });
+    expect(Buffer.byteLength(JSON.stringify({ composerRecall: metadata }))).toBe(41);
+  });
+});

--- a/packages/shared/src/composerRecall.ts
+++ b/packages/shared/src/composerRecall.ts
@@ -1,0 +1,68 @@
+import type { ComposerRecall } from "@t3tools/contracts";
+
+/** Record authored slices before trim, without copying the prompt into metadata. */
+export function createComposerRecall(
+  text: string,
+  authoredRanges: ComposerRecall["ranges"] = [[0, text.length]],
+): ComposerRecall {
+  const start = text.length - text.trimStart().length;
+  const end = start + text.trim().length;
+  const ranges: Array<[number, number]> = [];
+  let leadingWhitespace = "";
+  let trailingWhitespace = "";
+  for (const [from, to] of authoredRanges) {
+    leadingWhitespace += text.slice(from, Math.min(to, start));
+    trailingWhitespace += text.slice(Math.max(from, end), to);
+    const keptStart = Math.max(from, start);
+    const keptEnd = Math.min(to, end);
+    if (keptEnd > keptStart) ranges.push([keptStart - start, keptEnd - start]);
+  }
+  return {
+    ranges,
+    ...(leadingWhitespace ? { leadingWhitespace } : {}),
+    ...(trailingWhitespace ? { trailingWhitespace } : {}),
+  };
+}
+
+/** The formatter added a known prefix; appended context does not move kept text. */
+export function offsetComposerRecall(recall: ComposerRecall, prefixLength: number): ComposerRecall {
+  return {
+    ...recall,
+    ranges: recall.ranges.map(([start, end]) => [start + prefixLength, end + prefixLength]),
+  };
+}
+
+export function validComposerRecall(
+  text: string,
+  recall: ComposerRecall | undefined,
+): ComposerRecall | undefined {
+  if (recall === undefined) return undefined;
+  let previousEnd = 0;
+  for (const [start, end] of recall.ranges) {
+    if (
+      !Number.isSafeInteger(start) ||
+      !Number.isSafeInteger(end) ||
+      start < previousEnd ||
+      end < start ||
+      end > text.length
+    )
+      return undefined;
+    previousEnd = end;
+  }
+  if (recall.leadingWhitespace?.trim() || recall.trailingWhitespace?.trim()) return undefined;
+  return recall;
+}
+
+/** Unknown history is kept verbatim; origin cannot be recovered from matching text. */
+export function recallComposerText(message: {
+  text: string;
+  composerRecall?: ComposerRecall | undefined;
+}): string {
+  const recall = validComposerRecall(message.text, message.composerRecall);
+  if (recall === undefined) return message.text;
+  return (
+    (recall.leadingWhitespace ?? "") +
+    recall.ranges.map(([start, end]) => message.text.slice(start, end)).join("") +
+    (recall.trailingWhitespace ?? "")
+  );
+}


### PR DESCRIPTION
Closes #10056.

Human approval required. Please do not auto-merge this proposal.

ArrowUp guesses which parts of a saved message were generated. It can remove a literal `Ultrathink:` prefix or context markup the user wrote. Identical text can have different origins, so the final string cannot reliably tell us what to keep.

Record authored text ranges before adding generated prefixes and context. Recall reconstructs those ranges and any whitespace removed by the existing send-time trim. Provider-facing text stays unchanged. Optional metadata follows events, SQLite, snapshots, optimistic messages and mobile sends/outbox recovery. This includes the already merged mention-source fix in [#10100](https://github.com/pingdotgg/t3code/pull/10100).

Closes [#10056](https://github.com/pingdotgg/t3code/issues/10056).

## Decisions for review

- Unknown or legacy provenance recalls the full stored text. This avoids deleting authored content but can expose generated context in old messages. No backfill or text-based guess. Known generated-only messages are excluded from history; invalid ranges fall back to unknown.
- Editable text counts as authored, including picker-inserted prefixes. Existing visual mention chips are unchanged.
- New sends require the optional `composerRecall` server capability. Metadata uses a nullable SQLite column. Older clients keep their existing behavior and may discard optional outbox metadata.
- Range count follows chip count. There is no second full-prompt field, but copied edge whitespace is uncapped. For the tested 50,000-character prompt, metadata was 22 serialized bytes in SQLite and added 40 bytes to message JSON. This is not a storage-page or constant-cost claim.

## Verification

Reviewed [8c603df7](https://github.com/pingdotgg/t3code/commit/8c603df74a76732135d46a21597b080cf8a4ab2d) against [761d4bac](https://github.com/pingdotgg/t3code/commit/761d4bac1c238ea7af4dd36b56719ad5e30771c3), September 5, 2026.

- 601 focused tests pass: 74 server, 171 shared/contracts/mobile, 356 web. Server, web and mobile typechecks pass. Coverage includes committed events, SQLite/reopen/migration, snapshots, queue recovery, actual send assembly and Lexical serialization.
- Real-client history controls pass for literal prefixes, whitespace, generated terminal context and identical text typed literally, including backward/forward navigation and returning to empty.
- A fresh native Send stored 52 characters plus two spaces at each edge. The saved message, unique completed simulated turn and checkpoint agree across read-only SQLite, real client events and the HTTP snapshot. Recall restores all 56 characters, including after reload. No provider account/model was called.
- The latest-main client repeatedly recalls only 40 characters from that same message. The comparison below uses identical data and viewport with the same isolated candidate backend. It proves the client difference, not a full main-backend comparison. The fresh send separately exercises the candidate client, commands, events and SQLite.

Web and desktop share the recall UI. Mobile propagation has focused tests, not native phone verification, and gains no ArrowUp UI. No real-provider, relay or older-client runtime claim is made.

## Before

The literal prefix and whitespace disappear during recall.

![Before: the saved message contains Ultrathink, but the recalled composer has lost it](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/36efde777eff7aea/10056-current-main-before-settled.png)

[Before recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/ea5f393c9d1e30de/10056-before-visible.webm)

## After

Recall preserves the authored prefix and whitespace.

![After: the recalled composer preserves the literal Ultrathink prefix and authored text](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/f8d7009bdbedd8c1/10056-8c603-after-settled.png)

[After recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/b8bf92923cb02b51/10056-after-visible.webm)

GPT 6 Astra via Codex in T3 Code.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve authored composer text in prompt recall via `ComposerRecall` metadata
> - Adds a shared `ComposerRecall` contract and utilities in [composerRecall.ts](https://github.com/pingdotgg/t3code/pull/10102/files#diff-e18fe250bcf43c331404d1a2707570be39fbd546b2533f31289f6522233496c7) that record authored UTF-16 ranges and boundary whitespace so generated context (ultrathink prefixes, terminal/element blocks, review markup) can be stripped on recall instead of heuristically guessed
> - Server persists recall in a new nullable JSON column via migration 048 in [048_ProjectionMessageComposerRecall.ts](https://github.com/pingdotgg/t3code/pull/10102/files#diff-f5416150d0709fc2f9b05478662ef982caab774d788ae4312e46a66e5461b230); the decider, projector, projection pipeline, and snapshot queries all carry and retain recall through message lifecycle events
> - Web and mobile clients attach `composerRecall` to sends, optimistic messages, and outbox records when the environment advertises the capability in [environment.ts](https://github.com/pingdotgg/t3code/pull/10102/files#diff-b65c7cdf3624689c7649437c1a0f4c45f1ce579724f52098249d43ccf0aa7203); prompt history and outbox recovery now reconstruct authored text from stored metadata
> - Removes the old `recallableComposerPrompt` heuristic helper from [composerPromptHistory.ts](https://github.com/pingdotgg/t3code/pull/10102/files#diff-2ad40a6be7c25e07c66fd56d0a04cf57663f432ef1f5455f20d13d33e9747f5c)
> - Risk: projection upsert and streaming-append in [ProjectionThreadMessages.ts](https://github.com/pingdotgg/t3code/pull/10102/files#diff-72dbfc4251beab0913df32bedf59889c9a9dc50f6a0c763754f98d2a764fefd5) clear stored recall on text-changing updates and preserve it only for empty completions; migration 048 adds a column to `projection_thread_messages` that existing rows leave null
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2643377.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->