### PR TITLE
refactor(web): share bulk thread deletion between sidebars

### DIFF
--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -179,6 +179,7 @@ import { isCommandPaletteOpen, openCommandPalette } from "../commandPaletteBus";
 import {
   archiveSelectedThreadEntries,
   buildMultiSelectThreadContextMenuItems,
+  deleteSelectedThreadEntries,
   getSidebarThreadIdsToPrewarm,
   resolveAdjacentThreadId,
   isContextMenuPointerDown,
@@ -1926,21 +1927,13 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         if (!confirmed) return;
       }
 
-      // Only discount batch members after their deletions succeed.
-      const deletedThreadKeys = new Set<string>();
-      let firstError: unknown = null;
-      for (const { threadKey, threadRef } of selectedThreadEntries) {
-        const result = await deleteThread(threadRef, {
-          deletedThreadKeys,
-        });
-        if (result._tag === "Failure") {
-          if (isAtomCommandInterrupted(result)) break;
-          firstError ??= squashAtomCommandFailure(result);
-          continue;
-        }
-        deletedThreadKeys.add(threadKey);
-      }
-      if (firstError !== null) {
+      const { deletedThreadKeys, firstFailure } = await deleteSelectedThreadEntries({
+        entries: selectedThreadEntries,
+        delete: ({ threadRef }, deletedThreadKeys) =>
+          deleteThread(threadRef, { deletedThreadKeys }),
+      });
+      if (firstFailure !== null) {
+        const firstError = squashAtomCommandFailure(firstFailure);
         toastManager.add(
           stackedThreadToast({
             type: "error",

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { defaultAnimateLayoutChanges, type AnimateLayoutChanges } from "@dnd-kit/sortable";
+import * as Cause from "effect/Cause";
+import { AsyncResult } from "effect/unstable/reactivity";
 import {
   animatePinnedLayoutChanges,
   archiveSelectedThreadEntries,
@@ -7,6 +9,7 @@ import {
   buildBulkUnpinContextMenuItem,
   buildMultiSelectThreadContextMenuItems,
   createThreadJumpHintVisibilityController,
+  deleteSelectedThreadEntries,
   filterSidebarProjectScopeItems,
   getSidebarThreadIdsToPrewarm,
   resolveAdjacentThreadId,
@@ -78,6 +81,102 @@ describe("animatePinnedLayoutChanges", () => {
 
   it("keeps layout movement while the user is sorting", () => {
     expect(animatePinnedLayoutChanges({ ...baseArgs, isSorting: true })).toBe(true);
+  });
+});
+
+describe("deleteSelectedThreadEntries", () => {
+  const entries = [{ threadKey: "one" }, { threadKey: "two" }, { threadKey: "three" }] as const;
+  const success = AsyncResult.success(undefined);
+  const failure = AsyncResult.failure(Cause.fail(new Error("Delete failed")));
+  const interrupted = AsyncResult.failure(Cause.interrupt());
+
+  it("waits for each delete and excludes only earlier successes from worktree checks", async () => {
+    let resolveDelete!: (result: typeof success) => void;
+    const pendingDelete = new Promise<typeof success>((resolve) => {
+      resolveDelete = resolve;
+    });
+    const worktreeChecks: { threadKey: string; deletedThreadKeys: string[] }[] = [];
+    const deletion = deleteSelectedThreadEntries({
+      entries,
+      delete: async ({ threadKey }, deletedThreadKeys) => {
+        worktreeChecks.push({ threadKey, deletedThreadKeys: [...deletedThreadKeys] });
+        return threadKey === "one" ? pendingDelete : success;
+      },
+    });
+
+    expect(worktreeChecks).toEqual([{ threadKey: "one", deletedThreadKeys: [] }]);
+    resolveDelete(success);
+    const outcome = await deletion;
+
+    expect(worktreeChecks).toEqual([
+      { threadKey: "one", deletedThreadKeys: [] },
+      { threadKey: "two", deletedThreadKeys: ["one"] },
+      { threadKey: "three", deletedThreadKeys: ["one", "two"] },
+    ]);
+    expect(outcome).toEqual({
+      deletedThreadKeys: new Set(["one", "two", "three"]),
+      firstFailure: null,
+    });
+  });
+
+  it("continues after ordinary failures and keeps the first failure", async () => {
+    const laterFailure = AsyncResult.failure(Cause.fail(new Error("Later failure")));
+    const deletedKeysAtLastEntry: string[][] = [];
+    const outcome = await deleteSelectedThreadEntries({
+      entries: [...entries, { threadKey: "four" }],
+      delete: async ({ threadKey }, deletedThreadKeys) => {
+        if (threadKey === "one") return failure;
+        if (threadKey === "three") return laterFailure;
+        if (threadKey === "four") deletedKeysAtLastEntry.push([...deletedThreadKeys]);
+        return success;
+      },
+    });
+
+    expect(deletedKeysAtLastEntry).toEqual([["two"]]);
+    expect(outcome).toEqual({
+      deletedThreadKeys: new Set(["two", "four"]),
+      firstFailure: failure,
+    });
+  });
+
+  it.each([
+    { firstResult: success, deletedThreadKeys: new Set(["one"]), firstFailure: null },
+    { firstResult: failure, deletedThreadKeys: new Set<string>(), firstFailure: failure },
+  ])("stops on interruption and preserves earlier results %#", async (testCase) => {
+    const attemptedThreadKeys: string[] = [];
+    const outcome = await deleteSelectedThreadEntries({
+      entries,
+      delete: async ({ threadKey }) => {
+        attemptedThreadKeys.push(threadKey);
+        return threadKey === "one" ? testCase.firstResult : interrupted;
+      },
+    });
+
+    expect(attemptedThreadKeys).toEqual(["one", "two"]);
+    expect(outcome).toEqual({
+      deletedThreadKeys: testCase.deletedThreadKeys,
+      firstFailure: testCase.firstFailure,
+    });
+  });
+
+  it("does not count a skipped entry as deleted", async () => {
+    const visibleEntries = new Set(entries.map(({ threadKey }) => threadKey));
+    const worktreeChecks: string[][] = [];
+    const outcome = await deleteSelectedThreadEntries({
+      entries,
+      delete: async ({ threadKey }, deletedThreadKeys) => {
+        if (!visibleEntries.has(threadKey)) return null;
+        worktreeChecks.push([...deletedThreadKeys]);
+        visibleEntries.delete("two");
+        return success;
+      },
+    });
+
+    expect(worktreeChecks).toEqual([[], ["one"]]);
+    expect(outcome).toEqual({
+      deletedThreadKeys: new Set(["one", "three"]),
+      firstFailure: null,
+    });
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -1,7 +1,12 @@
 import * as React from "react";
 import { defaultAnimateLayoutChanges, type AnimateLayoutChanges } from "@dnd-kit/sortable";
+import {
+  isAtomCommandInterrupted,
+  type AtomCommandResult,
+} from "@t3tools/client-runtime/state/runtime";
 import type { ContextMenuItem } from "@t3tools/contracts";
 import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "@t3tools/contracts/settings";
+import type { AsyncResult } from "effect/unstable/reactivity";
 import {
   activeThreadAnchorTimestampMs,
   getThreadSortTimestamp,
@@ -108,6 +113,36 @@ type LogicalSidebarProject = SidebarProject & {
 };
 
 export type ThreadTraversalDirection = "previous" | "next";
+
+/**
+ * Shared-worktree checks must exclude only successful deletions, never the
+ * whole batch. A null result skips an entry that the caller can no longer find.
+ */
+export async function deleteSelectedThreadEntries<
+  TEntry extends { readonly threadKey: string },
+>(input: {
+  entries: readonly TEntry[];
+  delete: (
+    entry: TEntry,
+    deletedThreadKeys: ReadonlySet<string>,
+  ) => Promise<AtomCommandResult<unknown, unknown> | null>;
+}) {
+  const deletedThreadKeys = new Set<string>();
+  let firstFailure: AsyncResult.Failure<unknown, unknown> | null = null;
+
+  for (const entry of input.entries) {
+    const result = await input.delete(entry, deletedThreadKeys);
+    if (result === null) continue;
+    if (result._tag === "Failure") {
+      if (isAtomCommandInterrupted(result)) break;
+      firstFailure ??= result;
+      continue;
+    }
+    deletedThreadKeys.add(entry.threadKey);
+  }
+
+  return { deletedThreadKeys, firstFailure };
+}
 
 export async function archiveSelectedThreadEntries<
   TEntry extends { readonly threadKey: string },

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -140,6 +140,7 @@ import {
   animatePinnedLayoutChanges,
   buildBulkTitleRegenerationContextMenuItem,
   buildBulkUnpinContextMenuItem,
+  deleteSelectedThreadEntries,
   filterSidebarProjectScopeItems,
   formatWorkingDurationLabel,
   firstValidTimestampMs,
@@ -3219,26 +3220,18 @@ export default function Sidebar() {
         );
         if (confirmed._tag === "Failure" || !confirmed.value) return;
       }
-      // Grown as deletions actually land, never seeded with the whole batch:
-      // orphaned-worktree detection must only discount threads that are
-      // really gone, or the first delete would treat still-alive batch mates
-      // as deleted and remove a worktree they still point at.
-      const deletedThreadKeys = new Set<string>();
-      let firstError: unknown = null;
-      for (const threadKey of threadKeys) {
-        const thread = threadByKeyRef.current.get(threadKey);
-        if (!thread) continue;
-        const result = await deleteThread(scopeThreadRef(thread.environmentId, thread.id), {
-          deletedThreadKeys,
-        });
-        if (result._tag === "Failure") {
-          if (isAtomCommandInterrupted(result)) break;
-          firstError ??= squashAtomCommandFailure(result);
-          continue;
-        }
-        deletedThreadKeys.add(threadKey);
-      }
-      if (firstError !== null) {
+      const { deletedThreadKeys, firstFailure } = await deleteSelectedThreadEntries({
+        entries: threadKeys.map((threadKey) => ({ threadKey })),
+        delete: async ({ threadKey }, deletedThreadKeys) => {
+          const thread = threadByKeyRef.current.get(threadKey);
+          if (!thread) return null;
+          return deleteThread(scopeThreadRef(thread.environmentId, thread.id), {
+            deletedThreadKeys,
+          });
+        },
+      });
+      if (firstFailure !== null) {
+        const firstError = squashAtomCommandFailure(firstFailure);
         toastManager.add(
           stackedThreadToast({
             type: "error",


### PR DESCRIPTION
Both sidebar layouts keep their own bulk-delete loop. [#4615](https://github.com/pingdotgg/t3code/pull/4615) had to fix both copies so one failed deletion would not stop the remaining threads.

Use one shared loop for both layouts. It counts only successful deletions for shared-worktree checks, continues ordinary failures, and stops on interruption. Menus, confirmation dialogs, layout choice, and selection cleanup stay in their existing callers.

## Verification

- 153 focused sidebar, selection, and worktree tests pass.
- Web typecheck and formatting pass.
- Targeted lint passes with warnings in unchanged code.
- Both disposable sidebar browser checks passed. No visual change is intended.

## Browser verification

Both sidebar layouts passed Cancel and Confirm checks with disposable local threads. Cancel kept both selected threads. Confirm deleted only the two selected threads. Unselected threads and navigation remained available. A final confirmation check on the combined build kept the same dialog in both layouts.

Before uses main at 0c200c5f83. After uses the combined PR build at 8316ed24a9. Screenshots show confirmation only. The separate behavior checks exercised deletion.

### Current sidebar

![Before: current sidebar confirmation](https://files.tslop.org/2026/09/before-main-0c200c5f-sidebar-current-dialog-c779a729.png)

![After: current sidebar confirmation](https://files.tslop.org/2026/09/after-final-8316ed24-sidebar-current-dialog-e738f3aa.png)

### Legacy sidebar

![Before: legacy sidebar confirmation](https://files.tslop.org/2026/09/before-main-0c200c5f-sidebar-legacy-dialog-1f3e77cd.png)

![After: legacy sidebar confirmation](https://files.tslop.org/2026/09/after-final-8316ed24-sidebar-legacy-dialog-964de49f.png)

Created with GPT-6 Astra in Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share bulk thread deletion logic between `LegacySidebar` and `Sidebar`
> - Adds `deleteSelectedThreadEntries` helper in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/10106/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) that processes entries sequentially, tracks successful keys, preserves the first failure, stops on interruption, and skips null results
> - Refactors `SidebarProjectItem` in [LegacySidebar.tsx](https://github.com/pingdotgg/t3code/pull/10106/files#diff-ef6c49faf62e0e2403f09772084537ac313e826ae0f90db230a898204f3bdd86) and the bulk-delete flow in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/10106/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) to call the shared helper instead of inline deletion loops
> - Adds tests in [Sidebar.logic.test.ts](https://github.com/pingdotgg/t3code/pull/10106/files#diff-32549f6f09ae3a1d9d846a62727c17b9f9ec246030982995fd972b497a87335a) covering ordering, failures, interruption, and skipped entries
> - Behavioral Change: `Sidebar` now treats threads missing from `threadByKeyRef` as skipped (null) entries rather than failing; error toast still reports only the first failure
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da8035f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->