### PR TITLE
refactor(mobile): make outbox ownership checks explicit

### DIFF
--- a/apps/mobile/src/state/pending-task-editor-writes.test.ts
+++ b/apps/mobile/src/state/pending-task-editor-writes.test.ts
@@ -19,7 +19,7 @@ vi.mock("./thread-outbox", async () => {
   harness.manager = createThreadOutboxManager({
     registry: appAtomRegistry,
     storage: {
-      load: async () => ({ messages: [], errors: [] }),
+      load: async () => ({ messages: [], status: "complete" }),
       write: async (message) => {
         const pending = harness.writeGates.shift();
         if (pending) {

--- a/apps/mobile/src/state/thread-outbox-manager.ts
+++ b/apps/mobile/src/state/thread-outbox-manager.ts
@@ -37,6 +37,10 @@ export interface ThreadOutboxManagerOptions {
   readonly warn?: (message: string, error: unknown) => void;
 }
 
+type ThreadOutboxHydrationResult =
+  | { readonly status: "complete" }
+  | { readonly status: "incomplete"; readonly error: ThreadOutboxManagerError };
+
 export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
   const queuedMessagesByThreadKeyAtom = Atom.make<
     Record<string, ReadonlyArray<QueuedThreadMessage>>
@@ -46,7 +50,7 @@ export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
     ((message: string, error: unknown) => {
       console.warn(message, error);
     });
-  let loadPromise: Promise<boolean> | null = null;
+  let loadPromise: Promise<ThreadOutboxHydrationResult> | null = null;
   let mutationQueue: Promise<void> = Promise.resolve();
   // Monotonic per-message write counter. Every accepted write (enqueue publish
   // or update) bumps it, so a writer that captured a revision before slow work
@@ -72,14 +76,14 @@ export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
     options.registry.set(queuedMessagesByThreadKeyAtom, groupQueuedThreadMessages(messages));
   };
 
-  // Readable messages can be used after a partial load. Only a complete load
-  // returns true, so cleanup cannot delete files owned by unreadable records.
-  // A later call retries failed reads without replacing live message objects.
-  const load = (): Promise<boolean> => {
+  // Readable messages enter the atom even when ownership is incomplete.
+  // Cleanup and account changes require a complete inventory. Failed reads
+  // can be retried without replacing live messages or retaining old snapshots.
+  const load = (): Promise<ThreadOutboxHydrationResult> => {
     if (loadPromise !== null) {
       return loadPromise;
     }
-    loadPromise = serialize(async () => {
+    loadPromise = serialize<ThreadOutboxHydrationResult>(async () => {
       const result = await options.storage.load();
       const current = currentMessages();
       const currentIds = new Set(current.map((message) => message.messageId));
@@ -89,23 +93,21 @@ export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
       // Accepted edits and removals win over a later disk read. Retaining
       // current objects also keeps retries from restarting the drain.
       if (recovered.length > 0) setMessages([...recovered, ...current]);
-      if (result.errors.length > 0) {
-        throw new AggregateError(result.errors, "Some queued messages could not be read.");
+      if (result.status === "incomplete") {
+        throw result.error;
       }
-      return true;
+      return { status: "complete" };
     }).catch((cause) => {
       loadPromise = null;
-      warn(
-        "[thread-outbox] failed to load persisted messages",
-        new ThreadOutboxManagerError({
-          operation: "load",
-          environmentId: null,
-          threadId: null,
-          messageId: null,
-          cause,
-        }),
-      );
-      return false;
+      const error = new ThreadOutboxManagerError({
+        operation: "load",
+        environmentId: null,
+        threadId: null,
+        messageId: null,
+        cause,
+      });
+      warn("[thread-outbox] failed to load persisted messages", error);
+      return { status: "incomplete", error };
     });
     return loadPromise;
   };
@@ -288,8 +290,8 @@ export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
       const persisted = await options.storage
         .load()
         .then((result) => {
-          if (result.errors.length > 0) {
-            throw new AggregateError(result.errors, "Some queued messages could not be read.");
+          if (result.status === "incomplete") {
+            throw result.error;
           }
           return result.messages;
         })

--- a/apps/mobile/src/state/thread-outbox-model.ts
+++ b/apps/mobile/src/state/thread-outbox-model.ts
@@ -27,7 +27,9 @@ import type { DraftComposerAttachment } from "../lib/composerImages";
 import { scopedThreadKey } from "../lib/scopedEntities";
 import { resolveProviderInteractionMode } from "../features/threads/legacy-plan-mode";
 
-// Keep current writes until a compatible native baseline includes the v4 reader.
+// Keep v3 writes until each platform has a new native runtime with embedded
+// v4 readers and storage-failure guards. The runtime must exclude old binaries
+// whose embedded JavaScript cannot recover file-backed drafts after OTA rollback.
 const THREAD_OUTBOX_SCHEMA_VERSION = 3;
 const THREAD_OUTBOX_MAX_RETRY_DELAY_MS = 16_000;
 

--- a/apps/mobile/src/state/thread-outbox-removal.test.ts
+++ b/apps/mobile/src/state/thread-outbox-removal.test.ts
@@ -19,7 +19,7 @@ vi.mock("./thread-outbox", async () => {
   harness.manager = createThreadOutboxManager({
     registry: appAtomRegistry,
     storage: {
-      load: async () => ({ messages: [], errors: [] }),
+      load: async () => ({ messages: [], status: "complete" }),
       write: async () => undefined,
       remove: async () => undefined,
     },

--- a/apps/mobile/src/state/thread-outbox-storage.ts
+++ b/apps/mobile/src/state/thread-outbox-storage.ts
@@ -44,10 +44,12 @@ export class ThreadOutboxStorageError extends Schema.TaggedErrorClass<ThreadOutb
   }
 }
 
-export interface ThreadOutboxLoadResult {
+export type ThreadOutboxLoadResult = {
   readonly messages: ReadonlyArray<QueuedThreadMessage>;
-  readonly errors: ReadonlyArray<ThreadOutboxStorageError>;
-}
+} & (
+  | { readonly status: "complete" }
+  | { readonly status: "incomplete"; readonly error: ThreadOutboxStorageError }
+);
 
 export interface ThreadOutboxStorage {
   readonly load: () => Promise<ThreadOutboxLoadResult>;
@@ -100,17 +102,24 @@ export const expoThreadOutboxStorage: ThreadOutboxStorage = {
           );
         }
       }
+      if (errors.length > 0) {
+        throw new AggregateError(errors, "Some queued messages could not be read.");
+      }
+      return { status: "complete", messages };
     } catch (cause) {
-      throw new ThreadOutboxStorageError({
-        operation: "load",
-        environmentId: null,
-        threadId: null,
-        messageId: null,
-        fileName: null,
-        cause,
-      });
+      return {
+        status: "incomplete",
+        messages,
+        error: new ThreadOutboxStorageError({
+          operation: "load",
+          environmentId: null,
+          threadId: null,
+          messageId: null,
+          fileName: null,
+          cause,
+        }),
+      };
     }
-    return { messages, errors };
   },
   write: async (message) => {
     const fileName = messageFileName(message.messageId);

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -11,12 +11,14 @@ import { AtomRegistry } from "effect/unstable/reactivity";
 import { onTestFinished, vi } from "vite-plus/test";
 
 const outboxFiles = vi.hoisted(() => new Map<string, string | Error>());
+const outboxDirectory = vi.hoisted<{ error: Error | null }>(() => ({ error: null }));
 
 vi.mock("expo-file-system", () => {
   class Directory {
     create() {}
 
     list() {
+      if (outboxDirectory.error) throw outboxDirectory.error;
       return Array.from(outboxFiles.keys(), (name) => new File(name));
     }
   }
@@ -133,8 +135,12 @@ describe("thread outbox", () => {
       const unreadable = outboxFiles.get("message-2.json");
 
       await expect(expoThreadOutboxStorage.load()).resolves.toMatchObject({
+        status: "incomplete",
         messages: [first],
-        errors: [{ operation: "read-message", fileName: "message-2.json" }],
+        error: {
+          operation: "load",
+          cause: { errors: [{ operation: "read-message", fileName: "message-2.json" }] },
+        },
       });
 
       const registry = AtomRegistry.make();
@@ -144,7 +150,7 @@ describe("thread outbox", () => {
         storage: expoThreadOutboxStorage,
         warn: () => {},
       });
-      await expect(manager.load()).resolves.toBe(false);
+      await expect(manager.load()).resolves.toMatchObject({ status: "incomplete" });
       const recovered = registry.get(manager.queuedMessagesByThreadKeyAtom)[
         "environment-1:thread-1"
       ]![0]!;
@@ -153,7 +159,7 @@ describe("thread outbox", () => {
       const edited = { ...recovered, text: "Edited after recovery" };
       await expect(manager.update(edited)).resolves.toBe(true);
       const beforeRetry = registry.get(manager.queuedMessagesByThreadKeyAtom);
-      await expect(manager.load()).resolves.toBe(false);
+      await expect(manager.load()).resolves.toMatchObject({ status: "incomplete" });
       expect(registry.get(manager.queuedMessagesByThreadKeyAtom)).toBe(beforeRetry);
       await expect(manager.clearEnvironment(first.environmentId)).rejects.toMatchObject({
         operation: "clear-environment-load",
@@ -167,49 +173,59 @@ describe("thread outbox", () => {
       expect(outboxFiles.has("message-1.json")).toBe(false);
 
       outboxFiles.set("message-2.json", JSON.stringify(encodeQueuedThreadMessage(second)));
-      await expect(manager.load()).resolves.toBe(true);
+      await expect(manager.load()).resolves.toEqual({ status: "complete" });
       expect(registry.get(manager.queuedMessagesByThreadKeyAtom)).toEqual({
         "environment-2:thread-1": [second],
       });
       await expect(expoThreadOutboxStorage.load()).resolves.toEqual({
         messages: [second],
-        errors: [],
+        status: "complete",
       });
     },
   );
 
   it("preserves queued messages when environment cleanup cannot read the outbox", async () => {
     const registry = AtomRegistry.make();
-    onTestFinished(() => registry.dispose());
+    onTestFinished(() => {
+      registry.dispose();
+      outboxDirectory.error = null;
+      outboxFiles.clear();
+    });
     const message = queuedMessage({
       messageId: "message-1",
       createdAt: "2026-06-08T10:00:01.000Z",
     });
-    const stored = new Map<MessageId, QueuedThreadMessage>();
     const manager = createThreadOutboxManager({
       registry,
       warn: () => {},
-      storage: {
-        load: async () => {
-          throw new Error("storage unavailable");
-        },
-        write: async (entry) => {
-          stored.set(entry.messageId, entry);
-        },
-        remove: async (entry) => {
-          stored.delete(entry.messageId);
-        },
-      },
+      storage: expoThreadOutboxStorage,
     });
     await manager.enqueue(message);
+    outboxDirectory.error = new Error("storage unavailable");
 
+    await expect(expoThreadOutboxStorage.load()).resolves.toMatchObject({
+      status: "incomplete",
+      messages: [],
+      error: { operation: "load", cause: outboxDirectory.error },
+    });
+    await expect(manager.load()).resolves.toMatchObject({
+      status: "incomplete",
+      error: { operation: "load" },
+    });
     await expect(manager.clearEnvironment(message.environmentId)).rejects.toMatchObject({
       operation: "clear-environment-load",
     });
-    expect([...stored.values()]).toEqual([message]);
+    expect(outboxFiles.get("message-1.json")).toBe(
+      JSON.stringify(encodeQueuedThreadMessage(message)),
+    );
     expect(registry.get(manager.queuedMessagesByThreadKeyAtom)).toEqual({
       "environment-1:thread-1": [message],
     });
+    await expect(manager.confirmQueued(message)).resolves.toBe(true);
+
+    outboxDirectory.error = null;
+    await expect(manager.load()).resolves.toEqual({ status: "complete" });
+    await expect(manager.confirmQueued(message)).resolves.toBe(true);
   });
 
   it("keeps in-session edits and removals when an incomplete load is retried", async () => {
@@ -223,7 +239,7 @@ describe("thread outbox", () => {
     const response = Promise.withResolvers<ThreadOutboxLoadResult>();
     const load = vi.fn<ThreadOutboxStorage["load"]>(async () => ({
       messages: [message],
-      errors: [],
+      status: "complete",
     }));
     load.mockImplementationOnce(() => {
       started.resolve();
@@ -240,18 +256,17 @@ describe("thread outbox", () => {
     const writing = manager.enqueue(edited);
     response.resolve({
       messages: [message],
-      errors: [
-        new ThreadOutboxStorageError({
-          operation: "read-message",
-          environmentId: null,
-          threadId: null,
-          messageId: null,
-          fileName: "unreadable.json",
-          cause: new Error("unreadable record"),
-        }),
-      ],
+      status: "incomplete",
+      error: new ThreadOutboxStorageError({
+        operation: "read-message",
+        environmentId: null,
+        threadId: null,
+        messageId: null,
+        fileName: "unreadable.json",
+        cause: new Error("unreadable record"),
+      }),
     });
-    await expect(loading).resolves.toBe(false);
+    await expect(loading).resolves.toMatchObject({ status: "incomplete" });
     await writing;
     expect(registry.get(manager.queuedMessagesByThreadKeyAtom)).toEqual({
       "environment-1:thread-1": [edited],
@@ -260,7 +275,7 @@ describe("thread outbox", () => {
 
     await manager.remove(edited);
     // A later repaired record can contain a stale copy of a removed message.
-    await expect(manager.load()).resolves.toBe(true);
+    await expect(manager.load()).resolves.toEqual({ status: "complete" });
     expect(registry.get(manager.queuedMessagesByThreadKeyAtom)).toEqual({});
     expect(load).toHaveBeenCalledTimes(2);
   });
@@ -462,7 +477,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => ({ messages: [], errors: [] }),
+        load: async () => ({ messages: [], status: "complete" }),
         write: async () => undefined,
         remove: async () => undefined,
       },
@@ -509,7 +524,7 @@ describe("thread outbox", () => {
         if (loadCalls === 1) {
           await initialLoadBlocked;
         }
-        return { messages: [...stored.values()], errors: [] };
+        return { messages: [...stored.values()], status: "complete" };
       },
       write: async () => undefined,
       remove: async (candidate) => {
@@ -545,7 +560,7 @@ describe("thread outbox", () => {
         load: async () => {
           loadCalls += 1;
           if (loadCalls === 1) throw loadCause;
-          return { messages: [], errors: [] };
+          return { messages: [], status: "complete" };
         },
         write: async () => undefined,
         remove: async () => undefined,
@@ -578,7 +593,7 @@ describe("thread outbox", () => {
     const removalCause = new Error("remove failed");
     let failRemoval = true;
     const storage: ThreadOutboxStorage = {
-      load: async () => ({ messages: [...stored.values()], errors: [] }),
+      load: async () => ({ messages: [...stored.values()], status: "complete" }),
       write: async (message) => {
         stored.set(message.messageId, message);
       },
@@ -628,7 +643,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => ({ messages: [], errors: [] }),
+        load: async () => ({ messages: [], status: "complete" }),
         write: async () => writeBlocked,
         remove: async () => undefined,
       },
@@ -657,7 +672,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => ({ messages: [], errors: [] }),
+        load: async () => ({ messages: [], status: "complete" }),
         write: async () => {
           throw writeCause;
         },
@@ -688,7 +703,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => ({ messages: [], errors: [] }),
+        load: async () => ({ messages: [], status: "complete" }),
         write: async () => {
           throw new Error("disk full");
         },
@@ -720,7 +735,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => ({ messages: [], errors: [] }),
+        load: async () => ({ messages: [], status: "complete" }),
         write: async () => {
           if (failNextWrite) {
             failNextWrite = false;
@@ -757,7 +772,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => ({ messages: [], errors: [] }),
+        load: async () => ({ messages: [], status: "complete" }),
         write: async () => undefined,
         remove: async () => undefined,
       },
@@ -781,7 +796,7 @@ describe("thread outbox", () => {
     const registry = AtomRegistry.make();
     const stored = new Map<MessageId, QueuedThreadMessage>();
     const storage: ThreadOutboxStorage = {
-      load: async () => ({ messages: [...stored.values()], errors: [] }),
+      load: async () => ({ messages: [...stored.values()], status: "complete" }),
       write: async (message) => {
         stored.set(message.messageId, message);
       },
@@ -816,7 +831,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => ({ messages: [], errors: [] }),
+        load: async () => ({ messages: [], status: "complete" }),
         write: async (message) => {
           writes.push(message.text);
         },
@@ -860,7 +875,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => ({ messages: [], errors: [] }),
+        load: async () => ({ messages: [], status: "complete" }),
         write: async (message) => {
           writes.push(message.text);
           if (message.text === "stale upload") {
@@ -904,7 +919,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => ({ messages: [...stored.values()], errors: [] }),
+        load: async () => ({ messages: [...stored.values()], status: "complete" }),
         write: async (message) => {
           stored.set(message.messageId, message);
         },
@@ -953,7 +968,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => ({ messages: [...stored.values()], errors: [] }),
+        load: async () => ({ messages: [...stored.values()], status: "complete" }),
         write: async (message) => {
           if (message === retried) {
             replacementWriteStarted.resolve();
@@ -1003,7 +1018,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => ({ messages: [...stored.values()], errors: [] }),
+        load: async () => ({ messages: [...stored.values()], status: "complete" }),
         write: async (message) => {
           stored.set(message.messageId, message);
         },
@@ -1042,7 +1057,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => ({ messages: [...stored.values()], errors: [] }),
+        load: async () => ({ messages: [...stored.values()], status: "complete" }),
         write: async (message) => {
           stored.set(message.messageId, message);
         },
@@ -1106,7 +1121,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => ({ messages: [...stored.values()], errors: [] }),
+        load: async () => ({ messages: [...stored.values()], status: "complete" }),
         write: async (message) => {
           stored.set(message.messageId, message);
         },
@@ -1149,7 +1164,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => ({ messages: [...stored.values()], errors: [] }),
+        load: async () => ({ messages: [...stored.values()], status: "complete" }),
         write: async (message) => {
           stored.set(message.messageId, message);
         },

--- a/apps/mobile/src/state/use-composer-drafts.test.ts
+++ b/apps/mobile/src/state/use-composer-drafts.test.ts
@@ -147,6 +147,7 @@ vi.mock("../features/sharing/incoming-share-storage", () => ({
 
 import { appAtomRegistry } from "./atom-registry";
 import { threadOutboxManager } from "./thread-outbox";
+import { ThreadOutboxManagerError } from "./thread-outbox-manager";
 import {
   appendComposerDraftAttachments,
   archiveCloudComposerDrafts,
@@ -263,7 +264,9 @@ describe("mobile composer drafts", () => {
   });
 
   it("releases videos rejected by the live draft limit and keeps accepted files", async () => {
-    const outboxLoad = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
+    const outboxLoad = vi
+      .spyOn(threadOutboxManager, "load")
+      .mockResolvedValue({ status: "complete" });
     onTestFinished(() => outboxLoad.mockRestore());
     const cleanup = Promise.withResolvers<void>();
     composerAttachmentCleanupMocks.remove.mockImplementationOnce(async () => {
@@ -308,7 +311,9 @@ describe("mobile composer drafts", () => {
   });
 
   it("keeps shared attachment files until every draft releases them", async () => {
-    const outboxLoad = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
+    const outboxLoad = vi
+      .spyOn(threadOutboxManager, "load")
+      .mockResolvedValue({ status: "complete" });
     onTestFinished(() => outboxLoad.mockRestore());
     const file = {
       id: "file-1",
@@ -338,7 +343,9 @@ describe("mobile composer drafts", () => {
   });
 
   it("retains a referenced file-backed image and releases it once unreferenced", async () => {
-    const outboxLoad = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
+    const outboxLoad = vi
+      .spyOn(threadOutboxManager, "load")
+      .mockResolvedValue({ status: "complete" });
     onTestFinished(() => outboxLoad.mockRestore());
     const image = {
       id: "image-1",
@@ -438,7 +445,9 @@ describe("mobile composer drafts", () => {
   });
 
   it("keeps a failed-send draft's pending upload for retry", async () => {
-    const outboxLoad = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
+    const outboxLoad = vi
+      .spyOn(threadOutboxManager, "load")
+      .mockResolvedValue({ status: "complete" });
     onTestFinished(() => outboxLoad.mockRestore());
     const file = {
       id: "file-failed-send",
@@ -496,7 +505,9 @@ describe("mobile composer drafts", () => {
   });
 
   it("cleans up an unreferenced image upload even when there is no local file URI", async () => {
-    const outboxLoad = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
+    const outboxLoad = vi
+      .spyOn(threadOutboxManager, "load")
+      .mockResolvedValue({ status: "complete" });
     onTestFinished(() => outboxLoad.mockRestore());
     const environmentId = EnvironmentId.make("environment-1");
     await releaseUnusedComposerAttachmentFiles([
@@ -521,7 +532,7 @@ describe("mobile composer drafts", () => {
   it.each(["file", "image"] as const)(
     "keeps signed-out %s attachments through cleanup and restart, and restores only the owning account",
     async (type) => {
-      const load = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
+      const load = vi.spyOn(threadOutboxManager, "load").mockResolvedValue({ status: "complete" });
       onTestFinished(() => load.mockRestore());
       await waitForComposerDraftsLoaded();
       const environmentId = EnvironmentId.make("cloud-environment");
@@ -575,6 +586,24 @@ describe("mobile composer drafts", () => {
       expect(appAtomRegistry.get(threadOutboxManager.queuedMessagesByThreadKeyAtom)).toEqual({});
       const enqueue = vi.spyOn(threadOutboxManager, "enqueue").mockResolvedValue();
       onTestFinished(() => enqueue.mockRestore());
+      const savedDrafts = appAtomRegistry.get(composerCloudDraftsAtom);
+      const activeDrafts = appAtomRegistry.get(composerDraftsAtom);
+      const loadError = new ThreadOutboxManagerError({
+        operation: "load",
+        environmentId: null,
+        threadId: null,
+        messageId: null,
+        cause: new Error("An outbox record is unreadable"),
+      });
+      load.mockResolvedValueOnce({ status: "incomplete", error: loadError });
+      await expect(restoreCloudComposerDrafts("account-a")).rejects.toMatchObject({
+        message: "Could not restore queued messages.",
+        cause: loadError,
+      });
+      expect(enqueue).not.toHaveBeenCalled();
+      expect(appAtomRegistry.get(composerDraftsAtom)).toBe(activeDrafts);
+      expect(appAtomRegistry.get(composerCloudDraftsAtom)).toBe(savedDrafts);
+
       await restoreCloudComposerDrafts("account-a");
       expect(getComposerDraftSnapshot(key)).toEqual({ text: "Unsent notes", attachments: [file] });
       expect(getComposerDraftSnapshot("pending-task:queued-1").text).toBe("Edited queued task");
@@ -589,7 +618,7 @@ describe("mobile composer drafts", () => {
   );
 
   it("fails sign-out preservation before cleanup if a durable backup cannot be written", async () => {
-    const load = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
+    const load = vi.spyOn(threadOutboxManager, "load").mockResolvedValue({ status: "complete" });
     onTestFinished(() => load.mockRestore());
     await waitForComposerDraftsLoaded();
     appAtomRegistry.set(composerDraftsAtom, { "environment-1:thread-1": DRAFT });
@@ -614,7 +643,9 @@ describe("mobile composer drafts", () => {
   it.each(["file", "image"] as const)(
     "keeps a removed %s until both preview and a share copy finish",
     async (type) => {
-      const outboxLoad = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
+      const outboxLoad = vi
+        .spyOn(threadOutboxManager, "load")
+        .mockResolvedValue({ status: "complete" });
       onTestFinished(() => outboxLoad.mockRestore());
       const name = type === "image" ? "photo.png" : "recording.mp4";
       const fileName = `33333333-3333-4333-8333-333333333333-${name}`;
@@ -659,7 +690,9 @@ describe("mobile composer drafts", () => {
   );
 
   it("preserves a preview opened while cleanup is checking the incoming inbox", async () => {
-    const outboxLoad = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
+    const outboxLoad = vi
+      .spyOn(threadOutboxManager, "load")
+      .mockResolvedValue({ status: "complete" });
     onTestFinished(() => outboxLoad.mockRestore());
     const file = {
       id: "file-opening-preview",
@@ -695,7 +728,9 @@ describe("mobile composer drafts", () => {
   });
 
   it("removes an unreferenced local file and its pending upload", async () => {
-    const outboxLoad = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
+    const outboxLoad = vi
+      .spyOn(threadOutboxManager, "load")
+      .mockResolvedValue({ status: "complete" });
     onTestFinished(() => outboxLoad.mockRestore());
     const environmentId = EnvironmentId.make("environment-1");
     const file = {
@@ -718,7 +753,9 @@ describe("mobile composer drafts", () => {
   });
 
   it("keeps a pending upload referenced through another local file", async () => {
-    const outboxLoad = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
+    const outboxLoad = vi
+      .spyOn(threadOutboxManager, "load")
+      .mockResolvedValue({ status: "complete" });
     onTestFinished(() => outboxLoad.mockRestore());
     const environmentId = EnvironmentId.make("environment-1");
     const discarded = {
@@ -747,7 +784,9 @@ describe("mobile composer drafts", () => {
   });
 
   it("completes local cleanup when pending upload deletion fails", async () => {
-    const outboxLoad = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
+    const outboxLoad = vi
+      .spyOn(threadOutboxManager, "load")
+      .mockResolvedValue({ status: "complete" });
     onTestFinished(() => outboxLoad.mockRestore());
     const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     onTestFinished(() => warning.mockRestore());
@@ -825,7 +864,7 @@ describe("mobile composer drafts", () => {
           },
         ],
       });
-      return true;
+      return { status: "complete" };
     });
 
     try {
@@ -839,7 +878,9 @@ describe("mobile composer drafts", () => {
   });
 
   it("keeps a file until its incoming share is consumed", async () => {
-    const outboxLoad = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
+    const outboxLoad = vi
+      .spyOn(threadOutboxManager, "load")
+      .mockResolvedValue({ status: "complete" });
     onTestFinished(() => outboxLoad.mockRestore());
     const file = {
       id: "file-incoming",
@@ -874,7 +915,9 @@ describe("mobile composer drafts", () => {
   });
 
   it("does not delete files when incoming share ownership cannot be loaded", async () => {
-    const outboxLoad = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
+    const outboxLoad = vi
+      .spyOn(threadOutboxManager, "load")
+      .mockResolvedValue({ status: "complete" });
     onTestFinished(() => outboxLoad.mockRestore());
     const file = {
       id: "file-incoming-unknown",
@@ -910,7 +953,9 @@ describe("mobile composer drafts", () => {
         ...oldFile,
         fileUri: `file:///var/mobile/Containers/Data/Application/22222222-2222-4222-8222-222222222222/Documents/t3-composer-attachments/${fileName}`,
       };
-      const outboxLoad = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
+      const outboxLoad = vi
+        .spyOn(threadOutboxManager, "load")
+        .mockResolvedValue({ status: "complete" });
       onTestFinished(() => outboxLoad.mockRestore());
       if (owner === "draft") {
         composerDraftFileMocks.setDocument({
@@ -933,7 +978,7 @@ describe("mobile composer drafts", () => {
               },
             ],
           });
-          return true;
+          return { status: "complete" };
         });
       } else {
         incomingShareStorageMocks.load.mockResolvedValue([
@@ -954,7 +999,7 @@ describe("mobile composer drafts", () => {
 
       appAtomRegistry.set(composerDraftsAtom, {});
       appAtomRegistry.set(threadOutboxManager.queuedMessagesByThreadKeyAtom, {});
-      outboxLoad.mockResolvedValue(true);
+      outboxLoad.mockResolvedValue({ status: "complete" });
       incomingShareStorageMocks.load.mockResolvedValue([]);
       await releaseUnusedComposerAttachmentFiles([currentFile]);
 
@@ -1722,7 +1767,9 @@ describe("mobile composer drafts", () => {
   });
 
   it("spares a file re-owned between the sweep's scan and its deletion", async () => {
-    const outboxLoad = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
+    const outboxLoad = vi
+      .spyOn(threadOutboxManager, "load")
+      .mockResolvedValue({ status: "complete" });
     onTestFinished(() => outboxLoad.mockRestore());
     const fileFor = (id: string) => ({
       id,
@@ -1780,11 +1827,12 @@ describe("mobile composer drafts", () => {
     };
     const saved = new Map([[readable.messageId, readable]]);
     let unreadable = true;
-    const load = vi.spyOn(storage, "load").mockImplementation(async () => ({
-      messages: [...saved.values()],
-      errors: unreadable
-        ? [
-            new ThreadOutboxStorageError({
+    const load = vi.spyOn(storage, "load").mockImplementation(async () =>
+      unreadable
+        ? {
+            messages: [...saved.values()],
+            status: "incomplete",
+            error: new ThreadOutboxStorageError({
               operation: "read-message",
               environmentId: null,
               threadId: null,
@@ -1792,9 +1840,9 @@ describe("mobile composer drafts", () => {
               fileName: "unreadable.json",
               cause: new Error("unreadable record"),
             }),
-          ]
-        : [],
-    }));
+          }
+        : { messages: [...saved.values()], status: "complete" },
+    );
     const remove = vi.spyOn(storage, "remove").mockImplementation(async (message) => {
       saved.delete(message.messageId);
     });
@@ -1803,7 +1851,20 @@ describe("mobile composer drafts", () => {
       remove.mockRestore();
     });
 
-    await expect(manager.load()).resolves.toBe(false);
+    await expect(manager.load()).resolves.toMatchObject({ status: "incomplete" });
+    await drafts.waitForComposerDraftsLoaded();
+    const currentDrafts = {
+      "environment-1:thread-1": { text: "Keep my draft during sign-out", attachments: [] },
+    };
+    registry.set(drafts.composerDraftsAtom, currentDrafts);
+    await expect(
+      drafts.archiveCloudComposerDrafts("account-a", new Set([readable.environmentId])),
+    ).rejects.toMatchObject({
+      message: "Could not preserve queued messages.",
+      cause: { operation: "load" },
+    });
+    expect(registry.get(drafts.composerDraftsAtom)).toBe(currentDrafts);
+    expect(registry.get(drafts.composerCloudDraftsAtom).signedOut).toEqual({});
     await expect(manager.confirmQueued(readable)).resolves.toBe(true);
     await expect(removeThreadOutboxMessage(readable)).resolves.toBe(true);
     await drafts.releaseUnusedComposerAttachmentFiles([file]);
@@ -1819,7 +1880,7 @@ describe("mobile composer drafts", () => {
     };
     saved.set(recovered.messageId, recovered);
     unreadable = false;
-    await expect(manager.load()).resolves.toBe(true);
+    await expect(manager.load()).resolves.toEqual({ status: "complete" });
     await drafts.releaseUnusedComposerAttachmentFiles([file]);
     expect(composerAttachmentCleanupMocks.remove).not.toHaveBeenCalled();
     expect(composerAttachmentCleanupMocks.releaseUploads).not.toHaveBeenCalled();

--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -324,10 +324,7 @@ async function writePersistedComposerState(
 export async function flushComposerDrafts(): Promise<void> {
   // Never land a pre-hydration snapshot: persisted state must merge into the
   // atoms first, or this write would clobber disk with partial data.
-  ensureComposerDraftsLoaded();
-  if (loadPromise !== null) {
-    await loadPromise;
-  }
+  await waitForComposerDraftsLoaded();
   // An edit during an awaited write schedules another debounced write, so
   // keep landing snapshots until no debounce is pending after a queue drain.
   do {
@@ -419,13 +416,10 @@ export async function releaseUnusedComposerAttachmentFiles(
     return;
   }
 
-  // Persisted drafts must hydrate before the reference scan. On a cold start
-  // the atom is still empty, and every file a persisted draft owns would look
-  // unused. Hydrate before flushing so a pending pre-hydration write cannot
-  // land an incomplete snapshot either.
-  await waitForComposerDraftsLoaded();
+  // Flushing loads saved drafts first, so a cold-start sweep sees every owner
+  // and cannot persist incomplete state before checking references.
   await flushComposerDrafts();
-  if (!(await threadOutboxManager.load())) {
+  if ((await threadOutboxManager.load()).status !== "complete") {
     // An unreadable outbox store must not look like an empty queue: deleting
     // now would take bytes a persisted queued message still needs. Skip the
     // sweep; the next one retries hydration.
@@ -610,7 +604,10 @@ export async function archiveCloudComposerDrafts(
   environmentIds: ReadonlySet<EnvironmentId>,
 ): Promise<void> {
   await waitForComposerDraftsLoaded();
-  if (!(await threadOutboxManager.load())) throw new Error("Could not preserve queued messages.");
+  const outbox = await threadOutboxManager.load();
+  if (outbox.status !== "complete") {
+    throw new Error("Could not preserve queued messages.", { cause: outbox.error });
+  }
   await flushThreadOutbox();
   const cloud = appAtomRegistry.get(composerCloudDraftsAtom);
   const owner = accountId ?? cloud.accountId;
@@ -742,7 +739,10 @@ export async function restoreCloudComposerDrafts(accountId: string): Promise<voi
   const cloud = appAtomRegistry.get(composerCloudDraftsAtom);
   const saved = cloud.signedOut[accountId];
   if (saved) {
-    if (!(await threadOutboxManager.load())) throw new Error("Could not restore queued messages.");
+    const outbox = await threadOutboxManager.load();
+    if (outbox.status !== "complete") {
+      throw new Error("Could not restore queued messages.", { cause: outbox.error });
+    }
     for (const message of saved.queuedMessages) {
       const alreadyQueued = Object.values(
         appAtomRegistry.get(threadOutboxManager.queuedMessagesByThreadKeyAtom),

--- a/apps/mobile/src/state/use-thread-outbox-drain.test.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.test.ts
@@ -115,7 +115,7 @@ vi.mock("./thread-outbox", async () => {
   harness.manager = createThreadOutboxManager({
     registry: appAtomRegistry,
     storage: {
-      load: async () => ({ messages: [], errors: [] }),
+      load: async () => ({ messages: [], status: "complete" }),
       write: async () => undefined,
       remove: (message) => harness.removeOutboxMessage(message),
     },

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -585,7 +585,7 @@ export function useThreadOutboxDrain(): void {
   useEffect(() => {
     let mounted = true;
     const load = async () => {
-      if ((await threadOutboxManager.load()) || !mounted) return;
+      if ((await threadOutboxManager.load()).status === "complete" || !mounted) return;
       Alert.alert(
         "Some queued messages could not be loaded",
         "Unreadable records and attachment files are still saved. Other messages can still be sent.",


### PR DESCRIPTION
The outbox load API hid partial recovery behind a boolean. Cleanup and account changes had to interpret that result separately.

Storage now reports readable messages and whether ownership is complete. Cleanup, sign-out archives, account restore, and environment removal require complete ownership. Readable messages stay available. Failed account changes keep the load error as their cause. Draft flushing owns hydration before writes.

The saved formats and image writer are unchanged. The file-backed writer remains in [#9727](https://github.com/pingdotgg/t3code/pull/9727), held for a new native runtime on each platform with compatible embedded readers and storage guards. The source comment now states that condition.

## Verification

- 130 focused tests passed across outbox, composer drafts, removal, drain, and pending-task writes.
- Mobile `tsc --noEmit` passed.
- Changed-file lint passed with one existing extra-effect-dependency warning in the drain.
- Independent source review passed after adding incomplete-account-restore coverage.

No UI layout, native code, or runtime configuration changed. No device or browser check ran.

Created with GPT-6 Astra in Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace outbox errors-array contract with explicit complete/incomplete hydration result
> - Replaces the `errors` array and boolean success return on `ThreadOutboxStorage.load` and the manager load operation with a discriminated `ThreadOutboxLoadResult` / `ThreadOutboxHydrationResult` union carrying `status` and a single error object on `incomplete`.
> - `expoThreadOutboxStorage.load` no longer rejects on unreadable records or directory failures; it returns recovered messages plus `incomplete` status and an error, retrying on the next call.
> - Composer draft workflows in `use-composer-drafts.ts` (`releaseUnusedComposerAttachmentFiles`, `archiveCloudComposerDrafts`, `restoreCloudComposerDrafts`) now inspect the structured outbox status and abort destructive or state-changing operations before running when hydration is `incomplete`, surfacing the hydration error as the thrown cause.
> - `useThreadOutboxDrain` and `clearEnvironment` switch from boolean/errors checks to the new `incomplete` status, triggering the unreadable-record alert and retry path and blocking environment clear respectively.
> - Risk: any out-of-tree `ThreadOutboxStorage` implementation must adopt the new `complete`/`incomplete` load contract; the former `errors` array is gone. Existing storage mocks across tests are updated to the new shape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f003089.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->