### PR TITLE
fix(web): limit stored pull request details

### DIFF
--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -1,4 +1,5 @@
 import {
+  ProjectId,
   PullRequestAction,
   type PullRequestCheck,
   type PullRequestComment,
@@ -31,6 +32,8 @@ import {
   pullRequestFindingKey,
   pullRequestHandoffLabels,
   pullRequestReviewOutcome,
+  PULL_REQUEST_DETAIL_SNAPSHOT_MAX_BYTES,
+  PULL_REQUEST_DETAIL_SNAPSHOT_MAX_ENTRIES,
   readableFailure,
   readPullRequestDetailSnapshot,
   resolveDisplayedPullRequestDetail,
@@ -1313,7 +1316,9 @@ describe("which actions need the host read again after they run", () => {
 });
 
 describe("cached pull request detail", () => {
-  const reference = { projectId: "project-1", repository: "acme/web", number: 7 };
+  const reference = { projectId: ProjectId.make("project-1"), repository: "acme/web", number: 7 };
+  const snapshotPrefix = "t3.pullRequests.detail.v1:";
+  const indexKey = "t3.pullRequests.detail.index.v1";
   const detail = (overrides: Partial<PullRequestDetail> = {}): PullRequestDetail =>
     ({
       provider: "github",
@@ -1371,6 +1376,12 @@ describe("cached pull request detail", () => {
     return {
       getItem: (key: string) => held.get(key) ?? null,
       setItem: (key: string, value: string) => void held.set(key, value),
+      removeItem: (key: string) => void held.delete(key),
+      key: (position: number) => [...held.keys()][position] ?? null,
+      get length() {
+        return held.size;
+      },
+      entries: () => [...held.entries()],
     };
   };
 
@@ -1382,6 +1393,233 @@ describe("cached pull request detail", () => {
     expect(snapshot?.author?.login).toBe("octocat");
     expect(snapshot?.additions).toBe(12);
     expect(snapshot?.deletions).toBe(3);
+  });
+
+  it.each([
+    { environmentId: "env-2", reference },
+    { environmentId: "env-1", reference: { ...reference, projectId: ProjectId.make("project-2") } },
+    { environmentId: "env-1", reference: { ...reference, repository: "acme/api" } },
+    { environmentId: "env-1", reference: { ...reference, number: 8 } },
+  ])("isolates the cache by environment, project, repository, and number: %j", (other) => {
+    const storage = makeStorage();
+    writePullRequestDetailSnapshot(storage, "env-1", reference, detail());
+    expect(readPullRequestDetailSnapshot(storage, other.environmentId, other.reference)).toBeNull();
+    writePullRequestDetailSnapshot(
+      storage,
+      other.environmentId,
+      other.reference,
+      detail({ ...other.reference, title: "Another PR" }),
+    );
+    expect(readPullRequestDetailSnapshot(storage, "env-1", reference)?.title).toBe(
+      "Cache the title",
+    );
+    expect(
+      readPullRequestDetailSnapshot(storage, other.environmentId, other.reference)?.title,
+    ).toBe("Another PR");
+  });
+
+  it("keeps scope components distinct when they contain the old key separators", () => {
+    const storage = makeStorage();
+    const first = { ...reference, projectId: ProjectId.make("project:one") };
+    const second = { ...reference, projectId: ProjectId.make("one") };
+    writePullRequestDetailSnapshot(storage, "env", first, detail({ ...first, title: "First" }));
+    writePullRequestDetailSnapshot(
+      storage,
+      "env:project",
+      second,
+      detail({ ...second, title: "Second" }),
+    );
+    expect(readPullRequestDetailSnapshot(storage, "env", first)?.title).toBe("First");
+    expect(readPullRequestDetailSnapshot(storage, "env:project", second)?.title).toBe("Second");
+  });
+
+  it("evicts the least recently read or written detail across environments", () => {
+    const storage = makeStorage();
+    for (let number = 1; number <= PULL_REQUEST_DETAIL_SNAPSHOT_MAX_ENTRIES; number++) {
+      writePullRequestDetailSnapshot(
+        storage,
+        `env-${number}`,
+        { ...reference, number },
+        detail({ number }),
+      );
+    }
+    expect(
+      readPullRequestDetailSnapshot(storage, "env-1", { ...reference, number: 1 }),
+    ).not.toBeNull();
+    writePullRequestDetailSnapshot(
+      storage,
+      "env-2",
+      { ...reference, number: 2 },
+      detail({ number: 2 }),
+    );
+    writePullRequestDetailSnapshot(storage, "env-new", reference, detail());
+    expect(readPullRequestDetailSnapshot(storage, "env-3", { ...reference, number: 3 })).toBeNull();
+    expect(
+      readPullRequestDetailSnapshot(storage, "env-1", { ...reference, number: 1 }),
+    ).not.toBeNull();
+    expect(
+      readPullRequestDetailSnapshot(storage, "env-2", { ...reference, number: 2 }),
+    ).not.toBeNull();
+    expect(storage.entries().filter(([key]) => key.startsWith(snapshotPrefix))).toHaveLength(
+      PULL_REQUEST_DETAIL_SNAPSHOT_MAX_ENTRIES,
+    );
+  });
+
+  it("bounds UTF-16 storage bytes, including keys and the recency index", () => {
+    const storage = makeStorage();
+    const body = "🚀".repeat(PULL_REQUEST_DETAIL_SNAPSHOT_MAX_BYTES / 16);
+    for (let number = 1; number <= 4; number++) {
+      writePullRequestDetailSnapshot(
+        storage,
+        "env-1",
+        { ...reference, number },
+        detail({ number, body }),
+      );
+    }
+    expect(readPullRequestDetailSnapshot(storage, "env-1", { ...reference, number: 1 })).toBeNull();
+    expect(readPullRequestDetailSnapshot(storage, "env-1", { ...reference, number: 4 })?.body).toBe(
+      body,
+    );
+    const bytes = storage
+      .entries()
+      .reduce((total, [key, value]) => total + 2 * (key.length + value.length), 0);
+    expect(bytes).toBeLessThanOrEqual(PULL_REQUEST_DETAIL_SNAPSHOT_MAX_BYTES);
+
+    const longEnvironmentId = "e".repeat(PULL_REQUEST_DETAIL_SNAPSHOT_MAX_BYTES / 4);
+    writePullRequestDetailSnapshot(storage, longEnvironmentId, reference, detail());
+    expect(readPullRequestDetailSnapshot(storage, longEnvironmentId, reference)).toBeNull();
+    expect(readPullRequestDetailSnapshot(storage, "env-1", { ...reference, number: 4 })?.body).toBe(
+      body,
+    );
+  });
+
+  it("drops an oversized replacement without evicting other details", () => {
+    const storage = makeStorage();
+    writePullRequestDetailSnapshot(storage, "env-1", reference, detail());
+    writePullRequestDetailSnapshot(storage, "env-2", reference, detail());
+    writePullRequestDetailSnapshot(
+      storage,
+      "env-1",
+      reference,
+      detail({ body: "x".repeat(PULL_REQUEST_DETAIL_SNAPSHOT_MAX_BYTES) }),
+    );
+    expect(readPullRequestDetailSnapshot(storage, "env-1", reference)).toBeNull();
+    expect(readPullRequestDetailSnapshot(storage, "env-2", reference)?.title).toBe(
+      "Cache the title",
+    );
+    expect(storage.entries().filter(([key]) => key.startsWith(snapshotPrefix))).toHaveLength(1);
+  });
+
+  it("repairs stale byte accounting even when the next detail is oversized", () => {
+    const storage = makeStorage();
+    writePullRequestDetailSnapshot(storage, "env-1", reference, detail());
+    const key = storage.entries().find(([key]) => key.startsWith(snapshotPrefix))![0];
+    const oversized = detail({ body: "x".repeat(PULL_REQUEST_DETAIL_SNAPSHOT_MAX_BYTES) });
+    storage.setItem(key, JSON.stringify(oversized));
+    writePullRequestDetailSnapshot(storage, "env-2", reference, oversized);
+    const bytes = storage
+      .entries()
+      .reduce((total, [storedKey, value]) => total + 2 * (storedKey.length + value.length), 0);
+    expect(bytes).toBeLessThanOrEqual(PULL_REQUEST_DETAIL_SNAPSHOT_MAX_BYTES);
+    expect(readPullRequestDetailSnapshot(storage, "env-1", reference)).toBeNull();
+    expect(readPullRequestDetailSnapshot(storage, "env-2", reference)).toBeNull();
+  });
+
+  it("retires legacy and unindexed detail keys without touching other storage", () => {
+    const storage = makeStorage();
+    const retired = [
+      "t3.pullRequests.detail:env-1:project-1:acme/web#1",
+      "t3.pullRequests.detail:env-2:project-2:acme/api#2",
+      `${snapshotPrefix}interrupted-write`,
+    ];
+    const unrelated = ["t3.pullRequests.list:env-1", "t3.pullRequests.detailOther", "settings"];
+    for (const key of [...retired, ...unrelated]) storage.setItem(key, "keep if unrelated");
+    writePullRequestDetailSnapshot(storage, "env-1", reference, detail());
+    for (const key of retired) expect(storage.getItem(key)).toBeNull();
+    for (const key of unrelated) expect(storage.getItem(key)).toBe("keep if unrelated");
+    expect(readPullRequestDetailSnapshot(storage, "env-1", reference)?.title).toBe(
+      "Cache the title",
+    );
+  });
+
+  it.each(["{not json", JSON.stringify([{ key: "settings", bytes: 20 }])])(
+    "recovers from a corrupt index without deleting unrelated data: %s",
+    (index) => {
+      const storage = makeStorage();
+      writePullRequestDetailSnapshot(storage, "env-1", reference, detail());
+      storage.setItem("settings", "keep");
+      storage.setItem(indexKey, index);
+      writePullRequestDetailSnapshot(storage, "env-2", reference, detail());
+      expect(storage.getItem("settings")).toBe("keep");
+      expect(readPullRequestDetailSnapshot(storage, "env-2", reference)?.title).toBe(
+        "Cache the title",
+      );
+      expect(storage.entries().filter(([key]) => key.startsWith(snapshotPrefix))).toHaveLength(1);
+    },
+  );
+
+  it("reads only the selected payload and keeps it when a recency update fails", () => {
+    const storage = makeStorage();
+    writePullRequestDetailSnapshot(storage, "env-1", reference, detail());
+    const selectedKey = storage.entries().find(([key]) => key.startsWith(snapshotPrefix))![0];
+    writePullRequestDetailSnapshot(storage, "env-2", reference, detail());
+    const getItem = storage.getItem;
+    storage.getItem = (key) => {
+      if (key !== selectedKey && key !== indexKey) throw new Error("Read another payload");
+      return getItem(key);
+    };
+    storage.setItem = () => {
+      throw new Error("Storage is read-only");
+    };
+    expect(readPullRequestDetailSnapshot(storage, "env-1", reference)?.title).toBe(
+      "Cache the title",
+    );
+  });
+
+  it.each(["payload", "index"] as const)(
+    "tolerates a failed %s write without leaving an unindexed payload",
+    (failedWrite) => {
+      const storage = makeStorage();
+      writePullRequestDetailSnapshot(storage, "env-1", reference, detail());
+      const setItem = storage.setItem;
+      storage.setItem = (key, value) => {
+        if ((key === indexKey) === (failedWrite === "index")) {
+          throw new DOMException("Storage quota exceeded", "QuotaExceededError");
+        }
+        setItem(key, value);
+      };
+      expect(() =>
+        writePullRequestDetailSnapshot(storage, "env-2", reference, detail()),
+      ).not.toThrow();
+      expect(readPullRequestDetailSnapshot(storage, "env-1", reference)?.title).toBe(
+        "Cache the title",
+      );
+      expect(readPullRequestDetailSnapshot(storage, "env-2", reference)).toBeNull();
+      expect(storage.entries().filter(([key]) => key.startsWith(snapshotPrefix))).toHaveLength(1);
+      storage.setItem = setItem;
+      writePullRequestDetailSnapshot(storage, "env-2", reference, detail());
+      expect(readPullRequestDetailSnapshot(storage, "env-2", reference)?.title).toBe(
+        "Cache the title",
+      );
+    },
+  );
+
+  it("drops a replacement if the new payload cannot be recorded in the index", () => {
+    const storage = makeStorage();
+    writePullRequestDetailSnapshot(storage, "env-1", reference, detail());
+    const setItem = storage.setItem;
+    storage.setItem = (key, value) => {
+      if (key === indexKey) throw new Error("Index write failed");
+      setItem(key, value);
+    };
+    writePullRequestDetailSnapshot(
+      storage,
+      "env-1",
+      reference,
+      detail({ body: "larger".repeat(100) }),
+    );
+    expect(readPullRequestDetailSnapshot(storage, "env-1", reference)).toBeNull();
+    expect(storage.entries().filter(([key]) => key.startsWith(snapshotPrefix))).toHaveLength(0);
   });
 
   it("keeps a cached tab painted while the live read replaces the counts", () => {
@@ -1404,10 +1642,28 @@ describe("cached pull request detail", () => {
     expect(readPullRequestDetailSnapshot(makeStorage(), "env-2", reference)).toBeNull();
   });
 
-  it("shrugs off corrupt storage and no storage at all", () => {
+  it("tolerates corrupt, denied, missing, and non-evictable storage", () => {
     const storage = makeStorage();
-    storage.setItem("t3.pullRequests.detail:env-1:project-1:acme/web#7", "{not json");
+    writePullRequestDetailSnapshot(storage, "env-1", reference, detail());
+    const key = storage.entries().find(([key]) => key.startsWith(snapshotPrefix))![0];
+    storage.setItem(key, "{not json");
     expect(readPullRequestDetailSnapshot(storage, "env-1", reference)).toBeNull();
     expect(readPullRequestDetailSnapshot(undefined, "env-1", reference)).toBeNull();
+    expect(() =>
+      writePullRequestDetailSnapshot(undefined, "env-1", reference, detail()),
+    ).not.toThrow();
+    const limited = { getItem: storage.getItem, setItem: storage.setItem };
+    writePullRequestDetailSnapshot(limited, "env-2", reference, detail());
+    expect(readPullRequestDetailSnapshot(limited, "env-2", reference)).toBeNull();
+    storage.getItem = () => {
+      throw new Error("Storage is denied");
+    };
+    storage.setItem = () => {
+      throw new Error("Storage is denied");
+    };
+    expect(readPullRequestDetailSnapshot(storage, "env-1", reference)).toBeNull();
+    expect(() =>
+      writePullRequestDetailSnapshot(storage, "env-1", reference, detail()),
+    ).not.toThrow();
   });
 });

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -1006,7 +1006,58 @@ export function pullRequestActionNeedsHostRefresh(action: PullRequestAction): bo
   return ACTION_NEEDS_HOST_REFRESH[action];
 }
 
-type SnapshotStorage = Pick<Storage, "getItem" | "setItem">;
+type SnapshotStorage = Pick<Storage, "getItem" | "setItem"> &
+  Partial<Pick<Storage, "key" | "length" | "removeItem">>;
+
+export const PULL_REQUEST_DETAIL_SNAPSHOT_MAX_ENTRIES = 20;
+export const PULL_REQUEST_DETAIL_SNAPSHOT_MAX_BYTES = 2 * 1024 * 1024;
+
+const DETAIL_SNAPSHOT_LEGACY_PREFIX = "t3.pullRequests.detail:";
+const DETAIL_SNAPSHOT_PREFIX = "t3.pullRequests.detail.v1:";
+const DETAIL_SNAPSHOT_INDEX_KEY = "t3.pullRequests.detail.index.v1";
+
+const DetailSnapshotIndex = Schema.Array(
+  Schema.Struct({
+    key: Schema.String.check(Schema.isStartsWith(DETAIL_SNAPSHOT_PREFIX)),
+    bytes: Schema.Int.check(
+      Schema.isGreaterThan(0),
+      Schema.isLessThanOrEqualTo(PULL_REQUEST_DETAIL_SNAPSHOT_MAX_BYTES),
+    ),
+  }),
+).check(Schema.isMaxLength(PULL_REQUEST_DETAIL_SNAPSHOT_MAX_ENTRIES));
+
+const decodeDetailSnapshotIndex = Schema.decodeUnknownOption(DetailSnapshotIndex);
+
+// localStorage stores UTF-16 strings. Include keys and the small recency index in the limit.
+function detailSnapshotsFit(
+  index: typeof DetailSnapshotIndex.Type,
+  rawIndex = JSON.stringify(index),
+): boolean {
+  return (
+    index.length <= PULL_REQUEST_DETAIL_SNAPSHOT_MAX_ENTRIES &&
+    index.reduce((total, entry) => total + entry.bytes, 0) +
+      2 * (DETAIL_SNAPSHOT_INDEX_KEY.length + rawIndex.length) <=
+      PULL_REQUEST_DETAIL_SNAPSHOT_MAX_BYTES
+  );
+}
+
+function readDetailSnapshotIndex(storage: SnapshotStorage): typeof DetailSnapshotIndex.Type {
+  try {
+    const raw = storage.getItem(DETAIL_SNAPSHOT_INDEX_KEY);
+    if (!raw || raw.length * 2 > PULL_REQUEST_DETAIL_SNAPSHOT_MAX_BYTES) return [];
+    const decoded = decodeDetailSnapshotIndex(JSON.parse(raw));
+    if (
+      decoded._tag === "None" ||
+      new Set(decoded.value.map((entry) => entry.key)).size !== decoded.value.length ||
+      !detailSnapshotsFit(decoded.value, raw)
+    ) {
+      return [];
+    }
+    return decoded.value;
+  } catch {
+    return [];
+  }
+}
 
 export interface PullRequestDetailSnapshotRef {
   readonly projectId: string;
@@ -1018,26 +1069,42 @@ const pullRequestDetailSnapshotKey = (
   environmentId: string,
   reference: PullRequestDetailSnapshotRef,
 ) =>
-  `t3.pullRequests.detail:${environmentId}:${reference.projectId}:${reference.repository}#${reference.number}`;
+  `${DETAIL_SNAPSHOT_PREFIX}${JSON.stringify([
+    environmentId,
+    reference.projectId,
+    reference.repository,
+    reference.number,
+  ])}`;
 
 const decodeDetailSnapshot = Schema.decodeUnknownOption(PullRequestDetail);
 
-/**
- * The last detail answered for this change request, brought back across a reload. The registry
- * the queries live in is recreated with the renderer, so without this a reopen cold-starts
- * into a full-tab ghost even though the title, author, and the rest barely moved. Hydrated,
- * the chrome stays and the live read replaces fields in place — line counts included.
- */
+/** Hydrates one recent detail after a reload while the live query refreshes it. */
 export function readPullRequestDetailSnapshot(
   storage: SnapshotStorage | undefined,
   environmentId: string,
   reference: PullRequestDetailSnapshotRef,
 ): PullRequestDetail | null {
   try {
-    const raw = storage?.getItem(pullRequestDetailSnapshotKey(environmentId, reference));
-    if (!raw) return null;
+    if (!storage) return null;
+    const key = pullRequestDetailSnapshotKey(environmentId, reference);
+    const index = readDetailSnapshotIndex(storage);
+    const entry = index.find((entry) => entry.key === key);
+    if (!entry) return null;
+    const raw = storage.getItem(key);
+    if (!raw || entry.bytes !== 2 * (key.length + raw.length)) return null;
     const decoded = decodeDetailSnapshot(JSON.parse(raw));
-    return decoded._tag === "Some" ? decoded.value : null;
+    if (decoded._tag === "None") return null;
+    try {
+      if (index.at(-1) !== entry) {
+        storage.setItem(
+          DETAIL_SNAPSHOT_INDEX_KEY,
+          JSON.stringify([...index.filter((entry) => entry.key !== key), entry]),
+        );
+      }
+    } catch {
+      // A failed recency update must not discard a readable snapshot.
+    }
+    return decoded.value;
   } catch {
     return null;
   }
@@ -1050,13 +1117,48 @@ export function writePullRequestDetailSnapshot(
   detail: PullRequestDetail,
 ): void {
   try {
-    storage?.setItem(
-      pullRequestDetailSnapshotKey(environmentId, reference),
-      JSON.stringify(detail),
-    );
+    // Stores without eviction support remain readable but cannot grow this cache.
+    if (!storage?.removeItem || !storage.key || storage.length === undefined) return;
+    const key = pullRequestDetailSnapshotKey(environmentId, reference);
+    const index = readDetailSnapshotIndex(storage);
+    const indexedKeys = new Set(index.map((entry) => entry.key));
+    const retiredKeys: string[] = [];
+    for (let position = 0; position < storage.length; position++) {
+      const storedKey = storage.key(position);
+      if (
+        storedKey !== null &&
+        (storedKey.startsWith(DETAIL_SNAPSHOT_LEGACY_PREFIX) ||
+          (storedKey.startsWith(DETAIL_SNAPSHOT_PREFIX) && !indexedKeys.has(storedKey)))
+      ) {
+        retiredKeys.push(storedKey);
+      }
+    }
+    for (const retiredKey of retiredKeys) storage.removeItem(retiredKey);
+
+    // Remeasure retained values on writes to recover from missing or interrupted writes.
+    const retained = index.flatMap((entry) => {
+      if (entry.key === key) return [];
+      const raw = storage.getItem(entry.key);
+      return raw === null ? [] : [{ key: entry.key, bytes: 2 * (entry.key.length + raw.length) }];
+    });
+    const raw = JSON.stringify(detail);
+    const entry = { key, bytes: 2 * (key.length + raw.length) };
+    const canStore = detailSnapshotsFit([entry]);
+    const next = canStore ? [...retained, entry] : retained;
+    if (!canStore) storage.removeItem(key);
+    while (!detailSnapshotsFit(next)) {
+      const oldest = next.shift();
+      if (oldest) storage.removeItem(oldest.key);
+    }
+    if (canStore) storage.setItem(key, raw);
+    try {
+      storage.setItem(DETAIL_SNAPSHOT_INDEX_KEY, JSON.stringify(next));
+    } catch {
+      // Do not leave a successful payload write outside the index's byte accounting.
+      storage.removeItem(key);
+    }
   } catch {
-    // Quota or a private-mode store: the next open waits on the live read, which is the
-    // cold start this snapshot exists to avoid, not a failure of its own.
+    // Quota or denied storage: the next open can still use the live query.
   }
 }
 


### PR DESCRIPTION
Opening PRs kept adding full detail snapshots to localStorage with no limit. They could fill the browser's storage quota.

Keep at most 20 recent snapshots within 2 MiB, including keys and the recency index. Each read still decodes only the selected PR. Retire old detail-only keys and recover from partial writes without touching other stored data.

PR details can cold-load once after upgrading, then refill through live queries. There is no layout change. Missing, denied, or full storage still falls back to live loading.

Verified:

- 108 tests in `pullRequestDetail.logic.test.ts` pass, including eviction, byte limits, scope, legacy cleanup, and storage failures.
- Targeted lint passes for both changed files.
- Web typecheck and `git diff --check` pass.

Created with GPT-6 Astra in Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Limit stored pull request details with a bounded, indexed LRU cache
> - Replaces legacy delimiter-concatenated snapshot keys with a v1 prefix plus a JSON-serialized array of environment, project, repository, and pull-request number components, so scope parts with separator characters no longer collide.
> - Introduces a recency index and a `detailSnapshotsFit` validator that enforce a max of 20 entries and 2 MiB of accounted UTF-16 storage across all cached pull-request detail payloads.
> - Reworks `writePullRequestDetailSnapshot` to evict oldest entries until the cache fits, remove legacy and unindexed v1 keys, remeasure retained payloads, and roll back a payload write when its index update fails.
> - `readPullRequestDetailSnapshot` now returns a snapshot only when it is indexed, decodable, and size-verified; reads move the entry to the most-recent position without discarding a valid snapshot on recency-update failure.
> - `readDetailSnapshotIndex` treats missing, malformed, over-limit, or error cases as an empty index without deleting unrelated storage.
> - Risk: existing stored legacy keys under the old `pullRequestDetailSnapshotKey` format are ignored and removed on the next write; users will see cold cache misses until snapshots are repopulated under the v1 schema.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6a1ad7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->