### PR TITLE
fix(server): refresh only threads for the merged PR

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -1558,6 +1558,9 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           { cwd: worktreeDir, branch: "review/renamed-merge" },
         ].toSorted((left, right) => left.cwd.localeCompare(right.cwd)),
       );
+      expect((yield* manager.branchPullRequest({ cwd: repoDir, branch: headBranch }))?.state).toBe(
+        "merged",
+      );
       expect((yield* manager.status({ cwd: repoDir })).pr?.state).toBe("merged");
       expect(
         yield* manager.branchPullRequest({ cwd: worktreeDir, branch: "review/renamed-merge" }),
@@ -1565,7 +1568,12 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
       for (const checkout of otherCheckouts) {
         expect(yield* manager.remoteStatus({ cwd: checkout.cwd })).toBe(checkout.status);
       }
-      expect(ghCalls).toHaveLength(callsBeforeMerge);
+      expect(ghCalls).toHaveLength(callsBeforeMerge + 2);
+      yield* manager.observePullRequestMerge({ ...merge, url: unrelated[0]!.url });
+      expect((yield* manager.branchPullRequest({ cwd: repoDir, branch: headBranch }))?.state).toBe(
+        "merged",
+      );
+      expect(ghCalls).toHaveLength(callsBeforeMerge + 2);
 
       scenario.failAfterCalls = ghCalls.length;
       scenario.failWith = new GitHubCli.GitHubCliUnavailableError({
@@ -1578,7 +1586,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
-  it.effect("keeps a confirmed merge after a late open response without claiming a newer PR", () =>
+  it.effect("keeps a confirmed merge after a late open response", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");
       yield* initRepo(repoDir);
@@ -1608,9 +1616,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
             // @effect-diagnostics-next-line preferSchemaOverJson:off
             JSON.stringify([pullRequest]),
             // @effect-diagnostics-next-line preferSchemaOverJson:off
-            JSON.stringify([
-              { ...pullRequest, number: 43, url: "https://github.com/owner/repository/pull/43" },
-            ]),
+            JSON.stringify([pullRequest]),
           ],
         },
       });
@@ -1628,9 +1634,51 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
 
       expect(yield* Fiber.join(lookup)).toEqual({ state: "merged", updatedAt: merge.mergedAt });
       expect((yield* manager.status({ cwd: repoDir })).pr?.state).toBe("merged");
-      expect(ghCalls.filter((call) => call.startsWith("pr list "))).toHaveLength(1);
+      expect(ghCalls.filter((call) => call.startsWith("pr list "))).toHaveLength(2);
+    }),
+  );
 
-      yield* manager.invalidateStatus(repoDir);
+  it.effect("rechecks a warm branch association before applying an older PR's merge", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      const branch = "feature/reused-merge";
+      yield* runGit(repoDir, ["checkout", "-b", branch]);
+      yield* runGit(repoDir, ["push", "-u", "origin", branch]);
+      const pullRequest = {
+        number: 42,
+        title: "Earlier PR",
+        url: "https://github.com/owner/repository/pull/42",
+        baseRefName: "main",
+        headRefName: branch,
+        state: "OPEN",
+        updatedAt: "2026-09-01T00:00:00Z",
+      };
+      const { manager } = yield* makeManager({
+        ghScenario: {
+          prListSequence: [
+            // Fake gh returns raw JSON stdout at the CLI boundary.
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([pullRequest]),
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([
+              { ...pullRequest, state: "MERGED" },
+              { ...pullRequest, number: 43, url: "https://github.com/owner/repository/pull/43" },
+            ]),
+          ],
+        },
+      });
+      expect((yield* manager.branchPullRequest({ cwd: repoDir, branch }))?.state).toBe("open");
+      const merge = {
+        provider: "github" as const,
+        url: pullRequest.url,
+        mergedAt: "2026-09-03T00:00:00.000Z",
+      };
+      yield* manager.observePullRequestMerge(merge);
+
+      expect((yield* manager.branchPullRequest({ cwd: repoDir, branch }))?.state).toBe("open");
       const next = yield* manager.status({ cwd: repoDir });
       expect(next.pr).toMatchObject({ number: 43, state: "open" });
       expect(yield* manager.observePullRequestMerge(merge)).toEqual([]);

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -5,8 +5,10 @@ import * as NodeChildProcess from "node:child_process";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
@@ -42,6 +44,7 @@ import * as ServerSettings from "../serverSettings.ts";
 import * as GitManager from "./GitManager.ts";
 
 interface FakeGhScenario {
+  beforePrListResult?: Effect.Effect<void>;
   prListSequence?: string[];
   prListByHeadSelector?: Record<string, string>;
   prListSequenceByHeadSelector?: Record<string, string[]>;
@@ -385,7 +388,7 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
           ? scenario.prListByHeadSelector?.[headSelector]
           : undefined;
       const stdout = (mappedQueue ?? mappedStdout ?? prListQueue.shift() ?? "[]") + "\n";
-      return Effect.succeed(fakeGhOutput(stdout));
+      return (scenario.beforePrListResult ?? Effect.void).pipe(Effect.as(fakeGhOutput(stdout)));
     }
 
     if (args[0] === "pr" && args[1] === "create") {
@@ -1389,6 +1392,11 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         branch: "feature/repointed-lookup",
       });
       expect(first?.state).toBe("merged");
+      yield* manager.observePullRequestMerge({
+        provider: "github",
+        url: "https://github.com/old-owner/old-repository/pull/219",
+        mergedAt: "2026-04-06T15:00:00.000Z",
+      });
 
       const replacementRemoteDir = yield* createBareRemote();
       yield* configureVisibleRemoteUrlWithLocalRewrite(
@@ -1445,6 +1453,187 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
       expect(status.pr?.state).toBe("merged");
       expect(pullRequest?.state).toBe("merged");
       expect(ghCalls.filter((call) => call.startsWith("pr list "))).toHaveLength(1);
+    }),
+  );
+
+  it.effect("shares a confirmed merge with its worktrees and leaves other PRs cached", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "main"]);
+      const headBranch = "feature/shared-merge";
+      yield* runGit(repoDir, ["checkout", "-b", headBranch]);
+      yield* runGit(repoDir, ["push", "-u", "origin", headBranch]);
+      const worktreeDir = yield* makeTempDir("t3code-git-merge-worktree-");
+      yield* runGit(repoDir, [
+        "worktree",
+        "add",
+        "-b",
+        "review/renamed-merge",
+        worktreeDir,
+        `origin/${headBranch}`,
+      ]);
+      yield* configureVisibleRemoteUrlWithLocalRewrite(
+        repoDir,
+        "origin",
+        "https://github.com/owner/repository.git",
+        remoteDir,
+      );
+      const pullRequest = {
+        number: 42,
+        title: "Shared merge",
+        url: "https://github.com/owner/repository/pull/42",
+        baseRefName: "main",
+        headRefName: headBranch,
+        state: "OPEN",
+        updatedAt: "2026-09-01T00:00:00Z",
+      };
+      const unrelated = [
+        {
+          ...pullRequest,
+          headRefName: "feature/other-host",
+          url: "https://work.example.test/owner/repository/pull/42",
+          remoteUrl: "https://work.example.test/owner/repository.git",
+        },
+        {
+          ...pullRequest,
+          headRefName: "feature/other-owner",
+          url: "https://github.com/other-owner/repository/pull/42",
+          remoteUrl: "https://github.com/other-owner/repository.git",
+        },
+        {
+          ...pullRequest,
+          headRefName: "feature/other-port",
+          url: "https://github.com:8443/owner/repository/pull/42",
+          remoteUrl: "https://github.com:8443/owner/repository.git",
+        },
+        {
+          ...pullRequest,
+          number: 99,
+          headRefName: "feature/other-pr",
+          url: "https://github.com/owner/repository/pull/99",
+          remoteUrl: "https://github.com/owner/repository.git",
+        },
+      ];
+      const scenario: FakeGhScenario = {
+        prListByHeadSelector: Object.fromEntries(
+          [pullRequest, ...unrelated].map((pr) => [
+            pr.headRefName,
+            // Fake gh returns raw JSON stdout at the CLI boundary.
+            JSON.stringify([pr]),
+          ]),
+        ),
+      };
+      const { manager, ghCalls } = yield* makeManager({ ghScenario: scenario });
+      yield* manager.status({ cwd: repoDir });
+      yield* manager.branchPullRequest({ cwd: worktreeDir, branch: "review/renamed-merge" });
+      const otherCheckouts = [];
+      for (const pr of unrelated) {
+        const cwd = yield* makeTempDir("t3code-git-other-pr-");
+        yield* initRepo(cwd);
+        yield* runGit(cwd, ["remote", "add", "origin", remoteDir]);
+        yield* runGit(cwd, ["checkout", "-b", pr.headRefName]);
+        yield* runGit(cwd, ["push", "-u", "origin", pr.headRefName]);
+        yield* configureVisibleRemoteUrlWithLocalRewrite(cwd, "origin", pr.remoteUrl, remoteDir);
+        otherCheckouts.push({ cwd, status: yield* manager.remoteStatus({ cwd }) });
+      }
+      const callsBeforeMerge = ghCalls.length;
+      const merge = {
+        provider: "github" as const,
+        url: pullRequest.url,
+        mergedAt: "2026-09-03T00:00:00.000Z",
+      };
+      expect(yield* manager.observePullRequestMerge({ ...merge, provider: "gitlab" })).toEqual([]);
+      expect((yield* manager.branchPullRequest({ cwd: repoDir, branch: headBranch }))?.state).toBe(
+        "open",
+      );
+
+      const affected = yield* manager.observePullRequestMerge(merge);
+
+      expect(affected.toSorted((left, right) => left.cwd.localeCompare(right.cwd))).toEqual(
+        [
+          { cwd: repoDir, branch: headBranch },
+          { cwd: worktreeDir, branch: "review/renamed-merge" },
+        ].toSorted((left, right) => left.cwd.localeCompare(right.cwd)),
+      );
+      expect((yield* manager.status({ cwd: repoDir })).pr?.state).toBe("merged");
+      expect(
+        yield* manager.branchPullRequest({ cwd: worktreeDir, branch: "review/renamed-merge" }),
+      ).toEqual({ state: "merged", updatedAt: merge.mergedAt });
+      for (const checkout of otherCheckouts) {
+        expect(yield* manager.remoteStatus({ cwd: checkout.cwd })).toBe(checkout.status);
+      }
+      expect(ghCalls).toHaveLength(callsBeforeMerge);
+
+      scenario.failAfterCalls = ghCalls.length;
+      scenario.failWith = new GitHubCli.GitHubCliUnavailableError({
+        command: "gh",
+        cwd: repoDir,
+        cause: new Error("rate limited"),
+      });
+      yield* manager.invalidateStatus(repoDir);
+      expect((yield* manager.status({ cwd: repoDir })).pr?.state).toBe("merged");
+    }),
+  );
+
+  it.effect("keeps a confirmed merge after a late open response without claiming a newer PR", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      const branch = "feature/late-merge";
+      yield* runGit(repoDir, ["checkout", "-b", branch]);
+      yield* runGit(repoDir, ["push", "-u", "origin", branch]);
+      const started = yield* Deferred.make<void>();
+      const release = yield* Deferred.make<void>();
+      const pullRequest = {
+        number: 42,
+        title: "Late response",
+        url: "https://github.com/owner/repository/pull/42",
+        baseRefName: "main",
+        headRefName: branch,
+        state: "OPEN",
+        updatedAt: "2026-09-01T00:00:00Z",
+      };
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          beforePrListResult: Deferred.succeed(started, undefined).pipe(
+            Effect.andThen(Deferred.await(release)),
+          ),
+          prListSequence: [
+            // Fake gh returns raw JSON stdout at the CLI boundary.
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([pullRequest]),
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([
+              { ...pullRequest, number: 43, url: "https://github.com/owner/repository/pull/43" },
+            ]),
+          ],
+        },
+      });
+      const lookup = yield* manager
+        .branchPullRequest({ cwd: repoDir, branch })
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(started);
+      const merge = {
+        provider: "github" as const,
+        url: pullRequest.url,
+        mergedAt: "2026-09-03T00:00:00.000Z",
+      };
+      expect(yield* manager.observePullRequestMerge(merge)).toEqual([]);
+      yield* Deferred.succeed(release, undefined);
+
+      expect(yield* Fiber.join(lookup)).toEqual({ state: "merged", updatedAt: merge.mergedAt });
+      expect((yield* manager.status({ cwd: repoDir })).pr?.state).toBe("merged");
+      expect(ghCalls.filter((call) => call.startsWith("pr list "))).toHaveLength(1);
+
+      yield* manager.invalidateStatus(repoDir);
+      const next = yield* manager.status({ cwd: repoDir });
+      expect(next.pr).toMatchObject({ number: 43, state: "open" });
+      expect(yield* manager.observePullRequestMerge(merge)).toEqual([]);
     }),
   );
 
@@ -2133,7 +2322,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
                 url: "https://github.com/pingdotgg/codething-mvp/pull/91",
                 baseRefName: "main",
                 headRefName: "feature/fork-settle",
-                state: "MERGED",
+                state: "OPEN",
                 updatedAt: "2026-05-02T10:00:00Z",
                 isCrossRepository: true,
                 headRepository: { nameWithOwner: "contributor/codething-mvp" },
@@ -2144,12 +2333,17 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         },
       });
 
-      const pullRequest = yield* manager.branchPullRequest({
+      const input = {
         cwd: repoDir,
         branch: "feature/fork-settle",
+      };
+      expect((yield* manager.branchPullRequest(input))?.state).toBe("open");
+      yield* manager.observePullRequestMerge({
+        provider: "github",
+        url: "https://github.com/pingdotgg/codething-mvp/pull/91",
+        mergedAt: "2026-05-02T10:00:00.000Z",
       });
-
-      expect(pullRequest).toEqual({
+      expect(yield* manager.branchPullRequest(input)).toEqual({
         state: "merged",
         closedAt: null,
         mergedAt: null,

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -1564,7 +1564,12 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
       expect((yield* manager.status({ cwd: repoDir })).pr?.state).toBe("merged");
       expect(
         yield* manager.branchPullRequest({ cwd: worktreeDir, branch: "review/renamed-merge" }),
-      ).toEqual({ state: "merged", updatedAt: merge.mergedAt });
+      ).toEqual({
+        state: "merged",
+        updatedAt: merge.mergedAt,
+        closedAt: null,
+        mergedAt: merge.mergedAt,
+      });
       for (const checkout of otherCheckouts) {
         expect(yield* manager.remoteStatus({ cwd: checkout.cwd })).toBe(checkout.status);
       }
@@ -1632,7 +1637,12 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
       expect(yield* manager.observePullRequestMerge(merge)).toEqual([]);
       yield* Deferred.succeed(release, undefined);
 
-      expect(yield* Fiber.join(lookup)).toEqual({ state: "merged", updatedAt: merge.mergedAt });
+      expect(yield* Fiber.join(lookup)).toEqual({
+        state: "merged",
+        updatedAt: merge.mergedAt,
+        closedAt: null,
+        mergedAt: merge.mergedAt,
+      });
       expect((yield* manager.status({ cwd: repoDir })).pr?.state).toBe("merged");
       expect(ghCalls.filter((call) => call.startsWith("pr list "))).toHaveLength(2);
     }),
@@ -2394,7 +2404,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
       expect(yield* manager.branchPullRequest(input)).toEqual({
         state: "merged",
         closedAt: null,
-        mergedAt: null,
+        mergedAt: "2026-05-02T10:00:00.000Z",
         updatedAt: "2026-05-02T10:00:00.000Z",
       });
     }),

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -1580,6 +1580,26 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
       );
       expect(ghCalls).toHaveLength(callsBeforeMerge + 2);
 
+      scenario.prListByHeadSelector = {
+        ...scenario.prListByHeadSelector,
+        // Fake gh returns raw JSON stdout at the CLI boundary.
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        [headBranch]: JSON.stringify([
+          { ...pullRequest, state: "MERGED", mergedAt: merge.mergedAt },
+        ]),
+      };
+      // Retiring a confirmed merge must retire cached open answers that depended on it.
+      for (let number = 100; number < 100 + 2_048; number++) {
+        yield* manager.observePullRequestMerge({
+          ...merge,
+          url: `https://github.com/owner/repository/pull/${number}`,
+        });
+      }
+      expect((yield* manager.branchPullRequest({ cwd: repoDir, branch: headBranch }))?.state).toBe(
+        "merged",
+      );
+      expect((yield* manager.status({ cwd: worktreeDir })).pr?.state).toBe("merged");
+
       scenario.failAfterCalls = ghCalls.length;
       scenario.failWith = new GitHubCli.GitHubCliUnavailableError({
         command: "gh",
@@ -1591,62 +1611,83 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
-  it.effect("keeps a confirmed merge after a late open response", () =>
-    Effect.gen(function* () {
-      const repoDir = yield* makeTempDir("t3code-git-manager-");
-      yield* initRepo(repoDir);
-      const remoteDir = yield* createBareRemote();
-      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
-      const branch = "feature/late-merge";
-      yield* runGit(repoDir, ["checkout", "-b", branch]);
-      yield* runGit(repoDir, ["push", "-u", "origin", branch]);
-      const started = yield* Deferred.make<void>();
-      const release = yield* Deferred.make<void>();
-      const pullRequest = {
-        number: 42,
-        title: "Late response",
-        url: "https://github.com/owner/repository/pull/42",
-        baseRefName: "main",
-        headRefName: branch,
-        state: "OPEN",
-        updatedAt: "2026-09-01T00:00:00Z",
-      };
-      const { manager, ghCalls } = yield* makeManager({
-        ghScenario: {
-          beforePrListResult: Deferred.succeed(started, undefined).pipe(
-            Effect.andThen(Deferred.await(release)),
-          ),
-          prListSequence: [
-            // Fake gh returns raw JSON stdout at the CLI boundary.
-            // @effect-diagnostics-next-line preferSchemaOverJson:off
-            JSON.stringify([pullRequest]),
-            // @effect-diagnostics-next-line preferSchemaOverJson:off
-            JSON.stringify([pullRequest]),
-          ],
-        },
-      });
-      const lookup = yield* manager
-        .branchPullRequest({ cwd: repoDir, branch })
-        .pipe(Effect.forkChild);
-      yield* Deferred.await(started);
-      const merge = {
-        provider: "github" as const,
-        url: pullRequest.url,
-        mergedAt: "2026-09-03T00:00:00.000Z",
-      };
-      expect(yield* manager.observePullRequestMerge(merge)).toEqual([]);
-      yield* Deferred.succeed(release, undefined);
+  for (const retireConfirmations of [false, true]) {
+    it.effect(
+      `keeps a confirmed merge after a late open response, retirement=${retireConfirmations}`,
+      () =>
+        Effect.gen(function* () {
+          const repoDir = yield* makeTempDir("t3code-git-manager-");
+          yield* initRepo(repoDir);
+          const remoteDir = yield* createBareRemote();
+          yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+          const branch = "feature/late-merge";
+          yield* runGit(repoDir, ["checkout", "-b", branch]);
+          yield* runGit(repoDir, ["push", "-u", "origin", branch]);
+          const started = yield* Deferred.make<void>();
+          const release = yield* Deferred.make<void>();
+          const pullRequest = {
+            number: 42,
+            title: "Late response",
+            url: "https://github.com/owner/repository/pull/42",
+            baseRefName: "main",
+            headRefName: branch,
+            state: "OPEN",
+            updatedAt: "2026-09-01T00:00:00Z",
+          };
+          const { manager, ghCalls } = yield* makeManager({
+            ghScenario: {
+              beforePrListResult: Deferred.succeed(started, undefined).pipe(
+                Effect.andThen(Deferred.await(release)),
+              ),
+              prListSequence: [
+                // Fake gh returns raw JSON stdout at the CLI boundary.
+                // @effect-diagnostics-next-line preferSchemaOverJson:off
+                JSON.stringify([pullRequest]),
+                // @effect-diagnostics-next-line preferSchemaOverJson:off
+                JSON.stringify([
+                  {
+                    ...pullRequest,
+                    ...(retireConfirmations
+                      ? {
+                          state: "MERGED",
+                          mergedAt: "2026-09-03T00:00:00.000Z",
+                          updatedAt: "2026-09-03T00:00:00.000Z",
+                        }
+                      : {}),
+                  },
+                ]),
+              ],
+            },
+          });
+          const lookup = yield* manager
+            .branchPullRequest({ cwd: repoDir, branch })
+            .pipe(Effect.forkChild);
+          yield* Deferred.await(started);
+          const merge = {
+            provider: "github" as const,
+            url: pullRequest.url,
+            mergedAt: "2026-09-03T00:00:00.000Z",
+          };
+          expect(yield* manager.observePullRequestMerge(merge)).toEqual([]);
+          for (let number = 100; retireConfirmations && number < 100 + 2_048; number++) {
+            yield* manager.observePullRequestMerge({
+              ...merge,
+              url: `https://github.com/owner/repository/pull/${number}`,
+            });
+          }
+          yield* Deferred.succeed(release, undefined);
 
-      expect(yield* Fiber.join(lookup)).toEqual({
-        state: "merged",
-        updatedAt: merge.mergedAt,
-        closedAt: null,
-        mergedAt: merge.mergedAt,
-      });
-      expect((yield* manager.status({ cwd: repoDir })).pr?.state).toBe("merged");
-      expect(ghCalls.filter((call) => call.startsWith("pr list "))).toHaveLength(2);
-    }),
-  );
+          expect(yield* Fiber.join(lookup)).toEqual({
+            state: "merged",
+            updatedAt: merge.mergedAt,
+            closedAt: null,
+            mergedAt: merge.mergedAt,
+          });
+          expect((yield* manager.status({ cwd: repoDir })).pr?.state).toBe("merged");
+          expect(ghCalls.filter((call) => call.startsWith("pr list "))).toHaveLength(2);
+        }),
+    );
+  }
 
   it.effect("rechecks a warm branch association before applying an older PR's merge", () =>
     Effect.gen(function* () {

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -30,6 +30,7 @@ import {
   VcsStatusResult,
   ModelSelection,
   SourceControlProviderError,
+  type SourceControlProviderKind,
   type SourceControlWritingStyleSettings,
 } from "@t3tools/contracts";
 import {
@@ -108,6 +109,12 @@ export class GitManager extends Context.Service<
       } | null,
       GitManagerServiceError
     >;
+    /** Share a confirmed merge with checkouts already associated with that PR. */
+    readonly observePullRequestMerge: (input: {
+      readonly provider: SourceControlProviderKind;
+      readonly url: string;
+      readonly mergedAt: string;
+    }) => Effect.Effect<ReadonlyArray<{ readonly cwd: string; readonly branch: string }>>;
     readonly invalidateLocalStatus: (cwd: string) => Effect.Effect<void, never>;
     readonly invalidateRemoteStatus: (cwd: string) => Effect.Effect<void, never>;
     readonly invalidateStatus: (cwd: string) => Effect.Effect<void, never>;
@@ -174,6 +181,7 @@ interface OpenPrInfo {
 }
 
 interface PullRequestInfo extends OpenPrInfo, PullRequestHeadRemoteInfo {
+  provider: SourceControlProviderKind;
   state: "open" | "closed" | "merged";
   isDraft?: boolean;
   closedAt?: string | null;
@@ -333,7 +341,9 @@ function resolveExpectedHeadIdentity(
   };
 }
 
-function resolvePullRequestHeadIdentity(pr: PullRequestInfo): PullRequestHeadIdentity {
+function resolvePullRequestHeadIdentity(
+  pr: Omit<PullRequestInfo, "provider">,
+): PullRequestHeadIdentity {
   const repositoryNameWithOwner = normalizeOptionalRepositoryNameWithOwner(
     resolvePullRequestHeadRepositoryNameWithOwner(pr),
   );
@@ -346,7 +356,7 @@ function resolvePullRequestHeadIdentity(pr: PullRequestInfo): PullRequestHeadIde
 }
 
 export function matchesBranchHeadContext(
-  pr: PullRequestInfo,
+  pr: Omit<PullRequestInfo, "provider">,
   headContext: Pick<
     BranchHeadContext,
     "headBranch" | "headRepositoryNameWithOwner" | "headRepositoryOwnerLogin" | "isCrossRepository"
@@ -404,8 +414,12 @@ export function matchesBranchHeadContext(
   return true;
 }
 
-function toPullRequestInfo(summary: ChangeRequest): PullRequestInfo {
+function toPullRequestInfo(
+  summary: ChangeRequest,
+  provider: SourceControlProviderKind,
+): PullRequestInfo {
   return {
+    provider,
     number: summary.number,
     title: summary.title,
     url: summary.url,
@@ -1009,6 +1023,23 @@ export const make = Effect.gen(function* () {
     prLookupFailureStreakByKey.set(key, streak);
     return prLookupFailureTtl(streak);
   };
+  // A branch lookup owns the association. A confirmed merge belongs to the
+  // provider's full PR URL, including its host, port and repository path.
+  // Keep it separate so an older in-flight lookup cannot restore an open state.
+  const mergedPrByIdentity = new Map<string, DateTime.Utc>();
+  const prIdentity = (pr: { readonly provider: SourceControlProviderKind; readonly url: string }) =>
+    JSON.stringify([pr.provider, pr.url]);
+  const withObservedMerge = (pr: PullRequestInfo): PullRequestInfo => {
+    const mergedAt = mergedPrByIdentity.get(prIdentity(pr));
+    return mergedAt === undefined
+      ? pr
+      : {
+          ...pr,
+          state: "merged",
+          mergedAt: pr.mergedAt ?? DateTime.formatIso(mergedAt),
+          updatedAt: Option.some(mergedAt),
+        };
+  };
   const prLookupCache = yield* Cache.makeWith(
     (key: string) => {
       const [
@@ -1061,6 +1092,7 @@ export const make = Effect.gen(function* () {
   // branch retargeted to another remote/fork cannot inherit the old badge.
   interface LastKnownPr {
     readonly pr: ReturnType<typeof toStatusPr> | null;
+    readonly provider: SourceControlProviderKind | null;
     readonly upstreamRef: string | null;
     readonly headBranch: string;
     readonly remoteName: string | null;
@@ -1137,18 +1169,20 @@ export const make = Effect.gen(function* () {
     }
     return yield* Cache.get(prLookupCache, cacheKey).pipe(
       Effect.map(({ latest, headContext }) => {
-        if (!latest) return { pr: null, headContext };
+        if (!latest) return { pr: null, provider: null, headContext };
+        const observed = withObservedMerge(latest);
         // On the default branch, only surface open PRs.
         // Merged/closed matches are usually reverse-merge history, not the thread's PR context.
-        if (details.isDefaultBranch && latest.state !== "open") {
-          return { pr: null, headContext };
+        if (details.isDefaultBranch && observed.state !== "open") {
+          return { pr: null, provider: null, headContext };
         }
-        return { pr: toStatusPr(latest), headContext };
+        return { pr: toStatusPr(observed), provider: latest.provider, headContext };
       }),
-      Effect.tap(({ pr, headContext }) =>
+      Effect.tap(({ pr, provider, headContext }) =>
         Effect.sync(() =>
           rememberLastKnownPr(branchKey, {
             pr,
+            provider,
             upstreamRef: details.upstreamRef,
             headBranch: headContext.headBranch,
             remoteName: headContext.remoteName,
@@ -1517,14 +1551,15 @@ export const make = Effect.gen(function* () {
       | "isCrossRepository"
     >,
   ) {
+    const provider = yield* sourceControlProvider(cwd);
     for (const headSelector of headContext.headSelectors) {
-      const pullRequests = yield* (yield* sourceControlProvider(cwd)).listChangeRequests({
+      const pullRequests = yield* provider.listChangeRequests({
         cwd,
         headSelector,
         state: "open",
         limit: 1,
       });
-      const normalizedPullRequests = pullRequests.map(toPullRequestInfo);
+      const normalizedPullRequests = pullRequests.map((pr) => toPullRequestInfo(pr, provider.kind));
 
       const firstPullRequest = normalizedPullRequests.find((pullRequest) =>
         matchesBranchHeadContext(pullRequest, headContext),
@@ -1546,16 +1581,17 @@ export const make = Effect.gen(function* () {
     headContext: BranchHeadContext,
   ) {
     const parsedByNumber = new Map<number, PullRequestInfo>();
+    const provider = yield* sourceControlProvider(cwd);
 
     for (const headSelector of headContext.headSelectors) {
-      const pullRequests = yield* (yield* sourceControlProvider(cwd)).listChangeRequests({
+      const pullRequests = yield* provider.listChangeRequests({
         cwd,
         headSelector,
         state: "all",
         limit: 20,
       });
 
-      for (const pr of pullRequests.map(toPullRequestInfo)) {
+      for (const pr of pullRequests.map((pr) => toPullRequestInfo(pr, provider.kind))) {
         if (!matchesBranchHeadContext(pr, headContext)) {
           continue;
         }
@@ -2156,22 +2192,54 @@ export const make = Effect.gen(function* () {
         });
       }
     }
-    const { latest } = cached;
-    if (latest === null) return null;
-    if (
+    const latest = cached.latest === null ? null : withObservedMerge(cached.latest);
+    const hidesTerminalPr =
       (branch === defaultBranch ||
         (defaultBranch === null && (branch === "main" || branch === "master"))) &&
-      latest.state !== "open"
-    ) {
-      return null;
-    }
-    const statusPr = toStatusPr(latest);
+      latest?.state !== "open";
+    const statusPr = latest === null || hidesTerminalPr ? null : toStatusPr(latest);
+    rememberLastKnownPr(`${cacheCwd}\u0000${branch}`, {
+      pr: statusPr,
+      provider: latest?.provider ?? null,
+      upstreamRef,
+      headBranch: cached.headContext.headBranch,
+      remoteName: cached.headContext.remoteName,
+      headRemoteUrlKey: cached.headContext.headRemoteUrlKey,
+    });
+    if (statusPr === null) return null;
     return {
       state: statusPr.state,
       updatedAt: statusPr.updatedAt,
-      closedAt: latest.closedAt ?? null,
-      mergedAt: latest.mergedAt ?? null,
+      closedAt: latest?.closedAt ?? null,
+      mergedAt: latest?.mergedAt ?? null,
     };
+  });
+  const observePullRequestMerge: GitManager["Service"]["observePullRequestMerge"] = Effect.fn(
+    "observePullRequestMerge",
+  )(function* (input) {
+    const identity = prIdentity(input);
+    if (!mergedPrByIdentity.has(identity) && mergedPrByIdentity.size >= PR_LOOKUP_CACHE_CAPACITY) {
+      const oldest = mergedPrByIdentity.keys().next().value;
+      if (oldest !== undefined) mergedPrByIdentity.delete(oldest);
+    }
+    const mergedAt = DateTime.makeUnsafe(input.mergedAt);
+    mergedPrByIdentity.set(identity, mergedAt);
+    const branches: Array<{ readonly cwd: string; readonly branch: string }> = [];
+    const cwds = new Set<string>();
+    for (const [branchKey, known] of lastKnownPrByBranchKey) {
+      if (known.pr?.url !== input.url || known.provider !== input.provider) continue;
+      const [cwd = "", branch = ""] = branchKey.split("\u0000");
+      branches.push({ cwd, branch });
+      cwds.add(cwd);
+      lastKnownPrByBranchKey.set(branchKey, {
+        ...known,
+        pr: { ...known.pr, state: "merged", updatedAt: DateTime.formatIso(mergedAt) },
+      });
+    }
+    yield* Effect.forEach(cwds, (cwd) => Cache.invalidate(remoteStatusResultCache, cwd), {
+      discard: true,
+    });
+    return branches;
   });
   const invalidateLocalStatus: GitManager["Service"]["invalidateLocalStatus"] = Effect.fn(
     "invalidateLocalStatus",
@@ -2721,6 +2789,7 @@ export const make = Effect.gen(function* () {
     remoteStatus,
     status,
     branchPullRequest,
+    observePullRequestMerge,
     invalidateLocalStatus,
     invalidateRemoteStatus,
     invalidateStatus,

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -1026,18 +1026,22 @@ export const make = Effect.gen(function* () {
   // A branch lookup owns the association. A confirmed merge belongs to the
   // provider's full PR URL, including its host, port and repository path.
   // Keep it separate so an older in-flight lookup cannot restore an open state.
-  const mergedPrByIdentity = new Map<string, DateTime.Utc>();
+  let mergeRevision = 0;
+  const mergedPrByIdentity = new Map<
+    string,
+    { readonly mergedAt: DateTime.Utc; readonly revision: number }
+  >();
   const prIdentity = (pr: { readonly provider: SourceControlProviderKind; readonly url: string }) =>
     JSON.stringify([pr.provider, pr.url]);
   const withObservedMerge = (pr: PullRequestInfo): PullRequestInfo => {
-    const mergedAt = mergedPrByIdentity.get(prIdentity(pr));
-    return mergedAt === undefined
+    const observed = mergedPrByIdentity.get(prIdentity(pr));
+    return observed === undefined
       ? pr
       : {
           ...pr,
           state: "merged",
-          mergedAt: pr.mergedAt ?? DateTime.formatIso(mergedAt),
-          updatedAt: Option.some(mergedAt),
+          mergedAt: pr.mergedAt ?? DateTime.formatIso(observed.mergedAt),
+          updatedAt: Option.some(observed.mergedAt),
         };
   };
   const prLookupCache = yield* Cache.makeWith(
@@ -1058,9 +1062,10 @@ export const make = Effect.gen(function* () {
         ...(remoteName.length > 0 ? { remoteName } : {}),
       };
       return Effect.gen(function* () {
+        const lookupMergeRevision = mergeRevision;
         const { headContext, lookup } = yield* resolveLookupHeadContext(cwd, details);
         if (!lookup) {
-          return { latest: null, headContext };
+          return { latest: null, headContext, mergeRevision: lookupMergeRevision };
         }
         // Only skip when the branch is untracked as well: anything carrying an
         // upstream keeps the old behaviour.
@@ -1069,10 +1074,10 @@ export const make = Effect.gen(function* () {
           details.upstreamRef === null &&
           (yield* isUnpublishedBranch(cwd, headContext))
         ) {
-          return { latest: null, headContext };
+          return { latest: null, headContext, mergeRevision: lookupMergeRevision };
         }
         const latest = yield* findLatestPrForHeadContext(cwd, headContext);
-        return { latest, headContext };
+        return { latest, headContext, mergeRevision: lookupMergeRevision };
       });
     },
     {
@@ -2153,7 +2158,7 @@ export const make = Effect.gen(function* () {
     // is looked up on the fork. Verify against the remote the lookup used.
     const identityRemoteName = (headContext: BranchHeadContext) =>
       headContext.remoteName ?? remoteName ?? undefined;
-    const currentIdentity = yield* resolvePrLookupRepositoryIdentity(
+    let currentIdentity = yield* resolvePrLookupRepositoryIdentity(
       cacheCwd,
       branch,
       identityRemoteName(cached.headContext),
@@ -2166,31 +2171,34 @@ export const make = Effect.gen(function* () {
     const hasSameIdentity = (headContext: BranchHeadContext, identity: typeof currentIdentity) =>
       headContext.headRemoteUrlKey === identity.headRemoteUrlKey &&
       headContext.targetRemoteUrlKey === identity.targetRemoteUrlKey;
-    if (!canVerifyIdentity(cached.headContext, currentIdentity)) {
-      return yield* new GitManagerError({
-        operation: "branchPullRequest",
-        cwd: cacheCwd,
-        detail: `Repository identity for ${branch} could not be verified.`,
-      });
-    }
-    if (!hasSameIdentity(cached.headContext, currentIdentity)) {
-      yield* Cache.invalidate(prLookupCache, cacheKey);
+    let refreshed = false;
+    while (true) {
+      const sameIdentity = hasSameIdentity(cached.headContext, currentIdentity);
+      if (!canVerifyIdentity(cached.headContext, currentIdentity) || (!sameIdentity && refreshed)) {
+        return yield* new GitManagerError({
+          operation: "branchPullRequest",
+          cwd: cacheCwd,
+          detail: refreshed
+            ? `Repository identity for ${branch} changed during pull request lookup.`
+            : `Repository identity for ${branch} could not be verified.`,
+        });
+      }
+      // A newer PR can reuse a branch without changing its Git configuration.
+      // Before settlement, recheck associations read before this PR's merge.
+      // The revision is captured before I/O, so late replies need this check too.
+      const observed =
+        cached.latest === null ? undefined : mergedPrByIdentity.get(prIdentity(cached.latest));
+      const predatesMerge = observed !== undefined && cached.mergeRevision < observed.revision;
+      if (sameIdentity && !predatesMerge) break;
+
+      yield* Cache.invalidateWhen(prLookupCache, cacheKey, (value) => value === cached);
       cached = yield* Cache.get(prLookupCache, cacheKey);
-      const refreshedIdentity = yield* resolvePrLookupRepositoryIdentity(
+      currentIdentity = yield* resolvePrLookupRepositoryIdentity(
         cacheCwd,
         branch,
         identityRemoteName(cached.headContext),
       );
-      if (
-        !canVerifyIdentity(cached.headContext, refreshedIdentity) ||
-        !hasSameIdentity(cached.headContext, refreshedIdentity)
-      ) {
-        return yield* new GitManagerError({
-          operation: "branchPullRequest",
-          cwd: cacheCwd,
-          detail: `Repository identity for ${branch} changed during pull request lookup.`,
-        });
-      }
+      refreshed = true;
     }
     const latest = cached.latest === null ? null : withObservedMerge(cached.latest);
     const hidesTerminalPr =
@@ -2223,7 +2231,7 @@ export const make = Effect.gen(function* () {
       if (oldest !== undefined) mergedPrByIdentity.delete(oldest);
     }
     const mergedAt = DateTime.makeUnsafe(input.mergedAt);
-    mergedPrByIdentity.set(identity, mergedAt);
+    mergedPrByIdentity.set(identity, { mergedAt, revision: ++mergeRevision });
     const branches: Array<{ readonly cwd: string; readonly branch: string }> = [];
     const cwds = new Set<string>();
     for (const [branchKey, known] of lastKnownPrByBranchKey) {

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -1027,6 +1027,7 @@ export const make = Effect.gen(function* () {
   // provider's full PR URL, including its host, port and repository path.
   // Keep it separate so an older in-flight lookup cannot restore an open state.
   let mergeRevision = 0;
+  let retiredThroughMergeRevision = -1;
   const mergedPrByIdentity = new Map<
     string,
     { readonly mergedAt: DateTime.Utc; readonly revision: number }
@@ -1091,6 +1092,14 @@ export const make = Effect.gen(function* () {
       },
     },
   );
+  const readCurrentPrLookup = Effect.fn("readCurrentPrLookup")(function* (key: string) {
+    let result = yield* Cache.get(prLookupCache, key);
+    while (result.mergeRevision <= retiredThroughMergeRevision) {
+      yield* Cache.invalidateWhen(prLookupCache, key, (value) => value === result);
+      result = yield* Cache.get(prLookupCache, key);
+    }
+    return result;
+  });
   // A transient lookup failure (rate limit, network blip) must not clear an
   // already-known PR badge, so the last successful answer per branch sticks
   // around as the fallback. Keep the resolved head context with it so a
@@ -1172,7 +1181,7 @@ export const make = Effect.gen(function* () {
         yield* Cache.invalidate(prLookupCache, cacheKey);
       }
     }
-    return yield* Cache.get(prLookupCache, cacheKey).pipe(
+    return yield* readCurrentPrLookup(cacheKey).pipe(
       Effect.map(({ latest, headContext }) => {
         if (!latest) return { pr: null, provider: null, headContext };
         const observed = withObservedMerge(latest);
@@ -2152,7 +2161,7 @@ export const make = Effect.gen(function* () {
       localBranchExists,
       ...(localBranchExists ? {} : { remoteName }),
     });
-    let cached = yield* Cache.get(prLookupCache, cacheKey);
+    let cached = yield* readCurrentPrLookup(cacheKey);
     // The cached head context may have resolved on a different remote than
     // the saved upstream: a branch tracking origin/main but pushed to a fork
     // is looked up on the fork. Verify against the remote the lookup used.
@@ -2189,10 +2198,11 @@ export const make = Effect.gen(function* () {
       const observed =
         cached.latest === null ? undefined : mergedPrByIdentity.get(prIdentity(cached.latest));
       const predatesMerge = observed !== undefined && cached.mergeRevision < observed.revision;
-      if (sameIdentity && !predatesMerge) break;
+      if (sameIdentity && !predatesMerge && cached.mergeRevision > retiredThroughMergeRevision)
+        break;
 
       yield* Cache.invalidateWhen(prLookupCache, cacheKey, (value) => value === cached);
-      cached = yield* Cache.get(prLookupCache, cacheKey);
+      cached = yield* readCurrentPrLookup(cacheKey);
       currentIdentity = yield* resolvePrLookupRepositoryIdentity(
         cacheCwd,
         branch,
@@ -2226,14 +2236,22 @@ export const make = Effect.gen(function* () {
     "observePullRequestMerge",
   )(function* (input) {
     const identity = prIdentity(input);
-    if (!mergedPrByIdentity.has(identity) && mergedPrByIdentity.size >= PR_LOOKUP_CACHE_CAPACITY) {
-      const oldest = mergedPrByIdentity.keys().next().value;
-      if (oldest !== undefined) mergedPrByIdentity.delete(oldest);
+    const retireLookups =
+      !mergedPrByIdentity.has(identity) && mergedPrByIdentity.size >= PR_LOOKUP_CACHE_CAPACITY;
+    if (retireLookups) {
+      // Retire the whole batch with its cached answers. A version check makes
+      // in-flight reads retry too, without keeping another identity index.
+      retiredThroughMergeRevision = mergeRevision;
+      mergedPrByIdentity.clear();
     }
     const mergedAt = DateTime.makeUnsafe(input.mergedAt);
     mergedPrByIdentity.set(identity, { mergedAt, revision: ++mergeRevision });
-    const branches: Array<{ readonly cwd: string; readonly branch: string }> = [];
+    if (retireLookups) {
+      yield* Cache.invalidateAll(prLookupCache);
+      yield* Cache.invalidateAll(remoteStatusResultCache);
+    }
     const cwds = new Set<string>();
+    const branches: Array<{ readonly cwd: string; readonly branch: string }> = [];
     for (const [branchKey, known] of lastKnownPrByBranchKey) {
       if (known.pr?.url !== input.url || known.provider !== input.provider) continue;
       const [cwd = "", branch = ""] = branchKey.split("\u0000");

--- a/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
@@ -136,6 +136,8 @@ interface HarnessOptions {
   readonly snapshot: OrchestrationShellSnapshot;
   readonly settings?: ServerSettings;
   readonly branchPullRequest?: GitManager["Service"]["branchPullRequest"];
+  readonly observePullRequestMerge?: GitManager["Service"]["observePullRequestMerge"];
+  readonly mergeEvent?: Partial<PullRequestMergeEvent>;
   readonly pullRequestSummary?: PullRequestService["Service"]["summary"];
   readonly existingWorktreePaths?: ReadonlyArray<string>;
   readonly onDispatch?: (
@@ -226,6 +228,7 @@ const makeHarness = Effect.fn("makeThreadSettlementHarness")(function* (options:
     }),
     Layer.mock(GitManager)({
       branchPullRequest,
+      observePullRequestMerge: options.observePullRequestMerge ?? (() => Effect.succeed([])),
       invalidateStatus: (cwd) => Ref.update(invalidatedCwds, (cwds) => [...cwds, cwd]),
     }),
     Layer.mock(PullRequestService)({
@@ -263,8 +266,12 @@ const makeHarness = Effect.fn("makeThreadSettlementHarness")(function* (options:
       projectId: PROJECT_ID,
       repository: "owner/repository",
       number: 42,
+      provider: "github",
+      url: "https://example.test/owner/repository/pull/42",
+      repositoryKey: null,
       mergedAt: NOW,
-    }),
+      ...options.mergeEvent,
+    } satisfies PullRequestMergeEvent),
     layer: ThreadSettlementReactor.layer.pipe(Layer.provide(dependencies)),
   };
 });
@@ -460,62 +467,85 @@ describe("ThreadSettlementReactor", () => {
     ),
   );
 
-  it.effect(
-    "settles branch threads on a pull request merge without waiting for the next sweep",
-    () =>
-      Effect.scoped(
-        Effect.gen(function* () {
-          yield* TestClock.setTime(Date.parse(NOW));
-          const state = yield* Ref.make<"open" | "merged">("open");
-          const mergedThreadSettled = yield* Deferred.make<void>();
-          const fixture = yield* makeHarness({
-            snapshot: makeSnapshot([
-              makeThread("branch-thread", {
-                branch: "saved-feature",
-                latestUserMessageAt: "2026-08-27T00:00:00.000Z",
-              }),
-            ]),
-            branchPullRequest: () =>
-              Ref.get(state).pipe(
-                Effect.map((pullRequestState) => ({
-                  state: pullRequestState,
-                  updatedAt: NOW,
-                  closedAt: NOW,
-                  mergedAt: NOW,
-                })),
-              ),
-            onDispatch: () => Deferred.succeed(mergedThreadSettled, undefined),
-          });
+  it.effect("settles associated worktrees on merge without refreshing other checkouts", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(NOW));
+        const state = yield* Ref.make<"open" | "merged">("open");
+        const mergedThreadsSettled = yield* Queue.unbounded<void>();
+        const associatedBranches = [
+          { cwd: "/workspace/worktree-one", branch: "saved-feature" },
+          { cwd: "/workspace/worktree-two", branch: "renamed-feature" },
+        ];
+        const fixture = yield* makeHarness({
+          snapshot: makeSnapshot([
+            makeThread("branch-one", {
+              branch: "saved-feature",
+              worktreePath: "/workspace/worktree-one",
+              latestUserMessageAt: "2026-08-27T00:00:00.000Z",
+            }),
+            makeThread("branch-two", {
+              branch: "renamed-feature",
+              worktreePath: "/workspace/worktree-two",
+              latestUserMessageAt: "2026-08-27T00:00:00.000Z",
+            }),
+            makeThread("unrelated-checkout", {
+              branch: "saved-feature",
+              worktreePath: "/workspace/unrelated-worktree",
+              latestUserMessageAt: "2026-08-27T00:00:00.000Z",
+            }),
+          ]),
+          existingWorktreePaths: [
+            "/workspace/worktree-one",
+            "/workspace/worktree-two",
+            "/workspace/unrelated-worktree",
+          ],
+          observePullRequestMerge: () => Effect.succeed(associatedBranches),
+          branchPullRequest: () =>
+            Ref.get(state).pipe(
+              Effect.map((pullRequestState) => ({
+                state: pullRequestState,
+                updatedAt: NOW,
+                closedAt: NOW,
+                mergedAt: NOW,
+              })),
+            ),
+          onDispatch: () => Queue.offer(mergedThreadsSettled, undefined),
+        });
 
-          yield* Effect.gen(function* () {
-            const reactor = yield* ThreadSettlementReactor.ThreadSettlementReactor;
-            yield* startHarness(reactor, fixture.activation, fixture.snapshotReads);
-            assert.deepStrictEqual(yield* Ref.get(fixture.commands), []);
-            assert.deepStrictEqual(yield* Ref.get(fixture.invalidatedCwds), []);
+        yield* Effect.gen(function* () {
+          const reactor = yield* ThreadSettlementReactor.ThreadSettlementReactor;
+          yield* startHarness(reactor, fixture.activation, fixture.snapshotReads);
+          assert.deepStrictEqual(yield* Ref.get(fixture.commands), []);
+          assert.deepStrictEqual(yield* Ref.get(fixture.invalidatedCwds), []);
 
-            yield* Ref.set(state, "merged");
-            yield* fixture.publishMerge;
-            yield* Deferred.await(mergedThreadSettled);
+          yield* Ref.set(state, "merged");
+          yield* fixture.publishMerge;
+          yield* Queue.take(mergedThreadsSettled);
+          yield* Queue.take(mergedThreadsSettled);
 
-            assert.deepStrictEqual(
-              (yield* Ref.get(fixture.commands)).map((command) => command.threadId),
-              [ThreadId.make("branch-thread")],
-            );
-            assert.deepStrictEqual(yield* Ref.get(fixture.invalidatedCwds), ["/workspace/project"]);
-            yield* reactor.drain;
-          }).pipe(Effect.provide(fixture.layer));
-        }),
-      ),
+          assert.deepStrictEqual(
+            (yield* Ref.get(fixture.commands)).map((command) => command.threadId).toSorted(),
+            [ThreadId.make("branch-one"), ThreadId.make("branch-two")],
+          );
+          assert.deepStrictEqual(yield* Ref.get(fixture.invalidatedCwds), []);
+          assert.deepStrictEqual(
+            (yield* Ref.get(fixture.branchCalls))
+              .slice(3)
+              .toSorted((left, right) => left.cwd.localeCompare(right.cwd)),
+            associatedBranches,
+          );
+          yield* reactor.drain;
+        }).pipe(Effect.provide(fixture.layer));
+      }),
+    ),
   );
 
-  it.effect("a merge does not settle threads linked to an unrelated pull request", () =>
+  it.effect("a merge does not refresh unrelated linked PRs or cold branches", () =>
     Effect.scoped(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse(NOW));
         const mergedThreadSettled = yield* Deferred.make<void>();
-        const mergeLookupStarted = yield* Deferred.make<void>();
-        const releaseMergeLookup = yield* Deferred.make<void>();
-        const lookupCount = yield* Ref.make(0);
         const fixture = yield* makeHarness({
           snapshot: makeSnapshot([
             makeThread("merged-in-app", {
@@ -536,20 +566,13 @@ describe("ThreadSettlementReactor", () => {
                 url: "https://example.test/owner/repository/pull/99",
               },
             }),
+            makeThread("cold-branch", {
+              branch: "saved-feature",
+              latestUserMessageAt: "2026-08-27T00:00:00.000Z",
+            }),
           ]),
           pullRequestSummary: (input) =>
-            Ref.updateAndGet(lookupCount, (count) => count + 1).pipe(
-              // The initial sweep looks up both linked threads; the merge
-              // sweep only looks up the unrelated one, since the merged
-              // thread settles from the event itself.
-              Effect.tap((count) =>
-                count === 3 ? Deferred.succeed(mergeLookupStarted, undefined) : Effect.void,
-              ),
-              Effect.tap((count) =>
-                count === 3 ? Deferred.await(releaseMergeLookup) : Effect.void,
-              ),
-              Effect.map(() => makePullRequestSummary({ ...input, state: "open" })),
-            ),
+            Effect.succeed(makePullRequestSummary({ ...input, state: "open" })),
           onDispatch: () => Deferred.succeed(mergedThreadSettled, undefined),
         });
 
@@ -559,9 +582,7 @@ describe("ThreadSettlementReactor", () => {
           assert.deepStrictEqual(yield* Ref.get(fixture.commands), []);
 
           yield* fixture.publishMerge;
-          yield* Deferred.await(mergeLookupStarted);
           yield* Deferred.await(mergedThreadSettled);
-          yield* Deferred.succeed(releaseMergeLookup, undefined);
           yield* reactor.drain;
 
           assert.deepStrictEqual(
@@ -572,12 +593,103 @@ describe("ThreadSettlementReactor", () => {
             (yield* Ref.get(fixture.summaryCalls))
               .map((call) => call.number)
               .toSorted((left, right) => left - right),
-            [42, 99, 99],
+            [42, 99],
           );
+          assert.deepStrictEqual(yield* Ref.get(fixture.branchCalls), [
+            { cwd: "/workspace/project", branch: "saved-feature" },
+          ]);
         }).pipe(Effect.provide(fixture.layer));
       }),
     ),
   );
+
+  for (const scope of [
+    {
+      provider: "github",
+      repository: "owner/repository",
+      repositoryKey: "example.test/owner/repository",
+      url: "https://example.test/owner/repository/pull/42",
+    },
+    {
+      provider: "azure-devops",
+      repository: "repository",
+      repositoryKey: "dev.azure.com/account/project/_git/repository",
+      url: "https://dev.azure.com/account/project/_git/repository/pullrequest/42",
+    },
+  ] as const) {
+    it.effect(
+      `shares a ${scope.provider} merge across project roots without crossing repository scope`,
+      () =>
+        Effect.scoped(
+          Effect.gen(function* () {
+            yield* TestClock.setTime(Date.parse(NOW));
+            const settled = yield* Queue.unbounded<void>();
+            const scopedProject = (id: string, repositoryKey: string = scope.repositoryKey) => ({
+              ...makeProject(ProjectId.make(id), `/workspace/${id}`),
+              repositoryIdentity: {
+                canonicalKey: repositoryKey,
+                provider: scope.provider,
+                displayName: scope.repository,
+                locator: {
+                  source: "git-remote" as const,
+                  remoteName: "origin",
+                  remoteUrl: `https://${repositoryKey}.git`,
+                },
+              },
+            });
+            const projects = [
+              scopedProject(PROJECT_ID),
+              scopedProject("another-root"),
+              scopedProject(
+                "another-account",
+                scope.repositoryKey
+                  .replace("account", "other-account")
+                  .replace("example.test", "work.example.test"),
+              ),
+              scopedProject("retargeted-project", `${scope.repositoryKey}-other`),
+              scopedProject("another-port"),
+            ];
+            const threads = projects.map((project) =>
+              makeThread(project.id, {
+                projectId: project.id,
+                latestUserMessageAt: "2026-08-27T00:00:00.000Z",
+                linkedPullRequest: {
+                  projectId: project.id,
+                  repository: scope.repository,
+                  number: 42,
+                  url:
+                    project.id === "another-port"
+                      ? scope.url.replace(/^(https:\/\/[^/]+)/, "$1:8443")
+                      : scope.url,
+                },
+              }),
+            );
+            const fixture = yield* makeHarness({
+              snapshot: makeSnapshot(threads, projects),
+              mergeEvent: scope,
+              onDispatch: () => Queue.offer(settled, undefined),
+            });
+
+            yield* Effect.gen(function* () {
+              const reactor = yield* ThreadSettlementReactor.ThreadSettlementReactor;
+              yield* startHarness(reactor, fixture.activation, fixture.snapshotReads);
+              const initialReads = yield* Ref.get(fixture.summaryCalls);
+
+              yield* fixture.publishMerge;
+              yield* Queue.take(settled);
+              yield* Queue.take(settled);
+
+              assert.deepStrictEqual(
+                (yield* Ref.get(fixture.commands)).map((command) => command.threadId).toSorted(),
+                [ThreadId.make("another-root"), ThreadId.make(PROJECT_ID)].toSorted(),
+              );
+              assert.deepStrictEqual(yield* Ref.get(fixture.summaryCalls), initialReads);
+              assert.deepStrictEqual(yield* Ref.get(fixture.invalidatedCwds), []);
+            }).pipe(Effect.provide(fixture.layer));
+          }),
+        ),
+    );
+  }
 
   it.effect("uses fresh settlement settings after lookup and ignores unrelated changes", () =>
     Effect.scoped(

--- a/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
@@ -691,6 +691,76 @@ describe("ThreadSettlementReactor", () => {
     );
   }
 
+  it.effect("keeps a confirmed source-project merge when a later identity probe fails", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(NOW));
+        const settled = yield* Deferred.make<void>();
+        const sourceProject = {
+          ...makeProject(),
+          repositoryIdentity: {
+            canonicalKey: "example.test/owner/repository",
+            provider: "github",
+            locator: {
+              source: "git-remote" as const,
+              remoteName: "origin",
+              remoteUrl: "https://example.test/owner/repository.git",
+            },
+          },
+        };
+        const linkedPullRequest = {
+          projectId: PROJECT_ID,
+          repository: "owner/repository",
+          number: 42,
+          url: "https://example.test/owner/repository/pull/42",
+        };
+        const fixture = yield* makeHarness({
+          snapshot: makeSnapshot(
+            [
+              makeThread("source-project", {
+                latestUserMessageAt: "2026-08-27T00:00:00.000Z",
+                linkedPullRequest,
+              }),
+              makeThread("other-project", {
+                projectId: LINKED_PROJECT_ID,
+                latestUserMessageAt: "2026-08-27T00:00:00.000Z",
+                linkedPullRequest: { ...linkedPullRequest, projectId: LINKED_PROJECT_ID },
+              }),
+            ],
+            [
+              sourceProject,
+              { ...sourceProject, id: LINKED_PROJECT_ID, workspaceRoot: "/workspace/other" },
+            ],
+          ),
+          mergeEvent: { repositoryKey: sourceProject.repositoryIdentity.canonicalKey },
+          onDispatch: () => Deferred.succeed(settled, undefined),
+        });
+
+        yield* Effect.gen(function* () {
+          const reactor = yield* ThreadSettlementReactor.ThreadSettlementReactor;
+          yield* startHarness(reactor, fixture.activation, fixture.snapshotReads);
+          const initialReads = yield* Ref.get(fixture.summaryCalls);
+          yield* Ref.update(fixture.snapshots, (snapshot) => ({
+            ...snapshot,
+            projects: snapshot.projects.map((project) => ({
+              ...project,
+              repositoryIdentity: null,
+            })),
+          }));
+
+          yield* fixture.publishMerge;
+          yield* Deferred.await(settled);
+
+          assert.deepStrictEqual(
+            (yield* Ref.get(fixture.commands)).map((command) => command.threadId),
+            [ThreadId.make("source-project")],
+          );
+          assert.deepStrictEqual(yield* Ref.get(fixture.summaryCalls), initialReads);
+        }).pipe(Effect.provide(fixture.layer));
+      }),
+    ),
+  );
+
   it.effect("uses fresh settlement settings after lookup and ignores unrelated changes", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/apps/server/src/orchestration/ThreadSettlementReactor.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.ts
@@ -58,10 +58,12 @@ export const make = Effect.gen(function* () {
       const project = projects.get(linked.projectId);
       if (project === undefined) return false;
       const identity = project.repositoryIdentity;
+      // A local Git probe can fail after confirmation. Only the source project
+      // can then reuse the confirmed reference without a repository identity.
       const sameRepository =
-        mergedPullRequest.repositoryKey === null
-          ? linked.projectId === mergedPullRequest.projectId && identity == null
-          : identity?.canonicalKey.toLowerCase() === mergedPullRequest.repositoryKey.toLowerCase();
+        identity == null
+          ? linked.projectId === mergedPullRequest.projectId
+          : identity.canonicalKey.toLowerCase() === mergedPullRequest.repositoryKey?.toLowerCase();
       return (
         sameRepository &&
         (identity?.provider == null ||

--- a/apps/server/src/orchestration/ThreadSettlementReactor.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.ts
@@ -43,14 +43,45 @@ export const make = Effect.gen(function* () {
   const sweep = Effect.fn("ThreadSettlementReactor.sweep")(function* (
     mergedPullRequest: PullRequestService.PullRequestMergeEvent | null,
   ) {
+    const mergedBranches =
+      mergedPullRequest === null ? null : yield* git.observePullRequestMerge(mergedPullRequest);
+    const mergedBranchNames = new Set(mergedBranches?.map(({ branch }) => branch));
+    const mergedBranchKeys = new Set(
+      mergedBranches?.map(({ cwd, branch }) => `${cwd}\u0000${branch}`),
+    );
     const snapshot = yield* snapshots.getShellSnapshot();
     const now = DateTime.formatIso(yield* DateTime.now);
     const projects = new Map(snapshot.projects.map((project) => [project.id, project]));
-    // A merge event re-sweeps every candidate, not just the threads linked to
-    // the merged pull request: most threads carry no link and settle from
-    // their branch lookup, which would otherwise wait for the next minute's
-    // sweep on a possibly stale cached answer.
-    const candidates = snapshot.threads.filter((thread) => isAutoSettlementCandidate(thread, now));
+    const linkedToMerge = (thread: (typeof snapshot.threads)[number]) => {
+      const linked = thread.linkedPullRequest;
+      if (mergedPullRequest === null || linked == null) return false;
+      const project = projects.get(linked.projectId);
+      if (project === undefined) return false;
+      const identity = project.repositoryIdentity;
+      const sameRepository =
+        mergedPullRequest.repositoryKey === null
+          ? linked.projectId === mergedPullRequest.projectId && identity == null
+          : identity?.canonicalKey.toLowerCase() === mergedPullRequest.repositoryKey.toLowerCase();
+      return (
+        sameRepository &&
+        (identity?.provider == null ||
+          identity.provider === "unknown" ||
+          identity.provider === mergedPullRequest.provider) &&
+        linked.url === mergedPullRequest.url &&
+        linked.repository.toLowerCase() === mergedPullRequest.repository.toLowerCase() &&
+        linked.number === mergedPullRequest.number
+      );
+    };
+    // Merge events use known associations only. A cold branch still resolves
+    // during the next periodic sweep, without refreshing unrelated checkouts.
+    const candidates = snapshot.threads.filter(
+      (thread) =>
+        isAutoSettlementCandidate(thread, now) &&
+        (mergedPullRequest === null ||
+          (thread.linkedPullRequest != null
+            ? linkedToMerge(thread)
+            : thread.branch !== null && mergedBranchNames.has(thread.branch))),
+    );
 
     // Return the thread when it still needs a pull request decision. A rejected
     // dispatch skips it for this snapshot instead of retrying through a lookup.
@@ -112,28 +143,18 @@ export const make = Effect.gen(function* () {
           const worktreeExists =
             thread.worktreePath !== null &&
             (yield* fileSystem.exists(thread.worktreePath).pipe(Effect.orElseSucceed(() => false)));
-          lookupCwdByThreadId.set(
-            thread.id,
+          const cwd =
             worktreeExists && thread.worktreePath !== null
               ? thread.worktreePath
-              : project.workspaceRoot,
-          );
+              : project.workspaceRoot;
+          if (mergedPullRequest !== null) {
+            const cacheCwd = yield* fileSystem.realPath(cwd).pipe(Effect.orElseSucceed(() => cwd));
+            if (!mergedBranchKeys.has(`${cacheCwd}\u0000${thread.branch}`)) return;
+          }
+          lookupCwdByThreadId.set(thread.id, cwd);
         }),
       { concurrency: 8, discard: true },
     );
-    if (mergedPullRequest !== null) {
-      // The merge just confirmed a terminal state the lookup caches can still
-      // call open (branch answers live two minutes, the sweep runs every
-      // minute). Drop the swept checkouts' cached answers so the merge settles
-      // its branch threads now instead of on a later sweep. Threads linked to
-      // the merged pull request settle from the event itself below and need no
-      // lookup, so they are absent from this map by construction.
-      const cwds = [...new Set(lookupCwdByThreadId.values())];
-      yield* Effect.forEach(cwds, (cwd) => git.invalidateStatus(cwd), {
-        concurrency: 8,
-        discard: true,
-      });
-    }
     const lookupKey = (thread: (typeof candidates)[number]) => {
       if (thread.linkedPullRequest != null) {
         return JSON.stringify([
@@ -149,24 +170,21 @@ export const make = Effect.gen(function* () {
         cwd === undefined ? ["missing-project", thread.id] : ["branch", cwd, thread.branch],
       );
     };
-    const groups = Map.groupBy(lookupCandidates, lookupKey);
+    const groups = Map.groupBy(
+      lookupCandidates.filter(
+        (thread) =>
+          mergedPullRequest === null ||
+          thread.linkedPullRequest != null ||
+          lookupCwdByThreadId.has(thread.id),
+      ),
+      lookupKey,
+    );
 
     const pullRequestFor = Effect.fn("ThreadSettlementReactor.pullRequestFor")(function* (
       thread: (typeof candidates)[number],
     ) {
       if (thread.linkedPullRequest != null) {
-        // The event carries the merged state, so only the threads linked to
-        // that exact pull request settle from it. Every other linked thread
-        // falls through to a fresh summary lookup below: the merge sweep
-        // covers all candidates, and an unrelated merge must never settle
-        // them.
-        if (
-          mergedPullRequest !== null &&
-          thread.linkedPullRequest.projectId === mergedPullRequest.projectId &&
-          thread.linkedPullRequest.repository.toLowerCase() ===
-            mergedPullRequest.repository.toLowerCase() &&
-          thread.linkedPullRequest.number === mergedPullRequest.number
-        ) {
+        if (mergedPullRequest !== null && linkedToMerge(thread)) {
           return {
             state: "merged",
             mergedAt: mergedPullRequest.mergedAt,

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -1053,6 +1053,76 @@ it.effect("publishes a merge for immediate settlement only after host confirmati
 
       assert.deepStrictEqual(Option.getOrThrow(yield* Fiber.join(observedMerge)), {
         ...reference,
+        provider: "github",
+        url: "https://host/pull/1",
+        repositoryKey: "github.com/acme/web",
+        mergedAt,
+      });
+    }),
+  ),
+);
+
+it.effect("confirms a merge on the action's host when the project is retargeted", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const mergedAt = "2026-09-03T02:00:00.000Z";
+      yield* TestClock.setTime(Date.parse(mergedAt));
+      const actionStarted = yield* Deferred.make<void>();
+      const releaseAction = yield* Deferred.make<void>();
+      const projects = [
+        project({
+          id: "p1",
+          title: "web",
+          workspaceRoot: "/a",
+          repository: "acme/web",
+          host: "code.example.test",
+        }),
+      ];
+      const summaryHosts: string[] = [];
+      const service = yield* makeService({
+        projects,
+        providers: [
+          fakeProvider("github", {
+            runAction: () =>
+              Deferred.succeed(actionStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(releaseAction)),
+              ),
+            getChangeRequestSummary: ({ host }) =>
+              Effect.sync(() => {
+                summaryHosts.push(host);
+                return {
+                  ...changeRequest(1, mergedAt),
+                  url: `https://${host}/acme/web/pull/1`,
+                  state: "merged" as const,
+                };
+              }),
+          }),
+        ],
+      });
+      const reference = { projectId: "p1" as ProjectId, repository: "acme/web", number: 1 };
+      const observedMerge = yield* Stream.runHead(yield* service.subscribeMerges).pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+      const action = yield* service
+        .runAction({ ...reference, action: "merge" })
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(actionStarted);
+      projects[0] = project({
+        id: "p1",
+        title: "web",
+        workspaceRoot: "/a",
+        repository: "acme/web",
+        host: "other.example.test",
+      });
+      yield* Deferred.succeed(releaseAction, undefined);
+      yield* Fiber.join(action);
+
+      assert.deepStrictEqual(summaryHosts, ["code.example.test"]);
+      assert.deepStrictEqual(Option.getOrThrow(yield* Fiber.join(observedMerge)), {
+        ...reference,
+        provider: "github",
+        url: "https://code.example.test/acme/web/pull/1",
+        repositoryKey: "code.example.test/acme/web",
         mergedAt,
       });
     }),

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -69,6 +69,9 @@ import {
 import { PullRequestProviderRegistry } from "./PullRequestProviderRegistry.ts";
 
 export interface PullRequestMergeEvent extends PullRequestRef {
+  readonly provider: SourceControlProviderKind;
+  readonly url: string;
+  readonly repositoryKey: string | null;
   readonly mergedAt: string;
 }
 
@@ -1231,39 +1234,38 @@ export const make = Effect.gen(function* () {
   const viewerOf = (project: SupportedProject): Effect.Effect<string | null> =>
     resolveViewers([project], new Map()).pipe(Effect.map(([resolved]) => resolved?.viewer ?? null));
 
-  const summaryUncached: PullRequestService["Service"]["summary"] = (input) =>
-    requireProject(input).pipe(
-      Effect.flatMap((project) => {
-        const providerInput = {
-          cwd: project.project.workspaceRoot,
-          repository: project.repository,
-          host: project.host,
-          number: input.number,
-        };
-        const read =
-          project.api.getChangeRequestSummary === undefined
-            ? project.api.getChangeRequest(providerInput)
-            : project.api.getChangeRequestSummary(providerInput);
-        return read.pipe(
-          Effect.mapError(toPullRequestError("summary")),
-          Effect.map((changeRequest): PullRequestSummary => ({
-            provider: project.api.kind,
-            projectId: project.project.id,
-            repository: project.repository,
-            number: changeRequest.number,
-            title: changeRequest.title,
-            url: changeRequest.url,
-            state: changeRequest.state,
-            ...(changeRequest.isDraft === true ? { isDraft: true } : {}),
-            headBranch: changeRequest.headBranch,
-            baseBranch: changeRequest.baseBranch,
-            closedAt: changeRequest.closedAt ?? null,
-            mergedAt: changeRequest.mergedAt ?? null,
-            updatedAt: changeRequest.updatedAt,
-          })),
-        );
-      }),
+  const readSummary = (project: SupportedProject, number: number) => {
+    const providerInput = {
+      cwd: project.project.workspaceRoot,
+      repository: project.repository,
+      host: project.host,
+      number,
+    };
+    const read =
+      project.api.getChangeRequestSummary === undefined
+        ? project.api.getChangeRequest(providerInput)
+        : project.api.getChangeRequestSummary(providerInput);
+    return read.pipe(
+      Effect.mapError(toPullRequestError("summary")),
+      Effect.map((changeRequest): PullRequestSummary => ({
+        provider: project.api.kind,
+        projectId: project.project.id,
+        repository: project.repository,
+        number: changeRequest.number,
+        title: changeRequest.title,
+        url: changeRequest.url,
+        state: changeRequest.state,
+        ...(changeRequest.isDraft === true ? { isDraft: true } : {}),
+        headBranch: changeRequest.headBranch,
+        baseBranch: changeRequest.baseBranch,
+        closedAt: changeRequest.closedAt ?? null,
+        mergedAt: changeRequest.mergedAt ?? null,
+        updatedAt: changeRequest.updatedAt,
+      })),
     );
+  };
+  const summaryUncached: PullRequestService["Service"]["summary"] = (input) =>
+    requireProject(input).pipe(Effect.flatMap((project) => readSummary(project, input.number)));
 
   const detailUncached: PullRequestService["Service"]["detail"] = (input) =>
     requireProject(input).pipe(
@@ -1431,9 +1433,11 @@ export const make = Effect.gen(function* () {
       }),
     );
 
-  const runAction = (input: PullRequestActionInput): Effect.Effect<string, PullRequestError> =>
+  const runAction = (
+    input: PullRequestActionInput,
+  ): Effect.Effect<SupportedProject, PullRequestError> =>
     requireProject(input).pipe(
-      Effect.flatMap((project): Effect.Effect<string, PullRequestError> => {
+      Effect.flatMap((project): Effect.Effect<SupportedProject, PullRequestError> => {
         // The surface hides what a host cannot do, and this refuses it as well: a request that
         // reached here anyway must not be handed to a provider that never claimed the action.
         if (!project.api.capabilities.actions.includes(input.action)) {
@@ -1475,7 +1479,7 @@ export const make = Effect.gen(function* () {
         // have to say yes. The second is asked last, because it costs a request and the checks
         // above do not.
         return viewerPermissionsOf(project, input, "runAction").pipe(
-          Effect.flatMap((viewer): Effect.Effect<string, PullRequestError> => {
+          Effect.flatMap((viewer): Effect.Effect<SupportedProject, PullRequestError> => {
             if (!viewer.actions.includes(input.action)) {
               return Effect.fail(
                 new PullRequestOperationError({
@@ -1505,10 +1509,7 @@ export const make = Effect.gen(function* () {
                 ...(input.mergeMethod === undefined ? {} : { mergeMethod: input.mergeMethod }),
                 ...(input.updateMethod === undefined ? {} : { updateMethod: input.updateMethod }),
               })
-              .pipe(
-                Effect.mapError(toPullRequestError("runAction")),
-                Effect.as(project.repository),
-              );
+              .pipe(Effect.mapError(toPullRequestError("runAction")), Effect.as(project));
           }),
         );
       }),
@@ -2497,12 +2498,13 @@ export const make = Effect.gen(function* () {
   const runActionAndInvalidate: PullRequestService["Service"]["runAction"] = Effect.fn(
     "PullRequestService.runActionAndInvalidate",
   )(function* (input) {
-    const repository = yield* runAction(input);
+    const project = yield* runAction(input);
+    const repository = project.repository;
     bumpRefEpoch({ ...input, repository });
     listingsEpoch = ++epochCounter;
     if (input.action === "merge") {
       // A successful merge action can merely enqueue the PR or enable auto-merge.
-      const confirmed = yield* summaryUncached({ ...input, repository }).pipe(
+      const confirmed = yield* readSummary(project, input.number).pipe(
         Effect.catch((error) =>
           Effect.logWarning("failed to confirm pull request merge", { error }).pipe(
             Effect.as(null),
@@ -2514,6 +2516,9 @@ export const make = Effect.gen(function* () {
         projectId: input.projectId,
         repository,
         number: input.number,
+        provider: confirmed.provider,
+        url: confirmed.url,
+        repositoryKey: project.project.repositoryIdentity?.canonicalKey ?? null,
         mergedAt: DateTime.formatIso(yield* DateTime.now),
       });
     }


### PR DESCRIPTION
Merging one PR rechecked every candidate checkout. Threads linked through another project root could need a separate host read for the same confirmed merge.

Share confirmed merge state by provider and full PR URL. Refresh only known branch associations and matching linked references. Recheck affected branch associations before settlement, so a newer PR on the same branch stays active. Keep fork and upstream checks and failure fallback. An older open response cannot undo a confirmed merge.

Confirmed merges retire in batches of 2,048. Retiring a batch clears its cached lookup answers and makes pending old reads retry. This keeps memory bounded at the cost of a rare full PR cache refresh.

Branches with no known PR association still use the regular one-minute sweep. The existing account boundary is the host. Viewer data and permissions are not shared by this change.

Depends on [#10103](https://github.com/pingdotgg/t3code/pull/10103). Merge that PR first, then this PR.

## Verification

- 241 tests pass in the existing GitManager, PullRequestService, ThreadSettlementReactor, and ThreadSettlementPolicy suites with one test worker.
- Server typecheck passes.
- Lint passes on the six changed files, with one existing warning.
- Tests cover two worktrees, renamed and fork branches, host and port isolation, Azure project scope, late responses, warm branch reuse, project retargeting, cache retirement, and lookup failures.

Created with GPT-6 Astra in Codex. Follow-up fixes and current-main integration completed with Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh only threads for the exactly merged PR in `ThreadSettlementReactor.sweep`
> - Merge-triggered sweeps now call `GitManager.observePullRequestMerge` to get the checkout/branch pairs affected by the merge, and settle only those plus exactly linked pull-request threads — unrelated linked requests and cold branches are excluded.
> - `GitManager` records confirmed merges keyed by provider and full pull-request URL without querying the provider, immediately marks matching known branches as merged, and invalidates only their remote-status entries.
> - `branchPullRequest` lookups use revision-aware cache reads so a stale cached open-PR association is retried and overlaid with the observed merged state instead of returning the old result.
> - `PullRequestService` enriches `PullRequestMergeEvent` with provider kind, full PR URL, and canonical repository key, and confirms merges against the project selected when the action started rather than a project retargeted mid-action.
> - Risk: `PullRequestMergeEvent` gains new required fields (`providerKind`, `pullRequestUrl`, `repositoryKey`); any out-of-tree consumers of that event contract must be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a537f84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
