### PR TITLE
fix(web): toggle the terminal from a bottom-edge tab

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1764,6 +1764,23 @@ describe("session branch mismatch dismissal", () => {
 });
 
 describe("reconcileMountedTerminalThreadIds", () => {
+  it("retains a closed active drawer until navigation without mounting unopened drawers", () => {
+    const closed = reconcileMountedTerminalThreadIds({
+      currentThreadIds: ["thread-a"],
+      openThreadIds: [],
+      activeThreadId: "thread-a",
+      activeThreadTerminalOpen: false,
+    });
+    expect(closed).toEqual(["thread-a"]);
+    expect(
+      reconcileMountedTerminalThreadIds({
+        currentThreadIds: closed,
+        openThreadIds: [],
+        activeThreadId: "thread-b",
+        activeThreadTerminalOpen: false,
+      }),
+    ).toEqual([]);
+  });
   it("keeps open threads and makes the active thread most recent", () => {
     expect(
       reconcileMountedTerminalThreadIds({

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -659,7 +659,11 @@ export function reconcileMountedTerminalThreadIds(input: {
     currentThreadIds: input.currentThreadIds,
     openThreadIds: input.openThreadIds,
     activeThreadId: input.activeThreadId,
-    activeThreadOpen: input.activeThreadTerminalOpen,
+    // Keep the active drawer mounted after closing so CSS can finish its
+    // transition and reopening can reuse the viewport. Navigation releases it.
+    activeThreadOpen:
+      input.activeThreadTerminalOpen ||
+      (input.activeThreadId !== null && input.currentThreadIds.includes(input.activeThreadId)),
     maxHiddenThreadCount: input.maxHiddenThreadCount ?? MAX_HIDDEN_MOUNTED_TERMINAL_THREADS,
   });
 }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -334,7 +334,11 @@ import type { AssistantCitationRequest } from "./chat/AssistantCitationSource";
 import { resolveTimelineIsAtEnd } from "./chat/MessagesTimeline.logic";
 import { resolveComposerTimelineInset, resolveScrollToEndClearance } from "./composerFooterLayout";
 import { ChatHeader } from "./chat/ChatHeader";
-import { PanelLayoutControls, RightPanelMaximizeControl } from "./chat/PanelLayoutControls";
+import {
+  PanelLayoutControls,
+  RightPanelMaximizeControl,
+  TerminalDrawerToggle,
+} from "./chat/PanelLayoutControls";
 import { expandedImageKey, type ExpandedImagePreview } from "./chat/ExpandedImagePreview";
 import { NoActiveThreadState } from "./NoActiveThreadState";
 import { WorkspacePageHeader } from "./WorkspacePageHeader";
@@ -867,6 +871,8 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     selectThreadTerminalUiState(state.terminalUiStateByThreadKey, threadRef),
   );
   const visible = active && terminalUiState.terminalOpen;
+  const { active: animateDrawer, durationMs: drawerAnimationDurationMs } =
+    usePanelAnimationSettings(200);
   const knownTerminalSessions = useKnownTerminalSessions({
     environmentId: threadRef.environmentId,
     threadId,
@@ -1160,10 +1166,11 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
       className={cn(
         "grid shrink-0 overflow-clip",
         active ? (visible ? "grid-rows-[1fr]" : "grid-rows-[0fr]") : "hidden",
-        active &&
-          "[[data-panel-animations=true]_&]:transition-[grid-template-rows] [[data-panel-animations=true]_&]:[transition-duration:var(--panel-animation-duration)] [[data-panel-animations=true]_&]:ease-out",
-        active && visible && "[[data-panel-animations=true]_&]:starting:grid-rows-[0fr]!",
+        active && animateDrawer && "transition-[grid-template-rows] ease-out",
+        active && animateDrawer && visible && "starting:grid-rows-[0fr]!",
       )}
+      style={{ transitionDuration: animateDrawer ? `${drawerAnimationDurationMs}ms` : undefined }}
+      inert={!visible}
     >
       <div className="min-h-0 overflow-clip">
         <ThreadTerminalDrawer
@@ -1935,13 +1942,6 @@ export default function ChatView(props: ChatViewProps) {
   const rightPanelOpen = rightPanelState.isOpen;
   const { active: panelAnimationsActive, durationMs: panelAnimationDurationMs } =
     usePanelAnimationSettings();
-  const activeTerminalDrawerPresence = usePanelPresence(
-    Boolean(activeThreadKey && terminalUiState.terminalOpen),
-    true,
-    panelAnimationsActive,
-    activeThreadKey,
-    panelAnimationDurationMs,
-  );
   const rightPanelPresenceValue = useMemo(
     () => ({
       activeSurface: activeRightPanelSurface,
@@ -2017,7 +2017,7 @@ export default function ChatView(props: ChatViewProps) {
         currentThreadIds,
         openThreadIds: existingOpenTerminalThreadKeys,
         activeThreadId: activeThreadKey,
-        activeThreadTerminalOpen: activeTerminalDrawerPresence.present,
+        activeThreadTerminalOpen: terminalUiState.terminalOpen,
         maxHiddenThreadCount: MAX_HIDDEN_MOUNTED_TERMINAL_THREADS,
       });
       return currentThreadIds.length === nextThreadIds.length &&
@@ -2025,7 +2025,7 @@ export default function ChatView(props: ChatViewProps) {
         ? currentThreadIds
         : nextThreadIds;
     });
-  }, [activeTerminalDrawerPresence.present, activeThreadKey, existingOpenTerminalThreadKeys]);
+  }, [terminalUiState.terminalOpen, activeThreadKey, existingOpenTerminalThreadKeys]);
   const latestTurnSettled = isLatestTurnSettled(activeLatestTurn, activeThread?.session ?? null);
   const activeProjectRef = useMemo(
     () =>
@@ -8152,8 +8152,26 @@ export default function ChatView(props: ChatViewProps) {
     return <NoActiveThreadState />;
   }
 
+  const terminalDrawerControls = (
+    <div
+      className="absolute right-[calc(env(safe-area-inset-right)+0.75rem)] bottom-full z-30"
+      data-terminal-drawer-controls
+    >
+      <TerminalDrawerToggle
+        attached
+        terminalAvailable={activeProject !== null}
+        terminalOpen={terminalUiState.terminalOpen}
+        terminalShortcutLabel={shortcutLabelForCommand(keybindings, "terminal.toggle")}
+        onToggleTerminal={() => {
+          if (shouldUseRightPanelSheet && rightPanelOpen) closePreviewPanel();
+          toggleTerminalVisibility();
+        }}
+      />
+    </div>
+  );
   const panelToggleControls = (
     <PanelLayoutControls
+      showTerminalControl={rightPanelMaximized}
       terminalAvailable={activeProject !== null}
       terminalOpen={terminalUiState.terminalOpen}
       terminalShortcutLabel={shortcutLabelForCommand(keybindings, "terminal.toggle")}
@@ -8872,24 +8890,38 @@ export default function ChatView(props: ChatViewProps) {
         </div>
         {/* end horizontal flex container */}
 
-        {mountedTerminalThreadRefs.map(({ key: mountedThreadKey, threadRef: mountedThreadRef }) => (
-          <PersistentThreadTerminalDrawer
-            key={mountedThreadKey}
-            threadRef={mountedThreadRef}
-            threadId={mountedThreadRef.threadId}
-            active={mountedThreadKey === activeThreadKey}
-            launchContext={
-              mountedThreadKey === activeThreadKey ? (activeTerminalLaunchContext ?? null) : null
-            }
-            focusRequestId={mountedThreadKey === activeThreadKey ? terminalFocusRequestId : 0}
-            splitShortcutLabel={splitTerminalShortcutLabel ?? undefined}
-            splitVerticalShortcutLabel={splitTerminalVerticalShortcutLabel ?? undefined}
-            newShortcutLabel={newTerminalShortcutLabel ?? undefined}
-            closeShortcutLabel={closeTerminalShortcutLabel ?? undefined}
-            keybindings={keybindings}
-            onAddTerminalContext={addTerminalContextToDraft}
-          />
-        ))}
+        <div
+          className="relative shrink-0"
+          // Maximizing the inline right panel collapses this column to w-0
+          // with clipped overflow; keep the toggle out of the tab order
+          // instead of leaving an invisible, focusable control behind.
+          inert={rightPanelMaximized || undefined}
+        >
+          {!(rightPanelPresent && shouldUseRightPanelSheet && activeThreadRef) &&
+            terminalDrawerControls}
+          {mountedTerminalThreadRefs.map(
+            ({ key: mountedThreadKey, threadRef: mountedThreadRef }) => (
+              <PersistentThreadTerminalDrawer
+                key={mountedThreadKey}
+                threadRef={mountedThreadRef}
+                threadId={mountedThreadRef.threadId}
+                active={mountedThreadKey === activeThreadKey}
+                launchContext={
+                  mountedThreadKey === activeThreadKey
+                    ? (activeTerminalLaunchContext ?? null)
+                    : null
+                }
+                focusRequestId={mountedThreadKey === activeThreadKey ? terminalFocusRequestId : 0}
+                splitShortcutLabel={splitTerminalShortcutLabel ?? undefined}
+                splitVerticalShortcutLabel={splitTerminalVerticalShortcutLabel ?? undefined}
+                newShortcutLabel={newTerminalShortcutLabel ?? undefined}
+                closeShortcutLabel={closeTerminalShortcutLabel ?? undefined}
+                keybindings={keybindings}
+                onAddTerminalContext={addTerminalContextToDraft}
+              />
+            ),
+          )}
+        </div>
       </div>
 
       {rightPanelPresent && !shouldUseRightPanelSheet && activeThreadRef ? (
@@ -8994,6 +9026,9 @@ export default function ChatView(props: ChatViewProps) {
           >
             {rightPanelContent}
           </RightPanelTabs>
+          <div className="absolute inset-x-0 bottom-[env(safe-area-inset-bottom)]">
+            {terminalDrawerControls}
+          </div>
         </RightPanelSheet>
       ) : null}
 

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -371,6 +371,18 @@ export function TerminalViewport({
     reportFailure: false,
   });
   const hasHandledExitRef = useRef(false);
+  // Retained drawers stay mounted while closed, so a failed libghostty setup
+  // no longer remounts on reopen. Retry the setup the next time the viewport
+  // becomes visible to keep "close and reopen the terminal" a working
+  // recovery path for the failure message below.
+  const [setupAttempt, setSetupAttempt] = useState(0);
+  const setupFailedRef = useRef(false);
+  useEffect(() => {
+    if (!visible || !setupFailedRef.current) return;
+    setupFailedRef.current = false;
+    if (containerRef.current) containerRef.current.textContent = "";
+    setSetupAttempt((attempt) => attempt + 1);
+  }, [visible]);
   const selectionActionRequestIdRef = useRef(0);
   // Holds the request id of the selection popup currently on screen, so a
   // popup that was superseded (but whose menu promise has not settled yet)
@@ -909,6 +921,7 @@ export function TerminalViewport({
         setupTerminal?.dispose();
         setupTerminal = null;
         if (cancelled) return;
+        setupFailedRef.current = true;
         const message =
           error instanceof Error ? error.message : "Unable to initialize libghostty-vt";
         mount.textContent = `${message} — close and reopen the terminal to retry.`;
@@ -920,7 +933,7 @@ export function TerminalViewport({
       teardown?.();
       if (hadFocus && mount.isConnected) mount.focus({ preventScroll: true });
     };
-  }, [cwd, environmentId, runtimeEnvKey, terminalId, threadId, worktreePath]);
+  }, [cwd, environmentId, runtimeEnvKey, setupAttempt, terminalId, threadId, worktreePath]);
 
   useEffect(() => {
     const terminal = terminalRef.current;

--- a/apps/web/src/components/chat/PanelLayoutControls.tsx
+++ b/apps/web/src/components/chat/PanelLayoutControls.tsx
@@ -1,6 +1,8 @@
-import { Maximize2Icon, Minimize2Icon, PanelBottomIcon, PanelRightIcon } from "lucide-react";
+import { Maximize2Icon, Minimize2Icon, SquareTerminalIcon, PanelRightIcon } from "lucide-react";
 import { memo } from "react";
 
+// Reuses the project Toggle; the attached drawer treatment is a local variant.
+// https://ui.shadcn.com/docs/components/base/toggle
 import { Toggle } from "../ui/toggle";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
@@ -18,6 +20,40 @@ interface PanelLayoutControlsProps {
   onToggleTerminal: () => void;
   onToggleRightPanel: () => void;
 }
+
+export const TerminalDrawerToggle = memo(function TerminalDrawerToggle({
+  attached = false,
+  terminalAvailable,
+  terminalOpen,
+  terminalShortcutLabel,
+  onToggleTerminal,
+}: Pick<
+  PanelLayoutControlsProps,
+  "terminalAvailable" | "terminalOpen" | "terminalShortcutLabel" | "onToggleTerminal"
+> & { attached?: boolean }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger render={<span className="flex shrink-0" />}>
+        <Toggle
+          className="[-webkit-app-region:no-drag]"
+          pressed={terminalOpen}
+          onPressedChange={onToggleTerminal}
+          aria-label="Toggle terminal drawer"
+          variant={attached ? "drawer" : "ghost"}
+          size={attached ? "drawer" : "sm"}
+          disabled={!terminalAvailable}
+        >
+          <SquareTerminalIcon className="size-4" />
+        </Toggle>
+      </TooltipTrigger>
+      <TooltipPopup side="top">
+        {terminalAvailable
+          ? `Toggle terminal drawer${terminalShortcutLabel ? ` (${terminalShortcutLabel})` : ""}`
+          : "Terminal drawer is unavailable"}
+      </TooltipPopup>
+    </Tooltip>
+  );
+});
 
 export const PanelLayoutControls = memo(function PanelLayoutControls({
   showTerminalControl = true,
@@ -38,26 +74,12 @@ export const PanelLayoutControls = memo(function PanelLayoutControls({
       data-panel-layout-controls
     >
       {showTerminalControl ? (
-        <Tooltip>
-          <TooltipTrigger render={<span className="flex shrink-0" />}>
-            <Toggle
-              className="shrink-0 [-webkit-app-region:no-drag]"
-              pressed={terminalOpen}
-              onPressedChange={onToggleTerminal}
-              aria-label="Toggle terminal drawer"
-              variant="ghost"
-              size="sm"
-              disabled={!terminalAvailable}
-            >
-              <PanelBottomIcon className="size-4" />
-            </Toggle>
-          </TooltipTrigger>
-          <TooltipPopup side="bottom">
-            {terminalAvailable
-              ? `Toggle terminal drawer${terminalShortcutLabel ? ` (${terminalShortcutLabel})` : ""}`
-              : "Terminal drawer is unavailable"}
-          </TooltipPopup>
-        </Tooltip>
+        <TerminalDrawerToggle
+          terminalAvailable={terminalAvailable}
+          terminalOpen={terminalOpen}
+          terminalShortcutLabel={terminalShortcutLabel}
+          onToggleTerminal={onToggleTerminal}
+        />
       ) : null}
       <Tooltip>
         <TooltipTrigger render={<span className="flex shrink-0" />}>

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1296,7 +1296,7 @@ export function AppearanceSettingsPanel() {
       <SettingsSection id="motion" title="Motion">
         <SettingsRow
           {...searchableSetting("panel-animations")}
-          description="Set how fast panels open and close."
+          description="Set how fast panels open and close. The terminal drawer uses at least 200 ms. Reduced motion disables panel animations."
           control={
             <div className="grid w-full grid-cols-[5rem_minmax(0,1fr)] items-center gap-3 sm:w-auto sm:grid-cols-[7rem_13rem] sm:gap-4">
               <PanelAnimationsPreview durationMs={settings.panelAnimationDurationMs} />

--- a/apps/web/src/components/ui/toggle.tsx
+++ b/apps/web/src/components/ui/toggle.tsx
@@ -14,6 +14,7 @@ const toggleVariants = cva(
     },
     variants: {
       size: {
+        drawer: "h-8 w-10 px-[calc(--spacing(1.5)-1px)]",
         compact:
           "h-7 min-w-7 rounded-md px-[calc(--spacing(1)-1px)] text-xs before:rounded-[calc(var(--radius-md)-1px)] [&_svg:not([class*='size-'])]:size-3.5",
         default: "h-9 min-w-9 px-[calc(--spacing(2)-1px)] sm:h-8 sm:min-w-8",
@@ -24,6 +25,8 @@ const toggleVariants = cva(
         xs: "h-7 min-w-7 px-[calc(--spacing(1)-1px)] sm:h-6 sm:min-w-6 rounded-md",
       },
       variant: {
+        drawer:
+          "rounded-t-lg rounded-b-none border-b-0 border-border bg-muted shadow-none before:shadow-none data-pressed:bg-accent data-pressed:text-accent-foreground disabled:opacity-100 disabled:text-muted-foreground disabled:[&_svg]:opacity-100",
         default: "border-transparent",
         ghost:
           "border-transparent text-foreground shadow-none [:disabled,:active,[data-pressed]]:shadow-none before:shadow-none data-pressed:bg-accent data-pressed:text-accent-foreground disabled:opacity-100 disabled:text-muted-foreground disabled:[&_svg]:opacity-100",

--- a/apps/web/src/panelAnimations.test.tsx
+++ b/apps/web/src/panelAnimations.test.tsx
@@ -2,7 +2,11 @@ import { act, useLayoutEffect } from "react";
 import { create, type ReactTestRenderer } from "react-test-renderer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { usePanelNavigationSuppression } from "./panelAnimations";
+import {
+  PanelAnimationSuppressionProvider,
+  usePanelAnimationSettings,
+  usePanelNavigationSuppression,
+} from "./panelAnimations";
 
 let renderer: ReactTestRenderer | null = null;
 let pendingFrames: FrameRequestCallback[] = [];
@@ -62,3 +66,43 @@ describe("usePanelNavigationSuppression", () => {
     expect(observed.at(-1)).toBe(false);
   });
 });
+
+const motionSettings = vi.hoisted(() => ({ durationMs: 0, reducedMotion: false }));
+vi.mock("./hooks/useSettings", () => ({
+  useClientSettings: (select: (settings: { panelAnimationDurationMs: number }) => unknown) =>
+    select({ panelAnimationDurationMs: motionSettings.durationMs }),
+}));
+vi.mock("./hooks/useMediaQuery", () => ({
+  useMediaQuery: () => motionSettings.reducedMotion,
+}));
+
+it.each([
+  { configured: 0, minimum: 200, reduced: false, suppressed: false, duration: 200, active: true },
+  { configured: 100, minimum: 200, reduced: false, suppressed: false, duration: 200, active: true },
+  { configured: 350, minimum: 200, reduced: false, suppressed: false, duration: 350, active: true },
+  { configured: 0, minimum: 200, reduced: true, suppressed: false, duration: 200, active: false },
+  { configured: 0, minimum: 200, reduced: false, suppressed: true, duration: 200, active: false },
+  { configured: 0, minimum: 0, reduced: false, suppressed: false, duration: 0, active: false },
+])(
+  "resolves drawer motion with $configured ms, reduced=$reduced, suppressed=$suppressed",
+  async ({ configured, minimum, reduced, suppressed, duration, active }) => {
+    motionSettings.durationMs = configured;
+    motionSettings.reducedMotion = reduced;
+    let result: ReturnType<typeof usePanelAnimationSettings> | undefined;
+    function Probe() {
+      const settings = usePanelAnimationSettings(minimum);
+      useLayoutEffect(() => {
+        result = settings;
+      }, [settings]);
+      return null;
+    }
+    await act(() => {
+      renderer = create(
+        <PanelAnimationSuppressionProvider value={suppressed}>
+          <Probe />
+        </PanelAnimationSuppressionProvider>,
+      );
+    });
+    expect(result).toEqual({ active, durationMs: duration });
+  },
+);

--- a/apps/web/src/panelAnimations.ts
+++ b/apps/web/src/panelAnimations.ts
@@ -68,11 +68,12 @@ export function observeResponsiveBreakpointFade(options: {
   };
 }
 
-export function usePanelAnimationSettings(): {
+export function usePanelAnimationSettings(minimumDurationMs = 0): {
   active: boolean;
   durationMs: PanelAnimationDurationMs;
 } {
-  const durationMs = useClientSettings((settings) => settings.panelAnimationDurationMs);
+  const configuredDurationMs = useClientSettings((settings) => settings.panelAnimationDurationMs);
+  const durationMs = Math.max(minimumDurationMs, configuredDurationMs);
   const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
   const suppressed = useContext(PanelAnimationSuppressionContext);
   return { active: durationMs > 0 && !prefersReducedMotion && !suppressed, durationMs };


### PR DESCRIPTION
## Problem

The terminal toggle sat in the top-right titlebar, and the terminal appeared instantly at the bottom of the window, at the far side of the screen from the click. It was hard to see what the click had done.

## Fix

- Replace the titlebar toggle with a small terminal-icon tab attached to the drawer's top edge at the bottom-right of the chat column. The tab takes no layout space and moves with the drawer as it opens, closes, and resizes.
- The drawer opens and closes over at least 200 ms (`usePanelAnimationSettings(200)`), so it visibly rises from the bottom. Longer configured panel durations still apply. Reduced motion and navigation restoration stay immediate. The Motion setting description says this. **Maintainer call:** with the product default of 0 ms, this means the drawer now animates by default.
- The closed active drawer stays mounted (and `inert`) so the close transition can finish and reopening reuses the viewport. Navigating away releases it (`reconcileMountedTerminalThreadIds`). A failed libghostty setup is retried when the drawer next becomes visible, so "close and reopen the terminal to retry" still works. A stale, cancelled setup cannot mark the current one as failed.
- Compact layouts: while the right-panel sheet is open, the sheet has the only toggle, and using it closes the sheet. When the inline right panel is maximized, the titlebar toggle comes back because the chat column (and its tab) is collapsed and inert.
- The tab uses a new `drawer` size and variant on the shared `Toggle` primitive. Header instances keep the ghost styling.

Rebased onto current `main` as a single commit. The web app is the only client with this control, so desktop, which wraps web, gets it too. Mobile has its own terminal controls and is unchanged. No contract or server changes.

## UI changes

These recordings were made on an earlier revision of this branch. Same isolated web fixture, 1280 × 800, dark appearance, 280 px drawer. Before: `6270a6f88`, after: `cc92226bc`.

**After: the tab moves with the terminal as it opens and closes.**

![After: terminal opens upward and closes with its tab attached](https://github.com/saphid/t3code/releases/download/pr-10117-terminal-evidence/terminal-attached-realtime.gif)

**Before: the terminal appears and disappears instantly from the top-right control.**

![Before: instant terminal opening and closing](https://github.com/saphid/t3code/releases/download/pr-10117-terminal-evidence/terminal-before-realtime.gif)

<details>
<summary>Stills and videos</summary>

![Before: open terminal and titlebar toggle](https://github.com/saphid/t3code/releases/download/pr-10117-terminal-evidence/terminal-before-clear.png)

![After: open terminal and attached tab](https://github.com/saphid/t3code/releases/download/pr-10117-terminal-evidence/terminal-after-clear.png)

[Before video](https://github.com/saphid/t3code/releases/download/pr-10117-terminal-evidence/before-clean.mp4) · [After video](https://github.com/saphid/t3code/releases/download/pr-10117-terminal-evidence/attached-clean.mp4)

</details>

The compact-sheet and maximized-panel follow-ups have not had an integrated browser pass. They are covered by source review and typecheck only.

## Verification (on the rebased head)

- `cd apps/web && vp test run src/components/ChatView.logic.test.ts src/panelAnimations.test.tsx`: 145 tests pass. They cover retaining the drawer, releasing it on navigation, and the 200 ms minimum with reduced motion and suppression.
- `apps/web` typecheck passes. Targeted `vp lint` on the touched files shows only warnings that already exist on `main`.

Coordination trace: T3 thread 9277c060-1cf3-43ed-9b46-c6676f6decd1

Implemented by GPT-6 in the Codex/T3 harness. Rebased and updated by Claude Opus 5 in Claude Code (T3 Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent terminal drawer controls above mounted terminals and in the right-panel sheet.
  - Added updated terminal toggle styling and iconography.
  - Terminal setup now automatically retries when a previously failed terminal is closed and reopened.
  - Active terminal drawers remain available until navigating to another thread.

- **Bug Fixes**
  - Improved terminal drawer mounting and visibility behavior.
  - Ensured closed drawers are not mounted unnecessarily.

- **Documentation**
  - Clarified terminal drawer animation timing and reduced-motion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->