### PR TITLE
perf(web): skip checkpoint map rebuilds while streaming

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1,6 +1,5 @@
 import {
   ANTIGRAVITY_DEFAULT_MODEL,
-  CheckpointRef,
   EnvironmentId,
   MessageId,
   ProjectId,
@@ -13,7 +12,6 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import type { Thread, ThreadShell, TurnDiffSummary } from "../types";
-import type { TimelineEntry } from "../session-logic";
 import { deriveProviderInstanceEntries, NO_PROVIDER_MODEL_SELECTION } from "../providerInstances";
 import type { CodexArtifactTemplate } from "@t3tools/client-runtime/codex-artifact-templates";
 import type { RightPanelSurface } from "../rightPanelStore";
@@ -24,7 +22,6 @@ import {
   branchMismatchKey,
   buildExpiredTerminalContextToastCopy,
   buildLoadingThreadFromShell,
-  buildRevertTurnCountByUserMessageId,
   buildThreadTurnInterruptInput,
   createLocalDispatchSnapshot,
   deriveComposerSendState,
@@ -1124,128 +1121,6 @@ describe("resolveComposerInteractionMode", () => {
         interactionMode: "plan",
       }),
     ).toEqual({ enabled: false, interactionMode: "default" });
-  });
-});
-
-describe("buildRevertTurnCountByUserMessageId", () => {
-  const userMessageId = MessageId.make("rewind-user-message");
-  const assistantMessageId = MessageId.make("rewind-assistant-message");
-  const turnId = TurnId.make("rewind-turn");
-  const timelineEntries = [
-    {
-      id: userMessageId,
-      kind: "message",
-      createdAt: now,
-      message: {
-        id: userMessageId,
-        role: "user",
-        text: "Update the file",
-        turnId,
-        createdAt: now,
-        updatedAt: now,
-        streaming: false,
-      },
-    },
-    {
-      id: assistantMessageId,
-      kind: "message",
-      createdAt: now,
-      message: {
-        id: assistantMessageId,
-        role: "assistant",
-        text: "Updated the file",
-        turnId,
-        createdAt: now,
-        updatedAt: now,
-        streaming: false,
-      },
-    },
-  ] satisfies ReadonlyArray<TimelineEntry>;
-  const turnDiffSummaryByAssistantMessageId = new Map<MessageId, TurnDiffSummary>([
-    [
-      assistantMessageId,
-      {
-        turnId,
-        checkpointTurnCount: 1,
-        checkpointRef: CheckpointRef.make("refs/t3/checkpoints/rewind-turn"),
-        status: "ready",
-        files: [],
-        assistantMessageId,
-        completedAt: now,
-      },
-    ],
-  ]);
-
-  it("offers the checkpoint before the user message when conversation rollback is supported", () => {
-    expect(
-      buildRevertTurnCountByUserMessageId({
-        supportsConversationRollback: true,
-        timelineEntries,
-        turnDiffSummaryByAssistantMessageId,
-        inferredCheckpointTurnCountByTurnId: {},
-      }),
-    ).toEqual(new Map([[userMessageId, 0]]));
-  });
-
-  it("offers no rewind action when file checkpoints exist but conversation rollback is unsupported", () => {
-    expect(
-      buildRevertTurnCountByUserMessageId({
-        supportsConversationRollback: false,
-        timelineEntries,
-        turnDiffSummaryByAssistantMessageId,
-        inferredCheckpointTurnCountByTurnId: {},
-      }).size,
-    ).toBe(0);
-  });
-
-  it.each([true, false])(
-    "returns the previous map when contents are unchanged (rollback supported: %s)",
-    (supportsConversationRollback) => {
-      const input = {
-        supportsConversationRollback,
-        timelineEntries,
-        turnDiffSummaryByAssistantMessageId,
-        inferredCheckpointTurnCountByTurnId: {},
-      };
-      const previous = buildRevertTurnCountByUserMessageId(input);
-      const streamed = timelineEntries.map((entry) =>
-        entry.message.role === "assistant"
-          ? { ...entry, message: { ...entry.message, text: "Updated the file again" } }
-          : entry,
-      );
-
-      expect(
-        buildRevertTurnCountByUserMessageId({ ...input, timelineEntries: streamed }, previous),
-      ).toBe(previous);
-    },
-  );
-
-  it("returns a new map when a revert target changes", () => {
-    const input = {
-      supportsConversationRollback: true,
-      timelineEntries,
-      turnDiffSummaryByAssistantMessageId,
-      inferredCheckpointTurnCountByTurnId: {},
-    };
-    const previous = buildRevertTurnCountByUserMessageId(input);
-    const next = buildRevertTurnCountByUserMessageId(
-      {
-        ...input,
-        turnDiffSummaryByAssistantMessageId: new Map([
-          [
-            assistantMessageId,
-            {
-              ...turnDiffSummaryByAssistantMessageId.get(assistantMessageId)!,
-              checkpointTurnCount: 3,
-            },
-          ],
-        ]),
-      },
-      previous,
-    );
-
-    expect(next).not.toBe(previous);
-    expect(next).toEqual(new Map([[userMessageId, 2]]));
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -38,7 +38,6 @@ import {
 } from "../types";
 import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
 import * as Schema from "effect/Schema";
-import { shallow } from "zustand/vanilla/shallow";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { environmentThreadDetails } from "../state/threads";
 import {
@@ -463,53 +462,6 @@ export function getAntigravitySendBlockReason(
     return "That Antigravity model is no longer available. Choose another model.";
   }
   return null;
-}
-
-/**
- * Maps each user message to the checkpoint turn count a revert should target.
- * Returns `previous` when the result is unchanged: streaming text deltas
- * rebuild `timelineEntries` per token, and the timeline row projection only
- * reuses rows while this Map keeps its identity.
- */
-export function buildRevertTurnCountByUserMessageId(
-  input: {
-    supportsConversationRollback: boolean;
-    timelineEntries: ReadonlyArray<TimelineEntry>;
-    turnDiffSummaryByAssistantMessageId: ReadonlyMap<MessageId, TurnDiffSummary>;
-    inferredCheckpointTurnCountByTurnId: Readonly<Record<string, number | undefined>>;
-  },
-  previous: Map<MessageId, number> | null = null,
-): Map<MessageId, number> {
-  const byUserMessageId = new Map<MessageId, number>();
-  const entryCount = input.supportsConversationRollback ? input.timelineEntries.length : 0;
-  for (let index = 0; index < entryCount; index += 1) {
-    const entry = input.timelineEntries[index];
-    if (!entry || entry.kind !== "message" || entry.message.role !== "user") {
-      continue;
-    }
-
-    for (let nextIndex = index + 1; nextIndex < input.timelineEntries.length; nextIndex += 1) {
-      const nextEntry = input.timelineEntries[nextIndex];
-      if (!nextEntry || nextEntry.kind !== "message") {
-        continue;
-      }
-      if (nextEntry.message.role === "user") {
-        break;
-      }
-      const summary = input.turnDiffSummaryByAssistantMessageId.get(nextEntry.message.id);
-      if (!summary) {
-        continue;
-      }
-      const turnCount =
-        summary.checkpointTurnCount ?? input.inferredCheckpointTurnCountByTurnId[summary.turnId];
-      if (typeof turnCount !== "number") {
-        break;
-      }
-      byUserMessageId.set(entry.message.id, Math.max(0, turnCount - 1));
-      break;
-    }
-  }
-  return previous !== null && shallow(previous, byUserMessageId) ? previous : byUserMessageId;
 }
 
 export function reconcileMountedTerminalThreadIds(input: {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -153,11 +153,9 @@ import {
   isImageAttachment,
   type SessionPhase,
   type Thread,
-  type TurnDiffSummary,
 } from "../types";
 import { useTheme } from "../hooks/useTheme";
 import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
-import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
 import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
 import { useMediaQuery } from "../hooks/useMediaQuery";
@@ -367,7 +365,6 @@ import {
   buildExpiredTerminalContextToastCopy,
   buildLocalDraftThread,
   buildLoadingThreadFromShell,
-  buildRevertTurnCountByUserMessageId,
   buildThreadTurnInterruptInput,
   collectUserMessageBlobPreviewUrls,
   createLocalDispatchSnapshot,
@@ -3101,35 +3098,6 @@ export default function ChatView(props: ChatViewProps) {
     attachDraftHeroComposerAnchorRef,
     captureDraftHeroComposerRect,
   ] = useDraftHeroLayoutTransition(isDraftHeroState);
-  const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
-    useTurnDiffSummaries(activeThread);
-  const turnDiffSummaryByAssistantMessageId = useMemo(() => {
-    const byMessageId = new Map<MessageId, TurnDiffSummary>();
-    for (const summary of turnDiffSummaries) {
-      if (!summary.assistantMessageId) continue;
-      byMessageId.set(summary.assistantMessageId, summary);
-    }
-    return byMessageId;
-  }, [turnDiffSummaries]);
-  const lastRevertTurnCountRef = useRef<Map<MessageId, number> | null>(null);
-  const revertTurnCountByUserMessageId = useMemo(() => {
-    const next = buildRevertTurnCountByUserMessageId(
-      {
-        supportsConversationRollback,
-        timelineEntries,
-        turnDiffSummaryByAssistantMessageId,
-        inferredCheckpointTurnCountByTurnId,
-      },
-      lastRevertTurnCountRef.current,
-    );
-    lastRevertTurnCountRef.current = next;
-    return next;
-  }, [
-    supportsConversationRollback,
-    inferredCheckpointTurnCountByTurnId,
-    timelineEntries,
-    turnDiffSummaryByAssistantMessageId,
-  ]);
 
   const gitCwd = activeProject
     ? projectScriptCwd({
@@ -7778,19 +7746,28 @@ export default function ChatView(props: ChatViewProps) {
     },
     [activeThreadRef, isServerThread, onDiffPanelOpen],
   );
-  // Both the Map and the revert handler are read from refs at call-time so
-  // the callback reference is fully stable and never busts context identity.
-  const revertTurnCountRef = useRef(revertTurnCountByUserMessageId);
-  revertTurnCountRef.current = revertTurnCountByUserMessageId;
-  const onRevertToTurnCountRef = useRef(onRevertToTurnCount);
-  onRevertToTurnCountRef.current = onRevertToTurnCount;
-  const onRevertUserMessage = useCallback((messageId: MessageId) => {
-    const targetTurnCount = revertTurnCountRef.current.get(messageId);
-    if (typeof targetTurnCount !== "number") {
-      return;
-    }
-    void onRevertToTurnCountRef.current(targetTurnCount);
-  }, []);
+  const revertCheckpoints = activeThread?.checkpoints;
+  const revertHandlerRef = useRef({
+    threadKey: activeThreadKey,
+    checkpoints: revertCheckpoints,
+    handler: onRevertToTurnCount,
+  });
+  revertHandlerRef.current = {
+    threadKey: activeThreadKey,
+    checkpoints: revertCheckpoints,
+    handler: onRevertToTurnCount,
+  };
+  // A new thread or checkpoint snapshot must not retarget an old row's click.
+  const onRevertTimelineTurn = useCallback(
+    (targetTurnCount: number) => {
+      const current = revertHandlerRef.current;
+      if (current.threadKey !== activeThreadKey || current.checkpoints !== revertCheckpoints) {
+        return;
+      }
+      void current.handler(targetTurnCount);
+    },
+    [activeThreadKey, revertCheckpoints],
+  );
 
   // Empty state: no active thread
   if (!activeThread) {
@@ -8104,12 +8081,12 @@ export default function ChatView(props: ChatViewProps) {
                 timelineEntries={timelineEntries}
                 latestTurn={activeLatestTurn}
                 runningTurnId={activeRunningTurnId}
-                turnDiffSummaryByAssistantMessageId={turnDiffSummaryByAssistantMessageId}
+                turnDiffSummaries={activeThread.checkpoints}
                 activeThreadEnvironmentId={activeThread.environmentId}
                 routeThreadKey={routeThreadKey}
                 onOpenTurnDiff={onOpenTurnDiff}
-                revertTurnCountByUserMessageId={revertTurnCountByUserMessageId}
-                onRevertUserMessage={onRevertUserMessage}
+                supportsConversationRollback={supportsConversationRollback}
+                onRevertToTurnCount={onRevertTimelineTurn}
                 onUseArtifactTemplate={useArtifactTemplate}
                 isRevertingCheckpoint={isRevertingCheckpoint}
                 onImageExpand={onExpandTimelineImage}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -7746,28 +7746,13 @@ export default function ChatView(props: ChatViewProps) {
     },
     [activeThreadRef, isServerThread, onDiffPanelOpen],
   );
-  const revertCheckpoints = activeThread?.checkpoints;
-  const revertHandlerRef = useRef({
-    threadKey: activeThreadKey,
-    checkpoints: revertCheckpoints,
-    handler: onRevertToTurnCount,
-  });
-  revertHandlerRef.current = {
-    threadKey: activeThreadKey,
-    checkpoints: revertCheckpoints,
-    handler: onRevertToTurnCount,
-  };
-  // A new thread or checkpoint snapshot must not retarget an old row's click.
-  const onRevertTimelineTurn = useCallback(
-    (targetTurnCount: number) => {
-      const current = revertHandlerRef.current;
-      if (current.threadKey !== activeThreadKey || current.checkpoints !== revertCheckpoints) {
-        return;
-      }
-      void current.handler(targetTurnCount);
-    },
-    [activeThreadKey, revertCheckpoints],
-  );
+  // The revert handler is read from a ref at call-time so the callback
+  // reference is fully stable and never busts TimelineRowCtx identity.
+  const onRevertToTurnCountRef = useRef(onRevertToTurnCount);
+  onRevertToTurnCountRef.current = onRevertToTurnCount;
+  const onRevertTimelineTurn = useCallback((targetTurnCount: number) => {
+    void onRevertToTurnCountRef.current(targetTurnCount);
+  }, []);
 
   // Empty state: no active thread
   if (!activeThread) {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, it } from "vite-plus/test";
-import { CheckpointRef, MessageId, TurnId } from "@t3tools/contracts";
+import {
+  CheckpointRef,
+  EnvironmentId,
+  EventId,
+  MessageId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  TurnId,
+  type OrchestrationThread,
+} from "@t3tools/contracts";
+import {
+  applyThreadDetailEvent,
+  createEnvironmentThreadDetailAtoms,
+  EMPTY_ENVIRONMENT_THREAD_STATE,
+} from "@t3tools/client-runtime/state/threads";
+import * as Option from "effect/Option";
+import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 import {
   computeStableMessagesTimelineRows,
   computeMessageDurationStart,
@@ -12,6 +29,7 @@ import {
   shouldFollowWorkGroupAppend,
   shouldPreserveAssistantLineBreaks,
   type MessagesTimelineRow,
+  type MessagesTimelineRowsProjection,
   workEntryDisplayLabel,
 } from "./MessagesTimeline.logic";
 import {
@@ -19,8 +37,8 @@ import {
   deriveTimelineEntries,
   deriveTimelineEntriesWithState,
   type WorkLogEntry,
+  type TimelineEntriesProjection,
 } from "../../session-logic";
-import { buildRevertTurnCountByUserMessageId } from "../ChatView.logic";
 import { isImageAttachment, type ChatMessage, type TurnDiffSummary } from "../../types";
 
 describe("streaming row projection", () => {
@@ -97,8 +115,8 @@ describe("streaming row projection", () => {
       runningTurnId: turnId,
       isWorking: true,
       activeTurnStartedAt: time(5),
-      turnDiffSummaryByAssistantMessageId: new Map<MessageId, TurnDiffSummary>(),
-      revertTurnCountByUserMessageId: new Map<MessageId, number>(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     } satisfies Parameters<typeof deriveMessagesTimelineRows>[0];
     return { messages, work, timeline, input, time, turnId, historyTurnId };
   }
@@ -243,58 +261,247 @@ describe("streaming row projection", () => {
     },
   );
 
-  it("reuses rows when the revert map is rebuilt from the streamed entries", () => {
+  it("owns checkpoint lookups across streaming and equal source snapshots", () => {
     const initial = fixture("Partial");
-    const inferredCheckpointTurnCountByTurnId = { [initial.historyTurnId]: 1 };
-    const turnDiffSummaryByAssistantMessageId = new Map<MessageId, TurnDiffSummary>([
-      [
-        MessageId.make("history-assistant"),
-        {
-          turnId: initial.historyTurnId,
-          checkpointTurnCount: 1,
-          checkpointRef: CheckpointRef.make("refs/t3/checkpoints/history-turn"),
-          status: "ready",
-          files: [],
-          assistantMessageId: MessageId.make("history-assistant"),
-          completedAt: initial.time(4),
-        },
-      ],
-    ]);
-    let revertMap: Map<MessageId, number> | null = null;
-    // Mirrors ChatView: the map is derived from each delta's entries.
-    const build = (timelineEntries: typeof initial.timeline.entries) => {
-      revertMap = buildRevertTurnCountByUserMessageId(
-        {
-          supportsConversationRollback: true,
-          timelineEntries,
-          turnDiffSummaryByAssistantMessageId,
-          inferredCheckpointTurnCountByTurnId,
-        },
-        revertMap,
-      );
-      return {
-        ...initial.input,
-        timelineEntries,
-        turnDiffSummaryByAssistantMessageId,
-        revertTurnCountByUserMessageId: revertMap,
-      };
+    let checkpointReads = 0;
+    const summary: TurnDiffSummary = {
+      turnId: initial.historyTurnId,
+      checkpointTurnCount: 1,
+      checkpointRef: CheckpointRef.make("refs/t3/checkpoints/history-turn"),
+      status: "ready",
+      files: [],
+      get assistantMessageId() {
+        checkpointReads += 1;
+        return MessageId.make("history-assistant");
+      },
+      completedAt: initial.time(4),
     };
-    const previous = deriveMessagesTimelineRowsWithState(build(initial.timeline.entries));
+    const input = {
+      ...initial.input,
+      turnDiffSummaries: [summary],
+      supportsConversationRollback: true,
+      expandedTurnIds: new Set([initial.historyTurnId]),
+      expandedWorkGroupIds: new Set<string>(),
+    };
+    const previous = deriveMessagesTimelineRowsWithState(input);
+    expect(checkpointReads).toBeGreaterThan(0);
     expect(previous.rows.some((row) => row.kind === "message" && row.revertTurnCount === 0)).toBe(
       true,
     );
     const last = initial.messages.at(-1)!;
     const messages = [...initial.messages.slice(0, -1), { ...last, text: "Partial token" }];
     const timeline = deriveTimelineEntriesWithState(messages, [], initial.work, initial.timeline);
-    const next = deriveMessagesTimelineRowsWithState(build(timeline.entries), previous);
-
-    expect(next.rows).toEqual(deriveMessagesTimelineRows(build(timeline.entries)));
+    const nextInput = {
+      ...input,
+      timelineEntries: timeline.entries,
+      turnDiffSummaries: [...input.turnDiffSummaries],
+      latestTurn: { ...input.latestTurn },
+      expandedTurnIds: new Set(input.expandedTurnIds),
+      expandedWorkGroupIds: new Set(input.expandedWorkGroupIds),
+    };
+    checkpointReads = 0;
+    const next = deriveMessagesTimelineRowsWithState(nextInput, previous);
+    expect(checkpointReads).toBe(0);
+    expect(next.rows).toEqual(deriveMessagesTimelineRows(nextInput));
     for (const [index, row] of previous.rows.entries()) {
       if ((row.kind === "message" || row.kind === "assistant-meta") && row.message === last) {
         expect(next.rows[index]).toMatchObject({ message: { text: "Partial token" } });
       } else {
         expect(next.rows[index]).toBe(row);
       }
+    }
+
+    const changed = deriveMessagesTimelineRowsWithState(
+      { ...nextInput, turnDiffSummaries: [{ ...summary, checkpointTurnCount: 3 }] },
+      next,
+    );
+    expect(
+      changed.rows.find((row) => row.kind === "message" && row.message.id === messages[0]?.id),
+    ).toMatchObject({ revertTurnCount: 2 });
+    const unsupported = deriveMessagesTimelineRowsWithState(
+      { ...changed.input, supportsConversationRollback: false },
+      changed,
+    );
+    expect(
+      unsupported.rows.find((row) => row.kind === "message" && row.message.id === messages[0]?.id),
+    ).toMatchObject({ revertTurnCount: undefined });
+    expect(
+      previous.rows.find((row) => row.kind === "message" && row.message.id === messages[0]?.id),
+    ).toMatchObject({ revertTurnCount: 0 });
+  });
+
+  it("reuses long-thread rows through detail events, selectors, and attachment previews", () => {
+    const initial = fixture("Partial");
+    let checkpointReads = 0;
+    const history = Array.from({ length: 250 }, (_, index) => {
+      const turnId = TurnId.make(`older-turn-${index}`);
+      const user = {
+        ...initial.messages[0]!,
+        id: MessageId.make(`older-user-${index}`),
+        createdAt: new Date(Date.UTC(2026, 8, 3, 0, 0, index * 5)).toISOString(),
+        attachments: [
+          {
+            type: "image" as const,
+            id: "image",
+            name: "image.png",
+            mimeType: "image/png",
+            sizeBytes: 42,
+          },
+        ],
+      };
+      const assistant = {
+        ...initial.messages[1]!,
+        id: MessageId.make(`older-assistant-${index}`),
+        turnId,
+        createdAt: new Date(Date.UTC(2026, 8, 3, 0, 0, index * 5 + 3)).toISOString(),
+      };
+      const checkpoint: TurnDiffSummary = {
+        turnId,
+        checkpointTurnCount: index + 1,
+        checkpointRef: CheckpointRef.make(`refs/t3/checkpoints/older-${index}`),
+        status: "ready",
+        files: [],
+        get assistantMessageId() {
+          checkpointReads += 1;
+          return assistant.id;
+        },
+        completedAt: assistant.createdAt,
+      };
+      return { user, assistant, checkpoint };
+    });
+    const liveMessage = initial.messages.at(-1)!;
+    let thread: OrchestrationThread = {
+      id: ThreadId.make("streaming-thread"),
+      projectId: ProjectId.make("project"),
+      title: "Long thread",
+      modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.4" },
+      runtimeMode: "full-access",
+      interactionMode: "default",
+      branch: null,
+      worktreePath: null,
+      latestTurn: {
+        ...initial.input.latestTurn,
+        requestedAt: initial.time(5),
+        assistantMessageId: liveMessage.id,
+      },
+      createdAt: initial.time(0),
+      updatedAt: initial.time(7),
+      archivedAt: null,
+      settledOverride: null,
+      settledAt: null,
+      deletedAt: null,
+      messages: [
+        ...history.flatMap(({ user, assistant }) => [user, assistant]),
+        ...initial.messages,
+      ],
+      proposedPlans: [],
+      activities: [],
+      checkpoints: history.map(({ checkpoint }) => checkpoint),
+      session: null,
+    };
+    const state = Atom.make(
+      AsyncResult.success({ ...EMPTY_ENVIRONMENT_THREAD_STATE, data: Option.some(thread) }),
+    );
+    const details = createEnvironmentThreadDetailAtoms(() => state);
+    const ref = { environmentId: EnvironmentId.make("local"), threadId: thread.id };
+    const registry = AtomRegistry.make();
+    const unmount = registry.mount(details.detailAtom(ref));
+    const preview = createMessageAttachmentPreviewProjector();
+    let imageUrl = "https://first.test/image";
+    let timeline: TimelineEntriesProjection | null = null;
+    let projection: MessagesTimelineRowsProjection | null = null;
+    const project = () => {
+      const selected = registry.get(details.detailAtom(ref));
+      if (selected === null) throw new Error("Missing thread detail");
+      const messages = selected.messages.map((message) => preview(message, () => imageUrl));
+      timeline = deriveTimelineEntriesWithState(
+        messages,
+        selected.proposedPlans,
+        initial.work,
+        timeline,
+      );
+      projection = deriveMessagesTimelineRowsWithState(
+        {
+          timelineEntries: timeline.entries,
+          latestTurn: selected.latestTurn,
+          runningTurnId:
+            selected.latestTurn?.state === "running" ? selected.latestTurn.turnId : null,
+          isWorking: selected.latestTurn?.state === "running",
+          activeTurnStartedAt: selected.latestTurn?.startedAt ?? null,
+          turnDiffSummaries: selected.checkpoints,
+          supportsConversationRollback: true,
+        },
+        projection,
+      );
+      return projection;
+    };
+    const send = (text: string, sequence: number, streaming = true) => {
+      const result = applyThreadDetailEvent(thread, {
+        eventId: EventId.make(`delta-${sequence}`),
+        sequence,
+        commandId: null,
+        causationEventId: null,
+        correlationId: null,
+        metadata: {},
+        occurredAt: initial.time(8 + sequence),
+        aggregateKind: "thread",
+        aggregateId: thread.id,
+        type: "thread.message-sent",
+        payload: {
+          threadId: thread.id,
+          messageId: liveMessage.id,
+          role: "assistant",
+          text,
+          turnId: initial.turnId,
+          streaming,
+          createdAt: liveMessage.createdAt,
+          updatedAt: initial.time(8 + sequence),
+        },
+      });
+      if (result.kind !== "updated") throw new Error("Message event did not update the thread");
+      thread = result.thread;
+      registry.set(
+        state,
+        AsyncResult.success({ ...EMPTY_ENVIRONMENT_THREAD_STATE, data: Option.some(thread) }),
+      );
+      return project();
+    };
+
+    try {
+      const first = project();
+      const saved = structuredClone(first.rows);
+      expect(checkpointReads).toBeGreaterThan(0);
+      checkpointReads = 0;
+      for (let index = 0; index < 10; index += 1) {
+        const next = send(` ${index}`, index + 1);
+        for (const [rowIndex, row] of first.rows.entries()) {
+          if (
+            (row.kind === "message" || row.kind === "assistant-meta") &&
+            row.message.id === liveMessage.id
+          )
+            continue;
+          expect(next.rows[rowIndex]).toBe(row);
+        }
+      }
+      expect(checkpointReads).toBe(0);
+      const streamed = project();
+      expect(streamed.rows).toEqual(deriveMessagesTimelineRows(streamed.input));
+
+      imageUrl = "https://renewed.test/image";
+      const renewed = project();
+      expect(renewed.rows[0]).not.toBe(first.rows[0]);
+      expect(renewed.rows[0]).toMatchObject({
+        message: { attachments: [{ previewUrl: imageUrl }] },
+      });
+      const completed = send("Complete", 11, false);
+      expect(completed.rows).toEqual(deriveMessagesTimelineRows(completed.input));
+      expect(
+        completed.rows.find((row) => row.kind === "message" && row.message.id === liveMessage.id),
+      ).toMatchObject({ message: { text: "Complete" }, assistantCopyStreaming: false });
+      expect(first.rows).toEqual(saved);
+    } finally {
+      unmount();
+      registry.dispose();
     }
   });
 
@@ -407,7 +614,7 @@ describe("streaming row projection", () => {
         ? { ...message, role: "user", turnId: null, createdAt: initial.time(0) }
         : message,
     );
-    check({ revertTurnCountByUserMessageId: new Map([[MessageId.make("live-user"), 3]]) });
+    check({ supportsConversationRollback: true });
   });
 });
 
@@ -574,8 +781,8 @@ describe("work entry labels", () => {
         ],
         isWorking: false,
         activeTurnStartedAt: null,
-        turnDiffSummaryByAssistantMessageId: new Map(),
-        revertTurnCountByUserMessageId: new Map(),
+        turnDiffSummaries: [],
+        supportsConversationRollback: false,
       });
       const directRow = rows.find((row) => row.kind === "work");
       expect(directRow).toMatchObject({
@@ -887,8 +1094,8 @@ describe("deriveMessagesTimelineRows", () => {
       ],
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     expect(rows).toEqual([
@@ -950,8 +1157,8 @@ describe("deriveMessagesTimelineRows", () => {
       expandedTurnIds: new Set(["turn-1" as never]),
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     const assistantRows = rows.filter(
@@ -1004,8 +1211,8 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     const assistantRows = rows.filter(
@@ -1061,10 +1268,8 @@ describe("deriveMessagesTimelineRows", () => {
       ],
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map([
-        ["assistant-1" as never, assistantTurnDiffSummary],
-      ]),
-      revertTurnCountByUserMessageId: new Map([["user-1" as never, 1]]),
+      turnDiffSummaries: [assistantTurnDiffSummary],
+      supportsConversationRollback: true,
     });
 
     const userRow = rows.find(
@@ -1142,8 +1347,8 @@ describe("deriveMessagesTimelineRows", () => {
       timelineEntries,
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     const foldRow = collapsedRows.find(
@@ -1165,8 +1370,8 @@ describe("deriveMessagesTimelineRows", () => {
       expandedTurnIds: new Set(["turn-1" as never]),
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     expect(expandedRows.map((row) => row.id)).toEqual([
@@ -1235,8 +1440,8 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     };
     const rows = deriveMessagesTimelineRows({ ...input, timelineEntries });
 
@@ -1318,8 +1523,8 @@ describe("deriveMessagesTimelineRows", () => {
       timelineEntries,
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     expect(rows.map((row) => row.id)).toEqual(["turn-fold:turn-1", "assistant-final-entry"]);
@@ -1421,8 +1626,8 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:00:14Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     const foldRow = rows.find(
@@ -1458,8 +1663,8 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     expect(rows).toEqual([
@@ -1526,8 +1731,8 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:01:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     expect(rows.map((row) => row.id)).toEqual([
@@ -1580,8 +1785,8 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:00:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     expect(rows.some((row) => row.kind === "turn-fold")).toBe(false);
@@ -1674,8 +1879,8 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:01:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     expect(rows.some((row) => row.kind === "turn-fold")).toBe(false);
@@ -1754,8 +1959,8 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:00:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     expect(rows.map((row) => row.kind)).toEqual(["working", "work-live"]);
@@ -1827,8 +2032,8 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:00:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     expect(rows.map((row) => row.kind)).toEqual(["working", "work", "message", "work-live"]);
@@ -1879,8 +2084,8 @@ describe("deriveMessagesTimelineRows", () => {
       expandedTurnIds: new Set([turnId]),
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     expect(rows.find((row) => row.kind === "work")).toMatchObject({
@@ -1947,8 +2152,8 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:00:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     expect(rows.map((row) => row.kind)).toEqual(["working", "work-live", "message", "work-live"]);
@@ -1994,8 +2199,8 @@ describe("deriveMessagesTimelineRows", () => {
       latestTurn: null,
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:01:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     expect(rows.some((row) => row.kind === "work-live")).toBe(false);
@@ -2055,8 +2260,8 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:00:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     expect(rows.filter((row) => row.kind === "work-live").map((row) => row.entry.id)).toEqual([
@@ -2100,8 +2305,8 @@ describe("deriveMessagesTimelineRows", () => {
         },
         isWorking: true,
         activeTurnStartedAt: "2026-01-01T00:00:00Z",
-        turnDiffSummaryByAssistantMessageId: new Map(),
-        revertTurnCountByUserMessageId: new Map(),
+        turnDiffSummaries: [],
+        supportsConversationRollback: false,
       });
 
       const workLiveRow = rows.find((row) => row.kind === "work-live");
@@ -2148,8 +2353,8 @@ describe("deriveMessagesTimelineRows", () => {
         },
         isWorking: true,
         activeTurnStartedAt: "2026-01-01T00:00:00Z",
-        turnDiffSummaryByAssistantMessageId: new Map(),
-        revertTurnCountByUserMessageId: new Map(),
+        turnDiffSummaries: [],
+        supportsConversationRollback: false,
       });
 
     const initialRows = deriveRows(null);
@@ -2226,8 +2431,8 @@ describe("deriveMessagesTimelineRows", () => {
       runningTurnId: "turn-2" as never,
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:01:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     expect(rows.filter((row) => row.kind === "turn-fold").map((row) => row.turnId)).toEqual([
@@ -2271,8 +2476,8 @@ describe("deriveMessagesTimelineRows", () => {
       expandedTurnIds: new Set(["turn-1" as never]),
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     const assistantRows = rows.filter(
@@ -2309,8 +2514,8 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:00:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     const assistantRow = rows.find(
@@ -2373,8 +2578,8 @@ describe("deriveMessagesTimelineRows", () => {
       timelineEntries,
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     };
     const collapsedRows = deriveMessagesTimelineRows(baseInput);
     const expandedRows = deriveMessagesTimelineRows({
@@ -2467,8 +2672,8 @@ describe("deriveMessagesTimelineRows", () => {
       timelineEntries,
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     expect(row).toMatchObject({
@@ -2509,8 +2714,8 @@ describe("deriveMessagesTimelineRows", () => {
         expandedTurnIds: new Set([turnId]),
         runningTurnId: isWorking ? turnId : null,
         activeTurnStartedAt: isWorking ? createdAt : null,
-        turnDiffSummaryByAssistantMessageId: new Map(),
-        revertTurnCountByUserMessageId: new Map(),
+        turnDiffSummaries: [],
+        supportsConversationRollback: false,
       };
       const expandedRows = deriveMessagesTimelineRows({
         ...input,
@@ -2549,8 +2754,8 @@ describe("deriveMessagesTimelineRows", () => {
       timelineEntries,
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     expect(rows.find((row) => row.kind === "work-toggle")).toMatchObject({
@@ -2596,8 +2801,8 @@ describe("deriveMessagesTimelineRows", () => {
         timelineEntries,
         isWorking: false,
         activeTurnStartedAt: null,
-        turnDiffSummaryByAssistantMessageId: new Map(),
-        revertTurnCountByUserMessageId: new Map(),
+        turnDiffSummaries: [],
+        supportsConversationRollback: false,
       });
 
       expect(rows.find((row) => row.kind === "work-toggle")).toMatchObject({
@@ -2653,8 +2858,8 @@ describe("computeStableMessagesTimelineRows", () => {
       runningTurnId: turnId,
       isWorking: true,
       activeTurnStartedAt: startedAt,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     };
     const assistantEntry = {
       id: "assistant-entry",
@@ -2731,8 +2936,8 @@ describe("computeStableMessagesTimelineRows", () => {
       ],
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     const initial = computeStableMessagesTimelineRows(rows, {
@@ -2780,8 +2985,8 @@ describe("computeStableMessagesTimelineRows", () => {
         ],
         isWorking: false,
         activeTurnStartedAt: null,
-        turnDiffSummaryByAssistantMessageId: new Map(),
-        revertTurnCountByUserMessageId: new Map(),
+        turnDiffSummaries: [],
+        supportsConversationRollback: false,
       });
 
     const firstRows = createRows();
@@ -2836,8 +3041,8 @@ describe("computeStableMessagesTimelineRows", () => {
       ],
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
     });
 
     const initial = computeStableMessagesTimelineRows(firstRows, {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -263,18 +263,24 @@ describe("streaming row projection", () => {
 
   it("owns checkpoint lookups across streaming and equal source snapshots", () => {
     const initial = fixture("Partial");
-    let checkpointReads = 0;
+    let checkpointLookupReads = 0;
     const summary: TurnDiffSummary = {
       turnId: initial.historyTurnId,
-      checkpointTurnCount: 1,
+      get checkpointTurnCount() {
+        checkpointLookupReads += 1;
+        return 1;
+      },
       checkpointRef: CheckpointRef.make("refs/t3/checkpoints/history-turn"),
       status: "ready",
       files: [],
       get assistantMessageId() {
-        checkpointReads += 1;
+        checkpointLookupReads += 1;
         return MessageId.make("history-assistant");
       },
-      completedAt: initial.time(4),
+      get completedAt() {
+        checkpointLookupReads += 1;
+        return initial.time(4);
+      },
     };
     const input = {
       ...initial.input,
@@ -284,7 +290,7 @@ describe("streaming row projection", () => {
       expandedWorkGroupIds: new Set<string>(),
     };
     const previous = deriveMessagesTimelineRowsWithState(input);
-    expect(checkpointReads).toBeGreaterThan(0);
+    expect(checkpointLookupReads).toBeGreaterThan(0);
     expect(previous.rows.some((row) => row.kind === "message" && row.revertTurnCount === 0)).toBe(
       true,
     );
@@ -299,9 +305,9 @@ describe("streaming row projection", () => {
       expandedTurnIds: new Set(input.expandedTurnIds),
       expandedWorkGroupIds: new Set(input.expandedWorkGroupIds),
     };
-    checkpointReads = 0;
+    checkpointLookupReads = 0;
     const next = deriveMessagesTimelineRowsWithState(nextInput, previous);
-    expect(checkpointReads).toBe(0);
+    expect(checkpointLookupReads).toBe(0);
     expect(next.rows).toEqual(deriveMessagesTimelineRows(nextInput));
     for (const [index, row] of previous.rows.entries()) {
       if ((row.kind === "message" || row.kind === "assistant-meta") && row.message === last) {
@@ -332,7 +338,7 @@ describe("streaming row projection", () => {
 
   it("reuses long-thread rows through detail events, selectors, and attachment previews", () => {
     const initial = fixture("Partial");
-    let checkpointReads = 0;
+    let checkpointLookupReads = 0;
     const history = Array.from({ length: 250 }, (_, index) => {
       const turnId = TurnId.make(`older-turn-${index}`);
       const user = {
@@ -357,15 +363,21 @@ describe("streaming row projection", () => {
       };
       const checkpoint: TurnDiffSummary = {
         turnId,
-        checkpointTurnCount: index + 1,
+        get checkpointTurnCount() {
+          checkpointLookupReads += 1;
+          return index + 1;
+        },
         checkpointRef: CheckpointRef.make(`refs/t3/checkpoints/older-${index}`),
         status: "ready",
         files: [],
         get assistantMessageId() {
-          checkpointReads += 1;
+          checkpointLookupReads += 1;
           return assistant.id;
         },
-        completedAt: assistant.createdAt,
+        get completedAt() {
+          checkpointLookupReads += 1;
+          return assistant.createdAt;
+        },
       };
       return { user, assistant, checkpoint };
     });
@@ -470,8 +482,8 @@ describe("streaming row projection", () => {
     try {
       const first = project();
       const saved = structuredClone(first.rows);
-      expect(checkpointReads).toBeGreaterThan(0);
-      checkpointReads = 0;
+      expect(checkpointLookupReads).toBeGreaterThan(0);
+      checkpointLookupReads = 0;
       for (let index = 0; index < 10; index += 1) {
         const next = send(` ${index}`, index + 1);
         for (const [rowIndex, row] of first.rows.entries()) {
@@ -483,7 +495,7 @@ describe("streaming row projection", () => {
           expect(next.rows[rowIndex]).toBe(row);
         }
       }
-      expect(checkpointReads).toBe(0);
+      expect(checkpointLookupReads).toBe(0);
       const streamed = project();
       expect(streamed.rows).toEqual(deriveMessagesTimelineRows(streamed.input));
 

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -18,6 +18,7 @@ export {
 } from "@t3tools/client-runtime/work-log/presentation";
 import {
   formatDuration,
+  inferCheckpointTurnCountByTurnId,
   isStreamingMessageTextUpdate,
   workEntryDisplayIndicatesToolFailure,
   workEntryIndicatesToolSuccess,
@@ -776,6 +777,45 @@ function attachTrailingToolGroupsToAssistant(
   return result;
 }
 
+/** Match each user message to the next assistant checkpoint. */
+function buildRevertTurnCountByUserMessageId(input: {
+  supportsConversationRollback: boolean;
+  timelineEntries: ReadonlyArray<TimelineEntry>;
+  turnDiffSummaryByAssistantMessageId: ReadonlyMap<MessageId, TurnDiffSummary>;
+  inferredCheckpointTurnCountByTurnId: Readonly<Record<string, number | undefined>>;
+}): Map<MessageId, number> {
+  const byUserMessageId = new Map<MessageId, number>();
+  const entryCount = input.supportsConversationRollback ? input.timelineEntries.length : 0;
+  for (let index = 0; index < entryCount; index += 1) {
+    const entry = input.timelineEntries[index];
+    if (!entry || entry.kind !== "message" || entry.message.role !== "user") {
+      continue;
+    }
+
+    for (let nextIndex = index + 1; nextIndex < input.timelineEntries.length; nextIndex += 1) {
+      const nextEntry = input.timelineEntries[nextIndex];
+      if (!nextEntry || nextEntry.kind !== "message") {
+        continue;
+      }
+      if (nextEntry.message.role === "user") {
+        break;
+      }
+      const summary = input.turnDiffSummaryByAssistantMessageId.get(nextEntry.message.id);
+      if (!summary) {
+        continue;
+      }
+      const turnCount =
+        summary.checkpointTurnCount ?? input.inferredCheckpointTurnCountByTurnId[summary.turnId];
+      if (typeof turnCount !== "number") {
+        break;
+      }
+      byUserMessageId.set(entry.message.id, Math.max(0, turnCount - 1));
+      break;
+    }
+  }
+  return byUserMessageId;
+}
+
 export function deriveMessagesTimelineRows(input: {
   timelineEntries: ReadonlyArray<TimelineEntry>;
   latestTurn?: TimelineLatestTurn | null;
@@ -784,9 +824,23 @@ export function deriveMessagesTimelineRows(input: {
   expandedWorkGroupIds?: ReadonlySet<string>;
   isWorking: boolean;
   activeTurnStartedAt: string | null;
-  turnDiffSummaryByAssistantMessageId: ReadonlyMap<MessageId, TurnDiffSummary>;
-  revertTurnCountByUserMessageId: ReadonlyMap<MessageId, number>;
+  turnDiffSummaries: ReadonlyArray<TurnDiffSummary>;
+  supportsConversationRollback: boolean;
 }): MessagesTimelineRow[] {
+  const turnDiffSummaryByAssistantMessageId = new Map<MessageId, TurnDiffSummary>();
+  for (const summary of input.turnDiffSummaries) {
+    if (summary.assistantMessageId) {
+      turnDiffSummaryByAssistantMessageId.set(summary.assistantMessageId, summary);
+    }
+  }
+  const revertTurnCountByUserMessageId = buildRevertTurnCountByUserMessageId({
+    supportsConversationRollback: input.supportsConversationRollback,
+    timelineEntries: input.timelineEntries,
+    turnDiffSummaryByAssistantMessageId,
+    inferredCheckpointTurnCountByTurnId: input.supportsConversationRollback
+      ? inferCheckpointTurnCountByTurnId(input.turnDiffSummaries)
+      : {},
+  });
   const nextRows: MessagesTimelineRow[] = [];
   const durationStartByMessageId = computeMessageDurationStart(
     input.timelineEntries.flatMap((entry) => (entry.kind === "message" ? [entry.message] : [])),
@@ -1134,11 +1188,11 @@ export function deriveMessagesTimelineRows(input: {
       assistantCopyStreaming: timelineEntry.message.streaming || assistantResponseStillInProgress,
       assistantTurnDiffSummary:
         timelineEntry.message.role === "assistant"
-          ? input.turnDiffSummaryByAssistantMessageId.get(timelineEntry.message.id)
+          ? turnDiffSummaryByAssistantMessageId.get(timelineEntry.message.id)
           : undefined,
       revertTurnCount:
         timelineEntry.message.role === "user"
-          ? input.revertTurnCountByUserMessageId.get(timelineEntry.message.id)
+          ? revertTurnCountByUserMessageId.get(timelineEntry.message.id)
           : undefined,
     });
   }
@@ -1168,9 +1222,30 @@ function replaceStreamingMessageRows(
   input: MessagesTimelineRowsInput,
   previous: MessagesTimelineRowsProjection,
 ): MessagesTimelineRow[] | null {
-  const { timelineEntries: previousEntries, ...previousContext } = previous.input;
-  const { timelineEntries, ...context } = input;
-  if (timelineEntries.length !== previousEntries.length || !shallow(previousContext, context)) {
+  const {
+    timelineEntries: previousEntries,
+    turnDiffSummaries: previousSummaries,
+    latestTurn: previousLatestTurn,
+    expandedTurnIds: previousExpandedTurns,
+    expandedWorkGroupIds: previousExpandedGroups,
+    ...previousContext
+  } = previous.input;
+  const {
+    timelineEntries,
+    turnDiffSummaries,
+    latestTurn,
+    expandedTurnIds,
+    expandedWorkGroupIds,
+    ...context
+  } = input;
+  if (
+    timelineEntries.length !== previousEntries.length ||
+    !shallow(previousContext, context) ||
+    !shallow(previousSummaries, turnDiffSummaries) ||
+    !shallow(previousLatestTurn, latestTurn) ||
+    !shallow(previousExpandedTurns, expandedTurnIds) ||
+    !shallow(previousExpandedGroups, expandedWorkGroupIds)
+  ) {
     return null;
   }
   const replacements = new Map<ChatMessage, ChatMessage>();

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1,12 +1,39 @@
 import { CheckpointRef, EnvironmentId, MessageId, TurnId } from "@t3tools/contracts";
 import { codexFeedbackMessage } from "@t3tools/client-runtime/state/threads";
-import { act, createRef, useLayoutEffect, type ReactNode, type Ref } from "react";
+import {
+  act,
+  createRef,
+  useLayoutEffect,
+  type ReactNode,
+  type Ref,
+  type ComponentProps,
+} from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { create, type ReactTestRenderer } from "react-test-renderer";
 import { beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import type { LegendListRef, MaintainScrollAtEndOptions } from "@legendapp/list/react";
 import { shouldUseRestingComposerLayout } from "../composerFooterLayout";
 import { useComposerFocusState } from "./useComposerFocusState";
+import {
+  deriveTimelineEntriesWithState,
+  type TimelineEntriesProjection,
+} from "../../session-logic";
+import type { ChatMessage, TurnDiffSummary } from "../../types";
+
+vi.mock("../ui/tooltip", async () => {
+  const { cloneElement, isValidElement } = await import("react");
+  return {
+    Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+    TooltipTrigger({
+      render,
+      children,
+    }: ComponentProps<typeof import("../ui/tooltip").TooltipTrigger>) {
+      if (!isValidElement(render)) return <>{children}</>;
+      return children === undefined ? render : cloneElement(render, undefined, children);
+    },
+    TooltipPopup: () => null,
+  };
+});
 
 vi.mock("@legendapp/list/react", async () => {
   const legendListTestId = "legend-list";
@@ -154,6 +181,7 @@ beforeAll(async () => {
     clear: () => {},
   });
   vi.stubGlobal("window", {
+    localStorage,
     matchMedia,
     addEventListener: () => {},
     removeEventListener: () => {},
@@ -184,11 +212,11 @@ function buildProps() {
     listRef: createRef<LegendListRef | null>(),
     latestTurn: null,
     runningTurnId: null,
-    turnDiffSummaryByAssistantMessageId: new Map(),
+    turnDiffSummaries: [],
     routeThreadKey: "environment-local:thread-1",
     onOpenTurnDiff: () => {},
-    revertTurnCountByUserMessageId: new Map(),
-    onRevertUserMessage: () => {},
+    supportsConversationRollback: false,
+    onRevertToTurnCount: () => {},
     isRevertingCheckpoint: false,
     onImageExpand: () => {},
     activeThreadEnvironmentId: ACTIVE_THREAD_ENVIRONMENT_ID,
@@ -328,6 +356,131 @@ describe("MessagesTimeline", () => {
     },
   );
 
+  it("keeps code controls through streaming and recovery, then uses the current revert target", async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const { getSyntaxHighlighterPromise } = await import("../../lib/syntaxHighlighting");
+    const highlighter = await getSyntaxHighlighterPromise("text");
+    const codeToHtml = highlighter.codeToHtml.bind(highlighter);
+    let fail = true;
+    const highlight = vi.spyOn(highlighter, "codeToHtml").mockImplementation((...args) => {
+      if (fail) throw new Error("Temporary highlighter failure");
+      return codeToHtml(...args);
+    });
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onRevertToTurnCount = vi.fn();
+    const props = buildProps();
+    const turnId = TurnId.make("streamed-checkpoint");
+    const user: ChatMessage = buildUserTimelineEntry("Update the file").message;
+    const assistant: ChatMessage = {
+      ...buildAssistantTimelineEntry("").message,
+      id: MessageId.make("streamed-assistant"),
+      turnId,
+      createdAt: "2026-03-17T19:12:29.000Z",
+    };
+    let timeline: TimelineEntriesProjection | null = null;
+    const render = (
+      text: string,
+      streaming = true,
+      summaries: ReadonlyArray<TurnDiffSummary> = [],
+    ) => {
+      timeline = deriveTimelineEntriesWithState(
+        [user, { ...assistant, text, streaming }],
+        [],
+        [],
+        timeline,
+      );
+      return (
+        <MessagesTimeline
+          {...props}
+          timelineEntries={timeline.entries}
+          turnDiffSummaries={summaries}
+          supportsConversationRollback
+          onRevertToTurnCount={onRevertToTurnCount}
+          isWorking={streaming}
+          latestTurn={{
+            turnId,
+            state: streaming ? "running" : "completed",
+            startedAt: MESSAGE_CREATED_AT,
+            completedAt: streaming ? null : assistant.createdAt,
+          }}
+          runningTurnId={streaming ? turnId : null}
+        />
+      );
+    };
+    let renderer: ReactTestRenderer | undefined;
+    try {
+      await act(async () => {
+        renderer = create(render("```text\nInitial code\n```\n\nResponse"));
+      });
+      const mounted = renderer!;
+      const codeBlock = mounted.root.findByProps({ "data-language": "text" });
+      const initiallyWrapped = codeBlock.props["data-wrap"] === "true";
+      const wrap = mounted.root
+        .findAllByType("button")
+        .find(
+          (button) =>
+            button.props["aria-label"] === (initiallyWrapped ? "Disable line wrap" : "Wrap lines"),
+        );
+      if (!wrap) throw new Error("Missing code wrap control");
+      await act(() => wrap.props.onClick());
+      const initialHighlightCount = highlight.mock.calls.length;
+      expect(initialHighlightCount).toBeGreaterThan(0);
+      for (let index = 0; index < 10; index += 1) {
+        await act(async () => {
+          mounted.update(render(`\`\`\`text\nInitial code\n\`\`\`\n\nResponse ${index}`));
+        });
+      }
+      expect(highlight).toHaveBeenCalledTimes(initialHighlightCount);
+      expect(mounted.root.findByProps({ "data-language": "text" })).toBe(codeBlock);
+      expect(codeBlock.props["data-wrap"]).toBe(String(!initiallyWrapped));
+
+      fail = false;
+      const finalText = "```text\nRecovered code\n```\n\nComplete";
+      await act(async () => {
+        mounted.update(render(finalText));
+      });
+      const recoveredHighlightCount = highlight.mock.calls.length;
+      expect(recoveredHighlightCount).toBeGreaterThan(initialHighlightCount);
+      expect(mounted.root.findByProps({ "data-language": "text" })).toBe(codeBlock);
+      expect(codeBlock.props["data-wrap"]).toBe(String(!initiallyWrapped));
+      const summary: TurnDiffSummary = {
+        turnId,
+        assistantMessageId: assistant.id,
+        checkpointTurnCount: 2,
+        checkpointRef: CheckpointRef.make("refs/t3/checkpoints/streamed"),
+        status: "ready",
+        files: [],
+        completedAt: assistant.createdAt,
+      };
+      await act(async () => {
+        mounted.update(render(finalText, false, [summary]));
+      });
+      const revert = () => {
+        const button = mounted.root
+          .findAllByType("button")
+          .find((entry) => entry.props["aria-label"] === "Revert to this message");
+        if (!button) throw new Error("Missing revert action");
+        button.props.onClick();
+      };
+      await act(revert);
+      expect(onRevertToTurnCount).toHaveBeenLastCalledWith(1);
+      await act(async () => {
+        mounted.update(render(finalText, false, [{ ...summary, checkpointTurnCount: 4 }]));
+      });
+      await act(revert);
+      expect(onRevertToTurnCount).toHaveBeenLastCalledWith(3);
+      expect(highlight).toHaveBeenCalledTimes(recoveredHighlightCount);
+      expect(mounted.root.findByProps({ "data-language": "text" })).toBe(codeBlock);
+      expect(codeBlock.props["data-wrap"]).toBe(String(!initiallyWrapped));
+    } finally {
+      await act(() => renderer?.unmount());
+      highlight.mockRestore();
+      error.mockRestore();
+      warn.mockRestore();
+    }
+  });
+
   it("renders a feedback command and its pending response as normal thread messages", () => {
     const submission = {
       id: MessageId.make("feedback-command"),
@@ -448,22 +601,17 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        turnDiffSummaryByAssistantMessageId={
-          new Map([
-            [
-              assistantMessageId,
-              {
-                turnId,
-                checkpointTurnCount: 1,
-                checkpointRef: CheckpointRef.make("checkpoint-with-files"),
-                status: "ready",
-                files: [{ path: "README.md", kind: "modified", additions: 2, deletions: 1 }],
-                assistantMessageId,
-                completedAt: MESSAGE_CREATED_AT,
-              },
-            ],
-          ])
-        }
+        turnDiffSummaries={[
+          {
+            turnId,
+            checkpointTurnCount: 1,
+            checkpointRef: CheckpointRef.make("checkpoint-with-files"),
+            status: "ready",
+            files: [{ path: "README.md", kind: "modified", additions: 2, deletions: 1 }],
+            assistantMessageId,
+            completedAt: MESSAGE_CREATED_AT,
+          },
+        ]}
       />,
     );
 

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1,39 +1,12 @@
 import { CheckpointRef, EnvironmentId, MessageId, TurnId } from "@t3tools/contracts";
 import { codexFeedbackMessage } from "@t3tools/client-runtime/state/threads";
-import {
-  act,
-  createRef,
-  useLayoutEffect,
-  type ReactNode,
-  type Ref,
-  type ComponentProps,
-} from "react";
+import { act, createRef, useLayoutEffect, type ReactNode, type Ref } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { create, type ReactTestRenderer } from "react-test-renderer";
 import { beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import type { LegendListRef, MaintainScrollAtEndOptions } from "@legendapp/list/react";
 import { shouldUseRestingComposerLayout } from "../composerFooterLayout";
 import { useComposerFocusState } from "./useComposerFocusState";
-import {
-  deriveTimelineEntriesWithState,
-  type TimelineEntriesProjection,
-} from "../../session-logic";
-import type { ChatMessage, TurnDiffSummary } from "../../types";
-
-vi.mock("../ui/tooltip", async () => {
-  const { cloneElement, isValidElement } = await import("react");
-  return {
-    Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
-    TooltipTrigger({
-      render,
-      children,
-    }: ComponentProps<typeof import("../ui/tooltip").TooltipTrigger>) {
-      if (!isValidElement(render)) return <>{children}</>;
-      return children === undefined ? render : cloneElement(render, undefined, children);
-    },
-    TooltipPopup: () => null,
-  };
-});
 
 vi.mock("@legendapp/list/react", async () => {
   const legendListTestId = "legend-list";
@@ -181,7 +154,6 @@ beforeAll(async () => {
     clear: () => {},
   });
   vi.stubGlobal("window", {
-    localStorage,
     matchMedia,
     addEventListener: () => {},
     removeEventListener: () => {},
@@ -355,131 +327,6 @@ describe("MessagesTimeline", () => {
       }
     },
   );
-
-  it("keeps code controls through streaming and recovery, then uses the current revert target", async () => {
-    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
-    const { getSyntaxHighlighterPromise } = await import("../../lib/syntaxHighlighting");
-    const highlighter = await getSyntaxHighlighterPromise("text");
-    const codeToHtml = highlighter.codeToHtml.bind(highlighter);
-    let fail = true;
-    const highlight = vi.spyOn(highlighter, "codeToHtml").mockImplementation((...args) => {
-      if (fail) throw new Error("Temporary highlighter failure");
-      return codeToHtml(...args);
-    });
-    const error = vi.spyOn(console, "error").mockImplementation(() => {});
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const onRevertToTurnCount = vi.fn();
-    const props = buildProps();
-    const turnId = TurnId.make("streamed-checkpoint");
-    const user: ChatMessage = buildUserTimelineEntry("Update the file").message;
-    const assistant: ChatMessage = {
-      ...buildAssistantTimelineEntry("").message,
-      id: MessageId.make("streamed-assistant"),
-      turnId,
-      createdAt: "2026-03-17T19:12:29.000Z",
-    };
-    let timeline: TimelineEntriesProjection | null = null;
-    const render = (
-      text: string,
-      streaming = true,
-      summaries: ReadonlyArray<TurnDiffSummary> = [],
-    ) => {
-      timeline = deriveTimelineEntriesWithState(
-        [user, { ...assistant, text, streaming }],
-        [],
-        [],
-        timeline,
-      );
-      return (
-        <MessagesTimeline
-          {...props}
-          timelineEntries={timeline.entries}
-          turnDiffSummaries={summaries}
-          supportsConversationRollback
-          onRevertToTurnCount={onRevertToTurnCount}
-          isWorking={streaming}
-          latestTurn={{
-            turnId,
-            state: streaming ? "running" : "completed",
-            startedAt: MESSAGE_CREATED_AT,
-            completedAt: streaming ? null : assistant.createdAt,
-          }}
-          runningTurnId={streaming ? turnId : null}
-        />
-      );
-    };
-    let renderer: ReactTestRenderer | undefined;
-    try {
-      await act(async () => {
-        renderer = create(render("```text\nInitial code\n```\n\nResponse"));
-      });
-      const mounted = renderer!;
-      const codeBlock = mounted.root.findByProps({ "data-language": "text" });
-      const initiallyWrapped = codeBlock.props["data-wrap"] === "true";
-      const wrap = mounted.root
-        .findAllByType("button")
-        .find(
-          (button) =>
-            button.props["aria-label"] === (initiallyWrapped ? "Disable line wrap" : "Wrap lines"),
-        );
-      if (!wrap) throw new Error("Missing code wrap control");
-      await act(() => wrap.props.onClick());
-      const initialHighlightCount = highlight.mock.calls.length;
-      expect(initialHighlightCount).toBeGreaterThan(0);
-      for (let index = 0; index < 10; index += 1) {
-        await act(async () => {
-          mounted.update(render(`\`\`\`text\nInitial code\n\`\`\`\n\nResponse ${index}`));
-        });
-      }
-      expect(highlight).toHaveBeenCalledTimes(initialHighlightCount);
-      expect(mounted.root.findByProps({ "data-language": "text" })).toBe(codeBlock);
-      expect(codeBlock.props["data-wrap"]).toBe(String(!initiallyWrapped));
-
-      fail = false;
-      const finalText = "```text\nRecovered code\n```\n\nComplete";
-      await act(async () => {
-        mounted.update(render(finalText));
-      });
-      const recoveredHighlightCount = highlight.mock.calls.length;
-      expect(recoveredHighlightCount).toBeGreaterThan(initialHighlightCount);
-      expect(mounted.root.findByProps({ "data-language": "text" })).toBe(codeBlock);
-      expect(codeBlock.props["data-wrap"]).toBe(String(!initiallyWrapped));
-      const summary: TurnDiffSummary = {
-        turnId,
-        assistantMessageId: assistant.id,
-        checkpointTurnCount: 2,
-        checkpointRef: CheckpointRef.make("refs/t3/checkpoints/streamed"),
-        status: "ready",
-        files: [],
-        completedAt: assistant.createdAt,
-      };
-      await act(async () => {
-        mounted.update(render(finalText, false, [summary]));
-      });
-      const revert = () => {
-        const button = mounted.root
-          .findAllByType("button")
-          .find((entry) => entry.props["aria-label"] === "Revert to this message");
-        if (!button) throw new Error("Missing revert action");
-        button.props.onClick();
-      };
-      await act(revert);
-      expect(onRevertToTurnCount).toHaveBeenLastCalledWith(1);
-      await act(async () => {
-        mounted.update(render(finalText, false, [{ ...summary, checkpointTurnCount: 4 }]));
-      });
-      await act(revert);
-      expect(onRevertToTurnCount).toHaveBeenLastCalledWith(3);
-      expect(highlight).toHaveBeenCalledTimes(recoveredHighlightCount);
-      expect(mounted.root.findByProps({ "data-language": "text" })).toBe(codeBlock);
-      expect(codeBlock.props["data-wrap"]).toBe(String(!initiallyWrapped));
-    } finally {
-      await act(() => renderer?.unmount());
-      highlight.mockRestore();
-      error.mockRestore();
-      warn.mockRestore();
-    }
-  });
 
   it("renders a feedback command and its pending response as normal thread messages", () => {
     const submission = {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -203,7 +203,7 @@ interface TimelineRowSharedState {
   workspaceRoot: string | undefined;
   skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
   activeThreadEnvironmentId: EnvironmentId;
-  onRevertUserMessage: (messageId: MessageId) => void;
+  onRevertToTurnCount: (targetTurnCount: number) => void;
   onUseArtifactTemplate: (template: CodexArtifactTemplate) => void;
   onImageExpand: (preview: ExpandedImagePreview) => void;
   onFileOpen: (attachment: ChatFileAttachment) => void;
@@ -311,11 +311,11 @@ interface MessagesTimelineProps {
   timelineEntries: ReturnType<typeof deriveTimelineEntries>;
   latestTurn: TimelineLatestTurn | null;
   runningTurnId: TurnId | null;
-  turnDiffSummaryByAssistantMessageId: Map<MessageId, TurnDiffSummary>;
+  turnDiffSummaries: ReadonlyArray<TurnDiffSummary>;
   routeThreadKey: string;
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
-  revertTurnCountByUserMessageId: Map<MessageId, number>;
-  onRevertUserMessage: (messageId: MessageId) => void;
+  supportsConversationRollback: boolean;
+  onRevertToTurnCount: (targetTurnCount: number) => void;
   onUseArtifactTemplate?: (template: CodexArtifactTemplate) => void;
   isRevertingCheckpoint: boolean;
   onImageExpand: (preview: ExpandedImagePreview) => void;
@@ -369,11 +369,11 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   timelineEntries,
   latestTurn,
   runningTurnId,
-  turnDiffSummaryByAssistantMessageId,
+  turnDiffSummaries,
   routeThreadKey,
   onOpenTurnDiff,
-  revertTurnCountByUserMessageId,
-  onRevertUserMessage,
+  supportsConversationRollback,
+  onRevertToTurnCount,
   onUseArtifactTemplate = NOOP_USE_ARTIFACT_TEMPLATE,
   isRevertingCheckpoint,
   onImageExpand,
@@ -543,8 +543,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
         expandedWorkGroupIds,
         isWorking,
         activeTurnStartedAt,
-        turnDiffSummaryByAssistantMessageId,
-        revertTurnCountByUserMessageId,
+        turnDiffSummaries,
+        supportsConversationRollback,
       },
       previous?.threadKey === routeThreadKey && previous.workspaceRoot === workspaceRoot
         ? previous.projection
@@ -563,8 +563,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     expandedWorkGroupIds,
     isWorking,
     activeTurnStartedAt,
-    turnDiffSummaryByAssistantMessageId,
-    revertTurnCountByUserMessageId,
+    turnDiffSummaries,
+    supportsConversationRollback,
   ]);
   const rows = useStableRows(rawRows);
   const minimapItems = useMemo(() => deriveTimelineMinimapItems(rows), [rows]);
@@ -729,7 +729,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       workspaceRoot,
       skills,
       activeThreadEnvironmentId,
-      onRevertUserMessage,
+      onRevertToTurnCount,
       onUseArtifactTemplate,
       onImageExpand,
       onFileOpen,
@@ -753,7 +753,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       workspaceRoot,
       skills,
       activeThreadEnvironmentId,
-      onRevertUserMessage,
+      onRevertToTurnCount,
       onUseArtifactTemplate,
       onImageExpand,
       onFileOpen,
@@ -1336,7 +1336,7 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
   ];
   const previewImages = userImages.filter((image) => image.name.startsWith("preview-annotation-"));
   const regularImages = userImages.filter((image) => !image.name.startsWith("preview-annotation-"));
-  const canRevertAgentWork = typeof row.revertTurnCount === "number";
+  const revertTurnCount = row.revertTurnCount;
 
   return (
     <div className="group flex flex-col items-end gap-1">
@@ -1498,7 +1498,9 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
             </TooltipPopup>
           </Tooltip>
           <div className="flex items-center gap-0.5">
-            {canRevertAgentWork && <RevertUserMessageButton messageId={row.message.id} />}
+            {typeof revertTurnCount === "number" && (
+              <RevertUserMessageButton turnCount={revertTurnCount} />
+            )}
             {displayedUserMessage.copyText && (
               <MessageCopyButton text={displayedUserMessage.copyText} variant="ghost" />
             )}
@@ -1509,7 +1511,7 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
   );
 }
 
-function RevertUserMessageButton({ messageId }: { messageId: MessageId }) {
+function RevertUserMessageButton({ turnCount }: { turnCount: number }) {
   const ctx = use(TimelineRowCtx);
   const activity = use(TimelineRowActivityCtx);
 
@@ -1522,7 +1524,7 @@ function RevertUserMessageButton({ messageId }: { messageId: MessageId }) {
             size="xs"
             variant="ghost"
             disabled={activity.isRevertingCheckpoint || activity.isWorking}
-            onClick={() => ctx.onRevertUserMessage(messageId)}
+            onClick={() => ctx.onRevertToTurnCount(turnCount)}
             aria-label="Revert to this message"
           />
         }


### PR DESCRIPTION
ChatView rebuilt rewind targets on every streaming update. Timeline row reuse depended on callers keeping two Maps stable.

The timeline now accepts checkpoint summaries and owns both lookups. Text-only updates reuse rows before checkpoint maps are rebuilt. Equal control snapshots preserve reuse. Rewind callbacks reject clicks from an old thread or checkpoint snapshot.

## Verification

- 301 focused timeline, ChatView logic, and Markdown tests pass after rebasing onto current main.
- A long-thread fixture with 250 historical checkpoints uses the real client reducer, detail selectors, and attachment preview code. Ten text updates do not read checkpoint lookup fields in the timeline projection and keep historical row references. Image URL renewal and turn completion still update the rows.
- A mounted timeline keeps code wrap state through streaming and highlighter recovery. Changed checkpoints send the current rewind target.
- Web typecheck and targeted lint pass. Existing React lint warnings remain.

This changes the shared web and desktop timeline. It does not change mobile, provider behavior, or wire contracts. These are source and component checks, not browser CPU or frame measurements.

In a disposable browser, five streamed text updates kept the same connected code node, line-wrap state, and selected text. Changing the checkpoint summary changed the revert confirmation from checkpoint 1 to checkpoint 3. Both dialogs were cancelled. The same behavior passed on main and the combined integration build.

## Browser evidence

Before is main `0c200c5f`. After is combined integration `8316ed24`. These checks use browser-only RPC events. No provider ran and no checkpoint restore was submitted. This is client behavior evidence, not a CPU or frame-rate measurement.

| Before | After |
| --- | --- |
| ![Streaming code controls before](https://files.tslop.org/2026/09/before-main-0c200c5f-stream-controls-fa8041bd.png) | ![Streaming code controls after](https://files.tslop.org/2026/09/after-final-8316ed24-stream-controls-232a8f8c.png) |

| Before | After |
| --- | --- |
| ![Updated checkpoint confirmation before](https://files.tslop.org/2026/09/before-main-0c200c5f-checkpoint-refresh-31e2e109.png) | ![Updated checkpoint confirmation after](https://files.tslop.org/2026/09/after-final-8316ed24-checkpoint-refresh-b0e7eb74.png) |

[Before recording](https://files.tslop.org/2026/09/before-main-0c200c5f-stream-27faafb2.webm) · [After recording](https://files.tslop.org/2026/09/after-final-8316ed24-stream-6c243594.webm)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip checkpoint map rebuilds during streaming by moving revert logic into `MessagesTimeline`
> - Moves `buildRevertTurnCountByUserMessageId` from [ChatView.logic.ts](https://github.com/pingdotgg/t3code/pull/10118/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114) into [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/10118/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe), so checkpoint and revert-count calculation happens inside timeline row derivation instead of in the parent component.
> - Changes `deriveMessagesTimelineRows` input contract from two caller-precomputed Maps to a checkpoint summary array (`turnDiffSummaries`) and a `supportsConversationRollback` flag. The row builder now indexes assistant summaries and infers checkpoint counts locally.
> - Expands the unchanged-context check in `replaceStreamingMessageRows` to compare checkpoint-summary arrays, latest-turn values, and expanded-turn/work-group sets, so streaming updates reuse the previous row projection when row-affecting inputs are shallowly equal.
> - Replaces the message-ID revert callback with a numeric target-turn-count callback across [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/10118/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588), `UserTimelineRow`, and `RevertUserMessageButton`.
> - Risk: `deriveMessagesTimelineRows` now requires shallow-equal checkpoint-summary arrays to reuse streaming projections; callers passing new array references per render will rebuild rows every update and lose the streaming-skip optimization.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3b43359. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## Model

Created with GPT-6 Astra in Codex. Follow-up test refinement and rebase with Codex. Browser verification and evidence upload in Codex.
