### PR TITLE
fix(preview): replace guests after browser command timeouts

### DIFF
--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -90,3 +90,4 @@ export const PREVIEW_RECORDING_SAVE_CHANNEL = "desktop:preview-recording-save";
 export const PREVIEW_RECORDING_FRAME_CHANNEL = "desktop:preview-recording-frame";
 export const PREVIEW_STATE_CHANGE_CHANNEL = "desktop:preview-state-change";
 export const PREVIEW_POINTER_EVENT_CHANNEL = "desktop:preview-pointer-event";
+export const PREVIEW_WEBVIEW_RESET_CHANNEL = "desktop:preview-webview-reset";

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -90,4 +90,5 @@ export const PREVIEW_RECORDING_SAVE_CHANNEL = "desktop:preview-recording-save";
 export const PREVIEW_RECORDING_FRAME_CHANNEL = "desktop:preview-recording-frame";
 export const PREVIEW_STATE_CHANGE_CHANNEL = "desktop:preview-state-change";
 export const PREVIEW_POINTER_EVENT_CHANNEL = "desktop:preview-pointer-event";
+export const PREVIEW_WEBVIEW_REMOVED_CHANNEL = "desktop:preview-webview-removed";
 export const PREVIEW_WEBVIEW_RESET_CHANNEL = "desktop:preview-webview-reset";

--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -82,10 +82,10 @@ export const closeTab = DesktopIpc.makeIpcMethod({
 export const registerWebview = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_REGISTER_WEBVIEW_CHANNEL,
   payload: DesktopPreviewRegisterWebviewInputSchema,
-  result: Schema.Void,
+  result: Schema.Number,
   handler: Effect.fn("desktop.ipc.preview.registerWebview")(function* ({ tabId, webContentsId }) {
     const manager = yield* PreviewManager.PreviewManager;
-    yield* manager.registerWebview(tabId, webContentsId);
+    return yield* manager.registerWebview(tabId, webContentsId);
   }),
 });
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -303,6 +303,24 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       return () =>
         ipcRenderer.removeListener(IpcChannels.PREVIEW_STATE_CHANGE_CHANNEL, wrappedListener);
     },
+    onWebviewReset: (listener) => {
+      const wrappedListener = (
+        _event: Electron.IpcRendererEvent,
+        tabId: unknown,
+        webContentsId: unknown,
+      ) => {
+        if (
+          typeof tabId !== "string" ||
+          typeof webContentsId !== "number" ||
+          !Number.isInteger(webContentsId)
+        )
+          return;
+        listener(tabId, webContentsId);
+      };
+      ipcRenderer.on(IpcChannels.PREVIEW_WEBVIEW_RESET_CHANNEL, wrappedListener);
+      return () =>
+        ipcRenderer.removeListener(IpcChannels.PREVIEW_WEBVIEW_RESET_CHANNEL, wrappedListener);
+    },
     onPointerEvent: (listener) => {
       const wrappedListener = (_event: Electron.IpcRendererEvent, pointerEvent: unknown) => {
         if (typeof pointerEvent !== "object" || pointerEvent === null) return;

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -308,19 +308,24 @@ contextBridge.exposeInMainWorld("desktopBridge", {
         _event: Electron.IpcRendererEvent,
         tabId: unknown,
         webContentsId: unknown,
+        resetId: unknown,
       ) => {
         if (
           typeof tabId !== "string" ||
           typeof webContentsId !== "number" ||
-          !Number.isInteger(webContentsId)
+          !Number.isInteger(webContentsId) ||
+          typeof resetId !== "number" ||
+          !Number.isInteger(resetId)
         )
           return;
-        listener(tabId, webContentsId);
+        listener(tabId, webContentsId, resetId);
       };
       ipcRenderer.on(IpcChannels.PREVIEW_WEBVIEW_RESET_CHANNEL, wrappedListener);
       return () =>
         ipcRenderer.removeListener(IpcChannels.PREVIEW_WEBVIEW_RESET_CHANNEL, wrappedListener);
     },
+    confirmWebviewRemoved: (tabId, webContentsId, resetId) =>
+      ipcRenderer.send(IpcChannels.PREVIEW_WEBVIEW_REMOVED_CHANNEL, tabId, webContentsId, resetId),
     onPointerEvent: (listener) => {
       const wrappedListener = (_event: Electron.IpcRendererEvent, pointerEvent: unknown) => {
         if (typeof pointerEvent !== "object" || pointerEvent === null) return;

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -1,3 +1,5 @@
+import * as NodeEvents from "node:events";
+
 import { it as effectIt } from "@effect/vitest";
 import { DESKTOP_PREVIEW_RECORDING_CAPTURE_TRIGGER } from "@t3tools/contracts";
 import type { DesktopPreviewRecordingFrame } from "@t3tools/contracts";
@@ -219,6 +221,7 @@ interface TestHostWebContents {
   readonly id: number;
   readonly mainFrame: { readonly frameTreeNodeId: number };
   readonly executeJavaScript: ReturnType<typeof vi.fn>;
+  readonly send: ReturnType<typeof vi.fn>;
   readonly isDestroyed: () => boolean;
   readonly session: {
     readonly setDisplayMediaRequestHandler: ReturnType<typeof vi.fn>;
@@ -236,6 +239,7 @@ const makeTestHostWebContents = (): TestHostWebContents => {
     id: 7,
     mainFrame: { frameTreeNodeId: 7 },
     executeJavaScript: vi.fn(async () => true),
+    send: vi.fn(),
     isDestroyed: () => false,
     session: {
       setDisplayMediaRequestHandler: vi.fn((next: TestDisplayMediaHandler) => {
@@ -283,6 +287,73 @@ const makeTestPreviewWebContents = (
     },
     capturePage,
   } as unknown as TestPreviewWebContents;
+};
+
+const makeAutomationWebContents = (id = 42, host = makeTestHostWebContents()) => {
+  const events = new NodeEvents.EventEmitter();
+  const debuggerEvents = new NodeEvents.EventEmitter();
+  let destroyed = false;
+  let attached = false;
+  const sendCommand = vi.fn(
+    async (method: string, params?: Record<string, unknown>): Promise<unknown> =>
+      method === "Runtime.evaluate"
+        ? {
+            result: {
+              value:
+                params?.expression === "42"
+                  ? 42
+                  : {
+                      url: "https://example.com",
+                      title: "Example",
+                      loading: false,
+                      visibleText: "Example",
+                      interactiveElements: [],
+                    },
+            },
+          }
+        : undefined,
+  );
+  const wc = Object.assign(
+    makeTestPreviewWebContents(
+      async () => ({
+        toJPEG: () => Buffer.from("jpeg"),
+        toPNG: () => Buffer.from("png"),
+        getSize: () => ({ width: 100, height: 80 }),
+      }),
+      id,
+      host,
+    ),
+    {
+      isDestroyed: () => destroyed,
+      isDevToolsOpened: () => false,
+      focus: vi.fn(),
+      on: events.on.bind(events),
+      once: events.once.bind(events),
+      off: events.off.bind(events),
+      debugger: {
+        isAttached: () => attached,
+        attach: vi.fn(() => {
+          attached = true;
+        }),
+        detach: vi.fn(() => {
+          attached = false;
+          debuggerEvents.emit("detach", {}, "target closed");
+        }),
+        sendCommand,
+        on: debuggerEvents.on.bind(debuggerEvents),
+        off: debuggerEvents.off.bind(debuggerEvents),
+      },
+    },
+  );
+  return {
+    wc,
+    host,
+    sendCommand,
+    destroy: () => {
+      destroyed = true;
+      events.emit("destroyed");
+    },
+  };
 };
 
 /** Two ready tabs (41, 42) sharing one window, so they contend for the single display-media slot. */
@@ -2534,6 +2605,409 @@ describe("PreviewManager", () => {
           cause: { _tag: "TimeoutError" },
         });
         expect(yield* Fiber.join(evaluate)).toBe(42);
+      }),
+    ),
+  );
+
+  effectIt.effect("retires a stalled evaluation before admitting another guest", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const first = makeAutomationWebContents();
+        const replacement = makeAutomationWebContents(43, first.host);
+        fromId.mockImplementation((id) => (id === 43 ? replacement.wc : first.wc));
+        yield* manager.createTab("tab_deadline");
+        yield* manager.registerWebview("tab_deadline", 42);
+        yield* manager.automationEvaluate("tab_deadline", { expression: "42" });
+        const entered = yield* Deferred.make<void>();
+        const pending = Promise.withResolvers<unknown>();
+        first.sendCommand.mockClear().mockImplementation(async (method, params) => {
+          if (method === "Runtime.evaluate") {
+            queueMicrotask(() => Deferred.doneUnsafe(entered, Effect.void));
+            expect(params?.awaitPromise).toBe(true);
+            return pending.promise;
+          }
+        });
+        const evaluation = yield* manager
+          .automationEvaluate("tab_deadline", {
+            expression: "new Promise(() => {})",
+          })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(entered);
+        yield* TestClock.adjust(1_000);
+        const queued = yield* manager
+          .automationEvaluate("tab_deadline", {
+            expression: "document.title = 'queued'",
+          })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* TestClock.adjust(9_000);
+        expect(first.host.send).toHaveBeenCalledExactlyOnceWith(
+          "desktop:preview-webview-reset",
+          "tab_deadline",
+          42,
+        );
+        expect(evaluation.pollUnsafe()).toBeUndefined();
+        expect(queued.pollUnsafe()).toBeUndefined();
+        const registration = yield* manager
+          .registerWebview("tab_deadline", 43)
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        expect(registration.pollUnsafe()).toBeUndefined();
+        expect(replacement.sendCommand).not.toHaveBeenCalled();
+        expect(
+          first.sendCommand.mock.calls.filter(([method]) => method === "Runtime.evaluate"),
+        ).toHaveLength(1);
+
+        first.destroy();
+        const evaluationExit = yield* Fiber.await(evaluation);
+        expect(Exit.isFailure(evaluationExit)).toBe(true);
+        expect(Exit.isFailure(yield* Fiber.await(queued))).toBe(true);
+        yield* Fiber.join(registration);
+        pending.resolve({ result: { value: "late first reply" } });
+        yield* Effect.promise(() => pending.promise);
+        expect(yield* manager.automationEvaluate("tab_deadline", { expression: "42" })).toBe(42);
+        expect(
+          first.sendCommand.mock.calls.filter(([method]) => method === "Runtime.evaluate"),
+        ).toHaveLength(1);
+        expect(evaluation.pollUnsafe()).toEqual(evaluationExit);
+      }),
+    ),
+  );
+
+  effectIt.effect("keeps the tab unavailable when native guest teardown does not finish", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const first = makeAutomationWebContents();
+        const replacement = makeAutomationWebContents(43, first.host);
+        fromId.mockImplementation((id) => (id === 43 ? replacement.wc : first.wc));
+        yield* manager.createTab("tab_reset_failure");
+        yield* manager.registerWebview("tab_reset_failure", 42);
+        yield* manager.automationEvaluate("tab_reset_failure", { expression: "42" });
+        const pending = Promise.withResolvers<unknown>();
+        const entered = yield* Deferred.make<void>();
+        first.sendCommand.mockImplementation(async (method) => {
+          if (method === "Runtime.evaluate") {
+            queueMicrotask(() => Deferred.doneUnsafe(entered, Effect.void));
+            return pending.promise;
+          }
+        });
+        const evaluation = yield* manager
+          .automationEvaluate("tab_reset_failure", {
+            expression: "new Promise(() => {})",
+          })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(entered);
+        yield* TestClock.adjust(12_000);
+        expect(Exit.isFailure(yield* Fiber.await(evaluation))).toBe(true);
+        expect((yield* manager.automationStatus("tab_reset_failure")).available).toBe(false);
+        const blocked = yield* Effect.exit(
+          manager.automationEvaluate("tab_reset_failure", { expression: "42" }),
+        );
+        expect(Exit.isFailure(blocked)).toBe(true);
+        if (Exit.isFailure(blocked)) {
+          expect(Option.getOrThrow(Cause.findErrorOption(blocked.cause))).toMatchObject({
+            _tag: "PreviewAutomationGuestRetiredError",
+            webContentsId: 42,
+          });
+        }
+        const registration = yield* manager
+          .registerWebview("tab_reset_failure", 43)
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* TestClock.adjust(2_000);
+        expect(Exit.isFailure(yield* Fiber.await(registration))).toBe(true);
+        expect(replacement.sendCommand).not.toHaveBeenCalled();
+        pending.resolve({ result: { value: "late" } });
+        yield* Effect.promise(() => pending.promise);
+        expect((yield* manager.automationStatus("tab_reset_failure")).available).toBe(false);
+        expect(
+          Exit.isFailure(yield* Effect.exit(manager.registerWebview("tab_reset_failure", 42))),
+        ).toBe(true);
+
+        first.destroy();
+        yield* manager.registerWebview("tab_reset_failure", 43);
+        expect(yield* manager.automationEvaluate("tab_reset_failure", { expression: "42" })).toBe(
+          42,
+        );
+      }),
+    ),
+  );
+
+  effectIt.effect("counts a pending debugger reply against the waitFor deadline", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const guest = makeAutomationWebContents();
+        fromId.mockReturnValue(guest.wc);
+        yield* manager.createTab("tab_wait_deadline");
+        yield* manager.registerWebview("tab_wait_deadline", 42);
+        yield* manager.automationEvaluate("tab_wait_deadline", { expression: "42" });
+        const entered = yield* Deferred.make<void>();
+        guest.sendCommand.mockImplementation(async (method) => {
+          if (method === "Runtime.evaluate") {
+            queueMicrotask(() => Deferred.doneUnsafe(entered, Effect.void));
+            return new Promise(() => {});
+          }
+        });
+        guest.host.send.mockImplementation(() => guest.destroy());
+        const wait = yield* manager
+          .automationWaitFor("tab_wait_deadline", {
+            text: "ready",
+            timeoutMs: 500,
+          })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(entered);
+        yield* TestClock.adjust(500);
+        const exit = yield* Fiber.await(wait);
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          expect(Option.getOrThrow(Cause.findErrorOption(exit.cause))).toMatchObject({
+            _tag: "PreviewAutomationTimeoutError",
+            operation: "waitFor",
+            timeoutMs: 500,
+          });
+        }
+        expect(guest.host.send).toHaveBeenCalledOnce();
+      }),
+    ),
+  );
+
+  effectIt.effect("does not reset a responsive guest when a condition never matches", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const guest = makeAutomationWebContents();
+        fromId.mockReturnValue(guest.wc);
+        yield* manager.createTab("tab_wait_condition");
+        yield* manager.registerWebview("tab_wait_condition", 42);
+        guest.sendCommand.mockImplementation(async (method, params) =>
+          method === "Runtime.evaluate"
+            ? { result: { value: params?.expression === "42" ? 42 : { matched: false } } }
+            : undefined,
+        );
+        const wait = yield* manager
+          .automationWaitFor("tab_wait_condition", {
+            text: "missing",
+            timeoutMs: 500,
+          })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* TestClock.adjust(500);
+        expect(Exit.isFailure(yield* Fiber.await(wait))).toBe(true);
+        expect(guest.host.send).not.toHaveBeenCalled();
+        expect(yield* manager.automationEvaluate("tab_wait_condition", { expression: "42" })).toBe(
+          42,
+        );
+      }),
+    ),
+  );
+
+  effectIt.effect("does not reset or release the active guest when a queued waiter expires", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const guest = makeAutomationWebContents();
+        const states: PreviewManager.PreviewTabState[] = [];
+        yield* manager.subscribeStateChanges((_tabId, state) =>
+          Effect.sync(() => {
+            states.push(state);
+          }),
+        );
+        fromId.mockReturnValue(guest.wc);
+        yield* manager.createTab("tab_wait_queue");
+        yield* manager.registerWebview("tab_wait_queue", 42);
+        yield* manager.automationEvaluate("tab_wait_queue", { expression: "42" });
+        const pending = Promise.withResolvers<unknown>();
+        const entered = yield* Deferred.make<void>();
+        guest.sendCommand.mockImplementation(async (method) => {
+          if (method === "Runtime.evaluate") {
+            queueMicrotask(() => Deferred.doneUnsafe(entered, Effect.void));
+            return pending.promise;
+          }
+        });
+        const evaluation = yield* manager
+          .automationEvaluate("tab_wait_queue", {
+            expression: "new Promise(() => {})",
+          })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(entered);
+        const wait = yield* manager
+          .automationWaitFor("tab_wait_queue", { text: "ready", timeoutMs: 500 })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* TestClock.adjust(500);
+        expect(Exit.isFailure(yield* Fiber.await(wait))).toBe(true);
+        expect(guest.host.send).not.toHaveBeenCalled();
+        expect(states.at(-1)?.controller).toBe("agent");
+        pending.resolve({ result: { value: 42 } });
+        expect(yield* Fiber.join(evaluation)).toBe(42);
+      }),
+    ),
+  );
+
+  effectIt.effect("retires the guest when a key release command stalls", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const guest = makeAutomationWebContents();
+        fromId.mockReturnValue(guest.wc);
+        yield* manager.createTab("tab_cleanup_deadline");
+        yield* manager.registerWebview("tab_cleanup_deadline", 42);
+        yield* manager.automationEvaluate("tab_cleanup_deadline", { expression: "42" });
+        const entered = yield* Deferred.make<void>();
+        guest.sendCommand.mockImplementation(async (method, params) => {
+          if (method === "Input.dispatchKeyEvent" && params?.type === "keyUp") {
+            queueMicrotask(() => Deferred.doneUnsafe(entered, Effect.void));
+            return new Promise(() => {});
+          }
+        });
+        guest.host.send.mockImplementation(() => guest.destroy());
+        const press = yield* manager
+          .automationPress("tab_cleanup_deadline", { key: "x" })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(entered);
+        yield* TestClock.adjust(1_000);
+        expect(Exit.isFailure(yield* Fiber.await(press))).toBe(true);
+        expect(guest.host.send).toHaveBeenCalledOnce();
+        expect(guest.sendCommand).not.toHaveBeenCalledWith("Emulation.setFocusEmulationEnabled", {
+          enabled: false,
+        });
+      }),
+    ),
+  );
+
+  effectIt.effect("bounds stalled debugger initialization before accepting automation", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const guest = makeAutomationWebContents();
+        const second = makeAutomationWebContents(43);
+        fromId.mockImplementation((id) => (id === 43 ? second.wc : guest.wc));
+        const entered = yield* Deferred.make<void>();
+        guest.sendCommand.mockImplementation(async (method) => {
+          if (method === "Runtime.enable") {
+            queueMicrotask(() => Deferred.doneUnsafe(entered, Effect.void));
+            return new Promise(() => {});
+          }
+        });
+        guest.host.send.mockImplementation(() => guest.destroy());
+        yield* manager.createTab("tab_init_deadline");
+        yield* manager.registerWebview("tab_init_deadline", 42);
+        yield* Deferred.await(entered);
+        yield* manager.createTab("tab_init_independent");
+        yield* manager.registerWebview("tab_init_independent", 43);
+        expect(
+          yield* manager.automationEvaluate("tab_init_independent", { expression: "42" }),
+        ).toBe(42);
+        const evaluation = yield* manager
+          .automationEvaluate("tab_init_deadline", { expression: "42" })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* TestClock.adjust(10_000);
+        expect(Exit.isFailure(yield* Fiber.await(evaluation))).toBe(true);
+        expect(guest.host.send).toHaveBeenCalledOnce();
+        expect(guest.sendCommand.mock.calls.some(([method]) => method === "Runtime.evaluate")).toBe(
+          false,
+        );
+      }),
+    ),
+  );
+
+  effectIt.effect("retires pending evaluation before detaching for DevTools", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const guest = makeAutomationWebContents();
+        fromId.mockReturnValue(guest.wc);
+        yield* manager.createTab("tab_detach");
+        yield* manager.registerWebview("tab_detach", 42);
+        yield* manager.automationEvaluate("tab_detach", { expression: "42" });
+        const resetRequested = yield* Deferred.make<void>();
+        guest.host.send.mockImplementation(() => Deferred.doneUnsafe(resetRequested, Effect.void));
+        const entered = yield* Deferred.make<void>();
+        const pending = Promise.withResolvers<unknown>();
+        guest.sendCommand.mockImplementation(async (method) => {
+          if (method === "Runtime.evaluate") {
+            queueMicrotask(() => Deferred.doneUnsafe(entered, Effect.void));
+            return pending.promise;
+          }
+        });
+        guest.wc.debugger.detach.mockImplementation(() => {
+          pending.reject(new Error("target closed while handling command"));
+        });
+        const evaluation = yield* manager
+          .automationEvaluate("tab_detach", {
+            expression: "new Promise(() => {})",
+          })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(entered);
+        const detach = yield* manager
+          .openDevTools("tab_detach")
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(resetRequested);
+        expect(guest.host.send).toHaveBeenCalledOnce();
+        expect(guest.wc.debugger.detach).not.toHaveBeenCalled();
+        expect(
+          Exit.isFailure(
+            yield* Effect.exit(manager.navigate("tab_detach", "https://new.example.com")),
+          ),
+        ).toBe(true);
+        guest.destroy();
+        expect(Exit.isFailure(yield* Fiber.await(detach))).toBe(true);
+        expect(Exit.isFailure(yield* Fiber.await(evaluation))).toBe(true);
+        expect(guest.wc.debugger.detach).toHaveBeenCalledOnce();
+      }),
+    ),
+  );
+
+  effectIt.effect("keeps a transport-rejected evaluation from releasing its guest for reuse", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const guest = makeAutomationWebContents();
+        fromId.mockReturnValue(guest.wc);
+        yield* manager.createTab("tab_external_detach");
+        yield* manager.registerWebview("tab_external_detach", 42);
+        yield* manager.automationEvaluate("tab_external_detach", { expression: "42" });
+        const entered = yield* Deferred.make<void>();
+        const pending = Promise.withResolvers<unknown>();
+        guest.sendCommand.mockImplementation(async (method) => {
+          if (method === "Runtime.evaluate") {
+            queueMicrotask(() => Deferred.doneUnsafe(entered, Effect.void));
+            return pending.promise;
+          }
+        });
+        const evaluation = yield* manager
+          .automationEvaluate("tab_external_detach", {
+            expression: "new Promise(() => {})",
+          })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(entered);
+        guest.wc.debugger.detach();
+        pending.reject(new Error("target closed while handling command"));
+        expect(Exit.isFailure(yield* Fiber.await(evaluation))).toBe(true);
+        expect((yield* manager.automationStatus("tab_external_detach")).available).toBe(false);
+        expect(
+          Exit.isFailure(
+            yield* Effect.exit(
+              manager.automationEvaluate("tab_external_detach", { expression: "42" }),
+            ),
+          ),
+        ).toBe(true);
+        guest.destroy();
+      }),
+    ),
+  );
+
+  effectIt.effect("releases action history when a tab closes", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const first = makeAutomationWebContents();
+        const replacement = makeAutomationWebContents(43);
+        fromId.mockImplementation((id) => (id === 43 ? replacement.wc : first.wc));
+        yield* manager.createTab("tab_history");
+        yield* manager.registerWebview("tab_history", 42);
+        yield* manager.automationEvaluate("tab_history", { expression: "42" });
+        expect(
+          (yield* manager.automationSnapshot("tab_history")).actionTimeline.some(
+            (event) => event.action === "evaluate",
+          ),
+        ).toBe(true);
+        yield* manager.closeTab("tab_history");
+        yield* manager.createTab("tab_history");
+        yield* manager.registerWebview("tab_history", 43);
+        expect(
+          (yield* manager.automationSnapshot("tab_history")).actionTimeline.map(
+            (event) => event.action,
+          ),
+        ).toEqual(["snapshot"]);
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -218,6 +218,7 @@ type TestDisplayMediaHandler = (
 ) => void;
 
 interface TestHostWebContents {
+  readonly ipc: NodeEvents.EventEmitter;
   readonly id: number;
   readonly mainFrame: { readonly frameTreeNodeId: number };
   readonly executeJavaScript: ReturnType<typeof vi.fn>;
@@ -236,6 +237,7 @@ type TestPreviewWebContents = Electron.WebContents & {
 const makeTestHostWebContents = (): TestHostWebContents => {
   let handler: TestDisplayMediaHandler | undefined;
   return {
+    ipc: new NodeEvents.EventEmitter(),
     id: 7,
     mainFrame: { frameTreeNodeId: 7 },
     executeJavaScript: vi.fn(async () => true),
@@ -352,6 +354,14 @@ const makeAutomationWebContents = (id = 42, host = makeTestHostWebContents()) =>
     destroy: () => {
       destroyed = true;
       events.emit("destroyed");
+    },
+    remove: () => {
+      destroyed = true;
+      events.emit("destroyed");
+      const request = host.send.mock.calls.findLast(
+        ([channel, , guestId]) => channel === "desktop:preview-webview-reset" && guestId === id,
+      );
+      if (request) host.ipc.emit("desktop:preview-webview-removed", {}, ...request.slice(1));
     },
   };
 };
@@ -552,7 +562,7 @@ describe("PreviewManager", () => {
       Effect.gen(function* () {
         const preview = makeFaviconWebContents();
         const sendInputEvent = vi.fn();
-        const hostWebContents = { sendInputEvent };
+        const hostWebContents = { ...makeTestHostWebContents(), sendInputEvent };
         Object.assign(preview.webContents, { hostWebContents });
         fromId.mockReturnValue(preview.webContents);
         yield* manager.setMainWindow({
@@ -2644,6 +2654,7 @@ describe("PreviewManager", () => {
           "desktop:preview-webview-reset",
           "tab_deadline",
           42,
+          expect.any(Number),
         );
         expect(evaluation.pollUnsafe()).toBeUndefined();
         expect(queued.pollUnsafe()).toBeUndefined();
@@ -2657,6 +2668,18 @@ describe("PreviewManager", () => {
         ).toHaveLength(1);
 
         first.destroy();
+        const [, resetTab, resetGuest, resetId] = first.host.send.mock.calls[0]!;
+        first.host.ipc.emit(
+          "desktop:preview-webview-removed",
+          {},
+          resetTab,
+          resetGuest,
+          Number(resetId) + 1,
+        );
+        first.host.ipc.emit("desktop:preview-webview-removed", {}, resetTab, 99, resetId);
+        yield* TestClock.adjust(0);
+        expect(registration.pollUnsafe()).toBeUndefined();
+        first.remove();
         const evaluationExit = yield* Fiber.await(evaluation);
         expect(Exit.isFailure(evaluationExit)).toBe(true);
         expect(Exit.isFailure(yield* Fiber.await(queued))).toBe(true);
@@ -2721,7 +2744,12 @@ describe("PreviewManager", () => {
           Exit.isFailure(yield* Effect.exit(manager.registerWebview("tab_reset_failure", 42))),
         ).toBe(true);
 
-        first.destroy();
+        const close = yield* manager
+          .closeTab("tab_reset_failure")
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        first.remove();
+        yield* Fiber.join(close);
+        yield* manager.createTab("tab_reset_failure");
         yield* manager.registerWebview("tab_reset_failure", 43);
         expect(yield* manager.automationEvaluate("tab_reset_failure", { expression: "42" })).toBe(
           42,
@@ -2745,7 +2773,7 @@ describe("PreviewManager", () => {
             return new Promise(() => {});
           }
         });
-        guest.host.send.mockImplementation(() => guest.destroy());
+        guest.host.send.mockImplementation(() => guest.remove());
         const wait = yield* manager
           .automationWaitFor("tab_wait_deadline", {
             text: "ready",
@@ -2852,7 +2880,7 @@ describe("PreviewManager", () => {
             return new Promise(() => {});
           }
         });
-        guest.host.send.mockImplementation(() => guest.destroy());
+        guest.host.send.mockImplementation(() => guest.remove());
         const press = yield* manager
           .automationPress("tab_cleanup_deadline", { key: "x" })
           .pipe(Effect.forkChild({ startImmediately: true }));
@@ -2880,7 +2908,7 @@ describe("PreviewManager", () => {
             return new Promise(() => {});
           }
         });
-        guest.host.send.mockImplementation(() => guest.destroy());
+        guest.host.send.mockImplementation(() => guest.remove());
         yield* manager.createTab("tab_init_deadline");
         yield* manager.registerWebview("tab_init_deadline", 42);
         yield* Deferred.await(entered);
@@ -2940,10 +2968,101 @@ describe("PreviewManager", () => {
             yield* Effect.exit(manager.navigate("tab_detach", "https://new.example.com")),
           ),
         ).toBe(true);
-        guest.destroy();
+        guest.remove();
         expect(Exit.isFailure(yield* Fiber.await(detach))).toBe(true);
         expect(Exit.isFailure(yield* Fiber.await(evaluation))).toBe(true);
         expect(guest.wc.debugger.detach).toHaveBeenCalledOnce();
+      }),
+    ),
+  );
+
+  effectIt.effect(
+    "does not register a new guest when detaching its predecessor starts a failed reset",
+    () =>
+      withManager((manager) =>
+        Effect.gen(function* () {
+          const guest = makeAutomationWebContents();
+          const replacement = makeAutomationWebContents(43, guest.host);
+          fromId.mockImplementation((id) => (id === 43 ? replacement.wc : guest.wc));
+          yield* manager.createTab("tab_replacement_reset");
+          yield* manager.registerWebview("tab_replacement_reset", 42);
+          yield* manager.automationEvaluate("tab_replacement_reset", { expression: "42" });
+          const entered = yield* Deferred.make<void>();
+          const pending = Promise.withResolvers<unknown>();
+          guest.sendCommand.mockImplementation(async (method) => {
+            if (method === "Runtime.evaluate") {
+              queueMicrotask(() => Deferred.doneUnsafe(entered, Effect.void));
+              return pending.promise;
+            }
+          });
+          guest.wc.debugger.detach.mockImplementation(() => {
+            pending.reject(new Error("target closed while handling command"));
+          });
+          const evaluation = yield* manager
+            .automationEvaluate("tab_replacement_reset", {
+              expression: "new Promise(() => {})",
+            })
+            .pipe(Effect.forkChild({ startImmediately: true }));
+          yield* Deferred.await(entered);
+          const registration = yield* manager
+            .registerWebview("tab_replacement_reset", 43)
+            .pipe(Effect.forkChild({ startImmediately: true }));
+          yield* TestClock.adjust(4_000);
+          expect(Exit.isFailure(yield* Fiber.await(registration))).toBe(true);
+          expect(Exit.isFailure(yield* Fiber.await(evaluation))).toBe(true);
+          expect(replacement.sendCommand).not.toHaveBeenCalled();
+          expect((yield* manager.automationStatus("tab_replacement_reset")).available).toBe(false);
+          guest.remove();
+          yield* manager.registerWebview("tab_replacement_reset", 43);
+          expect(
+            yield* manager.automationEvaluate("tab_replacement_reset", { expression: "42" }),
+          ).toBe(42);
+        }),
+      ),
+  );
+
+  effectIt.effect("requests DOM removal after a pending guest loses its wrapper", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const guest = makeAutomationWebContents();
+        const replacement = makeAutomationWebContents(43, guest.host);
+        fromId.mockImplementation((id) => (id === 43 ? replacement.wc : guest.wc));
+        yield* manager.createTab("tab_wrapper_close");
+        yield* manager.registerWebview("tab_wrapper_close", 42);
+        yield* manager.automationEvaluate("tab_wrapper_close", { expression: "42" });
+        const entered = yield* Deferred.make<void>();
+        guest.sendCommand.mockImplementation(async (method) => {
+          if (method === "Runtime.evaluate") {
+            queueMicrotask(() => Deferred.doneUnsafe(entered, Effect.void));
+            return new Promise(() => {});
+          }
+        });
+        const evaluation = yield* manager
+          .automationEvaluate("tab_wrapper_close", {
+            expression: "new Promise(() => {})",
+          })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(entered);
+        guest.destroy();
+        guest.wc.debugger.detach();
+        yield* TestClock.adjust(12_000);
+        expect(guest.host.send).toHaveBeenCalledExactlyOnceWith(
+          "desktop:preview-webview-reset",
+          "tab_wrapper_close",
+          42,
+          expect.any(Number),
+        );
+        expect(Exit.isFailure(yield* Fiber.await(evaluation))).toBe(true);
+        const registration = yield* manager
+          .registerWebview("tab_wrapper_close", 43)
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* TestClock.adjust(2_000);
+        expect(Exit.isFailure(yield* Fiber.await(registration))).toBe(true);
+        guest.remove();
+        yield* manager.registerWebview("tab_wrapper_close", 43);
+        expect(yield* manager.automationEvaluate("tab_wrapper_close", { expression: "42" })).toBe(
+          42,
+        );
       }),
     ),
   );
@@ -2981,7 +3100,7 @@ describe("PreviewManager", () => {
             ),
           ),
         ).toBe(true);
-        guest.destroy();
+        guest.remove();
       }),
     ),
   );
@@ -4286,6 +4405,7 @@ describe("PreviewManager", () => {
         const restoreFocus = vi.fn();
         const focus = vi.fn();
         getFocusedWebContents.mockReturnValue({
+          ipc: new NodeEvents.EventEmitter(),
           id: 7,
           isDestroyed: () => false,
           focus: restoreFocus,

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -21,6 +21,7 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as ElectronWindow from "../electron/ElectronWindow.ts";
+import { HUMAN_INPUT_CHANNEL } from "./GuestProtocol.ts";
 import * as BrowserSession from "./BrowserSession.ts";
 import * as PreviewManager from "./Manager.ts";
 
@@ -355,13 +356,15 @@ const makeAutomationWebContents = (id = 42, host = makeTestHostWebContents()) =>
       destroyed = true;
       events.emit("destroyed");
     },
-    remove: () => {
+    remove: (registrationId?: number, tabId?: string) => {
       destroyed = true;
       events.emit("destroyed");
       const request = host.send.mock.calls.findLast(
         ([channel, , guestId]) => channel === "desktop:preview-webview-reset" && guestId === id,
       );
-      if (request) host.ipc.emit("desktop:preview-webview-removed", {}, ...request.slice(1));
+      if (registrationId !== undefined && tabId !== undefined) {
+        host.ipc.emit("desktop:preview-webview-removed", {}, tabId, id, registrationId);
+      } else if (request) host.ipc.emit("desktop:preview-webview-removed", {}, ...request.slice(1));
     },
   };
 };
@@ -3019,6 +3022,81 @@ describe("PreviewManager", () => {
           ).toBe(42);
         }),
       ),
+  );
+
+  effectIt.effect.each(["remount", "close"] as const)(
+    "accepts removal before the deadline during %s",
+    (mode) =>
+      withManager((manager) =>
+        Effect.gen(function* () {
+          const guest = makeAutomationWebContents();
+          const replacement = makeAutomationWebContents(43, guest.host);
+          fromId.mockImplementation((id) => (id === 43 ? replacement.wc : guest.wc));
+          const tabId = "tab_early_removal";
+          yield* manager.createTab(tabId);
+          const registrationId = yield* manager.registerWebview(tabId, 42);
+          yield* manager.automationEvaluate(tabId, { expression: "42" });
+          const entered = yield* Deferred.make<void>();
+          const pending = Promise.withResolvers<unknown>();
+          guest.sendCommand.mockImplementation(async (method) => {
+            if (method === "Runtime.evaluate") {
+              queueMicrotask(() => Deferred.doneUnsafe(entered, Effect.void));
+              return pending.promise;
+            }
+          });
+          guest.wc.debugger.detach.mockImplementation(() =>
+            pending.reject(new Error("guest removed")),
+          );
+          const evaluation = yield* manager
+            .automationEvaluate(tabId, {
+              expression: "new Promise(() => {})",
+            })
+            .pipe(Effect.forkChild({ startImmediately: true }));
+          yield* Deferred.await(entered);
+          const close =
+            mode === "close"
+              ? yield* manager.closeTab(tabId).pipe(Effect.forkChild({ startImmediately: true }))
+              : undefined;
+          guest.remove(registrationId, tabId);
+          if (close) {
+            yield* Fiber.join(close);
+            yield* manager.createTab(tabId);
+          }
+          yield* manager.registerWebview(tabId, 43);
+          expect(Exit.isFailure(yield* Fiber.await(evaluation))).toBe(true);
+          expect(yield* manager.automationEvaluate(tabId, { expression: "42" })).toBe(42);
+          yield* TestClock.adjust(12_000);
+          expect((yield* manager.automationStatus(tabId)).available).toBe(true);
+        }),
+      ),
+  );
+
+  effectIt.effect("keeps human control visible while replacing a guest", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const guest = makeAutomationWebContents();
+        const replacement = makeAutomationWebContents(43, guest.host);
+        const ipc = new NodeEvents.EventEmitter();
+        Object.assign(guest.wc, { ipc });
+        fromId.mockImplementation((id) => (id === 43 ? replacement.wc : guest.wc));
+        const states: Array<PreviewManager.PreviewTabState> = [];
+        const humanInput = yield* Deferred.make<void>();
+        yield* manager.subscribeStateChanges((_tabId, state) =>
+          Effect.sync(() => {
+            states.push(state);
+            if (state.controller === "human") Deferred.doneUnsafe(humanInput, Effect.void);
+          }),
+        );
+        yield* manager.createTab("tab_human_replace");
+        yield* manager.registerWebview("tab_human_replace", 42);
+        ipc.emit(HUMAN_INPUT_CHANNEL, {});
+        yield* Deferred.await(humanInput);
+        yield* manager.registerWebview("tab_human_replace", 43);
+        expect(states.at(-1)?.controller).toBe("human");
+        yield* TestClock.adjust(750);
+        expect(states.at(-1)?.controller).toBe("none");
+      }),
+    ),
   );
 
   effectIt.effect("requests DOM removal after a pending guest loses its wrapper", () =>

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -2761,6 +2761,60 @@ describe("PreviewManager", () => {
     ),
   );
 
+  effectIt.effect("releases retired guests when their native host window closes", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const first = makeAutomationWebContents();
+        const replacement = makeAutomationWebContents(43);
+        fromId.mockImplementation((id) => (id === 43 ? replacement.wc : first.wc));
+        let closeFirstWindow: (() => void) | undefined;
+        yield* manager.setMainWindow({
+          isDestroyed: () => false,
+          webContents: first.host,
+          once: vi.fn((event: string, listener: () => void) => {
+            if (event === "closed") closeFirstWindow = listener;
+          }),
+        } as never);
+        yield* manager.createTab("tab_host_close");
+        yield* manager.registerWebview("tab_host_close", 42);
+        yield* manager.automationEvaluate("tab_host_close", { expression: "42" });
+        const entered = yield* Deferred.make<void>();
+        const pending = Promise.withResolvers<unknown>();
+        first.sendCommand.mockImplementation(async (method) => {
+          if (method === "Runtime.evaluate") {
+            queueMicrotask(() => Deferred.doneUnsafe(entered, Effect.void));
+            return pending.promise;
+          }
+        });
+        const evaluation = yield* manager
+          .automationEvaluate("tab_host_close", { expression: "new Promise(() => {})" })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(entered);
+        yield* TestClock.adjust(12_000);
+        expect(Exit.isFailure(yield* Fiber.await(evaluation))).toBe(true);
+        expect((yield* manager.automationStatus("tab_host_close")).available).toBe(false);
+
+        // A native window close need not run the renderer's React cleanup.
+        first.destroy();
+        closeFirstWindow?.();
+        yield* manager.setMainWindow({
+          isDestroyed: () => false,
+          webContents: replacement.host,
+          once: vi.fn(),
+        } as never);
+        const registration = yield* manager
+          .registerWebview("tab_host_close", 43)
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* TestClock.adjust(2_000);
+        const registrationExit = yield* Fiber.await(registration);
+        first.remove();
+        pending.resolve({ result: { value: "late" } });
+        expect(Exit.isSuccess(registrationExit)).toBe(true);
+        expect(yield* manager.automationEvaluate("tab_host_close", { expression: "42" })).toBe(42);
+      }),
+    ),
+  );
+
   effectIt.effect("counts a pending debugger reply against the waitFor deadline", () =>
     withManager((manager) =>
       Effect.gen(function* () {

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -53,7 +53,10 @@ import * as Scope from "effect/Scope";
 import * as SynchronizedRef from "effect/SynchronizedRef";
 
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
-import { PREVIEW_PICTURE_IN_PICTURE_FRAME_CHANNEL } from "../ipc/channels.ts";
+import {
+  PREVIEW_PICTURE_IN_PICTURE_FRAME_CHANNEL,
+  PREVIEW_WEBVIEW_RESET_CHANNEL,
+} from "../ipc/channels.ts";
 import * as BrowserSession from "./BrowserSession.ts";
 import {
   ANNOTATION_CAPTURED_CHANNEL,
@@ -127,6 +130,9 @@ const PICTURE_IN_PICTURE_MIN_WIDTH = 240;
 const PICTURE_IN_PICTURE_MIN_HEIGHT = 160;
 const PICTURE_IN_PICTURE_ASPECT_RATIO_EPSILON = 0.002;
 const DIAGNOSTIC_BUFFER_LIMIT = 200;
+const AUTOMATION_TIMEOUT_MS = 10_000;
+const AUTOMATION_CLEANUP_TIMEOUT_MS = 1_000;
+const WEBVIEW_RESET_TIMEOUT_MS = 2_000;
 const MAX_ARTIFACT_SITE_SLUG_LENGTH = 80;
 const AGENT_CURSOR_MOVE_MS = 160;
 const AGENT_CURSOR_CLICK_LEAD_MS = 40;
@@ -445,6 +451,9 @@ interface PickSession {
 
 interface BrowserControlSession {
   readonly webContentsId: number;
+  readonly tabId: string;
+  readonly webContents: Electron.WebContents;
+  readonly pendingCommands: Set<Promise<unknown>>;
   // Pins the WebContents' Debugger wrapper for the session's lifetime.
   // Electron's Debugger is GC-managed but registered with Chromium as a raw
   // DevToolsAgentHostClient pointer; collecting it while attached crashes the
@@ -633,6 +642,20 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     { readonly semaphore: Semaphore.Semaphore; users: number }
   >();
   const tabLifecycleGenerations = new Map<string, number>();
+  const retiredWebContents = new WeakSet<Electron.WebContents>();
+  const controlInitializationLocks = new WeakMap<Electron.WebContents, Semaphore.Semaphore>();
+  const controlInitializationLock = (wc: Electron.WebContents) => {
+    let lock = controlInitializationLocks.get(wc);
+    if (!lock) {
+      lock = Semaphore.makeUnsafe(1);
+      controlInitializationLocks.set(wc, lock);
+    }
+    return lock;
+  };
+  const pendingWebviewResets = new Map<
+    string,
+    { readonly webContents: Electron.WebContents; readonly destroyed: Deferred.Deferred<void> }
+  >();
 
   const attempt = <A>(errorContext: PreviewOperationContext, evaluate: () => A) =>
     Effect.try({
@@ -891,11 +914,19 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   const update = Effect.fn("PreviewManager.update")(function* (
     tabId: string,
     patch: Partial<PreviewTabState>,
+    expectedGuest?: Electron.WebContents,
   ) {
     const updatedAt = yield* currentIso;
     const next = yield* SynchronizedRef.modify(tabsRef, (tabs) => {
       const current = tabs.get(tabId);
-      if (!current) return [Option.none<PreviewTabState>(), tabs] as const;
+      if (
+        !current ||
+        (expectedGuest &&
+          (current.webContentsId !== expectedGuest.id ||
+            webContents.fromId(expectedGuest.id) !== expectedGuest))
+      ) {
+        return [Option.none<PreviewTabState>(), tabs] as const;
+      }
       const state: PreviewTabState = { ...current, ...patch, updatedAt };
       return [
         Option.some(state),
@@ -995,11 +1026,14 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       return yield* new PreviewWebviewNotInitializedError({ tabId });
     }
     const wc = webContents.fromId(tab.webContentsId);
-    if (!wc) {
+    if (!wc || wc.isDestroyed()) {
       return yield* new PreviewWebContentsNotFoundError({
         tabId,
         webContentsId: tab.webContentsId,
       });
+    }
+    if (retiredWebContents.has(wc) || pendingWebviewResets.has(tabId)) {
+      return yield* new PreviewAutomationGuestRetiredError({ tabId, webContentsId: wc.id });
     }
     return wc;
   });
@@ -1029,13 +1063,6 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           : Effect.succeed(resolvedPath),
       ),
     );
-
-  const tabIdForWebContents = Effect.fnUntraced(function* (webContentsId: number) {
-    const tabs = yield* SynchronizedRef.get(tabsRef);
-    return (
-      Array.from(tabs.entries()).find(([, tab]) => tab.webContentsId === webContentsId)?.[0] ?? null
-    );
-  });
 
   const pushBounded = <A>(buffer: ReadonlyArray<A>, entry: A): ReadonlyArray<A> =>
     [...buffer, entry].slice(-DIAGNOSTIC_BUFFER_LIMIT);
@@ -1170,50 +1197,163 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
 
   const detachControlSession = Effect.fn("PreviewManager.detachControlSession")(function* (
     webContentsId: number,
+    expectedGuest?: Electron.WebContents,
+  ): Effect.fn.Return<void> {
+    const guest =
+      expectedGuest ??
+      (yield* SynchronizedRef.get(controlSessionsRef)).get(webContentsId)?.webContents ??
+      (yield* Ref.get(attachedRef)).get(webContentsId)?.webContents;
+    const detach = Effect.gen(function* () {
+      const control = yield* SynchronizedRef.modify(controlSessionsRef, (sessions) => {
+        const current = sessions.get(webContentsId);
+        if (current && guest && current.webContents !== guest) return [null, sessions] as const;
+        return [
+          current,
+          replaceMap(sessions, (copy) => {
+            copy.delete(webContentsId);
+          }),
+        ] as const;
+      });
+      if (control === null) return;
+      if (control) {
+        if (control.pendingCommands.size > 0) {
+          yield* retireWebview(control.tabId, control.webContents).pipe(Effect.ignore);
+        }
+        yield* Scope.close(control.scope, Exit.void).pipe(Effect.ignore);
+        return;
+      }
+      yield* Ref.update(diagnosticsRef, (diagnostics) =>
+        replaceMap(diagnostics, (copy) => {
+          copy.delete(webContentsId);
+        }),
+      );
+    });
+    return yield* guest ? controlInitializationLock(guest).withPermit(detach) : detach;
+  });
+
+  const requireCurrentGuest = Effect.fn("PreviewManager.requireCurrentGuest")(function* (
+    tabId: string,
+    wc: Electron.WebContents,
   ) {
-    const control = yield* SynchronizedRef.modify(controlSessionsRef, (sessions) => [
-      sessions.get(webContentsId),
-      replaceMap(sessions, (copy) => {
-        copy.delete(webContentsId);
-      }),
-    ]);
-    if (control) {
-      yield* Scope.close(control.scope, Exit.void).pipe(Effect.ignore);
-      return;
+    if ((yield* requireWebContents(tabId)) !== wc) {
+      return yield* new PreviewWebContentsNotFoundError({ tabId, webContentsId: wc.id });
     }
-    yield* Ref.update(diagnosticsRef, (diagnostics) =>
-      replaceMap(diagnostics, (copy) => {
-        copy.delete(webContentsId);
-      }),
+  });
+
+  // Removing the DOM webview retires its Chromium target. Calling wc.close()
+  // can destroy only Electron's wrapper while the outer frame still owns it.
+  // Detaching the debugger does not cancel page JavaScript either.
+  const retireWebview = Effect.fn("PreviewManager.retireWebview")(function* (
+    tabId: string,
+    wc: Electron.WebContents,
+  ): Effect.fn.Return<void, PreviewOperationError> {
+    retiredWebContents.add(wc);
+    if (wc.isDestroyed()) return;
+    let pending = pendingWebviewResets.get(tabId);
+    if (!pending) {
+      const destroyed = Deferred.makeUnsafe<void>();
+      pending = { webContents: wc, destroyed };
+      pendingWebviewResets.set(tabId, pending);
+      yield* attempt({ operation: "retireWebview", tabId, webContentsId: wc.id }, () => {
+        wc.once("destroyed", () => {
+          if (pendingWebviewResets.get(tabId)?.webContents === wc) {
+            pendingWebviewResets.delete(tabId);
+          }
+          Deferred.doneUnsafe(destroyed, Effect.void);
+          runFork(
+            Effect.all([detachControlSession(wc.id, wc), detachListeners(wc.id, wc)], {
+              concurrency: 2,
+              discard: true,
+            }),
+          );
+        });
+        const host = wc.hostWebContents;
+        if (!host || host.isDestroyed()) throw new Error("Preview host is unavailable.");
+        host.send(PREVIEW_WEBVIEW_RESET_CHANNEL, tabId, wc.id);
+      });
+    }
+    // Do not release this target to another action if its host cannot remove it.
+    // The entry remains until native destruction, even after this wait expires.
+    yield* Deferred.await(pending.destroyed).pipe(
+      Effect.interruptible,
+      Effect.timeout(WEBVIEW_RESET_TIMEOUT_MS),
+      Effect.mapError(
+        (cause) =>
+          new PreviewOperationError({
+            operation: "retireWebview",
+            tabId,
+            webContentsId: wc.id,
+            cause,
+          }),
+      ),
     );
   });
 
+  const sendDebuggerCommand = Effect.fn("PreviewManager.sendDebuggerCommand")(function* (
+    tabId: string,
+    wc: Electron.WebContents,
+    control: BrowserControlSession,
+    operation: string,
+    method: string,
+    commandParams?: Record<string, unknown>,
+    timeoutMs = AUTOMATION_TIMEOUT_MS,
+  ) {
+    yield* requireCurrentGuest(tabId, wc);
+    let pendingCommand: Promise<unknown> | undefined;
+    const result = yield* Effect.tryPromise({
+      // Interrupting this waiter does not cancel CDP. Retire its target before
+      // the action releases its permit, including caller interruption.
+      try: (_signal) => {
+        const command: Promise<unknown> = control.debugger.sendCommand(
+          method,
+          method === "Runtime.evaluate" ? { ...commandParams, timeout: timeoutMs } : commandParams,
+        );
+        pendingCommand = command;
+        control.pendingCommands.add(command);
+        return command.finally(() => {
+          control.pendingCommands.delete(command);
+          pendingCommand = undefined;
+        });
+      },
+      catch: (cause) =>
+        new PreviewOperationError({ operation, tabId, webContentsId: wc.id, cause }),
+    }).pipe(
+      Effect.onInterrupt(() =>
+        pendingCommand
+          ? retireWebview(tabId, wc).pipe(
+              Effect.catch((error) =>
+                Effect.logWarning("Preview guest reset did not finish.", { error }),
+              ),
+            )
+          : Effect.void,
+      ),
+      Effect.interruptible,
+      Effect.timeout(timeoutMs),
+      Effect.catchTag("TimeoutError", (cause) =>
+        Effect.fail(new PreviewOperationError({ operation, tabId, webContentsId: wc.id, cause })),
+      ),
+    );
+    yield* requireCurrentGuest(tabId, wc);
+    return result;
+  });
+
   const ensureControlSession = Effect.fn("PreviewManager.ensureControlSession")(function* (
+    tabId: string,
     wc: Electron.WebContents,
   ) {
-    return yield* SynchronizedRef.modifyEffect(
-      controlSessionsRef,
-      (
-        sessions,
-      ): Effect.Effect<
-        readonly [BrowserControlSession, ReadonlyMap<number, BrowserControlSession>],
-        PreviewManagerError
-      > => {
-        const existing = sessions.get(wc.id);
-        if (existing) return Effect.succeed([existing, sessions] as const);
+    yield* requireCurrentGuest(tabId, wc);
+    const existing = (yield* SynchronizedRef.get(controlSessionsRef)).get(wc.id);
+    if (existing) return existing;
+    return yield* controlInitializationLock(wc).withPermit(
+      Effect.gen(function* () {
+        yield* requireCurrentGuest(tabId, wc);
+        const existing = (yield* SynchronizedRef.get(controlSessionsRef)).get(wc.id);
+        if (existing) return existing;
         if (wc.isDevToolsOpened()) {
-          return Effect.fail(
-            new PreviewAutomationDevToolsOpenError({
-              webContentsId: wc.id,
-            }),
-          );
+          return yield* new PreviewAutomationDevToolsOpenError({ webContentsId: wc.id });
         }
         if (wc.debugger.isAttached()) {
-          return Effect.fail(
-            new PreviewAutomationDebuggerAttachedError({
-              webContentsId: wc.id,
-            }),
-          );
+          return yield* new PreviewAutomationDebuggerAttachedError({ webContentsId: wc.id });
         }
         const createControlSession = Effect.fn("PreviewManager.createControlSession")(function* () {
           const semaphore = yield* Semaphore.make(1);
@@ -1223,18 +1363,23 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             method: string,
             params: Record<string, unknown>,
           ) {
+            if (
+              retiredWebContents.has(wc) ||
+              (yield* SynchronizedRef.get(tabsRef)).get(tabId)?.webContentsId !== wc.id
+            )
+              return;
             if (method === "Page.screencastFrame") {
               const sessionId = params["sessionId"];
               if (typeof sessionId === "number") {
-                yield* attemptPromise(
-                  {
-                    operation: "ackScreencastFrame",
-                    webContentsId: wc.id,
-                  },
-                  () => wcDebugger.sendCommand("Page.screencastFrameAck", { sessionId }),
+                yield* sendDebuggerCommand(
+                  tabId,
+                  wc,
+                  control,
+                  "ackScreencastFrame",
+                  "Page.screencastFrameAck",
+                  { sessionId },
                 ).pipe(Effect.ignore);
               }
-              const tabId = yield* tabIdForWebContents(wc.id);
               const metadata =
                 typeof params["metadata"] === "object" && params["metadata"] !== null
                   ? (params["metadata"] as Record<string, unknown>)
@@ -1269,6 +1414,11 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           const onMessage: BrowserControlSession["onMessage"] = (_event, method, params) => {
             runFork(handleDebuggerMessage(method, params));
           };
+          const onDetach = () => {
+            if (control.pendingCommands.size === 0) return;
+            retiredWebContents.add(wc);
+            runFork(retireWebview(tabId, wc).pipe(Effect.ignore));
+          };
           yield* Scope.addFinalizer(
             scope,
             Effect.all(
@@ -1280,6 +1430,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
                 ),
                 attempt({ operation: "detachControlSession", webContentsId: wc.id }, () => {
                   wcDebugger.off("message", onMessage);
+                  wcDebugger.off("detach", onDetach);
                   if (wcDebugger.isAttached()) wcDebugger.detach();
                 }).pipe(Effect.ignore),
               ],
@@ -1288,6 +1439,9 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           );
           const control: BrowserControlSession = {
             webContentsId: wc.id,
+            tabId,
+            webContents: wc,
+            pendingCommands: new Set(),
             debugger: wcDebugger,
             semaphore,
             scope,
@@ -1305,40 +1459,47 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             );
             yield* attempt({ operation: "attachDebuggerListeners", webContentsId: wc.id }, () => {
               wcDebugger.on("message", onMessage);
+              wcDebugger.on("detach", onDetach);
               wcDebugger.attach("1.3");
             });
             yield* Effect.all(
               ["Runtime.enable", "Accessibility.enable", "Network.enable", "Log.enable"].map(
                 (method) =>
-                  attemptPromise(
-                    { operation: `initializeDebugger.${method}`, webContentsId: wc.id },
-                    () => wcDebugger.sendCommand(method),
-                  ),
+                  sendDebuggerCommand(tabId, wc, control, `initializeDebugger.${method}`, method),
               ),
               { concurrency: "unbounded", discard: true },
             );
-            return [
-              control,
+            yield* requireCurrentGuest(tabId, wc);
+            yield* SynchronizedRef.update(controlSessionsRef, (sessions) =>
               replaceMap(sessions, (copy) => {
                 copy.set(wc.id, control);
               }),
-            ] as const;
+            );
+            return control;
           });
           return yield* initialize().pipe(
             Effect.onError(() => Scope.close(scope, Exit.void).pipe(Effect.ignore)),
           );
         });
-        return createControlSession();
-      },
+        return yield* createControlSession();
+      }),
     );
   });
 
-  const pushAction = (tabId: string, event: PreviewAutomationActionEvent) =>
-    Ref.update(actionTimelineRef, (timelines) =>
-      replaceMap(timelines, (copy) => {
+  const pushAction = (
+    tabId: string,
+    wc: Electron.WebContents,
+    event: PreviewAutomationActionEvent,
+  ) =>
+    Ref.update(actionTimelineRef, (timelines) => {
+      // A queued action must not recreate history after its tab closes.
+      const current = SynchronizedRef.getUnsafe(tabsRef).get(tabId);
+      if (current?.webContentsId !== wc.id || webContents.fromId(wc.id) !== wc) return timelines;
+      return replaceMap(timelines, (copy) => {
         copy.set(tabId, [...(timelines.get(tabId) ?? []), event].slice(-200));
-      }),
-    );
+      });
+    });
+
   const replaceAction = (tabId: string, event: PreviewAutomationActionEvent) =>
     Ref.update(actionTimelineRef, (timelines) => {
       const timeline = timelines.get(tabId);
@@ -1374,62 +1535,77 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     wc: Electron.WebContents,
     action: string,
     use: (send: SendCommand, sendCleanup: SendCommand) => Effect.Effect<A, PreviewManagerError>,
+    timeoutMs = AUTOMATION_TIMEOUT_MS,
   ) {
     const sequence = yield* nextCounter(actionSequenceRef);
     const startedAt = yield* currentIso;
     const millis = yield* currentMillis;
+    const deadline = millis + timeoutMs;
     const actionEvent: PreviewAutomationActionEvent = {
       id: `browser-action-${millis.toString(36)}-${sequence.toString(36)}`,
       action,
       status: "running",
       startedAt,
     };
-    yield* pushAction(tabId, actionEvent);
+    yield* pushAction(tabId, wc, actionEvent);
     const epoch = (yield* Ref.get(controlEpochRef)).get(tabId) ?? 0;
-    const control = yield* ensureControlSession(wc);
-    const execute = Effect.fn("PreviewManager.executeControlAction")(function* () {
-      yield* update(tabId, { controller: "agent" });
+    const execute = Effect.gen(function* () {
+      const control = yield* ensureControlSession(tabId, wc);
+      const requireControl = Effect.gen(function* () {
+        yield* requireCurrentGuest(tabId, wc);
+        if (((yield* Ref.get(controlEpochRef)).get(tabId) ?? 0) !== epoch) {
+          return yield* new PreviewAutomationControlInterruptedError({
+            operation: action,
+            tabId,
+            webContentsId: wc.id,
+          });
+        }
+      });
       const send: SendCommand = Effect.fn("PreviewManager.sendCommand")(
         function* (method, commandParams) {
-          const before = (yield* Ref.get(controlEpochRef)).get(tabId) ?? 0;
-          if (before !== epoch) {
-            return yield* new PreviewAutomationControlInterruptedError({
-              operation: action,
+          yield* requireControl;
+          const remainingMs = deadline - (yield* currentMillis);
+          if (remainingMs <= 0) {
+            return yield* new PreviewAutomationTimeoutError({
               tabId,
-              webContentsId: wc.id,
+              operation: action,
+              timeoutMs,
             });
           }
-          const result = yield* attemptPromise(
-            { operation: `${action}.${method}`, tabId, webContentsId: wc.id },
-            () => control.debugger.sendCommand(method, commandParams),
+          const result = yield* sendDebuggerCommand(
+            tabId,
+            wc,
+            control,
+            `${action}.${method}`,
+            method,
+            commandParams,
+            remainingMs,
           );
-          const after = (yield* Ref.get(controlEpochRef)).get(tabId) ?? 0;
-          if (after !== epoch) {
-            return yield* new PreviewAutomationControlInterruptedError({
-              operation: action,
-              tabId,
-              webContentsId: wc.id,
-            });
-          }
+          yield* requireControl;
           return result;
         },
       );
-      // Cleanup commands must still run after human input invalidates the action's
-      // control epoch. Otherwise a partially dispatched input can leave Chromium
-      // with a held key or focus emulation enabled for subsequent actions.
-      const sendCleanup: SendCommand = Effect.fn("PreviewManager.sendCleanupCommand")(
-        function* (method, commandParams) {
-          return yield* attemptPromise(
-            {
-              operation: `${action}.cleanup.${method}`,
-              tabId,
-              webContentsId: wc.id,
-            },
-            () => control.debugger.sendCommand(method, commandParams),
-          );
-        },
+      // Human input invalidates the epoch, but keys still need releasing. A
+      // retired or replaced guest must not receive even cleanup commands.
+      const sendCleanup: SendCommand = (method, commandParams) =>
+        sendDebuggerCommand(
+          tabId,
+          wc,
+          control,
+          `${action}.cleanup.${method}`,
+          method,
+          commandParams,
+          AUTOMATION_CLEANUP_TIMEOUT_MS,
+        );
+      return yield* control.semaphore.withPermit(
+        Effect.gen(function* () {
+          yield* requireControl;
+          yield* update(tabId, { controller: "agent" }, wc);
+          const result = yield* use(send, sendCleanup);
+          yield* requireCurrentGuest(tabId, wc);
+          return result;
+        }).pipe(Effect.ensuring(update(tabId, { controller: "none" }, wc))),
       );
-      return yield* use(send, sendCleanup);
     });
     const finalize = Effect.fn("PreviewManager.finalizeControlAction")(function* (
       exit: Exit.Exit<A, PreviewManagerError>,
@@ -1460,10 +1636,14 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           error: errorMessage,
         });
       }
-      const tabs = yield* SynchronizedRef.get(tabsRef);
-      if (tabs.has(tabId)) yield* update(tabId, { controller: "none" });
     });
-    return yield* control.semaphore.withPermit(execute().pipe(Effect.onExit(finalize)));
+    return yield* execute.pipe(
+      Effect.timeout(timeoutMs),
+      Effect.catchTag("TimeoutError", () =>
+        Effect.fail(new PreviewAutomationTimeoutError({ tabId, operation: action, timeoutMs })),
+      ),
+      Effect.onExit(finalize),
+    );
   });
 
   const evaluateWithDebugger = <A = unknown>(
@@ -1550,13 +1730,19 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
 
   const detachListeners = Effect.fn("PreviewManager.detachListeners")(function* (
     webContentsId: number,
+    expectedGuest?: Electron.WebContents,
   ) {
-    const managed = yield* Ref.modify(attachedRef, (attached) => [
-      attached.get(webContentsId),
-      replaceMap(attached, (copy) => {
-        copy.delete(webContentsId);
-      }),
-    ]);
+    const managed = yield* Ref.modify(attachedRef, (attached) => {
+      const current = attached.get(webContentsId);
+      if (expectedGuest && current?.webContents !== expectedGuest)
+        return [undefined, attached] as const;
+      return [
+        current,
+        replaceMap(attached, (copy) => {
+          copy.delete(webContentsId);
+        }),
+      ] as const;
+    });
     if (managed) {
       managed.cancelFaviconCapture();
       yield* Scope.close(managed.scope, Exit.void).pipe(Effect.ignore);
@@ -2021,6 +2207,11 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     });
     if (Option.isNone(tab)) return;
     const closedTab = tab.value;
+    yield* Ref.update(actionTimelineRef, (timelines) =>
+      replaceMap(timelines, (copy) => {
+        copy.delete(tabId);
+      }),
+    );
     if (closedTab.webContentsId != null) {
       yield* Effect.all(
         [detachControlSession(closedTab.webContentsId), detachListeners(closedTab.webContentsId)],
@@ -2085,6 +2276,22 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       (Option.isSome(mainWindow) && wc.hostWebContents !== mainWindow.value.webContents)
     ) {
       return yield* new PreviewWebContentsNotFoundError({ tabId, webContentsId });
+    }
+    if (retiredWebContents.has(wc)) {
+      return yield* new PreviewAutomationGuestRetiredError({ tabId, webContentsId });
+    }
+    const pendingReset = pendingWebviewResets.get(tabId);
+    if (pendingReset) {
+      yield* Deferred.await(pendingReset.destroyed).pipe(
+        Effect.timeout(WEBVIEW_RESET_TIMEOUT_MS),
+        Effect.mapError(
+          () =>
+            new PreviewAutomationGuestRetiredError({
+              tabId,
+              webContentsId: pendingReset.webContents.id,
+            }),
+        ),
+      );
     }
     const attached = yield* Ref.get(attachedRef);
     const annotationTheme = yield* Ref.get(annotationThemeRef);
@@ -2163,6 +2370,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         const next: PreviewTabState = {
           ...currentWithoutFavicon,
           webContentsId,
+          controller: "none",
           navStatus: pendingUrl === null ? computeNavStatus(wc) : current.navStatus,
           canGoBack: wc.navigationHistory.canGoBack(),
           canGoForward: wc.navigationHistory.canGoForward(),
@@ -2319,6 +2527,9 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       );
       return;
     }
+    if (retiredWebContents.has(wc) || pendingWebviewResets.has(tabId)) {
+      return yield* new PreviewAutomationGuestRetiredError({ tabId, webContentsId });
+    }
     if (wc.getURL() === url) {
       yield* attempt({ operation: "navigate.reload", tabId, webContentsId: wc.id }, () =>
         wc.reload(),
@@ -2360,6 +2571,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       return;
     }
     yield* detachControlSession(wc.id);
+    yield* requireCurrentGuest(tabId, wc);
     yield* attempt({ operation: "openDevTools", tabId, webContentsId: wc.id }, () => {
       wc.once("devtools-closed", () => {
         if (!wc.isDestroyed()) runFork(restoreControlSession(tabId, wc));
@@ -2587,9 +2799,14 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     wc: Electron.WebContents,
     colorScheme: DesktopPreviewColorScheme,
   ) {
-    const control = yield* ensureControlSession(wc);
-    yield* attemptPromise({ operation: "applyColorScheme", tabId, webContentsId: wc.id }, () =>
-      control.debugger.sendCommand("Emulation.setEmulatedMedia", {
+    const control = yield* ensureControlSession(tabId, wc);
+    yield* sendDebuggerCommand(
+      tabId,
+      wc,
+      control,
+      "applyColorScheme",
+      "Emulation.setEmulatedMedia",
+      {
         features: [
           {
             name: "prefers-color-scheme",
@@ -2597,7 +2814,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             value: colorScheme === "system" ? "" : colorScheme,
           },
         ],
-      }),
+      },
     );
   });
 
@@ -2609,22 +2826,27 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     Effect.gen(function* () {
       const beforeAttach = (yield* SynchronizedRef.get(tabsRef)).get(tabId);
       if (beforeAttach?.webContentsId !== wc.id) return;
-      const control = yield* ensureControlSession(wc);
+      const control = yield* ensureControlSession(tabId, wc);
       const afterAttach = (yield* SynchronizedRef.get(tabsRef)).get(tabId);
       if (afterAttach?.webContentsId !== wc.id) {
         yield* detachControlSession(wc.id);
         return;
       }
       if (afterAttach.colorScheme !== "system") {
-        yield* attemptPromise({ operation: "applyColorScheme", tabId, webContentsId: wc.id }, () =>
-          control.debugger.sendCommand("Emulation.setEmulatedMedia", {
+        yield* sendDebuggerCommand(
+          tabId,
+          wc,
+          control,
+          "applyColorScheme",
+          "Emulation.setEmulatedMedia",
+          {
             features: [
               {
                 name: "prefers-color-scheme",
                 value: afterAttach.colorScheme,
               },
             ],
-          }),
+          },
         );
       }
     }).pipe(Effect.ignore);
@@ -3469,7 +3691,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       };
     }
     const wc = webContents.fromId(tab.webContentsId);
-    return !wc || wc.isDestroyed()
+    return !wc || wc.isDestroyed() || retiredWebContents.has(wc) || pendingWebviewResets.has(tabId)
       ? {
           available: false,
           visible: true,
@@ -3885,7 +4107,12 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       yield* sendCleanup("Emulation.setFocusEmulationEnabled", { enabled: false }).pipe(
         Effect.ignore,
       );
-      if (previouslyFocused && previouslyFocused.id !== wc.id && !previouslyFocused.isDestroyed()) {
+      if (
+        !retiredWebContents.has(wc) &&
+        previouslyFocused &&
+        previouslyFocused.id !== wc.id &&
+        !previouslyFocused.isDestroyed()
+      ) {
         yield* attempt(
           {
             operation: "automationPress.restoreFocusedWebContents",
@@ -4021,7 +4248,6 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     input: PreviewAutomationWaitForInput,
     send: SendCommand,
   ) {
-    const timeoutMs = input.timeoutMs ?? 15_000;
     yield* send("Runtime.enable");
     const locator = automationLocator(input);
     if (locator) yield* ensurePlaywrightInjected(tabId, send);
@@ -4036,8 +4262,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         ? encodeJson({ operation: "automationWaitFor.encodeUrl", tabId }, input.urlIncludes)
         : Effect.succeed(null),
     ]);
-    const deadline = (yield* currentMillis) + timeoutMs;
-    while ((yield* currentMillis) <= deadline) {
+    while (true) {
       const result = yield* evaluateWithDebugger<
         { matched: boolean } | { invalidSelector: true; message: string }
       >(
@@ -4071,10 +4296,6 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       if (result.matched) return;
       yield* Effect.sleep(100);
     }
-    return yield* new PreviewAutomationTimeoutError({
-      tabId,
-      timeoutMs,
-    });
   });
 
   const automationWaitFor = Effect.fn("PreviewManager.automationWaitFor")(function* (
@@ -4082,8 +4303,12 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     input: PreviewAutomationWaitForInput,
   ) {
     const wc = yield* requireWebContents(tabId);
-    yield* withControlSession(tabId, wc, "waitFor", (send) =>
-      performAutomationWaitFor(tabId, input, send),
+    yield* withControlSession(
+      tabId,
+      wc,
+      "waitFor",
+      (send) => performAutomationWaitFor(tabId, input, send),
+      input.timeoutMs ?? 15_000,
     );
   });
 
@@ -4428,11 +4653,21 @@ export class PreviewAutomationTimeoutError extends Schema.TaggedErrorClass<Previ
   "PreviewAutomationTimeoutError",
   {
     tabId: Schema.String,
+    operation: Schema.String,
     timeoutMs: Schema.Number,
   },
 ) {
   override get message(): string {
-    return `Preview condition did not match within ${this.timeoutMs}ms in tab ${this.tabId}`;
+    return `Preview automation ${this.operation} timed out after ${this.timeoutMs}ms in tab ${this.tabId}`;
+  }
+}
+
+export class PreviewAutomationGuestRetiredError extends Schema.TaggedErrorClass<PreviewAutomationGuestRetiredError>()(
+  "PreviewAutomationGuestRetiredError",
+  { tabId: Schema.String, webContentsId: Schema.Number },
+) {
+  override get message(): string {
+    return `Preview tab ${this.tabId} is resetting after a stalled browser command. Reopen the tab if it does not recover.`;
   }
 }
 
@@ -4468,6 +4703,7 @@ export const PreviewManagerError = Schema.Union([
   PreviewAutomationInvalidSelectorError,
   PreviewAutomationResultTooLargeError,
   PreviewAutomationTimeoutError,
+  PreviewAutomationGuestRetiredError,
   PreviewAutomationControlInterruptedError,
 ]);
 export type PreviewManagerError = typeof PreviewManagerError.Type;

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -1258,6 +1258,26 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     }
   });
 
+  const completeWebviewRemoval = (registrationId: number) => {
+    const registered = registeredWebviews.get(registrationId);
+    if (!registered) return;
+    registeredWebviews.delete(registrationId);
+    const guest = registered.webContents;
+    removedWebContents.add(guest);
+    retiredWebContents.add(guest);
+    const pending = pendingWebviewResets.get(registered.tabId);
+    if (pending?.webContents === guest && pending.resetId === registrationId) {
+      pendingWebviewResets.delete(registered.tabId);
+      Deferred.doneUnsafe(pending.removed, Effect.void);
+    }
+    runFork(
+      Effect.all([detachControlSession(guest.id, guest), detachListeners(guest.id, guest)], {
+        concurrency: 2,
+        discard: true,
+      }),
+    );
+  };
+
   // The host confirms removal of the DOM webview. Electron's destroyed event
   // can mean only wrapper loss, while the outer frame still owns the target.
   const observeWebviewHost = Effect.fn("PreviewManager.observeWebviewHost")(function* (
@@ -1288,21 +1308,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         registered.webContents.id !== webContentsId
       )
         return;
-      registeredWebviews.delete(resetId);
-      const guest = registered.webContents;
-      removedWebContents.add(guest);
-      retiredWebContents.add(guest);
-      const pending = pendingWebviewResets.get(registered.tabId);
-      if (pending?.webContents === guest && pending.resetId === resetId) {
-        pendingWebviewResets.delete(registered.tabId);
-        Deferred.doneUnsafe(pending.removed, Effect.void);
-      }
-      runFork(
-        Effect.all([detachControlSession(guest.id, guest), detachListeners(guest.id, guest)], {
-          concurrency: 2,
-          discard: true,
-        }),
-      );
+      completeWebviewRemoval(resetId);
     };
     yield* attempt({ operation: "observeWebviewHost", webContentsId: wc.id }, () => {
       hostIpc.on(PREVIEW_WEBVIEW_REMOVED_CHANNEL, onRemoved);
@@ -2182,7 +2188,13 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         yield* Ref.set(mainWindowRef, Option.some(window));
         currentMainWindow = window;
         frameCaptureWindowOpen = true;
+        const host = window.webContents;
         window.once("closed", () => {
+          // A native window close ends every guest DOM lifetime, even when
+          // the renderer exits without running its React cleanup.
+          for (const [registrationId, registered] of registeredWebviews) {
+            if (registered.host === host) completeWebviewRemoval(registrationId);
+          }
           if (currentMainWindow !== window) return;
           currentMainWindow = undefined;
           frameCaptureWindowOpen = false;

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -56,6 +56,7 @@ import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import {
   PREVIEW_PICTURE_IN_PICTURE_FRAME_CHANNEL,
   PREVIEW_WEBVIEW_RESET_CHANNEL,
+  PREVIEW_WEBVIEW_REMOVED_CHANNEL,
 } from "../ipc/channels.ts";
 import * as BrowserSession from "./BrowserSession.ts";
 import {
@@ -652,9 +653,18 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     }
     return lock;
   };
+  const webviewHosts = new WeakMap<Electron.WebContents, Electron.WebContents>();
+  const resetHosts = new WeakSet<Electron.WebContents>();
+  const removedWebContents = new WeakSet<Electron.WebContents>();
+  let nextWebviewResetId = 0;
   const pendingWebviewResets = new Map<
     string,
-    { readonly webContents: Electron.WebContents; readonly destroyed: Deferred.Deferred<void> }
+    {
+      readonly webContents: Electron.WebContents;
+      readonly host: Electron.WebContents | undefined;
+      readonly resetId: number;
+      readonly removed: Deferred.Deferred<void>;
+    }
   >();
 
   const attempt = <A>(errorContext: PreviewOperationContext, evaluate: () => A) =>
@@ -1240,41 +1250,80 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     }
   });
 
-  // Removing the DOM webview retires its Chromium target. Calling wc.close()
-  // can destroy only Electron's wrapper while the outer frame still owns it.
-  // Detaching the debugger does not cancel page JavaScript either.
+  // The host confirms removal of the DOM webview. Electron's destroyed event
+  // can mean only wrapper loss, while the outer frame still owns the target.
+  const observeWebviewHost = Effect.fn("PreviewManager.observeWebviewHost")(function* (
+    wc: Electron.WebContents,
+  ) {
+    const host = wc.hostWebContents;
+    if (!host) return;
+    webviewHosts.set(wc, host);
+    if (resetHosts.has(host)) return;
+    const hostIpc = host.ipc;
+    const onRemoved = (
+      _event: Electron.IpcMainEvent,
+      tabId: unknown,
+      webContentsId: unknown,
+      resetId: unknown,
+    ) => {
+      if (typeof tabId !== "string") return;
+      const pending = pendingWebviewResets.get(tabId);
+      if (
+        !pending ||
+        pending.host !== host ||
+        pending.resetId !== resetId ||
+        pending.webContents.id !== webContentsId
+      )
+        return;
+      pendingWebviewResets.delete(tabId);
+      removedWebContents.add(pending.webContents);
+      Deferred.doneUnsafe(pending.removed, Effect.void);
+      runFork(
+        Effect.all(
+          [
+            detachControlSession(pending.webContents.id, pending.webContents),
+            detachListeners(pending.webContents.id, pending.webContents),
+          ],
+          { concurrency: 2, discard: true },
+        ),
+      );
+    };
+    yield* attempt({ operation: "observeWebviewHost", webContentsId: wc.id }, () => {
+      hostIpc.on(PREVIEW_WEBVIEW_REMOVED_CHANNEL, onRemoved);
+      resetHosts.add(host);
+    });
+    yield* Scope.addFinalizer(
+      parentScope,
+      Effect.sync(() => {
+        hostIpc.off(PREVIEW_WEBVIEW_REMOVED_CHANNEL, onRemoved);
+      }),
+    );
+  });
+
   const retireWebview = Effect.fn("PreviewManager.retireWebview")(function* (
     tabId: string,
     wc: Electron.WebContents,
   ): Effect.fn.Return<void, PreviewOperationError> {
     retiredWebContents.add(wc);
-    if (wc.isDestroyed()) return;
+    if (removedWebContents.has(wc)) return;
     let pending = pendingWebviewResets.get(tabId);
     if (!pending) {
-      const destroyed = Deferred.makeUnsafe<void>();
-      pending = { webContents: wc, destroyed };
+      const host = webviewHosts.get(wc);
+      pending = {
+        webContents: wc,
+        host,
+        resetId: ++nextWebviewResetId,
+        removed: Deferred.makeUnsafe<void>(),
+      };
       pendingWebviewResets.set(tabId, pending);
+      const resetId = pending.resetId;
       yield* attempt({ operation: "retireWebview", tabId, webContentsId: wc.id }, () => {
-        wc.once("destroyed", () => {
-          if (pendingWebviewResets.get(tabId)?.webContents === wc) {
-            pendingWebviewResets.delete(tabId);
-          }
-          Deferred.doneUnsafe(destroyed, Effect.void);
-          runFork(
-            Effect.all([detachControlSession(wc.id, wc), detachListeners(wc.id, wc)], {
-              concurrency: 2,
-              discard: true,
-            }),
-          );
-        });
-        const host = wc.hostWebContents;
         if (!host || host.isDestroyed()) throw new Error("Preview host is unavailable.");
-        host.send(PREVIEW_WEBVIEW_RESET_CHANNEL, tabId, wc.id);
+        host.send(PREVIEW_WEBVIEW_RESET_CHANNEL, tabId, wc.id, resetId);
       });
     }
-    // Do not release this target to another action if its host cannot remove it.
-    // The entry remains until native destruction, even after this wait expires.
-    yield* Deferred.await(pending.destroyed).pipe(
+    // A missing acknowledgement keeps this guest unavailable after the deadline.
+    yield* Deferred.await(pending.removed).pipe(
       Effect.interruptible,
       Effect.timeout(WEBVIEW_RESET_TIMEOUT_MS),
       Effect.mapError(
@@ -1329,9 +1378,10 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       ),
       Effect.interruptible,
       Effect.timeout(timeoutMs),
-      Effect.catchTag("TimeoutError", (cause) =>
-        Effect.fail(new PreviewOperationError({ operation, tabId, webContentsId: wc.id, cause })),
-      ),
+      Effect.catchTags({
+        TimeoutError: (cause) =>
+          Effect.fail(new PreviewOperationError({ operation, tabId, webContentsId: wc.id, cause })),
+      }),
     );
     yield* requireCurrentGuest(tabId, wc);
     return result;
@@ -1639,9 +1689,10 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     });
     return yield* execute.pipe(
       Effect.timeout(timeoutMs),
-      Effect.catchTag("TimeoutError", () =>
-        Effect.fail(new PreviewAutomationTimeoutError({ tabId, operation: action, timeoutMs })),
-      ),
+      Effect.catchTags({
+        TimeoutError: () =>
+          Effect.fail(new PreviewAutomationTimeoutError({ tabId, operation: action, timeoutMs })),
+      }),
       Effect.onExit(finalize),
     );
   });
@@ -2254,6 +2305,24 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     );
   });
 
+  const awaitWebviewReset = Effect.fn("PreviewManager.awaitWebviewReset")(function* (
+    tabId: string,
+  ) {
+    const pendingReset = pendingWebviewResets.get(tabId);
+    if (pendingReset) {
+      yield* Deferred.await(pendingReset.removed).pipe(
+        Effect.timeout(WEBVIEW_RESET_TIMEOUT_MS),
+        Effect.mapError(
+          () =>
+            new PreviewAutomationGuestRetiredError({
+              tabId,
+              webContentsId: pendingReset.webContents.id,
+            }),
+        ),
+      );
+    }
+  });
+
   const registerWebviewUnlocked = Effect.fn("PreviewManager.registerWebviewUnlocked")(function* (
     tabId: string,
     webContentsId: number,
@@ -2280,19 +2349,8 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     if (retiredWebContents.has(wc)) {
       return yield* new PreviewAutomationGuestRetiredError({ tabId, webContentsId });
     }
-    const pendingReset = pendingWebviewResets.get(tabId);
-    if (pendingReset) {
-      yield* Deferred.await(pendingReset.destroyed).pipe(
-        Effect.timeout(WEBVIEW_RESET_TIMEOUT_MS),
-        Effect.mapError(
-          () =>
-            new PreviewAutomationGuestRetiredError({
-              tabId,
-              webContentsId: pendingReset.webContents.id,
-            }),
-        ),
-      );
-    }
+    yield* observeWebviewHost(wc);
+    yield* awaitWebviewReset(tabId);
     const attached = yield* Ref.get(attachedRef);
     const annotationTheme = yield* Ref.get(annotationThemeRef);
     const currentAttachment = attached.get(webContentsId);
@@ -2324,6 +2382,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         { concurrency: 3, discard: true },
       );
     }
+    yield* awaitWebviewReset(tabId);
     const currentTab = (yield* SynchronizedRef.get(tabsRef)).get(tabId);
     if (
       !currentTab ||

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -653,10 +653,18 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     }
     return lock;
   };
-  const webviewHosts = new WeakMap<Electron.WebContents, Electron.WebContents>();
+  const registeredWebviews = new Map<
+    number,
+    {
+      readonly tabId: string;
+      readonly webContents: Electron.WebContents;
+      readonly host: Electron.WebContents | undefined;
+    }
+  >();
+  const webviewRegistrationIds = new WeakMap<Electron.WebContents, number>();
   const resetHosts = new WeakSet<Electron.WebContents>();
   const removedWebContents = new WeakSet<Electron.WebContents>();
-  let nextWebviewResetId = 0;
+  let nextWebviewRegistrationId = 0;
   const pendingWebviewResets = new Map<
     string,
     {
@@ -1253,12 +1261,17 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   // The host confirms removal of the DOM webview. Electron's destroyed event
   // can mean only wrapper loss, while the outer frame still owns the target.
   const observeWebviewHost = Effect.fn("PreviewManager.observeWebviewHost")(function* (
+    tabId: string,
     wc: Electron.WebContents,
   ) {
-    const host = wc.hostWebContents;
-    if (!host) return;
-    webviewHosts.set(wc, host);
-    if (resetHosts.has(host)) return;
+    const host = wc.hostWebContents ?? undefined;
+    let registrationId = webviewRegistrationIds.get(wc);
+    if (registrationId === undefined) {
+      registrationId = ++nextWebviewRegistrationId;
+      webviewRegistrationIds.set(wc, registrationId);
+      registeredWebviews.set(registrationId, { tabId, webContents: wc, host });
+    }
+    if (!host || resetHosts.has(host)) return registrationId;
     const hostIpc = host.ipc;
     const onRemoved = (
       _event: Electron.IpcMainEvent,
@@ -1266,26 +1279,29 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       webContentsId: unknown,
       resetId: unknown,
     ) => {
-      if (typeof tabId !== "string") return;
-      const pending = pendingWebviewResets.get(tabId);
+      if (typeof resetId !== "number") return;
+      const registered = registeredWebviews.get(resetId);
       if (
-        !pending ||
-        pending.host !== host ||
-        pending.resetId !== resetId ||
-        pending.webContents.id !== webContentsId
+        !registered ||
+        registered.tabId !== tabId ||
+        registered.host !== host ||
+        registered.webContents.id !== webContentsId
       )
         return;
-      pendingWebviewResets.delete(tabId);
-      removedWebContents.add(pending.webContents);
-      Deferred.doneUnsafe(pending.removed, Effect.void);
+      registeredWebviews.delete(resetId);
+      const guest = registered.webContents;
+      removedWebContents.add(guest);
+      retiredWebContents.add(guest);
+      const pending = pendingWebviewResets.get(registered.tabId);
+      if (pending?.webContents === guest && pending.resetId === resetId) {
+        pendingWebviewResets.delete(registered.tabId);
+        Deferred.doneUnsafe(pending.removed, Effect.void);
+      }
       runFork(
-        Effect.all(
-          [
-            detachControlSession(pending.webContents.id, pending.webContents),
-            detachListeners(pending.webContents.id, pending.webContents),
-          ],
-          { concurrency: 2, discard: true },
-        ),
+        Effect.all([detachControlSession(guest.id, guest), detachListeners(guest.id, guest)], {
+          concurrency: 2,
+          discard: true,
+        }),
       );
     };
     yield* attempt({ operation: "observeWebviewHost", webContentsId: wc.id }, () => {
@@ -1298,6 +1314,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         hostIpc.off(PREVIEW_WEBVIEW_REMOVED_CHANNEL, onRemoved);
       }),
     );
+    return registrationId;
   });
 
   const retireWebview = Effect.fn("PreviewManager.retireWebview")(function* (
@@ -1308,15 +1325,15 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     if (removedWebContents.has(wc)) return;
     let pending = pendingWebviewResets.get(tabId);
     if (!pending) {
-      const host = webviewHosts.get(wc);
+      const resetId = webviewRegistrationIds.get(wc) ?? ++nextWebviewRegistrationId;
+      const host = registeredWebviews.get(resetId)?.host;
       pending = {
         webContents: wc,
         host,
-        resetId: ++nextWebviewResetId,
+        resetId,
         removed: Deferred.makeUnsafe<void>(),
       };
       pendingWebviewResets.set(tabId, pending);
-      const resetId = pending.resetId;
       yield* attempt({ operation: "retireWebview", tabId, webContentsId: wc.id }, () => {
         if (!host || host.isDestroyed()) throw new Error("Preview host is unavailable.");
         host.send(PREVIEW_WEBVIEW_RESET_CHANNEL, tabId, wc.id, resetId);
@@ -2349,7 +2366,6 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     if (retiredWebContents.has(wc)) {
       return yield* new PreviewAutomationGuestRetiredError({ tabId, webContentsId });
     }
-    yield* observeWebviewHost(wc);
     yield* awaitWebviewReset(tabId);
     const attached = yield* Ref.get(attachedRef);
     const annotationTheme = yield* Ref.get(annotationThemeRef);
@@ -2363,7 +2379,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       yield* attempt({ operation: "registerWebview.sendTheme", tabId, webContentsId }, () =>
         wc.send(ANNOTATION_THEME_CHANNEL, annotationTheme),
       );
-      return;
+      return yield* observeWebviewHost(tabId, wc);
     }
     const replacedWebContentsId =
       tab.webContentsId != null &&
@@ -2404,6 +2420,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     yield* attempt({ operation: "registerWebview.restoreAudioMuted", tabId, webContentsId }, () =>
       wc.setAudioMuted(currentTab.audioMuted),
     );
+    const registrationId = yield* observeWebviewHost(tabId, wc);
     yield* attachListeners(tabId, wc);
     const readAudible = attempt(
       { operation: "registerWebview.readAudible", tabId, webContentsId },
@@ -2429,7 +2446,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         const next: PreviewTabState = {
           ...currentWithoutFavicon,
           webContentsId,
-          controller: "none",
+          controller: current.controller === "human" ? "human" : "none",
           navStatus: pendingUrl === null ? computeNavStatus(wc) : current.navStatus,
           canGoBack: wc.navigationHistory.canGoBack(),
           canGoForward: wc.navigationHistory.canGoForward(),
@@ -2487,6 +2504,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         ).pipe(Effect.ignore),
       );
     }
+    return registrationId;
   });
 
   const registerWebview = Effect.fn("PreviewManager.registerWebview")(function* (
@@ -4794,7 +4812,7 @@ export class PreviewManager extends Context.Service<
     readonly registerWebview: (
       tabId: string,
       webContentsId: number,
-    ) => Effect.Effect<void, PreviewManagerError>;
+    ) => Effect.Effect<number, PreviewManagerError>;
     readonly navigate: (tabId: string, url: string) => Effect.Effect<void, PreviewManagerError>;
     readonly goBack: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
     readonly goForward: (tabId: string) => Effect.Effect<void, PreviewManagerError>;

--- a/apps/web/src/browser/HostedBrowserWebview.test.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   createTab: vi.fn<DesktopPreviewBridge["createTab"]>(),
   closeTab: vi.fn<DesktopPreviewBridge["closeTab"]>(),
   registerWebview: vi.fn<DesktopPreviewBridge["registerWebview"]>(),
+  onWebviewReset: vi.fn<NonNullable<DesktopPreviewBridge["onWebviewReset"]>>(),
   getPreviewConfig: vi.fn<DesktopPreviewBridge["getPreviewConfig"]>(),
   activeRecordings: new Set<string>(),
 }));
@@ -29,6 +30,7 @@ vi.mock("~/components/preview/previewBridge", () => ({
     createTab: mocks.createTab,
     closeTab: mocks.closeTab,
     registerWebview: mocks.registerWebview,
+    onWebviewReset: mocks.onWebviewReset,
     getPreviewConfig: mocks.getPreviewConfig,
   },
 }));
@@ -70,6 +72,7 @@ beforeEach(() => {
   mocks.createTab.mockReset().mockResolvedValue(undefined);
   mocks.closeTab.mockReset().mockResolvedValue(undefined);
   mocks.registerWebview.mockReset().mockResolvedValue(undefined);
+  mocks.onWebviewReset.mockReset().mockReturnValue(() => undefined);
   mocks.getPreviewConfig.mockReset().mockResolvedValue({
     partition: "persist:t3-preview-work",
     webPreferences: "contextIsolation=yes",
@@ -196,5 +199,70 @@ describe("HostedBrowserWebview settings hydration", () => {
     expect(mocks.registerWebview).toHaveBeenCalledExactlyOnceWith(runtimeTabId, 41);
     expect(mocks.closeTab).not.toHaveBeenCalled();
     expect(mocks.setClientSettings).not.toHaveBeenCalled();
+  });
+});
+
+describe("HostedBrowserWebview native reset", () => {
+  it("replaces only the requested guest and keeps late reset requests away from its replacement", async () => {
+    mocks.getClientSettings.mockResolvedValue(DEFAULT_CLIENT_SETTINGS);
+    const listeners = new Set<(tabId: string, webContentsId: number) => void>();
+    mocks.onWebviewReset.mockImplementation((listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    });
+    const guests: Array<EventTarget & { getWebContentsId: () => number }> = [];
+    const threadRef = {
+      environmentId: EnvironmentId.make("host-reset-test"),
+      threadId: ThreadId.make("thread-reset-test"),
+    };
+    const runtimeTabId = "native-reset-tab";
+    await act(() => {
+      renderer = create(
+        <HostedBrowserWebview
+          threadRef={threadRef}
+          tabId="server-tab"
+          runtimeTabId={runtimeTabId}
+          initialUrl="https://example.com"
+          viewport={FILL_PREVIEW_VIEWPORT}
+          pictureInPicture={false}
+          profileId="work"
+          zoomFactor={1}
+        />,
+        {
+          createNodeMock: (element) => {
+            if (element.type !== "webview")
+              return { scrollLeft: 0, scrollTop: 0, scrollTo: () => undefined };
+            const id = 41 + guests.length;
+            const guest = Object.assign(new EventTarget(), { getWebContentsId: () => id });
+            guests.push(guest);
+            return guest;
+          },
+        },
+      );
+    });
+    expect(mocks.registerWebview).toHaveBeenCalledWith(runtimeTabId, 41);
+    const staleListener = [...listeners][0]!;
+    await act(() => {
+      for (const listener of listeners) {
+        listener("another-tab", 41);
+        listener(runtimeTabId, 99);
+      }
+    });
+    expect(guests).toHaveLength(1);
+    await act(() => {
+      staleListener(runtimeTabId, 41);
+    });
+    expect(guests).toHaveLength(2);
+    expect(mocks.registerWebview).toHaveBeenCalledWith(runtimeTabId, 42);
+    await act(() => {
+      staleListener(runtimeTabId, 41);
+      guests[0]!.dispatchEvent(new Event("dom-ready"));
+      for (const listener of listeners) listener(runtimeTabId, 41);
+    });
+    expect(guests).toHaveLength(2);
+    expect(mocks.registerWebview.mock.calls.filter(([, id]) => id === 41)).toHaveLength(1);
+    expect(mocks.closeTab).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/browser/HostedBrowserWebview.test.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   createTab: vi.fn<DesktopPreviewBridge["createTab"]>(),
   closeTab: vi.fn<DesktopPreviewBridge["closeTab"]>(),
   registerWebview: vi.fn<DesktopPreviewBridge["registerWebview"]>(),
+  confirmWebviewRemoved: vi.fn<NonNullable<DesktopPreviewBridge["confirmWebviewRemoved"]>>(),
   onWebviewReset: vi.fn<NonNullable<DesktopPreviewBridge["onWebviewReset"]>>(),
   getPreviewConfig: vi.fn<DesktopPreviewBridge["getPreviewConfig"]>(),
   activeRecordings: new Set<string>(),
@@ -31,6 +32,7 @@ vi.mock("~/components/preview/previewBridge", () => ({
     closeTab: mocks.closeTab,
     registerWebview: mocks.registerWebview,
     onWebviewReset: mocks.onWebviewReset,
+    confirmWebviewRemoved: mocks.confirmWebviewRemoved,
     getPreviewConfig: mocks.getPreviewConfig,
   },
 }));
@@ -72,6 +74,7 @@ beforeEach(() => {
   mocks.createTab.mockReset().mockResolvedValue(undefined);
   mocks.closeTab.mockReset().mockResolvedValue(undefined);
   mocks.registerWebview.mockReset().mockResolvedValue(undefined);
+  mocks.confirmWebviewRemoved.mockReset();
   mocks.onWebviewReset.mockReset().mockReturnValue(() => undefined);
   mocks.getPreviewConfig.mockReset().mockResolvedValue({
     partition: "persist:t3-preview-work",
@@ -205,7 +208,7 @@ describe("HostedBrowserWebview settings hydration", () => {
 describe("HostedBrowserWebview native reset", () => {
   it("replaces only the requested guest and keeps late reset requests away from its replacement", async () => {
     mocks.getClientSettings.mockResolvedValue(DEFAULT_CLIENT_SETTINGS);
-    const listeners = new Set<(tabId: string, webContentsId: number) => void>();
+    const listeners = new Set<Parameters<NonNullable<DesktopPreviewBridge["onWebviewReset"]>>[0]>();
     mocks.onWebviewReset.mockImplementation((listener) => {
       listeners.add(listener);
       return () => {
@@ -236,6 +239,7 @@ describe("HostedBrowserWebview native reset", () => {
               return { scrollLeft: 0, scrollTop: 0, scrollTo: () => undefined };
             const id = 41 + guests.length;
             const guest = Object.assign(new EventTarget(), { getWebContentsId: () => id });
+            Object.defineProperty(guest, "isConnected", { get: () => guests.at(-1) === guest });
             guests.push(guest);
             return guest;
           },
@@ -246,20 +250,21 @@ describe("HostedBrowserWebview native reset", () => {
     const staleListener = [...listeners][0]!;
     await act(() => {
       for (const listener of listeners) {
-        listener("another-tab", 41);
-        listener(runtimeTabId, 99);
+        listener("another-tab", 41, 1);
+        listener(runtimeTabId, 99, 1);
       }
     });
     expect(guests).toHaveLength(1);
     await act(() => {
-      staleListener(runtimeTabId, 41);
+      staleListener(runtimeTabId, 41, 1);
     });
     expect(guests).toHaveLength(2);
+    expect(mocks.confirmWebviewRemoved).toHaveBeenCalledExactlyOnceWith(runtimeTabId, 41, 1);
     expect(mocks.registerWebview).toHaveBeenCalledWith(runtimeTabId, 42);
     await act(() => {
-      staleListener(runtimeTabId, 41);
+      staleListener(runtimeTabId, 41, 1);
       guests[0]!.dispatchEvent(new Event("dom-ready"));
-      for (const listener of listeners) listener(runtimeTabId, 41);
+      for (const listener of listeners) listener(runtimeTabId, 41, 1);
     });
     expect(guests).toHaveLength(2);
     expect(mocks.registerWebview.mock.calls.filter(([, id]) => id === 41)).toHaveLength(1);

--- a/apps/web/src/browser/HostedBrowserWebview.test.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.test.tsx
@@ -206,68 +206,87 @@ describe("HostedBrowserWebview settings hydration", () => {
 });
 
 describe("HostedBrowserWebview native reset", () => {
-  it("replaces only the requested guest and keeps late reset requests away from its replacement", async () => {
-    mocks.getClientSettings.mockResolvedValue(DEFAULT_CLIENT_SETTINGS);
-    const listeners = new Set<Parameters<NonNullable<DesktopPreviewBridge["onWebviewReset"]>>[0]>();
-    mocks.onWebviewReset.mockImplementation((listener) => {
-      listeners.add(listener);
-      return () => {
-        listeners.delete(listener);
+  it.each(["requested reset", "crash before reset", "crash before registration reply"] as const)(
+    "keeps removal proof through %s",
+    async (scenario) => {
+      vi.useFakeTimers();
+      const firstRegistration = deferred<number>();
+      mocks.registerWebview.mockImplementation(async (_tabId, id) => {
+        if (id === 41 && scenario === "crash before registration reply")
+          return firstRegistration.promise;
+        return id - 40;
+      });
+      mocks.getClientSettings.mockResolvedValue(DEFAULT_CLIENT_SETTINGS);
+      const listeners = new Set<
+        Parameters<NonNullable<DesktopPreviewBridge["onWebviewReset"]>>[0]
+      >();
+      mocks.onWebviewReset.mockImplementation((listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      });
+      const guests: Array<EventTarget & { getWebContentsId: () => number }> = [];
+      const threadRef = {
+        environmentId: EnvironmentId.make("host-reset-test"),
+        threadId: ThreadId.make("thread-reset-test"),
       };
-    });
-    const guests: Array<EventTarget & { getWebContentsId: () => number }> = [];
-    const threadRef = {
-      environmentId: EnvironmentId.make("host-reset-test"),
-      threadId: ThreadId.make("thread-reset-test"),
-    };
-    const runtimeTabId = "native-reset-tab";
-    await act(() => {
-      renderer = create(
-        <HostedBrowserWebview
-          threadRef={threadRef}
-          tabId="server-tab"
-          runtimeTabId={runtimeTabId}
-          initialUrl="https://example.com"
-          viewport={FILL_PREVIEW_VIEWPORT}
-          pictureInPicture={false}
-          profileId="work"
-          zoomFactor={1}
-        />,
-        {
-          createNodeMock: (element) => {
-            if (element.type !== "webview")
-              return { scrollLeft: 0, scrollTop: 0, scrollTo: () => undefined };
-            const id = 41 + guests.length;
-            const guest = Object.assign(new EventTarget(), { getWebContentsId: () => id });
-            Object.defineProperty(guest, "isConnected", { get: () => guests.at(-1) === guest });
-            guests.push(guest);
-            return guest;
+      const runtimeTabId = "native-reset-tab";
+      await act(() => {
+        renderer = create(
+          <HostedBrowserWebview
+            threadRef={threadRef}
+            tabId="server-tab"
+            runtimeTabId={runtimeTabId}
+            initialUrl="https://example.com"
+            viewport={FILL_PREVIEW_VIEWPORT}
+            pictureInPicture={false}
+            profileId="work"
+            zoomFactor={1}
+          />,
+          {
+            createNodeMock: (element) => {
+              if (element.type !== "webview")
+                return { scrollLeft: 0, scrollTop: 0, scrollTo: () => undefined };
+              const id = 41 + guests.length;
+              const guest = Object.assign(new EventTarget(), { getWebContentsId: () => id });
+              Object.defineProperty(guest, "isConnected", { get: () => guests.at(-1) === guest });
+              guests.push(guest);
+              return guest;
+            },
           },
-        },
-      );
-    });
-    expect(mocks.registerWebview).toHaveBeenCalledWith(runtimeTabId, 41);
-    const staleListener = [...listeners][0]!;
-    await act(() => {
-      for (const listener of listeners) {
-        listener("another-tab", 41, 1);
-        listener(runtimeTabId, 99, 1);
+        );
+      });
+      expect(mocks.registerWebview).toHaveBeenCalledWith(runtimeTabId, 41);
+      const staleListener = [...listeners][0]!;
+      await act(() => {
+        for (const listener of listeners) {
+          listener("another-tab", 41, 1);
+          listener(runtimeTabId, 99, 1);
+        }
+      });
+      expect(guests).toHaveLength(1);
+      if (scenario !== "requested reset") {
+        await act(async () => {
+          guests[0]!.dispatchEvent(new Event("render-process-gone"));
+          await vi.advanceTimersByTimeAsync(250);
+        });
       }
-    });
-    expect(guests).toHaveLength(1);
-    await act(() => {
-      staleListener(runtimeTabId, 41, 1);
-    });
-    expect(guests).toHaveLength(2);
-    expect(mocks.confirmWebviewRemoved).toHaveBeenCalledExactlyOnceWith(runtimeTabId, 41, 1);
-    expect(mocks.registerWebview).toHaveBeenCalledWith(runtimeTabId, 42);
-    await act(() => {
-      staleListener(runtimeTabId, 41, 1);
-      guests[0]!.dispatchEvent(new Event("dom-ready"));
-      for (const listener of listeners) listener(runtimeTabId, 41, 1);
-    });
-    expect(guests).toHaveLength(2);
-    expect(mocks.registerWebview.mock.calls.filter(([, id]) => id === 41)).toHaveLength(1);
-    expect(mocks.closeTab).not.toHaveBeenCalled();
-  });
+      await act(() => {
+        staleListener(runtimeTabId, 41, 1);
+      });
+      firstRegistration.resolve(1);
+      expect(guests).toHaveLength(2);
+      expect(mocks.confirmWebviewRemoved).toHaveBeenCalledExactlyOnceWith(runtimeTabId, 41, 1);
+      expect(mocks.registerWebview).toHaveBeenCalledWith(runtimeTabId, 42);
+      await act(() => {
+        staleListener(runtimeTabId, 41, 1);
+        guests[0]!.dispatchEvent(new Event("dom-ready"));
+        for (const listener of listeners) listener(runtimeTabId, 41, 1);
+      });
+      expect(guests).toHaveLength(2);
+      expect(mocks.registerWebview.mock.calls.filter(([, id]) => id === 41)).toHaveLength(1);
+      expect(mocks.closeTab).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/apps/web/src/browser/HostedBrowserWebview.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.tsx
@@ -123,6 +123,7 @@ export function HostedBrowserWebview(props: {
     const bridge = previewBridge;
     if (!clientSettingsHydrated || !webview || !config || !bridge) return;
     let disposed = false;
+    let replacing = false;
     let recoveryTimeout: ReturnType<typeof setTimeout> | null = null;
     const register = () => {
       const lease = tabLeaseRef.current;
@@ -143,17 +144,31 @@ export function HostedBrowserWebview(props: {
         }
       })();
     };
+    const replaceGuest = () => {
+      if (disposed || replacing || webviewRef.current !== webview) return;
+      replacing = true;
+      setRecoverySrc(latestUrlRef.current ?? initialSrc);
+      setWebviewGeneration((generation) => generation + 1);
+    };
+    const unsubscribeReset = bridge.onWebviewReset?.((tabId, webContentsId) => {
+      if (tabId !== runtimeTabId || disposed || replacing) return;
+      try {
+        if (webview.getWebContentsId() !== webContentsId) return;
+      } catch {
+        return;
+      }
+      // Remounting removes Electron's outer frame. Closing the main-process
+      // WebContents wrapper alone does not retire an attached guest target.
+      replaceGuest();
+    });
     const recoverGuest = () => {
-      if (disposed || recoveryTimeout !== null) return;
+      if (disposed || replacing || recoveryTimeout !== null) return;
       const recovery = planWebviewCrashRecovery(crashRecoveryRef.current, Date.now());
       if (!recovery) return;
       crashRecoveryRef.current = recovery.state;
       recoveryTimeout = setTimeout(() => {
         recoveryTimeout = null;
-        if (!disposed) {
-          setRecoverySrc(latestUrlRef.current ?? initialSrc);
-          setWebviewGeneration((generation) => generation + 1);
-        }
+        replaceGuest();
       }, recovery.delayMs);
     };
     webview.addEventListener("did-attach", register);
@@ -162,6 +177,7 @@ export function HostedBrowserWebview(props: {
     register();
     return () => {
       disposed = true;
+      unsubscribeReset?.();
       if (recoveryTimeout !== null) clearTimeout(recoveryTimeout);
       webview.removeEventListener("did-attach", register);
       webview.removeEventListener("dom-ready", register);

--- a/apps/web/src/browser/HostedBrowserWebview.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.tsx
@@ -73,6 +73,15 @@ export function HostedBrowserWebview(props: {
   const tabLeaseRef = useRef<AcquiredDesktopTab | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const webviewRef = useRef<ElectronWebview | null>(null);
+  const ownedWebviewsRef = useRef(
+    new Map<
+      number,
+      {
+        webview: ElectronWebview;
+        registrationId: number | undefined;
+      }
+    >(),
+  );
   const crashRecoveryRef = useRef<WebviewCrashRecoveryState>(INITIAL_WEBVIEW_CRASH_RECOVERY_STATE);
   const [aspectRatioLocked, setAspectRatioLocked] = useState(false);
   const presentation = useBrowserSurfaceStore(
@@ -118,6 +127,38 @@ export function HostedBrowserWebview(props: {
     webviewRef.current = node as ElectronWebview | null;
   }, []);
 
+  const confirmRemovedWebview = useCallback(
+    (webContentsId: number) => {
+      const owned = ownedWebviewsRef.current.get(webContentsId);
+      if (!owned || owned.webview.isConnected || owned.registrationId === undefined) return;
+      previewBridge?.confirmWebviewRemoved?.(runtimeTabId, webContentsId, owned.registrationId);
+      ownedWebviewsRef.current.delete(webContentsId);
+    },
+    [runtimeTabId],
+  );
+
+  // Keep removal proof across crash remounts and late registration replies.
+  useEffect(
+    () =>
+      previewBridge?.onWebviewReset?.((tabId, webContentsId, registrationId) => {
+        if (tabId !== runtimeTabId) return;
+        const owned = ownedWebviewsRef.current.get(webContentsId);
+        if (
+          !owned ||
+          (owned.registrationId !== undefined && owned.registrationId !== registrationId)
+        )
+          return;
+        owned.registrationId = registrationId;
+        if (!owned.webview.isConnected) {
+          confirmRemovedWebview(webContentsId);
+        } else if (owned.webview === webviewRef.current) {
+          setRecoverySrc(latestUrlRef.current ?? initialSrc);
+          setWebviewGeneration((generation) => generation + 1);
+        }
+      }),
+    [confirmRemovedWebview, initialSrc, runtimeTabId],
+  );
+
   useEffect(() => {
     const webview = webviewRef.current;
     const bridge = previewBridge;
@@ -125,7 +166,6 @@ export function HostedBrowserWebview(props: {
     let disposed = false;
     let replacing = false;
     let registeredWebContentsId: number | undefined;
-    let pendingReset: { webContentsId: number; resetId: number } | undefined;
     let recoveryTimeout: ReturnType<typeof setTimeout> | null = null;
     const register = () => {
       const lease = tabLeaseRef.current;
@@ -140,7 +180,16 @@ export function HostedBrowserWebview(props: {
           const webContentsId = webview.getWebContentsId();
           if (Number.isInteger(webContentsId) && webContentsId > 0) {
             registeredWebContentsId = webContentsId;
-            await bridge.registerWebview(runtimeTabId, webContentsId);
+            const owned = ownedWebviewsRef.current.get(webContentsId) ?? {
+              webview,
+              registrationId: undefined,
+            };
+            ownedWebviewsRef.current.set(webContentsId, owned);
+            const registrationId = await bridge.registerWebview(runtimeTabId, webContentsId);
+            if (typeof registrationId === "number") {
+              owned.registrationId = registrationId;
+              confirmRemovedWebview(webContentsId);
+            }
           }
         } catch {
           // did-attach/dom-ready will retry if the guest was not ready yet.
@@ -153,14 +202,6 @@ export function HostedBrowserWebview(props: {
       setRecoverySrc(latestUrlRef.current ?? initialSrc);
       setWebviewGeneration((generation) => generation + 1);
     };
-    const unsubscribeReset = bridge.onWebviewReset?.((tabId, webContentsId, resetId) => {
-      if (tabId !== runtimeTabId || disposed || replacing) return;
-      if (registeredWebContentsId !== webContentsId) return;
-      pendingReset = { webContentsId, resetId };
-      // Remounting removes Electron's outer frame. Closing the main-process
-      // WebContents wrapper alone does not retire an attached guest target.
-      replaceGuest();
-    });
     const recoverGuest = () => {
       if (disposed || replacing || recoveryTimeout !== null) return;
       const recovery = planWebviewCrashRecovery(crashRecoveryRef.current, Date.now());
@@ -177,22 +218,20 @@ export function HostedBrowserWebview(props: {
     register();
     return () => {
       disposed = true;
-      unsubscribeReset?.();
-      // Passive cleanup runs after React removes the old node. The connection
-      // check also excludes effect reruns that keep the same DOM webview.
-      if (pendingReset && !webview.isConnected) {
-        bridge.confirmWebviewRemoved?.(
-          runtimeTabId,
-          pendingReset.webContentsId,
-          pendingReset.resetId,
-        );
-      }
+      if (registeredWebContentsId !== undefined) confirmRemovedWebview(registeredWebContentsId);
       if (recoveryTimeout !== null) clearTimeout(recoveryTimeout);
       webview.removeEventListener("did-attach", register);
       webview.removeEventListener("dom-ready", register);
       webview.removeEventListener("render-process-gone", recoverGuest);
     };
-  }, [clientSettingsHydrated, config, initialSrc, runtimeTabId, webviewGeneration]);
+  }, [
+    clientSettingsHydrated,
+    config,
+    confirmRemovedWebview,
+    initialSrc,
+    runtimeTabId,
+    webviewGeneration,
+  ]);
 
   const active = presentation.visible && presentation.rect !== null;
   const lastRect = presentation.rect;

--- a/apps/web/src/browser/HostedBrowserWebview.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.tsx
@@ -124,6 +124,8 @@ export function HostedBrowserWebview(props: {
     if (!clientSettingsHydrated || !webview || !config || !bridge) return;
     let disposed = false;
     let replacing = false;
+    let registeredWebContentsId: number | undefined;
+    let pendingReset: { webContentsId: number; resetId: number } | undefined;
     let recoveryTimeout: ReturnType<typeof setTimeout> | null = null;
     const register = () => {
       const lease = tabLeaseRef.current;
@@ -137,6 +139,7 @@ export function HostedBrowserWebview(props: {
           if (disposed || webviewRef.current !== webview) return;
           const webContentsId = webview.getWebContentsId();
           if (Number.isInteger(webContentsId) && webContentsId > 0) {
+            registeredWebContentsId = webContentsId;
             await bridge.registerWebview(runtimeTabId, webContentsId);
           }
         } catch {
@@ -150,13 +153,10 @@ export function HostedBrowserWebview(props: {
       setRecoverySrc(latestUrlRef.current ?? initialSrc);
       setWebviewGeneration((generation) => generation + 1);
     };
-    const unsubscribeReset = bridge.onWebviewReset?.((tabId, webContentsId) => {
+    const unsubscribeReset = bridge.onWebviewReset?.((tabId, webContentsId, resetId) => {
       if (tabId !== runtimeTabId || disposed || replacing) return;
-      try {
-        if (webview.getWebContentsId() !== webContentsId) return;
-      } catch {
-        return;
-      }
+      if (registeredWebContentsId !== webContentsId) return;
+      pendingReset = { webContentsId, resetId };
       // Remounting removes Electron's outer frame. Closing the main-process
       // WebContents wrapper alone does not retire an attached guest target.
       replaceGuest();
@@ -178,6 +178,15 @@ export function HostedBrowserWebview(props: {
     return () => {
       disposed = true;
       unsubscribeReset?.();
+      // Passive cleanup runs after React removes the old node. The connection
+      // check also excludes effect reruns that keep the same DOM webview.
+      if (pendingReset && !webview.isConnected) {
+        bridge.confirmWebviewRemoved?.(
+          runtimeTabId,
+          pendingReset.webContentsId,
+          pendingReset.resetId,
+        );
+      }
       if (recoveryTimeout !== null) clearTimeout(recoveryTimeout);
       webview.removeEventListener("did-attach", register);
       webview.removeEventListener("dom-ready", register);

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1171,6 +1171,8 @@ export interface DesktopPreviewBridge {
   createTab: (tabId: string, defaults?: DesktopPreviewTabDefaults) => Promise<void>;
   closeTab: (tabId: string) => Promise<void>;
   registerWebview: (tabId: string, webContentsId: number) => Promise<void>;
+  /** Remove and replace this exact guest after its native command stops responding. */
+  onWebviewReset?: (listener: (tabId: string, webContentsId: number) => void) => () => void;
   navigate: (tabId: string, url: string) => Promise<void>;
   goBack: (tabId: string) => Promise<void>;
   goForward: (tabId: string) => Promise<void>;

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1170,7 +1170,7 @@ export const DESKTOP_PREVIEW_RECORDING_CAPTURE_TRIGGER = "__t3DesktopPreviewReco
 export interface DesktopPreviewBridge {
   createTab: (tabId: string, defaults?: DesktopPreviewTabDefaults) => Promise<void>;
   closeTab: (tabId: string) => Promise<void>;
-  registerWebview: (tabId: string, webContentsId: number) => Promise<void>;
+  registerWebview: (tabId: string, webContentsId: number) => Promise<number | void>;
   /** Remove and replace this exact guest after its native command stops responding. */
   onWebviewReset?: (
     listener: (tabId: string, webContentsId: number, resetId: number) => void,

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1172,7 +1172,10 @@ export interface DesktopPreviewBridge {
   closeTab: (tabId: string) => Promise<void>;
   registerWebview: (tabId: string, webContentsId: number) => Promise<void>;
   /** Remove and replace this exact guest after its native command stops responding. */
-  onWebviewReset?: (listener: (tabId: string, webContentsId: number) => void) => () => void;
+  onWebviewReset?: (
+    listener: (tabId: string, webContentsId: number, resetId: number) => void,
+  ) => () => void;
+  confirmWebviewRemoved?: (tabId: string, webContentsId: number, resetId: number) => void;
   navigate: (tabId: string, url: string) => Promise<void>;
   goBack: (tabId: string) => Promise<void>;
   goForward: (tabId: string) => Promise<void>;


### PR DESCRIPTION
Browser actions can leave an Electron command running after the caller times out. Later actions can wait forever or reuse the same guest after its debugger detaches.

Bound action and cleanup waits. Replace the actual webview when pending native work is interrupted. Each registration returns a guest token. The host confirms DOM removal with that exact token before Manager accepts a replacement. Cleanup keeps this proof across crash remounts and late registration replies. A native host window close releases that host's guests, including when the renderer never runs its cleanup. Electron wrapper destruction alone does not release the guest. If removal is not confirmed, keep the tab unavailable.

The page reloads during recovery. The change does not undo network or storage writes that already started, and it never replays an action.

## Verification

- 112 focused tests pass across the preview manager, preview IPC methods, and hosted webview.
- Tests cover wrapper loss, wrong removal tokens, failed replacement, early removal, close/reopen, crash remounts, and human-control expiry.
- Mutation checks confirm that the wrapper-loss and human-control tests fail with their old behavior.
- Desktop, web, and contracts typechecks pass. Scoped lint passes with two existing effect-dependency warnings.
- Real Electron 43.4.1 and Chromium 150 checks passed on 394a8480ab for recovery, failed reset, a synchronous hang, wrapper loss, early remount, early tab close, and native host-window close. All seven cases passed in 61.8 seconds. The fixture imports Manager and uses real guests, but does not mount the product React UI.

## Desktop recovery check

The actual desktop app passed in an isolated integrated build containing this PR's `394a8480ab` code. A stalled evaluation timed out after 10.014 seconds. React replaced guest 4 with guest 5, then the next automation click and evaluation succeeded. Main, preload, React, backend, and Manager all used product code.

Providers were disabled. The test used fresh state and blocked nonlocal requests and OS protocol changes. This Linux host required runner-only `--no-sandbox`. The product sandbox is unchanged.

Both images use the fixed build. They show before the stalled action and after recovery, not a pre-fix comparison.

| Before stalled action | After recovery |
| --- | --- |
| ![Preview before the stalled action](https://files.tslop.org/2026/09/preview-product-before-5d947c19.png) | ![Preview working after guest replacement](https://files.tslop.org/2026/09/preview-product-after-75503026.png) |

[28-second recovery recording](https://files.tslop.org/2026/09/preview-product-recovery-710cbc94.mp4)

Created with GPT-6 Astra in Codex. Updated with Codex.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retire and replace preview guests after browser command timeouts
> - Adds guest retirement and host reset coordination to `PreviewManager` in [Manager.ts](https://github.com/pingdotgg/t3code/pull/10119/files#diff-089eb443c0884e11dbe412c68c0a1b7b22e3f1d0b8672c79facba02399e3dc53). Stalled or timed-out debugger commands mark the guest retired, send a reset request to the host, and keep the tab unavailable until native removal is acknowledged.
> - Binds debugger commands to a shared action timeout and adds per-WebContents initialization locks to prevent concurrent duplicate setup.
> - `registerWebview` now returns a numeric registration ID, and `PreviewAutomationGuestRetiredError` is added to the `PreviewManager` error union.
> - Risk: The `registerWebview` service contract changed its return type from `Effect<void, PreviewManagerError>` to `Effect<number, PreviewManagerError>` in [Manager.ts](https://github.com/pingdotgg/t3code/pull/10119/files#diff-089eb443c0884e11dbe412c68c0a1b7b22e3f1d0b8672c79facba02399e3dc53); existing callers must handle the registration ID.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 394a848.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
