### PR TITLE
refactor(server): normalize provider settings before use

### DIFF
--- a/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
@@ -31,7 +31,7 @@ import {
   type PullRequestMergeEvent,
 } from "../pullRequest/PullRequestService.ts";
 import { ServerActivation } from "../serverActivation.ts";
-import { ServerSettingsService } from "../serverSettings.ts";
+import { resolveServerSettings, ServerSettingsService } from "../serverSettings.ts";
 import { OrchestrationCommandInvariantError } from "./Errors.ts";
 import {
   OrchestrationEngineService,
@@ -206,11 +206,13 @@ const makeHarness = Effect.fn("makeThreadSettlementHarness")(function* (options:
   const serverSettings = ServerSettingsService.of({
     start: Effect.void,
     ready: Effect.void,
-    getSettings: Ref.get(settings),
-    updateSettings,
-    streamChanges: Stream.fromPubSub(settingsChanges),
+    getSettings: Ref.get(settings).pipe(Effect.map(resolveServerSettings)),
+    updateSettings: (patch) => updateSettings(patch).pipe(Effect.map(resolveServerSettings)),
+    streamChanges: Stream.fromPubSub(settingsChanges).pipe(Stream.map(resolveServerSettings)),
     subscribeChanges: PubSub.subscribe(settingsChanges).pipe(
-      Effect.map((subscription) => Stream.fromSubscription(subscription)),
+      Effect.map((subscription) =>
+        Stream.fromSubscription(subscription).pipe(Stream.map(resolveServerSettings)),
+      ),
     ),
   });
 

--- a/apps/server/src/project/AgentSessionScanner.ts
+++ b/apps/server/src/project/AgentSessionScanner.ts
@@ -19,7 +19,6 @@ import {
   AgentSessionScanError,
   ClaudeSettings,
   CodexSettings,
-  ProviderDriverKind,
   ProviderInstanceId,
   resolveProviderInstanceEnabled,
   type AgentSessionImportSource,
@@ -930,18 +929,6 @@ export const make = Effect.gen(function* () {
           instanceId: ProviderInstanceId.make(instanceId),
           config,
         }));
-      if (!Object.hasOwn(settings.providerInstances, source)) {
-        const legacyInstance = {
-          instanceId: ProviderInstanceId.make(source),
-          config: {
-            driver: ProviderDriverKind.make(source),
-            config: settings.providers[source],
-          },
-        };
-        if (resolveProviderInstanceEnabled(legacyInstance.config)) {
-          instances.push(legacyInstance);
-        }
-      }
 
       // A shared home contains one copy of each session. Prefer the built-in
       // instance as its owner, then keep configured order for custom accounts.

--- a/apps/server/src/provider/Drivers/CodexHomeLayout.ts
+++ b/apps/server/src/provider/Drivers/CodexHomeLayout.ts
@@ -42,7 +42,7 @@ function resolveHomePath(path: Path.Path, value: string | undefined): string {
 }
 
 export const resolveCodexHomeLayout = Effect.fn("resolveCodexHomeLayout")(function* (
-  config: CodexSettings,
+  config: Pick<CodexSettings, "homePath" | "shadowHomePath">,
 ): Effect.fn.Return<CodexHomeLayout, never, Path.Path> {
   const path = yield* Path.Path;
   const sharedHomePath = resolveHomePath(path, config.homePath);

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -33,6 +33,7 @@ import { makeCursorAdapter } from "./CursorAdapter.ts";
 import { execScriptSource, writeFakeCli } from "../../testUtils/fakeCli.ts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 const decodeCursorSettings = Schema.decodeSync(CursorSettings);
+const decodeCurrentCursorSettings = Schema.decodeUnknownEffect(CursorSettings);
 
 // Test-local service tag so the rest of the file can keep using `yield* CursorAdapter`.
 class CursorAdapter extends Context.Service<CursorAdapter, CursorAdapterShape>()(
@@ -136,7 +137,11 @@ const makeResolveCursorSettings = Effect.gen(function* () {
   const serverSettings = yield* ServerSettingsService;
   return yield* Effect.succeed(
     serverSettings.getSettings.pipe(
-      Effect.map((snapshot) => snapshot.providers.cursor),
+      Effect.flatMap((snapshot) =>
+        decodeCurrentCursorSettings(
+          snapshot.providerInstances[ProviderInstanceId.make("cursor")]?.config ?? {},
+        ),
+      ),
       Effect.orDie,
     ),
   );

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
@@ -1,52 +1,4 @@
-/**
- * ProviderInstanceRegistryHydration — derive a `ProviderInstanceConfigMap`
- * from `ServerSettings` and keep `ProviderInstanceRegistry` in sync with it.
- *
- * The server still reads two shapes:
- *
- *   1. `settings.providerInstances` — the new driver-agnostic map the
- *      registry expects. Keyed by `ProviderInstanceId`, values are
- *      `ProviderInstanceConfig` envelopes.
- *   2. `settings.providers.<kind>` — the legacy single-instance-per-driver
- *      fields (`providers.codex`, `providers.claudeAgent`, …). These are
- *      the source of truth for every deployment that hasn't been migrated
- *      yet to an explicit `providerInstances` entry.
- *
- * This module bridges (2) into (1) and wires the resulting map into a
- * mutable registry. For every built-in driver whose id is not already
- * present in `providerInstances` (keyed on
- * `defaultInstanceIdForDriver(driverKind)` — literally the driver kind as a
- * routing slug), we synthesize an envelope from the legacy field. The
- * registry decodes both flavours through the same `configSchema` and ends
- * up with one uniform `ProviderInstance` per entry.
- *
- * Explicit `providerInstances` entries always win — users can already
- * override the legacy `providers.<kind>` blob by authoring a
- * `providerInstances.codex` entry with a matching driver, and we don't
- * want the synthesized envelope to silently stomp their config.
- *
- * Hot-reload
- * ----------
- * On layer build we:
- *   1. Read the current `ServerSettings` once and use it to seed the
- *      registry's initial state via `ProviderInstanceRegistryMutableLayer`.
- *   2. Fork a daemon fiber (lifetime tied to the layer's scope) that
- *      acquires `ServerSettingsService.subscribeChanges` and calls
- *      `ProviderInstanceRegistryMutator.reconcile` on every emission.
- *
- * Failures inside the watcher are logged and swallowed so a single bad
- * settings emission cannot kill the registry. Unknown drivers and invalid
- * configs already round-trip through the registry's own "unavailable"
- * shadow bucket.
- *
- * @module provider/Layers/ProviderInstanceRegistryHydration
- */
-import {
-  defaultInstanceIdForDriver,
-  type ProviderInstanceConfig,
-  type ProviderInstanceConfigMap,
-  ServerSettings,
-} from "@t3tools/contracts";
+/** Keep the provider instance registry in sync with normalized server settings. */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Stream from "effect/Stream";
@@ -56,52 +8,6 @@ import { BUILT_IN_DRIVERS, type BuiltInDriversEnv } from "../builtInDrivers.ts";
 import { ProviderInstanceRegistry } from "../Services/ProviderInstanceRegistry.ts";
 import { ProviderInstanceRegistryMutator } from "../Services/ProviderInstanceRegistryMutator.ts";
 import { ProviderInstanceRegistryMutableLayer } from "./ProviderInstanceRegistryLive.ts";
-
-/**
- * Synthesize a `ProviderInstanceConfigMap` from a `ServerSettings` snapshot.
- *
- * Strategy:
- *   1. Copy all explicit `settings.providerInstances` entries verbatim.
- *   2. For each built-in driver whose `defaultInstanceIdForDriver(id)` key
- *      is *not* already in the explicit map, synthesize an entry from the
- *      matching legacy `settings.providers.<kind>` blob.
- *
- * The returned map is the input the registry consumes; pure & exported
- * separately so the hydration logic can be exercised by unit tests
- * without layering.
- */
-export const deriveProviderInstanceConfigMap = (
-  settings: ServerSettings,
-): ProviderInstanceConfigMap => {
-  const merged: Record<string, ProviderInstanceConfig> = { ...settings.providerInstances };
-
-  for (const driver of BUILT_IN_DRIVERS) {
-    const instanceId = defaultInstanceIdForDriver(driver.driverKind);
-    if (instanceId in merged) {
-      // Explicit `providerInstances` entry for this slot — user-authored
-      // config always wins over the legacy mirror.
-      continue;
-    }
-
-    // Only built-in drivers have a legacy mirror; the registry's
-    // `providers` struct is keyed on the same literal slug as
-    // `driverKind`. Access is dynamic (the driver kind is a branded string),
-    // but it's constrained to `keyof settings.providers` by the union of
-    // built-in driver kinds.
-    const legacyKey = driver.driverKind as keyof ServerSettings["providers"];
-    const legacyConfig = settings.providers[legacyKey];
-    if (legacyConfig === undefined) {
-      continue;
-    }
-
-    merged[instanceId] = {
-      driver: driver.driverKind,
-      config: legacyConfig,
-    };
-  }
-
-  return merged as ProviderInstanceConfigMap;
-};
 
 /**
  * Layer that consumes `ProviderInstanceRegistryMutator` and forks a
@@ -122,7 +28,7 @@ const SettingsWatcherLive = Layer.effectDiscard(
     yield* settingsChanges.pipe(
       Stream.runForEach((next) =>
         mutator
-          .reconcile(deriveProviderInstanceConfigMap(next))
+          .reconcile(next.providerInstances)
           .pipe(
             Effect.catchCause((cause) =>
               Effect.logError("ProviderInstanceRegistry reconcile failed", cause),
@@ -157,17 +63,13 @@ export const ProviderInstanceRegistryHydrationLive: Layer.Layer<
 > = Layer.unwrap(
   Effect.gen(function* () {
     const serverSettings = yield* ServerSettingsService;
-    const initialSettings: ServerSettings | undefined = yield* serverSettings.getSettings.pipe(
+    const initialSettings = yield* serverSettings.getSettings.pipe(
       Effect.orElseSucceed(() => undefined),
     );
-    const initialConfigMap =
-      initialSettings === undefined
-        ? ({} as ProviderInstanceConfigMap)
-        : deriveProviderInstanceConfigMap(initialSettings);
 
     const mutableLayer = ProviderInstanceRegistryMutableLayer({
       drivers: BUILT_IN_DRIVERS,
-      configMap: initialConfigMap,
+      configMap: initialSettings?.providerInstances ?? {},
     });
 
     return SettingsWatcherLive.pipe(Layer.provideMerge(mutableLayer));

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -324,7 +324,9 @@ function makeMutableServerSettingsService(
     return {
       start: Effect.void,
       ready: Effect.void,
-      getSettings: Ref.get(settingsRef),
+      getSettings: Ref.get(settingsRef).pipe(
+        Effect.map(ServerSettingsModule.resolveServerSettings),
+      ),
       updateSettings: (patch) =>
         Effect.gen(function* () {
           const current = yield* Ref.get(settingsRef);
@@ -332,14 +334,20 @@ function makeMutableServerSettingsService(
           encodeServerSettings(next);
           yield* Ref.set(settingsRef, next);
           yield* PubSub.publish(changes, next);
-          return next;
+          return ServerSettingsModule.resolveServerSettings(next);
         }),
       get streamChanges() {
-        return Stream.fromPubSub(changes);
+        return Stream.fromPubSub(changes).pipe(
+          Stream.map(ServerSettingsModule.resolveServerSettings),
+        );
       },
       get subscribeChanges() {
         return PubSub.subscribe(changes).pipe(
-          Effect.map((subscription) => Stream.fromSubscription(subscription)),
+          Effect.map((subscription) =>
+            Stream.fromSubscription(subscription).pipe(
+              Stream.map(ServerSettingsModule.resolveServerSettings),
+            ),
+          ),
         );
       },
     } satisfies ServerSettingsModule.ServerSettingsService["Service"];

--- a/apps/server/src/provider/makeManagedServerProvider.test.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.test.ts
@@ -18,7 +18,7 @@ import * as Stream from "effect/Stream";
 import { TestClock } from "effect/testing";
 
 import * as BackgroundPolicy from "../background/BackgroundPolicy.ts";
-import { ServerSettingsService } from "../serverSettings.ts";
+import { resolveServerSettings, ServerSettingsService } from "../serverSettings.ts";
 import { makeManagedServerProvider } from "./makeManagedServerProvider.ts";
 
 const emptyCapabilities = createModelCapabilities({ optionDescriptors: [] });
@@ -298,11 +298,13 @@ describe("makeManagedServerProvider", () => {
           ServerSettingsService.of({
             start: Effect.void,
             ready: Effect.void,
-            getSettings: Ref.get(serverSettingsRef),
+            getSettings: Ref.get(serverSettingsRef).pipe(Effect.map(resolveServerSettings)),
             updateSettings: () => Effect.die(new Error("unused in this test")),
             streamChanges: Stream.empty,
             subscribeChanges: PubSub.subscribe(serverSettingsChanges).pipe(
-              Effect.map((subscription) => Stream.fromSubscription(subscription)),
+              Effect.map((subscription) =>
+                Stream.fromSubscription(subscription).pipe(Stream.map(resolveServerSettings)),
+              ),
             ),
           }),
         );

--- a/apps/server/src/provider/providerInstallation.ts
+++ b/apps/server/src/provider/providerInstallation.ts
@@ -16,7 +16,6 @@ import {
   AntigravityInstallation,
   type AntigravityInstallationError,
 } from "./AntigravityInstallation.ts";
-import { deriveProviderInstanceConfigMap } from "./Layers/ProviderInstanceRegistryHydration.ts";
 import { ProviderInstanceRegistry } from "./Services/ProviderInstanceRegistry.ts";
 import { ProviderRegistry } from "./Services/ProviderRegistry.ts";
 import { mergeProviderInstanceEnvironment } from "./ProviderInstanceEnvironment.ts";
@@ -46,7 +45,7 @@ export const makeProviderInstallation = Effect.fn("makeProviderInstallation")(fu
           }),
       ),
     );
-    return deriveProviderInstanceConfigMap(current);
+    return current.providerInstances;
   });
 
   const requireInstance = Effect.fn("ProviderInstallation.requireInstance")(function* (

--- a/apps/server/src/provider/providerUpdateSettings.ts
+++ b/apps/server/src/provider/providerUpdateSettings.ts
@@ -12,7 +12,7 @@ export interface ProviderSnapshotSettings<Settings> {
 
 export function makeProviderSnapshotSettings<Settings>(
   provider: Settings,
-  settings: ServerSettings,
+  settings: Pick<ServerSettings, "enableProviderUpdateChecks">,
 ): ProviderSnapshotSettings<Settings> {
   return {
     provider,
@@ -34,7 +34,7 @@ export function makeProviderSnapshotSettingsSource<Settings>(
   readonly getSettings: Effect.Effect<ProviderSnapshotSettings<Settings>, ServerSettingsError>;
   readonly streamSettings: Stream.Stream<ProviderSnapshotSettings<Settings>>;
 } {
-  const mapSettings = (settings: ServerSettings) =>
+  const mapSettings = (settings: Pick<ServerSettings, "enableProviderUpdateChecks">) =>
     makeProviderSnapshotSettings(provider, settings);
   return {
     getSettings: serverSettings.getSettings.pipe(Effect.map(mapSettings)),

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -804,8 +804,11 @@ const buildAppUnderTest = (options?: {
         Layer.mock(ServerSettings.ServerSettingsService)({
           start: Effect.void,
           ready: Effect.void,
-          getSettings: Effect.succeed(DEFAULT_SERVER_SETTINGS),
-          updateSettings: () => Effect.succeed(DEFAULT_SERVER_SETTINGS),
+          getSettings: Effect.succeed(
+            ServerSettings.resolveServerSettings(DEFAULT_SERVER_SETTINGS),
+          ),
+          updateSettings: () =>
+            Effect.succeed(ServerSettings.resolveServerSettings(DEFAULT_SERVER_SETTINGS)),
           streamChanges: Stream.empty,
           ...options?.layers?.serverSettings,
         }),
@@ -5406,6 +5409,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
               providerInstances: {
                 [ProviderInstanceId.make("codex")]: {
                   driver: ProviderDriverKind.make("codex"),
+                  enabled: true,
                   config: { homePath: codexHome },
                 },
                 [ProviderInstanceId.make("claudeAgent")]: {
@@ -6096,7 +6100,12 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         assert.equal(first.config.observability.otlpTracesEnabled, true);
         assert.equal(first.config.observability.otlpMetricsUrl, "http://localhost:4318/v1/metrics");
         assert.equal(first.config.observability.otlpMetricsEnabled, true);
-        assert.deepEqual(first.config.settings, DEFAULT_SERVER_SETTINGS);
+        assert.deepEqual(
+          first.config.settings,
+          ServerSettings.redactServerSettingsForClient(
+            ServerSettings.resolveServerSettings(DEFAULT_SERVER_SETTINGS),
+          ),
+        );
       }
       assert.deepEqual(second, {
         version: 1,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -466,11 +466,8 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
     Layer.mergeAll(Keybindings.layer, EnvironmentTheme.layer, UsageLimitSources.layer),
   ),
   Layer.provideMerge(ProviderRegistryLive),
-  // The instance registry is the new routing keystone — text generation,
-  // adapter lookup, and runtime ingestion all resolve `ProviderInstanceId`
-  // through this layer. Built-in drivers come from `BUILT_IN_DRIVERS`;
-  // `providerInstances` hydration merges `settings.providers.<kind>`
-  // with explicit `providerInstances` entries on boot.
+  // Text generation, adapter lookup, and runtime ingestion route by instance ID.
+  // The settings service converts legacy files before the registry reads them.
   Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
 ).pipe(
   Layer.provideMerge(AntigravityInstallation.layer),

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -27,6 +27,11 @@ import { resolveProviderInstanceTerminalEnvironment } from "./terminal/Manager.t
 
 const decodeSettingsPatch = Schema.decodeUnknownEffect(ServerSettingsPatch);
 const decodeServerSettings = Schema.decodeUnknownEffect(ServerSettings);
+const encodeServerSettings = Schema.encodeEffect(ServerSettings);
+const encodeJson = Schema.encodeEffect(Schema.fromJsonString(Schema.Unknown));
+const decodePersistedServerSettings = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(ServerSettings),
+);
 
 const makeServerSettingsLayer = () =>
   ServerSettingsModule.layer.pipe(
@@ -221,7 +226,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         },
       });
 
-      assert.deepEqual(next.providers.codex, {
+      assert.deepEqual(ServerSettingsModule.redactServerSettingsForClient(next).providers.codex, {
         enabled: true,
         binaryPath: "/opt/homebrew/bin/codex",
         homePath: "/Users/julius/.codex",
@@ -229,14 +234,17 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         launchArgs: "",
         customModels: [],
       });
-      assert.deepEqual(next.providers.claudeAgent, {
-        enabled: true,
-        binaryPath: "/usr/local/bin/claude",
-        homePath: "",
-        customModels: ["claude-custom"],
-        launchArgs: "",
-        autoCompactWindow: "",
-      });
+      assert.deepEqual(
+        ServerSettingsModule.redactServerSettingsForClient(next).providers.claudeAgent,
+        {
+          enabled: true,
+          binaryPath: "/usr/local/bin/claude",
+          homePath: "",
+          customModels: ["claude-custom"],
+          launchArgs: "",
+          autoCompactWindow: "",
+        },
+      );
       assert.deepEqual(
         next.textGenerationModelSelection,
         createModelSelection(
@@ -247,6 +255,217 @@ it.layer(NodeServices.layer)("server settings", (it) => {
             { id: "fastMode", value: false },
           ],
         ),
+      );
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect(
+    "normalizes legacy settings and keeps instance overrides stable after save and reload",
+    () =>
+      Effect.gen(function* () {
+        const config = yield* ServerConfig.ServerConfig;
+        const fs = yield* FileSystem.FileSystem;
+        const settingsService = yield* ServerSettingsModule.ServerSettingsService;
+        const forkConfig = {
+          enabled: false,
+          endpoint: "https://provider.example",
+          extra: { mode: "fork" },
+        };
+        yield* fs.writeFileString(
+          config.settingsPath,
+          yield* encodeJson({
+            providers: {
+              codex: { enabled: true, homePath: "/old/codex" },
+              opencode: { serverUrl: "http://127.0.0.1:4096" },
+            },
+            providerInstances: {
+              codex: {
+                driver: "codex",
+                enabled: false,
+                config: { enabled: true, homePath: "/new/codex" },
+              },
+              fork_work: { driver: "fork", config: forkConfig },
+            },
+          }),
+        );
+        yield* recordProviderUsage("opencode");
+
+        const initial = yield* settingsService.getSettings;
+        assert.notProperty(initial, "providers");
+        assert.deepEqual(initial.providerInstances[ProviderInstanceId.make("codex")], {
+          driver: ProviderDriverKind.make("codex"),
+          enabled: false,
+          config: { homePath: "/new/codex" },
+        });
+        assert.deepInclude(initial.providerInstances[ProviderInstanceId.make("opencode")], {
+          enabled: true,
+          config: {
+            binaryPath: "opencode",
+            serverUrl: "http://127.0.0.1:4096",
+            serverPassword: "",
+            customModels: [],
+          },
+        });
+        assert.deepEqual(
+          initial.providerInstances[ProviderInstanceId.make("fork_work")]?.config,
+          forkConfig,
+        );
+        assert.notProperty(
+          initial.providerInstances[ProviderInstanceId.make("fork_work")],
+          "enabled",
+        );
+
+        const saved = yield* settingsService.updateSettings({
+          providerInstances: initial.providerInstances,
+        });
+        const reloaded = yield* Effect.gen(function* () {
+          return yield* (yield* ServerSettingsModule.ServerSettingsService).getSettings;
+        }).pipe(
+          Effect.provide(
+            Layer.fresh(ServerSettingsModule.layer.pipe(Layer.provide(ServerSecretStore.layer))),
+          ),
+        );
+        assert.deepEqual(reloaded.providerInstances, saved.providerInstances);
+
+        const clientSettings = ServerSettingsModule.redactServerSettingsForClient(reloaded);
+        assert.isFalse(clientSettings.providers.codex.enabled);
+        assert.equal(clientSettings.providers.codex.homePath, "/new/codex");
+        assert.deepEqual(
+          clientSettings.providerInstances[ProviderInstanceId.make("fork_work")]?.config,
+          forkConfig,
+        );
+        assert.deepEqual(
+          yield* decodeServerSettings(yield* encodeServerSettings(clientSettings)),
+          clientSettings,
+        );
+      }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect(
+    "does not use a legacy enabled flag to select a disabled text generation instance",
+    () =>
+      Effect.gen(function* () {
+        const settings = yield* ServerSettingsModule.ServerSettingsService;
+        const result = yield* settings.updateSettings({
+          providerInstances: {
+            [ProviderInstanceId.make("codex")]: {
+              driver: ProviderDriverKind.make("codex"),
+              enabled: false,
+            },
+          },
+        });
+        assert.equal(result.textGenerationModelSelection.instanceId, "claudeAgent");
+        assert.isFalse(result.providerInstances[ProviderInstanceId.make("codex")]?.enabled);
+
+        const customOnly = yield* settings.updateSettings({
+          providerInstances: {
+            ...result.providerInstances,
+            [ProviderInstanceId.make("claudeAgent")]: {
+              driver: ProviderDriverKind.make("claudeAgent"),
+              enabled: false,
+            },
+            [ProviderInstanceId.make("codex_work")]: {
+              driver: ProviderDriverKind.make("codex"),
+              enabled: true,
+            },
+          },
+        });
+        assert.equal(customOnly.textGenerationModelSelection.instanceId, "codex_work");
+
+        const unknownOnly = yield* settings.updateSettings({
+          providerInstances: {
+            ...result.providerInstances,
+            [ProviderInstanceId.make("claudeAgent")]: {
+              driver: ProviderDriverKind.make("claudeAgent"),
+              enabled: false,
+            },
+            [ProviderInstanceId.make("unknown")]: {
+              driver: ProviderDriverKind.make("constructor"),
+              enabled: true,
+            },
+          },
+        });
+        assert.equal(unknownOnly.textGenerationModelSelection.instanceId, "codex");
+      }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect("does not pin untouched legacy providers when a client saves the normalized map", () =>
+    Effect.gen(function* () {
+      const config = yield* ServerConfig.ServerConfig;
+      const fs = yield* FileSystem.FileSystem;
+      const service = yield* ServerSettingsModule.ServerSettingsService;
+      const initial = ServerSettingsModule.redactServerSettingsForClient(
+        yield* service.getSettings,
+      );
+      const claudeId = ProviderInstanceId.make("claudeAgent");
+      const codexId = ProviderInstanceId.make("codex");
+      const patch = yield* decodeSettingsPatch({
+        providers: { claudeAgent: DEFAULT_SERVER_SETTINGS.providers.claudeAgent },
+        providerInstances: {
+          ...initial.providerInstances,
+          [claudeId]: {
+            driver: "claudeAgent",
+            enabled: true,
+            config: { homePath: "/configured/claude" },
+          },
+        },
+      });
+      yield* service.updateSettings(patch);
+      const persisted = yield* decodePersistedServerSettings(
+        yield* fs.readFileString(config.settingsPath),
+      );
+      assert.deepEqual(Object.keys(persisted.providerInstances), [claudeId]);
+
+      const changed = yield* service.updateSettings({ providers: { codex: { enabled: false } } });
+      assert.isFalse(changed.providerInstances[codexId]?.enabled);
+      assert.deepEqual(changed.providerInstances[claudeId]?.config, {
+        homePath: "/configured/claude",
+      });
+
+      const { [claudeId]: _removed, ...remainingInstances } = changed.providerInstances;
+      const reset = yield* service.updateSettings({
+        providers: { claudeAgent: DEFAULT_SERVER_SETTINGS.providers.claudeAgent },
+        providerInstances: remainingInstances,
+      });
+      assert.equal(
+        ServerSettingsModule.redactServerSettingsForClient(reset).providers.claudeAgent.homePath,
+        "",
+      );
+      assert.isFalse(reset.providerInstances[codexId]?.enabled);
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect("preserves invalid and unknown instance configs in client settings", () =>
+    Effect.gen(function* () {
+      const service = yield* ServerSettingsModule.ServerSettingsService;
+      const invalidConfig = { enabled: "invalid", binaryPath: 42 };
+      const unknownConfig = { enabled: true, mode: "custom" };
+      const settings = yield* service.updateSettings({
+        providerInstances: {
+          [ProviderInstanceId.make("codex")]: {
+            driver: ProviderDriverKind.make("codex"),
+            config: invalidConfig,
+          },
+          [ProviderInstanceId.make("claudeAgent")]: {
+            driver: ProviderDriverKind.make("fork"),
+            config: unknownConfig,
+          },
+        },
+      });
+      const clientSettings = ServerSettingsModule.redactServerSettingsForClient(settings);
+      assert.isFalse(clientSettings.providers.codex.enabled);
+      assert.isFalse(clientSettings.providers.claudeAgent.enabled);
+      assert.deepEqual(
+        clientSettings.providerInstances[ProviderInstanceId.make("codex")]?.config,
+        invalidConfig,
+      );
+      assert.deepEqual(
+        clientSettings.providerInstances[ProviderInstanceId.make("claudeAgent")]?.config,
+        unknownConfig,
+      );
+      assert.deepEqual(
+        yield* decodeServerSettings(yield* encodeServerSettings(clientSettings)),
+        clientSettings,
       );
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
@@ -267,7 +486,9 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
         const firstChange = yield* changes.pipe(Stream.runHead, Effect.timeout("1 second"));
         assert.equal(
-          Option.getOrUndefined(firstChange)?.providers.codex.binaryPath,
+          Option.getOrUndefined(
+            Option.map(firstChange, ServerSettingsModule.redactServerSettingsForClient),
+          )?.providers.codex.binaryPath,
           "/usr/local/bin/codex-next",
         );
       }),
@@ -600,10 +821,13 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
       const settings = yield* serverSettings.getSettings;
 
-      assert.isFalse(settings.providers.grok.enabled);
-      assert.isTrue(settings.providers.opencode.enabled);
-      assert.isFalse(settings.providers.cursor.enabled);
-      assert.equal(settings.providers.opencode.serverUrl, "http://127.0.0.1:4096");
+      assert.isFalse(settings.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
+      assert.isTrue(settings.providerInstances[ProviderInstanceId.make("opencode")]?.enabled);
+      assert.isFalse(settings.providerInstances[ProviderInstanceId.make("cursor")]?.enabled);
+      assert.equal(
+        ServerSettingsModule.redactServerSettingsForClient(settings).providers.opencode.serverUrl,
+        "http://127.0.0.1:4096",
+      );
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
@@ -622,7 +846,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
       const settings = yield* serverSettings.getSettings;
 
-      assert.isTrue(settings.providers.cursor.enabled);
+      assert.isTrue(settings.providerInstances[ProviderInstanceId.make("cursor")]?.enabled);
       assert.isTrue(settings.providerInstances[ProviderInstanceId.make("cursor_work")]?.enabled);
       assert.isTrue(settings.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
       assert.isTrue(settings.providerInstances[ProviderInstanceId.make("opencode_work")]?.enabled);
@@ -647,9 +871,6 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
       const settings = yield* serverSettings.getSettings;
 
-      assert.isFalse(settings.providers.grok.enabled);
-      assert.isFalse(settings.providers.opencode.enabled);
-      assert.isFalse(settings.providers.cursor.enabled);
       assert.isFalse(settings.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
       assert.isFalse(settings.providerInstances[ProviderInstanceId.make("opencode")]?.enabled);
       assert.isFalse(settings.providerInstances[ProviderInstanceId.make("cursor")]?.enabled);
@@ -665,9 +886,9 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
       const settings = yield* serverSettings.getSettings;
 
-      assert.isFalse(settings.providers.grok.enabled);
-      assert.isFalse(settings.providers.opencode.enabled);
-      assert.isFalse(settings.providers.cursor.enabled);
+      assert.isFalse(settings.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
+      assert.isFalse(settings.providerInstances[ProviderInstanceId.make("opencode")]?.enabled);
+      assert.isFalse(settings.providerInstances[ProviderInstanceId.make("cursor")]?.enabled);
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
@@ -678,9 +899,9 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
       const settings = yield* serverSettings.getSettings;
 
-      assert.isTrue(settings.providers.grok.enabled);
-      assert.isFalse(settings.providers.opencode.enabled);
-      assert.isFalse(settings.providers.cursor.enabled);
+      assert.isTrue(settings.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
+      assert.isFalse(settings.providerInstances[ProviderInstanceId.make("opencode")]?.enabled);
+      assert.isFalse(settings.providerInstances[ProviderInstanceId.make("cursor")]?.enabled);
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
@@ -694,9 +915,9 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
       const settings = yield* serverSettings.getSettings;
 
-      assert.isTrue(settings.providers.cursor.enabled);
-      assert.isFalse(settings.providers.grok.enabled);
-      assert.isFalse(settings.providers.opencode.enabled);
+      assert.isTrue(settings.providerInstances[ProviderInstanceId.make("cursor")]?.enabled);
+      assert.isFalse(settings.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
+      assert.isFalse(settings.providerInstances[ProviderInstanceId.make("opencode")]?.enabled);
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
@@ -713,9 +934,9 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
       const settings = yield* serverSettings.getSettings;
 
-      assert.isFalse(settings.providers.cursor.enabled);
-      assert.isTrue(settings.providers.grok.enabled);
-      assert.isFalse(settings.providers.opencode.enabled);
+      assert.isFalse(settings.providerInstances[ProviderInstanceId.make("cursor")]?.enabled);
+      assert.isTrue(settings.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
+      assert.isFalse(settings.providerInstances[ProviderInstanceId.make("opencode")]?.enabled);
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
@@ -744,9 +965,9 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
       const settings = yield* serverSettings.getSettings;
 
-      assert.isFalse(settings.providers.grok.enabled);
-      assert.isTrue(settings.providers.opencode.enabled);
-      assert.isFalse(settings.providers.cursor.enabled);
+      assert.isFalse(settings.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
+      assert.isTrue(settings.providerInstances[ProviderInstanceId.make("opencode")]?.enabled);
+      assert.isFalse(settings.providerInstances[ProviderInstanceId.make("cursor")]?.enabled);
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
@@ -757,12 +978,15 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
       yield* recordProviderUsage("grok");
 
-      assert.isTrue((yield* serverSettings.getSettings).providers.grok.enabled);
+      assert.isTrue(
+        (yield* serverSettings.getSettings).providerInstances[ProviderInstanceId.make("grok")]
+          ?.enabled,
+      );
 
       const settings = yield* serverSettings.updateSettings({
         providers: { grok: { enabled: false } },
       });
-      assert.isFalse(settings.providers.grok.enabled);
+      assert.isFalse(settings.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
 
       const raw = yield* fileSystem.readFileString(serverConfig.settingsPath);
       // @effect-diagnostics-next-line preferSchemaOverJson:off
@@ -801,9 +1025,9 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
 
       const initial = yield* serverSettings.getSettings;
-      assert.isFalse(initial.providers.grok.enabled);
-      assert.isFalse(initial.providers.opencode.enabled);
-      assert.isFalse(initial.providers.cursor.enabled);
+      assert.isFalse(initial.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
+      assert.isFalse(initial.providerInstances[ProviderInstanceId.make("opencode")]?.enabled);
+      assert.isFalse(initial.providerInstances[ProviderInstanceId.make("cursor")]?.enabled);
 
       const next = yield* serverSettings.updateSettings({
         addProjectBaseDirectory: "~/Development",
@@ -815,9 +1039,9 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         },
       });
 
-      assert.isFalse(next.providers.grok.enabled);
-      assert.isFalse(next.providers.opencode.enabled);
-      assert.isFalse(next.providers.cursor.enabled);
+      assert.isFalse(next.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
+      assert.isFalse(next.providerInstances[ProviderInstanceId.make("opencode")]?.enabled);
+      assert.isFalse(next.providerInstances[ProviderInstanceId.make("cursor")]?.enabled);
       const grok = next.providerInstances[ProviderInstanceId.make("grok")];
       assert.isDefined(grok);
       assert.isFalse(resolveProviderInstanceEnabled(grok));
@@ -863,6 +1087,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       // surface it instead of the fold silently repairing the config.
       assert.deepEqual(settings.providerInstances[ProviderInstanceId.make("cursor")], {
         driver: ProviderDriverKind.make("cursor"),
+        enabled: false,
         config: { enabled: "nope" },
       });
     }).pipe(Effect.provide(makeServerSettingsLayer())),
@@ -912,7 +1137,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         },
       });
 
-      assert.deepEqual(next.providers.codex, {
+      assert.deepEqual(ServerSettingsModule.redactServerSettingsForClient(next).providers.codex, {
         enabled: true,
         binaryPath: "/opt/homebrew/bin/codex",
         homePath: "",
@@ -920,22 +1145,28 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         launchArgs: "",
         customModels: [],
       });
-      assert.deepEqual(next.providers.claudeAgent, {
-        enabled: true,
-        binaryPath: "/opt/homebrew/bin/claude",
-        homePath: "",
-        customModels: [],
-        launchArgs: "",
-        autoCompactWindow: "",
-      });
-      assert.deepEqual(next.providers.opencode, {
-        // OpenCode is disabled by default; this update only touches paths.
-        enabled: false,
-        binaryPath: "/opt/homebrew/bin/opencode",
-        serverUrl: "http://127.0.0.1:4096",
-        serverPassword: "secret-password",
-        customModels: [],
-      });
+      assert.deepEqual(
+        ServerSettingsModule.redactServerSettingsForClient(next).providers.claudeAgent,
+        {
+          enabled: true,
+          binaryPath: "/opt/homebrew/bin/claude",
+          homePath: "",
+          customModels: [],
+          launchArgs: "",
+          autoCompactWindow: "",
+        },
+      );
+      assert.deepEqual(
+        ServerSettingsModule.redactServerSettingsForClient(next).providers.opencode,
+        {
+          // OpenCode is disabled by default; this update only touches paths.
+          enabled: false,
+          binaryPath: "/opt/homebrew/bin/opencode",
+          serverUrl: "http://127.0.0.1:4096",
+          serverPassword: "secret-password",
+          customModels: [],
+        },
+      );
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
@@ -974,8 +1205,14 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         },
       });
 
-      assert.equal(next.providers.codex.binaryPath, "codex");
-      assert.equal(next.providers.claudeAgent.binaryPath, "claude");
+      assert.equal(
+        ServerSettingsModule.redactServerSettingsForClient(next).providers.codex.binaryPath,
+        "codex",
+      );
+      assert.equal(
+        ServerSettingsModule.redactServerSettingsForClient(next).providers.claudeAgent.binaryPath,
+        "claude",
+      );
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
@@ -1002,7 +1239,10 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         automaticGitFetchInterval: Duration.seconds(10),
       });
 
-      assert.equal(next.providers.codex.binaryPath, "/opt/homebrew/bin/codex");
+      assert.equal(
+        ServerSettingsModule.redactServerSettingsForClient(next).providers.codex.binaryPath,
+        "/opt/homebrew/bin/codex",
+      );
 
       const raw = yield* fileSystem.readFileString(serverConfig.settingsPath);
       // @effect-diagnostics-next-line preferSchemaOverJson:off

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -21,6 +21,7 @@ import {
   type UsageLimitSourceConfig,
   ProviderDriverKind,
   ProviderInstanceId,
+  resolveProviderInstanceEnabled,
   ServerSettings,
   ServerSettingsError,
   type ServerSettingsPatch,
@@ -59,17 +60,24 @@ export { resolveSourceControlWriterModelSelection } from "@t3tools/shared/server
 const encodeServerSettings = Schema.encodeEffect(ServerSettings);
 const encodeServerSettingsJson = Schema.encodeUnknownEffect(fromJsonStringPretty(ServerSettings));
 const decodeServerSettings = Schema.decodeUnknownEffect(ServerSettings);
+const legacyProviderReaders = Object.entries(ServerSettings.fields.providers.to.fields).map(
+  ([driver, schema]) => ({
+    driver,
+    decode: Schema.decodeUnknownOption(schema),
+    defaults: Schema.decodeUnknownSync(schema)({}),
+  }),
+);
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
+/** Runtime consumers use instance IDs. Legacy settings stay at the file and client boundaries. */
+export type RuntimeServerSettings = Omit<ServerSettings, "providers">;
+
 /**
- * Fold the legacy in-config `enabled` flag into the envelope-level
- * `ProviderInstanceConfig.enabled` and strip it from the config blob, so
- * explicit provider instances carry exactly one enabled flag. Old settings
- * files can hold both flags with conflicting values; an explicit false on
- * either side wins so a user's disable is never silently undone. Runs on
- * every load and update — the file converges on the next write.
+ * Move old built-in `enabled` flags into the instance envelope. An explicit
+ * false on either flag wins. Unknown driver configs stay unchanged. The next
+ * settings write persists the normalized flags.
  */
 const foldProviderInstanceEnabledFlags = (settings: ServerSettings): ServerSettings => {
   let changed = false;
@@ -80,6 +88,7 @@ const foldProviderInstanceEnabledFlags = (settings: ServerSettings): ServerSetti
     // stay in the blob so driver schema validation flags it instead of the
     // fold silently repairing the config.
     if (
+      !Object.hasOwn(DEFAULT_SERVER_SETTINGS.providers, instance.driver) ||
       config === null ||
       typeof config !== "object" ||
       Array.isArray(config) ||
@@ -110,6 +119,62 @@ const foldProviderInstanceEnabledFlags = (settings: ServerSettings): ServerSetti
     providerInstances: providerInstances as ServerSettings["providerInstances"],
   };
 };
+
+/** Convert old default-provider settings before they reach the runtime. Explicit entries win. */
+export function resolveServerSettings(settings: ServerSettings): RuntimeServerSettings {
+  const { providers, ...resolved } = foldProviderInstanceEnabledFlags(settings);
+  const providerInstances: Record<ProviderInstanceId, ProviderInstanceConfig> = Object.fromEntries(
+    Object.entries(resolved.providerInstances).map(([instanceId, instance]) => [
+      instanceId,
+      Object.hasOwn(providers, instance.driver)
+        ? { ...instance, enabled: resolveProviderInstanceEnabled(instance) }
+        : instance,
+    ]),
+  );
+  for (const [driver, { enabled, ...config }] of Object.entries(providers)) {
+    const instanceId = ProviderInstanceId.make(driver);
+    if (Object.hasOwn(providerInstances, instanceId)) continue;
+    providerInstances[instanceId] = { driver: ProviderDriverKind.make(driver), enabled, config };
+  }
+  return { ...resolved, providerInstances };
+}
+
+/** Do not turn unchanged legacy defaults into explicit overrides when clients save the full map. */
+function applySettingsPatch(current: ServerSettings, patch: ServerSettingsPatch): ServerSettings {
+  const next = applyServerSettingsPatch(current, patch);
+  if (patch.providerInstances === undefined) return next;
+  const legacyInstances = resolveServerSettings({
+    ...next,
+    providerInstances: {},
+  }).providerInstances;
+  return {
+    ...next,
+    providerInstances: Object.fromEntries(
+      Object.entries(next.providerInstances).filter(
+        ([instanceId, instance]) =>
+          Object.hasOwn(current.providerInstances, instanceId) ||
+          !Equal.equals(instance, legacyInstances[ProviderInstanceId.make(instanceId)]),
+      ),
+    ),
+  };
+}
+
+/** Keep old clients readable without exposing a second settings source to runtime code. */
+function legacyProvidersForClient(settings: RuntimeServerSettings): ServerSettings["providers"] {
+  const entries = legacyProviderReaders.map(({ driver, decode, defaults }) => {
+    const instance = settings.providerInstances[ProviderInstanceId.make(driver)];
+    const decoded = decode(instance?.config ?? {});
+    const config = Option.getOrElse(decoded, () => defaults);
+    return [
+      driver,
+      {
+        ...config,
+        enabled: instance?.driver === driver && Option.isSome(decoded) && instance.enabled === true,
+      },
+    ];
+  });
+  return Object.fromEntries(entries) as ServerSettings["providers"];
+}
 
 const normalizeServerSettings = (
   settings: ServerSettings,
@@ -159,7 +224,7 @@ function redactProviderEnvironmentVariable(
   };
 }
 
-export function redactServerSettingsForClient(settings: ServerSettings): ServerSettings {
+export function redactServerSettingsForClient(settings: RuntimeServerSettings): ServerSettings {
   const providerInstances = Object.fromEntries(
     Object.entries(settings.providerInstances).map(([instanceId, instance]) => [
       instanceId,
@@ -181,7 +246,12 @@ export function redactServerSettingsForClient(settings: ServerSettings): ServerS
       },
     ]),
   );
-  return { ...settings, providerInstances, usageLimitSources };
+  return {
+    ...settings,
+    providers: legacyProvidersForClient(settings),
+    providerInstances,
+    usageLimitSources,
+  };
 }
 
 export class ServerSettingsService extends Context.Service<
@@ -194,22 +264,26 @@ export class ServerSettingsService extends Context.Service<
     readonly ready: Effect.Effect<void, ServerSettingsError>;
 
     /** Read the current settings. */
-    readonly getSettings: Effect.Effect<ServerSettings, ServerSettingsError>;
+    readonly getSettings: Effect.Effect<RuntimeServerSettings, ServerSettingsError>;
 
     /** Patch settings and persist. Returns the new full settings object. */
     readonly updateSettings: (
       patch: ServerSettingsPatch,
-    ) => Effect.Effect<ServerSettings, ServerSettingsError>;
+    ) => Effect.Effect<RuntimeServerSettings, ServerSettingsError>;
 
     /** Stream of settings change events. */
-    readonly streamChanges: Stream.Stream<ServerSettings>;
+    readonly streamChanges: Stream.Stream<RuntimeServerSettings>;
 
     /**
      * Acquire a settings change subscription synchronously in the current
      * fiber. Use this before reading a snapshot when changes between the
      * snapshot and a lazily started stream must not be lost.
      */
-    readonly subscribeChanges: Effect.Effect<Stream.Stream<ServerSettings>, never, Scope.Scope>;
+    readonly subscribeChanges: Effect.Effect<
+      Stream.Stream<RuntimeServerSettings>,
+      never,
+      Scope.Scope
+    >;
   }
 >()("t3/serverSettings/ServerSettingsService") {
   /** @deprecated Import and use `layerTest` from this module. */
@@ -235,12 +309,16 @@ const makeTest = (overrides: DeepPartial<ServerSettings> = {}) =>
     return {
       start: Effect.void,
       ready: Effect.void,
-      getSettings: Ref.get(currentSettingsRef).pipe(Effect.map(resolveTextGenerationProvider)),
+      getSettings: Ref.get(currentSettingsRef).pipe(
+        Effect.map(resolveServerSettings),
+        Effect.map(resolveTextGenerationProvider),
+      ),
       updateSettings: (patch) =>
         Ref.get(currentSettingsRef).pipe(
-          Effect.map((currentSettings) => applyServerSettingsPatch(currentSettings, patch)),
+          Effect.map((currentSettings) => applySettingsPatch(currentSettings, patch)),
           Effect.flatMap(normalizeServerSettings),
           Effect.tap((nextSettings) => Ref.set(currentSettingsRef, nextSettings)),
+          Effect.map(resolveServerSettings),
           Effect.map(resolveTextGenerationProvider),
         ),
       streamChanges: Stream.empty,
@@ -314,15 +392,25 @@ function restoreUsedProviders(
   };
 }
 
-function resolveTextGenerationProvider(settings: ServerSettings): ServerSettings {
+function resolveTextGenerationProvider(settings: RuntimeServerSettings): RuntimeServerSettings {
   return isModelSelectionProviderEnabled(settings, settings.textGenerationModelSelection)
     ? settings
     : fallbackTextGenerationProvider(settings);
 }
 
-function fallbackTextGenerationProvider(settings: ServerSettings): ServerSettings {
-  const fallbackEntry = Object.entries(settings.providers).find(([, provider]) => provider.enabled);
-  const fallback = fallbackEntry ? ProviderDriverKind.make(fallbackEntry[0]) : undefined;
+function fallbackTextGenerationProvider(settings: RuntimeServerSettings): RuntimeServerSettings {
+  let fallback = Object.entries(settings.providerInstances).find(
+    ([, instance]) => instance.enabled && Object.hasOwn(DEFAULT_MODEL_BY_PROVIDER, instance.driver),
+  );
+  // Keep the default-provider order, but never bypass an instance's disabled flag.
+  for (const driver of Object.keys(DEFAULT_MODEL_BY_PROVIDER)) {
+    const instanceId = ProviderInstanceId.make(driver);
+    const instance = settings.providerInstances[instanceId];
+    if (instance?.driver === driver && instance.enabled) {
+      fallback = [instanceId, instance];
+      break;
+    }
+  }
   if (!fallback) {
     return settings;
   }
@@ -330,10 +418,10 @@ function fallbackTextGenerationProvider(settings: ServerSettings): ServerSetting
   return {
     ...settings,
     textGenerationModelSelection: {
-      instanceId: ProviderInstanceId.make(fallback),
+      instanceId: ProviderInstanceId.make(fallback[0]),
       model:
-        DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER[fallback] ??
-        DEFAULT_MODEL_BY_PROVIDER[fallback] ??
+        DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER[fallback[1].driver] ??
+        DEFAULT_MODEL_BY_PROVIDER[fallback[1].driver] ??
         DEFAULT_TEXT_GENERATION_MODEL,
     } satisfies ModelSelection,
   };
@@ -573,6 +661,7 @@ const make = Effect.gen(function* () {
           ),
         ),
       ),
+      Stream.map(resolveServerSettings),
       Stream.map(resolveTextGenerationProvider),
     );
 
@@ -817,6 +906,7 @@ const make = Effect.gen(function* () {
     ready: Deferred.await(startedDeferred),
     getSettings: getSettingsFromCache.pipe(
       Effect.flatMap(materializeProviderEnvironmentSecrets),
+      Effect.map(resolveServerSettings),
       Effect.map(resolveTextGenerationProvider),
     ),
     updateSettings: (patch) =>
@@ -825,14 +915,14 @@ const make = Effect.gen(function* () {
           const current = yield* getSettingsFromCache;
           const nextPersisted = yield* persistProviderEnvironmentSecrets(
             current,
-            applyServerSettingsPatch(current, patch),
+            applySettingsPatch(current, patch),
           );
           const next = yield* normalizeServerSettings(nextPersisted);
           yield* writeSettingsAtomically(next);
           yield* Cache.set(settingsCache, cacheKey, next);
           yield* emitChange(next);
           const materialized = yield* materializeProviderEnvironmentSecrets(next);
-          return resolveTextGenerationProvider(materialized);
+          return resolveTextGenerationProvider(resolveServerSettings(materialized));
         }),
       ),
     get streamChanges() {

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -60,7 +60,6 @@ import * as ServerConfig from "../config.ts";
 import { mergeProviderInstanceEnvironment } from "../provider/ProviderInstanceEnvironment.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
 import { makeClaudeEnvironment } from "../provider/Drivers/ClaudeHome.ts";
-import { deriveProviderInstanceConfigMap } from "../provider/Layers/ProviderInstanceRegistryHydration.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import {
   increment,
@@ -1343,7 +1342,7 @@ export const resolveProviderInstanceTerminalEnvironment = Effect.fn(
   const settings = yield* input.serverSettings.getSettings.pipe(
     Effect.mapError((cause) => new TerminalProviderEnvironmentError({ providerInstanceId, cause })),
   );
-  const instance = deriveProviderInstanceConfigMap(settings)[providerInstanceId];
+  const instance = settings.providerInstances[providerInstanceId];
   if (instance === undefined) {
     return yield* new TerminalProviderInstanceNotFoundError({ providerInstanceId });
   }

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -7,7 +7,12 @@ import * as NodePath from "node:path";
 import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
-import { UsageDay, type UsageSummaryInput } from "@t3tools/contracts";
+import {
+  ProviderDriverKind,
+  ProviderInstanceId,
+  UsageDay,
+  type UsageSummaryInput,
+} from "@t3tools/contracts";
 import * as Duration from "effect/Duration";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
@@ -98,6 +103,37 @@ function totalOutputTokens(summary: { buckets: readonly { totals: { outputTokens
 }
 
 describe("UsageService", () => {
+  it.live("reads the normalized default instance home instead of the legacy home", () =>
+    Effect.gen(function* () {
+      const { transcript, settings, home } = yield* setup;
+      const instanceHome = NodePath.join(home, "claude-instance");
+      const instanceTranscripts = NodePath.join(instanceHome, "projects", "proj");
+      yield* Effect.promise(() => NodeFSP.mkdir(instanceTranscripts, { recursive: true }));
+      yield* Effect.promise(() => NodeFSP.writeFile(transcript, claudeLine(1, 5)));
+      yield* Effect.promise(() =>
+        NodeFSP.writeFile(NodePath.join(instanceTranscripts, "session.jsonl"), claudeLine(2, 11)),
+      );
+      const service = yield* UsageService.make.pipe(
+        Effect.provide(
+          serviceLayers({
+            prefix: "usage-service-instance-home-test",
+            home,
+            settings: {
+              ...settings,
+              providerInstances: {
+                [ProviderInstanceId.make("claudeAgent")]: {
+                  driver: ProviderDriverKind.make("claudeAgent"),
+                  config: { homePath: instanceHome, binaryPath: 42 },
+                },
+              },
+            },
+          }),
+        ),
+      );
+      assert.strictEqual(totalOutputTokens(yield* service.readSummary(WINDOW)), 11);
+    }).pipe(Effect.scoped),
+  );
+
   it.live("reprices unchanged transcripts when custom prices are added, edited, or removed", () =>
     Effect.gen(function* () {
       const { transcript, settings, home } = yield* setup;

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -15,8 +15,10 @@
 import * as NodeOS from "node:os";
 
 import {
+  ClaudeSettings,
+  CodexSettings,
+  ProviderInstanceId,
   USAGE_CONTRACT_VERSION,
-  type ServerSettings as ServerSettingsValue,
   type UsageProviderKind,
   type UsageSource,
   type UsagePricing,
@@ -78,6 +80,16 @@ const MAX_HOURLY_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 /** Longest window the UI offers, plus slack. Older entries are pruned. */
 const CACHE_RETENTION_DAYS = 90;
+
+const decodeClaudeTranscriptSettings = Schema.decodeUnknownEffect(
+  Schema.Struct({ homePath: ClaudeSettings.fields.homePath }),
+);
+const decodeCodexTranscriptSettings = Schema.decodeUnknownEffect(
+  Schema.Struct({
+    homePath: CodexSettings.fields.homePath,
+    shadowHomePath: CodexSettings.fields.shadowHomePath,
+  }),
+);
 
 /** On-disk shape of the rate snapshot. */
 const RatesCacheFile = Schema.Struct({
@@ -247,11 +259,39 @@ export const make = Effect.gen(function* () {
 
   /** Resolves the transcript directory for each provider. */
   const resolveTranscriptDirs = Effect.fn("UsageService.resolveTranscriptDirs")(function* (
-    settings: ServerSettingsValue,
+    settings: ServerSettings.RuntimeServerSettings,
   ) {
-    const claudeHome = yield* resolveClaudeHomePath(settings.providers.claudeAgent);
-    const claudeDir = yield* resolveClaudeTranscriptDir(claudeHome);
-    const codexLayout = yield* resolveCodexHomeLayout(settings.providers.codex);
+    const directories: Array<{ provider: UsageProviderKind; dir: string; fileName?: string }> = [];
+    const claude = settings.providerInstances[ProviderInstanceId.make("claudeAgent")];
+    if (claude?.driver === "claudeAgent") {
+      const config = yield* decodeClaudeTranscriptSettings(claude.config ?? {}).pipe(
+        Effect.mapError(
+          (cause) =>
+            new UsageReadError({
+              reason: "scanFailed",
+              detail: "Claude settings could not be read.",
+              cause,
+            }),
+        ),
+      );
+      const home = yield* resolveClaudeHomePath(config);
+      directories.push({ provider: "claude", dir: yield* resolveClaudeTranscriptDir(home) });
+    }
+    const codex = settings.providerInstances[ProviderInstanceId.make("codex")];
+    if (codex?.driver === "codex") {
+      const config = yield* decodeCodexTranscriptSettings(codex.config ?? {}).pipe(
+        Effect.mapError(
+          (cause) =>
+            new UsageReadError({
+              reason: "scanFailed",
+              detail: "Codex settings could not be read.",
+              cause,
+            }),
+        ),
+      );
+      const layout = yield* resolveCodexHomeLayout(config);
+      directories.push({ provider: "codex", dir: path.join(layout.sharedHomePath, "sessions") });
+    }
     // Grok Settings only expose the binary path; home is `$GROK_HOME` or `~/.grok`.
     // Empty/whitespace GROK_HOME must fall back: coalescing alone would scan cwd.
     const grokHomeEnv = hostEnvironment["GROK_HOME"]?.trim() ?? "";
@@ -261,8 +301,7 @@ export const make = Effect.gen(function* () {
         : path.join(NodeOS.homedir(), ".grok");
 
     return [
-      { provider: "claude" as const, dir: claudeDir },
-      { provider: "codex" as const, dir: path.join(codexLayout.sharedHomePath, "sessions") },
+      ...directories,
       {
         provider: "grok" as const,
         dir: path.join(grokHome, "sessions"),
@@ -380,7 +419,7 @@ export const make = Effect.gen(function* () {
 
   const collectDirs = Effect.fn("UsageService.collectDirs")(function* (
     windowStartMs: number,
-    settings: ServerSettingsValue,
+    settings: ServerSettings.RuntimeServerSettings,
   ) {
     // The home resolvers ask for `Path` themselves; satisfy them from the
     // instance we already hold so the scan stays context-free.
@@ -412,7 +451,7 @@ export const make = Effect.gen(function* () {
 
   const scanSummary = Effect.fn("UsageService.scanSummary")(function* (
     input: UsageSummaryInput,
-    settings: ServerSettingsValue,
+    settings: ServerSettings.RuntimeServerSettings,
   ) {
     if (input.sinceDay > input.untilDay) {
       return yield* new UsageReadError({
@@ -564,7 +603,7 @@ export const make = Effect.gen(function* () {
 
   const scanKey = (
     input: UsageSummaryInput,
-    priceOverrides: ServerSettingsValue["usagePriceOverrides"],
+    priceOverrides: ServerSettings.RuntimeServerSettings["usagePriceOverrides"],
   ): string =>
     JSON.stringify([
       input.timeZone,

--- a/apps/web/src/components/settings/ProviderSettingsPanel.logic.test.ts
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.logic.test.ts
@@ -1,14 +1,62 @@
-import { AuthOrchestrationOperateScope, EnvironmentId } from "@t3tools/contracts";
+import {
+  AuthOrchestrationOperateScope,
+  DEFAULT_SERVER_SETTINGS,
+  EnvironmentId,
+  ProviderDriverKind,
+  type ProviderInstanceConfig,
+} from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
   buildProviderEnvironmentOptions,
   classifyProviderEnvironmentAccess,
+  isDefaultProviderInstanceDirty,
   isProviderSettingsEnvironmentAvailable,
   resolvePrimaryOperateAccess,
   resolveRemoteOperateAccess,
   resolveSelectedProviderEnvironmentId,
 } from "./ProviderSettingsPanel.logic";
+
+describe("default provider Reset", () => {
+  const { enabled, ...config } = DEFAULT_SERVER_SETTINGS.providers.codex;
+  const defaults = { driver: ProviderDriverKind.make("codex"), enabled, config };
+
+  it.each([undefined, {}, { binaryPath: "codex" }, config])(
+    "keeps default config %j unchanged",
+    (config) => {
+      expect(isDefaultProviderInstanceDirty({ ...defaults, config }, defaults)).toBe(false);
+    },
+  );
+
+  it("keeps an omitted config unchanged for a disabled default provider", () => {
+    const { enabled, ...config } = DEFAULT_SERVER_SETTINGS.providers.cursor;
+    const defaults = { driver: ProviderDriverKind.make("cursor"), enabled, config };
+    expect(isDefaultProviderInstanceDirty({ driver: defaults.driver, enabled }, defaults)).toBe(
+      false,
+    );
+  });
+
+  it.each([
+    { enabled: false },
+    { displayName: "Work" },
+    { accentColor: "#ffffff" },
+    { environment: [{ name: "PROJECT_MODE", value: "work", sensitive: false }] },
+    { config: { binaryPath: "custom-codex" } },
+    { config: { futureSetting: true } },
+  ] satisfies ReadonlyArray<Partial<ProviderInstanceConfig>>)(
+    "keeps the override %j available to Reset",
+    (override) => {
+      expect(isDefaultProviderInstanceDirty({ ...defaults, ...override }, defaults)).toBe(true);
+    },
+  );
+
+  it.each([null, [], "codex", false, 7, { binaryPath: 7 }, { binaryPath: null }])(
+    "keeps invalid config %j available to Reset",
+    (config) => {
+      expect(isDefaultProviderInstanceDirty({ ...defaults, config }, defaults)).toBe(true);
+    },
+  );
+});
 
 const primaryId = EnvironmentId.make("primary");
 const relayId = EnvironmentId.make("relay");

--- a/apps/web/src/components/settings/ProviderSettingsPanel.logic.ts
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.logic.ts
@@ -3,7 +3,28 @@ import {
   AuthOrchestrationOperateScope,
   type AuthSessionState,
   type EnvironmentId,
+  type ProviderInstanceConfig,
 } from "@t3tools/contracts";
+import * as Equal from "effect/Equal";
+
+/** Omitted config fields use defaults. Keep unknown keys and invalid values visible to Reset. */
+export function isDefaultProviderInstanceDirty(
+  instance: ProviderInstanceConfig,
+  defaults: {
+    readonly driver: ProviderInstanceConfig["driver"];
+    readonly enabled: boolean | undefined;
+    readonly config: Readonly<Record<string, unknown>>;
+  },
+): boolean {
+  const config = instance.config;
+  if (
+    config !== undefined &&
+    (config === null || typeof config !== "object" || Array.isArray(config))
+  ) {
+    return true;
+  }
+  return !Equal.equals({ ...instance, config: { ...defaults.config, ...config } }, defaults);
+}
 
 export interface ProviderEnvironmentOptionLike {
   readonly environmentId: EnvironmentId;

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -742,8 +742,12 @@ export function EnvironmentProviderSettings({
     // Only the default slot depends on the legacy blob; custom instances for
     // the driver must still render even when the slot has nothing to show.
     if (effectiveInstance !== undefined) {
-      const isDirty =
-        explicitInstance !== undefined || !Equal.equals(legacyConfig, defaultLegacyConfig);
+      const { enabled: defaultEnabled, ...defaultConfig } = defaultLegacyConfig ?? {};
+      const isDirty = !Equal.equals(effectiveInstance, {
+        driver,
+        enabled: defaultEnabled,
+        config: defaultConfig,
+      });
       rows.push({
         instanceId: defaultInstanceId,
         instance: effectiveInstance,

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -22,7 +22,6 @@ import {
 } from "@t3tools/shared/backgroundActivitySettings";
 import * as Arr from "effect/Array";
 import * as Duration from "effect/Duration";
-import * as Equal from "effect/Equal";
 import * as Result from "effect/Result";
 import { PlusIcon, RefreshCwIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
@@ -99,6 +98,7 @@ import {
 import {
   buildProviderEnvironmentOptions,
   classifyProviderEnvironmentAccess,
+  isDefaultProviderInstanceDirty,
   isProviderSettingsEnvironmentAvailable,
   type ProviderEnvironmentAccess,
   type ProviderOperateAccess,
@@ -743,7 +743,7 @@ export function EnvironmentProviderSettings({
     // the driver must still render even when the slot has nothing to show.
     if (effectiveInstance !== undefined) {
       const { enabled: defaultEnabled, ...defaultConfig } = defaultLegacyConfig ?? {};
-      const isDirty = !Equal.equals(effectiveInstance, {
+      const isDirty = isDefaultProviderInstanceDirty(effectiveInstance, {
         driver,
         enabled: defaultEnabled,
         config: defaultConfig,

--- a/apps/web/src/modelSelection.ts
+++ b/apps/web/src/modelSelection.ts
@@ -43,15 +43,10 @@ const DEFAULT_TEXT_GENERATION_INSTANCE_ID = ProviderInstanceId.make("codex");
  * present and falling back to the legacy per-kind
  * `settings.providers[kind].customModels` bucket for default instances only.
  *
- * The Settings UI promotes the legacy bucket into an explicit
- * `providerInstances[defaultId]` entry on every edit (the "migrate on
- * first write" scheme documented in
- * `ProviderInstanceRegistryHydration`), so this helper exists primarily
- * so readers pick up that promotion immediately — and so first-time
- * viewers on pre-migration settings still see their legacy list on
- * default slots. Custom instances intentionally do not read the legacy
- * per-driver bucket; otherwise one custom model added to `claude_openrouter`
- * can appear on the stock `claudeAgent` instance.
+ * Current servers include default instances in the map. The legacy fallback
+ * supports older servers that omit them. Custom instances never read the
+ * legacy per-driver bucket, so one account's custom models cannot appear
+ * on another account.
  */
 function readInstanceCustomModels(
   settings: UnifiedSettings,

--- a/apps/web/src/providerInstances.ts
+++ b/apps/web/src/providerInstances.ts
@@ -169,10 +169,9 @@ function resolveInstanceDisplayName(
 
 /**
  * Project the wire `ServerProvider[]` into instance entries, one per
- * configured instance. Preserves the server's ordering (which sources
- * from `deriveProviderInstanceConfigMap` — explicit `providerInstances.*`
- * first, synthesized defaults after) so callers that want "default first"
- * should sort with `sortProviderInstanceEntries` below.
+ * configured instance. Keeps the server's order: explicit instances first,
+ * then legacy defaults. Callers that want default instances first can use
+ * `sortProviderInstanceEntries`.
  */
 export function deriveProviderInstanceEntries(
   providers: ReadonlyArray<ServerProvider>,

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -925,12 +925,9 @@ export const ServerSettings = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed(null)),
   ),
 
-  // Legacy single-instance-per-driver settings. Continues to be the source
-  // of truth until `providerInstances` (below) lands per-driver migration
-  // shims and the server starts hydrating instances from it. Driver-specific
-  // schemas live here for the duration of the migration; once each driver
-  // owns its config in its own package, this struct shrinks to nothing and
-  // is removed entirely.
+  // Legacy file and client compatibility. The server converts these settings
+  // to providerInstances before runtime consumers read them. New provider
+  // configuration belongs in the instance map, not this legacy struct.
   providers: Schema.Struct({
     codex: CodexSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     claudeAgent: ClaudeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),

--- a/packages/shared/src/backgroundActivitySettings.ts
+++ b/packages/shared/src/backgroundActivitySettings.ts
@@ -195,7 +195,13 @@ export function normalizeBackgroundActivitySettings(
 }
 
 export function resolveServerBackgroundActivitySettings(
-  settings: ServerSettings,
+  settings: Pick<
+    ServerSettings,
+    | "backgroundActivity"
+    | "backgroundActivityProfile"
+    | "automaticGitFetchInterval"
+    | "providerHealthRefreshInterval"
+  >,
 ): ResolvedBackgroundActivitySettings {
   const defaultBackgroundActivity: BackgroundActivitySettings = {
     schemaVersion: 1,
@@ -248,7 +254,7 @@ export function resolveServerBackgroundActivitySettings(
 }
 
 export function normalizeServerBackgroundActivitySettings(
-  settings: ServerSettings,
+  settings: Parameters<typeof resolveServerBackgroundActivitySettings>[0],
 ): BackgroundActivitySettings {
   const resolved = resolveServerBackgroundActivitySettings(settings);
   return normalizeBackgroundActivitySettings({

--- a/packages/shared/src/serverSettings.ts
+++ b/packages/shared/src/serverSettings.ts
@@ -26,28 +26,36 @@ const decodeServerSettingsJson = Schema.decodeUnknownOption(ServerSettingsJson);
 type LegacyProviderSettings = ServerSettings["providers"][keyof ServerSettings["providers"]];
 
 const getLegacyProviderSettings = (
-  settings: ServerSettings,
+  settings: Pick<ServerSettings, "providers">,
   provider: ProviderDriverKind,
 ): LegacyProviderSettings | undefined =>
   (settings.providers as Record<string, LegacyProviderSettings | undefined>)[provider];
 
 export function isModelSelectionProviderEnabled(
-  settings: ServerSettings,
+  settings: Pick<ServerSettings, "providerInstances"> & Partial<Pick<ServerSettings, "providers">>,
   selection: ModelSelection,
 ): boolean {
-  const instanceConfig = settings.providerInstances[selection.instanceId];
+  const instanceConfig = Object.hasOwn(settings.providerInstances, selection.instanceId)
+    ? settings.providerInstances[selection.instanceId]
+    : undefined;
   if (instanceConfig !== undefined) {
     return resolveProviderInstanceEnabled(instanceConfig);
   }
 
   return (
+    settings.providers !== undefined &&
     isProviderDriverKind(selection.instanceId) &&
-    getLegacyProviderSettings(settings, selection.instanceId)?.enabled === true
+    getLegacyProviderSettings({ providers: settings.providers }, selection.instanceId)?.enabled ===
+      true
   );
 }
 
 export function resolveSourceControlWriterModelSelection(
-  settings: ServerSettings,
+  settings: Pick<
+    ServerSettings,
+    "providerInstances" | "sourceControlWriterModelSelection" | "textGenerationModelSelection"
+  > &
+    Partial<Pick<ServerSettings, "providers">>,
   providers?: ReadonlyArray<ServerProvider>,
 ): ModelSelection {
   const selection = settings.sourceControlWriterModelSelection;


### PR DESCRIPTION
Runtime code still interprets both provider settings formats. The text-generation fallback can select a default instance that was explicitly disabled.

Normalize old settings into one instance map before runtime code reads them. Keep old file and client formats at the settings boundary. Preserve explicit disables, unknown driver configs, and sparse defaults when clients save the full map. Registry, terminal, installation, session scan, and usage reads now use instance IDs. The provider Reset action compares values with defaults instead of treating every normalized entry as an edit. Omitted config fields count as defaults for this comparison. Unknown keys, invalid config, and instance edits still show Reset.

## Verification

- 525 focused tests across 15 server, shared, and web suites pass.
- Server and web typechecks pass. Changed-file lint passes with warnings in unchanged code. Formatting passes.
- Read-only source review is clear after fixes for old-client saves, unknown driver defaults, and usage config validation.
- The sparse-config Reset fix passed 56 focused tests, web typecheck, lint, and formatting.
- Disposable browser checks pass: default settings hide Reset, an edited display name shows it, and Reset restores the default. No live state or provider session was used.

Closes #7533
Closes #5805

## Browser check

| Before | After |
| --- | --- |
| ![Provider settings before](https://files.tslop.org/2026/09/before-main-84aebb72-provider-settings-d09213c6.png) | ![Provider settings after](https://files.tslop.org/2026/09/after-stage1-provider-settings-b5563baf.png) |

After editing the display name:

![Reset available after editing](https://files.tslop.org/2026/09/after-stage1-provider-edited-d6d3025f.png)

### Sparse default config

Both disposable builds received the same valid server-config input: `{"providerInstances":{"codex":{"driver":"codex","enabled":true}}}`.

Before `dd1e088f54` shows Reset. After `7b62fb288b`, which includes fix `56ccf1b5d6`, hides it. The actual client ran in both checks. All non-read application requests were blocked. No real settings change or provider command ran.

| Before | After |
| --- | --- |
| ![Sparse default shows Reset before](https://files.tslop.org/2026/09/provider-reset-sparse-before-70b12c77.png) | ![Sparse default hides Reset after](https://files.tslop.org/2026/09/provider-reset-sparse-after-6b82af9d.png) |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize provider settings into `RuntimeServerSettings` before use
> - Introduces `resolveServerSettings` in [serverSettings.ts](https://github.com/pingdotgg/t3code/pull/10121/files#diff-ec910be99e19e00c0e09b15484059b34164d71de8d0026f4ba98471bbbb3680e), which converts persisted settings to `RuntimeServerSettings` by folding legacy enabled flags, synthesizing default provider instances from legacy `providers` entries, and dropping the legacy map from the runtime shape. `providerInstances` becomes the single source of truth for runtime consumers.
> - Updates `ServerSettingsService` contract and all consumers — usage scanner, terminal manager, provider registry hydration, provider installation, agent session scanner, and text-generation fallback — to read provider configuration from `providerInstances` directly instead of legacy `providers` fields.
> - Reconstructs a legacy `providers` map via `legacyProvidersForClient` only for client-facing redaction responses, preserving backward compatibility without making it a runtime source of truth.
> - `applySettingsPatch` filters out synthesized default instances that merely match legacy defaults, so saving unchanged settings does not persist them as explicit overrides.
> - Risk: `RuntimeServerSettings` replaces `ServerSettings` across `ServerSettingsService` methods (`getSettings`, `updateSettings`, `streamChanges`, `subscribeChanges`) and downstream parameter types in [UsageService.ts](https://github.com/pingdotgg/t3code/pull/10121/files#diff-1d90d173860922c384f65961de4b51bba0176aadd7982190e0dcf87e663f1a70), [Manager.ts](https://github.com/pingdotgg/t3code/pull/10121/files#diff-9b98fe5056129db24d311ed1bd8f66a72127cf90fa7529da47e0725f2813532e), [ProviderInstanceRegistryHydration.ts](https://github.com/pingdotgg/t3code/pull/10121/files#diff-178004a31896bcf4abd061f33ad3d95f0fd2a03d9e724863557102de06dafdc0), and [providerInstallation.ts](https://github.com/pingdotgg/t3code/pull/10121/files#diff-f4364f321d0772d33c7ca771048548f55a494c6f515bfbeffdd4965707a1de5e); any out-of-tree consumers of these signatures must update. Invalid known-driver instance configs now surface as `scanFailed` in usage instead of silently using defaults.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56ccf1b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## Model

Created with GPT-6 Astra in Codex. Sparse-default correction, browser verification, and evidence upload in Codex.

