### PR TITLE
Add nix flake devshell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788316716,
+        "narHash": "sha256-bc7rSpXIdn9QWGNqfWcPZWOhEVF8NoeAZkWq0XWnf/k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3ed67ec0a4d3c7ab4ae1f04f8ee8df07bfa506a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,8 @@
         {
           default = pkgs.mkShell {
             packages = [
+              pkgs.nodejs
+              pkgs.pnpm
               pkgs.pkg-config
               pkgs.libsecret
               pkgs.stdenv.cc

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "T3 Code development shell";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { nixpkgs, ... }:
+    let
+      forLinuxSystems = nixpkgs.lib.genAttrs [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+    in
+    {
+      devShells = forLinuxSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              pkgs.pkg-config
+              pkgs.libsecret
+              pkgs.stdenv.cc
+            ];
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
With recent changes `npm run build` doesn't work anymore on baseline
NixOS due to native library requirements.

This adds a Nix flake with a devshell that has the required deps.


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Nix flake development shell with Node.js, pnpm, and libsecret
> Adds a `flake.nix` that defines a development shell for `x86_64-linux` and `aarch64-linux`, pinning nixpkgs to the NixOS unstable channel. The shell provides Node.js, pnpm, pkg-config, libsecret, and the system C compiler toolchain. A `flake.lock` locks the nixpkgs input.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized bea986b. 1 file reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>flake.nix — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 23](https://github.com/pingdotgg/t3code/blob/bea986b1a79c3318d8aae682409e526665fb15b7/flake.nix#L23): `pkgs.libsecret` installs only libsecret's default `out` output in this shell, but its headers and `libsecret-1.pc` are split into the separate `dev` output. Consequently `pkg-config --cflags --libs libsecret-1`, which the desktop build invokes, cannot find the package in `nix develop`; add `pkgs.libsecret.dev` (or otherwise include that output). <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->