### PR TITLE
fix(server): stop blaming Google sign-in for Antigravity session errors

### DIFF
--- a/apps/server/src/provider/AntigravityAuth.test.ts
+++ b/apps/server/src/provider/AntigravityAuth.test.ts
@@ -61,7 +61,7 @@ const makeHarness = Effect.fn("makeAuthTestHarness")(function* (
   } = {},
 ) {
   const authenticated = yield* Deferred.make<void, AcpErrors.AcpError>();
-  const discovered = yield* Deferred.make<void>();
+  const discovered = yield* Deferred.make<void, AcpErrors.AcpError>();
   const closed = yield* Deferred.make<void>();
   const events: string[] = [];
   let receiveAuthorizationUrl:
@@ -240,6 +240,25 @@ it.layer(NodeServices.layer)("AntigravityAuth", (it) => {
       assert.isNull(failed.authorizationUrl);
       assert.deepEqual(harness.catalog(), ["previous-account-model"]);
       yield* Deferred.await(harness.closed);
+    }),
+  );
+
+  it.effect("keeps a failed session request from reading as a Google sign-in failure", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      const state = yield* harness.auth.controller.start(owner);
+      yield* phase(harness.auth, "waiting");
+      yield* harness.auth.controller.complete(owner, { flowId: state.flowId!, callbackUrl });
+      yield* Deferred.succeed(harness.authenticated, undefined);
+      yield* Deferred.fail(
+        harness.discovered,
+        AcpErrors.AcpRequestError.internalError("Internal error", undefined, {
+          method: "session/new",
+        }),
+      );
+      const failed = yield* phase(harness.auth, "failed");
+      assert.notInclude(failed.message ?? "", "Google sign-in failed");
+      assert.include(failed.message ?? "", "could not start a session");
     }),
   );
 

--- a/apps/server/src/provider/AntigravityAuth.ts
+++ b/apps/server/src/provider/AntigravityAuth.ts
@@ -117,6 +117,12 @@ function safeAuthFailure(cause: Cause.Cause<unknown>, usesBrowser: boolean): str
       if (!usesBrowser && error.value.code === -32602) {
         return "Antigravity rejected the configured credentials. Check the provider settings.";
       }
+      // Authentication already succeeded once the flow reaches a session
+      // request, so the stored credentials are valid. Telling the user to sign
+      // in again would send them through a sign-out that deletes them.
+      if (error.value.method?.startsWith("session/")) {
+        return "Signed in, but Antigravity could not start a session. Retry without signing out.";
+      }
     }
   }
   return usesBrowser


### PR DESCRIPTION
Antigravity setup runs `authenticate` and then a `session/new` probe in the same flow. When that probe fails, `safeAuthFailure` has no case for it and falls through to **"Google sign-in failed. Start sign-in again."** — even though Google succeeded and `acp_token.json` was already written. Acting on that banner means signing out, which deletes the token that was working, so the user loops forever.

An `AcpRequestError` already carries the `method` it failed on, so a `session/*` failure can be recognised as post-authentication and reported as such. `initialize` is deliberately left alone: it runs before `authenticate`, so the existing wording is still correct there.

- Before: `Google sign-in failed. Start sign-in again.`
- After: `Signed in, but Antigravity could not start a session. Retry without signing out.`

On the underlying failure from #9655: it is not the throwaway setup cwd, as that issue guessed. The agent's own log shows `session/new` dying in the harness handshake with `Failed to parse initial message: proto: (line 3:5): unknown field "cascadeid"`. `agy_acp_server` 1.1.1 serializes `HarnessConfig.cascade_id` as lowercase `cascadeid`, and the `localharness_external` binary shipped in the same archive only accepts `cascadeId`. Probing that harness directly confirms it: `cascadeId` parses, `cascadeid` produces exactly the reported error, and Go's protojson reports unknown field names verbatim. `cascade_id` comes from a session id the agent generates itself, so nothing T3 sends reaches it, and the ACP registry still lists 1.1.1 as current — there is no newer build to pin. That part is not fixable here; this PR only stops T3 from misreporting it as a sign-in failure and pushing users into a destructive sign-out.

Fixes #9655

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `safeAuthFailure` to report `session/*` ACP errors as Antigravity session failures, not Google sign-in failures
> - Adds handling in `safeAuthFailure` ([AntigravityAuth.ts](https://github.com/pingdotgg/t3code/pull/10137/files#diff-8778c1f1cd17b502557d5c28d6fe8a5fbcbcbdb2dcb3b22c2affbcba8ad17038)) for ACP request errors whose method starts with `session/`. When no earlier case matches, the formatter now reports sign-in succeeded but Antigravity could not start a session, advising retry without signing out.
> - Updates the auth test harness ([AntigravityAuth.test.ts](https://github.com/pingdotgg/t3code/pull/10137/files#diff-ae8c7e4eacbcc409292a467800efffe678d6e307b70c34811f32c49b5ac3c861)) so the `discovered` deferred can fail with `AcpErrors.AcpError`, and adds a test verifying the corrected failure classification after a `session/new` error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9bd867a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->