### PR TITLE
fix(server): probe Claude capabilities under an enterprise MCP config

### DIFF
--- a/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
@@ -5,7 +5,11 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 
-import { discoverClaudeSkills, skillOverrideSettingsPaths } from "./ClaudeSkills.ts";
+import {
+  claudeManagedMcpConfigPath,
+  discoverClaudeSkills,
+  skillOverrideSettingsPaths,
+} from "./ClaudeSkills.ts";
 
 const writeSkill = Effect.fn(function* (
   skillsDir: string,
@@ -552,6 +556,27 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
           "/etc/claude-code/managed-settings.json",
         ],
       );
+    }),
+  );
+
+  it.effect("locates the enterprise MCP config beside the managed policy file", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path.pipe(Effect.provide(NodePath.layerPosix));
+      const win32Path = yield* Path.Path.pipe(Effect.provide(NodePath.layerWin32));
+
+      assert.equal(
+        claudeManagedMcpConfigPath(path, "darwin", {}),
+        "/Library/Application Support/ClaudeCode/managed-mcp.json",
+      );
+      assert.equal(
+        claudeManagedMcpConfigPath(path, "linux", {}),
+        "/etc/claude-code/managed-mcp.json",
+      );
+      assert.equal(
+        claudeManagedMcpConfigPath(win32Path, "win32", { PROGRAMDATA: "C:\\ProgramData" }),
+        "C:\\ProgramData\\ClaudeCode\\managed-mcp.json",
+      );
+      assert.equal(claudeManagedMcpConfigPath(win32Path, "win32", {}), undefined);
     }),
   );
 

--- a/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
@@ -518,13 +518,17 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
 
       assert.deepEqual(
         skillOverrideSettingsPaths(win32Path, "C:\\Users\\me\\.claude", undefined, "win32", {
+          ProgramFiles: "D:\\Program Files",
           PROGRAMDATA: "C:\\ProgramData",
         }).at(-1),
-        "C:\\ProgramData\\ClaudeCode\\managed-settings.json",
+        "D:\\Program Files\\ClaudeCode\\managed-settings.json",
       );
       assert.deepEqual(
         skillOverrideSettingsPaths(win32Path, "C:\\Users\\me\\.claude", undefined, "win32", {}),
-        ["C:\\Users\\me\\.claude\\settings.json"],
+        [
+          "C:\\Users\\me\\.claude\\settings.json",
+          "C:\\Program Files\\ClaudeCode\\managed-settings.json",
+        ],
       );
 
       // Only the repository root's local file joins in, after the
@@ -573,10 +577,18 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
         "/etc/claude-code/managed-mcp.json",
       );
       assert.equal(
-        claudeManagedMcpConfigPath(win32Path, "win32", { PROGRAMDATA: "C:\\ProgramData" }),
-        "C:\\ProgramData\\ClaudeCode\\managed-mcp.json",
+        claudeManagedMcpConfigPath(win32Path, "win32", {
+          ProgramFiles: " D:\\Program Files ",
+          PROGRAMDATA: "C:\\ProgramData",
+        }),
+        "D:\\Program Files\\ClaudeCode\\managed-mcp.json",
       );
-      assert.equal(claudeManagedMcpConfigPath(win32Path, "win32", {}), undefined);
+      for (const environment of [{}, { ProgramFiles: "   " }, { PROGRAMDATA: "C:\\ProgramData" }]) {
+        assert.equal(
+          claudeManagedMcpConfigPath(win32Path, "win32", environment),
+          "C:\\Program Files\\ClaudeCode\\managed-mcp.json",
+        );
+      }
     }),
   );
 

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -113,8 +113,8 @@ function claudeManagedConfigDirectory(
     return "/Library/Application Support/ClaudeCode";
   }
   if (platform === "win32") {
-    const programData = environment.PROGRAMDATA?.trim();
-    return programData ? path.join(programData, "ClaudeCode") : undefined;
+    const programFiles = environment.ProgramFiles?.trim() || "C:\\Program Files";
+    return path.join(programFiles, "ClaudeCode");
   }
   return "/etc/claude-code";
 }

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -100,23 +100,46 @@ function parseSkillFrontmatter(contents: string): SkillFrontmatter {
 }
 
 /**
- * Where an administrator installs the policy file whose settings outrank every
- * user and project one. Absent on almost every machine, which is why a missing
- * file is the normal case rather than an error.
+ * Where an administrator installs Claude Code's machine-wide policy files.
+ * Absent on almost every machine, which is why a missing file is the normal
+ * case rather than an error.
  */
-function claudeManagedSettingsPath(
+function claudeManagedConfigDirectory(
   path: Path.Path,
   platform: NodeJS.Platform,
   environment: NodeJS.ProcessEnv,
 ): string | undefined {
   if (platform === "darwin") {
-    return "/Library/Application Support/ClaudeCode/managed-settings.json";
+    return "/Library/Application Support/ClaudeCode";
   }
   if (platform === "win32") {
     const programData = environment.PROGRAMDATA?.trim();
-    return programData ? path.join(programData, "ClaudeCode", "managed-settings.json") : undefined;
+    return programData ? path.join(programData, "ClaudeCode") : undefined;
   }
-  return "/etc/claude-code/managed-settings.json";
+  return "/etc/claude-code";
+}
+
+/** The policy file whose settings outrank every user and project one. */
+function claudeManagedSettingsPath(
+  path: Path.Path,
+  platform: NodeJS.Platform,
+  environment: NodeJS.ProcessEnv,
+): string | undefined {
+  const directory = claudeManagedConfigDirectory(path, platform, environment);
+  return directory === undefined ? undefined : path.join(directory, "managed-settings.json");
+}
+
+/**
+ * The enterprise MCP config. While it exists Claude Code gives it exclusive
+ * control over MCP servers and refuses `--strict-mcp-config` outright.
+ */
+export function claudeManagedMcpConfigPath(
+  path: Path.Path,
+  platform: NodeJS.Platform,
+  environment: NodeJS.ProcessEnv,
+): string | undefined {
+  const directory = claudeManagedConfigDirectory(path, platform, environment);
+  return directory === undefined ? undefined : path.join(directory, "managed-mcp.json");
 }
 
 /**

--- a/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
@@ -34,6 +34,7 @@ it("isolates Claude capability probes without dropping workspace setting sources
       FORCE_CODE_TERMINAL: "1",
     },
     cwd: "/workspace/project",
+    enterpriseMcpConfigPresent: false,
   });
 
   assert.deepEqual(options.mcpServers, {});
@@ -50,6 +51,22 @@ it("isolates Claude capability probes without dropping workspace setting sources
   assert.equal(options.env?.FORCE_CODE_TERMINAL, undefined);
   assert.equal(options.env?.CLAUDE_CODE_AUTO_CONNECT_IDE, "0");
   assert.equal(options.env?.CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL, "1");
+});
+
+it("leaves strict MCP mode off when an enterprise MCP config is installed", () => {
+  const options = buildClaudeCapabilitiesProbeQueryOptions({
+    executablePath: "/usr/bin/claude",
+    abortController: new AbortController(),
+    environment: { HOME: "/home/user" },
+    cwd: undefined,
+    enterpriseMcpConfigPresent: true,
+  });
+
+  // Claude refuses --strict-mcp-config next to managed-mcp.json; the empty
+  // explicit map still keeps the probe from adding servers of its own.
+  assert.equal(options.strictMcpConfig, undefined);
+  assert.deepEqual(options.mcpServers, {});
+  assert.equal(options.env?.ENABLE_CLAUDEAI_MCP_SERVERS, "false");
 });
 
 it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -11,6 +11,7 @@ import * as Path from "effect/Path";
 import * as Ref from "effect/Ref";
 import * as Result from "effect/Result";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { createModelCapabilities } from "@t3tools/shared/model";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import {
@@ -348,7 +349,7 @@ const probeClaudeCapabilities = (
     );
     const managedMcpConfigPath = claudeManagedMcpConfigPath(
       path,
-      process.platform,
+      yield* HostProcessPlatform,
       claudeEnvironment,
     );
     const enterpriseMcpConfigPresent =

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -34,7 +34,7 @@ import {
 } from "../providerSnapshot.ts";
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
-import { discoverClaudeSkills } from "../Drivers/ClaudeSkills.ts";
+import { claudeManagedMcpConfigPath, discoverClaudeSkills } from "../Drivers/ClaudeSkills.ts";
 import { makeUnavailableUsageLimits } from "../providerUsageLimits.ts";
 import {
   type ClaudeScopedLimitNames,
@@ -186,6 +186,8 @@ export function buildClaudeCapabilitiesProbeQueryOptions(input: {
   readonly abortController: AbortController;
   readonly environment: NodeJS.ProcessEnv;
   readonly cwd: string | undefined;
+  /** An enterprise managed-mcp.json is installed on this machine. */
+  readonly enterpriseMcpConfigPresent: boolean;
 }): ClaudeQueryOptions {
   return {
     persistSession: false,
@@ -198,9 +200,12 @@ export function buildClaudeCapabilitiesProbeQueryOptions(input: {
     settings: { disableAllHooks: true },
     allowedTools: [],
     // Ignore MCP definitions from every filesystem setting source above. The
-    // SDK combines this empty explicit map with --strict-mcp-config.
+    // SDK combines this empty explicit map with --strict-mcp-config. Claude
+    // exits before initializing when that flag meets an enterprise
+    // managed-mcp.json, so the probe leaves it off there; the enterprise
+    // config already ignores user and project MCP servers on its own.
     mcpServers: {},
-    strictMcpConfig: true,
+    ...(input.enterpriseMcpConfigPresent ? {} : { strictMcpConfig: true }),
     env: {
       ...input.environment,
       // Connected claude.ai MCP servers are discovered outside filesystem
@@ -334,11 +339,23 @@ const probeClaudeCapabilities = (
 ) => {
   const abort = new AbortController();
   return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
     const claudeEnvironment = yield* makeClaudeEnvironment(claudeSettings, environment);
     const executablePath = yield* resolveClaudeSdkExecutablePath(
       claudeSettings.binaryPath,
       claudeEnvironment,
     );
+    const managedMcpConfigPath = claudeManagedMcpConfigPath(
+      path,
+      process.platform,
+      claudeEnvironment,
+    );
+    const enterpriseMcpConfigPresent =
+      managedMcpConfigPath !== undefined &&
+      (yield* fileSystem
+        .exists(managedMcpConfigPath)
+        .pipe(Effect.orElseSucceed((): boolean => false)));
     return yield* Effect.tryPromise(async () => {
       const q = claudeQuery({
         // Never yield — we only need initialization data, not a conversation.
@@ -352,6 +369,7 @@ const probeClaudeCapabilities = (
           abortController: abort,
           environment: claudeEnvironment,
           cwd,
+          enterpriseMcpConfigPresent,
         }),
       });
       const init = await q.initializationResult();


### PR DESCRIPTION
Fixes https://github.com/pingdotgg/t3code/issues/5392

## Problem

The periodic Claude capability probe runs with `mcpServers: {}` plus `strictMcpConfig: true` so the health check never starts the user's MCP servers (https://github.com/pingdotgg/t3code/issues/3909). On machines with an enterprise-managed MCP config (`/Library/Application Support/ClaudeCode/managed-mcp.json`, `/etc/claude-code/managed-mcp.json`, or `%ProgramFiles%\ClaudeCode\managed-mcp.json`) Claude Code exits before initializing:

```
You cannot use --strict-mcp-config when an enterprise MCP config is present.
```

T3 then reports "Could not verify Claude authentication status from initialization result." and the provider stays unselectable, even though `claude` works fine from a terminal.

## Fix

The probe checks whether `managed-mcp.json` exists in Claude Code's managed config directory and leaves `strictMcpConfig` off when it does. The empty explicit MCP map and the claude.ai connector opt-out stay in place. An enterprise MCP config already takes exclusive control over MCP servers (Claude ignores user, project and `--mcp-config` servers next to it), so the probe still only sees what the administrator configured.

`claudeManagedSettingsPath` now derives from a shared managed-directory helper alongside the new `claudeManagedMcpConfigPath`, so both files resolve from one place per platform.

## Why dropping strict mode there is safe

Strings from the Claude Code binary (2.1.261) that drive this:

- `You cannot use --strict-mcp-config when an enterprise MCP config is present` is returned before initialization, which is the failure the probe hits today.
- `Warning: an enterprise MCP config (managed-mcp.json) is present and has exclusive control over MCP servers; ignoring ... MCP servers supplied via --mcp-config` shows that with `managed-mcp.json` installed Claude only loads the administrator's servers. User, project and `--mcp-config` servers are ignored regardless of the strict flag.

So without the flag the probe on an enterprise machine starts exactly the servers the administrator mandated and nothing else. The https://github.com/pingdotgg/t3code/issues/3909 failure mode (a health check every few minutes spawning the user's own MCP servers) cannot come back through this path. On every other machine the probe is unchanged.

## Verification

- `ClaudeCapabilitiesProbe.test.ts`: the probe options keep strict mode without an enterprise config and drop it when one is present.
- `ClaudeSkills.test.ts`: `managed-mcp.json` resolves next to `managed-settings.json` on macOS, Linux and Windows. Windows uses `ProgramFiles`, falling back to `C:\Program Files` when it is missing or blank. Tests use the Windows path service on macOS; no Windows runtime test was performed.
- Server typecheck.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable `strictMcpConfig` in `probeClaudeCapabilities` when enterprise MCP config is present
> - Adds `claudeManagedMcpConfigPath` to resolve the platform-specific enterprise `managed-mcp.json` path, reusing a centralized `claudeManagedConfigDirectory` helper shared with `managed-settings.json` resolution
> - `probeClaudeCapabilities` now checks whether `managed-mcp.json` exists on the host filesystem before building probe options; filesystem-check failures are treated as absence
> - `buildClaudeCapabilitiesQueryOptions` gains an `enterpriseMcpConfigPresent` input and omits `strictMcpConfig: true` when that flag is true, while the explicit MCP server map stays empty and connected claude.ai MCP servers remain disabled
> - Adds tests covering enterprise MCP path resolution across macOS, Linux, and Windows (including missing or blank `ProgramFiles`) and probe option construction with and without enterprise config
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39a3109.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Claude Code compatibility when an enterprise-managed MCP configuration is installed.
  - Prevented Claude from exiting before initialization in environments using managed MCP configuration.
  - Claude now avoids conflicting MCP server settings and allows enterprise configuration to control server access.
  - Improved platform-aware discovery of enterprise-managed configuration files across macOS, Linux, and Windows, including Windows installations under Program Files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->