### PR TITLE
fix(web): Antigravity restart no longer shows Needs attention

### DIFF
--- a/apps/web/src/components/chat/ProviderStatusBanner.tsx
+++ b/apps/web/src/components/chat/ProviderStatusBanner.tsx
@@ -4,18 +4,12 @@ import { InfoIcon, XIcon } from "lucide-react";
 import { cn } from "~/lib/utils";
 import { Button } from "../ui/button";
 import { formatProviderDriverKindLabel } from "../../providerModels";
+import { isUncheckedAntigravityAuth } from "../settings/providerStatus";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
 export function getProviderStatusBannerKey(status: ServerProvider | null): string | null {
   if (!status || status.status === "ready" || status.status === "disabled") return null;
-  // Antigravity checks saved credentials when a session starts. Its local
-  // health check leaves auth unknown after a restart, which is not a failure.
-  if (
-    status.driver === "antigravity" &&
-    status.installed &&
-    status.status === "warning" &&
-    status.auth.status === "unknown"
-  ) {
+  if (isUncheckedAntigravityAuth(status)) {
     return null;
   }
   return [status.instanceId, status.status, status.auth.status, status.message ?? ""].join(

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -52,6 +52,7 @@ import {
   PROVIDER_STATUS_STYLES,
   getProviderSummary,
   getProviderVersionLabel,
+  isUncheckedAntigravityAuth,
   type ProviderStatusKey,
 } from "./providerStatus";
 
@@ -421,9 +422,11 @@ export function ProviderInstanceCard({
   const enabled = resolveProviderInstanceEnabled(instance);
   // A locally disabled provider reads "Disabled" with a muted dot even if its
   // last server status is stale. Enabled providers use the server status.
-  const statusKey: ProviderStatusKey = enabled
-    ? ((liveProvider?.status as ProviderStatusKey | undefined) ?? "warning")
-    : "disabled";
+  const statusKey: ProviderStatusKey = !enabled
+    ? "disabled"
+    : liveProvider && isUncheckedAntigravityAuth(liveProvider)
+      ? "ready"
+      : ((liveProvider?.status as ProviderStatusKey | undefined) ?? "warning");
   const statusStyle = PROVIDER_STATUS_STYLES[statusKey];
   const summary = enabled
     ? getProviderSummary(liveProvider)

--- a/apps/web/src/components/settings/ProviderSetupSection.test.tsx
+++ b/apps/web/src/components/settings/ProviderSetupSection.test.tsx
@@ -338,6 +338,30 @@ describe("Antigravity setup", () => {
     expect(setup.removeInstall).toHaveBeenCalledWith({ environmentId, input: { instanceId } });
   });
 
+  it("does not offer Google sign-in while Antigravity auth is unchecked after a restart", () => {
+    setup.auth = authState({ phase: "idle", flowId: null, authorizationUrl: null });
+    const message = "Antigravity is installed. Google account access is not checked yet.";
+    const view = renderSetup({
+      provider: {
+        ...provider,
+        installed: true,
+        status: "warning",
+        auth: { status: "unknown" },
+        message,
+      },
+    });
+
+    expect(button(view, "Sign in with Google")).toBeNull();
+    expect(button(view, "Sign out of Google")).not.toBeNull();
+    expect(
+      visitElements(
+        view,
+        (element) => element.props.children === "Sign in with your Google account.",
+      ),
+    ).toBeNull();
+    expect(visitElements(view, (element) => element.props.children === message)).not.toBeNull();
+  });
+
   it.each([true, false])(
     "can sign out an unchecked account when its instance is enabled=%s",
     async (enabled) => {

--- a/apps/web/src/components/settings/ProviderSetupSection.tsx
+++ b/apps/web/src/components/settings/ProviderSetupSection.tsx
@@ -20,6 +20,7 @@ import { serverEnvironment } from "../../state/server";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
+import { isUncheckedAntigravityAuth } from "./providerStatus";
 
 interface ProviderSetupSectionProps {
   readonly environmentId: EnvironmentId;
@@ -154,6 +155,7 @@ function ProviderSetupActions({
   const installed =
     provider.installed || (!usesCustomBinary && installation?.installedVersion != null);
   const authenticated = provider.auth.status === "authenticated";
+  const uncheckedAntigravityAuth = isUncheckedAntigravityAuth(provider);
   const authStatusMessage =
     auth === null
       ? "Reading sign-in status."
@@ -163,9 +165,11 @@ function ProviderSetupActions({
           ? usesBrowser
             ? "Signed in with Google."
             : "Connected."
-          : auth.phase === "idle" && auth.message
-            ? auth.message
-            : phaseLabels.idle;
+          : uncheckedAntigravityAuth
+            ? (provider.message ?? "Google account access is checked when a session starts.")
+            : auth.phase === "idle" && auth.message
+              ? auth.message
+              : phaseLabels.idle;
   const authorizationUrl = auth?.phase === "waiting" ? auth.authorizationUrl : null;
   const queryError = authQuery.error ?? installQuery.error;
   const actionsDisabled = pendingLabel !== null || queryError !== null;
@@ -428,7 +432,10 @@ function ProviderSetupActions({
             >
               Cancel sign-in
             </Button>
-          ) : !authActive && !authenticated && provider.setup?.canAuthenticate ? (
+          ) : !authActive &&
+            !authenticated &&
+            !uncheckedAntigravityAuth &&
+            provider.setup?.canAuthenticate ? (
             <Button
               size="xs"
               variant="outline"

--- a/apps/web/src/components/settings/providerStatus.test.ts
+++ b/apps/web/src/components/settings/providerStatus.test.ts
@@ -1,7 +1,7 @@
 import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { getProviderSummary } from "./providerStatus";
+import { getProviderSummary, isUncheckedAntigravityAuth } from "./providerStatus";
 
 const provider: ServerProvider = {
   instanceId: ProviderInstanceId.make("codex"),
@@ -67,5 +67,44 @@ describe("getProviderSummary", () => {
 
   it("treats a disabled provider status as disabled even before its enabled flag updates", () => {
     expect(getProviderSummary({ ...provider, status: "disabled" }).headline).toBe("Disabled");
+  });
+
+  it("does not treat Antigravity's unchecked auth after a restart as a failure", () => {
+    const antigravity: ServerProvider = {
+      ...provider,
+      instanceId: ProviderInstanceId.make("antigravity"),
+      driver: ProviderDriverKind.make("antigravity"),
+      status: "warning",
+      auth: { status: "unknown" },
+      message: "Antigravity is installed. Google account access is not checked yet.",
+    };
+
+    expect(isUncheckedAntigravityAuth(antigravity)).toBe(true);
+    expect(getProviderSummary(antigravity)).toEqual({
+      headline: "Available",
+      detail: "Antigravity is installed. Google account access is not checked yet.",
+    });
+    expect(getProviderSummary({ ...antigravity, auth: { status: "authenticated" } })).toEqual({
+      headline: "Needs attention",
+      detail: "Antigravity is installed. Google account access is not checked yet.",
+    });
+    expect(getProviderSummary({ ...antigravity, auth: { status: "unauthenticated" } })).toEqual({
+      headline: "Not authenticated",
+      detail: "Antigravity is installed. Google account access is not checked yet.",
+    });
+    expect(getProviderSummary({ ...antigravity, installed: false }).headline).toBe("Not found");
+    expect(getProviderSummary({ ...antigravity, status: "error" }).headline).toBe("Unavailable");
+    expect(
+      isUncheckedAntigravityAuth({
+        ...antigravity,
+        driver: ProviderDriverKind.make("codex"),
+      }),
+    ).toBe(false);
+    expect(
+      getProviderSummary({
+        ...antigravity,
+        driver: ProviderDriverKind.make("codex"),
+      }).headline,
+    ).toBe("Needs attention");
   });
 });

--- a/apps/web/src/components/settings/providerStatus.ts
+++ b/apps/web/src/components/settings/providerStatus.ts
@@ -1,6 +1,21 @@
 import type { ServerProvider, ServerProviderVersionAdvisory } from "@t3tools/contracts";
 
 /**
+ * Antigravity's local health check leaves auth unknown after a restart. Chat
+ * already treats that as "not a failure"; Settings and onboarding must too.
+ */
+export function isUncheckedAntigravityAuth(
+  provider: Pick<ServerProvider, "driver" | "installed" | "status" | "auth">,
+): boolean {
+  return (
+    provider.driver === "antigravity" &&
+    provider.installed &&
+    provider.status === "warning" &&
+    provider.auth.status === "unknown"
+  );
+}
+
+/**
  * Visual treatment for each server-reported provider status. Centralized so
  * the default-driver card and per-instance cards share the same language.
  */
@@ -55,7 +70,7 @@ export function getProviderSummary(provider: ServerProvider | undefined) {
       detail: provider.message ?? null,
     };
   }
-  if (provider.status === "warning") {
+  if (provider.status === "warning" && !isUncheckedAntigravityAuth(provider)) {
     return {
       headline: "Needs attention",
       detail:

--- a/apps/web/src/onboarding/providerReadiness.logic.test.ts
+++ b/apps/web/src/onboarding/providerReadiness.logic.test.ts
@@ -63,6 +63,27 @@ describe("getOnboardingProviderState", () => {
     expect(getOnboardingProviderState({ ...readyCodex, status: "warning" })).toBe("attention");
   });
 
+  it("treats installed Antigravity with unchecked auth after a restart as ready", () => {
+    const antigravity: ServerProvider = {
+      ...readyCodex,
+      instanceId: ProviderInstanceId.make("antigravity"),
+      driver: ProviderDriverKind.make("antigravity"),
+      status: "warning",
+      auth: { status: "unknown" },
+      message: "Antigravity is installed. Google account access is not checked yet.",
+    };
+
+    expect(getOnboardingProviderState(antigravity)).toBe("ready");
+    expect(
+      getOnboardingProviderState({
+        ...antigravity,
+        auth: { status: "unauthenticated" },
+      }),
+    ).toBe("signIn");
+    expect(getOnboardingProviderState({ ...antigravity, status: "error" })).toBe("attention");
+    expect(getOnboardingProviderState({ ...antigravity, installed: false })).toBe("install");
+  });
+
   it("does not offer installation or sign-in for disabled providers", () => {
     expect(getOnboardingProviderState({ ...readyCodex, enabled: false, installed: false })).toBe(
       "disabled",

--- a/apps/web/src/onboarding/providerReadiness.logic.ts
+++ b/apps/web/src/onboarding/providerReadiness.logic.ts
@@ -8,6 +8,8 @@ import {
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 
+import { isUncheckedAntigravityAuth } from "../components/settings/providerStatus";
+
 const decodeClaudeSettings = Schema.decodeUnknownOption(ClaudeSettings);
 const decodeCodexSettings = Schema.decodeUnknownOption(CodexSettings);
 const SAFE_SHELL_BINARY_PATTERN = /^[A-Za-z0-9_./:\\-]+$/;
@@ -38,7 +40,7 @@ export function getOnboardingProviderState(provider: ServerProvider | undefined)
   if (!provider.enabled || provider.status === "disabled") return "disabled";
   if (!provider.installed) return "install";
   if (provider.auth.status === "unauthenticated") return "signIn";
-  if (provider.status === "ready") return "ready";
+  if (provider.status === "ready" || isUncheckedAntigravityAuth(provider)) return "ready";
   return "attention";
 }
 

--- a/docs/user/providers-antigravity.md
+++ b/docs/user/providers-antigravity.md
@@ -123,6 +123,9 @@ is refused while the runtime is in use.
 
 ## Check access and troubleshoot
 
+A server restart does not sign you out. Settings stays available until a session
+or a refresh checks the saved Google account.
+
 To check access and reload models, use **Refresh provider status** in web or desktop
 provider settings, or **Refresh models** in mobile thread settings. If asked to
 sign in again, use setup on web or desktop.


### PR DESCRIPTION
## What Changed

Settings, provider setup, and the welcome wizard now use the same Antigravity rule chat already uses: installed + warning + unknown auth is not a failure.

After a server restart those surfaces say the provider is available, skip the fake **Sign in with Google** CTA, and keep confirmed unauthenticated / missing-install / error states as they were. The health probe is unchanged.

## Why

[#10110](https://github.com/pingdotgg/t3code/issues/10110): Antigravity's local health check leaves `auth` unknown after a restart. Chat already hid that (`#9647`). Settings still rendered **Needs attention** and offered Google sign-in, even when the account was already signed in.

This is the smallest leftover Julius called out: reuse the chat banner predicate in `getProviderSummary`, setup CTA, and onboarding readiness.

Fixes #10110

## UI Changes

Copy and status only. No motion.

**Before** (Settings / setup / onboarding, after restart, already signed in):
- Headline: Needs attention
- Detail: Antigravity is installed. Google account access is not checked yet.
- Setup: Sign in with Google

**After:**
- Headline: Available
- Detail: unchanged server message
- Setup: no sign-in CTA; Sign out of Google remains
- Onboarding: Ready

I do not have live screenshots. Reproducing the restart-unknown state needs an Antigravity install and a server process restart. The new tests pin the copy and CTA behavior.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (not applicable)

Grok 4.6 (Grok Build)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Treat Antigravity restart with unchecked auth as ready instead of Needs attention
> - Adds a shared `isUncheckedAntigravityAuth` predicate in [providerStatus.ts](https://github.com/pingdotgg/t3code/pull/10143/files#diff-29f82599bd9e3758e651b26db3d787ab623fa61350b9009233b476cd7d4e67fc) that matches installed Antigravity providers in warning status with unknown authentication — the state that occurs right after a server restart
> - `getProviderSummary` now reports this combination as `Available` instead of `Needs attention`, preserving the server message as detail
> - Updates chat, settings, and onboarding consumers to use the shared predicate: `ProviderSetupActions` no longer offers Google sign-in and shows the provider message or an unchecked-access explanation instead, `ProviderInstanceCard` renders ready styling, and `getOnboardingProviderState` returns ready
> - Adds user docs explaining that a restart does not sign the user out and Settings remains available until a session checks the saved Google account
> - Risk: the `getProviderSummary` warning-status branch now excludes `isUncheckedAntigravityAuth` matches; any out-of-tree consumer relying on warning status for this exact provider/auth combination will see `Available` instead
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 363d618.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->