### PR TITLE
refactor(ssh): keep package internals private

### DIFF
--- a/packages/ssh/src/auth.ts
+++ b/packages/ssh/src/auth.ts
@@ -17,7 +17,7 @@ export interface SshPasswordRequest {
   readonly attempt: number;
 }
 
-export interface SshAskpassFile {
+interface SshAskpassFile {
   readonly path: string;
   readonly contents: string;
   readonly mode?: number;
@@ -71,7 +71,7 @@ function joinSshAskpassPath(
   return platform === "win32" ? `${trimmed}\\${fileName}` : `${trimmed}/${fileName}`;
 }
 
-export const ASKPASS_POSIX_SCRIPT = `#!/bin/sh
+const ASKPASS_POSIX_SCRIPT = `#!/bin/sh
 # Invoked by ssh via SSH_ASKPASS when T3 Code re-runs ssh with a cached password
 # from the renderer's in-app prompt. We never expose a native dialog here - if
 # T3_SSH_AUTH_SECRET is missing, that's a caller bug and we fail loudly.
@@ -83,11 +83,11 @@ printf 'T3 Code ssh-askpass invoked without T3_SSH_AUTH_SECRET.\\n' >&2
 exit 1
 `;
 
-export const ASKPASS_WINDOWS_LAUNCHER_SCRIPT = `@echo off\r
+const ASKPASS_WINDOWS_LAUNCHER_SCRIPT = `@echo off\r
 powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0ssh-askpass.ps1" %*\r
 `;
 
-export const ASKPASS_WINDOWS_SCRIPT = `# Invoked by ssh via SSH_ASKPASS (through ssh-askpass.cmd) when T3 Code re-runs\r
+const ASKPASS_WINDOWS_SCRIPT = `# Invoked by ssh via SSH_ASKPASS (through ssh-askpass.cmd) when T3 Code re-runs\r
 # ssh with a cached password from the renderer's in-app prompt. We never expose\r
 # a native dialog here - if T3_SSH_AUTH_SECRET is missing, that's a caller bug\r
 # and we fail loudly.\r
@@ -99,7 +99,7 @@ if ($null -ne $env:T3_SSH_AUTH_SECRET) {\r
 exit 1\r
 `;
 
-export const getDefaultSshAskpassDirectory = Effect.fn("ssh/auth.getDefaultSshAskpassDirectory")(
+const getDefaultSshAskpassDirectory = Effect.fn("ssh/auth.getDefaultSshAskpassDirectory")(
   function* () {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
@@ -146,31 +146,29 @@ export const buildSshAskpassHelperDescriptor = Effect.fn(
   };
 });
 
-export const ensureSshAskpassHelpers = Effect.fn("ssh/auth.ensureSshAskpassHelpers")(
-  function* (input: {
-    readonly directory: string;
-  }): Effect.fn.Return<string, PlatformError.PlatformError, FileSystem.FileSystem | Path.Path> {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const descriptor = yield* buildSshAskpassHelperDescriptor(input);
-    const platform = yield* HostProcessPlatform;
+const ensureSshAskpassHelpers = Effect.fn("ssh/auth.ensureSshAskpassHelpers")(function* (input: {
+  readonly directory: string;
+}): Effect.fn.Return<string, PlatformError.PlatformError, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const descriptor = yield* buildSshAskpassHelperDescriptor(input);
+  const platform = yield* HostProcessPlatform;
 
-    yield* fs.makeDirectory(path.dirname(descriptor.launcherPath), { recursive: true });
+  yield* fs.makeDirectory(path.dirname(descriptor.launcherPath), { recursive: true });
 
-    for (const file of descriptor.files) {
-      const existing = yield* fs.exists(file.path);
-      const current = existing ? yield* fs.readFileString(file.path) : null;
-      if (current !== file.contents) {
-        yield* fs.writeFileString(file.path, file.contents);
-      }
-      if (file.mode !== undefined && platform !== "win32") {
-        yield* fs.chmod(file.path, file.mode);
-      }
+  for (const file of descriptor.files) {
+    const existing = yield* fs.exists(file.path);
+    const current = existing ? yield* fs.readFileString(file.path) : null;
+    if (current !== file.contents) {
+      yield* fs.writeFileString(file.path, file.contents);
     }
+    if (file.mode !== undefined && platform !== "win32") {
+      yield* fs.chmod(file.path, file.mode);
+    }
+  }
 
-    return descriptor.launcherPath;
-  },
-);
+  return descriptor.launcherPath;
+});
 
 export const buildSshChildEnvironment = Effect.fn("ssh/auth.buildSshChildEnvironment")(function* (
   input: SshChildEnvironmentOptions = {},

--- a/packages/ssh/src/command.ts
+++ b/packages/ssh/src/command.ts
@@ -80,7 +80,7 @@ export function remoteStateKey(target: DesktopSshEnvironmentTarget): string {
     .slice(0, 16);
 }
 
-export function buildSshHostSpec(target: DesktopSshEnvironmentTarget): string {
+function buildSshHostSpec(target: DesktopSshEnvironmentTarget): string {
   const destination = target.alias.trim() || target.hostname.trim();
   if (destination.length === 0) {
     throw new Error("SSH target is missing its alias/hostname.");

--- a/packages/ssh/src/config.ts
+++ b/packages/ssh/src/config.ts
@@ -89,7 +89,7 @@ const expandGlob = Effect.fnUntraced(function* (pattern: string) {
   return matchedPaths.toSorted((left, right) => left.localeCompare(right));
 });
 
-export const collectSshConfigAliasesFromFile = Effect.fnUntraced(function* (
+const collectSshConfigAliasesFromFile = Effect.fnUntraced(function* (
   filePath: string,
   visited = new Set<string>(),
   homeDir: string,

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -49,7 +49,7 @@ import {
   SshReadinessError,
 } from "./errors.ts";
 
-export const DEFAULT_REMOTE_PORT = 3773;
+const DEFAULT_REMOTE_PORT = 3773;
 const REMOTE_PORT_SCAN_WINDOW = 200;
 const SSH_READY_TIMEOUT_MS = 20_000;
 const SSH_READY_PROBE_TIMEOUT_MS = 1_000;
@@ -209,7 +209,7 @@ function buildRemoteNodeEngineCheckScript(): string {
 (${remoteNodeEngineCheckMain.toString()})();`;
 }
 
-export function normalizeSshErrorMessage(stderr: string, fallbackMessage: string): string {
+function normalizeSshErrorMessage(stderr: string, fallbackMessage: string): string {
   const cleaned = stderr.trim();
   return cleaned.length > 0 ? cleaned : fallbackMessage;
 }
@@ -270,7 +270,7 @@ function tryPort(port) {
 })().catch(() => process.exit(1));
 `;
 
-export const REMOTE_WAIT_READY_SCRIPT = `const http = require("node:http");
+const REMOTE_WAIT_READY_SCRIPT = `const http = require("node:http");
 const port = Number.parseInt(process.argv[2] ?? "", 10);
 const timeoutMs = Number.parseInt(process.argv[3] ?? "", 10);
 const probeTimeoutMs = Number.parseInt(process.argv[4] ?? "", 10);
@@ -318,7 +318,7 @@ function probe() {
 })().catch(() => process.exit(1));
 `;
 
-export const REMOTE_NODE_ENV_SCRIPT = `prepend_path_if_dir() {
+const REMOTE_NODE_ENV_SCRIPT = `prepend_path_if_dir() {
   if [ -d "$1" ]; then
     case ":$PATH:" in
       *":$1:"*) ;;
@@ -411,7 +411,7 @@ ensure_remote_node_path() {
 }
 `;
 
-export const REMOTE_RUNNER_SCRIPT = `#!/bin/sh
+const REMOTE_RUNNER_SCRIPT = `#!/bin/sh
 set -eu
 @@T3_NODE_ENV_SCRIPT@@
 ensure_remote_node_path || true
@@ -456,7 +456,7 @@ printf 'Remote host is missing the t3 CLI and could not install @@T3_PACKAGE_SPE
 exit 1
 `;
 
-export const REMOTE_LAUNCH_SCRIPT = `set -eu
+const REMOTE_LAUNCH_SCRIPT = `set -eu
 @@T3_NODE_ENV_SCRIPT@@
 STATE_KEY="$1"
 STATE_DIR="$HOME/.t3/ssh-launch/$STATE_KEY"
@@ -615,7 +615,7 @@ fi
 printf '{"remotePort":%s,"serverKind":"%s"}\\n' "$REMOTE_PORT" "\${REMOTE_MANAGED:-managed}"
 `;
 
-export const REMOTE_PAIRING_SCRIPT = `set -eu
+const REMOTE_PAIRING_SCRIPT = `set -eu
 STATE_DIR="$HOME/.t3/ssh-launch/@@T3_STATE_KEY@@"
 DEFAULT_SERVER_HOME="$HOME/.t3"
 RUNNER_FILE="$STATE_DIR/run-t3.sh"
@@ -628,7 +628,7 @@ PAIRING_BASE_DIR="$DEFAULT_SERVER_HOME"
 "$RUNNER_FILE" auth pairing create --base-dir "$PAIRING_BASE_DIR" --json
 `;
 
-export const REMOTE_STOP_SCRIPT = `set -eu
+const REMOTE_STOP_SCRIPT = `set -eu
 STATE_DIR="$HOME/.t3/ssh-launch/@@T3_STATE_KEY@@"
 PID_FILE="$STATE_DIR/pid"
 PORT_FILE="$STATE_DIR/port"
@@ -823,7 +823,7 @@ export const issueRemotePairingToken = Effect.fn("ssh/tunnel.issueRemotePairingT
   };
 });
 
-export const stopRemoteServer = Effect.fn("ssh/tunnel.stopRemoteServer")(function* (
+const stopRemoteServer = Effect.fn("ssh/tunnel.stopRemoteServer")(function* (
   target: DesktopSshEnvironmentTarget,
   input?: SshAuthOptions,
 ): Effect.fn.Return<


### PR DESCRIPTION
SSH exported 16 values and one type that have no consumers outside their defining modules. Keep those declarations private without changing their implementations or existing tests.

Checked repository-wide named references and the desktop namespace imports. Remote runner, authentication, shutdown, and config discovery behavior remain unchanged. The package is private to this monorepo.

Verification: all 42 tests across five SSH suites pass; SSH typecheck, targeted lint, and the scoped Knip export scan pass. Knip reports zero SSH export/type findings after the change, down from 17. Formatting reflows one helper after removing its export modifier. No UI changes.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `export` from `ssh` package internal helpers and constants
> - Removes the `export` modifier from helpers, constants, and types across [auth.ts](https://github.com/pingdotgg/t3code/pull/10144/files#diff-f44637611b224bd98686e1e19fb4ddce93029e086220bd1d2a152e81fbc88d47), [command.ts](https://github.com/pingdotgg/t3code/pull/10144/files#diff-4f1aef4b11679d8551404a853942f04f47c3a80c050bc25b784d2b0c48ec9e5e), [config.ts](https://github.com/pingdotgg/t3code/pull/10144/files#diff-bd8cd3cba70a22c13818f6a099ee23a94386d85db59fd55c32de0979505d88d2), and [tunnel.ts](https://github.com/pingdotgg/t3code/pull/10144/files#diff-7338be65675ab0699d0c8c6426e54f3421747885231f9bbb0ace4ec129cb2072)
> - Keeps these symbols private to their modules: `SshAskpassFile`, `ASKPASS_*` scripts, `getDefaultSshAskpassDirectory`, `ensureSshAskpassHelpers`, `buildSshHostSpec`, `collectSshConfigAliasesFromFile`, `DEFAULT_REMOTE_PORT`, `normalizeSshErrorMessage`, and `REMOTE_*` scripts
> - Risk: any out-of-tree code importing these now-private symbols will break at compile time
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 957f823.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->