### PR TITLE
ci: reject unused SSH exports with Knip

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "tc": "vp run -r --concurrency-limit 2 typecheck",
     "lint": "vp lint --report-unused-disable-directives",
     "knip": "knip",
-    "knip:check": "knip --include files,dependencies --no-config-hints && knip --workspace packages/tailscale --workspace packages/effect-codex-app-server --exports --no-config-hints",
+    "knip:check": "knip --include files,dependencies --no-config-hints && knip --workspace packages/tailscale --workspace packages/effect-codex-app-server --workspace packages/ssh --exports --no-config-hints",
     "knip:production": "knip --production",
     "lint:mobile": "node scripts/mobile-native-static-check.ts",
     "test": "vp run -r test",


### PR DESCRIPTION
SSH's unused exports are now cleaned up in the preceding layer. Add packages/ssh to the existing Knip export check so CI rejects new unused SSH exports and types.

The existing files/dependencies check and other workspace checks stay enabled. No dependencies, suppressions, or entry-point exceptions are added.

Verification: vp run knip:check passes with SSH included. The preceding layer resolves the 17 SSH findings that would otherwise fail this gate. No runtime or UI changes.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `packages/ssh` to `knip:check` workspace list
> Extends the Knip export analysis to cover the `packages/ssh` workspace so unused SSH exports are caught in CI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2cf0792.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->