### PR TITLE
refactor(mobile): remove unused pairing redaction wrapper

### DIFF
--- a/apps/mobile/src/lib/connection.test.ts
+++ b/apps/mobile/src/lib/connection.test.ts
@@ -1,11 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { EnvironmentId } from "@t3tools/contracts";
 
-import {
-  isRelayManagedConnection,
-  redactPairingCredential,
-  toStableSavedRemoteConnection,
-} from "./connection";
+import { isRelayManagedConnection, toStableSavedRemoteConnection } from "./connection";
 import { authClientMetadata } from "./authClientMetadata";
 
 const mobilePlatform = vi.hoisted(() => ({ OS: "ios" as "ios" | "android" }));
@@ -81,23 +77,6 @@ describe("mobile remote connection records", () => {
       surface: "mobile",
       appVersion: "1.2.3",
     });
-  });
-
-  it("removes one-time bootstrap credentials before persisting pairing URLs", () => {
-    expect(redactPairingCredential("https://desktop.example/#token=bootstrap-token")).toBe(
-      "https://desktop.example/",
-    );
-    expect(redactPairingCredential("https://desktop.example/?token=bootstrap-token")).toBe(
-      "https://desktop.example/",
-    );
-  });
-
-  it("removes hosted pairing credentials while keeping the advertised host", () => {
-    expect(
-      redactPairingCredential(
-        "https://app.t3.codes/pair?host=https%3A%2F%2Fdesktop.example&token=bootstrap-token&label=Desktop",
-      ),
-    ).toBe("https://app.t3.codes/pair?host=https%3A%2F%2Fdesktop.example&label=Desktop");
   });
 
   it("recognizes explicitly managed relay connections", () => {

--- a/apps/mobile/src/lib/connection.ts
+++ b/apps/mobile/src/lib/connection.ts
@@ -1,5 +1,4 @@
 import { EnvironmentId } from "@t3tools/contracts";
-import { stripPairingTokenFromUrl } from "@t3tools/shared/remote";
 import { type EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
 
 export interface SavedRemoteConnection {
@@ -16,15 +15,6 @@ export interface SavedRemoteConnection {
 }
 
 export type RemoteClientConnectionState = EnvironmentConnectionPhase;
-
-export function redactPairingCredential(pairingUrl: string): string {
-  const trimmed = pairingUrl.trim();
-  try {
-    return stripPairingTokenFromUrl(new URL(trimmed)).toString();
-  } catch {
-    return trimmed;
-  }
-}
 
 export function isRelayManagedConnection(
   connection: Pick<SavedRemoteConnection, "authenticationMethod" | "relayManaged">,


### PR DESCRIPTION
The mobile redactPairingCredential wrapper has no production callers. Only its two direct unit tests reference it. Remove the wrapper, unused import, and those tests.

Cloud linking continues to call the shared stripPairingTokenFromUrl implementation directly. Its test still verifies that the persisted pairing URL excludes the one-time credential. Native client metadata, managed relay records, and short-lived credential stripping tests remain.

Verification: connection, cloud-linking, and shared remote suites pass, 42 tests total. Targeted lint passes. Repository-wide reference search confirms no remaining wrapper callers. No UI changes.

Model: gpt-6 astra. Harness: Codex in T3 Code.
