### PR TITLE
test(web): drop provider banner styling assertions

### DIFF
--- a/apps/web/src/components/chat/ProviderStatusBanner.test.tsx
+++ b/apps/web/src/components/chat/ProviderStatusBanner.test.tsx
@@ -78,16 +78,6 @@ describe("ProviderStatusBanner", () => {
 
     expect(markup).toContain('role="alert"');
     expect(markup).toContain('aria-label="Dismiss Codex provider warning"');
-    expect(markup).toContain("absolute top-2 right-2");
-  });
-
-  it("renders on a glass surface so the timeline never reads through the banner", () => {
-    const markup = renderToStaticMarkup(
-      <ProviderStatusBanner status={warningProvider()} onDismiss={() => {}} />,
-    );
-
-    expect(markup).toContain("alert-glass");
-    expect(markup).toContain('data-variant="warning"');
   });
 
   it("labels error dismiss controls with the correct severity", () => {


### PR DESCRIPTION
The provider warning banner tests asserted literal positioning classes and a glass styling token. Those assertions cannot verify whether the banner is visually readable. Remove the styling-only test and positioning assertion.

Keep the auth-probe rules, installation and startup failures, dismissed-warning state, accessible dismiss labels and severity, and provider error messages. Production code is unchanged.

Verification: the focused ProviderStatusBanner suite passes, nine tests. No visual behavior changes.

Model: gpt-6 astra. Harness: Codex in T3 Code.
