### PR TITLE
feat(web): pin turn diff baselines

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3960,7 +3960,10 @@ export default function ChatView(props: ChatViewProps) {
     };
     if (diffAction !== "open" || newlyCompletedTurnId === null) return;
 
-    useDiffPanelStore.getState().selectTurn(activeThreadRef, newlyCompletedTurnId);
+    const diffSelection = useDiffPanelStore.getState().byThreadKey[activeThreadKey];
+    if (diffSelection?.kind !== "turn" || !diffSelection.baselineTurnId) {
+      useDiffPanelStore.getState().selectTurn(activeThreadRef, newlyCompletedTurnId);
+    }
     useRightPanelStore.getState().open(activeThreadRef, "diff");
     onDiffPanelOpen?.();
   }, [

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -233,6 +233,22 @@ export default function DiffPanel({
     selectedTurn &&
     (selectedTurn.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[selectedTurn.turnId]);
   const latestTurn = orderedTurnDiffSummaries[0];
+  const [baselineMenuOpen, setBaselineMenuOpen] = useState(false);
+  const firstCheckpoint = orderedTurnDiffSummaries.findLast(
+    (summary) => summary.status === "ready" && summary.checkpointTurnCount > 0,
+  );
+  // A completion checkpoint can exist without Turn 0 when Git was initialized mid-turn.
+  // Check the earliest available range only when the baseline menu is opened.
+  const initialCheckpointDiff = useCheckpointDiff(
+    {
+      environmentId: activeThread?.environmentId ?? null,
+      threadId: activeThread?.id ?? null,
+      fromTurnCount: 0,
+      toTurnCount: firstCheckpoint?.checkpointTurnCount ?? null,
+      ignoreWhitespace: true,
+    },
+    { enabled: baselineMenuOpen && isGitRepo },
+  );
   const isLatestTurnSelection =
     baselineTurnCount === undefined ? selectedTurn?.turnId === latestTurn?.turnId : followsLatest;
   const selectedScopeLabel =
@@ -655,14 +671,17 @@ export default function DiffPanel({
                 })}
               </DropdownMenuSubContent>
             </DropdownMenuSub>
-            <DropdownMenuSub>
+            <DropdownMenuSub onOpenChange={setBaselineMenuOpen}>
               <DropdownMenuSubTrigger>Pin baseline</DropdownMenuSubTrigger>
               <DropdownMenuSubContent className="w-64">
                 <DropdownMenuItem
-                  disabled={!latestTurn}
+                  disabled={
+                    initialCheckpointDiff.data === null || initialCheckpointDiff.error !== null
+                  }
                   onClick={() => pinBaseline(THREAD_START_DIFF_BASELINE)}
                 >
                   Start of thread (Turn 0){baselineTurnCount === 0 ? " (pinned)" : ""}
+                  {initialCheckpointDiff.error ? " (unavailable)" : ""}
                 </DropdownMenuItem>
                 {orderedTurnDiffSummaries.map((summary) => (
                   <DropdownMenuItem

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -30,7 +30,13 @@ import { type DraftId } from "../composerDraftStore";
 import { openDiffFilePrimaryAction } from "../diffFileActions";
 import { useCheckpointDiff } from "~/lib/checkpointDiffState";
 import { cn } from "~/lib/utils";
-import { selectThreadDiffPanelSelection, useDiffPanelStore } from "../diffPanelStore";
+import {
+  type DiffBaseline,
+  getCheckpointDiffRange,
+  THREAD_START_DIFF_BASELINE,
+  selectThreadDiffPanelSelection,
+  useDiffPanelStore,
+} from "../diffPanelStore";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useTheme } from "../hooks/useTheme";
 import {
@@ -193,14 +199,26 @@ export default function DiffPanel({
   );
 
   useEffect(() => {
-    if (!routeThreadRef || diffSelection.kind !== "turn") return;
+    if (!routeThreadRef || !activeThread || diffSelection.kind !== "turn") return;
     useDiffPanelStore.getState().reconcileTurnSelection(
       routeThreadRef,
       orderedTurnDiffSummaries.map((summary) => summary.turnId),
     );
-  }, [diffSelection, orderedTurnDiffSummaries, routeThreadRef]);
+  }, [activeThread, diffSelection, orderedTurnDiffSummaries, routeThreadRef]);
 
-  const selectedTurnId = diffSelection.kind === "turn" ? diffSelection.turnId : null;
+  const selectedTurnId =
+    diffSelection.kind === "turn"
+      ? diffSelection.followLatest
+        ? (orderedTurnDiffSummaries[0]?.turnId ?? diffSelection.turnId)
+        : diffSelection.turnId
+      : null;
+  const baselineTurnId = diffSelection.kind === "turn" ? diffSelection.baselineTurnId : undefined;
+  const baselineTurn = orderedTurnDiffSummaries.find(
+    (summary) => summary.turnId === baselineTurnId,
+  );
+  const baselineTurnCount =
+    baselineTurnId === THREAD_START_DIFF_BASELINE ? 0 : baselineTurn?.checkpointTurnCount;
+  const followsLatest = diffSelection.kind === "turn" && diffSelection.followLatest === true;
   const selectedGitScope = diffSelection.kind === "unstaged" ? "unstaged" : "branch";
   const selectedBaseRef = diffSelection.kind === "branch" ? diffSelection.baseRef : null;
   const selectedFilePath = diffSelection.kind === "turn" ? diffSelection.filePath : null;
@@ -215,15 +233,25 @@ export default function DiffPanel({
     selectedTurn &&
     (selectedTurn.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[selectedTurn.turnId]);
   const latestTurn = orderedTurnDiffSummaries[0];
+  const isLatestTurnSelection =
+    baselineTurnCount === undefined ? selectedTurn?.turnId === latestTurn?.turnId : followsLatest;
   const selectedScopeLabel =
     selectedTurnId === null
       ? selectedGitScope === "unstaged"
         ? "Working tree"
         : "Branch changes"
-      : selectedTurn?.turnId === latestTurn?.turnId
+      : isLatestTurnSelection
         ? "Latest turn"
         : `Turn ${selectedCheckpointTurnCount ?? "?"}`;
-  const reviewSectionId = selectedTurn ? `turn:${selectedTurn.turnId}` : selectedGitScope;
+  const comparisonLabel =
+    baselineTurnCount !== undefined
+      ? `Turn ${baselineTurnCount} → ${selectedScopeLabel}`
+      : selectedScopeLabel;
+  const reviewSectionId = selectedTurn
+    ? baselineTurnCount !== undefined
+      ? `turn:${baselineTurnId}:${selectedTurn.turnId}`
+      : `turn:${selectedTurn.turnId}`
+    : selectedGitScope;
   const collapseScopeKey = routeThreadRef
     ? `${routeThreadRef.environmentId}:${routeThreadRef.threadId}:${reviewSectionId}`
     : null;
@@ -233,19 +261,15 @@ export default function DiffPanel({
       ? collapsedDiffFiles.fileKeys
       : EMPTY_COLLAPSED_DIFF_FILE_KEYS;
   const reviewSectionTitle = selectedTurn
-    ? `Turn ${selectedCheckpointTurnCount ?? "?"}`
+    ? baselineTurnCount !== undefined
+      ? comparisonLabel
+      : `Turn ${selectedCheckpointTurnCount ?? "?"}`
     : selectedGitScope === "unstaged"
       ? "Working tree"
       : "Branch changes";
-  const selectedCheckpointRange = useMemo(
-    () =>
-      typeof selectedCheckpointTurnCount === "number"
-        ? {
-            fromTurnCount: Math.max(0, selectedCheckpointTurnCount - 1),
-            toTurnCount: selectedCheckpointTurnCount,
-          }
-        : null,
-    [selectedCheckpointTurnCount],
+  const selectedCheckpointRange = getCheckpointDiffRange(
+    selectedCheckpointTurnCount,
+    baselineTurnCount,
   );
   const activeCheckpointDiff = useCheckpointDiff(
     {
@@ -254,7 +278,7 @@ export default function DiffPanel({
       fromTurnCount: selectedCheckpointRange?.fromTurnCount ?? null,
       toTurnCount: selectedCheckpointRange?.toTurnCount ?? null,
       ignoreWhitespace: diffIgnoreWhitespace,
-      cacheScope: selectedTurn ? `turn:${selectedTurn.turnId}` : null,
+      cacheScope: selectedTurn ? reviewSectionId : null,
     },
     { enabled: isGitRepo && selectedTurn !== undefined },
   );
@@ -532,7 +556,11 @@ export default function DiffPanel({
 
   const selectTurn = (turnId: TurnId) => {
     if (!routeThreadRef) return;
-    useDiffPanelStore.getState().selectTurn(routeThreadRef, turnId);
+    useDiffPanelStore.getState().selectTurn(routeThreadRef, turnId, undefined, { baselineTurnId });
+  };
+  const pinBaseline = (baseline: DiffBaseline | null) => {
+    if (routeThreadRef && latestTurn)
+      useDiffPanelStore.getState().pinBaseline(routeThreadRef, baseline, latestTurn.turnId);
   };
   const selectGitScope = (scope: "branch" | "unstaged") => {
     if (!routeThreadRef) return;
@@ -549,9 +577,9 @@ export default function DiffPanel({
         <DropdownMenu>
           <DropdownMenuTrigger
             className="inline-flex h-6 max-w-full items-center gap-1 rounded-md bg-accent px-2 text-xs font-medium text-accent-foreground outline-none transition-colors hover:bg-accent/80 focus-visible:ring-2 focus-visible:ring-ring"
-            aria-label={`Diff scope: ${selectedScopeLabel}`}
+            aria-label={`Diff scope: ${comparisonLabel}`}
           >
-            <span className="truncate">{selectedScopeLabel}</span>
+            <span className="truncate">{comparisonLabel}</span>
             <ChevronDownIcon className="size-3.5 shrink-0 opacity-70" />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start" className="w-60">
@@ -577,12 +605,13 @@ export default function DiffPanel({
             </DropdownMenuItem>
             <DropdownMenuItem
               className={
-                selectedTurnId !== null && selectedTurn?.turnId === latestTurn?.turnId
+                selectedTurnId !== null && isLatestTurnSelection
                   ? "bg-foreground/[0.08]"
                   : undefined
               }
               onClick={() => {
-                if (latestTurn) selectTurn(latestTurn.turnId);
+                if (latestTurn && routeThreadRef)
+                  useDiffPanelStore.getState().selectLatestTurn(routeThreadRef, latestTurn.turnId);
               }}
             >
               <span>Latest turn</span>
@@ -598,12 +627,26 @@ export default function DiffPanel({
                   return (
                     <DropdownMenuItem
                       key={summary.turnId}
-                      className={
-                        summary.turnId === selectedTurn?.turnId ? "bg-foreground/[0.08]" : undefined
+                      className={cn(
+                        summary.turnId === selectedTurn?.turnId &&
+                          !followsLatest &&
+                          "bg-foreground/[0.08]",
+                        summary.status === "ready" &&
+                          summary.files.length === 0 &&
+                          "text-muted-foreground",
+                      )}
+                      disabled={
+                        baselineTurnCount !== undefined &&
+                        summary.checkpointTurnCount < baselineTurnCount
                       }
                       onClick={() => selectTurn(summary.turnId)}
                     >
-                      <span>Turn {turnCount}</span>
+                      <span>
+                        Turn {turnCount}
+                        {summary.status === "ready" && summary.files.length === 0
+                          ? " · No changes"
+                          : ""}
+                      </span>
                       <span className="ml-auto text-xs tabular-nums text-muted-foreground">
                         {formatShortTimestamp(summary.completedAt, settings.timestampFormat)}
                       </span>
@@ -612,6 +655,32 @@ export default function DiffPanel({
                 })}
               </DropdownMenuSubContent>
             </DropdownMenuSub>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>Pin baseline</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="w-64">
+                <DropdownMenuItem
+                  disabled={!latestTurn}
+                  onClick={() => pinBaseline(THREAD_START_DIFF_BASELINE)}
+                >
+                  Start of thread (Turn 0){baselineTurnCount === 0 ? " (pinned)" : ""}
+                </DropdownMenuItem>
+                {orderedTurnDiffSummaries.map((summary) => (
+                  <DropdownMenuItem
+                    key={summary.turnId}
+                    disabled={summary.status !== "ready"}
+                    onClick={() => pinBaseline(summary.turnId)}
+                  >
+                    Turn {summary.checkpointTurnCount}
+                    {summary.turnId === baselineTurnId ? " (pinned)" : ""}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+            {baselineTurnCount !== undefined && (
+              <DropdownMenuItem onClick={() => pinBaseline(null)}>
+                Unpin baseline (Turn {baselineTurnCount})
+              </DropdownMenuItem>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
         {selectedTurnId === null && selectedGitScope === "branch" && selectedGitSource?.baseRef && (

--- a/apps/web/src/diffPanelStore.test.ts
+++ b/apps/web/src/diffPanelStore.test.ts
@@ -2,7 +2,12 @@ import { scopeThreadRef } from "@t3tools/client-runtime/environment";
 import { EnvironmentId, ThreadId, TurnId } from "@t3tools/contracts";
 import { beforeEach, describe, expect, it } from "vite-plus/test";
 
-import { selectThreadDiffPanelSelection, useDiffPanelStore } from "./diffPanelStore";
+import {
+  getCheckpointDiffRange,
+  THREAD_START_DIFF_BASELINE,
+  selectThreadDiffPanelSelection,
+  useDiffPanelStore,
+} from "./diffPanelStore";
 
 const THREAD_REF = scopeThreadRef(EnvironmentId.make("environment-1"), ThreadId.make("thread-1"));
 
@@ -83,5 +88,94 @@ describe("diffPanelStore", () => {
       filePath: "src/app.ts",
       revealRequestId: 1,
     });
+  });
+  it.each([TurnId.make("turn-1"), THREAD_START_DIFF_BASELINE] as const)(
+    "keeps %s pinned while latest advances and a fixed endpoint stays put",
+    (baseline) => {
+      const first = TurnId.make("turn-1");
+      const second = TurnId.make("turn-2");
+      const third = TurnId.make("turn-3");
+      const store = useDiffPanelStore.getState();
+      store.pinBaseline(THREAD_REF, baseline, second);
+      store.reconcileTurnSelection(THREAD_REF, [third, second, first]);
+      expect(
+        selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, THREAD_REF),
+      ).toMatchObject({ turnId: third, baselineTurnId: baseline, followLatest: true });
+      store.selectTurn(THREAD_REF, second, undefined, { baselineTurnId: baseline });
+      store.reconcileTurnSelection(THREAD_REF, [third, second, first]);
+      expect(
+        selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, THREAD_REF),
+      ).toMatchObject({ turnId: second, baselineTurnId: baseline });
+      store.selectLatestTurn(THREAD_REF, third);
+      expect(
+        selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, THREAD_REF),
+      ).toMatchObject({ turnId: third, baselineTurnId: baseline, followLatest: true });
+      store.pinBaseline(THREAD_REF, null, third);
+      expect(
+        selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, THREAD_REF),
+      ).not.toHaveProperty("baselineTurnId");
+    },
+  );
+
+  it("drops a removed baseline and falls back when every checkpoint is removed", () => {
+    const baseline = TurnId.make("turn-1");
+    const latest = TurnId.make("turn-2");
+    const store = useDiffPanelStore.getState();
+    store.pinBaseline(THREAD_REF, baseline, latest);
+    store.reconcileTurnSelection(THREAD_REF, [latest]);
+    expect(
+      selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, THREAD_REF),
+    ).toMatchObject({ turnId: latest, baselineTurnId: undefined });
+    store.pinBaseline(THREAD_REF, THREAD_START_DIFF_BASELINE, latest);
+    store.reconcileTurnSelection(THREAD_REF, []);
+    expect(
+      selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, THREAD_REF),
+    ).toEqual({ kind: "branch", baseRef: null });
+  });
+
+  it("opens a timeline turn on its own and isolates pins by environment", () => {
+    const turn = TurnId.make("turn-1");
+    const store = useDiffPanelStore.getState();
+    store.pinBaseline(THREAD_REF, turn, turn);
+    const other = scopeThreadRef(EnvironmentId.make("environment-2"), THREAD_REF.threadId);
+    expect(selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, other)).toEqual(
+      { kind: "branch", baseRef: null },
+    );
+    store.selectTurn(THREAD_REF, turn);
+    expect(
+      selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, THREAD_REF),
+    ).not.toHaveProperty("baselineTurnId");
+  });
+
+  it("preserves the existing unpinned latest-turn selection behavior", () => {
+    const first = TurnId.make("turn-1");
+    const second = TurnId.make("turn-2");
+    const store = useDiffPanelStore.getState();
+    store.selectLatestTurn(THREAD_REF, first);
+    store.reconcileTurnSelection(THREAD_REF, [second, first]);
+    store.reconcileTurnSelection(THREAD_REF, []);
+    expect(
+      selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, THREAD_REF),
+    ).toMatchObject({ kind: "turn", turnId: first });
+  });
+});
+
+describe("getCheckpointDiffRange", () => {
+  it("compares a single turn to its preceding snapshot by default", () => {
+    expect(getCheckpointDiffRange(1)).toEqual({ fromTurnCount: 0, toTurnCount: 1 });
+    expect(getCheckpointDiffRange(5)).toEqual({ fromTurnCount: 4, toTurnCount: 5 });
+  });
+  it("excludes the pinned turn's changes and follows the supplied endpoint", () => {
+    expect(getCheckpointDiffRange(5, 2)).toEqual({ fromTurnCount: 2, toTurnCount: 5 });
+    expect(getCheckpointDiffRange(6, 2)).toEqual({ fromTurnCount: 2, toTurnCount: 6 });
+    expect(getCheckpointDiffRange(2, 2)).toEqual({ fromTurnCount: 2, toTurnCount: 2 });
+  });
+  it("includes turn one when pinned to the initial snapshot", () => {
+    expect(getCheckpointDiffRange(1, 0)).toEqual({ fromTurnCount: 0, toTurnCount: 1 });
+    expect(getCheckpointDiffRange(6, 0)).toEqual({ fromTurnCount: 0, toTurnCount: 6 });
+  });
+  it("does not request an unavailable or reversed range", () => {
+    expect(getCheckpointDiffRange(null, 2)).toBeNull();
+    expect(getCheckpointDiffRange(1, 2)).toBeNull();
   });
 });

--- a/apps/web/src/diffPanelStore.ts
+++ b/apps/web/src/diffPanelStore.ts
@@ -5,10 +5,19 @@ import { createJSONStorage, persist } from "zustand/middleware";
 
 import { resolveStorage } from "./lib/storage";
 
+export type DiffBaseline = TurnId | typeof THREAD_START_DIFF_BASELINE;
+
 export type DiffPanelSelection =
   | { kind: "branch"; baseRef: string | null }
   | { kind: "unstaged" }
-  | { kind: "turn"; turnId: TurnId; filePath: string | null; revealRequestId: number };
+  | {
+      kind: "turn";
+      turnId: TurnId;
+      filePath: string | null;
+      revealRequestId: number;
+      baselineTurnId?: DiffBaseline | undefined;
+      followLatest?: boolean;
+    };
 
 const DEFAULT_SELECTION: DiffPanelSelection = { kind: "branch", baseRef: null };
 const DEFAULT_WORKING_TREE_SELECTION: DiffPanelSelection = { kind: "unstaged" };
@@ -18,7 +27,18 @@ interface DiffPanelStoreState {
   branchBaseRefByThreadKey: Record<string, string | null>;
   selectGitScope: (ref: ScopedThreadRef, scope: "branch" | "unstaged") => void;
   selectBranchBaseRef: (ref: ScopedThreadRef, baseRef: string | null) => void;
-  selectTurn: (ref: ScopedThreadRef, turnId: TurnId, filePath?: string) => void;
+  selectTurn: (
+    ref: ScopedThreadRef,
+    turnId: TurnId,
+    filePath?: string,
+    comparison?: { baselineTurnId?: DiffBaseline | undefined; followLatest?: boolean },
+  ) => void;
+  pinBaseline: (
+    ref: ScopedThreadRef,
+    baselineTurnId: DiffBaseline | null,
+    latestTurnId: TurnId,
+  ) => void;
+  selectLatestTurn: (ref: ScopedThreadRef, turnId: TurnId) => void;
   reconcileTurnSelection: (ref: ScopedThreadRef, availableTurnIds: ReadonlyArray<TurnId>) => void;
   removeThread: (ref: ScopedThreadRef) => void;
 }
@@ -30,7 +50,7 @@ function normalizeBaseRef(baseRef: string | null): string | null {
 
 export const useDiffPanelStore = create<DiffPanelStoreState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       byThreadKey: {},
       branchBaseRefByThreadKey: {},
       selectGitScope: (ref, scope) =>
@@ -70,7 +90,7 @@ export const useDiffPanelStore = create<DiffPanelStoreState>()(
             },
           };
         }),
-      selectTurn: (ref, turnId, filePath) =>
+      selectTurn: (ref, turnId, filePath, comparison) =>
         set((state) => {
           const threadKey = scopedThreadKey(ref);
           const previous = state.byThreadKey[threadKey];
@@ -80,28 +100,67 @@ export const useDiffPanelStore = create<DiffPanelStoreState>()(
               [threadKey]: {
                 kind: "turn",
                 turnId,
+                ...comparison,
                 filePath: filePath?.trim() || null,
                 revealRequestId: previous?.kind === "turn" ? previous.revealRequestId + 1 : 1,
               },
             },
           };
         }),
+      pinBaseline: (ref, baselineTurnId, latestTurnId) => {
+        const previous = get().byThreadKey[scopedThreadKey(ref)];
+        const turnId =
+          !baselineTurnId && previous?.kind === "turn" ? previous.turnId : latestTurnId;
+        get().selectTurn(
+          ref,
+          turnId,
+          undefined,
+          baselineTurnId ? { baselineTurnId, followLatest: true } : undefined,
+        );
+      },
+      selectLatestTurn: (ref, turnId) => {
+        const previous = get().byThreadKey[scopedThreadKey(ref)];
+        get().selectTurn(
+          ref,
+          turnId,
+          undefined,
+          previous?.kind === "turn" && previous.baselineTurnId
+            ? { baselineTurnId: previous.baselineTurnId, followLatest: true }
+            : undefined,
+        );
+      },
       reconcileTurnSelection: (ref, availableTurnIds) =>
         set((state) => {
           const threadKey = scopedThreadKey(ref);
           const previous = state.byThreadKey[threadKey];
           const latestTurnId = availableTurnIds[0];
-          if (
-            previous?.kind !== "turn" ||
-            latestTurnId === undefined ||
-            availableTurnIds.includes(previous.turnId)
-          ) {
-            return state;
+          if (previous?.kind !== "turn") return state;
+          if (latestTurnId === undefined) {
+            return previous.baselineTurnId
+              ? { byThreadKey: { ...state.byThreadKey, [threadKey]: DEFAULT_SELECTION } }
+              : state;
           }
+          const turnId =
+            previous.followLatest || !availableTurnIds.includes(previous.turnId)
+              ? latestTurnId
+              : previous.turnId;
+          const baselineTurnId =
+            previous.baselineTurnId &&
+            (previous.baselineTurnId === THREAD_START_DIFF_BASELINE ||
+              availableTurnIds.includes(previous.baselineTurnId))
+              ? previous.baselineTurnId
+              : undefined;
+          if (turnId === previous.turnId && baselineTurnId === previous.baselineTurnId)
+            return state;
           return {
             byThreadKey: {
               ...state.byThreadKey,
-              [threadKey]: { ...previous, turnId: latestTurnId },
+              [threadKey]: {
+                ...previous,
+                turnId,
+                baselineTurnId,
+                ...(previous.followLatest ? { followLatest: baselineTurnId !== undefined } : {}),
+              },
             },
           };
         }),
@@ -142,3 +201,18 @@ export function selectThreadDiffPanelSelection(
     (hasWorkingTreeChanges ? DEFAULT_WORKING_TREE_SELECTION : DEFAULT_SELECTION)
   );
 }
+
+/** Compare completed snapshots; a pinned turn excludes that turn's own changes. */
+export function getCheckpointDiffRange(
+  toTurnCount: number | null | undefined,
+  baselineTurnCount?: number | null,
+) {
+  if (toTurnCount == null || (baselineTurnCount != null && baselineTurnCount > toTurnCount))
+    return null;
+  return {
+    fromTurnCount: baselineTurnCount ?? Math.max(0, toTurnCount - 1),
+    toTurnCount,
+  };
+}
+
+export const THREAD_START_DIFF_BASELINE = "thread-start";

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -62,6 +62,17 @@ For a local Git repository without a remote, **Publish Repository** creates a ho
 adds it as `origin`, and pushes your commits. If there are no commits yet, it creates the remote;
 make your first commit before pushing.
 
+## Compare work across turns
+
+On web and desktop, in the diff scope menu, choose **Pin baseline** and a completed turn to compare its final state
+with **Latest turn**. Choose **Start of thread (Turn 0)** to include turn 1's changes. For imported
+sessions, the initial snapshot starts when T3 begins capturing checkpoints, not at the start of
+historic CLI work. Choose a numbered **Turn** to fix the endpoint instead of following new turns.
+
+**Unpin baseline** returns to a single-turn diff. Working-tree and branch scopes clear the pin.
+Pins are local to the current client, thread, and environment. An empty turn can still be a useful
+comparison endpoint; its individual file count does not describe the whole pinned range.
+
 ## Create a pull request
 
 Use a thread's Git actions to commit, push, and create a pull request. T3 Code can generate commit


### PR DESCRIPTION
## What Changed

Add a pinned baseline to the web/desktop diff scope menu, using the server's existing checkpoint-range API.

- **Pin baseline** compares the saved state after a completed turn with **Latest turn**. **Start of thread (Turn 0)** includes the first captured turn's changes.
- Selecting a numbered **Turn** fixes the comparison endpoint; **Latest turn** resumes following completed turns. New completed turns preserve the baseline and any fixed endpoint.
- The scope label shows both endpoints. **Unpin baseline** returns to a single-turn diff; working-tree and branch scopes clear the pin.
- Completed turns with no individual file changes are muted and labeled **No changes**. They remain selectable when valid for the range; endpoints before the baseline are disabled.

Pins are stored per client, thread, and environment. Comparison caches and review state distinguish both endpoints. Includes focused store/range tests and a short user-guide section.

## Why

Work often spans an implementation turn and a small follow-up correction. Reviewing those turns separately makes it harder to see the combined result. Pinning a saved baseline lets users review the net changes across that chunk of work.

Scope is limited to web and the shared desktop UI. No server, contract, mobile, or development-infrastructure changes. Imported CLI sessions can only compare snapshots captured by T3; Turn 0 does not reconstruct earlier CLI history.

## UI Changes

| Before | After |
| --- | --- |
| <img width="323" alt="Existing diff scope menu" src="https://github.com/user-attachments/assets/446d9ffb-87b2-4da3-81a2-66f69d8425d9" /> | <img width="430" alt="Pin baseline submenu including Turn 0" src="https://github.com/user-attachments/assets/077fbb82-e936-41ac-b59d-8dd93e4c4021" /> |

### Pinned comparison labels

**Follow latest:** `Turn 18 → Latest turn` keeps Turn 18 as the baseline while the endpoint advances with completed turns. The menu below shows numbered endpoints and the new **No changes** labels.

<img width="820" alt="Turn 18 to Latest turn with endpoint choices" src="https://github.com/user-attachments/assets/262c79b0-16bf-4e28-a786-8b0bf9947248" />

**Fixed endpoint:** choosing Turn N changes the label to `Turn 18 → Turn N` and keeps both endpoints fixed. This example uses `Turn 14 → Turn 16` to show a range with code changes.

<img width="820" alt="Fixed comparison from Turn 14 to Turn 16" src="https://github.com/user-attachments/assets/64e91f0f-7906-49b3-bd98-794065715237" />

### Validation

- 120 focused tests passed: `diffPanelStore.test.ts` and `ChatView.logic.test.ts`.
- Web TypeScript check passed.
- Targeted lint completed with existing warnings and no errors; formatting and diff whitespace checks passed.
- Manually verified in the current web build: pin Turn 14 to Latest, switch to Turn 16, and unpin back to the single-turn view. Checked Turn 0 availability, disabled earlier endpoints, and No changes labels.
- Mobile is intentionally outside this PR and was not tested.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Implemented with GPT-6-Astra using Codex CLI in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pinned baseline support to diff panel turn comparisons
> - Adds the ability to pin a completed turn or the thread-start snapshot as a diff baseline, then compare a fixed or latest-following endpoint turn against it via the scope menu in [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/10150/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3)
> - Extends [diffPanelStore.ts](https://github.com/pingdotgg/t3code/pull/10150/files#diff-eb6dbce5a9ef0d2678422b84fa0bf2eceea78f2041f2846faefe4d959b49c5de) with `DiffBaseline` and `DiffPanelSelection` types, `pinBaseline` and `selectLatestTurn` actions, and a `getCheckpointDiffRange` helper that returns null for unavailable or reversed endpoints
> - Updates the completion effect in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/10150/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) so a pinned-baseline comparison is not replaced when a new turn completes; unpinned selections still auto-select the latest turn
> - Reconciliation now independently validates the endpoint and the pinned baseline, clearing invalid baselines and falling back to branch scope when no checkpoints remain
> - Adds user-facing documentation for baseline pinning, thread-start comparisons, and scope menu behavior in [source-control.md](https://github.com/pingdotgg/t3code/pull/10150/files#diff-a171985f6d647c7bc51efc65cf1a0b7261bb1313fe7c275c74f3836f919d1c05)
> - Behavioral Change: `reconcileTurnSelection` in [diffPanelStore.ts](https://github.com/pingdotgg/t3code/pull/10150/files#diff-eb6dbce5a9ef0d2678422b84fa0bf2eceea78f2041f2846faefe4d959b49c5de) now clears an unavailable pinned baseline and falls back to branch scope when the available turn list is empty; previously the selection stayed on the removed turn
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2d94ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->