### PR TITLE
refactor(client-runtime): remove unused relay token waiter

### DIFF
--- a/packages/client-runtime/src/relay/managedRelayState.test.ts
+++ b/packages/client-runtime/src/relay/managedRelayState.test.ts
@@ -25,7 +25,6 @@ import {
   managedRelaySessionAtom,
   readManagedRelaySnapshotState,
   setManagedRelaySession,
-  waitForManagedRelayClerkToken,
 } from "./managedRelayState.ts";
 
 let registry = AtomRegistry.make();
@@ -117,17 +116,6 @@ function clerkToken(expiresAtSeconds: number): string {
 
 describe("createManagedRelayQueryManager", () => {
   afterEach(resetRegistry);
-
-  it.effect("waits for the current cloud session before reading its token", () =>
-    Effect.gen(function* () {
-      const tokenFiber = yield* waitForManagedRelayClerkToken(registry).pipe(Effect.forkChild);
-
-      setSession();
-
-      expect(yield* Fiber.join(tokenFiber)).toBe("clerk-token");
-      expect(registry.getNodes().get(managedRelaySessionAtom)?.listeners.size).toBe(0);
-    }),
-  );
 
   it.effect("deregisters an environment through the current Clerk session", () =>
     Effect.gen(function* () {

--- a/packages/client-runtime/src/relay/managedRelayState.ts
+++ b/packages/client-runtime/src/relay/managedRelayState.ts
@@ -192,36 +192,6 @@ function readSessionClerkToken(
   );
 }
 
-export const waitForManagedRelayClerkToken = Effect.fn(
-  "clientRuntime.managedRelaySession.waitForClerkToken",
-)(function* (registry: AtomRegistry.AtomRegistry) {
-  return yield* Effect.callback<string, ManagedRelaySessionError>((resume) => {
-    let unsubscribe: (() => void) | undefined;
-    let completed = false;
-    const readCurrentSession = () => {
-      if (completed) {
-        return true;
-      }
-      const session = registry.get(managedRelaySessionAtom);
-      if (!session) {
-        return false;
-      }
-      completed = true;
-      unsubscribe?.();
-      resume(readSessionClerkToken(session));
-      return true;
-    };
-
-    if (readCurrentSession()) {
-      return;
-    }
-
-    unsubscribe = registry.subscribe(managedRelaySessionAtom, readCurrentSession);
-    readCurrentSession();
-    return Effect.sync(() => unsubscribe?.());
-  });
-});
-
 /** Removes an environment from the signed-in account without contacting that environment. */
 export const deregisterManagedRelayEnvironment = Effect.fn(
   "clientRuntime.managedRelaySession.deregisterEnvironment",


### PR DESCRIPTION
waitForManagedRelayClerkToken has no production callers. Its only caller is a direct unit test. Remove that unused subscription/wait implementation and its test.

The live session token reader remains in place for deregistration and relay queries. Keep the tests for account changes, concurrent token-read deduplication, expiry, replacing token readers, pending reads, and query behavior. Repository-wide references, including the relay barrel's consumers in web and mobile, do not use this helper.

Verification: all 13 remaining managedRelayState tests pass, along with targeted lint and the client-runtime typecheck. Typecheck reports two existing suggestions in unrelated files, no errors. No UI changes.

Model: gpt-6 astra. Harness: Codex in T3 Code.
