### PR TITLE
test(web): drop sidebar artwork styling snapshots

### DIFF
--- a/apps/web/src/components/SidebarStageBackdrop.test.tsx
+++ b/apps/web/src/components/SidebarStageBackdrop.test.tsx
@@ -4,9 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import {
   resolveEnvironmentIdentificationPillLabel,
   resolveSidebarStageBackdropVariant,
-  resolveSidebarStageFocusRingOffsetClass,
   StageBackdropArt,
-  StageBackdropButtonArt,
 } from "./SidebarStageBackdrop";
 
 describe("SidebarStageBackdrop", () => {
@@ -24,15 +22,6 @@ describe("SidebarStageBackdrop", () => {
     expect(resolveEnvironmentIdentificationPillLabel("Alpha")).toBeNull();
   });
 
-  it("matches the focus-ring offset to each artwork palette", () => {
-    expect(resolveSidebarStageFocusRingOffsetClass("nightly")).toBe(
-      "focus-visible:ring-offset-(--stage-night-bottom)",
-    );
-    expect(resolveSidebarStageFocusRingOffsetClass("dev")).toBe(
-      "focus-visible:ring-offset-(--stage-art-bottom)",
-    );
-  });
-
   it.each(["nightly", "dev"] as const)(
     "uses unique SVG definition ids when %s artwork is rendered more than once",
     (variant) => {
@@ -48,26 +37,4 @@ describe("SidebarStageBackdrop", () => {
       expect(new Set(ids).size).toBe(ids.length);
     },
   );
-
-  it("paints each artwork variant with theme-owned color tokens", () => {
-    const nightlyMarkup = renderToStaticMarkup(<StageBackdropArt variant="nightly" />);
-    const devMarkup = renderToStaticMarkup(<StageBackdropArt variant="dev" />);
-
-    expect(nightlyMarkup).toContain("var(--stage-night-bottom)");
-    expect(nightlyMarkup).toContain("var(--stage-night-line)");
-    expect(devMarkup).toContain("var(--stage-art-bottom)");
-    expect(devMarkup).toContain("var(--stage-art-line)");
-    expect(nightlyMarkup).not.toMatch(/#[0-9a-f]{3,8}/i);
-    expect(devMarkup).not.toMatch(/#[0-9a-f]{3,8}/i);
-  });
-
-  it.each([
-    ["nightly", "96 0 8192 96"],
-    ["dev", "64 0 8192 96"],
-  ] as const)("uses the compact %s crop inside the send button", (variant, viewBox) => {
-    const markup = renderToStaticMarkup(<StageBackdropButtonArt variant={variant} />);
-
-    expect(markup).toContain(`viewBox="${viewBox}"`);
-    expect(markup).toContain(`stage-${variant === "dev" ? "blueprint" : "nightly"}`);
-  });
 });


### PR DESCRIPTION
The sidebar artwork tests asserted literal focus-ring classes, theme token strings, and SVG crop coordinates. Remove those implementation snapshots without changing production artwork.

Keep enabled/disabled artwork and supported environment-label coverage. Keep both repeated-render SVG ID collision tests, since duplicate definition IDs can break multiple artwork instances.

Verification: all four remaining SidebarStageBackdrop tests pass. Production code and visuals are unchanged.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `SidebarStageBackdrop` styling snapshots and artwork assertions
> Deletes three tests from the SidebarStageBackdrop suite that asserted focus-ring offset classes, theme-owned color tokens, and compact crop viewBox values for nightly and dev variants. The suite still tests environment-to-artwork resolution, supported labels, and SVG definition ID uniqueness.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 03f36e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->