### PR TITLE
refactor(acp): keep protocol implementation exports private

### DIFF
--- a/packages/effect-acp/src/agent.ts
+++ b/packages/effect-acp/src/agent.ts
@@ -254,7 +254,7 @@ interface AcpCoreAgentRequestHandlers {
 
 const decodeCancelNotification = Schema.decodeUnknownEffect(AcpSchema.CancelNotification);
 
-export const make = Effect.fn("effect-acp/AcpAgent.make")(function* (
+const make = Effect.fn("effect-acp/AcpAgent.make")(function* (
   stdio: Stdio.Stdio,
   options: AcpAgentOptions = {},
 ): Effect.fn.Return<AcpAgent["Service"], never, Scope.Scope> {

--- a/packages/effect-acp/src/agent.ts
+++ b/packages/effect-acp/src/agent.ts
@@ -254,7 +254,8 @@ interface AcpCoreAgentRequestHandlers {
 
 const decodeCancelNotification = Schema.decodeUnknownEffect(AcpSchema.CancelNotification);
 
-const make = Effect.fn("effect-acp/AcpAgent.make")(function* (
+/** @public Service construction is part of the canonical Effect module API. */
+export const make = Effect.fn("effect-acp/AcpAgent.make")(function* (
   stdio: Stdio.Stdio,
   options: AcpAgentOptions = {},
 ): Effect.fn.Return<AcpAgent["Service"], never, Scope.Scope> {

--- a/packages/effect-acp/src/client.ts
+++ b/packages/effect-acp/src/client.ts
@@ -585,11 +585,6 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
   });
 });
 
-export const layer = (
-  stdio: AcpProtocol.AcpStdio,
-  options: AcpClientOptions = {},
-): Layer.Layer<AcpClient> => Layer.effect(AcpClient, make(stdio, options));
-
 export const layerChildProcess = (
   handle: ChildProcessSpawner.ChildProcessHandle,
   options: AcpClientOptions = {},

--- a/packages/effect-acp/src/errors.ts
+++ b/packages/effect-acp/src/errors.ts
@@ -3,7 +3,7 @@ import type * as SchemaIssue from "effect/SchemaIssue";
 
 import * as AcpSchema from "./_generated/schema.gen.ts";
 
-export const AcpRequestOperation = Schema.Literals([
+const AcpRequestOperation = Schema.Literals([
   "decode-extension-request-payload",
   "encode-extension-response",
   "handle-request",
@@ -11,12 +11,12 @@ export const AcpRequestOperation = Schema.Literals([
   "receive-response",
   "receive-streaming-response",
 ]);
-export type AcpRequestOperation = typeof AcpRequestOperation.Type;
+type AcpRequestOperation = typeof AcpRequestOperation.Type;
 
 export const AcpRequestId = Schema.Union([Schema.String, Schema.Number]);
 export type AcpRequestId = typeof AcpRequestId.Type;
 
-export const AcpSchemaIssueKind = Schema.Literals([
+const AcpSchemaIssueKind = Schema.Literals([
   "Filter",
   "Encoding",
   "Pointer",
@@ -29,9 +29,9 @@ export const AcpSchemaIssueKind = Schema.Literals([
   "Forbidden",
   "OneOf",
 ]);
-export type AcpSchemaIssueKind = typeof AcpSchemaIssueKind.Type;
+type AcpSchemaIssueKind = typeof AcpSchemaIssueKind.Type;
 
-export interface AcpSchemaIssueDiagnostics {
+interface AcpSchemaIssueDiagnostics {
   readonly issueCount: number;
   readonly issueKinds: ReadonlyArray<AcpSchemaIssueKind>;
   readonly maximumPathDepth: number;

--- a/packages/effect-acp/src/rpc.ts
+++ b/packages/effect-acp/src/rpc.ts
@@ -4,127 +4,127 @@ import * as RpcGroup from "effect/unstable/rpc/RpcGroup";
 import * as AcpSchema from "./_generated/schema.gen.ts";
 import { AGENT_METHODS, CLIENT_METHODS } from "./_generated/meta.gen.ts";
 
-export const InitializeRpc = Rpc.make(AGENT_METHODS.initialize, {
+const InitializeRpc = Rpc.make(AGENT_METHODS.initialize, {
   payload: AcpSchema.InitializeRequest,
   success: AcpSchema.InitializeResponse,
   error: AcpSchema.Error,
 });
 
-export const AuthenticateRpc = Rpc.make(AGENT_METHODS.authenticate, {
+const AuthenticateRpc = Rpc.make(AGENT_METHODS.authenticate, {
   payload: AcpSchema.AuthenticateRequest,
   success: AcpSchema.AuthenticateResponse,
   error: AcpSchema.Error,
 });
 
-export const LogoutRpc = Rpc.make(AGENT_METHODS.logout, {
+const LogoutRpc = Rpc.make(AGENT_METHODS.logout, {
   payload: AcpSchema.LogoutRequest,
   success: AcpSchema.LogoutResponse,
   error: AcpSchema.Error,
 });
 
-export const NewSessionRpc = Rpc.make(AGENT_METHODS.session_new, {
+const NewSessionRpc = Rpc.make(AGENT_METHODS.session_new, {
   payload: AcpSchema.NewSessionRequest,
   success: AcpSchema.NewSessionResponse,
   error: AcpSchema.Error,
 });
 
-export const LoadSessionRpc = Rpc.make(AGENT_METHODS.session_load, {
+const LoadSessionRpc = Rpc.make(AGENT_METHODS.session_load, {
   payload: AcpSchema.LoadSessionRequest,
   success: AcpSchema.LoadSessionResponse,
   error: AcpSchema.Error,
 });
 
-export const ListSessionsRpc = Rpc.make(AGENT_METHODS.session_list, {
+const ListSessionsRpc = Rpc.make(AGENT_METHODS.session_list, {
   payload: AcpSchema.ListSessionsRequest,
   success: AcpSchema.ListSessionsResponse,
   error: AcpSchema.Error,
 });
 
-export const ForkSessionRpc = Rpc.make(AGENT_METHODS.session_fork, {
+const ForkSessionRpc = Rpc.make(AGENT_METHODS.session_fork, {
   payload: AcpSchema.ForkSessionRequest,
   success: AcpSchema.ForkSessionResponse,
   error: AcpSchema.Error,
 });
 
-export const ResumeSessionRpc = Rpc.make(AGENT_METHODS.session_resume, {
+const ResumeSessionRpc = Rpc.make(AGENT_METHODS.session_resume, {
   payload: AcpSchema.ResumeSessionRequest,
   success: AcpSchema.ResumeSessionResponse,
   error: AcpSchema.Error,
 });
 
-export const CloseSessionRpc = Rpc.make(AGENT_METHODS.session_close, {
+const CloseSessionRpc = Rpc.make(AGENT_METHODS.session_close, {
   payload: AcpSchema.CloseSessionRequest,
   success: AcpSchema.CloseSessionResponse,
   error: AcpSchema.Error,
 });
 
-export const PromptRpc = Rpc.make(AGENT_METHODS.session_prompt, {
+const PromptRpc = Rpc.make(AGENT_METHODS.session_prompt, {
   payload: AcpSchema.PromptRequest,
   success: AcpSchema.PromptResponse,
   error: AcpSchema.Error,
 });
 
-export const SetSessionModelRpc = Rpc.make(AGENT_METHODS.session_set_model, {
+const SetSessionModelRpc = Rpc.make(AGENT_METHODS.session_set_model, {
   payload: AcpSchema.SetSessionModelRequest,
   success: AcpSchema.SetSessionModelResponse,
   error: AcpSchema.Error,
 });
 
-export const SetSessionConfigOptionRpc = Rpc.make(AGENT_METHODS.session_set_config_option, {
+const SetSessionConfigOptionRpc = Rpc.make(AGENT_METHODS.session_set_config_option, {
   payload: AcpSchema.SetSessionConfigOptionRequest,
   success: AcpSchema.SetSessionConfigOptionResponse,
   error: AcpSchema.Error,
 });
 
-export const ReadTextFileRpc = Rpc.make(CLIENT_METHODS.fs_read_text_file, {
+const ReadTextFileRpc = Rpc.make(CLIENT_METHODS.fs_read_text_file, {
   payload: AcpSchema.ReadTextFileRequest,
   success: AcpSchema.ReadTextFileResponse,
   error: AcpSchema.Error,
 });
 
-export const WriteTextFileRpc = Rpc.make(CLIENT_METHODS.fs_write_text_file, {
+const WriteTextFileRpc = Rpc.make(CLIENT_METHODS.fs_write_text_file, {
   payload: AcpSchema.WriteTextFileRequest,
   success: AcpSchema.WriteTextFileResponse,
   error: AcpSchema.Error,
 });
 
-export const RequestPermissionRpc = Rpc.make(CLIENT_METHODS.session_request_permission, {
+const RequestPermissionRpc = Rpc.make(CLIENT_METHODS.session_request_permission, {
   payload: AcpSchema.RequestPermissionRequest,
   success: AcpSchema.RequestPermissionResponse,
   error: AcpSchema.Error,
 });
 
-export const ElicitationRpc = Rpc.make(CLIENT_METHODS.session_elicitation, {
+const ElicitationRpc = Rpc.make(CLIENT_METHODS.session_elicitation, {
   payload: AcpSchema.ElicitationRequest,
   success: AcpSchema.ElicitationResponse,
   error: AcpSchema.Error,
 });
 
-export const CreateTerminalRpc = Rpc.make(CLIENT_METHODS.terminal_create, {
+const CreateTerminalRpc = Rpc.make(CLIENT_METHODS.terminal_create, {
   payload: AcpSchema.CreateTerminalRequest,
   success: AcpSchema.CreateTerminalResponse,
   error: AcpSchema.Error,
 });
 
-export const TerminalOutputRpc = Rpc.make(CLIENT_METHODS.terminal_output, {
+const TerminalOutputRpc = Rpc.make(CLIENT_METHODS.terminal_output, {
   payload: AcpSchema.TerminalOutputRequest,
   success: AcpSchema.TerminalOutputResponse,
   error: AcpSchema.Error,
 });
 
-export const ReleaseTerminalRpc = Rpc.make(CLIENT_METHODS.terminal_release, {
+const ReleaseTerminalRpc = Rpc.make(CLIENT_METHODS.terminal_release, {
   payload: AcpSchema.ReleaseTerminalRequest,
   success: AcpSchema.ReleaseTerminalResponse,
   error: AcpSchema.Error,
 });
 
-export const WaitForTerminalExitRpc = Rpc.make(CLIENT_METHODS.terminal_wait_for_exit, {
+const WaitForTerminalExitRpc = Rpc.make(CLIENT_METHODS.terminal_wait_for_exit, {
   payload: AcpSchema.WaitForTerminalExitRequest,
   success: AcpSchema.WaitForTerminalExitResponse,
   error: AcpSchema.Error,
 });
 
-export const KillTerminalRpc = Rpc.make(CLIENT_METHODS.terminal_kill, {
+const KillTerminalRpc = Rpc.make(CLIENT_METHODS.terminal_kill, {
   payload: AcpSchema.KillTerminalRequest,
   success: AcpSchema.KillTerminalResponse,
   error: AcpSchema.Error,


### PR DESCRIPTION
The private ACP package exports individual RPC definitions and implementation helpers that no repository consumer imports.

Keep those definitions local and remove the unused client `layer` wrapper. The live client factory, child-process layer, agent constructor/layers, and RPC groups remain exported. The agent constructor has a local `@public` explanation because the repository's Effect service convention requires public construction APIs. Generated upstream protocol definitions are untouched.

Verification on the integrated stack:

- ACP Knip export scan passes.
- All 40 existing ACP tests pass.
- ACP typecheck, targeted lint, and formatting pass.

No tests or runtime protocol behavior changed. This is the first cleanup layer; [#10171](https://github.com/pingdotgg/t3code/pull/10171) enforces exports across all seven internal packages.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope's pull request summary ends here -->

Model: gpt-6 astra. Harness: Codex in T3 Code.
