### PR TITLE
refactor(contracts): keep RPC implementation exports private

### DIFF
--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -33,23 +33,23 @@ const RuntimeEventRawSource = Schema.Union([
 ]);
 export type RuntimeEventRawSource = typeof RuntimeEventRawSource.Type;
 
-export const RuntimeEventRaw = Schema.Struct({
+const RuntimeEventRaw = Schema.Struct({
   source: RuntimeEventRawSource,
   method: Schema.optional(TrimmedNonEmptyStringSchema),
   messageType: Schema.optional(TrimmedNonEmptyStringSchema),
   payload: Schema.Unknown,
 });
-export type RuntimeEventRaw = typeof RuntimeEventRaw.Type;
+type RuntimeEventRaw = typeof RuntimeEventRaw.Type;
 
 const ProviderRequestId = TrimmedNonEmptyStringSchema;
-export type ProviderRequestId = typeof ProviderRequestId.Type;
+type ProviderRequestId = typeof ProviderRequestId.Type;
 
 const ProviderRefs = Schema.Struct({
   providerTurnId: Schema.optional(TrimmedNonEmptyStringSchema),
   providerItemId: Schema.optional(ProviderItemId),
   providerRequestId: Schema.optional(ProviderRequestId),
 });
-export type ProviderRefs = typeof ProviderRefs.Type;
+type ProviderRefs = typeof ProviderRefs.Type;
 
 const RuntimeSessionState = Schema.Literals([
   "starting",
@@ -59,7 +59,7 @@ const RuntimeSessionState = Schema.Literals([
   "stopped",
   "error",
 ]);
-export type RuntimeSessionState = typeof RuntimeSessionState.Type;
+type RuntimeSessionState = typeof RuntimeSessionState.Type;
 
 const RuntimeThreadState = Schema.Literals([
   "active",
@@ -69,16 +69,16 @@ const RuntimeThreadState = Schema.Literals([
   "compacted",
   "error",
 ]);
-export type RuntimeThreadState = typeof RuntimeThreadState.Type;
+type RuntimeThreadState = typeof RuntimeThreadState.Type;
 
 const RuntimeTurnState = Schema.Literals(["completed", "failed", "interrupted", "cancelled"]);
-export type RuntimeTurnState = typeof RuntimeTurnState.Type;
+type RuntimeTurnState = typeof RuntimeTurnState.Type;
 
 const RuntimePlanStepStatus = Schema.Literals(["pending", "inProgress", "completed"]);
-export type RuntimePlanStepStatus = typeof RuntimePlanStepStatus.Type;
+type RuntimePlanStepStatus = typeof RuntimePlanStepStatus.Type;
 
 const RuntimeItemStatus = Schema.Literals(["inProgress", "completed", "failed", "declined"]);
-export type RuntimeItemStatus = typeof RuntimeItemStatus.Type;
+type RuntimeItemStatus = typeof RuntimeItemStatus.Type;
 
 const RuntimeContentStreamKind = Schema.Literals([
   "assistant_text",
@@ -92,7 +92,7 @@ const RuntimeContentStreamKind = Schema.Literals([
 export type RuntimeContentStreamKind = typeof RuntimeContentStreamKind.Type;
 
 const RuntimeSessionExitKind = Schema.Literals(["graceful", "error"]);
-export type RuntimeSessionExitKind = typeof RuntimeSessionExitKind.Type;
+type RuntimeSessionExitKind = typeof RuntimeSessionExitKind.Type;
 
 const RuntimeErrorClass = Schema.Literals([
   "provider_error",
@@ -101,9 +101,9 @@ const RuntimeErrorClass = Schema.Literals([
   "validation_error",
   "unknown",
 ]);
-export type RuntimeErrorClass = typeof RuntimeErrorClass.Type;
+type RuntimeErrorClass = typeof RuntimeErrorClass.Type;
 
-export const TOOL_LIFECYCLE_ITEM_TYPES = [
+const TOOL_LIFECYCLE_ITEM_TYPES = [
   "command_execution",
   "file_change",
   "mcp_tool_call",
@@ -266,37 +266,37 @@ const ProviderRuntimeEventBase = Schema.Struct({
   providerRefs: Schema.optional(ProviderRefs),
   raw: Schema.optional(RuntimeEventRaw),
 });
-export type ProviderRuntimeEventBase = typeof ProviderRuntimeEventBase.Type;
+type ProviderRuntimeEventBase = typeof ProviderRuntimeEventBase.Type;
 
 const SessionStartedPayload = Schema.Struct({
   message: Schema.optional(TrimmedNonEmptyStringSchema),
   resume: Schema.optional(Schema.Unknown),
 });
-export type SessionStartedPayload = typeof SessionStartedPayload.Type;
+type SessionStartedPayload = typeof SessionStartedPayload.Type;
 
 const SessionConfiguredPayload = Schema.Struct({
   config: UnknownRecordSchema,
 });
-export type SessionConfiguredPayload = typeof SessionConfiguredPayload.Type;
+type SessionConfiguredPayload = typeof SessionConfiguredPayload.Type;
 
 const SessionStateChangedPayload = Schema.Struct({
   state: RuntimeSessionState,
   reason: Schema.optional(TrimmedNonEmptyStringSchema),
   detail: Schema.optional(Schema.Unknown),
 });
-export type SessionStateChangedPayload = typeof SessionStateChangedPayload.Type;
+type SessionStateChangedPayload = typeof SessionStateChangedPayload.Type;
 
 const SessionExitedPayload = Schema.Struct({
   reason: Schema.optional(TrimmedNonEmptyStringSchema),
   recoverable: Schema.optional(Schema.Boolean),
   exitKind: Schema.optional(RuntimeSessionExitKind),
 });
-export type SessionExitedPayload = typeof SessionExitedPayload.Type;
+type SessionExitedPayload = typeof SessionExitedPayload.Type;
 
 const ThreadStartedPayload = Schema.Struct({
   providerThreadId: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-export type ThreadStartedPayload = typeof ThreadStartedPayload.Type;
+type ThreadStartedPayload = typeof ThreadStartedPayload.Type;
 
 const ThreadStateChangedPayload = Schema.Struct({
   state: RuntimeThreadState,
@@ -304,13 +304,13 @@ const ThreadStateChangedPayload = Schema.Struct({
   afterTokens: Schema.optional(NonNegativeInt),
   detail: Schema.optional(Schema.Unknown),
 });
-export type ThreadStateChangedPayload = typeof ThreadStateChangedPayload.Type;
+type ThreadStateChangedPayload = typeof ThreadStateChangedPayload.Type;
 
 const ThreadMetadataUpdatedPayload = Schema.Struct({
   name: Schema.optional(TrimmedNonEmptyStringSchema),
   metadata: Schema.optional(UnknownRecordSchema),
 });
-export type ThreadMetadataUpdatedPayload = typeof ThreadMetadataUpdatedPayload.Type;
+type ThreadMetadataUpdatedPayload = typeof ThreadMetadataUpdatedPayload.Type;
 
 export const ThreadTokenUsageSnapshot = Schema.Struct({
   usedTokens: NonNegativeInt,
@@ -335,38 +335,38 @@ export type ThreadTokenUsageSnapshot = typeof ThreadTokenUsageSnapshot.Type;
 const ThreadTokenUsageUpdatedPayload = Schema.Struct({
   usage: ThreadTokenUsageSnapshot,
 });
-export type ThreadTokenUsageUpdatedPayload = typeof ThreadTokenUsageUpdatedPayload.Type;
+type ThreadTokenUsageUpdatedPayload = typeof ThreadTokenUsageUpdatedPayload.Type;
 
 const ThreadRealtimeStartedPayload = Schema.Struct({
   realtimeSessionId: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-export type ThreadRealtimeStartedPayload = typeof ThreadRealtimeStartedPayload.Type;
+type ThreadRealtimeStartedPayload = typeof ThreadRealtimeStartedPayload.Type;
 
 const ThreadRealtimeItemAddedPayload = Schema.Struct({
   item: Schema.Unknown,
 });
-export type ThreadRealtimeItemAddedPayload = typeof ThreadRealtimeItemAddedPayload.Type;
+type ThreadRealtimeItemAddedPayload = typeof ThreadRealtimeItemAddedPayload.Type;
 
 const ThreadRealtimeAudioDeltaPayload = Schema.Struct({
   audio: Schema.Unknown,
 });
-export type ThreadRealtimeAudioDeltaPayload = typeof ThreadRealtimeAudioDeltaPayload.Type;
+type ThreadRealtimeAudioDeltaPayload = typeof ThreadRealtimeAudioDeltaPayload.Type;
 
 const ThreadRealtimeErrorPayload = Schema.Struct({
   message: TrimmedNonEmptyStringSchema,
 });
-export type ThreadRealtimeErrorPayload = typeof ThreadRealtimeErrorPayload.Type;
+type ThreadRealtimeErrorPayload = typeof ThreadRealtimeErrorPayload.Type;
 
 const ThreadRealtimeClosedPayload = Schema.Struct({
   reason: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-export type ThreadRealtimeClosedPayload = typeof ThreadRealtimeClosedPayload.Type;
+type ThreadRealtimeClosedPayload = typeof ThreadRealtimeClosedPayload.Type;
 
 const TurnStartedPayload = Schema.Struct({
   model: Schema.optional(TrimmedNonEmptyStringSchema),
   effort: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-export type TurnStartedPayload = typeof TurnStartedPayload.Type;
+type TurnStartedPayload = typeof TurnStartedPayload.Type;
 
 /**
  * Normalized main-agent usage for one turn. Input includes cache reads and
@@ -412,34 +412,34 @@ const TurnAbortedPayload = Schema.Struct({
   reason: TrimmedNonEmptyStringSchema,
   tokenUsage: Schema.optional(TurnTokenUsage),
 });
-export type TurnAbortedPayload = typeof TurnAbortedPayload.Type;
+type TurnAbortedPayload = typeof TurnAbortedPayload.Type;
 
 const RuntimePlanStep = Schema.Struct({
   step: TrimmedNonEmptyStringSchema,
   status: RuntimePlanStepStatus,
 });
-export type RuntimePlanStep = typeof RuntimePlanStep.Type;
+type RuntimePlanStep = typeof RuntimePlanStep.Type;
 
 const TurnPlanUpdatedPayload = Schema.Struct({
   explanation: Schema.optional(Schema.NullOr(TrimmedNonEmptyStringSchema)),
   plan: Schema.Array(RuntimePlanStep),
 });
-export type TurnPlanUpdatedPayload = typeof TurnPlanUpdatedPayload.Type;
+type TurnPlanUpdatedPayload = typeof TurnPlanUpdatedPayload.Type;
 
 const TurnProposedDeltaPayload = Schema.Struct({
   delta: Schema.String,
 });
-export type TurnProposedDeltaPayload = typeof TurnProposedDeltaPayload.Type;
+type TurnProposedDeltaPayload = typeof TurnProposedDeltaPayload.Type;
 
 const TurnProposedCompletedPayload = Schema.Struct({
   planMarkdown: TrimmedNonEmptyStringSchema,
 });
-export type TurnProposedCompletedPayload = typeof TurnProposedCompletedPayload.Type;
+type TurnProposedCompletedPayload = typeof TurnProposedCompletedPayload.Type;
 
 const TurnDiffUpdatedPayload = Schema.Struct({
   unifiedDiff: Schema.String,
 });
-export type TurnDiffUpdatedPayload = typeof TurnDiffUpdatedPayload.Type;
+type TurnDiffUpdatedPayload = typeof TurnDiffUpdatedPayload.Type;
 
 export const ToolActivitySurface = Schema.Literals(["browser", "computer"]);
 export type ToolActivitySurface = typeof ToolActivitySurface.Type;
@@ -481,7 +481,7 @@ export const ToolActivitySource = Schema.Struct({
 });
 export type ToolActivitySource = typeof ToolActivitySource.Type;
 
-export const ItemLifecyclePayload = Schema.Struct({
+const ItemLifecyclePayload = Schema.Struct({
   itemType: CanonicalItemType,
   status: Schema.optional(RuntimeItemStatus),
   title: Schema.optional(TrimmedNonEmptyStringSchema),
@@ -498,7 +498,7 @@ export const ItemLifecyclePayload = Schema.Struct({
   agentId: Schema.optional(TrimmedNonEmptyStringSchema),
   parentToolUseId: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-export type ItemLifecyclePayload = typeof ItemLifecyclePayload.Type;
+type ItemLifecyclePayload = typeof ItemLifecyclePayload.Type;
 
 const ContentDeltaPayload = Schema.Struct({
   streamKind: RuntimeContentStreamKind,
@@ -506,7 +506,7 @@ const ContentDeltaPayload = Schema.Struct({
   contentIndex: Schema.optional(Schema.Int),
   summaryIndex: Schema.optional(Schema.Int),
 });
-export type ContentDeltaPayload = typeof ContentDeltaPayload.Type;
+type ContentDeltaPayload = typeof ContentDeltaPayload.Type;
 
 const RequestOpenedPayload = Schema.Struct({
   requestType: CanonicalRequestType,
@@ -515,21 +515,21 @@ const RequestOpenedPayload = Schema.Struct({
   options: Schema.optional(Schema.Array(ProviderApprovalOption)),
   args: Schema.optional(Schema.Unknown),
 });
-export type RequestOpenedPayload = typeof RequestOpenedPayload.Type;
+type RequestOpenedPayload = typeof RequestOpenedPayload.Type;
 
 const RequestResolvedPayload = Schema.Struct({
   requestType: CanonicalRequestType,
   decision: Schema.optional(TrimmedNonEmptyStringSchema),
   resolution: Schema.optional(Schema.Unknown),
 });
-export type RequestResolvedPayload = typeof RequestResolvedPayload.Type;
+type RequestResolvedPayload = typeof RequestResolvedPayload.Type;
 
 const UserInputQuestionOption = Schema.Struct({
   label: TrimmedNonEmptyStringSchema,
   description: Schema.String,
   value: Schema.optional(Schema.String),
 });
-export type UserInputQuestionOption = typeof UserInputQuestionOption.Type;
+type UserInputQuestionOption = typeof UserInputQuestionOption.Type;
 
 export const UserInputQuestion = Schema.Struct({
   id: TrimmedNonEmptyStringSchema,
@@ -552,7 +552,7 @@ export type UserInputRequestedPayload = typeof UserInputRequestedPayload.Type;
 const UserInputResolvedPayload = Schema.Struct({
   answers: UnknownRecordSchema,
 });
-export type UserInputResolvedPayload = typeof UserInputResolvedPayload.Type;
+type UserInputResolvedPayload = typeof UserInputResolvedPayload.Type;
 
 /**
  * Typed per-task usage rollup. Field names match the orchestration-v2 subagent
@@ -571,11 +571,11 @@ export const RuntimeTaskUsage = Schema.Struct({
 });
 export type RuntimeTaskUsage = typeof RuntimeTaskUsage.Type;
 
-export const TaskWorkflowPhase = Schema.Struct({
+const TaskWorkflowPhase = Schema.Struct({
   index: NonNegativeInt,
   title: TrimmedNonEmptyStringSchema,
 });
-export type TaskWorkflowPhase = typeof TaskWorkflowPhase.Type;
+type TaskWorkflowPhase = typeof TaskWorkflowPhase.Type;
 
 export const TaskRunHandles = Schema.Struct({
   runId: Schema.optional(TrimmedNonEmptyStringSchema),
@@ -677,7 +677,7 @@ const TaskStartedPayload = Schema.Struct({
   description: Schema.optional(TrimmedNonEmptyStringSchema),
   ...taskAgentLinkageFields,
 });
-export type TaskStartedPayload = typeof TaskStartedPayload.Type;
+type TaskStartedPayload = typeof TaskStartedPayload.Type;
 
 export const RuntimeTaskStatus = Schema.Literals([
   "pending",
@@ -703,7 +703,7 @@ const TaskProgressPayload = Schema.Struct({
   error: Schema.optional(TrimmedNonEmptyStringSchema),
   ...taskAgentLinkageFields,
 });
-export type TaskProgressPayload = typeof TaskProgressPayload.Type;
+type TaskProgressPayload = typeof TaskProgressPayload.Type;
 
 /**
  * Non-terminal status patch (from the Claude SDK's task_updated, which main
@@ -719,7 +719,7 @@ const TaskUpdatedPayload = Schema.Struct({
   isBackgrounded: Schema.optional(Schema.Boolean),
   ...taskAgentLinkageFields,
 });
-export type TaskUpdatedPayload = typeof TaskUpdatedPayload.Type;
+type TaskUpdatedPayload = typeof TaskUpdatedPayload.Type;
 
 const TaskCompletedPayload = Schema.Struct({
   taskId: RuntimeTaskId,
@@ -729,14 +729,14 @@ const TaskCompletedPayload = Schema.Struct({
   typedUsage: Schema.optional(RuntimeTaskUsage),
   ...taskAgentLinkageFields,
 });
-export type TaskCompletedPayload = typeof TaskCompletedPayload.Type;
+type TaskCompletedPayload = typeof TaskCompletedPayload.Type;
 
 const HookStartedPayload = Schema.Struct({
   hookId: TrimmedNonEmptyStringSchema,
   hookName: TrimmedNonEmptyStringSchema,
   hookEvent: TrimmedNonEmptyStringSchema,
 });
-export type HookStartedPayload = typeof HookStartedPayload.Type;
+type HookStartedPayload = typeof HookStartedPayload.Type;
 
 const HookProgressPayload = Schema.Struct({
   hookId: TrimmedNonEmptyStringSchema,
@@ -744,7 +744,7 @@ const HookProgressPayload = Schema.Struct({
   stdout: Schema.optional(Schema.String),
   stderr: Schema.optional(Schema.String),
 });
-export type HookProgressPayload = typeof HookProgressPayload.Type;
+type HookProgressPayload = typeof HookProgressPayload.Type;
 
 const HookCompletedPayload = Schema.Struct({
   hookId: TrimmedNonEmptyStringSchema,
@@ -754,7 +754,7 @@ const HookCompletedPayload = Schema.Struct({
   stderr: Schema.optional(Schema.String),
   exitCode: Schema.optional(Schema.Int),
 });
-export type HookCompletedPayload = typeof HookCompletedPayload.Type;
+type HookCompletedPayload = typeof HookCompletedPayload.Type;
 
 const ToolProgressPayload = Schema.Struct({
   toolUseId: Schema.optional(TrimmedNonEmptyStringSchema),
@@ -765,25 +765,25 @@ const ToolProgressPayload = Schema.Struct({
   taskId: Schema.optional(RuntimeTaskId),
   parentToolUseId: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-export type ToolProgressPayload = typeof ToolProgressPayload.Type;
+type ToolProgressPayload = typeof ToolProgressPayload.Type;
 
 const ToolSummaryPayload = Schema.Struct({
   summary: TrimmedNonEmptyStringSchema,
   precedingToolUseIds: Schema.optional(Schema.Array(TrimmedNonEmptyStringSchema)),
 });
-export type ToolSummaryPayload = typeof ToolSummaryPayload.Type;
+type ToolSummaryPayload = typeof ToolSummaryPayload.Type;
 
 const AuthStatusPayload = Schema.Struct({
   isAuthenticating: Schema.optional(Schema.Boolean),
   output: Schema.optional(Schema.Array(Schema.String)),
   error: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-export type AuthStatusPayload = typeof AuthStatusPayload.Type;
+type AuthStatusPayload = typeof AuthStatusPayload.Type;
 
 const AccountUpdatedPayload = Schema.Struct({
   account: Schema.Unknown,
 });
-export type AccountUpdatedPayload = typeof AccountUpdatedPayload.Type;
+type AccountUpdatedPayload = typeof AccountUpdatedPayload.Type;
 
 /**
  * Adapters normalise their native rate-limit payload at the boundary so the
@@ -792,26 +792,26 @@ export type AccountUpdatedPayload = typeof AccountUpdatedPayload.Type;
 const AccountRateLimitsUpdatedPayload = Schema.Struct({
   limits: ProviderUsageLimitsUpdate,
 });
-export type AccountRateLimitsUpdatedPayload = typeof AccountRateLimitsUpdatedPayload.Type;
+type AccountRateLimitsUpdatedPayload = typeof AccountRateLimitsUpdatedPayload.Type;
 
 const McpStatusUpdatedPayload = Schema.Struct({
   status: Schema.Unknown,
 });
-export type McpStatusUpdatedPayload = typeof McpStatusUpdatedPayload.Type;
+type McpStatusUpdatedPayload = typeof McpStatusUpdatedPayload.Type;
 
 const McpOauthCompletedPayload = Schema.Struct({
   success: Schema.Boolean,
   name: Schema.optional(TrimmedNonEmptyStringSchema),
   error: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-export type McpOauthCompletedPayload = typeof McpOauthCompletedPayload.Type;
+type McpOauthCompletedPayload = typeof McpOauthCompletedPayload.Type;
 
 const ModelReroutedPayload = Schema.Struct({
   fromModel: TrimmedNonEmptyStringSchema,
   toModel: TrimmedNonEmptyStringSchema,
   reason: TrimmedNonEmptyStringSchema,
 });
-export type ModelReroutedPayload = typeof ModelReroutedPayload.Type;
+type ModelReroutedPayload = typeof ModelReroutedPayload.Type;
 
 const ConfigWarningPayload = Schema.Struct({
   summary: TrimmedNonEmptyStringSchema,
@@ -819,13 +819,13 @@ const ConfigWarningPayload = Schema.Struct({
   path: Schema.optional(TrimmedNonEmptyStringSchema),
   range: Schema.optional(Schema.Unknown),
 });
-export type ConfigWarningPayload = typeof ConfigWarningPayload.Type;
+type ConfigWarningPayload = typeof ConfigWarningPayload.Type;
 
 const DeprecationNoticePayload = Schema.Struct({
   summary: TrimmedNonEmptyStringSchema,
   details: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-export type DeprecationNoticePayload = typeof DeprecationNoticePayload.Type;
+type DeprecationNoticePayload = typeof DeprecationNoticePayload.Type;
 
 const FilesPersistedPayload = Schema.Struct({
   files: Schema.Array(
@@ -843,7 +843,7 @@ const FilesPersistedPayload = Schema.Struct({
     ),
   ),
 });
-export type FilesPersistedPayload = typeof FilesPersistedPayload.Type;
+type FilesPersistedPayload = typeof FilesPersistedPayload.Type;
 
 const ToolDeniedPayload = Schema.Struct({
   toolName: TrimmedNonEmptyStringSchema,
@@ -851,72 +851,69 @@ const ToolDeniedPayload = Schema.Struct({
   reason: Schema.optional(TrimmedNonEmptyStringSchema),
   agentId: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-export type ToolDeniedPayload = typeof ToolDeniedPayload.Type;
+type ToolDeniedPayload = typeof ToolDeniedPayload.Type;
 
 const RuntimeWarningPayload = Schema.Struct({
   message: TrimmedNonEmptyStringSchema,
   detail: Schema.optional(Schema.Unknown),
 });
-export type RuntimeWarningPayload = typeof RuntimeWarningPayload.Type;
+type RuntimeWarningPayload = typeof RuntimeWarningPayload.Type;
 
 const RuntimeErrorPayload = Schema.Struct({
   message: TrimmedNonEmptyStringSchema,
   class: Schema.optional(RuntimeErrorClass),
   detail: Schema.optional(Schema.Unknown),
 });
-export type RuntimeErrorPayload = typeof RuntimeErrorPayload.Type;
+type RuntimeErrorPayload = typeof RuntimeErrorPayload.Type;
 
 const ProviderRuntimeSessionStartedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: SessionStartedType,
   payload: SessionStartedPayload,
 });
-export type ProviderRuntimeSessionStartedEvent = typeof ProviderRuntimeSessionStartedEvent.Type;
+type ProviderRuntimeSessionStartedEvent = typeof ProviderRuntimeSessionStartedEvent.Type;
 
 const ProviderRuntimeSessionConfiguredEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: SessionConfiguredType,
   payload: SessionConfiguredPayload,
 });
-export type ProviderRuntimeSessionConfiguredEvent =
-  typeof ProviderRuntimeSessionConfiguredEvent.Type;
+type ProviderRuntimeSessionConfiguredEvent = typeof ProviderRuntimeSessionConfiguredEvent.Type;
 
 const ProviderRuntimeSessionStateChangedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: SessionStateChangedType,
   payload: SessionStateChangedPayload,
 });
-export type ProviderRuntimeSessionStateChangedEvent =
-  typeof ProviderRuntimeSessionStateChangedEvent.Type;
+type ProviderRuntimeSessionStateChangedEvent = typeof ProviderRuntimeSessionStateChangedEvent.Type;
 
 const ProviderRuntimeSessionExitedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: SessionExitedType,
   payload: SessionExitedPayload,
 });
-export type ProviderRuntimeSessionExitedEvent = typeof ProviderRuntimeSessionExitedEvent.Type;
+type ProviderRuntimeSessionExitedEvent = typeof ProviderRuntimeSessionExitedEvent.Type;
 
 const ProviderRuntimeThreadStartedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ThreadStartedType,
   payload: ThreadStartedPayload,
 });
-export type ProviderRuntimeThreadStartedEvent = typeof ProviderRuntimeThreadStartedEvent.Type;
+type ProviderRuntimeThreadStartedEvent = typeof ProviderRuntimeThreadStartedEvent.Type;
 
 const ProviderRuntimeThreadStateChangedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ThreadStateChangedType,
   payload: ThreadStateChangedPayload,
 });
-export type ProviderRuntimeThreadStateChangedEvent =
-  typeof ProviderRuntimeThreadStateChangedEvent.Type;
+type ProviderRuntimeThreadStateChangedEvent = typeof ProviderRuntimeThreadStateChangedEvent.Type;
 
 const ProviderRuntimeThreadMetadataUpdatedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ThreadMetadataUpdatedType,
   payload: ThreadMetadataUpdatedPayload,
 });
-export type ProviderRuntimeThreadMetadataUpdatedEvent =
+type ProviderRuntimeThreadMetadataUpdatedEvent =
   typeof ProviderRuntimeThreadMetadataUpdatedEvent.Type;
 
 const ProviderRuntimeThreadTokenUsageUpdatedEvent = Schema.Struct({
@@ -924,7 +921,7 @@ const ProviderRuntimeThreadTokenUsageUpdatedEvent = Schema.Struct({
   type: ThreadTokenUsageUpdatedType,
   payload: ThreadTokenUsageUpdatedPayload,
 });
-export type ProviderRuntimeThreadTokenUsageUpdatedEvent =
+type ProviderRuntimeThreadTokenUsageUpdatedEvent =
   typeof ProviderRuntimeThreadTokenUsageUpdatedEvent.Type;
 
 const ProviderRuntimeThreadRealtimeStartedEvent = Schema.Struct({
@@ -932,7 +929,7 @@ const ProviderRuntimeThreadRealtimeStartedEvent = Schema.Struct({
   type: ThreadRealtimeStartedType,
   payload: ThreadRealtimeStartedPayload,
 });
-export type ProviderRuntimeThreadRealtimeStartedEvent =
+type ProviderRuntimeThreadRealtimeStartedEvent =
   typeof ProviderRuntimeThreadRealtimeStartedEvent.Type;
 
 const ProviderRuntimeThreadRealtimeItemAddedEvent = Schema.Struct({
@@ -940,7 +937,7 @@ const ProviderRuntimeThreadRealtimeItemAddedEvent = Schema.Struct({
   type: ThreadRealtimeItemAddedType,
   payload: ThreadRealtimeItemAddedPayload,
 });
-export type ProviderRuntimeThreadRealtimeItemAddedEvent =
+type ProviderRuntimeThreadRealtimeItemAddedEvent =
   typeof ProviderRuntimeThreadRealtimeItemAddedEvent.Type;
 
 const ProviderRuntimeThreadRealtimeAudioDeltaEvent = Schema.Struct({
@@ -948,7 +945,7 @@ const ProviderRuntimeThreadRealtimeAudioDeltaEvent = Schema.Struct({
   type: ThreadRealtimeAudioDeltaType,
   payload: ThreadRealtimeAudioDeltaPayload,
 });
-export type ProviderRuntimeThreadRealtimeAudioDeltaEvent =
+type ProviderRuntimeThreadRealtimeAudioDeltaEvent =
   typeof ProviderRuntimeThreadRealtimeAudioDeltaEvent.Type;
 
 const ProviderRuntimeThreadRealtimeErrorEvent = Schema.Struct({
@@ -956,15 +953,14 @@ const ProviderRuntimeThreadRealtimeErrorEvent = Schema.Struct({
   type: ThreadRealtimeErrorType,
   payload: ThreadRealtimeErrorPayload,
 });
-export type ProviderRuntimeThreadRealtimeErrorEvent =
-  typeof ProviderRuntimeThreadRealtimeErrorEvent.Type;
+type ProviderRuntimeThreadRealtimeErrorEvent = typeof ProviderRuntimeThreadRealtimeErrorEvent.Type;
 
 const ProviderRuntimeThreadRealtimeClosedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ThreadRealtimeClosedType,
   payload: ThreadRealtimeClosedPayload,
 });
-export type ProviderRuntimeThreadRealtimeClosedEvent =
+type ProviderRuntimeThreadRealtimeClosedEvent =
   typeof ProviderRuntimeThreadRealtimeClosedEvent.Type;
 
 const ProviderRuntimeTurnStartedEvent = Schema.Struct({
@@ -972,43 +968,42 @@ const ProviderRuntimeTurnStartedEvent = Schema.Struct({
   type: TurnStartedType,
   payload: TurnStartedPayload,
 });
-export type ProviderRuntimeTurnStartedEvent = typeof ProviderRuntimeTurnStartedEvent.Type;
+type ProviderRuntimeTurnStartedEvent = typeof ProviderRuntimeTurnStartedEvent.Type;
 
 const ProviderRuntimeTurnCompletedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TurnCompletedType,
   payload: TurnCompletedPayload,
 });
-export type ProviderRuntimeTurnCompletedEvent = typeof ProviderRuntimeTurnCompletedEvent.Type;
+type ProviderRuntimeTurnCompletedEvent = typeof ProviderRuntimeTurnCompletedEvent.Type;
 
 const ProviderRuntimeTurnAbortedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TurnAbortedType,
   payload: TurnAbortedPayload,
 });
-export type ProviderRuntimeTurnAbortedEvent = typeof ProviderRuntimeTurnAbortedEvent.Type;
+type ProviderRuntimeTurnAbortedEvent = typeof ProviderRuntimeTurnAbortedEvent.Type;
 
 const ProviderRuntimeTurnPlanUpdatedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TurnPlanUpdatedType,
   payload: TurnPlanUpdatedPayload,
 });
-export type ProviderRuntimeTurnPlanUpdatedEvent = typeof ProviderRuntimeTurnPlanUpdatedEvent.Type;
+type ProviderRuntimeTurnPlanUpdatedEvent = typeof ProviderRuntimeTurnPlanUpdatedEvent.Type;
 
 const ProviderRuntimeTurnProposedDeltaEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TurnProposedDeltaType,
   payload: TurnProposedDeltaPayload,
 });
-export type ProviderRuntimeTurnProposedDeltaEvent =
-  typeof ProviderRuntimeTurnProposedDeltaEvent.Type;
+type ProviderRuntimeTurnProposedDeltaEvent = typeof ProviderRuntimeTurnProposedDeltaEvent.Type;
 
 const ProviderRuntimeTurnProposedCompletedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TurnProposedCompletedType,
   payload: TurnProposedCompletedPayload,
 });
-export type ProviderRuntimeTurnProposedCompletedEvent =
+type ProviderRuntimeTurnProposedCompletedEvent =
   typeof ProviderRuntimeTurnProposedCompletedEvent.Type;
 
 const ProviderRuntimeTurnDiffUpdatedEvent = Schema.Struct({
@@ -1016,149 +1011,147 @@ const ProviderRuntimeTurnDiffUpdatedEvent = Schema.Struct({
   type: TurnDiffUpdatedType,
   payload: TurnDiffUpdatedPayload,
 });
-export type ProviderRuntimeTurnDiffUpdatedEvent = typeof ProviderRuntimeTurnDiffUpdatedEvent.Type;
+type ProviderRuntimeTurnDiffUpdatedEvent = typeof ProviderRuntimeTurnDiffUpdatedEvent.Type;
 
 const ProviderRuntimeItemStartedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ItemStartedType,
   payload: ItemLifecyclePayload,
 });
-export type ProviderRuntimeItemStartedEvent = typeof ProviderRuntimeItemStartedEvent.Type;
+type ProviderRuntimeItemStartedEvent = typeof ProviderRuntimeItemStartedEvent.Type;
 
 const ProviderRuntimeItemUpdatedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ItemUpdatedType,
   payload: ItemLifecyclePayload,
 });
-export type ProviderRuntimeItemUpdatedEvent = typeof ProviderRuntimeItemUpdatedEvent.Type;
+type ProviderRuntimeItemUpdatedEvent = typeof ProviderRuntimeItemUpdatedEvent.Type;
 
 const ProviderRuntimeItemCompletedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ItemCompletedType,
   payload: ItemLifecyclePayload,
 });
-export type ProviderRuntimeItemCompletedEvent = typeof ProviderRuntimeItemCompletedEvent.Type;
+type ProviderRuntimeItemCompletedEvent = typeof ProviderRuntimeItemCompletedEvent.Type;
 
 const ProviderRuntimeContentDeltaEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ContentDeltaType,
   payload: ContentDeltaPayload,
 });
-export type ProviderRuntimeContentDeltaEvent = typeof ProviderRuntimeContentDeltaEvent.Type;
+type ProviderRuntimeContentDeltaEvent = typeof ProviderRuntimeContentDeltaEvent.Type;
 
 const ProviderRuntimeRequestOpenedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: RequestOpenedType,
   payload: RequestOpenedPayload,
 });
-export type ProviderRuntimeRequestOpenedEvent = typeof ProviderRuntimeRequestOpenedEvent.Type;
+type ProviderRuntimeRequestOpenedEvent = typeof ProviderRuntimeRequestOpenedEvent.Type;
 
 const ProviderRuntimeRequestResolvedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: RequestResolvedType,
   payload: RequestResolvedPayload,
 });
-export type ProviderRuntimeRequestResolvedEvent = typeof ProviderRuntimeRequestResolvedEvent.Type;
+type ProviderRuntimeRequestResolvedEvent = typeof ProviderRuntimeRequestResolvedEvent.Type;
 
 const ProviderRuntimeUserInputRequestedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: UserInputRequestedType,
   payload: UserInputRequestedPayload,
 });
-export type ProviderRuntimeUserInputRequestedEvent =
-  typeof ProviderRuntimeUserInputRequestedEvent.Type;
+type ProviderRuntimeUserInputRequestedEvent = typeof ProviderRuntimeUserInputRequestedEvent.Type;
 
 const ProviderRuntimeUserInputResolvedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: UserInputResolvedType,
   payload: UserInputResolvedPayload,
 });
-export type ProviderRuntimeUserInputResolvedEvent =
-  typeof ProviderRuntimeUserInputResolvedEvent.Type;
+type ProviderRuntimeUserInputResolvedEvent = typeof ProviderRuntimeUserInputResolvedEvent.Type;
 
 const ProviderRuntimeTaskStartedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TaskStartedType,
   payload: TaskStartedPayload,
 });
-export type ProviderRuntimeTaskStartedEvent = typeof ProviderRuntimeTaskStartedEvent.Type;
+type ProviderRuntimeTaskStartedEvent = typeof ProviderRuntimeTaskStartedEvent.Type;
 
 const ProviderRuntimeTaskProgressEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TaskProgressType,
   payload: TaskProgressPayload,
 });
-export type ProviderRuntimeTaskProgressEvent = typeof ProviderRuntimeTaskProgressEvent.Type;
+type ProviderRuntimeTaskProgressEvent = typeof ProviderRuntimeTaskProgressEvent.Type;
 
 const ProviderRuntimeTaskUpdatedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TaskUpdatedType,
   payload: TaskUpdatedPayload,
 });
-export type ProviderRuntimeTaskUpdatedEvent = typeof ProviderRuntimeTaskUpdatedEvent.Type;
+type ProviderRuntimeTaskUpdatedEvent = typeof ProviderRuntimeTaskUpdatedEvent.Type;
 
 const ProviderRuntimeTaskCompletedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TaskCompletedType,
   payload: TaskCompletedPayload,
 });
-export type ProviderRuntimeTaskCompletedEvent = typeof ProviderRuntimeTaskCompletedEvent.Type;
+type ProviderRuntimeTaskCompletedEvent = typeof ProviderRuntimeTaskCompletedEvent.Type;
 
 const ProviderRuntimeHookStartedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: HookStartedType,
   payload: HookStartedPayload,
 });
-export type ProviderRuntimeHookStartedEvent = typeof ProviderRuntimeHookStartedEvent.Type;
+type ProviderRuntimeHookStartedEvent = typeof ProviderRuntimeHookStartedEvent.Type;
 
 const ProviderRuntimeHookProgressEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: HookProgressType,
   payload: HookProgressPayload,
 });
-export type ProviderRuntimeHookProgressEvent = typeof ProviderRuntimeHookProgressEvent.Type;
+type ProviderRuntimeHookProgressEvent = typeof ProviderRuntimeHookProgressEvent.Type;
 
 const ProviderRuntimeHookCompletedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: HookCompletedType,
   payload: HookCompletedPayload,
 });
-export type ProviderRuntimeHookCompletedEvent = typeof ProviderRuntimeHookCompletedEvent.Type;
+type ProviderRuntimeHookCompletedEvent = typeof ProviderRuntimeHookCompletedEvent.Type;
 
 const ProviderRuntimeToolProgressEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ToolProgressType,
   payload: ToolProgressPayload,
 });
-export type ProviderRuntimeToolProgressEvent = typeof ProviderRuntimeToolProgressEvent.Type;
+type ProviderRuntimeToolProgressEvent = typeof ProviderRuntimeToolProgressEvent.Type;
 
 const ProviderRuntimeToolSummaryEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ToolSummaryType,
   payload: ToolSummaryPayload,
 });
-export type ProviderRuntimeToolSummaryEvent = typeof ProviderRuntimeToolSummaryEvent.Type;
+type ProviderRuntimeToolSummaryEvent = typeof ProviderRuntimeToolSummaryEvent.Type;
 
 const ProviderRuntimeAuthStatusEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: AuthStatusType,
   payload: AuthStatusPayload,
 });
-export type ProviderRuntimeAuthStatusEvent = typeof ProviderRuntimeAuthStatusEvent.Type;
+type ProviderRuntimeAuthStatusEvent = typeof ProviderRuntimeAuthStatusEvent.Type;
 
 const ProviderRuntimeAccountUpdatedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: AccountUpdatedType,
   payload: AccountUpdatedPayload,
 });
-export type ProviderRuntimeAccountUpdatedEvent = typeof ProviderRuntimeAccountUpdatedEvent.Type;
+type ProviderRuntimeAccountUpdatedEvent = typeof ProviderRuntimeAccountUpdatedEvent.Type;
 
 const ProviderRuntimeAccountRateLimitsUpdatedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: AccountRateLimitsUpdatedType,
   payload: AccountRateLimitsUpdatedPayload,
 });
-export type ProviderRuntimeAccountRateLimitsUpdatedEvent =
+type ProviderRuntimeAccountRateLimitsUpdatedEvent =
   typeof ProviderRuntimeAccountRateLimitsUpdatedEvent.Type;
 
 const ProviderRuntimeMcpStatusUpdatedEvent = Schema.Struct({
@@ -1166,67 +1159,65 @@ const ProviderRuntimeMcpStatusUpdatedEvent = Schema.Struct({
   type: McpStatusUpdatedType,
   payload: McpStatusUpdatedPayload,
 });
-export type ProviderRuntimeMcpStatusUpdatedEvent = typeof ProviderRuntimeMcpStatusUpdatedEvent.Type;
+type ProviderRuntimeMcpStatusUpdatedEvent = typeof ProviderRuntimeMcpStatusUpdatedEvent.Type;
 
 const ProviderRuntimeMcpOauthCompletedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: McpOauthCompletedType,
   payload: McpOauthCompletedPayload,
 });
-export type ProviderRuntimeMcpOauthCompletedEvent =
-  typeof ProviderRuntimeMcpOauthCompletedEvent.Type;
+type ProviderRuntimeMcpOauthCompletedEvent = typeof ProviderRuntimeMcpOauthCompletedEvent.Type;
 
 const ProviderRuntimeModelReroutedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ModelReroutedType,
   payload: ModelReroutedPayload,
 });
-export type ProviderRuntimeModelReroutedEvent = typeof ProviderRuntimeModelReroutedEvent.Type;
+type ProviderRuntimeModelReroutedEvent = typeof ProviderRuntimeModelReroutedEvent.Type;
 
 const ProviderRuntimeConfigWarningEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ConfigWarningType,
   payload: ConfigWarningPayload,
 });
-export type ProviderRuntimeConfigWarningEvent = typeof ProviderRuntimeConfigWarningEvent.Type;
+type ProviderRuntimeConfigWarningEvent = typeof ProviderRuntimeConfigWarningEvent.Type;
 
 const ProviderRuntimeDeprecationNoticeEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: DeprecationNoticeType,
   payload: DeprecationNoticePayload,
 });
-export type ProviderRuntimeDeprecationNoticeEvent =
-  typeof ProviderRuntimeDeprecationNoticeEvent.Type;
+type ProviderRuntimeDeprecationNoticeEvent = typeof ProviderRuntimeDeprecationNoticeEvent.Type;
 
 const ProviderRuntimeFilesPersistedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: FilesPersistedType,
   payload: FilesPersistedPayload,
 });
-export type ProviderRuntimeFilesPersistedEvent = typeof ProviderRuntimeFilesPersistedEvent.Type;
+type ProviderRuntimeFilesPersistedEvent = typeof ProviderRuntimeFilesPersistedEvent.Type;
 
 const ProviderRuntimeToolDeniedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ToolDeniedType,
   payload: ToolDeniedPayload,
 });
-export type ProviderRuntimeToolDeniedEvent = typeof ProviderRuntimeToolDeniedEvent.Type;
+type ProviderRuntimeToolDeniedEvent = typeof ProviderRuntimeToolDeniedEvent.Type;
 
 const ProviderRuntimeWarningEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: RuntimeWarningType,
   payload: RuntimeWarningPayload,
 });
-export type ProviderRuntimeWarningEvent = typeof ProviderRuntimeWarningEvent.Type;
+type ProviderRuntimeWarningEvent = typeof ProviderRuntimeWarningEvent.Type;
 
 const ProviderRuntimeErrorEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: RuntimeErrorType,
   payload: RuntimeErrorPayload,
 });
-export type ProviderRuntimeErrorEvent = typeof ProviderRuntimeErrorEvent.Type;
+type ProviderRuntimeErrorEvent = typeof ProviderRuntimeErrorEvent.Type;
 
-export const ProviderRuntimeEventV2 = Schema.Union([
+const ProviderRuntimeEventV2 = Schema.Union([
   ProviderRuntimeSessionStartedEvent,
   ProviderRuntimeSessionConfiguredEvent,
   ProviderRuntimeSessionStateChangedEvent,
@@ -1277,10 +1268,9 @@ export const ProviderRuntimeEventV2 = Schema.Union([
   ProviderRuntimeWarningEvent,
   ProviderRuntimeErrorEvent,
 ]);
-export type ProviderRuntimeEventV2 = typeof ProviderRuntimeEventV2.Type;
+type ProviderRuntimeEventV2 = typeof ProviderRuntimeEventV2.Type;
 
 export const ProviderRuntimeEvent = ProviderRuntimeEventV2;
 export type ProviderRuntimeEvent = ProviderRuntimeEventV2;
 
-export const ProviderRuntimeTurnStatus = RuntimeTurnState;
 export type ProviderRuntimeTurnStatus = RuntimeTurnState;

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -33,23 +33,23 @@ const RuntimeEventRawSource = Schema.Union([
 ]);
 export type RuntimeEventRawSource = typeof RuntimeEventRawSource.Type;
 
-const RuntimeEventRaw = Schema.Struct({
+export const RuntimeEventRaw = Schema.Struct({
   source: RuntimeEventRawSource,
   method: Schema.optional(TrimmedNonEmptyStringSchema),
   messageType: Schema.optional(TrimmedNonEmptyStringSchema),
   payload: Schema.Unknown,
 });
-type RuntimeEventRaw = typeof RuntimeEventRaw.Type;
+export type RuntimeEventRaw = typeof RuntimeEventRaw.Type;
 
 const ProviderRequestId = TrimmedNonEmptyStringSchema;
-type ProviderRequestId = typeof ProviderRequestId.Type;
+export type ProviderRequestId = typeof ProviderRequestId.Type;
 
 const ProviderRefs = Schema.Struct({
   providerTurnId: Schema.optional(TrimmedNonEmptyStringSchema),
   providerItemId: Schema.optional(ProviderItemId),
   providerRequestId: Schema.optional(ProviderRequestId),
 });
-type ProviderRefs = typeof ProviderRefs.Type;
+export type ProviderRefs = typeof ProviderRefs.Type;
 
 const RuntimeSessionState = Schema.Literals([
   "starting",
@@ -59,7 +59,7 @@ const RuntimeSessionState = Schema.Literals([
   "stopped",
   "error",
 ]);
-type RuntimeSessionState = typeof RuntimeSessionState.Type;
+export type RuntimeSessionState = typeof RuntimeSessionState.Type;
 
 const RuntimeThreadState = Schema.Literals([
   "active",
@@ -69,16 +69,16 @@ const RuntimeThreadState = Schema.Literals([
   "compacted",
   "error",
 ]);
-type RuntimeThreadState = typeof RuntimeThreadState.Type;
+export type RuntimeThreadState = typeof RuntimeThreadState.Type;
 
 const RuntimeTurnState = Schema.Literals(["completed", "failed", "interrupted", "cancelled"]);
-type RuntimeTurnState = typeof RuntimeTurnState.Type;
+export type RuntimeTurnState = typeof RuntimeTurnState.Type;
 
 const RuntimePlanStepStatus = Schema.Literals(["pending", "inProgress", "completed"]);
-type RuntimePlanStepStatus = typeof RuntimePlanStepStatus.Type;
+export type RuntimePlanStepStatus = typeof RuntimePlanStepStatus.Type;
 
 const RuntimeItemStatus = Schema.Literals(["inProgress", "completed", "failed", "declined"]);
-type RuntimeItemStatus = typeof RuntimeItemStatus.Type;
+export type RuntimeItemStatus = typeof RuntimeItemStatus.Type;
 
 const RuntimeContentStreamKind = Schema.Literals([
   "assistant_text",
@@ -92,7 +92,7 @@ const RuntimeContentStreamKind = Schema.Literals([
 export type RuntimeContentStreamKind = typeof RuntimeContentStreamKind.Type;
 
 const RuntimeSessionExitKind = Schema.Literals(["graceful", "error"]);
-type RuntimeSessionExitKind = typeof RuntimeSessionExitKind.Type;
+export type RuntimeSessionExitKind = typeof RuntimeSessionExitKind.Type;
 
 const RuntimeErrorClass = Schema.Literals([
   "provider_error",
@@ -101,7 +101,7 @@ const RuntimeErrorClass = Schema.Literals([
   "validation_error",
   "unknown",
 ]);
-type RuntimeErrorClass = typeof RuntimeErrorClass.Type;
+export type RuntimeErrorClass = typeof RuntimeErrorClass.Type;
 
 const TOOL_LIFECYCLE_ITEM_TYPES = [
   "command_execution",
@@ -266,37 +266,37 @@ const ProviderRuntimeEventBase = Schema.Struct({
   providerRefs: Schema.optional(ProviderRefs),
   raw: Schema.optional(RuntimeEventRaw),
 });
-type ProviderRuntimeEventBase = typeof ProviderRuntimeEventBase.Type;
+export type ProviderRuntimeEventBase = typeof ProviderRuntimeEventBase.Type;
 
 const SessionStartedPayload = Schema.Struct({
   message: Schema.optional(TrimmedNonEmptyStringSchema),
   resume: Schema.optional(Schema.Unknown),
 });
-type SessionStartedPayload = typeof SessionStartedPayload.Type;
+export type SessionStartedPayload = typeof SessionStartedPayload.Type;
 
 const SessionConfiguredPayload = Schema.Struct({
   config: UnknownRecordSchema,
 });
-type SessionConfiguredPayload = typeof SessionConfiguredPayload.Type;
+export type SessionConfiguredPayload = typeof SessionConfiguredPayload.Type;
 
 const SessionStateChangedPayload = Schema.Struct({
   state: RuntimeSessionState,
   reason: Schema.optional(TrimmedNonEmptyStringSchema),
   detail: Schema.optional(Schema.Unknown),
 });
-type SessionStateChangedPayload = typeof SessionStateChangedPayload.Type;
+export type SessionStateChangedPayload = typeof SessionStateChangedPayload.Type;
 
 const SessionExitedPayload = Schema.Struct({
   reason: Schema.optional(TrimmedNonEmptyStringSchema),
   recoverable: Schema.optional(Schema.Boolean),
   exitKind: Schema.optional(RuntimeSessionExitKind),
 });
-type SessionExitedPayload = typeof SessionExitedPayload.Type;
+export type SessionExitedPayload = typeof SessionExitedPayload.Type;
 
 const ThreadStartedPayload = Schema.Struct({
   providerThreadId: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-type ThreadStartedPayload = typeof ThreadStartedPayload.Type;
+export type ThreadStartedPayload = typeof ThreadStartedPayload.Type;
 
 const ThreadStateChangedPayload = Schema.Struct({
   state: RuntimeThreadState,
@@ -304,13 +304,13 @@ const ThreadStateChangedPayload = Schema.Struct({
   afterTokens: Schema.optional(NonNegativeInt),
   detail: Schema.optional(Schema.Unknown),
 });
-type ThreadStateChangedPayload = typeof ThreadStateChangedPayload.Type;
+export type ThreadStateChangedPayload = typeof ThreadStateChangedPayload.Type;
 
 const ThreadMetadataUpdatedPayload = Schema.Struct({
   name: Schema.optional(TrimmedNonEmptyStringSchema),
   metadata: Schema.optional(UnknownRecordSchema),
 });
-type ThreadMetadataUpdatedPayload = typeof ThreadMetadataUpdatedPayload.Type;
+export type ThreadMetadataUpdatedPayload = typeof ThreadMetadataUpdatedPayload.Type;
 
 export const ThreadTokenUsageSnapshot = Schema.Struct({
   usedTokens: NonNegativeInt,
@@ -335,38 +335,38 @@ export type ThreadTokenUsageSnapshot = typeof ThreadTokenUsageSnapshot.Type;
 const ThreadTokenUsageUpdatedPayload = Schema.Struct({
   usage: ThreadTokenUsageSnapshot,
 });
-type ThreadTokenUsageUpdatedPayload = typeof ThreadTokenUsageUpdatedPayload.Type;
+export type ThreadTokenUsageUpdatedPayload = typeof ThreadTokenUsageUpdatedPayload.Type;
 
 const ThreadRealtimeStartedPayload = Schema.Struct({
   realtimeSessionId: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-type ThreadRealtimeStartedPayload = typeof ThreadRealtimeStartedPayload.Type;
+export type ThreadRealtimeStartedPayload = typeof ThreadRealtimeStartedPayload.Type;
 
 const ThreadRealtimeItemAddedPayload = Schema.Struct({
   item: Schema.Unknown,
 });
-type ThreadRealtimeItemAddedPayload = typeof ThreadRealtimeItemAddedPayload.Type;
+export type ThreadRealtimeItemAddedPayload = typeof ThreadRealtimeItemAddedPayload.Type;
 
 const ThreadRealtimeAudioDeltaPayload = Schema.Struct({
   audio: Schema.Unknown,
 });
-type ThreadRealtimeAudioDeltaPayload = typeof ThreadRealtimeAudioDeltaPayload.Type;
+export type ThreadRealtimeAudioDeltaPayload = typeof ThreadRealtimeAudioDeltaPayload.Type;
 
 const ThreadRealtimeErrorPayload = Schema.Struct({
   message: TrimmedNonEmptyStringSchema,
 });
-type ThreadRealtimeErrorPayload = typeof ThreadRealtimeErrorPayload.Type;
+export type ThreadRealtimeErrorPayload = typeof ThreadRealtimeErrorPayload.Type;
 
 const ThreadRealtimeClosedPayload = Schema.Struct({
   reason: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-type ThreadRealtimeClosedPayload = typeof ThreadRealtimeClosedPayload.Type;
+export type ThreadRealtimeClosedPayload = typeof ThreadRealtimeClosedPayload.Type;
 
 const TurnStartedPayload = Schema.Struct({
   model: Schema.optional(TrimmedNonEmptyStringSchema),
   effort: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-type TurnStartedPayload = typeof TurnStartedPayload.Type;
+export type TurnStartedPayload = typeof TurnStartedPayload.Type;
 
 /**
  * Normalized main-agent usage for one turn. Input includes cache reads and
@@ -412,34 +412,34 @@ const TurnAbortedPayload = Schema.Struct({
   reason: TrimmedNonEmptyStringSchema,
   tokenUsage: Schema.optional(TurnTokenUsage),
 });
-type TurnAbortedPayload = typeof TurnAbortedPayload.Type;
+export type TurnAbortedPayload = typeof TurnAbortedPayload.Type;
 
 const RuntimePlanStep = Schema.Struct({
   step: TrimmedNonEmptyStringSchema,
   status: RuntimePlanStepStatus,
 });
-type RuntimePlanStep = typeof RuntimePlanStep.Type;
+export type RuntimePlanStep = typeof RuntimePlanStep.Type;
 
 const TurnPlanUpdatedPayload = Schema.Struct({
   explanation: Schema.optional(Schema.NullOr(TrimmedNonEmptyStringSchema)),
   plan: Schema.Array(RuntimePlanStep),
 });
-type TurnPlanUpdatedPayload = typeof TurnPlanUpdatedPayload.Type;
+export type TurnPlanUpdatedPayload = typeof TurnPlanUpdatedPayload.Type;
 
 const TurnProposedDeltaPayload = Schema.Struct({
   delta: Schema.String,
 });
-type TurnProposedDeltaPayload = typeof TurnProposedDeltaPayload.Type;
+export type TurnProposedDeltaPayload = typeof TurnProposedDeltaPayload.Type;
 
 const TurnProposedCompletedPayload = Schema.Struct({
   planMarkdown: TrimmedNonEmptyStringSchema,
 });
-type TurnProposedCompletedPayload = typeof TurnProposedCompletedPayload.Type;
+export type TurnProposedCompletedPayload = typeof TurnProposedCompletedPayload.Type;
 
 const TurnDiffUpdatedPayload = Schema.Struct({
   unifiedDiff: Schema.String,
 });
-type TurnDiffUpdatedPayload = typeof TurnDiffUpdatedPayload.Type;
+export type TurnDiffUpdatedPayload = typeof TurnDiffUpdatedPayload.Type;
 
 export const ToolActivitySurface = Schema.Literals(["browser", "computer"]);
 export type ToolActivitySurface = typeof ToolActivitySurface.Type;
@@ -481,7 +481,7 @@ export const ToolActivitySource = Schema.Struct({
 });
 export type ToolActivitySource = typeof ToolActivitySource.Type;
 
-const ItemLifecyclePayload = Schema.Struct({
+export const ItemLifecyclePayload = Schema.Struct({
   itemType: CanonicalItemType,
   status: Schema.optional(RuntimeItemStatus),
   title: Schema.optional(TrimmedNonEmptyStringSchema),
@@ -498,7 +498,7 @@ const ItemLifecyclePayload = Schema.Struct({
   agentId: Schema.optional(TrimmedNonEmptyStringSchema),
   parentToolUseId: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-type ItemLifecyclePayload = typeof ItemLifecyclePayload.Type;
+export type ItemLifecyclePayload = typeof ItemLifecyclePayload.Type;
 
 const ContentDeltaPayload = Schema.Struct({
   streamKind: RuntimeContentStreamKind,
@@ -506,7 +506,7 @@ const ContentDeltaPayload = Schema.Struct({
   contentIndex: Schema.optional(Schema.Int),
   summaryIndex: Schema.optional(Schema.Int),
 });
-type ContentDeltaPayload = typeof ContentDeltaPayload.Type;
+export type ContentDeltaPayload = typeof ContentDeltaPayload.Type;
 
 const RequestOpenedPayload = Schema.Struct({
   requestType: CanonicalRequestType,
@@ -515,21 +515,21 @@ const RequestOpenedPayload = Schema.Struct({
   options: Schema.optional(Schema.Array(ProviderApprovalOption)),
   args: Schema.optional(Schema.Unknown),
 });
-type RequestOpenedPayload = typeof RequestOpenedPayload.Type;
+export type RequestOpenedPayload = typeof RequestOpenedPayload.Type;
 
 const RequestResolvedPayload = Schema.Struct({
   requestType: CanonicalRequestType,
   decision: Schema.optional(TrimmedNonEmptyStringSchema),
   resolution: Schema.optional(Schema.Unknown),
 });
-type RequestResolvedPayload = typeof RequestResolvedPayload.Type;
+export type RequestResolvedPayload = typeof RequestResolvedPayload.Type;
 
 const UserInputQuestionOption = Schema.Struct({
   label: TrimmedNonEmptyStringSchema,
   description: Schema.String,
   value: Schema.optional(Schema.String),
 });
-type UserInputQuestionOption = typeof UserInputQuestionOption.Type;
+export type UserInputQuestionOption = typeof UserInputQuestionOption.Type;
 
 export const UserInputQuestion = Schema.Struct({
   id: TrimmedNonEmptyStringSchema,
@@ -552,7 +552,7 @@ export type UserInputRequestedPayload = typeof UserInputRequestedPayload.Type;
 const UserInputResolvedPayload = Schema.Struct({
   answers: UnknownRecordSchema,
 });
-type UserInputResolvedPayload = typeof UserInputResolvedPayload.Type;
+export type UserInputResolvedPayload = typeof UserInputResolvedPayload.Type;
 
 /**
  * Typed per-task usage rollup. Field names match the orchestration-v2 subagent
@@ -571,11 +571,11 @@ export const RuntimeTaskUsage = Schema.Struct({
 });
 export type RuntimeTaskUsage = typeof RuntimeTaskUsage.Type;
 
-const TaskWorkflowPhase = Schema.Struct({
+export const TaskWorkflowPhase = Schema.Struct({
   index: NonNegativeInt,
   title: TrimmedNonEmptyStringSchema,
 });
-type TaskWorkflowPhase = typeof TaskWorkflowPhase.Type;
+export type TaskWorkflowPhase = typeof TaskWorkflowPhase.Type;
 
 export const TaskRunHandles = Schema.Struct({
   runId: Schema.optional(TrimmedNonEmptyStringSchema),
@@ -677,7 +677,7 @@ const TaskStartedPayload = Schema.Struct({
   description: Schema.optional(TrimmedNonEmptyStringSchema),
   ...taskAgentLinkageFields,
 });
-type TaskStartedPayload = typeof TaskStartedPayload.Type;
+export type TaskStartedPayload = typeof TaskStartedPayload.Type;
 
 export const RuntimeTaskStatus = Schema.Literals([
   "pending",
@@ -703,7 +703,7 @@ const TaskProgressPayload = Schema.Struct({
   error: Schema.optional(TrimmedNonEmptyStringSchema),
   ...taskAgentLinkageFields,
 });
-type TaskProgressPayload = typeof TaskProgressPayload.Type;
+export type TaskProgressPayload = typeof TaskProgressPayload.Type;
 
 /**
  * Non-terminal status patch (from the Claude SDK's task_updated, which main
@@ -719,7 +719,7 @@ const TaskUpdatedPayload = Schema.Struct({
   isBackgrounded: Schema.optional(Schema.Boolean),
   ...taskAgentLinkageFields,
 });
-type TaskUpdatedPayload = typeof TaskUpdatedPayload.Type;
+export type TaskUpdatedPayload = typeof TaskUpdatedPayload.Type;
 
 const TaskCompletedPayload = Schema.Struct({
   taskId: RuntimeTaskId,
@@ -729,14 +729,14 @@ const TaskCompletedPayload = Schema.Struct({
   typedUsage: Schema.optional(RuntimeTaskUsage),
   ...taskAgentLinkageFields,
 });
-type TaskCompletedPayload = typeof TaskCompletedPayload.Type;
+export type TaskCompletedPayload = typeof TaskCompletedPayload.Type;
 
 const HookStartedPayload = Schema.Struct({
   hookId: TrimmedNonEmptyStringSchema,
   hookName: TrimmedNonEmptyStringSchema,
   hookEvent: TrimmedNonEmptyStringSchema,
 });
-type HookStartedPayload = typeof HookStartedPayload.Type;
+export type HookStartedPayload = typeof HookStartedPayload.Type;
 
 const HookProgressPayload = Schema.Struct({
   hookId: TrimmedNonEmptyStringSchema,
@@ -744,7 +744,7 @@ const HookProgressPayload = Schema.Struct({
   stdout: Schema.optional(Schema.String),
   stderr: Schema.optional(Schema.String),
 });
-type HookProgressPayload = typeof HookProgressPayload.Type;
+export type HookProgressPayload = typeof HookProgressPayload.Type;
 
 const HookCompletedPayload = Schema.Struct({
   hookId: TrimmedNonEmptyStringSchema,
@@ -754,7 +754,7 @@ const HookCompletedPayload = Schema.Struct({
   stderr: Schema.optional(Schema.String),
   exitCode: Schema.optional(Schema.Int),
 });
-type HookCompletedPayload = typeof HookCompletedPayload.Type;
+export type HookCompletedPayload = typeof HookCompletedPayload.Type;
 
 const ToolProgressPayload = Schema.Struct({
   toolUseId: Schema.optional(TrimmedNonEmptyStringSchema),
@@ -765,25 +765,25 @@ const ToolProgressPayload = Schema.Struct({
   taskId: Schema.optional(RuntimeTaskId),
   parentToolUseId: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-type ToolProgressPayload = typeof ToolProgressPayload.Type;
+export type ToolProgressPayload = typeof ToolProgressPayload.Type;
 
 const ToolSummaryPayload = Schema.Struct({
   summary: TrimmedNonEmptyStringSchema,
   precedingToolUseIds: Schema.optional(Schema.Array(TrimmedNonEmptyStringSchema)),
 });
-type ToolSummaryPayload = typeof ToolSummaryPayload.Type;
+export type ToolSummaryPayload = typeof ToolSummaryPayload.Type;
 
 const AuthStatusPayload = Schema.Struct({
   isAuthenticating: Schema.optional(Schema.Boolean),
   output: Schema.optional(Schema.Array(Schema.String)),
   error: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-type AuthStatusPayload = typeof AuthStatusPayload.Type;
+export type AuthStatusPayload = typeof AuthStatusPayload.Type;
 
 const AccountUpdatedPayload = Schema.Struct({
   account: Schema.Unknown,
 });
-type AccountUpdatedPayload = typeof AccountUpdatedPayload.Type;
+export type AccountUpdatedPayload = typeof AccountUpdatedPayload.Type;
 
 /**
  * Adapters normalise their native rate-limit payload at the boundary so the
@@ -792,26 +792,26 @@ type AccountUpdatedPayload = typeof AccountUpdatedPayload.Type;
 const AccountRateLimitsUpdatedPayload = Schema.Struct({
   limits: ProviderUsageLimitsUpdate,
 });
-type AccountRateLimitsUpdatedPayload = typeof AccountRateLimitsUpdatedPayload.Type;
+export type AccountRateLimitsUpdatedPayload = typeof AccountRateLimitsUpdatedPayload.Type;
 
 const McpStatusUpdatedPayload = Schema.Struct({
   status: Schema.Unknown,
 });
-type McpStatusUpdatedPayload = typeof McpStatusUpdatedPayload.Type;
+export type McpStatusUpdatedPayload = typeof McpStatusUpdatedPayload.Type;
 
 const McpOauthCompletedPayload = Schema.Struct({
   success: Schema.Boolean,
   name: Schema.optional(TrimmedNonEmptyStringSchema),
   error: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-type McpOauthCompletedPayload = typeof McpOauthCompletedPayload.Type;
+export type McpOauthCompletedPayload = typeof McpOauthCompletedPayload.Type;
 
 const ModelReroutedPayload = Schema.Struct({
   fromModel: TrimmedNonEmptyStringSchema,
   toModel: TrimmedNonEmptyStringSchema,
   reason: TrimmedNonEmptyStringSchema,
 });
-type ModelReroutedPayload = typeof ModelReroutedPayload.Type;
+export type ModelReroutedPayload = typeof ModelReroutedPayload.Type;
 
 const ConfigWarningPayload = Schema.Struct({
   summary: TrimmedNonEmptyStringSchema,
@@ -819,13 +819,13 @@ const ConfigWarningPayload = Schema.Struct({
   path: Schema.optional(TrimmedNonEmptyStringSchema),
   range: Schema.optional(Schema.Unknown),
 });
-type ConfigWarningPayload = typeof ConfigWarningPayload.Type;
+export type ConfigWarningPayload = typeof ConfigWarningPayload.Type;
 
 const DeprecationNoticePayload = Schema.Struct({
   summary: TrimmedNonEmptyStringSchema,
   details: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-type DeprecationNoticePayload = typeof DeprecationNoticePayload.Type;
+export type DeprecationNoticePayload = typeof DeprecationNoticePayload.Type;
 
 const FilesPersistedPayload = Schema.Struct({
   files: Schema.Array(
@@ -843,7 +843,7 @@ const FilesPersistedPayload = Schema.Struct({
     ),
   ),
 });
-type FilesPersistedPayload = typeof FilesPersistedPayload.Type;
+export type FilesPersistedPayload = typeof FilesPersistedPayload.Type;
 
 const ToolDeniedPayload = Schema.Struct({
   toolName: TrimmedNonEmptyStringSchema,
@@ -851,69 +851,72 @@ const ToolDeniedPayload = Schema.Struct({
   reason: Schema.optional(TrimmedNonEmptyStringSchema),
   agentId: Schema.optional(TrimmedNonEmptyStringSchema),
 });
-type ToolDeniedPayload = typeof ToolDeniedPayload.Type;
+export type ToolDeniedPayload = typeof ToolDeniedPayload.Type;
 
 const RuntimeWarningPayload = Schema.Struct({
   message: TrimmedNonEmptyStringSchema,
   detail: Schema.optional(Schema.Unknown),
 });
-type RuntimeWarningPayload = typeof RuntimeWarningPayload.Type;
+export type RuntimeWarningPayload = typeof RuntimeWarningPayload.Type;
 
 const RuntimeErrorPayload = Schema.Struct({
   message: TrimmedNonEmptyStringSchema,
   class: Schema.optional(RuntimeErrorClass),
   detail: Schema.optional(Schema.Unknown),
 });
-type RuntimeErrorPayload = typeof RuntimeErrorPayload.Type;
+export type RuntimeErrorPayload = typeof RuntimeErrorPayload.Type;
 
 const ProviderRuntimeSessionStartedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: SessionStartedType,
   payload: SessionStartedPayload,
 });
-type ProviderRuntimeSessionStartedEvent = typeof ProviderRuntimeSessionStartedEvent.Type;
+export type ProviderRuntimeSessionStartedEvent = typeof ProviderRuntimeSessionStartedEvent.Type;
 
 const ProviderRuntimeSessionConfiguredEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: SessionConfiguredType,
   payload: SessionConfiguredPayload,
 });
-type ProviderRuntimeSessionConfiguredEvent = typeof ProviderRuntimeSessionConfiguredEvent.Type;
+export type ProviderRuntimeSessionConfiguredEvent =
+  typeof ProviderRuntimeSessionConfiguredEvent.Type;
 
 const ProviderRuntimeSessionStateChangedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: SessionStateChangedType,
   payload: SessionStateChangedPayload,
 });
-type ProviderRuntimeSessionStateChangedEvent = typeof ProviderRuntimeSessionStateChangedEvent.Type;
+export type ProviderRuntimeSessionStateChangedEvent =
+  typeof ProviderRuntimeSessionStateChangedEvent.Type;
 
 const ProviderRuntimeSessionExitedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: SessionExitedType,
   payload: SessionExitedPayload,
 });
-type ProviderRuntimeSessionExitedEvent = typeof ProviderRuntimeSessionExitedEvent.Type;
+export type ProviderRuntimeSessionExitedEvent = typeof ProviderRuntimeSessionExitedEvent.Type;
 
 const ProviderRuntimeThreadStartedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ThreadStartedType,
   payload: ThreadStartedPayload,
 });
-type ProviderRuntimeThreadStartedEvent = typeof ProviderRuntimeThreadStartedEvent.Type;
+export type ProviderRuntimeThreadStartedEvent = typeof ProviderRuntimeThreadStartedEvent.Type;
 
 const ProviderRuntimeThreadStateChangedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ThreadStateChangedType,
   payload: ThreadStateChangedPayload,
 });
-type ProviderRuntimeThreadStateChangedEvent = typeof ProviderRuntimeThreadStateChangedEvent.Type;
+export type ProviderRuntimeThreadStateChangedEvent =
+  typeof ProviderRuntimeThreadStateChangedEvent.Type;
 
 const ProviderRuntimeThreadMetadataUpdatedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ThreadMetadataUpdatedType,
   payload: ThreadMetadataUpdatedPayload,
 });
-type ProviderRuntimeThreadMetadataUpdatedEvent =
+export type ProviderRuntimeThreadMetadataUpdatedEvent =
   typeof ProviderRuntimeThreadMetadataUpdatedEvent.Type;
 
 const ProviderRuntimeThreadTokenUsageUpdatedEvent = Schema.Struct({
@@ -921,7 +924,7 @@ const ProviderRuntimeThreadTokenUsageUpdatedEvent = Schema.Struct({
   type: ThreadTokenUsageUpdatedType,
   payload: ThreadTokenUsageUpdatedPayload,
 });
-type ProviderRuntimeThreadTokenUsageUpdatedEvent =
+export type ProviderRuntimeThreadTokenUsageUpdatedEvent =
   typeof ProviderRuntimeThreadTokenUsageUpdatedEvent.Type;
 
 const ProviderRuntimeThreadRealtimeStartedEvent = Schema.Struct({
@@ -929,7 +932,7 @@ const ProviderRuntimeThreadRealtimeStartedEvent = Schema.Struct({
   type: ThreadRealtimeStartedType,
   payload: ThreadRealtimeStartedPayload,
 });
-type ProviderRuntimeThreadRealtimeStartedEvent =
+export type ProviderRuntimeThreadRealtimeStartedEvent =
   typeof ProviderRuntimeThreadRealtimeStartedEvent.Type;
 
 const ProviderRuntimeThreadRealtimeItemAddedEvent = Schema.Struct({
@@ -937,7 +940,7 @@ const ProviderRuntimeThreadRealtimeItemAddedEvent = Schema.Struct({
   type: ThreadRealtimeItemAddedType,
   payload: ThreadRealtimeItemAddedPayload,
 });
-type ProviderRuntimeThreadRealtimeItemAddedEvent =
+export type ProviderRuntimeThreadRealtimeItemAddedEvent =
   typeof ProviderRuntimeThreadRealtimeItemAddedEvent.Type;
 
 const ProviderRuntimeThreadRealtimeAudioDeltaEvent = Schema.Struct({
@@ -945,7 +948,7 @@ const ProviderRuntimeThreadRealtimeAudioDeltaEvent = Schema.Struct({
   type: ThreadRealtimeAudioDeltaType,
   payload: ThreadRealtimeAudioDeltaPayload,
 });
-type ProviderRuntimeThreadRealtimeAudioDeltaEvent =
+export type ProviderRuntimeThreadRealtimeAudioDeltaEvent =
   typeof ProviderRuntimeThreadRealtimeAudioDeltaEvent.Type;
 
 const ProviderRuntimeThreadRealtimeErrorEvent = Schema.Struct({
@@ -953,14 +956,15 @@ const ProviderRuntimeThreadRealtimeErrorEvent = Schema.Struct({
   type: ThreadRealtimeErrorType,
   payload: ThreadRealtimeErrorPayload,
 });
-type ProviderRuntimeThreadRealtimeErrorEvent = typeof ProviderRuntimeThreadRealtimeErrorEvent.Type;
+export type ProviderRuntimeThreadRealtimeErrorEvent =
+  typeof ProviderRuntimeThreadRealtimeErrorEvent.Type;
 
 const ProviderRuntimeThreadRealtimeClosedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ThreadRealtimeClosedType,
   payload: ThreadRealtimeClosedPayload,
 });
-type ProviderRuntimeThreadRealtimeClosedEvent =
+export type ProviderRuntimeThreadRealtimeClosedEvent =
   typeof ProviderRuntimeThreadRealtimeClosedEvent.Type;
 
 const ProviderRuntimeTurnStartedEvent = Schema.Struct({
@@ -968,42 +972,43 @@ const ProviderRuntimeTurnStartedEvent = Schema.Struct({
   type: TurnStartedType,
   payload: TurnStartedPayload,
 });
-type ProviderRuntimeTurnStartedEvent = typeof ProviderRuntimeTurnStartedEvent.Type;
+export type ProviderRuntimeTurnStartedEvent = typeof ProviderRuntimeTurnStartedEvent.Type;
 
 const ProviderRuntimeTurnCompletedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TurnCompletedType,
   payload: TurnCompletedPayload,
 });
-type ProviderRuntimeTurnCompletedEvent = typeof ProviderRuntimeTurnCompletedEvent.Type;
+export type ProviderRuntimeTurnCompletedEvent = typeof ProviderRuntimeTurnCompletedEvent.Type;
 
 const ProviderRuntimeTurnAbortedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TurnAbortedType,
   payload: TurnAbortedPayload,
 });
-type ProviderRuntimeTurnAbortedEvent = typeof ProviderRuntimeTurnAbortedEvent.Type;
+export type ProviderRuntimeTurnAbortedEvent = typeof ProviderRuntimeTurnAbortedEvent.Type;
 
 const ProviderRuntimeTurnPlanUpdatedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TurnPlanUpdatedType,
   payload: TurnPlanUpdatedPayload,
 });
-type ProviderRuntimeTurnPlanUpdatedEvent = typeof ProviderRuntimeTurnPlanUpdatedEvent.Type;
+export type ProviderRuntimeTurnPlanUpdatedEvent = typeof ProviderRuntimeTurnPlanUpdatedEvent.Type;
 
 const ProviderRuntimeTurnProposedDeltaEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TurnProposedDeltaType,
   payload: TurnProposedDeltaPayload,
 });
-type ProviderRuntimeTurnProposedDeltaEvent = typeof ProviderRuntimeTurnProposedDeltaEvent.Type;
+export type ProviderRuntimeTurnProposedDeltaEvent =
+  typeof ProviderRuntimeTurnProposedDeltaEvent.Type;
 
 const ProviderRuntimeTurnProposedCompletedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TurnProposedCompletedType,
   payload: TurnProposedCompletedPayload,
 });
-type ProviderRuntimeTurnProposedCompletedEvent =
+export type ProviderRuntimeTurnProposedCompletedEvent =
   typeof ProviderRuntimeTurnProposedCompletedEvent.Type;
 
 const ProviderRuntimeTurnDiffUpdatedEvent = Schema.Struct({
@@ -1011,147 +1016,149 @@ const ProviderRuntimeTurnDiffUpdatedEvent = Schema.Struct({
   type: TurnDiffUpdatedType,
   payload: TurnDiffUpdatedPayload,
 });
-type ProviderRuntimeTurnDiffUpdatedEvent = typeof ProviderRuntimeTurnDiffUpdatedEvent.Type;
+export type ProviderRuntimeTurnDiffUpdatedEvent = typeof ProviderRuntimeTurnDiffUpdatedEvent.Type;
 
 const ProviderRuntimeItemStartedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ItemStartedType,
   payload: ItemLifecyclePayload,
 });
-type ProviderRuntimeItemStartedEvent = typeof ProviderRuntimeItemStartedEvent.Type;
+export type ProviderRuntimeItemStartedEvent = typeof ProviderRuntimeItemStartedEvent.Type;
 
 const ProviderRuntimeItemUpdatedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ItemUpdatedType,
   payload: ItemLifecyclePayload,
 });
-type ProviderRuntimeItemUpdatedEvent = typeof ProviderRuntimeItemUpdatedEvent.Type;
+export type ProviderRuntimeItemUpdatedEvent = typeof ProviderRuntimeItemUpdatedEvent.Type;
 
 const ProviderRuntimeItemCompletedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ItemCompletedType,
   payload: ItemLifecyclePayload,
 });
-type ProviderRuntimeItemCompletedEvent = typeof ProviderRuntimeItemCompletedEvent.Type;
+export type ProviderRuntimeItemCompletedEvent = typeof ProviderRuntimeItemCompletedEvent.Type;
 
 const ProviderRuntimeContentDeltaEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ContentDeltaType,
   payload: ContentDeltaPayload,
 });
-type ProviderRuntimeContentDeltaEvent = typeof ProviderRuntimeContentDeltaEvent.Type;
+export type ProviderRuntimeContentDeltaEvent = typeof ProviderRuntimeContentDeltaEvent.Type;
 
 const ProviderRuntimeRequestOpenedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: RequestOpenedType,
   payload: RequestOpenedPayload,
 });
-type ProviderRuntimeRequestOpenedEvent = typeof ProviderRuntimeRequestOpenedEvent.Type;
+export type ProviderRuntimeRequestOpenedEvent = typeof ProviderRuntimeRequestOpenedEvent.Type;
 
 const ProviderRuntimeRequestResolvedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: RequestResolvedType,
   payload: RequestResolvedPayload,
 });
-type ProviderRuntimeRequestResolvedEvent = typeof ProviderRuntimeRequestResolvedEvent.Type;
+export type ProviderRuntimeRequestResolvedEvent = typeof ProviderRuntimeRequestResolvedEvent.Type;
 
 const ProviderRuntimeUserInputRequestedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: UserInputRequestedType,
   payload: UserInputRequestedPayload,
 });
-type ProviderRuntimeUserInputRequestedEvent = typeof ProviderRuntimeUserInputRequestedEvent.Type;
+export type ProviderRuntimeUserInputRequestedEvent =
+  typeof ProviderRuntimeUserInputRequestedEvent.Type;
 
 const ProviderRuntimeUserInputResolvedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: UserInputResolvedType,
   payload: UserInputResolvedPayload,
 });
-type ProviderRuntimeUserInputResolvedEvent = typeof ProviderRuntimeUserInputResolvedEvent.Type;
+export type ProviderRuntimeUserInputResolvedEvent =
+  typeof ProviderRuntimeUserInputResolvedEvent.Type;
 
 const ProviderRuntimeTaskStartedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TaskStartedType,
   payload: TaskStartedPayload,
 });
-type ProviderRuntimeTaskStartedEvent = typeof ProviderRuntimeTaskStartedEvent.Type;
+export type ProviderRuntimeTaskStartedEvent = typeof ProviderRuntimeTaskStartedEvent.Type;
 
 const ProviderRuntimeTaskProgressEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TaskProgressType,
   payload: TaskProgressPayload,
 });
-type ProviderRuntimeTaskProgressEvent = typeof ProviderRuntimeTaskProgressEvent.Type;
+export type ProviderRuntimeTaskProgressEvent = typeof ProviderRuntimeTaskProgressEvent.Type;
 
 const ProviderRuntimeTaskUpdatedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TaskUpdatedType,
   payload: TaskUpdatedPayload,
 });
-type ProviderRuntimeTaskUpdatedEvent = typeof ProviderRuntimeTaskUpdatedEvent.Type;
+export type ProviderRuntimeTaskUpdatedEvent = typeof ProviderRuntimeTaskUpdatedEvent.Type;
 
 const ProviderRuntimeTaskCompletedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: TaskCompletedType,
   payload: TaskCompletedPayload,
 });
-type ProviderRuntimeTaskCompletedEvent = typeof ProviderRuntimeTaskCompletedEvent.Type;
+export type ProviderRuntimeTaskCompletedEvent = typeof ProviderRuntimeTaskCompletedEvent.Type;
 
 const ProviderRuntimeHookStartedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: HookStartedType,
   payload: HookStartedPayload,
 });
-type ProviderRuntimeHookStartedEvent = typeof ProviderRuntimeHookStartedEvent.Type;
+export type ProviderRuntimeHookStartedEvent = typeof ProviderRuntimeHookStartedEvent.Type;
 
 const ProviderRuntimeHookProgressEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: HookProgressType,
   payload: HookProgressPayload,
 });
-type ProviderRuntimeHookProgressEvent = typeof ProviderRuntimeHookProgressEvent.Type;
+export type ProviderRuntimeHookProgressEvent = typeof ProviderRuntimeHookProgressEvent.Type;
 
 const ProviderRuntimeHookCompletedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: HookCompletedType,
   payload: HookCompletedPayload,
 });
-type ProviderRuntimeHookCompletedEvent = typeof ProviderRuntimeHookCompletedEvent.Type;
+export type ProviderRuntimeHookCompletedEvent = typeof ProviderRuntimeHookCompletedEvent.Type;
 
 const ProviderRuntimeToolProgressEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ToolProgressType,
   payload: ToolProgressPayload,
 });
-type ProviderRuntimeToolProgressEvent = typeof ProviderRuntimeToolProgressEvent.Type;
+export type ProviderRuntimeToolProgressEvent = typeof ProviderRuntimeToolProgressEvent.Type;
 
 const ProviderRuntimeToolSummaryEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ToolSummaryType,
   payload: ToolSummaryPayload,
 });
-type ProviderRuntimeToolSummaryEvent = typeof ProviderRuntimeToolSummaryEvent.Type;
+export type ProviderRuntimeToolSummaryEvent = typeof ProviderRuntimeToolSummaryEvent.Type;
 
 const ProviderRuntimeAuthStatusEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: AuthStatusType,
   payload: AuthStatusPayload,
 });
-type ProviderRuntimeAuthStatusEvent = typeof ProviderRuntimeAuthStatusEvent.Type;
+export type ProviderRuntimeAuthStatusEvent = typeof ProviderRuntimeAuthStatusEvent.Type;
 
 const ProviderRuntimeAccountUpdatedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: AccountUpdatedType,
   payload: AccountUpdatedPayload,
 });
-type ProviderRuntimeAccountUpdatedEvent = typeof ProviderRuntimeAccountUpdatedEvent.Type;
+export type ProviderRuntimeAccountUpdatedEvent = typeof ProviderRuntimeAccountUpdatedEvent.Type;
 
 const ProviderRuntimeAccountRateLimitsUpdatedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: AccountRateLimitsUpdatedType,
   payload: AccountRateLimitsUpdatedPayload,
 });
-type ProviderRuntimeAccountRateLimitsUpdatedEvent =
+export type ProviderRuntimeAccountRateLimitsUpdatedEvent =
   typeof ProviderRuntimeAccountRateLimitsUpdatedEvent.Type;
 
 const ProviderRuntimeMcpStatusUpdatedEvent = Schema.Struct({
@@ -1159,65 +1166,67 @@ const ProviderRuntimeMcpStatusUpdatedEvent = Schema.Struct({
   type: McpStatusUpdatedType,
   payload: McpStatusUpdatedPayload,
 });
-type ProviderRuntimeMcpStatusUpdatedEvent = typeof ProviderRuntimeMcpStatusUpdatedEvent.Type;
+export type ProviderRuntimeMcpStatusUpdatedEvent = typeof ProviderRuntimeMcpStatusUpdatedEvent.Type;
 
 const ProviderRuntimeMcpOauthCompletedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: McpOauthCompletedType,
   payload: McpOauthCompletedPayload,
 });
-type ProviderRuntimeMcpOauthCompletedEvent = typeof ProviderRuntimeMcpOauthCompletedEvent.Type;
+export type ProviderRuntimeMcpOauthCompletedEvent =
+  typeof ProviderRuntimeMcpOauthCompletedEvent.Type;
 
 const ProviderRuntimeModelReroutedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ModelReroutedType,
   payload: ModelReroutedPayload,
 });
-type ProviderRuntimeModelReroutedEvent = typeof ProviderRuntimeModelReroutedEvent.Type;
+export type ProviderRuntimeModelReroutedEvent = typeof ProviderRuntimeModelReroutedEvent.Type;
 
 const ProviderRuntimeConfigWarningEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ConfigWarningType,
   payload: ConfigWarningPayload,
 });
-type ProviderRuntimeConfigWarningEvent = typeof ProviderRuntimeConfigWarningEvent.Type;
+export type ProviderRuntimeConfigWarningEvent = typeof ProviderRuntimeConfigWarningEvent.Type;
 
 const ProviderRuntimeDeprecationNoticeEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: DeprecationNoticeType,
   payload: DeprecationNoticePayload,
 });
-type ProviderRuntimeDeprecationNoticeEvent = typeof ProviderRuntimeDeprecationNoticeEvent.Type;
+export type ProviderRuntimeDeprecationNoticeEvent =
+  typeof ProviderRuntimeDeprecationNoticeEvent.Type;
 
 const ProviderRuntimeFilesPersistedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: FilesPersistedType,
   payload: FilesPersistedPayload,
 });
-type ProviderRuntimeFilesPersistedEvent = typeof ProviderRuntimeFilesPersistedEvent.Type;
+export type ProviderRuntimeFilesPersistedEvent = typeof ProviderRuntimeFilesPersistedEvent.Type;
 
 const ProviderRuntimeToolDeniedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ToolDeniedType,
   payload: ToolDeniedPayload,
 });
-type ProviderRuntimeToolDeniedEvent = typeof ProviderRuntimeToolDeniedEvent.Type;
+export type ProviderRuntimeToolDeniedEvent = typeof ProviderRuntimeToolDeniedEvent.Type;
 
 const ProviderRuntimeWarningEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: RuntimeWarningType,
   payload: RuntimeWarningPayload,
 });
-type ProviderRuntimeWarningEvent = typeof ProviderRuntimeWarningEvent.Type;
+export type ProviderRuntimeWarningEvent = typeof ProviderRuntimeWarningEvent.Type;
 
 const ProviderRuntimeErrorEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: RuntimeErrorType,
   payload: RuntimeErrorPayload,
 });
-type ProviderRuntimeErrorEvent = typeof ProviderRuntimeErrorEvent.Type;
+export type ProviderRuntimeErrorEvent = typeof ProviderRuntimeErrorEvent.Type;
 
-const ProviderRuntimeEventV2 = Schema.Union([
+export const ProviderRuntimeEventV2 = Schema.Union([
   ProviderRuntimeSessionStartedEvent,
   ProviderRuntimeSessionConfiguredEvent,
   ProviderRuntimeSessionStateChangedEvent,
@@ -1268,9 +1277,10 @@ const ProviderRuntimeEventV2 = Schema.Union([
   ProviderRuntimeWarningEvent,
   ProviderRuntimeErrorEvent,
 ]);
-type ProviderRuntimeEventV2 = typeof ProviderRuntimeEventV2.Type;
+export type ProviderRuntimeEventV2 = typeof ProviderRuntimeEventV2.Type;
 
 export const ProviderRuntimeEvent = ProviderRuntimeEventV2;
 export type ProviderRuntimeEvent = ProviderRuntimeEventV2;
 
+export const ProviderRuntimeTurnStatus = RuntimeTurnState;
 export type ProviderRuntimeTurnStatus = RuntimeTurnState;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -194,7 +194,6 @@ import {
   ServerProviderUpdateInput,
   ServerLifecycleStreamEvent,
   ServerRemoveKeybindingInput,
-  ServerRemoveKeybindingResult,
   ServerProviderUpdatedPayload,
   ServerSelfUpdateError,
   ServerSelfUpdateInput,
@@ -378,31 +377,31 @@ export const WS_METHODS = {
   subscribeResourceTelemetry: "subscribeResourceTelemetry",
 } as const;
 
-export const WsServerUpsertKeybindingRpc = Rpc.make(WS_METHODS.serverUpsertKeybinding, {
+const WsServerUpsertKeybindingRpc = Rpc.make(WS_METHODS.serverUpsertKeybinding, {
   payload: ServerUpsertKeybindingInput,
   success: ServerUpsertKeybindingResult,
   error: Schema.Union([KeybindingsConfigError, EnvironmentAuthorizationError]),
 });
 
-export const WsServerRemoveKeybindingRpc = Rpc.make(WS_METHODS.serverRemoveKeybinding, {
+const WsServerRemoveKeybindingRpc = Rpc.make(WS_METHODS.serverRemoveKeybinding, {
   payload: ServerRemoveKeybindingInput,
-  success: ServerRemoveKeybindingResult,
+  success: ServerUpsertKeybindingResult,
   error: Schema.Union([KeybindingsConfigError, EnvironmentAuthorizationError]),
 });
 
-export const WsServerProbeRpc = Rpc.make(WS_METHODS.serverProbe, {
+const WsServerProbeRpc = Rpc.make(WS_METHODS.serverProbe, {
   payload: Schema.Struct({}),
   success: Schema.Struct({}),
   error: EnvironmentAuthorizationError,
 });
 
-export const WsServerGetConfigRpc = Rpc.make(WS_METHODS.serverGetConfig, {
+const WsServerGetConfigRpc = Rpc.make(WS_METHODS.serverGetConfig, {
   payload: Schema.Struct({}),
   success: ServerConfig,
   error: Schema.Union([KeybindingsConfigError, ServerSettingsError, EnvironmentAuthorizationError]),
 });
 
-export const WsServerRefreshProvidersRpc = Rpc.make(WS_METHODS.serverRefreshProviders, {
+const WsServerRefreshProvidersRpc = Rpc.make(WS_METHODS.serverRefreshProviders, {
   payload: Schema.Struct({
     /**
      * When supplied, only refresh this specific provider instance. When
@@ -419,7 +418,7 @@ export const WsServerRefreshProvidersRpc = Rpc.make(WS_METHODS.serverRefreshProv
   error: Schema.Union([EnvironmentAuthorizationError, ProviderSetupError]),
 });
 
-export const WsServerUpdateProviderRpc = Rpc.make(WS_METHODS.serverUpdateProvider, {
+const WsServerUpdateProviderRpc = Rpc.make(WS_METHODS.serverUpdateProvider, {
   payload: ServerProviderUpdateInput,
   success: ServerProviderUpdatedPayload,
   error: Schema.Union([ServerProviderUpdateError, EnvironmentAuthorizationError]),
@@ -427,130 +426,124 @@ export const WsServerUpdateProviderRpc = Rpc.make(WS_METHODS.serverUpdateProvide
 
 const ProviderSetupRpcError = Schema.Union([ProviderSetupError, EnvironmentAuthorizationError]);
 
-export const WsProviderConsumeResetCreditRpc = Rpc.make(WS_METHODS.providerConsumeResetCredit, {
+const WsProviderConsumeResetCreditRpc = Rpc.make(WS_METHODS.providerConsumeResetCredit, {
   payload: ProviderConsumeResetCreditInput,
   success: ProviderConsumeResetCreditResult,
   error: ProviderSetupRpcError,
 });
 
-export const WsProviderAuthStartRpc = Rpc.make(WS_METHODS.providerAuthStart, {
+const WsProviderAuthStartRpc = Rpc.make(WS_METHODS.providerAuthStart, {
   payload: ProviderSetupInput,
   success: ProviderAuthState,
   error: ProviderSetupRpcError,
 });
 
-export const WsProviderAuthCompleteRpc = Rpc.make(WS_METHODS.providerAuthComplete, {
+const WsProviderAuthCompleteRpc = Rpc.make(WS_METHODS.providerAuthComplete, {
   payload: ProviderAuthCompleteInput,
   success: ProviderAuthState,
   error: ProviderSetupRpcError,
 });
 
-export const WsProviderAuthCancelRpc = Rpc.make(WS_METHODS.providerAuthCancel, {
+const WsProviderAuthCancelRpc = Rpc.make(WS_METHODS.providerAuthCancel, {
   payload: ProviderAuthCancelInput,
   success: ProviderAuthState,
   error: ProviderSetupRpcError,
 });
 
-export const WsProviderAuthLogoutRpc = Rpc.make(WS_METHODS.providerAuthLogout, {
+const WsProviderAuthLogoutRpc = Rpc.make(WS_METHODS.providerAuthLogout, {
   payload: ProviderSetupInput,
   success: ProviderAuthState,
   error: ProviderSetupRpcError,
 });
 
-export const WsProviderAuthSubscribeRpc = Rpc.make(WS_METHODS.providerAuthSubscribe, {
+const WsProviderAuthSubscribeRpc = Rpc.make(WS_METHODS.providerAuthSubscribe, {
   payload: ProviderSetupInput,
   success: ProviderAuthState,
   error: ProviderSetupRpcError,
   stream: true,
 });
 
-export const WsProviderInstallStartRpc = Rpc.make(WS_METHODS.providerInstallStart, {
+const WsProviderInstallStartRpc = Rpc.make(WS_METHODS.providerInstallStart, {
   payload: ProviderSetupInput,
   success: ProviderInstallState,
   error: ProviderSetupRpcError,
 });
 
-export const WsProviderInstallCancelRpc = Rpc.make(WS_METHODS.providerInstallCancel, {
+const WsProviderInstallCancelRpc = Rpc.make(WS_METHODS.providerInstallCancel, {
   payload: ProviderInstallCancelInput,
   success: ProviderInstallState,
   error: ProviderSetupRpcError,
 });
 
-export const WsProviderInstallSubscribeRpc = Rpc.make(WS_METHODS.providerInstallSubscribe, {
+const WsProviderInstallSubscribeRpc = Rpc.make(WS_METHODS.providerInstallSubscribe, {
   payload: ProviderSetupInput,
   success: ProviderInstallState,
   error: ProviderSetupRpcError,
   stream: true,
 });
 
-export const WsProviderInstallRemoveRpc = Rpc.make(WS_METHODS.providerInstallRemove, {
+const WsProviderInstallRemoveRpc = Rpc.make(WS_METHODS.providerInstallRemove, {
   payload: ProviderSetupInput,
   success: ProviderInstallState,
   error: ProviderSetupRpcError,
 });
 
-export const WsServerUpdateServerRpc = Rpc.make(WS_METHODS.serverUpdateServer, {
+const WsServerUpdateServerRpc = Rpc.make(WS_METHODS.serverUpdateServer, {
   payload: ServerSelfUpdateInput,
   success: ServerSelfUpdateResult,
   error: Schema.Union([ServerSelfUpdateError, EnvironmentAuthorizationError]),
 });
 
-export const WsServerUpdateServerWithProgressRpc = Rpc.make(
-  WS_METHODS.serverUpdateServerWithProgress,
-  {
-    payload: ServerSelfUpdateInput,
-    success: ServerSelfUpdateProgressEvent,
-    error: Schema.Union([ServerSelfUpdateError, EnvironmentAuthorizationError]),
-    stream: true,
-  },
-);
+const WsServerUpdateServerWithProgressRpc = Rpc.make(WS_METHODS.serverUpdateServerWithProgress, {
+  payload: ServerSelfUpdateInput,
+  success: ServerSelfUpdateProgressEvent,
+  error: Schema.Union([ServerSelfUpdateError, EnvironmentAuthorizationError]),
+  stream: true,
+});
 
-export const WsServerCommitDesktopUpdateRpc = Rpc.make(WS_METHODS.serverCommitDesktopUpdate, {
+const WsServerCommitDesktopUpdateRpc = Rpc.make(WS_METHODS.serverCommitDesktopUpdate, {
   payload: DesktopUpdateCommitInput,
   success: ServerSelfUpdateResult,
   error: Schema.Union([ServerSelfUpdateError, EnvironmentAuthorizationError]),
 });
 
-export const WsServerGetSettingsRpc = Rpc.make(WS_METHODS.serverGetSettings, {
+const WsServerGetSettingsRpc = Rpc.make(WS_METHODS.serverGetSettings, {
   payload: Schema.Struct({}),
   success: ServerSettings,
   error: Schema.Union([ServerSettingsError, EnvironmentAuthorizationError]),
 });
 
-export const WsServerUpdateSettingsRpc = Rpc.make(WS_METHODS.serverUpdateSettings, {
+const WsServerUpdateSettingsRpc = Rpc.make(WS_METHODS.serverUpdateSettings, {
   payload: Schema.Struct({ patch: ServerSettingsPatch }),
   success: ServerSettings,
   error: Schema.Union([ServerSettingsError, EnvironmentAuthorizationError]),
 });
 
-export const WsServerDiscoverSourceControlRpc = Rpc.make(WS_METHODS.serverDiscoverSourceControl, {
+const WsServerDiscoverSourceControlRpc = Rpc.make(WS_METHODS.serverDiscoverSourceControl, {
   payload: Schema.Struct({}),
   success: SourceControlDiscoveryResult,
   error: EnvironmentAuthorizationError,
 });
 
-export const WsServerGetTraceDiagnosticsRpc = Rpc.make(WS_METHODS.serverGetTraceDiagnostics, {
+const WsServerGetTraceDiagnosticsRpc = Rpc.make(WS_METHODS.serverGetTraceDiagnostics, {
   payload: Schema.Struct({}),
   success: ServerTraceDiagnosticsResult,
   error: EnvironmentAuthorizationError,
 });
 
-export const WsServerGetProcessDiagnosticsRpc = Rpc.make(WS_METHODS.serverGetProcessDiagnostics, {
+const WsServerGetProcessDiagnosticsRpc = Rpc.make(WS_METHODS.serverGetProcessDiagnostics, {
   payload: Schema.Struct({}),
   success: ServerProcessDiagnosticsResult,
   error: EnvironmentAuthorizationError,
 });
 
-export const WsServerGetProcessResourceHistoryRpc = Rpc.make(
-  WS_METHODS.serverGetProcessResourceHistory,
-  {
-    payload: ServerProcessResourceHistoryInput,
-    success: ServerProcessResourceHistoryResult,
-    error: EnvironmentAuthorizationError,
-  },
-);
+const WsServerGetProcessResourceHistoryRpc = Rpc.make(WS_METHODS.serverGetProcessResourceHistory, {
+  payload: ServerProcessResourceHistoryInput,
+  success: ServerProcessResourceHistoryResult,
+  error: EnvironmentAuthorizationError,
+});
 
-export const WsServerGetResourceTelemetryHistoryRpc = Rpc.make(
+const WsServerGetResourceTelemetryHistoryRpc = Rpc.make(
   WS_METHODS.serverGetResourceTelemetryHistory,
   {
     payload: ResourceTelemetryHistoryInput,
@@ -559,13 +552,13 @@ export const WsServerGetResourceTelemetryHistoryRpc = Rpc.make(
   },
 );
 
-export const WsServerRetryResourceTelemetryRpc = Rpc.make(WS_METHODS.serverRetryResourceTelemetry, {
+const WsServerRetryResourceTelemetryRpc = Rpc.make(WS_METHODS.serverRetryResourceTelemetry, {
   payload: Schema.Struct({}),
   success: ResourceTelemetryRetryResult,
   error: EnvironmentAuthorizationError,
 });
 
-export const WsServerGetUsageSummaryRpc = Rpc.make(WS_METHODS.serverGetUsageSummary, {
+const WsServerGetUsageSummaryRpc = Rpc.make(WS_METHODS.serverGetUsageSummary, {
   payload: UsageSummaryInput,
   success: UsageSummary,
   error: Schema.Union([EnvironmentAuthorizationError, UsageReadError]),
@@ -575,42 +568,42 @@ export const WsServerGetUsageSummaryRpc = Rpc.make(WS_METHODS.serverGetUsageSumm
  * Refetches the model rate table ahead of its daily TTL, so a model released
  * since the last fetch gets priced. The next usage summary uses the new table.
  */
-export const WsServerRefreshUsageRatesRpc = Rpc.make(WS_METHODS.serverRefreshUsageRates, {
+const WsServerRefreshUsageRatesRpc = Rpc.make(WS_METHODS.serverRefreshUsageRates, {
   payload: Schema.Struct({}),
   success: UsagePricing,
   error: EnvironmentAuthorizationError,
 });
 
-export const WsServerSignalProcessRpc = Rpc.make(WS_METHODS.serverSignalProcess, {
+const WsServerSignalProcessRpc = Rpc.make(WS_METHODS.serverSignalProcess, {
   payload: ServerSignalProcessInput,
   success: ServerSignalProcessResult,
   error: EnvironmentAuthorizationError,
 });
 
-export const WsCloudGetRelayClientStatusRpc = Rpc.make(WS_METHODS.cloudGetRelayClientStatus, {
+const WsCloudGetRelayClientStatusRpc = Rpc.make(WS_METHODS.cloudGetRelayClientStatus, {
   payload: Schema.Struct({}),
   success: RelayClientStatusSchema,
   error: EnvironmentAuthorizationError,
 });
 
-export const WsCloudInstallRelayClientRpc = Rpc.make(WS_METHODS.cloudInstallRelayClient, {
+const WsCloudInstallRelayClientRpc = Rpc.make(WS_METHODS.cloudInstallRelayClient, {
   payload: Schema.Struct({}),
   success: RelayClientInstallProgressEventSchema,
   error: Schema.Union([RelayClientInstallFailedError, EnvironmentAuthorizationError]),
   stream: true,
 });
 
-export const WsServerReportClientActivityRpc = Rpc.make(WS_METHODS.serverReportClientActivity, {
+const WsServerReportClientActivityRpc = Rpc.make(WS_METHODS.serverReportClientActivity, {
   payload: ClientActivityReportInput,
   error: EnvironmentAuthorizationError,
 });
 
-export const WsServerReportHostPowerStateRpc = Rpc.make(WS_METHODS.serverReportHostPowerState, {
+const WsServerReportHostPowerStateRpc = Rpc.make(WS_METHODS.serverReportHostPowerState, {
   payload: HostPowerSnapshot,
   error: EnvironmentAuthorizationError,
 });
 
-export const WsServerGetBackgroundPolicyRpc = Rpc.make(WS_METHODS.serverGetBackgroundPolicy, {
+const WsServerGetBackgroundPolicyRpc = Rpc.make(WS_METHODS.serverGetBackgroundPolicy, {
   payload: Schema.Struct({}),
   success: BackgroundPolicySnapshot,
   error: EnvironmentAuthorizationError,
@@ -622,7 +615,7 @@ const PullRequestRpcError = Schema.Union([
   EnvironmentAuthorizationError,
 ]);
 
-export const WsPullRequestsListRpc = Rpc.make(WS_METHODS.pullRequestsList, {
+const WsPullRequestsListRpc = Rpc.make(WS_METHODS.pullRequestsList, {
   payload: PullRequestListInput,
   success: PullRequestListResult,
   error: PullRequestRpcError,
@@ -633,214 +626,199 @@ export const WsPullRequestsListRpc = Rpc.make(WS_METHODS.pullRequestsList, {
  * 40-60% of the listing read that answers everything else on the row, so the rows arrive first
  * and their stats a moment later.
  */
-export const WsPullRequestsListStatsRpc = Rpc.make(WS_METHODS.pullRequestsListStats, {
+const WsPullRequestsListStatsRpc = Rpc.make(WS_METHODS.pullRequestsListStats, {
   payload: PullRequestListStatsInput,
   success: PullRequestListStatsResult,
   error: PullRequestRpcError,
 });
 
-export const WsPullRequestsSummaryRpc = Rpc.make(WS_METHODS.pullRequestsSummary, {
+const WsPullRequestsSummaryRpc = Rpc.make(WS_METHODS.pullRequestsSummary, {
   payload: PullRequestRef,
   success: PullRequestSummary,
   error: PullRequestRpcError,
 });
 
-export const WsPullRequestsDetailRpc = Rpc.make(WS_METHODS.pullRequestsDetail, {
+const WsPullRequestsDetailRpc = Rpc.make(WS_METHODS.pullRequestsDetail, {
   payload: PullRequestRef,
   success: PullRequestDetail,
   error: PullRequestRpcError,
 });
 
-export const WsPullRequestsActivityRpc = Rpc.make(WS_METHODS.pullRequestsActivity, {
+const WsPullRequestsActivityRpc = Rpc.make(WS_METHODS.pullRequestsActivity, {
   payload: PullRequestRef,
   success: PullRequestActivity,
   error: PullRequestRpcError,
 });
 
-export const WsPullRequestsThreadCommentsRpc = Rpc.make(WS_METHODS.pullRequestsThreadComments, {
+const WsPullRequestsThreadCommentsRpc = Rpc.make(WS_METHODS.pullRequestsThreadComments, {
   payload: PullRequestThreadCommentsInput,
   success: PullRequestThreadCommentsResult,
   error: PullRequestRpcError,
 });
 
-export const WsPullRequestsDiffFileContentsRpc = Rpc.make(WS_METHODS.pullRequestsDiffFileContents, {
+const WsPullRequestsDiffFileContentsRpc = Rpc.make(WS_METHODS.pullRequestsDiffFileContents, {
   payload: PullRequestDiffFileContentsInput,
   success: PullRequestDiffFileContentsResult,
   error: PullRequestRpcError,
 });
 
-export const WsPullRequestsRunActionRpc = Rpc.make(WS_METHODS.pullRequestsRunAction, {
+const WsPullRequestsRunActionRpc = Rpc.make(WS_METHODS.pullRequestsRunAction, {
   payload: PullRequestActionInput,
   success: Schema.Void,
   error: PullRequestRpcError,
 });
 
-export const WsPullRequestsUpdateRpc = Rpc.make(WS_METHODS.pullRequestsUpdate, {
+const WsPullRequestsUpdateRpc = Rpc.make(WS_METHODS.pullRequestsUpdate, {
   payload: PullRequestUpdateInput,
   success: Schema.Void,
   error: PullRequestRpcError,
 });
 
-export const WsPullRequestsCommentRpc = Rpc.make(WS_METHODS.pullRequestsComment, {
+const WsPullRequestsCommentRpc = Rpc.make(WS_METHODS.pullRequestsComment, {
   payload: PullRequestCommentInput,
   success: Schema.Void,
   error: PullRequestRpcError,
 });
 
-export const WsPullRequestsUpdateCommentRpc = Rpc.make(WS_METHODS.pullRequestsUpdateComment, {
+const WsPullRequestsUpdateCommentRpc = Rpc.make(WS_METHODS.pullRequestsUpdateComment, {
   payload: PullRequestCommentUpdateInput,
   success: Schema.Void,
   error: PullRequestRpcError,
 });
 
-export const WsPullRequestsSubmitReviewRpc = Rpc.make(WS_METHODS.pullRequestsSubmitReview, {
+const WsPullRequestsSubmitReviewRpc = Rpc.make(WS_METHODS.pullRequestsSubmitReview, {
   payload: PullRequestSubmitReviewInput,
   success: Schema.Void,
   error: PullRequestRpcError,
 });
 
-export const WsPullRequestsReplyToThreadRpc = Rpc.make(WS_METHODS.pullRequestsReplyToThread, {
+const WsPullRequestsReplyToThreadRpc = Rpc.make(WS_METHODS.pullRequestsReplyToThread, {
   payload: PullRequestThreadReplyInput,
   success: Schema.Void,
   error: PullRequestRpcError,
 });
 
-export const WsPullRequestsSetThreadResolutionRpc = Rpc.make(
-  WS_METHODS.pullRequestsSetThreadResolution,
-  {
-    payload: PullRequestThreadResolutionInput,
-    success: Schema.Void,
-    error: PullRequestRpcError,
-  },
-);
+const WsPullRequestsSetThreadResolutionRpc = Rpc.make(WS_METHODS.pullRequestsSetThreadResolution, {
+  payload: PullRequestThreadResolutionInput,
+  success: Schema.Void,
+  error: PullRequestRpcError,
+});
 
-export const WsPullRequestsSetReactionRpc = Rpc.make(WS_METHODS.pullRequestsSetReaction, {
+const WsPullRequestsSetReactionRpc = Rpc.make(WS_METHODS.pullRequestsSetReaction, {
   payload: PullRequestReactionInput,
   success: Schema.Void,
   error: PullRequestRpcError,
 });
 
-export const WsPullRequestsInvalidateRpc = Rpc.make(WS_METHODS.pullRequestsInvalidate, {
+const WsPullRequestsInvalidateRpc = Rpc.make(WS_METHODS.pullRequestsInvalidate, {
   payload: PullRequestInvalidateInput,
   success: Schema.Void,
   error: PullRequestRpcError,
 });
 
-export const WsPullRequestsSubscribeRefreshesRpc = Rpc.make(
-  WS_METHODS.pullRequestsSubscribeRefreshes,
-  {
-    payload: Schema.Struct({}),
-    success: NonNegativeInt,
-    error: EnvironmentAuthorizationError,
-    stream: true,
-  },
-);
+const WsPullRequestsSubscribeRefreshesRpc = Rpc.make(WS_METHODS.pullRequestsSubscribeRefreshes, {
+  payload: Schema.Struct({}),
+  success: NonNegativeInt,
+  error: EnvironmentAuthorizationError,
+  stream: true,
+});
 
 /**
  * Read on its own rather than as part of the detail: the people who may be asked are only wanted
  * once somebody opens the menu, and reading them with every change request would spend a request
  * per host on a list nobody looked at.
  */
-export const WsPullRequestsReviewerCandidatesRpc = Rpc.make(
-  WS_METHODS.pullRequestsReviewerCandidates,
-  {
-    payload: PullRequestRef,
-    success: PullRequestReviewerCandidateList,
-    error: PullRequestRpcError,
-  },
-);
+const WsPullRequestsReviewerCandidatesRpc = Rpc.make(WS_METHODS.pullRequestsReviewerCandidates, {
+  payload: PullRequestRef,
+  success: PullRequestReviewerCandidateList,
+  error: PullRequestRpcError,
+});
 
-export const WsPullRequestsRequestReviewersRpc = Rpc.make(WS_METHODS.pullRequestsRequestReviewers, {
+const WsPullRequestsRequestReviewersRpc = Rpc.make(WS_METHODS.pullRequestsRequestReviewers, {
   payload: PullRequestReviewerRequestInput,
   success: Schema.Void,
   error: PullRequestRpcError,
 });
 
 /** Read when the label menu opens, for the same reason the reviewer candidates are. */
-export const WsPullRequestsLabelCandidatesRpc = Rpc.make(WS_METHODS.pullRequestsLabelCandidates, {
+const WsPullRequestsLabelCandidatesRpc = Rpc.make(WS_METHODS.pullRequestsLabelCandidates, {
   payload: PullRequestRef,
   success: PullRequestLabelCandidateList,
   error: PullRequestRpcError,
 });
 
-export const WsPullRequestsSetLabelsRpc = Rpc.make(WS_METHODS.pullRequestsSetLabels, {
+const WsPullRequestsSetLabelsRpc = Rpc.make(WS_METHODS.pullRequestsSetLabels, {
   payload: PullRequestLabelChangeInput,
   success: Schema.Void,
   error: PullRequestRpcError,
 });
 
-export const WsSourceControlLookupRepositoryRpc = Rpc.make(
-  WS_METHODS.sourceControlLookupRepository,
-  {
-    payload: SourceControlRepositoryLookupInput,
-    success: SourceControlRepositoryInfo,
-    error: Schema.Union([SourceControlRepositoryError, EnvironmentAuthorizationError]),
-  },
-);
+const WsSourceControlLookupRepositoryRpc = Rpc.make(WS_METHODS.sourceControlLookupRepository, {
+  payload: SourceControlRepositoryLookupInput,
+  success: SourceControlRepositoryInfo,
+  error: Schema.Union([SourceControlRepositoryError, EnvironmentAuthorizationError]),
+});
 
-export const WsSourceControlCloneRepositoryRpc = Rpc.make(WS_METHODS.sourceControlCloneRepository, {
+const WsSourceControlCloneRepositoryRpc = Rpc.make(WS_METHODS.sourceControlCloneRepository, {
   payload: SourceControlCloneRepositoryInput,
   success: SourceControlCloneRepositoryResult,
   error: Schema.Union([SourceControlRepositoryError, EnvironmentAuthorizationError]),
 });
 
-export const WsSourceControlPublishRepositoryRpc = Rpc.make(
-  WS_METHODS.sourceControlPublishRepository,
-  {
-    payload: SourceControlPublishRepositoryInput,
-    success: SourceControlPublishRepositoryResult,
-    error: Schema.Union([SourceControlRepositoryError, EnvironmentAuthorizationError]),
-  },
-);
+const WsSourceControlPublishRepositoryRpc = Rpc.make(WS_METHODS.sourceControlPublishRepository, {
+  payload: SourceControlPublishRepositoryInput,
+  success: SourceControlPublishRepositoryResult,
+  error: Schema.Union([SourceControlRepositoryError, EnvironmentAuthorizationError]),
+});
 
-export const WsProjectsSearchEntriesRpc = Rpc.make(WS_METHODS.projectsSearchEntries, {
+const WsProjectsSearchEntriesRpc = Rpc.make(WS_METHODS.projectsSearchEntries, {
   payload: ProjectSearchEntriesInput,
   success: ProjectSearchEntriesResult,
   error: Schema.Union([ProjectSearchEntriesError, EnvironmentAuthorizationError]),
 });
 
-export const WsProjectsSearchContentsRpc = Rpc.make(WS_METHODS.projectsSearchContents, {
+const WsProjectsSearchContentsRpc = Rpc.make(WS_METHODS.projectsSearchContents, {
   payload: ProjectSearchContentsInput,
   success: ProjectSearchContentsResult,
   error: Schema.Union([ProjectSearchContentsError, EnvironmentAuthorizationError]),
 });
 
-export const WsProjectsListEntriesRpc = Rpc.make(WS_METHODS.projectsListEntries, {
+const WsProjectsListEntriesRpc = Rpc.make(WS_METHODS.projectsListEntries, {
   payload: ProjectListEntriesInput,
   success: ProjectListEntriesResult,
   error: Schema.Union([ProjectListEntriesError, EnvironmentAuthorizationError]),
 });
 
-export const WsProjectsReadFileRpc = Rpc.make(WS_METHODS.projectsReadFile, {
+const WsProjectsReadFileRpc = Rpc.make(WS_METHODS.projectsReadFile, {
   payload: ProjectReadFileInput,
   success: ProjectReadFileResult,
   error: Schema.Union([ProjectReadFileError, EnvironmentAuthorizationError]),
 });
 
-export const WsProjectsWriteFileRpc = Rpc.make(WS_METHODS.projectsWriteFile, {
+const WsProjectsWriteFileRpc = Rpc.make(WS_METHODS.projectsWriteFile, {
   payload: ProjectWriteFileInput,
   success: ProjectWriteFileResult,
   error: Schema.Union([ProjectWriteFileError, EnvironmentAuthorizationError]),
 });
 
-export const WsShellOpenInEditorRpc = Rpc.make(WS_METHODS.shellOpenInEditor, {
+const WsShellOpenInEditorRpc = Rpc.make(WS_METHODS.shellOpenInEditor, {
   payload: LaunchEditorInput,
   error: Schema.Union([ExternalLauncherError, EnvironmentAuthorizationError]),
 });
 
-export const WsFilesystemBrowseRpc = Rpc.make(WS_METHODS.filesystemBrowse, {
+const WsFilesystemBrowseRpc = Rpc.make(WS_METHODS.filesystemBrowse, {
   payload: FilesystemBrowseInput,
   success: FilesystemBrowseResult,
   error: Schema.Union([FilesystemBrowseError, EnvironmentAuthorizationError]),
 });
 
-export const WsAgentSessionsScanRpc = Rpc.make(WS_METHODS.agentSessionsScan, {
+const WsAgentSessionsScanRpc = Rpc.make(WS_METHODS.agentSessionsScan, {
   payload: AgentSessionScanInput,
   success: AgentSessionScanResult,
   error: Schema.Union([AgentSessionScanError, EnvironmentAuthorizationError]),
 });
 
-export const WsAgentSessionsImportRpc = Rpc.make(WS_METHODS.agentSessionsImport, {
+const WsAgentSessionsImportRpc = Rpc.make(WS_METHODS.agentSessionsImport, {
   payload: AgentSessionImportInput,
   success: AgentSessionImportResult,
   error: Schema.Union([
@@ -851,97 +829,97 @@ export const WsAgentSessionsImportRpc = Rpc.make(WS_METHODS.agentSessionsImport,
   ]),
 });
 
-export const WsAssetsCreateUrlRpc = Rpc.make(WS_METHODS.assetsCreateUrl, {
+const WsAssetsCreateUrlRpc = Rpc.make(WS_METHODS.assetsCreateUrl, {
   payload: AssetCreateUrlInput,
   success: AssetCreateUrlResult,
   error: Schema.Union([AssetAccessError, EnvironmentAuthorizationError]),
 });
 
-export const WsAttachmentsCreateUploadUrlRpc = Rpc.make(WS_METHODS.attachmentsCreateUploadUrl, {
+const WsAttachmentsCreateUploadUrlRpc = Rpc.make(WS_METHODS.attachmentsCreateUploadUrl, {
   payload: AttachmentCreateUploadUrlInput,
   success: AttachmentCreateUploadUrlResult,
   error: Schema.Union([AttachmentUploadSigningKeyError, EnvironmentAuthorizationError]),
 });
 
-export const WsAttachmentsDeleteRpc = Rpc.make(WS_METHODS.attachmentsDelete, {
+const WsAttachmentsDeleteRpc = Rpc.make(WS_METHODS.attachmentsDelete, {
   payload: AttachmentDeleteInput,
   error: EnvironmentAuthorizationError,
 });
 
-export const WsProviderUploadFeedbackRpc = Rpc.make(WS_METHODS.providerUploadFeedback, {
+const WsProviderUploadFeedbackRpc = Rpc.make(WS_METHODS.providerUploadFeedback, {
   payload: ProviderUploadFeedbackInput,
   success: ProviderUploadFeedbackResult,
   error: Schema.Union([ProviderUploadFeedbackError, EnvironmentAuthorizationError]),
 });
 
-export const WsSubscribeVcsStatusRpc = Rpc.make(WS_METHODS.subscribeVcsStatus, {
+const WsSubscribeVcsStatusRpc = Rpc.make(WS_METHODS.subscribeVcsStatus, {
   payload: VcsStatusInput,
   success: VcsStatusStreamEvent,
   error: Schema.Union([GitManagerServiceError, EnvironmentAuthorizationError]),
   stream: true,
 });
 
-export const WsVcsPullRpc = Rpc.make(WS_METHODS.vcsPull, {
+const WsVcsPullRpc = Rpc.make(WS_METHODS.vcsPull, {
   payload: VcsPullInput,
   success: VcsPullResult,
   error: Schema.Union([GitCommandError, EnvironmentAuthorizationError]),
 });
 
-export const WsVcsRefreshStatusRpc = Rpc.make(WS_METHODS.vcsRefreshStatus, {
+const WsVcsRefreshStatusRpc = Rpc.make(WS_METHODS.vcsRefreshStatus, {
   payload: VcsStatusInput,
   success: VcsStatusResult,
   error: Schema.Union([GitManagerServiceError, EnvironmentAuthorizationError]),
 });
 
-export const WsGitRunStackedActionRpc = Rpc.make(WS_METHODS.gitRunStackedAction, {
+const WsGitRunStackedActionRpc = Rpc.make(WS_METHODS.gitRunStackedAction, {
   payload: GitRunStackedActionInput,
   success: GitActionProgressEvent,
   error: Schema.Union([GitManagerServiceError, EnvironmentAuthorizationError]),
   stream: true,
 });
 
-export const WsGitResolvePullRequestRpc = Rpc.make(WS_METHODS.gitResolvePullRequest, {
+const WsGitResolvePullRequestRpc = Rpc.make(WS_METHODS.gitResolvePullRequest, {
   payload: GitPullRequestRefInput,
   success: GitResolvePullRequestResult,
   error: Schema.Union([GitManagerServiceError, EnvironmentAuthorizationError]),
 });
 
-export const WsGitPreparePullRequestThreadRpc = Rpc.make(WS_METHODS.gitPreparePullRequestThread, {
+const WsGitPreparePullRequestThreadRpc = Rpc.make(WS_METHODS.gitPreparePullRequestThread, {
   payload: GitPreparePullRequestThreadInput,
   success: GitPreparePullRequestThreadResult,
   error: Schema.Union([GitManagerServiceError, EnvironmentAuthorizationError]),
 });
 
-export const WsVcsListRefsRpc = Rpc.make(WS_METHODS.vcsListRefs, {
+const WsVcsListRefsRpc = Rpc.make(WS_METHODS.vcsListRefs, {
   payload: VcsListRefsInput,
   success: VcsListRefsResult,
   error: Schema.Union([GitCommandError, EnvironmentAuthorizationError]),
 });
 
-export const WsVcsCreateWorktreeRpc = Rpc.make(WS_METHODS.vcsCreateWorktree, {
+const WsVcsCreateWorktreeRpc = Rpc.make(WS_METHODS.vcsCreateWorktree, {
   payload: VcsCreateWorktreeInput,
   success: VcsCreateWorktreeResult,
   error: Schema.Union([GitCommandError, EnvironmentAuthorizationError]),
 });
 
-export const WsVcsRemoveWorktreeRpc = Rpc.make(WS_METHODS.vcsRemoveWorktree, {
+const WsVcsRemoveWorktreeRpc = Rpc.make(WS_METHODS.vcsRemoveWorktree, {
   payload: VcsRemoveWorktreeInput,
   error: Schema.Union([GitCommandError, EnvironmentAuthorizationError]),
 });
 
-export const WsVcsCreateRefRpc = Rpc.make(WS_METHODS.vcsCreateRef, {
+const WsVcsCreateRefRpc = Rpc.make(WS_METHODS.vcsCreateRef, {
   payload: VcsCreateRefInput,
   success: VcsCreateRefResult,
   error: Schema.Union([GitCommandError, EnvironmentAuthorizationError]),
 });
 
-export const WsVcsSwitchRefRpc = Rpc.make(WS_METHODS.vcsSwitchRef, {
+const WsVcsSwitchRefRpc = Rpc.make(WS_METHODS.vcsSwitchRef, {
   payload: VcsSwitchRefInput,
   success: VcsSwitchRefResult,
   error: Schema.Union([GitCommandError, EnvironmentAuthorizationError]),
 });
 
-export const WsVcsInitRpc = Rpc.make(WS_METHODS.vcsInit, {
+const WsVcsInitRpc = Rpc.make(WS_METHODS.vcsInit, {
   payload: VcsInitInput,
   error: Schema.Union([VcsError, EnvironmentAuthorizationError]),
 });
@@ -951,172 +929,160 @@ export const WsVcsInitRpc = Rpc.make(WS_METHODS.vcsInit, {
  * Not the persisted T3 Review model. Future review sessions should use
  * review.open* + review.getSnapshot.
  */
-export const WsReviewGetDiffPreviewRpc = Rpc.make(WS_METHODS.reviewGetDiffPreview, {
+const WsReviewGetDiffPreviewRpc = Rpc.make(WS_METHODS.reviewGetDiffPreview, {
   payload: ReviewDiffPreviewInput,
   success: ReviewDiffPreviewResult,
   error: Schema.Union([ReviewDiffPreviewError, EnvironmentAuthorizationError]),
 });
 
-export const WsReviewGetDiffFileContentsRpc = Rpc.make(WS_METHODS.reviewGetDiffFileContents, {
+const WsReviewGetDiffFileContentsRpc = Rpc.make(WS_METHODS.reviewGetDiffFileContents, {
   payload: ReviewDiffFileContentsInput,
   success: ReviewDiffFileContentsResult,
   error: Schema.Union([ReviewDiffPreviewError, EnvironmentAuthorizationError]),
 });
 
-export const WsTerminalOpenRpc = Rpc.make(WS_METHODS.terminalOpen, {
+const WsTerminalOpenRpc = Rpc.make(WS_METHODS.terminalOpen, {
   payload: TerminalOpenInput,
   success: TerminalSessionSnapshot,
   error: Schema.Union([TerminalError, EnvironmentAuthorizationError]),
 });
 
-export const WsTerminalAttachRpc = Rpc.make(WS_METHODS.terminalAttach, {
+const WsTerminalAttachRpc = Rpc.make(WS_METHODS.terminalAttach, {
   payload: TerminalAttachInput,
   success: TerminalAttachStreamEvent,
   error: Schema.Union([TerminalError, EnvironmentAuthorizationError]),
   stream: true,
 });
 
-export const WsTerminalWriteRpc = Rpc.make(WS_METHODS.terminalWrite, {
+const WsTerminalWriteRpc = Rpc.make(WS_METHODS.terminalWrite, {
   payload: TerminalWriteInput,
   error: Schema.Union([TerminalError, EnvironmentAuthorizationError]),
 });
 
-export const WsTerminalResizeRpc = Rpc.make(WS_METHODS.terminalResize, {
+const WsTerminalResizeRpc = Rpc.make(WS_METHODS.terminalResize, {
   payload: TerminalResizeInput,
   error: Schema.Union([TerminalError, EnvironmentAuthorizationError]),
 });
 
-export const WsTerminalClearRpc = Rpc.make(WS_METHODS.terminalClear, {
+const WsTerminalClearRpc = Rpc.make(WS_METHODS.terminalClear, {
   payload: TerminalClearInput,
   error: Schema.Union([TerminalError, EnvironmentAuthorizationError]),
 });
 
-export const WsTerminalRestartRpc = Rpc.make(WS_METHODS.terminalRestart, {
+const WsTerminalRestartRpc = Rpc.make(WS_METHODS.terminalRestart, {
   payload: TerminalRestartInput,
   success: TerminalSessionSnapshot,
   error: Schema.Union([TerminalError, EnvironmentAuthorizationError]),
 });
 
-export const WsTerminalCloseRpc = Rpc.make(WS_METHODS.terminalClose, {
+const WsTerminalCloseRpc = Rpc.make(WS_METHODS.terminalClose, {
   payload: TerminalCloseInput,
   error: Schema.Union([TerminalError, EnvironmentAuthorizationError]),
 });
 
-export const WsPreviewOpenRpc = Rpc.make(WS_METHODS.previewOpen, {
+const WsPreviewOpenRpc = Rpc.make(WS_METHODS.previewOpen, {
   payload: PreviewOpenInput,
   success: PreviewSessionSnapshot,
   error: Schema.Union([PreviewError, EnvironmentAuthorizationError]),
 });
 
-export const WsPreviewNavigateRpc = Rpc.make(WS_METHODS.previewNavigate, {
+const WsPreviewNavigateRpc = Rpc.make(WS_METHODS.previewNavigate, {
   payload: PreviewNavigateInput,
   success: PreviewSessionSnapshot,
   error: Schema.Union([PreviewError, EnvironmentAuthorizationError]),
 });
 
-export const WsPreviewResizeRpc = Rpc.make(WS_METHODS.previewResize, {
+const WsPreviewResizeRpc = Rpc.make(WS_METHODS.previewResize, {
   payload: PreviewResizeInput,
   success: PreviewSessionSnapshot,
   error: Schema.Union([PreviewError, EnvironmentAuthorizationError]),
 });
 
-export const WsPreviewRefreshRpc = Rpc.make(WS_METHODS.previewRefresh, {
+const WsPreviewRefreshRpc = Rpc.make(WS_METHODS.previewRefresh, {
   payload: PreviewRefreshInput,
   error: Schema.Union([PreviewError, EnvironmentAuthorizationError]),
 });
 
-export const WsPreviewCloseRpc = Rpc.make(WS_METHODS.previewClose, {
+const WsPreviewCloseRpc = Rpc.make(WS_METHODS.previewClose, {
   payload: PreviewCloseInput,
   error: Schema.Union([PreviewError, EnvironmentAuthorizationError]),
 });
 
-export const WsPreviewListRpc = Rpc.make(WS_METHODS.previewList, {
+const WsPreviewListRpc = Rpc.make(WS_METHODS.previewList, {
   payload: PreviewListInput,
   success: PreviewListResult,
   error: EnvironmentAuthorizationError,
 });
 
-export const WsPreviewReportStatusRpc = Rpc.make(WS_METHODS.previewReportStatus, {
+const WsPreviewReportStatusRpc = Rpc.make(WS_METHODS.previewReportStatus, {
   payload: PreviewReportStatusInput,
   error: Schema.Union([PreviewError, EnvironmentAuthorizationError]),
 });
 
-export const WsPreviewAutomationConnectRpc = Rpc.make(WS_METHODS.previewAutomationConnect, {
+const WsPreviewAutomationConnectRpc = Rpc.make(WS_METHODS.previewAutomationConnect, {
   payload: PreviewAutomationHost,
   success: PreviewAutomationStreamEvent,
   error: Schema.Union([PreviewAutomationError, EnvironmentAuthorizationError]),
   stream: true,
 });
 
-export const WsPreviewAutomationRespondRpc = Rpc.make(WS_METHODS.previewAutomationRespond, {
+const WsPreviewAutomationRespondRpc = Rpc.make(WS_METHODS.previewAutomationRespond, {
   payload: PreviewAutomationResponse,
   error: Schema.Union([PreviewAutomationError, EnvironmentAuthorizationError]),
 });
 
-export const WsPreviewAutomationFocusHostRpc = Rpc.make(WS_METHODS.previewAutomationFocusHost, {
+const WsPreviewAutomationFocusHostRpc = Rpc.make(WS_METHODS.previewAutomationFocusHost, {
   payload: PreviewAutomationHostFocus,
   error: EnvironmentAuthorizationError,
 });
 
-export const WsSubscribePreviewEventsRpc = Rpc.make(WS_METHODS.subscribePreviewEvents, {
+const WsSubscribePreviewEventsRpc = Rpc.make(WS_METHODS.subscribePreviewEvents, {
   payload: Schema.Struct({}),
   success: PreviewEvent,
   error: EnvironmentAuthorizationError,
   stream: true,
 });
 
-export const WsSubscribeDiscoveredLocalServersRpc = Rpc.make(
-  WS_METHODS.subscribeDiscoveredLocalServers,
-  {
-    payload: Schema.Struct({
-      configuredUrls: Schema.optional(ConfiguredLocalServerUrls),
-    }),
-    success: DiscoveredLocalServerList,
-    error: EnvironmentAuthorizationError,
-    stream: true,
-  },
-);
+const WsSubscribeDiscoveredLocalServersRpc = Rpc.make(WS_METHODS.subscribeDiscoveredLocalServers, {
+  payload: Schema.Struct({
+    configuredUrls: Schema.optional(ConfiguredLocalServerUrls),
+  }),
+  success: DiscoveredLocalServerList,
+  error: EnvironmentAuthorizationError,
+  stream: true,
+});
 
-export const WsOrchestrationDispatchCommandRpc = Rpc.make(
-  ORCHESTRATION_WS_METHODS.dispatchCommand,
-  {
-    payload: ClientOrchestrationCommand,
-    success: OrchestrationRpcSchemas.dispatchCommand.output,
-    error: Schema.Union([OrchestrationDispatchCommandError, EnvironmentAuthorizationError]),
-  },
-);
+const WsOrchestrationDispatchCommandRpc = Rpc.make(ORCHESTRATION_WS_METHODS.dispatchCommand, {
+  payload: ClientOrchestrationCommand,
+  success: OrchestrationRpcSchemas.dispatchCommand.output,
+  error: Schema.Union([OrchestrationDispatchCommandError, EnvironmentAuthorizationError]),
+});
 
-export const WsOrchestrationGetWorkflowScriptRpc = Rpc.make(
-  ORCHESTRATION_WS_METHODS.getWorkflowScript,
-  {
-    payload: OrchestrationRpcSchemas.getWorkflowScript.input,
-    success: OrchestrationRpcSchemas.getWorkflowScript.output,
-    error: Schema.Union([OrchestrationGetWorkflowScriptError, EnvironmentAuthorizationError]),
-  },
-);
+const WsOrchestrationGetWorkflowScriptRpc = Rpc.make(ORCHESTRATION_WS_METHODS.getWorkflowScript, {
+  payload: OrchestrationRpcSchemas.getWorkflowScript.input,
+  success: OrchestrationRpcSchemas.getWorkflowScript.output,
+  error: Schema.Union([OrchestrationGetWorkflowScriptError, EnvironmentAuthorizationError]),
+});
 
-export const WsOrchestrationGetTurnDiffRpc = Rpc.make(ORCHESTRATION_WS_METHODS.getTurnDiff, {
+const WsOrchestrationGetTurnDiffRpc = Rpc.make(ORCHESTRATION_WS_METHODS.getTurnDiff, {
   payload: OrchestrationGetTurnDiffInput,
   success: OrchestrationRpcSchemas.getTurnDiff.output,
   error: Schema.Union([OrchestrationGetTurnDiffError, EnvironmentAuthorizationError]),
 });
 
-export const WsOrchestrationGetFullThreadDiffRpc = Rpc.make(
-  ORCHESTRATION_WS_METHODS.getFullThreadDiff,
-  {
-    payload: OrchestrationGetFullThreadDiffInput,
-    success: OrchestrationRpcSchemas.getFullThreadDiff.output,
-    error: Schema.Union([OrchestrationGetFullThreadDiffError, EnvironmentAuthorizationError]),
-  },
-);
+const WsOrchestrationGetFullThreadDiffRpc = Rpc.make(ORCHESTRATION_WS_METHODS.getFullThreadDiff, {
+  payload: OrchestrationGetFullThreadDiffInput,
+  success: OrchestrationRpcSchemas.getFullThreadDiff.output,
+  error: Schema.Union([OrchestrationGetFullThreadDiffError, EnvironmentAuthorizationError]),
+});
 
-export const WsOrchestrationSearchThreadsRpc = Rpc.make(ORCHESTRATION_WS_METHODS.searchThreads, {
+const WsOrchestrationSearchThreadsRpc = Rpc.make(ORCHESTRATION_WS_METHODS.searchThreads, {
   payload: OrchestrationSearchThreadsInput,
   success: OrchestrationRpcSchemas.searchThreads.output,
   error: Schema.Union([OrchestrationSearchThreadsError, EnvironmentAuthorizationError]),
 });
 
-export const WsOrchestrationGetArchivedShellSnapshotRpc = Rpc.make(
+const WsOrchestrationGetArchivedShellSnapshotRpc = Rpc.make(
   ORCHESTRATION_WS_METHODS.getArchivedShellSnapshot,
   {
     payload: OrchestrationRpcSchemas.getArchivedShellSnapshot.input,
@@ -1125,31 +1091,28 @@ export const WsOrchestrationGetArchivedShellSnapshotRpc = Rpc.make(
   },
 );
 
-export const WsOrchestrationSubscribeShellRpc = Rpc.make(ORCHESTRATION_WS_METHODS.subscribeShell, {
+const WsOrchestrationSubscribeShellRpc = Rpc.make(ORCHESTRATION_WS_METHODS.subscribeShell, {
   payload: OrchestrationRpcSchemas.subscribeShell.input,
   success: OrchestrationRpcSchemas.subscribeShell.output,
   error: Schema.Union([OrchestrationGetSnapshotError, EnvironmentAuthorizationError]),
   stream: true,
 });
 
-export const WsOrchestrationSubscribeThreadRpc = Rpc.make(
-  ORCHESTRATION_WS_METHODS.subscribeThread,
-  {
-    payload: OrchestrationRpcSchemas.subscribeThread.input,
-    success: OrchestrationRpcSchemas.subscribeThread.output,
-    error: Schema.Union([OrchestrationGetSnapshotError, EnvironmentAuthorizationError]),
-    stream: true,
-  },
-);
+const WsOrchestrationSubscribeThreadRpc = Rpc.make(ORCHESTRATION_WS_METHODS.subscribeThread, {
+  payload: OrchestrationRpcSchemas.subscribeThread.input,
+  success: OrchestrationRpcSchemas.subscribeThread.output,
+  error: Schema.Union([OrchestrationGetSnapshotError, EnvironmentAuthorizationError]),
+  stream: true,
+});
 
-export const WsSubscribeTerminalEventsRpc = Rpc.make(WS_METHODS.subscribeTerminalEvents, {
+const WsSubscribeTerminalEventsRpc = Rpc.make(WS_METHODS.subscribeTerminalEvents, {
   payload: Schema.Struct({}),
   success: TerminalEvent,
   error: EnvironmentAuthorizationError,
   stream: true,
 });
 
-export const WsSubscribeTerminalMetadataRpc = Rpc.make(WS_METHODS.subscribeTerminalMetadata, {
+const WsSubscribeTerminalMetadataRpc = Rpc.make(WS_METHODS.subscribeTerminalMetadata, {
   payload: Schema.Struct({}),
   success: TerminalMetadataStreamEvent,
   error: EnvironmentAuthorizationError,
@@ -1174,28 +1137,28 @@ export const WsSubscribeServerConfigRpc = Rpc.make(WS_METHODS.subscribeServerCon
   stream: true,
 });
 
-export const WsSubscribeServerLifecycleRpc = Rpc.make(WS_METHODS.subscribeServerLifecycle, {
+const WsSubscribeServerLifecycleRpc = Rpc.make(WS_METHODS.subscribeServerLifecycle, {
   payload: Schema.Struct({}),
   success: ServerLifecycleStreamEvent,
   error: EnvironmentAuthorizationError,
   stream: true,
 });
 
-export const WsSubscribeAuthAccessRpc = Rpc.make(WS_METHODS.subscribeAuthAccess, {
+const WsSubscribeAuthAccessRpc = Rpc.make(WS_METHODS.subscribeAuthAccess, {
   payload: Schema.Struct({}),
   success: AuthAccessStreamEvent,
   error: Schema.Union([AuthAccessStreamError, EnvironmentAuthorizationError]),
   stream: true,
 });
 
-export const WsSubscribeBackgroundPolicyRpc = Rpc.make(WS_METHODS.subscribeBackgroundPolicy, {
+const WsSubscribeBackgroundPolicyRpc = Rpc.make(WS_METHODS.subscribeBackgroundPolicy, {
   payload: Schema.Struct({}),
   success: BackgroundPolicySnapshot,
   error: EnvironmentAuthorizationError,
   stream: true,
 });
 
-export const WsSubscribeResourceTelemetryRpc = Rpc.make(WS_METHODS.subscribeResourceTelemetry, {
+const WsSubscribeResourceTelemetryRpc = Rpc.make(WS_METHODS.subscribeResourceTelemetry, {
   payload: Schema.Struct({}),
   success: ResourceTelemetrySnapshot,
   error: EnvironmentAuthorizationError,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -194,6 +194,7 @@ import {
   ServerProviderUpdateInput,
   ServerLifecycleStreamEvent,
   ServerRemoveKeybindingInput,
+  ServerRemoveKeybindingResult,
   ServerProviderUpdatedPayload,
   ServerSelfUpdateError,
   ServerSelfUpdateInput,
@@ -385,7 +386,7 @@ const WsServerUpsertKeybindingRpc = Rpc.make(WS_METHODS.serverUpsertKeybinding, 
 
 const WsServerRemoveKeybindingRpc = Rpc.make(WS_METHODS.serverRemoveKeybinding, {
   payload: ServerRemoveKeybindingInput,
-  success: ServerUpsertKeybindingResult,
+  success: ServerRemoveKeybindingResult,
   error: Schema.Union([KeybindingsConfigError, EnvironmentAuthorizationError]),
 });
 

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -51,12 +51,8 @@ const ServerConfigIssues = ForwardCompatibleArray(ServerConfigIssue);
 export const ServerProviderState = Schema.Literals(["ready", "warning", "error", "disabled"]);
 export type ServerProviderState = typeof ServerProviderState.Type;
 
-export const ServerProviderAuthStatus = Schema.Literals([
-  "authenticated",
-  "unauthenticated",
-  "unknown",
-]);
-export type ServerProviderAuthStatus = typeof ServerProviderAuthStatus.Type;
+const ServerProviderAuthStatus = Schema.Literals(["authenticated", "unauthenticated", "unknown"]);
+type ServerProviderAuthStatus = typeof ServerProviderAuthStatus.Type;
 
 export const ServerProviderAuth = Schema.Struct({
   status: ServerProviderAuthStatus,
@@ -80,10 +76,10 @@ export const ServerProviderModel = Schema.Struct({
 });
 export type ServerProviderModel = typeof ServerProviderModel.Type;
 
-export const ServerProviderSlashCommandInput = Schema.Struct({
+const ServerProviderSlashCommandInput = Schema.Struct({
   hint: TrimmedNonEmptyString,
 });
-export type ServerProviderSlashCommandInput = typeof ServerProviderSlashCommandInput.Type;
+type ServerProviderSlashCommandInput = typeof ServerProviderSlashCommandInput.Type;
 
 export const ServerProviderSlashCommand = Schema.Struct({
   name: TrimmedNonEmptyString,
@@ -115,13 +111,13 @@ export const ServerProviderSkill = Schema.Struct({
 });
 export type ServerProviderSkill = typeof ServerProviderSkill.Type;
 
-export const ServerProviderWorkspaceSnapshot = Schema.Struct({
+const ServerProviderWorkspaceSnapshot = Schema.Struct({
   cwd: TrimmedNonEmptyString,
   checkedAt: IsoDateTime,
   slashCommands: Schema.Array(ServerProviderSlashCommand),
   skills: Schema.Array(ServerProviderSkill),
 });
-export type ServerProviderWorkspaceSnapshot = typeof ServerProviderWorkspaceSnapshot.Type;
+type ServerProviderWorkspaceSnapshot = typeof ServerProviderWorkspaceSnapshot.Type;
 
 /**
  * Availability of a configured provider instance from the runtime's POV.
@@ -140,20 +136,20 @@ export type ServerProviderWorkspaceSnapshot = typeof ServerProviderWorkspaceSnap
  * `installed: false` and `enabled: false`; the runtime refuses turn
  * starts against them with a structured error.
  */
-export const ServerProviderAvailability = Schema.Literals(["available", "unavailable"]);
-export type ServerProviderAvailability = typeof ServerProviderAvailability.Type;
+const ServerProviderAvailability = Schema.Literals(["available", "unavailable"]);
+type ServerProviderAvailability = typeof ServerProviderAvailability.Type;
 
-export const ServerProviderContinuation = Schema.Struct({
+const ServerProviderContinuation = Schema.Struct({
   groupKey: TrimmedNonEmptyString,
 });
-export type ServerProviderContinuation = typeof ServerProviderContinuation.Type;
+type ServerProviderContinuation = typeof ServerProviderContinuation.Type;
 
-export const ServerProviderVersionAdvisoryStatus = Schema.Literals([
+const ServerProviderVersionAdvisoryStatus = Schema.Literals([
   "unknown",
   "current",
   "behind_latest",
 ]);
-export type ServerProviderVersionAdvisoryStatus = typeof ServerProviderVersionAdvisoryStatus.Type;
+type ServerProviderVersionAdvisoryStatus = typeof ServerProviderVersionAdvisoryStatus.Type;
 
 export const ServerProviderVersionAdvisory = Schema.Struct({
   status: ServerProviderVersionAdvisoryStatus,
@@ -166,7 +162,7 @@ export const ServerProviderVersionAdvisory = Schema.Struct({
 });
 export type ServerProviderVersionAdvisory = typeof ServerProviderVersionAdvisory.Type;
 
-export const ServerProviderUpdateStatus = Schema.Literals([
+const ServerProviderUpdateStatus = Schema.Literals([
   "idle",
   "queued",
   "running",
@@ -174,7 +170,7 @@ export const ServerProviderUpdateStatus = Schema.Literals([
   "failed",
   "unchanged",
 ]);
-export type ServerProviderUpdateStatus = typeof ServerProviderUpdateStatus.Type;
+type ServerProviderUpdateStatus = typeof ServerProviderUpdateStatus.Type;
 
 export const ServerProviderUpdateState = Schema.Struct({
   status: ServerProviderUpdateStatus,
@@ -251,7 +247,7 @@ export type ServerProviders = typeof ServerProviders.Type;
 export const isProviderAvailable = (snapshot: ServerProvider): boolean =>
   snapshot.availability !== "unavailable";
 
-export const ServerObservability = Schema.Struct({
+const ServerObservability = Schema.Struct({
   logsDirectoryPath: TrimmedNonEmptyString,
   localTracingEnabled: Schema.Boolean,
   otlpTracesUrl: Schema.optional(TrimmedNonEmptyString),
@@ -259,7 +255,7 @@ export const ServerObservability = Schema.Struct({
   otlpMetricsUrl: Schema.optional(TrimmedNonEmptyString),
   otlpMetricsEnabled: Schema.Boolean,
 });
-export type ServerObservability = typeof ServerObservability.Type;
+type ServerObservability = typeof ServerObservability.Type;
 
 export const ServerTraceDiagnosticsErrorKind = Schema.Literals([
   "trace-file-not-found",
@@ -383,7 +379,7 @@ export const ServerProcessResourceHistoryInput = Schema.Struct({
 });
 export type ServerProcessResourceHistoryInput = typeof ServerProcessResourceHistoryInput.Type;
 
-export const ServerProcessResourceHistoryBucket = Schema.Struct({
+const ServerProcessResourceHistoryBucket = Schema.Struct({
   startedAt: Schema.DateTimeUtc,
   endedAt: Schema.DateTimeUtc,
   avgCpuPercent: Schema.Number,
@@ -391,7 +387,7 @@ export const ServerProcessResourceHistoryBucket = Schema.Struct({
   maxRssBytes: NonNegativeInt,
   maxProcessCount: NonNegativeInt,
 });
-export type ServerProcessResourceHistoryBucket = typeof ServerProcessResourceHistoryBucket.Type;
+type ServerProcessResourceHistoryBucket = typeof ServerProcessResourceHistoryBucket.Type;
 
 export const ServerProcessResourceHistorySummary = Schema.Struct({
   processKey: TrimmedNonEmptyString,
@@ -412,15 +408,14 @@ export const ServerProcessResourceHistorySummary = Schema.Struct({
 });
 export type ServerProcessResourceHistorySummary = typeof ServerProcessResourceHistorySummary.Type;
 
-export const ServerProcessResourceHistoryFailureTag = Schema.Literals([
+const ServerProcessResourceHistoryFailureTag = Schema.Literals([
   "ProcessDiagnosticsQueryTimeoutError",
   "ProcessDiagnosticsQueryFailedError",
   "ProcessDiagnosticsServerProcessSignalError",
   "ProcessDiagnosticsNotDescendantError",
   "ProcessDiagnosticsSignalFailedError",
 ]);
-export type ServerProcessResourceHistoryFailureTag =
-  typeof ServerProcessResourceHistoryFailureTag.Type;
+type ServerProcessResourceHistoryFailureTag = typeof ServerProcessResourceHistoryFailureTag.Type;
 
 export const ServerProcessResourceHistoryResult = Schema.Struct({
   readAt: Schema.DateTimeUtc,
@@ -462,10 +457,10 @@ export type ServerSignalProcessResult = typeof ServerSignalProcessResult.Type;
  * the same generator the guided theme editor uses, so a desktop theme carries
  * over as a coherent T3 Code palette instead of a foreign one.
  */
-export const EnvironmentThemeColor = Schema.String.check(
+const EnvironmentThemeColor = Schema.String.check(
   Schema.isPattern(/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/),
 );
-export type EnvironmentThemeColor = typeof EnvironmentThemeColor.Type;
+type EnvironmentThemeColor = typeof EnvironmentThemeColor.Type;
 
 /**
  * Matches the client-side theme id rule, so a published id is selectable.
@@ -628,92 +623,86 @@ export const ServerUpsertKeybindingResult = Schema.Struct({
 });
 export type ServerUpsertKeybindingResult = typeof ServerUpsertKeybindingResult.Type;
 
-export const ServerRemoveKeybindingResult = ServerUpsertKeybindingResult;
-export type ServerRemoveKeybindingResult = typeof ServerRemoveKeybindingResult.Type;
-
-export const ServerConfigUpdatedPayload = Schema.Struct({
+const ServerConfigUpdatedPayload = Schema.Struct({
   issues: ServerConfigIssues,
   providers: ServerProviders,
   settings: Schema.optional(ServerSettings),
 });
-export type ServerConfigUpdatedPayload = typeof ServerConfigUpdatedPayload.Type;
+type ServerConfigUpdatedPayload = typeof ServerConfigUpdatedPayload.Type;
 
-export const ServerConfigKeybindingsUpdatedPayload = Schema.Struct({
+const ServerConfigKeybindingsUpdatedPayload = Schema.Struct({
   keybindings: ResolvedKeybindingsConfig,
   issues: ServerConfigIssues,
 });
-export type ServerConfigKeybindingsUpdatedPayload =
-  typeof ServerConfigKeybindingsUpdatedPayload.Type;
+type ServerConfigKeybindingsUpdatedPayload = typeof ServerConfigKeybindingsUpdatedPayload.Type;
 
-export const ServerConfigProviderStatusesPayload = Schema.Struct({
+const ServerConfigProviderStatusesPayload = Schema.Struct({
   providers: ServerProviders,
 });
-export type ServerConfigProviderStatusesPayload = typeof ServerConfigProviderStatusesPayload.Type;
+type ServerConfigProviderStatusesPayload = typeof ServerConfigProviderStatusesPayload.Type;
 
-export const ServerConfigSettingsUpdatedPayload = Schema.Struct({
+const ServerConfigSettingsUpdatedPayload = Schema.Struct({
   settings: ServerSettings,
 });
-export type ServerConfigSettingsUpdatedPayload = typeof ServerConfigSettingsUpdatedPayload.Type;
+type ServerConfigSettingsUpdatedPayload = typeof ServerConfigSettingsUpdatedPayload.Type;
 
-export const ServerConfigStreamSnapshotEvent = Schema.Struct({
+const ServerConfigStreamSnapshotEvent = Schema.Struct({
   version: Schema.Literal(1),
   type: Schema.Literal("snapshot"),
   config: ServerConfig,
 });
-export type ServerConfigStreamSnapshotEvent = typeof ServerConfigStreamSnapshotEvent.Type;
+type ServerConfigStreamSnapshotEvent = typeof ServerConfigStreamSnapshotEvent.Type;
 
-export const ServerConfigStreamKeybindingsUpdatedEvent = Schema.Struct({
+const ServerConfigStreamKeybindingsUpdatedEvent = Schema.Struct({
   version: Schema.Literal(1),
   type: Schema.Literal("keybindingsUpdated"),
   payload: ServerConfigKeybindingsUpdatedPayload,
 });
-export type ServerConfigStreamKeybindingsUpdatedEvent =
+type ServerConfigStreamKeybindingsUpdatedEvent =
   typeof ServerConfigStreamKeybindingsUpdatedEvent.Type;
 
-export const ServerConfigStreamProviderStatusesEvent = Schema.Struct({
+const ServerConfigStreamProviderStatusesEvent = Schema.Struct({
   version: Schema.Literal(1),
   type: Schema.Literal("providerStatuses"),
   payload: ServerConfigProviderStatusesPayload,
 });
-export type ServerConfigStreamProviderStatusesEvent =
-  typeof ServerConfigStreamProviderStatusesEvent.Type;
+type ServerConfigStreamProviderStatusesEvent = typeof ServerConfigStreamProviderStatusesEvent.Type;
 
-export const ServerConfigStreamSettingsUpdatedEvent = Schema.Struct({
+const ServerConfigStreamSettingsUpdatedEvent = Schema.Struct({
   version: Schema.Literal(1),
   type: Schema.Literal("settingsUpdated"),
   payload: ServerConfigSettingsUpdatedPayload,
 });
-export type ServerConfigStreamSettingsUpdatedEvent =
-  typeof ServerConfigStreamSettingsUpdatedEvent.Type;
+type ServerConfigStreamSettingsUpdatedEvent = typeof ServerConfigStreamSettingsUpdatedEvent.Type;
 
-export const ServerConfigEnvironmentThemesUpdatedPayload = Schema.Struct({
+const ServerConfigEnvironmentThemesUpdatedPayload = Schema.Struct({
   /** The full published set; empty once the machine publishes none. */
   themes: Schema.Array(EnvironmentTheme),
 });
-export type ServerConfigEnvironmentThemesUpdatedPayload =
+type ServerConfigEnvironmentThemesUpdatedPayload =
   typeof ServerConfigEnvironmentThemesUpdatedPayload.Type;
 
-export const ServerConfigStreamEnvironmentThemesUpdatedEvent = Schema.Struct({
+const ServerConfigStreamEnvironmentThemesUpdatedEvent = Schema.Struct({
   version: Schema.Literal(1),
   type: Schema.Literal("environmentThemesUpdated"),
   payload: ServerConfigEnvironmentThemesUpdatedPayload,
 });
-export type ServerConfigStreamEnvironmentThemesUpdatedEvent =
+type ServerConfigStreamEnvironmentThemesUpdatedEvent =
   typeof ServerConfigStreamEnvironmentThemesUpdatedEvent.Type;
 
-export const ServerConfigUsageLimitSourcesUpdatedPayload = Schema.Struct({
+const ServerConfigUsageLimitSourcesUpdatedPayload = Schema.Struct({
   /** The full set; empty once no source is configured. */
   sources: UsageLimitSourceSnapshots,
 });
-export type ServerConfigUsageLimitSourcesUpdatedPayload =
+type ServerConfigUsageLimitSourcesUpdatedPayload =
   typeof ServerConfigUsageLimitSourcesUpdatedPayload.Type;
 
-export const ServerConfigStreamUsageLimitSourcesUpdatedEvent = Schema.Struct({
+const ServerConfigStreamUsageLimitSourcesUpdatedEvent = Schema.Struct({
   version: Schema.Literal(1),
   type: Schema.Literal("usageLimitSourcesUpdated"),
   payload: ServerConfigUsageLimitSourcesUpdatedPayload,
 });
-export type ServerConfigStreamUsageLimitSourcesUpdatedEvent =
+type ServerConfigStreamUsageLimitSourcesUpdatedEvent =
   typeof ServerConfigStreamUsageLimitSourcesUpdatedEvent.Type;
 
 export const ServerConfigStreamEvent = Schema.Union([
@@ -736,13 +725,13 @@ export const ServerSelfUpdateOutcome = Schema.Struct({
 });
 export type ServerSelfUpdateOutcome = typeof ServerSelfUpdateOutcome.Type;
 
-export const ServerLifecycleReadyPayload = Schema.Struct({
+const ServerLifecycleReadyPayload = Schema.Struct({
   at: IsoDateTime,
   environment: ExecutionEnvironmentDescriptor,
   /** Present when this process resumed a launcher-managed update. */
   updateOutcome: Schema.optionalKey(ServerSelfUpdateOutcome),
 });
-export type ServerLifecycleReadyPayload = typeof ServerLifecycleReadyPayload.Type;
+type ServerLifecycleReadyPayload = typeof ServerLifecycleReadyPayload.Type;
 
 export const ServerLifecycleWelcomePayload = Schema.Struct({
   environment: ExecutionEnvironmentDescriptor,
@@ -756,13 +745,13 @@ export const ServerLifecycleWelcomePayload = Schema.Struct({
 });
 export type ServerLifecycleWelcomePayload = typeof ServerLifecycleWelcomePayload.Type;
 
-export const ServerLifecycleStreamWelcomeEvent = Schema.Struct({
+const ServerLifecycleStreamWelcomeEvent = Schema.Struct({
   version: Schema.Literal(1),
   sequence: NonNegativeInt,
   type: Schema.Literal("welcome"),
   payload: ServerLifecycleWelcomePayload,
 });
-export type ServerLifecycleStreamWelcomeEvent = typeof ServerLifecycleStreamWelcomeEvent.Type;
+type ServerLifecycleStreamWelcomeEvent = typeof ServerLifecycleStreamWelcomeEvent.Type;
 
 export const ServerLifecycleStreamReadyEvent = Schema.Struct({
   version: Schema.Literal(1),

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -51,8 +51,12 @@ const ServerConfigIssues = ForwardCompatibleArray(ServerConfigIssue);
 export const ServerProviderState = Schema.Literals(["ready", "warning", "error", "disabled"]);
 export type ServerProviderState = typeof ServerProviderState.Type;
 
-const ServerProviderAuthStatus = Schema.Literals(["authenticated", "unauthenticated", "unknown"]);
-type ServerProviderAuthStatus = typeof ServerProviderAuthStatus.Type;
+export const ServerProviderAuthStatus = Schema.Literals([
+  "authenticated",
+  "unauthenticated",
+  "unknown",
+]);
+export type ServerProviderAuthStatus = typeof ServerProviderAuthStatus.Type;
 
 export const ServerProviderAuth = Schema.Struct({
   status: ServerProviderAuthStatus,
@@ -76,10 +80,10 @@ export const ServerProviderModel = Schema.Struct({
 });
 export type ServerProviderModel = typeof ServerProviderModel.Type;
 
-const ServerProviderSlashCommandInput = Schema.Struct({
+export const ServerProviderSlashCommandInput = Schema.Struct({
   hint: TrimmedNonEmptyString,
 });
-type ServerProviderSlashCommandInput = typeof ServerProviderSlashCommandInput.Type;
+export type ServerProviderSlashCommandInput = typeof ServerProviderSlashCommandInput.Type;
 
 export const ServerProviderSlashCommand = Schema.Struct({
   name: TrimmedNonEmptyString,
@@ -111,13 +115,13 @@ export const ServerProviderSkill = Schema.Struct({
 });
 export type ServerProviderSkill = typeof ServerProviderSkill.Type;
 
-const ServerProviderWorkspaceSnapshot = Schema.Struct({
+export const ServerProviderWorkspaceSnapshot = Schema.Struct({
   cwd: TrimmedNonEmptyString,
   checkedAt: IsoDateTime,
   slashCommands: Schema.Array(ServerProviderSlashCommand),
   skills: Schema.Array(ServerProviderSkill),
 });
-type ServerProviderWorkspaceSnapshot = typeof ServerProviderWorkspaceSnapshot.Type;
+export type ServerProviderWorkspaceSnapshot = typeof ServerProviderWorkspaceSnapshot.Type;
 
 /**
  * Availability of a configured provider instance from the runtime's POV.
@@ -136,20 +140,20 @@ type ServerProviderWorkspaceSnapshot = typeof ServerProviderWorkspaceSnapshot.Ty
  * `installed: false` and `enabled: false`; the runtime refuses turn
  * starts against them with a structured error.
  */
-const ServerProviderAvailability = Schema.Literals(["available", "unavailable"]);
-type ServerProviderAvailability = typeof ServerProviderAvailability.Type;
+export const ServerProviderAvailability = Schema.Literals(["available", "unavailable"]);
+export type ServerProviderAvailability = typeof ServerProviderAvailability.Type;
 
-const ServerProviderContinuation = Schema.Struct({
+export const ServerProviderContinuation = Schema.Struct({
   groupKey: TrimmedNonEmptyString,
 });
-type ServerProviderContinuation = typeof ServerProviderContinuation.Type;
+export type ServerProviderContinuation = typeof ServerProviderContinuation.Type;
 
-const ServerProviderVersionAdvisoryStatus = Schema.Literals([
+export const ServerProviderVersionAdvisoryStatus = Schema.Literals([
   "unknown",
   "current",
   "behind_latest",
 ]);
-type ServerProviderVersionAdvisoryStatus = typeof ServerProviderVersionAdvisoryStatus.Type;
+export type ServerProviderVersionAdvisoryStatus = typeof ServerProviderVersionAdvisoryStatus.Type;
 
 export const ServerProviderVersionAdvisory = Schema.Struct({
   status: ServerProviderVersionAdvisoryStatus,
@@ -162,7 +166,7 @@ export const ServerProviderVersionAdvisory = Schema.Struct({
 });
 export type ServerProviderVersionAdvisory = typeof ServerProviderVersionAdvisory.Type;
 
-const ServerProviderUpdateStatus = Schema.Literals([
+export const ServerProviderUpdateStatus = Schema.Literals([
   "idle",
   "queued",
   "running",
@@ -170,7 +174,7 @@ const ServerProviderUpdateStatus = Schema.Literals([
   "failed",
   "unchanged",
 ]);
-type ServerProviderUpdateStatus = typeof ServerProviderUpdateStatus.Type;
+export type ServerProviderUpdateStatus = typeof ServerProviderUpdateStatus.Type;
 
 export const ServerProviderUpdateState = Schema.Struct({
   status: ServerProviderUpdateStatus,
@@ -247,7 +251,7 @@ export type ServerProviders = typeof ServerProviders.Type;
 export const isProviderAvailable = (snapshot: ServerProvider): boolean =>
   snapshot.availability !== "unavailable";
 
-const ServerObservability = Schema.Struct({
+export const ServerObservability = Schema.Struct({
   logsDirectoryPath: TrimmedNonEmptyString,
   localTracingEnabled: Schema.Boolean,
   otlpTracesUrl: Schema.optional(TrimmedNonEmptyString),
@@ -255,7 +259,7 @@ const ServerObservability = Schema.Struct({
   otlpMetricsUrl: Schema.optional(TrimmedNonEmptyString),
   otlpMetricsEnabled: Schema.Boolean,
 });
-type ServerObservability = typeof ServerObservability.Type;
+export type ServerObservability = typeof ServerObservability.Type;
 
 export const ServerTraceDiagnosticsErrorKind = Schema.Literals([
   "trace-file-not-found",
@@ -379,7 +383,7 @@ export const ServerProcessResourceHistoryInput = Schema.Struct({
 });
 export type ServerProcessResourceHistoryInput = typeof ServerProcessResourceHistoryInput.Type;
 
-const ServerProcessResourceHistoryBucket = Schema.Struct({
+export const ServerProcessResourceHistoryBucket = Schema.Struct({
   startedAt: Schema.DateTimeUtc,
   endedAt: Schema.DateTimeUtc,
   avgCpuPercent: Schema.Number,
@@ -387,7 +391,7 @@ const ServerProcessResourceHistoryBucket = Schema.Struct({
   maxRssBytes: NonNegativeInt,
   maxProcessCount: NonNegativeInt,
 });
-type ServerProcessResourceHistoryBucket = typeof ServerProcessResourceHistoryBucket.Type;
+export type ServerProcessResourceHistoryBucket = typeof ServerProcessResourceHistoryBucket.Type;
 
 export const ServerProcessResourceHistorySummary = Schema.Struct({
   processKey: TrimmedNonEmptyString,
@@ -408,14 +412,15 @@ export const ServerProcessResourceHistorySummary = Schema.Struct({
 });
 export type ServerProcessResourceHistorySummary = typeof ServerProcessResourceHistorySummary.Type;
 
-const ServerProcessResourceHistoryFailureTag = Schema.Literals([
+export const ServerProcessResourceHistoryFailureTag = Schema.Literals([
   "ProcessDiagnosticsQueryTimeoutError",
   "ProcessDiagnosticsQueryFailedError",
   "ProcessDiagnosticsServerProcessSignalError",
   "ProcessDiagnosticsNotDescendantError",
   "ProcessDiagnosticsSignalFailedError",
 ]);
-type ServerProcessResourceHistoryFailureTag = typeof ServerProcessResourceHistoryFailureTag.Type;
+export type ServerProcessResourceHistoryFailureTag =
+  typeof ServerProcessResourceHistoryFailureTag.Type;
 
 export const ServerProcessResourceHistoryResult = Schema.Struct({
   readAt: Schema.DateTimeUtc,
@@ -457,10 +462,10 @@ export type ServerSignalProcessResult = typeof ServerSignalProcessResult.Type;
  * the same generator the guided theme editor uses, so a desktop theme carries
  * over as a coherent T3 Code palette instead of a foreign one.
  */
-const EnvironmentThemeColor = Schema.String.check(
+export const EnvironmentThemeColor = Schema.String.check(
   Schema.isPattern(/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/),
 );
-type EnvironmentThemeColor = typeof EnvironmentThemeColor.Type;
+export type EnvironmentThemeColor = typeof EnvironmentThemeColor.Type;
 
 /**
  * Matches the client-side theme id rule, so a published id is selectable.
@@ -623,86 +628,92 @@ export const ServerUpsertKeybindingResult = Schema.Struct({
 });
 export type ServerUpsertKeybindingResult = typeof ServerUpsertKeybindingResult.Type;
 
-const ServerConfigUpdatedPayload = Schema.Struct({
+export const ServerRemoveKeybindingResult = ServerUpsertKeybindingResult;
+export type ServerRemoveKeybindingResult = typeof ServerRemoveKeybindingResult.Type;
+
+export const ServerConfigUpdatedPayload = Schema.Struct({
   issues: ServerConfigIssues,
   providers: ServerProviders,
   settings: Schema.optional(ServerSettings),
 });
-type ServerConfigUpdatedPayload = typeof ServerConfigUpdatedPayload.Type;
+export type ServerConfigUpdatedPayload = typeof ServerConfigUpdatedPayload.Type;
 
-const ServerConfigKeybindingsUpdatedPayload = Schema.Struct({
+export const ServerConfigKeybindingsUpdatedPayload = Schema.Struct({
   keybindings: ResolvedKeybindingsConfig,
   issues: ServerConfigIssues,
 });
-type ServerConfigKeybindingsUpdatedPayload = typeof ServerConfigKeybindingsUpdatedPayload.Type;
+export type ServerConfigKeybindingsUpdatedPayload =
+  typeof ServerConfigKeybindingsUpdatedPayload.Type;
 
-const ServerConfigProviderStatusesPayload = Schema.Struct({
+export const ServerConfigProviderStatusesPayload = Schema.Struct({
   providers: ServerProviders,
 });
-type ServerConfigProviderStatusesPayload = typeof ServerConfigProviderStatusesPayload.Type;
+export type ServerConfigProviderStatusesPayload = typeof ServerConfigProviderStatusesPayload.Type;
 
-const ServerConfigSettingsUpdatedPayload = Schema.Struct({
+export const ServerConfigSettingsUpdatedPayload = Schema.Struct({
   settings: ServerSettings,
 });
-type ServerConfigSettingsUpdatedPayload = typeof ServerConfigSettingsUpdatedPayload.Type;
+export type ServerConfigSettingsUpdatedPayload = typeof ServerConfigSettingsUpdatedPayload.Type;
 
-const ServerConfigStreamSnapshotEvent = Schema.Struct({
+export const ServerConfigStreamSnapshotEvent = Schema.Struct({
   version: Schema.Literal(1),
   type: Schema.Literal("snapshot"),
   config: ServerConfig,
 });
-type ServerConfigStreamSnapshotEvent = typeof ServerConfigStreamSnapshotEvent.Type;
+export type ServerConfigStreamSnapshotEvent = typeof ServerConfigStreamSnapshotEvent.Type;
 
-const ServerConfigStreamKeybindingsUpdatedEvent = Schema.Struct({
+export const ServerConfigStreamKeybindingsUpdatedEvent = Schema.Struct({
   version: Schema.Literal(1),
   type: Schema.Literal("keybindingsUpdated"),
   payload: ServerConfigKeybindingsUpdatedPayload,
 });
-type ServerConfigStreamKeybindingsUpdatedEvent =
+export type ServerConfigStreamKeybindingsUpdatedEvent =
   typeof ServerConfigStreamKeybindingsUpdatedEvent.Type;
 
-const ServerConfigStreamProviderStatusesEvent = Schema.Struct({
+export const ServerConfigStreamProviderStatusesEvent = Schema.Struct({
   version: Schema.Literal(1),
   type: Schema.Literal("providerStatuses"),
   payload: ServerConfigProviderStatusesPayload,
 });
-type ServerConfigStreamProviderStatusesEvent = typeof ServerConfigStreamProviderStatusesEvent.Type;
+export type ServerConfigStreamProviderStatusesEvent =
+  typeof ServerConfigStreamProviderStatusesEvent.Type;
 
-const ServerConfigStreamSettingsUpdatedEvent = Schema.Struct({
+export const ServerConfigStreamSettingsUpdatedEvent = Schema.Struct({
   version: Schema.Literal(1),
   type: Schema.Literal("settingsUpdated"),
   payload: ServerConfigSettingsUpdatedPayload,
 });
-type ServerConfigStreamSettingsUpdatedEvent = typeof ServerConfigStreamSettingsUpdatedEvent.Type;
+export type ServerConfigStreamSettingsUpdatedEvent =
+  typeof ServerConfigStreamSettingsUpdatedEvent.Type;
 
-const ServerConfigEnvironmentThemesUpdatedPayload = Schema.Struct({
+export const ServerConfigEnvironmentThemesUpdatedPayload = Schema.Struct({
   /** The full published set; empty once the machine publishes none. */
   themes: Schema.Array(EnvironmentTheme),
 });
-type ServerConfigEnvironmentThemesUpdatedPayload =
+export type ServerConfigEnvironmentThemesUpdatedPayload =
   typeof ServerConfigEnvironmentThemesUpdatedPayload.Type;
 
-const ServerConfigStreamEnvironmentThemesUpdatedEvent = Schema.Struct({
+export const ServerConfigStreamEnvironmentThemesUpdatedEvent = Schema.Struct({
   version: Schema.Literal(1),
   type: Schema.Literal("environmentThemesUpdated"),
   payload: ServerConfigEnvironmentThemesUpdatedPayload,
 });
-type ServerConfigStreamEnvironmentThemesUpdatedEvent =
+export type ServerConfigStreamEnvironmentThemesUpdatedEvent =
   typeof ServerConfigStreamEnvironmentThemesUpdatedEvent.Type;
 
-const ServerConfigUsageLimitSourcesUpdatedPayload = Schema.Struct({
+export const ServerConfigUsageLimitSourcesUpdatedPayload = Schema.Struct({
   /** The full set; empty once no source is configured. */
   sources: UsageLimitSourceSnapshots,
 });
-type ServerConfigUsageLimitSourcesUpdatedPayload =
+export type ServerConfigUsageLimitSourcesUpdatedPayload =
   typeof ServerConfigUsageLimitSourcesUpdatedPayload.Type;
 
-const ServerConfigStreamUsageLimitSourcesUpdatedEvent = Schema.Struct({
+export const ServerConfigStreamUsageLimitSourcesUpdatedEvent = Schema.Struct({
   version: Schema.Literal(1),
   type: Schema.Literal("usageLimitSourcesUpdated"),
   payload: ServerConfigUsageLimitSourcesUpdatedPayload,
 });
-type ServerConfigStreamUsageLimitSourcesUpdatedEvent =
+export type ServerConfigStreamUsageLimitSourcesUpdatedEvent =
   typeof ServerConfigStreamUsageLimitSourcesUpdatedEvent.Type;
 
 export const ServerConfigStreamEvent = Schema.Union([
@@ -725,13 +736,13 @@ export const ServerSelfUpdateOutcome = Schema.Struct({
 });
 export type ServerSelfUpdateOutcome = typeof ServerSelfUpdateOutcome.Type;
 
-const ServerLifecycleReadyPayload = Schema.Struct({
+export const ServerLifecycleReadyPayload = Schema.Struct({
   at: IsoDateTime,
   environment: ExecutionEnvironmentDescriptor,
   /** Present when this process resumed a launcher-managed update. */
   updateOutcome: Schema.optionalKey(ServerSelfUpdateOutcome),
 });
-type ServerLifecycleReadyPayload = typeof ServerLifecycleReadyPayload.Type;
+export type ServerLifecycleReadyPayload = typeof ServerLifecycleReadyPayload.Type;
 
 export const ServerLifecycleWelcomePayload = Schema.Struct({
   environment: ExecutionEnvironmentDescriptor,
@@ -745,13 +756,13 @@ export const ServerLifecycleWelcomePayload = Schema.Struct({
 });
 export type ServerLifecycleWelcomePayload = typeof ServerLifecycleWelcomePayload.Type;
 
-const ServerLifecycleStreamWelcomeEvent = Schema.Struct({
+export const ServerLifecycleStreamWelcomeEvent = Schema.Struct({
   version: Schema.Literal(1),
   sequence: NonNegativeInt,
   type: Schema.Literal("welcome"),
   payload: ServerLifecycleWelcomePayload,
 });
-type ServerLifecycleStreamWelcomeEvent = typeof ServerLifecycleStreamWelcomeEvent.Type;
+export type ServerLifecycleStreamWelcomeEvent = typeof ServerLifecycleStreamWelcomeEvent.Type;
 
 export const ServerLifecycleStreamReadyEvent = Schema.Struct({
   version: Schema.Literal(1),


### PR DESCRIPTION
Individual WebSocket RPC definitions are consumed through the assembled RPC group, not as separate package exports.

Keep those RPC implementation values and the runtime tool-lifecycle constant private. Preserve all Effect schemas, schema aliases, and exported types. This PR no longer rewrites schema aliases or their consumers.

Verification: contracts and consumer typechecks pass, existing contracts tests pass, and the integrated Knip gate passes. No existing tests were changed or removed.

Follows [#10167](https://github.com/pingdotgg/t3code/pull/10167).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep RPC implementation exports private in `contracts`
> Converts all exported RPC definition constants in [rpc.ts](https://github.com/pingdotgg/t3code/pull/10168/files#diff-64c16995299d1af309c72e94a298ffcb5c2ee5c65774cf0c73bf997358e9c266) and the `TOOL_LIFECYCLE_ITEM_TYPES` constant in [providerRuntime.ts](https://github.com/pingdotgg/t3code/pull/10168/files#diff-448aaf2dfbb7547d852cc74c6bba5caea16c3c782a5f9cfbf43da71648ec61f7) to module-private. Schema fields and behavior are unchanged; several `Rpc.make` calls were reformatted to a compact layout.
> - Risk: external consumers importing these constants by name will fail to compile. In-tree references must rely on the public RPC contract surface rather than the implementation constants.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e36f20d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Model: gpt-6 astra. Harness: Codex in T3 Code.
