### PR TITLE
fix(mobile): restore live tool shimmer and add a Thinking row

### DIFF
--- a/apps/mobile/src/components/AppSymbol.tsx
+++ b/apps/mobile/src/components/AppSymbol.tsx
@@ -20,6 +20,7 @@ import IconArrowsMinimize from "@tabler/icons-react-native/IconArrowsMinimize";
 import IconBellRinging from "@tabler/icons-react-native/IconBellRinging";
 import IconBolt from "@tabler/icons-react-native/IconBolt";
 import IconBox from "@tabler/icons-react-native/IconBox";
+import IconBrain from "@tabler/icons-react-native/IconBrain";
 import IconCamera from "@tabler/icons-react-native/IconCamera";
 import IconChartBar from "@tabler/icons-react-native/IconChartBar";
 import IconCheck from "@tabler/icons-react-native/IconCheck";
@@ -109,6 +110,7 @@ const ANDROID_ICON_BY_SF_SYMBOL: Partial<Record<SFSymbol, Icon>> = {
   "bell.badge": IconBellRinging,
   "bolt.circle": IconBolt,
   "bolt.horizontal.circle": IconBolt,
+  brain: IconBrain,
   camera: IconCamera,
   "chart.bar.xaxis": IconChartBar,
   checkmark: IconCheck,

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -155,6 +155,7 @@ import {
   collapsedWorkLogHeight,
   ThreadDisclosureChevron,
   ThreadWorkGroupToggle,
+  ThreadThinkingRow,
   ThreadWorkLog,
   THREAD_DISCLOSURE_TRANSITION_MS,
   WORK_GROUP_TOGGLE_HEIGHT,
@@ -1364,6 +1365,10 @@ function renderFeedEntry(
     );
   }
 
+  if (entry.type === "thinking") {
+    return <ThreadThinkingRow rowSizing={props.workRowSizing} iconSubtleColor={iconSubtleColor} />;
+  }
+
   if (entry.type === "work-toggle") {
     return (
       <ThreadWorkGroupToggle
@@ -2570,6 +2575,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
         case "turn-fold":
           return TURN_FOLD_HEIGHT;
         case "work-toggle":
+        case "thinking":
           return WORK_GROUP_TOGGLE_HEIGHT;
         case "activity-group":
           if (isContextCompactionActivityGroup(entry)) {

--- a/apps/mobile/src/features/threads/thread-work-log.tsx
+++ b/apps/mobile/src/features/threads/thread-work-log.tsx
@@ -922,6 +922,28 @@ export function ThreadWorkGroupToggle(props: {
   );
 }
 
+export function ThreadThinkingRow(props: {
+  readonly rowSizing: ReturnType<typeof deriveThreadWorkLogSizing>;
+  readonly iconSubtleColor: ColorValue;
+}) {
+  return (
+    <View
+      accessible
+      accessibilityLabel="Thinking"
+      className="-mx-1 min-h-8 flex-row items-center px-1.5 py-0"
+      style={{ minHeight: props.rowSizing.estimatedRowHeight }}
+    >
+      <ShimmeringWorkContent
+        key={props.rowSizing.textSizeKey}
+        icon="brain"
+        iconSubtleColor={props.iconSubtleColor}
+        label="Thinking"
+        showIcon
+      />
+    </View>
+  );
+}
+
 function ToolActivityIconView(props: {
   readonly environmentId: EnvironmentId;
   readonly icon?: ToolActivityIcon;

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -2297,9 +2297,69 @@ describe("buildThreadFeed", () => {
       rows[1],
     );
     // Idle threads show no live activity.
-    expect(deriveThreadFeedPresentation(feed, latestTurn, new Set(), new Set(), null)).toEqual(
-      rows.slice(0, 1),
+    expect(
+      deriveThreadFeedPresentation(feed, latestTurn, new Set(), new Set(), null).map(
+        (entry) => entry.type,
+      ),
+    ).toEqual(["message"]);
+  });
+
+  it("hands a settled tool run off to Thinking once assistant text streams after it", () => {
+    const turnId = TurnId.make("turn-streaming-tail");
+    const latestTurn = {
+      turnId,
+      state: "running" as const,
+      requestedAt: "2026-04-01T00:00:00.000Z",
+      startedAt: "2026-04-01T00:00:00.000Z",
+      completedAt: null,
+      assistantMessageId: null,
+    };
+    const feed = buildThreadFeed(
+      makeThread({
+        id: ThreadId.make("thread-streaming-tail"),
+        projectId: ProjectId.make("project-1"),
+        title: "Streaming tail",
+        latestTurn,
+        messages: [
+          {
+            id: MessageId.make("assistant-1"),
+            role: "assistant",
+            text: "Here is what I found",
+            turnId,
+            streaming: true,
+            createdAt: "2026-04-01T00:00:05.000Z",
+            updatedAt: "2026-04-01T00:00:06.000Z",
+          },
+        ],
+        activities: [
+          makeActivity({
+            id: EventId.make("read-completed"),
+            kind: "tool.completed",
+            tone: "tool",
+            summary: "Read file",
+            createdAt: "2026-04-01T00:00:02.000Z",
+            turnId,
+            payload: {
+              itemType: "file_read",
+              toolCallId: "read-1",
+              title: "Read file",
+              status: "completed",
+              detail: "src/index.ts",
+            },
+          }),
+        ],
+      }),
     );
+
+    const rows = deriveThreadFeedPresentation(
+      feed,
+      latestTurn,
+      new Set(),
+      new Set(),
+      latestTurn.startedAt,
+    );
+    expect(rows.map((entry) => entry.type)).toEqual(["work-toggle", "message", "thinking"]);
+    expect(rows[0]).toMatchObject({ live: false, shimmer: false });
   });
 
   it("preserves serialized shell wrappers with non-matching boundary quotes", () => {

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -1566,7 +1566,8 @@ describe("buildThreadFeed", () => {
           summaryToolIcon: "browser",
           hasFailure,
           live: true,
-          shimmer: false,
+          // A successful trailing call keeps shining; a failure hands off to "Thinking".
+          shimmer: !hasFailure,
         },
         {
           type: "activity-group",
@@ -1580,6 +1581,7 @@ describe("buildThreadFeed", () => {
             },
           ],
         },
+        ...(hasFailure ? [{ type: "thinking", turnId }] : []),
       ]);
       const terminalGroup = terminalRows[1];
       if (terminalGroup?.type !== "activity-group") return;
@@ -2128,7 +2130,7 @@ describe("buildThreadFeed", () => {
       (
         [
           { lifecycleStatus: "inProgress", summary: "Running pnpm", shimmer: true },
-          { lifecycleStatus: "completed", summary: "Running pnpm", shimmer: false },
+          { lifecycleStatus: "completed", summary: "Running pnpm", shimmer: true },
           { lifecycleStatus: "failed", summary: "Failed pnpm", shimmer: false },
           { lifecycleStatus: "declined", summary: "Declined pnpm", shimmer: false },
           { lifecycleStatus: "stopped", summary: "Stopped pnpm", shimmer: false },
@@ -2228,8 +2230,12 @@ describe("buildThreadFeed", () => {
         shimmer,
       });
       expect(rows[0]).toMatchObject({ live: false, shimmer: false });
+      // Exactly one live activity: the shimmering call, or "Thinking" once it fails.
+      expect(rows.filter((entry) => entry.type === "thinking")).toHaveLength(shimmer ? 0 : 1);
+      expect(rows.at(-1)?.type).toBe(shimmer ? "work-toggle" : "thinking");
 
       const stoppedRows = deriveThreadFeedPresentation(feed, latestTurn, new Set());
+      expect(stoppedRows.some((entry) => entry.type === "thinking")).toBe(false);
       expect(stoppedRows.filter((entry) => entry.type === "work-toggle")).toMatchObject([
         { live: false, shimmer: false },
         {
@@ -2252,6 +2258,49 @@ describe("buildThreadFeed", () => {
       ]);
     },
   );
+
+  it("shows one Thinking row while a turn works without live tool activity", () => {
+    const turnId = TurnId.make("turn-thinking");
+    const latestTurn = {
+      turnId,
+      state: "running" as const,
+      requestedAt: "2026-04-01T00:00:00.000Z",
+      startedAt: "2026-04-01T00:00:00.000Z",
+      completedAt: null,
+      assistantMessageId: null,
+    };
+    const feed = buildThreadFeed(
+      makeThread({
+        id: ThreadId.make("thread-thinking"),
+        projectId: ProjectId.make("project-1"),
+        title: "Thinking",
+        latestTurn,
+        messages: [
+          {
+            id: MessageId.make("user-1"),
+            role: "user",
+            text: "hello",
+            turnId,
+            streaming: false,
+            createdAt: "2026-04-01T00:00:00.000Z",
+            updatedAt: "2026-04-01T00:00:00.000Z",
+          },
+        ],
+      }),
+    );
+
+    const rows = deriveThreadFeedPresentation(feed, latestTurn, new Set(), new Set(), "now");
+    expect(rows.map((entry) => entry.type)).toEqual(["message", "thinking"]);
+    expect(rows[1]).toMatchObject({ id: "thinking", createdAt: "now", turnId });
+    // The row identity is stable across re-derivations so the list can reuse it.
+    expect(deriveThreadFeedPresentation(feed, latestTurn, new Set(), new Set(), "now")[1]).toBe(
+      rows[1],
+    );
+    // Idle threads show no live activity.
+    expect(deriveThreadFeedPresentation(feed, latestTurn, new Set(), new Set(), null)).toEqual(
+      rows.slice(0, 1),
+    );
+  });
 
   it("preserves serialized shell wrappers with non-matching boundary quotes", () => {
     const turnId = TurnId.make("turn-serialized-shell-wrapper");

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -207,6 +207,7 @@ const turnFoldRowsCache = new WeakMap<
   ThreadFeedEntry,
   Extract<ThreadFeedEntry, { readonly type: "turn-fold" }>
 >();
+let cachedThinkingRow: Extract<ThreadFeedEntry, { readonly type: "thinking" }> | null = null;
 
 export function isContextCompactionActivityGroup(
   entry: Extract<ThreadFeedEntry, { readonly type: "activity-group" }>,
@@ -1588,12 +1589,9 @@ export function deriveThreadFeedPresentation(
   return result;
 }
 
-const THINKING_ROW_ID = "thinking";
-let cachedThinkingRow: Extract<ThreadFeedEntry, { readonly type: "thinking" }> | null = null;
-
 function thinkingRow(createdAt: string, turnId: TurnId | null) {
   if (cachedThinkingRow?.createdAt !== createdAt || cachedThinkingRow.turnId !== turnId) {
-    cachedThinkingRow = { type: "thinking", id: THINKING_ROW_ID, createdAt, turnId };
+    cachedThinkingRow = { type: "thinking", id: "thinking", createdAt, turnId };
   }
   return cachedThinkingRow;
 }

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -169,6 +169,12 @@ export type ThreadFeedEntry =
       readonly turnId: TurnId;
       readonly label: string;
       readonly expanded: boolean;
+    }
+  | {
+      readonly type: "thinking";
+      readonly id: string;
+      readonly createdAt: string;
+      readonly turnId: TurnId | null;
     };
 
 export type ThreadFeedLatestTurn = Pick<
@@ -1510,7 +1516,8 @@ export function deriveThreadFeedPresentation(
   activeWorkStartedAt: string | null = null,
 ): ThreadFeedEntry[] {
   const sourceFeed = feed.filter(
-    (entry) => entry.type !== "turn-fold" && entry.type !== "work-toggle",
+    (entry) =>
+      entry.type !== "turn-fold" && entry.type !== "work-toggle" && entry.type !== "thinking",
   );
   const activeTailGroup = sourceFeed.findLast(
     (entry) => entry.type !== "message" || !isEmptyMessage(entry),
@@ -1570,12 +1577,30 @@ export function deriveThreadFeedPresentation(
       );
     }
   }
+  // A working turn always shows one live activity. When no tool row is
+  // shimmering (no tools yet, or the latest failed), that row is "Thinking".
+  if (
+    activeWorkStartedAt !== null &&
+    !result.some((row) => row.type === "work-toggle" && row.shimmer)
+  ) {
+    result.push(thinkingRow(activeWorkStartedAt, unsettledTurnId));
+  }
   return result;
+}
+
+const THINKING_ROW_ID = "thinking";
+let cachedThinkingRow: Extract<ThreadFeedEntry, { readonly type: "thinking" }> | null = null;
+
+function thinkingRow(createdAt: string, turnId: TurnId | null) {
+  if (cachedThinkingRow?.createdAt !== createdAt || cachedThinkingRow.turnId !== turnId) {
+    cachedThinkingRow = { type: "thinking", id: THINKING_ROW_ID, createdAt, turnId };
+  }
+  return cachedThinkingRow;
 }
 
 function appendPresentedFeedEntry(
   result: ThreadFeedEntry[],
-  entry: Exclude<ThreadFeedEntry, { readonly type: "turn-fold" | "work-toggle" }>,
+  entry: Exclude<ThreadFeedEntry, { readonly type: "turn-fold" | "work-toggle" | "thinking" }>,
   expandedWorkGroupIds: ReadonlySet<string>,
   unsettledTurnId: TurnId | null,
   isWorking: boolean,
@@ -1696,6 +1721,9 @@ function appendToolGroupRows(
   const active = latestActiveActivity !== undefined;
   const live = activeTail || active;
   const latestActivity = latestActiveActivity ?? activities.at(-1)!;
+  // Like web, the trailing run keeps shining after its latest call succeeds;
+  // only a failed, declined, or stopped call hands the live slot to "Thinking".
+  const shimmer = active || (activeTail && latestActivity.status === "success");
   const singleActivity = activities.length === 1 ? latestActivity : null;
   const summary = live
     ? liveToolActivitySummary(latestActivity, live)
@@ -1751,7 +1779,7 @@ function appendToolGroupRows(
     ...(summaryToolIcon ? { summaryToolIcon } : {}),
     hasFailure: activities.findLast((activity) => activity.toolLike)?.status === "failure",
     live,
-    shimmer: active,
+    shimmer,
   });
   if (!expanded) {
     return;


### PR DESCRIPTION
## Problem

Two mobile regressions against the web chat view:

1. **The running tool row stopped shimmering.** #9106 narrowed the shimmer from "the trailing live run" to "a call whose lifecycle is still `inProgress`". Codex only reports `inProgress` on `item.started`, which the work log drops, so in practice the mobile summary row lost its shine the moment a call completed while the turn kept going. Web keeps shining until the latest call fails, is declined, or is stopped (#9098, restored again in #9777 after the perf pass).
2. **No "Thinking" row.** Web shows a shimmering `Thinking` live activity whenever a turn is working with no shimmering tool row (before the first call, and after a failed one, per #9165). Mobile never had it, so a working turn with no tools rendered nothing above the composer.

## Fix

Mirror web's live-row rules in `deriveThreadFeedPresentation`:

- The trailing tool group shimmers while its latest call is running **or** succeeded. A failed, declined, or stopped call turns the shine off.
- When a turn is working and no tool row shimmers, append one `thinking` feed entry. It renders through the existing `ShimmeringWorkContent` with a brain icon (SF `brain`, Tabler `IconBrain` on Android) and uses the same fixed row height as the group toggle, so the list's size estimates stay exact.

The thinking row object is reused across derivations while `createdAt`/`turnId` are unchanged, so LegendList keeps the row instance during streaming.

## Verification

- `vp test run apps/mobile/src/lib/threadActivity.test.ts` — 90 passed. Updated the completed/failed lifecycle expectations to the new rules and added a test for the standalone Thinking row (present while working, stable identity, absent when idle).
- `tsc --noEmit` for `apps/mobile`, targeted `vp lint` and `vp fmt --check` on the changed files (only pre-existing warnings in `ThreadFeed.tsx`).
- iOS Simulator (iPhone 17 Pro, iOS 26.5) against a disposable base dir seeded with three running turns. Before is `main` at 62ed748, after is this branch, same dev client, same seeded data.

### Working turn, no tool calls yet

![Before: nothing above the composer. After: a shimmering Thinking row with a brain icon.](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d445d673386560ac/pair-thinking.png)

### Latest tool call completed, turn still running

The label is identical in both; the difference is motion, so here is the recording (before on the left, after on the right):

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/3b2347f283343702/pair-completed.mp4

![Before and after stills of the Running vp row](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/32551c3e1b7c1951/pair-completed.png)

### Latest tool call failed, turn still running

![Before: only the failed row. After: the failed row stays and a Thinking row appears below it.](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/5c5eac3b90e5c31f/pair-failed.png)

Android was not exercised (no emulator on the verification host); the only Android-specific change is the Tabler icon mapping.

Implemented by Claude Fable 5 in the Claude Code harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore live tool shimmer and add a `thinking` row to mobile thread feed
> - Adds a `thinking` entry variant to the thread feed type union and renders it as a new `ThreadThinkingRow` component with a brain icon and shimmering label.
> - The presentation builder appends one `thinking` row at the tail when a turn is actively working and no work-toggle row is already shimmering; existing `thinking` rows are filtered out before rebuild to avoid duplicates.
> - A cached `thinking` entry keeps object identity stable across repeated derivations unless the active-work timestamp or turn id changes.
> - Updates work-group shimmer logic in `appendToolGroupRows` so a trailing work group shimmers when it has an active activity or when its latest activity succeeded, restoring the live-tool shimmer.
> - Maps the `brain` SF Symbol to the Tabler brain icon in the Android fallback so `ThreadThinkingRow` renders correctly on Android.
> - Risk: `appendPresentedFeedEntry` and `appendToolGroupRows` in [threadActivity.ts](https://github.com/pingdotgg/t3code/pull/10173/files#diff-a18e8ed6aa4a9d6b3d9e32ea2fa3034dfd7621b6af3d640ec1b95a8564c97eb5) now exclude and recompute shimmer for `thinking` entries; any out-of-tree callers of these helpers will need to handle the new `thinking` variant.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51cc1ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->