### PR TITLE
fix(web): capture digit shortcuts as numbers instead of shifted symbols

### DIFF
--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -65,6 +65,69 @@ describe("KeybindingsSettings.logic", () => {
     ).toBe("mod+shift+k");
   });
 
+  it("captures digit shortcuts as numbers instead of shifted symbols", () => {
+    // Shift + 6 produces key: "^" on US layout, but code is "Digit6"
+    expect(
+      keybindingFromKeyboardEvent(
+        { key: "^", code: "Digit6", metaKey: false, ctrlKey: false, altKey: false, shiftKey: true },
+        "Win32",
+      ),
+    ).toBe("shift+6");
+
+    // Shift + 1 produces key: "!" on US layout, but code is "Digit1"
+    expect(
+      keybindingFromKeyboardEvent(
+        { key: "!", code: "Digit1", metaKey: false, ctrlKey: true, altKey: false, shiftKey: true },
+        "Win32",
+      ),
+    ).toBe("mod+shift+1");
+
+    // Numpad digits map to numbers when NumLock is on (key is "3")
+    expect(
+      keybindingFromKeyboardEvent(
+        {
+          key: "3",
+          code: "Numpad3",
+          metaKey: false,
+          ctrlKey: true,
+          altKey: false,
+          shiftKey: false,
+        },
+        "Win32",
+      ),
+    ).toBe("mod+3");
+
+    // Numpad navigation when NumLock is off (key is "End") preserves navigation
+    expect(
+      keybindingFromKeyboardEvent(
+        {
+          key: "End",
+          code: "Numpad1",
+          metaKey: false,
+          ctrlKey: true,
+          altKey: false,
+          shiftKey: false,
+        },
+        "Win32",
+      ),
+    ).toBe("mod+end");
+
+    // BracketLeft / BracketRight shortcuts with shift
+    expect(
+      keybindingFromKeyboardEvent(
+        {
+          key: "{",
+          code: "BracketLeft",
+          metaKey: true,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: true,
+        },
+        "MacIntel",
+      ),
+    ).toBe("mod+shift+[");
+  });
+
   it("serializes shortcuts and when expressions for upserts", () => {
     expect(
       shortcutToKeybindingInput({

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -11,6 +11,7 @@ import {
   parseKeybindingWhenExpression,
 } from "@t3tools/shared/keybindings";
 
+import { canonicalKeyFromEventCode } from "../../keybindings";
 import { isMacPlatform } from "../../lib/utils";
 
 export type KeybindingSource = "Default" | "Custom" | "Project";
@@ -291,7 +292,7 @@ function titleCaseCommandSegment(segment: string): string {
   return words.join(" ");
 }
 
-function normalizeShortcutKeyToken(key: string): string | null {
+function normalizeShortcutKeyToken(key: string, code?: string): string | null {
   const normalized = key.toLowerCase();
   if (
     normalized === "meta" ||
@@ -302,6 +303,10 @@ function normalizeShortcutKeyToken(key: string): string | null {
     normalized === "option"
   ) {
     return null;
+  }
+  const codeKey = canonicalKeyFromEventCode(code);
+  if (codeKey) {
+    return codeKey;
   }
   if (normalized === " ") return "space";
   if (normalized === "escape") return "esc";
@@ -322,10 +327,12 @@ function normalizeShortcutKeyToken(key: string): string | null {
 }
 
 export function keybindingFromKeyboardEvent(
-  event: Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey">,
+  event: Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey"> & {
+    code?: string | undefined;
+  },
   platform: string,
 ): string | null {
-  const keyToken = normalizeShortcutKeyToken(event.key);
+  const keyToken = normalizeShortcutKeyToken(event.key, event.code);
   if (!keyToken) return null;
 
   const parts: string[] = [];

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -7,6 +7,7 @@ import {
   type ResolvedKeybindingsConfig,
 } from "@t3tools/contracts";
 import {
+  canonicalKeyFromEventCode,
   formatShortcutLabel,
   isDiffToggleShortcut,
   modelPickerJumpCommandForIndex,
@@ -539,6 +540,81 @@ describe("model picker navigation helpers", () => {
     assert.strictEqual(modelPickerJumpIndexFromCommand("modelPicker.jump.1"), 0);
     assert.strictEqual(modelPickerJumpIndexFromCommand("modelPicker.jump.3"), 2);
     assert.isNull(modelPickerJumpIndexFromCommand("thread.jump.1"));
+  });
+
+  it("maps physical event codes to canonical key tokens", () => {
+    assert.strictEqual(canonicalKeyFromEventCode("Digit0"), "0");
+    assert.strictEqual(canonicalKeyFromEventCode("Digit1"), "1");
+    assert.strictEqual(canonicalKeyFromEventCode("Digit6"), "6");
+    assert.strictEqual(canonicalKeyFromEventCode("BracketLeft"), "[");
+    assert.strictEqual(canonicalKeyFromEventCode("BracketRight"), "]");
+    assert.isNull(canonicalKeyFromEventCode("Numpad1"));
+    assert.isNull(canonicalKeyFromEventCode("KeyA"));
+    assert.isNull(canonicalKeyFromEventCode(undefined));
+  });
+
+  it("resolves shifted digit events to digit keybindings and preserves NumLock-off navigation", () => {
+    // When pressing Shift+1 on US layout, browser emits key: "!" with code: "Digit1".
+    // Runtime dispatch matches the physical alias "1", resolving mod+1.
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "!", code: "Digit1", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { modelPickerOpen: true },
+      }),
+      "modelPicker.jump.1",
+    );
+
+    // Shifted binding (e.g. shift+6) matches when Shift+6 is pressed (key: "^", code: "Digit6")
+    const customBindings = compile([
+      {
+        shortcut: {
+          key: "6",
+          shiftKey: true,
+          metaKey: false,
+          ctrlKey: false,
+          altKey: false,
+          modKey: false,
+        },
+        command: "test.shift6" as KeybindingCommand,
+      },
+    ]);
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "^", code: "Digit6", shiftKey: true }), customBindings, {
+        platform: "Win32",
+      }),
+      "test.shift6",
+    );
+
+    // Existing legacy bindings configured with shifted symbols (e.g. "shift+^")
+    // continue to match via event.key:
+    const legacyBindings = compile([
+      {
+        shortcut: {
+          key: "^",
+          shiftKey: true,
+          metaKey: false,
+          ctrlKey: false,
+          altKey: false,
+          modKey: false,
+        },
+        command: "test.legacyShift" as KeybindingCommand,
+      },
+    ]);
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "^", code: "Digit6", shiftKey: true }), legacyBindings, {
+        platform: "Win32",
+      }),
+      "test.legacyShift",
+    );
+
+    // With NumLock off, Numpad1 produces key: "End" and must not trigger mod+1
+    assert.isNull(
+      resolveShortcutCommand(
+        event({ key: "End", code: "Numpad1", metaKey: true }),
+        DEFAULT_BINDINGS,
+        { platform: "MacIntel", context: { modelPickerOpen: true } },
+      ),
+    );
   });
 });
 

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -64,6 +64,12 @@ const EVENT_CODE_KEY_ALIASES: Readonly<Record<string, readonly string[]>> = {
   Digit9: ["9"],
 };
 
+export function canonicalKeyFromEventCode(code?: string | null): string | null {
+  if (!code) return null;
+  const aliases = EVENT_CODE_KEY_ALIASES[code];
+  return aliases?.[0] ?? null;
+}
+
 function normalizeEventKey(key: string): string {
   const normalized = key.toLowerCase();
   if (normalized === "esc") return "escape";


### PR DESCRIPTION
When recording a shortcut in Settings > Keyboard Shortcuts that includes Shift (e.g. `Mod+Shift+1` or `Shift+6`), `keybindingFromKeyboardEvent` previously evaluated `event.key` directly. On standard keyboard layouts with Shift held down, this produced the shifted symbol (such as `!` or `^`) instead of the digit number, saving non-canonical bindings like `shift+^` or `mod+shift+!`.

While legacy `shift+^` bindings continued to match at runtime because `resolveEventKeys` matches `event.key`, storing shifted symbols produces non-canonical, ugly shortcut strings that diverge from standard keybinding conventions.

### Changes
- **Shared code canonicalization (`apps/web/src/keybindings.ts`)**: Exported `canonicalKeyFromEventCode`, which derives canonical key tokens directly from the existing `EVENT_CODE_KEY_ALIASES` mapping (`Digit0`..`Digit9` -> `0`..`9`, `BracketLeft` -> `[`, `BracketRight` -> `]`). This keeps a single source of truth for physical key aliasing between runtime dispatch and settings capture.
- **Settings capture (`KeybindingsSettings.logic.ts`)**: `normalizeShortcutKeyToken` now reuses `canonicalKeyFromEventCode(event.code)` before falling back to normalized layout keys. Numpad keys are not in the alias map, so NumLock-off keypad navigation (e.g. `End`) preserves navigation behavior and is never hijacked as a digit.
- **Backwards compatibility & Runtime tests (`keybindings.test.ts`)**:
  - Verified `canonicalKeyFromEventCode` mapping across digits, brackets, and non-aliased keys.
  - Added test verifying shifted keydown events (`key: !`, `code: Digit1`) resolve to canonical digit commands (`modelPicker.jump.1`).
  - Added test verifying shifted digit shortcuts (`key: ^`, `code: Digit6`) resolve to `shift+6` bindings.
  - Added test verifying legacy stored shifted symbol bindings (`shift+^`) remain backwards-compatible and continue to fire via `event.key`.
  - Added test verifying NumLock-off navigation (`key: End`, `code: Numpad1`) does not trigger digit shortcuts.

### Visual Comparison

| Before | After |
| --- | --- |
| ![Before](https://raw.githubusercontent.com/Invictine/t3code/587bf9545313bdddf4237c62bb782eeb654b107d/before.png) | ![After](https://raw.githubusercontent.com/Invictine/t3code/587bf9545313bdddf4237c62bb782eeb654b107d/after.png) |

### Validation
Ran test suite:
- `vp test apps/web/src/components/settings/KeybindingsSettings.logic.test.ts apps/web/src/keybindings.test.ts` (all 65 tests pass).
- `vp check --fix` (formatting compliant).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix keybinding digit shortcuts to capture numbers via `event.code` instead of shifted symbols
> - Adds `canonicalKeyFromEventCode` in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/10174/files#diff-0c56a39781768a3ed42f3d306e35b87e9d2426ccb4a81010bc2c4fe735001385) to map physical keyboard event codes (digits, brackets, numpad) to canonical key tokens
> - Updates `normalizeShortcutKeyToken` and `keybindingFromKeyboardEvent` in [KeybindingsSettings.logic.ts](https://github.com/pingdotgg/t3code/pull/10174/files#diff-3e063dd9ee56de309e7e9618f62b33b69ff212f57241c19cc7114065efb919dd) to prefer the physical code over `event.key`, so shifted digits like `!` or `@` are stored as `1` and `2`
> - Unmapped codes fall back to existing `event.key` normalization; modifier ordering and platform handling are unchanged
> - Behavioral Change: legacy keybindings stored with shifted symbols (e.g. `!`) remain resolvable, but newly captured digit shortcuts will now record numeric tokens instead
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f58bf2e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->