### PR TITLE
fix(web): prevent file tree search focus ring clipping

### DIFF
--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -373,7 +373,7 @@ export default function FileBrowserPanel({
       data-file-browser-panel={`${environmentId}:${cwd}`}
     >
       <div
-        className="flex h-10 min-h-10 shrink-0 items-center gap-1 border-b border-border/60 bg-background px-2 in-data-[preview-panel-mode=inline]:mb-3 in-data-[preview-panel-mode=inline]:h-7 in-data-[preview-panel-mode=inline]:min-h-7 in-data-[preview-panel-mode=inline]:border-b-transparent"
+        className="flex h-10 min-h-10 shrink-0 items-center gap-1 border-b border-border/60 bg-background px-2 in-data-[preview-panel-mode=inline]:mb-1 in-data-[preview-panel-mode=inline]:h-9 in-data-[preview-panel-mode=inline]:min-h-9 in-data-[preview-panel-mode=inline]:border-b-transparent"
         data-surface-subheader
       >
         <RefreshFilesButton isPending={entriesQuery.isPending} onRefresh={handleRefresh} />


### PR DESCRIPTION
## What changed

Give the inline file tree toolbar enough vertical room to display the search field's full focus ring. Increase its height from 28px to 36px and reduce the bottom margin from 12px to 4px, keeping the file rows in place.

## Why

The inline toolbar was the same height as the search field, so the preview container clipped the top of its 3px focus ring. This spacing fix applies to web and desktop.

## UI changes

Before, provided by the reporter:

![Before: the search field focus ring is clipped at the top](https://github.com/user-attachments/assets/9cb53954-4b77-47d1-8635-d9e2b08d3222)

After, provided by the reporter:

![After: the complete search field focus ring is visible](https://github.com/user-attachments/assets/f44ada02-ddbf-43b1-893a-7a229b3a9992)

## Validation

- Web typecheck passed.
- Targeted formatting and diff checks passed.
- Targeted lint completed with three existing warnings in unchanged code.
- Reporter compared the original and fixed UI in the local dev server.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes

Implemented with GPT-6 through Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix file tree search focus ring clipping in `FileBrowserPanel`
> Adjusts inline preview-mode header utility classes in [FileBrowserPanel.tsx](https://github.com/pingdotgg/t3code/pull/10175/files#diff-aeb8bbbac738f422eace5ad6cee4745362f7559fdd5668df4eb1be558f4b5fb3): bottom margin reduced from 3 to 1 spacing unit, and header height/min-height increased from 7 to 9 spacing units. This gives the search input's focus ring enough room to render without clipping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf07143.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->