### PR TITLE
feat(web): improve PR review and agent workflows

### DIFF
--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
@@ -87,7 +87,8 @@ layer("AzureDevOpsPullRequestCli.layer", (it) => {
       const error = yield* Effect.flip(
         cli.runPullRequestAction({ cwd: "/w", number: 7, action: "delete-source-branch" }),
       );
-      expect(error.message).toContain("staleOldObjectId");
+      expect(error.reason).toBe("delete-refused");
+      expect(error.cause).toEqual({ success: false, updateStatus: "staleOldObjectId" });
       expect(argsOfCall(3)).toEqual(
         expect.arrayContaining([
           "delete",

--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
@@ -61,6 +61,90 @@ afterEach(() => {
 });
 
 layer("AzureDevOpsPullRequestCli.layer", (it) => {
+  it.effect("preserves existing Azure actions when the source pull request cannot be read", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(
+        Effect.fail(
+          new AzureDevOpsCli.AzureDevOpsCliAuthenticationError({
+            operation: "execute",
+            command: "az",
+            cwd: "/w",
+            argumentCount: 7,
+            cause: new Error("unavailable"),
+          }),
+        ),
+      );
+      const provider = yield* AzureDevOpsPullRequestProvider.make;
+      const permissions = yield* provider.getViewerPermissions({
+        cwd: "/w",
+        repository: "base/web",
+        host: "dev.azure.com",
+        number: 7,
+      });
+      expect(permissions.deleteSourceBranch).toBe(false);
+      expect(permissions.actions).toEqual(provider.capabilities.actions);
+    }),
+  );
+  it.effect.each([
+    ['{"count":1,"value":[true]}', true],
+    ['{"count":1,"value":[false]}', false],
+    ['{"count":0,"value":[]}', false],
+  ] as const)("checks exact Azure source branch deletion permission from %s", ([body, allowed]) =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output(body)));
+      const cli = yield* AzureDevOpsPullRequestCli.AzureDevOpsPullRequestCli;
+      expect(
+        yield* cli.getSourceBranchPermission({
+          cwd: "/w",
+          projectId: "fork-project",
+          repositoryId: "fork-repo",
+          branch: "feat/A",
+        }),
+      ).toBe(allowed);
+      expect(argsOfCall(0)).toEqual(
+        expect.arrayContaining([
+          "devops",
+          "invoke",
+          "--area",
+          "security",
+          "--resource",
+          "permissions",
+          "securityNamespaceId=2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87",
+          "permissions=8",
+          "tokens=repoV2/fork-project/fork-repo/refs/heads/6600650061007400/4100/",
+          "alwaysAllowAdministrators=true",
+        ]),
+      );
+    }),
+  );
+
+  it.effect.each([
+    ['{"count":1,"value":[true]}', true],
+    ['{"count":1,"value":[false]}', false],
+    ["{}", false],
+  ] as const)("uses source permission for Azure viewer authorization from %s", ([body, allowed]) =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(
+          output(
+            '{"pullRequestId":7,"title":"PR","status":"completed","sourceRefName":"refs/heads/feat/A","targetRefName":"refs/heads/main","creationDate":"2026-07-01T00:00:00Z","url":"https://dev.azure.com/acme/_apis/git/repositories/base/pullRequests/7","repository":{"id":"base","name":"web","project":{"id":"base-project","name":"base"}},"forkSource":{"repository":{"id":"fork-repo","name":"web","project":{"id":"fork-project","name":"fork"}}}}',
+          ),
+        ),
+      );
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output(body)));
+      const provider = yield* AzureDevOpsPullRequestProvider.make;
+      const permissions = yield* provider.getViewerPermissions({
+        cwd: "/w",
+        repository: "base/web",
+        host: "dev.azure.com",
+        number: 7,
+      });
+      expect(permissions.deleteSourceBranch).toBe(allowed);
+      expect(argsOfCall(1)).toContain(
+        "tokens=repoV2/fork-project/fork-repo/refs/heads/6600650061007400/4100/",
+      );
+    }),
+  );
   it.effect("checks the Azure fork ref tip and reports concurrent changes", () =>
     Effect.gen(function* () {
       const cli = yield* AzureDevOpsPullRequestCli.AzureDevOpsPullRequestCli;

--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
@@ -61,33 +61,33 @@ afterEach(() => {
 });
 
 layer("AzureDevOpsPullRequestCli.layer", (it) => {
-  it.effect("deletes an Azure fork ref at its current object ID and reports host refusal", () =>
+  it.effect("checks the Azure fork ref tip and reports concurrent changes", () =>
     Effect.gen(function* () {
       const cli = yield* AzureDevOpsPullRequestCli.AzureDevOpsPullRequestCli;
       mockedExecute.mockReturnValueOnce(
         Effect.succeed(
           output(
-            '{"status":"completed","sourceRefName":"refs/heads/topic","targetRefName":"refs/heads/main","repository":{"id":"base","project":{"id":"base-project"}},"forkSource":{"repository":{"id":"fork","project":{"id":"fork-project"}}}}',
+            '{"status":"completed","sourceRefName":"refs/heads/main","targetRefName":"refs/heads/main","repository":{"id":"base","project":{"id":"base-project"}},"forkSource":{"repository":{"id":"fork","project":{"id":"fork-project"}}}}',
           ),
         ),
       );
       mockedExecute.mockReturnValueOnce(
-        Effect.succeed(output('{"defaultBranch":"refs/heads/main"}')),
+        Effect.succeed(output('{"defaultBranch":"refs/heads/develop"}')),
       );
       mockedExecute.mockReturnValueOnce(
         Effect.succeed(
           output(
-            '[{"name":"refs/heads/topic-extra","objectId":"wrong"},{"name":"refs/heads/topic","objectId":"abc123"}]',
+            '[{"name":"refs/heads/main-extra","objectId":"wrong"},{"name":"refs/heads/main","objectId":"abc123"}]',
           ),
         ),
       );
       mockedExecute.mockReturnValueOnce(
-        Effect.succeed(output('{"success":false,"customMessage":"Permission denied"}')),
+        Effect.succeed(output('{"success":false,"updateStatus":"staleOldObjectId"}')),
       );
       const error = yield* Effect.flip(
         cli.runPullRequestAction({ cwd: "/w", number: 7, action: "delete-source-branch" }),
       );
-      expect(error.message).toContain("Permission denied");
+      expect(error.message).toContain("staleOldObjectId");
       expect(argsOfCall(3)).toEqual(
         expect.arrayContaining([
           "delete",
@@ -96,11 +96,12 @@ layer("AzureDevOpsPullRequestCli.layer", (it) => {
           "--project",
           "fork-project",
           "--name",
-          "refs/heads/topic",
+          "refs/heads/main",
           "--object-id",
           "abc123",
         ]),
       );
+      expect(mockedExecute).toHaveBeenCalledTimes(4);
     }),
   );
 

--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
@@ -61,6 +61,49 @@ afterEach(() => {
 });
 
 layer("AzureDevOpsPullRequestCli.layer", (it) => {
+  it.effect("deletes an Azure fork ref at its current object ID and reports host refusal", () =>
+    Effect.gen(function* () {
+      const cli = yield* AzureDevOpsPullRequestCli.AzureDevOpsPullRequestCli;
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(
+          output(
+            '{"status":"completed","sourceRefName":"refs/heads/topic","targetRefName":"refs/heads/main","repository":{"id":"base","project":{"id":"base-project"}},"forkSource":{"repository":{"id":"fork","project":{"id":"fork-project"}}}}',
+          ),
+        ),
+      );
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(output('{"defaultBranch":"refs/heads/main"}')),
+      );
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(
+          output(
+            '[{"name":"refs/heads/topic-extra","objectId":"wrong"},{"name":"refs/heads/topic","objectId":"abc123"}]',
+          ),
+        ),
+      );
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(output('{"success":false,"customMessage":"Permission denied"}')),
+      );
+      const error = yield* Effect.flip(
+        cli.runPullRequestAction({ cwd: "/w", number: 7, action: "delete-source-branch" }),
+      );
+      expect(error.message).toContain("Permission denied");
+      expect(argsOfCall(3)).toEqual(
+        expect.arrayContaining([
+          "delete",
+          "--repository",
+          "fork",
+          "--project",
+          "fork-project",
+          "--name",
+          "refs/heads/topic",
+          "--object-id",
+          "abc123",
+        ]),
+      );
+    }),
+  );
+
   it.effect("asks for one row more than the page, to probe for a next page", () =>
     Effect.gen(function* () {
       mockedExecute.mockReturnValueOnce(Effect.succeed(output(pullRequests(3, 1))));
@@ -537,7 +580,7 @@ layer("AzureDevOpsPullRequestCli.layer", (it) => {
       );
       const cli = yield* AzureDevOpsPullRequestCli.AzureDevOpsPullRequestCli;
 
-      const comments = yield* cli.listThreads({
+      const { comments } = yield* cli.listThreads({
         cwd: "/w",
         threadsUrl: "https://dev.azure.com/acme/platform/_apis/git/r/web/pullRequests/42/threads",
       });

--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
@@ -87,8 +87,10 @@ layer("AzureDevOpsPullRequestCli.layer", (it) => {
       const error = yield* Effect.flip(
         cli.runPullRequestAction({ cwd: "/w", number: 7, action: "delete-source-branch" }),
       );
-      expect(error.reason).toBe("delete-refused");
-      expect(error.cause).toEqual({ success: false, updateStatus: "staleOldObjectId" });
+      expect(error).toMatchObject({
+        reason: "delete-refused",
+        cause: { success: false, updateStatus: "staleOldObjectId" },
+      });
       expect(argsOfCall(3)).toEqual(
         expect.arrayContaining([
           "delete",

--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
@@ -1,3 +1,8 @@
+import {
+  assertSourceBranchDeletable,
+  decodeBranchDeletionJson,
+  PullRequestBranchDeletionError,
+} from "./pullRequestBranchDeletion.ts";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -5,6 +10,7 @@ import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import type {
   PullRequestAction,
+  PullRequestTimelineEvent,
   PullRequestComment,
   PullRequestInvolvement,
   PullRequestListState,
@@ -103,6 +109,7 @@ export class AzureDevOpsReviewerNameError extends Schema.TaggedErrorClass<AzureD
 }
 
 export type AzureDevOpsPullRequestCliError =
+  | PullRequestBranchDeletionError
   | AzureDevOpsCli.AzureDevOpsCliError
   | AzureDevOpsPullRequestReadError
   | AzureDevOpsPullRequestIncompleteError
@@ -151,7 +158,13 @@ export class AzureDevOpsPullRequestCli extends Context.Service<
     readonly listThreads: (input: {
       readonly cwd: string;
       readonly threadsUrl: string;
-    }) => Effect.Effect<ReadonlyArray<PullRequestComment>, AzureDevOpsPullRequestCliError>;
+    }) => Effect.Effect<
+      {
+        readonly comments: ReadonlyArray<PullRequestComment>;
+        readonly timelineEvents: ReadonlyArray<PullRequestTimelineEvent>;
+      },
+      AzureDevOpsPullRequestCliError
+    >;
 
     readonly runPullRequestAction: (input: {
       readonly cwd: string;
@@ -219,6 +232,8 @@ function actionArgs(
   mergeMethod: PullRequestMergeMethod | undefined,
 ): ReadonlyArray<string> {
   switch (action) {
+    case "delete-source-branch":
+      throw new Error("Source branch deletion requires a fresh branch lookup");
     case "merge":
       return ["--status", "completed", "--squash", mergeMethod === "squash" ? "true" : "false"];
     // Auto-complete is Azure's own name for it: the pull request stays active and Azure completes
@@ -497,8 +512,102 @@ export const make = Effect.gen(function* () {
             })
             .pipe(Effect.asVoid),
 
-    runPullRequestAction: (input) =>
-      azure
+    runPullRequestAction: (input) => {
+      if (input.action === "delete-source-branch") {
+        return Effect.gen(function* () {
+          const response = yield* executeJson({
+            cwd: input.cwd,
+            args: ["repos", "pr", "show", ...detectArgs, "--id", String(input.number)],
+          });
+          const repositorySchema = Schema.Struct({
+            id: Schema.String,
+            project: Schema.Struct({ id: Schema.String }),
+          });
+          const current = yield* decodeBranchDeletionJson(
+            Schema.Struct({
+              status: Schema.String,
+              sourceRefName: Schema.String,
+              targetRefName: Schema.String,
+              repository: repositorySchema,
+              forkSource: Schema.optional(
+                Schema.NullOr(Schema.Struct({ repository: repositorySchema })),
+              ),
+            }),
+            response.stdout,
+          );
+          const source = current.forkSource?.repository ?? current.repository;
+          const sourceArgs = [
+            ...detectArgs,
+            "--repository",
+            source.id,
+            "--project",
+            source.project.id,
+          ];
+          const repository = yield* executeJson({
+            cwd: input.cwd,
+            args: ["repos", "show", ...sourceArgs],
+          });
+          const config = yield* decodeBranchDeletionJson(
+            Schema.Struct({ defaultBranch: Schema.String }),
+            repository.stdout,
+          );
+          yield* assertSourceBranchDeletable({
+            state: current.status,
+            sourceBranch: current.sourceRefName,
+            baseBranch: current.targetRefName,
+            defaultBranch: config.defaultBranch,
+          });
+          const refs = yield* executeJson({
+            cwd: input.cwd,
+            args: [
+              "repos",
+              "ref",
+              "list",
+              ...sourceArgs,
+              "--filter",
+              current.sourceRefName.replace(/^refs\//, ""),
+            ],
+          });
+          const branches = yield* decodeBranchDeletionJson(
+            Schema.Array(Schema.Struct({ name: Schema.String, objectId: Schema.String })),
+            refs.stdout,
+          );
+          const branch = branches.find((ref) => ref.name === current.sourceRefName);
+          if (branch === undefined)
+            return yield* new PullRequestBranchDeletionError({
+              detail: "The source branch has already been deleted.",
+            });
+          const deleted = yield* executeJson({
+            cwd: input.cwd,
+            args: [
+              "repos",
+              "ref",
+              "delete",
+              ...sourceArgs,
+              "--name",
+              branch.name,
+              "--object-id",
+              branch.objectId,
+            ],
+          });
+          const result = yield* decodeBranchDeletionJson(
+            Schema.Struct({
+              success: Schema.Boolean,
+              customMessage: Schema.optional(Schema.NullOr(Schema.String)),
+              updateStatus: Schema.optional(Schema.String),
+            }),
+            deleted.stdout,
+          );
+          if (!result.success)
+            return yield* new PullRequestBranchDeletionError({
+              detail:
+                result.customMessage ??
+                result.updateStatus ??
+                "Azure DevOps refused to delete the source branch.",
+            });
+        });
+      }
+      return azure
         .execute({
           cwd: input.cwd,
           args: [
@@ -514,7 +623,8 @@ export const make = Effect.gen(function* () {
             "json",
           ],
         })
-        .pipe(Effect.asVoid),
+        .pipe(Effect.asVoid);
+    },
 
     updatePullRequest: (input) =>
       azure

--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
@@ -1,3 +1,4 @@
+import * as NodeBuffer from "node:buffer";
 import {
   assertSourceBranchDeletable,
   decodeBranchDeletionJson,
@@ -149,6 +150,13 @@ export class AzureDevOpsPullRequestCli extends Context.Service<
       AzureDevOpsPullRequestCliError
     >;
 
+    readonly getSourceBranchPermission: (input: {
+      readonly cwd: string;
+      readonly projectId: string;
+      readonly repositoryId: string;
+      readonly branch: string;
+    }) => Effect.Effect<boolean, AzureDevOpsPullRequestCliError>;
+
     readonly getPullRequest: (input: {
       readonly cwd: string;
       readonly number: number;
@@ -275,6 +283,10 @@ function isReviewerName(value: string): boolean {
   const name = value.trim();
   return name.length > 0 && !name.startsWith("-");
 }
+
+const decodeSourceBranchPermission = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(Schema.Struct({ value: Schema.Array(Schema.Boolean) })),
+);
 
 export const make = Effect.gen(function* () {
   const azure = yield* AzureDevOpsCli.AzureDevOpsCli;
@@ -427,6 +439,50 @@ export const make = Effect.gen(function* () {
         cursorAdvance: 0,
         items: [],
       }),
+
+    getSourceBranchPermission: (input) => {
+      const branch = input.branch
+        .split("/")
+        .map((part) => NodeBuffer.Buffer.from(part, "utf16le").toString("hex"))
+        .join("/");
+      return executeJson({
+        cwd: input.cwd,
+        args: [
+          "devops",
+          "invoke",
+          ...detectArgs,
+          "--area",
+          "security",
+          "--resource",
+          "permissions",
+          "--route-parameters",
+          "securityNamespaceId=2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87",
+          "permissions=8",
+          "--query-parameters",
+          `tokens=repoV2/${input.projectId}/${input.repositoryId}/refs/heads/${branch}/`,
+          "alwaysAllowAdministrators=true",
+          "--api-version",
+          "7.1",
+          "--http-method",
+          "GET",
+        ],
+      }).pipe(
+        Effect.flatMap((response) =>
+          decodeSourceBranchPermission(response.stdout).pipe(
+            Effect.mapError(
+              (cause) =>
+                new AzureDevOpsPullRequestReadError({
+                  command: "az",
+                  cwd: input.cwd,
+                  operation: "getSourceBranchPermission",
+                  cause,
+                }),
+            ),
+          ),
+        ),
+        Effect.map((response) => response.value.length === 1 && response.value[0] === true),
+      );
+    },
 
     getPullRequest: (input) =>
       executeJson({

--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
@@ -577,7 +577,7 @@ export const make = Effect.gen(function* () {
           const branch = branches.find((ref) => ref.name === current.sourceRefName);
           if (branch === undefined)
             return yield* new PullRequestBranchDeletionError({
-              detail: "The source branch has already been deleted.",
+              reason: "source-branch-missing",
             });
           const deleted = yield* executeJson({
             cwd: input.cwd,
@@ -602,10 +602,8 @@ export const make = Effect.gen(function* () {
           );
           if (!result.success)
             return yield* new PullRequestBranchDeletionError({
-              detail:
-                result.customMessage ??
-                result.updateStatus ??
-                "Azure DevOps refused to delete the source branch.",
+              reason: "delete-refused",
+              cause: result,
             });
         });
       }

--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
@@ -553,6 +553,8 @@ export const make = Effect.gen(function* () {
           );
           yield* assertSourceBranchDeletable({
             state: current.status,
+            sourceRepository: source.id,
+            baseRepository: current.repository.id,
             sourceBranch: current.sourceRefName,
             baseBranch: current.targetRefName,
             defaultBranch: config.defaultBranch,

--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestProvider.ts
@@ -13,6 +13,7 @@ import {
 import type { AzureDevOpsPullRequest } from "./azureDevOpsPullRequestJson.ts";
 
 const CAPABILITIES: PullRequestCapabilities = {
+  deleteSourceBranch: true,
   // `az repos pr` has no diff command, and the REST route reports changed files without their
   // contents, so there is no patch to show. The Code tab is hidden rather than empty.
   diff: false,
@@ -57,6 +58,7 @@ const CAPABILITIES: PullRequestCapabilities = {
  * leaves them no way through and no reason given.
  */
 const AZURE_DEVOPS_VIEWER_PERMISSIONS: PullRequestViewerPermissions = {
+  deleteSourceBranch: true,
   actions: CAPABILITIES.actions,
   comment: CAPABILITIES.comment,
   resolve: CAPABILITIES.review.resolve,
@@ -81,6 +83,9 @@ function toChangeRequest(pullRequest: AzureDevOpsPullRequest): ProviderChangeReq
     url: pullRequest.url,
     author: pullRequest.author,
     headBranch: pullRequest.headBranch,
+    ...(pullRequest.headRepositoryNameWithOwner === undefined
+      ? {}
+      : { headRepositoryNameWithOwner: pullRequest.headRepositoryNameWithOwner }),
     baseBranch: pullRequest.baseBranch,
     state: pullRequest.state,
     isDraft: pullRequest.isDraft,
@@ -181,11 +186,15 @@ export const make = Effect.gen(function* () {
           (pullRequest.threadsUrl === null
             ? Effect.succeed({ comments: [], truncated: true })
             : cli.listThreads({ cwd: input.cwd, threadsUrl: pullRequest.threadsUrl }).pipe(
-                Effect.map((comments) => ({ comments, truncated: false })),
+                Effect.map((activity) => ({ ...activity, truncated: false })),
                 Effect.orElseSucceed(() => ({ comments: [], truncated: true })),
               )
           ).pipe(
             Effect.map((conversation): ProviderChangeRequestActivity => ({
+              timelineEvents: ("timelineEvents" in conversation
+                ? conversation.timelineEvents
+                : []
+              ).map((event) => ({ ...event, url: pullRequest.url })),
               comments: conversation.comments,
               commentCount: conversation.comments.length,
               commentsTruncated: conversation.truncated,

--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestProvider.ts
@@ -47,18 +47,8 @@ const CAPABILITIES: PullRequestCapabilities = {
   edit: { changeRequest: true, comment: false },
 };
 
-/**
- * Everything this host offers, granted to whoever is signed in. Azure DevOps states no permission
- * anywhere `az repos pr show` or `az repos pr list` reach: the answer lives in the security
- * namespaces, behind identity descriptors and token paths that would be several calls per pull
- * request to resolve.
- *
- * So the actions stay live and a viewer who may not take one is told so by Azure, at the moment
- * they try. That is the safer half of an unknown: hiding a control from someone entitled to it
- * leaves them no way through and no reason given.
- */
 const AZURE_DEVOPS_VIEWER_PERMISSIONS: PullRequestViewerPermissions = {
-  deleteSourceBranch: true,
+  deleteSourceBranch: false,
   actions: CAPABILITIES.actions,
   comment: CAPABILITIES.comment,
   resolve: CAPABILITIES.review.resolve,
@@ -126,6 +116,24 @@ export const make = Effect.gen(function* () {
       }),
     );
 
+  const viewerPermissions = (cwd: string, pullRequest: AzureDevOpsPullRequest) =>
+    (pullRequest.sourceProjectId === undefined || pullRequest.sourceRepositoryId === undefined
+      ? Effect.succeed(false)
+      : cli
+          .getSourceBranchPermission({
+            cwd,
+            projectId: pullRequest.sourceProjectId,
+            repositoryId: pullRequest.sourceRepositoryId,
+            branch: pullRequest.headBranch,
+          })
+          .pipe(Effect.orElseSucceed(() => false))
+    ).pipe(
+      Effect.map((deleteSourceBranch): PullRequestViewerPermissions => ({
+        ...AZURE_DEVOPS_VIEWER_PERMISSIONS,
+        deleteSourceBranch,
+      })),
+    );
+
   const provider: PullRequestProviderApi = {
     kind: "azure-devops",
     capabilities: CAPABILITIES,
@@ -162,21 +170,25 @@ export const make = Effect.gen(function* () {
     getChangeRequest: (input) =>
       cli.getPullRequest({ cwd: input.cwd, number: input.number }).pipe(
         Effect.mapError(fail("getChangeRequest")),
-        Effect.map((pullRequest): ProviderChangeRequestDetail => ({
-          ...toChangeRequest(pullRequest),
-          body: pullRequest.body,
-          changedFiles: 0,
-          mergedAt: pullRequest.state === "merged" ? pullRequest.closedAt : null,
-          closedAt: pullRequest.state === "closed" ? pullRequest.closedAt : null,
-          reviewers: pullRequest.reviewers,
-          checks: [],
-          mergeCapabilities: { merge: true, squash: true, rebase: false },
-          viewerPermissions: AZURE_DEVOPS_VIEWER_PERMISSIONS,
-          autoMergeEnabled: pullRequest.autoMergeEnabled,
-          ...(pullRequest.autoMergeMethod === undefined
-            ? {}
-            : { autoMergeMethod: pullRequest.autoMergeMethod }),
-        })),
+        Effect.flatMap((pullRequest) =>
+          viewerPermissions(input.cwd, pullRequest).pipe(
+            Effect.map((permissions): ProviderChangeRequestDetail => ({
+              ...toChangeRequest(pullRequest),
+              body: pullRequest.body,
+              changedFiles: 0,
+              mergedAt: pullRequest.state === "merged" ? pullRequest.closedAt : null,
+              closedAt: pullRequest.state === "closed" ? pullRequest.closedAt : null,
+              reviewers: pullRequest.reviewers,
+              checks: [],
+              mergeCapabilities: { merge: true, squash: true, rebase: false },
+              viewerPermissions: permissions,
+              autoMergeEnabled: pullRequest.autoMergeEnabled,
+              ...(pullRequest.autoMergeMethod === undefined
+                ? {}
+                : { autoMergeMethod: pullRequest.autoMergeMethod }),
+            })),
+          ),
+        ),
       ),
 
     getChangeRequestActivity: (input) =>
@@ -205,9 +217,11 @@ export const make = Effect.gen(function* () {
         ),
       ),
 
-    // No request at all: Azure has nothing to say about the viewer that a pull request read can
-    // reach, so the answer is the same constant the detail carries.
-    getViewerPermissions: () => Effect.succeed(AZURE_DEVOPS_VIEWER_PERMISSIONS),
+    getViewerPermissions: (input) =>
+      cli.getPullRequest(input).pipe(
+        Effect.flatMap((pullRequest) => viewerPermissions(input.cwd, pullRequest)),
+        Effect.orElseSucceed(() => AZURE_DEVOPS_VIEWER_PERMISSIONS),
+      ),
 
     // Never called: `capabilities.diff` is false, and the service refuses a diff without it.
     getDiff: () =>

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
@@ -83,6 +83,21 @@ afterEach(() => {
 });
 
 layer("BitbucketPullRequestApi.layer", (it) => {
+  it.effect.each([
+    ['{"values":[{"permission":"write"}]}', true],
+    ['{"values":[{"permission":"admin"}]}', true],
+    ['{"values":[{"permission":"read"}]}', false],
+    ['{"values":[]}', false],
+    ['{"values":[{}]}', false],
+  ] as const)("reads explicit source permission from %s", ([body, allowed]) =>
+    Effect.gen(function* () {
+      mockedRequest.mockReturnValueOnce(Effect.succeed(response(body)));
+      const api = yield* BitbucketPullRequestApi.BitbucketPullRequestApi;
+      expect(yield* api.getSourceRepositoryPermission({ repository: "fork/web" })).toBe(allowed);
+      expect(callAt(0).url).toMatch(/^\/user\/workspaces\/fork\/permissions\/repositories\?/);
+      expect(filterOfCall(0)).toBe('repository.full_name="fork/web"');
+    }),
+  );
   it.effect("deletes the fork source branch and refuses the pull request target branch", () =>
     Effect.gen(function* () {
       const api = yield* BitbucketPullRequestApi.BitbucketPullRequestApi;

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
@@ -120,7 +120,7 @@ layer("BitbucketPullRequestApi.layer", (it) => {
         Effect.succeed(response('{"mainbranch":{"name":"develop"}}')),
       );
       const error = yield* Effect.flip(api.runAction(target));
-      expect(error.reason).toBe("protected-branch");
+      expect(error).toMatchObject({ reason: "protected-branch" });
       expect(mockedRequest).toHaveBeenCalledTimes(5);
     }),
   );

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
@@ -83,6 +83,38 @@ afterEach(() => {
 });
 
 layer("BitbucketPullRequestApi.layer", (it) => {
+  it.effect("deletes the fork source branch and refuses the pull request target branch", () =>
+    Effect.gen(function* () {
+      const api = yield* BitbucketPullRequestApi.BitbucketPullRequestApi;
+      const target = { repository: "acme/web", number: 7, action: "delete-source-branch" as const };
+      const current = {
+        state: "MERGED",
+        source: { branch: { name: "feature/topic" }, repository: { full_name: "fork/renamed" } },
+        destination: { branch: { name: "release" } },
+      };
+      mockedRequest.mockReturnValueOnce(Effect.succeed(response(pullRequestJson(current))));
+      mockedRequest.mockReturnValueOnce(Effect.succeed(response('{"mainbranch":{"name":"main"}}')));
+      mockedRequest.mockReturnValueOnce(Effect.succeed(response("")));
+      yield* api.runAction(target);
+      expect(callAt(1).url).toBe("/repositories/fork/renamed");
+      expect(callAt(2)).toEqual({
+        method: "DELETE",
+        url: "/repositories/fork/renamed/refs/branches/feature%2Ftopic",
+      });
+      mockedRequest.mockReturnValueOnce(
+        Effect.succeed(
+          response(
+            pullRequestJson({ ...current, destination: { branch: { name: "feature/topic" } } }),
+          ),
+        ),
+      );
+      mockedRequest.mockReturnValueOnce(Effect.succeed(response('{"mainbranch":{"name":"main"}}')));
+      const error = yield* Effect.flip(api.runAction(target));
+      expect(error.message).toContain("cannot be deleted");
+      expect(mockedRequest).toHaveBeenCalledTimes(5);
+    }),
+  );
+
   it.effect("asks for reviewers, newest first, at Bitbucket's page ceiling", () =>
     Effect.gen(function* () {
       mockedRequest.mockReturnValueOnce(Effect.succeed(response(page(3, 1))));

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
@@ -89,26 +89,36 @@ layer("BitbucketPullRequestApi.layer", (it) => {
       const target = { repository: "acme/web", number: 7, action: "delete-source-branch" as const };
       const current = {
         state: "MERGED",
-        source: { branch: { name: "feature/topic" }, repository: { full_name: "fork/renamed" } },
-        destination: { branch: { name: "release" } },
+        source: {
+          branch: { name: "main" },
+          repository: { uuid: "{fork}", full_name: "fork/renamed" },
+        },
+        destination: { branch: { name: "main" }, repository: { uuid: "{base}" } },
       };
       mockedRequest.mockReturnValueOnce(Effect.succeed(response(pullRequestJson(current))));
-      mockedRequest.mockReturnValueOnce(Effect.succeed(response('{"mainbranch":{"name":"main"}}')));
+      mockedRequest.mockReturnValueOnce(
+        Effect.succeed(response('{"mainbranch":{"name":"develop"}}')),
+      );
       mockedRequest.mockReturnValueOnce(Effect.succeed(response("")));
       yield* api.runAction(target);
       expect(callAt(1).url).toBe("/repositories/fork/renamed");
       expect(callAt(2)).toEqual({
         method: "DELETE",
-        url: "/repositories/fork/renamed/refs/branches/feature%2Ftopic",
+        url: "/repositories/fork/renamed/refs/branches/main",
       });
       mockedRequest.mockReturnValueOnce(
         Effect.succeed(
           response(
-            pullRequestJson({ ...current, destination: { branch: { name: "feature/topic" } } }),
+            pullRequestJson({
+              ...current,
+              destination: { branch: { name: "main" }, repository: { uuid: "{fork}" } },
+            }),
           ),
         ),
       );
-      mockedRequest.mockReturnValueOnce(Effect.succeed(response('{"mainbranch":{"name":"main"}}')));
+      mockedRequest.mockReturnValueOnce(
+        Effect.succeed(response('{"mainbranch":{"name":"develop"}}')),
+      );
       const error = yield* Effect.flip(api.runAction(target));
       expect(error.message).toContain("cannot be deleted");
       expect(mockedRequest).toHaveBeenCalledTimes(5);

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
@@ -120,7 +120,7 @@ layer("BitbucketPullRequestApi.layer", (it) => {
         Effect.succeed(response('{"mainbranch":{"name":"develop"}}')),
       );
       const error = yield* Effect.flip(api.runAction(target));
-      expect(error.message).toContain("cannot be deleted");
+      expect(error.reason).toBe("protected-branch");
       expect(mockedRequest).toHaveBeenCalledTimes(5);
     }),
   );

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
@@ -776,7 +776,7 @@ export const make = Effect.gen(function* () {
             const sourceRepository = current.source.repository;
             if (sourceRepository === null)
               return yield* new PullRequestBranchDeletionError({
-                detail: "The source repository no longer exists.",
+                reason: "source-repository-missing",
               });
             return yield* withRepository(sourceRepository.full_name, (source) =>
               Effect.gen(function* () {
@@ -799,17 +799,17 @@ export const make = Effect.gen(function* () {
                     url: `${source}/refs/branches/${encodeURIComponent(current.source.branch.name)}`,
                   })
                   .pipe(
-                    Effect.catchTag(
-                      "BitbucketResponseError",
-                      (cause): Effect.Effect<never, BitbucketPullRequestApiError> =>
+                    Effect.catchTags({
+                      BitbucketResponseError: (
+                        cause,
+                      ): Effect.Effect<never, BitbucketPullRequestApiError> =>
                         cause.status === 404
                           ? new PullRequestBranchDeletionError({
-                              detail:
-                                "The source branch has already been deleted or is no longer accessible.",
+                              reason: "source-branch-missing",
                               cause,
                             })
                           : Effect.fail(cause),
-                    ),
+                    }),
                   );
               }),
             );

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
@@ -762,17 +762,23 @@ export const make = Effect.gen(function* () {
                 state: Schema.String,
                 source: Schema.Struct({
                   branch: Schema.Struct({ name: Schema.String }),
-                  repository: Schema.NullOr(Schema.Struct({ full_name: Schema.String })),
+                  repository: Schema.NullOr(
+                    Schema.Struct({ uuid: Schema.String, full_name: Schema.String }),
+                  ),
                 }),
-                destination: Schema.Struct({ branch: Schema.Struct({ name: Schema.String }) }),
+                destination: Schema.Struct({
+                  branch: Schema.Struct({ name: Schema.String }),
+                  repository: Schema.Struct({ uuid: Schema.String }),
+                }),
               }),
               response.body,
             );
-            if (current.source.repository === null)
+            const sourceRepository = current.source.repository;
+            if (sourceRepository === null)
               return yield* new PullRequestBranchDeletionError({
                 detail: "The source repository no longer exists.",
               });
-            return yield* withRepository(current.source.repository.full_name, (source) =>
+            return yield* withRepository(sourceRepository.full_name, (source) =>
               Effect.gen(function* () {
                 const repository = yield* bitbucket.request({ method: "GET", url: source });
                 const config = yield* decodeBranchDeletionJson(
@@ -781,6 +787,8 @@ export const make = Effect.gen(function* () {
                 );
                 yield* assertSourceBranchDeletable({
                   state: current.state,
+                  sourceRepository: sourceRepository.uuid,
+                  baseRepository: current.destination.repository.uuid,
                   sourceBranch: current.source.branch.name,
                   baseBranch: current.destination.branch.name,
                   defaultBranch: config.mainbranch.name,

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
@@ -1,3 +1,8 @@
+import {
+  assertSourceBranchDeletable,
+  decodeBranchDeletionJson,
+  PullRequestBranchDeletionError,
+} from "./pullRequestBranchDeletion.ts";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -5,6 +10,7 @@ import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import type {
   PullRequestAction,
+  PullRequestTimelineEvent,
   PullRequestCheck,
   PullRequestComment,
   PullRequestCommit,
@@ -30,6 +36,7 @@ import {
   decodeRepositoryPermissionJson,
   decodeStatusesJson,
   decodeViewerJson,
+  decodeTimelineEventsJson,
   decodeWorkspaceMembersJson,
   type BitbucketDiffStat,
   type BitbucketPullRequest,
@@ -102,6 +109,7 @@ export class BitbucketDiffCommitError extends Schema.TaggedErrorClass<BitbucketD
 }
 
 export type BitbucketPullRequestApiError =
+  | PullRequestBranchDeletionError
   | BitbucketApi.BitbucketApiError
   | BitbucketPullRequestReadError
   | BitbucketViewerUnavailableError
@@ -186,6 +194,11 @@ export class BitbucketPullRequestApi extends Context.Service<
       readonly repository: string;
       readonly number: number;
     }) => Effect.Effect<PullRequestMergeability, BitbucketPullRequestApiError>;
+
+    readonly listTimelineEvents: (input: {
+      readonly repository: string;
+      readonly number: number;
+    }) => Effect.Effect<ReadonlyArray<PullRequestTimelineEvent>, BitbucketPullRequestApiError>;
 
     readonly listComments: (input: {
       readonly repository: string;
@@ -633,6 +646,17 @@ export const make = Effect.gen(function* () {
         }),
       ),
 
+    listTimelineEvents: (input) =>
+      withRepository(input.repository, (path) =>
+        itemPages({
+          operation: "listTimelineEvents",
+          url: `${path}/pullrequests/${input.number}/activity?pagelen=${CONVERSATION_PAGE_SIZE}`,
+          decode: decodeTimelineEventsJson,
+          items: [],
+          prepend: false,
+        }),
+      ),
+
     listComments: (input) =>
       withRepository(input.repository, (path) =>
         commentsPage({
@@ -730,6 +754,59 @@ export const make = Effect.gen(function* () {
     runAction: (input) =>
       withRepository(input.repository, (path) => {
         const pullRequest = `${path}/pullrequests/${input.number}`;
+        if (input.action === "delete-source-branch") {
+          return Effect.gen(function* () {
+            const response = yield* bitbucket.request({ method: "GET", url: pullRequest });
+            const current = yield* decodeBranchDeletionJson(
+              Schema.Struct({
+                state: Schema.String,
+                source: Schema.Struct({
+                  branch: Schema.Struct({ name: Schema.String }),
+                  repository: Schema.NullOr(Schema.Struct({ full_name: Schema.String })),
+                }),
+                destination: Schema.Struct({ branch: Schema.Struct({ name: Schema.String }) }),
+              }),
+              response.body,
+            );
+            if (current.source.repository === null)
+              return yield* new PullRequestBranchDeletionError({
+                detail: "The source repository no longer exists.",
+              });
+            return yield* withRepository(current.source.repository.full_name, (source) =>
+              Effect.gen(function* () {
+                const repository = yield* bitbucket.request({ method: "GET", url: source });
+                const config = yield* decodeBranchDeletionJson(
+                  Schema.Struct({ mainbranch: Schema.Struct({ name: Schema.String }) }),
+                  repository.body,
+                );
+                yield* assertSourceBranchDeletable({
+                  state: current.state,
+                  sourceBranch: current.source.branch.name,
+                  baseBranch: current.destination.branch.name,
+                  defaultBranch: config.mainbranch.name,
+                });
+                yield* bitbucket
+                  .request({
+                    method: "DELETE",
+                    url: `${source}/refs/branches/${encodeURIComponent(current.source.branch.name)}`,
+                  })
+                  .pipe(
+                    Effect.catchTag(
+                      "BitbucketResponseError",
+                      (cause): Effect.Effect<never, BitbucketPullRequestApiError> =>
+                        cause.status === 404
+                          ? new PullRequestBranchDeletionError({
+                              detail:
+                                "The source branch has already been deleted or is no longer accessible.",
+                              cause,
+                            })
+                          : Effect.fail(cause),
+                    ),
+                  );
+              }),
+            );
+          });
+        }
         // Only merge and close reach here: the provider declares the others unsupported, so the
         // surface never offers them.
         if (input.action === "merge") {

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
@@ -170,6 +170,10 @@ export class BitbucketPullRequestApi extends Context.Service<
       readonly number: number;
     }) => Effect.Effect<BitbucketPullRequest, BitbucketPullRequestApiError>;
 
+    readonly getSourceRepositoryPermission: (input: {
+      readonly repository: string;
+    }) => Effect.Effect<boolean, BitbucketPullRequestApiError>;
+
     /** True where the credentials can write to the repository, which is what merging needs. */
     readonly getRepositoryPermission: (input: {
       readonly repository: string;
@@ -607,6 +611,15 @@ export const make = Effect.gen(function* () {
           decode: decodeRepositoryPermissionJson,
         }),
       ).pipe(Effect.catchIf(isRepositoryPermissionRemovedError, () => Effect.succeed(true))),
+
+    getSourceRepositoryPermission: (input) =>
+      withRepository(input.repository, () =>
+        readPage({
+          operation: "getSourceRepositoryPermission",
+          url: `/user/workspaces/${encodeURIComponent(input.repository.trim().split("/")[0]!)}/permissions/repositories?q=${encodeURIComponent(`repository.full_name="${filterLiteral(input.repository.trim())}"`)}`,
+          decode: (raw) => decodeRepositoryPermissionJson(raw, false),
+        }),
+      ),
 
     getPullRequestDiff: (input) =>
       input.commit !== undefined && !isCommitSha(input.commit)

--- a/apps/server/src/pullRequest/BitbucketPullRequestProvider.test.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestProvider.test.ts
@@ -23,6 +23,7 @@ describe("bitbucketProviderFailure", () => {
 describe("bitbucketViewerPermissions", () => {
   it("offers both actions to credentials with write access", () => {
     expect(bitbucketViewerPermissions({ canWrite: true })).toEqual({
+      deleteSourceBranch: true,
       actions: ["merge", "close"],
       comment: true,
       resolve: true,
@@ -35,6 +36,7 @@ describe("bitbucketViewerPermissions", () => {
 
   it("keeps merge from credentials that can only read the repository", () => {
     expect(bitbucketViewerPermissions({ canWrite: false })).toEqual({
+      deleteSourceBranch: true,
       actions: ["close"],
       comment: true,
       resolve: true,

--- a/apps/server/src/pullRequest/BitbucketPullRequestProvider.test.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestProvider.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 
 import * as BitbucketApi from "../sourceControl/BitbucketApi.ts";
+import * as BitbucketPullRequestApi from "./BitbucketPullRequestApi.ts";
 import {
   bitbucketProviderFailure,
   bitbucketViewerPermissions,
+  make,
 } from "./BitbucketPullRequestProvider.ts";
 
 describe("bitbucketProviderFailure", () => {
@@ -52,3 +56,74 @@ describe("bitbucketViewerPermissions", () => {
     expect(bitbucketViewerPermissions({ canWrite: false }).actions).toEqual(["close"]);
   });
 });
+
+it.effect("keeps historical verdict events while removing current review duplicates", () =>
+  Effect.gen(function* () {
+    const current = "2026-09-05T12:00:00.000Z";
+    const older = "2026-09-04T12:00:00.000Z";
+    const actor = (login: string) => ({ login, name: null, avatarUrl: null });
+    const review = (login: string, reviewState: string) => ({
+      id: login,
+      kind: "review" as const,
+      author: actor(login),
+      body: "",
+      createdAt: current,
+      url: null,
+      path: null,
+      reviewState,
+    });
+    const event = (id: string, kind: string, login: string, createdAt: string) => ({
+      id,
+      kind,
+      actor: actor(login),
+      createdAt,
+      url: null,
+      body: kind,
+    });
+    const provider = yield* make.pipe(
+      Effect.provide(
+        Layer.mock(BitbucketPullRequestApi.BitbucketPullRequestApi)({
+          getPullRequest: () =>
+            Effect.succeed({
+              number: 7,
+              title: "Pull request 7",
+              url: "https://bitbucket.org/acme/web/pull-requests/7",
+              author: null,
+              headBranch: "feature",
+              headRepositoryNameWithOwner: null,
+              baseBranch: "main",
+              state: "open" as const,
+              isDraft: false,
+              mergeability: "unknown" as const,
+              createdAt: older,
+              updatedAt: current,
+              body: "",
+              reviewRequestLogins: [],
+              reviewers: [],
+              reviewerIds: [],
+              reviews: [review("julius", "APPROVED"), review("theo", "CHANGES_REQUESTED")],
+            }),
+          listComments: () => Effect.succeed({ comments: [], threads: [], truncated: false }),
+          listCommits: () => Effect.succeed([]),
+          listTimelineEvents: () =>
+            Effect.succeed([
+              event("approved-current", "approved", "julius", current),
+              event("approved-old", "approved", "julius", older),
+              event("changes-current", "changes-requested", "theo", current),
+              event("changes-old", "changes-requested", "theo", older),
+            ]),
+        }),
+      ),
+    );
+    const activity = yield* provider.getChangeRequestActivity({
+      cwd: "/w",
+      repository: "acme/web",
+      host: "bitbucket.org",
+      number: 7,
+    });
+    expect(activity.timelineEvents?.map((entry) => entry.id)).toEqual([
+      "approved-old",
+      "changes-old",
+    ]);
+  }),
+);

--- a/apps/server/src/pullRequest/BitbucketPullRequestProvider.test.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestProvider.test.ts
@@ -1,14 +1,115 @@
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Result from "effect/Result";
 
 import * as BitbucketApi from "../sourceControl/BitbucketApi.ts";
 import * as BitbucketPullRequestApi from "./BitbucketPullRequestApi.ts";
+import { decodePullRequestJson } from "./bitbucketPullRequestJson.ts";
 import {
   bitbucketProviderFailure,
   bitbucketViewerPermissions,
   make,
 } from "./BitbucketPullRequestProvider.ts";
+
+const forkPullRequest = Result.getOrThrow(
+  decodePullRequestJson(
+    '{"id":7,"title":"PR","state":"MERGED","created_on":"2026-09-05T12:00:00Z","updated_on":"2026-09-05T12:00:00Z","source":{"branch":{"name":"feature"},"repository":{"full_name":"fork/web"}},"destination":{"branch":{"name":"main"}},"links":{"html":{"href":"https://bitbucket.org/acme/web/pull-requests/7"}}}',
+  ),
+);
+
+it.effect.each([true, false, "failed", "source-read-failed"] as const)(
+  "checks fork source access before authorization (%s)",
+  (sourceAccess) =>
+    Effect.gen(function* () {
+      const failure = new BitbucketApi.BitbucketResponseError({
+        operation: "request",
+        status: 403,
+        responseBodyLength: 0,
+      });
+      const provider = yield* make.pipe(
+        Effect.provide(
+          Layer.mock(BitbucketPullRequestApi.BitbucketPullRequestApi)({
+            getPullRequest: () =>
+              sourceAccess === "source-read-failed"
+                ? Effect.fail(failure)
+                : Effect.succeed(forkPullRequest),
+            getRepositoryPermission: () => Effect.succeed(true),
+            getSourceRepositoryPermission: (input) => {
+              expect(input.repository).toBe("fork/web");
+              return sourceAccess === "failed" || sourceAccess === "source-read-failed"
+                ? Effect.fail(failure)
+                : Effect.succeed(sourceAccess);
+            },
+          }),
+        ),
+      );
+      const permissions = yield* provider.getViewerPermissions({
+        cwd: "/w",
+        host: "bitbucket.org",
+        repository: "acme/web",
+        number: 7,
+      });
+      expect(permissions.deleteSourceBranch).toBe(sourceAccess === true);
+      expect(permissions.actions).toEqual(["merge", "close"]);
+    }),
+);
+
+it.effect("reports a failed Bitbucket timeline read as incomplete activity", () =>
+  Effect.gen(function* () {
+    const failure = new BitbucketApi.BitbucketResponseError({
+      operation: "request",
+      status: 500,
+      responseBodyLength: 0,
+    });
+    const comment = {
+      id: "comment",
+      kind: "issue-comment" as const,
+      author: null,
+      body: "Keep this",
+      createdAt: forkPullRequest.createdAt,
+      url: null,
+      path: null,
+      reviewState: null,
+    };
+    const thread = {
+      id: "thread",
+      path: "app.ts",
+      line: 1,
+      side: "right" as const,
+      isResolved: false,
+      isOutdated: false,
+      comments: [comment],
+    };
+    const commit = {
+      oid: "abc123",
+      messageHeadline: "Keep this commit",
+      committedDate: forkPullRequest.createdAt,
+    };
+    const provider = yield* make.pipe(
+      Effect.provide(
+        Layer.mock(BitbucketPullRequestApi.BitbucketPullRequestApi)({
+          getPullRequest: () => Effect.succeed(forkPullRequest),
+          listComments: () =>
+            Effect.succeed({ comments: [comment], threads: [thread], truncated: false }),
+          listCommits: () => Effect.succeed([commit]),
+          listTimelineEvents: () => Effect.fail(failure),
+        }),
+      ),
+    );
+    const activity = yield* provider.getChangeRequestActivity({
+      cwd: "/w",
+      host: "bitbucket.org",
+      repository: "acme/web",
+      number: 7,
+    });
+    expect(activity.timelineTruncated).toBe(true);
+    expect(activity.timelineEvents).toEqual([]);
+    expect(activity.comments).toEqual([comment]);
+    expect(activity.reviewThreads).toEqual([thread]);
+    expect(activity.commits).toEqual([commit]);
+  }),
+);
 
 describe("bitbucketProviderFailure", () => {
   it("treats only an HTTP 401 as unusable credentials", () => {
@@ -27,7 +128,7 @@ describe("bitbucketProviderFailure", () => {
 describe("bitbucketViewerPermissions", () => {
   it("offers both actions to credentials with write access", () => {
     expect(bitbucketViewerPermissions({ canWrite: true })).toEqual({
-      deleteSourceBranch: true,
+      deleteSourceBranch: false,
       actions: ["merge", "close"],
       comment: true,
       resolve: true,
@@ -40,7 +141,7 @@ describe("bitbucketViewerPermissions", () => {
 
   it("keeps merge from credentials that can only read the repository", () => {
     expect(bitbucketViewerPermissions({ canWrite: false })).toEqual({
-      deleteSourceBranch: true,
+      deleteSourceBranch: false,
       actions: ["close"],
       comment: true,
       resolve: true,
@@ -126,4 +227,16 @@ it.effect("keeps historical verdict events while removing current review duplica
       "changes-old",
     ]);
   }),
+);
+
+it.each([true, false, undefined])(
+  "requires known source access for deletion (%s)",
+  (sourceAccess) => {
+    expect(
+      bitbucketViewerPermissions({
+        canWrite: true,
+        ...(sourceAccess === undefined ? {} : { canWriteSource: sourceAccess }),
+      }).deleteSourceBranch,
+    ).toBe(sourceAccess === true);
+  },
 );

--- a/apps/server/src/pullRequest/BitbucketPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestProvider.ts
@@ -209,16 +209,23 @@ export const make = Effect.gen(function* () {
         Effect.map(
           ([pullRequest, comments, commits, timelineEvents]): ProviderChangeRequestActivity => ({
             timelineEvents: timelineEvents
-              .filter(
-                (event) =>
-                  event.kind !== "approved" ||
+              .filter((event) => {
+                const reviewState =
+                  event.kind === "approved"
+                    ? "approved"
+                    : event.kind === "changes-requested"
+                      ? "changes-requested"
+                      : null;
+                return (
+                  reviewState === null ||
                   !pullRequest.reviews.some(
                     (review) =>
                       review.author?.login === event.actor?.login &&
                       review.createdAt === event.createdAt &&
-                      review.reviewState?.toLowerCase() === "approved",
-                  ),
-              )
+                      review.reviewState?.toLowerCase().replaceAll("_", "-") === reviewState,
+                  )
+                );
+              })
               .map((event) => ({ ...event, url: event.url ?? pullRequest.url })),
             comments: [...comments.comments, ...pullRequest.reviews].toSorted((left, right) =>
               left.createdAt.localeCompare(right.createdAt),

--- a/apps/server/src/pullRequest/BitbucketPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestProvider.ts
@@ -13,6 +13,7 @@ import {
 import type { BitbucketPullRequest } from "./bitbucketPullRequestJson.ts";
 
 const CAPABILITIES: PullRequestCapabilities = {
+  deleteSourceBranch: true,
   diff: true,
   comment: true,
   // Bitbucket has no endpoint that reopens a declined pull request, and nothing documented that
@@ -51,6 +52,7 @@ export function bitbucketViewerPermissions(input: {
   readonly canWrite: boolean;
 }): PullRequestViewerPermissions {
   return {
+    deleteSourceBranch: true,
     actions: CAPABILITIES.actions.filter((action) => action !== "merge" || input.canWrite),
     comment: true,
     resolve: true,
@@ -199,19 +201,34 @@ export const make = Effect.gen(function* () {
             .listComments(target)
             .pipe(Effect.orElseSucceed(() => ({ comments: [], threads: [], truncated: true }))),
           api.listCommits(target).pipe(Effect.orElseSucceed(() => [])),
+          api.listTimelineEvents(target).pipe(Effect.orElseSucceed(() => [])),
         ],
-        { concurrency: 3 },
+        { concurrency: 4 },
       ).pipe(
         Effect.mapError(fail("getChangeRequestActivity")),
-        Effect.map(([pullRequest, comments, commits]): ProviderChangeRequestActivity => ({
-          comments: [...comments.comments, ...pullRequest.reviews].toSorted((left, right) =>
-            left.createdAt.localeCompare(right.createdAt),
-          ),
-          commentCount: comments.comments.length + pullRequest.reviews.length,
-          commentsTruncated: comments.truncated,
-          reviewThreads: comments.threads,
-          commits,
-        })),
+        Effect.map(
+          ([pullRequest, comments, commits, timelineEvents]): ProviderChangeRequestActivity => ({
+            timelineEvents: timelineEvents
+              .filter(
+                (event) =>
+                  event.kind !== "approved" ||
+                  !pullRequest.reviews.some(
+                    (review) =>
+                      review.author?.login === event.actor?.login &&
+                      review.createdAt === event.createdAt &&
+                      review.reviewState?.toLowerCase() === "approved",
+                  ),
+              )
+              .map((event) => ({ ...event, url: event.url ?? pullRequest.url })),
+            comments: [...comments.comments, ...pullRequest.reviews].toSorted((left, right) =>
+              left.createdAt.localeCompare(right.createdAt),
+            ),
+            commentCount: comments.comments.length + pullRequest.reviews.length,
+            commentsTruncated: comments.truncated,
+            reviewThreads: comments.threads,
+            commits,
+          }),
+        ),
       );
     },
 

--- a/apps/server/src/pullRequest/BitbucketPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestProvider.ts
@@ -49,10 +49,11 @@ const CAPABILITIES: PullRequestCapabilities = {
  * of the two this account is.
  */
 export function bitbucketViewerPermissions(input: {
+  readonly canWriteSource?: boolean;
   readonly canWrite: boolean;
 }): PullRequestViewerPermissions {
   return {
-    deleteSourceBranch: true,
+    deleteSourceBranch: input.canWriteSource === true,
     actions: CAPABILITIES.actions.filter((action) => action !== "merge" || input.canWrite),
     comment: true,
     resolve: true,
@@ -119,6 +120,11 @@ export const make = Effect.gen(function* () {
         cause: error,
       });
 
+  const sourcePermission = (repository: string | null) =>
+    repository === null
+      ? Effect.succeed(false)
+      : api.getSourceRepositoryPermission({ repository }).pipe(Effect.orElseSucceed(() => false));
+
   const provider: PullRequestProviderApi = {
     kind: "bitbucket",
     capabilities: CAPABILITIES,
@@ -151,7 +157,15 @@ export const make = Effect.gen(function* () {
       const target = { repository: input.repository, number: input.number };
       return Effect.all(
         [
-          api.getPullRequest(target),
+          api
+            .getPullRequest(target)
+            .pipe(
+              Effect.flatMap((pullRequest) =>
+                sourcePermission(pullRequest.headRepositoryNameWithOwner).pipe(
+                  Effect.map((canWriteSource) => ({ pullRequest, canWriteSource })),
+                ),
+              ),
+            ),
           api.getDiffStat(target),
           api.getMergeability(target).pipe(Effect.orElseSucceed(() => "unknown" as const)),
           api.listChecks(target).pipe(Effect.orElseSucceed(() => [])),
@@ -165,7 +179,7 @@ export const make = Effect.gen(function* () {
         Effect.mapError(fail("getChangeRequest")),
         Effect.map(
           ([
-            pullRequest,
+            { pullRequest, canWriteSource },
             diffStat,
             mergeability,
             checks,
@@ -184,7 +198,7 @@ export const make = Effect.gen(function* () {
             // Bitbucket publishes no per-repository list of allowed strategies, so the ones it
             // supports are all offered and a strategy the repository forbids fails on merge.
             mergeCapabilities: { merge: true, squash: true, rebase: true },
-            viewerPermissions: bitbucketViewerPermissions({ canWrite }),
+            viewerPermissions: bitbucketViewerPermissions({ canWrite, canWriteSource }),
           }),
         ),
       );
@@ -201,48 +215,63 @@ export const make = Effect.gen(function* () {
             .listComments(target)
             .pipe(Effect.orElseSucceed(() => ({ comments: [], threads: [], truncated: true }))),
           api.listCommits(target).pipe(Effect.orElseSucceed(() => [])),
-          api.listTimelineEvents(target).pipe(Effect.orElseSucceed(() => [])),
+          api.listTimelineEvents(target).pipe(
+            Effect.map((events) => ({ events, truncated: false })),
+            Effect.orElseSucceed(() => ({ events: [], truncated: true })),
+          ),
         ],
         { concurrency: 4 },
       ).pipe(
         Effect.mapError(fail("getChangeRequestActivity")),
-        Effect.map(
-          ([pullRequest, comments, commits, timelineEvents]): ProviderChangeRequestActivity => ({
-            timelineEvents: timelineEvents
-              .filter((event) => {
-                const reviewState =
-                  event.kind === "approved"
-                    ? "approved"
-                    : event.kind === "changes-requested"
-                      ? "changes-requested"
-                      : null;
-                return (
-                  reviewState === null ||
-                  !pullRequest.reviews.some(
-                    (review) =>
-                      review.author?.login === event.actor?.login &&
-                      review.createdAt === event.createdAt &&
-                      review.reviewState?.toLowerCase().replaceAll("_", "-") === reviewState,
-                  )
-                );
-              })
-              .map((event) => ({ ...event, url: event.url ?? pullRequest.url })),
-            comments: [...comments.comments, ...pullRequest.reviews].toSorted((left, right) =>
-              left.createdAt.localeCompare(right.createdAt),
-            ),
-            commentCount: comments.comments.length + pullRequest.reviews.length,
-            commentsTruncated: comments.truncated,
-            reviewThreads: comments.threads,
-            commits,
-          }),
-        ),
+        Effect.map(([pullRequest, comments, commits, timeline]): ProviderChangeRequestActivity => ({
+          timelineTruncated: timeline.truncated,
+          timelineEvents: timeline.events
+            .filter((event) => {
+              const reviewState =
+                event.kind === "approved"
+                  ? "approved"
+                  : event.kind === "changes-requested"
+                    ? "changes-requested"
+                    : null;
+              return (
+                reviewState === null ||
+                !pullRequest.reviews.some(
+                  (review) =>
+                    review.author?.login === event.actor?.login &&
+                    review.createdAt === event.createdAt &&
+                    review.reviewState?.toLowerCase().replaceAll("_", "-") === reviewState,
+                )
+              );
+            })
+            .map((event) => ({ ...event, url: event.url ?? pullRequest.url })),
+          comments: [...comments.comments, ...pullRequest.reviews].toSorted((left, right) =>
+            left.createdAt.localeCompare(right.createdAt),
+          ),
+          commentCount: comments.comments.length + pullRequest.reviews.length,
+          commentsTruncated: comments.truncated,
+          reviewThreads: comments.threads,
+          commits,
+        })),
       );
     },
 
     getViewerPermissions: (input) =>
-      api.getRepositoryPermission({ repository: input.repository }).pipe(
+      Effect.all(
+        [
+          api.getRepositoryPermission({ repository: input.repository }),
+          api.getPullRequest(input).pipe(
+            Effect.flatMap((pullRequest) =>
+              sourcePermission(pullRequest.headRepositoryNameWithOwner),
+            ),
+            Effect.orElseSucceed(() => false),
+          ),
+        ],
+        { concurrency: 2 },
+      ).pipe(
         Effect.mapError(fail("getViewerPermissions")),
-        Effect.map((canWrite) => bitbucketViewerPermissions({ canWrite })),
+        Effect.map(([canWrite, canWriteSource]) =>
+          bitbucketViewerPermissions({ canWrite, canWriteSource }),
+        ),
       ),
 
     // `/diff` answers with the whole patch and pages nothing, so the first slice is the last.

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, assert, expect, it, vi } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 import * as TestClock from "effect/testing/TestClock";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
@@ -11,6 +12,7 @@ import { BASE_COMPARISON_GRAPHQL_QUERY } from "./gitHubPullRequestJson.ts";
 
 const mockedExecute = vi.fn<GitHubCli.GitHubCli["Service"]["execute"]>();
 const mockedGetPullRequest = vi.fn<GitHubCli.GitHubCli["Service"]["getPullRequest"]>();
+const encodeTimelinePage = Schema.encodeEffect(Schema.fromJsonString(Schema.Unknown));
 
 const layer = it.layer(
   GitHubPullRequestCli.layer.pipe(
@@ -183,6 +185,96 @@ afterEach(() => {
 });
 
 layer("GitHubPullRequestCli.layer", (it) => {
+  it.effect("reads every timeline page with older gh and retains the native close actor", () =>
+    Effect.gen(function* () {
+      const closed = {
+        id: 30487715814,
+        event: "closed",
+        created_at: "2026-09-03T12:28:17Z",
+        actor: { login: "Bil0000" },
+      };
+      const firstPage = yield* encodeTimelinePage(
+        Array.from({ length: 100 }, () => ({ event: "committed" })),
+      );
+      const secondPage = yield* encodeTimelinePage([closed, closed]);
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output(firstPage)));
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output(secondPage)));
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+      const events = yield* cli.listTimelineEvents({
+        cwd: "/w",
+        host: "github.com",
+        repository: "pingdotgg/t3code",
+        number: 9256,
+      });
+      expect(events).toMatchObject([
+        {
+          id: "github:30487715814",
+          kind: "closed",
+          actor: { login: "Bil0000" },
+          createdAt: "2026-09-03T12:28:17Z",
+        },
+      ]);
+      expect(mockedExecute).toHaveBeenCalledTimes(2);
+      for (const page of [1, 2]) {
+        expect(callAt(page - 1).args).toEqual([
+          "api",
+          "--hostname",
+          "github.com",
+          `repos/pingdotgg/t3code/issues/9256/timeline?per_page=100&page=${page}`,
+        ]);
+      }
+    }),
+  );
+
+  it.effect("fails unreadable or truncated timeline pages instead of reporting no events", () =>
+    Effect.gen(function* () {
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+      for (const result of [output("broken"), output("[]", true), output("[]", false, true)]) {
+        mockedExecute.mockReturnValueOnce(Effect.succeed(result));
+        const error = yield* Effect.flip(
+          cli.listTimelineEvents({
+            cwd: "/w",
+            host: "github.com",
+            repository: "acme/web",
+            number: 7,
+          }),
+        );
+        expect(error._tag).toBe("GitHubPullRequestReadError");
+      }
+    }),
+  );
+
+  it.effect(
+    "deletes a finished PR branch from its fork and refuses the source default branch",
+    () =>
+      Effect.gen(function* () {
+        const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+        const target = {
+          cwd: "/w",
+          host: "github.com",
+          repository: "acme/web",
+          number: 7,
+          action: "delete-source-branch" as const,
+        };
+        const current =
+          '{"state":"closed","head":{"ref":"feature/topic","repo":{"full_name":"fork/renamed"}},"base":{"ref":"release"}}';
+        mockedExecute.mockReturnValueOnce(Effect.succeed(output(current)));
+        mockedExecute.mockReturnValueOnce(Effect.succeed(output('{"default_branch":"main"}')));
+        mockedExecute.mockReturnValueOnce(Effect.succeed(output("")));
+        yield* cli.runPullRequestAction(target);
+        expect(callAt(1).args).toContain("repos/fork/renamed");
+        expect(callAt(2).args).toContain("repos/fork/renamed/git/refs/heads/feature%2Ftopic");
+        expect(callAt(2).args).toContain("DELETE");
+        mockedExecute.mockReturnValueOnce(Effect.succeed(output(current)));
+        mockedExecute.mockReturnValueOnce(
+          Effect.succeed(output('{"default_branch":"feature/topic"}')),
+        );
+        const error = yield* Effect.flip(cli.runPullRequestAction(target));
+        expect(error.message).toContain("cannot be deleted");
+        expect(mockedExecute).toHaveBeenCalledTimes(5);
+      }),
+  );
+
   it.effect("reads linked pull request status through one narrow request", () =>
     Effect.gen(function* () {
       mockedGetPullRequest.mockReturnValueOnce(
@@ -2519,7 +2611,7 @@ layer("GitHubPullRequestCli.layer", (it) => {
       expect(detail.body).toBe("Core body");
       expect(activity.author?.login).toBe("octocat");
       expect(callAt(0).args.at(-1)).toBe(
-        "number,title,url,author,headRefName,baseRefName,state,isDraft,mergeable,reviewDecision,additions,deletions,createdAt,updatedAt,mergedAt,reviewRequests,labels,statusCheckRollup,body,changedFiles,closedAt,isCrossRepository,headRepositoryOwner,headRefOid,autoMergeRequest",
+        "number,title,url,author,headRefName,baseRefName,state,isDraft,mergeable,reviewDecision,additions,deletions,createdAt,updatedAt,mergedAt,reviewRequests,labels,statusCheckRollup,body,changedFiles,closedAt,isCrossRepository,headRepositoryOwner,headRepository,headRefOid,autoMergeRequest",
       );
       expect(callAt(1).args.at(-1)).toBe("author,comments,reviews,commits");
     }),

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -305,7 +305,7 @@ layer("GitHubPullRequestCli.layer", (it) => {
         mockedExecute.mockReturnValueOnce(Effect.succeed(output(current)));
         mockedExecute.mockReturnValueOnce(Effect.succeed(output('{"default_branch":"main"}')));
         const error = yield* Effect.flip(cli.runPullRequestAction(target));
-        expect(error.reason).toBe("protected-branch");
+        expect(error).toMatchObject({ reason: "protected-branch" });
         expect(mockedExecute).toHaveBeenCalledTimes(5);
       }),
   );
@@ -339,7 +339,7 @@ layer("GitHubPullRequestCli.layer", (it) => {
           action: "delete-source-branch",
         }),
       );
-      expect(error.reason).toBe("delete-refused");
+      expect(error).toMatchObject({ reason: "delete-refused" });
       expect(mockedExecute).toHaveBeenCalledTimes(3);
       expect(callAt(2).stdin).toContain('"beforeOid":"abcdef0123456789abcdef0123456789abcdef01"');
       expect(callAt(2).args).not.toContain("DELETE");

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -257,22 +257,68 @@ layer("GitHubPullRequestCli.layer", (it) => {
           action: "delete-source-branch" as const,
         };
         const current =
-          '{"state":"closed","head":{"ref":"feature/topic","repo":{"full_name":"fork/renamed"}},"base":{"ref":"release"}}';
+          '{"state":"closed","head":{"ref":"main","sha":"abcdef0123456789abcdef0123456789abcdef01","repo":{"id":42,"node_id":"R_fork","full_name":"fork/renamed"}},"base":{"ref":"main","repo":{"id":7}}}';
         mockedExecute.mockReturnValueOnce(Effect.succeed(output(current)));
-        mockedExecute.mockReturnValueOnce(Effect.succeed(output('{"default_branch":"main"}')));
+        mockedExecute.mockReturnValueOnce(Effect.succeed(output('{"default_branch":"develop"}')));
         mockedExecute.mockReturnValueOnce(Effect.succeed(output("")));
         yield* cli.runPullRequestAction(target);
         expect(callAt(1).args).toContain("repos/fork/renamed");
-        expect(callAt(2).args).toContain("repos/fork/renamed/git/refs/heads/feature%2Ftopic");
-        expect(callAt(2).args).toContain("DELETE");
+        expect(callAt(2).args).toEqual([
+          "api",
+          "graphql",
+          "--hostname",
+          "github.com",
+          "--input",
+          "-",
+        ]);
+        expect(callAt(2).stdin).toContain("updateRefs");
+        expect(callAt(2).stdin).toContain("beforeOid: $beforeOid");
+        expect(callAt(2).stdin).toContain('"repositoryId":"R_fork"');
+        expect(callAt(2).stdin).toContain('"name":"refs/heads/main"');
+        expect(callAt(2).stdin).toContain('"beforeOid":"abcdef0123456789abcdef0123456789abcdef01"');
+        expect(callAt(2).stdin).toContain("0000000000000000000000000000000000000000");
         mockedExecute.mockReturnValueOnce(Effect.succeed(output(current)));
-        mockedExecute.mockReturnValueOnce(
-          Effect.succeed(output('{"default_branch":"feature/topic"}')),
-        );
+        mockedExecute.mockReturnValueOnce(Effect.succeed(output('{"default_branch":"main"}')));
         const error = yield* Effect.flip(cli.runPullRequestAction(target));
         expect(error.message).toContain("cannot be deleted");
         expect(mockedExecute).toHaveBeenCalledTimes(5);
       }),
+  );
+
+  it.effect("refuses a moved source tip without retrying an unconditional deletion", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(
+          output(
+            '{"state":"closed","head":{"ref":"topic","sha":"abcdef0123456789abcdef0123456789abcdef01","repo":{"id":42,"node_id":"R_fork","full_name":"fork/web"}},"base":{"ref":"main","repo":{"id":7}}}',
+          ),
+        ),
+      );
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output('{"default_branch":"main"}')));
+      mockedExecute.mockReturnValueOnce(
+        Effect.fail(
+          new GitHubCli.GitHubCliCommandError({
+            command: "gh",
+            cwd: "/w",
+            cause: new Error("beforeOid does not match the current ref"),
+          }),
+        ),
+      );
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+      const error = yield* Effect.flip(
+        cli.runPullRequestAction({
+          cwd: "/w",
+          host: "github.com",
+          repository: "acme/web",
+          number: 7,
+          action: "delete-source-branch",
+        }),
+      );
+      expect(error.message).toContain("may have changed");
+      expect(mockedExecute).toHaveBeenCalledTimes(3);
+      expect(callAt(2).stdin).toContain('"beforeOid":"abcdef0123456789abcdef0123456789abcdef01"');
+      expect(callAt(2).args).not.toContain("DELETE");
+    }),
   );
 
   it.effect("reads linked pull request status through one narrow request", () =>

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -305,7 +305,7 @@ layer("GitHubPullRequestCli.layer", (it) => {
         mockedExecute.mockReturnValueOnce(Effect.succeed(output(current)));
         mockedExecute.mockReturnValueOnce(Effect.succeed(output('{"default_branch":"main"}')));
         const error = yield* Effect.flip(cli.runPullRequestAction(target));
-        expect(error.message).toContain("cannot be deleted");
+        expect(error.reason).toBe("protected-branch");
         expect(mockedExecute).toHaveBeenCalledTimes(5);
       }),
   );
@@ -339,7 +339,7 @@ layer("GitHubPullRequestCli.layer", (it) => {
           action: "delete-source-branch",
         }),
       );
-      expect(error.message).toContain("may have changed");
+      expect(error.reason).toBe("delete-refused");
       expect(mockedExecute).toHaveBeenCalledTimes(3);
       expect(callAt(2).stdin).toContain('"beforeOid":"abcdef0123456789abcdef0123456789abcdef01"');
       expect(callAt(2).args).not.toContain("DELETE");

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -206,7 +206,7 @@ layer("GitHubPullRequestCli.layer", (it) => {
         repository: "pingdotgg/t3code",
         number: 9256,
       });
-      expect(events).toMatchObject([
+      expect(events.events).toMatchObject([
         {
           id: "github:30487715814",
           kind: "closed",
@@ -214,6 +214,7 @@ layer("GitHubPullRequestCli.layer", (it) => {
           createdAt: "2026-09-03T12:28:17Z",
         },
       ]);
+      expect(events.truncated).toBe(false);
       expect(mockedExecute).toHaveBeenCalledTimes(2);
       for (const page of [1, 2]) {
         expect(callAt(page - 1).args).toEqual([
@@ -223,6 +224,30 @@ layer("GitHubPullRequestCli.layer", (it) => {
           `repos/pingdotgg/t3code/issues/9256/timeline?per_page=100&page=${page}`,
         ]);
       }
+    }),
+  );
+
+  it.effect("bounds long native timelines and reports incomplete history", () =>
+    Effect.gen(function* () {
+      const page = yield* encodeTimelinePage(
+        Array.from({ length: 100 }, () => ({
+          id: 1,
+          event: "reopened",
+          created_at: "2026-09-05T00:00:00Z",
+          actor: null,
+        })),
+      );
+      mockedExecute.mockReturnValue(Effect.succeed(output(page)));
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+      const result = yield* cli.listTimelineEvents({
+        cwd: "/w",
+        host: "github.com",
+        repository: "acme/web",
+        number: 7,
+      });
+      expect(result.truncated).toBe(true);
+      expect(result.events).toHaveLength(1);
+      expect(mockedExecute).toHaveBeenCalledTimes(10);
     }),
   );
 

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -2890,6 +2890,7 @@ layer("GitHubPullRequestCli.layer", (it) => {
         assert.strictEqual(mockedExecute.mock.calls.length, 1);
         expect(callAt(0).args).toContain("number=7");
         expect(access).toEqual({
+          canWriteSource: false,
           canWrite: false,
           canTriage: false,
           canUpdate: true,
@@ -3058,6 +3059,7 @@ layer("GitHubPullRequestCli.layer", (it) => {
 
       assert.strictEqual(mockedExecute.mock.calls.length, 2);
       expect(access).toEqual({
+        canWriteSource: false,
         canWrite: false,
         canTriage: false,
         canUpdate: true,

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -1,3 +1,8 @@
+import {
+  assertSourceBranchDeletable,
+  decodeBranchDeletionJson,
+  PullRequestBranchDeletionError,
+} from "./pullRequestBranchDeletion.ts";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -6,6 +11,7 @@ import * as Schema from "effect/Schema";
 import {
   resolvePullRequestAuthorFilter,
   type PullRequestAction,
+  type PullRequestTimelineEvent,
   type PullRequestActor,
   type PullRequestInvolvement,
   type PullRequestListFilters,
@@ -77,6 +83,7 @@ import {
   UPDATE_REVIEW_COMMENT_GRAPHQL_MUTATION,
   VIEWER_PERMISSIONS_GRAPHQL_QUERY,
   decodeViewerPermissionsJson,
+  decodeTimelineEventsJson,
   decodeWorkflowRunApprovalsJson,
   type GitHubBaseComparison,
   type GitHubPullRequestDetail,
@@ -332,6 +339,7 @@ export class GitHubWorkflowApprovalHeadChangedError extends Schema.TaggedErrorCl
 }
 
 export type GitHubPullRequestCliError =
+  | PullRequestBranchDeletionError
   | GitHubCli.GitHubCliError
   | GitHubPullRequestReadError
   | GitHubDiffCursorError
@@ -507,6 +515,13 @@ export class GitHubPullRequestCli extends Context.Service<
       /** Manual action checks may use the quota held back from automatic reads. */
       readonly allowReserve?: boolean | undefined;
     }) => Effect.Effect<GitHubBaseComparison, GitHubPullRequestCliError>;
+
+    readonly listTimelineEvents: (input: {
+      readonly cwd: string;
+      readonly repository: string;
+      readonly host: string;
+      readonly number: number;
+    }) => Effect.Effect<ReadonlyArray<PullRequestTimelineEvent>, GitHubPullRequestCliError>;
 
     readonly getPullRequestActivity: (input: {
       readonly cwd: string;
@@ -950,6 +965,8 @@ function actionArgs(
   updateMethod: PullRequestUpdateMethod | undefined,
 ): ReadonlyArray<string> {
   switch (action) {
+    case "delete-source-branch":
+      throw new Error("Source branch deletion requires a fresh branch lookup");
     case "merge":
       return ["merge", `--${mergeMethod ?? "merge"}`];
     // `--auto` arms the same command instead of running it, and still needs the strategy: GitHub
@@ -1678,6 +1695,41 @@ export const make = Effect.gen(function* () {
       });
     },
 
+    listTimelineEvents: (input) =>
+      Effect.gen(function* () {
+        const events = new Map<string, PullRequestTimelineEvent>();
+        for (let page = 1; ; page += 1) {
+          const response = yield* github.execute({
+            cwd: input.cwd,
+            args: [
+              "api",
+              "--hostname",
+              input.host,
+              `repos/${input.repository}/issues/${input.number}/timeline?per_page=100&page=${page}`,
+            ],
+          });
+          if (response.stdoutTruncated || response.stdoutInvalidUtf8) {
+            return yield* new GitHubPullRequestReadError({
+              command: "gh",
+              cwd: input.cwd,
+              operation: "listTimelineEvents",
+              cause: new Error(`Timeline page ${page} could not be read completely.`),
+            });
+          }
+          const decoded = decodeTimelineEventsJson(response.stdout);
+          if (!Result.isSuccess(decoded)) {
+            return yield* new GitHubPullRequestReadError({
+              command: "gh",
+              cwd: input.cwd,
+              operation: "listTimelineEvents",
+              cause: decoded.failure,
+            });
+          }
+          for (const event of decoded.success.events) events.set(event.id, event);
+          if (decoded.success.rawCount < 100) return [...events.values()];
+        }
+      }),
+
     getPullRequestActivity: (input) =>
       github
         .execute({
@@ -2052,6 +2104,63 @@ export const make = Effect.gen(function* () {
     },
 
     runPullRequestAction: (input) => {
+      if (input.action === "delete-source-branch") {
+        return Effect.gen(function* () {
+          const read = (path: string) =>
+            github.execute({ cwd: input.cwd, args: ["api", "--hostname", input.host, path] });
+          const response = yield* read(`repos/${input.repository}/pulls/${input.number}`);
+          const current = yield* decodeBranchDeletionJson(
+            Schema.Struct({
+              state: Schema.String,
+              head: Schema.Struct({
+                ref: Schema.String,
+                repo: Schema.NullOr(Schema.Struct({ full_name: Schema.String })),
+              }),
+              base: Schema.Struct({ ref: Schema.String }),
+            }),
+            response.stdout,
+          );
+          if (current.head.repo === null)
+            return yield* new PullRequestBranchDeletionError({
+              detail: "The source repository no longer exists.",
+            });
+          const source = current.head.repo.full_name;
+          const repository = yield* read(`repos/${source}`);
+          const config = yield* decodeBranchDeletionJson(
+            Schema.Struct({ default_branch: Schema.String }),
+            repository.stdout,
+          );
+          yield* assertSourceBranchDeletable({
+            state: current.state,
+            sourceBranch: current.head.ref,
+            baseBranch: current.base.ref,
+            defaultBranch: config.default_branch,
+          });
+          yield* github
+            .execute({
+              cwd: input.cwd,
+              args: [
+                "api",
+                "--hostname",
+                input.host,
+                "--method",
+                "DELETE",
+                `repos/${source}/git/refs/heads/${encodeURIComponent(current.head.ref)}`,
+              ],
+            })
+            .pipe(
+              Effect.catchTag(
+                "GitHubCliCommandError",
+                (cause) =>
+                  new PullRequestBranchDeletionError({
+                    detail:
+                      "The source branch could not be deleted. It may already be deleted, protected, or unavailable to this account.",
+                    cause,
+                  }),
+              ),
+            );
+        });
+      }
       if (input.action === "revert") {
         return pullRequestNodeId({ ...input, operation: "revertPullRequest" }).pipe(
           Effect.flatMap((pullRequestId) =>

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -521,7 +521,10 @@ export class GitHubPullRequestCli extends Context.Service<
       readonly repository: string;
       readonly host: string;
       readonly number: number;
-    }) => Effect.Effect<ReadonlyArray<PullRequestTimelineEvent>, GitHubPullRequestCliError>;
+    }) => Effect.Effect<
+      { events: ReadonlyArray<PullRequestTimelineEvent>; truncated: boolean },
+      GitHubPullRequestCliError
+    >;
 
     readonly getPullRequestActivity: (input: {
       readonly cwd: string;
@@ -1698,7 +1701,7 @@ export const make = Effect.gen(function* () {
     listTimelineEvents: (input) =>
       Effect.gen(function* () {
         const events = new Map<string, PullRequestTimelineEvent>();
-        for (let page = 1; ; page += 1) {
+        for (let page = 1; page <= 10; page += 1) {
           const response = yield* github.execute({
             cwd: input.cwd,
             args: [
@@ -1726,8 +1729,10 @@ export const make = Effect.gen(function* () {
             });
           }
           for (const event of decoded.success.events) events.set(event.id, event);
-          if (decoded.success.rawCount < 100) return [...events.values()];
+          if (decoded.success.rawCount < 100)
+            return { events: [...events.values()], truncated: false };
         }
+        return { events: [...events.values()], truncated: true };
       }),
 
     getPullRequestActivity: (input) =>

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -2134,7 +2134,7 @@ export const make = Effect.gen(function* () {
           );
           if (current.head.repo === null)
             return yield* new PullRequestBranchDeletionError({
-              detail: "The source repository no longer exists.",
+              reason: "source-repository-missing",
             });
           const source = current.head.repo.full_name;
           const repository = yield* read(`repos/${source}`);
@@ -2162,15 +2162,13 @@ export const make = Effect.gen(function* () {
               beforeOid: current.head.sha,
             },
           }).pipe(
-            Effect.catchTag(
-              "GitHubCliCommandError",
-              (cause) =>
+            Effect.catchTags({
+              GitHubCliCommandError: (cause) =>
                 new PullRequestBranchDeletionError({
-                  detail:
-                    "The source branch could not be deleted. It may have changed, already been deleted, be protected, or be unavailable to this account. Refresh the pull request before trying again.",
+                  reason: "delete-refused",
                   cause,
                 }),
-            ),
+            }),
           );
         });
       }

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -2114,9 +2114,16 @@ export const make = Effect.gen(function* () {
               state: Schema.String,
               head: Schema.Struct({
                 ref: Schema.String,
-                repo: Schema.NullOr(Schema.Struct({ full_name: Schema.String })),
+                sha: Schema.String,
+                repo: Schema.NullOr(
+                  Schema.Struct({
+                    id: Schema.Int,
+                    node_id: Schema.String,
+                    full_name: Schema.String,
+                  }),
+                ),
               }),
-              base: Schema.Struct({ ref: Schema.String }),
+              base: Schema.Struct({ ref: Schema.String, repo: Schema.Struct({ id: Schema.Int }) }),
             }),
             response.stdout,
           );
@@ -2132,33 +2139,34 @@ export const make = Effect.gen(function* () {
           );
           yield* assertSourceBranchDeletable({
             state: current.state,
+            sourceRepository: String(current.head.repo.id),
+            baseRepository: String(current.base.repo.id),
             sourceBranch: current.head.ref,
             baseBranch: current.base.ref,
             defaultBranch: config.default_branch,
           });
-          yield* github
-            .execute({
-              cwd: input.cwd,
-              args: [
-                "api",
-                "--hostname",
-                input.host,
-                "--method",
-                "DELETE",
-                `repos/${source}/git/refs/heads/${encodeURIComponent(current.head.ref)}`,
-              ],
-            })
-            .pipe(
-              Effect.catchTag(
-                "GitHubCliCommandError",
-                (cause) =>
-                  new PullRequestBranchDeletionError({
-                    detail:
-                      "The source branch could not be deleted. It may already be deleted, protected, or unavailable to this account.",
-                    cause,
-                  }),
-              ),
-            );
+          yield* graphql({
+            cwd: input.cwd,
+            host: input.host,
+            query: `mutation DeleteSourceBranch($repositoryId: ID!, $name: GitRefname!, $beforeOid: GitObjectID!) {
+                updateRefs(input: {repositoryId: $repositoryId, refUpdates: [{name: $name, beforeOid: $beforeOid, afterOid: "0000000000000000000000000000000000000000"}]}) { clientMutationId }
+              }`,
+            variables: {
+              repositoryId: current.head.repo.node_id,
+              name: `refs/heads/${current.head.ref}`,
+              beforeOid: current.head.sha,
+            },
+          }).pipe(
+            Effect.catchTag(
+              "GitHubCliCommandError",
+              (cause) =>
+                new PullRequestBranchDeletionError({
+                  detail:
+                    "The source branch could not be deleted. It may have changed, already been deleted, be protected, or be unavailable to this account. Refresh the pull request before trying again.",
+                  cause,
+                }),
+            ),
+          );
         });
       }
       if (input.action === "revert") {

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
@@ -627,7 +627,7 @@ describe("getChangeRequest commits", () => {
 
   const layerWith = (commits: GitHubReviewThreadComments["commits"]) =>
     Layer.mock(GitHubPullRequestCli.GitHubPullRequestCli)({
-      listTimelineEvents: () => Effect.succeed([]),
+      listTimelineEvents: () => Effect.succeed({ events: [], truncated: false }),
       getPullRequestActivity: () =>
         Effect.succeed({
           author: baseDetail.author,
@@ -711,7 +711,7 @@ describe("getChangeRequestActivity dismissed reviews", () => {
   };
   const layerFor = (body: string) =>
     Layer.mock(GitHubPullRequestCli.GitHubPullRequestCli)({
-      listTimelineEvents: () => Effect.succeed([]),
+      listTimelineEvents: () => Effect.succeed({ events: [], truncated: false }),
       getPullRequestActivity: () =>
         Effect.succeed({ author: null, comments: [dismissedReview(body)], commits: [] }),
       listReviewThreadComments: () => Effect.succeed(threadComments),

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
@@ -8,6 +8,36 @@ import * as GitHubPullRequestCli from "./GitHubPullRequestCli.ts";
 import { gitHubViewerPermissions, loginAvatarUrl, make } from "./GitHubPullRequestProvider.ts";
 import type { GitHubReviewThreadComments } from "./gitHubPullRequestJson.ts";
 
+it.effect("reports a timeline failure instead of returning complete activity without events", () =>
+  Effect.gen(function* () {
+    const failure = new GitHubPullRequestCli.GitHubPullRequestReadError({
+      command: "gh",
+      cwd: "/w",
+      operation: "listTimelineEvents",
+      cause: new Error("unreadable page"),
+    });
+    const provider = yield* make.pipe(
+      Effect.provide(
+        Layer.mock(GitHubPullRequestCli.GitHubPullRequestCli)({
+          getPullRequestActivity: () => Effect.succeed({ author: null, comments: [], commits: [] }),
+          listTimelineEvents: () => Effect.fail(failure),
+          listReviewThreadComments: () => Effect.fail(failure),
+        }),
+      ),
+    );
+    const error = yield* Effect.flip(
+      provider.getChangeRequestActivity({
+        cwd: "/w",
+        host: "github.com",
+        repository: "acme/web",
+        number: 7,
+      }),
+    );
+    expect(error.operation).toBe("getChangeRequestActivity");
+    expect(error.cause).toBe(failure);
+  }),
+);
+
 it.effect("uses one narrow read for a linked pull request summary", () =>
   Effect.gen(function* () {
     let summaryReads = 0;
@@ -55,6 +85,7 @@ describe("gitHubViewerPermissions", () => {
         didAuthor: false,
       }),
     ).toEqual({
+      deleteSourceBranch: true,
       // Arming a merge for later is the merge, so it travels with it.
       actions: [
         "merge",
@@ -86,6 +117,7 @@ describe("gitHubViewerPermissions", () => {
         didAuthor: false,
       }),
     ).toEqual({
+      deleteSourceBranch: false,
       actions: [],
       comment: true,
       resolve: false,
@@ -117,6 +149,7 @@ describe("gitHubViewerPermissions", () => {
         didAuthor: true,
       }),
     ).toEqual({
+      deleteSourceBranch: true,
       // Merging is the one thing writing is needed for, now or later; the rest an author may do.
       actions: ["ready", "draft", "close", "reopen"],
       comment: true,
@@ -139,6 +172,7 @@ describe("gitHubViewerPermissions", () => {
       });
 
       expect(detail.viewerPermissions).toEqual({
+        deleteSourceBranch: false,
         actions: ["ready", "draft", "close", "reopen"],
         comment: true,
         resolve: false,
@@ -593,6 +627,7 @@ describe("getChangeRequest commits", () => {
 
   const layerWith = (commits: GitHubReviewThreadComments["commits"]) =>
     Layer.mock(GitHubPullRequestCli.GitHubPullRequestCli)({
+      listTimelineEvents: () => Effect.succeed([]),
       getPullRequestActivity: () =>
         Effect.succeed({
           author: baseDetail.author,
@@ -676,6 +711,7 @@ describe("getChangeRequestActivity dismissed reviews", () => {
   };
   const layerFor = (body: string) =>
     Layer.mock(GitHubPullRequestCli.GitHubPullRequestCli)({
+      listTimelineEvents: () => Effect.succeed([]),
       getPullRequestActivity: () =>
         Effect.succeed({ author: null, comments: [dismissedReview(body)], commits: [] }),
       listReviewThreadComments: () => Effect.succeed(threadComments),

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
@@ -8,7 +8,7 @@ import * as GitHubPullRequestCli from "./GitHubPullRequestCli.ts";
 import { gitHubViewerPermissions, loginAvatarUrl, make } from "./GitHubPullRequestProvider.ts";
 import type { GitHubReviewThreadComments } from "./gitHubPullRequestJson.ts";
 
-it.effect("reports a timeline failure instead of returning complete activity without events", () =>
+it.effect("preserves GitHub activity and marks the timeline incomplete when its read fails", () =>
   Effect.gen(function* () {
     const failure = new GitHubPullRequestCli.GitHubPullRequestReadError({
       command: "gh",
@@ -16,25 +16,41 @@ it.effect("reports a timeline failure instead of returning complete activity wit
       operation: "listTimelineEvents",
       cause: new Error("unreadable page"),
     });
+    const comment = {
+      id: "comment",
+      kind: "issue-comment" as const,
+      author: null,
+      body: "Keep this",
+      createdAt: "2026-09-05T12:00:00Z",
+      url: null,
+      path: null,
+      reviewState: null,
+    };
+    const commit = {
+      oid: "abc123",
+      messageHeadline: "Keep this commit",
+      committedDate: comment.createdAt,
+    };
     const provider = yield* make.pipe(
       Effect.provide(
         Layer.mock(GitHubPullRequestCli.GitHubPullRequestCli)({
-          getPullRequestActivity: () => Effect.succeed({ author: null, comments: [], commits: [] }),
+          getPullRequestActivity: () =>
+            Effect.succeed({ author: null, comments: [comment], commits: [commit] }),
           listTimelineEvents: () => Effect.fail(failure),
           listReviewThreadComments: () => Effect.fail(failure),
         }),
       ),
     );
-    const error = yield* Effect.flip(
-      provider.getChangeRequestActivity({
-        cwd: "/w",
-        host: "github.com",
-        repository: "acme/web",
-        number: 7,
-      }),
-    );
-    expect(error.operation).toBe("getChangeRequestActivity");
-    expect(error.cause).toBe(failure);
+    const activity = yield* provider.getChangeRequestActivity({
+      cwd: "/w",
+      host: "github.com",
+      repository: "acme/web",
+      number: 7,
+    });
+    expect(activity.timelineTruncated).toBe(true);
+    expect(activity.timelineEvents).toEqual([]);
+    expect(activity.comments).toEqual([{ ...comment, reactions: [] }]);
+    expect(activity.commits).toMatchObject([commit]);
   }),
 );
 
@@ -85,7 +101,7 @@ describe("gitHubViewerPermissions", () => {
         didAuthor: false,
       }),
     ).toEqual({
-      deleteSourceBranch: true,
+      deleteSourceBranch: false,
       // Arming a merge for later is the merge, so it travels with it.
       actions: [
         "merge",
@@ -149,7 +165,7 @@ describe("gitHubViewerPermissions", () => {
         didAuthor: true,
       }),
     ).toEqual({
-      deleteSourceBranch: true,
+      deleteSourceBranch: false,
       // Merging is the one thing writing is needed for, now or later; the rest an author may do.
       actions: ["ready", "draft", "close", "reopen"],
       comment: true,
@@ -821,3 +837,18 @@ describe("loginAvatarUrl", () => {
     }
   });
 });
+
+it.each([true, false, undefined])(
+  "requires known source access for deletion (%s)",
+  (sourceAccess) => {
+    expect(
+      gitHubViewerPermissions({
+        canWrite: true,
+        canTriage: true,
+        canUpdate: true,
+        didAuthor: true,
+        ...(sourceAccess === undefined ? {} : { canWriteSource: sourceAccess }),
+      }).deleteSourceBranch,
+    ).toBe(sourceAccess === true);
+  },
+);

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
@@ -70,7 +70,7 @@ const CAPABILITIES: PullRequestCapabilities = {
  */
 export function gitHubViewerPermissions(access: GitHubViewerAccess): PullRequestViewerPermissions {
   return {
-    deleteSourceBranch: access.canWrite || access.didAuthor,
+    deleteSourceBranch: access.canWriteSource === true,
     actions: [
       // Arming a merge and taking the arming back are the merge, deferred: whoever may not
       // merge here may not leave an instruction to merge later either.
@@ -397,7 +397,9 @@ export const make = Effect.gen(function* () {
       Effect.all(
         [
           cli.getPullRequestActivity(input),
-          cli.listTimelineEvents(input),
+          cli
+            .listTimelineEvents(input)
+            .pipe(Effect.orElseSucceed(() => ({ events: [], truncated: true }))),
           // Line comments live on review threads, which `gh pr view --json` cannot reach. A
           // GraphQL hiccup degrades to a truncated conversation rather than blanking activity.
           cli.listReviewThreadComments(input).pipe(

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
@@ -21,6 +21,7 @@ import {
 import type { GitHubViewerAccess, GitHubWorkflowRunApproval } from "./gitHubPullRequestJson.ts";
 
 const CAPABILITIES: PullRequestCapabilities = {
+  deleteSourceBranch: true,
   diff: true,
   comment: true,
   actions: [
@@ -69,6 +70,7 @@ const CAPABILITIES: PullRequestCapabilities = {
  */
 export function gitHubViewerPermissions(access: GitHubViewerAccess): PullRequestViewerPermissions {
   return {
+    deleteSourceBranch: access.canWrite || access.didAuthor,
     actions: [
       // Arming a merge and taking the arming back are the merge, deferred: whoever may not
       // merge here may not leave an instruction to merge later either.
@@ -395,6 +397,7 @@ export const make = Effect.gen(function* () {
       Effect.all(
         [
           cli.getPullRequestActivity(input),
+          cli.listTimelineEvents(input),
           // Line comments live on review threads, which `gh pr view --json` cannot reach. A
           // GraphQL hiccup degrades to a truncated conversation rather than blanking activity.
           cli.listReviewThreadComments(input).pipe(
@@ -417,54 +420,52 @@ export const make = Effect.gen(function* () {
             })),
           ),
         ],
-        { concurrency: 2 },
+        { concurrency: 3 },
       ).pipe(
         Effect.mapError(fail("getChangeRequestActivity")),
-        Effect.map(([pullRequest, reviewThreads]): ProviderChangeRequestActivity => ({
-          author: withAvatar(pullRequest.author, reviewThreads.avatarsByLogin, input.host),
-          reviewers: reviewThreads.reviewers,
-          reactions: reviewThreads.reactions,
-          commits: (reviewThreads.commits.length > 0
-            ? reviewThreads.commits
-            : pullRequest.commits
-          ).map((commit) => ({
-            ...commit,
-            ...reviewThreads.commitStats.get(commit.oid),
-            authors: commit.authors?.map(
-              (author) => withAvatar(author, reviewThreads.avatarsByLogin, input.host) ?? author,
-            ),
-          })),
-          comments: [...pullRequest.comments, ...reviewThreads.comments]
-            .map((comment) => ({
-              ...comment,
-              // GitHub keeps the dismissal reason on the timeline event, not on the review,
-              // so a dismissed review with nothing visible of its own reads its words from
-              // there. "Visible" and not "empty": bot reviews often carry only an HTML
-              // marker comment, which markdown renders as nothing.
-              body:
-                comment.kind === "review" &&
-                comment.reviewState?.toUpperCase() === "DISMISSED" &&
-                rendersEmpty(comment.body)
-                  ? (reviewThreads.dismissalsByReviewId.get(comment.id) ?? comment.body)
-                  : comment.body,
-              author: withAvatar(comment.author, reviewThreads.avatarsByLogin, input.host),
-              // A comment out of `gh pr view --json` carries none of its own: that read
-              // reports no reaction at all, so they arrive from the GraphQL page by node id.
-              reactions: comment.reactions ?? reviewThreads.reactionsById.get(comment.id) ?? [],
-            }))
-            .toSorted((left, right) => left.createdAt.localeCompare(right.createdAt)),
-          // `gh pr view --json comments,reviews` follows GitHub's cursors itself, so those two
-          // are always whole and only the thread walk can stop short of the host.
-          commentCount: pullRequest.comments.length + reviewThreads.commentCount,
-          commentsTruncated: reviewThreads.truncated,
-          reviewThreads: reviewThreads.reviewThreads.map((thread) => ({
-            ...thread,
-            comments: thread.comments.map((comment) => ({
-              ...comment,
-              author: withAvatar(comment.author, reviewThreads.avatarsByLogin, input.host),
+        Effect.map(
+          ([pullRequest, timelineEvents, reviewThreads]): ProviderChangeRequestActivity => ({
+            timelineEvents: timelineEvents.map((event) => ({
+              ...event,
+              url: event.url ?? `https://${input.host}/${input.repository}/pull/${input.number}`,
             })),
-          })),
-        })),
+            author: withAvatar(pullRequest.author, reviewThreads.avatarsByLogin, input.host),
+            reviewers: reviewThreads.reviewers,
+            reactions: reviewThreads.reactions,
+            commits: (reviewThreads.commits.length > 0
+              ? reviewThreads.commits
+              : pullRequest.commits
+            ).map((commit) => ({
+              ...commit,
+              ...reviewThreads.commitStats.get(commit.oid),
+              authors: commit.authors?.map(
+                (author) => withAvatar(author, reviewThreads.avatarsByLogin, input.host) ?? author,
+              ),
+            })),
+            comments: [...pullRequest.comments, ...reviewThreads.comments]
+              .map((comment) => ({
+                ...comment,
+                body:
+                  comment.kind === "review" &&
+                  comment.reviewState?.toUpperCase() === "DISMISSED" &&
+                  rendersEmpty(comment.body)
+                    ? (reviewThreads.dismissalsByReviewId.get(comment.id) ?? comment.body)
+                    : comment.body,
+                author: withAvatar(comment.author, reviewThreads.avatarsByLogin, input.host),
+                reactions: comment.reactions ?? reviewThreads.reactionsById.get(comment.id) ?? [],
+              }))
+              .toSorted((left, right) => left.createdAt.localeCompare(right.createdAt)),
+            commentCount: pullRequest.comments.length + reviewThreads.commentCount,
+            commentsTruncated: reviewThreads.truncated,
+            reviewThreads: reviewThreads.reviewThreads.map((thread) => ({
+              ...thread,
+              comments: thread.comments.map((comment) => ({
+                ...comment,
+                author: withAvatar(comment.author, reviewThreads.avatarsByLogin, input.host),
+              })),
+            })),
+          }),
+        ),
       ),
 
     getReviewThreadComments: (input) =>

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
@@ -423,49 +423,48 @@ export const make = Effect.gen(function* () {
         { concurrency: 3 },
       ).pipe(
         Effect.mapError(fail("getChangeRequestActivity")),
-        Effect.map(
-          ([pullRequest, timelineEvents, reviewThreads]): ProviderChangeRequestActivity => ({
-            timelineEvents: timelineEvents.map((event) => ({
-              ...event,
-              url: event.url ?? `https://${input.host}/${input.repository}/pull/${input.number}`,
+        Effect.map(([pullRequest, timeline, reviewThreads]): ProviderChangeRequestActivity => ({
+          timelineTruncated: timeline.truncated,
+          timelineEvents: timeline.events.map((event) => ({
+            ...event,
+            url: event.url ?? `https://${input.host}/${input.repository}/pull/${input.number}`,
+          })),
+          author: withAvatar(pullRequest.author, reviewThreads.avatarsByLogin, input.host),
+          reviewers: reviewThreads.reviewers,
+          reactions: reviewThreads.reactions,
+          commits: (reviewThreads.commits.length > 0
+            ? reviewThreads.commits
+            : pullRequest.commits
+          ).map((commit) => ({
+            ...commit,
+            ...reviewThreads.commitStats.get(commit.oid),
+            authors: commit.authors?.map(
+              (author) => withAvatar(author, reviewThreads.avatarsByLogin, input.host) ?? author,
+            ),
+          })),
+          comments: [...pullRequest.comments, ...reviewThreads.comments]
+            .map((comment) => ({
+              ...comment,
+              body:
+                comment.kind === "review" &&
+                comment.reviewState?.toUpperCase() === "DISMISSED" &&
+                rendersEmpty(comment.body)
+                  ? (reviewThreads.dismissalsByReviewId.get(comment.id) ?? comment.body)
+                  : comment.body,
+              author: withAvatar(comment.author, reviewThreads.avatarsByLogin, input.host),
+              reactions: comment.reactions ?? reviewThreads.reactionsById.get(comment.id) ?? [],
+            }))
+            .toSorted((left, right) => left.createdAt.localeCompare(right.createdAt)),
+          commentCount: pullRequest.comments.length + reviewThreads.commentCount,
+          commentsTruncated: reviewThreads.truncated,
+          reviewThreads: reviewThreads.reviewThreads.map((thread) => ({
+            ...thread,
+            comments: thread.comments.map((comment) => ({
+              ...comment,
+              author: withAvatar(comment.author, reviewThreads.avatarsByLogin, input.host),
             })),
-            author: withAvatar(pullRequest.author, reviewThreads.avatarsByLogin, input.host),
-            reviewers: reviewThreads.reviewers,
-            reactions: reviewThreads.reactions,
-            commits: (reviewThreads.commits.length > 0
-              ? reviewThreads.commits
-              : pullRequest.commits
-            ).map((commit) => ({
-              ...commit,
-              ...reviewThreads.commitStats.get(commit.oid),
-              authors: commit.authors?.map(
-                (author) => withAvatar(author, reviewThreads.avatarsByLogin, input.host) ?? author,
-              ),
-            })),
-            comments: [...pullRequest.comments, ...reviewThreads.comments]
-              .map((comment) => ({
-                ...comment,
-                body:
-                  comment.kind === "review" &&
-                  comment.reviewState?.toUpperCase() === "DISMISSED" &&
-                  rendersEmpty(comment.body)
-                    ? (reviewThreads.dismissalsByReviewId.get(comment.id) ?? comment.body)
-                    : comment.body,
-                author: withAvatar(comment.author, reviewThreads.avatarsByLogin, input.host),
-                reactions: comment.reactions ?? reviewThreads.reactionsById.get(comment.id) ?? [],
-              }))
-              .toSorted((left, right) => left.createdAt.localeCompare(right.createdAt)),
-            commentCount: pullRequest.comments.length + reviewThreads.commentCount,
-            commentsTruncated: reviewThreads.truncated,
-            reviewThreads: reviewThreads.reviewThreads.map((thread) => ({
-              ...thread,
-              comments: thread.comments.map((comment) => ({
-                ...comment,
-                author: withAvatar(comment.author, reviewThreads.avatarsByLogin, input.host),
-              })),
-            })),
-          }),
-        ),
+          })),
+        })),
       ),
 
     getReviewThreadComments: (input) =>

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
@@ -130,7 +130,7 @@ layer("GitLabPullRequestCli.layer", (it) => {
       );
       mockedExecute.mockReturnValueOnce(Effect.succeed(output('{"default_branch":"main"}')));
       const error = yield* Effect.flip(cli.runMergeRequestAction(target));
-      expect(error.reason).toBe("not-finished");
+      expect(error).toMatchObject({ reason: "not-finished" });
       expect(mockedExecute).toHaveBeenCalledTimes(5);
     }),
   );

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
@@ -130,7 +130,7 @@ layer("GitLabPullRequestCli.layer", (it) => {
       );
       mockedExecute.mockReturnValueOnce(Effect.succeed(output('{"default_branch":"main"}')));
       const error = yield* Effect.flip(cli.runMergeRequestAction(target));
-      expect(error.message).toContain("Close or merge");
+      expect(error.reason).toBe("not-finished");
       expect(mockedExecute).toHaveBeenCalledTimes(5);
     }),
   );

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
@@ -102,6 +102,59 @@ afterEach(() => {
 });
 
 layer("GitLabPullRequestCli.layer", (it) => {
+  it.effect.each([
+    ['{"can_push":true}', true],
+    ['{"can_push":false}', false],
+    ["{}", false],
+    ["not JSON", false],
+  ] as const)("reads source branch access from %s", ([body, allowed]) =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(
+          output(
+            mergeRequestJson({
+              source_project_id: 42,
+              target_project_id: 7,
+              source_branch: "feat/fork",
+            }),
+          ),
+        ),
+      );
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(output('{"path_with_namespace":"fork/web"}')),
+      );
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output(body)));
+      const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
+      const detail = yield* cli.getMergeRequestDetail({
+        cwd: "/w",
+        repository: "acme/web",
+        number: 7,
+      });
+      expect(detail.viewerCanDeleteSourceBranch).toBe(allowed);
+      expect(detail.headRepositoryNameWithOwner).toBe("fork/web");
+      expect(argsOfCall(2)).toContain("projects/42/repository/branches/feat%2Ffork");
+    }),
+  );
+
+  it.effect("preserves core detail when optional source project data is malformed", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(output(mergeRequestJson({ source_project_id: 42, target_project_id: 7 }))),
+      );
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("{}")));
+      const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
+      const detail = yield* cli.getMergeRequestDetail({
+        cwd: "/w",
+        repository: "acme/web",
+        number: 7,
+      });
+      expect(detail.number).toBe(7);
+      expect(detail.viewerCanMerge).toBe(true);
+      expect(detail.headRepositoryNameWithOwner).toBeUndefined();
+      expect(detail.viewerCanDeleteSourceBranch).toBe(false);
+      expect(mockedExecute).toHaveBeenCalledTimes(2);
+    }),
+  );
   it.effect("deletes the fork source project branch and refuses an open merge request", () =>
     Effect.gen(function* () {
       const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
@@ -102,6 +102,38 @@ afterEach(() => {
 });
 
 layer("GitLabPullRequestCli.layer", (it) => {
+  it.effect("deletes the fork source project branch and refuses an open merge request", () =>
+    Effect.gen(function* () {
+      const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
+      const target = {
+        cwd: "/w",
+        repository: "acme/web",
+        number: 7,
+        action: "delete-source-branch" as const,
+      };
+      const current = {
+        state: "merged",
+        source_branch: "feature/topic",
+        target_branch: "release",
+        source_project_id: 42,
+      };
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output(mergeRequestJson(current))));
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output('{"default_branch":"main"}')));
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("")));
+      yield* cli.runMergeRequestAction(target);
+      expect(argsOfCall(1)).toContain("projects/42");
+      expect(argsOfCall(2)).toContain("projects/42/repository/branches/feature%2Ftopic");
+      expect(argsOfCall(2)).toContain("DELETE");
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(output(mergeRequestJson({ ...current, state: "opened" }))),
+      );
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output('{"default_branch":"main"}')));
+      const error = yield* Effect.flip(cli.runMergeRequestAction(target));
+      expect(error.message).toContain("Close or merge");
+      expect(mockedExecute).toHaveBeenCalledTimes(5);
+    }),
+  );
+
   it.effect("asks GitLab for one row more than the page, to probe for a next page", () =>
     Effect.gen(function* () {
       mockedExecute.mockReturnValueOnce(Effect.succeed(output(mergeRequests(3, 1))));

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
@@ -113,16 +113,17 @@ layer("GitLabPullRequestCli.layer", (it) => {
       };
       const current = {
         state: "merged",
-        source_branch: "feature/topic",
-        target_branch: "release",
+        source_branch: "main",
+        target_branch: "main",
         source_project_id: 42,
+        target_project_id: 7,
       };
       mockedExecute.mockReturnValueOnce(Effect.succeed(output(mergeRequestJson(current))));
-      mockedExecute.mockReturnValueOnce(Effect.succeed(output('{"default_branch":"main"}')));
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output('{"default_branch":"develop"}')));
       mockedExecute.mockReturnValueOnce(Effect.succeed(output("")));
       yield* cli.runMergeRequestAction(target);
       expect(argsOfCall(1)).toContain("projects/42");
-      expect(argsOfCall(2)).toContain("projects/42/repository/branches/feature%2Ftopic");
+      expect(argsOfCall(2)).toContain("projects/42/repository/branches/main");
       expect(argsOfCall(2)).toContain("DELETE");
       mockedExecute.mockReturnValueOnce(
         Effect.succeed(output(mergeRequestJson({ ...current, state: "opened" }))),

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.ts
@@ -1318,7 +1318,7 @@ export const make = Effect.gen(function* () {
           );
           if (current.source_project_id === null)
             return yield* new PullRequestBranchDeletionError({
-              detail: "The source repository no longer exists.",
+              reason: "source-repository-missing",
             });
           const source = `projects/${current.source_project_id}`;
           const repository = yield* api({ cwd: input.cwd, path: source });
@@ -1339,15 +1339,13 @@ export const make = Effect.gen(function* () {
             path: `${source}/repository/branches/${encodeURIComponent(current.source_branch)}`,
             method: "DELETE",
           }).pipe(
-            Effect.catchTag(
-              "GitLabCliCommandError",
-              (cause) =>
+            Effect.catchTags({
+              GitLabCliCommandError: (cause) =>
                 new PullRequestBranchDeletionError({
-                  detail:
-                    "The source branch could not be deleted. It may already be deleted, protected, or unavailable to this account.",
+                  reason: "delete-refused",
                   cause,
                 }),
-            ),
+            }),
           );
         });
       }

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.ts
@@ -1312,6 +1312,7 @@ export const make = Effect.gen(function* () {
               source_branch: Schema.String,
               target_branch: Schema.String,
               source_project_id: Schema.NullOr(Schema.Int),
+              target_project_id: Schema.Int,
             }),
             response.stdout,
           );
@@ -1327,6 +1328,8 @@ export const make = Effect.gen(function* () {
           );
           yield* assertSourceBranchDeletable({
             state: current.state,
+            sourceRepository: String(current.source_project_id),
+            baseRepository: String(current.target_project_id),
             sourceBranch: current.source_branch,
             baseBranch: current.target_branch,
             defaultBranch: config.default_branch,

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.ts
@@ -1,3 +1,8 @@
+import {
+  assertSourceBranchDeletable,
+  decodeBranchDeletionJson,
+  PullRequestBranchDeletionError,
+} from "./pullRequestBranchDeletion.ts";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -6,6 +11,7 @@ import * as Schema from "effect/Schema";
 import type {
   PullRequestAction,
   PullRequestComment,
+  PullRequestTimelineEvent,
   PullRequestCommit,
   PullRequestInvolvement,
   PullRequestListState,
@@ -176,6 +182,7 @@ export class GitLabDiffFileContentsUnavailableError extends Schema.TaggedErrorCl
 }
 
 export type GitLabPullRequestCliError =
+  | PullRequestBranchDeletionError
   | GitLabCli.GitLabCliError
   | GitLabMergeRequestReadError
   | GitLabDiffCursorError
@@ -245,7 +252,11 @@ export class GitLabPullRequestCli extends Context.Service<
       readonly repository: string;
       readonly number: number;
     }) => Effect.Effect<
-      { readonly comments: ReadonlyArray<PullRequestComment>; readonly truncated: boolean },
+      {
+        readonly comments: ReadonlyArray<PullRequestComment>;
+        readonly timelineEvents?: ReadonlyArray<PullRequestTimelineEvent>;
+        readonly truncated: boolean;
+      },
       GitLabPullRequestCliError
     >;
 
@@ -469,6 +480,8 @@ function actionArgs(
   mergeMethod: PullRequestMergeMethod | undefined,
 ): ReadonlyArray<string> {
   switch (action) {
+    case "delete-source-branch":
+      throw new Error("Source branch deletion requires a fresh branch lookup");
     case "merge":
       return [
         "merge",
@@ -736,8 +749,13 @@ export const make = Effect.gen(function* () {
     readonly number: number;
     readonly page: number;
     readonly collected: ReadonlyArray<PullRequestComment>;
+    readonly timelineEvents?: ReadonlyArray<PullRequestTimelineEvent>;
   }): Effect.Effect<
-    { readonly comments: ReadonlyArray<PullRequestComment>; readonly truncated: boolean },
+    {
+      readonly comments: ReadonlyArray<PullRequestComment>;
+      readonly timelineEvents?: ReadonlyArray<PullRequestTimelineEvent>;
+      readonly truncated: boolean;
+    },
     GitLabPullRequestCliError
   > =>
     api({
@@ -764,12 +782,13 @@ export const make = Effect.gen(function* () {
           );
         }
         const collected = [...input.collected, ...decoded.success.comments];
+        const timelineEvents = [...(input.timelineEvents ?? []), ...decoded.success.timelineEvents];
         if (decoded.success.rawCount < MAX_PAGE_SIZE) {
-          return Effect.succeed({ comments: collected, truncated: false });
+          return Effect.succeed({ comments: collected, timelineEvents, truncated: false });
         }
         return input.page >= CONVERSATION_PAGES
-          ? Effect.succeed({ comments: collected, truncated: true })
-          : notesPage({ ...input, page: input.page + 1, collected });
+          ? Effect.succeed({ comments: collected, timelineEvents, truncated: true })
+          : notesPage({ ...input, page: input.page + 1, collected, timelineEvents });
       }),
     );
 
@@ -1059,7 +1078,27 @@ export const make = Effect.gen(function* () {
       return listPage({ ...input, page, collected: [], cursorAdvance: 0 });
     },
 
-    getMergeRequestDetail: mergeRequestDetail,
+    getMergeRequestDetail: (input) =>
+      mergeRequestDetail(input).pipe(
+        Effect.flatMap((detail) => {
+          if (detail.sourceProjectId == null) return Effect.succeed(detail);
+          if (detail.sourceProjectId === detail.targetProjectId)
+            return Effect.succeed({ ...detail, headRepositoryNameWithOwner: input.repository });
+          return api({ cwd: input.cwd, path: `projects/${detail.sourceProjectId}` }).pipe(
+            Effect.flatMap((response) =>
+              decodeBranchDeletionJson(
+                Schema.Struct({ path_with_namespace: Schema.String }),
+                response.stdout,
+              ),
+            ),
+            Effect.map((source) => ({
+              ...detail,
+              headRepositoryNameWithOwner: source.path_with_namespace,
+            })),
+            Effect.orElseSucceed(() => detail),
+          );
+        }),
+      ),
 
     listNotes: (input) => notesPage({ ...input, page: 1, collected: [] }),
 
@@ -1261,6 +1300,54 @@ export const make = Effect.gen(function* () {
       ),
 
     runMergeRequestAction: (input) => {
+      if (input.action === "delete-source-branch") {
+        return Effect.gen(function* () {
+          const response = yield* api({
+            cwd: input.cwd,
+            path: `projects/${projectPath(input.repository)}/merge_requests/${input.number}`,
+          });
+          const current = yield* decodeBranchDeletionJson(
+            Schema.Struct({
+              state: Schema.String,
+              source_branch: Schema.String,
+              target_branch: Schema.String,
+              source_project_id: Schema.NullOr(Schema.Int),
+            }),
+            response.stdout,
+          );
+          if (current.source_project_id === null)
+            return yield* new PullRequestBranchDeletionError({
+              detail: "The source repository no longer exists.",
+            });
+          const source = `projects/${current.source_project_id}`;
+          const repository = yield* api({ cwd: input.cwd, path: source });
+          const config = yield* decodeBranchDeletionJson(
+            Schema.Struct({ default_branch: Schema.String }),
+            repository.stdout,
+          );
+          yield* assertSourceBranchDeletable({
+            state: current.state,
+            sourceBranch: current.source_branch,
+            baseBranch: current.target_branch,
+            defaultBranch: config.default_branch,
+          });
+          yield* api({
+            cwd: input.cwd,
+            path: `${source}/repository/branches/${encodeURIComponent(current.source_branch)}`,
+            method: "DELETE",
+          }).pipe(
+            Effect.catchTag(
+              "GitLabCliCommandError",
+              (cause) =>
+                new PullRequestBranchDeletionError({
+                  detail:
+                    "The source branch could not be deleted. It may already be deleted, protected, or unavailable to this account.",
+                  cause,
+                }),
+            ),
+          );
+        });
+      }
       // `glab mr merge` arms auto-merge and never disarms it, so the one direction the CLI has
       // no flag for is asked of GitLab directly through the same `api` passthrough the rest of
       // this module writes with.

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.ts
@@ -524,6 +524,13 @@ function actionArgs(
   }
 }
 
+const decodeSourceProject = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(Schema.Struct({ path_with_namespace: Schema.String })),
+);
+const decodeSourceBranchPermission = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(Schema.Struct({ can_push: Schema.optional(Schema.Boolean) })),
+);
+
 export const make = Effect.gen(function* () {
   const gitlab = yield* GitLabCli.GitLabCli;
 
@@ -1085,12 +1092,7 @@ export const make = Effect.gen(function* () {
           if (detail.sourceProjectId === detail.targetProjectId)
             return Effect.succeed({ ...detail, headRepositoryNameWithOwner: input.repository });
           return api({ cwd: input.cwd, path: `projects/${detail.sourceProjectId}` }).pipe(
-            Effect.flatMap((response) =>
-              decodeBranchDeletionJson(
-                Schema.Struct({ path_with_namespace: Schema.String }),
-                response.stdout,
-              ),
-            ),
+            Effect.flatMap((response) => decodeSourceProject(response.stdout)),
             Effect.map((source) => ({
               ...detail,
               headRepositoryNameWithOwner: source.path_with_namespace,
@@ -1098,6 +1100,24 @@ export const make = Effect.gen(function* () {
             Effect.orElseSucceed(() => detail),
           );
         }),
+        Effect.flatMap((detail) =>
+          (detail.sourceProjectId == null || detail.headRepositoryNameWithOwner == null
+            ? Effect.succeed(false)
+            : api({
+                cwd: input.cwd,
+                path: `projects/${detail.sourceProjectId}/repository/branches/${encodeURIComponent(detail.headBranch)}`,
+              }).pipe(
+                Effect.flatMap((response) => decodeSourceBranchPermission(response.stdout)),
+                Effect.map((branch) => branch.can_push === true),
+                Effect.orElseSucceed(() => false),
+              )
+          ).pipe(
+            Effect.map((viewerCanDeleteSourceBranch) => ({
+              ...detail,
+              viewerCanDeleteSourceBranch,
+            })),
+          ),
+        ),
       ),
 
     listNotes: (input) => notesPage({ ...input, page: 1, collected: [] }),

--- a/apps/server/src/pullRequest/GitLabPullRequestProvider.test.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestProvider.test.ts
@@ -8,6 +8,7 @@ import { gitLabViewerPermissions, make } from "./GitLabPullRequestProvider.ts";
 describe("gitLabViewerPermissions", () => {
   it("offers everything to a viewer GitLab says can merge", () => {
     expect(gitLabViewerPermissions({ viewerCanMerge: true })).toEqual({
+      deleteSourceBranch: true,
       // Arming a merge for later and taking the arming back answer to the same `can_merge`.
       actions: [
         "merge",
@@ -34,6 +35,7 @@ describe("gitLabViewerPermissions", () => {
     // `user.can_merge` already accounts for the role, the approval rules and a protected target
     // branch, so it is the one answer here that does not have to be inferred.
     expect(gitLabViewerPermissions({ viewerCanMerge: false })).toEqual({
+      deleteSourceBranch: true,
       actions: ["ready", "draft", "close", "reopen"],
       comment: true,
       resolve: true,

--- a/apps/server/src/pullRequest/GitLabPullRequestProvider.test.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestProvider.test.ts
@@ -8,7 +8,7 @@ import { gitLabViewerPermissions, make } from "./GitLabPullRequestProvider.ts";
 describe("gitLabViewerPermissions", () => {
   it("offers everything to a viewer GitLab says can merge", () => {
     expect(gitLabViewerPermissions({ viewerCanMerge: true })).toEqual({
-      deleteSourceBranch: true,
+      deleteSourceBranch: false,
       // Arming a merge for later and taking the arming back answer to the same `can_merge`.
       actions: [
         "merge",
@@ -35,7 +35,7 @@ describe("gitLabViewerPermissions", () => {
     // `user.can_merge` already accounts for the role, the approval rules and a protected target
     // branch, so it is the one answer here that does not have to be inferred.
     expect(gitLabViewerPermissions({ viewerCanMerge: false })).toEqual({
-      deleteSourceBranch: true,
+      deleteSourceBranch: false,
       actions: ["ready", "draft", "close", "reopen"],
       comment: true,
       resolve: true,
@@ -197,3 +197,15 @@ describe("rewriting what has already been said", () => {
     }),
   );
 });
+
+it.each([true, false, undefined])(
+  "requires known source access for deletion (%s)",
+  (sourceAccess) => {
+    expect(
+      gitLabViewerPermissions({
+        viewerCanMerge: true,
+        ...(sourceAccess === undefined ? {} : { viewerCanDeleteSourceBranch: sourceAccess }),
+      }).deleteSourceBranch,
+    ).toBe(sourceAccess === true);
+  },
+);

--- a/apps/server/src/pullRequest/GitLabPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestProvider.ts
@@ -15,6 +15,7 @@ import {
 } from "./PullRequestProvider.ts";
 
 const CAPABILITIES: PullRequestCapabilities = {
+  deleteSourceBranch: true,
   diff: true,
   comment: true,
   actions: [
@@ -77,6 +78,7 @@ export function gitLabViewerPermissions(input: {
   readonly viewerCanMerge: boolean;
 }): PullRequestViewerPermissions {
   return {
+    deleteSourceBranch: true,
     // Arming the merge and taking the arming back are the merge, deferred, so they answer to
     // the same `can_merge` the merge itself does.
     actions: CAPABILITIES.actions.filter(
@@ -188,6 +190,12 @@ export const make = Effect.gen(function* () {
       ).pipe(
         Effect.mapError(fail("getChangeRequestActivity")),
         Effect.map(([notes, commits, discussions, awards]): ProviderChangeRequestActivity => ({
+          timelineEvents: ("timelineEvents" in notes ? (notes.timelineEvents ?? []) : []).map(
+            (event) => ({
+              ...event,
+              url: `https://${input.host}/${input.repository}/-/merge_requests/${input.number}#note_${event.id.slice(5)}`,
+            }),
+          ),
           reactions: awards.reactions,
           comments: notes.comments.map((comment) => ({
             ...comment,

--- a/apps/server/src/pullRequest/GitLabPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestProvider.ts
@@ -75,10 +75,11 @@ const MERGE_ACTIONS: ReadonlySet<string> = new Set([
  * and from anyone with the Developer role, and states neither of those two facts here.
  */
 export function gitLabViewerPermissions(input: {
+  viewerCanDeleteSourceBranch?: boolean;
   readonly viewerCanMerge: boolean;
 }): PullRequestViewerPermissions {
   return {
-    deleteSourceBranch: true,
+    deleteSourceBranch: input.viewerCanDeleteSourceBranch === true,
     // Arming the merge and taking the arming back are the merge, deferred, so they answer to
     // the same `can_merge` the merge itself does.
     actions: CAPABILITIES.actions.filter(

--- a/apps/server/src/pullRequest/PullRequestProvider.ts
+++ b/apps/server/src/pullRequest/PullRequestProvider.ts
@@ -3,6 +3,7 @@ import * as Schema from "effect/Schema";
 import type {
   PullRequestAction,
   PullRequestActor,
+  PullRequestTimelineEvent,
   PullRequestBaseComparison,
   PullRequestCapabilities,
   PullRequestChecksState,
@@ -188,6 +189,7 @@ export interface ProviderChangeRequestDetail extends ProviderChangeRequest {
 
 /** The conversation-shaped half of a detail, loaded after the core can already render. */
 export interface ProviderChangeRequestActivity {
+  readonly timelineEvents?: ReadonlyArray<PullRequestTimelineEvent>;
   /** An optional richer actor, e.g. after GitHub's GraphQL read supplies an avatar. */
   readonly author?: PullRequestActor | null;
   /** Optional because most hosts already report their reviewer list in the core detail. */

--- a/apps/server/src/pullRequest/PullRequestProvider.ts
+++ b/apps/server/src/pullRequest/PullRequestProvider.ts
@@ -190,6 +190,7 @@ export interface ProviderChangeRequestDetail extends ProviderChangeRequest {
 /** The conversation-shaped half of a detail, loaded after the core can already render. */
 export interface ProviderChangeRequestActivity {
   readonly timelineEvents?: ReadonlyArray<PullRequestTimelineEvent>;
+  readonly timelineTruncated?: boolean;
   /** An optional richer actor, e.g. after GitHub's GraphQL read supplies an avatar. */
   readonly author?: PullRequestActor | null;
   /** Optional because most hosts already report their reviewer list in the core detail. */

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -4158,15 +4158,24 @@ it.effect("names the signed-in account in the detail, and says nothing where the
   }),
 );
 
-it.effect("accepts source branch deletion only when both optional permission flags allow it", () =>
+it.effect("accepts Azure source branch deletion and ignores unrelated methods", () =>
   Effect.gen(function* () {
-    const provider = fakeProvider("github");
+    const provider = fakeProvider("azure-devops");
     let canDelete = false;
     let deletions = 0;
     const service = yield* makeService({
-      projects: [project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" })],
+      projects: [
+        project({
+          id: "p1",
+          title: "web",
+          workspaceRoot: "/a",
+          repository: "web",
+          provider: "azure-devops",
+          host: "dev.azure.com",
+        }),
+      ],
       providers: [
-        fakeProvider("github", {
+        fakeProvider("azure-devops", {
           capabilities: { ...provider.capabilities, deleteSourceBranch: true },
           getViewerPermissions: (input) =>
             provider
@@ -4182,7 +4191,7 @@ it.effect("accepts source branch deletion only when both optional permission fla
     });
     const input = {
       projectId: "p1" as ProjectId,
-      repository: "acme/web",
+      repository: "web",
       number: 1,
       action: "delete-source-branch" as const,
     };
@@ -4190,7 +4199,7 @@ it.effect("accepts source branch deletion only when both optional permission fla
     assert.include(error.message, "write access on the source repository");
     assert.strictEqual(deletions, 0);
     canDelete = true;
-    yield* service.runAction(input);
+    yield* service.runAction({ ...input, mergeMethod: "rebase", updateMethod: "rebase" });
     assert.strictEqual(deletions, 1);
   }),
 );

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -991,16 +991,18 @@ it.effect("refuses an action the host never claimed it could run", () =>
       ],
     });
 
-    const error = yield* Effect.flip(
-      service.runAction({
-        projectId: "p1" as ProjectId,
-        repository: "acme/web",
-        number: 1,
-        action: "reopen",
-      }),
-    );
+    for (const action of ["reopen", "delete-source-branch"] as const) {
+      const error = yield* Effect.flip(
+        service.runAction({
+          projectId: "p1" as ProjectId,
+          repository: "acme/web",
+          number: 1,
+          action,
+        }),
+      );
 
-    assert.strictEqual(error._tag, "PullRequestOperationError");
+      assert.strictEqual(error._tag, "PullRequestOperationError");
+    }
     assert.isFalse(ran);
   }),
 );
@@ -3205,6 +3207,7 @@ it.effect(
               return Effect.succeed({
                 ...changeRequest(1, "2026-07-02T00:00:00Z"),
                 body: "Ready before the conversation",
+                reviewDecision: "review-required",
                 changedFiles: 2,
                 mergedAt: null,
                 closedAt: null,
@@ -3223,6 +3226,16 @@ it.effect(
             getChangeRequestActivity: () => {
               activityCalls += 1;
               return Effect.succeed({
+                timelineEvents: [
+                  {
+                    id: "event:1",
+                    kind: "closed",
+                    actor: null,
+                    createdAt: "2026-07-02T00:00:00Z",
+                    url: null,
+                    body: "closed this pull request",
+                  },
+                ],
                 comments: [],
                 commentCount: 0,
                 commentsTruncated: false,
@@ -3236,6 +3249,7 @@ it.effect(
 
       const core = yield* service.detail(reference);
       assert.strictEqual(core.body, "Ready before the conversation");
+      assert.strictEqual(core.reviewDecision, "review-required");
       assert.strictEqual(coreCalls, 1);
       assert.strictEqual(activityCalls, 0);
 
@@ -3249,9 +3263,13 @@ it.effect(
         },
       ]);
 
-      yield* Effect.all([service.activity(reference), service.activity(reference)], {
-        concurrency: 2,
-      });
+      const [activity] = yield* Effect.all(
+        [service.activity(reference), service.activity(reference)],
+        {
+          concurrency: 2,
+        },
+      );
+      assert.strictEqual(activity.timelineEvents?.[0]?.body, "closed this pull request");
       assert.strictEqual(activityCalls, 1);
 
       yield* service.invalidate({ reference });
@@ -4135,5 +4153,42 @@ it.effect("names the signed-in account in the detail, and says nothing where the
 
     assert.strictEqual(named.viewer, "bilal");
     assert.strictEqual(unnamed.viewer, undefined);
+  }),
+);
+
+it.effect("accepts source branch deletion only when both optional permission flags allow it", () =>
+  Effect.gen(function* () {
+    const provider = fakeProvider("github");
+    let canDelete = false;
+    let deletions = 0;
+    const service = yield* makeService({
+      projects: [project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" })],
+      providers: [
+        fakeProvider("github", {
+          capabilities: { ...provider.capabilities, deleteSourceBranch: true },
+          getViewerPermissions: (input) =>
+            provider
+              .getViewerPermissions(input)
+              .pipe(Effect.map((viewer) => ({ ...viewer, deleteSourceBranch: canDelete }))),
+          runAction: (input) =>
+            Effect.sync(() => {
+              assert.strictEqual(input.action, "delete-source-branch");
+              deletions += 1;
+            }),
+        }),
+      ],
+    });
+    const input = {
+      projectId: "p1" as ProjectId,
+      repository: "acme/web",
+      number: 1,
+      action: "delete-source-branch" as const,
+    };
+    const error = yield* Effect.flip(service.runAction(input));
+    assert.include(error.message, "write access on the source repository");
+    assert.strictEqual(deletions, 0);
+    canDelete = true;
+    yield* service.runAction(input);
+    assert.strictEqual(deletions, 1);
   }),
 );

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -3226,6 +3226,7 @@ it.effect(
             getChangeRequestActivity: () => {
               activityCalls += 1;
               return Effect.succeed({
+                timelineTruncated: true,
                 timelineEvents: [
                   {
                     id: "event:1",
@@ -3270,6 +3271,7 @@ it.effect(
         },
       );
       assert.strictEqual(activity.timelineEvents?.[0]?.body, "closed this pull request");
+      assert.strictEqual(activity.timelineTruncated, true);
       assert.strictEqual(activityCalls, 1);
 
       yield* service.invalidate({ reference });

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -1460,6 +1460,7 @@ export const make = Effect.gen(function* () {
         // provider maps an unrecognised method to its own default, so asking Azure DevOps to
         // rebase would quietly merge instead of failing.
         if (
+          (input.action === "merge" || input.action === "enable-auto-merge") &&
           input.mergeMethod !== undefined &&
           !project.api.capabilities.mergeMethods.includes(input.mergeMethod)
         ) {
@@ -1473,6 +1474,7 @@ export const make = Effect.gen(function* () {
         // The same for the way a stale branch is brought up to date: a host that only merges
         // must not be asked to rebase and left to pick something else.
         if (
+          input.action === "update-branch" &&
           input.updateMethod !== undefined &&
           !(project.api.capabilities.updateMethods ?? []).includes(input.updateMethod)
         ) {
@@ -1501,6 +1503,7 @@ export const make = Effect.gen(function* () {
               );
             }
             if (
+              input.action === "update-branch" &&
               input.updateMethod !== undefined &&
               !(viewer.updateMethods ?? []).includes(input.updateMethod)
             ) {

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -211,6 +211,7 @@ const VERDICT_LABELS: Record<PullRequestReviewVerdict, string> = {
  * else; the other four are also the author's to take, whatever access they have.
  */
 const ACTION_ACCESS_REFUSALS: Record<PullRequestAction, string> = {
+  "delete-source-branch": "You need write access on the source repository to delete its branch.",
   merge: "You need write access on this repository to merge.",
   ready:
     "You need write access on this repository, or to have opened this change request, to mark it ready for review.",
@@ -1290,6 +1291,9 @@ export const make = Effect.gen(function* () {
             number: changeRequest.number,
             title: changeRequest.title,
             body: changeRequest.body,
+            ...(changeRequest.reviewDecision === undefined
+              ? {}
+              : { reviewDecision: changeRequest.reviewDecision }),
             url: changeRequest.url,
             author: changeRequest.author,
             state: changeRequest.state,
@@ -1346,6 +1350,9 @@ export const make = Effect.gen(function* () {
             Effect.map((activity): PullRequestActivity => ({
               ...(activity.author === undefined ? {} : { author: activity.author }),
               ...(activity.reviewers === undefined ? {} : { reviewers: activity.reviewers }),
+              ...(activity.timelineEvents === undefined
+                ? {}
+                : { timelineEvents: activity.timelineEvents }),
               comments: activity.comments,
               commentCount: activity.commentCount,
               commentsTruncated: activity.commentsTruncated,
@@ -1434,7 +1441,11 @@ export const make = Effect.gen(function* () {
       Effect.flatMap((project): Effect.Effect<string, PullRequestError> => {
         // The surface hides what a host cannot do, and this refuses it as well: a request that
         // reached here anyway must not be handed to a provider that never claimed the action.
-        if (!project.api.capabilities.actions.includes(input.action)) {
+        if (
+          input.action === "delete-source-branch"
+            ? project.api.capabilities.deleteSourceBranch !== true
+            : !project.api.capabilities.actions.includes(input.action)
+        ) {
           return Effect.fail(
             new PullRequestOperationError({
               operation: "runAction",
@@ -1474,7 +1485,11 @@ export const make = Effect.gen(function* () {
         // above do not.
         return viewerPermissionsOf(project, input, "runAction").pipe(
           Effect.flatMap((viewer): Effect.Effect<string, PullRequestError> => {
-            if (!viewer.actions.includes(input.action)) {
+            if (
+              input.action === "delete-source-branch"
+                ? viewer.deleteSourceBranch !== true
+                : !viewer.actions.includes(input.action)
+            ) {
               return Effect.fail(
                 new PullRequestOperationError({
                   operation: "runAction",

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -1353,6 +1353,9 @@ export const make = Effect.gen(function* () {
               ...(activity.timelineEvents === undefined
                 ? {}
                 : { timelineEvents: activity.timelineEvents }),
+              ...(activity.timelineTruncated === undefined
+                ? {}
+                : { timelineTruncated: activity.timelineTruncated }),
               comments: activity.comments,
               commentCount: activity.commentCount,
               commentsTruncated: activity.commentsTruncated,

--- a/apps/server/src/pullRequest/azureDevOpsPullRequestJson.test.ts
+++ b/apps/server/src/pullRequest/azureDevOpsPullRequestJson.test.ts
@@ -238,7 +238,7 @@ describe("decodeViewerJson", () => {
 
 describe("decodeThreadsJson", () => {
   it("takes every real comment of every thread, oldest first", () => {
-    const comments = expectSuccess(
+    const { comments } = expectSuccess(
       decodeThreadsJson(
         asJson({
           value: [
@@ -279,7 +279,7 @@ describe("decodeThreadsJson", () => {
   });
 
   it("reads a thread pinned to a file as a review comment", () => {
-    const comments = expectSuccess(
+    const { comments } = expectSuccess(
       decodeThreadsJson(
         asJson({
           value: [
@@ -297,7 +297,7 @@ describe("decodeThreadsJson", () => {
   });
 
   it("keeps the replies under a thread, which are as much of the conversation", () => {
-    const comments = expectSuccess(
+    const { comments } = expectSuccess(
       decodeThreadsJson(
         asJson({
           value: [
@@ -319,7 +319,7 @@ describe("decodeThreadsJson", () => {
   });
 
   it("drops deleted threads and threads with nothing to show", () => {
-    const comments = expectSuccess(
+    const { comments } = expectSuccess(
       decodeThreadsJson(
         asJson({
           value: [

--- a/apps/server/src/pullRequest/azureDevOpsPullRequestJson.ts
+++ b/apps/server/src/pullRequest/azureDevOpsPullRequestJson.ts
@@ -61,8 +61,9 @@ const RawPullRequestSchema = Schema.Struct({
     Schema.NullOr(
       Schema.Struct({
         repository: Schema.Struct({
+          id: Schema.optional(Schema.String),
           name: Schema.String,
-          project: Schema.Struct({ name: Schema.String }),
+          project: Schema.Struct({ id: Schema.optional(Schema.String), name: Schema.String }),
         }),
       }),
     ),
@@ -75,10 +76,16 @@ const RawPullRequestSchema = Schema.Struct({
   repository: Schema.optional(
     Schema.NullOr(
       Schema.Struct({
+        id: Schema.optional(Schema.String),
         name: Schema.optional(Schema.NullOr(Schema.String)),
         webUrl: Schema.optional(Schema.NullOr(Schema.String)),
         project: Schema.optional(
-          Schema.NullOr(Schema.Struct({ name: Schema.optional(Schema.NullOr(Schema.String)) })),
+          Schema.NullOr(
+            Schema.Struct({
+              id: Schema.optional(Schema.String),
+              name: Schema.optional(Schema.NullOr(Schema.String)),
+            }),
+          ),
         ),
       }),
     ),
@@ -137,6 +144,8 @@ const RawViewerSchema = Schema.Struct({
 });
 
 export interface AzureDevOpsPullRequest {
+  readonly sourceRepositoryId?: string;
+  readonly sourceProjectId?: string;
   readonly headRepositoryNameWithOwner?: string | null;
   readonly number: number;
   readonly title: string;
@@ -263,7 +272,12 @@ function toPullRequest(
   const headBranch = trimmed(normalizeRefName(raw.sourceRefName));
   const baseBranch = trimmed(normalizeRefName(raw.targetRefName));
   if (url === null || headBranch === null || baseBranch === null) return null;
+  const sourceRepository = raw.forkSource?.repository ?? raw.repository;
   return {
+    ...(sourceRepository?.id === undefined ? {} : { sourceRepositoryId: sourceRepository.id }),
+    ...(sourceRepository?.project?.id === undefined
+      ? {}
+      : { sourceProjectId: sourceRepository.project.id }),
     number: raw.pullRequestId,
     title: raw.title,
     url,

--- a/apps/server/src/pullRequest/azureDevOpsPullRequestJson.ts
+++ b/apps/server/src/pullRequest/azureDevOpsPullRequestJson.ts
@@ -4,6 +4,7 @@ import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import type {
   PullRequestActor,
+  PullRequestTimelineEvent,
   PullRequestComment,
   PullRequestMergeMethod,
   PullRequestMergeability,
@@ -56,6 +57,16 @@ const RawPullRequestSchema = Schema.Struct({
   // Required, and required to be non-empty: the wire contract will not carry a change request
   // without a branch or a created time, so a row missing one is skipped rather than breaking the
   // response it travels in.
+  forkSource: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        repository: Schema.Struct({
+          name: Schema.String,
+          project: Schema.Struct({ name: Schema.String }),
+        }),
+      }),
+    ),
+  ),
   sourceRefName: TrimmedNonEmptyString,
   targetRefName: TrimmedNonEmptyString,
   creationDate: TrimmedNonEmptyString,
@@ -85,6 +96,14 @@ const RawPullRequestSchema = Schema.Struct({
 
 /** A pull request thread, which is how Azure keeps its conversation. */
 const RawThreadSchema = Schema.Struct({
+  properties: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        CodeReviewThreadType: Schema.optional(Schema.Struct({ $value: Schema.String })),
+        CodeReviewStatus: Schema.optional(Schema.Struct({ $value: Schema.String })),
+      }),
+    ),
+  ),
   id: Schema.Int,
   isDeleted: Schema.optional(Schema.NullOr(Schema.Boolean)),
   threadContext: Schema.optional(
@@ -118,6 +137,7 @@ const RawViewerSchema = Schema.Struct({
 });
 
 export interface AzureDevOpsPullRequest {
+  readonly headRepositoryNameWithOwner?: string | null;
   readonly number: number;
   readonly title: string;
   readonly url: string;
@@ -249,6 +269,13 @@ function toPullRequest(
     url,
     author: toActor(raw.createdBy),
     headBranch,
+    ...(raw.forkSource?.repository
+      ? {
+          headRepositoryNameWithOwner: `${raw.forkSource.repository.project.name}/${raw.forkSource.repository.name}`,
+        }
+      : raw.repository?.project?.name && raw.repository.name
+        ? { headRepositoryNameWithOwner: `${raw.repository.project.name}/${raw.repository.name}` }
+        : {}),
     baseBranch,
     state: toState(raw),
     isDraft: raw.isDraft ?? false,
@@ -330,28 +357,47 @@ export function decodeViewerJson(raw: string): Result.Result<string | null, Deco
  * Azure answers the whole thread collection in one response, with no cursor and no page to
  * follow, so what this returns is everything the host has.
  */
-export function decodeThreadsJson(
-  raw: string,
-): Result.Result<ReadonlyArray<PullRequestComment>, DecodeFailure> {
+export function decodeThreadsJson(raw: string): Result.Result<
+  {
+    readonly comments: ReadonlyArray<PullRequestComment>;
+    readonly timelineEvents: ReadonlyArray<PullRequestTimelineEvent>;
+  },
+  DecodeFailure
+> {
   const decoded = decodeThreadPage(raw);
   if (!Result.isSuccess(decoded)) {
     return Result.fail(decoded.failure);
   }
   const comments: PullRequestComment[] = [];
+  const timelineEvents: PullRequestTimelineEvent[] = [];
   for (const entry of decoded.success.value) {
     const decodedThread = decodeThreadEntry(entry);
     if (Exit.isFailure(decodedThread)) continue;
     const thread = decodedThread.value;
     if (thread.isDeleted === true) continue;
     const path = trimmed(thread.threadContext?.filePath);
+    const status =
+      thread.properties?.CodeReviewThreadType?.$value === "StatusUpdate"
+        ? thread.properties.CodeReviewStatus?.$value.toLowerCase()
+        : undefined;
     for (const comment of thread.comments ?? []) {
       const publishedDate = trimmed(comment.publishedDate);
       if (
         comment.isDeleted === true ||
-        comment.commentType?.trim().toLowerCase() === "system" ||
         (comment.content ?? "").trim().length === 0 ||
         publishedDate === null
       ) {
+        continue;
+      }
+      if (comment.commentType?.trim().toLowerCase() === "system") {
+        timelineEvents.push({
+          id: `azure:${thread.id}:${comment.id ?? 0}`,
+          kind: status === "completed" ? "merged" : status === "abandoned" ? "closed" : "system",
+          actor: toActor(comment.author),
+          createdAt: publishedDate,
+          body: comment.content ?? "",
+          url: null,
+        });
         continue;
       }
       comments.push({
@@ -366,7 +412,8 @@ export function decodeThreadsJson(
       });
     }
   }
-  return Result.succeed(
-    comments.toSorted((left, right) => left.createdAt.localeCompare(right.createdAt)),
-  );
+  return Result.succeed({
+    comments: comments.toSorted((left, right) => left.createdAt.localeCompare(right.createdAt)),
+    timelineEvents,
+  });
 }

--- a/apps/server/src/pullRequest/bitbucketPullRequestJson.ts
+++ b/apps/server/src/pullRequest/bitbucketPullRequestJson.ts
@@ -6,6 +6,7 @@ import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import type {
   PullRequestActor,
+  PullRequestTimelineEvent,
   PullRequestCheck,
   PullRequestCheckStatus,
   PullRequestComment,
@@ -309,6 +310,77 @@ function toPullRequest(raw: Schema.Schema.Type<typeof RawPullRequestSchema>): Bi
 }
 
 const decodePage = decodeJsonResult(RawPageSchema);
+
+const decodeActivityEntry = Schema.decodeUnknownExit(
+  Schema.Struct({
+    pull_request: Schema.optional(
+      Schema.Struct({
+        links: Schema.optional(Schema.Struct({ html: Schema.optional(RawLinkSchema) })),
+      }),
+    ),
+    approval: Schema.optional(
+      Schema.Struct({ date: Schema.String, user: Schema.optional(Schema.NullOr(RawUserSchema)) }),
+    ),
+    update: Schema.optional(
+      Schema.Struct({
+        date: Schema.String,
+        author: Schema.optional(Schema.NullOr(RawUserSchema)),
+        state: Schema.optional(Schema.String),
+        title: Schema.optional(Schema.String),
+        description: Schema.optional(Schema.String),
+      }),
+    ),
+  }),
+);
+
+export function decodeTimelineEventsJson(raw: string): Result.Result<
+  {
+    readonly items: ReadonlyArray<PullRequestTimelineEvent>;
+    readonly next: string | null;
+  },
+  DecodeFailure
+> {
+  const page = decodePage(raw);
+  if (!Result.isSuccess(page)) return Result.fail(page.failure);
+  const events: PullRequestTimelineEvent[] = [];
+  for (const entry of page.success.values) {
+    const decoded = decodeActivityEntry(entry);
+    if (Exit.isFailure(decoded)) continue;
+    const url = decoded.value.pull_request?.links?.html?.href ?? null;
+    const approval = decoded.value.approval;
+    if (approval !== undefined) {
+      const actor = toActor(approval.user);
+      events.push({
+        id: `bitbucket:approved:${approval.date}:${actor?.login ?? ""}`,
+        kind: "approved",
+        actor,
+        createdAt: toIsoUtc(approval.date),
+        url,
+        body: "approved this pull request",
+      });
+    }
+    if (decoded.value.update === undefined) continue;
+    const update = decoded.value.update;
+    const actor = toActor(update.author);
+    events.push({
+      id: `bitbucket:update:${update.date}:${actor?.login ?? ""}:${update.state ?? ""}`,
+      kind:
+        update.state?.toUpperCase() === "MERGED"
+          ? "merged"
+          : update.state?.toUpperCase() === "DECLINED" ||
+              update.state?.toUpperCase() === "SUPERSEDED"
+            ? "closed"
+            : "updated",
+      actor,
+      createdAt: toIsoUtc(update.date),
+      url,
+      body: update.state
+        ? `updated pull request: ${update.state.toLowerCase()}`
+        : "updated pull request",
+    });
+  }
+  return Result.succeed({ items: events, next: page.success.next ?? null });
+}
 const decodePullRequestEntry = Schema.decodeUnknownExit(RawPullRequestSchema);
 const decodePullRequest = decodeJsonResult(RawPullRequestSchema);
 const decodeCommentEntry = Schema.decodeUnknownExit(RawCommentSchema);

--- a/apps/server/src/pullRequest/bitbucketPullRequestJson.ts
+++ b/apps/server/src/pullRequest/bitbucketPullRequestJson.ts
@@ -454,13 +454,18 @@ export function decodeViewerJson(raw: string): Result.Result<string | null, Deco
  * Bitbucket answers `admin`, `write` or `read`, and an empty page means it named no permission at
  * all for this account — an unknown standing, which is granted rather than guessed away.
  */
-export function decodeRepositoryPermissionJson(raw: string): Result.Result<boolean, DecodeFailure> {
+export function decodeRepositoryPermissionJson(
+  raw: string,
+  allowUnknown = true,
+): Result.Result<boolean, DecodeFailure> {
   const decoded = decodeRepositoryPermissions(raw);
   if (!Result.isSuccess(decoded)) {
     return Result.fail(decoded.failure);
   }
   const permission = trimmed(decoded.success.values?.[0]?.permission)?.toLowerCase() ?? null;
-  return Result.succeed(permission === null || permission === "admin" || permission === "write");
+  return Result.succeed(
+    (allowUnknown && permission === null) || permission === "admin" || permission === "write",
+  );
 }
 
 /**

--- a/apps/server/src/pullRequest/bitbucketPullRequestJson.ts
+++ b/apps/server/src/pullRequest/bitbucketPullRequestJson.ts
@@ -321,6 +321,9 @@ const decodeActivityEntry = Schema.decodeUnknownExit(
     approval: Schema.optional(
       Schema.Struct({ date: Schema.String, user: Schema.optional(Schema.NullOr(RawUserSchema)) }),
     ),
+    request_changes: Schema.optional(
+      Schema.Struct({ date: Schema.String, user: Schema.optional(Schema.NullOr(RawUserSchema)) }),
+    ),
     update: Schema.optional(
       Schema.Struct({
         date: Schema.String,
@@ -357,6 +360,18 @@ export function decodeTimelineEventsJson(raw: string): Result.Result<
         createdAt: toIsoUtc(approval.date),
         url,
         body: "approved this pull request",
+      });
+    }
+    const requestChanges = decoded.value.request_changes;
+    if (requestChanges !== undefined) {
+      const actor = toActor(requestChanges.user);
+      events.push({
+        id: `bitbucket:changes-requested:${requestChanges.date}:${actor?.login ?? ""}`,
+        kind: "changes-requested",
+        actor,
+        createdAt: toIsoUtc(requestChanges.date),
+        url,
+        body: "requested changes",
       });
     }
     if (decoded.value.update === undefined) continue;

--- a/apps/server/src/pullRequest/gitHubPullRequestJson.test.ts
+++ b/apps/server/src/pullRequest/gitHubPullRequestJson.test.ts
@@ -225,6 +225,24 @@ describe("pull request detail decoding", () => {
     ]);
   });
 
+  it("reads the fork repository name and owner returned by gh pr view", () => {
+    const detail = expectSuccess(
+      decodePullRequestDetailJson(
+        JSON.stringify({
+          ...JSON.parse(detailJson),
+          headRepository: { id: "R_kgDOTkYJ5w", name: "t3code" },
+          headRepositoryOwner: {
+            id: "MDQ6VXNlcjYyMzM3MDAz",
+            name: "Bilal Bakr",
+            login: "Bil0000",
+          },
+          isCrossRepository: true,
+        }),
+      ),
+    );
+    expect(detail.headRepositoryNameWithOwner).toBe("Bil0000/t3code");
+  });
+
   it("keeps a workflow waiting for approval out of the passing state", () => {
     const raw = JSON.parse(detailJson) as Record<string, unknown>;
     const detail = expectSuccess(

--- a/apps/server/src/pullRequest/gitHubPullRequestJson.test.ts
+++ b/apps/server/src/pullRequest/gitHubPullRequestJson.test.ts
@@ -841,6 +841,26 @@ describe("viewer permission decoding", () => {
   const viewerJson = (repository: Record<string, unknown>) =>
     JSON.stringify({ data: { repository } });
 
+  it.each(["WRITE", "MAINTAIN", "ADMIN", "READ", "TRIAGE", undefined])(
+    "uses source role %s independently of target write or authorship",
+    (permission) => {
+      const access = expectSuccess(
+        decodeViewerPermissionsJson(
+          viewerJson({
+            viewerPermission: "ADMIN",
+            pullRequest: {
+              viewerDidAuthor: true,
+              headRepository: { viewerPermission: permission },
+            },
+          }),
+        ),
+      );
+      expect(access.canWriteSource).toBe(
+        permission === "WRITE" || permission === "MAINTAIN" || permission === "ADMIN",
+      );
+    },
+  );
+
   it("reads the repository's role and the pull request's own viewer fields together", () => {
     expect(
       expectSuccess(
@@ -851,7 +871,13 @@ describe("viewer permission decoding", () => {
           }),
         ),
       ),
-    ).toEqual({ canWrite: false, canTriage: false, canUpdate: true, didAuthor: true });
+    ).toEqual({
+      canWrite: false,
+      canWriteSource: false,
+      canTriage: false,
+      canUpdate: true,
+      didAuthor: true,
+    });
   });
 
   it("says no to a passer-by on a repository they can only read", () => {
@@ -864,7 +890,13 @@ describe("viewer permission decoding", () => {
           }),
         ),
       ),
-    ).toEqual({ canWrite: false, canTriage: false, canUpdate: false, didAuthor: false });
+    ).toEqual({
+      canWrite: false,
+      canWriteSource: false,
+      canTriage: false,
+      canUpdate: false,
+      didAuthor: false,
+    });
   });
 
   it("reads silence as permission, but not as authorship", () => {
@@ -873,6 +905,7 @@ describe("viewer permission decoding", () => {
     // and claiming it for someone who did not is how an author's own rules get handed out.
     expect(expectSuccess(decodeViewerPermissionsJson(viewerJson({ pullRequest: null })))).toEqual({
       canWrite: false,
+      canWriteSource: false,
       canTriage: false,
       canUpdate: true,
       didAuthor: false,

--- a/apps/server/src/pullRequest/gitHubPullRequestJson.ts
+++ b/apps/server/src/pullRequest/gitHubPullRequestJson.ts
@@ -4,6 +4,7 @@ import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import type {
   PullRequestActor,
+  PullRequestTimelineEvent,
   PullRequestCheck,
   PullRequestCheckStatus,
   PullRequestChecksState,
@@ -32,6 +33,103 @@ import type {
 import { decodeJsonResult } from "@t3tools/shared/schemaJson";
 
 import { dedupeChecks } from "./pullRequestChecks.ts";
+
+const decodeTimelinePage = decodeJsonResult(Schema.Array(Schema.Unknown));
+const decodeTimelineEvent = Schema.decodeUnknownExit(
+  Schema.Struct({
+    id: Schema.optional(Schema.Number),
+    event: Schema.String,
+    created_at: Schema.String,
+    actor: Schema.optional(
+      Schema.NullOr(
+        Schema.Struct({ login: Schema.String, avatar_url: Schema.optional(Schema.String) }),
+      ),
+    ),
+    html_url: Schema.optional(Schema.String),
+    requested_reviewer: Schema.optional(Schema.NullOr(Schema.Struct({ login: Schema.String }))),
+    requested_team: Schema.optional(Schema.NullOr(Schema.Struct({ name: Schema.String }))),
+    label: Schema.optional(Schema.NullOr(Schema.Struct({ name: Schema.String }))),
+    rename: Schema.optional(
+      Schema.NullOr(Schema.Struct({ from: Schema.String, to: Schema.String })),
+    ),
+    source: Schema.optional(
+      Schema.Struct({
+        issue: Schema.optional(
+          Schema.Struct({
+            id: Schema.Number,
+            title: Schema.String,
+            html_url: Schema.String,
+            state: Schema.String,
+            pull_request: Schema.optional(
+              Schema.Struct({ merged_at: Schema.optional(Schema.NullOr(Schema.String)) }),
+            ),
+          }),
+        ),
+      }),
+    ),
+  }),
+);
+
+export function decodeTimelineEventsJson(raw: string): Result.Result<
+  {
+    readonly events: ReadonlyArray<PullRequestTimelineEvent>;
+    readonly rawCount: number;
+  },
+  DecodeFailure
+> {
+  const page = decodeTimelinePage(raw);
+  if (!Result.isSuccess(page)) return Result.fail(page.failure);
+  const events = new Map<string, PullRequestTimelineEvent>();
+  for (const entry of page.success) {
+    const decoded = decodeTimelineEvent(entry);
+    if (Exit.isFailure(decoded)) continue;
+    const event = decoded.value;
+    if (
+      ["commented", "reviewed", "committed", "line-commented", "review_dismissed"].includes(
+        event.event,
+      )
+    )
+      continue;
+    const related = event.source?.issue;
+    const reviewer = event.requested_reviewer
+      ? `@${event.requested_reviewer.login}`
+      : event.requested_team?.name;
+    const body =
+      event.label?.name ??
+      reviewer ??
+      (event.rename ? `${event.rename.from} → ${event.rename.to}` : (related?.title ?? ""));
+    const id =
+      event.id === undefined
+        ? `${event.event}:${event.created_at}:${related?.id ?? event.actor?.login ?? ""}`
+        : String(event.id);
+    events.set(id, {
+      id: `github:${id}`,
+      kind: event.event.replaceAll("_", "-"),
+      actor: event.actor
+        ? { login: event.actor.login, name: null, avatarUrl: event.actor.avatar_url ?? null }
+        : null,
+      createdAt: event.created_at,
+      url: event.html_url ?? related?.html_url ?? null,
+      body:
+        body.replace(/[\\`*_[\]{}()#+.!|~<>-]/g, "\\$&") +
+        (related ? `\n\n${related.html_url}` : ""),
+      ...(related?.pull_request === undefined
+        ? {}
+        : {
+            relatedPullRequest: {
+              title: related.title,
+              url: related.html_url,
+              state: related.pull_request.merged_at
+                ? ("merged" as const)
+                : related.state === "closed"
+                  ? ("closed" as const)
+                  : ("open" as const),
+            },
+          }),
+    });
+  }
+  return Result.succeed({ events: [...events.values()], rawCount: page.success.length });
+}
 
 /**
  * Enum-ish GitHub CLI fields are decoded as plain strings and normalized here: a `gh`
@@ -366,6 +464,7 @@ const RawDetailSchema = Schema.Struct({
   isCrossRepository: Schema.optional(Schema.Boolean),
   /** Names the fork a pull request came from, which is what qualifies its head ref. */
   headRepositoryOwner: Schema.optional(Schema.NullOr(Schema.Struct({ login: Schema.String }))),
+  headRepository: Schema.optional(Schema.NullOr(Schema.Struct({ name: Schema.String }))),
   /** The exact head revision, used to find workflow runs that GitHub has not started yet. */
   headRefOid: Schema.optional(Schema.NullOr(Schema.String)),
   body: Schema.optional(Schema.String),
@@ -620,7 +719,7 @@ export function decodeActorAvatarsJson(
 export const PULL_REQUEST_LIST_JSON_FIELDS =
   "number,title,url,author,headRefName,baseRefName,state,isDraft,mergeable,reviewDecision,additions,deletions,createdAt,updatedAt,mergedAt,reviewRequests,labels,statusCheckRollup";
 
-export const PULL_REQUEST_DETAIL_JSON_FIELDS = `${PULL_REQUEST_LIST_JSON_FIELDS},body,changedFiles,closedAt,isCrossRepository,headRepositoryOwner,headRefOid,autoMergeRequest`;
+export const PULL_REQUEST_DETAIL_JSON_FIELDS = `${PULL_REQUEST_LIST_JSON_FIELDS},body,changedFiles,closedAt,isCrossRepository,headRepositoryOwner,headRepository,headRefOid,autoMergeRequest`;
 export const PULL_REQUEST_ACTIVITY_JSON_FIELDS = "author,comments,reviews,commits";
 
 /** GitHub's own ceiling on a connection page, which is what both thread reads ask for. */
@@ -1045,6 +1144,7 @@ export interface GitHubPullRequestListItem {
 }
 
 export interface GitHubPullRequestDetail extends GitHubPullRequestListItem {
+  readonly headRepositoryNameWithOwner?: string | null;
   /** True only when GitHub says the head belongs to another repository. */
   readonly isCrossRepository?: boolean;
   /** The owner of the head branch's repository; null where `gh` did not say. */
@@ -1420,12 +1520,22 @@ function toListItem(raw: Schema.Schema.Type<typeof RawListItemSchema>): GitHubPu
 
 function toDetail(raw: Schema.Schema.Type<typeof RawDetailSchema>): GitHubPullRequestDetail {
   const autoMergeMethod = toMergeMethod(raw.autoMergeRequest?.mergeMethod);
+  const headRepositoryOwner = trimmed(raw.headRepositoryOwner?.login);
+  const headRepositoryName = trimmed(raw.headRepository?.name);
   return {
     ...toListItem(raw),
     ...(typeof raw.isCrossRepository === "boolean"
       ? { isCrossRepository: raw.isCrossRepository }
       : {}),
-    headRepositoryOwner: trimmed(raw.headRepositoryOwner?.login),
+    headRepositoryOwner,
+    ...(raw.headRepository === undefined
+      ? {}
+      : {
+          headRepositoryNameWithOwner:
+            headRepositoryOwner && headRepositoryName
+              ? `${headRepositoryOwner}/${headRepositoryName}`
+              : null,
+        }),
     headSha: trimmed(raw.headRefOid),
     body: raw.body ?? "",
     changedFiles: raw.changedFiles ?? 0,

--- a/apps/server/src/pullRequest/gitHubPullRequestJson.ts
+++ b/apps/server/src/pullRequest/gitHubPullRequestJson.ts
@@ -2434,6 +2434,7 @@ export function buildLabelRequestJson(labels: ReadonlyArray<string>): string {
  * only read access can still be told apart from a passer-by.
  */
 export interface GitHubViewerAccess {
+  readonly canWriteSource?: boolean;
   readonly canWrite: boolean;
   /**
    * The viewer's role reaches triage, which is the least that may label. Everyone who can write
@@ -2460,7 +2461,7 @@ export interface GitHubViewerAccess {
 export const VIEWER_PERMISSIONS_GRAPHQL_QUERY = `query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     viewerPermission
-    pullRequest(number: $number) { viewerCanUpdate viewerDidAuthor }
+    pullRequest(number: $number) { viewerCanUpdate viewerDidAuthor headRepository { viewerPermission } }
   }
 }`;
 
@@ -2469,7 +2470,18 @@ const RawViewerPermissionsSchema = Schema.Struct({
     repository: Schema.Struct({
       viewerPermission: Schema.optional(Schema.NullOr(Schema.String)),
       /** Null for a number that names no pull request the viewer can see. */
-      pullRequest: Schema.NullOr(RawViewerFieldsSchema),
+      pullRequest: Schema.NullOr(
+        Schema.Struct({
+          ...RawViewerFieldsSchema.fields,
+          headRepository: Schema.optional(
+            Schema.NullOr(
+              Schema.Struct({
+                viewerPermission: Schema.optional(Schema.NullOr(Schema.String)),
+              }),
+            ),
+          ),
+        }),
+      ),
     }),
   }),
 });
@@ -2486,6 +2498,7 @@ export function decodeViewerPermissionsJson(
   const repository = decoded.success.data.repository;
   return Result.succeed({
     canWrite: toCanWrite(repository.viewerPermission),
+    canWriteSource: toCanWrite(repository.pullRequest?.headRepository?.viewerPermission),
     canTriage: toCanTriage(repository.viewerPermission),
     ...toPullRequestViewerFields(repository.pullRequest),
   });

--- a/apps/server/src/pullRequest/gitLabMergeRequestJson.ts
+++ b/apps/server/src/pullRequest/gitLabMergeRequestJson.ts
@@ -4,6 +4,7 @@ import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import type {
   PullRequestActor,
+  PullRequestTimelineEvent,
   PullRequestCheck,
   PullRequestCheckStatus,
   PullRequestComment,
@@ -43,6 +44,8 @@ const RawPipelineSchema = Schema.Struct({
 });
 
 const RawMergeRequestSchema = Schema.Struct({
+  source_project_id: Schema.optional(Schema.NullOr(Schema.Int)),
+  target_project_id: Schema.optional(Schema.Int),
   iid: Schema.Int,
   title: Schema.String,
   web_url: Schema.String,
@@ -220,6 +223,9 @@ export interface GitLabMergeRequestListItem {
 }
 
 export interface GitLabMergeRequestDetail extends GitLabMergeRequestListItem {
+  readonly sourceProjectId?: number | null;
+  readonly targetProjectId?: number;
+  readonly headRepositoryNameWithOwner?: string | null;
   readonly body: string;
   readonly changedFiles: number;
   readonly mergedAt: string | null;
@@ -381,6 +387,8 @@ function toDetail(raw: Schema.Schema.Type<typeof RawMergeRequestSchema>): GitLab
     }),
     checks: toChecks(raw),
     viewerCanMerge: raw.user?.can_merge !== false,
+    ...(raw.source_project_id === undefined ? {} : { sourceProjectId: raw.source_project_id }),
+    ...(raw.target_project_id === undefined ? {} : { targetProjectId: raw.target_project_id }),
     reviewerIds: (raw.reviewers ?? []).flatMap((reviewer) =>
       reviewer.id === undefined ? [] : [reviewer.id],
     ),
@@ -594,10 +602,12 @@ export function decodeDiffRefsJson(
   );
 }
 
-export function decodeNotesJson(
-  raw: string,
-): Result.Result<
-  { readonly comments: ReadonlyArray<PullRequestComment>; readonly rawCount: number },
+export function decodeNotesJson(raw: string): Result.Result<
+  {
+    readonly comments: ReadonlyArray<PullRequestComment>;
+    readonly timelineEvents: ReadonlyArray<PullRequestTimelineEvent>;
+    readonly rawCount: number;
+  },
   DecodeFailure
 > {
   const decoded = decodeUnknownList(raw);
@@ -605,11 +615,25 @@ export function decodeNotesJson(
     return Result.fail(decoded.failure);
   }
   const comments: PullRequestComment[] = [];
+  const timelineEvents: PullRequestTimelineEvent[] = [];
   for (const entry of decoded.success) {
     const note = decodeNoteEntry(entry);
     if (Exit.isFailure(note)) continue;
     const value = note.value;
-    if (value.system === true) continue;
+    if (value.system === true) {
+      if (value.body?.trim())
+        timelineEvents.push({
+          id: `note:${value.id}`,
+          kind:
+            value.body.trim().match(/^(merged|closed)(?:$| with | via | manually$)/)?.[1] ??
+            "system",
+          actor: toActor(value.author),
+          body: value.body,
+          createdAt: value.created_at,
+          url: null,
+        });
+      continue;
+    }
     const body = value.body ?? "";
     if (body.trim().length === 0) continue;
     const isDiffNote = value.type?.trim() === "DiffNote";
@@ -624,7 +648,7 @@ export function decodeNotesJson(
       reviewState: null,
     });
   }
-  return Result.succeed({ comments, rawCount: decoded.success.length });
+  return Result.succeed({ comments, timelineEvents, rawCount: decoded.success.length });
 }
 
 export function decodeCommitsJson(

--- a/apps/server/src/pullRequest/gitLabMergeRequestJson.ts
+++ b/apps/server/src/pullRequest/gitLabMergeRequestJson.ts
@@ -223,6 +223,7 @@ export interface GitLabMergeRequestListItem {
 }
 
 export interface GitLabMergeRequestDetail extends GitLabMergeRequestListItem {
+  readonly viewerCanDeleteSourceBranch?: boolean;
   readonly sourceProjectId?: number | null;
   readonly targetProjectId?: number;
   readonly headRepositoryNameWithOwner?: string | null;

--- a/apps/server/src/pullRequest/pullRequestBranchDeletion.test.ts
+++ b/apps/server/src/pullRequest/pullRequestBranchDeletion.test.ts
@@ -1,0 +1,81 @@
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import * as GitHub from "./GitHubPullRequestProvider.ts";
+import * as GitLab from "./GitLabPullRequestProvider.ts";
+import * as Bitbucket from "./BitbucketPullRequestProvider.ts";
+import * as Azure from "./AzureDevOpsPullRequestProvider.ts";
+import * as GitHubCli from "./GitHubPullRequestCli.ts";
+import * as GitLabCli from "./GitLabPullRequestCli.ts";
+import * as BitbucketApi from "./BitbucketPullRequestApi.ts";
+import * as AzureCli from "./AzureDevOpsPullRequestCli.ts";
+import { assertSourceBranchDeletable } from "./pullRequestBranchDeletion.ts";
+
+it.effect("allows only finished pull requests and refuses both protected branch identities", () =>
+  Effect.gen(function* () {
+    const input = {
+      state: "merged",
+      sourceBranch: "feat/change",
+      baseBranch: "release",
+      defaultBranch: "main",
+    };
+    yield* assertSourceBranchDeletable(input);
+    yield* assertSourceBranchDeletable({ ...input, state: "closed" });
+    yield* assertSourceBranchDeletable({ ...input, state: "SUPERSEDED" });
+    for (const state of ["open", "active", "unknown"]) {
+      const error = yield* Effect.flip(assertSourceBranchDeletable({ ...input, state }));
+      expect(error.detail).toContain("Close or merge");
+    }
+    for (const sourceBranch of ["main", "release"]) {
+      const error = yield* Effect.flip(assertSourceBranchDeletable({ ...input, sourceBranch }));
+      expect(error.detail).toContain("cannot be deleted");
+    }
+  }),
+);
+
+it.effect(
+  "advertises branch deletion without adding an unknown action to legacy capability arrays",
+  () =>
+    Effect.gen(function* () {
+      const providers = yield* Effect.all([GitHub.make, GitLab.make, Bitbucket.make, Azure.make]);
+      const legacyCapabilities = Schema.Struct({
+        actions: Schema.Array(
+          Schema.Literals([
+            "merge",
+            "ready",
+            "draft",
+            "close",
+            "reopen",
+            "update-branch",
+            "enable-auto-merge",
+            "disable-auto-merge",
+            "revert",
+            "approve-workflows",
+          ]),
+        ),
+      });
+      for (const provider of providers) {
+        expect(provider.capabilities.deleteSourceBranch).toBe(true);
+        yield* Schema.decodeUnknownEffect(legacyCapabilities)(provider.capabilities);
+      }
+      const azure = providers[3];
+      const viewer = yield* azure.getViewerPermissions({
+        cwd: "/w",
+        host: "dev.azure.com",
+        repository: "web",
+        number: 1,
+      });
+      expect(viewer.deleteSourceBranch).toBe(true);
+      yield* Schema.decodeUnknownEffect(legacyCapabilities)(viewer);
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.mock(GitHubCli.GitHubPullRequestCli)({}),
+          Layer.mock(GitLabCli.GitLabPullRequestCli)({}),
+          Layer.mock(BitbucketApi.BitbucketPullRequestApi)({}),
+          Layer.mock(AzureCli.AzureDevOpsPullRequestCli)({}),
+        ),
+      ),
+    ),
+);

--- a/apps/server/src/pullRequest/pullRequestBranchDeletion.test.ts
+++ b/apps/server/src/pullRequest/pullRequestBranchDeletion.test.ts
@@ -10,7 +10,10 @@ import * as GitHubCli from "./GitHubPullRequestCli.ts";
 import * as GitLabCli from "./GitLabPullRequestCli.ts";
 import * as BitbucketApi from "./BitbucketPullRequestApi.ts";
 import * as AzureCli from "./AzureDevOpsPullRequestCli.ts";
-import { assertSourceBranchDeletable } from "./pullRequestBranchDeletion.ts";
+import {
+  assertSourceBranchDeletable,
+  decodeBranchDeletionJson,
+} from "./pullRequestBranchDeletion.ts";
 
 it.effect("allows only finished pull requests and refuses both protected branch identities", () =>
   Effect.gen(function* () {
@@ -27,11 +30,11 @@ it.effect("allows only finished pull requests and refuses both protected branch 
     yield* assertSourceBranchDeletable({ ...input, state: "SUPERSEDED" });
     for (const state of ["open", "active", "unknown"]) {
       const error = yield* Effect.flip(assertSourceBranchDeletable({ ...input, state }));
-      expect(error.detail).toContain("Close or merge");
+      expect(error.reason).toBe("not-finished");
     }
     for (const sourceBranch of ["main", "release"]) {
       const error = yield* Effect.flip(assertSourceBranchDeletable({ ...input, sourceBranch }));
-      expect(error.detail).toContain("cannot be deleted");
+      expect(error.reason).toBe("protected-branch");
     }
   }),
 );
@@ -49,8 +52,18 @@ it.effect("distinguishes the upstream target from a same-named fork branch", () 
     yield* assertSourceBranchDeletable(input);
     for (const overrides of [{ baseRepository: "fork" }, { defaultBranch: "main" }]) {
       const error = yield* Effect.flip(assertSourceBranchDeletable({ ...input, ...overrides }));
-      expect(error.detail).toContain("cannot be deleted");
+      expect(error.reason).toBe("protected-branch");
     }
+  }),
+);
+
+it.effect("keeps the branch response decode failure as the structured error cause", () =>
+  Effect.gen(function* () {
+    const error = yield* Effect.flip(
+      decodeBranchDeletionJson(Schema.Struct({ branch: Schema.String }), '{"branch":1}'),
+    );
+    expect(error.reason).toBe("invalid-response");
+    expect(error.cause).toBeDefined();
   }),
 );
 

--- a/apps/server/src/pullRequest/pullRequestBranchDeletion.test.ts
+++ b/apps/server/src/pullRequest/pullRequestBranchDeletion.test.ts
@@ -92,15 +92,6 @@ it.effect(
         expect(provider.capabilities.deleteSourceBranch).toBe(true);
         yield* Schema.decodeUnknownEffect(legacyCapabilities)(provider.capabilities);
       }
-      const azure = providers[3];
-      const viewer = yield* azure.getViewerPermissions({
-        cwd: "/w",
-        host: "dev.azure.com",
-        repository: "web",
-        number: 1,
-      });
-      expect(viewer.deleteSourceBranch).toBe(true);
-      yield* Schema.decodeUnknownEffect(legacyCapabilities)(viewer);
     }).pipe(
       Effect.provide(
         Layer.mergeAll(

--- a/apps/server/src/pullRequest/pullRequestBranchDeletion.test.ts
+++ b/apps/server/src/pullRequest/pullRequestBranchDeletion.test.ts
@@ -16,6 +16,8 @@ it.effect("allows only finished pull requests and refuses both protected branch 
   Effect.gen(function* () {
     const input = {
       state: "merged",
+      sourceRepository: "42",
+      baseRepository: "42",
       sourceBranch: "feat/change",
       baseBranch: "release",
       defaultBranch: "main",
@@ -29,6 +31,24 @@ it.effect("allows only finished pull requests and refuses both protected branch 
     }
     for (const sourceBranch of ["main", "release"]) {
       const error = yield* Effect.flip(assertSourceBranchDeletable({ ...input, sourceBranch }));
+      expect(error.detail).toContain("cannot be deleted");
+    }
+  }),
+);
+
+it.effect("distinguishes the upstream target from a same-named fork branch", () =>
+  Effect.gen(function* () {
+    const input = {
+      state: "closed",
+      sourceRepository: "fork",
+      baseRepository: "upstream",
+      sourceBranch: "main",
+      baseBranch: "main",
+      defaultBranch: "develop",
+    };
+    yield* assertSourceBranchDeletable(input);
+    for (const overrides of [{ baseRepository: "fork" }, { defaultBranch: "main" }]) {
+      const error = yield* Effect.flip(assertSourceBranchDeletable({ ...input, ...overrides }));
       expect(error.detail).toContain("cannot be deleted");
     }
   }),

--- a/apps/server/src/pullRequest/pullRequestBranchDeletion.ts
+++ b/apps/server/src/pullRequest/pullRequestBranchDeletion.ts
@@ -1,0 +1,46 @@
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+export class PullRequestBranchDeletionError extends Schema.TaggedErrorClass<PullRequestBranchDeletionError>()(
+  "PullRequestBranchDeletionError",
+  { detail: Schema.String, cause: Schema.optional(Schema.Defect()) },
+) {
+  override get message(): string {
+    return this.detail;
+  }
+}
+
+export const assertSourceBranchDeletable = (input: {
+  readonly state: string;
+  readonly sourceBranch: string;
+  readonly baseBranch: string;
+  readonly defaultBranch: string;
+}) => {
+  const state = input.state.toLowerCase();
+  const detail =
+    !input.sourceBranch.trim() || !input.baseBranch.trim() || !input.defaultBranch.trim()
+      ? "The host did not identify the source, target, and default branches."
+      : !["closed", "merged", "declined", "superseded", "completed", "abandoned"].includes(state)
+        ? "Close or merge the pull request before deleting its source branch."
+        : input.sourceBranch === input.baseBranch || input.sourceBranch === input.defaultBranch
+          ? "The default branch or target branch cannot be deleted."
+          : null;
+  return detail === null
+    ? Effect.void
+    : Effect.fail(new PullRequestBranchDeletionError({ detail }));
+};
+
+export const decodeBranchDeletionJson = <
+  S extends Schema.Top & { readonly DecodingServices: never },
+>(
+  schema: S,
+  raw: string,
+) =>
+  Schema.decodeUnknownEffect(Schema.fromJsonString(schema))(raw).pipe(
+    Effect.mapError(
+      () =>
+        new PullRequestBranchDeletionError({
+          detail: "The host did not return enough branch data to delete the source branch safely.",
+        }),
+    ),
+  );

--- a/apps/server/src/pullRequest/pullRequestBranchDeletion.ts
+++ b/apps/server/src/pullRequest/pullRequestBranchDeletion.ts
@@ -12,17 +12,25 @@ export class PullRequestBranchDeletionError extends Schema.TaggedErrorClass<Pull
 
 export const assertSourceBranchDeletable = (input: {
   readonly state: string;
+  readonly sourceRepository: string;
+  readonly baseRepository: string;
   readonly sourceBranch: string;
   readonly baseBranch: string;
   readonly defaultBranch: string;
 }) => {
   const state = input.state.toLowerCase();
   const detail =
-    !input.sourceBranch.trim() || !input.baseBranch.trim() || !input.defaultBranch.trim()
-      ? "The host did not identify the source, target, and default branches."
+    !input.sourceRepository.trim() ||
+    !input.baseRepository.trim() ||
+    !input.sourceBranch.trim() ||
+    !input.baseBranch.trim() ||
+    !input.defaultBranch.trim()
+      ? "The host did not identify the source and target repositories and their branches."
       : !["closed", "merged", "declined", "superseded", "completed", "abandoned"].includes(state)
         ? "Close or merge the pull request before deleting its source branch."
-        : input.sourceBranch === input.baseBranch || input.sourceBranch === input.defaultBranch
+        : (input.sourceRepository === input.baseRepository &&
+              input.sourceBranch === input.baseBranch) ||
+            input.sourceBranch === input.defaultBranch
           ? "The default branch or target branch cannot be deleted."
           : null;
   return detail === null

--- a/apps/server/src/pullRequest/pullRequestBranchDeletion.ts
+++ b/apps/server/src/pullRequest/pullRequestBranchDeletion.ts
@@ -3,8 +3,35 @@ import * as Schema from "effect/Schema";
 
 export class PullRequestBranchDeletionError extends Schema.TaggedErrorClass<PullRequestBranchDeletionError>()(
   "PullRequestBranchDeletionError",
-  { detail: Schema.String, cause: Schema.optional(Schema.Defect()) },
+  {
+    reason: Schema.Literals([
+      "invalid-response",
+      "not-finished",
+      "protected-branch",
+      "source-repository-missing",
+      "source-branch-missing",
+      "delete-refused",
+    ]),
+    cause: Schema.optional(Schema.Defect()),
+  },
 ) {
+  get detail(): string {
+    switch (this.reason) {
+      case "invalid-response":
+        return "The host did not return enough branch data to delete the source branch safely.";
+      case "not-finished":
+        return "Close or merge the pull request before deleting its source branch.";
+      case "protected-branch":
+        return "The default branch or target branch cannot be deleted.";
+      case "source-repository-missing":
+        return "The source repository no longer exists.";
+      case "source-branch-missing":
+        return "The source branch has already been deleted or is no longer accessible.";
+      case "delete-refused":
+        return "The host refused to delete the source branch. It may have changed, already been deleted, be protected, or be unavailable to this account. Refresh the pull request before trying again.";
+    }
+  }
+
   override get message(): string {
     return this.detail;
   }
@@ -19,23 +46,23 @@ export const assertSourceBranchDeletable = (input: {
   readonly defaultBranch: string;
 }) => {
   const state = input.state.toLowerCase();
-  const detail =
+  const reason =
     !input.sourceRepository.trim() ||
     !input.baseRepository.trim() ||
     !input.sourceBranch.trim() ||
     !input.baseBranch.trim() ||
     !input.defaultBranch.trim()
-      ? "The host did not identify the source and target repositories and their branches."
+      ? "invalid-response"
       : !["closed", "merged", "declined", "superseded", "completed", "abandoned"].includes(state)
-        ? "Close or merge the pull request before deleting its source branch."
+        ? "not-finished"
         : (input.sourceRepository === input.baseRepository &&
               input.sourceBranch === input.baseBranch) ||
             input.sourceBranch === input.defaultBranch
-          ? "The default branch or target branch cannot be deleted."
+          ? "protected-branch"
           : null;
-  return detail === null
+  return reason === null
     ? Effect.void
-    : Effect.fail(new PullRequestBranchDeletionError({ detail }));
+    : Effect.fail(new PullRequestBranchDeletionError({ reason }));
 };
 
 export const decodeBranchDeletionJson = <
@@ -46,9 +73,10 @@ export const decodeBranchDeletionJson = <
 ) =>
   Schema.decodeUnknownEffect(Schema.fromJsonString(schema))(raw).pipe(
     Effect.mapError(
-      () =>
+      (cause) =>
         new PullRequestBranchDeletionError({
-          detail: "The host did not return enough branch data to delete the source branch safely.",
+          reason: "invalid-response",
+          cause,
         }),
     ),
   );

--- a/apps/server/src/pullRequest/pullRequestTimeline.test.ts
+++ b/apps/server/src/pullRequest/pullRequestTimeline.test.ts
@@ -1,0 +1,237 @@
+import { expect, it } from "vite-plus/test";
+import * as Result from "effect/Result";
+import { decodeTimelineEventsJson as github } from "./gitHubPullRequestJson.ts";
+import { decodeNotesJson as gitlab } from "./gitLabMergeRequestJson.ts";
+import { decodeTimelineEventsJson as bitbucket } from "./bitbucketPullRequestJson.ts";
+import { decodeThreadsJson as azure } from "./azureDevOpsPullRequestJson.ts";
+
+const date = "2026-09-05T12:00:00Z";
+
+it("keeps GitHub events and related PR metadata without repeating comments or reviews", () => {
+  const event = {
+    id: 1,
+    event: "cross-referenced",
+    created_at: date,
+    actor: { login: "bilal", avatar_url: "https://example.com/avatar" },
+    source: {
+      issue: {
+        id: 9,
+        title: "Follow-up",
+        state: "closed",
+        html_url: "https://github.com/acme/web/pull/9",
+        pull_request: { merged_at: date },
+      },
+    },
+  };
+  const decoded = github(
+    JSON.stringify([
+      event,
+      event,
+      { ...event, id: 2, event: "commented" },
+      { ...event, id: 3, event: "reviewed" },
+      {
+        id: 4,
+        event: "review_requested",
+        created_at: date,
+        requested_reviewer: { login: "octocat" },
+      },
+    ]),
+  );
+  expect(Result.isSuccess(decoded)).toBe(true);
+  if (!Result.isSuccess(decoded)) return;
+  expect(decoded.success.rawCount).toBe(5);
+  expect(decoded.success.events).toHaveLength(2);
+  expect(decoded.success.events[0]).toMatchObject({
+    id: "github:1",
+    actor: { login: "bilal" },
+    createdAt: date,
+    body: "Follow\\-up\n\nhttps://github.com/acme/web/pull/9",
+    relatedPullRequest: { title: "Follow-up", state: "merged", url: event.source.issue.html_url },
+  });
+  expect(decoded.success.events[1]?.body).toBe("@octocat");
+});
+
+it("uses native GitHub event details without repeating lifecycle titles", () => {
+  const decoded = github(
+    JSON.stringify(
+      [
+        { event: "labeled", label: { name: "bug [ui]" } },
+        { event: "unlabeled", label: { name: "bug" } },
+        { event: "review_requested", requested_team: { name: "Core team" } },
+        { event: "renamed", rename: { from: "Old *title*", to: "New title" } },
+        { event: "closed" },
+        { event: "reopened" },
+        { event: "mentioned" },
+      ].map((event, id) => ({ ...event, id, created_at: date })),
+    ),
+  );
+  expect(Result.isSuccess(decoded)).toBe(true);
+  if (!Result.isSuccess(decoded)) return;
+  expect(decoded.success.events.map((event) => event.body)).toEqual([
+    "bug \\[ui\\]",
+    "bug",
+    "Core team",
+    "Old \\*title\\* → New title",
+    "",
+    "",
+    "",
+  ]);
+});
+
+it("separates GitLab system notes from user comments", () => {
+  const decoded = gitlab(
+    JSON.stringify([
+      {
+        id: 1,
+        body: "marked this merge request as draft",
+        system: true,
+        author: { username: "bilal" },
+        created_at: date,
+      },
+      { id: 2, body: "Ready soon", created_at: date },
+    ]),
+  );
+  expect(Result.isSuccess(decoded)).toBe(true);
+  if (!Result.isSuccess(decoded)) return;
+  expect(decoded.success.comments.map((comment) => comment.id)).toEqual(["2"]);
+  expect(decoded.success.timelineEvents).toMatchObject([
+    {
+      id: "note:1",
+      body: "marked this merge request as draft",
+      actor: { login: "bilal" },
+      createdAt: date,
+    },
+  ]);
+});
+
+it.each([
+  ["merged", "merged"],
+  ["merged manually", "merged"],
+  ["merged with abc123", "merged"],
+  ["closed", "closed"],
+  ["closed via commit abc123", "closed"],
+  ["merged results pipeline enabled", "system"],
+])("normalizes GitLab lifecycle note %s", (body, kind) => {
+  const decoded = gitlab(
+    JSON.stringify([
+      { id: 1, system: true, body, created_at: date, author: { username: "bilal" } },
+      { id: 2, system: true, body, created_at: date },
+    ]),
+  );
+  expect(Result.isSuccess(decoded)).toBe(true);
+  if (!Result.isSuccess(decoded)) return;
+  expect(decoded.success.timelineEvents).toMatchObject([
+    { kind, actor: { login: "bilal" } },
+    { kind, actor: null },
+  ]);
+});
+
+it("reads Bitbucket updates and past approvals without repeating comments", () => {
+  const decoded = bitbucket(
+    JSON.stringify({
+      values: [
+        {
+          update: { date, state: "MERGED", author: { nickname: "bilal" } },
+          pull_request: {
+            links: { html: { href: "https://bitbucket.org/acme/web/pull-requests/7" } },
+          },
+        },
+        { approval: { date, user: { nickname: "julius" } } },
+        { comment: { content: { raw: "Hi" } } },
+      ],
+      next: "/activity?page=2",
+    }),
+  );
+  expect(Result.isSuccess(decoded)).toBe(true);
+  if (!Result.isSuccess(decoded)) return;
+  expect(decoded.success.items.map((event) => event.kind)).toEqual(["merged", "approved"]);
+  expect(decoded.success.items[0]?.url).toContain("/pull-requests/7");
+  expect(decoded.success.next).toBe("/activity?page=2");
+});
+
+it.each([
+  ["MERGED", "merged"],
+  ["DECLINED", "closed"],
+  ["SUPERSEDED", "closed"],
+  ["UNKNOWN", "updated"],
+])("normalizes Bitbucket lifecycle state %s", (state, kind) => {
+  const decoded = bitbucket(
+    JSON.stringify({
+      values: [
+        { update: { date, state, author: { nickname: "bilal" } } },
+        { update: { date, state } },
+      ],
+    }),
+  );
+  expect(Result.isSuccess(decoded)).toBe(true);
+  if (!Result.isSuccess(decoded)) return;
+  expect(decoded.success.items).toMatchObject([
+    { kind, actor: { login: "bilal" } },
+    { kind, actor: null },
+  ]);
+});
+
+it("reads Azure system events separately and ignores deleted threads", () => {
+  const raw = JSON.stringify({
+    value: [
+      {
+        id: 1,
+        comments: [
+          { id: 1, commentType: "system", content: "Marked as draft", publishedDate: date },
+          { id: 2, commentType: "text", content: "Hi", publishedDate: date },
+        ],
+      },
+      {
+        id: 2,
+        isDeleted: true,
+        comments: [{ commentType: "system", content: "Old", publishedDate: date }],
+      },
+    ],
+  });
+  const activity = azure(raw);
+  expect(Result.isSuccess(activity)).toBe(true);
+  if (!Result.isSuccess(activity)) return;
+  expect(activity.success.timelineEvents).toMatchObject([
+    { id: "azure:1:1", body: "Marked as draft", createdAt: date },
+  ]);
+  expect(activity.success.comments.map((comment) => comment.body)).toEqual(["Hi"]);
+});
+
+it.each([
+  ["StatusUpdate", "Completed", "merged"],
+  ["StatusUpdate", "Abandoned", "closed"],
+  ["StatusUpdate", "Unknown", "system"],
+  ["Unknown", "Completed", "system"],
+])("normalizes Azure lifecycle metadata %s/%s", (threadType, status, kind) => {
+  const decoded = azure(
+    JSON.stringify({
+      value: [
+        {
+          id: 1,
+          properties: {
+            CodeReviewThreadType: { $value: threadType },
+            CodeReviewStatus: { $value: status },
+          },
+          comments: [
+            {
+              id: 1,
+              commentType: "system",
+              content: "Status changed",
+              publishedDate: date,
+              author: { uniqueName: "bilal" },
+            },
+            { id: 2, commentType: "system", content: "Status changed", publishedDate: date },
+            { id: 3, commentType: "text", content: "User reply", publishedDate: date },
+          ],
+        },
+      ],
+    }),
+  );
+  expect(Result.isSuccess(decoded)).toBe(true);
+  if (!Result.isSuccess(decoded)) return;
+  expect(decoded.success.timelineEvents).toMatchObject([
+    { kind, actor: { login: "bilal" } },
+    { kind, actor: null },
+  ]);
+  expect(decoded.success.comments.map((comment) => comment.body)).toEqual(["User reply"]);
+});

--- a/apps/server/src/pullRequest/pullRequestTimeline.test.ts
+++ b/apps/server/src/pullRequest/pullRequestTimeline.test.ts
@@ -149,6 +149,31 @@ it("reads Bitbucket updates and past approvals without repeating comments", () =
   expect(decoded.success.next).toBe("/activity?page=2");
 });
 
+it("reads Bitbucket change requests with their actor and time", () => {
+  const decoded = bitbucket(
+    JSON.stringify({
+      values: [
+        {
+          request_changes: { date, user: { nickname: "julius" } },
+          pull_request: {
+            links: { html: { href: "https://bitbucket.org/acme/web/pull-requests/7" } },
+          },
+        },
+      ],
+    }),
+  );
+  expect(Result.isSuccess(decoded)).toBe(true);
+  if (!Result.isSuccess(decoded)) return;
+  expect(decoded.success.items).toMatchObject([
+    {
+      kind: "changes-requested",
+      actor: { login: "julius" },
+      createdAt: "2026-09-05T12:00:00.000Z",
+      url: "https://bitbucket.org/acme/web/pull-requests/7",
+    },
+  ]);
+});
+
 it.each([
   ["MERGED", "merged"],
   ["DECLINED", "closed"],

--- a/apps/web/src/components/pullRequest/PullRequestActivityUnavailableState.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestActivityUnavailableState.tsx
@@ -1,3 +1,4 @@
+import { pullRequestErrorHint } from "./pullRequestError.logic";
 import { RefreshCwIcon } from "lucide-react";
 
 import { cn } from "~/lib/utils";
@@ -21,7 +22,15 @@ export function PullRequestActivityUnavailableState({
       )}
     >
       <p className="text-sm font-medium text-foreground">Could not load pull request activity</p>
-      <p className="max-w-md text-xs text-muted-foreground">{error}</p>
+      <p className="max-w-md text-xs text-muted-foreground">
+        {pullRequestErrorHint(error) ?? error}
+      </p>
+      {pullRequestErrorHint(error) ? (
+        <details className="max-w-md text-xs text-muted-foreground">
+          <summary className="cursor-pointer">Error details</summary>
+          <p className="mt-2 whitespace-pre-wrap break-words">{error}</p>
+        </details>
+      ) : null}
       <Button size="sm" variant="outline" onClick={onRetry}>
         <RefreshCwIcon aria-hidden className="size-3.5" />
         Retry

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -8,7 +8,6 @@ import type {
   PullRequestRef,
   PullRequestReviewPosition,
   PullRequestReviewThread,
-  PullRequestThreadCommentsResult,
 } from "@t3tools/contracts";
 import {
   ChevronDownIcon,
@@ -32,8 +31,7 @@ import { useLocalStorage } from "~/hooks/useLocalStorage";
 import { useClientSettings, useUpdateClientSettings } from "~/hooks/useSettings";
 import { useTheme } from "~/hooks/useTheme";
 import { areAllDiffFilesCollapsed } from "~/lib/diffCollapse";
-import { pullRequestFindingKey, type PullRequestFinding } from "./pullRequestDetail.logic";
-import { canEditPullRequestComment } from "./pullRequestEditing.logic";
+import { type PullRequestFinding } from "./pullRequestDetail.logic";
 import { orderDiffFiles } from "./pullRequestFileOrder.logic";
 import {
   buildFileDiffRenderKey,
@@ -71,10 +69,10 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "../ui/menu";
-import { toastManager } from "../ui/toast";
 import { Toggle, ToggleGroup } from "../ui/toggle-group";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
-import { PendingReviewCommentCard, ReviewThreadCard } from "./PullRequestReviewAnnotation";
+import { PullRequestConversation } from "./PullRequestConversation";
+import { PendingReviewCommentCard } from "./PullRequestReviewAnnotation";
 import { PullRequestReviewBar } from "./PullRequestReviewBar";
 import {
   isFileDiffCollapsed,
@@ -237,7 +235,6 @@ export function PullRequestCodeTab({
     range: SelectedLineRange;
   } | null>(null);
   const [draft, setDraft] = useState<DraftAnchor | null>(null);
-  const [threadPending, setThreadPending] = useState(false);
   const [orphansOpen, setOrphansOpen] = useState(false);
   // Closed by default so the review form does not permanently eat vertical space below the
   // diff; opened on demand as a floating overlay instead.
@@ -343,18 +340,6 @@ export function PullRequestCodeTab({
   const pendingComments = usePendingReviewComments(reference);
   const addComment = usePullRequestReviewStore((store) => store.addComment);
   const removeComment = usePullRequestReviewStore((store) => store.removeComment);
-  const replyToThread = useAtomCommand(pullRequestEnvironment.replyToThread, {
-    reportFailure: false,
-  });
-  const setThreadResolution = useAtomCommand(pullRequestEnvironment.setThreadResolution, {
-    reportFailure: false,
-  });
-  const updateComment = useAtomCommand(pullRequestEnvironment.updateComment, {
-    reportFailure: false,
-  });
-  const loadThreadComments = useAtomCommand(pullRequestEnvironment.threadComments, {
-    reportFailure: false,
-  });
   const getDiffFileContents = useAtomCommand(pullRequestEnvironment.diffFileContents);
   const loadDiffFiles = useMemo(
     () =>
@@ -786,104 +771,21 @@ export function PullRequestCodeTab({
     [diffLayout, wordWrap, resolvedTheme, loadDiffFiles, canCommentOnLines, draft, beginComment],
   );
 
-  const runThreadCommand = useCallback(
-    async (label: string, run: () => Promise<{ readonly _tag: string }>): Promise<boolean> => {
-      if (threadPending) return false;
-      setThreadPending(true);
-      const result = await run();
-      setThreadPending(false);
-      if (result._tag === "Failure") {
-        toastManager.add({ type: "error", title: label });
-        return false;
-      }
-      onRefresh();
-      return true;
-    },
-    [onRefresh, threadPending],
-  );
-
-  // A conversation is the same card wired to the same commands whether it sits on its line or
-  // was stranded off the diff; only where it is drawn differs.
   const renderThreadCard = useCallback(
     (thread: PullRequestReviewThread) => (
-      <ReviewThreadCard
-        // Named with the pull request too: a thread's id is the host's own, and two pull requests
-        // can hand out the same one — which would leave one card's open editor standing over the
-        // other's conversation.
-        key={`${reference.projectId}#${reference.number}:${thread.id}`}
+      <PullRequestConversation
+        key={`${environmentId}:${reference.projectId}#${reference.number}:${thread.id}`}
         thread={thread}
-        workspaceRoot={detail.workspaceRoot}
-        canReply={review.reply}
-        canResolve={review.resolve}
-        canReact={detail.capabilities.reactions === true}
+        detail={detail}
         environmentId={environmentId}
         reference={reference}
-        pending={threadPending}
-        fixPending={pendingFinding === pullRequestFindingKey({ kind: "thread", thread })}
+        pendingFinding={pendingFinding}
         fixLabel={fixFindingLabel}
-        {...(onFixFinding ? { onFix: () => onFixFinding({ kind: "thread", thread }) } : {})}
-        onLoadMore={async (cursor): Promise<PullRequestThreadCommentsResult | null> => {
-          const result = await loadThreadComments({
-            environmentId,
-            input: { ...reference, threadId: thread.id, cursor },
-          });
-          if (result._tag === "Failure") {
-            toastManager.add({
-              type: "error",
-              title: "More comments could not be loaded",
-            });
-            return null;
-          }
-          return result.value;
-        }}
-        onReply={(body) =>
-          runThreadCommand("Reply could not be posted", () =>
-            replyToThread({
-              environmentId,
-              input: { ...reference, threadId: thread.id, body },
-            }),
-          )
-        }
-        // A conversation on a line is made of review comments, whatever the host filed them as.
-        canEditComment={(comment) =>
-          canEditPullRequestComment(detail, { author: comment.author, kind: "review-comment" })
-        }
-        onEditComment={(commentId, body) =>
-          runThreadCommand("The comment could not be saved", () =>
-            updateComment({
-              environmentId,
-              input: { ...reference, commentId, kind: "review-comment", body },
-            }),
-          )
-        }
-        onToggleResolved={() =>
-          void runThreadCommand("The conversation could not be updated", () =>
-            setThreadResolution({
-              environmentId,
-              input: { ...reference, threadId: thread.id, resolved: !thread.isResolved },
-            }),
-          )
-        }
-        onReacted={onRefresh}
+        onFixFinding={onFixFinding}
+        onRefresh={onRefresh}
       />
     ),
-    [
-      detail,
-      environmentId,
-      fixFindingLabel,
-      loadThreadComments,
-      onRefresh,
-      onFixFinding,
-      pendingFinding,
-      reference,
-      replyToThread,
-      review.reply,
-      review.resolve,
-      runThreadCommand,
-      setThreadResolution,
-      threadPending,
-      updateComment,
-    ],
+    [detail, environmentId, reference, pendingFinding, fixFindingLabel, onFixFinding, onRefresh],
   );
 
   const renderAnnotation = useCallback(

--- a/apps/web/src/components/pullRequest/PullRequestCommentActions.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCommentActions.tsx
@@ -1,0 +1,104 @@
+import type { EnvironmentId, PullRequestRef, ScopedThreadRef } from "@t3tools/contracts";
+import { CheckIcon, LinkIcon, ReplyIcon, BotIcon } from "lucide-react";
+import { createContext, useContext, useState } from "react";
+import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
+import { useAtomCommand } from "~/state/use-atom-command";
+import { pullRequestEnvironment } from "~/state/pullRequests";
+import { formatEnvironmentQueryError } from "~/state/query";
+import { Button } from "../ui/button";
+import { toastManager } from "../ui/toast";
+import { PullRequestMarkdownEditor } from "./PullRequestMarkdownEditor";
+
+export const PullRequestCommentAgentContext = createContext<
+  ((body: string, url: string | null) => void) | null
+>(null);
+
+export function PullRequestCommentActions({
+  body,
+  url,
+  canReply,
+  cwd,
+  environmentId,
+  threadRef,
+  reference,
+  onRefresh,
+}: {
+  body: string;
+  url: string | null;
+  canReply: boolean;
+  cwd: string;
+  environmentId: EnvironmentId;
+  threadRef?: ScopedThreadRef | null | undefined;
+  reference: PullRequestRef;
+  onRefresh: () => void;
+}) {
+  const addToAgent = useContext(PullRequestCommentAgentContext);
+  const [replying, setReplying] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const { copyToClipboard, isCopied } = useCopyToClipboard({
+    onError: () => toastManager.add({ type: "error", title: "Could not copy the comment link" }),
+  });
+  const comment = useAtomCommand(pullRequestEnvironment.comment, { reportFailure: false });
+  return (
+    <div className="mt-2">
+      <div className="flex flex-wrap items-center gap-1">
+        {addToAgent ? (
+          <Button size="xs" variant="ghost" onClick={() => addToAgent(body, url)}>
+            <BotIcon aria-hidden className="size-3" />
+            Add to agent
+          </Button>
+        ) : null}
+        {canReply ? (
+          <Button size="xs" variant="ghost" onClick={() => setReplying(true)}>
+            <ReplyIcon aria-hidden className="size-3" />
+            Quote reply
+          </Button>
+        ) : null}
+        {url ? (
+          <Button size="xs" variant="ghost" onClick={() => copyToClipboard(url)}>
+            {isCopied ? (
+              <CheckIcon aria-hidden className="size-3" />
+            ) : (
+              <LinkIcon aria-hidden className="size-3" />
+            )}
+            {isCopied ? "Copied" : "Copy link"}
+          </Button>
+        ) : null}
+      </div>
+      {replying ? (
+        <PullRequestMarkdownEditor
+          className="mt-2"
+          value={
+            body
+              .split("\n")
+              .map((line) => "> " + line)
+              .join("\n") + "\n\n"
+          }
+          cwd={cwd}
+          environmentId={environmentId}
+          threadRef={threadRef ?? null}
+          label="Quote reply"
+          saveLabel="Post reply"
+          saving={saving}
+          onCancel={() => setReplying(false)}
+          onSave={async (body) => {
+            if (saving) return;
+            setSaving(true);
+            const result = await comment({ environmentId, input: { ...reference, body } });
+            setSaving(false);
+            if (result._tag === "Failure") {
+              toastManager.add({
+                type: "error",
+                title: "Could not post the reply",
+                description: formatEnvironmentQueryError(result.cause),
+              });
+              return;
+            }
+            setReplying(false);
+            onRefresh();
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/pullRequest/PullRequestConversation.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestConversation.tsx
@@ -1,0 +1,122 @@
+import type {
+  EnvironmentId,
+  PullRequestDetailView,
+  PullRequestRef,
+  PullRequestReviewThread,
+} from "@t3tools/contracts";
+import { useRef, useState } from "react";
+import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
+import { useAtomCommand } from "~/state/use-atom-command";
+import { pullRequestEnvironment } from "~/state/pullRequests";
+import { formatEnvironmentQueryError } from "~/state/query";
+import { toastManager } from "../ui/toast";
+import { ReviewThreadCard } from "./PullRequestReviewAnnotation";
+import { canEditPullRequestComment } from "./pullRequestEditing.logic";
+import { pullRequestFindingKey, type PullRequestFinding } from "./pullRequestDetail.logic";
+
+export function PullRequestConversation({
+  thread,
+  detail,
+  environmentId,
+  reference,
+  onRefresh,
+  onFixFinding,
+  pendingFinding,
+  fixLabel,
+}: {
+  thread: PullRequestReviewThread;
+  detail: PullRequestDetailView;
+  environmentId: EnvironmentId;
+  reference: PullRequestRef;
+  onRefresh: () => void;
+  onFixFinding?: ((finding: PullRequestFinding) => void) | undefined;
+  pendingFinding?: string | null | undefined;
+  fixLabel?: string | undefined;
+}) {
+  const [pending, setPending] = useState(false);
+  const running = useRef(false);
+  const reply = useAtomCommand(pullRequestEnvironment.replyToThread, { reportFailure: false });
+  const resolve = useAtomCommand(pullRequestEnvironment.setThreadResolution, {
+    reportFailure: false,
+  });
+  const update = useAtomCommand(pullRequestEnvironment.updateComment, { reportFailure: false });
+  const load = useAtomCommand(pullRequestEnvironment.threadComments, { reportFailure: false });
+  const run = async (title: string, command: () => Promise<AtomCommandResult<void, unknown>>) => {
+    if (running.current) return false;
+    running.current = true;
+    setPending(true);
+    try {
+      const result = await command();
+      if (result._tag === "Failure") {
+        toastManager.add({
+          type: "error",
+          title,
+          description: formatEnvironmentQueryError(result.cause),
+        });
+        return false;
+      }
+      onRefresh();
+      return true;
+    } finally {
+      running.current = false;
+      setPending(false);
+    }
+  };
+  return (
+    <ReviewThreadCard
+      thread={thread}
+      workspaceRoot={detail.workspaceRoot}
+      canReply={detail.capabilities.review.reply && detail.viewerPermissions.comment}
+      canResolve={detail.capabilities.review.resolve && detail.viewerPermissions.resolve}
+      canReact={detail.capabilities.reactions === true}
+      environmentId={environmentId}
+      reference={reference}
+      pending={pending}
+      fixPending={pendingFinding === pullRequestFindingKey({ kind: "thread", thread })}
+      {...(fixLabel ? { fixLabel } : {})}
+      {...(onFixFinding && !thread.isResolved
+        ? { onFix: () => onFixFinding({ kind: "thread", thread }) }
+        : {})}
+      onLoadMore={async (cursor) => {
+        const result = await load({
+          environmentId,
+          input: { ...reference, threadId: thread.id, cursor },
+        });
+        if (result._tag === "Failure") {
+          toastManager.add({
+            type: "error",
+            title: "More comments could not be loaded",
+            description: formatEnvironmentQueryError(result.cause),
+          });
+          return null;
+        }
+        return result.value;
+      }}
+      onReply={(body) =>
+        run("Reply could not be posted", () =>
+          reply({ environmentId, input: { ...reference, threadId: thread.id, body } }),
+        )
+      }
+      canEditComment={(comment) =>
+        canEditPullRequestComment(detail, { author: comment.author, kind: "review-comment" })
+      }
+      onEditComment={(commentId, body) =>
+        run("The comment could not be saved", () =>
+          update({
+            environmentId,
+            input: { ...reference, commentId, kind: "review-comment", body },
+          }),
+        )
+      }
+      onToggleResolved={() =>
+        void run("The conversation could not be updated", () =>
+          resolve({
+            environmentId,
+            input: { ...reference, threadId: thread.id, resolved: !thread.isResolved },
+          }),
+        )
+      }
+      onReacted={onRefresh}
+    />
+  );
+}

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -154,6 +154,7 @@ import {
 type DetailTab = "summary" | "timeline" | "code";
 
 const ACTION_SUCCESS_LABELS: Record<PullRequestAction, string> = {
+  "delete-source-branch": "Source branch deleted",
   merge: "Pull request merged",
   ready: "Marked ready for review",
   draft: "Converted to draft",
@@ -177,6 +178,7 @@ const MERGE_METHOD_LABELS: Record<PullRequestMergeMethod, string> = {
 
 /** Said as the thing that did not happen, rather than as the operation that returned an error. */
 const ACTION_FAILURE_LABELS: Record<PullRequestAction, string> = {
+  "delete-source-branch": "Could not delete the source branch",
   merge: "Could not merge this pull request",
   ready: "Could not mark this ready for review",
   draft: "Could not convert this to a draft",
@@ -191,6 +193,8 @@ const ACTION_FAILURE_LABELS: Record<PullRequestAction, string> = {
 
 /** What to try, for the times the host says only that it refused. */
 const ACTION_FAILURE_HINTS: Record<PullRequestAction, string> = {
+  "delete-source-branch":
+    "Check that you have write access to the source repository and that the branch is not protected.",
   merge:
     "The host refused the merge. Check that you have write access, that the checks it requires have passed, and that the branch is not conflicting.",
   ready: "The host refused it. Check that you have write access to this repository.",

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1,4 +1,10 @@
-import { scopedThreadKey, scopeProjectRef } from "@t3tools/client-runtime/environment";
+import { mergePullRequestActivity } from "./pullRequestDetail.logic";
+import { PullRequestCommentAgentContext } from "./PullRequestCommentActions";
+import {
+  scopedThreadKey,
+  scopeProjectRef,
+  scopeThreadRef,
+} from "@t3tools/client-runtime/environment";
 import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
 import {
   type EnvironmentId,
@@ -60,7 +66,9 @@ import { usePreparePullRequestThreadAction } from "~/lib/sourceControlActions";
 import { cn } from "~/lib/utils";
 import { readLocalApi } from "~/localApi";
 import type { ReviewCommentContext } from "~/reviewCommentContext";
-import { useProjects } from "~/state/entities";
+import { useNavigate } from "@tanstack/react-router";
+import { buildThreadRouteParams } from "~/threadRoutes";
+import { useProjects, useThreadShells } from "~/state/entities";
 import { useEnvironments } from "~/state/environments";
 import { useEnvironmentQuery } from "~/state/query";
 import { useLiveRefresh } from "~/hooks/useLiveRefresh";
@@ -86,6 +94,17 @@ import { EnvironmentMachineIcon } from "../EnvironmentMachineIcon";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
+import { Textarea } from "../ui/textarea";
+import {
+  Dialog,
+  DialogPopup,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogPanel,
+  DialogFooter,
+} from "../ui/dialog";
+import { Select, SelectTrigger, SelectValue, SelectPopup, SelectItem } from "../ui/select";
 import { Toggle, ToggleGroup } from "../ui/toggle-group";
 import {
   Menu,
@@ -572,7 +591,13 @@ export function PullRequestDetailPanel({
   };
   const [confirmation, setConfirmation] = useState<{
     readonly open: boolean;
-    readonly action: "merge" | "close" | "enable-auto-merge" | "revert" | "approve-workflows";
+    readonly action:
+      | "merge"
+      | "close"
+      | "enable-auto-merge"
+      | "revert"
+      | "approve-workflows"
+      | "delete-source-branch";
   }>({ open: false, action: "merge" });
   const confirmAction = confirmation.action;
   // Which handoff is preparing, keyed so a per-finding button can say "Preparing..." on itself
@@ -639,20 +664,7 @@ export function PullRequestDetailPanel({
   );
   const activity = activityQuery.data;
   const detail = useMemo(
-    () =>
-      coreDetail === null
-        ? null
-        : {
-            ...coreDetail,
-            author: activity?.author ?? coreDetail.author,
-            reviewers: activity?.reviewers ?? coreDetail.reviewers,
-            comments: activity?.comments ?? [],
-            commentCount: activity?.commentCount ?? 0,
-            commentsTruncated: activity?.commentsTruncated ?? false,
-            reviewThreads: activity?.reviewThreads ?? [],
-            commits: activity?.commits ?? [],
-            reactions: activity?.reactions ?? [],
-          },
+    () => mergePullRequestActivity(coreDetail, activity),
     [activity, coreDetail],
   );
   useEffect(() => {
@@ -760,6 +772,16 @@ export function PullRequestDetailPanel({
   const titleDraft = titleScope?.pullRequestKey === pullRequestKey ? titleScope.text : null;
   const [titleSaving, setTitleSaving] = useState(false);
   const newThread = useNewThreadHandler();
+  const navigate = useNavigate();
+  const threadShells = useThreadShells();
+  const [handoffRequest, setHandoffRequest] = useState<{
+    key: string;
+    kind: string;
+    task: ThreadTask | null;
+    checkout: boolean;
+  } | null>(null);
+  const [handoffMode, setHandoffMode] = useState<"worktree" | "local">("worktree");
+  const [targetThread, setTargetThread] = useState("new");
   const { environments } = useEnvironments();
   const projects = useProjects();
   const unavailableGitHubUrl = useMemo(() => {
@@ -768,28 +790,25 @@ export function PullRequestDetailPanel({
     )?.repositoryIdentity;
     return gitHubPullRequestBrowserUrl(identity, reference.repository, reference.number);
   }, [environmentId, projects, reference.number, reference.projectId, reference.repository]);
-  // Beside a thread there is nothing to pick: the hand-offs land in that thread's composer, and
-  // the thread is already on one server's copy of the branch.
   const pickableEnvironments = useMemo(
     () =>
-      context === "page"
-        ? resolvePickableEnvironments(
-            { environmentId, projectId: reference.projectId },
-            projects,
-            environments.map((environment) => ({
-              environmentId: environment.environmentId,
-              label: environment.label,
-              machine: resolveEnvironmentMachineKind(environment.serverConfig),
-            })),
-          )
-        : [],
-    [context, environmentId, environments, projects, reference.projectId],
+      resolvePickableEnvironments(
+        { environmentId, projectId: reference.projectId },
+        projects,
+        environments.map((environment) => ({
+          environmentId: environment.environmentId,
+          label: environment.label,
+          machine: resolveEnvironmentMachineKind(environment.serverConfig),
+        })),
+      ),
+    [environmentId, environments, projects, reference.projectId],
   );
   // Which server the reader chose, and only for the pull request they chose it on: this one panel
   // shows a different pull request every time it is opened, and the choice does not follow.
   const [actingScope, setActingScope] = useState<{
     readonly pullRequestKey: string;
     readonly environmentId: EnvironmentId;
+    readonly projectId?: string;
   } | null>(null);
   const chosenEnvironmentId =
     actingScope?.pullRequestKey === pullRequestKey ? actingScope.environmentId : environmentId;
@@ -798,9 +817,35 @@ export function PullRequestDetailPanel({
   const acting =
     pickableEnvironments.find((entry) => entry.environmentId === chosenEnvironmentId) ?? null;
   const actingEnvironmentId = acting?.environmentId ?? environmentId;
+  const selectedCheckout = projects.find(
+    (project) =>
+      project.environmentId === actingEnvironmentId &&
+      project.id ===
+        (actingScope?.pullRequestKey === pullRequestKey ? actingScope.projectId : undefined),
+  );
+  const actingProjectId = selectedCheckout?.id ?? acting?.projectId ?? reference.projectId;
+  const actingWorkspaceRoot =
+    selectedCheckout?.workspaceRoot ?? acting?.workspaceRoot ?? detail?.workspaceRoot ?? null;
+  const currentProject = projects.find(
+    (project) => project.environmentId === environmentId && project.id === reference.projectId,
+  );
+  const currentRepositoryKey = currentProject?.repositoryIdentity?.canonicalKey?.toLowerCase();
+  const checkoutProjects = projects.filter(
+    (project) =>
+      project.environmentId === actingEnvironmentId &&
+      (project.id === actingProjectId ||
+        (currentRepositoryKey &&
+          project.repositoryIdentity?.canonicalKey?.toLowerCase() === currentRepositoryKey)),
+  );
+  const availableThreads = threadShells.filter(
+    (thread) =>
+      thread.environmentId === actingEnvironmentId &&
+      thread.projectId === actingProjectId &&
+      thread.archivedAt === null,
+  );
   const prepareThread = usePreparePullRequestThreadAction({
     environmentId: actingEnvironmentId,
-    cwd: acting?.workspaceRoot ?? detail?.workspaceRoot ?? null,
+    cwd: actingWorkspaceRoot,
   });
 
   const finishAction = async (
@@ -964,8 +1009,8 @@ export function PullRequestDetailPanel({
   };
 
   /** A question about the change, which needs a thread and nothing else. */
-  const startAsk = async (kind: string, task: ThreadTask) => {
-    if (!detail || handoff !== null) return;
+  const executeAsk = async (kind: string, task: ThreadTask): Promise<boolean> => {
+    if (!detail || handoff !== null) return false;
     if (attachTarget !== null) {
       writeTaskToComposer(attachTarget, task);
       toastManager.add({
@@ -976,10 +1021,10 @@ export function PullRequestDetailPanel({
             ? "The question is in the composer — read it over, then send."
             : "The pull request is in the composer — type your question, then send.",
       });
-      return;
+      return true;
     }
     setHandoff(kind);
-    const projectRef = scopeProjectRef(actingEnvironmentId, acting?.projectId ?? detail.projectId);
+    const projectRef = scopeProjectRef(actingEnvironmentId, actingProjectId);
     const opened = await openThreadWithTask(projectRef, task);
     setHandoff(null);
     if (opened === null) {
@@ -988,7 +1033,7 @@ export function PullRequestDetailPanel({
         title: "Could not open a thread",
         description: "Try again from the project, or open a thread first.",
       });
-      return;
+      return false;
     }
     toastManager.add({
       type: "success",
@@ -1000,40 +1045,29 @@ export function PullRequestDetailPanel({
           ? "The question is in the composer — read it over, then send."
           : "The pull request is in the composer — type your question, then send.",
     });
+    return true;
   };
 
   // Every handoff works the same way: check the pull request out into its own worktree, open a
   // thread there, and — when it carries a task — put that in the composer for the user to read
   // before sending. Checking out is the whole point of the ones that carry nothing.
-  const startHandoff = async (
+  const executeHandoff = async (
     kind: string,
     task: { prompt: string; reviewComments?: ReadonlyArray<ReviewCommentContext> } | null,
     // A worktree leaves whatever is open alone, which is why it is the default. Checking out in
     // the repository itself is what you want when the point is to run the thing where you
     // already work — and it moves the branch under everything else that is open there.
     mode: "worktree" | "local" = "worktree",
-  ) => {
-    if (!detail || handoff !== null) return;
-    if (attachTarget !== null && task !== null) {
-      writeTaskToComposer(attachTarget, task);
-      toastManager.add({
-        type: "success",
-        title: "Added to the composer",
-        description: "The task is in the composer — read it over, then send.",
-      });
-      return;
-    }
+  ): Promise<boolean> => {
+    if (!detail || handoff !== null) return false;
     setHandoff(kind);
-    // The menu closes on the press and takes its "Preparing..." label with it, so this is the
-    // only thing answering for the checkout. It carries no timeout of its own: a loading toast
-    // never expires, and an explicit one would survive the update and pin the result on screen.
     const toastId = toastManager.add({
       type: "loading",
       title: "Preparing the pull request checkout...",
     });
     // Wherever the reader chose to act: the thread, the checkout it is pointed at and the composer
     // the task lands in are all one server's, and picking another one moves all three.
-    const projectRef = scopeProjectRef(actingEnvironmentId, acting?.projectId ?? detail.projectId);
+    const projectRef = scopeProjectRef(actingEnvironmentId, actingProjectId);
     // The thread is opened before the checkout rather than after it, because the project's setup
     // script only runs for a checkout that knows which thread it is for — and a worktree with no
     // dependencies installed is not something anyone can test.
@@ -1051,7 +1085,7 @@ export function PullRequestDetailPanel({
         title: "Could not open a thread for the checkout",
         description: "Try again from the project, or open a thread first.",
       });
-      return;
+      return false;
     }
     const prepared = await prepareThread.run({
       reference: detail.url,
@@ -1069,7 +1103,7 @@ export function PullRequestDetailPanel({
         title: "Could not prepare the pull request checkout",
         ...(detailMessage ? { description: detailMessage } : {}),
       });
-      return;
+      return false;
     }
     // The same thread again, now that there is somewhere to point it at. A local checkout has
     // no worktree of its own, so the thread runs where the repository already is.
@@ -1091,7 +1125,7 @@ export function PullRequestDetailPanel({
         title: "Checked out, but the thread stayed where it was",
         description: `The checkout is ready on \`${prepared.value.branch}\`. Point a thread at it from the branch picker, then ask again.`,
       });
-      return;
+      return false;
     }
     // Released here whatever happened next: a loading toast never expires on its own, so leaving
     // this set would spin forever and lock every handoff behind it until a reload.
@@ -1119,7 +1153,7 @@ export function PullRequestDetailPanel({
             }
           : staleCheckoutToast,
       );
-      return;
+      return true;
     }
     await openThreadWithTask(projectRef, task, opened);
     toastManager.update(
@@ -1132,6 +1166,22 @@ export function PullRequestDetailPanel({
           }
         : staleCheckoutToast,
     );
+    return true;
+  };
+
+  const startAsk = (kind: string, task: ThreadTask) => {
+    if (attachTarget !== null) return void executeAsk(kind, task);
+    setTargetThread("new");
+    setHandoffRequest({ key: pullRequestKey, kind, task, checkout: false });
+  };
+  const startHandoff = (
+    kind: string,
+    task: ThreadTask | null,
+    mode: "worktree" | "local" = "worktree",
+  ) => {
+    setTargetThread(attachTarget !== null && task !== null ? "current" : "new");
+    setHandoffMode(mode);
+    setHandoffRequest({ key: pullRequestKey, kind, task, checkout: true });
   };
 
   const askAboutPullRequest = () => {
@@ -1265,8 +1315,12 @@ export function PullRequestDetailPanel({
   // whether this account may. A reader with read access on someone else's project sees the pull
   // request and none of the buttons that would only ever be refused.
   const can = (action: PullRequestAction) =>
-    detail?.capabilities.actions.includes(action) === true &&
-    detail.viewerPermissions.actions.includes(action);
+    action === "delete-source-branch"
+      ? detail?.capabilities.deleteSourceBranch === true &&
+        detail.viewerPermissions.deleteSourceBranch === true &&
+        Boolean(detail.headRepositoryNameWithOwner?.trim())
+      : detail?.capabilities.actions.includes(action) === true &&
+        detail.viewerPermissions.actions.includes(action);
   const checksState = detail ? pullRequestChecksState(detail.checks) : null;
   // The merge state remains in one stable slot from waiting through completion. Conflicts take
   // the slot while they need a person; the armed badge remains beside them so that state is not lost.
@@ -1674,9 +1728,35 @@ export function PullRequestDetailPanel({
                   <MoreHorizontalIcon className="size-4" />
                 </MenuTrigger>
                 <MenuPopup align="end" side="bottom" className="min-w-72">
+                  {detail.state !== "open" && can("delete-source-branch") ? (
+                    <MenuItem
+                      disabled={actionPending}
+                      onClick={() =>
+                        setConfirmation({ open: true, action: "delete-source-branch" })
+                      }
+                    >
+                      Delete source branch
+                    </MenuItem>
+                  ) : null}
                   <MenuItem disabled={detailQuery.isPending} onClick={() => void refreshFromHost()}>
                     <RefreshCwIcon className="size-3.5" />
                     Refresh
+                  </MenuItem>
+                  <MenuItem
+                    disabled={handoff !== null}
+                    onClick={() => {
+                      if (!detail) return;
+                      setTargetThread("new");
+                      setHandoffRequest({
+                        key: pullRequestKey,
+                        kind: "note",
+                        checkout: false,
+                        task: buildAskAboutPullRequestHandoff(detail),
+                      });
+                    }}
+                  >
+                    <PencilIcon className="size-3.5" />
+                    Add note to agent
                   </MenuItem>
                   <MenuItem disabled={handoff !== null} onClick={askAboutPullRequest}>
                     <MessageCircleQuestionIcon className="mt-0.5 size-3.5 shrink-0 self-start" />
@@ -2323,70 +2403,328 @@ export function PullRequestDetailPanel({
             {...(unavailableGitHubUrl ? { gitHubUrl: unavailableGitHubUrl } : {})}
           />
         ) : detail ? (
-          <PullRequestMarkdownContext value={detail.provider === "github" ? repositoryUrl : null}>
-            {mountedTabs.has("summary") ? (
-              <div className={cn("absolute inset-0", tab !== "summary" && "invisible")}>
-                <PullRequestSummaryTab
-                  environmentId={environmentId}
-                  threadRef={threadRef}
-                  reference={reference}
-                  detail={detail}
-                  activityPending={activityPending}
-                  activityError={activityError}
-                  pendingFinding={handoff}
-                  fixFindingLabel={handoffLabels.fixFinding}
-                  fixCheckLabel={handoffLabels.fixCheck}
-                  onFixFinding={startFixFinding}
-                  actionPending={actionPending}
-                  onCommentAction={performCommentAction}
-                  onRefresh={refreshDetail}
-                />
-              </div>
-            ) : null}
-            {mountedTabs.has("timeline") ? (
-              <div className={cn("absolute inset-0", tab !== "timeline" && "invisible")}>
-                {activityPending ? (
-                  <PullRequestTimelineGhost />
-                ) : activityError ? (
-                  <PullRequestActivityUnavailableState
-                    error={activityError}
-                    onRetry={activityQuery.refresh}
-                  />
-                ) : (
-                  <PullRequestTimelineTab
-                    detail={detail}
+          <PullRequestCommentAgentContext
+            value={(body, url) => {
+              const task = buildAskAboutPullRequestHandoff(detail);
+              startAsk("comment", {
+                ...task,
+                reviewComments: task.reviewComments.map((comment) => ({
+                  ...comment,
+                  text: comment.text + "\nQuoted comment " + (url ?? "") + ":\n" + body,
+                })),
+              });
+            }}
+          >
+            <PullRequestMarkdownContext value={detail.provider === "github" ? repositoryUrl : null}>
+              {mountedTabs.has("summary") ? (
+                <div className={cn("absolute inset-0", tab !== "summary" && "invisible")}>
+                  <PullRequestSummaryTab
                     environmentId={environmentId}
                     threadRef={threadRef}
                     reference={reference}
-                    order={timelineOrder}
-                    onOpenCommit={openCommit}
-                    onRefresh={refreshDetail}
-                  />
-                )}
-              </div>
-            ) : null}
-            {mountedTabs.has("code") ? (
-              <div className={cn("absolute inset-0", tab !== "code" && "invisible")}>
-                <Suspense fallback={<DiffPanelLoadingState label="Loading pull request diff..." />}>
-                  <PullRequestCodeTab
-                    {...(attachTarget ? { onAddToAgentSelection: addSelectionToAgent } : {})}
-                    environmentId={environmentId}
-                    reference={reference}
                     detail={detail}
-                    selectedCommitOid={selectedCodeCommitOid}
-                    onSelectedCommitChange={selectCodeCommit}
+                    activityPending={activityPending}
+                    activityError={activityError}
                     pendingFinding={handoff}
                     fixFindingLabel={handoffLabels.fixFinding}
+                    fixCheckLabel={handoffLabels.fixCheck}
                     onFixFinding={startFixFinding}
+                    actionPending={actionPending}
+                    onCommentAction={performCommentAction}
                     onRefresh={refreshDetail}
-                    refreshToken={codeRefreshToken}
                   />
-                </Suspense>
-              </div>
-            ) : null}
-          </PullRequestMarkdownContext>
+                </div>
+              ) : null}
+              {mountedTabs.has("timeline") ? (
+                <div className={cn("absolute inset-0", tab !== "timeline" && "invisible")}>
+                  {activityPending ? (
+                    <PullRequestTimelineGhost />
+                  ) : activityError ? (
+                    <PullRequestActivityUnavailableState
+                      error={activityError}
+                      onRetry={activityQuery.refresh}
+                    />
+                  ) : (
+                    <PullRequestTimelineTab
+                      detail={detail}
+                      environmentId={environmentId}
+                      threadRef={threadRef}
+                      reference={reference}
+                      order={timelineOrder}
+                      onOpenCommit={openCommit}
+                      onRefresh={refreshDetail}
+                    />
+                  )}
+                </div>
+              ) : null}
+              {mountedTabs.has("code") ? (
+                <div className={cn("absolute inset-0", tab !== "code" && "invisible")}>
+                  <Suspense
+                    fallback={<DiffPanelLoadingState label="Loading pull request diff..." />}
+                  >
+                    <PullRequestCodeTab
+                      onAddToAgentSelection={addSelectionToAgent}
+                      environmentId={environmentId}
+                      reference={reference}
+                      detail={detail}
+                      selectedCommitOid={selectedCodeCommitOid}
+                      onSelectedCommitChange={selectCodeCommit}
+                      pendingFinding={handoff}
+                      fixFindingLabel={handoffLabels.fixFinding}
+                      onFixFinding={startFixFinding}
+                      onRefresh={refreshDetail}
+                      refreshToken={codeRefreshToken}
+                    />
+                  </Suspense>
+                </div>
+              ) : null}
+            </PullRequestMarkdownContext>
+          </PullRequestCommentAgentContext>
         ) : null}
       </div>
+
+      <Dialog
+        open={handoffRequest?.key === pullRequestKey}
+        onOpenChange={(open) => {
+          if (!open) setHandoffRequest(null);
+        }}
+      >
+        <DialogPopup>
+          <DialogHeader>
+            <DialogTitle>
+              {handoffRequest?.checkout ? "Prepare a thread" : "Add to agent"}
+            </DialogTitle>
+            <DialogDescription>
+              {handoffRequest?.checkout
+                ? "Choose where to work on this pull request."
+                : "Add the PR context and your notes to a thread. Review the draft before sending."}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel className="space-y-4">
+            {handoffRequest?.checkout && attachTarget !== null && handoffRequest.task !== null ? (
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium" htmlFor="pr-handoff-destination">
+                  Destination
+                </label>
+                <Select
+                  value={targetThread}
+                  onValueChange={(value) => setTargetThread(value ?? "current")}
+                >
+                  <SelectTrigger id="pr-handoff-destination">
+                    <SelectValue>
+                      {targetThread === "current" ? "Current thread" : "New thread"}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup>
+                    <SelectItem value="current">Current thread</SelectItem>
+                    <SelectItem value="new">New thread and checkout</SelectItem>
+                  </SelectPopup>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  {targetThread === "current"
+                    ? "Adds the task here without changing this thread's checkout."
+                    : "Creates a thread on the server, project, and checkout selected below."}
+                </p>
+              </div>
+            ) : null}
+            {targetThread !== "current" && pickableEnvironments.length > 0 ? (
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium" htmlFor="pr-handoff-server">
+                  Server
+                </label>
+                <Select
+                  value={actingEnvironmentId}
+                  onValueChange={(value) => {
+                    const entry = pickableEnvironments.find(
+                      (entry) => entry.environmentId === value,
+                    );
+                    if (entry) {
+                      setActingScope({ pullRequestKey, environmentId: entry.environmentId });
+                      setTargetThread("new");
+                    }
+                  }}
+                >
+                  <SelectTrigger id="pr-handoff-server">
+                    <SelectValue>
+                      {
+                        pickableEnvironments.find(
+                          (entry) => entry.environmentId === actingEnvironmentId,
+                        )?.label
+                      }
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup>
+                    {pickableEnvironments.map((entry) => (
+                      <SelectItem key={entry.environmentId} value={entry.environmentId}>
+                        {entry.label}
+                      </SelectItem>
+                    ))}
+                  </SelectPopup>
+                </Select>
+              </div>
+            ) : null}
+            {targetThread !== "current" ? (
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium" htmlFor="pr-handoff-project">
+                  Project
+                </label>
+                <Select
+                  value={actingProjectId}
+                  onValueChange={(value) => {
+                    const project = checkoutProjects.find((project) => project.id === value);
+                    if (project) {
+                      setActingScope({
+                        pullRequestKey,
+                        environmentId: actingEnvironmentId,
+                        projectId: project.id,
+                      });
+                      setTargetThread("new");
+                    }
+                  }}
+                >
+                  <SelectTrigger id="pr-handoff-project">
+                    <SelectValue>{actingWorkspaceRoot}</SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup>
+                    {checkoutProjects.map((project) => (
+                      <SelectItem key={project.id} value={project.id}>
+                        {project.workspaceRoot}
+                      </SelectItem>
+                    ))}
+                  </SelectPopup>
+                </Select>
+              </div>
+            ) : null}
+            {handoffRequest?.checkout && targetThread !== "current" ? (
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium" htmlFor="pr-handoff-mode">
+                  Checkout
+                </label>
+                <Select
+                  value={handoffMode}
+                  onValueChange={(value) => {
+                    if (value === "worktree" || value === "local") setHandoffMode(value);
+                  }}
+                >
+                  <SelectTrigger id="pr-handoff-mode">
+                    <SelectValue>
+                      {handoffMode === "worktree" ? "New worktree" : "Use this checkout"}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup>
+                    <SelectItem value="worktree">New worktree</SelectItem>
+                    <SelectItem value="local">Use this checkout</SelectItem>
+                  </SelectPopup>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  {handoffMode === "worktree"
+                    ? "Keeps your current checkout in place."
+                    : "Switches this checkout to the PR branch. Local changes can prevent the switch."}
+                </p>
+              </div>
+            ) : attachTarget === null ? (
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium" htmlFor="pr-handoff-thread">
+                  Thread
+                </label>
+                <Select
+                  value={targetThread}
+                  onValueChange={(value) => setTargetThread(value ?? "new")}
+                >
+                  <SelectTrigger id="pr-handoff-thread">
+                    <SelectValue>
+                      {targetThread === "new"
+                        ? "New thread"
+                        : availableThreads.find((thread) => thread.id === targetThread)?.title}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup>
+                    <SelectItem value="new">New thread</SelectItem>
+                    {availableThreads.map((thread) => (
+                      <SelectItem key={thread.id} value={thread.id}>
+                        {thread.title}
+                      </SelectItem>
+                    ))}
+                  </SelectPopup>
+                </Select>
+              </div>
+            ) : null}
+            {!handoffRequest?.checkout ? (
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium" htmlFor="pr-handoff-note">
+                  Notes
+                </label>
+                <Textarea
+                  id="pr-handoff-note"
+                  rows={4}
+                  value={handoffRequest?.task?.prompt ?? ""}
+                  onChange={(event) =>
+                    setHandoffRequest((request) =>
+                      request
+                        ? { ...request, task: { ...request.task, prompt: event.target.value } }
+                        : null,
+                    )
+                  }
+                  placeholder="What should the agent do?"
+                />
+              </div>
+            ) : null}
+          </DialogPanel>
+          <DialogFooter>
+            <Button variant="outline" size="sm" onClick={() => setHandoffRequest(null)}>
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              disabled={handoff !== null || (targetThread !== "current" && !actingWorkspaceRoot)}
+              onClick={async () => {
+                const request = handoffRequest;
+                if (!request || request.key !== pullRequestKey) return;
+                if (
+                  request.checkout &&
+                  targetThread === "current" &&
+                  attachTarget !== null &&
+                  request.task !== null
+                ) {
+                  writeTaskToComposer(attachTarget, request.task);
+                  toastManager.add({
+                    type: "success",
+                    title: "Added to the composer",
+                    description: "The task is in the composer — read it over, then send.",
+                  });
+                  setHandoffRequest(null);
+                  return;
+                }
+                if (!request.checkout && targetThread !== "new" && attachTarget === null) {
+                  const thread = availableThreads.find((thread) => thread.id === targetThread);
+                  if (!thread || !request.task) return;
+                  const target = scopeThreadRef(thread.environmentId, thread.id);
+                  writeTaskToComposer(target, request.task);
+                  setHandoffRequest(null);
+                  await navigate({
+                    to: "/$environmentId/$threadId",
+                    params: buildThreadRouteParams(target),
+                  });
+                  return;
+                }
+                const succeeded = request.checkout
+                  ? await executeHandoff(request.kind, request.task, handoffMode)
+                  : request.task
+                    ? await executeAsk(request.kind, request.task)
+                    : false;
+                if (succeeded)
+                  setHandoffRequest((current) => (current === request ? null : current));
+              }}
+            >
+              {handoffRequest?.checkout && targetThread === "current"
+                ? "Add to this thread"
+                : handoffRequest?.checkout
+                  ? "Prepare thread"
+                  : "Add to agent"}
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
 
       <AlertDialog
         open={confirmation.open}
@@ -2398,29 +2736,36 @@ export function PullRequestDetailPanel({
         <AlertDialogPopup>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              {confirmAction === "merge"
-                ? "Merge pull request?"
-                : confirmAction === "enable-auto-merge"
-                  ? "Enable auto-merge?"
-                  : confirmAction === "revert"
-                    ? "Revert these changes?"
-                    : confirmAction === "approve-workflows"
-                      ? "Approve workflows to run?"
-                      : "Close pull request?"}
+              {confirmAction === "delete-source-branch"
+                ? "Delete source branch?"
+                : confirmAction === "merge"
+                  ? "Merge pull request?"
+                  : confirmAction === "enable-auto-merge"
+                    ? "Enable auto-merge?"
+                    : confirmAction === "revert"
+                      ? "Revert these changes?"
+                      : confirmAction === "approve-workflows"
+                        ? "Approve workflows to run?"
+                        : "Close pull request?"}
             </AlertDialogTitle>
             <AlertDialogDescription>
-              {confirmAction === "merge"
-                ? `This merges #${reference.number} using ${selectedMergeMethod}.`
-                : confirmAction === "enable-auto-merge"
-                  ? // The host merges this as soon as it considers the pull request ready, which
-                    // may be immediately — there is no telling from here whether anything is
-                    // still outstanding.
-                    `This merges #${reference.number} using ${selectedMergeMethod} as soon as the host considers it ready, which may be immediately.`
-                  : confirmAction === "revert"
-                    ? `This opens a new pull request that reverses the changes merged by #${reference.number}.`
-                    : confirmAction === "approve-workflows"
-                      ? `This allows ${workflowApprovalsRequired} ${workflowApprovalsRequired === 1 ? "workflow" : "workflows"} from #${reference.number} to run. Review the code and workflow changes first.`
-                      : `This closes #${reference.number} without merging it.`}
+              {confirmAction === "delete-source-branch"
+                ? "Delete source branch " +
+                  detail?.headBranch +
+                  " from " +
+                  detail?.headRepositoryNameWithOwner +
+                  " #" +
+                  reference.number +
+                  "? This removes the branch on the source host, including when it belongs to a fork. Local checkouts are kept."
+                : confirmAction === "merge"
+                  ? `This merges #${reference.number} using ${selectedMergeMethod}.`
+                  : confirmAction === "enable-auto-merge"
+                    ? `This merges #${reference.number} using ${selectedMergeMethod} as soon as the host considers it ready, which may be immediately.`
+                    : confirmAction === "revert"
+                      ? `This opens a new pull request that reverses the changes merged by #${reference.number}.`
+                      : confirmAction === "approve-workflows"
+                        ? `This allows ${workflowApprovalsRequired} ${workflowApprovalsRequired === 1 ? "workflow" : "workflows"} from #${reference.number} to run. Review the code and workflow changes first.`
+                        : `This closes #${reference.number} without merging it.`}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -2429,11 +2774,16 @@ export function PullRequestDetailPanel({
             </AlertDialogClose>
             <Button
               size="sm"
-              variant={confirmAction === "close" ? "destructive" : "default"}
+              variant={
+                confirmAction === "close" || confirmAction === "delete-source-branch"
+                  ? "destructive"
+                  : "default"
+              }
               disabled={actionPending}
               onClick={() => {
                 const action = confirmAction;
                 setConfirmation((current) => ({ ...current, open: false }));
+                if (action === "delete-source-branch") void perform("delete-source-branch");
                 if (action === "merge") void perform("merge", selectedMergeMethod);
                 if (action === "enable-auto-merge")
                   void perform("enable-auto-merge", selectedMergeMethod);
@@ -2442,15 +2792,17 @@ export function PullRequestDetailPanel({
                 if (action === "close") void perform("close");
               }}
             >
-              {confirmAction === "merge"
-                ? selectedMergeMethodLabel
-                : confirmAction === "enable-auto-merge"
-                  ? "Enable auto-merge"
-                  : confirmAction === "revert"
-                    ? "Create revert PR"
-                    : confirmAction === "approve-workflows"
-                      ? "Approve and run"
-                      : "Close"}
+              {confirmAction === "delete-source-branch"
+                ? "Delete branch"
+                : confirmAction === "merge"
+                  ? selectedMergeMethodLabel
+                  : confirmAction === "enable-auto-merge"
+                    ? "Enable auto-merge"
+                    : confirmAction === "revert"
+                      ? "Create revert PR"
+                      : confirmAction === "approve-workflows"
+                        ? "Approve and run"
+                        : "Close"}
             </Button>
           </AlertDialogFooter>
         </AlertDialogPopup>

--- a/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
@@ -33,6 +33,7 @@ import {
   Menu,
   MenuCheckboxItem,
   MenuGroupLabel,
+  MenuGroup,
   MenuItem,
   MenuPopup,
   MenuRadioGroup,
@@ -424,7 +425,21 @@ export function PullRequestFiltersMenu({
   projectEnvironmentId,
   unavailable,
   onProject,
+  exclusionProjects,
+  excludedProjects,
+  onExcludeProject,
 }: {
+  exclusionProjects?: ReadonlyArray<{
+    readonly id: ProjectId;
+    readonly environmentId: EnvironmentId;
+    readonly title: string;
+    readonly workspaceRoot: string;
+  }>;
+  excludedProjects?: ReadonlyArray<string>;
+  onExcludeProject?: (
+    project: { readonly id: ProjectId; readonly environmentId: EnvironmentId },
+    excluded: boolean,
+  ) => void;
   onOpenChange?: (open: boolean) => void;
   state: PullRequestListState;
   stateOptions: ReadonlyArray<PullRequestFilterOption<PullRequestListState>>;
@@ -487,6 +502,7 @@ export function PullRequestFiltersMenu({
     filters.checks,
     filters.author,
     ...selectedLabels,
+    ...(excludedProjects ?? []),
   ].filter(Boolean).length;
   const updateFilters = (next: Partial<PullRequestListFilters>) =>
     onFilters(
@@ -624,6 +640,40 @@ export function PullRequestFiltersMenu({
             else if (projectId !== undefined) onProject(undefined, undefined);
           }}
         />
+        {onExcludeProject &&
+        exclusionProjects &&
+        excludedProjects &&
+        exclusionProjects.length > 0 ? (
+          <MenuSub>
+            <MenuSubTrigger>
+              <EyeOffIcon aria-hidden className="size-4" />
+              <span className="flex-1">Excluded projects</span>
+              {excludedProjects.length > 0 ? (
+                <span className="text-xs text-muted-foreground">{excludedProjects.length}</span>
+              ) : null}
+            </MenuSubTrigger>
+            <MenuSubPopup className="max-h-80 min-w-64 overflow-y-auto">
+              <MenuGroup>
+                <MenuGroupLabel>Hide from this PR list</MenuGroupLabel>
+                {exclusionProjects.map((project) => (
+                  <MenuCheckboxItem
+                    key={pullRequestProjectKey(project)}
+                    checked={excludedProjects.includes(pullRequestProjectKey(project))}
+                    onCheckedChange={(checked) => onExcludeProject(project, checked)}
+                    closeOnClick={false}
+                  >
+                    <span className="min-w-0">
+                      <span className="block truncate">{project.title}</span>
+                      <span className="block max-w-72 truncate text-xs text-muted-foreground">
+                        {project.workspaceRoot}
+                      </span>
+                    </span>
+                  </MenuCheckboxItem>
+                ))}
+              </MenuGroup>
+            </MenuSubPopup>
+          </MenuSub>
+        ) : null}
       </MenuPopup>
     </Menu>
   );

--- a/apps/web/src/components/pullRequest/PullRequestMarkdownEditor.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestMarkdownEditor.tsx
@@ -25,6 +25,7 @@ export function PullRequestMarkdownEditor({
   label,
   saving,
   allowEmpty = false,
+  saveLabel = "Save",
   className,
   onSave,
   onCancel,
@@ -39,6 +40,7 @@ export function PullRequestMarkdownEditor({
   readonly saving: boolean;
   /** A description may be cleared, which is how one is removed; a remark may not be emptied. */
   readonly allowEmpty?: boolean;
+  readonly saveLabel?: string;
   readonly className?: string | undefined;
   readonly onSave: (next: string) => void;
   readonly onCancel: () => void;
@@ -112,7 +114,7 @@ export function PullRequestMarkdownEditor({
           disabled={saving || (empty && !allowEmpty)}
           onClick={() => onSave(draft)}
         >
-          {saving ? "Saving..." : "Save"}
+          {saving ? "Saving..." : saveLabel}
         </Button>
       </div>
     </div>

--- a/apps/web/src/components/pullRequest/PullRequestReviewAnnotation.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestReviewAnnotation.tsx
@@ -30,6 +30,7 @@ import {
   mergePullRequestThreadComments,
 } from "./pullRequestDetail.logic";
 import { PullRequestActorLabel } from "./pullRequestPresentation";
+import { PullRequestCommentActions } from "./PullRequestCommentActions";
 import { PullRequestMarkdown } from "./PullRequestMarkdown";
 import { PullRequestMarkdownEditor } from "./PullRequestMarkdownEditor";
 import { PullRequestReactionBar } from "./PullRequestReactions";
@@ -215,6 +216,7 @@ export function ReviewThreadCard({
   return (
     <div
       className={CARD_CLASS}
+      data-pr-conversation={thread.isResolved ? "resolved" : "unresolved"}
       contentEditable={false}
       onPointerDown={(event) => event.stopPropagation()}
     >
@@ -300,6 +302,15 @@ export function ReviewThreadCard({
                     ) : null}
                   </div>
                 )}
+                <PullRequestCommentActions
+                  body={comment.body}
+                  url={comment.url}
+                  canReply={false}
+                  cwd={workspaceRoot}
+                  environmentId={environmentId}
+                  reference={reference}
+                  onRefresh={onReacted}
+                />
                 <PullRequestReactionBar
                   className="mt-1.5"
                   reactions={comment.reactions ?? []}
@@ -331,6 +342,7 @@ export function ReviewThreadCard({
               <div className="mt-2">
                 <Textarea
                   autoFocus
+                  disabled={pending}
                   size="sm"
                   value={reply}
                   placeholder="Reply"
@@ -340,11 +352,18 @@ export function ReviewThreadCard({
                     value: reply,
                     pending,
                     onSubmit: () => void send(),
-                    onCancel: () => setReplying(false),
+                    onCancel: () => {
+                      if (!pending) setReplying(false);
+                    },
                   })}
                 />
                 <div className="mt-2 flex justify-end gap-2">
-                  <Button size="xs" variant="ghost" onClick={() => setReplying(false)}>
+                  <Button
+                    size="xs"
+                    variant="ghost"
+                    disabled={pending}
+                    onClick={() => setReplying(false)}
+                  >
                     Cancel
                   </Button>
                   <Button

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -30,6 +30,7 @@ import { cn } from "~/lib/utils";
 import { useOpenLink } from "~/browser/useOpenLink";
 import { formatRelativeTimeLabel } from "~/timestampFormat";
 
+import { Alert, AlertDescription } from "../ui/alert";
 import { Button } from "../ui/button";
 import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "../ui/collapsible";
 import { Textarea } from "../ui/textarea";
@@ -1021,10 +1022,13 @@ export function PullRequestSummaryTab({
         ) : (
           <>
             {detail.commentsTruncated ? (
-              <p className="mb-2 rounded-md border border-amber-500/30 bg-amber-500/5 px-2 py-1.5 text-xs">
-                This conversation is longer than this page reads in one go. The most recent comments
-                are shown in Comments and Conversations; open it on the host to read the rest.
-              </p>
+              <Alert variant="warning" className="mb-2">
+                <AlertDescription>
+                  This conversation is longer than this page reads in one go. The most recent
+                  comments are shown in Comments and Conversations; open it on the host to read the
+                  rest.
+                </AlertDescription>
+              </Alert>
             ) : null}
             {comments.length === 0 ? (
               <p className="py-2 text-xs text-muted-foreground">No comments yet.</p>

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -1,3 +1,6 @@
+import { relatedPullRequests } from "./pullRequestRelated.logic";
+import { useOpenChangeRequestLink } from "~/lib/openPullRequestLink";
+import { formatEnvironmentQueryError } from "~/state/query";
 import type {
   EnvironmentId,
   PullRequestActor,
@@ -47,6 +50,8 @@ import { PullRequestReviewerPicker } from "./PullRequestReviewerPicker";
 import { PullRequestActivityUnavailableState } from "./PullRequestActivityUnavailableState";
 import {
   latestPullRequestReviewOutcomes,
+  pullRequestGeneralComments,
+  pullRequestAttentionItems,
   orderPullRequestComments,
   pullRequestFindingKey,
   pullRequestReviewOutcome,
@@ -60,6 +65,8 @@ import {
 import { PullRequestMarkdown } from "./PullRequestMarkdown";
 import { PullRequestMarkdownEditor } from "./PullRequestMarkdownEditor";
 import { PullRequestReactionBar } from "./PullRequestReactions";
+import { PullRequestCommentActions } from "./PullRequestCommentActions";
+import { PullRequestConversation } from "./PullRequestConversation";
 import { PullRequestConversationGhost } from "./PullRequestGhosts";
 import { pullRequestLabelColor } from "./pullRequestList.logic";
 import { sectionCollapseAnchorScrollTop } from "./pullRequestSummaryScroll.logic";
@@ -100,6 +107,9 @@ interface CommentEditing {
   readonly saving: boolean;
   readonly onEdit: (comment: PullRequestComment | null) => void;
   readonly onSave: (comment: PullRequestComment, body: string) => void;
+  readonly reference: PullRequestRef;
+  readonly canReply: boolean;
+  readonly onRefresh: () => void;
 }
 
 /**
@@ -131,25 +141,37 @@ function CommentBody({
     );
   }
   return (
-    <div className={cn("flex items-start gap-1", className)}>
-      <PullRequestMarkdown
-        className="min-w-0 flex-1"
-        text={comment.body}
+    <div className={className}>
+      <div className="flex items-start gap-1">
+        <PullRequestMarkdown
+          className="min-w-0 flex-1"
+          text={comment.body}
+          cwd={editing.cwd}
+          environmentId={editing.environmentId}
+          threadRef={editing.threadRef}
+        />
+        {editing.canEdit(comment) ? (
+          <Button
+            size="icon-xs"
+            variant="ghost"
+            className="shrink-0 text-muted-foreground opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100"
+            aria-label="Edit comment"
+            onClick={() => editing.onEdit(comment)}
+          >
+            <PencilIcon className="size-3" />
+          </Button>
+        ) : null}
+      </div>
+      <PullRequestCommentActions
+        body={comment.body}
+        url={comment.url}
+        canReply={editing.canReply}
         cwd={editing.cwd}
         environmentId={editing.environmentId}
         threadRef={editing.threadRef}
+        reference={editing.reference}
+        onRefresh={editing.onRefresh}
       />
-      {editing.canEdit(comment) ? (
-        <Button
-          size="icon-xs"
-          variant="ghost"
-          className="shrink-0 text-muted-foreground opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100"
-          aria-label="Edit comment"
-          onClick={() => editing.onEdit(comment)}
-        >
-          <PencilIcon className="size-3" />
-        </Button>
-      ) : null}
     </div>
   );
 }
@@ -279,6 +301,7 @@ function Section({
     <Collapsible
       open={open}
       onOpenChange={setOpenWithScrollAnchor}
+      data-pull-request-section-title={title}
       data-pull-request-summary-section
     >
       {/* The heading rides the top of the scroll box the way a diff's file header does, so a
@@ -363,7 +386,11 @@ function CommentComposer({
     });
     if (result._tag === "Failure") {
       setSubmitting(null);
-      toastManager.add({ type: "error", title: "Could not post the comment" });
+      toastManager.add({
+        type: "error",
+        title: "Could not post the comment",
+        description: formatEnvironmentQueryError(result.cause),
+      });
       return;
     }
     setBody("");
@@ -464,8 +491,18 @@ export function PullRequestSummaryTab({
   const shownComments = shown.url === detail.url ? shown.count : COMMENT_PAGE;
   // Windowed by recency regardless of display order: expanding always reaches further back in
   // time, whether the newest comment currently reads first or last.
-  const recentComments = detail.comments.slice(Math.max(0, detail.comments.length - shownComments));
-  const hiddenCommentCount = detail.comments.length - recentComments.length;
+  const comments = pullRequestGeneralComments(detail.comments, detail.reviewThreads);
+  const recentComments = comments.slice(Math.max(0, comments.length - shownComments));
+  const hiddenCommentCount = comments.length - recentComments.length;
+  const [unresolvedOnly, setUnresolvedOnly] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const nextConversation = useRef(0);
+  const attention = pullRequestAttentionItems(detail);
+  const related = relatedPullRequests(detail);
+  const openChangeRequest = useOpenChangeRequestLink(threadRef ?? undefined);
+  const conversations = detail.reviewThreads.filter(
+    (thread) => !unresolvedOnly || !thread.isResolved,
+  );
   const [commentOrder, setCommentOrder] = useState<"newest" | "oldest">("newest");
   const visibleComments = orderPullRequestComments(recentComments, commentOrder);
   const showOldestCommentsButton =
@@ -517,15 +554,6 @@ export function PullRequestSummaryTab({
       })),
   ];
 
-  // A comment that already lives on a review thread is that thread: the thread carries the line
-  // and side the bare comment has lost, and a resolved one is finished work nobody should be
-  // invited to fix again — the same call the whole-review hand-off makes.
-  const threadByCommentId = new Map(
-    detail.reviewThreads.flatMap((thread) =>
-      thread.comments.map((comment) => [comment.id, thread] as const),
-    ),
-  );
-
   const openLink = useOpenLink(threadRef);
   const openCheck = (url: string) => {
     void openLink(url).catch((error: unknown) => {
@@ -559,7 +587,11 @@ export function PullRequestSummaryTab({
     const result = await update({ environmentId, input: { ...reference, body } });
     setBodySaving(false);
     if (result._tag === "Failure") {
-      toastManager.add({ type: "error", title: "Could not save the description" });
+      toastManager.add({
+        type: "error",
+        title: "Could not save the description",
+        description: formatEnvironmentQueryError(result.cause),
+      });
       return;
     }
     setBodyScope(null);
@@ -571,6 +603,9 @@ export function PullRequestSummaryTab({
     environmentId,
     threadRef,
     canEdit: (comment) => canEditPullRequestComment(detail, comment),
+    reference,
+    canReply: detail.capabilities.comment && detail.viewerPermissions.comment,
+    onRefresh,
     editingId: editingCommentId,
     saving: commentSaving,
     onEdit: (comment) =>
@@ -586,7 +621,11 @@ export function PullRequestSummaryTab({
       });
       setCommentSaving(false);
       if (result._tag === "Failure") {
-        toastManager.add({ type: "error", title: "Could not save the comment" });
+        toastManager.add({
+          type: "error",
+          title: "Could not save the comment",
+          description: formatEnvironmentQueryError(result.cause),
+        });
         return;
       }
       setCommentScope(null);
@@ -595,7 +634,40 @@ export function PullRequestSummaryTab({
   };
 
   return (
-    <div className="h-full overflow-y-auto" data-pull-request-summary-scroll>
+    <div ref={scrollRef} className="h-full overflow-y-auto" data-pull-request-summary-scroll>
+      {attention.length > 0 ? (
+        <div className="border-b border-border/60 px-4 py-3">
+          <p className="mb-1 text-xs font-medium">Needs attention</p>
+          <div className="flex flex-wrap gap-1">
+            {attention.map((item) =>
+              item.section === null ? (
+                <span
+                  key={item.label}
+                  className="inline-flex h-6 items-center px-2 text-xs text-muted-foreground"
+                >
+                  {item.label}
+                </span>
+              ) : (
+                <Button
+                  key={item.label}
+                  size="xs"
+                  variant="ghost"
+                  onClick={() => {
+                    const section = [
+                      ...(scrollRef.current?.querySelectorAll<HTMLElement>(
+                        "[data-pull-request-section-title]",
+                      ) ?? []),
+                    ].find((element) => element.dataset.pullRequestSectionTitle === item.section);
+                    section?.scrollIntoView({ block: "start" });
+                  }}
+                >
+                  {item.label}
+                </Button>
+              ),
+            )}
+          </div>
+        </div>
+      ) : null}
       <section className="px-4 py-3">
         <div>
           <MetaRow icon={<UsersIcon className="size-3.5" />} label="Reviewers">
@@ -736,6 +808,31 @@ export function PullRequestSummaryTab({
         </div>
       </section>
 
+      {related.length > 0 ? (
+        <Section title="Related pull requests">
+          <div className="space-y-2">
+            {related.map((reference) => (
+              <div key={reference.url} className="flex items-center gap-2 text-xs">
+                <a
+                  href={reference.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="min-w-0 text-primary hover:underline"
+                  onClick={(event) =>
+                    openChangeRequest(event, reference.url, threadRef ?? undefined, environmentId)
+                  }
+                >
+                  {reference.title}
+                </a>
+                {reference.state ? (
+                  <span className="shrink-0 text-muted-foreground">{reference.state}</span>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </Section>
+      ) : null}
+
       <Section title="Description">
         <div className="group">
           {bodyScope === detail.url ? (
@@ -838,11 +935,68 @@ export function PullRequestSummaryTab({
         )}
       </Section>
 
+      {detail.reviewThreads.length > 0 ? (
+        <Section
+          title="Conversations"
+          count={detail.reviewThreads.length}
+          actions={
+            <div className="flex gap-1">
+              <Button
+                size="xs"
+                variant="ghost"
+                disabled={!detail.reviewThreads.some((thread) => !thread.isResolved)}
+                onClick={() => {
+                  const cards = scrollRef.current?.querySelectorAll<HTMLElement>(
+                    '[data-pr-conversation="unresolved"]',
+                  );
+                  if (!cards?.length) return;
+                  cards[nextConversation.current % cards.length]?.scrollIntoView({
+                    block: "center",
+                  });
+                  nextConversation.current += 1;
+                }}
+              >
+                Next unresolved
+              </Button>
+              <Button
+                size="xs"
+                variant="ghost"
+                aria-pressed={unresolvedOnly}
+                onClick={() => setUnresolvedOnly((value) => !value)}
+              >
+                {unresolvedOnly ? "Show all" : "Unresolved only"}
+              </Button>
+            </div>
+          }
+        >
+          {conversations.length === 0 ? (
+            <p className="text-xs text-muted-foreground">All conversations are resolved.</p>
+          ) : null}
+          <div className="space-y-3 [&>div]:mx-0 [&>div]:my-0 [&>div]:shadow-none">
+            {conversations.map((thread) => (
+              <PullRequestConversation
+                key={`${environmentId}:${detail.url}:${thread.id}`}
+                thread={thread}
+                detail={detail}
+                environmentId={environmentId}
+                reference={reference}
+                pendingFinding={pendingFinding}
+                fixLabel={fixFindingLabel}
+                onFixFinding={onFixFinding}
+                onRefresh={onRefresh}
+              />
+            ))}
+          </div>
+        </Section>
+      ) : null}
+
       <Section
         title="Comments"
-        {...(activityPending || activityError ? {} : { count: detail.commentCount })}
+        {...(activityPending || activityError || detail.commentsTruncated
+          ? {}
+          : { count: comments.length })}
         actions={
-          !activityPending && !activityError && detail.comments.length > 0 ? (
+          !activityPending && !activityError && comments.length > 0 ? (
             <Button
               size="xs"
               variant="ghost"
@@ -868,26 +1022,25 @@ export function PullRequestSummaryTab({
           <>
             {detail.commentsTruncated ? (
               <p className="mb-2 rounded-md border border-amber-500/30 bg-amber-500/5 px-2 py-1.5 text-xs">
-                This conversation is longer than this page reads in one go. The most recent{" "}
-                {detail.comments.length} are here; open it on the host to read the rest.
+                This conversation is longer than this page reads in one go. The most recent comments
+                are shown in Comments and Conversations; open it on the host to read the rest.
               </p>
             ) : null}
-            {detail.comments.length === 0 ? (
+            {comments.length === 0 ? (
               <p className="py-2 text-xs text-muted-foreground">No comments yet.</p>
             ) : (
               <div className="space-y-3">
                 {commentOrder === "oldest" ? showOldestCommentsButton : null}
                 {visibleComments.map((comment) => {
-                  const thread = threadByCommentId.get(comment.id);
                   const body = visibleBody(comment.body);
                   const outcome = pullRequestReviewOutcome(comment.reviewState);
-                  if (thread?.isResolved || outcome === "dismissed") {
+                  if (outcome === "dismissed") {
                     return (
                       <CollapsedComment
                         key={comment.id}
                         comment={comment}
                         editing={commentEditing}
-                        label={thread?.isResolved ? "Resolved" : "Approval dismissed"}
+                        label="Approval dismissed"
                         body={body}
                         reactionBar={
                           <PullRequestReactionBar
@@ -906,15 +1059,10 @@ export function PullRequestSummaryTab({
                   // An approval is a verdict, not a finding: there is nothing in it to fix.
                   const finding: PullRequestFinding | null =
                     (comment.kind !== "review" && comment.kind !== "review-comment") ||
-                    outcome === "approved"
+                    outcome === "approved" ||
+                    body === null
                       ? null
-                      : thread === undefined
-                        ? // Nor is a remark with nothing in it: offering to hand an empty review
-                          // to a thread promises work it does not describe.
-                          body === null
-                          ? null
-                          : { kind: "comment", comment }
-                        : { kind: "thread", thread };
+                      : { kind: "comment", comment };
                   // One bar, two homes. Under a card with words in it, it is the row beneath
                   // them. A bodiless verdict has nothing above it, so a row reserved for an add
                   // button nobody can see until they hover is a hole — there it rides the header

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -972,7 +972,7 @@ export function PullRequestSummaryTab({
           {conversations.length === 0 ? (
             <p className="text-xs text-muted-foreground">All conversations are resolved.</p>
           ) : null}
-          <div className="space-y-3 [&>div]:mx-0 [&>div]:my-0 [&>div]:shadow-none">
+          <div className="space-y-3">
             {conversations.map((thread) => (
               <PullRequestConversation
                 key={`${environmentId}:${detail.url}:${thread.id}`}

--- a/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
@@ -1,3 +1,4 @@
+import { formatEnvironmentQueryError } from "~/state/query";
 import type {
   EnvironmentId,
   PullRequestActor,
@@ -39,6 +40,8 @@ import {
   type PullRequestTimelineEvent,
 } from "./pullRequestDetail.logic";
 import { canEditPullRequestComment } from "./pullRequestEditing.logic";
+import { PullRequestConversation } from "./PullRequestConversation";
+import { PullRequestCommentActions } from "./PullRequestCommentActions";
 import { PullRequestMarkdown } from "./PullRequestMarkdown";
 import { PullRequestMarkdownEditor } from "./PullRequestMarkdownEditor";
 import { PullRequestReactionBar } from "./PullRequestReactions";
@@ -55,6 +58,7 @@ import {
 /** What every comment on the timeline needs to react; only the subject differs between them. */
 interface ReactionSurface {
   readonly canReact: boolean;
+  readonly canReply: boolean;
   readonly environmentId: EnvironmentId;
   /** Thread the timeline is shown beside, so body links can open in its in-app browser. */
   readonly threadRef: ScopedThreadRef | null;
@@ -209,7 +213,11 @@ function ConversationCard({
     });
     setSaving(false);
     if (result._tag === "Failure") {
-      toastManager.add({ type: "error", title: "Could not save the comment" });
+      toastManager.add({
+        type: "error",
+        title: "Could not save the comment",
+        description: formatEnvironmentQueryError(result.cause),
+      });
       return;
     }
     setEditing(false);
@@ -274,6 +282,16 @@ function ConversationCard({
           />
         </div>
       ) : null}
+      <PullRequestCommentActions
+        body={event.body ?? ""}
+        url={event.url}
+        canReply={reactions.canReply}
+        cwd={cwd}
+        environmentId={reactions.environmentId}
+        threadRef={reactions.threadRef}
+        reference={reactions.reference}
+        onRefresh={reactions.onRefresh}
+      />
       {reactions.canReact || event.reactions.length > 0 ? (
         <div className="px-2 pb-2">
           <PullRequestReactionBar
@@ -415,7 +433,17 @@ function CommitEvent({
   );
 }
 
-function LifecycleEvent({ event }: { event: PullRequestTimelineEvent }) {
+function LifecycleEvent({
+  event,
+  cwd,
+  reactions,
+  onOpen,
+}: {
+  event: PullRequestTimelineEvent;
+  cwd: string;
+  reactions: ReactionSurface;
+  onOpen: (url: string) => void;
+}) {
   const presentation =
     event.kind === "opened"
       ? {
@@ -427,10 +455,12 @@ function LifecycleEvent({ event }: { event: PullRequestTimelineEvent }) {
             icon: <GitMergeIcon className="size-3.5" />,
             label: "Pull request merged",
           }
-        : {
-            icon: <GitPullRequestClosedIcon className="size-3.5" />,
-            label: "Pull request closed",
-          };
+        : event.kind === "closed"
+          ? {
+              icon: <GitPullRequestClosedIcon className="size-3.5" />,
+              label: "Pull request closed",
+            }
+          : { icon: <GitPullRequestIcon className="size-3.5" />, label: event.title };
 
   return (
     <div className="relative mb-5 pl-12 [contain-intrinsic-block-size:48px] [content-visibility:auto]">
@@ -439,7 +469,17 @@ function LifecycleEvent({ event }: { event: PullRequestTimelineEvent }) {
         <div className="flex flex-wrap items-center gap-1.5">
           {event.actor ? <ActorName actor={event.actor} /> : null}
           <span className="font-semibold text-foreground">{presentation.label}</span>
+          <OpenOnHostButton url={event.url} onOpen={onOpen} />
         </div>
+        {event.body ? (
+          <TimelineBody
+            body={event.body}
+            markdown={event.markdown}
+            cwd={cwd}
+            environmentId={reactions.environmentId}
+            threadRef={reactions.threadRef}
+          />
+        ) : null}
         <div className="mt-0.5 text-[11px] text-muted-foreground">
           {formatRelativeTimeLabel(event.at)}
         </div>
@@ -565,10 +605,42 @@ export function PullRequestTimelineTab({
   onOpenCommit: (oid: string) => void;
   onRefresh: () => void;
 }) {
-  const events = buildPullRequestTimeline(detail);
+  const threadByComment = new Map(
+    detail.reviewThreads.flatMap((thread) =>
+      thread.comments.map((comment) => [comment.id, thread] as const),
+    ),
+  );
+  const events = buildPullRequestTimeline(detail).filter((event) => !threadByComment.has(event.id));
+  const conversationEvents = detail.reviewThreads.flatMap((thread) => {
+    const comment = thread.comments[0];
+    return comment
+      ? [
+          {
+            id: "thread:" + thread.id,
+            at: comment.createdAt,
+            kind: "conversation",
+            title: "Conversation",
+            body: null,
+            markdown: false,
+            url: null,
+            actor: comment.author,
+            commitAuthors: [],
+            additions: null,
+            deletions: null,
+            path: thread.path,
+            reviewState: null,
+            reactions: [],
+          },
+        ]
+      : [];
+  });
+  const timeline = [...events, ...conversationEvents].toSorted((left, right) =>
+    right.at.localeCompare(left.at),
+  );
   const newestCommitAt = newestPullRequestCommitAt(detail.commits);
   const reactions: ReactionSurface = {
     canReact: detail.capabilities.reactions === true,
+    canReply: detail.capabilities.comment && detail.viewerPermissions.comment,
     environmentId,
     threadRef,
     reference,
@@ -581,7 +653,7 @@ export function PullRequestTimelineTab({
       .filter((comment) => canEditPullRequestComment(detail, comment))
       .map((comment) => [comment.id, comment] as const),
   );
-  const orderedEvents = order === "newest" ? events : events.toReversed();
+  const orderedEvents = order === "newest" ? timeline : timeline.toReversed();
   const rows = groupPullRequestTimelineConversations(orderedEvents);
   const openOnHost = (url: string) => {
     void readLocalApi()?.shell.openExternal(url);
@@ -606,6 +678,31 @@ export function PullRequestTimelineTab({
               );
             }
             const event = row.event;
+            if (event.kind === "conversation") {
+              const thread = detail.reviewThreads.find(
+                (thread) => "thread:" + thread.id === event.id,
+              );
+              return thread ? (
+                <div
+                  key={JSON.stringify([
+                    environmentId,
+                    reference.projectId,
+                    reference.repository,
+                    reference.number,
+                    thread.id,
+                  ])}
+                  className="relative mb-5 pl-9"
+                >
+                  <PullRequestConversation
+                    thread={thread}
+                    detail={detail}
+                    environmentId={environmentId}
+                    reference={reference}
+                    onRefresh={onRefresh}
+                  />
+                </div>
+              ) : null;
+            }
             if (event.kind === "commit") {
               return <CommitEvent key={event.id} event={event} onOpen={onOpenCommit} />;
             }
@@ -623,7 +720,15 @@ export function PullRequestTimelineTab({
                 />
               );
             }
-            return <LifecycleEvent key={event.id} event={event} />;
+            return (
+              <LifecycleEvent
+                key={event.id}
+                event={event}
+                cwd={detail.workspaceRoot}
+                reactions={reactions}
+                onOpen={openOnHost}
+              />
+            );
           })}
         </div>
 

--- a/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
@@ -26,6 +26,7 @@ import { pullRequestEnvironment } from "~/state/pullRequests";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { formatRelativeTimeLabel } from "~/timestampFormat";
 
+import { Alert, AlertDescription } from "../ui/alert";
 import { Button } from "../ui/button";
 import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "../ui/collapsible";
 import { toastManager } from "../ui/toast";
@@ -662,12 +663,16 @@ export function PullRequestTimelineTab({
     <div className="h-full overflow-y-auto px-4 py-5">
       <div className="mx-auto max-w-3xl">
         {detail.timelineTruncated ? (
-          <p className="mb-4 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs">
-            Some host events are not loaded.{" "}
-            <a className="underline" href={detail.url} target="_blank" rel="noreferrer">
-              Open the full history on the host.
-            </a>
-          </p>
+          <Alert variant="warning" className="mb-4">
+            <AlertDescription>
+              <p>
+                Some host events are not loaded.{" "}
+                <a className="underline" href={detail.url} target="_blank" rel="noreferrer">
+                  Open the full history on the host.
+                </a>
+              </p>
+            </AlertDescription>
+          </Alert>
         ) : null}
         <div className="relative">
           <span aria-hidden className="absolute bottom-5 left-[15px] top-1 w-px bg-border/45" />

--- a/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
@@ -32,6 +32,7 @@ import { toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import {
   buildPullRequestTimeline,
+  comparePullRequestTimelineEvents,
   groupPullRequestTimelineConversations,
   isPullRequestVerdictStale,
   newestPullRequestCommitAt,
@@ -634,9 +635,7 @@ export function PullRequestTimelineTab({
         ]
       : [];
   });
-  const timeline = [...events, ...conversationEvents].toSorted((left, right) =>
-    right.at.localeCompare(left.at),
-  );
+  const timeline = [...events, ...conversationEvents].toSorted(comparePullRequestTimelineEvents);
   const newestCommitAt = newestPullRequestCommitAt(detail.commits);
   const reactions: ReactionSurface = {
     canReact: detail.capabilities.reactions === true,
@@ -662,6 +661,14 @@ export function PullRequestTimelineTab({
   return (
     <div className="h-full overflow-y-auto px-4 py-5">
       <div className="mx-auto max-w-3xl">
+        {detail.timelineTruncated ? (
+          <p className="mb-4 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs">
+            Some host events are not loaded.{" "}
+            <a className="underline" href={detail.url} target="_blank" rel="noreferrer">
+              Open the full history on the host.
+            </a>
+          </p>
+        ) : null}
         <div className="relative">
           <span aria-hidden className="absolute bottom-5 left-[15px] top-1 w-px bg-border/45" />
           {rows.map((row) => {

--- a/apps/web/src/components/pullRequest/PullRequestsUnavailableState.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestsUnavailableState.tsx
@@ -1,3 +1,4 @@
+import { pullRequestErrorHint } from "./pullRequestError.logic";
 import { ExternalLinkIcon, GitPullRequestIcon, RefreshCwIcon } from "lucide-react";
 
 import { Button } from "../ui/button";
@@ -30,7 +31,13 @@ export function PullRequestsUnavailableState({
         <EmptyTitle>{title}</EmptyTitle>
         {/* The caller names the fix — update the environment, install gh, sign in — so this
             shows its message rather than trying to infer one from the failure text. */}
-        <EmptyDescription>{error}</EmptyDescription>
+        <EmptyDescription>{pullRequestErrorHint(error) ?? error}</EmptyDescription>
+        {pullRequestErrorHint(error) ? (
+          <details className="max-w-md text-xs text-muted-foreground">
+            <summary className="cursor-pointer">Error details</summary>
+            <p className="mt-2 whitespace-pre-wrap break-words">{error}</p>
+          </details>
+        ) : null}
       </EmptyHeader>
       {onRetry || gitHubUrl ? (
         <EmptyContent className="flex-row flex-wrap justify-center gap-2">

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -1484,6 +1484,39 @@ describe("host timeline events", () => {
       { id: "activity:host-merge", actor: { login: "maintainer" } },
     ]);
   });
+  it("keeps the current close when only an older close is loaded", () => {
+    const closedAt = "2026-07-06T00:00:00Z";
+    const source = {
+      ...TIMELINE_SOURCE,
+      closedAt,
+      timelineEvents: [
+        {
+          id: "host-close",
+          kind: "closed",
+          body: "closed",
+          createdAt: "2026-07-04T00:00:00Z",
+          actor: null,
+          url: null,
+        },
+      ],
+    };
+    expect(
+      buildPullRequestTimeline(source)
+        .filter((event) => event.kind === "closed")
+        .map((event) => event.at),
+    ).toEqual([closedAt, "2026-07-04T00:00:00Z"]);
+    expect(
+      buildPullRequestTimeline({
+        ...source,
+        timelineEvents: source.timelineEvents.map((event) => ({
+          ...event,
+          createdAt: "2026-07-06T02:00:00+02:00",
+        })),
+      })
+        .filter((event) => event.kind === "closed")
+        .map((event) => event.id),
+    ).toEqual(["activity:host-close"]);
+  });
   it("keeps close and reopen history in time order", () => {
     const events = buildPullRequestTimeline({
       ...TIMELINE_SOURCE,

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   pullRequestGeneralComments,
   mergePullRequestActivity,
+  comparePullRequestTimelineEvents,
   buildAddSelectionToAgentHandoff,
   buildAskAboutPullRequestHandoff,
   buildExplainPullRequestHandoff,
@@ -1395,8 +1396,11 @@ describe("cached pull request detail", () => {
       reviewThreads: [],
       commits: [],
       timelineEvents,
+      timelineTruncated: true,
     };
     expect(mergePullRequestActivity(detail(), activity)?.timelineEvents).toEqual(timelineEvents);
+    expect(mergePullRequestActivity(detail(), activity)?.timelineTruncated).toBe(true);
+    expect(mergePullRequestActivity(detail(), undefined)?.timelineTruncated).toBe(false);
     expect(mergePullRequestActivity(detail(), undefined)?.timelineEvents).toEqual([]);
     expect(mergePullRequestActivity(null, activity)).toBeNull();
   });
@@ -1440,6 +1444,27 @@ describe("cached pull request detail", () => {
 });
 
 describe("host timeline events", () => {
+  it("orders native events and conversation rows by instant across timezone offsets", () => {
+    const earlier = { at: "2026-07-05T01:00:00+02:00" };
+    const later = { at: "2026-07-05T00:30:00Z" };
+    expect([earlier, later].toSorted(comparePullRequestTimelineEvents)).toEqual([later, earlier]);
+    const events = buildPullRequestTimeline({
+      ...TIMELINE_SOURCE,
+      timelineEvents: [earlier, later].map((event, index) => ({
+        id: String(index),
+        kind: "reopened",
+        body: "",
+        actor: null,
+        url: null,
+        createdAt: event.at,
+      })),
+    });
+    expect(events.filter((event) => event.kind === "reopened").map((event) => event.at)).toEqual([
+      later.at,
+      earlier.at,
+    ]);
+  });
+
   it("uses the host actor without adding a second merge event", () => {
     const events = buildPullRequestTimeline({
       ...TIMELINE_SOURCE,

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -9,6 +9,8 @@ import {
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  pullRequestGeneralComments,
+  mergePullRequestActivity,
   buildAddSelectionToAgentHandoff,
   buildAskAboutPullRequestHandoff,
   buildExplainPullRequestHandoff,
@@ -38,6 +40,7 @@ import {
   shouldRefreshPullRequestActivity,
   resolveBaseFreshness,
   buildPullRequestTimeline,
+  pullRequestAttentionItems,
   editPullRequestThreadComment,
   writePullRequestDetailSnapshot,
 } from "./pullRequestDetail.logic";
@@ -1374,6 +1377,30 @@ describe("cached pull request detail", () => {
     };
   };
 
+  it("passes native activity to the rendered detail and supports older activity responses", () => {
+    const timelineEvents = [
+      {
+        id: "closed",
+        kind: "closed",
+        actor: null,
+        createdAt: "2026-09-05T00:00:00Z",
+        url: null,
+        body: "Closed",
+      },
+    ];
+    const activity = {
+      comments: [],
+      commentCount: 0,
+      commentsTruncated: false,
+      reviewThreads: [],
+      commits: [],
+      timelineEvents,
+    };
+    expect(mergePullRequestActivity(detail(), activity)?.timelineEvents).toEqual(timelineEvents);
+    expect(mergePullRequestActivity(detail(), undefined)?.timelineEvents).toEqual([]);
+    expect(mergePullRequestActivity(null, activity)).toBeNull();
+  });
+
   it("hydrates the last title, author, and counts so a reopen does not ghost the tab", () => {
     const storage = makeStorage();
     writePullRequestDetailSnapshot(storage, "env-1", reference, detail());
@@ -1409,5 +1436,81 @@ describe("cached pull request detail", () => {
     storage.setItem("t3.pullRequests.detail:env-1:project-1:acme/web#7", "{not json");
     expect(readPullRequestDetailSnapshot(storage, "env-1", reference)).toBeNull();
     expect(readPullRequestDetailSnapshot(undefined, "env-1", reference)).toBeNull();
+  });
+});
+
+describe("host timeline events", () => {
+  it("uses the host actor without adding a second merge event", () => {
+    const events = buildPullRequestTimeline({
+      ...TIMELINE_SOURCE,
+      mergedAt: "2026-07-04T00:00:00Z",
+      timelineEvents: [
+        {
+          id: "host-merge",
+          kind: "merged",
+          body: "merged into main",
+          createdAt: "2026-07-04T00:00:00Z",
+          actor: { login: "maintainer", name: null, avatarUrl: null },
+          url: null,
+        },
+      ],
+    });
+    expect(events.filter((event) => event.kind === "merged")).toMatchObject([
+      { id: "activity:host-merge", actor: { login: "maintainer" } },
+    ]);
+  });
+  it("keeps close and reopen history in time order", () => {
+    const events = buildPullRequestTimeline({
+      ...TIMELINE_SOURCE,
+      closedAt: null,
+      timelineEvents: [
+        {
+          id: "close",
+          kind: "closed",
+          body: "closed",
+          createdAt: "2026-07-04T00:00:00Z",
+          actor: null,
+          url: null,
+        },
+        {
+          id: "reopen",
+          kind: "reopened",
+          body: "reopened",
+          createdAt: "2026-07-05T00:00:00Z",
+          actor: null,
+          url: null,
+        },
+      ],
+    });
+    expect(events.slice(0, 2).map((event) => event.kind)).toEqual(["reopened", "closed"]);
+    expect(events.slice(0, 2).map((event) => event.body)).toEqual([null, null]);
+  });
+});
+
+describe("pull request attention", () => {
+  it("lists reported problems and removes them after closure", () => {
+    const detail = {
+      state: "open" as const,
+      mergeability: "conflicting" as const,
+      reviewDecision: "review-required" as const,
+      checks: [{ name: "CI", status: "failure" as const, url: null, description: null }],
+      reviewThreads: [],
+    };
+    expect(pullRequestAttentionItems(detail).map((item) => item.label)).toEqual([
+      "Merge conflicts",
+      "Review required",
+      "1 failed check",
+    ]);
+    expect(pullRequestAttentionItems({ ...detail, state: "merged" })).toEqual([]);
+  });
+});
+
+describe("pullRequestGeneralComments", () => {
+  it("excludes threaded replies from the general comments count and empty state", () => {
+    const reply = { id: "reply", body: "review reply" };
+    const general = { id: "general", body: "top-level comment" };
+    const threads = [{ comments: [reply] }];
+    expect(pullRequestGeneralComments([reply], threads)).toEqual([]);
+    expect(pullRequestGeneralComments([reply, general], threads)).toEqual([general]);
   });
 });

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -506,7 +506,7 @@ export function buildPullRequestTimeline(
           },
         ]
       : []),
-  ].toSorted((left, right) => right.at.localeCompare(left.at));
+  ].toSorted(comparePullRequestTimelineEvents);
 }
 
 const FINDING_LIMIT = 20;
@@ -1158,7 +1158,12 @@ export function mergePullRequestActivity(
         commentsTruncated: activity?.commentsTruncated ?? false,
         reviewThreads: activity?.reviewThreads ?? [],
         timelineEvents: activity?.timelineEvents ?? [],
+        timelineTruncated: activity?.timelineTruncated ?? false,
         commits: activity?.commits ?? [],
         reactions: activity?.reactions ?? [],
       };
+}
+
+export function comparePullRequestTimelineEvents(left: { at: string }, right: { at: string }) {
+  return instant(right.at) - instant(left.at);
 }

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -1000,6 +1000,7 @@ const ACTION_NEEDS_HOST_REFRESH: Record<PullRequestAction, boolean> = {
   "disable-auto-merge": false,
   revert: false,
   "approve-workflows": true,
+  "delete-source-branch": false,
 };
 
 export function pullRequestActionNeedsHostRefresh(action: PullRequestAction): boolean {

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -396,6 +396,7 @@ export function buildPullRequestTimeline(
     "createdAt" | "author" | "commits" | "comments" | "mergedAt" | "closedAt" | "timelineEvents"
   >,
 ): ReadonlyArray<PullRequestTimelineEvent> {
+  const { closedAt } = detail;
   return [
     {
       id: "created",
@@ -484,13 +485,15 @@ export function buildPullRequestTimeline(
           },
         ]
       : []),
-    ...(detail.closedAt &&
+    ...(closedAt &&
     !detail.mergedAt &&
-    !detail.timelineEvents?.some((event) => event.kind === "closed")
+    !detail.timelineEvents?.some(
+      (event) => event.kind === "closed" && instant(event.createdAt) === instant(closedAt),
+    )
       ? [
           {
             id: "closed",
-            at: detail.closedAt,
+            at: closedAt,
             kind: "closed" as const,
             title: "Pull request closed",
             body: null,

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -3,6 +3,7 @@ import * as Schema from "effect/Schema";
 import {
   PullRequestDetail,
   type PullRequestAction,
+  type PullRequestActivity,
   type PullRequestActor,
   type PullRequestBaseComparison,
   type PullRequestCheck,
@@ -317,7 +318,7 @@ export function latestPullRequestReviewOutcomes(
 export interface PullRequestTimelineEvent {
   readonly id: string;
   readonly at: string;
-  readonly kind: "opened" | "commit" | "comment" | "review" | "merged" | "closed";
+  readonly kind: string;
   readonly title: string;
   readonly body: string | null;
   /** Whether `body` is markdown. A commit headline is plain text and must not be parsed as one. */
@@ -392,7 +393,7 @@ export function visibleBody(body: string): string | null {
 export function buildPullRequestTimeline(
   detail: Pick<
     PullRequestDetailView,
-    "createdAt" | "author" | "commits" | "comments" | "mergedAt" | "closedAt"
+    "createdAt" | "author" | "commits" | "comments" | "mergedAt" | "closedAt" | "timelineEvents"
   >,
 ): ReadonlyArray<PullRequestTimelineEvent> {
   return [
@@ -444,7 +445,26 @@ export function buildPullRequestTimeline(
       reviewState: comment.reviewState,
       reactions: comment.reactions ?? [],
     })),
-    ...(detail.mergedAt
+    ...(detail.timelineEvents ?? []).map((event) => ({
+      id: "activity:" + event.id,
+      at: event.createdAt,
+      kind: event.kind,
+      title: event.kind.replaceAll("-", " "),
+      body:
+        event.body.trim().toLowerCase() === event.kind.replaceAll("-", " ")
+          ? null
+          : event.body || null,
+      markdown: true,
+      url: event.url,
+      actor: event.actor,
+      commitAuthors: [],
+      additions: null,
+      deletions: null,
+      path: null,
+      reviewState: null,
+      reactions: [],
+    })),
+    ...(detail.mergedAt && !detail.timelineEvents?.some((event) => event.kind === "merged")
       ? [
           {
             id: "merged",
@@ -464,7 +484,9 @@ export function buildPullRequestTimeline(
           },
         ]
       : []),
-    ...(detail.closedAt && !detail.mergedAt
+    ...(detail.closedAt &&
+    !detail.mergedAt &&
+    !detail.timelineEvents?.some((event) => event.kind === "closed")
       ? [
           {
             id: "closed",
@@ -1077,4 +1099,66 @@ export function resolveDisplayedPullRequestDetail(input: {
     return input.cached;
   }
   return null;
+}
+
+export function pullRequestAttentionItems(
+  detail: Pick<
+    PullRequestDetailView,
+    "state" | "mergeability" | "reviewDecision" | "checks" | "reviewThreads"
+  >,
+) {
+  if (detail.state !== "open") return [];
+  const items: { label: string; section: string | null }[] = [];
+  if (detail.mergeability === "conflicting")
+    items.push({ label: "Merge conflicts", section: null });
+  if (detail.reviewDecision === "changes-requested")
+    items.push({ label: "Changes requested", section: null });
+  if (detail.reviewDecision === "review-required")
+    items.push({ label: "Review required", section: null });
+  const failed = detail.checks.filter(
+    (check) => check.status === "failure" || check.status === "cancelled",
+  ).length;
+  if (failed > 0)
+    items.push({
+      label: failed + (failed === 1 ? " failed check" : " failed checks"),
+      section: "Checks",
+    });
+  const unresolved = detail.reviewThreads.filter((thread) => !thread.isResolved).length;
+  if (unresolved > 0)
+    items.push({
+      label:
+        unresolved + (unresolved === 1 ? " unresolved conversation" : " unresolved conversations"),
+      section: "Conversations",
+    });
+  return items;
+}
+
+export function pullRequestGeneralComments<T extends { id: string }>(
+  comments: readonly T[],
+  reviewThreads: readonly { comments: readonly { id: string }[] }[],
+): T[] {
+  const threadedIds = new Set(
+    reviewThreads.flatMap((thread) => thread.comments.map((comment) => comment.id)),
+  );
+  return comments.filter((comment) => !threadedIds.has(comment.id));
+}
+
+export function mergePullRequestActivity(
+  detail: PullRequestDetail | null,
+  activity: PullRequestActivity | null | undefined,
+): PullRequestDetailView | null {
+  return detail === null
+    ? null
+    : {
+        ...detail,
+        author: activity?.author ?? detail.author,
+        reviewers: activity?.reviewers ?? detail.reviewers,
+        comments: activity?.comments ?? [],
+        commentCount: activity?.commentCount ?? 0,
+        commentsTruncated: activity?.commentsTruncated ?? false,
+        reviewThreads: activity?.reviewThreads ?? [],
+        timelineEvents: activity?.timelineEvents ?? [],
+        commits: activity?.commits ?? [],
+        reactions: activity?.reactions ?? [],
+      };
 }

--- a/apps/web/src/components/pullRequest/pullRequestError.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestError.logic.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vite-plus/test";
+import { pullRequestErrorHint } from "./pullRequestError.logic";
+
+describe("pull request error guidance", () => {
+  it.each([
+    ["HTTP 429: API rate limit exceeded", "Wait for the limit"],
+    ["HTTP 403: API rate limit exceeded", "Wait for the limit"],
+    ["invalid_credential", "Sign in"],
+    ["HTTP 403 Forbidden", "signed-in account"],
+    ["HTTP 404 Not Found", "repository access"],
+    ["fetch failed: ECONNRESET", "connection"],
+  ])("explains recovery for %s", (message, hint) => {
+    expect(pullRequestErrorHint(message)).toContain(hint);
+  });
+  it("does not guess a cause for an unknown host error", () => {
+    expect(pullRequestErrorHint("The host could not complete this action")).toBeNull();
+  });
+});

--- a/apps/web/src/components/pullRequest/pullRequestError.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestError.logic.ts
@@ -1,0 +1,18 @@
+export function pullRequestErrorHint(message: string): string | null {
+  if (/rate.limit|too many requests|HTTP 429/i.test(message)) {
+    return "The host has limited requests. Wait for the limit to reset, then retry.";
+  }
+  if (/unauthenticated|authentication|not logged|invalid.credential|HTTP 401/i.test(message)) {
+    return "Sign in to the source control host on the selected server, then retry.";
+  }
+  if (/forbidden|permission|access denied|HTTP 403/i.test(message)) {
+    return "Check that the signed-in account has access to this repository and action.";
+  }
+  if (/not found|HTTP 404/i.test(message)) {
+    return "Check the PR link and repository access. The host can hide private PRs from accounts without access.";
+  }
+  if (/offline|disconnected|network|ECONN|ENOTFOUND|fetch failed|timed out/i.test(message)) {
+    return "Check the selected server's connection, then retry. Your loaded PR data is kept.";
+  }
+  return null;
+}

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -34,6 +34,8 @@ import {
 import {
   pullRequestListPreferences,
   readPullRequestListPreferences,
+  readExcludedPullRequestProjects,
+  writeExcludedPullRequestProjects,
   writePullRequestListPreferences,
 } from "./pullRequestListPreferences";
 
@@ -1494,5 +1496,39 @@ describe("the priority groups against a paginated feed", () => {
     expect(
       groups.find((group) => group.key === "others")?.entries.map((row) => row.number),
     ).toEqual([6123]);
+  });
+});
+
+describe("excluded pull request projects", () => {
+  it("remembers exclusions separately from the list filters and allows restoring them", () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        values.set(key, value);
+      },
+    };
+    const excluded = [JSON.stringify(["server-a", "project-a"])];
+    expect(writeExcludedPullRequestProjects(excluded, storage)).toBe(true);
+    writePullRequestListPreferences({ involvement: "all", state: "merged" }, storage);
+    expect(readExcludedPullRequestProjects(storage)).toEqual(excluded);
+    writeExcludedPullRequestProjects([], storage);
+    expect(readExcludedPullRequestProjects(storage)).toEqual([]);
+  });
+
+  it("rejects invalid saved exclusions and reports storage failure", () => {
+    expect(readExcludedPullRequestProjects({ getItem: () => "[1]", setItem: () => {} })).toEqual(
+      [],
+    );
+    const denied = {
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("denied");
+      },
+    };
+    expect(readExcludedPullRequestProjects(denied)).toEqual([]);
+    expect(writeExcludedPullRequestProjects(["project"], denied)).toBe(false);
   });
 });

--- a/apps/web/src/components/pullRequest/pullRequestListPreferences.ts
+++ b/apps/web/src/components/pullRequest/pullRequestListPreferences.ts
@@ -120,3 +120,45 @@ export function writePullRequestListPreferences(
     // Storage can be full or denied; the URL remains the source of truth for this visit.
   }
 }
+
+const EXCLUDED_PROJECTS_STORAGE_KEY = "t3.pullRequests.excludedProjects";
+const decodeExcludedProjects = Schema.decodeUnknownOption(Schema.Array(Schema.String));
+const decodeExcludedProject = Schema.decodeUnknownOption(Schema.Tuple([EnvironmentId, ProjectId]));
+
+export function readExcludedPullRequestProjects(
+  storage?: PreferenceStorage,
+): ReadonlyArray<string> {
+  try {
+    const raw = resolvePreferenceStorage(storage)?.getItem(EXCLUDED_PROJECTS_STORAGE_KEY);
+    const decoded = decodeExcludedProjects(raw ? JSON.parse(raw) : []);
+    if (decoded._tag === "None") return [];
+    return [
+      ...new Set(
+        decoded.value.flatMap((key) => {
+          try {
+            const project = decodeExcludedProject(JSON.parse(key));
+            return project._tag === "Some" ? [JSON.stringify(project.value)] : [];
+          } catch {
+            return [];
+          }
+        }),
+      ),
+    ];
+  } catch {
+    return [];
+  }
+}
+
+export function writeExcludedPullRequestProjects(
+  projects: ReadonlyArray<string>,
+  storage?: PreferenceStorage,
+): boolean {
+  try {
+    const target = resolvePreferenceStorage(storage);
+    if (!target) return false;
+    target.setItem(EXCLUDED_PROJECTS_STORAGE_KEY, JSON.stringify(projects));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/components/pullRequest/pullRequestProjectAssignment.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestProjectAssignment.logic.ts
@@ -135,3 +135,39 @@ export function resolvePickableEnvironments(
     ...others,
   ];
 }
+
+export function pullRequestEnvironmentQueries(input: {
+  projects: ReadonlyArray<AssignableProject>;
+  listedProjects: ReadonlyArray<AssignableProject>;
+  environmentIds: ReadonlyArray<EnvironmentId>;
+  projectsKnown: boolean;
+  hasExclusions: boolean;
+  projectId: ProjectId | undefined;
+}): ReadonlyArray<{ environmentId: EnvironmentId; projectIds?: ReadonlyArray<ProjectId> }> {
+  if (!input.projectsKnown && input.hasExclusions) return [];
+  const plain = input.environmentIds.map((environmentId) => ({ environmentId }));
+  if (!input.projectsKnown || input.projectId !== undefined) return plain;
+  const assignment = assignProjectsToEnvironments(
+    input.listedProjects,
+    input.environmentIds,
+    input.environmentIds[0],
+  );
+  return input.environmentIds.flatMap((environmentId) => {
+    const projectIds = assignment.get(environmentId);
+    if (!projectIds?.length) return [];
+    const total = input.projects.filter(
+      (project) => project.environmentId === environmentId,
+    ).length;
+    return projectIds.length === total ? [{ environmentId }] : [{ environmentId, projectIds }];
+  });
+}
+
+export function includedPullRequestEntries<
+  Entry extends { environmentId: EnvironmentId; projectId: ProjectId },
+>(entries: ReadonlyArray<Entry>, exclusions: ReadonlyArray<string>): ReadonlyArray<Entry> {
+  if (exclusions.length === 0) return entries;
+  const excluded = new Set(exclusions);
+  return entries.filter(
+    (entry) => !excluded.has(JSON.stringify([entry.environmentId, entry.projectId])),
+  );
+}

--- a/apps/web/src/components/pullRequest/pullRequestProjectFilter.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestProjectFilter.logic.test.ts
@@ -1,3 +1,7 @@
+import {
+  pullRequestEnvironmentQueries,
+  includedPullRequestEntries,
+} from "./pullRequestProjectAssignment.logic";
 import { EnvironmentId, ProjectId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
@@ -154,5 +158,49 @@ describe("pull request project filter choices", () => {
 
     expect(pullRequestFilterProjects([app, tools], labels)).toEqual([tools, app]);
     expect(pullRequestFilterProjects([], labels)).toEqual([]);
+  });
+});
+
+describe("excluded project queries and cached rows", () => {
+  it("does not fetch until saved exclusions can be applied", () => {
+    expect(
+      pullRequestEnvironmentQueries({
+        projects: [],
+        listedProjects: [],
+        environmentIds: [cups],
+        projectsKnown: false,
+        hasExclusions: true,
+        projectId: undefined,
+      }),
+    ).toEqual([]);
+  });
+  it("sends only included project IDs and skips empty environments", () => {
+    const first = project("first", cups);
+    const second = project("second", cups, "github.com/acme/second");
+    const third = project("third", nucbox);
+    const input = {
+      projects: [first, second, third],
+      listedProjects: [second],
+      environmentIds: [cups, nucbox],
+      projectsKnown: true,
+      hasExclusions: true,
+      projectId: undefined,
+    };
+    expect(pullRequestEnvironmentQueries(input)).toEqual([
+      { environmentId: cups, projectIds: [second.id] },
+    ]);
+    expect(pullRequestEnvironmentQueries({ ...input, listedProjects: [] })).toEqual([]);
+  });
+  it("filters cached entries by server and project without changing detail lookup", () => {
+    const first = project("same", cups);
+    const second = project("same", nucbox);
+    const entries = [first, second].map((project) => ({
+      projectId: project.id,
+      environmentId: project.environmentId,
+    }));
+    expect(includedPullRequestEntries(entries, [JSON.stringify([cups, first.id])])).toEqual([
+      entries[1],
+    ]);
+    expect(findScopedProject([first, second], cups, first.id)).toEqual(first);
   });
 });

--- a/apps/web/src/components/pullRequest/pullRequestRelated.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestRelated.logic.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vite-plus/test";
+import { relatedPullRequests } from "./pullRequestRelated.logic";
+
+describe("relatedPullRequests", () => {
+  it("finds links for each host and excludes the current request and duplicate anchors", () => {
+    const urls = [
+      "https://github.com/team/repo/pull/2",
+      "https://gitlab.com/team/repo/-/merge_requests/3",
+      "https://bitbucket.org/team/repo/pull-requests/4",
+      "https://dev.azure.com/team/project/_git/repo/pullrequest/5",
+    ];
+    const own = "https://github.com/team/repo/pull/1";
+    expect(
+      relatedPullRequests({
+        url: own,
+        body: [own, ...urls, urls[0] + "#discussion"].join(" "),
+        comments: [],
+        timelineEvents: [],
+      }).map((entry) => entry.url),
+    ).toEqual(urls);
+  });
+
+  it("uses the native title and state when the timeline enriches a mentioned URL", () => {
+    const reference = {
+      title: "Fix [thread] replies",
+      url: "https://github.com/team/repo/pull/2",
+      state: "merged" as const,
+    };
+    expect(
+      relatedPullRequests({
+        url: "https://github.com/team/repo/pull/1",
+        body: reference.url,
+        comments: [],
+        timelineEvents: [
+          {
+            id: "mention",
+            kind: "cross-referenced",
+            body: "",
+            actor: null,
+            createdAt: "2026-09-05T00:00:00Z",
+            url: null,
+            relatedPullRequest: reference,
+          },
+        ],
+      }),
+    ).toEqual([reference]);
+  });
+});

--- a/apps/web/src/components/pullRequest/pullRequestRelated.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestRelated.logic.ts
@@ -1,0 +1,33 @@
+import type { PullRequestDetailView } from "@t3tools/contracts";
+import { parseChangeRequestUrl } from "~/lib/openPullRequestLink";
+
+export function relatedPullRequests(
+  detail: Pick<PullRequestDetailView, "url" | "body" | "comments" | "timelineEvents">,
+) {
+  const keyOf = (url: string) => {
+    const link = parseChangeRequestUrl(url);
+    return link ? link.host + "/" + link.repository + "/" + link.number : null;
+  };
+  const ownKey = keyOf(detail.url);
+  const related = new Map<string, { title: string; url: string; state?: string }>();
+  for (const body of [
+    detail.body,
+    ...detail.comments.map((comment) => comment.body),
+    ...(detail.timelineEvents ?? []).map((event) => event.body),
+  ]) {
+    for (const match of body.matchAll(/https?:\/\/[^\s<>"\x60)\]]+/g)) {
+      const url = match[0].replace(/[.,;:]+$/, "");
+      const link = parseChangeRequestUrl(url);
+      const key = keyOf(url);
+      if (link && key && key !== ownKey && !related.has(key)) {
+        related.set(key, { title: link.repository + " #" + link.number, url });
+      }
+    }
+  }
+  for (const event of detail.timelineEvents ?? []) {
+    const reference = event.relatedPullRequest;
+    const key = reference ? keyOf(reference.url) : null;
+    if (reference && key && key !== ownKey) related.set(key, reference);
+  }
+  return [...related.values()];
+}

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -84,8 +84,13 @@ import {
   type PullRequestListPreferences,
   type PullRequestListSort,
   writePullRequestListPreferences,
+  readExcludedPullRequestProjects,
+  writeExcludedPullRequestProjects,
 } from "../components/pullRequest/pullRequestListPreferences";
-import { assignProjectsToEnvironments } from "../components/pullRequest/pullRequestProjectAssignment.logic";
+import {
+  pullRequestEnvironmentQueries,
+  includedPullRequestEntries,
+} from "../components/pullRequest/pullRequestProjectAssignment.logic";
 import { pullRequestFilterProjects } from "../components/pullRequest/pullRequestProjectFilter.logic";
 import { environmentMachineIcon } from "../components/EnvironmentMachineIcon";
 import { PullRequestDetailPanel } from "../components/pullRequest/PullRequestDetailPanel";
@@ -141,6 +146,7 @@ import {
 } from "../state/pullRequests";
 import { useAtomCommand } from "../state/use-atom-command";
 import { cn } from "~/lib/utils";
+import { toastManager } from "../components/ui/toast";
 import { primaryServerKeybindingsAtom } from "~/state/server";
 import { getSourceControlPresentationForKind } from "~/sourceControlPresentation";
 
@@ -350,6 +356,11 @@ function PullRequestsRouteView() {
     () => allProjects.filter((project) => environmentIds.includes(project.environmentId)),
     [allProjects, environmentIds],
   );
+  const [excludedProjects, setExcludedProjects] = useState(readExcludedPullRequestProjects);
+  const listedProjects = useMemo(
+    () => projects.filter((project) => !excludedProjects.includes(pullRequestProjectKey(project))),
+    [projects, excludedProjects],
+  );
   const environmentLabels = useMemo(
     () =>
       new Map(
@@ -359,16 +370,16 @@ function PullRequestsRouteView() {
   );
   // The scope the URL asks for, once the environments have had their say about whether it exists.
   const scopedProjectId = useMemo(
-    () => resolveProjectScope(search.projectId, projects, projectsKnown),
-    [projects, projectsKnown, search.projectId],
+    () => resolveProjectScope(search.projectId, listedProjects, projectsKnown),
+    [listedProjects, projectsKnown, search.projectId],
   );
   const scopedProject = useMemo(
     () => findScopedProject(projects, scopedEnvironmentId, scopedProjectId),
     [projects, scopedEnvironmentId, scopedProjectId],
   );
   const scopedProjects = useMemo(
-    () => pullRequestFilterProjects(projects, environmentLabels, scopedProject),
-    [environmentLabels, projects, scopedProject],
+    () => pullRequestFilterProjects(listedProjects, environmentLabels, scopedProject),
+    [environmentLabels, listedProjects, scopedProject],
   );
 
   // A link from a thread or the sidebar only knows the repository, so the owning project is
@@ -568,12 +579,12 @@ function PullRequestsRouteView() {
     () =>
       resolveQueryEnvironmentIds(
         environmentIds,
-        projects,
+        listedProjects,
         scopedProject,
         scopedProjectId,
         projectsKnown,
       ),
-    [environmentIds, projects, projectsKnown, scopedProject, scopedProjectId],
+    [environmentIds, listedProjects, projectsKnown, scopedProject, scopedProjectId],
   );
   /**
    * Which projects each server is asked about. Two servers holding the same repository would both
@@ -584,30 +595,25 @@ function PullRequestsRouteView() {
    * Left alone while the projects are still arriving, and while the scope is a single project:
    * that path deliberately asks both servers holding an ambiguous id.
    */
-  const environmentQueries = useMemo((): ReadonlyArray<{
-    readonly environmentId: EnvironmentId;
-    readonly projectIds?: ReadonlyArray<ProjectId>;
-  }> => {
-    const plain = queryEnvironmentIds.map((environmentId) => ({ environmentId }));
-    if (!projectsKnown || scopedProjectId !== undefined) return plain;
-    const assignment = assignProjectsToEnvironments(
+  const environmentQueries = useMemo(
+    () =>
+      pullRequestEnvironmentQueries({
+        projects,
+        listedProjects,
+        environmentIds: queryEnvironmentIds,
+        projectsKnown,
+        hasExclusions: excludedProjects.length > 0,
+        projectId: scopedProjectId,
+      }),
+    [
       projects,
+      listedProjects,
       queryEnvironmentIds,
-      queryEnvironmentIds[0],
-    );
-    const totals = new Map<EnvironmentId, number>();
-    for (const project of projects) {
-      totals.set(project.environmentId, (totals.get(project.environmentId) ?? 0) + 1);
-    }
-    return queryEnvironmentIds.flatMap((environmentId) => {
-      const projectIds = assignment.get(environmentId);
-      if (projectIds === undefined) return [];
-      // It lists everything it holds anyway, so the filter is left off and a one-server workspace
-      // asks exactly the question it asked before.
-      if (projectIds.length === (totals.get(environmentId) ?? 0)) return [{ environmentId }];
-      return [{ environmentId, projectIds }];
-    });
-  }, [projects, projectsKnown, queryEnvironmentIds, scopedProjectId]);
+      projectsKnown,
+      excludedProjects.length,
+      scopedProjectId,
+    ],
+  );
   // Part of the scope, since a different split is a different question and its answers must not
   // be filed under the same page state.
   const assignmentKey = useMemo(
@@ -624,7 +630,7 @@ function PullRequestsRouteView() {
     .map(([environmentId, revision]) => `${environmentId}:${revision}`)
     .join("|");
   // Page size is view state, not a URL concern: a shared link should open the first page.
-  const scopeKey = `${environmentKey}:${assignmentKey}:${search.state}:${search.involvement}:${scopedProjectId ?? ""}:${search.host ?? ""}:${search.draft ?? ""}:${search.review ?? ""}:${search.checks ?? ""}:${search.author ?? ""}:${search.labels?.join("\u0000") ?? ""}`;
+  const scopeKey = `${JSON.stringify(excludedProjects)}:${environmentKey}:${assignmentKey}:${search.state}:${search.involvement}:${scopedProjectId ?? ""}:${search.host ?? ""}:${search.draft ?? ""}:${search.review ?? ""}:${search.checks ?? ""}:${search.author ?? ""}:${search.labels?.join("\u0000") ?? ""}`;
   const filterKey = `${scopeKey}:${sentQuery}`;
   const statsScopeRef = useRef<PullRequestStatsScope>({ key: filterKey, policy: statsPolicy });
   statsScopeRef.current = { key: filterKey, policy: statsPolicy };
@@ -1146,7 +1152,11 @@ function PullRequestsRouteView() {
 
   const entries = useMemo(() => {
     const known = ordered?.key === filterKey ? ordered.entries : (listData?.entries ?? []);
-    const involvementEntries = filterPullRequestsByInvolvement(known, viewers, search.involvement);
+    const involvementEntries = filterPullRequestsByInvolvement(
+      includedPullRequestEntries(known, excludedProjects),
+      viewers,
+      search.involvement,
+    );
     // The hosts search more than the row shows — a body, a review, a commit message — so once
     // their answer is in, narrowing it again here would throw away matches the reader asked for.
     // The local pass stands in for the answer that has not arrived yet, and for the hosts that
@@ -1175,6 +1185,7 @@ function PullRequestsRouteView() {
         matchesPullRequestQuery(entry, typedParsed.text),
     );
   }, [
+    excludedProjects,
     filterKey,
     hasLocalFilters,
     localFilters,
@@ -1225,11 +1236,18 @@ function PullRequestsRouteView() {
     // narrowing: a host that cannot filter for itself would otherwise put rows into Authored
     // that the filters above just took out of the feed.
     const narrow = (rows: ReadonlyArray<EnvironmentPullRequestEntry> | undefined) =>
-      rows === undefined || !hasLocalFilters
-        ? rows
-        : rows.filter((entry) =>
-            matchesPullRequestFilters(entry, localFilters, pullRequestEntryViewer(entry, viewers)),
+      rows === undefined
+        ? undefined
+        : includedPullRequestEntries(rows, excludedProjects).filter(
+            (entry) =>
+              !hasLocalFilters ||
+              matchesPullRequestFilters(
+                entry,
+                localFilters,
+                pullRequestEntryViewer(entry, viewers),
+              ),
           );
+
     const authored = narrow(
       partitionsWanted ? (authoredQuery.data?.entries ?? held?.authored) : undefined,
     );
@@ -1244,6 +1262,7 @@ function PullRequestsRouteView() {
     hasLocalFilters,
     localFilters,
     authoredQuery.data?.entries,
+    excludedProjects,
     entries,
     environmentKey,
     loaded,
@@ -1578,6 +1597,13 @@ function PullRequestsRouteView() {
           title="Pull requests unavailable"
           error="Update your T3 Code servers to browse pull requests."
         />
+      ) : projectsKnown && projects.length > 0 && listedProjects.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 px-4 py-16 text-center">
+          <p className="text-sm font-medium">All projects are excluded</p>
+          <p className="text-xs text-muted-foreground">
+            Include a project from Filters to see its pull requests.
+          </p>
+        </div>
       ) : firstLoad ? (
         <PullRequestListGhost rows={7} />
       ) : listQuery.error && entries.length === 0 ? (
@@ -1591,6 +1617,7 @@ function PullRequestsRouteView() {
           onRefresh={() => void refreshFromHost()}
           query={typedQuery}
           filtered={
+            excludedProjects.length > 0 ||
             menuFiltered ||
             search.state !== "open" ||
             search.involvement !== "all" ||
@@ -1747,6 +1774,22 @@ function PullRequestsRouteView() {
       // Narrowing to one server drops a project scope belonging to another, which would
       // otherwise narrow the list to nothing with no visible filter to explain it.
       onServer={(server) => updateListScope({ environmentId: server, projectId: undefined })}
+      exclusionProjects={projects}
+      excludedProjects={excludedProjects}
+      onExcludeProject={(project, excluded) => {
+        const key = pullRequestProjectKey(project);
+        const next = excluded
+          ? [...new Set([...excludedProjects, key])]
+          : excludedProjects.filter((entry) => entry !== key);
+        setExcludedProjects(next);
+        if (!writeExcludedPullRequestProjects(next)) {
+          toastManager.add({
+            type: "error",
+            title: "Project exclusions could not be saved",
+            description: "This change will last until you reload the page.",
+          });
+        }
+      }}
       projects={scopedProjects}
       projectId={scopedProjectId}
       projectEnvironmentId={scopedProject?.environmentId}

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -97,6 +97,7 @@ export const PullRequestAction = Schema.Literals([
   "revert",
   /** Allow Actions workflows from a fork pull request to begin running. */
   "approve-workflows",
+  "delete-source-branch",
 ]);
 export type PullRequestAction = typeof PullRequestAction.Type;
 
@@ -377,6 +378,7 @@ export type PullRequestReviewerCapabilities = typeof PullRequestReviewerCapabili
  * buttons.
  */
 export const PullRequestCapabilities = Schema.Struct({
+  deleteSourceBranch: Schema.optional(Schema.Boolean),
   /** A unified patch can be fetched for the change request. */
   diff: Schema.Boolean,
   /** A comment can be posted, and the conversation read back. */
@@ -426,12 +428,9 @@ export type PullRequestCapabilities = typeof PullRequestCapabilities.Type;
  * `capabilities`: that says what the host is able to do at all, and this says whether this viewer
  * is allowed to ask for it. A host that merges pull requests still will not let a stranger merge
  * one, so a control belongs on the page only where the two agree.
- *
- * A permission the host reports nothing about is granted rather than withheld. Hiding a control
- * from someone who may in fact use it leaves them no way through and no reason given, while
- * offering one they may not use ends in the host's own refusal — which at least says why.
  */
 export const PullRequestViewerPermissions = Schema.Struct({
+  deleteSourceBranch: Schema.optional(Schema.Boolean),
   /** Which of the actions this viewer may take; anything absent is theirs to look at only. */
   actions: Schema.Array(PullRequestAction),
   /** This viewer may write a remark: a comment, a reply, or a note against a line. */
@@ -692,6 +691,7 @@ export const PullRequestInvalidateInput = Schema.Struct({
 export type PullRequestInvalidateInput = typeof PullRequestInvalidateInput.Type;
 
 export const PullRequestDetail = Schema.Struct({
+  reviewDecision: Schema.optional(Schema.NullOr(PullRequestReviewDecision)),
   provider: SourceControlProviderKind,
   capabilities: PullRequestCapabilities,
   /** What this viewer may do, which `capabilities` says nothing about. Both narrow the page. */
@@ -750,6 +750,23 @@ export const PullRequestDetail = Schema.Struct({
 });
 export type PullRequestDetail = typeof PullRequestDetail.Type;
 
+export const PullRequestTimelineEvent = Schema.Struct({
+  id: TrimmedNonEmptyString,
+  kind: TrimmedNonEmptyString,
+  actor: Schema.NullOr(PullRequestActor),
+  createdAt: IsoDateTime,
+  url: Schema.NullOr(Schema.String),
+  body: Schema.String,
+  relatedPullRequest: Schema.optional(
+    Schema.Struct({
+      title: Schema.String,
+      url: Schema.String,
+      state: PullRequestState,
+    }),
+  ),
+});
+export type PullRequestTimelineEvent = typeof PullRequestTimelineEvent.Type;
+
 /**
  * The slower, conversation-shaped half of a change request. It is read independently from the
  * core detail so a host with a deeply paginated review history cannot hold the title, body,
@@ -757,6 +774,7 @@ export type PullRequestDetail = typeof PullRequestDetail.Type;
  * conversation query carries avatars and completed reviewers that its basic detail does not.
  */
 export const PullRequestActivity = Schema.Struct({
+  timelineEvents: Schema.optional(Schema.Array(PullRequestTimelineEvent)),
   author: Schema.optional(Schema.NullOr(PullRequestActor)),
   reviewers: Schema.optional(Schema.Array(PullRequestActor)),
   comments: Schema.Array(PullRequestComment),

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -775,6 +775,7 @@ export type PullRequestTimelineEvent = typeof PullRequestTimelineEvent.Type;
  */
 export const PullRequestActivity = Schema.Struct({
   timelineEvents: Schema.optional(Schema.Array(PullRequestTimelineEvent)),
+  timelineTruncated: Schema.optional(Schema.Boolean),
   author: Schema.optional(Schema.NullOr(PullRequestActor)),
   reviewers: Schema.optional(Schema.Array(PullRequestActor)),
   comments: Schema.Array(PullRequestComment),


### PR DESCRIPTION
## What Changed

The PR page lacks parts of the conversation and host history, and preparing an agent task often requires leaving the page. This change keeps those steps in the existing PR page and shared right panel.

- Show review conversations with their replies in Summary and Timeline. Reuse the Code tab's reply, edit, resolve, and load-more controls. Add quote replies for top-level comments, copy-link actions, and unresolved-only navigation.
- Show native host events with the actor and time, including close/reopen history. Show related PRs from host cross-references and explicit PR links. Avoid duplicate synthetic merge/close rows.
- Offer source-branch deletion after close or merge. The confirmation names the exact source repository and branch. Each host rechecks the PR, source repository, and default/target branches before deletion, including forks. Deletion requires known access to the source repository or branch on all four hosts; unknown access keeps the action unavailable.
- Add PR notes, comments, and selected code to an agent composer. Choose a new or existing thread for notes, or choose a server, project, and local checkout/worktree for a fix. Right-panel fixes can still use the current thread. Nothing is sent to an agent automatically.
- Save project exclusions per environment and project, with an include-again control. Excluded projects are removed from list reads and cached rows; direct PR links still work.
- Keep drafts through refresh and failed writes, show useful failure details and recovery hints, and summarize reported merge blockers.

## Why

The implementation uses the existing UI controls, conversation card, composer handoff, and source-control adapters. Optional activity and permission fields keep older clients compatible. The new deletion action is not advertised through legacy action arrays, and missing deletion permissions or source identity keep the action unavailable.

## Verification

- 606 server PR tests and 354 web PR tests passed.
- 26 contract/client-runtime PR tests passed.
- Web and server typechecks, scoped lint, formatting, and whitespace checks passed.
- Real browser checks covered reply drafts across refresh, note-to-composer handoff, native close/reopen actors, exclusion persistence and restore, unresolved-only navigation, checkout choices, and exact-source deletion confirmation. No external comment, merge, or branch deletion was performed.
- Independent code review and a simplicity review passed.

## UI Changes

The integrated browser pass used public PR data in an isolated local environment. Before/after screenshots and a 25-second note/checkout demo were recorded. GitHub's official attachment preview refused uploads because the contributing account does not have write access to this repository; the media is retained locally.

## Scope and limits

GitHub, GitLab, Azure DevOps, and Bitbucket have focused adapter tests. The integrated browser pass uses GitHub; live writes against the other hosts were not performed. Events and actions follow the data and capabilities each host exposes. Related-PR links do not guess whether a bare issue number is a PR. Review-decision blockers appear only when the host reports them. GitHub timeline reads stop after 1,000 host records and show a link to the full host history when capped.

GitHub and Azure branch deletion use an expected commit ID to reject a branch that moves before deletion. GitLab and Bitbucket expose no conditional-delete option in their branch APIs, so a branch can move between validation and deletion. PR state and default-branch checks are separate host reads on all four providers.

Web and desktop share this PR interface. Mobile has no corresponding PR page in this branch; the shared wire changes remain optional.

## Checklist

- [x] Explained the behavior and its limits
- [x] Added focused regression coverage
- [ ] Upload before/after images and the interaction video (blocked by repository upload permissions)
- [x] Completed an independent code and simplicity review

Built with GPT-6 Astra and GPT-5.6 Sol in the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add source-branch deletion, native timeline events, and review/agent workflow improvements to pull requests
> - Adds `delete-source-branch` as a new pull-request action across GitHub, GitLab, Bitbucket, and Azure DevOps, with per-provider source repository permission checks, safety guards against deleting protected/default branches, and a structured `PullRequestBranchDeletionError` error type
> - Introduces native timeline event decoding and `timelineTruncated` flag for all four providers; system notes and activity events are now surfaced as `PullRequestTimelineEvent` records instead of being dropped or misclassified as comments
> - Reworks the web UI: PR detail shows attention items (conflicts, required reviews, failed checks), related pull requests, and review conversations with unresolved-only filtering and next-unresolved navigation; comment bodies expose reply, copy-link, and agent-handoff actions via `PullRequestCommentActions`
> - Adds project exclusion filtering to the PR list route with separate persistence, filter menu toggles, and an all-projects-excluded empty state
> - Adds agent ask/handoff flows to `PullRequestDetailPanel` with selectable server, project, destination, and thread; wraps tab content in `PullRequestCommentAgentContext` so comment actions can invoke the handoff flow
> - Risk: `decodeThreadsJson` (Azure) and `decodeNotesJson` (GitLab) changed their return shape from a comment array to an object `{ comments, timelineEvents }`; all in-tree callers are updated, but out-of-tree consumers of these decoders will break. `PullRequestTimelineEvent.kind` changed from a fixed union to `string` to accommodate native host event kinds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dcfa00b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
