### PR TITLE
fix(ios): scroll short source files from blank space

### DIFF
--- a/apps/mobile/modules/t3-review-diff/ios/T3ReviewDiffView.swift
+++ b/apps/mobile/modules/t3-review-diff/ios/T3ReviewDiffView.swift
@@ -1348,7 +1348,14 @@ private final class ReviewDiffContentView: UIView, UIGestureRecognizerDelegate {
     }
 
     guard let row = row(at: point) else {
-      return nil
+      guard verticalOffset + point.y >= contentHeight,
+            fileHeaderRowIndices.isEmpty,
+            contentWidthsByFileId.count == 1,
+            let fileId = contentWidthsByFileId.keys.first,
+            !collapsedFileIds.contains(fileId) else {
+        return nil
+      }
+      return (fileId, .code)
     }
 
     let fileId = resolvedFileId(for: row)


### PR DESCRIPTION
Horizontal dragging below the last line of a short iOS source file does nothing, even when its lines overflow. Starting the same gesture over a code row works.

Let that trailing blank area target the existing single, expanded, headerless file. Reuse the current pan, overflow and back-navigation guards. The full review screen keeps its existing hit testing because its file headers exclude this fallback. Headerless single-file snippets in inline review-comment cards also gain blank-area scrolling. No new state or row scan.

Related [#5157](https://github.com/pingdotgg/t3code/issues/5157). This reproduces the narrower blank-area failure, not the author's unspecified touch path on iOS 27.

## Verification

- Built baseline [62ed748a](https://github.com/pingdotgg/t3code/commit/62ed748ac94a73dca1b3eb99b1da52d71ebed247) and candidate [2d39d4fd](https://github.com/pingdotgg/t3code/commit/2d39d4fdf885aa8bc366a2de992e603c1e9e7944) independently for the same iPhone 17 Pro Max simulator, iOS 26.5. The mobile source is unchanged on latest main [cb9a6942](https://github.com/pingdotgg/t3code/commit/cb9a6942363ed7f097c7d1fb075bf3a265fbf5d2).
- Same synthetic C# file, unwrapped rows, 440×956 viewport. Two leftward drags from `(360,650)` to `(80,650)` do nothing before and reach all three right-hand line endings after. Reverse drags restore the left edge. Row-origin scrolling works in both builds.
- A nonoverflowing source stays stationary on a leftward blank-area drag. A rightward drag returns to Files. Reopening the overflowing file starts at its left edge.
- Focused SwiftLint with the existing mobile configuration passes. No JavaScript test was added to mirror a native gesture implementation.
- Native syntax highlighting fell back to JavaScript in both builds; the native source canvas was separately confirmed through accessibility. Existing test-state storage warnings were dismissed without deleting records. Android, the reporter's iOS 27 device, inline review-comment cards, long-file vertical scrolling, and a full multi-file review gesture matrix were not native-tested. All three callers, full-review header exclusion, and vertical gesture guards were source-reviewed.

## Before and after

After the same two blank-area drags:

| Before | After |
| --- | --- |
| ![Before: long C# lines remain at the left edge after dragging below the file](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/42f23e29f67dd68d/5157-signed-before-blank-ignored.png) | ![After: dragging below the file reveals all three right-hand line endings](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/e2031f0665383c0d/5157-signed-after-final-blank-right.png) |

[Before recording: blank-area drags ignored, followed by a working row drag](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/0c2bdc9a0e869bfc/5157-signed-before-blank-pan.mp4)

[After recording: blank-area drags scroll right and back left](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/17c60027323d9fb2/5157-signed-after-matched-blank-pan.mp4)

Hold for native-release timing. This native change should be coordinated with the next store build under the repository's fingerprint workflow. Do not automatically close the original report on this narrower reproduction.

Prepared by GPT 6 Astra via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `horizontalPanTarget` to scroll short source files from blank space on iOS
> Adds a fallback in [T3ReviewDiffView.swift](https://github.com/pingdotgg/t3code/pull/10178/files#diff-03d8ff8aefff42415f719caaef2a97eb49caf930754ebbd65de845001ba36de5) for pan points that do not map to a row. When the point is at or below the content end, no file-header rows exist, exactly one file has measured content width, and that file is expanded, the method now returns a code-scrolling target so horizontal pans in the bottom blank area scroll the file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d39d4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->