### PR TITLE
fix(web): only confirm closing active terminals

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -269,7 +269,7 @@ import { appendReviewCommentsToPrompt, type ReviewCommentContext } from "../revi
 import { environmentCatalog } from "../connection/catalog";
 import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
 import {
-  selectTerminalIdsRequiringCloseConfirmation,
+  selectIdleTerminalIds,
   useKnownTerminalSessions,
   useThreadRunningTerminalIds,
 } from "../state/terminalSessions";
@@ -851,13 +851,9 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
       knownTerminalSessions.filter((session) => !panelTerminalIds.has(session.target.terminalId)),
     [knownTerminalSessions, panelTerminalIds],
   );
-  const runningTerminalIds = useMemo(
-    () =>
-      selectTerminalIdsRequiringCloseConfirmation(
-        terminalUiState.terminalIds,
-        drawerTerminalSessions,
-      ),
-    [drawerTerminalSessions, terminalUiState.terminalIds],
+  const idleTerminalIds = useMemo(
+    () => selectIdleTerminalIds(drawerTerminalSessions),
+    [drawerTerminalSessions],
   );
   const terminalLabelsById = useMemo(() => {
     const next = new Map<string, string>();
@@ -1159,7 +1155,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
           newShortcutLabel={visible ? newShortcutLabel : undefined}
           closeShortcutLabel={visible ? closeShortcutLabel : undefined}
           keybindings={keybindings}
-          runningTerminalIds={runningTerminalIds}
+          idleTerminalIds={idleTerminalIds}
           onActiveTerminalChange={activateTerminal}
           onCloseTerminal={closeTerminal}
           onHeightChange={setTerminalHeight}
@@ -1221,9 +1217,9 @@ const PersistentThreadTerminalPanel = memo(function PersistentThreadTerminalPane
     environmentId: threadRef.environmentId,
     threadId: threadRef.threadId,
   });
-  const runningTerminalIds = useMemo(
-    () => selectTerminalIdsRequiringCloseConfirmation(surface.terminalIds, knownTerminalSessions),
-    [knownTerminalSessions, surface.terminalIds],
+  const idleTerminalIds = useMemo(
+    () => selectIdleTerminalIds(knownTerminalSessions),
+    [knownTerminalSessions],
   );
   const threadWorktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
   const activeSummary =
@@ -1337,7 +1333,7 @@ const PersistentThreadTerminalPanel = memo(function PersistentThreadTerminalPane
       splitVerticalShortcutLabel={splitVerticalShortcutLabel}
       newShortcutLabel={newShortcutLabel}
       closeShortcutLabel={closeShortcutLabel}
-      runningTerminalIds={runningTerminalIds}
+      idleTerminalIds={idleTerminalIds}
       onActiveTerminalChange={onActiveTerminalChange}
       onCloseTerminal={onCloseTerminal}
       onHeightChange={() => undefined}
@@ -1817,6 +1813,10 @@ export default function ChatView(props: ChatViewProps) {
   }, [activeThreadId, activeThreadKnownSessionsRaw]);
   const activeServerOrderedTerminalIds = useMemo(
     () => activeThreadKnownSessions.map((session) => session.target.terminalId),
+    [activeThreadKnownSessions],
+  );
+  const idleTerminalIds = useMemo(
+    () => selectIdleTerminalIds(activeThreadKnownSessions),
     [activeThreadKnownSessions],
   );
   const activeKnownTerminalIds = useMemo(
@@ -4163,24 +4163,24 @@ export default function ChatView(props: ChatViewProps) {
   const requestCloseTerminal = useCallback(
     (terminalId: string) => {
       const label = activeTerminalLabelsById.get(terminalId) ?? getTerminalLabel(terminalId);
-      void confirmTerminalClose(runningTerminalIds.includes(terminalId) ? [label] : []).then(
+      void confirmTerminalClose(idleTerminalIds.includes(terminalId) ? [] : [label]).then(
         (confirmed) => {
           if (confirmed) closeTerminal(terminalId);
         },
       );
     },
-    [activeTerminalLabelsById, closeTerminal, runningTerminalIds],
+    [activeTerminalLabelsById, closeTerminal, idleTerminalIds],
   );
   const requestClosePanelTerminal = useCallback(
     (terminalId: string) => {
       const label = activeTerminalLabelsById.get(terminalId) ?? getTerminalLabel(terminalId);
-      void confirmTerminalClose(runningTerminalIds.includes(terminalId) ? [label] : []).then(
+      void confirmTerminalClose(idleTerminalIds.includes(terminalId) ? [] : [label]).then(
         (confirmed) => {
           if (confirmed) closePanelTerminal(terminalId);
         },
       );
     },
-    [activeTerminalLabelsById, closePanelTerminal, runningTerminalIds],
+    [activeTerminalLabelsById, closePanelTerminal, idleTerminalIds],
   );
   const activateRightPanelSurface = useCallback(
     (surface: RightPanelSurface) => {
@@ -4299,7 +4299,7 @@ export default function ChatView(props: ChatViewProps) {
         return;
       }
       const labels = surface.terminalIds
-        .filter((terminalId) => runningTerminalIds.includes(terminalId))
+        .filter((terminalId) => !idleTerminalIds.includes(terminalId))
         .map(
           (terminalId) => activeTerminalLabelsById.get(terminalId) ?? getTerminalLabel(terminalId),
         );
@@ -4312,7 +4312,7 @@ export default function ChatView(props: ChatViewProps) {
       activeTerminalLabelsById,
       closeAfterAgentBrowserConfirmation,
       finishRightPanelSurfaceClose,
-      runningTerminalIds,
+      idleTerminalIds,
     ],
   );
   const closeOtherRightPanelSurfaces = useCallback(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -847,6 +847,13 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
       knownTerminalSessions.filter((session) => !panelTerminalIds.has(session.target.terminalId)),
     [knownTerminalSessions, panelTerminalIds],
   );
+  const runningTerminalIds = useMemo(
+    () =>
+      drawerTerminalSessions
+        .filter((session) => session.state.hasRunningSubprocess)
+        .map((session) => session.target.terminalId),
+    [drawerTerminalSessions],
+  );
   const terminalLabelsById = useMemo(() => {
     const next = new Map<string, string>();
     for (const session of drawerTerminalSessions) {
@@ -1147,6 +1154,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
           newShortcutLabel={visible ? newShortcutLabel : undefined}
           closeShortcutLabel={visible ? closeShortcutLabel : undefined}
           keybindings={keybindings}
+          runningTerminalIds={runningTerminalIds}
           onActiveTerminalChange={activateTerminal}
           onCloseTerminal={closeTerminal}
           onHeightChange={setTerminalHeight}
@@ -1208,6 +1216,13 @@ const PersistentThreadTerminalPanel = memo(function PersistentThreadTerminalPane
     environmentId: threadRef.environmentId,
     threadId: threadRef.threadId,
   });
+  const runningTerminalIds = useMemo(
+    () =>
+      knownTerminalSessions
+        .filter((session) => session.state.hasRunningSubprocess)
+        .map((session) => session.target.terminalId),
+    [knownTerminalSessions],
+  );
   const threadWorktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
   const activeSummary =
     knownTerminalSessions.find((session) => session.target.terminalId === surface.activeTerminalId)
@@ -1320,6 +1335,7 @@ const PersistentThreadTerminalPanel = memo(function PersistentThreadTerminalPane
       splitVerticalShortcutLabel={splitVerticalShortcutLabel}
       newShortcutLabel={newShortcutLabel}
       closeShortcutLabel={closeShortcutLabel}
+      runningTerminalIds={runningTerminalIds}
       onActiveTerminalChange={onActiveTerminalChange}
       onCloseTerminal={onCloseTerminal}
       onHeightChange={() => undefined}
@@ -4145,20 +4161,24 @@ export default function ChatView(props: ChatViewProps) {
   const requestCloseTerminal = useCallback(
     (terminalId: string) => {
       const label = activeTerminalLabelsById.get(terminalId) ?? getTerminalLabel(terminalId);
-      void confirmTerminalClose([label]).then((confirmed) => {
-        if (confirmed) closeTerminal(terminalId);
-      });
+      void confirmTerminalClose(runningTerminalIds.includes(terminalId) ? [label] : []).then(
+        (confirmed) => {
+          if (confirmed) closeTerminal(terminalId);
+        },
+      );
     },
-    [activeTerminalLabelsById, closeTerminal],
+    [activeTerminalLabelsById, closeTerminal, runningTerminalIds],
   );
   const requestClosePanelTerminal = useCallback(
     (terminalId: string) => {
       const label = activeTerminalLabelsById.get(terminalId) ?? getTerminalLabel(terminalId);
-      void confirmTerminalClose([label]).then((confirmed) => {
-        if (confirmed) closePanelTerminal(terminalId);
-      });
+      void confirmTerminalClose(runningTerminalIds.includes(terminalId) ? [label] : []).then(
+        (confirmed) => {
+          if (confirmed) closePanelTerminal(terminalId);
+        },
+      );
     },
-    [activeTerminalLabelsById, closePanelTerminal],
+    [activeTerminalLabelsById, closePanelTerminal, runningTerminalIds],
   );
   const activateRightPanelSurface = useCallback(
     (surface: RightPanelSurface) => {
@@ -4276,15 +4296,12 @@ export default function ChatView(props: ChatViewProps) {
         finishClose();
         return;
       }
-      const activeLabel =
-        activeTerminalLabelsById.get(surface.activeTerminalId) ??
-        getTerminalLabel(surface.activeTerminalId);
-      const otherLabels = surface.terminalIds
-        .filter((terminalId) => terminalId !== surface.activeTerminalId)
+      const labels = surface.terminalIds
+        .filter((terminalId) => runningTerminalIds.includes(terminalId))
         .map(
           (terminalId) => activeTerminalLabelsById.get(terminalId) ?? getTerminalLabel(terminalId),
         );
-      void confirmTerminalClose([activeLabel, ...otherLabels]).then((confirmed) => {
+      void confirmTerminalClose(labels).then((confirmed) => {
         if (confirmed) finishClose();
       });
     },
@@ -4293,6 +4310,7 @@ export default function ChatView(props: ChatViewProps) {
       activeTerminalLabelsById,
       closeAfterAgentBrowserConfirmation,
       finishRightPanelSurfaceClose,
+      runningTerminalIds,
     ],
   );
   const closeOtherRightPanelSurfaces = useCallback(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -268,7 +268,11 @@ import { appendPreviewAnnotationPrompt } from "../lib/previewAnnotation";
 import { appendReviewCommentsToPrompt, type ReviewCommentContext } from "../reviewCommentContext";
 import { environmentCatalog } from "../connection/catalog";
 import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
-import { useKnownTerminalSessions, useThreadRunningTerminalIds } from "../state/terminalSessions";
+import {
+  selectTerminalIdsRequiringCloseConfirmation,
+  useKnownTerminalSessions,
+  useThreadRunningTerminalIds,
+} from "../state/terminalSessions";
 import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
 import {
@@ -849,10 +853,11 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   );
   const runningTerminalIds = useMemo(
     () =>
-      drawerTerminalSessions
-        .filter((session) => session.state.hasRunningSubprocess)
-        .map((session) => session.target.terminalId),
-    [drawerTerminalSessions],
+      selectTerminalIdsRequiringCloseConfirmation(
+        terminalUiState.terminalIds,
+        drawerTerminalSessions,
+      ),
+    [drawerTerminalSessions, terminalUiState.terminalIds],
   );
   const terminalLabelsById = useMemo(() => {
     const next = new Map<string, string>();
@@ -1217,11 +1222,8 @@ const PersistentThreadTerminalPanel = memo(function PersistentThreadTerminalPane
     threadId: threadRef.threadId,
   });
   const runningTerminalIds = useMemo(
-    () =>
-      knownTerminalSessions
-        .filter((session) => session.state.hasRunningSubprocess)
-        .map((session) => session.target.terminalId),
-    [knownTerminalSessions],
+    () => selectTerminalIdsRequiringCloseConfirmation(surface.terminalIds, knownTerminalSessions),
+    [knownTerminalSessions, surface.terminalIds],
   );
   const threadWorktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
   const activeSummary =

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1012,7 +1012,7 @@ interface ThreadTerminalDrawerProps {
   onHeightChange: (height: number) => void;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
   keybindings: ResolvedKeybindingsConfig;
-  runningTerminalIds: ReadonlyArray<string>;
+  idleTerminalIds: ReadonlyArray<string>;
   /** Prefer server-provided tab titles when present (e.g. active subprocess name). */
   terminalLabelsById?: ReadonlyMap<string, string>;
   /** Prefer per-session launch locations when the server already knows a terminal. */
@@ -1074,7 +1074,7 @@ export default function ThreadTerminalDrawer({
   onHeightChange,
   onAddTerminalContext,
   keybindings,
-  runningTerminalIds,
+  idleTerminalIds,
   terminalLabelsById,
   terminalLaunchLocationsById,
 }: ThreadTerminalDrawerProps) {
@@ -1282,13 +1282,13 @@ export default function ThreadTerminalDrawer({
   const confirmCloseTerminal = useCallback(
     (terminalId: string) => {
       const label = terminalLabelById.get(terminalId) ?? getTerminalLabel(terminalId);
-      void confirmTerminalClose(runningTerminalIds.includes(terminalId) ? [label] : []).then(
+      void confirmTerminalClose(idleTerminalIds.includes(terminalId) ? [] : [label]).then(
         (confirmed) => {
           if (confirmed) onCloseTerminal(terminalId);
         },
       );
     },
-    [onCloseTerminal, runningTerminalIds, terminalLabelById],
+    [onCloseTerminal, idleTerminalIds, terminalLabelById],
   );
 
   useEffect(() => {

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1012,6 +1012,7 @@ interface ThreadTerminalDrawerProps {
   onHeightChange: (height: number) => void;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
   keybindings: ResolvedKeybindingsConfig;
+  runningTerminalIds: ReadonlyArray<string>;
   /** Prefer server-provided tab titles when present (e.g. active subprocess name). */
   terminalLabelsById?: ReadonlyMap<string, string>;
   /** Prefer per-session launch locations when the server already knows a terminal. */
@@ -1073,6 +1074,7 @@ export default function ThreadTerminalDrawer({
   onHeightChange,
   onAddTerminalContext,
   keybindings,
+  runningTerminalIds,
   terminalLabelsById,
   terminalLaunchLocationsById,
 }: ThreadTerminalDrawerProps) {
@@ -1280,11 +1282,13 @@ export default function ThreadTerminalDrawer({
   const confirmCloseTerminal = useCallback(
     (terminalId: string) => {
       const label = terminalLabelById.get(terminalId) ?? getTerminalLabel(terminalId);
-      void confirmTerminalClose([label]).then((confirmed) => {
-        if (confirmed) onCloseTerminal(terminalId);
-      });
+      void confirmTerminalClose(runningTerminalIds.includes(terminalId) ? [label] : []).then(
+        (confirmed) => {
+          if (confirmed) onCloseTerminal(terminalId);
+        },
+      );
     },
-    [onCloseTerminal, terminalLabelById],
+    [onCloseTerminal, runningTerminalIds, terminalLabelById],
   );
 
   useEffect(() => {

--- a/apps/web/src/lib/terminalCloseConfirm.test.ts
+++ b/apps/web/src/lib/terminalCloseConfirm.test.ts
@@ -39,6 +39,11 @@ describe("terminal close confirmation", () => {
     expect(isTerminalCloseConfirmPending()).toBe(false);
   });
 
+  it("closes without prompting when no process is running", async () => {
+    await expect(confirmTerminalClose([])).resolves.toBe(true);
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+
   it("clears pending state and resolves false when the dialog rejects", async () => {
     let reject: (reason?: unknown) => void = () => undefined;
     confirmMock.mockImplementation(

--- a/apps/web/src/lib/terminalCloseConfirm.ts
+++ b/apps/web/src/lib/terminalCloseConfirm.ts
@@ -8,14 +8,11 @@ export function isTerminalCloseConfirmPending(): boolean {
 }
 
 /**
- * Confirmation for individual terminal close actions: drawer buttons, panel
- * buttons, the `terminal.close` keybinding, and closing a terminal surface from
- * the tab strip. Auto-exit cleanup and bulk tab closes skip this path and close
- * directly.
+ * Confirmation for terminal close actions. Labels name only terminals with a
+ * running subprocess; idle terminals close directly.
  */
-export async function confirmTerminalClose(
-  labels: readonly [string, ...string[]],
-): Promise<boolean> {
+export async function confirmTerminalClose(labels: readonly string[]): Promise<boolean> {
+  if (labels.length === 0) return true;
   const localApi = readLocalApi();
   if (!localApi) return true;
   pendingConfirmations += 1;

--- a/apps/web/src/lib/terminalCloseConfirm.ts
+++ b/apps/web/src/lib/terminalCloseConfirm.ts
@@ -8,8 +8,8 @@ export function isTerminalCloseConfirmPending(): boolean {
 }
 
 /**
- * Confirmation for terminal close actions. Labels name only terminals with a
- * running subprocess; idle terminals close directly.
+ * Confirmation for terminal close actions. Labels exclude confirmed-idle
+ * terminals; running terminals and those awaiting metadata require confirmation.
  */
 export async function confirmTerminalClose(labels: readonly string[]): Promise<boolean> {
   if (labels.length === 0) return true;

--- a/apps/web/src/state/terminalSessions.test.ts
+++ b/apps/web/src/state/terminalSessions.test.ts
@@ -2,10 +2,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import { EnvironmentId, ThreadId, type TerminalSummary } from "@t3tools/contracts";
 import { selectRunningSubprocessTerminalIds } from "@t3tools/client-runtime/state/terminal";
 
-import {
-  selectKnownTerminalSessions,
-  selectTerminalIdsRequiringCloseConfirmation,
-} from "./terminalSessions";
+import { selectKnownTerminalSessions, selectIdleTerminalIds } from "./terminalSessions";
 
 vi.mock("./terminal", () => ({ terminalEnvironment: {} }));
 
@@ -173,16 +170,20 @@ describe("selectKnownTerminalSessions", () => {
   });
 });
 
-describe("selectTerminalIdsRequiringCloseConfirmation", () => {
-  it("keeps client-side terminals pending until metadata confirms they are idle", () => {
-    const sessions = selectKnownTerminalSessions(
-      [summary(threadA, "terminal-1", { hasRunningSubprocess: false })],
-      environmentA,
-      threadA,
-    );
+describe("selectIdleTerminalIds", () => {
+  it("only permits skipping confirmation while metadata explicitly reports idle", () => {
+    const idle = summary(threadA, "terminal-idle", { hasRunningSubprocess: false });
+    const running = summary(threadA, "terminal-new");
+    const select = (metadata: TerminalSummary[]) =>
+      selectIdleTerminalIds(selectKnownTerminalSessions(metadata, environmentA, threadA));
 
-    expect(
-      selectTerminalIdsRequiringCloseConfirmation(["terminal-1", "terminal-new"], sessions),
-    ).toEqual(["terminal-new"]);
+    expect(select([])).toEqual([]);
+    expect(select([idle])).toEqual(["terminal-idle"]);
+    expect(select([idle, running])).toEqual(["terminal-idle"]);
+    expect(select([idle, { ...running, hasRunningSubprocess: false }])).toEqual([
+      "terminal-idle",
+      "terminal-new",
+    ]);
+    expect(select([idle, running])).toEqual(["terminal-idle"]);
   });
 });

--- a/apps/web/src/state/terminalSessions.test.ts
+++ b/apps/web/src/state/terminalSessions.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import { EnvironmentId, ThreadId, type TerminalSummary } from "@t3tools/contracts";
 import { selectRunningSubprocessTerminalIds } from "@t3tools/client-runtime/state/terminal";
 
-import { selectKnownTerminalSessions } from "./terminalSessions";
+import {
+  selectKnownTerminalSessions,
+  selectTerminalIdsRequiringCloseConfirmation,
+} from "./terminalSessions";
 
 vi.mock("./terminal", () => ({ terminalEnvironment: {} }));
 
@@ -167,5 +170,19 @@ describe("selectKnownTerminalSessions", () => {
     }
     expect(selectKnownTerminalSessions(metadata, environmentA, null)).toHaveLength(source.length);
     expect(reads).toBe(source.length);
+  });
+});
+
+describe("selectTerminalIdsRequiringCloseConfirmation", () => {
+  it("keeps client-side terminals pending until metadata confirms they are idle", () => {
+    const sessions = selectKnownTerminalSessions(
+      [summary(threadA, "terminal-1", { hasRunningSubprocess: false })],
+      environmentA,
+      threadA,
+    );
+
+    expect(
+      selectTerminalIdsRequiringCloseConfirmation(["terminal-1", "terminal-new"], sessions),
+    ).toEqual(["terminal-new"]);
   });
 });

--- a/apps/web/src/state/terminalSessions.ts
+++ b/apps/web/src/state/terminalSessions.ts
@@ -121,16 +121,13 @@ export function selectKnownTerminalSessions(
   return sessions;
 }
 
-export function selectTerminalIdsRequiringCloseConfirmation(
-  terminalIds: ReadonlyArray<string>,
+export function selectIdleTerminalIds(
   sessions: ReadonlyArray<KnownTerminalSession>,
 ): ReadonlyArray<string> {
-  // Client-created terminal IDs can lead metadata, so only an explicit idle state skips confirmation.
-  return terminalIds.filter(
-    (terminalId) =>
-      sessions.find((session) => session.target.terminalId === terminalId)?.state
-        .hasRunningSubprocess !== false,
-  );
+  // Only confirmed-idle IDs may skip confirmation; client-created IDs can lead metadata.
+  return sessions
+    .filter((session) => session.state.hasRunningSubprocess === false)
+    .map((session) => session.target.terminalId);
 }
 
 export function useAttachedTerminalSession(input: {

--- a/apps/web/src/state/terminalSessions.ts
+++ b/apps/web/src/state/terminalSessions.ts
@@ -121,6 +121,18 @@ export function selectKnownTerminalSessions(
   return sessions;
 }
 
+export function selectTerminalIdsRequiringCloseConfirmation(
+  terminalIds: ReadonlyArray<string>,
+  sessions: ReadonlyArray<KnownTerminalSession>,
+): ReadonlyArray<string> {
+  // Client-created terminal IDs can lead metadata, so only an explicit idle state skips confirmation.
+  return terminalIds.filter(
+    (terminalId) =>
+      sessions.find((session) => session.target.terminalId === terminalId)?.state
+        .hasRunningSubprocess !== false,
+  );
+}
+
 export function useAttachedTerminalSession(input: {
   readonly environmentId: EnvironmentId | null;
   readonly terminal: TerminalAttachInput | null;


### PR DESCRIPTION
Closing an idle terminal no longer shows a destructive confirmation. Drawer and panel buttons, terminal-close shortcuts, and terminal panel-tab close all skip the prompt only when server metadata explicitly reports no running subprocess. Terminals missing from metadata still require confirmation.

A shared confirmed-idle selector keeps that rule consistent without merging client terminal IDs. Closing a panel with several terminals names only the running or unknown terminals in the confirmation.

## Proof

- 36 focused tests passed, including terminal metadata transitions, confirmation behavior, and close shortcut handling.
- Web typecheck passed. Targeted lint completed with existing warnings.
- Browser evidence of idle and running terminal behavior:

Idle terminal closes without confirmation:

https://github.com/user-attachments/assets/9cece30e-9dca-401f-9ff1-9ac9dae472d5

Running terminal requires confirmation:

https://github.com/user-attachments/assets/165b142c-0bb3-4a7b-ada2-9b7618c207f9

Implemented by gpt-5.6-sol; reviewed and revised by GPT-6 in T3 Code through the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix(web): skip close confirmation for explicitly idle terminals
> - Adds `selectIdleTerminalIds` selector in [terminalSessions.ts](https://github.com/pingdotgg/t3code/pull/10180/files#diff-0b0201ce16a59f126842895a626e274e3d597250ed46ad9e26d72dbac2d6ab9a) that returns IDs only for sessions whose subprocess state is exactly `false`; sessions with missing or non-false metadata are excluded.
> - Updates `confirmTerminalClose` in [terminalCloseConfirm.ts](https://github.com/pingdotgg/t3code/pull/10180/files#diff-97d7b427d9f5cadc931ebe26d9d7a4345b73a07cb1b2633b35b5ad5d723e0b74) to resolve `true` without opening a dialog when the label list is empty.
> - `ChatView`, `ThreadTerminalDrawer`, and persistent thread panel/drawer components now derive idle IDs and pass empty labels for idle terminals, so only active or unknown-state terminals trigger confirmation.
> - Risk: terminals whose subprocess metadata is absent (not explicitly `false`) still require confirmation — any component relying on implicit idle detection will not skip the dialog.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93ec5dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
