### PR TITLE
fix(web): keep the compaction notice visible above monitoring

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5555,6 +5555,7 @@ export default function ChatView(props: ChatViewProps) {
     return {
       id: `resume-compaction:${resumeCompactionKey}`,
       variant: "info",
+      alwaysVisible: true,
       icon: <Minimize2Icon />,
       title: "Resume with less context",
       description: `${formatContextWindowTokens(activeContextWindow.usedTokens)} tokens from earlier`,

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -13,6 +13,7 @@ export interface ComposerBannerStackItem {
   readonly id: string;
   readonly variant: ComposerBannerVariant;
   readonly priority?: "urgent" | "activity" | "notice";
+  readonly alwaysVisible?: boolean;
   readonly icon: ReactNode;
   readonly title: ReactNode;
   readonly description?: ReactNode;
@@ -24,7 +25,7 @@ export interface ComposerBannerStackItem {
 
 export type ComposerBannerStackContent = Pick<
   ComposerBannerStackItem,
-  "id" | "variant" | "priority"
+  "id" | "variant" | "priority" | "alwaysVisible"
 > & { readonly content: ReactNode };
 
 type ComposerBannerStackEntry = ComposerBannerStackItem | ComposerBannerStackContent;
@@ -57,6 +58,13 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
     requestedExitingItemId !== null && items.some((item) => item.id === requestedExitingItemId)
       ? requestedExitingItemId
       : null;
+  // Activity stays attached. Persistent actions remain above it without changing notice priority.
+  const orderedItems = items.toSorted((a, b) => bannerPriority(a) - bannerPriority(b));
+  const frontItem = orderedItems[0];
+  const remainingItems = orderedItems.slice(1);
+  const visibleItems = remainingItems.filter((item) => item.alwaysVisible);
+  const stackedItems = remainingItems.filter((item) => !item.alwaysVisible);
+  const hasStack = stackedItems.length > 0;
 
   useEffect(() => {
     return () => {
@@ -67,8 +75,8 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
   }, []);
 
   useEffect(() => {
-    if (items.length < 2) setStackExpanded(false);
-  }, [items.length]);
+    if (!hasStack) setStackExpanded(false);
+  }, [hasStack]);
 
   useLayoutEffect(() => {
     if (stackExpanded && pendingFocusRef.current === "notice") {
@@ -83,18 +91,9 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
     }
   }, [stackExpanded]);
 
-  if (items.length === 0) {
-    return null;
-  }
-
-  // Activity stays attached. Urgency and severity only order the notices behind it.
-  const orderedItems = items.toSorted((a, b) => bannerPriority(a) - bannerPriority(b));
-  const frontItem = orderedItems[0];
   if (!frontItem) {
     return null;
   }
-  const stackedItems = orderedItems.slice(1);
-  const hasStack = stackedItems.length > 0;
   const showCollapsedStackCap = hasStack && exitingItemId !== frontItem.id;
   const firstStackedItem = stackedItems[0];
 
@@ -144,6 +143,28 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
             onDismissRequest={() => requestDismiss(frontItem)}
           />
         </div>
+        {visibleItems.length > 0 ? (
+          <div className="space-y-2 pb-2">
+            {visibleItems.map((item) => (
+              <div
+                key={item.id}
+                className={cn(
+                  "transition-[translate,opacity] duration-220 ease-in",
+                  exitingItemId === item.id
+                    ? "pointer-events-none translate-y-28 opacity-0"
+                    : "opacity-100",
+                )}
+              >
+                <ComposerBannerStackAlert
+                  item={item}
+                  attached={false}
+                  exiting={exitingItemId === item.id}
+                  onDismissRequest={() => requestDismiss(item)}
+                />
+              </div>
+            ))}
+          </div>
+        ) : null}
         {hasStack ? (
           <div
             ref={noticesRef}


### PR DESCRIPTION
Monitoring keeps its Stop action attached to the composer, but currently hides the resume-compaction notice behind a 12px hover target.

Keep that compaction notice visible above the attached activity row. Other notices retain the existing Peek behavior, and compaction availability and dismissal remain unchanged.

Closes #10164.

Verified in the actual web client with matching synthetic thread state, Chromium 152 and a 1280×900 viewport. Before, Compact is hidden in a zero-height drawer and hovering Monitoring does not reveal it. After, Compact and Stop remain visible without hovering. Keyboard navigation reaches Compact and Keep full history directly; dismissing the notice leaves Stop visible. An unsent draft still disables Compact, and clearing it restores availability. A 390px-wide layout wraps the actions without clipping.

107 focused existing tests passed; targeted lint, formatting and diff checks passed. These tests cover nearby logic, while the real-client pass verifies the placement. Local web typecheck reports the same unrelated fileEditorVirtualization.test.ts argument-count error on clean main and this candidate. No diagnostic suppression or unrelated fix was added.

The baseline is [cb9a6942](https://github.com/pingdotgg/t3code/commit/cb9a6942363ed7f097c7d1fb075bf3a265fbf5d2); the relevant composer and liveness code is unchanged on refreshed main [6349a0e6](https://github.com/pingdotgg/t3code/commit/6349a0e68a958cc51b7b5198683c1d1db88b8d28). The fixture uses an inert Claude capability probe, synthetic projection rows and one in-memory liveness entry through the production service. No provider turn, compaction or real monitor was run. Original Firefox behavior and native mobile were not verified. Web and desktop share this renderer; the mobile composer is unchanged.

The pre-existing keyboard-focus failure for other Peek notices is not fixed by this change. Those notices retain their existing behavior. This presentation choice is held for human review; no auto-merge.

Before, at rest:

![Before: Monitoring and Stop are visible, while the Compact notice is hidden](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/70c37ecffe12653f/10164-before-collapsed.png)

After, at rest:

![After: Compact remains visible above Monitoring, with Stop still attached](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d4dc656c0a8bbb96/10164-after-at-rest.png)

[Before recording: the small Peek reveals Compact](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/94d2a8d3e29a53d2/10164-before-hover.mp4)

[After recording: persistent Compact, keyboard access and dismissal](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/f30a1f1581ad100c/10164-after-interaction.mp4)

Prepared by GPT 6 Astra via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep compaction notice visible above monitoring in `ComposerBannerStack`
> - Adds an optional `alwaysVisible` property to `ComposerBannerStackItem` so specific banners can render as separate alerts outside the collapsible stack.
> - Marks the resume-compaction banner in `ChatView` with `alwaysVisible` so it stays visible instead of being collapsed behind the monitoring banner.
> - `ComposerBannerStack` now separates always-visible items from collapsible items before deriving stack state; only unmarked non-front banners participate in stack expansion and the stack cap.
> - Behavioral Change: non-front banners without `alwaysVisible` are still collapsed into the stack as before; the change only affects banners explicitly marked `alwaysVisible`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 87aa849.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
