### PR TITLE
test(web): cancel pending highlight fixture frames during cleanup

### DIFF
--- a/apps/web/src/components/files/fileEditorHighlight.test.ts
+++ b/apps/web/src/components/files/fileEditorHighlight.test.ts
@@ -64,6 +64,7 @@ let renderer: FileRenderer;
 let tokenizer: Tokenizer;
 let file: FileContents;
 let document: TextDocument<unknown>;
+const animationFrames = new Set<ReturnType<typeof setImmediate>>();
 
 function nextResponse(): Promise<HeldResponse> {
   const response = responses.shift();
@@ -147,10 +148,18 @@ beforeEach(async () => {
   responses = [];
   responseWaiters = [];
   terminationPromises = [];
-  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
-    setImmediate(() => callback(0)),
-  );
-  vi.stubGlobal("cancelAnimationFrame", clearImmediate);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    const frame = setImmediate(() => {
+      animationFrames.delete(frame);
+      callback(0);
+    });
+    animationFrames.add(frame);
+    return frame;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (frame: ReturnType<typeof setImmediate>) => {
+    animationFrames.delete(frame);
+    clearImmediate(frame);
+  });
   vi.stubGlobal("window", { matchMedia: () => ({ matches: true }) });
   pool = new WorkerPoolManager(
     // Adapt browser transport only; Pierre's real worker produces each response.
@@ -176,15 +185,41 @@ beforeEach(async () => {
   renderContents();
 });
 
-afterEach(async () => {
+async function cleanUpFixture() {
   tokenizer?.cleanUp();
   renderer?.cleanUp();
   pool?.terminate();
   await Promise.all(terminationPromises);
+  // Pool termination can queue a final broadcast after its workers have exited.
+  for (const frame of animationFrames) clearImmediate(frame);
+  animationFrames.clear();
   vi.unstubAllGlobals();
-});
+}
+
+afterEach(cleanUpFixture);
 
 describe("editable file highlighting", () => {
+  it("cleans up an already terminated worker pool", async () => {
+    (await nextResponse()).deliver();
+    expect(pool.getStats().totalWorkers).toBe(1);
+    pool.terminate();
+    await Promise.all(terminationPromises);
+    expect(pool.getStats().totalWorkers).toBe(0);
+
+    const animationFrame = globalThis.requestAnimationFrame;
+    const cancelFrame = globalThis.cancelAnimationFrame;
+    const window = globalThis.window;
+    try {
+      await cleanUpFixture();
+      // Deliver the real Immediate queue after cleanup has removed the browser globals.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    } finally {
+      vi.stubGlobal("requestAnimationFrame", animationFrame);
+      vi.stubGlobal("cancelAnimationFrame", cancelFrame);
+      vi.stubGlobal("window", window);
+    }
+  });
+
   it("still accepts an asynchronous highlight when the file has not changed", async () => {
     expect(renderContents()).not.toContain('style="color:');
     (await nextResponse()).deliver();


### PR DESCRIPTION
File-editor highlighting tests could finish successfully and still fail CI when a queued Pierre stats broadcast ran after their animation-frame globals had been removed. This appeared in [#10182](https://github.com/pingdotgg/t3code/pull/10182) and is independent of its compaction UI change.

Track the test fixture's scheduled frames and cancel any that remain after real workers terminate, before restoring globals. Keep the real worker transport and existing highlighting assertions. Add a controlled already-exited-worker case that invokes the same cleanup and then delivers Node's real Immediate queue.

Verification:

- The new lifecycle control produces the original uncaught `cancelAnimationFrame is not defined` error with unchanged cleanup, then passes with the fix.
- All 8 focused tests pass, including the 7 existing highlighting cases, with one test worker and no unhandled errors.
- Targeted lint, formatting, web typecheck and diff checks pass.
- Test-only change; screenshots are not applicable.

The controlled reproduction uses an already-exited real worker. It does not establish that the original CI failure followed that exact worker-exit ordering.

Prepared by GPT 6 Astra via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cancel pending `requestAnimationFrame` stubs during `fileEditorHighlight` fixture cleanup
> - Adds a module-scoped set to track immediate handles created by the `requestAnimationFrame` test stub, and updates the stub to register and remove handles on schedule and cancel
> - Extracts fixture teardown into an async `cleanUpFixture` helper that clears any remaining tracked animation-frame callbacks after worker termination resolves
> - Adds a test that terminates the worker pool and then runs fixture cleanup, verifying no queued callback references removed browser globals
> - Risk: tests relying on animation-frame callbacks surviving past `afterEach` will now have those callbacks cancelled
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c805254.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->