### PR TITLE
fix(web): remember usage page selection

### DIFF
--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -5,8 +5,9 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const testState = vi.hoisted(() => ({
   useUsage: vi.fn(),
-  metric: "cost" as "cost" | "tokens",
+  metric: "cost" as "cost" | "tokens" | "limits",
   breakdown: "time" as "model" | "time",
+  setPreferences: vi.fn(),
 }));
 
 vi.mock("react", async (importOriginal) => {
@@ -37,6 +38,9 @@ vi.mock("react", async (importOriginal) => {
 });
 
 vi.mock("../../env", () => ({ isElectron: false }));
+vi.mock("../../hooks/useLocalStorage", () => ({
+  useLocalStorage: () => [{ metric: testState.metric, windowDays: 30 }, testState.setPreferences],
+}));
 vi.mock("../../state/usage", () => ({ useUsage: testState.useUsage }));
 vi.mock("../ui/button", () => ({ Button: "button" }));
 vi.mock("../ui/scroll-area", () => ({ ScrollArea: "div" }));

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -7,7 +7,6 @@ const testState = vi.hoisted(() => ({
   useUsage: vi.fn(),
   metric: "cost" as "cost" | "tokens" | "limits",
   breakdown: "time" as "model" | "time",
-  setPreferences: vi.fn(),
 }));
 
 vi.mock("react", async (importOriginal) => {
@@ -15,32 +14,31 @@ vi.mock("react", async (importOriginal) => {
   return {
     ...actual,
     useState: vi.fn((initial: unknown) => [
-      typeof initial === "function"
-        ? {
-            days: 1,
-            window: {
-              sinceDay: "2026-08-10",
-              untilDay: "2026-08-11",
-              timeZone: "UTC",
-              resolution: "hour",
-              sinceTime: "2026-08-10T12:37:00.000Z",
-              untilTime: "2026-08-11T12:37:00.000Z",
-            },
-          }
-        : initial === "cost"
-          ? testState.metric
-          : initial === "model"
-            ? testState.breakdown
-            : initial,
+      initial === readUsagePagePreferences
+        ? { metric: testState.metric, windowDays: 30 }
+        : typeof initial === "function"
+          ? {
+              days: 1,
+              window: {
+                sinceDay: "2026-08-10",
+                untilDay: "2026-08-11",
+                timeZone: "UTC",
+                resolution: "hour",
+                sinceTime: "2026-08-10T12:37:00.000Z",
+                untilTime: "2026-08-11T12:37:00.000Z",
+              },
+            }
+          : initial === "cost"
+            ? testState.metric
+            : initial === "model"
+              ? testState.breakdown
+              : initial,
       vi.fn(),
     ]),
   };
 });
 
 vi.mock("../../env", () => ({ isElectron: false }));
-vi.mock("../../hooks/useLocalStorage", () => ({
-  useLocalStorage: () => [{ metric: testState.metric, windowDays: 30 }, testState.setPreferences],
-}));
 vi.mock("../../state/usage", () => ({ useUsage: testState.useUsage }));
 vi.mock("../ui/button", () => ({ Button: "button" }));
 vi.mock("../ui/scroll-area", () => ({ ScrollArea: "div" }));
@@ -74,6 +72,7 @@ vi.mock("./usageProviders", async (importOriginal) => {
 });
 
 import { UsagePage } from "./UsagePage";
+import { readUsagePagePreferences } from "./usagePagePreferences";
 
 const providerTotals = (codex: number, claude: number) =>
   new Map([

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -1,4 +1,5 @@
 import { useAtomValue } from "@effect/atom-react";
+import * as Schema from "effect/Schema";
 import {
   USAGE_CONTRACT_VERSION,
   type EnvironmentId,
@@ -20,6 +21,7 @@ import {
 } from "@t3tools/shared/usageMerge";
 
 import { isElectron } from "../../env";
+import { useLocalStorage } from "../../hooks/useLocalStorage";
 import { cn } from "../../lib/utils";
 import { environmentPresentations } from "../../state/presentation";
 import { serverEnvironment } from "../../state/server";
@@ -70,6 +72,20 @@ const METRIC_OPTIONS = [
   { value: "limits", label: "Limits" },
 ] as const satisfies readonly { value: UsageMetric; label: string }[];
 
+const USAGE_PAGE_PREFERENCES_STORAGE_KEY = "t3code:usage-page-preferences:v1";
+const UsageMetricSchema = Schema.Literals(["cost", "tokens", "limits"]);
+const UsageWindowDaysSchema = Schema.Literals([1, 7, 30, 90]);
+type UsageWindowDays = typeof UsageWindowDaysSchema.Type;
+const UsagePagePreferencesSchema = Schema.Struct({
+  metric: UsageMetricSchema,
+  windowDays: UsageWindowDaysSchema,
+});
+type UsagePagePreferences = typeof UsagePagePreferencesSchema.Type;
+const DEFAULT_USAGE_PAGE_PREFERENCES: UsagePagePreferences = {
+  metric: "cost",
+  windowDays: 30,
+};
+
 function isUsageMetric(value: string | null | undefined): value is UsageMetric {
   return METRIC_OPTIONS.some((option) => option.value === value);
 }
@@ -81,12 +97,25 @@ const WINDOW_OPTIONS = [
   { days: 90, label: "90 days" },
 ] as const;
 
+function isUsageWindowDays(value: number): value is UsageWindowDays {
+  return WINDOW_OPTIONS.some((option) => option.days === value);
+}
+
 export function UsagePage() {
+  const [preferences, setPreferences] = useLocalStorage(
+    USAGE_PAGE_PREFERENCES_STORAGE_KEY,
+    DEFAULT_USAGE_PAGE_PREFERENCES,
+    UsagePagePreferencesSchema,
+  );
   const [windowSelection, setWindowSelection] = useState(() => ({
-    days: 30,
-    window: makeWindow(30),
+    days: preferences.windowDays,
+    window: makeWindow(
+      preferences.windowDays,
+      undefined,
+      preferences.windowDays === 1 ? "hour" : "day",
+    ),
   }));
-  const [metric, setMetric] = useState<UsageMetric>("cost");
+  const metric = preferences.metric;
   const showingLimits = metric === "limits";
   const [breakdown, setBreakdown] = useState<"model" | "time">("model");
   const [selectedEnvironmentIds, setSelectedEnvironmentIds] =
@@ -132,10 +161,15 @@ export function UsagePage() {
   const timeValueColumnWidth = `${60 / (activeProviders.length + 2)}%`;
 
   const selectWindow = (days: number) => {
+    if (!isUsageWindowDays(days)) return;
+    setPreferences((current) => ({ ...current, windowDays: days }));
     setWindowSelection({
       days,
       window: makeWindow(days, undefined, days === 1 ? "hour" : "day"),
     });
+  };
+  const selectMetric = (nextMetric: UsageMetric) => {
+    setPreferences((current) => ({ ...current, metric: nextMetric }));
   };
   const refreshWindow = () => {
     if (showingLimits) {
@@ -195,7 +229,7 @@ export function UsagePage() {
           value={[metric]}
           onValueChange={(next) => {
             const value = next[0];
-            if (isUsageMetric(value)) setMetric(value);
+            if (isUsageMetric(value)) selectMetric(value);
           }}
         >
           {METRIC_OPTIONS.map((option) => (
@@ -235,7 +269,7 @@ export function UsagePage() {
         <Select
           value={metric}
           onValueChange={(value) => {
-            if (isUsageMetric(value)) setMetric(value);
+            if (isUsageMetric(value)) selectMetric(value);
           }}
         >
           <SelectTrigger

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -1,5 +1,4 @@
 import { useAtomValue } from "@effect/atom-react";
-import * as Schema from "effect/Schema";
 import {
   USAGE_CONTRACT_VERSION,
   type EnvironmentId,
@@ -21,7 +20,6 @@ import {
 } from "@t3tools/shared/usageMerge";
 
 import { isElectron } from "../../env";
-import { useLocalStorage } from "../../hooks/useLocalStorage";
 import { cn } from "../../lib/utils";
 import { environmentPresentations } from "../../state/presentation";
 import { serverEnvironment } from "../../state/server";
@@ -64,6 +62,11 @@ import { UsageLimitsSection } from "./UsageLimits";
 import { UsagePriceOverrides } from "./UsagePriceOverrides";
 import { UsageProviderChart, type UsageChartMetric } from "./UsageProviderChart";
 import { PROVIDER_ORDER, PROVIDER_PRESENTATION, providersWithUsage } from "./usageProviders";
+import {
+  readUsagePagePreferences,
+  saveUsagePagePreferences,
+  type UsagePagePreferences,
+} from "./usagePagePreferences";
 
 type UsageMetric = UsageChartMetric | "limits";
 const METRIC_OPTIONS = [
@@ -71,20 +74,6 @@ const METRIC_OPTIONS = [
   { value: "tokens", label: "Tokens" },
   { value: "limits", label: "Limits" },
 ] as const satisfies readonly { value: UsageMetric; label: string }[];
-
-const USAGE_PAGE_PREFERENCES_STORAGE_KEY = "t3code:usage-page-preferences:v1";
-const UsageMetricSchema = Schema.Literals(["cost", "tokens", "limits"]);
-const UsageWindowDaysSchema = Schema.Literals([1, 7, 30, 90]);
-type UsageWindowDays = typeof UsageWindowDaysSchema.Type;
-const UsagePagePreferencesSchema = Schema.Struct({
-  metric: UsageMetricSchema,
-  windowDays: UsageWindowDaysSchema,
-});
-type UsagePagePreferences = typeof UsagePagePreferencesSchema.Type;
-const DEFAULT_USAGE_PAGE_PREFERENCES: UsagePagePreferences = {
-  metric: "cost",
-  windowDays: 30,
-};
 
 function isUsageMetric(value: string | null | undefined): value is UsageMetric {
   return METRIC_OPTIONS.some((option) => option.value === value);
@@ -97,16 +86,12 @@ const WINDOW_OPTIONS = [
   { days: 90, label: "90 days" },
 ] as const;
 
-function isUsageWindowDays(value: number): value is UsageWindowDays {
+function isUsageWindowDays(value: number): value is UsagePagePreferences["windowDays"] {
   return WINDOW_OPTIONS.some((option) => option.days === value);
 }
 
 export function UsagePage() {
-  const [preferences, setPreferences] = useLocalStorage(
-    USAGE_PAGE_PREFERENCES_STORAGE_KEY,
-    DEFAULT_USAGE_PAGE_PREFERENCES,
-    UsagePagePreferencesSchema,
-  );
+  const [preferences, setPreferences] = useState(readUsagePagePreferences);
   const [windowSelection, setWindowSelection] = useState(() => ({
     days: preferences.windowDays,
     window: makeWindow(
@@ -162,14 +147,18 @@ export function UsagePage() {
 
   const selectWindow = (days: number) => {
     if (!isUsageWindowDays(days)) return;
-    setPreferences((current) => ({ ...current, windowDays: days }));
+    const nextPreferences = { metric, windowDays: days };
+    setPreferences(nextPreferences);
+    saveUsagePagePreferences(nextPreferences);
     setWindowSelection({
       days,
       window: makeWindow(days, undefined, days === 1 ? "hour" : "day"),
     });
   };
   const selectMetric = (nextMetric: UsageMetric) => {
-    setPreferences((current) => ({ ...current, metric: nextMetric }));
+    const nextPreferences = { metric: nextMetric, windowDays };
+    setPreferences(nextPreferences);
+    saveUsagePagePreferences(nextPreferences);
   };
   const refreshWindow = () => {
     if (showingLimits) {

--- a/apps/web/src/components/usage/usagePagePreferences.test.ts
+++ b/apps/web/src/components/usage/usagePagePreferences.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { readUsagePagePreferences, saveUsagePagePreferences } from "./usagePagePreferences";
+
+const key = "t3code:usage-page-preferences:v1";
+let values: Map<string, string>;
+let storage: Pick<Storage, "getItem" | "setItem">;
+
+beforeEach(() => {
+  values = new Map();
+  storage = {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => {
+      values.set(key, value);
+    },
+  };
+  vi.stubGlobal("window", { localStorage: storage });
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("Usage page preferences", () => {
+  it("uses defaults when no preference has been saved", () => {
+    expect(readUsagePagePreferences()).toEqual({ metric: "cost", windowDays: 30 });
+  });
+
+  it.each([1, 7, 30, 90] as const)("round-trips every metric with a %i-day range", (windowDays) => {
+    for (const metric of ["cost", "tokens", "limits"] as const) {
+      saveUsagePagePreferences({ metric, windowDays });
+      expect(readUsagePagePreferences()).toEqual({ metric, windowDays });
+    }
+  });
+
+  it.each([
+    "not-json",
+    '{"metric":"unknown","windowDays":7}',
+    '{"metric":"cost","windowDays":365}',
+  ])("replaces invalid preferences on the next save: %s", (value) => {
+    values.set(key, value);
+    expect(readUsagePagePreferences()).toEqual({ metric: "cost", windowDays: 30 });
+    saveUsagePagePreferences({ metric: "tokens", windowDays: 7 });
+    expect(readUsagePagePreferences()).toEqual({ metric: "tokens", windowDays: 7 });
+  });
+
+  it("contains write failures and can save again after storage recovers", () => {
+    saveUsagePagePreferences({ metric: "cost", windowDays: 30 });
+    const write = vi.spyOn(storage, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    expect(() => saveUsagePagePreferences({ metric: "tokens", windowDays: 7 })).not.toThrow();
+    expect(readUsagePagePreferences()).toEqual({ metric: "cost", windowDays: 30 });
+    write.mockRestore();
+    saveUsagePagePreferences({ metric: "limits", windowDays: 7 });
+    expect(readUsagePagePreferences()).toEqual({ metric: "limits", windowDays: 7 });
+  });
+
+  it("contains failures when the browser blocks storage access", () => {
+    vi.stubGlobal("window", {
+      get localStorage() {
+        throw new Error("SecurityError");
+      },
+    });
+    expect(readUsagePagePreferences()).toEqual({ metric: "cost", windowDays: 30 });
+    expect(() => saveUsagePagePreferences({ metric: "tokens", windowDays: 7 })).not.toThrow();
+  });
+});

--- a/apps/web/src/components/usage/usagePagePreferences.ts
+++ b/apps/web/src/components/usage/usagePagePreferences.ts
@@ -1,0 +1,32 @@
+import * as Schema from "effect/Schema";
+
+import { getLocalStorageItem, setLocalStorageItem } from "../../hooks/useLocalStorage";
+
+const STORAGE_KEY = "t3code:usage-page-preferences:v1";
+const UsagePagePreferencesSchema = Schema.Struct({
+  metric: Schema.Literals(["cost", "tokens", "limits"]),
+  windowDays: Schema.Literals([1, 7, 30, 90]),
+});
+export type UsagePagePreferences = typeof UsagePagePreferencesSchema.Type;
+
+export function readUsagePagePreferences(): UsagePagePreferences {
+  try {
+    return (
+      getLocalStorageItem(STORAGE_KEY, UsagePagePreferencesSchema) ?? {
+        metric: "cost",
+        windowDays: 30,
+      }
+    );
+  } catch (error) {
+    console.error("Could not read Usage page preferences.", error);
+    return { metric: "cost", windowDays: 30 };
+  }
+}
+
+export function saveUsagePagePreferences(preferences: UsagePagePreferences): void {
+  try {
+    setLocalStorageItem(STORAGE_KEY, preferences, UsagePagePreferencesSchema);
+  } catch (error) {
+    console.error("Could not save Usage page preferences.", error);
+  }
+}


### PR DESCRIPTION
The Usage page forgot the selected metric and time range whenever you navigated away.

This persists both choices in browser storage so returning to Usage restores the last view. This now lets people use the Usage page to quickly view their Usage Limits without too many clicks.

Implemented with GPT 6 in T3 Code with the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist UsagePage metric and time range selections in local storage
> - Adds `UsagePagePreferencesSchema`, `readUsagePagePreferences`, and `saveUsagePagePreferences` in [usagePagePreferences.ts](https://github.com/pingdotgg/t3code/pull/10189/files#diff-9e7569f9f3ffc3b95dee43b08521001023acb45c4e9854373bd7ce8ee1f42a40) to validate, read, and write the selected metric and day range from browser local storage.
> - `UsagePage` in [UsagePage.tsx](https://github.com/pingdotgg/t3code/pull/10189/files#diff-e076db2611ea0a07e1c8ec8571cc21103a2a4c7fc0feb865192fc12c8a18dead) initializes its metric and time range from stored preferences and persists both whenever the user changes either control. A saved one-day range renders with hourly resolution; other supported ranges use daily resolution.
> - Adds `isUsageWindowDays` so unsupported window values are ignored rather than treated as valid.
> - Risk: existing users with no stored preference start from defaults (default metric, 30-day range); malformed or unsupported stored values silently fall back to defaults instead of surfacing an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50f517b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->