### PR TITLE
feat(web): add an opt-in Discord-style project rail to the sidebar

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -166,12 +166,30 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const [sidebarWidth, setSidebarWidth] = useState(() =>
     readInitialThreadSidebarWidth(sidebarExtraWidth),
   );
+  // Client settings hydrate after mount, so the rail's width contribution is
+  // still 0 when the initializer above runs. Recompute once it changes, or the
+  // panel keeps its no-rail width and the rail eats the thread column instead
+  // of widening the sidebar. A width the user dragged is persisted, and
+  // resolveInitialThreadSidebarWidth preserves it, so this only ever restores
+  // the default.
+  const [appliedExtraWidth, setAppliedExtraWidth] = useState(sidebarExtraWidth);
+  if (appliedExtraWidth !== sidebarExtraWidth) {
+    setAppliedExtraWidth(sidebarExtraWidth);
+    setSidebarWidth(readInitialThreadSidebarWidth(sidebarExtraWidth));
+  }
   // Subscribed rather than read once: the clamp must track live window size,
   // and a clamped drag ends with an unchanged width, which skips the re-render
   // that would otherwise refresh a render-time snapshot.
   const viewportWidth = useSyncExternalStore(subscribeToViewportWidth, readViewportWidth);
-  const sidebarMaximumWidth = resolveThreadSidebarMaximumWidth(viewportWidth);
   const sidebarMinimumWidth = THREAD_SIDEBAR_MIN_WIDTH + sidebarExtraWidth;
+  // On a viewport narrow enough that the main content's floor leaves less room
+  // than the sidebar's own floor, the two constraints cannot both hold. The
+  // floor wins, so the range stays coherent for the drag handle instead of
+  // handing it a maximum below its minimum.
+  const sidebarMaximumWidth = Math.max(
+    sidebarMinimumWidth,
+    resolveThreadSidebarMaximumWidth(viewportWidth),
+  );
   const resetSidebarWidth = () => {
     try {
       removeLocalStorageItem(THREAD_SIDEBAR_WIDTH_STORAGE_KEY);
@@ -185,7 +203,7 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   // current floor rather than only at mount.
   const clampedSidebarWidth = Math.min(
     Math.max(sidebarWidth, sidebarMinimumWidth),
-    Math.max(sidebarMinimumWidth, sidebarMaximumWidth),
+    sidebarMaximumWidth,
   );
   const [isWindowFullscreen, setIsWindowFullscreen] = useState(() => {
     const getWindowFullscreenState = window.desktopBridge?.getWindowFullscreenState;

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -14,7 +14,11 @@ import { getLocalStorageItem, removeLocalStorageItem } from "../hooks/useLocalSt
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import { cn, isMacPlatform } from "../lib/utils";
 import { primaryServerKeybindingsAtom } from "../state/server";
-import { useEnvironmentIdentificationMode, useLegacySidebarEnabled } from "../hooks/useSettings";
+import {
+  useEnvironmentIdentificationMode,
+  useLegacySidebarEnabled,
+  useSidebarProjectRailEnabled,
+} from "../hooks/useSettings";
 import {
   PanelAnimationSuppressionProvider,
   usePanelAnimationSettings,
@@ -23,6 +27,7 @@ import {
 import LegacyThreadSidebar from "./LegacySidebar";
 import ThreadSidebar from "./Sidebar";
 import { SettingsSidebarNav } from "./settings/SettingsSidebarNav";
+import { PROJECT_RAIL_WIDTH } from "./sidebar/project-rail/projectRail.constants";
 import { SidebarChromeHeader } from "./sidebar/SidebarChrome";
 import {
   resolveSidebarStageFocusRingOffsetClass,
@@ -57,15 +62,16 @@ function readViewportWidth(): number {
   return window.innerWidth;
 }
 
-function readInitialThreadSidebarWidth(): number {
+function readInitialThreadSidebarWidth(extraWidth: number): number {
   try {
     return resolveInitialThreadSidebarWidth(
       getLocalStorageItem(THREAD_SIDEBAR_WIDTH_STORAGE_KEY, Schema.Finite),
       window.innerWidth,
+      extraWidth,
     );
   } catch (error) {
     console.error("Could not read persisted thread sidebar width.", error);
-    return resolveInitialThreadSidebarWidth(null, window.innerWidth);
+    return resolveInitialThreadSidebarWidth(null, window.innerWidth, extraWidth);
   }
 }
 
@@ -153,20 +159,34 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const routePanelAnimationsActive = panelAnimationsActive && !panelAnimationsSuppressed;
   const isOnSettings = pathname === "/settings" || pathname.startsWith("/settings/");
   const isMacosDesktop = isElectron && isMacPlatform(navigator.platform);
-  const [sidebarWidth, setSidebarWidth] = useState(readInitialThreadSidebarWidth);
+  // The rail lives inside the sidebar, so it widens the whole panel rather than
+  // eating into the thread column.
+  const projectRailEnabled = useSidebarProjectRailEnabled() && !legacySidebarEnabled;
+  const sidebarExtraWidth = projectRailEnabled ? PROJECT_RAIL_WIDTH : 0;
+  const [sidebarWidth, setSidebarWidth] = useState(() =>
+    readInitialThreadSidebarWidth(sidebarExtraWidth),
+  );
   // Subscribed rather than read once: the clamp must track live window size,
   // and a clamped drag ends with an unchanged width, which skips the re-render
   // that would otherwise refresh a render-time snapshot.
   const viewportWidth = useSyncExternalStore(subscribeToViewportWidth, readViewportWidth);
   const sidebarMaximumWidth = resolveThreadSidebarMaximumWidth(viewportWidth);
+  const sidebarMinimumWidth = THREAD_SIDEBAR_MIN_WIDTH + sidebarExtraWidth;
   const resetSidebarWidth = () => {
     try {
       removeLocalStorageItem(THREAD_SIDEBAR_WIDTH_STORAGE_KEY);
     } catch (error) {
       console.error("Could not clear persisted thread sidebar width.", error);
     }
-    setSidebarWidth(resolveInitialThreadSidebarWidth(null, viewportWidth));
+    setSidebarWidth(resolveInitialThreadSidebarWidth(null, viewportWidth, sidebarExtraWidth));
   };
+  // Toggling the rail while the app is open must not leave the thread column
+  // narrower than its floor, so the persisted width is re-clamped against the
+  // current floor rather than only at mount.
+  const clampedSidebarWidth = Math.min(
+    Math.max(sidebarWidth, sidebarMinimumWidth),
+    Math.max(sidebarMinimumWidth, sidebarMaximumWidth),
+  );
   const [isWindowFullscreen, setIsWindowFullscreen] = useState(() => {
     const getWindowFullscreenState = window.desktopBridge?.getWindowFullscreenState;
     return isMacosDesktop && typeof getWindowFullscreenState === "function"
@@ -174,7 +194,7 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
       : false;
   });
   const sidebarProviderStyle = {
-    "--sidebar-width": `${sidebarWidth}px`,
+    "--sidebar-width": `${clampedSidebarWidth}px`,
     "--panel-animation-duration": `${panelAnimationDurationMs}ms`,
     ...(isMacosDesktop && !isWindowFullscreen
       ? { "--workspace-controls-left": MACOS_TRAFFIC_LIGHTS_LEFT_INSET }
@@ -234,7 +254,7 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
           className="border-r border-sidebar-border bg-sidebar text-sidebar-foreground"
           resizable={{
             maxWidth: sidebarMaximumWidth,
-            minWidth: THREAD_SIDEBAR_MIN_WIDTH,
+            minWidth: sidebarMinimumWidth,
             shouldAcceptWidth: ({ currentWidth, nextWidth, wrapper }) =>
               nextWidth <= currentWidth ||
               wrapper.clientWidth - nextWidth >= THREAD_MAIN_CONTENT_MIN_WIDTH,

--- a/apps/web/src/components/ProjectFavicon.tsx
+++ b/apps/web/src/components/ProjectFavicon.tsx
@@ -94,6 +94,19 @@ const PROJECT_ICON_COLOR_BY_NAME: Record<ProjectIconName, ProjectIconColor> = {
   web: "sky",
 };
 
+/**
+ * The color the automatic icon model would tint this project with. Surfaces
+ * that draw their own tile (the project rail's initials) reuse it so one
+ * project reads the same color whichever fallback it lands on.
+ */
+export function resolveAutomaticProjectIconColor(
+  projectName: string,
+  cwd: string,
+): ProjectIconColor | null {
+  const selection = selectProjectIcon(projectName, cwd);
+  return selection.kind === "lucide" ? PROJECT_ICON_COLOR_BY_NAME[selection.icon] : null;
+}
+
 export function ProjectFavicon(input: {
   environmentId: EnvironmentId;
   cwd: string;

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -433,16 +433,50 @@ describe("isSidebarNestedLinkClick", () => {
 
 describe("shouldCreateNewThreadInCurrentProject", () => {
   it("creates directly on shift+click in a multi-project setup", () => {
-    expect(shouldCreateNewThreadInCurrentProject(true, 2)).toBe(true);
+    expect(
+      shouldCreateNewThreadInCurrentProject({
+        shiftKey: true,
+        projectGroupCount: 2,
+        projectScoped: false,
+      }),
+    ).toBe(true);
   });
 
-  it("opens the picker on a plain click in a multi-project setup", () => {
-    expect(shouldCreateNewThreadInCurrentProject(false, 2)).toBe(false);
+  it("opens the picker on a plain click in an unscoped multi-project setup", () => {
+    expect(
+      shouldCreateNewThreadInCurrentProject({
+        shiftKey: false,
+        projectGroupCount: 2,
+        projectScoped: false,
+      }),
+    ).toBe(false);
   });
 
   it("creates directly on any click with a single project", () => {
-    expect(shouldCreateNewThreadInCurrentProject(false, 1)).toBe(true);
-    expect(shouldCreateNewThreadInCurrentProject(true, 1)).toBe(true);
+    expect(
+      shouldCreateNewThreadInCurrentProject({
+        shiftKey: false,
+        projectGroupCount: 1,
+        projectScoped: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldCreateNewThreadInCurrentProject({
+        shiftKey: true,
+        projectGroupCount: 1,
+        projectScoped: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("skips the picker while the sidebar is scoped to one project", () => {
+    expect(
+      shouldCreateNewThreadInCurrentProject({
+        shiftKey: false,
+        projectGroupCount: 5,
+        projectScoped: true,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -359,12 +359,16 @@ export function isSidebarNestedLinkClick(target: EventTarget | null): boolean {
 // Shift+click on the new thread button creates directly in the current
 // project, skipping the command palette's project picker. With a single
 // project there is nothing to pick, so a plain click already creates
-// immediately and the modifier changes nothing.
-export function shouldCreateNewThreadInCurrentProject(
-  shiftKey: boolean,
-  projectGroupCount: number,
-): boolean {
-  return shiftKey || projectGroupCount <= 1;
+// immediately and the modifier changes nothing. Scoping the sidebar to one
+// project (the scope combobox or a project rail tile) is the same statement
+// made a different way: the answer the picker would ask for is already given,
+// so it stays out of the way until the scope goes back to all projects.
+export function shouldCreateNewThreadInCurrentProject(input: {
+  readonly shiftKey: boolean;
+  readonly projectGroupCount: number;
+  readonly projectScoped: boolean;
+}): boolean {
+  return input.shiftKey || input.projectScoped || input.projectGroupCount <= 1;
 }
 
 export function orderItemsByPreferredIds<TItem, TId>(input: {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -110,7 +110,8 @@ import { useThreadActions } from "../hooks/useThreadActions";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { isCommandPaletteOpen, openCommandPalette } from "../commandPaletteBus";
 import { startNewThreadFromContext } from "../lib/chatThreadActions";
-import { useClientSettings } from "../hooks/useSettings";
+import { useClientSettings, useSidebarProjectRailEnabled } from "../hooks/useSettings";
+import { ProjectRail } from "./sidebar/project-rail/ProjectRail";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useNowMinute } from "../hooks/useNowMinute";
@@ -1864,6 +1865,23 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
   );
 });
 
+/**
+ * The two-column region below the sidebar header: the optional project rail
+ * beside the thread column. With the rail off this is a plain passthrough
+ * column, so the sidebar lays out exactly as it did before the rail existed.
+ */
+function SidebarBody({ rail, children }: { rail: ReactNode; children: ReactNode }) {
+  if (!rail) {
+    return <>{children}</>;
+  }
+  return (
+    <div className="flex min-h-0 flex-1 flex-row">
+      {rail}
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">{children}</div>
+    </div>
+  );
+}
+
 export default function Sidebar() {
   const projects = useProjects();
   const projectOrder = useUiStateStore((store) => store.projectOrder);
@@ -1874,6 +1892,7 @@ export default function Sidebar() {
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const confirmThreadArchive = useClientSettings((s) => s.confirmThreadArchive);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
+  const projectRailEnabled = useSidebarProjectRailEnabled();
   const timestampFormat = useClientSettings((s) => s.timestampFormat);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const {
@@ -3607,20 +3626,29 @@ export default function Sidebar() {
       // One project: nothing to pick, create immediately. Shift+click creates
       // directly in the current project even with several projects, skipping
       // the palette picker.
-      if (shouldCreateNewThreadInCurrentProject(event?.shiftKey ?? false, projectGroups.length)) {
+      if (
+        shouldCreateNewThreadInCurrentProject({
+          shiftKey: event?.shiftKey ?? false,
+          projectGroupCount: projectGroups.length,
+          projectScoped: scopedProjectGroup !== null,
+        })
+      ) {
         if (isMobile) setOpenMobile(false);
         void startNewThreadFromContext({
           activeDraftThread: newThreadContext.activeDraftThread,
           activeThread: newThreadContext.activeThread ?? undefined,
           defaultProjectRef: newThreadContext.defaultProjectRef,
           handleNewThread: newThreadContext.handleNewThread,
+          projectRefOverride: scopedProjectGroup
+            ? scopeProjectRef(scopedProjectGroup.environmentId, scopedProjectGroup.id)
+            : null,
         });
         return;
       }
       if (isMobile) setOpenMobile(false);
       openCommandPalette({ open: "new-thread-in" });
     },
-    [isMobile, newThreadContext, projectGroups.length, setOpenMobile],
+    [isMobile, newThreadContext, projectGroups.length, scopedProjectGroup, setOpenMobile],
   );
 
   // The button mirrors chat.new: in multi-project setups both route through
@@ -3638,663 +3666,687 @@ export default function Sidebar() {
   return (
     <>
       <SidebarChromeHeader isElectron={isElectron} />
-      <SidebarContent
-        className="gap-0"
-        fixedHeader={
-          // Lifted above the stage backdrop, whose fade bleeds below the
-          // header and would otherwise paint across the search row's outline.
-          <SidebarGroup className="relative z-[1] gap-1 p-[var(--sidebar-content-inset)]">
-            <div className="flex items-center gap-1">
-              <div className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium text-sidebar-muted-foreground hover:bg-sidebar-row-hover hover:text-sidebar-foreground">
-                <SearchIcon className="size-4 shrink-0 text-sidebar-muted-foreground/80" />
-                <Input
-                  ref={threadSearchInputRef}
-                  nativeInput
-                  unstyled
-                  type="search"
-                  value={threadSearchQuery}
-                  onChange={(event) => {
-                    setThreadSearchQuery(event.currentTarget.value);
-                    setActiveSearchResultIndex(0);
-                  }}
-                  onKeyDown={handleThreadSearchKeyDown}
-                  placeholder="Search"
-                  aria-label="Search threads"
-                  role="combobox"
-                  aria-autocomplete="list"
-                  aria-expanded={isSearchingThreads && threadSearchResults.length > 0}
-                  aria-controls={
-                    isSearchingThreads && threadSearchResults.length > 0
-                      ? "sidebar-thread-search-results"
-                      : undefined
-                  }
-                  aria-activedescendant={
-                    isSearchingThreads && threadSearchResults[activeSearchResultIndex]
-                      ? `sidebar-thread-search-result-${activeSearchResultIndex}`
-                      : undefined
-                  }
-                  className="min-w-0 flex-1 [&_[data-slot=input]]:h-auto [&_[data-slot=input]]:p-0 [&_[data-slot=input]]:leading-normal [&_[data-slot=input]]:text-sm [&_[data-slot=input]]:font-medium [&_[data-slot=input]]:text-sidebar-foreground [&_[data-slot=input]]:placeholder:text-sidebar-muted-foreground"
-                />
-                {isSearchingThreads ? (
-                  <Button
-                    type="button"
-                    size="icon-micro"
-                    variant="ghost"
-                    className="shrink-0 text-sidebar-muted-foreground hover:bg-sidebar-control-surface hover:text-sidebar-foreground"
-                    aria-label="Clear thread search"
-                    onClick={() => {
-                      clearThreadSearch();
-                      threadSearchInputRef.current?.focus();
-                    }}
-                  >
-                    <XIcon className="size-3" />
-                  </Button>
-                ) : null}
-              </div>
-              <div className="shrink-0">
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <SidebarMenuButton
-                        size="icon"
-                        type="button"
-                        className="relative focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
-                        onClick={handleNewThreadClick}
-                        disabled={projects.length === 0}
-                        aria-label="New thread"
-                      />
-                    }
-                  >
-                    <SquarePenIcon />
-                    <span
-                      className="pointer-events-none absolute left-1/2 top-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
-                      aria-hidden="true"
-                    />
-                  </TooltipTrigger>
-                  <TooltipPopup side="right">
-                    {projectGroups.length > 1 ? (
-                      <span className="flex flex-col gap-0.5">
-                        <span>
-                          {newThreadShortcutLabel
-                            ? `New thread (${newThreadShortcutLabel})`
-                            : "New thread"}
-                        </span>
-                        <span className="text-muted-foreground">
-                          New thread in current project: Shift+click
-                          {newThreadInProjectShortcutLabel
-                            ? ` (${newThreadInProjectShortcutLabel})`
-                            : ""}
-                        </span>
-                      </span>
-                    ) : newThreadShortcutLabel ? (
-                      `New thread (${newThreadShortcutLabel})`
-                    ) : (
-                      "New thread"
-                    )}
-                  </TooltipPopup>
-                </Tooltip>
-              </div>
-            </div>
-            {projectGroups.length > 0 ? (
-              <div className="flex items-center gap-1">
-                <Combobox
-                  items={projectScopeItems}
-                  filteredItems={filteredProjectScopeItems}
-                  autoHighlight
-                  itemToStringLabel={(item) => item.label}
-                  isItemEqualToValue={(a, b) => a.value === b.value}
-                  open={projectScopeMenuState.open}
-                  onOpenChange={(open) => {
-                    if (open) suppressNextScopeChangeRef.current = false;
-                    dispatchProjectScopeMenu({ type: "open-changed", open });
-                  }}
-                  onItemHighlighted={(item) => {
-                    highlightedProjectScopeKeyRef.current = item?.value ?? null;
-                  }}
-                  value={selectedProjectScopeItem}
-                  onValueChange={(item) => {
-                    if (suppressNextScopeChangeRef.current) {
-                      suppressNextScopeChangeRef.current = false;
-                      return;
-                    }
-                    if (!item) return;
-                    setProjectScopeKey(item.value === "all" ? null : item.value);
-                  }}
-                >
-                  <ComboboxTrigger
-                    render={
-                      <SidebarMenuButton
-                        aria-label="Filter threads by project"
-                        className="min-w-0 flex-1 ps-[calc(var(--sidebar-row-content-inset)-1px)] focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
-                      />
-                    }
-                  >
-                    {scopedProjectGroup ? (
-                      <span className="flex shrink-0">
-                        <ProjectFavicon
-                          environmentId={scopedProjectGroup.environmentId}
-                          cwd={scopedProjectGroup.workspaceRoot}
-                          projectName={scopedProjectGroup.title}
-                          faviconPath={scopedProjectGroup.faviconPath}
-                          projectIcon={scopedProjectGroup.projectIcon}
-                          className="size-4"
-                        />
-                      </span>
-                    ) : (
-                      <FolderIcon className="size-4 shrink-0" />
-                    )}
-                    <span className="min-w-0 flex-1 truncate">
-                      {scopedProjectGroup?.displayName ?? "All projects"}
-                    </span>
-                    <ChevronDownIcon className="-mr-px size-4 shrink-0" />
-                  </ComboboxTrigger>
-                  <ComboboxPopup
-                    align="start"
-                    className="w-(--anchor-width) min-w-0 overflow-hidden"
-                  >
-                    <div className="shrink-0 px-3 pt-2.5">
-                      <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">
-                        <SearchIcon
-                          aria-hidden="true"
-                          className="pointer-events-none absolute top-1.5 left-0 size-4 shrink-0 text-muted-foreground/55"
-                        />
-                        <ComboboxInput
-                          aria-label="Search projects"
-                          className="[&_input]:h-6.5 [&_input]:ps-5 [&_input]:font-sans [&_input]:leading-6.5"
-                          inputClassName="rounded-none bg-transparent text-sm"
-                          placeholder="Search projects..."
-                          showTrigger={false}
-                          size="sm"
-                          unstyled
-                          value={projectScopeMenuState.query}
-                          onKeyDown={(event) => {
-                            if (
-                              event.defaultPrevented ||
-                              event.nativeEvent.isComposing ||
-                              event.ctrlKey ||
-                              event.altKey ||
-                              event.metaKey ||
-                              (event.key !== "ContextMenu" &&
-                                !(event.shiftKey && event.key === "F10"))
-                            ) {
-                              return;
-                            }
-                            // Combobox items use virtual focus: keyboard events
-                            // stay on this input, not on the highlighted option.
-                            const scopeKey = highlightedProjectScopeKeyRef.current;
-                            const project = scopeKey ? projectGroupByScopeKey.get(scopeKey) : null;
-                            if (project) handleProjectSettings(event, project);
-                          }}
-                          onChange={(event) =>
-                            dispatchProjectScopeMenu({
-                              type: "query-changed",
-                              query: event.target.value,
-                            })
-                          }
-                        />
-                      </div>
-                    </div>
-                    <ComboboxEmpty>No matching projects.</ComboboxEmpty>
-                    <ComboboxList>
-                      {(item: (typeof projectScopeItems)[number]) => {
-                        const project = projectGroupByScopeKey.get(item.value) ?? null;
-                        return (
-                          <ComboboxItem
-                            key={item.value}
-                            hideIndicator
-                            value={item}
-                            className="h-8 min-h-8 py-0 font-medium"
-                            contentClassName="flex min-w-0 items-center gap-2"
-                            onContextMenu={(event) => {
-                              if (project) handleProjectSettings(event, project);
-                            }}
-                          >
-                            {project ? (
-                              <ProjectFavicon
-                                environmentId={project.environmentId}
-                                cwd={project.workspaceRoot}
-                                projectName={project.title}
-                                faviconPath={project.faviconPath}
-                                projectIcon={project.projectIcon}
-                                className="size-4 shrink-0"
-                              />
-                            ) : (
-                              <FolderIcon className="size-4 shrink-0" />
-                            )}
-                            <span className="min-w-0 flex-1 truncate text-sm">{item.label}</span>
-                            {project ? (
-                              <Button
-                                size="icon-xs"
-                                variant="ghost-muted"
-                                tabIndex={-1}
-                                aria-hidden="true"
-                                title={`Project settings for ${project.displayName}`}
-                                className="ml-auto size-6 [--control-icon-color:currentColor] text-icon-muted focus-visible:bg-accent focus-visible:text-foreground"
-                                onPointerDown={(event) => event.stopPropagation()}
-                                onClick={(event) => {
-                                  void handleProjectSettings(event, project);
-                                }}
-                              >
-                                <SettingsIcon className="size-3.5" />
-                              </Button>
-                            ) : null}
-                          </ComboboxItem>
-                        );
-                      }}
-                    </ComboboxList>
-                  </ComboboxPopup>
-                </Combobox>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <SidebarMenuButton
-                        size="icon"
-                        className="relative shrink-0 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
-                        onClick={openAddProjectCommandPalette}
-                        type="button"
-                        aria-label="New project"
-                      />
-                    }
-                  >
-                    <FolderPlusIcon />
-                    <span
-                      className="pointer-events-none absolute left-1/2 top-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
-                      aria-hidden="true"
-                    />
-                  </TooltipTrigger>
-                  <TooltipPopup side="right">New project</TooltipPopup>
-                </Tooltip>
-              </div>
-            ) : null}
-          </SidebarGroup>
+      {/* Below the header the sidebar splits into two real columns: the rail
+          and the thread column. A flex row rather than an overlay, so the rail
+          can size its own tiles (the add button pins to its bottom) and the
+          thread column's fixed search header is never painted under it. The
+          sidebar shell above stays a plain flex-col, so collapse, resize, the
+          mobile sheet and the Electron drag region are untouched. */}
+      <SidebarBody
+        rail={
+          projectRailEnabled ? (
+            <ProjectRail
+              projectGroups={projectGroups}
+              scopeKey={projectScopeKey}
+              onSelectScope={setProjectScopeKey}
+              onOpenProjectSettings={handleProjectSettings}
+              onAddProject={openAddProjectCommandPalette}
+            />
+          ) : null
         }
       >
-        <SidebarGroup className="ps-[calc(var(--sidebar-content-inset)+1px)] pe-[var(--sidebar-content-inset)] pb-1 pt-0">
-          {isSearchingThreads ? (
-            threadSearchResults.length > 0 ? (
+        <SidebarContent
+          className="gap-0"
+          fixedHeader={
+            // Lifted above the stage backdrop, whose fade bleeds below the
+            // header and would otherwise paint across the search row's outline.
+            <SidebarGroup className="relative z-[1] gap-1 p-[var(--sidebar-content-inset)]">
+              <div className="flex items-center gap-1">
+                <div className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium text-sidebar-muted-foreground hover:bg-sidebar-row-hover hover:text-sidebar-foreground">
+                  <SearchIcon className="size-4 shrink-0 text-sidebar-muted-foreground/80" />
+                  <Input
+                    ref={threadSearchInputRef}
+                    nativeInput
+                    unstyled
+                    type="search"
+                    value={threadSearchQuery}
+                    onChange={(event) => {
+                      setThreadSearchQuery(event.currentTarget.value);
+                      setActiveSearchResultIndex(0);
+                    }}
+                    onKeyDown={handleThreadSearchKeyDown}
+                    placeholder="Search"
+                    aria-label="Search threads"
+                    role="combobox"
+                    aria-autocomplete="list"
+                    aria-expanded={isSearchingThreads && threadSearchResults.length > 0}
+                    aria-controls={
+                      isSearchingThreads && threadSearchResults.length > 0
+                        ? "sidebar-thread-search-results"
+                        : undefined
+                    }
+                    aria-activedescendant={
+                      isSearchingThreads && threadSearchResults[activeSearchResultIndex]
+                        ? `sidebar-thread-search-result-${activeSearchResultIndex}`
+                        : undefined
+                    }
+                    className="min-w-0 flex-1 [&_[data-slot=input]]:h-auto [&_[data-slot=input]]:p-0 [&_[data-slot=input]]:leading-normal [&_[data-slot=input]]:text-sm [&_[data-slot=input]]:font-medium [&_[data-slot=input]]:text-sidebar-foreground [&_[data-slot=input]]:placeholder:text-sidebar-muted-foreground"
+                  />
+                  {isSearchingThreads ? (
+                    <Button
+                      type="button"
+                      size="icon-micro"
+                      variant="ghost"
+                      className="shrink-0 text-sidebar-muted-foreground hover:bg-sidebar-control-surface hover:text-sidebar-foreground"
+                      aria-label="Clear thread search"
+                      onClick={() => {
+                        clearThreadSearch();
+                        threadSearchInputRef.current?.focus();
+                      }}
+                    >
+                      <XIcon className="size-3" />
+                    </Button>
+                  ) : null}
+                </div>
+                <div className="shrink-0">
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <SidebarMenuButton
+                          size="icon"
+                          type="button"
+                          className="relative focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
+                          onClick={handleNewThreadClick}
+                          disabled={projects.length === 0}
+                          aria-label="New thread"
+                        />
+                      }
+                    >
+                      <SquarePenIcon />
+                      <span
+                        className="pointer-events-none absolute left-1/2 top-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
+                        aria-hidden="true"
+                      />
+                    </TooltipTrigger>
+                    <TooltipPopup side="right">
+                      {projectGroups.length > 1 ? (
+                        <span className="flex flex-col gap-0.5">
+                          <span>
+                            {newThreadShortcutLabel
+                              ? `New thread (${newThreadShortcutLabel})`
+                              : "New thread"}
+                          </span>
+                          <span className="text-muted-foreground">
+                            New thread in current project: Shift+click
+                            {newThreadInProjectShortcutLabel
+                              ? ` (${newThreadInProjectShortcutLabel})`
+                              : ""}
+                          </span>
+                        </span>
+                      ) : newThreadShortcutLabel ? (
+                        `New thread (${newThreadShortcutLabel})`
+                      ) : (
+                        "New thread"
+                      )}
+                    </TooltipPopup>
+                  </Tooltip>
+                </div>
+              </div>
+              {!projectRailEnabled && projectGroups.length > 0 ? (
+                <div className="flex items-center gap-1">
+                  <Combobox
+                    items={projectScopeItems}
+                    filteredItems={filteredProjectScopeItems}
+                    autoHighlight
+                    itemToStringLabel={(item) => item.label}
+                    isItemEqualToValue={(a, b) => a.value === b.value}
+                    open={projectScopeMenuState.open}
+                    onOpenChange={(open) => {
+                      if (open) suppressNextScopeChangeRef.current = false;
+                      dispatchProjectScopeMenu({ type: "open-changed", open });
+                    }}
+                    onItemHighlighted={(item) => {
+                      highlightedProjectScopeKeyRef.current = item?.value ?? null;
+                    }}
+                    value={selectedProjectScopeItem}
+                    onValueChange={(item) => {
+                      if (suppressNextScopeChangeRef.current) {
+                        suppressNextScopeChangeRef.current = false;
+                        return;
+                      }
+                      if (!item) return;
+                      setProjectScopeKey(item.value === "all" ? null : item.value);
+                    }}
+                  >
+                    <ComboboxTrigger
+                      render={
+                        <SidebarMenuButton
+                          aria-label="Filter threads by project"
+                          className="min-w-0 flex-1 ps-[calc(var(--sidebar-row-content-inset)-1px)] focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
+                        />
+                      }
+                    >
+                      {scopedProjectGroup ? (
+                        <span className="flex shrink-0">
+                          <ProjectFavicon
+                            environmentId={scopedProjectGroup.environmentId}
+                            cwd={scopedProjectGroup.workspaceRoot}
+                            projectName={scopedProjectGroup.title}
+                            faviconPath={scopedProjectGroup.faviconPath}
+                            projectIcon={scopedProjectGroup.projectIcon}
+                            className="size-4"
+                          />
+                        </span>
+                      ) : (
+                        <FolderIcon className="size-4 shrink-0" />
+                      )}
+                      <span className="min-w-0 flex-1 truncate">
+                        {scopedProjectGroup?.displayName ?? "All projects"}
+                      </span>
+                      <ChevronDownIcon className="-mr-px size-4 shrink-0" />
+                    </ComboboxTrigger>
+                    <ComboboxPopup
+                      align="start"
+                      className="w-(--anchor-width) min-w-0 overflow-hidden"
+                    >
+                      <div className="shrink-0 px-3 pt-2.5">
+                        <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">
+                          <SearchIcon
+                            aria-hidden="true"
+                            className="pointer-events-none absolute top-1.5 left-0 size-4 shrink-0 text-muted-foreground/55"
+                          />
+                          <ComboboxInput
+                            aria-label="Search projects"
+                            className="[&_input]:h-6.5 [&_input]:ps-5 [&_input]:font-sans [&_input]:leading-6.5"
+                            inputClassName="rounded-none bg-transparent text-sm"
+                            placeholder="Search projects..."
+                            showTrigger={false}
+                            size="sm"
+                            unstyled
+                            value={projectScopeMenuState.query}
+                            onKeyDown={(event) => {
+                              if (
+                                event.defaultPrevented ||
+                                event.nativeEvent.isComposing ||
+                                event.ctrlKey ||
+                                event.altKey ||
+                                event.metaKey ||
+                                (event.key !== "ContextMenu" &&
+                                  !(event.shiftKey && event.key === "F10"))
+                              ) {
+                                return;
+                              }
+                              // Combobox items use virtual focus: keyboard events
+                              // stay on this input, not on the highlighted option.
+                              const scopeKey = highlightedProjectScopeKeyRef.current;
+                              const project = scopeKey
+                                ? projectGroupByScopeKey.get(scopeKey)
+                                : null;
+                              if (project) handleProjectSettings(event, project);
+                            }}
+                            onChange={(event) =>
+                              dispatchProjectScopeMenu({
+                                type: "query-changed",
+                                query: event.target.value,
+                              })
+                            }
+                          />
+                        </div>
+                      </div>
+                      <ComboboxEmpty>No matching projects.</ComboboxEmpty>
+                      <ComboboxList>
+                        {(item: (typeof projectScopeItems)[number]) => {
+                          const project = projectGroupByScopeKey.get(item.value) ?? null;
+                          return (
+                            <ComboboxItem
+                              key={item.value}
+                              hideIndicator
+                              value={item}
+                              className="h-8 min-h-8 py-0 font-medium"
+                              contentClassName="flex min-w-0 items-center gap-2"
+                              onContextMenu={(event) => {
+                                if (project) handleProjectSettings(event, project);
+                              }}
+                            >
+                              {project ? (
+                                <ProjectFavicon
+                                  environmentId={project.environmentId}
+                                  cwd={project.workspaceRoot}
+                                  projectName={project.title}
+                                  faviconPath={project.faviconPath}
+                                  projectIcon={project.projectIcon}
+                                  className="size-4 shrink-0"
+                                />
+                              ) : (
+                                <FolderIcon className="size-4 shrink-0" />
+                              )}
+                              <span className="min-w-0 flex-1 truncate text-sm">{item.label}</span>
+                              {project ? (
+                                <Button
+                                  size="icon-xs"
+                                  variant="ghost-muted"
+                                  tabIndex={-1}
+                                  aria-hidden="true"
+                                  title={`Project settings for ${project.displayName}`}
+                                  className="ml-auto size-6 [--control-icon-color:currentColor] text-icon-muted focus-visible:bg-accent focus-visible:text-foreground"
+                                  onPointerDown={(event) => event.stopPropagation()}
+                                  onClick={(event) => {
+                                    void handleProjectSettings(event, project);
+                                  }}
+                                >
+                                  <SettingsIcon className="size-3.5" />
+                                </Button>
+                              ) : null}
+                            </ComboboxItem>
+                          );
+                        }}
+                      </ComboboxList>
+                    </ComboboxPopup>
+                  </Combobox>
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <SidebarMenuButton
+                          size="icon"
+                          className="relative shrink-0 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
+                          onClick={openAddProjectCommandPalette}
+                          type="button"
+                          aria-label="New project"
+                        />
+                      }
+                    >
+                      <FolderPlusIcon />
+                      <span
+                        className="pointer-events-none absolute left-1/2 top-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
+                        aria-hidden="true"
+                      />
+                    </TooltipTrigger>
+                    <TooltipPopup side="right">New project</TooltipPopup>
+                  </Tooltip>
+                </div>
+              ) : null}
+            </SidebarGroup>
+          }
+        >
+          <SidebarGroup className="ps-[calc(var(--sidebar-content-inset)+1px)] pe-[var(--sidebar-content-inset)] pb-1 pt-0">
+            {isSearchingThreads ? (
+              threadSearchResults.length > 0 ? (
+                <TooltipProvider
+                  key="sidebar-thread-search-tooltips-150"
+                  delay={150}
+                  closeDelay={0}
+                  timeout={400}
+                >
+                  <ul
+                    id="sidebar-thread-search-results"
+                    role="listbox"
+                    aria-label="Thread search results"
+                    className="flex flex-col gap-px"
+                  >
+                    {threadSearchResults.map((thread, index) => {
+                      const threadKey = scopedThreadKey(
+                        scopeThreadRef(thread.environmentId, thread.id),
+                      );
+                      return (
+                        <SidebarSearchResultRow
+                          key={threadKey}
+                          thread={thread}
+                          projectCwd={
+                            projectCwdByKey.get(`${thread.environmentId}:${thread.projectId}`) ??
+                            null
+                          }
+                          projectFaviconPath={
+                            projectFaviconPathByKey.get(
+                              `${thread.environmentId}:${thread.projectId}`,
+                            ) ?? null
+                          }
+                          projectIcon={
+                            projectIconByKey.get(`${thread.environmentId}:${thread.projectId}`) ??
+                            null
+                          }
+                          projectTitle={
+                            projectTitleByKey.get(`${thread.environmentId}:${thread.projectId}`) ??
+                            null
+                          }
+                          projectDisplayName={
+                            projectDisplayNameByKey.get(
+                              `${thread.environmentId}:${thread.projectId}`,
+                            ) ?? null
+                          }
+                          environmentLabel={environmentLabelById.get(thread.environmentId) ?? null}
+                          environmentMachine={
+                            environmentMachineById.get(thread.environmentId) ?? "server"
+                          }
+                          providerEntryByInstanceId={
+                            providerEntriesByEnvironment.get(thread.environmentId) ??
+                            EMPTY_PROVIDER_ENTRIES
+                          }
+                          isHighlighted={activeSearchResultIndex === index}
+                          isRouteActive={routeThreadKey === threadKey}
+                          resultId={`sidebar-thread-search-result-${index}`}
+                          onHighlight={() => setActiveSearchResultIndex(index)}
+                          onSelect={() => selectThreadSearchResult(thread)}
+                        />
+                      );
+                    })}
+                  </ul>
+                </TooltipProvider>
+              ) : (
+                <p
+                  role="status"
+                  className="px-2 py-6 text-center text-xs text-sidebar-muted-foreground"
+                >
+                  No threads found
+                </p>
+              )
+            ) : null}
+            {!isSearchingThreads ? (
               <TooltipProvider
-                key="sidebar-thread-search-tooltips-150"
+                key="sidebar-thread-tooltips-150"
                 delay={150}
                 closeDelay={0}
                 timeout={400}
               >
-                <ul
-                  id="sidebar-thread-search-results"
-                  role="listbox"
-                  aria-label="Thread search results"
-                  className="flex flex-col gap-px"
-                >
-                  {threadSearchResults.map((thread, index) => {
-                    const threadKey = scopedThreadKey(
-                      scopeThreadRef(thread.environmentId, thread.id),
-                    );
-                    return (
-                      <SidebarSearchResultRow
-                        key={threadKey}
-                        thread={thread}
-                        projectCwd={
-                          projectCwdByKey.get(`${thread.environmentId}:${thread.projectId}`) ?? null
-                        }
-                        projectFaviconPath={
-                          projectFaviconPathByKey.get(
-                            `${thread.environmentId}:${thread.projectId}`,
-                          ) ?? null
-                        }
-                        projectIcon={
-                          projectIconByKey.get(`${thread.environmentId}:${thread.projectId}`) ??
-                          null
-                        }
-                        projectTitle={
-                          projectTitleByKey.get(`${thread.environmentId}:${thread.projectId}`) ??
-                          null
-                        }
-                        projectDisplayName={
-                          projectDisplayNameByKey.get(
-                            `${thread.environmentId}:${thread.projectId}`,
-                          ) ?? null
-                        }
-                        environmentLabel={environmentLabelById.get(thread.environmentId) ?? null}
-                        environmentMachine={
-                          environmentMachineById.get(thread.environmentId) ?? "server"
-                        }
-                        providerEntryByInstanceId={
-                          providerEntriesByEnvironment.get(thread.environmentId) ??
-                          EMPTY_PROVIDER_ENTRIES
-                        }
-                        isHighlighted={activeSearchResultIndex === index}
-                        isRouteActive={routeThreadKey === threadKey}
-                        resultId={`sidebar-thread-search-result-${index}`}
-                        onHighlight={() => setActiveSearchResultIndex(index)}
-                        onSelect={() => selectThreadSearchResult(thread)}
-                      />
-                    );
-                  })}
+                <ul ref={attachListAutoAnimateRef} role="list" className="flex flex-col gap-px">
+                  {(() => {
+                    const renderThreadRow = (
+                      thread: EnvironmentThreadShell,
+                      section: "pinned" | "active" | "snoozed" | "settled",
+                      sortable?: SortablePinnedRowBag,
+                    ) => {
+                      const threadKey = scopedThreadKey(
+                        scopeThreadRef(thread.environmentId, thread.id),
+                      );
+                      // Settled and snoozed are the ONLY things that collapse a
+                      // row: every other thread is a full card. Density comes
+                      // from users (or the auto rules) actually parking work,
+                      // not from the sidebar second-guessing what still matters.
+                      const isCard = section === "active" || section === "pinned";
+                      const rowVariant = isCard ? "card" : "slim";
+                      return (
+                        <SidebarThreadRow
+                          // Keyed per variant on purpose: when a thread settles,
+                          // the card fades out in place and the slim row fades
+                          // in at its settled position instead of one element
+                          // FLIP-sliding through every row in between (rows here
+                          // are translucent, so a crossing row reads as text
+                          // painted over text).
+                          key={`${threadKey}:${rowVariant}`}
+                          thread={thread}
+                          variant={rowVariant}
+                          // Snoozed rows wake, settled rows un-settle, and cards settle.
+                          variantAction={
+                            section === "snoozed"
+                              ? "unsnooze"
+                              : section === "settled"
+                                ? "unsettle"
+                                : "settle"
+                          }
+                          settlementSupported={
+                            serverConfigs.get(thread.environmentId)?.environment.capabilities
+                              .threadSettlement === true
+                          }
+                          snoozeSupported={
+                            serverConfigs.get(thread.environmentId)?.environment.capabilities
+                              .threadSnooze === true
+                          }
+                          pinningSupported={
+                            serverConfigs.get(thread.environmentId)?.environment.capabilities
+                              .threadPinning === true
+                          }
+                          isPinned={thread.pinnedAt != null}
+                          sortable={sortable}
+                          snoozeWakeLabelText={
+                            section === "snoozed" && thread.snoozedUntil != null
+                              ? snoozeWakeLabel(thread.snoozedUntil, {
+                                  now: new Date().toISOString(),
+                                })
+                              : null
+                          }
+                          // All sections: a woken thread can classify straight
+                          // into the settled tail (PR merged while snoozed), and
+                          // the wake signal must survive the trip. Still-snoozed
+                          // rows resolve to null on their own.
+                          wokeAt={threadWokeAt(thread, { now: snoozeNow })}
+                          isActive={routeThreadKey === threadKey}
+                          openPullRequestsInRightPanel={routeThreadRef !== null}
+                          jumpLabel={
+                            showThreadJumpHints ? (jumpLabelByKey.get(threadKey) ?? null) : null
+                          }
+                          currentEnvironmentId={primaryEnvironmentId}
+                          environmentLabel={environmentLabelById.get(thread.environmentId) ?? null}
+                          environmentMachine={
+                            environmentMachineById.get(thread.environmentId) ?? "server"
+                          }
+                          projectCwd={
+                            projectCwdByKey.get(`${thread.environmentId}:${thread.projectId}`) ??
+                            null
+                          }
+                          projectFaviconPath={
+                            projectFaviconPathByKey.get(
+                              `${thread.environmentId}:${thread.projectId}`,
+                            ) ?? null
+                          }
+                          projectIcon={
+                            projectIconByKey.get(`${thread.environmentId}:${thread.projectId}`) ??
+                            null
+                          }
+                          projectTitle={
+                            projectTitleByKey.get(`${thread.environmentId}:${thread.projectId}`) ??
+                            null
+                          }
+                          projectDisplayName={
+                            projectDisplayNameByKey.get(
+                              `${thread.environmentId}:${thread.projectId}`,
+                            ) ?? null
+                          }
+                          providerEntryByInstanceId={
+                            providerEntriesByEnvironment.get(thread.environmentId) ??
+                            EMPTY_PROVIDER_ENTRIES
+                          }
+                          timestampFormat={timestampFormat}
+                          onThreadClick={handleThreadClick}
+                          onThreadActivate={navigateToThread}
+                          onStartRename={startThreadRename}
+                          onRenameTitleChange={setRenamingTitle}
+                          onCommitRename={commitThreadRename}
+                          onCancelRename={cancelThreadRename}
+                          isRenaming={renamingThreadKey === threadKey}
+                          renamingTitle={renamingThreadKey === threadKey ? renamingTitle : ""}
+                          onContextMenu={handleThreadContextMenu}
+                          onSettle={attemptSettle}
+                          onUnsettle={attemptUnsettle}
+                          onSnooze={attemptSnooze}
+                          onUnsnooze={attemptUnsnooze}
+                          onUnpin={attemptUnpin}
+                          onAcknowledgeWoke={acknowledgeWoke}
+                          changeRequestSnapshot={changeRequestSnapshotByKey.get(threadKey) ?? null}
+                          onChangeRequestSnapshot={setThreadChangeRequestSnapshot}
+                        />
+                      );
+                    };
+                    // Draft block above everything, then the pinned block:
+                    // full cards above the inbox, closed by a thin divider (the
+                    // pin glyphs carry the meaning, so no header text). Both
+                    // vanish entirely at count 0.
+                    // Pinned rows render in the one shared pinned order; only
+                    // reorder-capable rows register as sortable (legacy-server
+                    // pins render in place as plain rows).
+                    const items: ReactNode[] = [
+                      <SidebarDraftBlock
+                        key="draft-sessions"
+                        projectTitleByKey={projectTitleByKey}
+                        projectDisplayNameByKey={projectDisplayNameByKey}
+                        projectCwdByKey={projectCwdByKey}
+                        projectFaviconPathByKey={projectFaviconPathByKey}
+                        projectIconByKey={projectIconByKey}
+                        scopedProjectKeys={scopedProjectKeys}
+                        routeDraftId={routeDraftIdForRows}
+                        onNavigateToDraft={navigateToDraft}
+                      />,
+                      pinnedThreads.length > 0 ? (
+                        <li key="pinned-dnd" className="list-none">
+                          <DndContext
+                            sensors={pinnedDndSensors}
+                            collisionDetection={closestCenter}
+                            modifiers={[restrictToVerticalAxis, restrictToFirstScrollableAncestor]}
+                            onDragEnd={handlePinnedDragEnd}
+                          >
+                            <SortableContext
+                              items={orderedPinnedThreads
+                                .map((thread) =>
+                                  scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+                                )
+                                .filter((threadKey) => reorderablePinnedKeys.has(threadKey))}
+                              strategy={verticalListSortingStrategy}
+                            >
+                              <ul
+                                role="list"
+                                aria-label="Pinned threads"
+                                className="flex flex-col gap-px"
+                              >
+                                {orderedPinnedThreads.map((thread) => {
+                                  const threadKey = scopedThreadKey(
+                                    scopeThreadRef(thread.environmentId, thread.id),
+                                  );
+                                  if (!reorderablePinnedKeys.has(threadKey)) {
+                                    return renderThreadRow(thread, "pinned");
+                                  }
+                                  return (
+                                    <SortablePinnedThreadRow key={threadKey} id={threadKey}>
+                                      {(bag) => renderThreadRow(thread, "pinned", bag)}
+                                    </SortablePinnedThreadRow>
+                                  );
+                                })}
+                              </ul>
+                            </SortableContext>
+                          </DndContext>
+                        </li>
+                      ) : null,
+                    ];
+                    if (pinnedThreads.length > 0) {
+                      items.push(
+                        <li
+                          key="pinned-divider"
+                          aria-hidden
+                          data-testid="sidebar-pinned-divider"
+                          className="mx-2.5 my-1.5 h-px list-none bg-sidebar-border/60"
+                        />,
+                      );
+                    }
+                    for (const thread of activeThreads) {
+                      items.push(renderThreadRow(thread, "active"));
+                    }
+                    // Snoozed shelf: between the inbox and Settled — out of the
+                    // way, never gone. The header always renders while anything
+                    // is snoozed (the count is the whole footprint when
+                    // collapsed); rows only when expanded. Vanishes entirely at
+                    // count 0.
+                    if (snoozedThreads.length > 0) {
+                      items.push(
+                        <li
+                          key="snoozed-shelf-header"
+                          data-thread-selection-safe
+                          className="list-none"
+                        >
+                          <button
+                            type="button"
+                            onClick={toggleSnoozedShelf}
+                            aria-expanded={snoozedShelfExpanded}
+                            data-testid="sidebar-snoozed-shelf-toggle"
+                            className="mb-1 mt-3 flex w-full cursor-pointer items-center gap-2 px-2.5 text-left"
+                          >
+                            <span className="text-xs font-medium text-blue-600 dark:text-blue-400">
+                              {snoozedShelfExpanded
+                                ? "Snoozed"
+                                : `Snoozed (${snoozedThreads.length})`}
+                            </span>
+                            <span className="h-px flex-1 bg-blue-500/20 dark:bg-blue-400/15" />
+                            <ChevronDownIcon
+                              aria-hidden
+                              className={cn(
+                                "size-3 text-blue-600 transition-transform dark:text-blue-400",
+                                snoozedShelfExpanded && "rotate-180",
+                              )}
+                            />
+                          </button>
+                        </li>,
+                      );
+                      for (const thread of visibleSnoozedThreads) {
+                        items.push(renderThreadRow(thread, "snoozed"));
+                      }
+                    }
+                    if (settledThreads.length > 0) {
+                      items.push(
+                        <li
+                          key="settled-shelf-header"
+                          data-thread-selection-safe
+                          className="list-none"
+                        >
+                          <button
+                            type="button"
+                            onClick={toggleSettledShelf}
+                            aria-expanded={settledShelfExpanded}
+                            data-testid="sidebar-settled-shelf-toggle"
+                            className="mb-1 mt-3 flex w-full cursor-pointer items-center gap-2 px-2.5 text-left"
+                          >
+                            <span className="text-xs font-medium text-muted-foreground/50">
+                              {settledShelfExpanded
+                                ? "Settled"
+                                : `Settled (${settledThreads.length})`}
+                            </span>
+                            <span className="h-px flex-1 bg-sidebar-border/60" />
+                            <ChevronDownIcon
+                              aria-hidden
+                              className={cn(
+                                "size-3 text-muted-foreground/50 transition-transform",
+                                settledShelfExpanded && "rotate-180",
+                              )}
+                            />
+                          </button>
+                        </li>,
+                      );
+                    }
+                    for (const thread of renderedSettledThreads) {
+                      items.push(renderThreadRow(thread, "settled"));
+                    }
+                    return items;
+                  })()}
+                  {settledShelfExpanded && hiddenSettledCount > 0 ? (
+                    <li className="list-none">
+                      <button
+                        type="button"
+                        onClick={showMoreSettled}
+                        className="flex h-9 w-full cursor-pointer items-center gap-2.5 rounded-md px-2.5 text-left text-sm text-sidebar-muted-foreground/55 hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
+                      >
+                        <PlusIcon aria-hidden className="size-4 shrink-0" />
+                        Show {Math.min(hiddenSettledCount, SETTLED_TAIL_PAGE_COUNT)} more
+                      </button>
+                    </li>
+                  ) : null}
                 </ul>
               </TooltipProvider>
-            ) : (
-              <p
-                role="status"
-                className="px-2 py-6 text-center text-xs text-sidebar-muted-foreground"
-              >
-                No threads found
-              </p>
-            )
-          ) : null}
-          {!isSearchingThreads ? (
-            <TooltipProvider
-              key="sidebar-thread-tooltips-150"
-              delay={150}
-              closeDelay={0}
-              timeout={400}
-            >
-              <ul ref={attachListAutoAnimateRef} role="list" className="flex flex-col gap-px">
-                {(() => {
-                  const renderThreadRow = (
-                    thread: EnvironmentThreadShell,
-                    section: "pinned" | "active" | "snoozed" | "settled",
-                    sortable?: SortablePinnedRowBag,
-                  ) => {
-                    const threadKey = scopedThreadKey(
-                      scopeThreadRef(thread.environmentId, thread.id),
-                    );
-                    // Settled and snoozed are the ONLY things that collapse a
-                    // row: every other thread is a full card. Density comes
-                    // from users (or the auto rules) actually parking work,
-                    // not from the sidebar second-guessing what still matters.
-                    const isCard = section === "active" || section === "pinned";
-                    const rowVariant = isCard ? "card" : "slim";
-                    return (
-                      <SidebarThreadRow
-                        // Keyed per variant on purpose: when a thread settles,
-                        // the card fades out in place and the slim row fades
-                        // in at its settled position instead of one element
-                        // FLIP-sliding through every row in between (rows here
-                        // are translucent, so a crossing row reads as text
-                        // painted over text).
-                        key={`${threadKey}:${rowVariant}`}
-                        thread={thread}
-                        variant={rowVariant}
-                        // Snoozed rows wake, settled rows un-settle, and cards settle.
-                        variantAction={
-                          section === "snoozed"
-                            ? "unsnooze"
-                            : section === "settled"
-                              ? "unsettle"
-                              : "settle"
-                        }
-                        settlementSupported={
-                          serverConfigs.get(thread.environmentId)?.environment.capabilities
-                            .threadSettlement === true
-                        }
-                        snoozeSupported={
-                          serverConfigs.get(thread.environmentId)?.environment.capabilities
-                            .threadSnooze === true
-                        }
-                        pinningSupported={
-                          serverConfigs.get(thread.environmentId)?.environment.capabilities
-                            .threadPinning === true
-                        }
-                        isPinned={thread.pinnedAt != null}
-                        sortable={sortable}
-                        snoozeWakeLabelText={
-                          section === "snoozed" && thread.snoozedUntil != null
-                            ? snoozeWakeLabel(thread.snoozedUntil, {
-                                now: new Date().toISOString(),
-                              })
-                            : null
-                        }
-                        // All sections: a woken thread can classify straight
-                        // into the settled tail (PR merged while snoozed), and
-                        // the wake signal must survive the trip. Still-snoozed
-                        // rows resolve to null on their own.
-                        wokeAt={threadWokeAt(thread, { now: snoozeNow })}
-                        isActive={routeThreadKey === threadKey}
-                        openPullRequestsInRightPanel={routeThreadRef !== null}
-                        jumpLabel={
-                          showThreadJumpHints ? (jumpLabelByKey.get(threadKey) ?? null) : null
-                        }
-                        currentEnvironmentId={primaryEnvironmentId}
-                        environmentLabel={environmentLabelById.get(thread.environmentId) ?? null}
-                        environmentMachine={
-                          environmentMachineById.get(thread.environmentId) ?? "server"
-                        }
-                        projectCwd={
-                          projectCwdByKey.get(`${thread.environmentId}:${thread.projectId}`) ?? null
-                        }
-                        projectFaviconPath={
-                          projectFaviconPathByKey.get(
-                            `${thread.environmentId}:${thread.projectId}`,
-                          ) ?? null
-                        }
-                        projectIcon={
-                          projectIconByKey.get(`${thread.environmentId}:${thread.projectId}`) ??
-                          null
-                        }
-                        projectTitle={
-                          projectTitleByKey.get(`${thread.environmentId}:${thread.projectId}`) ??
-                          null
-                        }
-                        projectDisplayName={
-                          projectDisplayNameByKey.get(
-                            `${thread.environmentId}:${thread.projectId}`,
-                          ) ?? null
-                        }
-                        providerEntryByInstanceId={
-                          providerEntriesByEnvironment.get(thread.environmentId) ??
-                          EMPTY_PROVIDER_ENTRIES
-                        }
-                        timestampFormat={timestampFormat}
-                        onThreadClick={handleThreadClick}
-                        onThreadActivate={navigateToThread}
-                        onStartRename={startThreadRename}
-                        onRenameTitleChange={setRenamingTitle}
-                        onCommitRename={commitThreadRename}
-                        onCancelRename={cancelThreadRename}
-                        isRenaming={renamingThreadKey === threadKey}
-                        renamingTitle={renamingThreadKey === threadKey ? renamingTitle : ""}
-                        onContextMenu={handleThreadContextMenu}
-                        onSettle={attemptSettle}
-                        onUnsettle={attemptUnsettle}
-                        onSnooze={attemptSnooze}
-                        onUnsnooze={attemptUnsnooze}
-                        onUnpin={attemptUnpin}
-                        onAcknowledgeWoke={acknowledgeWoke}
-                        changeRequestSnapshot={changeRequestSnapshotByKey.get(threadKey) ?? null}
-                        onChangeRequestSnapshot={setThreadChangeRequestSnapshot}
-                      />
-                    );
-                  };
-                  // Draft block above everything, then the pinned block:
-                  // full cards above the inbox, closed by a thin divider (the
-                  // pin glyphs carry the meaning, so no header text). Both
-                  // vanish entirely at count 0.
-                  // Pinned rows render in the one shared pinned order; only
-                  // reorder-capable rows register as sortable (legacy-server
-                  // pins render in place as plain rows).
-                  const items: ReactNode[] = [
-                    <SidebarDraftBlock
-                      key="draft-sessions"
-                      projectTitleByKey={projectTitleByKey}
-                      projectDisplayNameByKey={projectDisplayNameByKey}
-                      projectCwdByKey={projectCwdByKey}
-                      projectFaviconPathByKey={projectFaviconPathByKey}
-                      projectIconByKey={projectIconByKey}
-                      scopedProjectKeys={scopedProjectKeys}
-                      routeDraftId={routeDraftIdForRows}
-                      onNavigateToDraft={navigateToDraft}
-                    />,
-                    pinnedThreads.length > 0 ? (
-                      <li key="pinned-dnd" className="list-none">
-                        <DndContext
-                          sensors={pinnedDndSensors}
-                          collisionDetection={closestCenter}
-                          modifiers={[restrictToVerticalAxis, restrictToFirstScrollableAncestor]}
-                          onDragEnd={handlePinnedDragEnd}
-                        >
-                          <SortableContext
-                            items={orderedPinnedThreads
-                              .map((thread) =>
-                                scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-                              )
-                              .filter((threadKey) => reorderablePinnedKeys.has(threadKey))}
-                            strategy={verticalListSortingStrategy}
-                          >
-                            <ul
-                              role="list"
-                              aria-label="Pinned threads"
-                              className="flex flex-col gap-px"
-                            >
-                              {orderedPinnedThreads.map((thread) => {
-                                const threadKey = scopedThreadKey(
-                                  scopeThreadRef(thread.environmentId, thread.id),
-                                );
-                                if (!reorderablePinnedKeys.has(threadKey)) {
-                                  return renderThreadRow(thread, "pinned");
-                                }
-                                return (
-                                  <SortablePinnedThreadRow key={threadKey} id={threadKey}>
-                                    {(bag) => renderThreadRow(thread, "pinned", bag)}
-                                  </SortablePinnedThreadRow>
-                                );
-                              })}
-                            </ul>
-                          </SortableContext>
-                        </DndContext>
-                      </li>
-                    ) : null,
-                  ];
-                  if (pinnedThreads.length > 0) {
-                    items.push(
-                      <li
-                        key="pinned-divider"
-                        aria-hidden
-                        data-testid="sidebar-pinned-divider"
-                        className="mx-2.5 my-1.5 h-px list-none bg-sidebar-border/60"
-                      />,
-                    );
-                  }
-                  for (const thread of activeThreads) {
-                    items.push(renderThreadRow(thread, "active"));
-                  }
-                  // Snoozed shelf: between the inbox and Settled — out of the
-                  // way, never gone. The header always renders while anything
-                  // is snoozed (the count is the whole footprint when
-                  // collapsed); rows only when expanded. Vanishes entirely at
-                  // count 0.
-                  if (snoozedThreads.length > 0) {
-                    items.push(
-                      <li
-                        key="snoozed-shelf-header"
-                        data-thread-selection-safe
-                        className="list-none"
-                      >
-                        <button
-                          type="button"
-                          onClick={toggleSnoozedShelf}
-                          aria-expanded={snoozedShelfExpanded}
-                          data-testid="sidebar-snoozed-shelf-toggle"
-                          className="mb-1 mt-3 flex w-full cursor-pointer items-center gap-2 px-2.5 text-left"
-                        >
-                          <span className="text-xs font-medium text-blue-600 dark:text-blue-400">
-                            {snoozedShelfExpanded
-                              ? "Snoozed"
-                              : `Snoozed (${snoozedThreads.length})`}
-                          </span>
-                          <span className="h-px flex-1 bg-blue-500/20 dark:bg-blue-400/15" />
-                          <ChevronDownIcon
-                            aria-hidden
-                            className={cn(
-                              "size-3 text-blue-600 transition-transform dark:text-blue-400",
-                              snoozedShelfExpanded && "rotate-180",
-                            )}
-                          />
-                        </button>
-                      </li>,
-                    );
-                    for (const thread of visibleSnoozedThreads) {
-                      items.push(renderThreadRow(thread, "snoozed"));
-                    }
-                  }
-                  if (settledThreads.length > 0) {
-                    items.push(
-                      <li
-                        key="settled-shelf-header"
-                        data-thread-selection-safe
-                        className="list-none"
-                      >
-                        <button
-                          type="button"
-                          onClick={toggleSettledShelf}
-                          aria-expanded={settledShelfExpanded}
-                          data-testid="sidebar-settled-shelf-toggle"
-                          className="mb-1 mt-3 flex w-full cursor-pointer items-center gap-2 px-2.5 text-left"
-                        >
-                          <span className="text-xs font-medium text-muted-foreground/50">
-                            {settledShelfExpanded
-                              ? "Settled"
-                              : `Settled (${settledThreads.length})`}
-                          </span>
-                          <span className="h-px flex-1 bg-sidebar-border/60" />
-                          <ChevronDownIcon
-                            aria-hidden
-                            className={cn(
-                              "size-3 text-muted-foreground/50 transition-transform",
-                              settledShelfExpanded && "rotate-180",
-                            )}
-                          />
-                        </button>
-                      </li>,
-                    );
-                  }
-                  for (const thread of renderedSettledThreads) {
-                    items.push(renderThreadRow(thread, "settled"));
-                  }
-                  return items;
-                })()}
-                {settledShelfExpanded && hiddenSettledCount > 0 ? (
-                  <li className="list-none">
+            ) : null}
+            {!isSearchingThreads &&
+            visibleDraftSessionCount === 0 &&
+            pinnedThreads.length +
+              activeThreads.length +
+              snoozedThreads.length +
+              settledThreads.length ===
+              0 ? (
+              <div className="flex flex-col items-center gap-2 px-2 py-6 text-center text-xs text-muted-foreground/60">
+                {projects.length === 0 ? (
+                  <>
+                    <span>No projects yet</span>
                     <button
                       type="button"
-                      onClick={showMoreSettled}
-                      className="flex h-9 w-full cursor-pointer items-center gap-2.5 rounded-md px-2.5 text-left text-sm text-sidebar-muted-foreground/55 hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
+                      onClick={openAddProjectCommandPalette}
+                      className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-sidebar-border px-2.5 py-1 text-[11px] font-medium text-sidebar-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
                     >
-                      <PlusIcon aria-hidden className="size-4 shrink-0" />
-                      Show {Math.min(hiddenSettledCount, SETTLED_TAIL_PAGE_COUNT)} more
+                      <PlusIcon className="-mx-0.5 size-3" />
+                      Add project
                     </button>
-                  </li>
-                ) : null}
-              </ul>
-            </TooltipProvider>
-          ) : null}
-          {!isSearchingThreads &&
-          visibleDraftSessionCount === 0 &&
-          pinnedThreads.length +
-            activeThreads.length +
-            snoozedThreads.length +
-            settledThreads.length ===
-            0 ? (
-            <div className="flex flex-col items-center gap-2 px-2 py-6 text-center text-xs text-muted-foreground/60">
-              {projects.length === 0 ? (
-                <>
-                  <span>No projects yet</span>
-                  <button
-                    type="button"
-                    onClick={openAddProjectCommandPalette}
-                    className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-sidebar-border px-2.5 py-1 text-[11px] font-medium text-sidebar-muted-foreground transition-colors hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
-                  >
-                    <PlusIcon className="-mx-0.5 size-3" />
-                    Add project
-                  </button>
-                </>
-              ) : scopedProjectGroup ? (
-                `No threads in ${scopedProjectGroup.displayName} yet`
-              ) : (
-                "No threads yet"
-              )}
-            </div>
-          ) : null}
-        </SidebarGroup>
-      </SidebarContent>
+                  </>
+                ) : scopedProjectGroup ? (
+                  `No threads in ${scopedProjectGroup.displayName} yet`
+                ) : (
+                  "No threads yet"
+                )}
+              </div>
+            ) : null}
+          </SidebarGroup>
+        </SidebarContent>
+      </SidebarBody>
       <SidebarChromeFooter />
     </>
   );

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -2092,6 +2092,20 @@ export function GeneralSettingsPanel() {
       <SharedSettingsMismatchAlert />
       <SettingsSection id="organization" title="Organization">
         <SettingsRow
+          {...searchableSetting("project-rail")}
+          description="Switch projects from a column of icons on the left of the sidebar."
+          control={
+            <Switch
+              checked={settings.sidebarProjectRailEnabled}
+              onCheckedChange={(checked) =>
+                updateSettings({ sidebarProjectRailEnabled: Boolean(checked) })
+              }
+              aria-label="Project rail"
+            />
+          }
+        />
+
+        <SettingsRow
           {...searchableSetting("project-grouping")}
           description="Combine matching repositories across environments."
           resetAction={

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -145,6 +145,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     searchTerms: ["long lines code blocks tables diffs file previews"],
   },
   {
+    id: "project-rail",
+    title: "Project rail",
+    to: "/settings/general",
+    searchTerms: ["discord icons column switch projects quick left strip"],
+  },
+  {
     id: "project-grouping",
     title: "Project grouping",
     to: "/settings/general",

--- a/apps/web/src/components/sidebar/project-rail/ProjectRail.tsx
+++ b/apps/web/src/components/sidebar/project-rail/ProjectRail.tsx
@@ -1,0 +1,84 @@
+import { FolderIcon, PlusIcon } from "lucide-react";
+import type { MouseEvent as ReactMouseEvent } from "react";
+import { memo } from "react";
+
+import { cn } from "~/lib/utils";
+
+import type { SidebarProjectSnapshot } from "../../../sidebarProjectGrouping";
+import { ScrollArea } from "../../ui/scroll-area";
+import { ProjectRailAvatar } from "./ProjectRailAvatar";
+import { ProjectRailTile } from "./ProjectRailTile";
+import { PROJECT_RAIL_WIDTH } from "./projectRail.constants";
+
+function resolveRemoteLabel(project: SidebarProjectSnapshot): string | undefined {
+  if (project.environmentPresence === "local-only") return undefined;
+  const labels = project.remoteEnvironmentLabels;
+  return labels.length > 0 ? labels.join(", ") : undefined;
+}
+
+/**
+ * The Discord-style project column: "all projects" on top, one tile per
+ * project, "new project" pinned to the bottom. It is a view over the same
+ * project scope the combobox drives, so switching here filters the thread list
+ * exactly as the combobox does.
+ */
+export const ProjectRail = memo(function ProjectRail({
+  className,
+  projectGroups,
+  scopeKey,
+  onSelectScope,
+  onOpenProjectSettings,
+  onAddProject,
+}: {
+  readonly className?: string | undefined;
+  readonly projectGroups: readonly SidebarProjectSnapshot[];
+  readonly scopeKey: string | null;
+  readonly onSelectScope: (projectKey: string | null) => void;
+  readonly onOpenProjectSettings: (
+    event: ReactMouseEvent<HTMLElement>,
+    project: SidebarProjectSnapshot,
+  ) => void;
+  readonly onAddProject: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 flex-col items-center gap-2 border-r border-sidebar-border py-[var(--sidebar-content-inset)]",
+        className,
+      )}
+      style={{ width: `${PROJECT_RAIL_WIDTH}px` }}
+      data-project-rail=""
+    >
+      <ProjectRailTile
+        active={scopeKey === null}
+        label="All projects"
+        onClick={() => onSelectScope(null)}
+      >
+        <FolderIcon className={cn("size-5", scopeKey === null && "text-sidebar-foreground")} />
+      </ProjectRailTile>
+
+      <span aria-hidden="true" className="h-px w-6 shrink-0 rounded-full bg-sidebar-border" />
+
+      <ScrollArea hideScrollbars className="min-h-0 flex-1">
+        <div className="flex flex-col items-center gap-2">
+          {projectGroups.map((project) => (
+            <ProjectRailTile
+              key={project.projectKey}
+              active={scopeKey === project.projectKey}
+              label={project.displayName}
+              secondaryLabel={resolveRemoteLabel(project)}
+              onClick={() => onSelectScope(project.projectKey)}
+              onContextMenu={(event) => onOpenProjectSettings(event, project)}
+            >
+              <ProjectRailAvatar project={project} />
+            </ProjectRailTile>
+          ))}
+        </div>
+      </ScrollArea>
+
+      <ProjectRailTile active={false} label="New project" onClick={onAddProject}>
+        <PlusIcon className="size-5 text-sidebar-muted-foreground" />
+      </ProjectRailTile>
+    </div>
+  );
+});

--- a/apps/web/src/components/sidebar/project-rail/ProjectRailAvatar.tsx
+++ b/apps/web/src/components/sidebar/project-rail/ProjectRailAvatar.tsx
@@ -1,0 +1,56 @@
+import { isProjectFaviconFallbackUrl } from "@t3tools/shared/projectFavicon";
+
+import { cn } from "~/lib/utils";
+
+import { isGenericProjectIcon, selectProjectIcon } from "../../../projectIconModel";
+import type { SidebarProjectSnapshot } from "../../../sidebarProjectGrouping";
+import { ProjectFavicon, useProjectFaviconAsset } from "../../ProjectFavicon";
+import { resolveProjectInitials, resolveProjectTileColorClassName } from "./projectRailInitials";
+
+/**
+ * What a rail tile shows, in falling order of how much it says about the
+ * project: its favicon, an icon the user picked, an icon the model actually
+ * recognized from the name, and otherwise the project's initials. The model
+ * hands out a generic code glyph for names it cannot place, and a rail of
+ * identical glyphs is unreadable — initials at least differ per project.
+ */
+export function ProjectRailAvatar({ project }: { project: SidebarProjectSnapshot }) {
+  const faviconState = useProjectFaviconAsset({
+    environmentId: project.environmentId,
+    cwd: project.workspaceRoot,
+    faviconPath: project.faviconPath,
+  });
+  // A resolved URL can still be the server's "no favicon here" marker, which
+  // ProjectFavicon itself treats as absent.
+  const hasFavicon =
+    faviconState._tag === "Success" && !isProjectFaviconFallbackUrl(faviconState.url);
+  const hasChosenIcon = project.projectIcon != null;
+  const isRecognizedName = !isGenericProjectIcon(
+    selectProjectIcon(project.title, project.workspaceRoot),
+  );
+
+  if (hasFavicon || hasChosenIcon || isRecognizedName) {
+    return (
+      <ProjectFavicon
+        environmentId={project.environmentId}
+        cwd={project.workspaceRoot}
+        projectName={project.title}
+        faviconPath={project.faviconPath}
+        projectIcon={project.projectIcon}
+        className="size-5"
+      />
+    );
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "text-[0.6875rem] font-semibold leading-none tracking-tight",
+        resolveProjectTileColorClassName(project.title, project.workspaceRoot),
+      )}
+    >
+      {resolveProjectInitials(project.displayName)}
+    </span>
+  );
+}

--- a/apps/web/src/components/sidebar/project-rail/ProjectRailAvatar.tsx
+++ b/apps/web/src/components/sidebar/project-rail/ProjectRailAvatar.tsx
@@ -8,11 +8,14 @@ import { ProjectFavicon, useProjectFaviconAsset } from "../../ProjectFavicon";
 import { resolveProjectInitials, resolveProjectTileColorClassName } from "./projectRailInitials";
 
 /**
- * What a rail tile shows, in falling order of how much it says about the
- * project: its favicon, an icon the user picked, an icon the model actually
- * recognized from the name, and otherwise the project's initials. The model
- * hands out a generic code glyph for names it cannot place, and a rail of
- * identical glyphs is unreadable — initials at least differ per project.
+ * Decides whether a rail tile can show a real icon at all, and falls back to
+ * initials when it cannot. A tile has something to show when the project has a
+ * favicon, an icon the user picked, or a name the icon model recognizes;
+ * `ProjectFavicon` then picks between those exactly as every other surface does
+ * (a user-chosen icon outranks the favicon, since picking one is a deliberate
+ * override). The model hands out a generic code glyph for names it cannot
+ * place, and a rail of identical glyphs is unreadable — initials at least
+ * differ per project.
  */
 export function ProjectRailAvatar({ project }: { project: SidebarProjectSnapshot }) {
   const faviconState = useProjectFaviconAsset({

--- a/apps/web/src/components/sidebar/project-rail/ProjectRailTile.tsx
+++ b/apps/web/src/components/sidebar/project-rail/ProjectRailTile.tsx
@@ -1,0 +1,70 @@
+import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+
+import { cn } from "~/lib/utils";
+
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../../ui/tooltip";
+
+/**
+ * One square button in the rail. The squircle-to-rounded-square transition and
+ * the left-edge pill are the Discord affordances that make a column of icons
+ * readable as a selector; both are finite transitions, never a running
+ * animation.
+ */
+export function ProjectRailTile({
+  active,
+  label,
+  secondaryLabel,
+  children,
+  onClick,
+  onContextMenu,
+}: {
+  readonly active: boolean;
+  readonly label: string;
+  readonly secondaryLabel?: string | undefined;
+  readonly children: ReactNode;
+  readonly onClick: () => void;
+  readonly onContextMenu?: ((event: ReactMouseEvent<HTMLElement>) => void) | undefined;
+}) {
+  return (
+    <div className="group/rail-tile relative flex w-full justify-center">
+      <span
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute left-0 top-1/2 w-1 -translate-y-1/2 rounded-r-full bg-sidebar-foreground transition-[height,opacity] duration-150 ease-out",
+          active ? "h-5 opacity-100" : "h-2 opacity-0 group-hover/rail-tile:opacity-60",
+        )}
+      />
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              aria-label={label}
+              aria-pressed={active}
+              onClick={onClick}
+              {...(onContextMenu ? { onContextMenu } : {})}
+              className={cn(
+                "flex size-10 cursor-pointer items-center justify-center overflow-hidden rounded-2xl outline-hidden ring-ring transition-[border-radius,background-color] duration-150 ease-out focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar",
+                active
+                  ? "rounded-xl bg-sidebar-row-selected"
+                  : "bg-sidebar-control-surface hover:rounded-xl hover:bg-sidebar-row-hover",
+              )}
+            >
+              {children}
+            </button>
+          }
+        />
+        <TooltipPopup side="right">
+          {secondaryLabel ? (
+            <span className="flex flex-col gap-0.5">
+              <span>{label}</span>
+              <span className="text-muted-foreground">{secondaryLabel}</span>
+            </span>
+          ) : (
+            label
+          )}
+        </TooltipPopup>
+      </Tooltip>
+    </div>
+  );
+}

--- a/apps/web/src/components/sidebar/project-rail/projectRail.constants.ts
+++ b/apps/web/src/components/sidebar/project-rail/projectRail.constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Width of the project rail column in pixels. The sidebar's `--sidebar-width`
+ * covers the rail plus the thread column, so the width math in
+ * `threadSidebarWidth.ts` adds this on top of the thread column's minimum.
+ */
+export const PROJECT_RAIL_WIDTH = 56;

--- a/apps/web/src/components/sidebar/project-rail/projectRailInitials.test.ts
+++ b/apps/web/src/components/sidebar/project-rail/projectRailInitials.test.ts
@@ -24,6 +24,13 @@ describe("resolveProjectInitials", () => {
     expect(resolveProjectInitials("x")).toBe("X");
   });
 
+  it("keeps astral characters whole", () => {
+    // Indexing by code unit would split the surrogate pair and render a
+    // replacement glyph instead of the emoji.
+    expect(resolveProjectInitials("🚀 Rocket")).toBe("🚀R");
+    expect(resolveProjectInitials("🚀🛰️")).toBe("🚀🛰");
+  });
+
   it("stays renderable for an empty name", () => {
     expect(resolveProjectInitials("")).toBe("?");
     expect(resolveProjectInitials("   ")).toBe("?");

--- a/apps/web/src/components/sidebar/project-rail/projectRailInitials.test.ts
+++ b/apps/web/src/components/sidebar/project-rail/projectRailInitials.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveProjectInitials } from "./projectRailInitials";
+
+describe("resolveProjectInitials", () => {
+  it("takes the first letter of the first two words", () => {
+    expect(resolveProjectInitials("Waterfruit Puzzle")).toBe("WP");
+    expect(resolveProjectInitials("T3 Code")).toBe("T3");
+  });
+
+  it("treats separators as word boundaries", () => {
+    expect(resolveProjectInitials("orange-cli")).toBe("OC");
+    expect(resolveProjectInitials("my_app")).toBe("MA");
+    expect(resolveProjectInitials("scripts/build-tools")).toBe("SB");
+  });
+
+  it("splits camelCase and digit boundaries", () => {
+    expect(resolveProjectInitials("webApp")).toBe("WA");
+    expect(resolveProjectInitials("t3code")).toBe("T3");
+  });
+
+  it("falls back to the first two characters of a single word", () => {
+    expect(resolveProjectInitials("monocode")).toBe("MO");
+    expect(resolveProjectInitials("x")).toBe("X");
+  });
+
+  it("stays renderable for an empty name", () => {
+    expect(resolveProjectInitials("")).toBe("?");
+    expect(resolveProjectInitials("   ")).toBe("?");
+  });
+});

--- a/apps/web/src/components/sidebar/project-rail/projectRailInitials.ts
+++ b/apps/web/src/components/sidebar/project-rail/projectRailInitials.ts
@@ -27,8 +27,11 @@ function splitProjectNameWords(name: string): string[] {
 export function resolveProjectInitials(displayName: string): string {
   const words = splitProjectNameWords(displayName.trim());
   if (words.length === 0) return "?";
-  if (words.length === 1) return words[0]!.slice(0, 2).toUpperCase();
-  return `${words[0]![0]!}${words[1]![0]!}`.toUpperCase();
+  // Indexed by code point, not code unit: a name starting with an emoji or any
+  // other astral character would otherwise yield half a surrogate pair and
+  // render as a replacement glyph.
+  if (words.length === 1) return Array.from(words[0]!).slice(0, 2).join("").toUpperCase();
+  return `${Array.from(words[0]!)[0]!}${Array.from(words[1]!)[0]!}`.toUpperCase();
 }
 
 /** Text color for an initials tile, matching the color the icon model would pick. */

--- a/apps/web/src/components/sidebar/project-rail/projectRailInitials.ts
+++ b/apps/web/src/components/sidebar/project-rail/projectRailInitials.ts
@@ -1,0 +1,38 @@
+import { projectIconColorClassName } from "../../../projectIconColors";
+import { resolveAutomaticProjectIconColor } from "../../ProjectFavicon";
+
+// Splits on separators and camelCase boundaries so "orange-cli", "orange_cli"
+// and "orangeCli" all read as two words. Digits start their own token too, so
+// "t3code" keeps its "3".
+const SEPARATORS = /[\s\-_./\\:]+/;
+
+function splitProjectNameWords(name: string): string[] {
+  return name
+    .split(SEPARATORS)
+    .flatMap((segment) =>
+      segment
+        .replace(/([a-z])([A-Z])/g, "$1 $2")
+        .replace(/([A-Za-z])(\d)/g, "$1 $2")
+        .replace(/(\d)([A-Za-z])/g, "$1 $2")
+        .split(" "),
+    )
+    .filter((word) => word.length > 0);
+}
+
+/**
+ * Two-character monogram for a project tile: the first letters of the first two
+ * words, or the first two characters when the name is a single word.
+ * "orange-cli" reads "OC", "Waterfruit Puzzle" reads "WP", "t3code" reads "T3".
+ */
+export function resolveProjectInitials(displayName: string): string {
+  const words = splitProjectNameWords(displayName.trim());
+  if (words.length === 0) return "?";
+  if (words.length === 1) return words[0]!.slice(0, 2).toUpperCase();
+  return `${words[0]![0]!}${words[1]![0]!}`.toUpperCase();
+}
+
+/** Text color for an initials tile, matching the color the icon model would pick. */
+export function resolveProjectTileColorClassName(projectName: string, cwd: string): string {
+  const color = resolveAutomaticProjectIconColor(projectName, cwd);
+  return color ? projectIconColorClassName(color) : "text-sidebar-muted-foreground";
+}

--- a/apps/web/src/components/threadSidebarWidth.ts
+++ b/apps/web/src/components/threadSidebarWidth.ts
@@ -12,9 +12,10 @@ export function resolveThreadSidebarMaximumWidth(viewportWidth: number): number 
 
 /**
  * `extraWidth` covers columns that live inside the sidebar but are not the
- * thread list (today: the project rail). They widen both the default and the
- * floor so turning the rail on never shrinks the thread column below the width
- * it has without it.
+ * thread list (today: the project rail). It widens both the default and the
+ * floor, so a sidebar at its default width keeps the same thread column with
+ * the rail on, and one the user has resized keeps at least the thread column's
+ * minimum.
  */
 export function resolveInitialThreadSidebarWidth(
   storedWidth: number | null,

--- a/apps/web/src/components/threadSidebarWidth.ts
+++ b/apps/web/src/components/threadSidebarWidth.ts
@@ -10,13 +10,24 @@ export function resolveThreadSidebarMaximumWidth(viewportWidth: number): number 
   );
 }
 
+/**
+ * `extraWidth` covers columns that live inside the sidebar but are not the
+ * thread list (today: the project rail). They widen both the default and the
+ * floor so turning the rail on never shrinks the thread column below the width
+ * it has without it.
+ */
 export function resolveInitialThreadSidebarWidth(
   storedWidth: number | null,
   viewportWidth: number,
+  extraWidth = 0,
 ): number {
+  const minimumWidth = THREAD_SIDEBAR_MIN_WIDTH + extraWidth;
   const preferredWidth =
     storedWidth === null
-      ? THREAD_SIDEBAR_DEFAULT_WIDTH
-      : Math.max(THREAD_SIDEBAR_MIN_WIDTH, storedWidth);
-  return Math.min(preferredWidth, resolveThreadSidebarMaximumWidth(viewportWidth));
+      ? THREAD_SIDEBAR_DEFAULT_WIDTH + extraWidth
+      : Math.max(minimumWidth, storedWidth);
+  return Math.min(
+    preferredWidth,
+    Math.max(minimumWidth, resolveThreadSidebarMaximumWidth(viewportWidth)),
+  );
 }

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -383,7 +383,8 @@ export function useLegacySidebarEnabled(): boolean {
 
 /**
  * Whether the default sidebar shows the Discord-style project rail
- * (Settings → General → Organization) in place of the project scope combobox.
+ * (Settings → General → Organization → Project rail) in place of the project
+ * scope combobox.
  *
  * Hydration-gated for the same reason as the legacy sidebar: the rail changes
  * the sidebar's width floor, so resolving against the pre-hydration schema

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -381,6 +381,20 @@ export function useLegacySidebarEnabled(): boolean {
   return settingsHydrated && legacySidebarEnabled;
 }
 
+/**
+ * Whether the default sidebar shows the Discord-style project rail
+ * (Settings → General → Organization) in place of the project scope combobox.
+ *
+ * Hydration-gated for the same reason as the legacy sidebar: the rail changes
+ * the sidebar's width floor, so resolving against the pre-hydration schema
+ * defaults would lay out one width and then jump to another.
+ */
+export function useSidebarProjectRailEnabled(): boolean {
+  const settingsHydrated = useClientSettingsHydrated();
+  const projectRailEnabled = useClientSettingsValue().sidebarProjectRailEnabled;
+  return settingsHydrated && projectRailEnabled;
+}
+
 /** Read current settings for one environment, merged with client-local preferences. */
 export function useEnvironmentSettings<T = UnifiedSettings>(
   environmentId: EnvironmentId,

--- a/apps/web/src/lib/chatThreadActions.test.ts
+++ b/apps/web/src/lib/chatThreadActions.test.ts
@@ -115,6 +115,21 @@ describe("chatThreadActions", () => {
     expect(projectRef).toEqual(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID));
   });
 
+  it("prefers an explicit project override over the viewed thread's project", () => {
+    const scopedProjectId = ProjectId.make("project-3");
+    const projectRef = resolveThreadActionProjectRef(
+      createContext({
+        activeThread: {
+          environmentId: ENVIRONMENT_ID,
+          projectId: PROJECT_ID,
+        },
+        projectRefOverride: scopeProjectRef(ENVIRONMENT_ID, scopedProjectId),
+      }),
+    );
+
+    expect(projectRef).toEqual(scopeProjectRef(ENVIRONMENT_ID, scopedProjectId));
+  });
+
   it("falls back to the active draft thread project when there is no active thread", () => {
     const projectRef = resolveThreadActionProjectRef(
       createContext({

--- a/apps/web/src/lib/chatThreadActions.ts
+++ b/apps/web/src/lib/chatThreadActions.ts
@@ -35,6 +35,11 @@ export interface ChatThreadActionContext {
   readonly activeThread: ThreadContextLike | undefined;
   readonly defaultProjectRef: ScopedProjectRef | null;
   readonly handleNewThread: NewThreadHandler;
+  // Set when the surface starting the thread already knows which project it
+  // means, and that answer outranks the viewed thread. Scoping the sidebar to
+  // one project is such a statement: creating a thread from there must land in
+  // the scoped project even while a thread from another project is open.
+  readonly projectRefOverride?: ScopedProjectRef | null;
 }
 
 export function resolveNewDraftStartFromOrigin(input: {
@@ -71,6 +76,9 @@ export function hasExplicitComposerModelSelection(
 export function resolveThreadActionProjectRef(
   context: ChatThreadActionContext,
 ): ScopedProjectRef | null {
+  if (context.projectRefOverride) {
+    return context.projectRefOverride;
+  }
   if (context.activeThread) {
     return scopeProjectRef(context.activeThread.environmentId, context.activeThread.projectId);
   }

--- a/apps/web/src/projectIconModel.ts
+++ b/apps/web/src/projectIconModel.ts
@@ -123,7 +123,11 @@ const PROJECT_ICON_MODEL: ReadonlyArray<ProjectIconClass> = [
   },
 ];
 
-const GENERIC_PROJECT_ICONS: ReadonlyArray<ProjectIconName> = [
+// Chosen by hash when no term matched, so one of these means "the model did
+// not recognize this name" rather than "this project is about code". Callers
+// that want to show something more identifying (the project rail's initials)
+// key off this list.
+export const GENERIC_PROJECT_ICONS: ReadonlyArray<ProjectIconName> = [
   "code",
   "braces",
   "circuit",
@@ -189,4 +193,9 @@ export function selectProjectIcon(
   const icon: ProjectIconSelection = { kind: "lucide", icon: iconName };
   projectIconCache.set(cacheKey, icon);
   return icon;
+}
+
+/** True when `selectProjectIcon` fell back to a generic icon instead of classifying the name. */
+export function isGenericProjectIcon(selection: ProjectIconSelection): boolean {
+  return selection.kind === "lucide" && GENERIC_PROJECT_ICONS.includes(selection.icon);
 }

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -5,7 +5,9 @@ import { useEffect, useMemo } from "react";
 import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { useClientSettings, useLegacySidebarEnabled } from "../hooks/useSettings";
 import { openCommandPalette } from "../commandPaletteBus";
+import { scopeProjectRef } from "@t3tools/client-runtime/environment";
 import { useProjects } from "../state/entities";
+import { useUiStateStore } from "../uiStateStore";
 import { usePrimaryEnvironmentId } from "../state/environments";
 import { selectProjectGroupingSettings } from "../logicalProject";
 import { buildSidebarProjectSnapshots } from "../sidebarProjectGrouping";
@@ -32,15 +34,26 @@ function ChatRouteGlobalShortcuts() {
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const projects = useProjects();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
-  const projectGroupCount = useMemo(
+  const projectGroups = useMemo(
     () =>
       buildSidebarProjectSnapshots({
         projects,
         settings: projectGroupingSettings,
         primaryEnvironmentId,
         resolveEnvironmentLabel: () => null,
-      }).length,
+      }),
     [primaryEnvironmentId, projectGroupingSettings, projects],
+  );
+  const projectGroupCount = projectGroups.length;
+  // The sidebar's project scope answers the picker's question ahead of time,
+  // so chat.new creates straight into the scoped project instead of asking.
+  const projectScopeKey = useUiStateStore((store) => store.sidebarProjectScopeKey);
+  const scopedProjectGroup = useMemo(
+    () =>
+      projectScopeKey === null
+        ? null
+        : (projectGroups.find((project) => project.projectKey === projectScopeKey) ?? null),
+    [projectGroups, projectScopeKey],
   );
   const terminalOpen = useTerminalUiStateStore((state) =>
     routeThreadRef
@@ -95,7 +108,7 @@ function ChatRouteGlobalShortcuts() {
         // The default sidebar routes creation through the command palette
         // whenever there is a real choice to make; the legacy sidebar (and
         // single-project setups) keep the immediate contextual create.
-        if (!legacySidebarEnabled && projectGroupCount > 1) {
+        if (!legacySidebarEnabled && projectGroupCount > 1 && scopedProjectGroup === null) {
           openCommandPalette({ open: "new-thread-in" });
           return;
         }
@@ -104,6 +117,10 @@ function ChatRouteGlobalShortcuts() {
           activeThread: activeThread ?? undefined,
           defaultProjectRef,
           handleNewThread,
+          projectRefOverride:
+            !legacySidebarEnabled && scopedProjectGroup
+              ? scopeProjectRef(scopedProjectGroup.environmentId, scopedProjectGroup.id)
+              : null,
         });
         return;
       }
@@ -165,6 +182,7 @@ function ChatRouteGlobalShortcuts() {
     defaultProjectRef,
     previewOpen,
     projectGroupCount,
+    scopedProjectGroup,
     routeThreadRef,
     selectedThreadKeysSize,
     legacySidebarEnabled,

--- a/docs/user/project-settings.md
+++ b/docs/user/project-settings.md
@@ -8,6 +8,14 @@ Choose an icon, emoji, or image from the project to make it easier to recognize.
 to every checkout in the project group and appears on connected clients. Choose **Automatic** to
 let T3 Code detect an icon again.
 
+## Switch projects from the rail
+
+Turn on **Settings → General → Project rail** to replace the sidebar's project menu with a column of
+project icons on the left. Select the top tile to see every project's threads, a project tile to see
+only its threads, or the bottom tile to add a project. Hover a tile for the full project name, and
+right-click it to open that project's settings. Projects whose name T3 Code cannot place show their
+initials instead of an icon.
+
 ## Keep the default branch current
 
 Enable **Automatically pull** to keep the default-branch checkout up to date with its configured

--- a/docs/user/project-settings.md
+++ b/docs/user/project-settings.md
@@ -13,8 +13,8 @@ let T3 Code detect an icon again.
 Turn on **Settings → General → Project rail** to replace the sidebar's project menu with a column of
 project icons on the left. Select the top tile to see every project's threads, a project tile to see
 only its threads, or the bottom tile to add a project. Hover a tile for the full project name, and
-right-click it to open that project's settings. Projects whose name T3 Code cannot place show their
-initials instead of an icon.
+right-click it to open that project's settings. A project with no favicon or chosen icon, whose name
+T3 Code cannot place, shows its initials instead.
 
 ## Keep the default branch current
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -294,6 +294,17 @@ describe("ClientSettings sidebar", () => {
     );
   });
 
+  it("keeps the project rail opt-in and patchable", () => {
+    expect(decodeClientSettings({}).sidebarProjectRailEnabled).toBe(false);
+    expect(
+      decodeClientSettings({ sidebarProjectRailEnabled: true }).sidebarProjectRailEnabled,
+    ).toBe(true);
+    expect(
+      decodeClientSettingsPatch({ sidebarProjectRailEnabled: true }).sidebarProjectRailEnabled,
+    ).toBe(true);
+    expect(() => decodeClientSettingsPatch({ sidebarProjectRailEnabled: "yes" })).toThrow();
+  });
+
   it("keeps unpin confirmation opt-in and patchable", () => {
     expect(decodeClientSettings({}).confirmThreadUnpin).toBe(false);
     expect(decodeClientSettingsPatch({ confirmThreadUnpin: true }).confirmThreadUnpin).toBe(true);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -336,6 +336,10 @@ export const ClientSettingsSchema = Schema.Struct({
   // old keys, so everyone, including prior beta opt-outs, resets to the new
   // default sidebar.
   legacySidebarEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  // Discord-style vertical column of project icons on the left of the default
+  // sidebar. Opt-in: it replaces the project scope combobox, so nobody's
+  // sidebar changes shape until they ask for it.
+  sidebarProjectRailEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   sidebarProjectGroupingMode: SidebarProjectGroupingMode.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE)),
   ),
@@ -1233,6 +1237,7 @@ export const ClientSettingsPatch = Schema.Struct({
   proactivePanelsEnabled: Schema.optionalKey(Schema.Boolean),
   showSkillsInSlashMenu: Schema.optionalKey(Schema.Boolean),
   legacySidebarEnabled: Schema.optionalKey(Schema.Boolean),
+  sidebarProjectRailEnabled: Schema.optionalKey(Schema.Boolean),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),
   sidebarProjectGroupingOverrides: Schema.optionalKey(
     Schema.Record(TrimmedNonEmptyString, SidebarProjectGroupingMode),


### PR DESCRIPTION
## The problem

The v2 sidebar traded away fast project switching. Scoping threads now goes through the
"All projects" combobox, which means two clicks per switch and no visible answer to
"which projects do I even have?".

The practical cost is focus. Switching projects through a dropdown loses your place every
time, and the list of projects is only visible while the menu is open. I ended up turning
the **legacy sidebar back on** purely to stop losing track of where I was — giving up
everything v2 does better in the process.

That is the real tension this PR targets. The old sidebar was good at one thing: one-click
project switching, always-visible projects. The new sidebar is better at everything about
threads — settled/unsettled grouping, the flat list, search. Today you have to pick one.

## The change

An opt-in, Discord-inspired vertical rail on the left of the sidebar. One tile per project,
"All projects" on top, "New project" at the bottom. One click to switch. The thread column
keeps its current behavior entirely.

The result combines both sidebars instead of choosing between them: the old sidebar's
one-click project switching, plus the new sidebar's thread model, unchanged.

**Off by default**, behind `Settings → General → Project rail`. Nobody's sidebar changes
shape until they ask for it. Turning it off restores the combobox row exactly as it is today.

### Details

- Tiles reuse the existing project scope state (`sidebarProjectScopeKey`), so thread
  filtering, stale-scope reset and selection clearing all keep working untouched.
- Tile content falls back in order: favicon → user-chosen icon → an icon the model actually
  recognized from the name → the project's initials. The icon model hands out a generic code
  glyph for names it cannot place, and a rail of identical glyphs is unreadable, so initials
  at least differ per project ("orange-cli" → OC, "Waterfruit Puzzle" → WP).
- Hover a tile for the full project name; right-click opens that project's settings.
- The rail lives inside the existing sidebar shell, so collapse, drag-resize, the mobile
  sheet and the Electron drag region needed no changes. It widens the panel rather than
  squeezing the thread column below its current minimum width.
- When the sidebar is scoped to a single project, the new-thread button creates directly in
  that project instead of opening the project picker — inside a project, the picker has
  nothing left to ask. The scoped project also takes precedence over the currently viewed
  thread's project, so creating from a scoped rail lands where you expect.

Transitions are finite (border-radius/background on hover), with no continuously repainting
animation.

## Screenshot

<img src="https://raw.githubusercontent.com/m1trenv0/t3code-sidebar-rail/pr-assets/project-rail.png" alt="The project rail enabled in the sidebar, showing one tile per project with the thread list beside it" width="360" />

## Testing

- `vp test run` on the touched test files: project rail initials, client settings contract,
  sidebar logic, chat thread actions, command palette logic — all passing.
- Typecheck clean for `@t3tools/web` and `@t3tools/contracts`.
- Lint on touched files reports only pre-existing warnings.

## Notes

Mobile (React Native) is out of scope; the rail is a web/desktop sidebar feature. Possible
follow-ups deliberately left out: unread/attention badges on tiles, and drag-to-reorder.

Model: Claude Opus 5, via Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add opt-in Discord-style project rail to the sidebar
> - Adds a `sidebarProjectRailEnabled` boolean client setting (defaults to `false`) with a toggle in General settings and a settings-search entry
> - Introduces `ProjectRail` with per-project tiles, an all-projects tile, and an add-project action; tiles show the project favicon/icon or fallback initials with an automatic color
> - Updates [AppSidebarLayout.tsx](https://github.com/pingdotgg/t3code/pull/10196/files#diff-b580a936d60a70bebcccf38ac9a82ca5f4440c99445dbccb0c176ebe5dc1d301) and the width resolvers to reserve `PROJECT_RAIL_WIDTH` (56px) outside the thread column, recalculating bounds when the rail setting changes
> - Makes `shouldCreateNewThreadInCurrentProject` accept an options object and bypass project selection when the sidebar is project-scoped; thread-action project resolution now honors an explicit project override before the active thread or default project
> - The `chat.new` shortcut starts a thread directly in the scoped project for the non-legacy sidebar, falling back to the picker for multi-project scopes
> - Risk: legacy sidebar keeps the project-scope combobox and add-project button; when the rail is enabled these are removed and project selection goes through `ProjectRail` only
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14ae835.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->