### PR TITLE
fix(server): exclude between-turn edits from V2 turn diffs

### DIFF
--- a/apps/server/src/checkpointing/CheckpointDiffQuery.test.ts
+++ b/apps/server/src/checkpointing/CheckpointDiffQuery.test.ts
@@ -8,6 +8,7 @@ import { OrchestratorProjectionError } from "../orchestration-v2/Orchestrator.ts
 import type { ProjectionCheckpointContext } from "../orchestration-v2/ProjectionStore.ts";
 import * as ThreadManagement from "../orchestration-v2/ThreadManagementService.ts";
 import * as CheckpointDiffQuery from "./CheckpointDiffQuery.ts";
+import { checkpointStartRef } from "./Utils.ts";
 import * as CheckpointStore from "./CheckpointStore.ts";
 import {
   CheckpointRefUnavailableError,
@@ -46,6 +47,7 @@ function makeProjection(): ProjectionCheckpointContext {
 
 function makeLayer(input: {
   readonly projection: Effect.Effect<ProjectionCheckpointContext, OrchestratorProjectionError>;
+  readonly hasStartSnapshot?: boolean;
   readonly diffCheckpoints?: CheckpointStore.CheckpointStore["Service"]["diffCheckpoints"];
 }) {
   return CheckpointDiffQuery.layer.pipe(
@@ -55,6 +57,7 @@ function makeLayer(input: {
           getCheckpointContext: () => input.projection,
         }),
         Layer.mock(CheckpointStore.CheckpointStore)({
+          hasCheckpointRef: () => Effect.succeed(input.hasStartSnapshot ?? false),
           diffCheckpoints: input.diffCheckpoints ?? (() => Effect.succeed("diff")),
         }),
       ),
@@ -66,7 +69,11 @@ it.effect("computes V2 run diffs from projected checkpoint scopes", () => {
   const diffCheckpoints = vi.fn((_input: CheckpointStore.DiffCheckpointsInput) =>
     Effect.succeed("diff --git a/file b/file"),
   );
-  const layer = makeLayer({ projection: Effect.succeed(makeProjection()), diffCheckpoints });
+  const layer = makeLayer({
+    projection: Effect.succeed(makeProjection()),
+    diffCheckpoints,
+    hasStartSnapshot: true,
+  });
 
   return Effect.gen(function* () {
     const query = yield* CheckpointDiffQuery.CheckpointDiffQuery;
@@ -193,3 +200,44 @@ it.effect("preserves the typed missing-baseline-ref error contract", () => {
     );
   }).pipe(Effect.provide(layer));
 });
+
+for (const hasStartSnapshot of [false, true]) {
+  it.effect(
+    `uses ${hasStartSnapshot ? "fresh" : "legacy"} baseline for an individual V2 turn`,
+    () => {
+      const projection = makeProjection();
+      const firstRef = checkpointRefForScopeOrdinal({
+        scopeId: firstScopeId,
+        ordinalWithinScope: 1,
+      });
+      const diffCheckpoints = vi.fn((_input: CheckpointStore.DiffCheckpointsInput) =>
+        Effect.succeed("patch"),
+      );
+      const layer = makeLayer({
+        hasStartSnapshot,
+        diffCheckpoints,
+        projection: Effect.succeed({
+          ...projection,
+          checkpoints: [
+            ...projection.checkpoints,
+            {
+              scopeId: firstScopeId,
+              runId: firstRunId,
+              appRunOrdinal: 1,
+              status: "ready",
+              ref: firstRef,
+            },
+          ],
+        }),
+      });
+      return Effect.gen(function* () {
+        const query = yield* CheckpointDiffQuery.CheckpointDiffQuery;
+        yield* query.getTurnDiff({ threadId, fromTurnCount: 1, toTurnCount: 2 });
+        assert.equal(
+          diffCheckpoints.mock.calls[0]?.[0].fromCheckpointRef,
+          hasStartSnapshot ? checkpointStartRef(secondRef) : firstRef,
+        );
+      }).pipe(Effect.provide(layer));
+    },
+  );
+}

--- a/apps/server/src/checkpointing/CheckpointDiffQuery.ts
+++ b/apps/server/src/checkpointing/CheckpointDiffQuery.ts
@@ -29,6 +29,7 @@ import {
   CheckpointWorkspacePathMissingError,
   type CheckpointServiceError,
 } from "./Errors.ts";
+import { checkpointStartRef } from "./Utils.ts";
 import * as CheckpointStore from "./CheckpointStore.ts";
 
 /** Service tag for checkpoint diff queries. */
@@ -181,10 +182,16 @@ export const make = Effect.gen(function* () {
         });
       }
 
+      const startRef = checkpointStartRef(toCheckpoint.ref);
+      const turnBaselineRef =
+        input.toTurnCount === input.fromTurnCount + 1 &&
+        (yield* checkpointStore.hasCheckpointRef({ cwd: toScope.cwd, checkpointRef: startRef }))
+          ? startRef
+          : fromCheckpointRef;
       const diff = yield* checkpointStore
         .diffCheckpoints({
           cwd: toScope.cwd,
-          fromCheckpointRef,
+          fromCheckpointRef: turnBaselineRef,
           toCheckpointRef: toCheckpoint.ref,
           fallbackFromToHead: false,
           ignoreWhitespace,

--- a/apps/server/src/checkpointing/Utils.ts
+++ b/apps/server/src/checkpointing/Utils.ts
@@ -26,3 +26,8 @@ function resolveThreadWorkspaceCwd(input: {
 
   return input.projects.find((project) => project.id === input.thread.projectId)?.workspaceRoot;
 }
+
+/** A separate starting snapshot keeps turn diffs independent of edits made while idle. */
+export function checkpointStartRef(checkpointRef: CheckpointRef): CheckpointRef {
+  return CheckpointRef.make(`${checkpointRef}-start`);
+}

--- a/apps/server/src/orchestration-v2/CheckpointCaptureService.test.ts
+++ b/apps/server/src/orchestration-v2/CheckpointCaptureService.test.ts
@@ -8,6 +8,7 @@ import {
   NodeId,
   type OrchestrationV2DomainEvent,
   type OrchestrationV2Run,
+  type OrchestrationV2ThreadProjection,
   ProjectId,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -37,6 +38,55 @@ const projectId = ProjectId.make("project:checkpoint-capture-delegated");
 const runId = RunId.make("run:checkpoint-capture-delegated");
 const scopeId = CheckpointScopeId.make("scope:checkpoint-capture-delegated");
 const rootNodeId = NodeId.make("node:checkpoint-capture-delegated-root");
+
+it.effect.each([
+  { status: "failed", checkpoint: null, removed: true },
+  { status: "interrupted", checkpoint: null, removed: true },
+  { status: "cancelled", checkpoint: null, removed: true },
+  // A completed run reclaims its baseline only once capture recorded a failure.
+  { status: "completed", checkpoint: "error", removed: true },
+  { status: "completed", checkpoint: "ready", removed: false },
+  // Capture is still queued behind this cleanup and needs the baseline.
+  { status: "completed", checkpoint: null, removed: false },
+  { status: "running", checkpoint: null, removed: false },
+  { status: "waiting", checkpoint: null, removed: false },
+] as const)(
+  "cleans abandoned baselines for $status (checkpoint: $checkpoint)",
+  ({ status, checkpoint, removed }) =>
+    Effect.gen(function* () {
+      const discarded: number[] = [];
+      const projection = {
+        runs: [{ id: runId, ordinal: 3, status }],
+        checkpointScopes: [{ id: scopeId }],
+        checkpoints:
+          checkpoint === null
+            ? []
+            : [{ scopeId, runId, ordinalWithinScope: 3, status: checkpoint }],
+      } as unknown as OrchestrationV2ThreadProjection;
+      const layer = CheckpointCaptureService.layer.pipe(
+        Layer.provide(
+          Layer.mergeAll(
+            Layer.mock(ProjectionStore.ProjectionStoreV2)({
+              getThreadProjection: () => Effect.succeed(projection),
+            }),
+            Layer.mock(CheckpointServiceV2)({
+              discardBaseline: (input) =>
+                Effect.sync(() => {
+                  discarded.push(input.ordinalWithinScope);
+                }),
+            }),
+            Layer.mock(EventSinkV2)({}),
+            IdAllocator.layer,
+          ),
+        ),
+      );
+      yield* Effect.gen(function* () {
+        const service = yield* CheckpointCaptureService.CheckpointCaptureServiceV2;
+        yield* service.cleanupBaseline({ threadId, runId, scopeId });
+      }).pipe(Effect.provide(layer));
+      assert.deepEqual(discarded, removed ? [3] : []);
+    }),
+);
 const taskId = NodeId.make("node:checkpoint-capture-task");
 const deliveryMessageId = MessageId.make("message:checkpoint-capture-delivery");
 const providerThreadId = ProviderThreadId.make("provider-thread:checkpoint-capture-delegated");

--- a/apps/server/src/orchestration-v2/CheckpointCaptureService.ts
+++ b/apps/server/src/orchestration-v2/CheckpointCaptureService.ts
@@ -33,6 +33,11 @@ export class CheckpointCaptureExecutionError extends Schema.TaggedError<Checkpoi
 const isCheckpointCaptureExecutionError = Schema.is(CheckpointCaptureExecutionError);
 
 export interface CheckpointCaptureServiceV2Shape {
+  readonly cleanupBaseline: (input: {
+    readonly threadId: ThreadId;
+    readonly runId: RunId;
+    readonly scopeId: CheckpointScopeId;
+  }) => Effect.Effect<void, CheckpointCaptureExecutionError>;
   readonly execute: (input: {
     readonly threadId: ThreadId;
     readonly runId: RunId;
@@ -133,7 +138,21 @@ export const layer: Layer.Layer<
         threadId: input.threadId,
         commandType: "checkpoint.capture",
         acceptedAt: capturedAt,
-        effects: [],
+        effects:
+          checkpoint.status === "ready"
+            ? []
+            : [
+                {
+                  id: `effect:checkpoint.baseline.cleanup:${run.id}`,
+                  commandId,
+                  threadId: input.threadId,
+                  request: {
+                    type: "checkpoint.baseline.cleanup",
+                    runId: run.id,
+                    scopeId: scope.id,
+                  },
+                },
+              ],
         events: [
           ...(threadStartCheckpoint === null
             ? []
@@ -227,6 +246,40 @@ export const layer: Layer.Layer<
     });
 
     return CheckpointCaptureServiceV2.of({
+      cleanupBaseline: Effect.fn("checkpoint.cleanupBaseline")(
+        function* (input) {
+          const projection = yield* projections.getThreadProjection(input.threadId);
+          const run = projection.runs.find((candidate) => candidate.id === input.runId);
+          const scope = projection.checkpointScopes.find(
+            (candidate) => candidate.id === input.scopeId,
+          );
+          if (run === undefined || scope === undefined) return;
+          // Never discard a baseline still needed by capture or a historical diff.
+          if (
+            !["completed", "interrupted", "failed", "cancelled", "rolled_back"].includes(run.status)
+          )
+            return;
+          // A later turn can materialize a ready baseline at this ordinal with
+          // no run owner. Only this run's own checkpoint can retain its start ref.
+          const checkpoint = projection.checkpoints.find(
+            (candidate) =>
+              candidate.scopeId === scope.id &&
+              candidate.ordinalWithinScope === run.ordinal &&
+              candidate.runId === run.id,
+          );
+          if (checkpoint?.status === "ready") return;
+          // A completed run only abandons its baseline once capture has actually
+          // run and failed, which commits a non-ready row alongside this effect.
+          // No row means capture is still queued behind us and would lose the
+          // per-turn baseline it is about to diff against.
+          if (run.status === "completed" && checkpoint === undefined) return;
+          yield* checkpoints.discardBaseline({ scope, ordinalWithinScope: run.ordinal });
+        },
+        (effect, input) =>
+          effect.pipe(
+            Effect.mapError((cause) => new CheckpointCaptureExecutionError({ ...input, cause })),
+          ),
+      ),
       execute: (input) =>
         execute(input).pipe(
           Effect.mapError((cause) =>

--- a/apps/server/src/orchestration-v2/CheckpointService.test.ts
+++ b/apps/server/src/orchestration-v2/CheckpointService.test.ts
@@ -1,3 +1,10 @@
+import * as Path from "effect/Path";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as FileSystem from "effect/FileSystem";
+import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+import * as VcsProcess from "../vcs/VcsProcess.ts";
+import { ServerConfig } from "../config.ts";
+import { checkpointStartRef } from "../checkpointing/Utils.ts";
 import { assert, it, vi } from "@effect/vitest";
 import {
   CheckpointScopeId,
@@ -70,3 +77,120 @@ it.effect("materializes the captured baseline at the requested scope ordinal", (
     });
   }).pipe(Effect.provide(testLayer));
 });
+
+const processLayer = VcsProcess.layer.pipe(Layer.provide(NodeServices.layer));
+const storeLayer = CheckpointStore.layer.pipe(
+  Layer.provide(VcsDriverRegistry.layer.pipe(Layer.provide(processLayer))),
+  Layer.provide(NodeServices.layer),
+);
+const integrationLayer = checkpointServiceLayer.pipe(
+  Layer.provideMerge(storeLayer),
+  Layer.provide(idAllocatorLayer),
+  Layer.provideMerge(processLayer),
+  Layer.provideMerge(ServerConfig.layerTest(process.cwd(), { prefix: "t3-v2-turn-baseline-" })),
+  Layer.provideMerge(NodeServices.layer),
+);
+
+it.effect("excludes idle edits, preserves history, and discards baselines on rollback", () =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const cwd = yield* fs.makeTempDirectoryScoped({ prefix: "t3-v2-turn-baseline-" });
+    const process = yield* VcsProcess.VcsProcess;
+    const git = (args: ReadonlyArray<string>) =>
+      process.run({
+        operation: "CheckpointService.test",
+        command: "git",
+        cwd,
+        args,
+        timeoutMs: 10000,
+      });
+    yield* git(["init"]);
+    yield* git(["config", "user.name", "Test"]);
+    yield* git(["config", "user.email", "test@example.com"]);
+    const readme = path.join(cwd, "README.md");
+    yield* fs.writeFileString(readme, "initial\n");
+    yield* git(["add", "."]);
+    yield* git(["commit", "-m", "initial"]);
+    const checkpoints = yield* CheckpointServiceV2;
+    const store = yield* CheckpointStore.CheckpointStore;
+    const scope = yield* checkpoints.prepareRootRunScope({
+      threadId: ThreadId.make("thread:idle-edits"),
+      runId: RunId.make("run:idle-edits"),
+      rootNodeId: NodeId.make("node:idle-edits"),
+      providerThreadId: ProviderThreadId.make("provider:idle-edits"),
+      cwd,
+      createdAt: DateTime.makeUnsafe("2026-01-01T00:00:00Z"),
+    });
+    const capture = (ordinal: number) =>
+      checkpoints.capture({
+        scope,
+        runId: RunId.make(`run:${ordinal}`),
+        nodeId: scope.nodeId,
+        ordinalWithinScope: ordinal,
+        appRunOrdinal: ordinal,
+        capturedAt: DateTime.makeUnsafe("2026-01-01T00:01:00Z"),
+      });
+    yield* checkpoints.captureBaseline({ scope, ordinalWithinScope: 0 });
+    const first = yield* capture(1);
+    assert.deepEqual(first.files, []);
+    yield* fs.writeFileString(readme, "upstream\n");
+    yield* git(["commit", "-am", "external update"]);
+    yield* checkpoints.captureBaseline({ scope, ordinalWithinScope: 1 });
+    const second = yield* capture(2);
+    assert.deepEqual(second.files, []);
+    assert.equal((yield* git(["show", `${first.ref}:README.md`])).stdout, "initial\n");
+    yield* fs.writeFileString(path.join(cwd, "outside.txt"), "outside\n");
+    yield* checkpoints.captureBaseline({ scope, ordinalWithinScope: 2 });
+    yield* fs.writeFileString(readme, "agent\n");
+    // Duplicate start delivery must not move the baseline past agent edits.
+    yield* checkpoints.captureBaseline({ scope, ordinalWithinScope: 2 });
+    const third = yield* capture(3);
+    assert.deepEqual(third.files, [
+      { path: "README.md", kind: "modified", additions: 1, deletions: 1 },
+    ]);
+    assert.equal((yield* git(["show", `${second.ref}:README.md`])).stdout, "upstream\n");
+    yield* checkpoints.restore({ scope, checkpoint: second });
+    assert.equal(yield* fs.readFileString(readme), "upstream\n");
+    yield* checkpoints.deleteStaleRefs({ scope, checkpoints: [third] });
+    assert.equal(
+      yield* store.hasCheckpointRef({ cwd, checkpointRef: checkpointStartRef(third.ref) }),
+      false,
+    );
+    yield* fs.writeFileString(readme, "new external state\n");
+    yield* checkpoints.captureBaseline({ scope, ordinalWithinScope: 2 });
+    assert.deepEqual((yield* capture(3)).files, []);
+    yield* checkpoints.captureBaseline({ scope, ordinalWithinScope: 3 });
+    const abandonedRef = checkpointStartRef(
+      checkpointRefForScopeOrdinal({
+        scopeId: scope.id,
+        ordinalWithinScope: 4,
+      }),
+    );
+    assert.isTrue(yield* store.hasCheckpointRef({ cwd, checkpointRef: abandonedRef }));
+    yield* checkpoints.discardBaseline({ scope, ordinalWithinScope: 4 });
+    yield* checkpoints.discardBaseline({ scope, ordinalWithinScope: 4 });
+    assert.isFalse(yield* store.hasCheckpointRef({ cwd, checkpointRef: abandonedRef }));
+    assert.isTrue(
+      yield* store.hasCheckpointRef({ cwd, checkpointRef: checkpointStartRef(third.ref) }),
+    );
+  }).pipe(Effect.provide(integrationLayer), Effect.scoped),
+);
+
+it.effect("discards baselines without failing in a workspace that has no repository", () =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const cwd = yield* fs.makeTempDirectoryScoped({ prefix: "t3-v2-turn-baseline-nogit-" });
+    const checkpoints = yield* CheckpointServiceV2;
+    const scope = yield* checkpoints.prepareRootRunScope({
+      threadId: ThreadId.make("thread:no-git"),
+      runId: RunId.make("run:no-git"),
+      rootNodeId: NodeId.make("node:no-git"),
+      providerThreadId: ProviderThreadId.make("provider:no-git"),
+      cwd,
+      createdAt: DateTime.makeUnsafe("2026-01-01T00:00:00Z"),
+    });
+    // Cleanup runs from the outbox, so failing here would retry forever.
+    yield* checkpoints.discardBaseline({ scope, ordinalWithinScope: 1 });
+  }).pipe(Effect.provide(integrationLayer), Effect.scoped),
+);

--- a/apps/server/src/orchestration-v2/CheckpointService.ts
+++ b/apps/server/src/orchestration-v2/CheckpointService.ts
@@ -19,6 +19,7 @@ import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Semaphore from "effect/Semaphore";
 
+import { checkpointStartRef } from "../checkpointing/Utils.ts";
 import { parseTurnDiffFilesFromNumstat } from "../checkpointing/Diffs.ts";
 import * as CheckpointStore from "../checkpointing/CheckpointStore.ts";
 import { IdAllocatorV2, type IdAllocatorV2Shape } from "./IdAllocator.ts";
@@ -115,6 +116,11 @@ export type CheckpointServiceV2Error = typeof CheckpointServiceV2Error.Type;
 
 const isCheckpointRestoreError = Schema.is(CheckpointRestoreError);
 
+export class CheckpointBaselineCleanupError extends Schema.TaggedError<CheckpointBaselineCleanupError>()(
+  "CheckpointBaselineCleanupError",
+  { scopeId: CheckpointScopeId, ordinalWithinScope: Schema.Number, cause: Schema.Defect() },
+) {}
+
 export interface CheckpointServiceV2Shape {
   readonly prepareRootRunScope: (input: {
     readonly threadId: ThreadId;
@@ -135,6 +141,10 @@ export interface CheckpointServiceV2Shape {
     readonly scope: OrchestrationV2CheckpointScope;
     readonly ordinalWithinScope: number;
   }) => Effect.Effect<OrchestrationV2Checkpoint, CheckpointServiceV2Error>;
+  readonly discardBaseline: (input: {
+    readonly scope: OrchestrationV2CheckpointScope;
+    readonly ordinalWithinScope: number;
+  }) => Effect.Effect<void, CheckpointBaselineCleanupError>;
   readonly capture: (input: {
     readonly scope: OrchestrationV2CheckpointScope;
     readonly runId: RunId | null;
@@ -294,13 +304,25 @@ export const layer: Layer.Layer<
             cwd: input.scope.cwd,
             checkpointRef,
           });
-          if (exists) {
-            return;
+          if (!exists) {
+            yield* checkpointStore.captureCheckpoint({ cwd: input.scope.cwd, checkpointRef });
           }
-
+          const startRef = checkpointStartRef(
+            checkpointRefForScopeOrdinal({
+              scopeId: input.scope.id,
+              ordinalWithinScope: input.ordinalWithinScope + 1,
+            }),
+          );
+          if (
+            yield* checkpointStore.hasCheckpointRef({
+              cwd: input.scope.cwd,
+              checkpointRef: startRef,
+            })
+          )
+            return;
           yield* checkpointStore.captureCheckpoint({
             cwd: input.scope.cwd,
-            checkpointRef,
+            checkpointRef: startRef,
           });
         }),
       ).pipe(
@@ -377,7 +399,7 @@ export const layer: Layer.Layer<
             scopeId: input.scope.id,
             ordinalWithinScope: input.ordinalWithinScope,
           });
-          const previousCheckpointRef = checkpointRefForScopeOrdinal({
+          const legacyPreviousCheckpointRef = checkpointRefForScopeOrdinal({
             scopeId: input.scope.id,
             ordinalWithinScope: Math.max(0, input.ordinalWithinScope - 1),
           });
@@ -430,6 +452,13 @@ export const layer: Layer.Layer<
             });
           }
 
+          const startRef = checkpointStartRef(checkpointRef);
+          const previousCheckpointRef = (yield* checkpointStore.hasCheckpointRef({
+            cwd: input.scope.cwd,
+            checkpointRef: startRef,
+          }))
+            ? startRef
+            : legacyPreviousCheckpointRef;
           const previousExists = yield* checkpointStore.hasCheckpointRef({
             cwd: input.scope.cwd,
             checkpointRef: previousCheckpointRef,
@@ -529,7 +558,10 @@ export const layer: Layer.Layer<
         input.scope.cwd,
         checkpointStore.deleteCheckpointRefs({
           cwd: input.scope.cwd,
-          checkpointRefs: input.checkpoints.map((checkpoint) => checkpoint.ref),
+          checkpointRefs: input.checkpoints.flatMap((checkpoint) => [
+            checkpoint.ref,
+            checkpointStartRef(checkpoint.ref),
+          ]),
         }),
       ).pipe(
         Effect.mapError(
@@ -543,6 +575,38 @@ export const layer: Layer.Layer<
       );
 
     return CheckpointServiceV2.of({
+      discardBaseline: (input) =>
+        withWorkspaceLock(
+          input.scope.cwd,
+          Effect.gen(function* () {
+            // Mirrors captureBaseline: a workspace without a Git repository
+            // never stored a start ref, and resolving a driver for one here
+            // would fail this cleanup into an endless outbox retry.
+            if (!(yield* isGitCheckpointable(input.scope.cwd))) {
+              return;
+            }
+            yield* checkpointStore.deleteCheckpointRefs({
+              cwd: input.scope.cwd,
+              checkpointRefs: [
+                checkpointStartRef(
+                  checkpointRefForScopeOrdinal({
+                    scopeId: input.scope.id,
+                    ordinalWithinScope: input.ordinalWithinScope,
+                  }),
+                ),
+              ],
+            });
+          }),
+        ).pipe(
+          Effect.mapError(
+            (cause) =>
+              new CheckpointBaselineCleanupError({
+                scopeId: input.scope.id,
+                ordinalWithinScope: input.ordinalWithinScope,
+                cause,
+              }),
+          ),
+        ),
       prepareRootRunScope: (input) =>
         makeRootRunScope({ ...input, idAllocator }).pipe(
           Effect.mapError(

--- a/apps/server/src/orchestration-v2/EffectOutbox.ts
+++ b/apps/server/src/orchestration-v2/EffectOutbox.ts
@@ -89,6 +89,11 @@ export const OrchestrationEffectRequestV2 = Schema.Union([
     scopeId: CheckpointScopeId,
   }),
   Schema.Struct({
+    type: Schema.Literal("checkpoint.baseline.cleanup"),
+    runId: RunId,
+    scopeId: CheckpointScopeId,
+  }),
+  Schema.Struct({
     type: Schema.Literal("terminal.cleanup"),
   }),
   Schema.Struct({
@@ -110,6 +115,7 @@ export const REPLAY_SAFE_EFFECT_TYPES_AFTER_PROCESS_LOSS = [
   "provider-session.detach",
   "provider-thread.rollback",
   "checkpoint.capture",
+  "checkpoint.baseline.cleanup",
   "terminal.cleanup",
   "attachment.cleanup",
   "thread-title.generate",

--- a/apps/server/src/orchestration-v2/EffectWorker.test.ts
+++ b/apps/server/src/orchestration-v2/EffectWorker.test.ts
@@ -21,6 +21,7 @@ import * as Ref from "effect/Ref";
 import * as TestClock from "effect/testing/TestClock";
 
 import { CheckpointRollbackServiceV2 } from "./CheckpointRollbackService.ts";
+import { CheckpointCaptureServiceV2 } from "./CheckpointCaptureService.ts";
 import { EffectOutboxError, EffectOutboxV2, type OrchestrationEffectV2 } from "./EffectOutbox.ts";
 import {
   executorLayer,
@@ -158,6 +159,7 @@ function makeExecutorLayer(input: {
     Layer.provide(
       Layer.mergeAll(
         dependencies,
+        Layer.mock(CheckpointCaptureServiceV2)({}),
         Layer.mock(ThreadManagementService)({}),
         ServerSettings.layerTest(),
       ),

--- a/apps/server/src/orchestration-v2/EffectWorker.ts
+++ b/apps/server/src/orchestration-v2/EffectWorker.ts
@@ -24,6 +24,7 @@ import {
   type OrchestrationEffectV2,
 } from "./EffectOutbox.ts";
 import { CheckpointRollbackServiceV2 } from "./CheckpointRollbackService.ts";
+import { CheckpointCaptureServiceV2 } from "./CheckpointCaptureService.ts";
 import { ProviderSessionManagerV2 } from "./ProviderSessionManager.ts";
 import { ProviderTurnControlServiceV2 } from "./ProviderTurnControlService.ts";
 import { ProviderTurnStartServiceV2 } from "./ProviderTurnStartService.ts";
@@ -83,6 +84,7 @@ export const executorLayer: Layer.Layer<
   | ProviderSessionManagerV2
   | RunFinalizationService
   | CheckpointRollbackServiceV2
+  | CheckpointCaptureServiceV2
   | ProviderTurnControlServiceV2
   | ProviderTurnStartServiceV2
   | RuntimeRequestServiceV2
@@ -95,6 +97,7 @@ export const executorLayer: Layer.Layer<
     const runFinalization = yield* RunFinalizationService;
     const resourceCleanup = yield* ResourceCleanupService;
     const checkpointRollback = yield* CheckpointRollbackServiceV2;
+    const checkpointCapture = yield* CheckpointCaptureServiceV2;
     const providerSessions = yield* ProviderSessionManagerV2;
     const providerTurnControl = yield* ProviderTurnControlServiceV2;
     const providerTurnStart = yield* ProviderTurnStartServiceV2;
@@ -344,6 +347,23 @@ export const executorLayer: Layer.Layer<
           case "checkpoint.capture":
             return runFinalization
               .finalize({
+                threadId: effect.threadId,
+                runId: effect.request.runId,
+                scopeId: effect.request.scopeId,
+              })
+              .pipe(
+                Effect.mapError(
+                  (cause) =>
+                    new OrchestrationEffectExecutionError({
+                      effectId: effect.id,
+                      effectType: effect.request.type,
+                      cause,
+                    }),
+                ),
+              );
+          case "checkpoint.baseline.cleanup":
+            return checkpointCapture
+              .cleanupBaseline({
                 threadId: effect.threadId,
                 runId: effect.request.runId,
                 scopeId: effect.request.scopeId,

--- a/apps/server/src/orchestration-v2/Orchestrator.ts
+++ b/apps/server/src/orchestration-v2/Orchestrator.ts
@@ -6650,6 +6650,24 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           payload: { ...run, status: "interrupted", completedAt: now },
         });
         yield* stopCompletionCohort();
+        const scopeId = rootNode.checkpointScopeId;
+        if (scopeId !== null) {
+          // Commit cleanup with cancellation: the worker may already have saved
+          // its baseline and will be interrupted before it can enqueue cleanup.
+          yield* Ref.update(effects, (existing) => [
+            ...existing,
+            {
+              id: `effect:checkpoint.baseline.cleanup:${run.id}`,
+              commandId: command.commandId,
+              threadId: command.threadId,
+              request: {
+                type: "checkpoint.baseline.cleanup",
+                runId: run.id,
+                scopeId,
+              },
+            } satisfies PendingOrchestrationEffectV2,
+          ]);
+        }
         return {
           effectTypes: ["provider-turn.start", "provider-turn.restart"],
           reason: `Run ${run.id} was interrupted before its provider turn started.`,

--- a/apps/server/src/orchestration-v2/ProviderRuntimeRecoveryService.test.ts
+++ b/apps/server/src/orchestration-v2/ProviderRuntimeRecoveryService.test.ts
@@ -1,6 +1,7 @@
 import { assert, it, vi } from "@effect/vitest";
 import {
   MessageId,
+  CheckpointScopeId,
   NodeId,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -411,11 +412,18 @@ it.effect("cancels a stale waiting run when no checkpoint capture can finish it"
       {
         id: runId,
         status: "waiting",
+        rootNodeId: NodeId.make("node_stale_waiting"),
         providerInstanceId: ProviderInstanceId.make("codex"),
       },
     ],
     attempts: [],
-    nodes: [],
+    nodes: [
+      {
+        id: NodeId.make("node_stale_waiting"),
+        status: "waiting",
+        checkpointScopeId: CheckpointScopeId.make("scope_stale_waiting"),
+      },
+    ],
     subagents: [],
     messages: [],
     turnItems: [],
@@ -450,6 +458,11 @@ it.effect("cancels a stale waiting run when no checkpoint capture can finish it"
     const summary =
       yield* (yield* ProviderRuntimeRecovery.ProviderRuntimeRecoveryService).reconcile("startup");
     assert.equal(summary.terminalizedRuns, 1);
+    assert.isTrue(
+      committedInput?.effects.some(
+        (effect) => effect.request.type === "checkpoint.baseline.cleanup",
+      ) ?? false,
+    );
     const runEvent = committedInput?.events.find((event) => event.type === "run.updated");
     assert.equal(runEvent?.type === "run.updated" ? runEvent.payload.status : null, "cancelled");
   }).pipe(Effect.provide(layer));

--- a/apps/server/src/orchestration-v2/ProviderRuntimeRecoveryService.ts
+++ b/apps/server/src/orchestration-v2/ProviderRuntimeRecoveryService.ts
@@ -222,6 +222,19 @@ export const make = Effect.gen(function* () {
         });
       }
       for (const run of runs) {
+        const node = projection.nodes.find((candidate) => candidate.id === run.rootNodeId);
+        if (node?.checkpointScopeId != null) {
+          effects.push({
+            id: `effect:checkpoint.baseline.cleanup:${run.id}`,
+            commandId,
+            threadId: projection.thread.id,
+            request: {
+              type: "checkpoint.baseline.cleanup",
+              runId: run.id,
+              scopeId: node.checkpointScopeId,
+            },
+          });
+        }
         events.push({
           id: yield* allocateEventId(),
           type: "run.updated",

--- a/apps/server/src/orchestration-v2/RunExecutionService.test.ts
+++ b/apps/server/src/orchestration-v2/RunExecutionService.test.ts
@@ -2715,7 +2715,7 @@ it.effect("omits interrupt results and subagent cascade for a superseded attempt
 
 it.effect("emits run_interrupt_result when superseded attempt still has a hard-stop request", () =>
   Effect.gen(function* () {
-    const { written, observed } = yield* captureRootRunTermination({
+    const { written, observed, effects } = yield* captureRootRunTermination({
       key: "stop-then-steer-supersede",
       shouldFinalizeRun: () => Effect.succeed(false),
       hasUnpairedRunInterruptRequest: () => Effect.succeed(true),
@@ -2725,6 +2725,7 @@ it.effect("emits run_interrupt_result when superseded attempt still has a hard-s
       ["run_interrupt_result"],
     );
     assert.deepEqual(observed, ["pull-requests-refreshed"]);
+    assert.deepEqual(effects, ["checkpoint.baseline.cleanup"]);
     const ids = backgroundScenarioIds("stop-then-steer-supersede");
     const expectedRequestId = yield* Effect.gen(function* () {
       const idAllocator = yield* IdAllocatorV2;
@@ -2889,6 +2890,7 @@ function captureRootRunTermination(input: {
     const writtenItems = yield* Ref.make<
       ReadonlyArray<{ readonly type: string; readonly parentItemId: string | null }>
     >([]);
+    const effects: string[] = [];
     const observed = yield* Ref.make<ReadonlyArray<string>>([]);
     const ingestionDone = yield* Deferred.make<void>();
     const captureTurnItem = (payload: {
@@ -2915,6 +2917,7 @@ function captureRootRunTermination(input: {
               }),
             writeWithEffects: (payload) =>
               Effect.gen(function* () {
+                effects.push(...payload.effects.map((effect) => effect.request.type));
                 for (const event of payload.events) {
                   if (event.type === "turn-item.updated") {
                     yield* captureTurnItem(event.payload);
@@ -3037,7 +3040,7 @@ function captureRootRunTermination(input: {
     }).pipe(Effect.provide(testLayer));
 
     yield* Deferred.await(ingestionDone);
-    return { written: yield* Ref.get(writtenItems), observed: yield* Ref.get(observed) };
+    return { written: yield* Ref.get(writtenItems), observed: yield* Ref.get(observed), effects };
   });
 }
 
@@ -3354,6 +3357,26 @@ function rootTerminalEvent(
     : { ...common, status, failure: null };
 }
 
+it.effect.each(["completed", "interrupted", "failed", "cancelled"] as const)(
+  "persists checkpoint work appropriate to a $status terminal",
+  (status) =>
+    Effect.gen(function* () {
+      const requests: string[] = [];
+      yield* runBackgroundItemScenario(
+        `baseline-cleanup-${status}`,
+        (ids) => [rootTerminalEvent(ids, status)],
+        {
+          onEffects: (effects) => {
+            requests.push(...effects.map((effect) => effect.request.type));
+          },
+        },
+      );
+      assert.deepEqual(requests, [
+        status === "completed" ? "checkpoint.capture" : "checkpoint.baseline.cleanup",
+      ]);
+    }),
+);
+
 function runBackgroundItemScenario(
   key: string,
   makeEvents: (ids: BackgroundScenarioIds) => ReadonlyArray<ProviderAdapterV2Event>,
@@ -3363,6 +3386,9 @@ function runBackgroundItemScenario(
       ReadonlyArray<{ readonly id: TurnItemId; readonly runId: RunId }>
     >;
     readonly onSubscribe?: Effect.Effect<void>;
+    readonly onEffects?: (
+      effects: Parameters<EventSinkV2["Service"]["writeWithEffects"]>[0]["effects"],
+    ) => void;
   },
 ) {
   return Effect.gen(function* () {
@@ -3378,6 +3404,7 @@ function runBackgroundItemScenario(
             write: () => Effect.succeed([]),
             writeWithEffects: (input) =>
               Effect.gen(function* () {
+                options?.onEffects?.(input.effects);
                 if (
                   input.events.some(
                     (event) => event.type === "run.updated" && event.runId === ids.runId,

--- a/apps/server/src/orchestration-v2/RunExecutionService.ts
+++ b/apps/server/src/orchestration-v2/RunExecutionService.ts
@@ -590,6 +590,25 @@ export const layer: Layer.Layer<
         const shouldFinalizeRun =
           input.shouldFinalizeRun === undefined ? true : yield* input.shouldFinalizeRun();
         if (!shouldFinalizeRun) {
+          if (input.terminal.status !== "completed") {
+            yield* eventSink.writeWithEffects({
+              events: [],
+              effects: [
+                {
+                  id: `effect:checkpoint.baseline.cleanup:${input.run.id}:attempt:${input.attempt.id}`,
+                  commandId: CommandId.make(
+                    `command:checkpoint.baseline.cleanup:${input.attempt.id}`,
+                  ),
+                  threadId: input.run.threadId,
+                  request: {
+                    type: "checkpoint.baseline.cleanup",
+                    runId: input.run.id,
+                    scopeId: input.checkpointScope.id,
+                  },
+                },
+              ],
+            });
+          }
           // Superseded attempt (steer / selection restart). Emit
           // run_interrupt_result only when hard Stop left an unpaired request
           // for this run; plain steers and already-paired stops emit nothing.
@@ -686,7 +705,18 @@ export const layer: Layer.Layer<
                     },
                   },
                 ]
-              : [],
+              : [
+                  {
+                    id: `effect:checkpoint.baseline.cleanup:${input.run.id}`,
+                    commandId: checkpointCaptureCommandId,
+                    threadId: input.run.threadId,
+                    request: {
+                      type: "checkpoint.baseline.cleanup" as const,
+                      runId: input.run.id,
+                      scopeId: input.checkpointScope.id,
+                    },
+                  },
+                ],
           events: [
             // Terminalize open run-owned subagent rows before the root run
             // settles so projections never keep a forever-running subagent card.
@@ -820,6 +850,32 @@ export const layer: Layer.Layer<
             input.shouldStartProviderTurn !== undefined &&
             !(yield* input.shouldStartProviderTurn())
           ) {
+            yield* eventSink
+              .writeWithEffects({
+                events: [],
+                effects: [
+                  {
+                    id: `effect:checkpoint.baseline.cleanup:${input.run.id}:before-start:${input.attempt.id}`,
+                    commandId: input.commandId,
+                    threadId: input.run.threadId,
+                    request: {
+                      type: "checkpoint.baseline.cleanup",
+                      runId: input.run.id,
+                      scopeId: input.checkpointScope.id,
+                    },
+                  },
+                ],
+              })
+              .pipe(
+                Effect.mapError(
+                  (cause) =>
+                    new RunExecutionStartError({
+                      commandId: input.commandId,
+                      runId: input.run.id,
+                      cause,
+                    }),
+                ),
+              );
             return;
           }
           // Startup failure and stream shutdown can report the same attempt.

--- a/apps/server/src/orchestration-v2/runtimeLayer.test.ts
+++ b/apps/server/src/orchestration-v2/runtimeLayer.test.ts
@@ -33,6 +33,14 @@ import * as TestClock from "effect/testing/TestClock";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import * as CheckpointStore from "../checkpointing/CheckpointStore.ts";
+import { checkpointStartRef } from "../checkpointing/Utils.ts";
+import {
+  CheckpointServiceV2,
+  layer as checkpointServiceLayer,
+  checkpointRefForScopeOrdinal,
+} from "./CheckpointService.ts";
+import { layer as idAllocatorLayer } from "./IdAllocator.ts";
+import { checkpointWorkspace } from "./testkit/ReplayFixtureWorkspace.ts";
 import * as GitWorkflow from "../git/GitWorkflowService.ts";
 import { ServerConfig } from "../config.ts";
 import { OrchestrationEngineService } from "../orchestration/Services/OrchestrationEngine.ts";
@@ -319,9 +327,12 @@ it.layer(ProjectDeletionTestLayer)("project deletion during thread commands", (i
   );
 });
 
-const SharedApplicationDataPlaneTestLayer = Layer.merge(
+const SharedApplicationDataPlaneTestLayer = Layer.mergeAll(
   OrchestrationLayerLive,
   OrchestrationV2LayerLive,
+  OrchestrationV2EventSinkLayerLive,
+  checkpointServiceLayer,
+  effectOutboxLayer,
 ).pipe(
   Layer.provide(
     Layer.succeed(ProjectEnrichmentService, {
@@ -344,7 +355,8 @@ const SharedApplicationDataPlaneTestLayer = Layer.merge(
   ),
   Layer.provide(mcpSessionRegistryTestLayer),
   Layer.provideMerge(SqlitePersistenceMemory),
-  Layer.provide(CheckpointStoreTestLayer),
+  Layer.provideMerge(CheckpointStoreTestLayer),
+  Layer.provide(idAllocatorLayer),
   Layer.provide(ServerConfigLayer),
   Layer.provide(ServerSettingsService.layerTest()),
   Layer.provide(TestProviderInstanceRegistry),
@@ -2416,81 +2428,153 @@ it.layer(TestLayer)("OrchestrationV2LayerLive lifecycle", (it) => {
 });
 
 it.layer(SharedApplicationDataPlaneTestLayer)("pending provider interruption", (it) => {
-  it.effect("interrupts a pending provider start without launching provider work", () =>
-    Effect.gen(function* () {
-      const applicationEngine = yield* OrchestrationEngineService;
-      const orchestrator = yield* OrchestratorV2;
-      const threadManagement = yield* ThreadManagementService;
-      const effectWorker = yield* OrchestrationEffectWorkerV2;
-      const projectId = ProjectId.make("runtime-layer-pending-interrupt-project");
-      const threadId = ThreadId.make("runtime-layer-pending-interrupt-thread");
+  for (const scenario of ["pending", "captured", "later-baseline"] as const) {
+    it.effect(`interrupts ${scenario} startup and reclaims only its abandoned baseline`, () =>
+      Effect.gen(function* () {
+        const applicationEngine = yield* OrchestrationEngineService;
+        const orchestrator = yield* OrchestratorV2;
+        const threadManagement = yield* ThreadManagementService;
+        const effectWorker = yield* OrchestrationEffectWorkerV2;
+        const checkpoints = yield* CheckpointServiceV2;
+        const store = yield* CheckpointStore.CheckpointStore;
+        const outbox = yield* EffectOutboxV2;
+        const eventSink = yield* EventSinkV2;
+        const workspace = yield* checkpointWorkspace(`startup-cancel-${scenario}`);
+        const projectId = ProjectId.make(`runtime-layer-${scenario}-interrupt-project`);
+        const threadId = ThreadId.make(`runtime-layer-${scenario}-interrupt-thread`);
 
-      yield* applicationEngine.dispatch({
-        type: "project.create",
-        commandId: CommandId.make("runtime-layer-pending-interrupt-project-create"),
-        projectId,
-        title: "Pending interrupt project",
-        workspaceRoot: "/tmp/runtime-layer-pending-interrupt-project",
-        defaultModelSelection: modelSelection,
-        scripts: [],
-        createdAt: "2026-06-22T00:00:00.000Z",
-      });
-      yield* orchestrator.dispatch({
-        type: "thread.create",
-        createdBy: "user",
-        creationSource: "web",
-        commandId: CommandId.make("runtime-layer-pending-interrupt-create"),
-        threadId,
-        projectId,
-        title: "Pending interrupt",
-        modelSelection,
-        runtimeMode: "full-access",
-        interactionMode: "default",
-        branch: null,
-        worktreePath: null,
-      });
-      yield* orchestrator.dispatch({
-        type: "message.dispatch",
-        createdBy: "user",
-        creationSource: "web",
-        commandId: CommandId.make("runtime-layer-pending-interrupt-message"),
-        threadId,
-        messageId: MessageId.make("runtime-layer-pending-interrupt-message"),
-        text: "Do not reach the provider.",
-        attachments: [],
-        modelSelection,
-        dispatchMode: { type: "start_immediately" },
-      });
+        yield* applicationEngine.dispatch({
+          type: "project.create",
+          commandId: CommandId.make(`runtime-layer-pending-interrupt-project-create-${scenario}`),
+          projectId,
+          title: "Pending interrupt project",
+          workspaceRoot: workspace,
+          defaultModelSelection: modelSelection,
+          scripts: [],
+          createdAt: "2026-06-22T00:00:00.000Z",
+        });
+        yield* orchestrator.dispatch({
+          type: "thread.create",
+          createdBy: "user",
+          creationSource: "web",
+          commandId: CommandId.make(`runtime-layer-pending-interrupt-create-${scenario}`),
+          threadId,
+          projectId,
+          title: "Pending interrupt",
+          modelSelection,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+        });
+        yield* orchestrator.dispatch({
+          type: "message.dispatch",
+          createdBy: "user",
+          creationSource: "web",
+          commandId: CommandId.make(`runtime-layer-pending-interrupt-message-${scenario}`),
+          threadId,
+          messageId: MessageId.make(`runtime-layer-pending-interrupt-message-${scenario}`),
+          text: "Do not reach the provider.",
+          attachments: [],
+          modelSelection,
+          dispatchMode: { type: "start_immediately" },
+        });
 
-      const starting = yield* orchestrator.getThreadProjection(threadId);
-      const run = starting.runs[0];
-      assert.isDefined(run);
-      assert.equal(run.status, "starting");
+        const starting = yield* orchestrator.getThreadProjection(threadId);
+        const run = starting.runs[0];
+        assert.isDefined(run);
+        assert.equal(run.status, "starting");
+        const scope = starting.checkpointScopes[0];
+        assert.isDefined(scope);
+        const checkpointRef = checkpointRefForScopeOrdinal({
+          scopeId: scope.id,
+          ordinalWithinScope: run.ordinal,
+        });
+        const startRef = checkpointStartRef(checkpointRef);
+        let claimedId: string | undefined;
+        if (scenario !== "pending") {
+          // Stop races the worker after its durable claim and Git snapshot, before
+          // a provider turn exists. The cancelled worker cannot enqueue cleanup.
+          const claimed = yield* outbox.claimNext({
+            workerId: "cancelled-start",
+            leaseDurationMs: 30000,
+          });
+          assert.isTrue(Option.isSome(claimed));
+          if (Option.isNone(claimed)) return;
+          assert.equal(claimed.value.request.type, "provider-turn.start");
+          claimedId = claimed.value.id;
+          yield* checkpoints.captureBaseline({ scope, ordinalWithinScope: run.ordinal - 1 });
+          assert.isTrue(yield* store.hasCheckpointRef({ cwd: workspace, checkpointRef: startRef }));
+        }
 
-      const interrupt = yield* threadManagement.interruptThread({
-        projectId,
-        commandId: CommandId.make("runtime-layer-pending-interrupt-command"),
-        threadId,
-        runId: run.id,
-        reason: "Cancelled before provider start",
-      });
-      assert.equal(interrupt.type, "interrupt_requested");
+        const interrupt = yield* threadManagement.interruptThread({
+          projectId,
+          commandId: CommandId.make(`runtime-layer-pending-interrupt-command-${scenario}`),
+          threadId,
+          runId: run.id,
+          reason: "Cancelled before provider start",
+        });
+        assert.equal(interrupt.type, "interrupt_requested");
 
-      const interrupted = yield* orchestrator.getThreadProjection(threadId);
-      assert.equal(interrupted.runs[0]?.status, "interrupted");
-      assert.equal(interrupted.attempts[0]?.status, "interrupted");
-      assert.equal(
-        interrupted.nodes.find((node) => node.kind === "root_turn")?.status,
-        "interrupted",
-      );
-      assert.deepEqual(
-        interrupted.turnItems.filter((item) => item.runId === run.id).map((item) => item.type),
-        ["user_message", "run_interrupt_request", "run_interrupt_result"],
-      );
-      assert.deepEqual(interrupted.providerTurns, []);
-      assert.isFalse(yield* effectWorker.runOnce);
-    }),
-  );
+        const interrupted = yield* orchestrator.getThreadProjection(threadId);
+        assert.equal(interrupted.runs[0]?.status, "interrupted");
+        assert.equal(interrupted.attempts[0]?.status, "interrupted");
+        assert.equal(
+          interrupted.nodes.find((node) => node.kind === "root_turn")?.status,
+          "interrupted",
+        );
+        assert.deepEqual(
+          interrupted.turnItems.filter((item) => item.runId === run.id).map((item) => item.type),
+          ["user_message", "run_interrupt_request", "run_interrupt_result"],
+        );
+        assert.deepEqual(interrupted.providerTurns, []);
+        if (claimedId !== undefined) {
+          const cancelled = yield* outbox.get(claimedId);
+          assert.isTrue(Option.isSome(cancelled));
+          if (Option.isSome(cancelled)) assert.equal(cancelled.value.status, "cancelled");
+        }
+        if (scenario === "later-baseline") {
+          // A cleanup retry may run after a later turn has materialized a ready
+          // baseline at the interrupted run's ordinal. That row owns no run.
+          yield* checkpoints.captureBaseline({ scope, ordinalWithinScope: run.ordinal });
+          const baseline = yield* checkpoints.materializeBaselineCheckpoint({
+            scope,
+            ordinalWithinScope: run.ordinal,
+          });
+          assert.isNull(baseline.runId);
+          assert.equal(baseline.status, "ready");
+          yield* eventSink.write({
+            events: [
+              {
+                id: EventId.make(`later-baseline-${scenario}`),
+                type: "checkpoint.captured",
+                threadId,
+                nodeId: baseline.nodeId,
+                providerInstanceId: modelSelection.instanceId,
+                occurredAt: yield* DateTime.now,
+                payload: baseline,
+              },
+            ],
+          });
+        }
+        assert.equal(yield* effectWorker.drain(), 1);
+        assert.isFalse(yield* store.hasCheckpointRef({ cwd: workspace, checkpointRef: startRef }));
+        if (scenario === "later-baseline") {
+          assert.isTrue(yield* store.hasCheckpointRef({ cwd: workspace, checkpointRef }));
+          const nextStart = checkpointStartRef(
+            checkpointRefForScopeOrdinal({
+              scopeId: scope.id,
+              ordinalWithinScope: run.ordinal + 1,
+            }),
+          );
+          assert.isTrue(
+            yield* store.hasCheckpointRef({ cwd: workspace, checkpointRef: nextStart }),
+          );
+        }
+        assert.isFalse(yield* effectWorker.runOnce);
+      }).pipe(Effect.scoped),
+    );
+  }
 });
 
 it.layer(SharedApplicationDataPlaneTestLayer)("snooze projection", (it) => {

--- a/apps/server/src/orchestration-v2/runtimeLayer.ts
+++ b/apps/server/src/orchestration-v2/runtimeLayer.ts
@@ -253,6 +253,7 @@ const effectExecutorProvided = effectExecutorLayer.pipe(
   Layer.provide(
     Layer.mergeAll(
       runFinalizationServiceProvided,
+      checkpointCaptureServiceProvided,
       checkpointRollbackServiceProvided,
       providerSessionManagerProvided,
       providerTurnControlServiceProvided,

--- a/apps/server/src/orchestration-v2/testkit/ProviderReplayHarness.ts
+++ b/apps/server/src/orchestration-v2/testkit/ProviderReplayHarness.ts
@@ -393,6 +393,7 @@ export function makeOrchestratorV2ReplayLayerWithRegistry<Error>(
     Layer.provide(
       Layer.mergeAll(
         runFinalizationServiceProvided,
+        checkpointCaptureServiceProvided,
         checkpointRollbackServiceProvided,
         providerSessionManagerProvided,
         providerTurnControlServiceProvided,


### PR DESCRIPTION
External changes made between V2 turns currently appear in the next turn's changed-files summary and diff, even when the agent edits nothing. For example, committing two new README lines while the thread is idle produces a misleading README.md +2 card on the next no-edit reply.

Capture a separate starting snapshot for each V2 turn and compare the completed snapshot against it for the changed-files summary and individual turn diff. Existing completed checkpoints remain intact for history and restore. Older checkpoints without a starting snapshot retain the previous diff behavior. Multi-turn comparisons continue to use their checkpoint endpoints. Changes made during a turn remain part of that turn's diff; this does not attribute changes by Git author.

A replay-safe `checkpoint.baseline.cleanup` effect reclaims abandoned starting snapshots after non-completed runs, aborted starts, unsuccessful checkpoint capture, and restart recovery. Stopping a run before its provider turn starts queues cleanup in the same transaction as cancellation. Cleanup re-reads the projection, skips active runs and ready checkpoints owned by that run, and preserves a completed run's baseline while capture is still pending. A later turn's baseline at the same ordinal does not prevent cleanup of an abandoned starting snapshot. Ref deletion runs under the workspace lock and is harmless when repeated or when the workspace has no Git repository. Rollback cleanup also removes the starting snapshots associated with discarded checkpoints.

Targets the orchestration V2 branch from #2829 (`t3code/codex-turn-mapping`), related to #4249, and addresses #10348 for orchestration V2. The separate main backport is outside this PR; this change does not fix the legacy orchestration implementation by itself.

Validation:

- 148 tests passed across 13 focused suites on base 0d606c8a2c, covering checkpoint diffs, capture, storage, scope ownership and rollback, run execution and interruption, recovery, effect workers, replay, selection restart, and steering completion.
- Regression coverage includes external commits, uncommitted idle edits, actual turn edits, duplicate baseline capture, historical snapshots, rollback cleanup, legacy diff fallback, abandoned-baseline cleanup, and non-Git workspaces. New integration cases use real Git refs to verify cleanup after startup cancellation and delayed cleanup after a later turn creates a baseline at the same ordinal, while preserving that later turn's refs.
- Formatting passed across all 18 changed files. Targeted lint completed with three upstream unused-declaration warnings in Utils.ts, EffectWorker.ts, and Orchestrator.ts. Server typecheck still reports the two upstream errors in HostPowerMonitor.ts:69 and NativeTelemetryClient.ts (now line 509), previously reproduced on untouched base 6102d00bdb. No additional type errors were reported with this PR applied.
- Earlier manual V2 verification reported no changed-files card after an idle external commit, followed by only notes.txt +1 for an actual agent edit. Before/after screenshots are attached in the PR comments. This manual verification was not repeated after updating the base.
- Earlier manual rollback verification restored the files, but Codex rejected conversation rollback with `paginated threads do not support thread/rollback`, also reproduced on the unpatched nightly. Full client rollback is not marked as passing.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope's pull request summary ends here -->

Implemented with GPT-6 through the Codex harness in T3 Code. Earlier review follow-ups were implemented with Opus 5 in T3 Code. Merge integration, history cleanup, and description review used GPT-6 through Codex.
