### PR TITLE
fix(mobile): size a chat image's frame before its bytes arrive

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -177,6 +177,7 @@ import {
 } from "../files/filePath";
 import { fileChipMenu, resolveFileChipTarget, type FileChipAction } from "./fileChipMenu";
 import {
+  MarkdownImageAvailableWidthContext,
   ThreadMarkdownImage,
   ThreadMarkdownImageUnavailable,
   ThreadMarkdownImageView,
@@ -1331,6 +1332,8 @@ function renderFeedEntry(
     readonly reviewCommentBubbleWidth: number;
     readonly themeAppearance: "light" | "dark";
     readonly userBubbleMaxWidth: number;
+    /** Width assistant markdown lays out in, so images can size their frame before layout. */
+    readonly markdownContentWidth: number;
   },
 ) {
   const entry = info.item;
@@ -1452,14 +1455,16 @@ function renderFeedEntry(
             }}
           >
             {message.text.trim().length > 0 ? (
-              <UserMessageContent
-                text={renderedText}
-                markdownStyles={styles}
-                reviewCommentColors={props.reviewCommentColors}
-                skills={props.skills}
-                linkHandlers={props.markdownLinkHandlers}
-                renderImage={props.renderMarkdownImage}
-              />
+              <MarkdownImageAvailableWidthContext value={props.userBubbleMaxWidth - 28}>
+                <UserMessageContent
+                  text={renderedText}
+                  markdownStyles={styles}
+                  reviewCommentColors={props.reviewCommentColors}
+                  skills={props.skills}
+                  linkHandlers={props.markdownLinkHandlers}
+                  renderImage={props.renderMarkdownImage}
+                />
+              </MarkdownImageAvailableWidthContext>
             ) : null}
             {attachments.map((attachment) => {
               return isImageAttachment(attachment) ? (
@@ -1516,14 +1521,16 @@ function renderFeedEntry(
         {...(enterAnimated ? { entering: FadeIn.duration(220) } : {})}
       >
         {renderedText.trim().length > 0 ? (
-          <AssistantMarkdownContent
-            markdown={renderedText}
-            markdownStyles={styles}
-            linkHandlers={props.markdownLinkHandlers}
-            onUseArtifactTemplate={props.onUseArtifactTemplate}
-            renderImage={props.renderMarkdownImage}
-            skills={props.skills}
-          />
+          <MarkdownImageAvailableWidthContext value={props.markdownContentWidth}>
+            <AssistantMarkdownContent
+              markdown={renderedText}
+              markdownStyles={styles}
+              linkHandlers={props.markdownLinkHandlers}
+              onUseArtifactTemplate={props.onUseArtifactTemplate}
+              renderImage={props.renderMarkdownImage}
+              skills={props.skills}
+            />
+          </MarkdownImageAvailableWidthContext>
         ) : null}
         {attachments.map((attachment) => {
           return isImageAttachment(attachment) ? (
@@ -1942,6 +1949,8 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
   });
   const contentWidth = Math.max(0, viewportWidth - contentHorizontalPadding * 2);
   const userBubbleMaxWidth = contentWidth * 0.85;
+  // Assistant rows sit inside px-1.
+  const markdownContentWidth = Math.max(0, contentWidth - 8);
   const reviewCommentBubbleWidth = Math.min(Math.max(280, contentWidth * 0.85), contentWidth);
   const insets = useSafeAreaInsets();
   const topContentInset = props.contentTopInset ?? insets.top + IOS_NAV_BAR_HEIGHT;
@@ -2620,6 +2629,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
             reviewCommentBubbleWidth,
             themeAppearance,
             userBubbleMaxWidth,
+            markdownContentWidth,
             skills: props.skills,
             onUseArtifactTemplate: props.onUseArtifactTemplate,
           })}
@@ -2641,6 +2651,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       reviewCommentBubbleWidth,
       themeAppearance,
       userBubbleMaxWidth,
+      markdownContentWidth,
       onCopyWorkRow,
       markdownLinkHandlers,
       onPressPreview,

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -207,6 +207,10 @@ function formatMessageTime(input: string): string {
 // text fits at the current font settings. Larger accessibility text is measured.
 const TURN_FOLD_HEIGHT = 42; // min-h-11 (38.5) + mb-1 (3.5), with the mobile 14px rem
 const THREAD_FEED_LAYOUT_TRANSITION = LinearTransition.duration(THREAD_DISCLOSURE_TRANSITION_MS);
+// Tailwind spacing on the mobile 14px rem: px-3.5 on the user bubble, px-1 on
+// assistant rows. Images size their frame from these before their own layout.
+const USER_BUBBLE_HORIZONTAL_PADDING = 3.5 * 3.5;
+const ASSISTANT_ROW_HORIZONTAL_PADDING = 3.5;
 // Let neighboring rows move out of the new rows' space before showing their text.
 const THREAD_FEED_DISCLOSURE_ENTER_TRANSITION = FadeIn.delay(
   THREAD_DISCLOSURE_TRANSITION_MS,
@@ -1455,7 +1459,9 @@ function renderFeedEntry(
             }}
           >
             {message.text.trim().length > 0 ? (
-              <MarkdownImageAvailableWidthContext value={props.userBubbleMaxWidth - 28}>
+              <MarkdownImageAvailableWidthContext
+                value={props.userBubbleMaxWidth - USER_BUBBLE_HORIZONTAL_PADDING * 2}
+              >
                 <UserMessageContent
                   text={renderedText}
                   markdownStyles={styles}
@@ -1949,8 +1955,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
   });
   const contentWidth = Math.max(0, viewportWidth - contentHorizontalPadding * 2);
   const userBubbleMaxWidth = contentWidth * 0.85;
-  // Assistant rows sit inside px-1.
-  const markdownContentWidth = Math.max(0, contentWidth - 8);
+  const markdownContentWidth = Math.max(0, contentWidth - ASSISTANT_ROW_HORIZONTAL_PADDING * 2);
   const reviewCommentBubbleWidth = Math.min(Math.max(280, contentWidth * 0.85), contentWidth);
   const insets = useSafeAreaInsets();
   const topContentInset = props.contentTopInset ?? insets.top + IOS_NAV_BAR_HEIGHT;

--- a/apps/mobile/src/features/threads/ThreadMarkdownImage.tsx
+++ b/apps/mobile/src/features/threads/ThreadMarkdownImage.tsx
@@ -25,7 +25,9 @@ import {
  * Width the feed lays markdown out in. The feed already knows this from its
  * viewport, so an image can size its frame on the first render instead of
  * waiting for its own onLayout, which would change the row's height once
- * more after the list has positioned the rows below it.
+ * more after the list has positioned the rows below it. It is an upper
+ * bound: a list item or blockquote indents its column, and the measured
+ * width takes over once it is known.
  */
 export const MarkdownImageAvailableWidthContext = createContext(0);
 
@@ -43,7 +45,10 @@ export function ThreadMarkdownImageView(props: {
   const mediaActions = useMediaActions(props.actionsSource);
   const contextWidth = useContext(MarkdownImageAvailableWidthContext);
   const [measuredWidth, setMeasuredWidth] = useState(0);
-  const availableWidth = contextWidth > 0 ? contextWidth : measuredWidth;
+  const availableWidth =
+    measuredWidth > 0 && contextWidth > 0
+      ? Math.min(contextWidth, measuredWidth)
+      : contextWidth || measuredWidth;
   const [decodedSize, setDecodedSize] = useState<{ width: number; height: number } | null>(null);
   const [failedUri, setFailedUri] = useState<string | null>(null);
 
@@ -55,7 +60,9 @@ export function ThreadMarkdownImageView(props: {
     setFailedUri(null);
   }, [props.uri]);
 
-  const sourceSize = props.knownSize ?? decodedSize;
+  // The decoded size is what the platform actually drew, so it wins over the
+  // server's header hint once it exists.
+  const sourceSize = decodedSize ?? props.knownSize ?? null;
   const displaySize: MarkdownImageDisplaySize | null =
     sourceSize === null || availableWidth <= 0
       ? null
@@ -71,9 +78,7 @@ export function ThreadMarkdownImageView(props: {
 
   return (
     <View
-      onLayout={
-        contextWidth > 0 ? undefined : (event) => setMeasuredWidth(event.nativeEvent.layout.width)
-      }
+      onLayout={(event) => setMeasuredWidth(event.nativeEvent.layout.width)}
       style={{ alignSelf: "stretch", gap: 6 }}
     >
       {props.uri === null || failed ? (

--- a/apps/mobile/src/features/threads/ThreadMarkdownImage.tsx
+++ b/apps/mobile/src/features/threads/ThreadMarkdownImage.tsx
@@ -1,5 +1,5 @@
 import type { AssetResource, EnvironmentId } from "@t3tools/contracts";
-import { useEffect, useId, useState } from "react";
+import { createContext, useContext, useEffect, useId, useState } from "react";
 import {
   ActivityIndicator,
   Image,
@@ -15,32 +15,49 @@ import { MediaActionsMenu } from "../../components/MediaActionsMenu";
 import { PresentationSource } from "../../components/NativePresentation";
 import { useMediaActions, type MediaActionsSource } from "../../lib/mediaActions";
 import { useAssetUrlState } from "../../state/assets";
-import { MARKDOWN_IMAGE_MAX_WIDTH, resolveMarkdownImageDisplaySize } from "./markdownImageSize";
+import {
+  MARKDOWN_IMAGE_MAX_WIDTH,
+  type MarkdownImageDisplaySize,
+  resolveMarkdownImageDisplaySize,
+} from "./markdownImageSize";
+
+/**
+ * Width the feed lays markdown out in. The feed already knows this from its
+ * viewport, so an image can size its frame on the first render instead of
+ * waiting for its own onLayout, which would change the row's height once
+ * more after the list has positioned the rows below it.
+ */
+export const MarkdownImageAvailableWidthContext = createContext(0);
 
 export function ThreadMarkdownImageView(props: {
   readonly uri: string | null;
   readonly sourceKey: string;
   readonly unavailable: boolean;
   readonly alt: string | null;
+  /** Pixel size from the server, when it could read the header; the frame is final from the first render. */
+  readonly knownSize?: { readonly width: number; readonly height: number } | undefined;
   readonly actionsSource?: MediaActionsSource;
   readonly onPressPreview: (source: FilePreviewSource) => void;
 }) {
   const sourceIdentifier = useId();
   const mediaActions = useMediaActions(props.actionsSource);
-  const [availableWidth, setAvailableWidth] = useState(0);
-  const [sourceSize, setSourceSize] = useState<{ width: number; height: number } | null>(null);
+  const contextWidth = useContext(MarkdownImageAvailableWidthContext);
+  const [measuredWidth, setMeasuredWidth] = useState(0);
+  const availableWidth = contextWidth > 0 ? contextWidth : measuredWidth;
+  const [decodedSize, setDecodedSize] = useState<{ width: number; height: number } | null>(null);
   const [failedUri, setFailedUri] = useState<string | null>(null);
 
   useEffect(() => {
-    setSourceSize(null);
+    setDecodedSize(null);
   }, [props.sourceKey]);
 
   useEffect(() => {
     setFailedUri(null);
   }, [props.uri]);
 
-  const displaySize =
-    sourceSize === null
+  const sourceSize = props.knownSize ?? decodedSize;
+  const displaySize: MarkdownImageDisplaySize | null =
+    sourceSize === null || availableWidth <= 0
       ? null
       : resolveMarkdownImageDisplaySize({
           sourceWidth: sourceSize.width,
@@ -54,7 +71,9 @@ export function ThreadMarkdownImageView(props: {
 
   return (
     <View
-      onLayout={(event) => setAvailableWidth(event.nativeEvent.layout.width)}
+      onLayout={
+        contextWidth > 0 ? undefined : (event) => setMeasuredWidth(event.nativeEvent.layout.width)
+      }
       style={{ alignSelf: "stretch", gap: 6 }}
     >
       {props.uri === null || failed ? (
@@ -97,14 +116,12 @@ export function ThreadMarkdownImageView(props: {
             >
               <View
                 className="items-center justify-center overflow-hidden rounded-[10px] bg-md-code-bg"
-                style={{
-                  ...frameStyle,
-                }}
+                style={frameStyle}
               >
                 <ThreadMarkdownImageRequest
                   key={props.uri}
                   uri={props.uri}
-                  onLoad={setSourceSize}
+                  onLoad={setDecodedSize}
                   onError={() => setFailedUri(props.uri)}
                 />
               </View>
@@ -173,6 +190,7 @@ export function ThreadMarkdownImage(props: {
           : `workspace:${props.resource.path}`
       }
       unavailable={assetUrl._tag === "Failure"}
+      knownSize={assetUrl._tag === "Success" ? assetUrl.imageDimensions : undefined}
       alt={props.alt}
       actionsSource={props.actionsSource}
       onPressPreview={props.onPressPreview}


### PR DESCRIPTION
Stack 2/3 (#10201). Depends on #10198.

## Problem

An assistant image on mobile went through three sizes: full width on first render, the measured width after its own `onLayout`, then the decoded size (up to 480px tall for a portrait screenshot). Each step changed the row's height after LegendList had already placed the rows below it. That's the "scroll area cut off under the composer" and "tool calls render under the media" reports.

## Fix

- `ThreadFeed` hands markdown its content width through `MarkdownImageAvailableWidthContext`, so the placeholder is the right width on the first render instead of after `onLayout`. The context is an upper bound: a list item or blockquote indents its column, and the measured width takes over once known.
- `ThreadMarkdownImage` uses the server's `imageDimensions` (#10198) to size the frame exactly before the first byte arrives. The decoded size still wins once it exists, so a wrong hint can never stick. An image the server couldn't measure keeps the 16:9 slot.
- Padding constants use the mobile 14px rem (`px-3.5` on the bubble, `px-1` on assistant rows).

## Evidence

iPhone 17 Pro simulator on macmini, seeded thread with landscape/portrait/wide screenshots, asset responses delayed 2.5 s through a proxy so the loading phase is observable. Frames captured every ~100 ms during thread open.

**Before** (main): portrait placeholder is 16:9; when the image decodes the row grows ~250px and everything below reflows.
**After**: the frame is portrait from first paint; rows below never move.

![iOS before/after](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/067d737e35aa246a/t3-media-ios-compare.png)

## Verification

- `apps/mobile` typecheck clean; lint on changed files clean (pre-existing effect warnings unchanged).
- Simulator pass above.

Model: Claude Fable 5 · Harness: Claude Code in T3 Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Size chat image frames before bytes arrive in mobile thread feed
> - `ThreadFeed` derives a markdown content width from the centered content width and row padding, then passes it to `renderFeedEntry` so user and assistant markdown rows have a width estimate before their own `onLayout` fires.
> - `ThreadMarkdownImage` combines the feed-provided width with a server-supplied image size to render an aspect-ratio frame before decode; after decode, decoded dimensions take precedence and the measured layout width constrains the estimate.
> - `readJpeg` now skips later APP1 segments once a rotated EXIF orientation is detected, and `IMAGE_DIMENSIONS_HEADER_BYTES` is raised from 64 KiB to 256 KiB to reach JPEG frame headers after multiple metadata segments.
> - Risk: in [ThreadMarkdownImageView](https://github.com/pingdotgg/t3code/pull/10199/files#diff-f1433714b28719fc0e23737d491c56eecb60b76b849aa6301035d711b646e9e3) the frame resolves only when both a source size and a positive available width exist, otherwise it falls back to the placeholder frame; rows lacking a width context or unknown image size may keep the placeholder longer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cced7aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->