### PR TITLE
fix(web): size the chat image slot from server-reported dimensions

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1539,11 +1539,16 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
   const relativePath = reference?.relativePath;
   const src = assetUrl._tag === "Success" ? assetUrl.url + (props.srcFragment ?? "") : null;
   // The server reads the pixel size from the file header, so the slot can be
-  // the image's final box instead of a 16:9 guess. An authored size still wins.
+  // the image's final box instead of a 16:9 guess. An authored size, or a
+  // caller's cap such as the viewed-image row's max height, layers on top.
   const knownSize = assetUrl._tag === "Success" ? assetUrl.imageDimensions : undefined;
+  const knownSizeStyle = knownSize
+    ? authoredImageSizeStyle(knownSize.width, knownSize.height)
+    : undefined;
   const style =
-    props.style ??
-    (knownSize ? authoredImageSizeStyle(knownSize.width, knownSize.height) : undefined);
+    knownSizeStyle && props.style
+      ? { ...knownSizeStyle, ...props.style }
+      : (props.style ?? knownSizeStyle);
   const actionsSource: MediaActionSource = {
     kind: props.kind ?? "image",
     name: props.alt || (props.kind ?? "image"),

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1538,6 +1538,12 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
   const reference = path ? mediaFileReference(path, props.workspaceRoot) : undefined;
   const relativePath = reference?.relativePath;
   const src = assetUrl._tag === "Success" ? assetUrl.url + (props.srcFragment ?? "") : null;
+  // The server reads the pixel size from the file header, so the slot can be
+  // the image's final box instead of a 16:9 guess. An authored size still wins.
+  const knownSize = assetUrl._tag === "Success" ? assetUrl.imageDimensions : undefined;
+  const style =
+    props.style ??
+    (knownSize ? authoredImageSizeStyle(knownSize.width, knownSize.height) : undefined);
   const actionsSource: MediaActionSource = {
     kind: props.kind ?? "image",
     name: props.alt || (props.kind ?? "image"),
@@ -1581,7 +1587,7 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
       copyMarkdown={props.copyMarkdown}
       standalone={props.standalone ?? true}
       className={CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME}
-      style={props.style}
+      style={style}
       actionsSource={actionsSource}
       onImageExpand={props.onImageExpand}
     />

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1235,9 +1235,15 @@ function markdownImageCopy(alt: string, src: string, title: string | undefined):
   return `![${escapedAlt}](${src}${titleSuffix})`;
 }
 
+/**
+ * `maxHeightRem` folds a height cap into the width bound: `max-height` alone
+ * would not feed back through `aspect-ratio` once `width` is definite, so a
+ * tall image would keep a box wider than the picture it draws.
+ */
 function authoredImageSizeStyle(
   width: string | number | undefined,
   height: string | number | undefined,
+  maxHeightRem = 30,
 ): CSSProperties | undefined {
   const parsedWidth = Number(width);
   const parsedHeight = Number(height);
@@ -1248,7 +1254,7 @@ function authoredImageSizeStyle(
       width: parsedWidth,
       height: "auto",
       aspectRatio: `${parsedWidth} / ${parsedHeight}`,
-      maxWidth: `min(100%, 30rem, ${(30 * parsedWidth) / parsedHeight}rem)`,
+      maxWidth: `min(100%, 30rem, ${(maxHeightRem * parsedWidth) / parsedHeight}rem)`,
     };
   }
   if (hasWidth) return { maxWidth: `min(100%, 30rem, ${parsedWidth}px)` };
@@ -1522,6 +1528,8 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
   readonly srcFragment?: string;
   /** Reserve a slot while loading; off for images that share a line with text. */
   readonly standalone?: boolean | undefined;
+  /** Caps the box height in rem while keeping the image's ratio; 30 by default. */
+  readonly maxHeightRem?: number | undefined;
   readonly style?: CSSProperties | undefined;
   readonly workspaceRoot?: string | undefined;
   readonly onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
@@ -1539,16 +1547,17 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
   const relativePath = reference?.relativePath;
   const src = assetUrl._tag === "Success" ? assetUrl.url + (props.srcFragment ?? "") : null;
   // The server reads the pixel size from the file header, so the slot can be
-  // the image's final box instead of a 16:9 guess. An authored size, or a
-  // caller's cap such as the viewed-image row's max height, layers on top.
+  // the image's final box instead of a 16:9 guess. An authored size wins; a
+  // caller's height cap shrinks the box while keeping the ratio.
   const knownSize = assetUrl._tag === "Success" ? assetUrl.imageDimensions : undefined;
-  const knownSizeStyle = knownSize
-    ? authoredImageSizeStyle(knownSize.width, knownSize.height)
-    : undefined;
+  const maxHeightRem = props.maxHeightRem ?? 30;
   const style =
-    knownSizeStyle && props.style
-      ? { ...knownSizeStyle, ...props.style }
-      : (props.style ?? knownSizeStyle);
+    props.style ??
+    (knownSize
+      ? authoredImageSizeStyle(knownSize.width, knownSize.height, maxHeightRem)
+      : maxHeightRem !== 30
+        ? { maxHeight: `${maxHeightRem}rem` }
+        : undefined);
   const actionsSource: MediaActionSource = {
     kind: props.kind ?? "image",
     name: props.alt || (props.kind ?? "image"),

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 const testState = vi.hoisted(() => ({
   resources: [] as Array<unknown>,
   assetState: "success" as "success" | "loading" | "failure",
+  imageDimensions: undefined as { width: number; height: number } | undefined,
 }));
 
 vi.mock("@effect/atom-react", () => ({ useAtomValue: () => null }));
@@ -14,7 +15,11 @@ vi.mock("../assets/assetUrls", () => ({
     testState.resources.push(resource);
     if (testState.assetState === "loading") return { _tag: "Loading" };
     if (testState.assetState === "failure") return { _tag: "Failure" };
-    return { _tag: "Success", url: "https://signed.test/workspace-image.svg" };
+    return {
+      _tag: "Success",
+      url: "https://signed.test/workspace-image.svg",
+      ...(testState.imageDimensions ? { imageDimensions: testState.imageDimensions } : {}),
+    };
   },
 }));
 vi.mock("../hooks/useTheme", () => ({ useTheme: () => ({ resolvedTheme: "dark" }) }));
@@ -92,6 +97,7 @@ describe("ChatMarkdown workspace images", () => {
   beforeEach(() => {
     testState.resources = [];
     testState.assetState = "success";
+    testState.imageDimensions = undefined;
   });
 
   it.each([
@@ -243,6 +249,24 @@ describe("ChatMarkdown workspace images", () => {
 
     // The sanitizer prefixes authored ids; the loading slot carries it too.
     expect(html).toContain('<span id="user-content-diagram"');
+  });
+
+  it("sizes the slot from server-reported dimensions so a portrait image never grows", () => {
+    testState.imageDimensions = { width: 720, height: 1400 };
+
+    const style = firstInlineStyle(render("![shot](.t3/workspace-image.svg)"));
+
+    expect(style).toMatchObject({ width: "720px", "aspect-ratio": "720 / 1400" });
+  });
+
+  it("lets an authored size override server-reported dimensions", () => {
+    testState.imageDimensions = { width: 720, height: 1400 };
+
+    const style = firstInlineStyle(
+      render('<img src=".t3/workspace-image.svg" alt="sized" width="96" height="128">'),
+    );
+
+    expect(style).toMatchObject({ width: "96px", "aspect-ratio": "96 / 128" });
   });
 
   it("reserves a slot for an image that is alone in a list item", () => {

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -47,7 +47,7 @@ vi.mock("~/lib/openPullRequestLink", () => ({
   useOpenChangeRequestLink: () => vi.fn(),
 }));
 
-import ChatMarkdown from "./ChatMarkdown";
+import ChatMarkdown, { ChatMarkdownAssetImage } from "./ChatMarkdown";
 import { FileMarkdownPreview } from "./files/FileMarkdownPreview";
 
 const threadRef = {
@@ -257,6 +257,24 @@ describe("ChatMarkdown workspace images", () => {
     const style = firstInlineStyle(render("![shot](.t3/workspace-image.svg)"));
 
     expect(style).toMatchObject({ width: "720px", "aspect-ratio": "720 / 1400" });
+  });
+
+  it("folds a caller's height cap into the width bound so the ratio holds", () => {
+    testState.imageDimensions = { width: 720, height: 1400 };
+
+    const html = renderToStaticMarkup(
+      <ChatMarkdownAssetImage
+        environmentId={threadRef.environmentId}
+        resource={{ _tag: "media-file", threadId: threadRef.threadId, path: "/shot.png" }}
+        alt="shot"
+        maxHeightRem={16}
+      />,
+    );
+
+    expect(firstInlineStyle(html)).toMatchObject({
+      "aspect-ratio": "720 / 1400",
+      "max-width": `min(100%, 30rem, ${(16 * 720) / 1400}rem)`,
+    });
   });
 
   it("lets an authored size override server-reported dimensions", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -3342,7 +3342,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
             alt={viewedImage.alt}
             srcFragment={viewedImage.srcFragment}
             workspaceRoot={workspaceRoot}
-            style={{ maxHeight: "16rem" }}
+            maxHeightRem={16}
             onImageExpand={onImageExpand}
           />
         </div>


### PR DESCRIPTION
Stack 3/3 (#10201). Depends on #10198.

## Problem

After #9938 a workspace image on web still moved the rows below it once: a portrait screenshot grew past its 16:9 slot when it decoded.

## Fix

`ChatMarkdownAssetImage` applies the server's `imageDimensions` (#10198) through the existing `authoredImageSizeStyle`, so the slot is the image's final box from the moment the URL resolves. An authored `width`/`height` still wins; a caller's cap (the viewed-image row's `maxHeight: 16rem`) layers on top rather than shadowing the dimensions.

## Evidence

Cold thread mount with image responses delayed 4 s, `layout-shift` observer armed before mount (same harness as #9938):

| | #9938 | this PR |
|---|---|---|
| Media layout-shift entries | 1 (0.013 — portrait growing past 16:9) | **0** |

The only remaining entry on the page is the composer resizing, unrelated to media.

## Verification

- `ChatMarkdown.workspace-images.test.tsx`: slot is sized from server dimensions (`width: 720px; aspect-ratio: 720 / 1400`); authored size overrides server dimensions. 32 passed.
- `apps/web` typecheck clean.
- In-browser: portrait image renders with `aspect-ratio: 720 / 1400` on the slot and the settled `<img>`; a 16rem `maxHeight` cap yields a 247×256 box.

Model: Claude Fable 5 · Harness: Claude Code in T3 Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Size chat asset images from server-reported dimensions
> - `ChatMarkdownAssetImage` now reads reported width and height from successful asset URL loads and derives inline width, aspect ratio, and a height-derived max-width
> - `authoredImageSizeStyle` gains an optional height-cap argument (default 30rem); when both dimensions are present the cap is folded into the max-width calculation
> - `PlainWorkEntryRow` in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/10200/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) switches from an inline `max-height` style to the new `maxHeightRem` prop, keeping the 16rem value
> - Explicit incoming `style` props still take precedence; callers without dimensions can still apply a custom rem height cap as a fallback
> - Risk: asset images without server-reported dimensions no longer get a computed aspect ratio — they fall back to the height-cap path only, which may shift layout for previously auto-sized images in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/10200/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d18793c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->