### PR TITLE
fix(mobile): even out the working pill's spacing

### DIFF
--- a/apps/mobile/src/features/threads/floating-working-control.tsx
+++ b/apps/mobile/src/features/threads/floating-working-control.tsx
@@ -18,8 +18,12 @@ import { SymbolView } from "../../components/AppSymbol";
 import { ControlPill } from "../../components/ControlPill";
 import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../../native/native-glass";
 
-const CONTROL_HEIGHT = 44;
-const CONTROL_COMPOSER_GAP = 8;
+const CONTROL_HEIGHT = 38.5; // h-11 with the mobile 14px rem
+// The collapsed composer capsule starts 6 below its overlay's top edge, so
+// the pill sits at (gap - 6) above the overlay to leave the same gap to the
+// capsule as the feed's end inset leaves between it and the last row.
+const CONTROL_GAP = 8;
+const COMPOSER_CAPSULE_INSET = 6;
 const GLASS_MERGE_SPACING = 12;
 const CONTROL_ENTERING = FadeIn.duration(180).reduceMotion(ReduceMotion.System);
 const CONTROL_EXITING = FadeOut.duration(120).reduceMotion(ReduceMotion.System);
@@ -40,7 +44,8 @@ const UniwindGlassContainer = withUniwind(GlassContainer, {
 });
 const AnimatedGlassView = Animated.createAnimatedComponent(UniwindGlassView);
 
-export const FLOATING_WORKING_CONTROL_COVERAGE = CONTROL_HEIGHT + CONTROL_COMPOSER_GAP;
+const CONTROL_OVERLAY_OFFSET = CONTROL_HEIGHT + CONTROL_GAP - COMPOSER_CAPSULE_INSET;
+export const FLOATING_WORKING_CONTROL_COVERAGE = CONTROL_OVERLAY_OFFSET + CONTROL_GAP;
 
 /**
  * What the floating pill says. Syncing and working share one element so the
@@ -81,7 +86,7 @@ export function FloatingWorkingControl(props: {
     <Animated.View
       pointerEvents="box-none"
       className="absolute left-0 right-0 z-20 items-center"
-      style={{ top: -FLOATING_WORKING_CONTROL_COVERAGE }}
+      style={{ top: -CONTROL_OVERLAY_OFFSET }}
       entering={NATIVE_LIQUID_GLASS_SUPPORTED ? undefined : CONTROL_ENTERING}
       exiting={NATIVE_LIQUID_GLASS_SUPPORTED ? undefined : CONTROL_EXITING}
     >


### PR DESCRIPTION
Stacked on #10173.

## Problem

The floating "Working for…" pill sat 20 above the composer capsule but only a few points below the last timeline row, so it read as attached to the feed and detached from the composer.

## Fix

Size the offsets from the pill's real height (`h-11` = 38.5, not the 44 the constant claimed) and the composer capsule's 6-point inset inside its overlay, so the pill sits 8 above the capsule. Reserve the same 8 above the pill in the feed's end inset. `CONTROL_SEPARATION` picks up the corrected height too; it is the arrow button's width, which is also `w-11`.

## Verification

- `tsc --noEmit` for `apps/mobile`, targeted lint and format.
- iPhone 17 Pro simulator, same seeded thread on `main` and this branch. Measured from screenshots: pill-to-capsule gap 19.7 → 8.0; last-row-to-pill gap ~7 → ~8.

![Before: the pill floats high above the composer. After: the pill sits 8 points above the composer capsule and 8 below the last row.](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/2bf0c4be01e9182e/pair-pill.png)

Implemented by Claude Fable 5 in the Claude Code harness.
