### PR TITLE
fix(mobile): only make work rows expandable when the body adds something

### DIFF
--- a/apps/mobile/src/features/threads/thread-work-log.tsx
+++ b/apps/mobile/src/features/threads/thread-work-log.tsx
@@ -34,7 +34,7 @@ import { AppText as Text } from "../../components/AppText";
 import { T3Wordmark } from "../../components/T3Wordmark";
 import { cn } from "../../lib/cn";
 import { THREAD_WORK_ROW_MIN_HEIGHT, type deriveThreadWorkLogSizing } from "../../lib/layout";
-import type { ThreadFeedActivity } from "../../lib/threadActivity";
+import { type ThreadFeedActivity, workEntryRowLabel } from "../../lib/threadActivity";
 import {
   resolveThreadWorkGroupInitialScroll,
   shouldFollowThreadWorkGroupAppend,
@@ -305,21 +305,6 @@ export function ShimmeringWorkContent(props: {
       ) : null}
     </View>
   );
-}
-
-function stripShellWrapper(value: string): string {
-  const trimmed = value.trim();
-  const match = trimmed.match(/^\/bin\/zsh -lc ['"]?([\s\S]*?)['"]?$/);
-  return (match?.[1] ?? trimmed).trim();
-}
-
-function compactActivityDetail(detail: string | null): string | null {
-  if (!detail) {
-    return null;
-  }
-
-  const cleaned = stripShellWrapper(detail).replace(/\s+/g, " ").trim();
-  return cleaned.length > 0 ? cleaned : null;
 }
 
 function workRowSymbolName(icon: ThreadFeedActivity["icon"]): AppSymbolName {
@@ -697,8 +682,7 @@ const ThreadWorkLogRow = memo(function ThreadWorkLogRow(
   const fullDetail = expanded ? row.getFullDetail() : null;
   const viewedImagePath = workEntryViewedImagePath(row.workEntry);
   const toolPresentation = resolveWorkEntryToolPresentation(row.workEntry);
-  const previewText =
-    toolPresentation?.displayName ?? compactActivityDetail(row.detail) ?? row.summary;
+  const previewText = workEntryRowLabel(row.workEntry);
   const displayText =
     !toolPresentation && expanded && row.workEntry.command?.trim() ? "Command" : previewText;
   const iconIsDestructive = row.icon === "alert" || row.icon === "warning";

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -21,6 +21,7 @@ import {
   isPendingUserInputOptionSelected,
   setPendingUserInputCustomAnswer,
   togglePendingUserInputOptionSelection,
+  workEntryRowLabel,
   type ThreadFeedActivity,
   type ThreadFeedEntry,
 } from "./threadActivity";
@@ -702,6 +703,95 @@ describe("buildThreadFeed", () => {
     const [row] = group.activities;
     expect(row?.workEntry.detail).toBe(command);
     expect(row?.getFullDetail()).toBe(`${command}\n\n${command}`);
+    // Opening it would only repeat the command the row already shows.
+    expect(row?.canExpand).toBe(false);
+  });
+
+  it.each([
+    {
+      name: "a task summary that is its own detail",
+      activity: {
+        kind: "task.completed" as const,
+        tone: "info" as const,
+        summary: "Task completed",
+        payload: {
+          taskId: "bh2p996o4",
+          status: "completed",
+          title: "Check CI on the new head",
+          summary: "Check CI on the new head",
+          detail: "Check CI on the new head",
+          agentKind: "background",
+          taskType: "local_bash",
+        },
+      },
+      label: "Check CI on the new head",
+      canExpand: false,
+    },
+    {
+      name: "a runtime warning with only its message",
+      activity: {
+        kind: "runtime.warning" as const,
+        tone: "info" as const,
+        summary: "Bash is unusable in this environment",
+        payload: { detail: "Bash is unusable in this environment" },
+      },
+      label: "Bash is unusable in this environment",
+      canExpand: false,
+    },
+    {
+      name: "a multi-line task report",
+      activity: {
+        kind: "task.completed" as const,
+        tone: "info" as const,
+        summary: "Task completed",
+        payload: {
+          taskId: "ae3f85a",
+          status: "completed",
+          title: "Audit the PR",
+          detail: "**Tooling note:** Bash is unusable.\n\n# Audit\n\nNo blockers.",
+          agentKind: "agent",
+          taskType: "local_agent",
+        },
+      },
+      label: "**Tooling note:** Bash is unusable. # Audit No blockers.",
+      canExpand: true,
+    },
+    {
+      name: "a command whose output differs from the command",
+      activity: {
+        kind: "tool.completed" as const,
+        tone: "tool" as const,
+        summary: "Command run",
+        payload: {
+          itemType: "command_execution",
+          title: "Command run",
+          detail: "Bash: printf hello",
+          data: { toolName: "Bash", command: "printf hello", rawOutput: { content: "hello" } },
+        },
+      },
+      label: "printf hello",
+      canExpand: true,
+    },
+  ])("only lets $name expand when the body adds something: $canExpand", (input) => {
+    const thread = makeThread({
+      id: ThreadId.make("thread-expand-rule"),
+      projectId: ProjectId.make("project-1"),
+      title: "Expand rule",
+      activities: [
+        makeActivity({
+          id: EventId.make("expand-rule"),
+          createdAt: "2026-09-01T00:00:00.000Z",
+          ...input.activity,
+        }),
+      ],
+    });
+
+    const [group] = buildThreadFeed(thread);
+    expect(group?.type).toBe("activity-group");
+    if (group?.type !== "activity-group") return;
+    const [row] = group.activities;
+    expect(workEntryRowLabel(row!.workEntry)).toBe(input.label);
+    expect(row?.canExpand).toBe(input.canExpand);
   });
 
   it("drops a truncated Claude echo of a long command", () => {

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -878,13 +878,43 @@ function buildWorkEntryExpandedBody(entry: WorkLogEntry): string | null {
   return blocks.length > 0 ? blocks.join("\n\n") : null;
 }
 
-function workEntryHasExpandedBody(entry: WorkLogEntry): boolean {
-  return (
-    (entry.itemType === "mcp_tool_call" && entry.toolData !== undefined) ||
-    Boolean((entry.rawCommand ?? entry.command)?.trim()) ||
-    Boolean(entry.detail?.trim()) ||
-    (entry.changedFiles?.some((path) => path.trim().length > 0) ?? false)
-  );
+/**
+ * A row only opens when its body says more than its collapsed line. A row
+ * whose only detail is the single-line text it already shows (a runtime
+ * warning, a task summary, a short command) has nothing to reveal.
+ * Multi-line text still expands: the collapsed row truncates it to one line.
+ * Cheap field checks come first so large tool payloads are not serialized
+ * for every row (see the deferred-expansion test).
+ */
+function workEntryHasExpandedBody(entry: WorkLogEntry, collapsedText: string): boolean {
+  if (entry.itemType === "mcp_tool_call" && entry.toolData !== undefined) return true;
+  if (entry.changedFiles?.some((path) => path.trim().length > 0)) return true;
+  const parts = [entry.rawCommand ?? entry.command, entry.detail]
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value));
+  if (parts.length === 0) return false;
+  if (parts.length > 1 && new Set(parts).size > 1) return true;
+  const only = parts[0]!;
+  return only.includes("\n") || collapseWhitespace(only) !== collapseWhitespace(collapsedText);
+}
+
+function collapseWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function stripShellWrapper(value: string): string {
+  const trimmed = value.trim();
+  const match = trimmed.match(/^\/bin\/zsh -lc ['"]?([\s\S]*?)['"]?$/);
+  return (match?.[1] ?? trimmed).trim();
+}
+
+/** The one-line text a collapsed work row shows. */
+export function workEntryRowLabel(entry: WorkLogEntry): string {
+  const presentation = resolveWorkEntryToolPresentation(entry);
+  if (presentation) return presentation.displayName;
+  const preview = workEntryPreview(entry);
+  const compactPreview = preview === null ? null : collapseWhitespace(stripShellWrapper(preview));
+  return compactPreview || workEntryHeading(entry);
 }
 
 function memoizeValue<T>(build: () => T): () => T {
@@ -2098,7 +2128,7 @@ function toThreadFeedActivityEntry(
       turnId: entry.turnId,
       summary,
       detail,
-      canExpand: workEntryHasExpandedBody(entry),
+      canExpand: workEntryHasExpandedBody(entry, workEntryRowLabel(entry)),
       getFullDetail,
       getCopyText,
       icon: workEntryIcon(entry),


### PR DESCRIPTION
Stacked on #10209.

## Problem

Every work row with a `command` or `detail` got a chevron, so runtime warnings, background-task summaries, and short commands opened to repeat the one line they already showed. Web only marks a row expandable when its body adds something beyond the visible label (`PlainWorkEntryRow.canExpand`); mobile checked field presence.

## Fix

Decide `canExpand` against the collapsed label the row actually renders (`workEntryRowLabel`, now shared between the feed model and `ThreadWorkLogRow` so they cannot drift). Multi-line bodies stay expandable because the collapsed row truncates them to one line; MCP payloads and changed-file lists always do. Cheap field checks run first so large tool outputs are not serialized per row (the existing deferred-expansion test guards that).

## Verification

- `vp test run apps/mobile/src/lib/threadActivity.test.ts` — 95 passed, with new cases for a task summary that is its own detail, a runtime warning, a multi-line task report, and a command whose output differs from the command.
- `tsc --noEmit` for `apps/mobile`, targeted lint and format.
- Simulator, same seeded group on `main` and this branch: the "Run mobile threadActivity tests" and "git status --short" rows lose their chevrons; the multi-line `ffmpeg` command and the file read keep theirs.

![Before: every row in the group has a chevron. After: only rows with more to show have one.](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/7623c70a64e2032e/pair-rows.png)

Implemented by Claude Fable 5 in the Claude Code harness.
