### PR TITLE
fix(mobile): stop clipping expanded tool groups

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -1326,6 +1326,7 @@ function renderFeedEntry(
     readonly renderMarkdownImage: MarkdownImageRenderer;
     readonly renderViewedImage: MarkdownImageRenderer;
     readonly iconSubtleColor: string | import("react-native").ColorValue;
+    readonly screenColor: string;
     readonly userBubbleColor: string | import("react-native").ColorValue;
     readonly markdownStyles: MarkdownStyleSets;
     readonly reviewCommentColors: ReviewCommentColors;
@@ -1584,6 +1585,7 @@ function renderFeedEntry(
       rowSizing={props.workRowSizing}
       scrollPositions={props.workGroupScrollPositions}
       iconSubtleColor={iconSubtleColor}
+      edgeFadeColor={props.screenColor}
       themeAppearance={props.themeAppearance}
       onCopyRow={props.onCopyWorkRow}
       onToggleRow={props.onToggleWorkRow}
@@ -1972,6 +1974,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
 
   const theme = useUniwindTheme();
   const iconSubtleColor = theme["--color-icon-subtle"];
+  const screenColor = theme["--color-screen"];
   const userBubbleColor = theme["--color-user-bubble"];
   const onMarkdownLinkPress = useCallback(
     (href: string) => {
@@ -2620,6 +2623,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
             renderMarkdownImage,
             renderViewedImage,
             iconSubtleColor,
+            screenColor,
             userBubbleColor,
             markdownStyles,
             reviewCommentColors,
@@ -2641,6 +2645,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       terminalAssistantMessageIds,
       unsettledTurnId,
       iconSubtleColor,
+      screenColor,
       userBubbleColor,
       markdownStyles,
       reviewCommentColors,

--- a/apps/mobile/src/features/threads/thread-work-log.tsx
+++ b/apps/mobile/src/features/threads/thread-work-log.tsx
@@ -385,6 +385,8 @@ interface ThreadWorkLogProps {
   readonly rowSizing: ReturnType<typeof deriveThreadWorkLogSizing>;
   readonly scrollPositions: Map<string, ThreadWorkGroupScrollPosition>;
   readonly iconSubtleColor: ColorValue;
+  /** Feed background, painted as the scroll-edge fade over a long group. */
+  readonly edgeFadeColor: string;
   readonly themeAppearance: "light" | "dark";
   readonly onCopyRow: (rowId: string, value: string) => void;
   readonly onToggleRow: (rowId: string, anchorKey: string) => void;
@@ -430,6 +432,7 @@ export function ThreadWorkLog(props: ThreadWorkLogProps) {
       {props.activities[0]?.groupedToolDetail ? (
         <ThreadWorkGroupList
           activities={props.activities}
+          edgeFadeColor={props.edgeFadeColor}
           expandedRows={props.expandedRows}
           groupId={props.anchorKey}
           rowSizing={props.rowSizing}
@@ -445,6 +448,7 @@ export function ThreadWorkLog(props: ThreadWorkLogProps) {
 
 function ThreadWorkGroupList(props: {
   readonly activities: ReadonlyArray<ThreadFeedActivity>;
+  readonly edgeFadeColor: string;
   readonly expandedRows: Readonly<Record<string, boolean>>;
   readonly groupId: string;
   readonly rowSizing: ReturnType<typeof deriveThreadWorkLogSizing>;
@@ -485,21 +489,17 @@ function ThreadWorkGroupList(props: {
   const height = Math.min(contentHeight, WORK_GROUP_MAX_HEIGHT);
   const scrollOffset = useSharedValue(initialPosition?.scrollOffset ?? 0);
   const sharedValues = useMemo(() => ({ scrollOffset }), [scrollOffset]);
-  const gradientId = `work-group-fade-${useId().replaceAll(":", "")}`;
-  const fadeFraction = WORK_GROUP_EDGE_FADE_HEIGHT / height;
 
-  // Opaque covers remove each edge fade at the scroll boundary. Scroll offset
-  // stays on the UI thread; only content-size changes update React state.
-  const topCoverStyle = useAnimatedStyle(() => ({
-    opacity: 1 - Math.min(1, Math.max(0, scrollOffset.value) / WORK_GROUP_EDGE_FADE_HEIGHT),
+  // Each edge fades only while content continues past it. Scroll offset stays
+  // on the UI thread; only content-size changes update React state.
+  const topFadeStyle = useAnimatedStyle(() => ({
+    opacity: Math.min(1, Math.max(0, scrollOffset.value) / WORK_GROUP_EDGE_FADE_HEIGHT),
   }));
-  const bottomCoverStyle = useAnimatedStyle(() => ({
-    opacity:
-      1 -
-      Math.min(
-        1,
-        Math.max(0, contentHeight - height - scrollOffset.value) / WORK_GROUP_EDGE_FADE_HEIGHT,
-      ),
+  const bottomFadeStyle = useAnimatedStyle(() => ({
+    opacity: Math.min(
+      1,
+      Math.max(0, contentHeight - height - scrollOffset.value) / WORK_GROUP_EDGE_FADE_HEIGHT,
+    ),
   }));
   const rememberPosition = useCallback(() => {
     if (!loadedRef.current) return;
@@ -525,7 +525,7 @@ function ThreadWorkGroupList(props: {
     }
   }, []);
   const onContentSizeChange = useCallback(
-    (_width: number, nextHeight: number) => {
+    (nextHeight: number) => {
       const previous = previousContent.current;
       const detailsChanged = previous.expandedRows !== props.expandedRows;
       const followAppend =
@@ -565,6 +565,24 @@ function ThreadWorkGroupList(props: {
     },
     [props.activities, props.expandedRows, scrollOffset, finishPendingAppend, rememberPosition],
   );
+  // The native ScrollView reports its content size a frame or more after
+  // LegendList has laid the rows out, so a detail toggle rendered the group
+  // at its old height while the rows below already moved. Read the size
+  // LegendList computes on the JS thread instead; it settles in the same
+  // commit as the row measurement that changed it.
+  const onContentSizeChangeRef = useRef(onContentSizeChange);
+  useLayoutEffect(() => {
+    onContentSizeChangeRef.current = onContentSizeChange;
+  }, [onContentSizeChange]);
+  const subscribeToContentSize = useCallback((list: LegendListRef | null) => {
+    listRef.current = list;
+    if (!list) return;
+    const unsubscribe = list.getState().listen("totalSize", () => {
+      onContentSizeChangeRef.current(list.getState().contentLength);
+    });
+    onContentSizeChangeRef.current(list.getState().contentLength);
+    return unsubscribe;
+  }, []);
   const getFixedItemSize = useCallback(
     (row: ThreadFeedActivity, index: number) =>
       props.expandedRows[row.id] || props.rowSizing.fixedRowHeight === undefined
@@ -582,34 +600,9 @@ function ThreadWorkGroupList(props: {
   );
 
   return (
-    <MaskedView
-      style={{ height }}
-      maskElement={
-        <View style={StyleSheet.absoluteFill} pointerEvents="none">
-          <Svg width="100%" height="100%">
-            <Defs>
-              <LinearGradient id={gradientId} x1="0%" x2="0%" y1="0%" y2="100%">
-                <Stop offset={0} stopColor="white" stopOpacity={0} />
-                <Stop offset={fadeFraction} stopColor="white" stopOpacity={1} />
-                <Stop offset={1 - fadeFraction} stopColor="white" stopOpacity={1} />
-                <Stop offset={1} stopColor="white" stopOpacity={0} />
-              </LinearGradient>
-            </Defs>
-            <Rect width="100%" height="100%" fill={`url(#${gradientId})`} />
-          </Svg>
-          <Animated.View
-            className="absolute inset-x-0 top-0 bg-white"
-            style={[{ height: WORK_GROUP_EDGE_FADE_HEIGHT }, topCoverStyle]}
-          />
-          <Animated.View
-            className="absolute inset-x-0 bottom-0 bg-white"
-            style={[{ height: WORK_GROUP_EDGE_FADE_HEIGHT }, bottomCoverStyle]}
-          />
-        </View>
-      }
-    >
+    <View style={{ height, overflow: "hidden" }}>
       <AnimatedLegendList
-        ref={listRef}
+        ref={subscribeToContentSize}
         data={props.activities}
         keyExtractor={workLogRowKey}
         estimatedItemSize={props.rowSizing.estimatedRowHeight + WORK_ROW_GAP}
@@ -624,7 +617,6 @@ function ThreadWorkGroupList(props: {
         extraData={props.renderRow}
         renderItem={renderItem}
         sharedValues={sharedValues}
-        onContentSizeChange={onContentSizeChange}
         onLayout={finishPendingAppend}
         onLoad={() => {
           loadedRef.current = true;
@@ -654,12 +646,47 @@ function ThreadWorkGroupList(props: {
         scrollsToTop={false}
         bounces={false}
         keyboardShouldPersistTaps="handled"
-        // MaskedView bridges through a native host whose absolute-fill bounds
-        // can lag behind a resize. Keep the list's viewport at the group's
-        // current height when expanding details or appending calls.
-        style={[StyleSheet.absoluteFill, { height }]}
+        style={{ height }}
       />
-    </MaskedView>
+      <Animated.View
+        pointerEvents="none"
+        className="absolute inset-x-0 top-0"
+        style={[{ height: WORK_GROUP_EDGE_FADE_HEIGHT }, topFadeStyle]}
+      >
+        <EdgeFade color={props.edgeFadeColor} direction="down" />
+      </Animated.View>
+      <Animated.View
+        pointerEvents="none"
+        className="absolute inset-x-0 bottom-0"
+        style={[{ height: WORK_GROUP_EDGE_FADE_HEIGHT }, bottomFadeStyle]}
+      >
+        <EdgeFade color={props.edgeFadeColor} direction="up" />
+      </Animated.View>
+    </View>
+  );
+}
+
+/** A screen-colored gradient painted over the list edge that still has content past it. */
+function EdgeFade(props: { readonly color: string; readonly direction: "up" | "down" }) {
+  const gradientId = `work-group-fade-${useId().replaceAll(":", "")}`;
+  return (
+    <Svg width="100%" height="100%">
+      <Defs>
+        <LinearGradient id={gradientId} x1="0%" x2="0%" y1="0%" y2="100%">
+          <Stop
+            offset={0}
+            stopColor={props.color}
+            stopOpacity={props.direction === "down" ? 1 : 0}
+          />
+          <Stop
+            offset={1}
+            stopColor={props.color}
+            stopOpacity={props.direction === "down" ? 0 : 1}
+          />
+        </LinearGradient>
+      </Defs>
+      <Rect width="100%" height="100%" fill={`url(#${gradientId})`} />
+    </Svg>
   );
 }
 
@@ -670,7 +697,12 @@ function workLogRowKey(row: ThreadFeedActivity): string {
 const ThreadWorkLogRow = memo(function ThreadWorkLogRow(
   props: Omit<
     ThreadWorkLogProps,
-    "activities" | "copiedRowId" | "expandedRows" | "rowSizing" | "scrollPositions"
+    | "activities"
+    | "copiedRowId"
+    | "edgeFadeColor"
+    | "expandedRows"
+    | "rowSizing"
+    | "scrollPositions"
   > & {
     readonly row: ThreadFeedActivity;
     readonly copied: boolean;


### PR DESCRIPTION
Stacked on #10211.

## Problem

Opening a row's details inside an expanded tool group left an unpainted band the size of the growth (88 points for a five-line command output). Layout was correct everywhere — LegendList's sizes, the outer row's measured height, and accessibility frames all matched — but the pixels for everything past the group's old bottom edge were missing until the group was collapsed and reopened.

The group's scroll-edge fades come from `@expo/ui`'s `MaskedView`, which hosts the list inside a SwiftUI `.mask` via `RNHostView`. That host keeps the bounds it had when the mask was built, so a resize clips the tail. #9359 worked around the first symptom by forcing the list's height; this is the second.

Confirmed by elimination on the simulator: removing layout animations, the inner `ScrollView`, `selectable`, `absoluteFill`, and `maintainVisibleContentPosition` each left the band in place; swapping `MaskedView` for a plain clipped `View` removed it.

## Fix

- Render the group in a plain `overflow: hidden` view and draw the fades as two screen-colored SVG gradients over the edges, each fading in only while content continues past that edge (same scroll-offset math, inverted from "cover" to "fade"). The screen color comes from `ThreadFeed`, which already reads the theme.
- Read the group's content size from LegendList's `totalSize` signal instead of the native `onContentSizeChange`, so the outer row resizes in the same commit as the row measurement that changed it.

`ShimmeringWorkContent` still uses `MaskedView`; its mask never resizes.

## Verification

- `tsc --noEmit` for `apps/mobile`, targeted lint and format.
- iPhone 17 Pro simulator, same seeded group on `main` and this branch. The blank band after expanding the `ffmpeg` row: 88 points → 0. Fades verified on a 12-call group: bottom fade present at offset 0, top fade present when scrolled to the end, both painted in the screen color.
- 14 consecutive expand/collapse cycles across home → thread → group → row with the process pinned: no crash.

![Before: an 88-point blank band under the expanded row. After: the rows below paint in place.](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d3e4b128daabc92e/stack-pair-expanded.png)

Recording of the expand/collapse, before on the left:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/f0dfbe332a6d42b8/stack-pair-expand.mp4

Implemented by Claude Fable 5 in the Claude Code harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix clipped expanded tool groups and settle workflow coordinator members in thread activity
> - Replaces the `MaskedView` composite mask in `ThreadWorkGroupList` with a clipped container and separate animated `EdgeFade` overlays that fade only at edges with remaining content, using the current screen theme color
> - Propagates the Uniwind theme screen color through `ThreadFeed` and `ThreadWorkLog` so edge fades match the background
> - Updates `isAgentInternalActivity` to retain task lifecycle rows with a task identifier and agent kind for batch processing instead of filtering them as internal
> - In `agentSpawnRow`, a terminal workflow coordinator now settles members that lack their own end event or remain in progress; explicitly reported member statuses are preserved
> - Maps idle task status to completed in `toDerivedWorkLogEntry` when no other lifecycle status is present
> - Adds tests for bypassed workflow members and idle Codex children folding into coordinator batch rows
> - Risk: `ThreadWorkGroupList` now uses a ref callback subscribing to LegendList total-size updates instead of the native content-size callback; verify scroll fade visibility and content-height bookkeeping remain correct under rapid resize and theme switches
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65b1b9c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->