### PR TITLE
fix(provider): stop restoring cleared custom options

### DIFF
--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1228,6 +1228,50 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         ]);
       });
 
+      it("keeps cleared custom model capabilities cleared", () => {
+        const previousProvider = {
+          instanceId: ProviderInstanceId.make("claudeAgent"),
+          driver: ProviderDriverKind.make("claudeAgent"),
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          checkedAt: "2026-09-05T00:00:00.000Z",
+          version: "2.1.0",
+          models: [
+            {
+              slug: "custom-model",
+              name: "Custom model",
+              isCustom: true,
+              capabilities: createModelCapabilities({
+                optionDescriptors: [
+                  selectDescriptor("effort", "Reasoning", [
+                    { id: "high", label: "High", isDefault: true },
+                  ]),
+                ],
+              }),
+            },
+          ],
+          slashCommands: [],
+          skills: [],
+        } as const satisfies ServerProvider;
+        const refreshedProvider = {
+          ...previousProvider,
+          checkedAt: "2026-09-05T00:01:00.000Z",
+          models: [
+            {
+              ...previousProvider.models[0],
+              capabilities: createModelCapabilities({ optionDescriptors: [] }),
+            },
+          ],
+        } satisfies ServerProvider;
+
+        assert.deepStrictEqual(
+          mergeProviderSnapshot(previousProvider, refreshedProvider).models,
+          refreshedProvider.models,
+        );
+      });
+
       it.effect("does not run provider probes during layer construction", () =>
         Effect.gen(function* () {
           const codexDriver = ProviderDriverKind.make("codex");

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -148,7 +148,12 @@ const mergeProviderModels = (
   const previousBySlug = new Map(previousModels.map((model) => [model.slug, model] as const));
   const mergedModels = nextModels.map((model) => {
     const previousModel = previousBySlug.get(model.slug);
-    if (!previousModel || hasModelCapabilities(model) || !hasModelCapabilities(previousModel)) {
+    if (
+      model.isCustom ||
+      !previousModel ||
+      hasModelCapabilities(model) ||
+      !hasModelCapabilities(previousModel)
+    ) {
       return model;
     }
     return {


### PR DESCRIPTION
Custom model option descriptors are settings-owned. After a user cleared every descriptor, `mergeProviderModels` treated the empty list as incomplete provider discovery and restored the previous capabilities. Web and mobile kept showing stale controls until the server restarted.

Custom rows now bypass capability backfill. Built-in rows still retain discovered capabilities across incomplete refreshes.

## Verification

- The new regression test failed before the fix because the previous Reasoning descriptor was restored.
- `vp test run apps/server/src/provider/Layers/ProviderRegistry.test.ts` passes all 48 tests.
- `vp run --filter=t3 typecheck` passes with existing Effect suggestions only.
- Targeted lint, formatting, and `git diff --check` pass.

This is a focused follow-up to #9807. #8964 is closed because #9807 superseded its broader custom-model profile design.

## Risk and rollback

The change affects only custom rows during provider snapshot merging. Revert `af66745a9` to restore the previous behavior.

Review tier: standard.

Implemented with GPT-5.6 Sol via Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `mergeProviderModels` restoring cleared custom options
> Custom models in a refreshed provider snapshot now return directly from that snapshot before the existing capability-retention logic runs. Non-custom models still keep previous capabilities when the refreshed model lacks them. Adds a test confirming cleared custom model capabilities stay cleared.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized af66745.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->