### PR TITLE
refactor(web): test file cache identity through its public helpers

### DIFF
--- a/apps/web/src/components/files/fileContentRevision.test.ts
+++ b/apps/web/src/components/files/fileContentRevision.test.ts
@@ -1,19 +1,11 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import {
-  fileContentRevision,
-  projectFileCacheKey,
-  projectFileEditorCacheKey,
-} from "./fileContentRevision";
+import { projectFileCacheKey, projectFileEditorCacheKey } from "./fileContentRevision";
 
-describe("fileContentRevision", () => {
+describe("file cache identity", () => {
   it("changes for same-length edits", () => {
-    expect(fileContentRevision("nodeVersion")).not.toBe(fileContentRevision("nodeVeasdrs"));
-  });
-
-  it("keeps identical contents stable", () => {
-    expect(projectFileCacheKey("/repo", "file.json", "contents")).toBe(
-      projectFileCacheKey("/repo", "file.json", "contents"),
+    expect(projectFileCacheKey("/repo", "file.json", "nodeVersion")).not.toBe(
+      projectFileCacheKey("/repo", "file.json", "nodeVeasdrs"),
     );
   });
 

--- a/apps/web/src/components/files/fileContentRevision.ts
+++ b/apps/web/src/components/files/fileContentRevision.ts
@@ -1,4 +1,4 @@
-export function fileContentRevision(contents: string): string {
+function fileContentRevision(contents: string): string {
   let hash = 2_166_136_261;
   for (let index = 0; index < contents.length; index += 1) {
     hash ^= contents.charCodeAt(index);


### PR DESCRIPTION
The file-content hash was exported only for a unit test, although the file preview uses the cache-key functions that wrap it.

Keep the hash private and check same-length edits through `projectFileCacheKey`. Remove the redundant identical-call assertion and retain the editor identity tests for local edits, external edits, and environment changes.

Verification: all 3 focused tests pass, web typecheck passes, and focused lint/format checks pass. Runtime behavior and rendered UI are unchanged, so screenshots do not apply.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `fileContentRevision` private and test cache identity via `projectFileCacheKey`
> - Removes the module export of `fileContentRevision` in [fileContentRevision.ts](https://github.com/pingdotgg/t3code/pull/10219/files#diff-baddab2b5c0027e50610b56efe8e902d1ef55b45be94bf09bd5b4629fdc74e84), making the hash helper private to its module
> - Reworks the test suite in [fileContentRevision.test.ts](https://github.com/pingdotgg/t3code/pull/10219/files#diff-35b045c19e48e0763aa8703778990ebd3e2840f099731acf7b88dd650251c238) to assert cache identity through the public `projectFileCacheKey` helper instead of the now-private function
> - Behavioral Change: out-of-tree consumers importing `fileContentRevision` directly will no longer find the export; the hashing algorithm and revision format are unchanged
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9fce39c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->