### PR TITLE
refactor(web): test favicon fallback through the component

### DIFF
--- a/apps/web/src/components/preview/PreviewFaviconIcon.test.tsx
+++ b/apps/web/src/components/preview/PreviewFaviconIcon.test.tsx
@@ -1,51 +1,43 @@
-import { EnvironmentId, ThreadId } from "@t3tools/contracts";
-import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { act } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, expect, it, vi } from "vite-plus/test";
 
-const mocks = vi.hoisted(() => ({ favicon: null as string | null }));
+vi.mock("~/browserFaviconStore", () => ({ useFaviconForThreadUrl: () => null }));
 
-vi.mock("~/browserFaviconStore", () => ({
-  useFaviconForThreadUrl: () => mocks.favicon,
-}));
+import { FaviconImage } from "./PreviewFaviconIcon";
 
-import { FaviconImage, PreviewFaviconIcon, selectFaviconSource } from "./PreviewFaviconIcon";
+let renderer: ReactTestRenderer | undefined;
 
-const threadRef = {
-  environmentId: EnvironmentId.make("env-1"),
-  threadId: ThreadId.make("thread-1"),
-};
+afterEach(async () => {
+  await act(async () => renderer?.unmount());
+  vi.unstubAllGlobals();
+});
 
-describe("preview favicon image", () => {
-  it("renders a captured source before later fallback sources", () => {
-    expect(
-      renderToStaticMarkup(
-        <FaviconImage
-          sources={["data:image/png;base64,AAAA", "https://public.example/icon"]}
-          fallback={<span>fallback</span>}
-        />,
-      ),
-    ).toContain('src="data:image/png;base64,AAAA"');
-    const captured = "data:image/png;base64,AAAA";
-    const google = "https://public.example/icon";
-    expect(selectFaviconSource([captured, google], new Set())).toBe(captured);
-    expect(selectFaviconSource([captured, google], new Set([captured]))).toBe(google);
-    expect(selectFaviconSource([captured, google], new Set([captured, google]))).toBeNull();
-    expect(selectFaviconSource(["data:image/png;base64,BBBB", google], new Set([captured]))).toBe(
-      "data:image/png;base64,BBBB",
+it("falls through failed favicon sources and retries when the source list changes", async () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  const captured = "data:image/png;base64,AAAA";
+  const remote = "https://public.example/icon";
+  await act(async () => {
+    renderer = create(
+      <FaviconImage sources={[captured, remote]} fallback={<span>fallback</span>} />,
     );
   });
+  expect(renderer!.root.findByType("img").props.src).toBe(captured);
 
-  it("uses a stored project icon or falls back to the browser mockup", () => {
-    mocks.favicon = null;
-    const html = renderToStaticMarkup(
-      <PreviewFaviconIcon threadRef={threadRef} url="http://localhost:3000/" />,
+  await act(async () => renderer!.root.findByType("img").props.onError());
+  expect(renderer!.root.findByType("img").props.src).toBe(remote);
+
+  await act(async () => renderer!.root.findByType("img").props.onError());
+  expect(renderer!.root.findAllByType("img")).toHaveLength(0);
+  expect(renderer!.root.findByType("span").children).toEqual(["fallback"]);
+
+  await act(async () => {
+    renderer!.update(
+      <FaviconImage
+        sources={[captured, "https://public.example/new-icon"]}
+        fallback={<span>fallback</span>}
+      />,
     );
-    expect(html).not.toContain("<img");
-    expect(html).toContain("rounded-[5px]");
-    mocks.favicon = "data:image/png;base64,AAAA";
-    const faviconHtml = renderToStaticMarkup(
-      <PreviewFaviconIcon threadRef={threadRef} url="http://localhost:3000/" />,
-    );
-    expect(faviconHtml).toContain('src="data:image/png;base64,AAAA"');
   });
+  expect(renderer!.root.findByType("img").props.src).toBe(captured);
 });

--- a/apps/web/src/components/preview/PreviewFaviconIcon.tsx
+++ b/apps/web/src/components/preview/PreviewFaviconIcon.tsx
@@ -6,13 +6,6 @@ import { cn } from "~/lib/utils";
 
 import { BrowserMockup } from "./BrowserMockup";
 
-export function selectFaviconSource(
-  sources: ReadonlyArray<string>,
-  failed: ReadonlySet<string>,
-): string | null {
-  return sources.find((candidate) => !failed.has(candidate)) ?? null;
-}
-
 export function FaviconImage(props: {
   sources: ReadonlyArray<string | null | undefined>;
   fallback: ReactNode;
@@ -35,7 +28,7 @@ function FaviconImageAttempt(props: {
   className?: string | undefined;
 }) {
   const [failed, setFailed] = useState<ReadonlySet<string>>(() => new Set());
-  const source = selectFaviconSource(props.sources, failed);
+  const source = props.sources.find((candidate) => !failed.has(candidate));
   if (!source) return props.fallback;
   return (
     <img


### PR DESCRIPTION
The favicon component exported a one-line source selector for direct tests. Those tests combined helper assertions with static markup and CSS checks, without exercising image failure state.

Inline the selector and replace those tests with one stateful component test. It checks fallback after each image failure and verifies that a changed source list retries a previously failed URL.

Verification: the focused component test, web typecheck, and focused lint/format checks pass. The rendered UI and fallback behavior are unchanged; no screenshots are needed.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Inline favicon source selection into `FaviconImageAttempt` and test fallback through the component
> - Moves the "first non-failed source" selection from the removed exported `selectFaviconSource` utility directly into [PreviewFaviconIcon.tsx](https://github.com/pingdotgg/t3code/pull/10220/files#diff-4a7c01cc86cc040cbeaa70b227749b6a990c529ed439a16fcfe7539e584e116f)
> - Replaces server-side static markup tests and the mutable favicon-store mock with a `react-test-renderer` harness that mounts `FaviconImage` and triggers its error handler to verify captured-source, remote-source, fallback, and source-list-update states
> - Tests now cover the full error-driven fallback cycle: advancing through sources on image error, reaching the fallback, and retrying from the first source when the source list updates
> - Risk: removing the exported `selectFaviconSource` utility may break any out-of-tree consumers importing it from `PreviewFaviconIcon`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90478ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->