### PR TITLE
refactor(web): test formatted timestamps instead of formatter options

### DIFF
--- a/apps/web/src/timestampFormat.test.ts
+++ b/apps/web/src/timestampFormat.test.ts
@@ -8,36 +8,8 @@ import {
   formatRelativeTimeLabel,
   formatShortTimestamp,
   getRelativeTimeState,
-  getTimestampFormatOptions,
   resolveTimestampLocale,
 } from "./timestampFormat";
-
-describe("getTimestampFormatOptions", () => {
-  it("omits hour12 when locale formatting is requested", () => {
-    expect(getTimestampFormatOptions("locale", true)).toEqual({
-      hour: "numeric",
-      minute: "2-digit",
-      second: "2-digit",
-    });
-  });
-
-  it("builds a 12-hour formatter with seconds when requested", () => {
-    expect(getTimestampFormatOptions("12-hour", true)).toEqual({
-      hour: "numeric",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: true,
-    });
-  });
-
-  it("builds a 24-hour formatter without seconds when requested", () => {
-    expect(getTimestampFormatOptions("24-hour", false)).toEqual({
-      hour: "numeric",
-      minute: "2-digit",
-      hour12: false,
-    });
-  });
-});
 
 describe("resolveTimestampLocale", () => {
   it("defers to the runtime default when the host reports no locale", () => {
@@ -57,19 +29,26 @@ describe("resolveTimestampLocale", () => {
     expect(resolveTimestampLocale("not a locale")).toBeUndefined();
     expect(resolveTimestampLocale("en_GB")).toBeUndefined();
   });
+});
 
-  it("renders the host locale's hour cycle under the locale setting", () => {
-    const formatAt1544 = (systemLocale: string | null) =>
-      new Intl.DateTimeFormat(resolveTimestampLocale(systemLocale), {
-        ...getTimestampFormatOptions("locale", false),
-        timeZone: "UTC",
-      })
-        .format(new Date("2026-04-07T15:44:00.000Z"))
-        // ICU separates the day period with a narrow no-break space.
-        .replace(/[  ]/g, " ");
+describe("formatShortTimestamp", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
 
-    expect(formatAt1544("en-GB")).toBe("15:44");
-    expect(formatAt1544("en-US")).toBe("3:44 PM");
+  it.each([
+    ["en-GB", "15:44"],
+    ["en-US", "3:44 PM"],
+  ])("honors %s and the explicit hour-cycle settings", async (locale, localTime) => {
+    vi.stubGlobal("window", { desktopBridge: { getSystemLocale: () => locale } });
+    vi.resetModules();
+    const { formatShortTimestamp: format } = await import("./timestampFormat");
+    const date = new Date(2026, 3, 7, 15, 44).toISOString();
+    // ICU can separate the day period with a narrow no-break space.
+    expect(format(date, "locale").replace(/[  ]/g, " ")).toBe(localTime);
+    expect(format(date, "12-hour").replace(/[  ]/g, " ")).toMatch(/^3:44 [ap]m$/i);
+    expect(format(date, "24-hour")).toBe("15:44");
   });
 });
 

--- a/apps/web/src/timestampFormat.ts
+++ b/apps/web/src/timestampFormat.ts
@@ -1,6 +1,6 @@
 import { type TimestampFormat } from "@t3tools/contracts/settings";
 
-export function getTimestampFormatOptions(
+function getTimestampFormatOptions(
   timestampFormat: TimestampFormat,
   includeSeconds: boolean,
 ): Intl.DateTimeFormatOptions {


### PR DESCRIPTION
The timestamp formatter exported its options builder only so tests could compare its implementation details.

Keep that helper private and test formatted timestamps through `formatShortTimestamp`. The tests exercise British and US host locales and explicit 12-hour and 24-hour preferences. Keep the existing locale-validation, calendar-day, countdown, and invalid-input tests.

Verification: all 23 focused tests, web typecheck, and focused lint/format checks pass. Production logic and rendered output are unchanged, so screenshots do not apply.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `getTimestampFormatOptions` private and test formatted timestamps instead of options
> - Replaces tests that inspected `Intl.DateTimeFormatOptions` from `getTimestampFormatOptions` with tests that check actual formatted output for en-GB and en-US locales.
> - New `formatShortTimestamp` test suite stubs the desktop bridge locale, reloads the module, and verifies locale, 12-hour, and 24-hour output, normalizing ICU spacing around day periods.
> - Changes `getTimestampFormatOptions` from an exported function to a module-private function in [timestampFormat.ts](https://github.com/pingdotgg/t3code/pull/10221/files#diff-3c87b91789abf1f3644a1a66f0da1d791ac92e439c18f8a651d177cd2ed1601b); its parameters and logic are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd93b5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->