### PR TITLE
refactor(web): remove unused layout and menu components

### DIFF
--- a/apps/web/src/components/ui/autocomplete.tsx
+++ b/apps/web/src/components/ui/autocomplete.tsx
@@ -136,16 +136,6 @@ function AutocompleteItem({ className, children, ...props }: AutocompletePrimiti
   );
 }
 
-function AutocompleteSeparator({ className, ...props }: AutocompletePrimitive.Separator.Props) {
-  return (
-    <AutocompletePrimitive.Separator
-      className={cn("mx-2 my-1 h-px bg-border last:hidden", className)}
-      data-slot="autocomplete-separator"
-      {...props}
-    />
-  );
-}
-
 function AutocompleteGroup({ className, ...props }: AutocompletePrimitive.Group.Props) {
   return (
     <AutocompletePrimitive.Group
@@ -231,7 +221,6 @@ export {
   AutocompleteInput,
   AutocompletePopup,
   AutocompleteItem,
-  AutocompleteSeparator,
   AutocompleteGroup,
   AutocompleteGroupLabel,
   AutocompleteEmpty,

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -57,4 +57,4 @@ function Badge({ className, variant, size, render, ...props }: BadgeProps) {
   });
 }
 
-export { Badge, badgeVariants };
+export { Badge };

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -7,13 +7,11 @@ import { cn } from "~/lib/utils";
 import {
   Autocomplete,
   AutocompleteCollection,
-  AutocompleteEmpty,
   AutocompleteGroup,
   AutocompleteGroupLabel,
   AutocompleteInput,
   AutocompleteItem,
   AutocompleteList,
-  AutocompleteSeparator,
 } from "~/components/ui/autocomplete";
 import { DIALOG_BACKDROP_CLASS, DIALOG_POPUP_CLASS } from "~/components/ui/dialog-styles";
 import { Button } from "~/components/ui/button";
@@ -21,8 +19,6 @@ import { Button } from "~/components/ui/button";
 const CommandDialog = CommandDialogPrimitive.Root;
 
 const CommandDialogPortal = CommandDialogPrimitive.Portal;
-
-const CommandCreateHandle = CommandDialogPrimitive.createHandle;
 
 function CommandDialogTrigger(props: CommandDialogPrimitive.Trigger.Props) {
   return <CommandDialogPrimitive.Trigger data-slot="command-dialog-trigger" {...props} />;
@@ -135,16 +131,6 @@ function CommandList({ className, ...props }: React.ComponentProps<typeof Autoco
   );
 }
 
-function CommandEmpty({ className, ...props }: React.ComponentProps<typeof AutocompleteEmpty>) {
-  return (
-    <AutocompleteEmpty
-      className={cn("not-empty:py-6", className)}
-      data-slot="command-empty"
-      {...props}
-    />
-  );
-}
-
 function CommandPanel({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -182,19 +168,6 @@ function CommandItem({ className, ...props }: React.ComponentProps<typeof Autoco
         className,
       )}
       data-slot="command-item"
-      {...props}
-    />
-  );
-}
-
-function CommandSeparator({
-  className,
-  ...props
-}: React.ComponentProps<typeof AutocompleteSeparator>) {
-  return (
-    <AutocompleteSeparator
-      className={cn("my-2", className)}
-      data-slot="command-separator"
       {...props}
     />
   );
@@ -241,13 +214,11 @@ function CommandFooterAction({
 }
 
 export {
-  CommandCreateHandle,
   Command,
   CommandCollection,
   CommandDialog,
   CommandDialogPopup,
   CommandDialogTrigger,
-  CommandEmpty,
   CommandFooter,
   CommandFooterAction,
   CommandGroup,
@@ -256,6 +227,5 @@ export {
   CommandItem,
   CommandList,
   CommandPanel,
-  CommandSeparator,
   CommandShortcut,
 };

--- a/apps/web/src/components/ui/group.tsx
+++ b/apps/web/src/components/ui/group.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { mergeProps } from "@base-ui/react/merge-props";
-import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 
@@ -48,21 +46,6 @@ function Group({
   );
 }
 
-function GroupText({ className, render, ...props }: useRender.ComponentProps<"div">) {
-  const defaultProps = {
-    className: cn(
-      "relative inline-flex items-center whitespace-nowrap gap-2 rounded-lg border border-input bg-muted not-dark:bg-clip-padding px-[calc(--spacing(3)-1px)] text-muted-foreground text-base sm:text-sm shadow-xs/5 outline-none transition-shadow before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:shadow-[0_1px_--theme(--color-black/6%)] dark:bg-input/64 dark:before:shadow-[0_-1px_--theme(--color-white/6%)] [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 [&_svg]:-mx-0.5",
-      className,
-    ),
-    "data-slot": "group-text",
-  };
-  return useRender({
-    defaultTagName: "div",
-    props: mergeProps(defaultProps, props),
-    render,
-  });
-}
-
 function GroupSeparator({
   className,
   orientation = "vertical",
@@ -82,12 +65,4 @@ function GroupSeparator({
   );
 }
 
-export {
-  Group,
-  Group as ButtonGroup,
-  GroupText,
-  GroupText as ButtonGroupText,
-  GroupSeparator,
-  GroupSeparator as ButtonGroupSeparator,
-  groupVariants,
-};
+export { Group, GroupSeparator };

--- a/apps/web/src/components/ui/menu.tsx
+++ b/apps/web/src/components/ui/menu.tsx
@@ -6,11 +6,7 @@ import type * as React from "react";
 
 import { cn } from "~/lib/utils";
 
-const MenuCreateHandle = MenuPrimitive.createHandle;
-
 const Menu = MenuPrimitive.Root;
-
-const MenuPortal = MenuPrimitive.Portal;
 
 function MenuTrigger({ className, children, ...props }: MenuPrimitive.Trigger.Props) {
   return (
@@ -297,33 +293,22 @@ function MenuSubPopup({
 }
 
 export {
-  MenuCreateHandle,
-  MenuCreateHandle as DropdownMenuCreateHandle,
   Menu,
   Menu as DropdownMenu,
-  MenuPortal,
-  MenuPortal as DropdownMenuPortal,
   MenuTrigger,
   MenuTrigger as DropdownMenuTrigger,
   MenuPopup,
   MenuPopup as DropdownMenuContent,
   MenuGroup,
-  MenuGroup as DropdownMenuGroup,
   MenuItem,
   MenuItem as DropdownMenuItem,
   MenuCheckboxItem,
-  MenuCheckboxItem as DropdownMenuCheckboxItem,
   MenuRadioGroup,
-  MenuRadioGroup as DropdownMenuRadioGroup,
   MenuRadioItem,
-  MenuRadioItem as DropdownMenuRadioItem,
   MenuRadioItemIndicator,
   MenuGroupLabel,
-  MenuGroupLabel as DropdownMenuLabel,
   MenuSeparator,
-  MenuSeparator as DropdownMenuSeparator,
   MenuShortcut,
-  MenuShortcut as DropdownMenuShortcut,
   MenuSub,
   MenuSub as DropdownMenuSub,
   MenuSubTrigger,

--- a/apps/web/src/components/ui/scroll-area.tsx
+++ b/apps/web/src/components/ui/scroll-area.tsx
@@ -88,4 +88,4 @@ function ScrollBar({
   );
 }
 
-export { getVirtualizedScrollFadeClassName, ScrollArea, ScrollBar };
+export { getVirtualizedScrollFadeClassName, ScrollArea };

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -5,9 +5,7 @@ import { PanelLeftCloseIcon, PanelLeftIcon } from "lucide-react";
 import * as React from "react";
 import { cn } from "~/lib/utils";
 import { Button } from "~/components/ui/button";
-import { Input } from "~/components/ui/input";
 import { ScrollArea } from "~/components/ui/scroll-area";
-import { Separator } from "~/components/ui/separator";
 import {
   Sheet,
   SheetDescription,
@@ -15,7 +13,6 @@ import {
   SheetPopup,
   SheetTitle,
 } from "~/components/ui/sheet";
-import { Skeleton } from "~/components/ui/skeleton";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { useIsMobile } from "~/hooks/useMediaQuery";
 import { getLocalStorageItem, setLocalStorageItem } from "~/hooks/useLocalStorage";
@@ -645,17 +642,6 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
   );
 }
 
-function SidebarInput({ className, ...props }: React.ComponentProps<typeof Input>) {
-  return (
-    <Input
-      className={cn("h-8 w-full bg-background shadow-none", className)}
-      data-sidebar="input"
-      data-slot="sidebar-input"
-      {...props}
-    />
-  );
-}
-
 function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -673,17 +659,6 @@ function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("flex flex-col gap-2 p-2", className)}
       data-sidebar="footer"
       data-slot="sidebar-footer"
-      {...props}
-    />
-  );
-}
-
-function SidebarSeparator({ className, ...props }: React.ComponentProps<typeof Separator>) {
-  return (
-    <Separator
-      className={cn("mx-2 w-auto! bg-sidebar-border", className)}
-      data-sidebar="separator"
-      data-slot="sidebar-separator"
       {...props}
     />
   );
@@ -723,55 +698,6 @@ function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
       )}
       data-sidebar="group"
       data-slot="sidebar-group"
-      {...props}
-    />
-  );
-}
-
-function SidebarGroupLabel({ className, render, ...props }: useRender.ComponentProps<"div">) {
-  const defaultProps = {
-    className: cn(
-      "flex h-8 shrink-0 items-center rounded-lg px-2 font-medium text-sidebar-foreground text-xs outline-hidden ring-ring transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
-      "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
-      className,
-    ),
-    "data-sidebar": "group-label",
-    "data-slot": "sidebar-group-label",
-  };
-
-  return useRender({
-    defaultTagName: "div",
-    props: mergeProps(defaultProps, props),
-    render,
-  });
-}
-
-function SidebarGroupAction({ className, render, ...props }: useRender.ComponentProps<"button">) {
-  const defaultProps = {
-    className: cn(
-      "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-lg p-0 text-sidebar-foreground outline-hidden ring-ring transition-transform hover:bg-sidebar-row-hover hover:text-sidebar-foreground focus-visible:ring-2 [&>svg:not([class*='size-'])]:size-4 [&>svg]:shrink-0",
-      // Increases the hit area of the button on mobile.
-      "after:-inset-2 after:absolute md:after:hidden",
-      "group-data-[collapsible=icon]:hidden",
-      className,
-    ),
-    "data-sidebar": "group-action",
-    "data-slot": "sidebar-group-action",
-  };
-
-  return useRender({
-    defaultTagName: "button",
-    props: mergeProps(defaultProps, props),
-    render,
-  });
-}
-
-function SidebarGroupContent({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      className={cn("w-full text-sm", className)}
-      data-sidebar="group-content"
-      data-slot="sidebar-group-content"
       {...props}
     />
   );
@@ -875,58 +801,6 @@ function SidebarMenuButton({
   );
 }
 
-function SidebarMenuBadge({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      className={cn(
-        "pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center rounded-lg px-1 font-medium text-sidebar-foreground text-xs tabular-nums",
-        "peer-hover/menu-button:text-sidebar-foreground peer-data-[active=true]/menu-button:text-sidebar-foreground",
-        "peer-data-[size=sm]/menu-button:top-1",
-        "peer-data-[size=default]/menu-button:top-1.5",
-        "peer-data-[size=lg]/menu-button:top-2.5",
-        "group-data-[collapsible=icon]:hidden",
-        className,
-      )}
-      data-sidebar="menu-badge"
-      data-slot="sidebar-menu-badge"
-      {...props}
-    />
-  );
-}
-
-function SidebarMenuSkeleton({
-  className,
-  showIcon = false,
-  ...props
-}: React.ComponentProps<"div"> & {
-  showIcon?: boolean;
-}) {
-  // Random width between 50 to 90%. Intentionally wrapped in useMemo to avoid changing width on every render.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
-  }, []);
-
-  return (
-    <div
-      className={cn("flex h-8 items-center gap-2 rounded-lg px-2", className)}
-      data-sidebar="menu-skeleton"
-      data-slot="sidebar-menu-skeleton"
-      {...props}
-    >
-      {showIcon && <Skeleton className="size-4 rounded-lg" data-sidebar="menu-skeleton-icon" />}
-      <Skeleton
-        className="h-4 max-w-(--skeleton-width) flex-1"
-        data-sidebar="menu-skeleton-text"
-        style={
-          {
-            "--skeleton-width": width,
-          } as React.CSSProperties
-        }
-      />
-    </div>
-  );
-}
-
 function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
   return (
     <ul
@@ -990,23 +864,16 @@ export {
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
-  SidebarGroupAction,
-  SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarHeader,
-  SidebarInput,
   SidebarInset,
   SidebarMenu,
-  SidebarMenuBadge,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarMenuSkeleton,
   SidebarMenuSub,
   SidebarMenuSubButton,
   SidebarMenuSubItem,
   SidebarProvider,
   SidebarRail,
-  SidebarSeparator,
   SidebarTrigger,
   useSidebar,
   useSidebarVisibility,

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -28,16 +28,6 @@ function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
   );
 }
 
-function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
-  return (
-    <tfoot
-      data-slot="table-footer"
-      className={cn("border-t bg-muted/50 font-medium [&>tr]:last:border-b-0", className)}
-      {...props}
-    />
-  );
-}
-
 function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
   return (
     <tr
@@ -74,14 +64,4 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
   );
 }
 
-function TableCaption({ className, ...props }: React.ComponentProps<"caption">) {
-  return (
-    <caption
-      data-slot="table-caption"
-      className={cn("mt-4 text-xs text-muted-foreground", className)}
-      {...props}
-    />
-  );
-}
-
-export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };
+export { Table, TableHeader, TableBody, TableHead, TableRow, TableCell };


### PR DESCRIPTION
The sidebar, command, menu, group, and table modules retain unused wrappers and export aliases. Remove those declarations and keep locally used scroll and style helpers private.

Removing CommandSeparator leaves AutocompleteSeparator unused, so that wrapper is removed in this layer too. Active components and their behavior are unchanged.

Layer 3 of 7 in the web runtime-export cleanup stack. Based on [#10223](https://github.com/pingdotgg/t3code/pull/10223).

Verification at the integrated stack tip: `vp run --filter @t3tools/web test` passes all 4,052 tests across 333 files. Web typecheck and changed-file lint/format pass. The stack passes `vp run knip:check`, including repository file/dependency checks and runtime-export checks for web and all seven internal packages.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused layout and menu component wrappers and aliases in `apps/web`
> - Removes unused wrapper components and aliases across UI modules: [autocomplete.tsx](https://github.com/pingdotgg/t3code/pull/10224/files#diff-97edfff0276fda8a5e3f20147b67956bb253dec7cd81bdd32537c2a92ea94dde), [badge.tsx](https://github.com/pingdotgg/t3code/pull/10224/files#diff-7d13f452a101fd74830056ff36861be7711cef615b51371dc287645206e50e6d), [command.tsx](https://github.com/pingdotgg/t3code/pull/10224/files#diff-a7353b0e68c4fef64c878ccbcb5e69b63cd9ba3f09da247a83c582f8647e1bf4), [group.tsx](https://github.com/pingdotgg/t3code/pull/10224/files#diff-be5948d8d5bbdc197e4d1af5d6c4f888907bc3a52b8351ae1833e02f6f76b67f), [menu.tsx](https://github.com/pingdotgg/t3code/pull/10224/files#diff-e0c9f33f4f308eae4b7e310785187bc81767e547539de6fcd955fa42aaccc621), [scroll-area.tsx](https://github.com/pingdotgg/t3code/pull/10224/files#diff-065d9938063e2eb1a135871d2daf8a02f24528ad85dbc653955b23d805a9fb06), [sidebar.tsx](https://github.com/pingdotgg/t3code/pull/10224/files#diff-224383fe35d78f69b89d11dbdf0c045779e7ba45ca023f26abc828cd88e309cd), and [table.tsx](https://github.com/pingdotgg/t3code/pull/10224/files#diff-5e3f1590b71b9d58a386f99169c1f9f81249c0d3899bd4604a9bb922dcf4f1e5)
> - Sidebar has the largest removal scope: drops `SidebarGroupAction`, `SidebarGroupContent`, `SidebarGroupLabel`, `SidebarInput`, `SidebarMenuBadge`, `SidebarMenuSkeleton`, and `SidebarSeparator`
> - Other removed exports include `AutocompleteSeparator`, `badgeVariants`, `CommandCreateHandle`, `CommandEmpty`, `CommandSeparator`, `GroupText`, `groupVariants`, `ButtonGroup` aliases, `MenuCreateHandle`, `MenuPortal`, dropdown menu aliases, `ScrollBar`, `TableFooter`, and `TableCaption`
> - Risk: these are breaking removals for any out-of-tree or remaining in-tree consumers importing the dropped named exports from the affected modules
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00330cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->