### PR TITLE
refactor(web): remove unused runtime wrappers and exports

### DIFF
--- a/apps/web/src/assets/assetUrls.ts
+++ b/apps/web/src/assets/assetUrls.ts
@@ -32,14 +32,6 @@ export function useAssetUrlState(
   );
 }
 
-export function useAssetUrl(
-  environmentId: EnvironmentId | null,
-  resource: AssetResource | null,
-): string | null {
-  const result = useAssetUrlState(environmentId, resource);
-  return result._tag === "Success" ? result.url : null;
-}
-
 export function useAssetUrlRefresh(
   environmentId: EnvironmentId | null,
   resource: AssetResource | null,

--- a/apps/web/src/assets/projectFaviconCache.ts
+++ b/apps/web/src/assets/projectFaviconCache.ts
@@ -46,7 +46,7 @@ async function withStore<A>(
 }
 
 /** Rasterizes a bitmap that is too large to inline, retrying at half size. */
-export async function downscaleProjectFavicon(
+async function downscaleProjectFavicon(
   image: { readonly mimeType: string; readonly bytes: Uint8Array<ArrayBuffer> },
   signal: AbortSignal,
 ) {

--- a/apps/web/src/cloud/connectCliAuth.ts
+++ b/apps/web/src/cloud/connectCliAuth.ts
@@ -12,7 +12,7 @@ import { hasCloudPublicConfig, resolveCloudPublicConfig, trimNonEmpty } from "./
 
 const CONNECT_CLI_AUTH_STATE_STORAGE_KEY = "t3code-connect-cli-auth-state";
 
-export function resolveConnectCliOAuthClientId(): string | null {
+function resolveConnectCliOAuthClientId(): string | null {
   return trimNonEmpty(import.meta.env.VITE_CLERK_CLI_OAUTH_CLIENT_ID as string | undefined);
 }
 

--- a/apps/web/src/cloud/managedRelayLayer.ts
+++ b/apps/web/src/cloud/managedRelayLayer.ts
@@ -13,7 +13,7 @@ import {
   type BrowserDpopKey,
 } from "./dpop";
 
-export const relayDpopSignerLayer = Layer.effect(
+const relayDpopSignerLayer = Layer.effect(
   ManagedRelay.ManagedRelayDpopSigner,
   Effect.gen(function* () {
     const crypto = yield* Crypto.Crypto;

--- a/apps/web/src/cloud/managedRelayState.ts
+++ b/apps/web/src/cloud/managedRelayState.ts
@@ -33,7 +33,7 @@ const managedRelayAtomRuntime = Atom.runtime(
   ),
 );
 
-export const managedRelayQueryManager = createManagedRelayQueryManager(managedRelayAtomRuntime);
+const managedRelayQueryManager = createManagedRelayQueryManager(managedRelayAtomRuntime);
 
 const managedRelayMutationScheduler = createAtomCommandScheduler();
 
@@ -113,11 +113,4 @@ export function useManagedRelayDevices() {
     accountId,
     refresh,
   };
-}
-
-export function refreshManagedRelayEnvironments(): void {
-  const session = appAtomRegistry.get(managedRelaySessionAtom);
-  if (session) {
-    managedRelayQueryManager.refreshEnvironments(appAtomRegistry, session.accountId);
-  }
 }

--- a/apps/web/src/cloud/primaryCloudLinkState.ts
+++ b/apps/web/src/cloud/primaryCloudLinkState.ts
@@ -42,7 +42,7 @@ function targetKey(target: CloudLinkTarget): string {
   return JSON.stringify(target);
 }
 
-export function refreshPrimaryCloudLinkState(target: CloudLinkTarget | null): void {
+function refreshPrimaryCloudLinkState(target: CloudLinkTarget | null): void {
   if (target) {
     appAtomRegistry.refresh(primaryCloudLinkStateAtom(targetKey(target)));
   }

--- a/apps/web/src/connection/desktopLocal.ts
+++ b/apps/web/src/connection/desktopLocal.ts
@@ -17,7 +17,7 @@ import {
  * via {@link isDesktopLocalConnectionTarget}, so the convention can never drift
  * between the two.
  */
-export const DESKTOP_LOCAL_CONNECTION_ID_PREFIX = "local:";
+const DESKTOP_LOCAL_CONNECTION_ID_PREFIX = "local:";
 
 export function desktopLocalConnectionId(backendId: string): string {
   return `${DESKTOP_LOCAL_CONNECTION_ID_PREFIX}${backendId}`;

--- a/apps/web/src/environments/primary/auth.ts
+++ b/apps/web/src/environments/primary/auth.ts
@@ -9,7 +9,6 @@ import type {
 } from "@t3tools/contracts";
 import { EnvironmentHttpCommonError, PRIMARY_LOCAL_ENVIRONMENT_ID } from "@t3tools/contracts";
 import type { EnvironmentHttpCommonError as EnvironmentHttpCommonErrorType } from "@t3tools/contracts";
-import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import { HttpClientError } from "effect/unstable/http";
@@ -66,7 +65,7 @@ export class PrimaryEnvironmentRequestError extends Schema.TaggedErrorClass<Prim
   }
 }
 
-export const isPrimaryEnvironmentRequestError = Schema.is(PrimaryEnvironmentRequestError);
+const isPrimaryEnvironmentRequestError = Schema.is(PrimaryEnvironmentRequestError);
 
 export class PrimaryEnvironmentPairingCredentialRejectedError extends Schema.TaggedErrorClass<PrimaryEnvironmentPairingCredentialRejectedError>()(
   "PrimaryEnvironmentPairingCredentialRejectedError",
@@ -96,10 +95,6 @@ export class PrimaryEnvironmentAuthSessionTimeoutError extends Schema.TaggedErro
   }
 }
 
-export const isPrimaryEnvironmentAuthSessionTimeoutError = Schema.is(
-  PrimaryEnvironmentAuthSessionTimeoutError,
-);
-
 export class PrimaryEnvironmentPairingCredentialRequiredError extends Schema.TaggedErrorClass<PrimaryEnvironmentPairingCredentialRequiredError>()(
   "PrimaryEnvironmentPairingCredentialRequiredError",
   {
@@ -110,10 +105,6 @@ export class PrimaryEnvironmentPairingCredentialRequiredError extends Schema.Tag
     return "Enter a pairing token to continue.";
   }
 }
-
-export const isPrimaryEnvironmentPairingCredentialRequiredError = Schema.is(
-  PrimaryEnvironmentPairingCredentialRequiredError,
-);
 
 const isEnvironmentHttpCommonError = Schema.is(EnvironmentHttpCommonError);
 
@@ -386,44 +377,6 @@ export async function createServerPairingCredential(input?: {
   }
 }
 
-export async function listServerPairingLinks(): Promise<ReadonlyArray<ServerPairingLinkRecord>> {
-  try {
-    const pairingLinks = await runPrimaryHttp(
-      PrimaryEnvironmentHttpClient.pipe(
-        Effect.flatMap((client) => client.auth.pairingLinks({ headers: {} })),
-      ),
-    );
-    return pairingLinks.map((pairingLink) => {
-      const timestamps = {
-        createdAt: DateTime.formatIso(pairingLink.createdAt),
-        expiresAt: DateTime.formatIso(pairingLink.expiresAt),
-      };
-      if (pairingLink.label === undefined) {
-        return {
-          id: pairingLink.id,
-          scopes: pairingLink.scopes,
-          subject: pairingLink.subject,
-          createdAt: timestamps.createdAt,
-          expiresAt: timestamps.expiresAt,
-        };
-      }
-      return {
-        id: pairingLink.id,
-        scopes: pairingLink.scopes,
-        subject: pairingLink.subject,
-        label: pairingLink.label,
-        createdAt: timestamps.createdAt,
-        expiresAt: timestamps.expiresAt,
-      };
-    });
-  } catch (error) {
-    throw PrimaryEnvironmentRequestError.fromCause({
-      operation: "list-pairing-links",
-      cause: error,
-    });
-  }
-}
-
 export async function revokeServerPairingLink(id: string): Promise<void> {
   try {
     await runPrimaryHttp(
@@ -435,38 +388,6 @@ export async function revokeServerPairingLink(id: string): Promise<void> {
     throw PrimaryEnvironmentRequestError.fromCause({
       operation: "revoke-pairing-link",
       pairingLinkId: id,
-      cause: error,
-    });
-  }
-}
-
-export async function listServerClientSessions(): Promise<
-  ReadonlyArray<ServerClientSessionRecord>
-> {
-  try {
-    const clientSessions = await runPrimaryHttp(
-      PrimaryEnvironmentHttpClient.pipe(
-        Effect.flatMap((client) => client.auth.clients({ headers: {} })),
-      ),
-    );
-    return clientSessions.map((clientSession) => ({
-      sessionId: clientSession.sessionId,
-      subject: clientSession.subject,
-      scopes: clientSession.scopes,
-      method: clientSession.method,
-      client: clientSession.client,
-      issuedAt: DateTime.formatIso(clientSession.issuedAt),
-      expiresAt: DateTime.formatIso(clientSession.expiresAt),
-      lastConnectedAt:
-        clientSession.lastConnectedAt === null
-          ? null
-          : DateTime.formatIso(clientSession.lastConnectedAt),
-      connected: clientSession.connected,
-      current: clientSession.current,
-    }));
-  } catch (error) {
-    throw PrimaryEnvironmentRequestError.fromCause({
-      operation: "list-client-sessions",
       cause: error,
     });
   }
@@ -529,16 +450,6 @@ export async function resolveInitialServerAuthGateState(): Promise<ServerAuthGat
         bootstrapPromise = null;
       }
     });
-}
-
-// Used by the WSL backend swap: invalidate the cached authenticated state
-// (the new backend signs sessions with a different key) and re-bootstrap
-// against the desktop bootstrap credential so the next WS reconnect doesn't
-// hit 401 and start a reauth loop in the renderer.
-export async function reauthenticatePrimaryEnvironment(): Promise<ServerAuthGateState> {
-  resolvedAuthenticatedGateState = null;
-  bootstrapPromise = null;
-  return resolveInitialServerAuthGateState();
 }
 
 export function __resetServerAuthBootstrapForTests() {

--- a/apps/web/src/environments/primary/context.ts
+++ b/apps/web/src/environments/primary/context.ts
@@ -54,7 +54,7 @@ async function fetchPrimaryEnvironmentDescriptor(): Promise<ExecutionEnvironment
   });
 }
 
-export function readPrimaryEnvironmentDescriptor(): ExecutionEnvironmentDescriptor | null {
+function readPrimaryEnvironmentDescriptor(): ExecutionEnvironmentDescriptor | null {
   return primaryEnvironmentDescriptor;
 }
 

--- a/apps/web/src/environments/primary/index.ts
+++ b/apps/web/src/environments/primary/index.ts
@@ -1,27 +1,16 @@
 export {
   getPrimaryKnownEnvironment,
-  readPrimaryEnvironmentDescriptor,
   resetPrimaryEnvironmentDescriptorForTests,
   resolveInitialPrimaryEnvironmentDescriptor,
   writePrimaryEnvironmentDescriptor,
 } from "./context";
 
 export {
-  resolveInitialPrimaryEnvironmentDescriptor as ensurePrimaryEnvironmentReady,
-  writePrimaryEnvironmentDescriptor as updatePrimaryEnvironmentDescriptor,
-} from "./context";
-
-export {
   createServerPairingCredential,
-  fetchSessionState,
   isPrimaryEnvironmentPairingCredentialRejectedError,
-  isPrimaryEnvironmentRequestError,
-  listServerClientSessions,
-  listServerPairingLinks,
   peekPairingTokenFromUrl,
   PrimaryEnvironmentPairingCredentialRejectedError,
   PrimaryEnvironmentRequestError,
-  reauthenticatePrimaryEnvironment,
   resolveInitialServerAuthGateState,
   revokeOtherServerClientSessions,
   revokeServerClientSession,
@@ -34,9 +23,7 @@ export {
   __resetServerAuthBootstrapForTests,
 } from "./auth";
 
-export { refreshPrimarySessionState, usePrimarySessionState } from "./sessionState";
-
-export { PrimaryEnvironmentHttpClient } from "./httpClient";
+export { usePrimarySessionState } from "./sessionState";
 
 export {
   DesktopEnvironmentBootstrapIncompleteError,

--- a/apps/web/src/environments/primary/sessionState.ts
+++ b/apps/web/src/environments/primary/sessionState.ts
@@ -14,7 +14,7 @@ const primarySessionStateAtom = Atom.make(Effect.promise(fetchSessionState)).pip
   Atom.withLabel("primary-environment:session"),
 );
 
-export function refreshPrimarySessionState(): void {
+function refreshPrimarySessionState(): void {
   appAtomRegistry.refresh(primarySessionStateAtom);
 }
 

--- a/apps/web/src/lib/runtime.ts
+++ b/apps/web/src/lib/runtime.ts
@@ -31,8 +31,6 @@ type RuntimeLayerSource =
   | typeof relayTracingLayer
   | ReturnType<typeof managedRelayClientLayer>;
 
-export const remoteHttpRuntime = ManagedRuntime.make(httpClientLayer);
-
 const primaryHttpRuntime = ManagedRuntime.make(
   PrimaryEnvironmentHttpClient.layer.pipe(Layer.provide(primaryEnvironmentHttpLayer)),
 );

--- a/apps/web/src/observability/clientTracing.ts
+++ b/apps/web/src/observability/clientTracing.ts
@@ -41,15 +41,6 @@ export interface ClientTracingConfig {
   readonly exportIntervalMs?: number;
 }
 
-export const ClientTracingLive = Layer.succeed(
-  Tracer.Tracer,
-  Tracer.make({
-    span(options) {
-      return activeDelegate?.span(options) ?? new Tracer.NativeSpan(options);
-    },
-  }),
-);
-
 export function configureClientTracing(config: ClientTracingConfig = {}): Promise<void> {
   if (config.exportIntervalMs === undefined && activeConfigKey !== null) {
     return pendingConfiguration;

--- a/apps/web/src/rpc/requestLatencyState.ts
+++ b/apps/web/src/rpc/requestLatencyState.ts
@@ -112,7 +112,7 @@ export function acknowledgeRpcRequest(requestId: string): void {
   setSlowRpcAckRequests(slowRequests.filter((request) => request.requestId !== requestId));
 }
 
-export function clearAllTrackedRpcRequests(): void {
+function clearAllTrackedRpcRequests(): void {
   for (const pending of pendingRpcAckRequests.values()) {
     clearTimeout(pending.timeoutId);
   }

--- a/apps/web/src/rpc/transportError.ts
+++ b/apps/web/src/rpc/transportError.ts
@@ -1,4 +1,1 @@
-export {
-  isTransportConnectionErrorMessage,
-  sanitizeThreadErrorMessage,
-} from "@t3tools/client-runtime/errors";
+export { sanitizeThreadErrorMessage } from "@t3tools/client-runtime/errors";

--- a/apps/web/src/state/entities.ts
+++ b/apps/web/src/state/entities.ts
@@ -39,7 +39,7 @@ const EMPTY_THREAD_STATUS_ATOM = Atom.make<EnvironmentThreadStatus>("empty").pip
   Atom.withLabel("web-thread-status:empty"),
 );
 
-export const activeEnvironmentIdAtom = Atom.make<EnvironmentId | null>(null).pipe(
+const activeEnvironmentIdAtom = Atom.make<EnvironmentId | null>(null).pipe(
   Atom.keepAlive,
   Atom.withLabel("web-active-environment-id"),
 );

--- a/apps/web/src/state/environments.ts
+++ b/apps/web/src/state/environments.ts
@@ -11,7 +11,6 @@ import { useMemo } from "react";
 import { environmentCatalog } from "../connection/catalog";
 import { environmentPresentations, useEnvironmentPresentation } from "./presentation";
 import { primaryEnvironmentIdAtom } from "./primaryEnvironment";
-import { useEnvironmentQuery } from "./query";
 import { relayEnvironmentDiscovery } from "./relay";
 import { usePreparedConnection } from "./session";
 
@@ -84,8 +83,4 @@ export function useEnvironmentHttpBaseUrl(environmentId: EnvironmentId | null): 
 
 export function useRelayEnvironmentDiscovery(): Discovery.RelayEnvironmentDiscoveryState {
   return useAtomValue(relayEnvironmentDiscovery.stateValueAtom);
-}
-
-export function useEnvironmentConnectionState(environmentId: EnvironmentId) {
-  return useEnvironmentQuery(environmentCatalog.stateAtom(environmentId));
 }

--- a/apps/web/src/state/queries.ts
+++ b/apps/web/src/state/queries.ts
@@ -14,7 +14,6 @@ import type {
   OrchestrationThread,
   ProjectContentMatch,
   ProjectEntryKind,
-  ThreadId,
   VcsListRefsResult,
   VcsRef,
 } from "@t3tools/contracts";
@@ -28,7 +27,6 @@ import { orchestrationEnvironment } from "./orchestration";
 import { isPaginatedBranchesNextPagePending } from "./paginatedBranches";
 import { projectContentSearch, projectEnvironment } from "./projects";
 import { useEnvironmentQuery } from "./query";
-import { useEnvironmentThread } from "./threads";
 import { vcsEnvironment } from "./vcs";
 
 const PROJECT_PATH_SEARCH_DEBOUNCE_MS = 120;
@@ -101,35 +99,6 @@ export function useThreadSearch(
     matches: isDebouncing ? EMPTY_THREAD_SEARCH_MATCHES : result.matches,
     isPending: canSearch && (isDebouncing || result.isLoading),
   };
-}
-
-export function useThreadDetail(
-  environmentId: EnvironmentId | null,
-  threadId: ThreadId | null,
-): ThreadDetailView {
-  const state = useEnvironmentThread(environmentId, threadId);
-  return {
-    data: Option.getOrNull(state.data),
-    error: Option.getOrNull(state.error),
-    isPending: state.status === "synchronizing",
-    isDeleted: state.status === "deleted",
-  };
-}
-
-export function useBranches(target: VcsRefTarget) {
-  const query = target.query?.trim() ?? "";
-  return useEnvironmentQuery(
-    target.environmentId !== null && target.cwd !== null
-      ? vcsEnvironment.listRefs({
-          environmentId: target.environmentId,
-          input: {
-            cwd: target.cwd,
-            ...(query.length > 0 ? { query } : {}),
-            limit: VCS_REF_LIST_LIMIT,
-          },
-        })
-      : null,
-  );
 }
 
 export function usePaginatedBranches(target: VcsRefTarget) {

--- a/apps/web/src/state/server.ts
+++ b/apps/web/src/state/server.ts
@@ -50,7 +50,7 @@ const EMPTY_PRIMARY_SERVER_STATE: PrimaryServerState = {
   welcome: null,
 };
 
-export const primaryServerStateAtom = Atom.make((get): PrimaryServerState => {
+const primaryServerStateAtom = Atom.make((get): PrimaryServerState => {
   const environmentId = get(primaryEnvironmentIdAtom);
   if (environmentId === null) {
     return EMPTY_PRIMARY_SERVER_STATE;

--- a/apps/web/src/state/shell.ts
+++ b/apps/web/src/state/shell.ts
@@ -4,7 +4,6 @@ import {
 } from "@t3tools/client-runtime/connection";
 import {
   createEnvironmentShellAtoms,
-  createEnvironmentShellSummaryAtom,
   createEnvironmentSnapshotAtom,
   createShellEnvironmentAtoms,
   type EnvironmentShellState,
@@ -21,10 +20,6 @@ import { isHostedStaticApp } from "../hostedPairing";
 export const shellEnvironment = createShellEnvironmentAtoms(connectionAtomRuntime);
 export const environmentShell = createEnvironmentShellAtoms(connectionAtomRuntime);
 export const environmentSnapshotAtom = createEnvironmentSnapshotAtom(environmentShell.stateAtom);
-export const environmentShellSummaryAtom = createEnvironmentShellSummaryAtom({
-  catalogValueAtom: environmentCatalog.catalogValueAtom,
-  shellStateValueAtom: environmentShell.stateValueAtom,
-});
 
 export const allEnvironmentShellsBootstrappedAtom = Atom.make((get) => {
   const catalog = AsyncResult.value(get(environmentCatalog.catalogAtom));

--- a/apps/web/src/state/threads.ts
+++ b/apps/web/src/state/threads.ts
@@ -16,7 +16,7 @@ import { connectionAtomRuntime } from "../connection/runtime";
 import { environmentSnapshotAtom } from "./shell";
 
 export const threadEnvironment = createThreadEnvironmentAtoms(connectionAtomRuntime);
-export const environmentThreads = createEnvironmentThreadStateAtoms(connectionAtomRuntime);
+const environmentThreads = createEnvironmentThreadStateAtoms(connectionAtomRuntime);
 export const environmentThreadDetails = createEnvironmentThreadDetailAtoms(
   environmentThreads.stateAtom,
 );


### PR DESCRIPTION
Knip identified unused hooks, auth wrappers, atoms, and re-export aliases in the web runtime. Remove dead wrappers and keep implementation details private where they still have local callers.

Preserve the bootstrap functions used through the primary-environment barrel, their existing tests, and all exported types and Effect schemas. This rebased revision also makes the newly landed web favicon downscaler private while retaining its local cache caller.

Core UI component modules are unchanged. Their named subcomponents are preserved as complete component sets.

Layer 1 of 4 in the web runtime-export cleanup stack.

Verification at the integrated stack tip: `vp run --filter @t3tools/web test` passes all 4,052 tests across 333 files. Web typecheck and changed-file lint/format pass. `vp run knip:check` passes. A negative probe confirmed that a wholly unused `components/ui/*.tsx` file still fails the file audit.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add persistent project favicon cache, PR terminal timestamps, and remaining-quota usage display
> - Adds a persistent project favicon cache backed by IndexedDB (web) and the mobile database with native image downscaling. A new `createProjectFaviconUrlAtom` family replaces the old `useAssetUrl` hook, retaining the last resolved icon across failures and serving hydrated cache images before remote refresh.
> - Adds optional `closedAt` and `mergedAt` fields to pull-request and change-request schemas across all providers (GitHub, GitLab, Bitbucket, Azure DevOps). `pullRequestSettles` in [ThreadSettlementPolicy.ts](https://github.com/pingdotgg/t3code/pull/10225/files#diff-1a7b1b5c03173a900198d178092ff4a33f844a21a2fa2486c7cd3df14821c106) now uses the state-specific terminal timestamp instead of `updatedAt`, so metadata updates after a merge or close no longer re-settle a thread.
> - Switches usage-limit displays from "used" to "remaining" quota and time. Both web and mobile refresh paths gain a shared `refreshUsage` workflow with explicit concurrency guards and abort-on-disconnect behavior.
> - `makeEnvironmentThreadState` in [threads.ts](https://github.com/pingdotgg/t3code/pull/10225/files#diff-3389d9e86e5f65222bc1be800d0aa21f5356629eaf916680112dcbd606822815) now retains synchronization errors and cached data after terminated loads, does not restart fatal loads on connection notifications, and clears errors only on actual retry.
> - Replaces direct Lucide refresh/loader icons with shared `RefreshIcon` and `Spinner` components across many web and mobile settings, chat, and file-preview components. Migrates mobile adaptive color classes to semantic theme tokens (danger, warning, primary, secondary, subtle).
> - Risk: `BitbucketPullRequestProvider` now always returns null for `mergedAt`/`closedAt` instead of deriving from `updatedAt`; settlement behavior changes for threads whose PR metadata updated after terminal state. The `useAssetUrl` hook and `useProjectFaviconAsset` hook are removed—any out-of-tree consumers will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fba39bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->