### PR TITLE
refactor(web): keep feature component helpers private

### DIFF
--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -18,7 +18,7 @@ import {
   SelectValue,
 } from "./ui/select";
 
-export const PREVIOUS_WORKTREE_SELECT_VALUE = "previous-worktree";
+const PREVIOUS_WORKTREE_SELECT_VALUE = "previous-worktree";
 
 interface BranchToolbarEnvModeSelectorProps {
   envLocked: boolean;

--- a/apps/web/src/components/ConfirmDialogHost.tsx
+++ b/apps/web/src/components/ConfirmDialogHost.tsx
@@ -23,7 +23,7 @@ type ConfirmationCopy = {
   readonly description: string | null;
 };
 
-export function resolveConfirmDialogCopy(message: string): ConfirmationCopy {
+function resolveConfirmDialogCopy(message: string): ConfirmationCopy {
   const normalizedMessage = message.trim();
   const lines = normalizedMessage.split("\n");
   const questionLineIndex = lines.findIndex((line) => line.trim().endsWith("?"));

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -104,8 +104,6 @@ interface DiffPanelProps {
   workspaceMutationId: string | null;
 }
 
-export { DiffWorkerPoolProvider } from "./DiffWorkerPoolProvider";
-
 export default function DiffPanel({
   mode = "inline",
   composerDraftTarget,

--- a/apps/web/src/components/EnvironmentMachineIcon.tsx
+++ b/apps/web/src/components/EnvironmentMachineIcon.tsx
@@ -23,7 +23,7 @@ function LucideLike(props: SVGProps<SVGSVGElement>) {
 }
 
 /** A Mac mini: squat rounded slab with a front-edge LED. */
-export function MacMiniIcon(props: SVGProps<SVGSVGElement>) {
+function MacMiniIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <LucideLike {...props}>
       <rect width="20" height="8" x="2" y="8" rx="2" />
@@ -33,7 +33,7 @@ export function MacMiniIcon(props: SVGProps<SVGSVGElement>) {
 }
 
 /** A Mac Studio: the same slab twice as tall, ports along the front foot. */
-export function MacStudioIcon(props: SVGProps<SVGSVGElement>) {
+function MacStudioIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <LucideLike {...props}>
       <rect width="18" height="14" x="3" y="5" rx="2" />

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -354,7 +354,7 @@ interface SidebarThreadRowProps {
   ) => boolean;
 }
 
-export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowProps) {
+const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowProps) {
   const {
     orderedProjectThreadKeys,
     isActive,

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
@@ -220,7 +220,7 @@ export function providerUpdateNotificationKey(
   return parts.length > 0 ? parts.join("|") : null;
 }
 
-export function formatProviderList(providers: ReadonlyArray<Pick<ServerProvider, "driver">>) {
+function formatProviderList(providers: ReadonlyArray<Pick<ServerProvider, "driver">>) {
   const names = providers.map(
     (provider) => PROVIDER_DISPLAY_NAMES[provider.driver] ?? provider.driver,
   );
@@ -249,7 +249,7 @@ export function shouldShowPrimaryProviderUpdateToast(view: ProviderUpdateToastVi
   return view.phase !== "running";
 }
 
-export function getProviderUpdateRunningToastView(providerCount: number): ProviderUpdateToastView {
+function getProviderUpdateRunningToastView(providerCount: number): ProviderUpdateToastView {
   return {
     phase: "running",
     type: "loading",

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -15,7 +15,7 @@ import type { SidebarThreadSummary, Thread } from "../types";
 import { cn } from "../lib/utils";
 import { isLatestTurnSettled } from "../session-logic";
 
-export const THREAD_SELECTION_SAFE_SELECTOR = "[data-thread-item], [data-thread-selection-safe]";
+const THREAD_SELECTION_SAFE_SELECTOR = "[data-thread-item], [data-thread-selection-safe]";
 export const THREAD_JUMP_HINT_SHOW_DELAY_MS = 200;
 // Visible sidebar rows are prewarmed into the thread-detail cache so opening a
 // nearby thread usually reuses an already-hot subscription. Each prewarmed
@@ -23,10 +23,10 @@ export const THREAD_JUMP_HINT_SHOW_DELAY_MS = 200;
 // activities, growing as agents work) for as long as the row stays visible,
 // so this limit is a direct renderer-heap and server-load multiplier — keep
 // it small; cold opens still render instantly from the cached snapshot.
-export const SIDEBAR_THREAD_PREWARM_LIMIT = 3;
+const SIDEBAR_THREAD_PREWARM_LIMIT = 3;
 // A small buffer keeps the next few rows warm without leasing every row that
 // content-visibility leaves mounted below the scroll viewport.
-export const SIDEBAR_ROW_SUBSCRIPTION_OVERSCAN_PX = 160;
+const SIDEBAR_ROW_SUBSCRIPTION_OVERSCAN_PX = 160;
 
 export function useSidebarRowSubscriptionLease(isActive: boolean): {
   readonly leaseLiveStatus: boolean;
@@ -544,13 +544,6 @@ export function resolveSidebarThreadStatus(thread: SidebarThreadStatusInput): Si
   return "ready";
 }
 
-/** NaN-safe Date.parse for sort comparators: a malformed timestamp must not
-    poison the whole ordering, so it sinks to the epoch instead. */
-export function parseTimestampMs(isoDate: string): number {
-  const parsed = Date.parse(isoDate);
-  return Number.isNaN(parsed) ? 0 : parsed;
-}
-
 /** First VALID timestamp wins: `a ?? b` falls through on null, but a present-
     yet-malformed string must also fall through to the next candidate rather
     than sink the row to the epoch. */
@@ -567,7 +560,7 @@ export function firstValidTimestampMs(
 
 /** String twin of firstValidTimestampMs for callers that need the ISO string
     (display labels, tick anchors) rather than epoch ms. */
-export function firstValidTimestamp(
+function firstValidTimestamp(
   ...candidates: ReadonlyArray<string | null | undefined>
 ): string | null {
   for (const candidate of candidates) {

--- a/apps/web/src/components/ThreadCommandSubtitle.tsx
+++ b/apps/web/src/components/ThreadCommandSubtitle.tsx
@@ -15,8 +15,7 @@ export type ThreadCommandSubtitleVariant =
   | "favicon-workspace"
   | "favicon-branch-harness";
 
-export const THREAD_COMMAND_SUBTITLE_VARIANT: ThreadCommandSubtitleVariant =
-  "favicon-workspace-harness";
+const THREAD_COMMAND_SUBTITLE_VARIANT: ThreadCommandSubtitleVariant = "favicon-workspace-harness";
 
 export const COMMAND_PALETTE_META_ICON_CLASS = "size-3 shrink-0 text-muted-foreground/70";
 

--- a/apps/web/src/components/chat/ComposerPendingElementContexts.tsx
+++ b/apps/web/src/components/chat/ComposerPendingElementContexts.tsx
@@ -39,7 +39,7 @@ function buildTooltipContent(context: ElementContextDraft): string {
   return lines.join("\n");
 }
 
-export function ComposerPendingElementContextChip({
+function ComposerPendingElementContextChip({
   context,
   onRemove,
 }: ComposerPendingElementContextChipProps) {

--- a/apps/web/src/components/chat/ComposerPendingTerminalContexts.tsx
+++ b/apps/web/src/components/chat/ComposerPendingTerminalContexts.tsx
@@ -1,15 +1,9 @@
-import { cn } from "~/lib/utils";
 import {
   type TerminalContextDraft,
   formatTerminalContextLabel,
   isTerminalContextExpired,
 } from "~/lib/terminalContext";
 import { TerminalContextInlineChip } from "./TerminalContextInlineChip";
-
-interface ComposerPendingTerminalContextsProps {
-  contexts: ReadonlyArray<TerminalContextDraft>;
-  className?: string;
-}
 
 interface ComposerPendingTerminalContextChipProps {
   context: TerminalContextDraft;
@@ -25,20 +19,4 @@ export function ComposerPendingTerminalContextChip({
     : context.text;
 
   return <TerminalContextInlineChip label={label} tooltipText={tooltipText} expired={expired} />;
-}
-
-export function ComposerPendingTerminalContexts(props: ComposerPendingTerminalContextsProps) {
-  const { contexts, className } = props;
-
-  if (contexts.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className={cn("flex flex-wrap gap-1.5", className)}>
-      {contexts.map((context) => (
-        <ComposerPendingTerminalContextChip key={context.id} context={context} />
-      ))}
-    </div>
-  );
 }

--- a/apps/web/src/components/chat/ContextWindowMeter.logic.ts
+++ b/apps/web/src/components/chat/ContextWindowMeter.logic.ts
@@ -9,8 +9,8 @@ import {
 } from "../../providerInstances";
 import { getTriggerDisplayModelName, type ModelEsque } from "./providerIconUtils";
 
-export const CLAUDE_RESUME_COMPACTION_MINUTES = 70;
-export const CLAUDE_RESUME_COMPACTION_TOKENS = 100_000;
+const CLAUDE_RESUME_COMPACTION_MINUTES = 70;
+const CLAUDE_RESUME_COMPACTION_TOKENS = 100_000;
 
 export function providerSupportsManualCompaction(
   provider: ProviderInstanceEntry | null | undefined,

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -14,7 +14,6 @@ import {
 } from "@t3tools/client-runtime/work-log/presentation";
 export {
   normalizeCompactToolLabel,
-  summarizeToolGroup,
   toolGroupAction,
 } from "@t3tools/client-runtime/work-log/presentation";
 import {
@@ -31,11 +30,11 @@ import { type ChatMessage, type ProposedPlan, type TurnDiffSummary } from "../..
 import { type MessageId, type OrchestrationLatestTurn, type TurnId } from "@t3tools/contracts";
 import { formatWorkspaceRelativePath } from "../../filePathDisplay";
 
-export const TIMELINE_MINIMAP_ITEM_SPACING = 8;
+const TIMELINE_MINIMAP_ITEM_SPACING = 8;
 export const TIMELINE_MINIMAP_MIN_ITEMS = 2;
-export const TIMELINE_MINIMAP_MAX_HEIGHT_CSS = "calc(100vh - 18rem)";
-export const TIMELINE_CONTENT_MAX_WIDTH = 768;
-export const TIMELINE_MINIMAP_PERSISTENT_GUTTER = 48;
+const TIMELINE_MINIMAP_MAX_HEIGHT_CSS = "calc(100vh - 18rem)";
+const TIMELINE_CONTENT_MAX_WIDTH = 768;
+const TIMELINE_MINIMAP_PERSISTENT_GUTTER = 48;
 
 function singleToolCallLabel(entry: WorkLogEntry): string {
   const toolPresentation = resolveWorkEntryToolPresentation(entry, "completed");
@@ -145,7 +144,7 @@ export interface TimelineEndState {
  * A small pixel band (instead of the 1px isAtEnd epsilon alone) keeps re-arming
  * reliable while streaming content is still growing under the viewport.
  */
-export const TIMELINE_FOLLOW_REARM_THRESHOLD_PX = 40;
+const TIMELINE_FOLLOW_REARM_THRESHOLD_PX = 40;
 
 export function resolveTimelineIsAtEnd(state: TimelineEndState | undefined): boolean | undefined {
   if (!state) {
@@ -207,9 +206,9 @@ export function resolveTimelineMinimapHasPersistentGutter(viewportWidth: number)
   return sideGutter >= TIMELINE_MINIMAP_PERSISTENT_GUTTER;
 }
 
-export const TIMELINE_MINIMAP_HIT_STRIP_LEFT = 12;
-export const TIMELINE_MINIMAP_HIT_STRIP_MAX_WIDTH = 40;
-export const TIMELINE_MINIMAP_EXPANDED_HIT_STRIP_WIDTH = "22rem";
+const TIMELINE_MINIMAP_HIT_STRIP_LEFT = 12;
+const TIMELINE_MINIMAP_HIT_STRIP_MAX_WIDTH = 40;
+const TIMELINE_MINIMAP_EXPANDED_HIT_STRIP_WIDTH = "22rem";
 
 /**
  * The minimap overlays the viewport's left edge while the content column is

--- a/apps/web/src/components/chat/externalLinkContextMenu.ts
+++ b/apps/web/src/components/chat/externalLinkContextMenu.ts
@@ -35,7 +35,7 @@ const EXTERNAL_LINK_CONTEXT_MENU_ITEMS = [
  * whole menu with the one item that cannot be honoured is what left a right-click on a link
  * showing the platform's cut-and-paste menu instead of a way to copy the link.
  */
-export function externalLinkContextMenuItems(options: {
+function externalLinkContextMenuItems(options: {
   readonly canOpenInPreview: boolean;
   readonly threadLinkAction?: "link-to-thread" | "unlink-from-thread" | undefined;
 }): readonly ContextMenuItem<ExternalLinkContextMenuAction>[] {

--- a/apps/web/src/components/cloud/CloudEnvironmentConnectList.tsx
+++ b/apps/web/src/components/cloud/CloudEnvironmentConnectList.tsx
@@ -32,7 +32,7 @@ export interface SavedCloudEnvironmentConnection {
   readonly connection: EnvironmentConnectionPresentation;
 }
 
-export function RemoteEnvironmentRowsSkeleton() {
+function RemoteEnvironmentRowsSkeleton() {
   return (
     <div className={ITEM_ROW_CLASSNAME}>
       <div className={ITEM_ROW_INNER_CLASSNAME}>

--- a/apps/web/src/components/composerFooterLayout.ts
+++ b/apps/web/src/components/composerFooterLayout.ts
@@ -1,6 +1,6 @@
 export const COMPOSER_FOOTER_COMPACT_BREAKPOINT_PX = 620;
 export const COMPOSER_FOOTER_WIDE_ACTIONS_COMPACT_BREAKPOINT_PX = 780;
-export const RESTING_COMPOSER_IMAGE_THUMBNAIL_LIMIT = 3;
+const RESTING_COMPOSER_IMAGE_THUMBNAIL_LIMIT = 3;
 
 export function getRestingComposerImagePreviewCounts(imageCount: number): {
   visibleCount: number;

--- a/apps/web/src/components/files/projectFilesQueryState.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.ts
@@ -33,7 +33,7 @@ interface ProjectQueryState<A> {
   readonly refresh: () => void;
 }
 
-export function getProjectEntriesQueryAtom(environmentId: EnvironmentId, cwd: string) {
+function getProjectEntriesQueryAtom(environmentId: EnvironmentId, cwd: string) {
   return projectEnvironment.listEntries({ environmentId, input: { cwd } });
 }
 

--- a/apps/web/src/components/media/MediaActions.tsx
+++ b/apps/web/src/components/media/MediaActions.tsx
@@ -33,7 +33,7 @@ function mediaFileName(source: MediaActionSource): string {
 }
 
 /** Explicit byte operations get fresh capabilities without replacing a player's active source. */
-export function useMediaActions(source: MediaActionSource) {
+function useMediaActions(source: MediaActionSource) {
   const createAssetUrl = useAtomQueryRunner(assetEnvironment.createUrl, {
     reportFailure: false,
     refresh: true,

--- a/apps/web/src/components/preview/previewAutomationErrors.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.ts
@@ -216,7 +216,7 @@ export const PreviewAutomationHostError = Schema.Union([
 ]);
 export type PreviewAutomationHostError = typeof PreviewAutomationHostError.Type;
 
-export const isPreviewAutomationHostError = Schema.is(PreviewAutomationHostError);
+const isPreviewAutomationHostError = Schema.is(PreviewAutomationHostError);
 
 export function serializePreviewAutomationHostError(
   error: PreviewAutomationHostError,

--- a/apps/web/src/components/preview/previewMiniPlayerLayout.ts
+++ b/apps/web/src/components/preview/previewMiniPlayerLayout.ts
@@ -4,7 +4,7 @@ export const PREVIEW_MINI_PLAYER_EDGE_GAP = 12;
 // The mini-player shell straddles this webview at 47 and 49; dialogs begin at 50.
 export const PREVIEW_MINI_PLAYER_WEBVIEW_Z_INDEX = 48;
 export const PREVIEW_MINI_PLAYER_DEFAULT_SIZE = { width: 320, height: 200 } as const;
-export const PREVIEW_MINI_PLAYER_MIN_SIZE = { width: 240, height: 150 } as const;
+const PREVIEW_MINI_PLAYER_MIN_SIZE = { width: 240, height: 150 } as const;
 
 export function clampPreviewMiniPlayerSize(
   size: PreviewMiniPlayerSize,

--- a/apps/web/src/components/projectScriptEditor.tsx
+++ b/apps/web/src/components/projectScriptEditor.tsx
@@ -49,7 +49,7 @@ import { Popover, PopoverPopup, PopoverTrigger } from "./ui/popover";
 import { Switch } from "./ui/switch";
 import { Textarea } from "./ui/textarea";
 
-export const SCRIPT_ICONS: Array<{ id: ProjectScriptIcon; label: string }> = [
+const SCRIPT_ICONS: Array<{ id: ProjectScriptIcon; label: string }> = [
   { id: "play", label: "Play" },
   { id: "test", label: "Test" },
   { id: "lint", label: "Lint" },

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -187,7 +187,7 @@ function getReviewPositionAnchor(position: PullRequestReviewPosition): {
  * host sit under the line they were written on, and a new comment joins the review being
  * drafted rather than being posted as it is typed.
  */
-export function PullRequestCodeTab({
+function PullRequestCodeTab({
   environmentId,
   reference,
   detail,

--- a/apps/web/src/components/pullRequest/pullRequestLinkContextMenu.ts
+++ b/apps/web/src/components/pullRequest/pullRequestLinkContextMenu.ts
@@ -8,7 +8,7 @@ import { toastManager } from "../ui/toast";
 export type PullRequestLinkContextMenuAction = "copy-link" | "open-external";
 
 /** Named for the host rather than "externally": the point is where you will land. */
-export const OPEN_ON_HOST_LABELS: Partial<Record<string, string>> = {
+const OPEN_ON_HOST_LABELS: Partial<Record<string, string>> = {
   github: "Open on GitHub",
   gitlab: "Open on GitLab",
   bitbucket: "Open on Bitbucket",

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -67,7 +67,7 @@ export type PullRequestViewers = PullRequestListResult["viewers"];
 /** A row plus the environment that read it, where the caller has one to give. */
 type ScopedEntry = PullRequestListEntry & { readonly environmentId?: string };
 
-export const pullRequestViewerKey = (entry: ScopedEntry): string =>
+const pullRequestViewerKey = (entry: ScopedEntry): string =>
   `${entry.environmentId ?? ""} ${entry.host}`;
 
 const GROUP_LABELS: Record<PullRequestGroupKey, string> = {

--- a/apps/web/src/components/pullRequest/pullRequestListPreferences.ts
+++ b/apps/web/src/components/pullRequest/pullRequestListPreferences.ts
@@ -37,7 +37,7 @@ export type PullRequestListPreferencePatch = {
   [Key in keyof PullRequestListPreferences]?: PullRequestListPreferences[Key] | undefined;
 };
 
-export const DEFAULT_PULL_REQUEST_LIST_PREFERENCES = {
+const DEFAULT_PULL_REQUEST_LIST_PREFERENCES = {
   involvement: "all",
   state: "open",
 } as const satisfies PullRequestListPreferences;

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -291,7 +291,7 @@ function titleCaseCommandSegment(segment: string): string {
   return words.join(" ");
 }
 
-export function normalizeShortcutKeyToken(key: string): string | null {
+function normalizeShortcutKeyToken(key: string): string | null {
   const normalized = key.toLowerCase();
   if (
     normalized === "meta" ||

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -127,14 +127,14 @@ const ProjectIconPickerDialog = lazy(() =>
   })),
 );
 
-export const PROJECT_GROUPING_MODE_LABELS: Record<SidebarProjectGroupingMode, string> = {
+const PROJECT_GROUPING_MODE_LABELS: Record<SidebarProjectGroupingMode, string> = {
   repository: "Group by repository",
   repository_path: "Group by repository path",
   separate: "Keep separate",
 };
 
 /** Logical project groups for the settings page, sorted by display name. */
-export function useSettingsProjectGroups(): SidebarProjectSnapshot[] {
+function useSettingsProjectGroups(): SidebarProjectSnapshot[] {
   const projects = useProjects();
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const primaryEnvironmentId = usePrimaryEnvironmentId();
@@ -253,7 +253,7 @@ function ProjectSettingsBreadcrumb({ projectKey }: { projectKey: string }) {
   );
 }
 
-export function ProjectSettingsPanel({ projectKey }: { projectKey: string }) {
+function ProjectSettingsPanel({ projectKey }: { projectKey: string }) {
   const groups = useSettingsProjectGroups();
   const navigate = useNavigate();
 

--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -80,7 +80,7 @@ const SETTINGS_SECTION_ICONS: Readonly<
   "/settings/archived": ArchiveIcon,
 };
 
-export const SETTINGS_NAV_ITEMS: ReadonlyArray<{
+const SETTINGS_NAV_ITEMS: ReadonlyArray<{
   label: string;
   to: SettingsPath;
   icon: ComponentType<{ className?: string }>;

--- a/apps/web/src/components/settings/ThemeWireframe.tsx
+++ b/apps/web/src/components/settings/ThemeWireframe.tsx
@@ -4,7 +4,7 @@ import type { ThemeCardPreviewColors } from "./ThemePreviewCircles";
 // A simple miniature of the app: sidebar, a short conversation, the
 // composer, and the orchestrator panel floating over the interface as an
 // island with horizontal agent rows.
-export function ThemeWireframePane({
+function ThemeWireframePane({
   colors,
   clip,
 }: {

--- a/apps/web/src/components/settings/customModelEditor.logic.ts
+++ b/apps/web/src/components/settings/customModelEditor.logic.ts
@@ -104,7 +104,7 @@ export const DESCRIPTOR_PRESETS_BY_KIND: Partial<
 };
 
 let nextKey = 0;
-export function newEditorKey(): string {
+function newEditorKey(): string {
   nextKey += 1;
   return `k${nextKey}`;
 }
@@ -140,7 +140,7 @@ export function emptyEditorChoice(): EditorChoice {
  * by built-in runtime profiles a custom entry does not have, so they are
  * dropped rather than stored as a plain option value.
  */
-export function descriptorToEditor(descriptor: ProviderOptionDescriptor): EditorDescriptor {
+function descriptorToEditor(descriptor: ProviderOptionDescriptor): EditorDescriptor {
   const promptInjected = new Set(
     descriptor.type === "select" ? (descriptor.promptInjectedValues ?? []) : [],
   );

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -43,7 +43,7 @@ export interface ProviderClientDefinition {
   readonly badgeLabel?: string;
 }
 
-export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = [
+const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = [
   {
     value: ProviderDriverKind.make("codex"),
     label: "Codex",
@@ -84,7 +84,7 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
   },
 ];
 
-export const PROVIDER_CLIENT_DEFINITION_BY_VALUE: Partial<
+const PROVIDER_CLIENT_DEFINITION_BY_VALUE: Partial<
   Record<ProviderDriverKind, ProviderClientDefinition>
 > = Object.fromEntries(
   PROVIDER_CLIENT_DEFINITIONS.map((definition) => [definition.value, definition]),

--- a/apps/web/src/components/settings/themeInspector.ts
+++ b/apps/web/src/components/settings/themeInspector.ts
@@ -14,7 +14,7 @@ const THEME_PAINT_KIND_ORDER: ReadonlyArray<ThemePaintKind> = [
   "foreground",
 ];
 
-export const THEME_INSPECTOR_MATCH_ATTRIBUTE = "data-theme-inspector-match";
+const THEME_INSPECTOR_MATCH_ATTRIBUTE = "data-theme-inspector-match";
 
 const THEME_TOKEN_PROBE_ATTRIBUTE = "data-theme-token-probe";
 const THEME_TOKEN_PROBE_COLOR = "#01fea7";


### PR DESCRIPTION
App feature modules export constants, helpers, and local components that no other module imports. Make those declarations private and remove stale re-exports and two unused helpers.

Keep the lazy-loaded PullRequestCodeTab default export, the project settings entry point, and existing behavior tests. Remove duplicate provider metadata exports while retaining the aliases callers use. Core UI component modules are outside this layer and remain intact.

Layer 2 of 4 in the web runtime-export cleanup stack. Based on [#10225](https://github.com/pingdotgg/t3code/pull/10225).

Verification at the integrated stack tip: `vp run --filter @t3tools/web test` passes all 4,052 tests across 333 files. Web typecheck and changed-file lint/format pass. `vp run knip:check` passes. A negative probe confirmed that a wholly unused `components/ui/*.tsx` file still fails the file audit.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `apps/web` feature component helpers, constants, and components module-local
> - Removes or narrows exports across ~25 web feature modules so helpers, constants, and components stay private to their defining file. Values, props, rendering, and logic are unchanged.
> - Deletes dead exports with no remaining callers: `parseTimestampMs` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/10226/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) and the plural `ComposerPendingTerminalContexts` component plus its props interface in [ComposerPendingTerminalContexts.tsx](https://github.com/pingdotgg/t3code/pull/10226/files#diff-9cd0dd02c717609e3a229af3206e033ff9f9d8a25ebc7ad5815460d3caa6e209).
> - Stops cross-module re-exports: `DiffWorkerPoolProvider` from [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/10226/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3) and `summarizeToolGroup` from [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/10226/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe).
> - Risk: any out-of-tree code importing these now-private symbols will fail to compile; in-tree imports were already module-local or have been removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dec7d74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->