### PR TITLE
ci: enforce unused runtime exports in the web app

### DIFF
--- a/docs/operations/development.md
+++ b/docs/operations/development.md
@@ -72,10 +72,13 @@ Windows investigation while that suite is not a required gate.
 ### Unused code
 
 `vp run knip:check` checks unused files and dependencies across the repo, then
-unused runtime exports in every internal package under `packages/`. CI enforces both checks.
+unused runtime exports in `apps/web` and every internal package under `packages/`.
+CI enforces both checks.
 Exported types and Effect schemas are allowed without consumers. The schema preprocessor
 recognizes schema types, including aliases and schema classes; functions that create or decode
 schemas remain checked. Completely unused files remain checked too.
+Named exports in web UI component modules are kept as complete component sets. Knip ignores
+unused exports in `apps/web/src/components/ui/*.tsx`, while still reporting an entire unused file.
 Use `vp run knip --workspace apps/web` to audit one workspace, including exports,
 or `vp run knip:production --workspace apps/web` to find code kept alive only by tests.
 The full export audit still has findings and is not a repo-wide CI gate. Extend the

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -43,6 +43,10 @@
     "apps/web": {
       // Worktree setup invokes this directly from t3.json.
       "entry": ["scripts/warm-dep-cache.ts"],
+      // UI component modules are copied and adapted as cohesive sets. Keep their
+      // named subcomponents even before they have callers; the file audit still
+      // reports an entire component module when nothing imports it.
+      "ignoreIssues": { "src/components/ui/*.tsx": ["exports", "nsExports", "duplicates"] },
     },
     "apps/mobile": {
       // Expo loads local config plugins by string; Metro handles platform variants.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "tc": "vp run -r --concurrency-limit 2 typecheck",
     "lint": "vp lint --report-unused-disable-directives",
     "knip": "knip --preprocessor ./scripts/knip-schemas.ts",
-    "knip:check": "knip --include files,dependencies --no-config-hints && knip --workspace packages/client-runtime --workspace packages/contracts --workspace packages/effect-acp --workspace packages/effect-codex-app-server --workspace packages/shared --workspace packages/ssh --workspace packages/tailscale --exports --preprocessor ./scripts/knip-schemas.ts --no-config-hints",
+    "knip:check": "knip --include files,dependencies --no-config-hints && knip --workspace apps/web --workspace packages/client-runtime --workspace packages/contracts --workspace packages/effect-acp --workspace packages/effect-codex-app-server --workspace packages/shared --workspace packages/ssh --workspace packages/tailscale --exports --preprocessor ./scripts/knip-schemas.ts --no-config-hints",
     "knip:production": "knip --production --preprocessor ./scripts/knip-schemas.ts",
     "lint:mobile": "node scripts/mobile-native-static-check.ts",
     "test": "vp run -r test",


### PR DESCRIPTION
Web runtime exports are not covered by the existing Knip CI gate. Add apps/web alongside the seven internal packages after the preceding cleanup layers.

Keep exported types and Effect schemas under the existing preprocessor policy. Web UI component modules are copied and adapted as complete component sets, so Knip ignores named exports and duplicate aliases in `apps/web/src/components/ui/*.tsx`. The exception does not include file findings: an unimported UI component module still fails the file audit.

No dependency or plugin changes. Before this cleanup, the ordinary scan reported 205 web runtime exports and three duplicate-export groups. The integrated stack now passes under the revised policy. Production-only findings remain a separate audit because tests can legitimately consume meaningful logic.

Layer 4 of 4 in the web runtime-export cleanup stack. Based on [#10227](https://github.com/pingdotgg/t3code/pull/10227).

Verification at the integrated stack tip: `vp run --filter @t3tools/web test` passes all 4,052 tests across 333 files. Web typecheck and changed-file lint/format pass. `vp run knip:check` passes. A negative probe confirmed that a wholly unused `components/ui/*.tsx` file still fails the file audit.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `apps/web` to `knip:check` and ignore export findings for UI components
> - Extends `knip:check` in [package.json](https://github.com/pingdotgg/t3code/pull/10228/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to audit files, dependencies, and exports in `apps/web`.
> - Adds an `ignoreIssues` rule in [knip.jsonc](https://github.com/pingdotgg/t3code/pull/10228/files#diff-48d5ba4681726b42e98dae10c08bd94f7f9836644c8f183c6475d10dcf67ebf1) for `src/components/ui/*.tsx` to suppress export-level findings, treating these files as cohesive sets while still reporting fully unused files.
> - Updates [docs/operations/development.md](https://github.com/pingdotgg/t3code/pull/10228/files#diff-d4193c695085935050d7dd7572ae2c767e26244ca27f5ae7fd015ff4c97c8ba2) to document the expanded audit scope and component rules.
> - Behavioral Change: Running `knip:check` now audits `apps/web`, which may fail CI if unused files or dependencies exist outside the ignored UI components.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78ed671.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->