### PR TITLE
fix(mcp): allow text-only preview snapshots

### DIFF
--- a/apps/server/src/mcp/McpHttpServer.test.ts
+++ b/apps/server/src/mcp/McpHttpServer.test.ts
@@ -2,8 +2,10 @@ import { expect, it } from "@effect/vitest";
 import { NodeHttpServer } from "@effect/platform-node";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { EnvironmentId, PreviewTabId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { McpProtocol, McpSchema, McpServer } from "effect/unstable/ai";
 import { HttpBody, HttpClient, HttpRouter, HttpServerResponse } from "effect/unstable/http";
@@ -16,6 +18,7 @@ const environmentId = EnvironmentId.make("environment-mcp-test");
 const threadId = ThreadId.make("thread-mcp-test");
 const tabId = PreviewTabId.make("tab-mcp-test");
 const alternateTabId = PreviewTabId.make("tab-mcp-alternate");
+const encodeJsonText = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
 const invocation = {
   environmentId,
   threadId,
@@ -51,50 +54,177 @@ it("normalizes empty successful notification responses to accepted", () => {
   expect(resultResponse.status).toBe(200);
 });
 
-it.effect("returns bounded structural preview snapshot failures", () =>
+it.effect.each([{}, { includeImage: false }])(
+  "returns bounded structural preview snapshot failures %#",
+  (input) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* McpServer.McpServer;
+        const broker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
+        const events = yield* broker.connect({
+          clientId: "mcp-failure-client",
+          environmentId,
+        });
+        yield* Stream.runForEach(events, (event) =>
+          event.type === "connected"
+            ? Effect.void
+            : broker.respond({
+                clientId: "mcp-failure-client",
+                connectionId: event.connectionId,
+                requestId: event.request.requestId,
+                ok: false,
+                error: {
+                  _tag: "PreviewAutomationExecutionError",
+                  message: "sensitive renderer failure",
+                  detail: { consoleOutput: "sensitive browser output" },
+                },
+              }),
+        ).pipe(Effect.forkScoped);
+        yield* Effect.yieldNow;
+
+        const snapshot = yield* server
+          .callTool({ name: "preview_snapshot", arguments: input })
+          .pipe(
+            Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+            Effect.provideService(McpSchema.McpServerClient, client),
+          );
+
+        expect(snapshot.isError).toBe(true);
+        expect(snapshot.content).toEqual([{ type: "text", text: "Preview snapshot failed." }]);
+        expect(snapshot.structuredContent).toEqual({
+          error: {
+            _tag: "PreviewAutomationExecutionError",
+            operation: "snapshot",
+            failureCount: 1,
+          },
+        });
+      }),
+    ).pipe(Effect.provide(TestLayer)),
+);
+
+it.effect.each([
+  { mode: "default", input: {}, images: true },
+  { mode: "explicit image", input: { includeImage: true }, images: true },
+  { mode: "text only", input: { includeImage: false }, images: false },
+])("returns fresh $mode snapshots on repeated MCP calls", ({ input, images }) =>
   Effect.scoped(
     Effect.gen(function* () {
       const server = yield* McpServer.McpServer;
       const broker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
-      const events = yield* broker.connect({
-        clientId: "mcp-failure-client",
-        environmentId,
-      });
-      yield* Stream.runForEach(events, (event) =>
-        event.type === "connected"
-          ? Effect.void
-          : broker.respond({
-              clientId: "mcp-failure-client",
-              connectionId: event.connectionId,
-              requestId: event.request.requestId,
-              ok: false,
-              error: {
-                _tag: "PreviewAutomationExecutionError",
-                message: "sensitive renderer failure",
-                detail: { consoleOutput: "sensitive browser output" },
-              },
-            }),
-      ).pipe(Effect.forkScoped);
-      yield* Effect.yieldNow;
+      const connected = yield* Deferred.make<void>();
+      const png =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jRZkAAAAASUVORK5CYII=";
+      const page = {
+        url: "http://example.test/",
+        loading: false,
+        visibleText: "Save your changes",
+        interactiveElements: [
+          {
+            tag: "button",
+            role: "button",
+            name: "Save",
+            selector: "#save",
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 10,
+          },
+        ],
+        accessibilityTree: { role: "document", name: "Example" },
+        consoleEntries: [],
+        networkEntries: [],
+        actionTimeline: [],
+      };
+      const screenshot = { mimeType: "image/png", width: 1, height: 1 };
+      let requests = 0;
+      const events = yield* broker.connect({ clientId: "mcp-image-option-client", environmentId });
+      yield* Stream.runForEach(events, (event) => {
+        if (event.type === "connected") return Deferred.succeed(connected, undefined);
+        requests += 1;
+        expect(event.request).toMatchObject({
+          operation: "snapshot",
+          tabId: alternateTabId,
+          threadId,
+        });
+        expect(event.request.input).toEqual({});
+        return broker.respond({
+          clientId: "mcp-image-option-client",
+          connectionId: event.connectionId,
+          requestId: event.request.requestId,
+          ok: true,
+          result: {
+            ...page,
+            title: `Snapshot ${requests}`,
+            screenshot: { ...screenshot, data: png },
+          },
+        });
+      }).pipe(Effect.forkScoped);
+      yield* Deferred.await(connected);
 
-      const snapshot = yield* server
-        .callTool({ name: "preview_snapshot", arguments: {} })
+      for (const call of [1, 2, 3, 4, 5, 6]) {
+        const snapshot = yield* server
+          .callTool({
+            name: "preview_snapshot",
+            arguments: { ...input, tabId: alternateTabId },
+          })
+          .pipe(
+            Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+            Effect.provideService(McpSchema.McpServerClient, client),
+          );
+        const metadata = { ...page, title: `Snapshot ${call}`, screenshot };
+        expect(snapshot.isError).toBe(false);
+        expect(snapshot.structuredContent).toEqual(metadata);
+        expect(snapshot.content).toEqual([
+          { type: "text", text: encodeJsonText(snapshot.structuredContent) },
+          ...(images
+            ? [
+                {
+                  type: "image",
+                  mimeType: "image/png",
+                  data: new Uint8Array(Buffer.from(png, "base64")),
+                },
+              ]
+            : []),
+        ]);
+      }
+
+      // Output selection belongs to this call, not the MCP session's history.
+      const nextDefault = yield* server
+        .callTool({
+          name: "preview_snapshot",
+          arguments: { tabId: alternateTabId },
+        })
         .pipe(
           Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
           Effect.provideService(McpSchema.McpServerClient, client),
         );
-
-      expect(snapshot.isError).toBe(true);
-      expect(snapshot.content).toEqual([{ type: "text", text: "Preview snapshot failed." }]);
-      expect(snapshot.structuredContent).toEqual({
-        error: {
-          _tag: "PreviewAutomationExecutionError",
-          operation: "snapshot",
-          failureCount: 1,
-        },
-      });
+      expect(nextDefault.content.map((content) => content.type)).toEqual(["text", "image"]);
+      expect(nextDefault.structuredContent).toEqual({ ...page, title: "Snapshot 7", screenshot });
+      expect(requests).toBe(7);
     }),
   ).pipe(Effect.provide(TestLayer)),
+);
+
+it.effect("rejects non-boolean snapshot image options before selecting a browser host", () =>
+  Effect.gen(function* () {
+    const server = yield* McpServer.McpServer;
+    for (const includeImage of ["false", 0, null]) {
+      const result = yield* server
+        .callTool({
+          name: "preview_snapshot",
+          arguments: { includeImage },
+        })
+        .pipe(
+          Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+          Effect.provideService(McpSchema.McpServerClient, client),
+        );
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([{ type: "text", text: "Preview snapshot failed." }]);
+      expect(result.structuredContent).toEqual({
+        error: { _tag: "AiError", operation: "snapshot", failureCount: 1 },
+      });
+    }
+  }).pipe(Effect.provide(TestLayer)),
 );
 
 it.effect("terminates HTTP MCP sessions with DELETE", () =>

--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -187,11 +187,15 @@ const registerPreviewSnapshot = Effect.fn("McpHttpServer.registerPreviewSnapshot
                   structuredContent: metadata,
                   content: [
                     { type: "text", text: JSON.stringify(metadata) },
-                    {
-                      type: "image",
-                      data: new Uint8Array(Buffer.from(screenshot.data, "base64")),
-                      mimeType: screenshot.mimeType,
-                    },
+                    ...(payload?.includeImage === false
+                      ? []
+                      : [
+                          {
+                            type: "image" as const,
+                            data: new Uint8Array(Buffer.from(screenshot.data, "base64")),
+                            mimeType: screenshot.mimeType,
+                          },
+                        ]),
                   ],
                 }),
               );

--- a/apps/server/src/mcp/toolkits/preview/handlers.ts
+++ b/apps/server/src/mcp/toolkits/preview/handlers.ts
@@ -77,7 +77,11 @@ const handlers = {
     invokeTargeted<PreviewAutomationResizeResult>("resize", input, input.timeoutMs),
   preview_set_appearance: (input) =>
     invokeTargeted<PreviewAutomationSetColorSchemeResult>("setColorScheme", input),
-  preview_snapshot: (input) => invokeTargeted<PreviewAutomationSnapshot>("snapshot", input ?? {}),
+  preview_snapshot: (input) => {
+    // Output selection is MCP-only; the browser still produces a complete snapshot.
+    const { includeImage: _includeImage, ...operationInput } = input ?? {};
+    return invokeTargeted<PreviewAutomationSnapshot>("snapshot", operationInput);
+  },
   preview_click: (input) =>
     invokeTargeted<void>("click", input, input.timeoutMs).pipe(Effect.as({})),
   preview_type: (input) => invokeTargeted<void>("type", input, input.timeoutMs).pipe(Effect.as({})),

--- a/apps/server/src/mcp/toolkits/preview/tools.ts
+++ b/apps/server/src/mcp/toolkits/preview/tools.ts
@@ -111,8 +111,16 @@ export const PreviewSetAppearanceTool = safeBrowserTool(
 export const PreviewSnapshotTool = readonlyBrowserTool(
   Tool.make("preview_snapshot", {
     description:
-      "Inspect a page before interacting. Pass tabId to inspect a specific tab; omit it to use this agent session's current tab. Returns page state, semantic elements, diagnostics, action history, and a PNG screenshot.",
-    parameters: PreviewAutomationTabTargetInput,
+      "Inspect a page before interacting. Pass tabId to inspect a specific tab; omit it to use this agent session's current tab. Returns page state, semantic elements, diagnostics, action history, and a PNG screenshot. Set includeImage=false for text-only output with the same page metadata.",
+    parameters: Schema.Struct({
+      ...PreviewAutomationTabTargetInput.fields,
+      includeImage: Schema.optional(
+        Schema.Boolean.annotate({
+          description:
+            "Include the PNG image in the tool response. Defaults to true. Set false for text-only output.",
+        }),
+      ),
+    }),
     success: PreviewAutomationSnapshot,
     failure: PreviewAutomationError,
     dependencies,


### PR DESCRIPTION
Closes #10187.

Repeated `preview_snapshot` calls add a PNG to each MCP result. Providers or gateways with image-count limits may reject the accumulated conversation.

Add optional `includeImage`. `{"includeImage":false}` returns fresh page metadata and JSON text without an image content part. Omitted or `true` preserves the existing PNG response. The flag stays inside the MCP server. Browser capture and the shared snapshot contract are unchanged.

The user selected this opt-in mitigation with current defaults preserved. It cannot remove images already in provider-owned history, does not stop host capture, and does not guarantee that a gateway accepts an existing conversation. The reporter's original gateway rejection was not replayed.

Verification on integrated main [585ce2c2](https://github.com/pingdotgg/t3code/commit/585ce2c2ab396e4c3c5ffcfc422449c07896ddf9):

- The registered MCP tool and real preview broker use a synthetic host. Exact-main before controls fail twice and pass 12 tests. The candidate passes all 14, including the existing HTTP session lifecycle test.
- Six text-only calls return fresh metadata with no image. A following default call returns PNG again. Repeated default and explicit-image calls preserve the PNG bytes and metadata. Tab targeting, bounded host errors and invalid inputs are covered.
- The orchestrator independently reviewed all four changed files, ran both sides, and passed scoped typecheck and changed-file lint. Two unchanged Effect suggestions remain in the server environment machine.

The subsequent [f12d3935](https://github.com/pingdotgg/t3code/commit/f12d39359f0f76a64ff2d77959c5baf821df15be) main update does not change the MCP implementation or preview contracts. No client UI changed, so screenshots are not applicable. This is protocol/output evidence, not a browser, native or real-provider claim.

Ready for human review; unmerged. Current-head CI finished with 16 successful and four skipped checks. The orchestrator read all check outputs, annotations, comments and reviews; no unresolved finding remains. The configured Cursor review is paused by its spending limit, so its successful dispatch is not claimed as a code review.

Implemented with GPT 6 Astra via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow text-only preview snapshots in `McpHttpServer`
> - Adds test coverage for `includeImage=false` and omitted `includeImage` in `preview_snapshot`, verifying failure responses stay bounded and omit image content
> - Adds a parameterized integration test confirming repeated `preview_snapshot` calls return fresh metadata with distinct titles, include a PNG by default or when explicitly enabled, and omit it when disabled
> - Adds rejection tests for non-boolean `includeImage` values (string, numeric, null), asserting they fail with an `AiError` summary before browser-host selection
> - Risk: no behavioral change beyond test coverage; all modifications are in [McpHttpServer.test.ts](https://github.com/pingdotgg/t3code/pull/10232/files#diff-552121f7256046a957f60f7f3476debc694a83547a2f5f9874be39fe468aa5f6)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d458d3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->