### PR TITLE
fix(server): keep the Antigravity Google sign-in across server restarts

### DIFF
--- a/apps/server/src/provider/Layers/AntigravityProvider.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.test.ts
@@ -264,6 +264,23 @@ it.layer(testLayer)("Antigravity provider snapshots", (it) => {
     ),
   );
 
+  it.effect("publishes the configured sign-in method before any account is checked", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const provider = yield* makeAntigravityProvider(decodeSettings({ enabled: true }), {
+          stampIdentity: (snapshot) => Effect.succeed({ ...snapshot, instanceId, driver }),
+          probe: Effect.succeed(initializeResult),
+          supportsTextGeneration: Effect.succeed(true),
+          auth: { type: "gemini-api-key", label: "Gemini API key" },
+        });
+        expect((yield* provider.snapshot.getSnapshot).auth).toEqual({
+          status: "unknown",
+          type: "gemini-api-key",
+        });
+      }),
+    ),
+  );
+
   it.effect("treats initialize as installation proof, not account or model discovery", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -144,7 +144,9 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
         installed: false,
         version: null,
         status: "warning",
-        auth: { status: "unknown" },
+        // The configured method rides along so the registry can tell a saved
+        // account for this method from one left by a previous configuration.
+        auth: { status: "unknown", ...(options.auth ? { type: options.auth.type } : {}) },
         message: settings.enabled
           ? "Checking Antigravity availability."
           : "Antigravity is disabled in T3 Code settings.",

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1179,6 +1179,97 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         });
       });
 
+      describe("Antigravity saved account", () => {
+        const signedIn = {
+          instanceId: ProviderInstanceId.make("antigravity-personal"),
+          driver: ProviderDriverKind.make("antigravity"),
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated", type: "oauth-personal", label: "Google account" },
+          checkedAt: "2026-09-05T00:00:00.000Z",
+          version: "agy_acp_server_1.1.1",
+          models: [
+            {
+              slug: "gemini-3.7-flash-high",
+              name: "Gemini 3.7 Flash",
+              isCustom: false,
+              capabilities: null,
+            },
+          ],
+          slashCommands: [{ name: "plan" }],
+          skills: [],
+        } as const satisfies ServerProvider;
+        const uncheckedMessage =
+          "Antigravity is installed. Google account access is not checked yet.";
+        const restartProbe = {
+          ...signedIn,
+          status: "warning",
+          auth: { status: "unknown" },
+          checkedAt: "2026-09-05T00:01:00.000Z",
+          message: uncheckedMessage,
+          models: [],
+        } as const satisfies ServerProvider;
+
+        it("keeps the saved Google account through restart health checks", () => {
+          const merged = mergeProviderSnapshot(signedIn, restartProbe);
+          const { message: _uncheckedMessage, ...probeWithoutMessage } = restartProbe;
+          assert.deepStrictEqual(merged, {
+            ...probeWithoutMessage,
+            status: "ready",
+            auth: signedIn.auth,
+            models: signedIn.models,
+          });
+          assert.equal("message" in merged, false);
+          // The next periodic probe reads the merged snapshot as its previous state.
+          assert.deepStrictEqual(mergeProviderSnapshot(merged, restartProbe), merged);
+        });
+
+        it("carries the account through the boot probe and a failed probe without hiding them", () => {
+          const booting = {
+            ...restartProbe,
+            installed: false,
+            version: null,
+            message: "Checking Antigravity availability.",
+          } satisfies ServerProvider;
+          assert.deepStrictEqual(mergeProviderSnapshot(signedIn, booting), {
+            ...booting,
+            auth: signedIn.auth,
+            models: signedIn.models,
+          });
+
+          const failed = {
+            ...restartProbe,
+            status: "error",
+            message: "Antigravity did not respond to its local health check within 90 seconds.",
+          } satisfies ServerProvider;
+          assert.deepStrictEqual(mergeProviderSnapshot(signedIn, failed), {
+            ...failed,
+            auth: signedIn.auth,
+            models: signedIn.models,
+          });
+        });
+
+        it("does not invent an account after sign-out, disable, uninstall, or for other providers", () => {
+          const untouched = [
+            { ...restartProbe, auth: { status: "unauthenticated" } },
+            { ...restartProbe, status: "disabled", enabled: false },
+            { ...restartProbe, status: "error", installed: false },
+            { ...restartProbe, driver: ProviderDriverKind.make("codex") },
+          ] satisfies ReadonlyArray<ServerProvider>;
+          for (const next of untouched) {
+            const merged = mergeProviderSnapshot(signedIn, next);
+            assert.deepStrictEqual(merged.auth, next.auth);
+            assert.equal(merged.status, next.status);
+            assert.equal(merged.message, next.message);
+          }
+          assert.deepStrictEqual(
+            mergeProviderSnapshot({ ...signedIn, auth: { status: "unknown" } }, restartProbe).auth,
+            { status: "unknown" },
+          );
+        });
+      });
+
       it("fills missing capabilities from the previous provider snapshot", () => {
         const previousProvider = {
           instanceId: ProviderInstanceId.make("cursor"),

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1256,6 +1256,8 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             { ...restartProbe, status: "disabled", enabled: false },
             { ...restartProbe, status: "error", installed: false },
             { ...restartProbe, driver: ProviderDriverKind.make("codex") },
+            // The instance was rebuilt with another sign-in method.
+            { ...restartProbe, auth: { status: "unknown", type: "gemini-api-key" } },
           ] satisfies ReadonlyArray<ServerProvider>;
           for (const next of untouched) {
             const merged = mergeProviderSnapshot(signedIn, next);
@@ -1266,6 +1268,20 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           assert.deepStrictEqual(
             mergeProviderSnapshot({ ...signedIn, auth: { status: "unknown" } }, restartProbe).auth,
             { status: "unknown" },
+          );
+          assert.equal(
+            mergeProviderSnapshot(
+              { ...signedIn, driver: ProviderDriverKind.make("codex") },
+              restartProbe,
+            ).auth.status,
+            "unknown",
+          );
+          assert.deepStrictEqual(
+            mergeProviderSnapshot(signedIn, {
+              ...restartProbe,
+              auth: { status: "unknown", type: "oauth-personal" },
+            }).auth,
+            signedIn.auth,
           );
         });
       });

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -167,17 +167,22 @@ const mergeProviderModels = (
  * restart it reports the account as unchecked. The saved Google login still
  * works, and the previous snapshot proves it. Carry that account state until
  * a session, refresh, or sign-out reports something new. A confirmed missing
- * installation, sign-out, or disabled instance is never overridden.
+ * installation, sign-out, disabled instance, or a changed sign-in method is
+ * never overridden.
  */
 const carrySavedAntigravityAccount = (
   previousProvider: ServerProvider,
   nextProvider: ServerProvider,
 ): Pick<ServerProvider, "auth" | "status"> | undefined => {
+  const antigravity = ProviderDriverKind.make("antigravity");
   if (
-    nextProvider.driver !== ProviderDriverKind.make("antigravity") ||
+    nextProvider.driver !== antigravity ||
+    previousProvider.driver !== antigravity ||
     !nextProvider.enabled ||
     nextProvider.auth.status !== "unknown" ||
     previousProvider.auth.status !== "authenticated" ||
+    (nextProvider.auth.type !== undefined &&
+      nextProvider.auth.type !== previousProvider.auth.type) ||
     (!nextProvider.installed && nextProvider.status !== "warning")
   ) {
     return undefined;

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -162,31 +162,64 @@ const mergeProviderModels = (
     : mergedModels;
 };
 
+/**
+ * Antigravity's health check only initializes the agent, so after a server
+ * restart it reports the account as unchecked. The saved Google login still
+ * works, and the previous snapshot proves it. Carry that account state until
+ * a session, refresh, or sign-out reports something new. A confirmed missing
+ * installation, sign-out, or disabled instance is never overridden.
+ */
+const carrySavedAntigravityAccount = (
+  previousProvider: ServerProvider,
+  nextProvider: ServerProvider,
+): Pick<ServerProvider, "auth" | "status"> | undefined => {
+  if (
+    nextProvider.driver !== ProviderDriverKind.make("antigravity") ||
+    !nextProvider.enabled ||
+    nextProvider.auth.status !== "unknown" ||
+    previousProvider.auth.status !== "authenticated" ||
+    (!nextProvider.installed && nextProvider.status !== "warning")
+  ) {
+    return undefined;
+  }
+  // The pending boot probe (`installed: false`, warning) and a failed probe
+  // keep their own status; only a passed health check reads as ready.
+  const status =
+    nextProvider.installed && nextProvider.status === "warning" ? "ready" : nextProvider.status;
+  return { auth: previousProvider.auth, status };
+};
+
 export const mergeProviderSnapshot = (
   previousProvider: ServerProvider | undefined,
   nextProvider: ServerProvider,
-): ServerProvider =>
-  !previousProvider
-    ? nextProvider
-    : {
-        ...nextProvider,
-        models: mergeProviderModels(nextProvider, previousProvider.models, nextProvider.models),
-        ...(nextProvider.workspaceSnapshots !== undefined
-          ? { workspaceSnapshots: nextProvider.workspaceSnapshots }
-          : previousProvider.workspaceSnapshots !== undefined
-            ? { workspaceSnapshots: previousProvider.workspaceSnapshots }
-            : {}),
-        ...(shouldRetainMissingOpenCodeMetadata(nextProvider)
-          ? {
-              slashCommands:
-                nextProvider.slashCommands.length === 0
-                  ? previousProvider.slashCommands
-                  : nextProvider.slashCommands,
-              skills:
-                nextProvider.skills.length === 0 ? previousProvider.skills : nextProvider.skills,
-            }
-          : {}),
-      };
+): ServerProvider => {
+  if (!previousProvider) {
+    return nextProvider;
+  }
+  const savedAccount = carrySavedAntigravityAccount(previousProvider, nextProvider);
+  // "Google account access is not checked yet" describes the probe, not the
+  // account; it must not outlive the state it explained.
+  const { message: _uncheckedMessage, ...nextWithoutMessage } = nextProvider;
+  return {
+    ...(savedAccount?.status === "ready" ? nextWithoutMessage : nextProvider),
+    ...savedAccount,
+    models: mergeProviderModels(nextProvider, previousProvider.models, nextProvider.models),
+    ...(nextProvider.workspaceSnapshots !== undefined
+      ? { workspaceSnapshots: nextProvider.workspaceSnapshots }
+      : previousProvider.workspaceSnapshots !== undefined
+        ? { workspaceSnapshots: previousProvider.workspaceSnapshots }
+        : {}),
+    ...(shouldRetainMissingOpenCodeMetadata(nextProvider)
+      ? {
+          slashCommands:
+            nextProvider.slashCommands.length === 0
+              ? previousProvider.slashCommands
+              : nextProvider.slashCommands,
+          skills: nextProvider.skills.length === 0 ? previousProvider.skills : nextProvider.skills,
+        }
+      : {}),
+  };
+};
 
 const haveProvidersChanged = (
   previousProviders: ReadonlyArray<ServerProvider>,

--- a/docs/user/providers-antigravity.md
+++ b/docs/user/providers-antigravity.md
@@ -123,6 +123,9 @@ is refused while the runtime is in use.
 
 ## Check access and troubleshoot
 
+A server restart keeps your Google sign-in. The provider shows the saved account
+until a session, a refresh, or a sign-out reports something new.
+
 To check access and reload models, use **Refresh provider status** in web or desktop
 provider settings, or **Refresh models** in mobile thread settings. If asked to
 sign in again, use setup on web or desktop.


### PR DESCRIPTION
## Problem

After a server restart, Antigravity showed **Needs attention** and offered **Sign in with Google** even though the saved Google login still worked. Clicking the button "signed in" instantly because the agent already had a valid token on disk. Nightly desktop and `t3 serve` installs restart the server process often, so users saw this after every reboot or update.

Reported on Twitter and in [#10110](https://github.com/pingdotgg/t3code/issues/10110).

## Cause

The Antigravity health check only calls `initialize` on the agent. It never authenticates, so after a restart the provider's in-memory auth state starts at `unknown` and stays there until a session or an explicit refresh runs. The registry merge then let that unchecked probe overwrite the `authenticated` snapshot restored from the on-disk status cache.

## Fix

`mergeProviderSnapshot` now carries the previous authenticated account through an unchecked Antigravity probe. A passed health check reads as `ready` and drops the "not checked yet" message. The boot probe and a failed probe keep their own status and message but keep the account. Sign-out, disable, a confirmed missing installation, and other providers are untouched.

The health probe itself is unchanged. It still never starts a session.

## Verification

- `vp test run apps/server/src/provider/Layers/ProviderRegistry.test.ts` (50 passed, 3 new)
- `vp test run apps/server/src/provider/Layers/AntigravityProvider.test.ts apps/server/src/provider/providerStatusCache.test.ts`
- `vpr typecheck` in `apps/server`
- `vp lint` on the touched files

Fixes #10110

Built with Claude Fable 5.1 through the Claude Code harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retain Antigravity Google sign-in across server restarts in `mergeProviderSnapshot`
> - Adds `carrySavedAntigravityAccount` helper in [ProviderRegistry.ts](https://github.com/pingdotgg/t3code/pull/10244/files#diff-5c33694fd7889294ecb21a88beafee2debe92f779baab4629651d4c8be8a9a97) that carries an authenticated account from a previous Antigravity snapshot when the next provider is enabled, uses the Antigravity driver, has unknown auth state, and the auth type matches.
> - Refuses to carry state after confirmed uninstall, sign-out, disabled provider, driver change, or authentication-method change; maps installed-warning snapshots to ready.
> - `mergeProviderSnapshot` now calls the carry helper first, overlays carried auth and status on eligible snapshots, and removes the transient account-not-checked message when status becomes ready.
> - AntigravityProvider initial snapshot now reports the configured auth type alongside unknown status, so the carry helper can match it.
> - Updates [providers-antigravity.md](https://github.com/pingdotgg/t3code/pull/10244/files#diff-62b2768fa557094d146d5aace8e013a4781458c8e9d23aeb4facd6a205bd64e7) to document restart retention behavior.
> - Behavioral Change: `mergeProviderSnapshot` in [ProviderRegistry.ts](https://github.com/pingdotgg/t3code/pull/10244/files#diff-5c33694fd7889294ecb21a88beafee2debe92f779baab4629651d4c8be8a9a97) now mutates merged Antigravity snapshots that previously reported unknown status — eligible ones become ready with carried account info. Pending-boot and failed snapshots keep their own status.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d276eae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->