### PR TITLE
fix(mobile): keep pending tasks queued when a send fails in flight

### DIFF
--- a/apps/mobile/src/state/thread-outbox-model.ts
+++ b/apps/mobile/src/state/thread-outbox-model.ts
@@ -251,14 +251,30 @@ function errorMessage(error: unknown): string | null {
   return typeof error === "string" ? error : null;
 }
 
+/**
+ * Only a failure the server actually decided (`OrchestrationDispatchCommandError`,
+ * or an authorization rejection) means the payload itself is bad. The other
+ * typed failures a queued send can hit are transport-shaped: a socket that
+ * dropped mid-request (`RpcClientError` wrapping a Socket read/write/close
+ * reason), or an environment that is not connected or not registered. Those
+ * are matched by tag, not by message text, because a `SocketReadError` message
+ * is just "An error occurred during Read". A wrong answer here restores the
+ * pending task into a draft and it disappears from the list.
+ */
 export function shouldRetryThreadOutboxDelivery(error: unknown): boolean {
-  if (
-    typeof error === "object" &&
-    error !== null &&
-    "_tag" in error &&
-    error._tag === "ConnectionTransientError"
-  ) {
-    return true;
+  if (typeof error === "object" && error !== null && "_tag" in error) {
+    switch (error._tag) {
+      case "OrchestrationDispatchCommandError":
+      case "EnvironmentAuthorizationError":
+        return false;
+      case "ConnectionTransientError":
+      case "RpcClientError":
+      case "EnvironmentRpcUnavailableError":
+      case "EnvironmentNotRegisteredError":
+        return true;
+      default:
+        break;
+    }
   }
   return isTransportConnectionErrorMessage(errorMessage(error));
 }

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it } from "@effect/vitest";
+import { EnvironmentNotRegisteredError } from "@t3tools/client-runtime/connection";
+import { isTransportConnectionErrorMessage } from "@t3tools/client-runtime/errors";
+import { EnvironmentRpcUnavailableError } from "@t3tools/client-runtime/rpc";
 import {
   CommandId,
+  EnvironmentAuthorizationError,
   EnvironmentId,
   MessageId,
+  OrchestrationDispatchCommandError,
   ProjectId,
   ProviderInstanceId,
   ThreadId,
 } from "@t3tools/contracts";
 import { AtomRegistry } from "effect/unstable/reactivity";
+import * as RpcClientError from "effect/unstable/rpc/RpcClientError";
+import * as Socket from "effect/unstable/socket/Socket";
 import { onTestFinished, vi } from "vite-plus/test";
 
 const outboxFiles = vi.hoisted(() => new Map<string, string | Error>());
@@ -1399,6 +1406,62 @@ describe("thread outbox", () => {
       }),
     ).toBe(true);
     expect(shouldRetryThreadOutboxDelivery(new Error("Thread no longer exists"))).toBe(false);
+    expect(
+      shouldRetryThreadOutboxDelivery(
+        new OrchestrationDispatchCommandError({ message: "Thread no longer exists" }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldRetryThreadOutboxDelivery(
+        new EnvironmentAuthorizationError({
+          message: "Missing scope",
+          requiredScope: "orchestration:operate",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  // A pending task created offline drains the moment the phone reconnects,
+  // which is exactly when the socket is most likely to drop again. Every way a
+  // request can fail in flight must retry; a restore turns the pending task
+  // into a draft and it disappears from the list.
+  it("retries every in-flight transport failure by tag, not by message text", () => {
+    const socketReasons = [
+      new Socket.SocketReadError({ cause: new Error("The network connection was lost.") }),
+      new Socket.SocketWriteError({ cause: new Error("Broken pipe") }),
+      new Socket.SocketCloseError({ code: 1006 }),
+      new Socket.SocketOpenError({ kind: "Timeout", cause: new Error("timeout") }),
+    ];
+    for (const reason of socketReasons) {
+      const error = new RpcClientError.RpcClientError({ reason });
+      expect(isTransportConnectionErrorMessage(error.message)).toBe(
+        reason._tag === "SocketCloseError" || reason._tag === "SocketOpenError",
+      );
+      expect(shouldRetryThreadOutboxDelivery(error)).toBe(true);
+    }
+    expect(
+      shouldRetryThreadOutboxDelivery(
+        new RpcClientError.RpcClientError({
+          reason: new RpcClientError.RpcClientDefect({
+            message: "Error decoding message",
+            cause: new Error("Unexpected end of JSON input"),
+          }),
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldRetryThreadOutboxDelivery(
+        new EnvironmentRpcUnavailableError({
+          environmentId: "environment-1",
+          message: "Home is not connected.",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldRetryThreadOutboxDelivery(
+        new EnvironmentNotRegisteredError({ environmentId: EnvironmentId.make("environment-1") }),
+      ),
+    ).toBe(true);
   });
 
   it("retains queued messages when settings synchronization fails before startTurn", () => {


### PR DESCRIPTION
## Problem

A pending task queued on the phone while offline was gone from the **Pending** section once the phone reconnected, and its text showed up as the project's new-task draft instead.

The outbox drain sends a queued creation as soon as the environment reconnects, which is exactly when the socket is most likely to drop again. When a `startTurn` fails in flight, Effect fails the request with an `RpcClientError` wrapping the socket reason. For a socket that dies after opening, that reason is `SocketReadError`, whose message is just `"An error occurred during Read"`. `shouldRetryThreadOutboxDelivery` classified failures by message text and only special-cased the `ConnectionTransientError` tag, so this read as a deterministic server rejection. The drain then took the `restore` path, which merges the queued text into the `new-task:<project>` draft and deletes the outbox entry.

The server side confirms it never rejected anything: no non-accepted command receipts, no `bootstrap-thread-delete` cleanup, and every mobile `dispatchCommand` span in the trace succeeded. The failure was client-side transport.

## Fix

Classify by error tag first, and only fall back to the message matcher for untagged errors:

- **Restore (payload is bad):** `OrchestrationDispatchCommandError`, `EnvironmentAuthorizationError` — the two errors the `dispatchCommand` RPC contract can return.
- **Retry (transport):** `ConnectionTransientError`, `RpcClientError` (any socket reason or protocol defect), `EnvironmentRpcUnavailableError`, `EnvironmentNotRegisteredError`.

## Verification

Added a test that constructs real `RpcClientError` instances for all four socket reasons plus a protocol defect and asserts each retries. It also pins that `SocketReadError`/`SocketWriteError` messages are *not* recognised by the text matcher, which documents why tag matching is required. The test fails on `main` and passes here.

```
apps/mobile: vp test run src/state/thread-outbox.test.ts   43 passed
apps/mobile: vpr typecheck                                   ok
```

No screenshots: the change is a classification function with no UI. Follow-up work to surface drafts and pending tasks together in the mobile sidebar is stacked on top of this PR.

Model: Claude Fable 5 · Harness: Claude Code in T3 Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `shouldRetryThreadOutboxDelivery` to stop retrying deterministic failures and retry RPC errors
> - Replaces the single `ConnectionTransientError` check in [thread-outbox-model.ts](https://github.com/pingdotgg/t3code/pull/10245/files#diff-70b765fdc85f11eba546273ca7f2459bb1a0ed084acdec2d67bce652f3cd7895) with tag-based classification so pending tasks stay queued on transient failures instead of being dropped
> - `OrchestrationDispatchCommandError` and `EnvironmentAuthorizationError` are now non-retryable; `RpcClientError`, `EnvironmentRpcUnavailableError`, and `EnvironmentNotRegisteredError` join `ConnectionTransientError` as retryable
> - Untagged errors still fall through to the existing message-based transport detection
> - Adds tests in [thread-outbox.test.ts](https://github.com/pingdotgg/t3code/pull/10245/files#diff-72c27bc8fd8aafae9a96593859117a27e1d454f06dd58bc981343e1243768f79) covering typed retryable and non-retryable cases
> - Behavioral Change: errors previously retried only via message matching are now classified by tag; untagged errors with unrecognized messages may stop retrying
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d738da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->