### PR TITLE
fix(mobile): keep the new-task draft when switching environment

### DIFF
--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -92,6 +92,7 @@ import {
   resolveNewTaskBranchWorktreePath,
   resolveNewTaskLocalWorkspaceSelection,
 } from "./new-task-context-presentation";
+import { resolveEnvironmentProjectMatch } from "./new-task-project-selection";
 
 type WorkspaceMode = "local" | "worktree";
 
@@ -622,51 +623,44 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     );
   }, [availableBranches, branchQuery]);
 
-  const setProject = useCallback(
+  // New-task drafts are keyed per (environment, project), so retargeting the
+  // composer would otherwise show the target's empty draft and strand what the
+  // user typed under the old key.
+  const carryDraftContentTo = useCallback(
     (project: EnvironmentProject) => {
-      const nextProjectKey = scopedProjectKey(project.environmentId, project.id);
-      const nextDraftKey = `new-task:${nextProjectKey}`;
+      const nextDraftKey = `new-task:${scopedProjectKey(project.environmentId, project.id)}`;
       if (
         selectedProjectDraftKey?.startsWith("new-task:") &&
         selectedProjectDraftKey !== nextDraftKey
       ) {
         void copyComposerDraftContentIfEmpty(selectedProjectDraftKey, nextDraftKey);
       }
-      setSelectedEnvironmentId(project.environmentId);
-      setSelectedProjectKey(nextProjectKey);
     },
     [selectedProjectDraftKey],
   );
 
+  const setProject = useCallback(
+    (project: EnvironmentProject) => {
+      carryDraftContentTo(project);
+      setSelectedEnvironmentId(project.environmentId);
+      setSelectedProjectKey(scopedProjectKey(project.environmentId, project.id));
+    },
+    [carryDraftContentTo],
+  );
+
   const selectEnvironment = useCallback(
     (environmentId: EnvironmentId) => {
-      const projectsOnTarget = projects.filter(
-        (project) => project.environmentId === environmentId,
+      const match = resolveEnvironmentProjectMatch(
+        projects.filter((project) => project.environmentId === environmentId),
+        selectedProject,
       );
-      const repositoryKey = selectedProject?.repositoryIdentity?.canonicalKey ?? null;
-      // Prefer the repository identity; projects without one (e.g. not yet
-      // indexed) fall back to workspace basename, then title, so switching
-      // computers still follows the same repo instead of resetting to
-      // whatever project is first on the target machine.
-      const workspaceBasename = selectedProject?.workspaceRoot.split("/").at(-1) || null;
-      const match =
-        (repositoryKey !== null
-          ? projectsOnTarget.find(
-              (project) => (project.repositoryIdentity?.canonicalKey ?? null) === repositoryKey,
-            )
-          : undefined) ??
-        (workspaceBasename !== null
-          ? projectsOnTarget.find(
-              (project) => project.workspaceRoot.split("/").at(-1) === workspaceBasename,
-            )
-          : undefined) ??
-        (selectedProject !== null
-          ? projectsOnTarget.find((project) => project.title === selectedProject.title)
-          : undefined);
+      if (match) {
+        carryDraftContentTo(match);
+      }
       setSelectedEnvironmentId(environmentId);
       setSelectedProjectKey(match ? scopedProjectKey(match.environmentId, match.id) : null);
     },
-    [projects, selectedProject],
+    [projects, selectedProject, carryDraftContentTo],
   );
 
   const setWorkspaceMode = useCallback(

--- a/apps/mobile/src/features/threads/new-task-project-selection.test.ts
+++ b/apps/mobile/src/features/threads/new-task-project-selection.test.ts
@@ -94,6 +94,22 @@ describe("resolveEnvironmentProjectMatch", () => {
     expect(resolveEnvironmentProjectMatch(byTitle, selected)).toBe(byTitle[1]);
   });
 
+  it("does not treat a known different repository as a basename or title match", () => {
+    const selected = makeProject("t3code", "mac", {
+      repositoryKey: "github.com/t3tools/t3code",
+      workspaceRoot: "/Users/me/t3code",
+    });
+    const fork = makeProject("fork", "server", {
+      repositoryKey: "github.com/someone/t3code",
+      title: "t3code",
+      workspaceRoot: "/home/me/t3code",
+    });
+    const unindexed = makeProject("unindexed", "server", { workspaceRoot: "/srv/t3code" });
+    expect(resolveEnvironmentProjectMatch([fork, unindexed], selected)).toBe(unindexed);
+    // Without any weaker match the fork is still the first-project fallback.
+    expect(resolveEnvironmentProjectMatch([fork], selected)).toBe(fork);
+  });
+
   it("falls back to the first project on the target so the draft has a key to carry over to", () => {
     const selected = makeProject("t3code", "mac", { repositoryKey: "github.com/t3tools/t3code" });
     const target = [makeProject("unrelated", "server"), makeProject("also-unrelated", "server")];

--- a/apps/mobile/src/features/threads/new-task-project-selection.test.ts
+++ b/apps/mobile/src/features/threads/new-task-project-selection.test.ts
@@ -6,15 +6,33 @@ import type { HomeProjectScope } from "../home/homeThreadList";
 import {
   getProjectScopeSelectionTarget,
   resolveDraftProjectSelection,
+  resolveEnvironmentProjectMatch,
 } from "./new-task-project-selection";
 
-function makeProject(id: string, environmentId = "environment"): EnvironmentProject {
+function makeProject(
+  id: string,
+  environmentId = "environment",
+  options: {
+    readonly title?: string;
+    readonly workspaceRoot?: string;
+    readonly repositoryKey?: string;
+  } = {},
+): EnvironmentProject {
   return {
     environmentId: EnvironmentId.make(environmentId),
     id: ProjectId.make(id),
-    title: id,
-    workspaceRoot: `/work/${id}`,
-    repositoryIdentity: null,
+    title: options.title ?? id,
+    workspaceRoot: options.workspaceRoot ?? `/work/${id}`,
+    repositoryIdentity: options.repositoryKey
+      ? {
+          canonicalKey: options.repositoryKey,
+          locator: {
+            source: "git-remote",
+            remoteName: "origin",
+            remoteUrl: `https://${options.repositoryKey}.git`,
+          },
+        }
+      : null,
     defaultModelSelection: null,
     scripts: [],
     createdAt: "2026-07-01T00:00:00.000Z",
@@ -48,6 +66,39 @@ describe("getProjectScopeSelectionTarget", () => {
     expect(getProjectScopeSelectionTarget(makeScope(projects), EnvironmentId.make("other"))).toBe(
       projects[0],
     );
+  });
+});
+
+describe("resolveEnvironmentProjectMatch", () => {
+  it("follows the same repository onto the target machine", () => {
+    const selected = makeProject("t3code", "mac", { repositoryKey: "github.com/t3tools/t3code" });
+    const target = [
+      makeProject("other", "server", { repositoryKey: "github.com/t3tools/other" }),
+      makeProject("t3code-clone", "server", { repositoryKey: "github.com/t3tools/t3code" }),
+    ];
+    expect(resolveEnvironmentProjectMatch(target, selected)).toBe(target[1]);
+  });
+
+  it("falls back to workspace basename, then title, for unindexed projects", () => {
+    const selected = makeProject("t3code", "mac", { workspaceRoot: "/Users/me/t3code" });
+    const byBasename = [
+      makeProject("other", "server"),
+      makeProject("srv", "server", { workspaceRoot: "/home/me/t3code" }),
+    ];
+    expect(resolveEnvironmentProjectMatch(byBasename, selected)).toBe(byBasename[1]);
+
+    const byTitle = [
+      makeProject("other", "server"),
+      makeProject("srv", "server", { title: "t3code" }),
+    ];
+    expect(resolveEnvironmentProjectMatch(byTitle, selected)).toBe(byTitle[1]);
+  });
+
+  it("falls back to the first project on the target so the draft has a key to carry over to", () => {
+    const selected = makeProject("t3code", "mac", { repositoryKey: "github.com/t3tools/t3code" });
+    const target = [makeProject("unrelated", "server"), makeProject("also-unrelated", "server")];
+    expect(resolveEnvironmentProjectMatch(target, selected)).toBe(target[0]);
+    expect(resolveEnvironmentProjectMatch([], selected)).toBeNull();
   });
 });
 

--- a/apps/mobile/src/features/threads/new-task-project-selection.ts
+++ b/apps/mobile/src/features/threads/new-task-project-selection.ts
@@ -26,6 +26,42 @@ function getOnlySelectableProject(
   return onlyScope?.representative ?? null;
 }
 
+/**
+ * Picks the project on a target environment that corresponds to the project
+ * currently selected in the new-task flow, so switching computers follows the
+ * same repo. Repository identity is preferred; projects without one (e.g. not
+ * yet indexed) fall back to workspace basename, then title. When nothing
+ * matches, the first project on the target stands in — the same fallback the
+ * render path applies when no key is selected — so the draft always has a
+ * concrete key to carry over to.
+ */
+export function resolveEnvironmentProjectMatch(
+  projectsOnTarget: ReadonlyArray<EnvironmentProject>,
+  selectedProject: EnvironmentProject | null,
+): EnvironmentProject | null {
+  const repositoryKey = selectedProject?.repositoryIdentity?.canonicalKey ?? null;
+  // `|| null` (not `??`): a pending-task placeholder project can have an empty
+  // workspaceRoot, and an "" basename would match nothing meaningful.
+  const workspaceBasename = selectedProject?.workspaceRoot.split("/").at(-1) || null;
+  return (
+    (repositoryKey !== null
+      ? projectsOnTarget.find(
+          (project) => (project.repositoryIdentity?.canonicalKey ?? null) === repositoryKey,
+        )
+      : undefined) ??
+    (workspaceBasename !== null
+      ? projectsOnTarget.find(
+          (project) => project.workspaceRoot.split("/").at(-1) === workspaceBasename,
+        )
+      : undefined) ??
+    (selectedProject !== null
+      ? projectsOnTarget.find((project) => project.title === selectedProject.title)
+      : undefined) ??
+    projectsOnTarget[0] ??
+    null
+  );
+}
+
 export function resolveDraftProjectSelection(
   selectedProjectKey: string | null,
   projects: ReadonlyArray<EnvironmentProject>,

--- a/apps/mobile/src/features/threads/new-task-project-selection.ts
+++ b/apps/mobile/src/features/threads/new-task-project-selection.ts
@@ -43,6 +43,13 @@ export function resolveEnvironmentProjectMatch(
   // `|| null` (not `??`): a pending-task placeholder project can have an empty
   // workspaceRoot, and an "" basename would match nothing meaningful.
   const workspaceBasename = selectedProject?.workspaceRoot.split("/").at(-1) || null;
+  // The weaker signals only apply where identity is unknown on at least one
+  // side; two known, different repositories never match on a shared basename
+  // or title (mirrors the environment list filter in the new-task flow).
+  const isKnownMismatch = (project: EnvironmentProject) => {
+    const projectKey = project.repositoryIdentity?.canonicalKey ?? null;
+    return repositoryKey !== null && projectKey !== null && projectKey !== repositoryKey;
+  };
   return (
     (repositoryKey !== null
       ? projectsOnTarget.find(
@@ -51,11 +58,15 @@ export function resolveEnvironmentProjectMatch(
       : undefined) ??
     (workspaceBasename !== null
       ? projectsOnTarget.find(
-          (project) => project.workspaceRoot.split("/").at(-1) === workspaceBasename,
+          (project) =>
+            !isKnownMismatch(project) &&
+            project.workspaceRoot.split("/").at(-1) === workspaceBasename,
         )
       : undefined) ??
     (selectedProject !== null
-      ? projectsOnTarget.find((project) => project.title === selectedProject.title)
+      ? projectsOnTarget.find(
+          (project) => !isKnownMismatch(project) && project.title === selectedProject.title,
+        )
       : undefined) ??
     projectsOnTarget[0] ??
     null

--- a/apps/mobile/src/state/use-composer-drafts.test.ts
+++ b/apps/mobile/src/state/use-composer-drafts.test.ts
@@ -145,6 +145,7 @@ vi.mock("../features/sharing/incoming-share-storage", () => ({
   loadIncomingShareDrafts: incomingShareStorageMocks.load,
 }));
 
+import type { DraftComposerAttachment } from "../lib/composerImages";
 import { appAtomRegistry } from "./atom-registry";
 import { threadOutboxManager } from "./thread-outbox";
 import {
@@ -1431,6 +1432,48 @@ describe("mobile composer drafts", () => {
     };
 
     expect(copyComposerDraftContentState(drafts, sourceKey, targetKey)).toBe(drafts);
+  });
+
+  it("drops another environment's upload stamp when carrying attachments across machines", () => {
+    const sourceKey = "new-task:environment-1:project-1";
+    const targetKey = "new-task:environment-2:project-2";
+    const uploadedElsewhere: DraftComposerAttachment = {
+      id: "image-1",
+      type: "image",
+      name: "screen.png",
+      mimeType: "image/png",
+      sizeBytes: 1,
+      previewUri: "file:///drafts/screen.png",
+      fileUri: "file:///drafts/screen.png",
+      uploadedAttachmentId: "upload-1",
+      uploadEnvironmentId: EnvironmentId.make("environment-1"),
+    };
+    const uploadedOnTarget: DraftComposerAttachment = {
+      ...uploadedElsewhere,
+      id: "image-2",
+      uploadedAttachmentId: "upload-2",
+      uploadEnvironmentId: EnvironmentId.make("environment-2"),
+    };
+
+    const next = copyComposerDraftContentState(
+      { [sourceKey]: { text: "Ship it", attachments: [uploadedElsewhere, uploadedOnTarget] } },
+      sourceKey,
+      targetKey,
+    );
+
+    expect(next[targetKey]?.attachments).toEqual([
+      {
+        id: "image-1",
+        type: "image",
+        name: "screen.png",
+        mimeType: "image/png",
+        sizeBytes: 1,
+        previewUri: "file:///drafts/screen.png",
+        fileUri: "file:///drafts/screen.png",
+      },
+      uploadedOnTarget,
+    ]);
+    expect(next[sourceKey]?.attachments).toEqual([uploadedElsewhere, uploadedOnTarget]);
   });
 
   it("merges shared content into a project draft without duplicating retries", () => {

--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -1049,15 +1049,33 @@ export function copyComposerDraftContentState(
   if (!sourceHasContent || targetHasContent) {
     return current;
   }
+  // Pending uploads live on one server. Crossing environments keeps the local
+  // bytes (the upload worker re-sends them to the new key's environment) but
+  // drops the old stamp, so it cannot pin the source environment's pending
+  // upload alive from the copy.
+  const targetEnvironmentId = composerDraftEnvironmentId(targetDraftKey, []);
+  const attachments = source.attachments.map((attachment) =>
+    attachment.uploadEnvironmentId !== undefined &&
+    attachment.uploadEnvironmentId !== targetEnvironmentId
+      ? stripAttachmentUploadReference(attachment)
+      : attachment,
+  );
   return {
     ...current,
     [targetDraftKey]: {
       ...target,
       text: source.text,
-      attachments: source.attachments,
+      attachments,
       ...(source.importedShareIds ? { importedShareIds: source.importedShareIds } : {}),
     },
   };
+}
+
+function stripAttachmentUploadReference(
+  attachment: DraftComposerAttachment,
+): DraftComposerAttachment {
+  const { uploadedAttachmentId: _id, uploadEnvironmentId: _environmentId, ...rest } = attachment;
+  return rest;
 }
 
 export async function copyComposerDraftContentIfEmpty(


### PR DESCRIPTION
## What Changed

On mobile, switching the target machine in the new-task flow now carries the composer text and attachments over to the new environment, the same way switching project already did.

- `selectEnvironment` runs the same draft carry-over as `setProject`. The repo-matching logic moved into a pure `resolveEnvironmentProjectMatch` (with tests) and gained a first-project-on-target fallback, so there is always a concrete draft key to copy to; previously the no-match case set the key to `null` and let the render path fall through.
- `copyComposerDraftContentState` drops `uploadedAttachmentId`/`uploadEnvironmentId` on attachments whose stamp belongs to a different environment than the target key. The local bytes stay, and the upload worker re-sends them to the new environment. Without this, the copied stamp kept the old environment's pending upload referenced (the GC checks every draft), so it lived until server-side expiry. Web already does this in `clearStaleFileUploadMetadata`.

## Why

New-task drafts are keyed `new-task:<environmentId>:<projectId>`. Changing environment changed the key without moving the content, so a dictated prompt appeared to vanish the moment you picked another machine. The text was actually stranded under the old key, which is why closing and reopening the flow on the original machine showed it again.

## UI Changes

iOS simulator, two disposable environments on the same host both hosting `example/draft-repo`. Prompt typed, then the other environment picked from the "on …" control.

| Prompt typed on environment 1 | After switching to environment 2 (this branch) |
|---|---|
| ![Composer with the prompt typed, before switching](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/1bd5408e40c249b9/after-typed-before-switch.png) | ![Composer still showing the prompt after the environment switch](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d63b2a74036127f4/after-environment-switched.png) |

The persisted draft store on the device (`composer-drafts/drafts.json`, keys abbreviated) confirms the copy:

```
before switch:
  07d7fa98:a2575719 => "Add retry logic to the upload worker and cover it with tests"
after switch:
  07d7fa98:a2575719 => "Add retry logic to the upload worker and cover it with tests"
  573155b0:8974a71e => "Add retry logic to the upload worker and cover it with tests"
```

No "before" screenshot on `main`: the composer would render the second key's empty draft, and the simulator host was contended when I tried to capture it. The unit test on `resolveEnvironmentProjectMatch` and the draft-store listing above cover the behavior change.

## Verification

- `vp test run apps/mobile/src/features/threads/new-task-project-selection.test.ts` — 9 passed (3 new)
- `vp test run apps/mobile/src/state/use-composer-drafts.test.ts` — 57 passed (1 new)
- Mobile `tsc --noEmit`, lint, and fmt on the touched files.
- Manual pass on the iOS simulator as above.

Not in scope: the native composer editor can drop a parent-driven value restore after a clear→restore round trip (revision-guard race in `T3ComposerEditorView`). That is why switching back to the original machine did not show the stranded text without a remount. It is independent of drafts and tracked separately.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (n/a)

Claude Fable 5 via Claude Code (T3 Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep new-task draft when switching environment and strip cross-environment upload refs
> - Environment switching in the new-task flow now resolves the matching target project via `resolveEnvironmentProjectMatch` (repository identity → workspace basename → title → first project) and copies the current draft to that project before selection changes.
> - Extracts `carryDraftContentTo` so both environment and direct project selection transfer draft content to the target project's draft key.
> - `copyComposerDraftContentState` removes `uploadedAttachmentId` and `uploadEnvironmentId` from attachments whose upload environment differs from the target, preserving local attachment data and leaving the source draft untouched.
> - Risk: environments with projects but no repository/basename/title match now fall back to the first target project rather than `null`; verify `selectEnvironment` fallback in [new-task-flow-provider.tsx](https://github.com/pingdotgg/t3code/pull/10247/files#diff-70cedfb5c403f777ceda2ca120dd7f822b033acf06053841f85a63b7d0cd3192) matches product intent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae929fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->