### PR TITLE
fix(web): keep timestamp tooltip dates in English

### DIFF
--- a/apps/web/src/timestampFormat.test.ts
+++ b/apps/web/src/timestampFormat.test.ts
@@ -52,6 +52,25 @@ describe("formatShortTimestamp", () => {
   });
 });
 
+describe("formatChatTimestampTooltip", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it.each(["de-DE", "it-IT"])("keeps the English date label in a %s runtime", async (locale) => {
+    const DateTimeFormat = Intl.DateTimeFormat;
+    vi.spyOn(Intl, "DateTimeFormat").mockImplementation(function (locales, options) {
+      return new DateTimeFormat(locales ?? locale, options);
+    });
+    vi.resetModules();
+    const { formatChatTimestampTooltip: format } = await import("./timestampFormat");
+    const date = new Date(2026, 5, 4, 14, 4).toISOString();
+
+    expect(format(date, "24-hour")).toBe("14:04, 4th June 2026");
+  });
+});
+
 describe("formatExpiresInLabel", () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/apps/web/src/timestampFormat.ts
+++ b/apps/web/src/timestampFormat.ts
@@ -81,7 +81,7 @@ export function parseTimestampDate(isoDate: string): Date | null {
 // Deliberately not the host locale: the tooltip's ordinal suffix and
 // day-before-month order below are English, so a localized month alone would
 // read "4th Juni 2026". Localizing the whole label is a separate change.
-const monthNameFormatter = new Intl.DateTimeFormat(undefined, { month: "long" });
+const monthNameFormatter = new Intl.DateTimeFormat("en-US", { month: "long" });
 
 function ordinalSuffix(day: number): string {
   const lastTwo = day % 100;


### PR DESCRIPTION
## What Changed

Message timestamp tooltips mix an English ordinal with a localized month, for example `4th giugno 2026` in an Italian browser. Pin the month formatter to `en-US` so it matches the rest of the date label.

## Why

The existing comment explicitly calls for an English tooltip date. This one-line fix implements that intent without changing clock preferences, numeric dates, or other timestamp helpers. Regression tests cover German and Italian runtime locales.

```mermaid
flowchart LR
    A[Message timestamp] --> B[Time using existing locale and clock preference]
    A --> C[English ordinal day and year]
    A --> D[Month formatted in en-US]
    B --> E[Chat timestamp tooltip]
    C --> E
    D --> E
```

## UI Changes

Same seeded conversation in the running web app, Chromium with `it-IT` locale and `Europe/Rome` timezone. Both images are cropped PNGs at 2× density. Before uses the unchanged formatter from `eee05575eb`; after uses this fix. Verified both user and assistant message tooltips. No mobile or packaged desktop run.

Before:

![Before: an Italian month mixed with an English ordinal](https://github.com/user-attachments/assets/d0ff0323-3534-403c-89e2-20f7d9beb192)

After:

![After: the month matches the English date label](https://github.com/user-attachments/assets/3b3a3411-4536-417a-bd4c-c5e3812c94c6)

## Verification

- `vp test run src/timestampFormat.test.ts --project unit --maxWorkers 1` in `apps/web`: 25 passed. Both new regression cases failed before the fix.
- Targeted lint, formatting, and typecheck of the changed files: passed.
- Full web-package typecheck is blocked by `TS2554` in unchanged `src/components/files/fileEditorVirtualization.test.ts:260`, which passes four arguments to a method accepting at most three. No diagnostics were suppressed.
- Fallow audit against `eee05575eb`, scoped to web with one thread: passed with no introduced findings.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes. Not applicable, only tooltip text changes.

Model: GPT-5. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Force English locale for `monthNameFormatter` in timestamp tooltips
> Sets the module-level month formatter in [timestampFormat.ts](https://github.com/pingdotgg/t3code/pull/10256/files#diff-3c87b91789abf1f3644a1a66f0da1d791ac92e439c18f8a651d177cd2ed1601b) to `en-US` instead of the runtime default locale. Adds tests in [timestampFormat.test.ts](https://github.com/pingdotgg/t3code/pull/10256/files#diff-e312e9610bc89fd0c1096c9fbbdd99058a70f6ff0893092c34aec0fec7124f54) that mock German and Italian runtime locales and confirm the tooltip output stays in English.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ff911d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat timestamp tooltips now consistently display month names in English, regardless of the device or browser locale.
  * Added coverage to verify consistent English formatting across German and Italian locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->