### PR TITLE
fix(web): respect reduced motion in shared disclosures

### DIFF
--- a/apps/web/src/components/ui/collapsible.tsx
+++ b/apps/web/src/components/ui/collapsible.tsx
@@ -19,10 +19,12 @@ function CollapsibleTrigger({ className, ...props }: CollapsiblePrimitive.Trigge
 }
 
 function CollapsiblePanel({ className, ...props }: CollapsiblePrimitive.Panel.Props) {
+  // Reuses the local shadcn/Base UI panel; skip height travel for reduced motion.
+  // https://ui.shadcn.com/docs/components/base/collapsible
   return (
     <CollapsiblePrimitive.Panel
       className={cn(
-        "h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-200 data-ending-style:h-0 data-starting-style:h-0 data-open:data-ending-style:[height:var(--collapsible-panel-height)]",
+        "h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-200 motion-reduce:transition-none data-ending-style:h-0 data-starting-style:h-0 data-open:data-ending-style:[height:var(--collapsible-panel-height)]",
         className,
       )}
       data-slot="collapsible-panel"


### PR DESCRIPTION
Closes #10255.

## What Changed

The shared Collapsible panel now skips its height transition when the user prefers reduced motion. It retains its existing 200 ms transition otherwise. The local shadcn/Base UI primitive, final height, trigger, and open state are preserved.

## Why

The panel applied its height transition under both motion preferences. The global stylesheet has reduced-motion rules for other specific surfaces, but none covering this panel. This one-class correction also covers callers using the CollapsibleContent alias.

Addresses #10255.

## UI Changes

Primary exercised Settings → Legacy features in the isolated running app, on base eee05575e and candidate 5710f475. Under normal motion both retained the height transition, focus stayed on the trigger, and open → close → reopen interrupted after 75 ms ended expanded with a 272.375 CSS-pixel panel. 1280×800 CSS viewport, dark theme.

[Candidate normal-motion regression recording](https://github.com/saphid/t3code/releases/download/pr-evidence-task-motion-20260906/disclosure-normal-regression.mp4) is supporting evidence that ordinary disclosure behavior is retained; it does not prove the reduced-motion fix. The attached preview has no reduced-motion emulation API and the host reports no-preference. Actual reduced-motion before/after GIFs and narrow-layout verification remain missing, so this PR remains draft. Caller-owned chevrons are unchanged.

## Verification

- `vp fmt --check apps/web/src/components/ui/collapsible.tsx`, `vp lint apps/web/src/components/ui/collapsible.tsx`, and `git diff --check` passed. Initial lint could not load its workspace plugin dependency; linking that existing dependency resolved it.
- Installed Tailwind compiled the new variant to `transition-property: none` inside `prefers-reduced-motion: reduce`. Installed tailwind-merge preserved that variant with caller timing classes. Base UI 1.5.0 and its Collapsible export were verified against the lockfile and installed package.
- The worker's borrowed-dependency typechecks failed on stale workspace declarations. Primary installed fresh dependencies in an isolated integration worktree and ran `vp run --filter @t3tools/web typecheck`: exit 0, first with this change alone, then with task-progress PR #10259 integrated.
- Direct `claude --model claude-opus-5 --effort high --permission-mode plan --tools Read --allowedTools Read -p …` review exited 1 because OAuth expired and could not refresh. No Claude review occurred. Read-only standards baseline: `144fbf46af335d8d18a95c8d4b4f2e9e0207fa2e`.

Web/Electron shared UI only; native clients are unchanged. Normal-motion focus retention, interruption, final height and computed transition were observed. Keyboard-only expansion and runtime reduced-motion remain unverified. This draft is not review-ready.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Implemented and assessed by GPT-6 Astra medium in Codex. No other model supplied review findings.


## Maintainer verification, September 6

This supersedes the missing browser-proof notes above. I independently reviewed the one-file change at [5710f475](https://github.com/pingdotgg/t3code/commit/5710f47546033b7715966dae7b9ff70379fb3abb) and exercised the actual Settings → Legacy features control in isolated Chromium with synthetic data and all real providers disabled.

With reduced motion enabled, the baseline emitted height transitions lasting 200 ms and showed intermediate heights. This candidate emits no panel transition events and computes `transition-property: none`. Mouse expansion and keyboard close/reopen preserve focus on the trigger and finish at the same 272.375 CSS-pixel height. Normal-motion keyboard reversal still emits transition and cancellation events and ends expanded. At 390×844, reduced-motion keyboard close/reopen also has no height transition; page width remains 390 and panel content width equals its 338-pixel box. No settings, provider turns or live user database were changed.

Matched before/after recordings, six seconds each, crop the same actual 1280×2600 capture around the disclosure. Playback speed is unchanged. The stills intentionally show the same settled state; the recordings and transition measurements demonstrate the fix.

Before, reduced motion still animates:

[Before recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/5c4d582ce28afb81/10255-before-reduced-motion.mp4)

![Before: expanded Legacy features after the unwanted transition](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/9237da4d70b50f20/10255-base-reduced-full-expanded.png)

After, reduced motion changes state immediately:

[After recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/96f89470bf77b8a9/10255-after-reduced-motion.mp4)

![After: identical expanded Legacy features without a height transition](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/5f85190687b986dd/10255-candidate-reduced-full-expanded.png)

The retained host is main [bd16b86d](https://github.com/pingdotgg/t3code/commit/bd16b86d50c1df49afeb7c0a7568a4908ade4048) with separately reviewed usage overlays. I verified the actually served disclosure module's source map against exact baseline and candidate bytes. Disclosure and General settings sources are unchanged through [ab67795d](https://github.com/pingdotgg/t3code/commit/ab67795dde448a3608d8689f7ad1975bb977e5a9), committed 03:54:49 UTC. This is not an entirely latest-main app run or a native Electron OS-preference test. The change is shared web/Electron CSS only; native mobile, providers, connection modes and wire contracts are untouched.

Current-head checks before marking ready: 15 successful, four skipped, no findings or pending jobs. Exact-file lint and formatting passed. No repo-wide local suite was run. Marking ready requests the configured reviewers; it is not a merge claim.

Independent review and browser verification by GPT 6 Astra via Codex in T3 Code. The author's implementation and attribution are preserved.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `motion-reduce:transition-none` to `CollapsiblePanel`
> Users who request reduced motion at the OS level no longer get the panel's height transition animation. Other users keep the existing transition behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5710f47.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

