### PR TITLE
feat(mobile): show new-task drafts alongside pending tasks in the thread list

### DIFF
--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -370,7 +370,7 @@ export function HomeScreen(props: HomeScreenProps) {
           ? props.pendingTasks
           : props.pendingTasks.filter((pendingTask) =>
               selectedProjectRefKeys.has(
-                scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
+                scopedProjectKey(pendingTask.environmentId, pendingTask.projectId),
               ),
             ),
     [threadListV2Enabled, props.pendingTasks, selectedProjectRefKeys],
@@ -740,10 +740,10 @@ export function HomeScreen(props: HomeScreenProps) {
       props.pendingTasks.filter(
         (pendingTask) =>
           (props.selectedEnvironmentId === null ||
-            pendingTask.message.environmentId === props.selectedEnvironmentId) &&
+            pendingTask.environmentId === props.selectedEnvironmentId) &&
           (v2ScopedProjectKeys === null ||
             v2ScopedProjectKeys.has(
-              scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
+              scopedProjectKey(pendingTask.environmentId, pendingTask.projectId),
             )) &&
           (v2SearchQuery.length === 0 ||
             pendingTask.title.toLocaleLowerCase().includes(v2SearchQuery)),
@@ -774,8 +774,8 @@ export function HomeScreen(props: HomeScreenProps) {
         (nextItem?.type === "v2-pending" && !nextItem.showPendingDivider);
       if (item.type === "v2-pending") {
         const pendingScopeKey = scopedProjectKey(
-          item.pendingTask.message.environmentId,
-          item.pendingTask.creation.projectId,
+          item.pendingTask.environmentId,
+          item.pendingTask.projectId,
         );
         return (
           <ThreadListV2PendingRow
@@ -784,11 +784,11 @@ export function HomeScreen(props: HomeScreenProps) {
             projectTitle={v2ProjectTitleByProjectKey.get(pendingScopeKey)}
             environmentLabel={
               Object.keys(props.savedConnectionsById).length > 1
-                ? (props.savedConnectionsById[item.pendingTask.message.environmentId]
-                    ?.environmentLabel ?? null)
+                ? (props.savedConnectionsById[item.pendingTask.environmentId]?.environmentLabel ??
+                  null)
                 : null
             }
-            environmentMachine={machineByEnvironmentId.get(item.pendingTask.message.environmentId)}
+            environmentMachine={machineByEnvironmentId.get(item.pendingTask.environmentId)}
             showPendingDivider={item.showPendingDivider}
             showTrailingDivider={showTrailingDivider}
             onSelectPendingTask={props.onSelectPendingTask}
@@ -984,12 +984,9 @@ export function HomeScreen(props: HomeScreenProps) {
               variant="compact"
               pendingTask={item.pendingTask}
               environmentLabel={
-                props.savedConnectionsById[item.pendingTask.message.environmentId]
-                  ?.environmentLabel ?? null
+                props.savedConnectionsById[item.pendingTask.environmentId]?.environmentLabel ?? null
               }
-              environmentMachine={machineByEnvironmentId.get(
-                item.pendingTask.message.environmentId,
-              )}
+              environmentMachine={machineByEnvironmentId.get(item.pendingTask.environmentId)}
               isLast={item.isLast}
               onSelectPendingTask={props.onSelectPendingTask}
               onDeletePendingTask={props.onDeletePendingTask}

--- a/apps/mobile/src/features/home/homeListItems.ts
+++ b/apps/mobile/src/features/home/homeListItems.ts
@@ -173,7 +173,7 @@ export function buildHomeListLayout(input: {
     for (const [pendingIndex, pendingTask] of group.pendingTasks.entries()) {
       items.push({
         type: "pending-task",
-        key: `pending-task:${pendingTask.message.messageId}`,
+        key: pendingTask.key,
         pendingTask,
         isLast:
           pendingIndex === group.pendingTasks.length - 1 &&

--- a/apps/mobile/src/features/home/homeThreadList.ts
+++ b/apps/mobile/src/features/home/homeThreadList.ts
@@ -105,10 +105,8 @@ export function sortHomeProjectScopes(input: {
   }
   for (const pendingTask of input.pendingTasks) {
     recordActivity(
-      scopeKeyByProjectRef.get(
-        scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
-      ),
-      Date.parse(pendingTask.message.createdAt),
+      scopeKeyByProjectRef.get(scopedProjectKey(pendingTask.environmentId, pendingTask.projectId)),
+      Date.parse(pendingTask.createdAt),
     );
   }
 
@@ -177,7 +175,7 @@ function groupSortTimestamp(group: HomeThreadGroup, sortOrder: HomeProjectSortOr
     Number.NEGATIVE_INFINITY,
   );
   return group.pendingTasks.reduce((latest, pendingTask) => {
-    const timestamp = Date.parse(pendingTask.message.createdAt);
+    const timestamp = Date.parse(pendingTask.createdAt);
     return Number.isNaN(timestamp) ? latest : Math.max(latest, timestamp);
   }, latestThread);
 }
@@ -235,14 +233,11 @@ export function buildHomeThreadGroups(input: {
   }
 
   for (const pendingTask of input.pendingTasks ?? []) {
-    if (input.environmentId !== null && pendingTask.message.environmentId !== input.environmentId) {
+    if (input.environmentId !== null && pendingTask.environmentId !== input.environmentId) {
       continue;
     }
 
-    const physicalKey = scopedProjectKey(
-      pendingTask.message.environmentId,
-      pendingTask.creation.projectId,
-    );
+    const physicalKey = scopedProjectKey(pendingTask.environmentId, pendingTask.projectId);
     let groupKey = groupKeyByProjectKey.get(physicalKey);
     if (!groupKey) {
       // The project shell is not loaded (environment offline / project gone).
@@ -254,16 +249,15 @@ export function buildHomeThreadGroups(input: {
         key: groupKey,
         projects: [
           {
-            environmentId: pendingTask.message.environmentId,
-            id: pendingTask.creation.projectId,
-            title: pendingTask.creation.projectTitle ?? "Unknown project",
-            workspaceRoot:
-              pendingTask.creation.projectCwd ?? String(pendingTask.creation.projectId),
+            environmentId: pendingTask.environmentId,
+            id: pendingTask.projectId,
+            title: pendingTask.projectTitle ?? "Unknown project",
+            workspaceRoot: pendingTask.projectCwd ?? String(pendingTask.projectId),
             repositoryIdentity: null,
             defaultModelSelection: null,
             scripts: [],
-            createdAt: pendingTask.message.createdAt,
-            updatedAt: pendingTask.message.createdAt,
+            createdAt: pendingTask.createdAt,
+            updatedAt: pendingTask.createdAt,
           },
         ],
         pendingTasks: [],

--- a/apps/mobile/src/features/home/usePendingTaskListActions.ts
+++ b/apps/mobile/src/features/home/usePendingTaskListActions.ts
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import { Alert } from "react-native";
 
 import { removeThreadOutboxMessage } from "../../state/thread-outbox-removal";
+import { clearComposerDraftContent } from "../../state/use-composer-drafts";
 import type { PendingNewTask } from "../../state/use-pending-new-tasks";
 import { releaseEditingQueuedMessage } from "../../state/use-thread-outbox";
 
@@ -14,12 +15,16 @@ export function usePendingTaskListActions(): {
 
   const openPendingTask = useCallback(
     (pendingTask: PendingNewTask) => {
+      // A draft is the project's own new-task composer content, so opening
+      // the project's new-task screen lands on it without extra params.
       navigation.navigate("NewTaskSheet", {
         screen: "NewTaskDraft",
         params: {
-          environmentId: String(pendingTask.message.environmentId),
-          projectId: String(pendingTask.creation.projectId),
-          pendingTaskId: String(pendingTask.message.messageId),
+          environmentId: String(pendingTask.environmentId),
+          projectId: String(pendingTask.projectId),
+          ...(pendingTask.kind === "pending"
+            ? { pendingTaskId: String(pendingTask.message.messageId) }
+            : {}),
         },
       });
     },
@@ -27,6 +32,24 @@ export function usePendingTaskListActions(): {
   );
 
   const confirmDeletePendingTask = useCallback((pendingTask: PendingNewTask) => {
+    if (pendingTask.kind === "draft") {
+      Alert.alert("Discard draft?", `“${pendingTask.title}” will be removed.`, [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Discard",
+          style: "destructive",
+          onPress: () => {
+            // Same reset a submit performs: the next task in this project
+            // re-resolves project defaults instead of inheriting the pick.
+            clearComposerDraftContent(pendingTask.draftKey, {
+              clearModelSelection: true,
+              clearWorkspaceSelection: true,
+            });
+          },
+        },
+      ]);
+      return;
+    }
     Alert.alert(
       "Delete pending task?",
       `“${pendingTask.title}” has not been sent yet and will be removed from the outbox.`,

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -300,7 +300,7 @@ function ThreadNavigationSidebarPane(
           ? pendingTasks
           : pendingTasks.filter((pendingTask) =>
               selectedProjectRefs.has(
-                scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
+                scopedProjectKey(pendingTask.environmentId, pendingTask.projectId),
               ),
             ),
     [threadListV2Enabled, pendingTasks, selectedProjectRefs],
@@ -569,10 +569,10 @@ function ThreadNavigationSidebarPane(
     const v2PendingTasks = pendingTasks.filter(
       (pendingTask) =>
         (options.selectedEnvironmentId === null ||
-          pendingTask.message.environmentId === options.selectedEnvironmentId) &&
+          pendingTask.environmentId === options.selectedEnvironmentId) &&
         (selectedProjectRefs === null ||
           selectedProjectRefs.has(
-            scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
+            scopedProjectKey(pendingTask.environmentId, pendingTask.projectId),
           )) &&
         (v2SearchQuery.length === 0 ||
           pendingTask.title.toLocaleLowerCase().includes(v2SearchQuery)),
@@ -852,8 +852,8 @@ function ThreadNavigationSidebarPane(
       switch (item.type) {
         case "v2-pending": {
           const pendingScopeKey = scopedProjectKey(
-            item.pendingTask.message.environmentId,
-            item.pendingTask.creation.projectId,
+            item.pendingTask.environmentId,
+            item.pendingTask.projectId,
           );
           return (
             <ThreadListV2PendingRow
@@ -862,13 +862,10 @@ function ThreadNavigationSidebarPane(
               projectTitle={projectTitleByProjectKey.get(pendingScopeKey)}
               environmentLabel={
                 Object.keys(savedConnectionsById).length > 1
-                  ? (savedConnectionsById[item.pendingTask.message.environmentId]
-                      ?.environmentLabel ?? null)
+                  ? (savedConnectionsById[item.pendingTask.environmentId]?.environmentLabel ?? null)
                   : null
               }
-              environmentMachine={machineByEnvironmentId.get(
-                item.pendingTask.message.environmentId,
-              )}
+              environmentMachine={machineByEnvironmentId.get(item.pendingTask.environmentId)}
               pane="sidebar"
               showPendingDivider={item.showPendingDivider}
               onSelectPendingTask={openPendingTask}
@@ -1006,12 +1003,9 @@ function ThreadNavigationSidebarPane(
               variant="sidebar"
               pendingTask={item.pendingTask}
               environmentLabel={
-                savedConnectionsById[item.pendingTask.message.environmentId]?.environmentLabel ??
-                null
+                savedConnectionsById[item.pendingTask.environmentId]?.environmentLabel ?? null
               }
-              environmentMachine={machineByEnvironmentId.get(
-                item.pendingTask.message.environmentId,
-              )}
+              environmentMachine={machineByEnvironmentId.get(item.pendingTask.environmentId)}
               isLast={item.isLast}
               onSelectPendingTask={openPendingTask}
               onDeletePendingTask={confirmDeletePendingTask}

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -267,10 +267,17 @@ const PENDING_TASK_MENU_ACTIONS: MenuAction[] = [
   { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
 ];
 
+const DRAFT_TASK_MENU_ACTIONS: MenuAction[] = [
+  { id: "delete", title: "Discard", image: "trash", attributes: { destructive: true } },
+];
+
 /**
- * A queued new task waiting in the outbox for its environment to reconnect.
- * Tapping reopens the new-task composer with everything prefilled; the row
- * disappears once the task is delivered and the real thread arrives.
+ * Unsent work: a task queued in the outbox for its environment to reconnect,
+ * or a draft still sitting in the project's new-task composer. Tapping
+ * reopens the composer with everything prefilled; the row disappears once
+ * the work is sent and the real thread arrives. The two kinds differ in what
+ * happens next, so the pill and icon say which one this is: a queued task
+ * sends itself, a draft waits for the user.
  */
 export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
   readonly variant: ThreadListVariant;
@@ -284,8 +291,9 @@ export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
   const compact = props.variant === "compact";
 
   const { pendingTask, onSelectPendingTask, onDeletePendingTask } = props;
-  const timestamp = relativeTime(pendingTask.message.createdAt);
-  const subtitleParts = [props.environmentLabel, pendingTask.creation.branch].filter(
+  const isDraft = pendingTask.kind === "draft";
+  const timestamp = isDraft ? null : relativeTime(pendingTask.createdAt);
+  const subtitleParts = [props.environmentLabel, pendingTask.branch].filter(
     (part): part is string => Boolean(part),
   );
 
@@ -296,7 +304,11 @@ export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
     [onDeletePendingTask, pendingTask],
   );
 
-  const statusPill = (
+  const statusPill = isDraft ? (
+    <View className="rounded-full bg-adaptive-amber-500-a12-a16 px-1.5 py-0.5">
+      <Text className="text-3xs font-t3-bold text-adaptive-amber-700-300">Draft</Text>
+    </View>
+  ) : (
     <View className="rounded-full bg-subtle px-1.5 py-0.5">
       <Text className="text-3xs font-t3-bold text-foreground-muted">Pending</Text>
     </View>
@@ -306,7 +318,7 @@ export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
     subtitleParts.length > 0 ? (
       <View className="mt-px flex-row items-center gap-1.5">
         <SymbolView
-          name="tray.and.arrow.up"
+          name={isDraft ? "square.and.pencil" : "tray.and.arrow.up"}
           size={10}
           tintColorClassName={compact ? "accent-icon-subtle" : "accent-foreground-muted"}
           type="monochrome"
@@ -331,9 +343,13 @@ export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
       </View>
     ) : null;
 
+  const accessibilityHint = isDraft
+    ? "Opens the draft in the new task composer"
+    : "Opens the queued task for editing";
+
   const rowContent = compact ? (
     <Pressable
-      accessibilityHint="Opens the queued task for editing"
+      accessibilityHint={accessibilityHint}
       accessibilityLabel={pendingTask.title}
       accessibilityRole="button"
       className="bg-screen active:opacity-70"
@@ -347,7 +363,9 @@ export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
             </Text>
             <View className="flex-row items-center gap-2">
               {statusPill}
-              <Text className="text-base tabular-nums text-foreground-tertiary">{timestamp}</Text>
+              {timestamp !== null ? (
+                <Text className="text-base tabular-nums text-foreground-tertiary">{timestamp}</Text>
+              ) : null}
               <SymbolView
                 name="chevron.right"
                 size={13}
@@ -362,7 +380,7 @@ export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
     </Pressable>
   ) : (
     <Pressable
-      accessibilityHint="Opens the queued task for editing"
+      accessibilityHint={accessibilityHint}
       accessibilityLabel={pendingTask.title}
       accessibilityRole="button"
       className="active:bg-subtle"
@@ -383,9 +401,11 @@ export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
           </Text>
           <View className="flex-row items-center gap-2">
             {statusPill}
-            <Text className="text-xs tabular-nums text-foreground-muted" numberOfLines={1}>
-              {timestamp}
-            </Text>
+            {timestamp !== null ? (
+              <Text className="text-xs tabular-nums text-foreground-muted" numberOfLines={1}>
+                {timestamp}
+              </Text>
+            ) : null}
           </View>
         </View>
         {subtitleRow}
@@ -395,7 +415,7 @@ export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
 
   return (
     <ControlPillMenu
-      actions={PENDING_TASK_MENU_ACTIONS}
+      actions={isDraft ? DRAFT_TASK_MENU_ACTIONS : PENDING_TASK_MENU_ACTIONS}
       onPressAction={handleMenuAction}
       shouldOpenOnLongPress
     >

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -293,9 +293,13 @@ export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
   const { pendingTask, onSelectPendingTask, onDeletePendingTask } = props;
   const isDraft = pendingTask.kind === "draft";
   const timestamp = isDraft ? null : relativeTime(pendingTask.createdAt);
-  const subtitleParts = [props.environmentLabel, pendingTask.branch].filter(
-    (part): part is string => Boolean(part),
-  );
+  // The pill only has room for one word, so what happens next goes in the
+  // subtitle: a queued task sends itself, a draft waits for the user.
+  const subtitleParts = [
+    isDraft ? null : "Sends on reconnect",
+    props.environmentLabel,
+    pendingTask.branch,
+  ].filter((part): part is string => Boolean(part));
 
   const handleMenuAction = useCallback(
     ({ nativeEvent }: { readonly nativeEvent: { readonly event: string } }) => {
@@ -345,7 +349,7 @@ export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
 
   const accessibilityHint = isDraft
     ? "Opens the draft in the new task composer"
-    : "Opens the queued task for editing";
+    : "Sends when the environment reconnects. Opens the task for editing";
 
   const rowContent = compact ? (
     <Pressable

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -186,12 +186,16 @@ const PENDING_TASK_MENU_ACTIONS: MenuAction[] = [
   { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
 ];
 
+const DRAFT_TASK_MENU_ACTIONS: MenuAction[] = [
+  { id: "delete", title: "Discard", image: "trash", attributes: { destructive: true } },
+];
+
 /**
- * A queued new task, in the same idiom as an active v2 row: it is work the
- * user wrote, so it reads like the threads it will become. "Queued" takes
- * the status slot — the state is the one thing that differs — and stays
- * uncolored because nothing is asked of the user; the environment is simply
- * not reachable yet.
+ * Unsent work, in the same idiom as an active v2 row: it is work the user
+ * wrote, so it reads like the thread it will become. The status slot says
+ * what happens next. "Queued" stays uncolored because nothing is asked of
+ * the user; the environment is simply not reachable yet. "Draft" takes the
+ * amber the web sidebar uses for drafts, because this one waits on the user.
  */
 export const ThreadListV2PendingRow = memo(function ThreadListV2PendingRow(props: {
   readonly pendingTask: PendingNewTask;
@@ -201,7 +205,7 @@ export const ThreadListV2PendingRow = memo(function ThreadListV2PendingRow(props
   /** Drawn beside the label; ignored while the label is null. */
   readonly environmentMachine?: EnvironmentMachineKind;
   readonly pane?: "screen" | "sidebar";
-  /** Draws the "Pending" divider above the first queued row. */
+  /** Draws the "Unsent" divider above the first draft or queued row. */
   readonly showPendingDivider: boolean;
   /** Keeps row hairlines inside a section; section headers draw their own rule. */
   readonly showTrailingDivider?: boolean;
@@ -210,9 +214,9 @@ export const ThreadListV2PendingRow = memo(function ThreadListV2PendingRow(props
 }) {
   const { pendingTask, onSelectPendingTask, onDeletePendingTask } = props;
   const sidebarPane = props.pane === "sidebar";
-  const projectTitle =
-    props.projectTitle ?? props.project?.title ?? pendingTask.creation.projectTitle ?? "";
-  const branch = pendingTask.creation.branch;
+  const isDraft = pendingTask.kind === "draft";
+  const projectTitle = props.projectTitle ?? props.project?.title ?? pendingTask.projectTitle ?? "";
+  const branch = pendingTask.branch;
 
   const handleMenuAction = useCallback(
     ({ nativeEvent }: { readonly nativeEvent: { readonly event: string } }) => {
@@ -226,7 +230,7 @@ export const ThreadListV2PendingRow = memo(function ThreadListV2PendingRow(props
       <View className="flex-row items-center gap-1.5">
         {props.project ? (
           <ProjectFavicon
-            environmentId={pendingTask.message.environmentId}
+            environmentId={pendingTask.environmentId}
             faviconPath={props.project.faviconPath}
             size={15}
             projectTitle={projectTitle}
@@ -236,7 +240,19 @@ export const ThreadListV2PendingRow = memo(function ThreadListV2PendingRow(props
         <Text className="flex-1 text-sm font-t3-medium text-foreground-muted" numberOfLines={1}>
           {projectTitle}
         </Text>
-        <Text className="text-xs text-foreground-tertiary">Queued</Text>
+        {isDraft ? (
+          <View className="flex-row items-center gap-1">
+            <SymbolView
+              name="square.and.pencil"
+              size={10}
+              tintColorClassName="accent-adaptive-amber-700-300"
+              type="monochrome"
+            />
+            <Text className="text-xs text-adaptive-amber-700-300">Draft</Text>
+          </View>
+        ) : (
+          <Text className="text-xs text-foreground-tertiary">Queued</Text>
+        )}
       </View>
       {/* One line, unlike the two an active row allows: a queued title is
           derived from the whole prompt rather than written as a title, so the
@@ -272,15 +288,19 @@ export const ThreadListV2PendingRow = memo(function ThreadListV2PendingRow(props
   return (
     <>
       {props.showPendingDivider ? (
-        <ThreadListV2SectionDivider label="Pending" pane={props.pane} />
+        <ThreadListV2SectionDivider label="Unsent" pane={props.pane} />
       ) : null}
       <ControlPillMenu
-        actions={PENDING_TASK_MENU_ACTIONS}
+        actions={isDraft ? DRAFT_TASK_MENU_ACTIONS : PENDING_TASK_MENU_ACTIONS}
         onPressAction={handleMenuAction}
         shouldOpenOnLongPress
       >
         <Pressable
-          accessibilityHint="Opens the queued task for editing"
+          accessibilityHint={
+            isDraft
+              ? "Opens the draft in the new task composer"
+              : "Opens the queued task for editing"
+          }
           accessibilityLabel={pendingTask.title}
           accessibilityRole="button"
           className={sidebarPane ? "bg-drawer active:bg-subtle" : undefined}

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -193,9 +193,9 @@ const DRAFT_TASK_MENU_ACTIONS: MenuAction[] = [
 /**
  * Unsent work, in the same idiom as an active v2 row: it is work the user
  * wrote, so it reads like the thread it will become. The status slot says
- * what happens next. "Queued" stays uncolored because nothing is asked of
- * the user; the environment is simply not reachable yet. "Draft" takes the
- * amber the web sidebar uses for drafts, because this one waits on the user.
+ * what happens next, not where the item sits: "Sends on reconnect" stays
+ * uncolored because nothing is asked of the user; "Draft" takes the amber the
+ * web sidebar uses for drafts, because this one waits on the user.
  */
 export const ThreadListV2PendingRow = memo(function ThreadListV2PendingRow(props: {
   readonly pendingTask: PendingNewTask;
@@ -251,7 +251,7 @@ export const ThreadListV2PendingRow = memo(function ThreadListV2PendingRow(props
             <Text className="text-xs text-adaptive-amber-700-300">Draft</Text>
           </View>
         ) : (
-          <Text className="text-xs text-foreground-tertiary">Queued</Text>
+          <Text className="text-xs text-foreground-tertiary">Sends on reconnect</Text>
         )}
       </View>
       {/* One line, unlike the two an active row allows: a queued title is
@@ -299,7 +299,7 @@ export const ThreadListV2PendingRow = memo(function ThreadListV2PendingRow(props
           accessibilityHint={
             isDraft
               ? "Opens the draft in the new task composer"
-              : "Opens the queued task for editing"
+              : "Sends when the environment reconnects. Opens the task for editing"
           }
           accessibilityLabel={pendingTask.title}
           accessibilityRole="button"

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -866,7 +866,22 @@ describe("buildThreadListV2Items settled paging", () => {
 });
 
 function makePendingTask(id: string): PendingNewTask {
+  const creation = {
+    projectId: ProjectId.make("project-1"),
+    workspaceMode: "worktree" as const,
+    branch: null,
+    worktreePath: null,
+  };
   return {
+    kind: "pending",
+    key: `pending-task:${id}`,
+    environmentId,
+    projectId: creation.projectId,
+    projectTitle: undefined,
+    projectCwd: undefined,
+    branch: null,
+    title: id,
+    createdAt: NOW,
     message: {
       environmentId,
       threadId: ThreadId.make(`thread-${id}`),
@@ -875,20 +890,9 @@ function makePendingTask(id: string): PendingNewTask {
       text: id,
       attachments: [],
       createdAt: NOW,
-      creation: {
-        projectId: ProjectId.make("project-1"),
-        workspaceMode: "worktree",
-        branch: null,
-        worktreePath: null,
-      },
+      creation,
     },
-    creation: {
-      projectId: ProjectId.make("project-1"),
-      workspaceMode: "worktree",
-      branch: null,
-      worktreePath: null,
-    },
-    title: id,
+    creation,
   };
 }
 

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -298,7 +298,7 @@ export function buildThreadListV2ListItems(input: {
   }));
   const pendingItems = input.pendingTasks.map((pendingTask, index): ThreadListV2ListItem => ({
     type: "v2-pending",
-    key: `v2-pending:${pendingTask.message.messageId}`,
+    key: `v2-${pendingTask.key}`,
     pendingTask,
     showPendingDivider: index === 0,
   }));

--- a/apps/mobile/src/state/pending-new-tasks-model.test.ts
+++ b/apps/mobile/src/state/pending-new-tasks-model.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "@effect/vitest";
+import { CommandId, EnvironmentId, MessageId, ProjectId, ThreadId } from "@t3tools/contracts";
+
+import type { QueuedThreadMessage } from "./thread-outbox-model";
+import type { ComposerDraft } from "./use-composer-drafts";
+import { buildPendingNewTasks, parseNewTaskDraftKey } from "./pending-new-tasks-model";
+
+const environmentId = EnvironmentId.make("env-1");
+const projectId = ProjectId.make("project-1");
+const NOW = "2026-09-05T12:00:00.000Z";
+
+function queuedCreation(id: string, createdAt: string): QueuedThreadMessage {
+  return {
+    environmentId,
+    threadId: ThreadId.make(`thread-${id}`),
+    messageId: MessageId.make(id),
+    commandId: CommandId.make(`command-${id}`),
+    text: `queued ${id}`,
+    attachments: [],
+    createdAt,
+    creation: {
+      projectId,
+      workspaceMode: "local",
+      branch: "main",
+      worktreePath: null,
+    },
+  };
+}
+
+function draft(text: string, overrides: Partial<ComposerDraft> = {}): ComposerDraft {
+  return { text, attachments: [], ...overrides };
+}
+
+describe("parseNewTaskDraftKey", () => {
+  it("splits the environment and project ids", () => {
+    expect(parseNewTaskDraftKey(`new-task:${environmentId}:${projectId}`)).toEqual({
+      environmentId,
+      projectId,
+    });
+  });
+
+  it("ignores thread drafts and pending-task editor drafts", () => {
+    expect(parseNewTaskDraftKey(`${environmentId}:thread-1`)).toBeNull();
+    expect(parseNewTaskDraftKey("pending-task:message-1")).toBeNull();
+    expect(parseNewTaskDraftKey("new-task:")).toBeNull();
+    expect(parseNewTaskDraftKey("new-task:env-only")).toBeNull();
+  });
+});
+
+describe("buildPendingNewTasks", () => {
+  it("surfaces new-task drafts with content alongside queued creations", () => {
+    const tasks = buildPendingNewTasks({
+      queuedMessages: [queuedCreation("a", "2026-09-05T10:00:00.000Z")],
+      drafts: {
+        [`new-task:${environmentId}:${projectId}`]: draft("fix the offline outbox", {
+          workspaceSelection: { mode: "worktree", branch: "main", worktreePath: null },
+        }),
+      },
+      now: NOW,
+    });
+
+    expect(tasks.map((task) => [task.kind, task.title, task.branch])).toEqual([
+      ["draft", "fix the offline outbox", "main"],
+      ["pending", "queued a", "main"],
+    ]);
+    expect(tasks[0]).toMatchObject({
+      key: `draft-task:new-task:${environmentId}:${projectId}`,
+      environmentId,
+      projectId,
+      draftKey: `new-task:${environmentId}:${projectId}`,
+    });
+  });
+
+  it("hides settings-only drafts and drafts for other surfaces", () => {
+    const tasks = buildPendingNewTasks({
+      queuedMessages: [],
+      drafts: {
+        [`new-task:${environmentId}:${projectId}`]: draft("", {
+          modelSelection: { instanceId: "codex" as never, model: "gpt" },
+        }),
+        [`new-task:${environmentId}:${projectId}-2`]: draft("   "),
+        [`${environmentId}:thread-1`]: draft("thread composer text"),
+        "pending-task:message-1": draft("editor copy of a queued task"),
+      },
+      now: NOW,
+    });
+
+    expect(tasks).toEqual([]);
+  });
+
+  it("titles an attachment-only draft by its attachment count", () => {
+    const attachment = {
+      type: "image",
+      id: "image-1",
+      uri: "file:///image-1.png",
+      mimeType: "image/png",
+      name: "image-1.png",
+      width: 1,
+      height: 1,
+      sizeBytes: 1,
+    } as unknown as ComposerDraft["attachments"][number];
+    const tasks = buildPendingNewTasks({
+      queuedMessages: [],
+      drafts: {
+        [`new-task:${environmentId}:${projectId}`]: draft("", { attachments: [attachment] }),
+      },
+      now: NOW,
+    });
+
+    expect(tasks.map((task) => task.title)).toEqual(["1 attachment"]);
+  });
+
+  it("orders queued creations newest first and skips existing-thread messages", () => {
+    const tasks = buildPendingNewTasks({
+      queuedMessages: [
+        queuedCreation("old", "2026-09-05T08:00:00.000Z"),
+        { ...queuedCreation("follow-up", "2026-09-05T11:00:00.000Z"), creation: undefined },
+        queuedCreation("new", "2026-09-05T10:00:00.000Z"),
+      ],
+      drafts: {},
+      now: NOW,
+    });
+
+    expect(tasks.map((task) => task.title)).toEqual(["queued new", "queued old"]);
+  });
+});

--- a/apps/mobile/src/state/pending-new-tasks-model.ts
+++ b/apps/mobile/src/state/pending-new-tasks-model.ts
@@ -1,0 +1,134 @@
+import { EnvironmentId, ProjectId } from "@t3tools/contracts";
+
+import { deriveThreadTitleFromPrompt } from "../lib/projectThreadStartTurn";
+import type { QueuedThreadCreation, QueuedThreadMessage } from "./thread-outbox-model";
+import type { ComposerDraft } from "./use-composer-drafts";
+
+/**
+ * Unsent work that will become a thread, shaped for thread-list presentation.
+ * A `pending` task sits in the outbox and sends itself when its environment
+ * reconnects; a `draft` is the project's new-task composer content, which
+ * only sends when the user submits it. Both share the list slot so the user
+ * can find everything they have written but not yet started in one place.
+ */
+export type PendingNewTask = PendingQueuedTask | PendingDraftTask;
+
+export interface PendingQueuedTask {
+  readonly kind: "pending";
+  readonly key: string;
+  readonly environmentId: EnvironmentId;
+  readonly projectId: ProjectId;
+  readonly projectTitle: string | undefined;
+  readonly projectCwd: string | undefined;
+  readonly branch: string | null;
+  readonly title: string;
+  readonly createdAt: string;
+  readonly message: QueuedThreadMessage;
+  readonly creation: QueuedThreadCreation;
+}
+
+export interface PendingDraftTask {
+  readonly kind: "draft";
+  readonly key: string;
+  readonly environmentId: EnvironmentId;
+  readonly projectId: ProjectId;
+  readonly projectTitle: undefined;
+  readonly projectCwd: undefined;
+  readonly branch: string | null;
+  readonly title: string;
+  /** Drafts have no creation timestamp; they sort as current work. */
+  readonly createdAt: string;
+  readonly draftKey: string;
+  readonly draft: ComposerDraft;
+}
+
+const NEW_TASK_DRAFT_PREFIX = "new-task:";
+
+/** Parses a `new-task:<environmentId>:<projectId>` composer draft key. */
+export function parseNewTaskDraftKey(
+  draftKey: string,
+): { readonly environmentId: EnvironmentId; readonly projectId: ProjectId } | null {
+  if (!draftKey.startsWith(NEW_TASK_DRAFT_PREFIX)) {
+    return null;
+  }
+  const scope = draftKey.slice(NEW_TASK_DRAFT_PREFIX.length);
+  const separator = scope.lastIndexOf(":");
+  if (separator <= 0 || separator === scope.length - 1) {
+    return null;
+  }
+  return {
+    environmentId: EnvironmentId.make(scope.slice(0, separator)),
+    projectId: ProjectId.make(scope.slice(separator + 1)),
+  };
+}
+
+/**
+ * Settings-only drafts (a model pick with no text) are not work the user
+ * would look for in the list; only text or attachments make a draft visible.
+ */
+export function composerDraftHasUserContent(draft: ComposerDraft): boolean {
+  return draft.text.trim().length > 0 || draft.attachments.length > 0;
+}
+
+function draftTitle(draft: ComposerDraft): string {
+  if (draft.text.trim().length > 0) {
+    return deriveThreadTitleFromPrompt(draft.text);
+  }
+  const count = draft.attachments.length;
+  return count === 1 ? "1 attachment" : `${count} attachments`;
+}
+
+export function buildPendingNewTasks(input: {
+  readonly queuedMessages: ReadonlyArray<QueuedThreadMessage>;
+  readonly drafts: Readonly<Record<string, ComposerDraft>>;
+  /** ISO timestamp drafts sort by; they carry no creation time of their own. */
+  readonly now: string;
+}): ReadonlyArray<PendingNewTask> {
+  const tasks: PendingNewTask[] = [];
+  for (const message of input.queuedMessages) {
+    if (!message.creation) {
+      continue;
+    }
+    tasks.push({
+      kind: "pending",
+      key: `pending-task:${message.messageId}`,
+      environmentId: message.environmentId,
+      projectId: message.creation.projectId,
+      projectTitle: message.creation.projectTitle,
+      projectCwd: message.creation.projectCwd,
+      branch: message.creation.branch,
+      title: deriveThreadTitleFromPrompt(message.text),
+      createdAt: message.createdAt,
+      message,
+      creation: message.creation,
+    });
+  }
+  for (const [draftKey, draft] of Object.entries(input.drafts)) {
+    const ref = parseNewTaskDraftKey(draftKey);
+    if (ref === null || !composerDraftHasUserContent(draft)) {
+      continue;
+    }
+    tasks.push({
+      kind: "draft",
+      key: `draft-task:${draftKey}`,
+      environmentId: ref.environmentId,
+      projectId: ref.projectId,
+      projectTitle: undefined,
+      projectCwd: undefined,
+      branch: draft.workspaceSelection?.branch ?? null,
+      title: draftTitle(draft),
+      createdAt: input.now,
+      draftKey,
+      draft,
+    });
+  }
+  // Drafts are what the user is writing now, so they lead; queued tasks
+  // follow newest-first.
+  tasks.sort((left, right) => {
+    if (left.kind !== right.kind) {
+      return left.kind === "draft" ? -1 : 1;
+    }
+    return right.createdAt.localeCompare(left.createdAt) || left.key.localeCompare(right.key);
+  });
+  return tasks;
+}

--- a/apps/mobile/src/state/use-pending-new-tasks.ts
+++ b/apps/mobile/src/state/use-pending-new-tasks.ts
@@ -1,35 +1,29 @@
+import { useAtomValue } from "@effect/atom-react";
 import { useMemo } from "react";
 
-import { deriveThreadTitleFromPrompt } from "../lib/projectThreadStartTurn";
-import {
-  flattenQueuedThreadMessages,
-  type QueuedThreadCreation,
-  type QueuedThreadMessage,
-} from "./thread-outbox-model";
+import { buildPendingNewTasks, type PendingNewTask } from "./pending-new-tasks-model";
+import { flattenQueuedThreadMessages } from "./thread-outbox-model";
+import { composerDraftsAtom } from "./use-composer-drafts";
 import { useThreadOutboxMessages } from "./use-thread-outbox";
 
-/** A queued new-task creation, shaped for thread-list presentation. */
-export interface PendingNewTask {
-  readonly message: QueuedThreadMessage;
-  readonly creation: QueuedThreadCreation;
-  readonly title: string;
-}
+export type {
+  PendingDraftTask,
+  PendingNewTask,
+  PendingQueuedTask,
+} from "./pending-new-tasks-model";
 
 export function usePendingNewTasks(): ReadonlyArray<PendingNewTask> {
   const queuedMessagesByThreadKey = useThreadOutboxMessages();
-  return useMemo(() => {
-    const tasks: PendingNewTask[] = [];
-    for (const message of flattenQueuedThreadMessages(queuedMessagesByThreadKey)) {
-      if (!message.creation) {
-        continue;
-      }
-      tasks.push({
-        message,
-        creation: message.creation,
-        title: deriveThreadTitleFromPrompt(message.text),
-      });
-    }
-    tasks.sort((left, right) => right.message.createdAt.localeCompare(left.message.createdAt));
-    return tasks;
-  }, [queuedMessagesByThreadKey]);
+  const drafts = useAtomValue(composerDraftsAtom);
+  return useMemo(
+    () =>
+      buildPendingNewTasks({
+        queuedMessages: flattenQueuedThreadMessages(queuedMessagesByThreadKey),
+        drafts,
+        // Stamped when the inputs change, not per render, so a draft keeps one
+        // sort position while the user is not typing in it.
+        now: new Date().toISOString(),
+      }),
+    [queuedMessagesByThreadKey, drafts],
+  );
 }


### PR DESCRIPTION
Stacked on #10245.

## Problem

On mobile, text typed into a project's new-task composer is only discoverable by opening that project's new-task screen again. Nothing on Home or the iPad sidebar shows that a draft exists, so unsent work is easy to lose track of. That also made the outbox's restore path (a rejected pending task gets merged back into the project draft) feel like the task vanished: it moved from the visible Pending section into an invisible draft. Web already lists drafts at the top of its sidebar.

## Fix

`PendingNewTask` is now a union of two kinds of unsent work: `pending` (queued in the outbox, sends itself when the environment reconnects) and `draft` (the project's new-task composer content, sends only when the user submits). Only drafts with user content (text or attachments) are listed; a bare model pick is not surfaced. The pure builder lives in `pending-new-tasks-model.ts`.

Both list surfaces render drafts in the same slot as pending tasks:

- **v2 flat list** (Home and iPad sidebar): the section divider now reads **Unsent**. Drafts get an amber **Draft** label with a pen icon; queued tasks say **Sends on reconnect** in the uncolored status slot, describing what happens next rather than where the item sits.
- **v1 grouped list**: drafts get an amber **Draft** pill and pen icon. The pill has room for one word, so queued tasks keep the **Pending** pill and the subtitle leads with **Sends on reconnect**. Drafts have no timestamp since they have no creation time.

Tapping a draft opens the project's new-task composer, which already loads that draft. Long-press offers **Discard** (clears the draft, same reset a submit performs). Deleting a pending task is unchanged.

Drafts sort first (they are what the user is writing now), then queued tasks newest-first.

## Verification

`vp test run` on the touched suites in `apps/mobile`: `pending-new-tasks-model.test.ts` (new), `threadListV2.test.ts`, `homeThreadList.test.ts`, `homeListItems.test.ts`, `showcasePendingTasks.test.ts` — 73 passed. `vpr typecheck` passes. Lint on the touched files shows only pre-existing warnings (same 23 on the base branch).

### Before / after — v2 flat list (default)

![Before: only the queued task appears under Pending, labelled Queued. After: the Unsent section shows the amber Draft row above a row labelled Sends on reconnect](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/939d0274d4de30ae/drafts-v2-before-after-2.png)

### Before / after — v1 grouped list (Legacy Thread List setting)

![Before: only the Pending pill row. After: a Draft pill row with pen icon leads the group, followed by the Pending row whose subtitle reads Sends on reconnect](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/7727759335765e6c/drafts-v1-before-after-2.png)

### Tapping the draft row

![The new-task composer opens on the draft's project with the draft text loaded](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/ad82da6f085177d2/drafts-open-draft.png)

Captured on an iPhone 17 Pro simulator with the dev client, same seeded state (one draft, one queued task, one real thread) on both revisions, environment filter scoped to the test backend.

## Surfaces

- Entry points: Home list (v1 and v2), iPad `ThreadNavigationSidebar` (v1 and v2), new-task composer (open target).
- Clients: mobile only. Web already has draft rows; the server is untouched.
- Reverse state: Discard from the row menu, or clear the composer.

Model: Claude Fable 5 · Harness: Claude Code in T3 Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
