### PR TITLE
fix(web): keep settings inputs focused during IME composition

### DIFF
--- a/apps/web/src/hooks/useCommitOnBlur.ts
+++ b/apps/web/src/hooks/useCommitOnBlur.ts
@@ -34,6 +34,7 @@ export function useCommitOnBlur(value: string, onCommit: (next: string) => void)
       }
     },
     onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.nativeEvent.isComposing || event.keyCode === 229) return;
       if (event.key === "Enter") {
         event.preventDefault();
         (event.target as HTMLInputElement).blur();


### PR DESCRIPTION
## What changed

Ignore IME keydowns in `useCommitOnBlur` using the same `isComposing` / `keyCode === 229` guard already used by thread rename in #6281. Normal Enter and blur still commit changed values.

## Why

Pressing Enter to confirm an IME candidate in a settings `DraftInput` currently blurs the field and saves an unfinished value. Further typing no longer reaches the input. This affects fields such as provider display names.

The shared hook covers web and desktop settings. Mobile uses separate inputs. No provider adapters, contracts, product defaults, or diagnostic settings change.

```mermaid
flowchart LR
    A[Enter in DraftInput] --> B{IME composition?}
    B -->|Yes| C[Keep focus and draft]
    B -->|No| D[Blur]
    D --> E[Commit changed value]
```

## Verification

Tested the running app in local Chromium with synthetic IME keydown events on Settings → Providers → Display name. This does not claim a native OS IME or Safari test.

- Before: both `isComposing=true` and `isComposing=false, keyCode=229` blur and save prematurely.
- After: both retain focus and leave the saved provider label unchanged. Typing can continue.
- Normal Enter and Tab still save; the committed value survives a reload.
- Targeted lint, formatting, and hook-only TypeScript checks pass. Fallow's changed-file audit passes with no introduced findings.

## UI changes

PNG captures at 2×, immediately after the same synthetic composing Enter.

Before: focus is lost and the partial name has already replaced the provider label.

![Before: IME Enter prematurely saves the display name](https://github.com/user-attachments/assets/e6cd786c-386b-4113-b0b6-15209118d67c)

After: the input keeps focus and the provider label remains unchanged until a normal commit.

![After: IME Enter keeps focus and the unsaved draft](https://github.com/user-attachments/assets/263cf21b-f8f8-4d22-b693-9688548d1217)

Before video, typing `team` after the composing Enter is lost:

https://github.com/user-attachments/assets/a6a8c768-1e8d-4ef9-a57f-1140f80ee00d

After video, typing continues and a normal Enter saves the full name:

https://github.com/user-attachments/assets/dd2f1f7b-9cf1-416a-8909-d23b7022459f

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes
- [x] I included videos for interaction changes

Model: GPT-5. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `useCommitOnBlur` hook to ignore Enter during IME composition
> Adds an early return in [useCommitOnBlur.ts](https://github.com/pingdotgg/t3code/pull/10262/files#diff-e3476511df87a7d4e3472508373640063344dd8af303f1150bf77c3ea7dedb92) when the keyboard event is part of IME composition or uses the IME composition key code. This prevents the hook from committing and blurring the input while users are mid-composition with input methods like CJK keyboards. Non-composition Enter handling is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f7adcf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text input behavior for IME users by preventing premature commits or field blurs when confirming composed text with the Enter key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->