### PR TITLE
refactor(desktop): classify backend exports

### DIFF
--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -15,8 +15,8 @@ const repoRoot = NodePath.resolve(desktopDir, "..", "..");
 const devBundleIdSuffix = NodePath.basename(repoRoot)
   .toLowerCase()
   .replaceAll(/[^a-z0-9]+/g, "");
-export const APP_DISPLAY_NAME = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
-export const APP_BUNDLE_ID = isDevelopment
+const APP_DISPLAY_NAME = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
+const APP_BUNDLE_ID = isDevelopment
   ? `com.t3tools.t3code.dev.${devBundleIdSuffix || "local"}`
   : "com.t3tools.t3code";
 const APP_PROTOCOL_SCHEMES = isDevelopment ? ["t3code-dev"] : ["t3code"];
@@ -387,7 +387,7 @@ function resolveLinuxSandboxArgs(electronBinaryPath) {
   return ["--no-sandbox"];
 }
 
-export function resolveElectronPath() {
+function resolveElectronPath() {
   const electronBinaryPath = resolveElectronBinaryPath();
 
   if (hostPlatform !== "darwin") {

--- a/apps/desktop/src/backend/DesktopBackendConfiguration.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.ts
@@ -737,6 +737,7 @@ const resolveWslStartConfig = Effect.fn("desktop.backendConfiguration.resolveWsl
   } satisfies DesktopBackendManager.DesktopBackendStartConfig;
 });
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/desktop/src/backend/DesktopLocalEnvironmentAuth.ts
+++ b/apps/desktop/src/backend/DesktopLocalEnvironmentAuth.ts
@@ -42,6 +42,7 @@ export class DesktopLocalEnvironmentAuth extends Context.Service<
   }
 >()("@t3tools/desktop/backend/DesktopLocalEnvironmentAuth") {}
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const pool = yield* DesktopBackendPool.DesktopBackendPool;
   const httpClient = yield* HttpClient.HttpClient;

--- a/apps/desktop/src/backend/DesktopNetworkInterfaces.ts
+++ b/apps/desktop/src/backend/DesktopNetworkInterfaces.ts
@@ -39,6 +39,7 @@ export class DesktopNetworkInterfaces extends Context.Service<
   }
 >()("@t3tools/desktop/backend/DesktopNetworkInterfaces") {}
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const platform = yield* HostProcessPlatform;
   return DesktopNetworkInterfaces.of({

--- a/apps/desktop/src/backend/DesktopServerExposure.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.ts
@@ -27,7 +27,7 @@ import { resolveTailscaleAdvertisedEndpoints } from "./tailscaleEndpointProvider
 
 const TAILSCALE_STATUS_CACHE_TTL = Duration.seconds(60);
 
-export const DESKTOP_LOOPBACK_HOST = "127.0.0.1";
+const DESKTOP_LOOPBACK_HOST = "127.0.0.1";
 const DESKTOP_LAN_BIND_HOST = "0.0.0.0";
 
 interface ResolvedDesktopServerExposure {
@@ -411,6 +411,7 @@ const requiresBackendRelaunch = (previous: RuntimeState, next: RuntimeState): bo
   previous.bindHost !== next.bindHost ||
   previous.localHttpUrl !== next.localHttpUrl;
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const config = yield* DesktopConfig.DesktopConfig;
   const networkInterfaces = yield* DesktopNetworkInterfaces.DesktopNetworkInterfaces;

--- a/apps/desktop/src/backend/tailscaleEndpointProvider.ts
+++ b/apps/desktop/src/backend/tailscaleEndpointProvider.ts
@@ -14,7 +14,7 @@ import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawne
 
 import type { NetworkInterfaces } from "./DesktopNetworkInterfaces.ts";
 
-export { isTailscaleIpv4Address, parseTailscaleMagicDnsName } from "@t3tools/tailscale";
+export { parseTailscaleMagicDnsName } from "@t3tools/tailscale";
 
 const TAILSCALE_ENDPOINT_PROVIDER: AdvertisedEndpointProvider = {
   id: "tailscale",

--- a/apps/desktop/src/settings/DesktopAppSettings.ts
+++ b/apps/desktop/src/settings/DesktopAppSettings.ts
@@ -55,7 +55,7 @@ export interface DesktopSettingsChange {
   readonly changed: boolean;
 }
 
-export const DEFAULT_TAILSCALE_SERVE_PORT = 443;
+const DEFAULT_TAILSCALE_SERVE_PORT = 443;
 const MIN_MAIN_WINDOW_SIZE = {
   width: 840,
   height: 620,
@@ -450,6 +450,7 @@ const writeSettings = Effect.fn("desktop.settings.writeSettings")(function* (inp
   );
 });
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/desktop/src/settings/DesktopSavedEnvironments.ts
+++ b/apps/desktop/src/settings/DesktopSavedEnvironments.ts
@@ -9,7 +9,6 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
-import * as Ref from "effect/Ref";
 
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as ElectronSafeStorage from "../electron/ElectronSafeStorage.ts";
@@ -365,6 +364,7 @@ function decodeSecretBytes(
   );
 }
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const fileSystem = yield* FileSystem.FileSystem;
@@ -555,55 +555,3 @@ export const make = Effect.gen(function* () {
 });
 
 export const layer = Layer.effect(DesktopSavedEnvironments, make);
-
-export const layerTest = (input?: {
-  readonly records?: readonly PersistedSavedEnvironmentRecord[];
-  readonly secrets?: ReadonlyMap<string, string>;
-}) =>
-  Layer.effect(
-    DesktopSavedEnvironments,
-    Effect.gen(function* () {
-      const recordsRef = yield* Ref.make(input?.records ?? []);
-      const secretsRef = yield* Ref.make(new Map(input?.secrets ?? []));
-
-      return DesktopSavedEnvironments.of({
-        getRegistry: Ref.get(recordsRef),
-        setRegistry: (records) => Ref.set(recordsRef, records),
-        removeEnvironment: (environmentId) =>
-          Ref.update(recordsRef, (records) =>
-            records.filter((record) => record.environmentId !== environmentId),
-          ).pipe(
-            Effect.andThen(
-              Ref.update(secretsRef, (secrets) => {
-                const nextSecrets = new Map(secrets);
-                nextSecrets.delete(environmentId);
-                return nextSecrets;
-              }),
-            ),
-          ),
-        getSecret: (environmentId) =>
-          Ref.get(secretsRef).pipe(
-            Effect.map((secrets) => Option.fromNullishOr(secrets.get(environmentId))),
-          ),
-        setSecret: ({ environmentId, secret }) =>
-          Ref.get(recordsRef).pipe(
-            Effect.flatMap((records) => {
-              if (!records.some((record) => record.environmentId === environmentId)) {
-                return Effect.succeed(false);
-              }
-              return Ref.update(secretsRef, (secrets) => {
-                const nextSecrets = new Map(secrets);
-                nextSecrets.set(environmentId, secret);
-                return nextSecrets;
-              }).pipe(Effect.as(true));
-            }),
-          ),
-        removeSecret: (environmentId) =>
-          Ref.update(secretsRef, (secrets) => {
-            const nextSecrets = new Map(secrets);
-            nextSecrets.delete(environmentId);
-            return nextSecrets;
-          }),
-      });
-    }),
-  );

--- a/apps/desktop/src/telemetry/DesktopTelemetryPublisher.ts
+++ b/apps/desktop/src/telemetry/DesktopTelemetryPublisher.ts
@@ -145,6 +145,7 @@ function sampleInterval(
   return LIVE_SAMPLE_INTERVAL;
 }
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.fn("desktop.telemetryPublisher.make")(function* () {
   const electronApp = yield* ElectronApp.ElectronApp;
   const powerMonitor = yield* ElectronPowerMonitor.ElectronPowerMonitor;

--- a/apps/desktop/src/wsl/DesktopWslServerTree.ts
+++ b/apps/desktop/src/wsl/DesktopWslServerTree.ts
@@ -116,6 +116,7 @@ const copyTree = (
       }),
   );
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const fs = yield* FileSystem.FileSystem;


### PR DESCRIPTION
Desktop backend, settings, telemetry, WSL, and launcher modules had 15 unclassified runtime exports. This marks eight canonical Effect service constructors as intentional public APIs, narrows seven implementation exports, and removes an unused 53-line saved-environments test layer. Exported types and schemas remain unchanged.

This is layer 1 of 5 in the desktop Knip cleanup stack.

Verification after the full stack: desktop typecheck; desktop Knip export audit; 831 desktop tests; changed-file lint and format checks. The native libsecret test cannot start on this machine because the system libsecret-1 development package is unavailable.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tighten desktop backend export surface and document service constructors
> - Removes named exports for constants and helpers in `electron-launcher.mjs`, `DesktopServerExposure.ts`, `tailscaleEndpointProvider.ts`, and `DesktopAppSettings.ts`, keeping their internal definitions unchanged.
> - Adds API doc comments to the `.make` service construction values across the desktop backend modules.
> - Removes the in-memory `DesktopSavedEnvironments.layerTest` test layer and its mutable test-state implementations.
> - Risk: `DesktopSavedEnvironments.layerTest` removal may break out-of-tree tests that import it; in-tree tests should be updated accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe8fffa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added public API documentation across desktop backend, settings, telemetry, and WSL modules.

- **Refactor**
  - Reduced the public API surface by keeping implementation constants and internal helpers private.
  - Removed an internal test-only environment layer.
  - Limited endpoint utility re-exports to the supported parsing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->