### PR TITLE
ci(knip): enforce desktop exports

### DIFF
--- a/docs/operations/development.md
+++ b/docs/operations/development.md
@@ -74,8 +74,8 @@ Windows investigation while that suite is not a required gate.
 ### Unused code
 
 `vp run knip:check` checks unused files and dependencies across the repo, then
-unused runtime exports in `apps/web` and every internal package under `packages/`.
-CI enforces both checks.
+unused runtime exports in `apps/desktop`, `apps/web`, and every internal package under
+`packages/`. CI enforces both checks.
 Exported types and Effect schemas are allowed without consumers. The schema preprocessor
 recognizes schema types, including aliases and schema classes; functions that create or decode
 schemas remain checked. Completely unused files remain checked too.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "tc": "vp run -r --concurrency-limit 2 typecheck",
     "lint": "vp lint --report-unused-disable-directives",
     "knip": "knip --preprocessor ./scripts/knip-schemas.ts",
-    "knip:check": "knip --include files,dependencies --no-config-hints && knip --workspace apps/web --workspace packages/client-runtime --workspace packages/contracts --workspace packages/effect-acp --workspace packages/effect-codex-app-server --workspace packages/shared --workspace packages/ssh --workspace packages/tailscale --exports --preprocessor ./scripts/knip-schemas.ts --no-config-hints",
+    "knip:check": "knip --include files,dependencies --no-config-hints && knip --workspace apps/desktop --workspace apps/web --workspace packages/client-runtime --workspace packages/contracts --workspace packages/effect-acp --workspace packages/effect-codex-app-server --workspace packages/shared --workspace packages/ssh --workspace packages/tailscale --exports --preprocessor ./scripts/knip-schemas.ts --no-config-hints",
     "knip:production": "knip --production --preprocessor ./scripts/knip-schemas.ts",
     "lint:mobile": "node scripts/mobile-native-static-check.ts",
     "test": "vp run -r test",


### PR DESCRIPTION
The desktop export audit was clean locally but was not part of the long-term Knip gate. This adds apps/desktop to the runtime-export check and updates the maintainer guidance; exported types and Effect schemas remain allowed.

This is layer 5 of 5 in the desktop Knip cleanup stack.

Verification: vp run knip:check; desktop typecheck; 831 desktop tests; changed-file lint and format checks. The native libsecret test cannot start on this machine because the system libsecret-1 development package is unavailable.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `apps/desktop` to `knip:check` export coverage
> Extends the `knip:check` script in [package.json](https://github.com/pingdotgg/t3code/pull/10269/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to scan `apps/desktop` for unused runtime exports, alongside the existing `apps/web` and `packages/` workspaces. Updates the related docs in [docs/operations/development.md](https://github.com/pingdotgg/t3code/pull/10269/files#diff-d4193c695085935050d7dd7572ae2c767e26244ca27f5ae7fd015ff4c97c8ba2). Risk: any currently-unused desktop exports will now fail the Knip check in CI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fae727e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated development documentation to clarify that unused-code checks include runtime exports in the desktop application.

- **Chores**
  - Expanded the unused-code validation command to scan the desktop application alongside existing workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->