### PR TITLE
refactor(server): classify orchestration exports

### DIFF
--- a/apps/server/src/orchestration/Errors.ts
+++ b/apps/server/src/orchestration/Errors.ts
@@ -126,34 +126,11 @@ export type OrchestrationEngineError =
   | OrchestrationCommandJsonParseError
   | OrchestrationCommandDecodeError;
 
-export function toOrchestrationCommandDecodeError(error: Schema.SchemaError) {
-  return new OrchestrationCommandDecodeError({
-    issue: SchemaIssue.makeFormatterDefault()(error.issue),
-    cause: error,
-  });
-}
-
 export function toProjectorDecodeError(eventType: string) {
   return (error: Schema.SchemaError): OrchestrationProjectorDecodeError =>
     new OrchestrationProjectorDecodeError({
       eventType,
       issue: SchemaIssue.makeFormatterDefault()(error.issue),
       cause: error,
-    });
-}
-
-export function toOrchestrationJsonParseError(cause: unknown) {
-  return new OrchestrationCommandJsonParseError({
-    detail: `Failed to parse orchestration command JSON`,
-    cause,
-  });
-}
-
-export function toListenerCallbackError(listener: "read-model" | "domain-event") {
-  return (cause: unknown): OrchestrationListenerCallbackError =>
-    new OrchestrationListenerCallbackError({
-      listener,
-      detail: `Failed to invoke orchestration ${listener} listener`,
-      cause,
     });
 }

--- a/apps/server/src/orchestration/LiveStreamBudget.ts
+++ b/apps/server/src/orchestration/LiveStreamBudget.ts
@@ -6,8 +6,8 @@ import * as Exit from "effect/Exit";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 
-export const LIVE_STREAM_MAX_ITEMS = 1_000;
-export const LIVE_STREAM_MAX_SERIALIZED_BYTES = 8 * 1024 * 1024;
+const LIVE_STREAM_MAX_ITEMS = 1_000;
+const LIVE_STREAM_MAX_SERIALIZED_BYTES = 8 * 1024 * 1024;
 
 export interface RetainedLiveItem<A> {
   readonly value: A;

--- a/apps/server/src/orchestration/ThreadPullRequestReactor.ts
+++ b/apps/server/src/orchestration/ThreadPullRequestReactor.ts
@@ -77,6 +77,7 @@ export function pullRequestMatchesProject(
   );
 }
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const engine = yield* OrchestrationEngine.OrchestrationEngineService;
   const snapshots = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;

--- a/apps/server/src/orchestration/ThreadSettlementPolicy.ts
+++ b/apps/server/src/orchestration/ThreadSettlementPolicy.ts
@@ -8,7 +8,7 @@ export interface SettlementPullRequest {
 }
 
 const DAY_MS = 24 * 60 * 60 * 1_000;
-export const QUEUED_TURN_START_GRACE_MS = 2 * 60 * 1_000;
+const QUEUED_TURN_START_GRACE_MS = 2 * 60 * 1_000;
 
 function latestTimestamp(values: ReadonlyArray<string | null | undefined>): string | null {
   let latest: string | null = null;

--- a/apps/server/src/orchestration/ThreadSettlementReactor.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.ts
@@ -32,6 +32,7 @@ export class ThreadSettlementReactor extends Context.Service<
   }
 >()("t3/orchestration/ThreadSettlementReactor") {}
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const engine = yield* OrchestrationEngine.OrchestrationEngineService;
   const snapshots = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;

--- a/apps/server/src/orchestration/commandInvariants.ts
+++ b/apps/server/src/orchestration/commandInvariants.ts
@@ -25,7 +25,7 @@ function findThreadById(
   return readModel.threads.find((thread) => thread.id === threadId);
 }
 
-export function findProjectById(
+function findProjectById(
   readModel: OrchestrationReadModel,
   projectId: ProjectId,
 ): OrchestrationProject | undefined {

--- a/apps/server/src/orchestration/runtimeLayer.ts
+++ b/apps/server/src/orchestration/runtimeLayer.ts
@@ -8,16 +8,16 @@ import { OrchestrationProjectionSnapshotQueryLive } from "./Layers/ProjectionSna
 import * as ThreadBackgroundLiveness from "./ThreadBackgroundLiveness.ts";
 import * as ThreadPlanProgress from "./ThreadPlanProgress.ts";
 
-export const OrchestrationEventInfrastructureLayerLive = Layer.mergeAll(
+const OrchestrationEventInfrastructureLayerLive = Layer.mergeAll(
   OrchestrationEventStoreLive,
   OrchestrationCommandReceiptRepositoryLive,
 );
 
-export const OrchestrationProjectionPipelineLayerLive = OrchestrationProjectionPipelineLive.pipe(
+const OrchestrationProjectionPipelineLayerLive = OrchestrationProjectionPipelineLive.pipe(
   Layer.provide(OrchestrationEventStoreLive),
 );
 
-export const OrchestrationInfrastructureLayerLive = Layer.mergeAll(
+const OrchestrationInfrastructureLayerLive = Layer.mergeAll(
   OrchestrationProjectionSnapshotQueryLive,
   OrchestrationEventInfrastructureLayerLive,
   OrchestrationProjectionPipelineLayerLive,


### PR DESCRIPTION
Orchestration modules had 11 unclassified runtime exports. This keeps the ThreadSettlementReactor service constructor public, narrows seven implementation values, and deletes three unused error adapters without changing command, event, or projection contracts.

This is layer 2 of 9 in the server Knip cleanup stack.

The reactor constructor added on main uses the same explicit `@public` annotation.

Verification after rebasing onto current main: server typecheck and the server-only Knip export audit pass. Changed-file lint and formatting pass, with one existing lint warning. Focused auth, provider, source-control, preview toolkit, orchestration, and Knip preprocessor tests pass: 90 tests across 9 files. This changes server export visibility and static analysis; screenshots do not apply.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Reduced the public surface of orchestration internals by making implementation details private.
  - Removed several internal error-construction helpers from the public API.
  - Kept orchestration behavior and budget limits unchanged.
  - No user-facing behavior changes.

- **Documentation**
  - Clarified which orchestration service construction APIs are public.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->