### PR TITLE
refactor(server): classify provider exports

### DIFF
--- a/apps/server/src/provider/ClaudeModelCatalog.ts
+++ b/apps/server/src/provider/ClaudeModelCatalog.ts
@@ -118,7 +118,7 @@ export function scopeClaudeModelCatalog(
   return { models: [...builtInModels, ...customCatalogModels] };
 }
 
-export function resolveClaudeCatalogModel(
+function resolveClaudeCatalogModel(
   catalog: ClaudeModelCatalog,
   slugOrAlias: string | null | undefined,
 ): ClaudeCatalogModel | undefined {
@@ -215,7 +215,7 @@ export function isClaudeCatalogUltracodeEffort(effort: string | null | undefined
   return effort === "ultracode";
 }
 
-export function resolveClaudeCatalogContextWindow(
+function resolveClaudeCatalogContextWindow(
   catalog: ClaudeModelCatalog,
   modelSelection: ModelSelection | undefined,
 ): string | undefined {

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -104,7 +104,7 @@ function parseSkillFrontmatter(contents: string): SkillFrontmatter {
  * user and project one. Absent on almost every machine, which is why a missing
  * file is the normal case rather than an error.
  */
-export function claudeManagedSettingsPath(
+function claudeManagedSettingsPath(
   path: Path.Path,
   platform: NodeJS.Platform,
   environment: NodeJS.ProcessEnv,

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
@@ -80,13 +80,6 @@ export const ProviderAdapterRegistryLive = Layer.effect(
   makeProviderAdapterRegistry(),
 );
 
-// Exposed for tests that want to build a facade over a pre-assembled
-// `ProviderInstanceRegistry` without pulling in the whole boot graph.
-export { makeProviderAdapterRegistry };
-
-// Re-export for consumers that need the accessor shape. The service tag
-// itself lives in `Services/ProviderAdapterRegistry.ts`.
-export { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
 // Re-export for consumers (including tests) that construct a
 // `ProviderInstanceId` before calling `getByInstance`.
 export { ProviderInstanceId };

--- a/apps/server/src/provider/Layers/ProviderEventLoggers.ts
+++ b/apps/server/src/provider/Layers/ProviderEventLoggers.ts
@@ -61,6 +61,8 @@ export const NoOpProviderEventLoggers: ProviderEventLoggers["Service"] = {
 /**
  * Builds both stream views over one shared store. Setup failures are logged
  * and downgraded to the no-op service so diagnostics never block startup.
+ *
+ * @public Service construction is part of the canonical Effect module API.
  */
 export const make = Effect.gen(function* () {
   const { providerEventLogPath } = yield* ServerConfig;

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
@@ -33,7 +33,6 @@
  * @module provider/Layers/ProviderInstanceRegistryLive
  */
 import {
-  defaultInstanceIdForDriver,
   providerInstanceConfigEnabledFlag,
   ProviderInstanceId,
   type ProviderInstanceConfig,
@@ -430,5 +429,3 @@ export const ProviderInstanceRegistryMutableLayer = <R>(input: {
       ),
     ),
   ) as Layer.Layer<ProviderInstanceRegistry | ProviderInstanceRegistryMutator, never, R>;
-
-export { defaultInstanceIdForDriver };

--- a/apps/server/src/provider/Layers/codexLaunchArgs.ts
+++ b/apps/server/src/provider/Layers/codexLaunchArgs.ts
@@ -1,14 +1,13 @@
 import { tokenizeCliArgs } from "@t3tools/shared/cliArgs";
 
-export const T3CODE_CODEX_LAUNCH_ARGS_ENV = "T3CODE_CODEX_LAUNCH_ARGS";
+const T3CODE_CODEX_LAUNCH_ARGS_ENV = "T3CODE_CODEX_LAUNCH_ARGS";
 
 export const resolveCodexLaunchArgs = (
   launchArgs?: string,
   environment: NodeJS.ProcessEnv = process.env,
 ) => environment[T3CODE_CODEX_LAUNCH_ARGS_ENV]?.trim() || launchArgs?.trim() || "";
 
-export const codexLaunchArgv = (launchArgs?: string): ReadonlyArray<string> =>
-  tokenizeCliArgs(launchArgs);
+const codexLaunchArgv = (launchArgs?: string): ReadonlyArray<string> => tokenizeCliArgs(launchArgs);
 
 export const codexAppServerArgs = (launchArgs?: string) => [
   "app-server",

--- a/apps/server/src/provider/Layers/codexResetCredit.ts
+++ b/apps/server/src/provider/Layers/codexResetCredit.ts
@@ -45,6 +45,7 @@ export class CodexResetCreditCoordinator extends Context.Service<
   }
 >()("t3/provider/Layers/codexResetCredit/CodexResetCreditCoordinator") {}
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const crypto = yield* Crypto.Crypto;
   const statesRef = yield* Ref.make<ReadonlyMap<string, AccountRedemptionState>>(new Map());

--- a/apps/server/src/provider/Layers/codexUsageLimits.ts
+++ b/apps/server/src/provider/Layers/codexUsageLimits.ts
@@ -67,7 +67,7 @@ function labelForKind(kind: ServerProviderUsageWindow["kind"]): string {
  * `windowDurationMins`; when it does not, paid plans expose the 5-hour and
  * weekly pair and Free/Go expose one monthly allowance.
  */
-export function codexRateLimitsToWindows(
+function codexRateLimitsToWindows(
   snapshot: CodexRateLimitSnapshot,
 ): ReadonlyArray<ServerProviderUsageWindow> {
   // Show the main allowance only. Model-specific notifications (such as Spark)

--- a/apps/server/src/provider/ModelManifest.ts
+++ b/apps/server/src/provider/ModelManifest.ts
@@ -207,7 +207,7 @@ export const encodeManifestCache = Schema.encodeEffect(
 );
 
 /** True when the manifest classifies `slug` as legacy for `driverKind`. */
-export function isLegacyModel(
+function isLegacyModel(
   manifest: ModelManifestData,
   driverKind: ProviderDriverKind,
   slug: string,
@@ -310,8 +310,8 @@ export class ModelManifest extends Context.Service<
   }
 >()("t3/provider/ModelManifest") {}
 
-/** Constant service for tests and callers that only need the bundled data. */
-export const BundledOnlyModelManifest: ModelManifest["Service"] = {
+/** Constant service backing the bundled-data test layer. */
+const BundledOnlyModelManifest: ModelManifest["Service"] = {
   current: Effect.succeed(BUNDLED_MODEL_MANIFEST),
   refresh: Effect.succeed(BUNDLED_MODEL_MANIFEST),
   refreshInBackground: Effect.void,

--- a/apps/server/src/provider/OpenCodeServerOwner.ts
+++ b/apps/server/src/provider/OpenCodeServerOwner.ts
@@ -8,7 +8,7 @@ import * as Semaphore from "effect/Semaphore";
 
 import * as OpenCodeRuntime from "./opencodeRuntime.ts";
 
-export const OPENCODE_SERVER_IDLE_TTL = "30 seconds";
+const OPENCODE_SERVER_IDLE_TTL = "30 seconds";
 
 interface OpenCodeServerOwnerState {
   server: OpenCodeRuntime.OpenCodeServerProcess | null;
@@ -176,6 +176,7 @@ export const make = Effect.fn("OpenCodeServerOwner.make")(function* (input: {
   });
 });
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const layer = (input: {
   readonly binaryPath: string;
   readonly directory: string;

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.ts
@@ -181,7 +181,7 @@ const AUDIO_MIME_TYPES = new Set([
   "audio/x-wav",
   "audio/webm",
 ]);
-export const ANTIGRAVITY_MAX_AUDIO_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+const ANTIGRAVITY_MAX_AUDIO_ATTACHMENT_BYTES = 20 * 1024 * 1024;
 const TEXT_MIME_TYPES = new Set([
   "application/json",
   "application/ld+json",

--- a/apps/server/src/provider/acp/AntigravityProtocol.ts
+++ b/apps/server/src/provider/acp/AntigravityProtocol.ts
@@ -72,9 +72,7 @@ const decodeSecurityWarning = Schema.decodeUnknownOption(
  * The agent marks "Allow Always" on shell and web tools with a prompt injection
  * warning in `_meta`. Surface it as option text so both clients can show it.
  */
-export function antigravitySecurityWarning(
-  option: EffectAcpSchema.PermissionOption,
-): string | undefined {
+function antigravitySecurityWarning(option: EffectAcpSchema.PermissionOption): string | undefined {
   const meta = option._meta;
   if (!Predicate.isObject(meta)) return undefined;
   const warning = Option.getOrUndefined(decodeSecurityWarning(meta[SECURITY_WARNING_META_KEY]));

--- a/apps/server/src/provider/antigravityRelease.ts
+++ b/apps/server/src/provider/antigravityRelease.ts
@@ -1,4 +1,4 @@
-export const ANTIGRAVITY_RELEASE_VERSION = "agy_acp_server_1.1.1";
+const ANTIGRAVITY_RELEASE_VERSION = "agy_acp_server_1.1.1";
 
 export interface AntigravityReleaseAsset {
   readonly version: string;

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -438,9 +438,9 @@ export function openCodeQuestionId(
  * puts in the prompt.
  */
 const OPENCODE_NATIVE_IMAGE_MIMES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
-export const OPENCODE_NATIVE_FILE_PART_MAX_BYTES = 20 * 1024 * 1024;
+const OPENCODE_NATIVE_FILE_PART_MAX_BYTES = 20 * 1024 * 1024;
 
-export function isOpenCodeNativeFilePart(input: {
+function isOpenCodeNativeFilePart(input: {
   readonly mimeType: string;
   readonly sizeBytes: number;
 }): boolean {

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -33,7 +33,7 @@ const PROVIDER_UPDATE_ACTION_TOAST_MESSAGE = "Install the update now or review p
  * move on their own, so this mostly bounds how stale a Homebrew "latest" can
  * get; the npm registry check keeps its own cache.
  */
-export const MAINTENANCE_CAPABILITIES_CACHE_TTL = Duration.hours(1);
+const MAINTENANCE_CAPABILITIES_CACHE_TTL = Duration.hours(1);
 
 const compactEnv = (input: Record<string, Option.Option<string>>): NodeJS.ProcessEnv =>
   Object.fromEntries(
@@ -348,7 +348,7 @@ const runHomebrew = Effect.fn("runHomebrew")(function* (
  * owns that path; anything unproven stays manual-only so T3 Code never runs
  * a package manager against an install it did not create.
  */
-export const resolvePackageManagedProviderMaintenance = Effect.fn(
+const resolvePackageManagedProviderMaintenance = Effect.fn(
   "resolvePackageManagedProviderMaintenance",
 )(function* (
   definition: PackageManagedProviderMaintenanceDefinition,

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -348,7 +348,7 @@ const runHomebrew = Effect.fn("runHomebrew")(function* (
  * owns that path; anything unproven stays manual-only so T3 Code never runs
  * a package manager against an install it did not create.
  */
-const resolvePackageManagedProviderMaintenance = Effect.fn(
+export const resolvePackageManagedProviderMaintenance = Effect.fn(
   "resolvePackageManagedProviderMaintenance",
 )(function* (
   definition: PackageManagedProviderMaintenanceDefinition,

--- a/apps/server/src/provider/providerMaintenanceRunner.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.ts
@@ -211,6 +211,7 @@ function makeUpdateState(input: {
   };
 }
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
   const providerRegistry = yield* ProviderRegistry;
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -105,42 +105,6 @@ export const spawnAndCollect = (binaryPath: string, command: ChildProcess.Comman
     return result;
   }).pipe(Effect.scoped);
 
-export function detailFromResult(
-  result: CommandResult & { readonly timedOut?: boolean },
-): string | undefined {
-  if (result.timedOut) return "Timed out while running command.";
-  const stderr = nonEmptyTrimmed(result.stderr);
-  if (stderr) return stderr;
-  const stdout = nonEmptyTrimmed(result.stdout);
-  if (stdout) return stdout;
-  if (result.code !== 0) {
-    return `Command exited with code ${result.code}.`;
-  }
-  return undefined;
-}
-
-export function extractAuthBoolean(value: unknown): boolean | undefined {
-  if (globalThis.Array.isArray(value)) {
-    for (const entry of value) {
-      const nested = extractAuthBoolean(entry);
-      if (nested !== undefined) return nested;
-    }
-    return undefined;
-  }
-
-  if (!value || typeof value !== "object") return undefined;
-
-  const record = value as Record<string, unknown>;
-  for (const key of ["authenticated", "isAuthenticated", "loggedIn", "isLoggedIn"] as const) {
-    if (typeof record[key] === "boolean") return record[key];
-  }
-  for (const key of ["auth", "status", "session", "account"] as const) {
-    const nested = extractAuthBoolean(record[key]);
-    if (nested !== undefined) return nested;
-  }
-  return undefined;
-}
-
 export function parseGenericCliVersion(output: string): string | null {
   const match = output.match(/\b(\d+\.\d+\.\d+)\b/);
   return match?.[1] ?? null;

--- a/apps/server/src/provider/providerUpdateSettings.ts
+++ b/apps/server/src/provider/providerUpdateSettings.ts
@@ -10,7 +10,7 @@ export interface ProviderSnapshotSettings<Settings> {
   readonly enableProviderUpdateChecks: boolean;
 }
 
-export function makeProviderSnapshotSettings<Settings>(
+function makeProviderSnapshotSettings<Settings>(
   provider: Settings,
   settings: ServerSettings,
 ): ProviderSnapshotSettings<Settings> {

--- a/apps/server/src/provider/testUtils/providerRegistryMock.ts
+++ b/apps/server/src/provider/testUtils/providerRegistryMock.ts
@@ -5,7 +5,7 @@ import * as Layer from "effect/Layer";
 import * as Stream from "effect/Stream";
 import { makeManualOnlyProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
 
-export const makeProviderRegistryMock = (
+const makeProviderRegistryMock = (
   providers: ReadonlyArray<ServerProvider> = [],
 ): ProviderRegistryShape => ({
   getProviders: Effect.succeed(providers),


### PR DESCRIPTION
Provider modules had 27 unclassified runtime exports. This marks four canonical Effect construction APIs as intentionally public, narrows implementation-only constants and helpers, removes redundant re-exports, and deletes two unused provider snapshot parsers.

This is layer 5 of 9 in the server Knip cleanup stack.

The maintenance helper remains exported because current main imports it in behavior tests.

Verification after rebasing onto current main: server typecheck and the server-only Knip export audit pass. Changed-file lint and formatting pass, with one existing lint warning. Focused auth, provider, source-control, preview toolkit, orchestration, and Knip preprocessor tests pass: 90 tests across 9 files. This changes server export visibility and static analysis; screenshots do not apply.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reduced the publicly accessible surface of provider integrations and internal helpers by making implementation details private.
  - Removed several internal utilities and re-exports that were not intended for external use.
  - Existing provider behavior remains unchanged.

- **Documentation**
  - Added and updated API documentation for service construction and bundled-data support.
  - Clarified public API annotations for select provider services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->