### PR TITLE
refactor(server): classify source control exports

### DIFF
--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
@@ -261,6 +261,7 @@ function isReviewerName(value: string): boolean {
   return name.length > 0 && !name.startsWith("-");
 }
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const azure = yield* AzureDevOpsCli.AzureDevOpsCli;
 

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
@@ -378,6 +378,7 @@ function bitbucketReviewPosition(
   }
 }
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const bitbucket = yield* BitbucketApi.BitbucketApi;
 

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -714,7 +714,7 @@ export class GitHubPullRequestCli extends Context.Service<
  * The host is not read off the identity: it travels alongside it, because the identity a
  * project records is the path below its host and never names the host itself.
  */
-export function parseRepositorySelector(value: string): {
+function parseRepositorySelector(value: string): {
   readonly owner: string;
   readonly name: string;
 } {
@@ -980,6 +980,7 @@ function actionArgs(
   }
 }
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const github = yield* GitHubCli.GitHubCli;
   const graphQlBudget = yield* GitHubGraphQlBudget.GitHubGraphQlBudget;

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.ts
@@ -511,6 +511,7 @@ function actionArgs(
   }
 }
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const gitlab = yield* GitLabCli.GitLabCli;
 

--- a/apps/server/src/pullRequest/PullRequestProviderRegistry.ts
+++ b/apps/server/src/pullRequest/PullRequestProviderRegistry.ts
@@ -41,6 +41,8 @@ export function fromProviders(
 /**
  * The hosts this build can read change requests from. A host with no entry here still shows up
  * in the provider list as unimplemented, so its projects are explained rather than missing.
+ *
+ * @public Service construction is part of the canonical Effect module API.
  */
 export const make = Effect.map(
   Effect.all([

--- a/apps/server/src/sourceControl/AzureDevOpsCli.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.ts
@@ -203,8 +203,6 @@ export const AzureDevOpsCliError = Schema.Union([
 ]);
 export type AzureDevOpsCliError = typeof AzureDevOpsCliError.Type;
 
-export const isAzureDevOpsCliError = Schema.is(AzureDevOpsCliError);
-
 export interface AzureDevOpsRepositoryCloneUrls {
   readonly nameWithOwner: string;
   readonly url: string;
@@ -352,6 +350,7 @@ function decodeAzureDevOpsJson<S extends Schema.Top>(
   );
 }
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const process = yield* VcsProcess.VcsProcess;
 

--- a/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
@@ -1,5 +1,4 @@
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 import { SourceControlProviderError, type ChangeRequest } from "@t3tools/contracts";
 
 import * as AzureDevOpsCli from "./AzureDevOpsCli.ts";
@@ -235,5 +234,3 @@ export const make = Effect.gen(function* () {
         ),
   });
 });
-
-export const layer = Layer.effect(SourceControlProvider.SourceControlProvider, make);

--- a/apps/server/src/sourceControl/BitbucketApi.ts
+++ b/apps/server/src/sourceControl/BitbucketApi.ts
@@ -262,7 +262,7 @@ export const BitbucketApiError = Schema.Union([
   BitbucketCheckoutError,
 ]);
 export type BitbucketApiError = typeof BitbucketApiError.Type;
-export const isBitbucketApiError = Schema.is(BitbucketApiError);
+const isBitbucketApiError = Schema.is(BitbucketApiError);
 
 const RawBitbucketRepositorySchema = Schema.Struct({
   full_name: TrimmedNonEmptyString,
@@ -606,6 +606,7 @@ function responseError(
   });
 }
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const config = yield* BitbucketApiEnvConfig;
   const httpClient = yield* HttpClient.HttpClient;

--- a/apps/server/src/sourceControl/BitbucketSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/BitbucketSourceControlProvider.ts
@@ -1,5 +1,4 @@
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import { SourceControlProviderError, type ChangeRequest } from "@t3tools/contracts";
 
@@ -185,8 +184,6 @@ export const make = Effect.gen(function* () {
         ),
   });
 });
-
-export const layer = Layer.effect(SourceControlProvider.SourceControlProvider, make);
 
 export const makeDiscovery = Effect.gen(function* () {
   const bitbucket = yield* BitbucketApi.BitbucketApi;

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -338,6 +338,7 @@ function deriveRepositoryCloneUrlsFromCreateOutput(
   };
 }
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const process = yield* VcsProcess.VcsProcess;
 

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -1,6 +1,5 @@
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Result from "effect/Result";
 import {
@@ -322,5 +321,3 @@ export const make = Effect.gen(function* () {
       ),
   });
 });
-
-export const layer = Layer.effect(SourceControlProvider.SourceControlProvider, make);

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -237,7 +237,6 @@ export const GitLabCliError = Schema.Union([
   GitLabNamespaceDecodeError,
 ]);
 export type GitLabCliError = typeof GitLabCliError.Type;
-export const isGitLabCliError = Schema.is(GitLabCliError);
 
 export interface GitLabMergeRequestSummary {
   readonly number: number;
@@ -409,6 +408,7 @@ function parseRepositoryPath(repository: string): {
   return { namespacePath, projectPath };
 }
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const process = yield* VcsProcess.VcsProcess;
 

--- a/apps/server/src/sourceControl/GitLabSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitLabSourceControlProvider.ts
@@ -1,5 +1,4 @@
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import { SourceControlProviderError, type ChangeRequest } from "@t3tools/contracts";
 
@@ -250,5 +249,3 @@ export const make = Effect.gen(function* () {
       ),
   });
 });
-
-export const layer = Layer.effect(SourceControlProvider.SourceControlProvider, make);

--- a/apps/server/src/sourceControl/SourceControlDiscovery.ts
+++ b/apps/server/src/sourceControl/SourceControlDiscovery.ts
@@ -64,6 +64,7 @@ export class SourceControlDiscovery extends Context.Service<
   }
 >()("t3/sourceControl/SourceControlDiscovery") {}
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const config = yield* ServerConfig;
   const process = yield* VcsProcess.VcsProcess;

--- a/apps/server/src/sourceControl/SourceControlProvider.ts
+++ b/apps/server/src/sourceControl/SourceControlProvider.ts
@@ -61,7 +61,7 @@ export function parseSourceControlOwnerRef(
   return owner && refName ? { owner, refName } : undefined;
 }
 
-export function normalizeSourceBranch(headSelector: string): string {
+function normalizeSourceBranch(headSelector: string): string {
   return parseSourceControlOwnerRef(headSelector)?.refName ?? headSelector.trim();
 }
 

--- a/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
@@ -115,7 +115,7 @@ export function providerAuth(input: {
   };
 }
 
-export function unknownAuth(detail?: string): SourceControlProviderAuth {
+function unknownAuth(detail?: string): SourceControlProviderAuth {
   return providerAuth({ status: "unknown", detail });
 }
 

--- a/apps/server/src/sourceControl/SourceControlRateLimit.ts
+++ b/apps/server/src/sourceControl/SourceControlRateLimit.ts
@@ -82,6 +82,7 @@ export function retryAtFromHeader(value: string | undefined, now: number): numbe
   return Number.isFinite(retryAt) && retryAt > now ? retryAt : undefined;
 }
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const entries = yield* Ref.make<ReadonlyMap<string, RateLimitEntry>>(new Map());
 

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -77,6 +77,7 @@ function selectRemoteUrl(
   }
 }
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const config = yield* ServerConfig;
   const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/sourceControl/azureDevOpsPullRequests.ts
+++ b/apps/server/src/sourceControl/azureDevOpsPullRequests.ts
@@ -5,7 +5,7 @@ import * as Option from "effect/Option";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import { PositiveInt, TrimmedNonEmptyString } from "@t3tools/contracts";
-import { decodeJsonResult, formatSchemaError } from "@t3tools/shared/schemaJson";
+import { decodeJsonResult } from "@t3tools/shared/schemaJson";
 
 export interface NormalizedAzureDevOpsPullRequestRecord {
   readonly number: number;
@@ -189,8 +189,6 @@ function normalizeAzureDevOpsPullRequestRecord(
 const decodeAzureDevOpsPullRequestList = decodeJsonResult(Schema.Array(Schema.Unknown));
 const decodeAzureDevOpsPullRequest = decodeJsonResult(AzureDevOpsPullRequestSchema);
 const decodeAzureDevOpsPullRequestEntry = Schema.decodeUnknownExit(AzureDevOpsPullRequestSchema);
-
-export const formatAzureDevOpsJsonDecodeError = formatSchemaError;
 
 export function decodeAzureDevOpsPullRequestListJson(
   raw: string,

--- a/apps/server/src/sourceControl/gitHubPullRequests.ts
+++ b/apps/server/src/sourceControl/gitHubPullRequests.ts
@@ -5,7 +5,7 @@ import * as Option from "effect/Option";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import { PositiveInt, TrimmedNonEmptyString } from "@t3tools/contracts";
-import { decodeJsonResult, formatSchemaError } from "@t3tools/shared/schemaJson";
+import { decodeJsonResult } from "@t3tools/shared/schemaJson";
 
 export interface NormalizedGitHubPullRequestRecord {
   readonly number: number;
@@ -113,8 +113,6 @@ function normalizeGitHubPullRequestRecord(
 const decodeGitHubPullRequestList = decodeJsonResult(Schema.Array(Schema.Unknown));
 const decodeGitHubPullRequest = decodeJsonResult(GitHubPullRequestSchema);
 const decodeGitHubPullRequestEntry = Schema.decodeUnknownExit(GitHubPullRequestSchema);
-
-export const formatGitHubJsonDecodeError = formatSchemaError;
 
 export function decodeGitHubPullRequestListJson(
   raw: string,

--- a/apps/server/src/sourceControl/gitLabMergeRequests.ts
+++ b/apps/server/src/sourceControl/gitLabMergeRequests.ts
@@ -5,7 +5,7 @@ import * as Option from "effect/Option";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import { PositiveInt, TrimmedNonEmptyString } from "@t3tools/contracts";
-import { decodeJsonResult, formatSchemaError } from "@t3tools/shared/schemaJson";
+import { decodeJsonResult } from "@t3tools/shared/schemaJson";
 
 export interface NormalizedGitLabMergeRequestRecord {
   readonly number: number;
@@ -128,8 +128,6 @@ function normalizeGitLabMergeRequestRecord(
 const decodeGitLabMergeRequestList = decodeJsonResult(Schema.Array(Schema.Unknown));
 const decodeGitLabMergeRequest = decodeJsonResult(GitLabMergeRequestSchema);
 const decodeGitLabMergeRequestEntry = Schema.decodeUnknownExit(GitLabMergeRequestSchema);
-
-export const formatGitLabJsonDecodeError = formatSchemaError;
 
 export function decodeGitLabMergeRequestListJson(
   raw: string,

--- a/apps/server/src/sourceControl/githubGraphQlBudget.ts
+++ b/apps/server/src/sourceControl/githubGraphQlBudget.ts
@@ -77,6 +77,7 @@ function withRateLimit(document: string): string {
   return `${document.slice(0, end)}\n  ${RATE_LIMIT_SELECTION}\n${document.slice(end)}`;
 }
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const snapshots = yield* Ref.make<ReadonlyMap<string, GraphQlBudgetSnapshot>>(new Map());
 


### PR DESCRIPTION
Source-control and pull-request modules had 26 unclassified runtime exports. This marks 13 canonical Effect service constructors as intentionally public, narrows local parsing and formatting helpers, and removes four redundant generic provider layers whose modules do not own the service tag.

This is layer 6 of 9 in the server Knip cleanup stack.

Verification after rebasing onto current main: server typecheck and the server-only Knip export audit pass. Changed-file lint and formatting pass, with one existing lint warning. Focused auth, provider, source-control, preview toolkit, orchestration, and Knip preprocessor tests pass: 90 tests across 9 files. This changes server export visibility and static analysis; screenshots do not apply.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added public API documentation for service construction across source control and pull request integrations.
  - Clarified which service entry points are intended for public use.

- **Refactor**
  - Removed unused helper exports, error-formatting aliases, and prebuilt provider layers.
  - Internalized implementation details while preserving source control operations, decoding behavior, and runtime functionality.
  - Reduced the publicly exposed API surface for implementation-only utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->