### PR TITLE
refactor(server): classify source control registry API

### DIFF
--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
@@ -194,6 +194,7 @@ function bindProviderContext(
   });
 }
 
+/** @public Service construction is part of the canonical Effect module API. */
 export const makeWithProviders = Effect.fn("makeSourceControlProviderRegistryWithProviders")(
   function* (registrations: ReadonlyArray<SourceControlProviderRegistration>) {
     const config = yield* ServerConfig;


### PR DESCRIPTION
The source-control registry's alternate constructor is part of the module-owned Effect service API even though the runtime currently uses the default constructor. This marks it explicitly public so Knip preserves the construction seam without a broad ignore.

This is layer 7 of 9 in the server Knip cleanup stack.

Verification after rebasing onto current main: server typecheck and the server-only Knip export audit pass. Changed-file lint and formatting pass, with one existing lint warning. Focused auth, provider, source-control, preview toolkit, orchestration, and Knip preprocessor tests pass: 90 tests across 9 files. This changes server export visibility and static analysis; screenshots do not apply.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added public API documentation for service construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tighten module exports and add API docs to `sourceControl` services
> - Removes `export` from many internal helpers, constants, error guards, and factory functions across the server, making them module-private. The public service constructors and manifest exports remain.
> - Adds public API documentation annotations to Effect service constructors throughout `apps/server/src`, especially in `sourceControl` provider and registry modules.
> - Removes unused `Layer` imports and the exported layer wrappers in `AzureDevOpsSourceControlProvider.ts`, `BitbucketSourceControlProvider.ts`, `GitHubSourceControlProvider.ts`, and `GitLabSourceControlProvider.ts`; the provider constructors themselves remain exported.
> - Removes `formatSchemaError` imports and the exported `format*JsonDecodeError` aliases in the Azure DevOps, GitHub, and GitLab pull-request JSON helper modules.
> - Risk: consumers importing any of the now-private symbols (e.g. `defaultTextGenerationPolicy`, `makeServerLayer`, `isGitLabCliError`, `defaultInstanceIdForDriver`) will fail to compile. All in-tree references are updated, but out-of-tree or downstream code relying on these exports will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b0e2bc4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->