### PR TITLE
refactor(server): classify preview toolkit exports

### DIFF
--- a/apps/server/src/mcp/toolkits/preview/handlers.ts
+++ b/apps/server/src/mcp/toolkits/preview/handlers.ts
@@ -200,5 +200,3 @@ export const PreviewStandardToolkitHandlersLive = PreviewStandardToolkit.toLayer
 export const PreviewSnapshotToolkitHandlersLive = PreviewSnapshotToolkit.toLayer({
   preview_snapshot,
 });
-
-export const PreviewToolkitHandlersLive = PreviewToolkit.toLayer(handlers);

--- a/apps/server/src/mcp/toolkits/preview/tools.ts
+++ b/apps/server/src/mcp/toolkits/preview/tools.ts
@@ -47,7 +47,7 @@ const safeBrowserTool = <T extends Tool.Any>(tool: T): T =>
 const readonlyBrowserTool = <T extends Tool.Any>(tool: T): T =>
   safeBrowserTool(tool).annotate(Tool.Readonly, true).annotate(Tool.Idempotent, true) as T;
 
-export const PreviewStatusTool = Tool.make("preview_status", {
+const PreviewStatusTool = Tool.make("preview_status", {
   description:
     "Report whether a collaborative browser tab is automation-capable, including its URL, title, visibility, loading state, viewport mode, and measured CSS-pixel size. Pass tabId to inspect a specific tab; omit it to use this agent session's current tab.",
   parameters: PreviewAutomationTabTargetInput,
@@ -60,7 +60,7 @@ export const PreviewStatusTool = Tool.make("preview_status", {
   .annotate(Tool.Destructive, false)
   .annotate(Tool.Idempotent, true);
 
-export const PreviewOpenTool = browserTool(
+const PreviewOpenTool = browserTool(
   Tool.make("preview_open", {
     description:
       "Initialize a collaborative browser tab and open its thread-bound inline preview by default. Set open=false for background-only automation. Pass tabId to reuse a specific existing tab, set reuseExistingTab=false to create another tab, or omit both to use this agent session's current tab.",
@@ -73,7 +73,7 @@ export const PreviewOpenTool = browserTool(
     .annotate(Tool.Destructive, false),
 );
 
-export const PreviewNavigateTool = safeBrowserTool(
+const PreviewNavigateTool = safeBrowserTool(
   Tool.make("preview_navigate", {
     description:
       "Navigate a collaborative browser tab. Pass tabId to target a specific tab, plus {url:'https://t3.chat'} for a website or {target:{kind:'environment-port',port:5173}} for a dev server. Exactly one of url or target is required.",
@@ -84,7 +84,7 @@ export const PreviewNavigateTool = safeBrowserTool(
   }).annotate(Tool.Title, "Navigate browser preview"),
 );
 
-export const PreviewResizeTool = safeBrowserTool(
+const PreviewResizeTool = safeBrowserTool(
   Tool.make("preview_resize", {
     description:
       "Resize a collaborative browser tab, optionally selected by tabId. Use {mode:'fill'}, {mode:'freeform',width:1024,height:768}, or {mode:'preset',preset:'iphone-12-pro',orientation:'portrait'}. This changes CSS layout breakpoints without changing the desktop browser user agent.",
@@ -97,7 +97,7 @@ export const PreviewResizeTool = safeBrowserTool(
     .annotate(Tool.Idempotent, true),
 );
 
-export const PreviewSetAppearanceTool = safeBrowserTool(
+const PreviewSetAppearanceTool = safeBrowserTool(
   Tool.make("preview_set_appearance", {
     description:
       "Emulate prefers-color-scheme in a collaborative browser tab, optionally selected by tabId. Use {colorScheme:'dark'} or {colorScheme:'light'} to preview the page in that appearance, and {colorScheme:'system'} to clear the override and follow the OS appearance.",
@@ -129,7 +129,7 @@ export const PreviewSnapshotTool = readonlyBrowserTool(
   }).annotate(Tool.Title, "Inspect browser page"),
 );
 
-export const PreviewClickTool = browserTool(
+const PreviewClickTool = browserTool(
   Tool.make("preview_click", {
     description:
       "Click exactly one target in the tab selected by tabId, or this agent session's current tab when omitted. Prefer a Playwright locator; selector accepts legacy CSS; x and y must be supplied together.",
@@ -140,7 +140,7 @@ export const PreviewClickTool = browserTool(
   }).annotate(Tool.Title, "Click preview page"),
 );
 
-export const PreviewTypeTool = browserTool(
+const PreviewTypeTool = browserTool(
   Tool.make("preview_type", {
     description:
       "Insert literal text into one input in the tab selected by tabId, or this agent session's current tab when omitted. Prefer a Playwright locator; set clear=true to replace existing text.",
@@ -151,7 +151,7 @@ export const PreviewTypeTool = browserTool(
   }).annotate(Tool.Title, "Type into preview page"),
 );
 
-export const PreviewPressTool = browserTool(
+const PreviewPressTool = browserTool(
   Tool.make("preview_press", {
     description:
       "Press one keyboard key in the tab selected by tabId, or this agent session's current tab when omitted. Examples: {key:'Enter'}, {key:'Escape'}, or {key:'a',modifiers:['Meta']}.",
@@ -162,7 +162,7 @@ export const PreviewPressTool = browserTool(
   }).annotate(Tool.Title, "Press key in preview page"),
 );
 
-export const PreviewScrollTool = safeBrowserTool(
+const PreviewScrollTool = safeBrowserTool(
   Tool.make("preview_scroll", {
     description:
       "Scroll the tab selected by tabId, or this agent session's current tab when omitted. Positive deltaY scrolls down and positive deltaX scrolls right; a locator/selector targets a container.",
@@ -173,7 +173,7 @@ export const PreviewScrollTool = safeBrowserTool(
   }).annotate(Tool.Title, "Scroll preview page"),
 );
 
-export const PreviewEvaluateTool = browserTool(
+const PreviewEvaluateTool = browserTool(
   Tool.make("preview_evaluate", {
     description:
       "Evaluate JavaScript in the tab selected by tabId, or this agent session's current tab when omitted. Returns a serializable result up to 64 KB; the expression may mutate page state.",
@@ -184,7 +184,7 @@ export const PreviewEvaluateTool = browserTool(
   }).annotate(Tool.Title, "Evaluate JavaScript in preview"),
 );
 
-export const PreviewWaitForTool = readonlyBrowserTool(
+const PreviewWaitForTool = readonlyBrowserTool(
   Tool.make("preview_wait_for", {
     description:
       "Wait in the tab selected by tabId, or this agent session's current tab when omitted, until all supplied locator, selector, text, and URL conditions match.",
@@ -195,7 +195,7 @@ export const PreviewWaitForTool = readonlyBrowserTool(
   }).annotate(Tool.Title, "Wait for preview page condition"),
 );
 
-export const PreviewRecordingStartTool = safeBrowserTool(
+const PreviewRecordingStartTool = safeBrowserTool(
   Tool.make("preview_recording_start", {
     description:
       "Start recording the collaborative browser tab selected by tabId, or this agent session's current tab when omitted.",
@@ -206,7 +206,7 @@ export const PreviewRecordingStartTool = safeBrowserTool(
   }).annotate(Tool.Title, "Start browser recording"),
 );
 
-export const PreviewRecordingStopTool = safeBrowserTool(
+const PreviewRecordingStopTool = safeBrowserTool(
   Tool.make("preview_recording_stop", {
     description:
       "Stop recording the collaborative browser tab selected by tabId, or this agent session's current tab when omitted, and transfer the compressed recording once (up to 50 MiB) to an evidence file readable in this agent's environment. Returns its environment-local path after transfer succeeds.",


### PR DESCRIPTION
The MCP preview toolkit had 14 unclassified runtime exports. This keeps each tool definition private to its toolkit assembly and removes the unused broad handler layer while retaining the standard and snapshot handler layers used by the server.

This is layer 8 of 9 in the server Knip cleanup stack.

Verification after rebasing onto current main: server typecheck and the server-only Knip export audit pass. Changed-file lint and formatting pass, with one existing lint warning. Focused auth, provider, source-control, preview toolkit, orchestration, and Knip preprocessor tests pass: 90 tests across 9 files. This changes server export visibility and static analysis; screenshots do not apply.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the preview toolkit’s internal structure without changing the behavior or schemas of available preview tools.
  * Preview tool definitions are no longer individually exposed through the public interface, while snapshot functionality remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->