### PR TITLE
ci(knip): enforce server exports

### DIFF
--- a/docs/operations/development.md
+++ b/docs/operations/development.md
@@ -74,11 +74,12 @@ Windows investigation while that suite is not a required gate.
 ### Unused code
 
 `vp run knip:check` checks unused files and dependencies across the repo, then
-unused runtime exports in `apps/desktop`, `apps/web`, and every internal package under
+unused runtime exports in `apps/server`, `apps/desktop`, `apps/web`, and every internal package under
 `packages/`. CI enforces both checks.
 Exported types and Effect schemas are allowed without consumers. The schema preprocessor
 recognizes schema types, including aliases and schema classes; functions that create or decode
-schemas remain checked. Completely unused files remain checked too.
+schemas remain checked. Canonical Effect service construction APIs stay exported with an explicit
+`@public` annotation, which Knip recognizes. Completely unused files remain checked too.
 Named exports in web UI component modules are kept as complete component sets. Knip ignores
 unused exports in `apps/web/src/components/ui/*.tsx`, while still reporting an entire unused file.
 Use `vp run knip --workspace apps/web` to audit one workspace, including exports,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tc": "vp run -r --concurrency-limit 2 typecheck",
     "lint": "vp lint --report-unused-disable-directives",
     "knip": "knip --preprocessor ./scripts/knip-schemas.ts",
-    "knip:check": "knip --include files,dependencies --no-config-hints && knip --workspace apps/desktop --workspace apps/web --workspace packages/client-runtime --workspace packages/contracts --workspace packages/effect-acp --workspace packages/effect-codex-app-server --workspace packages/shared --workspace packages/ssh --workspace packages/tailscale --exports --preprocessor ./scripts/knip-schemas.ts --no-config-hints",
+    "knip:check": "knip --include files,dependencies --no-config-hints && knip --workspace apps/server --workspace apps/desktop --workspace apps/web --workspace packages/client-runtime --workspace packages/contracts --workspace packages/effect-acp --workspace packages/effect-codex-app-server --workspace packages/shared --workspace packages/ssh --workspace packages/tailscale --exports --preprocessor ./scripts/knip-schemas.ts --no-config-hints",
     "knip:production": "knip --production --preprocessor ./scripts/knip-schemas.ts",
     "lint:mobile": "node scripts/mobile-native-static-check.ts",
     "test": "vp run -r test",


### PR DESCRIPTION
The server export audit was clean locally but was not part of the long-term Knip gate. This adds apps/server to the runtime-export check and documents the explicit rules for exported types, Effect schemas, and canonical Effect service construction APIs.

This is layer 9 of 9 in the server Knip cleanup stack.

Verification after rebasing onto current main: server typecheck and the server-only Knip export audit pass. Changed-file lint and formatting pass, with one existing lint warning. Focused auth, provider, source-control, preview toolkit, orchestration, and Knip preprocessor tests pass: 90 tests across 9 files. This changes server export visibility and static analysis; screenshots do not apply.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated unused-code guidance to cover server workspace checks.
  * Clarified that publicly marked service construction APIs remain exported.

* **Chores**
  * Expanded automated unused-code checks to include the server workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce Knip unused-export checks on `apps/server`
> - Adds `apps/server` to the export-analysis portion of the root `knip:check` script in [package.json](https://github.com/pingdotgg/t3code/pull/10282/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and documents the expanded coverage in [development.md](https://github.com/pingdotgg/t3code/pull/10282/files#diff-d4193c695085935050d7dd7572ae2c767e26244ca27f5ae7fd015ff4c97c8ba2).
> - Converts preview toolkit bindings (12 tool declarations in [tools.ts](https://github.com/pingdotgg/t3code/pull/10282/files#diff-d7c6963f373bb55873fb4513dbf26923eb77ba575bc372d61d84743b26bd9676) and the handler layer in [handlers.ts](https://github.com/pingdotgg/t3code/pull/10282/files#diff-a664bd3eec0c91699dcf17690ce287659766c7bc533a09463a7140089297388f)) from exported to module-local.
> - Marks the `makeWithProviders` function in [SourceControlProviderRegistry.ts](https://github.com/pingdotgg/t3code/pull/10282/files#diff-1617d49a52e7bc96a9ab278b5f5b2028c6b5d917e84c91f779119e18ccb935fd) with a `@public` JSDoc tag so Knip recognizes it as a canonical public API.
> - Risk: any out-of-tree or cross-workspace consumer importing the now-internal preview toolkit bindings (`PreviewStatusTool`, `PreviewOpenTool`, etc.) will break; in-tree usages are already updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1535b27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->