### PR TITLE
test(desktop): cover WSL hashes through runtime resolution

### DIFF
--- a/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
@@ -218,14 +218,6 @@ const withPackagedWslHarness = <A, E, R>(
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer));
 
 describe("DesktopBackendConfiguration", () => {
-  it("accepts only normalized SHA-256 archive identities", () => {
-    assert.equal(
-      DesktopBackendConfiguration.parseWslRuntimeArchiveHash(`  ${"A".repeat(64)}\n`),
-      "a".repeat(64),
-    );
-    assert.isNull(DesktopBackendConfiguration.parseWslRuntimeArchiveHash("abc123"));
-  });
-
   it.effect("resolvePrimary produces a stable scoped bootstrap token", () =>
     withHarness(
       Effect.gen(function* () {

--- a/apps/desktop/src/backend/DesktopBackendConfiguration.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.ts
@@ -243,7 +243,7 @@ const WSL_RUNTIME_ARCHIVE_NAME = "wsl-runtime.tar.gz";
 const WSL_RUNTIME_ARCHIVE_HASH_NAME = `${WSL_RUNTIME_ARCHIVE_NAME}.sha256`;
 const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/i;
 
-export const parseWslRuntimeArchiveHash = (value: string): string | null => {
+const parseWslRuntimeArchiveHash = (value: string): string | null => {
   const trimmed = value.trim();
   return SHA256_HEX_PATTERN.test(trimmed) ? trimmed.toLowerCase() : null;
 };


### PR DESCRIPTION
The WSL archive hash parser was exported only for a two-assertion unit test. The resolveWsl tests already exercise valid hashes, changed hashes, and invalid hashes through the runtime-selection behavior that consumes them.

This makes the parser private and removes the redundant direct test. The remaining integration-style configuration test proves both cache identity and invalid-hash fallback.

Verification: targeted DesktopBackendConfiguration test, 30 tests passing; desktop typecheck; changed-file lint and format checks.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `parseWslRuntimeArchiveHash` module-private and drop its direct unit test
> Converts the WSL hash parser from a named export to a module-private constant in [DesktopBackendConfiguration.ts](https://github.com/pingdotgg/t3code/pull/10285/files#diff-8a9cd9d84f556b82ed8678110af5a99dea2cc1cfe1e6c6c46dc3a2e3bcb1f94c); its parsing logic is unchanged. Removes the standalone test case for the function from [DesktopBackendConfiguration.test.ts](https://github.com/pingdotgg/t3code/pull/10285/files#diff-1249037d55046a0fac1534a735fd14f75f78cff314f170b0305116ad2e443614), leaving WSL hash coverage to the runtime-resolution tests.
> - Behavioral Change: `parseWslRuntimeArchiveHash` is no longer importable from this module; any out-of-tree imports will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2881e6a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->