### PR TITLE
test(desktop): cover password store through startup

### DIFF
--- a/apps/desktop/src/app/DesktopPreReadyPlatform.test.ts
+++ b/apps/desktop/src/app/DesktopPreReadyPlatform.test.ts
@@ -37,45 +37,22 @@ describe("DesktopPreReadyPlatform", () => {
     registerSchemesMock.mockReset();
   });
 
-  it("reads an explicit Electron command-line switch value", () => {
-    const value = DesktopPreReadyPlatform.readCommandLineSwitchValue(
-      {
-        hasSwitch: (switchName) => switchName === "password-store",
-        getSwitchValue: (switchName) => {
-          assert.equal(switchName, "password-store");
-          return "basic";
-        },
-      },
-      "password-store",
+  it.effect("preserves an explicit Linux password-store switch", () => {
+    hasSwitchMock.mockImplementation((switchName) => switchName === "password-store");
+    getSwitchValueMock.mockReturnValue(" basic ");
+
+    return Effect.gen(function* () {
+      const options = yield* DesktopPreReadyPlatform.DesktopPreReadyElectronOptions;
+
+      assert.equal(options.linuxPasswordStoreCommandLine, "basic");
+      assert.isFalse(appendSwitchMock.mock.calls.some(([name]) => name === "password-store"));
+    }).pipe(
+      Effect.provide(
+        DesktopPreReadyPlatform.layer.pipe(
+          Layer.provide(Layer.succeed(HostProcessPlatform, "linux")),
+        ),
+      ),
     );
-
-    assert.equal(value, "basic");
-  });
-
-  it("treats valueless Electron command-line switches as absent", () => {
-    const value = DesktopPreReadyPlatform.readCommandLineSwitchValue(
-      {
-        hasSwitch: () => true,
-        getSwitchValue: () => "",
-      },
-      "password-store",
-    );
-
-    assert.isNull(value);
-  });
-
-  it("returns null for missing Electron command-line switches", () => {
-    const value = DesktopPreReadyPlatform.readCommandLineSwitchValue(
-      {
-        hasSwitch: () => false,
-        getSwitchValue: () => {
-          throw new Error("Unexpected switch value read.");
-        },
-      },
-      "password-store",
-    );
-
-    assert.isNull(value);
   });
 
   it.effect(

--- a/apps/desktop/src/app/DesktopPreReadyPlatform.ts
+++ b/apps/desktop/src/app/DesktopPreReadyPlatform.ts
@@ -17,7 +17,7 @@ export interface DesktopPreReadyCommandLineReader {
   readonly getSwitchValue: (switchName: string) => string;
 }
 
-export function readCommandLineSwitchValue(
+function readCommandLineSwitchValue(
   commandLine: DesktopPreReadyCommandLineReader,
   switchName: string,
 ): string | null {


### PR DESCRIPTION
DesktopPreReadyPlatform exported a command-line parsing helper for three direct tests. Those tests exercised boolean plumbing instead of the startup behavior that depends on the result.

This makes the helper private and replaces the three direct cases with one service-level test. The remaining test verifies that an explicit Linux password-store choice reaches the pre-ready options and is not overwritten.

Verification: targeted DesktopPreReadyPlatform test, 2 tests passing; desktop typecheck; changed-file lint and format checks.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace direct unit tests with effect-based test for `DesktopPreReadyPlatform` password-store handling
> Replaces three direct unit tests for the command-line switch reader with a single effect-based test on Linux. The test supplies a whitespace-padded password-store switch value, verifies the option is trimmed, and confirms the switch is not appended again through the `DesktopPreReadyPlatform` service layer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ed8e53.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->