### PR TITLE
test(desktop): rely on tailscale parser coverage

### DIFF
--- a/apps/desktop/src/backend/tailscaleEndpointProvider.test.ts
+++ b/apps/desktop/src/backend/tailscaleEndpointProvider.test.ts
@@ -4,10 +4,7 @@ import * as Layer from "effect/Layer";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
-import {
-  parseTailscaleMagicDnsName,
-  resolveTailscaleAdvertisedEndpoints,
-} from "./tailscaleEndpointProvider.ts";
+import { resolveTailscaleAdvertisedEndpoints } from "./tailscaleEndpointProvider.ts";
 
 const unusedTailscaleExternalServicesLayer = Layer.mergeAll(
   Layer.succeed(
@@ -21,18 +18,6 @@ const unusedTailscaleExternalServicesLayer = Layer.mergeAll(
 );
 
 describe("tailscale endpoint provider", () => {
-  it.effect("parses MagicDNS names from tailscale status", () =>
-    Effect.gen(function* () {
-      const dnsName = yield* parseTailscaleMagicDnsName(
-        `{"Self":{"DNSName":"desktop.tail.ts.net."}}`,
-      );
-      assert.equal(dnsName, "desktop.tail.ts.net");
-      assert.equal(yield* parseTailscaleMagicDnsName("{}"), null);
-      const malformed = yield* Effect.result(parseTailscaleMagicDnsName("not-json"));
-      assert.isTrue(malformed._tag === "Failure");
-    }),
-  );
-
   it.effect("resolves Tailscale endpoints as add-on advertised endpoints", () =>
     Effect.gen(function* () {
       const endpoints = yield* resolveTailscaleAdvertisedEndpoints({

--- a/apps/desktop/src/backend/tailscaleEndpointProvider.ts
+++ b/apps/desktop/src/backend/tailscaleEndpointProvider.ts
@@ -14,8 +14,6 @@ import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawne
 
 import type { NetworkInterfaces } from "./DesktopNetworkInterfaces.ts";
 
-export { isTailscaleIpv4Address } from "@t3tools/tailscale";
-
 const TAILSCALE_ENDPOINT_PROVIDER: AdvertisedEndpointProvider = {
   id: "tailscale",
   label: "Tailscale",

--- a/apps/desktop/src/backend/tailscaleEndpointProvider.ts
+++ b/apps/desktop/src/backend/tailscaleEndpointProvider.ts
@@ -14,7 +14,7 @@ import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawne
 
 import type { NetworkInterfaces } from "./DesktopNetworkInterfaces.ts";
 
-export { isTailscaleIpv4Address, parseTailscaleMagicDnsName } from "@t3tools/tailscale";
+export { isTailscaleIpv4Address } from "@t3tools/tailscale";
 
 const TAILSCALE_ENDPOINT_PROVIDER: AdvertisedEndpointProvider = {
   id: "tailscale",


### PR DESCRIPTION
The desktop Tailscale endpoint module re-exported shared parsing and address helpers even though production consumers already import them from the Tailscale package. The desktop test also repeated package-level parser coverage.

This removes both compatibility re-exports and the duplicate direct parser test. Shared parser and address coverage remains in the Tailscale package, while the desktop endpoint test continues to cover the assembled advertised endpoints.

Verification: targeted desktop and package Tailscale tests, 17 tests passing; desktop typecheck; changed-file lint and format checks.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove MagicDNS parser re-exports and tests from `tailscaleEndpointProvider`
> Drops the MagicDNS parsing test case and removes re-exports of the IPv4 address predicate and MagicDNS parser from [tailscaleEndpointProvider.ts](https://github.com/pingdotgg/t3code/pull/10288/files#diff-548598b8a457a1ccc770855bf24608c9522669beeabe6fcb4376be7b9959203d). The parser is covered by its own tests, so the desktop module no longer duplicates that coverage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10c0771.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->