### PR TITLE
test(desktop): cover WSL paths through public behavior

### DIFF
--- a/apps/desktop/src/wsl/wslPathParsing.test.ts
+++ b/apps/desktop/src/wsl/wslPathParsing.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect } from "vite-plus/test";
 
 import {
-  DISTRO_NAME_PATTERN,
   extractDistroFromUncPath,
   isValidDistroName,
   parseWslDistroList,
-  resolveWslHomeUncPath,
   resolveWslPickFolderDefaultPath,
   wslUncPathToLinuxPath,
 } from "./wslPathParsing.ts";
@@ -116,29 +114,6 @@ describe("wslUncPathToLinuxPath", () => {
   });
 });
 
-describe("resolveWslHomeUncPath", () => {
-  const distros = [
-    { name: "Debian", isDefault: true, version: 2 as const },
-    { name: "Ubuntu", isDefault: false, version: 2 as const },
-  ];
-
-  it("uses the configured distro when one is selected", () => {
-    expect(resolveWslHomeUncPath({ distro: "Ubuntu" }, distros)).toBe(
-      "\\\\wsl.localhost\\Ubuntu\\home",
-    );
-  });
-
-  it("uses the actual default distro when config uses the WSL default", () => {
-    expect(resolveWslHomeUncPath({ distro: null }, distros)).toBe(
-      "\\\\wsl.localhost\\Debian\\home",
-    );
-  });
-
-  it("omits the default path when no default distro is known", () => {
-    expect(resolveWslHomeUncPath({ distro: null }, [])).toBeNull();
-  });
-});
-
 describe("resolveWslPickFolderDefaultPath", () => {
   const config = { distro: null };
   const distros = [{ name: "Debian", isDefault: true, version: 2 as const }];
@@ -184,23 +159,22 @@ describe("resolveWslPickFolderDefaultPath", () => {
   });
 });
 
-describe("DISTRO_NAME_PATTERN / isValidDistroName", () => {
+describe("isValidDistroName", () => {
   it("accepts common distro names", () => {
     for (const name of ["Ubuntu", "Ubuntu-22.04", "kali-linux", "Debian", "Ubuntu 22.04"]) {
-      expect(DISTRO_NAME_PATTERN.test(name)).toBe(true);
       expect(isValidDistroName(name)).toBe(true);
     }
   });
 
   it("rejects names with trailing whitespace, hyphen, or dot", () => {
     for (const name of ["Ubuntu ", "Ubuntu-", "Ubuntu."]) {
-      expect(DISTRO_NAME_PATTERN.test(name)).toBe(false);
+      expect(isValidDistroName(name)).toBe(false);
     }
   });
 
   it("rejects names containing control or shell-meta characters", () => {
     for (const name of ["bad\nname", "bad\tname", "bad/name", "bad!name", "bad;name"]) {
-      expect(DISTRO_NAME_PATTERN.test(name)).toBe(false);
+      expect(isValidDistroName(name)).toBe(false);
     }
   });
 });

--- a/apps/desktop/src/wsl/wslPathParsing.ts
+++ b/apps/desktop/src/wsl/wslPathParsing.ts
@@ -10,7 +10,7 @@ export interface WslConfig {
 
 // Literal space — \s would also match \n/\t/\r and corrupt UNC paths like \\wsl.localhost\<distro>\...
 // Trailing char must also be \w so hand-edited config like "Ubuntu " / "Ubuntu-" / "Ubuntu." rejects.
-export const DISTRO_NAME_PATTERN = /^\w(?:[\w \-.]*\w)?$/;
+const DISTRO_NAME_PATTERN = /^\w(?:[\w \-.]*\w)?$/;
 
 export function parseWslDistroList(stdout: Buffer): readonly WslDistro[] {
   const hasUtf16Bom = stdout.length >= 2 && stdout[0] === 0xff && stdout[1] === 0xfe;
@@ -61,10 +61,7 @@ export function wslUncPathToLinuxPath(windowsPath: string): string | null {
   return `/${rest.split("\\").filter(Boolean).join("/")}`;
 }
 
-export function resolveWslHomeUncPath(
-  config: WslConfig,
-  distros: readonly WslDistro[],
-): string | null {
+function resolveWslHomeUncPath(config: WslConfig, distros: readonly WslDistro[]): string | null {
   const distroName = config.distro ?? distros.find((distro) => distro.isDefault)?.name ?? null;
   return distroName ? `\\\\wsl.localhost\\${distroName}\\home` : null;
 }


### PR DESCRIPTION
The WSL path module exported its internal distro-name regex and home-path helper so tests could inspect them directly. The public validation and folder-picker functions already exercise those same rules through behavior used by settings and the file picker.

This makes both implementation details private, removes the direct home-helper cases, and keeps the distro-name cases against isValidDistroName instead of the raw regex.

Verification: targeted WSL path test, 22 tests passing; desktop typecheck; changed-file lint and format checks.

Model: gpt-6 astra. Harness: Codex in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `DISTRO_NAME_PATTERN` and `resolveWslHomeUncPath` private in `wslPathParsing`
> - Makes the distro-name regex and the WSL home UNC-path resolver module-private in [wslPathParsing.ts](https://github.com/pingdotgg/t3code/pull/10289/files#diff-2dbe3428dcc1395e5a4a256fa7591773b2a472c468719f49d916e5f14c29d58d), removing them from the public API surface.
> - Updates [wslPathParsing.test.ts](https://github.com/pingdotgg/t3code/pull/10289/files#diff-8ff630321b0e892c775b9e8fa0daf884f8ad53e25fad65a6413d2499ff96c724) to cover only the public `isValidDistroName` validator, dropping direct tests for the now-private internals.
> - Risk: external callers importing `DISTRO_NAME_PATTERN` or `resolveWslHomeUncPath` will break; no in-tree consumers remain.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e7cd38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->