### PR TITLE
perf(server): count pending questions without loading history

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -2513,7 +2513,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
     }),
   );
 
-  it.effect("reads only user-input activities when refreshing shell summaries", () =>
+  it.effect("counts pending questions without decoding retained question history", () =>
     Effect.gen(function* () {
       const projectionPipeline = yield* OrchestrationProjectionPipeline;
       const eventStore = yield* OrchestrationEventStore;
@@ -2571,7 +2571,34 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
         },
       });
 
-      // Invalid JSON proves the summary query filters tool rows before decoding payloads.
+      // Large resolved payloads must not be loaded into the shell. Invalid tone
+      // values prove the count does not decode complete activity rows.
+      yield* sql`
+        WITH RECURSIVE history(n) AS (
+          SELECT 1
+          UNION ALL
+          SELECT n + 1 FROM history WHERE n < 1000
+        ), lifecycle(kind) AS (
+          SELECT 'user-input.requested'
+          UNION ALL
+          SELECT 'user-input.resolved'
+        )
+        INSERT INTO projection_thread_activities (
+          activity_id, thread_id, turn_id, tone, kind, summary, payload_json, created_at
+        )
+        SELECT
+          'history-' || kind || '-' || n,
+          'thread-stale-user-input',
+          NULL,
+          'invalid-tone',
+          kind,
+          'Old question activity',
+          json_object('requestId', 'history-' || n, 'questions', ${"x".repeat(4096)}),
+          '2026-02-25T12:00:00.000Z'
+        FROM history CROSS JOIN lifecycle
+      `;
+
+      // Invalid JSON proves the count excludes unrelated tool payloads too.
       yield* sql`
         INSERT INTO projection_thread_activities (
           activity_id,
@@ -3112,6 +3139,20 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
         },
       });
 
+      // A failed reply must not decode other requests or tool output.
+      yield* sql`
+        INSERT INTO projection_thread_activities (
+          activity_id, thread_id, turn_id, tone, kind, summary, payload_json, created_at
+        ) VALUES
+          ('nonstale-approval-tool', 'thread-nonstale-approval', NULL, 'info', 'tool.completed',
+            'Tool output', '{not-json', '2026-02-26T12:45:02.000Z'),
+          ('nonstale-other-request', 'thread-nonstale-approval', NULL, 'invalid-tone',
+            'approval.requested', '', json_object('requestId', 'other-request'), '2026-02-26T12:45:02.000Z'),
+          ('nonstale-other-thread', 'thread-nonstale-approval-other', NULL, 'info',
+            'approval.resolved', '', json_object('requestId', 'approval-request-nonstale-existing'),
+            '2026-02-26T12:45:02.000Z')
+      `;
+
       yield* appendAndProject({
         type: "thread.activity-appended",
         eventId: EventId.make("evt-nonstale-approval-4"),
@@ -3268,7 +3309,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
     }),
   );
 
-  it.effect("does not fallback-retain messages whose turnId is removed by revert", () =>
+  it.effect("retains checkpointed messages and recomputes questions after revert", () =>
     Effect.gen(function* () {
       const projectionPipeline = yield* OrchestrationProjectionPipeline;
       const eventStore = yield* OrchestrationEventStore;
@@ -3435,6 +3476,52 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
         },
       });
 
+      const questionActivities = [
+        { kind: "user-input.requested", requestId: "revert-question", turnId: null },
+        {
+          kind: "user-input.resolved",
+          requestId: "revert-question",
+          turnId: TurnId.make("turn-2"),
+        },
+        {
+          kind: "user-input.requested",
+          requestId: "retained-question",
+          turnId: TurnId.make("turn-1"),
+        },
+        { kind: "user-input.resolved", requestId: "retained-question", turnId: null },
+      ];
+      for (const [index, activity] of questionActivities.entries()) {
+        yield* appendAndProject({
+          type: "thread.activity-appended",
+          eventId: EventId.make(`evt-revert-question-${index}`),
+          aggregateKind: "thread",
+          aggregateId: ThreadId.make("thread-revert"),
+          occurredAt: "2026-02-26T12:00:03.200Z",
+          commandId: null,
+          causationEventId: null,
+          correlationId: null,
+          metadata: {},
+          payload: {
+            threadId: ThreadId.make("thread-revert"),
+            activity: {
+              id: EventId.make(`activity-revert-question-${index}`),
+              tone: "info",
+              kind: activity.kind,
+              summary: "Question activity",
+              payload: { requestId: activity.requestId },
+              turnId: activity.turnId,
+              createdAt: "2026-02-26T12:00:03.200Z",
+            },
+          },
+        });
+      }
+
+      const beforeRevert = yield* sql<{ readonly count: number }>`
+        SELECT pending_user_input_count AS count
+        FROM projection_threads WHERE thread_id = 'thread-revert'
+      `;
+      assert.deepEqual(beforeRevert, [{ count: 0 }]);
+
       yield* appendAndProject({
         type: "thread.reverted",
         eventId: EventId.make("evt-revert-8"),
@@ -3471,6 +3558,11 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           role: "assistant",
         },
       ]);
+      const afterRevert = yield* sql<{ readonly count: number }>`
+        SELECT pending_user_input_count AS count
+        FROM projection_threads WHERE thread_id = 'thread-revert'
+      `;
+      assert.deepEqual(afterRevert, [{ count: 1 }]);
     }),
   );
 });

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -141,31 +141,6 @@ function shouldRefreshThreadShellSummary(event: OrchestrationEvent): boolean {
   }
 }
 
-function derivePendingUserInputCountFromActivities(
-  activities: ReadonlyArray<ProjectionThreadActivity>,
-): number {
-  const openRequestIds = new Set<string>();
-  const closedRequestIds = new Set<string>();
-
-  for (const activity of activities) {
-    const requestId = extractActivityRequestId(activity.payload);
-    if (requestId === null) {
-      continue;
-    }
-    if (activity.kind === "user-input.requested") {
-      if (!closedRequestIds.has(requestId)) openRequestIds.add(requestId);
-      continue;
-    }
-
-    if (activity.kind === "user-input.resolved" || isRequestResponseStale(activity)) {
-      closedRequestIds.add(requestId);
-      openRequestIds.delete(requestId);
-    }
-  }
-
-  return openRequestIds.size;
-}
-
 function deriveHasActionableProposedPlan(input: {
   readonly latestTurnId: string | null;
   readonly proposedPlans: ReadonlyArray<ProjectionThreadProposedPlan>;
@@ -564,15 +539,14 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         return;
       }
 
-      const [latestUserMessageAt, proposedPlans, activities, pendingApprovalCount] =
+      const [latestUserMessageAt, proposedPlans, pendingUserInputCount, pendingApprovalCount] =
         yield* Effect.all([
           projectionThreadMessageRepository.getLatestUserMessageAt({ threadId }),
           projectionThreadProposedPlanRepository.listByThreadId({ threadId }),
-          projectionThreadActivityRepository.listUserInputLifecycleByThreadId({ threadId }),
+          projectionThreadActivityRepository.countPendingUserInputsByThreadId({ threadId }),
           projectionPendingApprovalRepository.countPendingByThreadId({ threadId }),
         ]);
 
-      const pendingUserInputCount = derivePendingUserInputCountFromActivities(activities);
       const hasActionableProposedPlan = deriveHasActionableProposedPlan({
         latestTurnId: existingRow.value.latestTurnId,
         proposedPlans,
@@ -1697,9 +1671,11 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             // Sending a reply clears the badge before the provider accepts it.
             // A failed reply must restore the request unless a terminal event
             // already closed it, including a reply from another client.
-            const requestActivities = (yield* projectionThreadActivityRepository.listByThreadId({
-              threadId: existingRow.value.threadId,
-            })).filter((activity) => extractActivityRequestId(activity.payload) === requestId);
+            const requestActivities =
+              yield* projectionThreadActivityRepository.listApprovalLifecycleByRequestId({
+                threadId: existingRow.value.threadId,
+                requestId,
+              });
             const wasRequested = requestActivities.some(
               (activity) => activity.kind === "approval.requested",
             );
@@ -1722,8 +1698,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           // Only approval-requested activities should create pending-approval
           // rows.  Other activity kinds that happen to carry a requestId
           // (e.g. user-input.requested / user-input.resolved) must not
-          // pollute this projection — they have their own accounting via
-          // derivePendingUserInputCountFromActivities.
+          // create pending approvals. Questions have a separate count.
           if (event.payload.activity.kind !== "approval.requested") {
             return;
           }

--- a/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
@@ -1,4 +1,11 @@
-import { ProjectId, ThreadId, ProviderInstanceId } from "@t3tools/contracts";
+import {
+  ApprovalRequestId,
+  EventId,
+  ProjectId,
+  ThreadId,
+  ProviderInstanceId,
+} from "@t3tools/contracts";
+import { legacyStaleRequestFailureDetails } from "@t3tools/shared/requestActivity";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -8,18 +15,194 @@ import * as SqlClient from "effect/unstable/sql/SqlClient";
 import { SqlitePersistenceMemory } from "./Sqlite.ts";
 import { ProjectionProjectRepositoryLive } from "./ProjectionProjects.ts";
 import { ProjectionThreadRepositoryLive } from "./ProjectionThreads.ts";
+import { ProjectionThreadActivityRepositoryLive } from "./ProjectionThreadActivities.ts";
 import { ProjectionProjectRepository } from "../Services/ProjectionProjects.ts";
 import { ProjectionThreadRepository } from "../Services/ProjectionThreads.ts";
+import { ProjectionThreadActivityRepository } from "../Services/ProjectionThreadActivities.ts";
 
 const projectionRepositoriesLayer = it.layer(
   Layer.mergeAll(
     ProjectionProjectRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
     ProjectionThreadRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
+    ProjectionThreadActivityRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
     SqlitePersistenceMemory,
   ),
 );
 
 projectionRepositoriesLayer("Projection repositories", (it) => {
+  it.effect("counts pending questions from the retained lifecycle without event ordering", () =>
+    Effect.gen(function* () {
+      const activities = yield* ProjectionThreadActivityRepository;
+      const threadId = ThreadId.make("thread-question-count");
+      const createdAt = "2026-09-01T00:00:00.000Z";
+      const upsert = (activityId: string, kind: string, payload: unknown) =>
+        activities.upsert({
+          activityId: EventId.make(activityId),
+          threadId,
+          turnId: null,
+          tone: "info",
+          kind,
+          summary: "Question activity",
+          payload,
+          createdAt,
+        });
+
+      assert.strictEqual(yield* activities.countPendingUserInputsByThreadId({ threadId }), 0);
+
+      yield* upsert("question-resolved-first", "user-input.resolved", { requestId: "closed" });
+      yield* upsert("question-requested-later", "user-input.requested", { requestId: "closed" });
+      yield* upsert("question-duplicate", "user-input.requested", { requestId: "closed" });
+      yield* upsert("question-failed-after-resolution", "provider.user-input.respond.failed", {
+        requestId: "closed",
+        reason: "provider-error",
+      });
+      yield* upsert("question-active", "user-input.requested", { requestId: "17" });
+      yield* upsert("question-active-duplicate", "user-input.requested", { requestId: "17" });
+      yield* upsert("question-active-failure", "provider.user-input.respond.failed", {
+        requestId: "17",
+        reason: "provider-error",
+      });
+      yield* upsert("question-number-resolution", "user-input.resolved", { requestId: 17 });
+      yield* upsert("question-number-request", "user-input.requested", { requestId: 18 });
+      yield* upsert("question-object-request", "user-input.requested", { requestId: { id: "19" } });
+      yield* upsert("question-no-request", "provider.user-input.respond.failed", {
+        requestId: "never-requested",
+        reason: "provider-error",
+      });
+      yield* activities.upsert({
+        activityId: EventId.make("question-other-thread-resolution"),
+        threadId: ThreadId.make("thread-question-count-other"),
+        turnId: null,
+        tone: "info",
+        kind: "user-input.resolved",
+        summary: "Other thread question resolved",
+        payload: { requestId: "17" },
+        sequence: 10,
+        createdAt,
+      });
+      assert.strictEqual(yield* activities.countPendingUserInputsByThreadId({ threadId }), 1);
+
+      yield* upsert("question-active-resolution", "user-input.resolved", { requestId: "17" });
+      assert.strictEqual(yield* activities.countPendingUserInputsByThreadId({ threadId }), 0);
+
+      // A replacement can remove the terminal fact from retained activity.
+      yield* upsert("question-active-resolution", "user-input.resolved", { requestId: "closed" });
+      assert.strictEqual(yield* activities.countPendingUserInputsByThreadId({ threadId }), 1);
+
+      yield* activities.deleteByThreadId({ threadId });
+      assert.strictEqual(yield* activities.countPendingUserInputsByThreadId({ threadId }), 0);
+      yield* upsert("question-recreated", "user-input.requested", { requestId: "closed" });
+      assert.strictEqual(yield* activities.countPendingUserInputsByThreadId({ threadId }), 1);
+    }),
+  );
+
+  it.effect("uses typed stale outcomes before legacy question failure text", () =>
+    Effect.gen(function* () {
+      const activities = yield* ProjectionThreadActivityRepository;
+      const createdAt = "2026-09-01T00:00:00.000Z";
+      const staleDetail = "Unknown pending user-input request";
+      const cases = [
+        { payload: { reason: "request-not-found" }, pending: 0 },
+        { payload: { reason: "provider-error", detail: staleDetail }, pending: 1 },
+        { payload: { reason: null, detail: staleDetail }, pending: 1 },
+        { payload: { reason: "future-reason", detail: staleDetail }, pending: 1 },
+        { payload: { reason: 1, detail: staleDetail }, pending: 1 },
+        { payload: { detail: [staleDetail] }, pending: 1 },
+        { payload: { detail: { message: staleDetail } }, pending: 1 },
+        ...legacyStaleRequestFailureDetails["provider.user-input.respond.failed"].map((detail) => ({
+          payload: { detail: detail.toUpperCase() },
+          pending: 0,
+        })),
+      ];
+
+      for (const [index, testCase] of cases.entries()) {
+        const threadId = ThreadId.make(`thread-question-reason-${index}`);
+        const requestId = `request-question-reason-${index}`;
+        yield* activities.upsert({
+          activityId: EventId.make(`question-reason-requested-${index}`),
+          threadId,
+          turnId: null,
+          tone: "info",
+          kind: "user-input.requested",
+          summary: "Question requested",
+          payload: { requestId },
+          sequence: 100,
+          createdAt: "2026-09-02T00:00:00.000Z",
+        });
+        yield* activities.upsert({
+          activityId: EventId.make(`question-reason-failed-${index}`),
+          threadId,
+          turnId: null,
+          tone: "error",
+          kind: "provider.user-input.respond.failed",
+          summary: "Question reply failed",
+          payload: { requestId, ...testCase.payload },
+          createdAt,
+        });
+        assert.strictEqual(
+          yield* activities.countPendingUserInputsByThreadId({ threadId }),
+          testCase.pending,
+          `Failure case ${index}`,
+        );
+      }
+    }),
+  );
+
+  it.effect("reads only one approval lifecycle from its thread", () =>
+    Effect.gen(function* () {
+      const activities = yield* ProjectionThreadActivityRepository;
+      const sql = yield* SqlClient.SqlClient;
+      const threadId = ThreadId.make("thread-approval-lifecycle");
+      const requestId = ApprovalRequestId.make("approval-lifecycle");
+      const createdAt = "2026-09-01T00:00:00.000Z";
+
+      for (const kind of [
+        "approval.requested",
+        "approval.resolved",
+        "provider.approval.respond.failed",
+      ]) {
+        yield* activities.upsert({
+          activityId: EventId.make(`lifecycle-${kind}`),
+          threadId,
+          turnId: null,
+          tone: "info",
+          kind,
+          summary: "Approval activity",
+          payload: { requestId },
+          createdAt,
+        });
+      }
+
+      // These rows must be excluded before full activity decoding.
+      yield* sql`
+        INSERT INTO projection_thread_activities (
+          activity_id, thread_id, turn_id, tone, kind, summary, payload_json, created_at
+        ) VALUES
+          ('lifecycle-tool', ${threadId}, NULL, 'info', 'tool.completed', '', '{not-json', ${createdAt}),
+          ('lifecycle-other-request', ${threadId}, NULL, 'invalid-tone', 'approval.requested', '',
+            json_object('requestId', 'other-request'), ${createdAt}),
+          ('lifecycle-question', ${threadId}, NULL, 'invalid-tone', 'user-input.requested', '',
+            json_object('requestId', ${requestId}), ${createdAt}),
+          ('lifecycle-other-thread', 'thread-approval-lifecycle-other', NULL, 'invalid-tone',
+            'approval.requested', '', json_object('requestId', ${requestId}), ${createdAt})
+      `;
+
+      const rows = yield* activities.listApprovalLifecycleByRequestId({ threadId, requestId });
+      assert.deepEqual(rows.map((row) => row.activityId).toSorted(), [
+        "lifecycle-approval.requested",
+        "lifecycle-approval.resolved",
+        "lifecycle-provider.approval.respond.failed",
+      ]);
+      assert.deepEqual(
+        yield* activities.listApprovalLifecycleByRequestId({
+          threadId,
+          requestId: ApprovalRequestId.make("missing-approval"),
+        }),
+        [],
+      );
+    }),
+  );
+
   it.effect("stores SQL NULL for missing project model options", () =>
     Effect.gen(function* () {
       const projects = yield* ProjectionProjectRepository;

--- a/apps/server/src/persistence/Layers/ProjectionThreadActivities.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadActivities.ts
@@ -1,6 +1,7 @@
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as SqlSchema from "effect/unstable/sql/SqlSchema";
 import { NonNegativeInt } from "@t3tools/contracts";
+import { legacyStaleRequestFailureDetails } from "@t3tools/shared/requestActivity";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
@@ -10,6 +11,7 @@ import { toPersistenceDecodeError, toPersistenceSqlError } from "../Errors.ts";
 
 import {
   DeleteProjectionThreadActivitiesInput,
+  ListProjectionApprovalLifecycleInput,
   ListProjectionThreadActivitiesInput,
   ProjectionThreadActivity,
   ProjectionThreadActivityRepository,
@@ -151,6 +153,76 @@ const makeProjectionThreadActivityRepository = Effect.gen(function* () {
       `,
   });
 
+  // A terminal event closes its request regardless of activity order. Group in
+  // SQLite so shell refreshes do not decode retained question payloads.
+  const countPendingUserInputRows = SqlSchema.findOne({
+    Request: ListProjectionThreadActivitiesInput,
+    Result: Schema.Struct({ count: NonNegativeInt }),
+    execute: ({ threadId }) => sql`
+      SELECT COUNT(*) AS count
+      FROM (
+        SELECT json_extract(payload_json, '$.requestId')
+        FROM projection_thread_activities
+        WHERE thread_id = ${threadId}
+          AND CASE
+            WHEN kind IN (
+              'user-input.requested',
+              'user-input.resolved',
+              'provider.user-input.respond.failed'
+            ) THEN json_type(payload_json, '$.requestId') = 'text'
+            ELSE 0
+          END
+        GROUP BY json_extract(payload_json, '$.requestId')
+        HAVING MAX(kind = 'user-input.requested') = 1
+          AND MAX(CASE
+            WHEN kind = 'user-input.resolved' THEN 1
+            WHEN kind = 'provider.user-input.respond.failed' AND (
+              json_extract(payload_json, '$.reason') = 'request-not-found'
+              OR (
+                json_type(payload_json, '$.reason') IS NULL
+                AND json_type(payload_json, '$.detail') = 'text'
+                AND ${sql.or(
+                  legacyStaleRequestFailureDetails["provider.user-input.respond.failed"].map(
+                    (detail) =>
+                      sql`instr(lower(json_extract(payload_json, '$.detail')), ${detail}) > 0`,
+                  ),
+                )}
+              )
+            ) THEN 1
+            ELSE 0
+          END) = 0
+      )
+    `,
+  });
+
+  const listApprovalLifecycleRows = SqlSchema.findAll({
+    Request: ListProjectionApprovalLifecycleInput,
+    Result: ProjectionThreadActivityDbRowSchema,
+    execute: ({ threadId, requestId }) => sql`
+      SELECT
+        activity_id AS "activityId",
+        thread_id AS "threadId",
+        turn_id AS "turnId",
+        tone,
+        kind,
+        summary,
+        payload_json AS "payload",
+        sequence,
+        created_at AS "createdAt"
+      FROM projection_thread_activities
+      WHERE thread_id = ${threadId}
+        AND CASE
+          WHEN kind IN (
+            'approval.requested',
+            'approval.resolved',
+            'provider.approval.respond.failed'
+          ) THEN json_type(payload_json, '$.requestId') = 'text'
+            AND json_extract(payload_json, '$.requestId') = ${requestId}
+          ELSE 0
+        END
+    `,
+  });
+
   const upsert: ProjectionThreadActivityRepositoryShape["upsert"] = (row) =>
     upsertProjectionThreadActivityRow(row).pipe(
       Effect.mapError(
@@ -191,10 +263,36 @@ const makeProjectionThreadActivityRepository = Effect.gen(function* () {
       ),
     );
 
+  const countPendingUserInputsByThreadId: ProjectionThreadActivityRepositoryShape["countPendingUserInputsByThreadId"] =
+    (input) =>
+      countPendingUserInputRows(input).pipe(
+        Effect.mapError(
+          toPersistenceSqlOrDecodeError(
+            "ProjectionThreadActivityRepository.countPendingUserInputsByThreadId:query",
+            "ProjectionThreadActivityRepository.countPendingUserInputsByThreadId:decodeRows",
+          ),
+        ),
+        Effect.map((row) => row.count),
+      );
+
+  const listApprovalLifecycleByRequestId: ProjectionThreadActivityRepositoryShape["listApprovalLifecycleByRequestId"] =
+    (input) =>
+      listApprovalLifecycleRows(input).pipe(
+        Effect.mapError(
+          toPersistenceSqlOrDecodeError(
+            "ProjectionThreadActivityRepository.listApprovalLifecycleByRequestId:query",
+            "ProjectionThreadActivityRepository.listApprovalLifecycleByRequestId:decodeRows",
+          ),
+        ),
+        Effect.map(mapActivityRows),
+      );
+
   return {
     upsert,
     listByThreadId,
     listUserInputLifecycleByThreadId,
+    countPendingUserInputsByThreadId,
+    listApprovalLifecycleByRequestId,
     deleteByThreadId,
   } satisfies ProjectionThreadActivityRepositoryShape;
 });

--- a/apps/server/src/persistence/Services/ProjectionThreadActivities.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadActivities.ts
@@ -7,6 +7,7 @@
  * @module ProjectionThreadActivityRepository
  */
 import {
+  ApprovalRequestId,
   EventId,
   IsoDateTime,
   NonNegativeInt,
@@ -37,6 +38,12 @@ export const ListProjectionThreadActivitiesInput = Schema.Struct({
   threadId: ThreadId,
 });
 export type ListProjectionThreadActivitiesInput = typeof ListProjectionThreadActivitiesInput.Type;
+
+export const ListProjectionApprovalLifecycleInput = Schema.Struct({
+  threadId: ThreadId,
+  requestId: ApprovalRequestId,
+});
+export type ListProjectionApprovalLifecycleInput = typeof ListProjectionApprovalLifecycleInput.Type;
 
 export const DeleteProjectionThreadActivitiesInput = Schema.Struct({
   threadId: ThreadId,
@@ -74,6 +81,16 @@ export interface ProjectionThreadActivityRepositoryShape {
    */
   readonly listUserInputLifecycleByThreadId: (
     input: ListProjectionThreadActivitiesInput,
+  ) => Effect.Effect<ReadonlyArray<ProjectionThreadActivity>, ProjectionRepositoryError>;
+
+  /** Count requested questions that have no terminal response in the retained activity. */
+  readonly countPendingUserInputsByThreadId: (
+    input: ListProjectionThreadActivitiesInput,
+  ) => Effect.Effect<number, ProjectionRepositoryError>;
+
+  /** Read one approval's lifecycle without loading the rest of the thread history. */
+  readonly listApprovalLifecycleByRequestId: (
+    input: ListProjectionApprovalLifecycleInput,
   ) => Effect.Effect<ReadonlyArray<ProjectionThreadActivity>, ProjectionRepositoryError>;
 
   /**


### PR DESCRIPTION
Thread summary refreshes loaded every saved question payload to count pending questions. Failed approval replies loaded the whole activity history to recover one request.

Count pending questions in SQLite and read only the matching approval lifecycle. Keep the shared request rules, including final closure, typed stale outcomes, legacy error text, and rewind behavior.

Stacks on [#10108](https://github.com/pingdotgg/t3code/pull/10108), after [#10123](https://github.com/pingdotgg/t3code/pull/10123). Those PRs own turn-start reads and request lifecycle semantics. This PR changes question and approval reads.

Verification: 37 focused repository and projection tests, server-only typecheck, and changed-file lint and formatting pass on the updated dependency. The rebase preserves the original query patch.

The disposable SQLite fixture returned one count instead of 10,002 question lifecycle rows and 22.84 MB of JSON. Approval recovery returned two matching rows instead of 20,002 rows. Both queries still scan one thread's history. No new projection, migration, wire contract, or UI change.

Created with GPT-6 Astra in Codex. Follow-up review and rebase with Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Count pending questions via SQL aggregate instead of decoding activity history
> - Replaces in-memory traversal of decoded user-input activity rows with a SQLite aggregate (`countPendingUserInputRows`) that groups by textual request ID and excludes resolved or stale-failed groups.
> - Scopes approval lifecycle reads to a single thread and request ID via `listApprovalLifecycleRows`, so malformed or unrelated activity rows are never decoded during failed-approval recovery.
> - Adds `ListProjectionApprovalLifecycleInput` schema and two new repository methods on `ProjectionThreadActivityRepositoryShape`.
> - Expands tests in [ProjectionPipeline.test.ts](https://github.com/pingdotgg/t3code/pull/10290/files#diff-929eb6fd844fad565d5af8faa7348834ab85ad5457f22d71861e6ee886a18fda) and [ProjectionRepositories.test.ts](https://github.com/pingdotgg/t3code/pull/10290/files#diff-590df2173cd087230c7d9f461436c7f726c25e9b1d8426eba115f65198a22311) to cover large payloads, invalid tones, cross-thread rows, stale-outcome classification, and revert recompute.
> - Behavioral Change: `refreshThreadShellSummary` and the thread activity projection handler now rely on repository-level SQL filtering; any out-of-tree consumer expecting full activity rows to be loaded and decoded during these operations will no longer see that behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a465772.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->