### PR TITLE
refactor(server): preserve pending operation kind on upgrade

### DIFF
--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -59,6 +59,7 @@ import Migration0044 from "./Migrations/044_ClearAutomaticProjectModelDefaults.t
 import Migration0045 from "./Migrations/045_ProjectionProjectsAutoPull.ts";
 import Migration0046 from "./Migrations/046_RepairAutomaticSettlementTimestamps.ts";
 import Migration0047 from "./Migrations/047_ProjectionProjectIcon.ts";
+import Migration0048 from "./Migrations/048_ProjectionPendingOperation.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -118,6 +119,7 @@ export const migrationEntries = [
   [45, "ProjectionProjectsAutoPull", Migration0045],
   [46, "RepairAutomaticSettlementTimestamps", Migration0046],
   [47, "ProjectionProjectIcon", Migration0047],
+  [48, "ProjectionPendingOperation", Migration0048],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);

--- a/apps/server/src/persistence/Migrations/048_ProjectionPendingOperation.test.ts
+++ b/apps/server/src/persistence/Migrations/048_ProjectionPendingOperation.test.ts
@@ -1,0 +1,66 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import * as NodeSqliteClient from "@t3tools/shared/nodeSqliteClient";
+
+import { runMigrations } from "../Migrations.ts";
+
+it.layer(NodeSqliteClient.layerMemory())("048_ProjectionPendingOperation", (it) => {
+  it.effect("preserves pending compaction and ordinary messages across upgrade", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations({ toMigrationInclusive: 47 });
+      const messages = [
+        { id: "compact", text: "\t /CoMpAcT\n", attachments: null },
+        { id: "arguments", text: "/compact keep recent edits", attachments: null },
+        { id: "ordinary", text: "hello", attachments: null },
+        {
+          id: "attachment",
+          text: "/compact",
+          attachments:
+            '[{"type":"image","id":"image","name":"image.png","mimeType":"image/png","sizeBytes":1}]',
+        },
+      ];
+      for (const message of messages) {
+        yield* sql`
+          INSERT INTO projection_thread_messages (
+            message_id, thread_id, role, text, attachments_json, is_streaming, created_at, updated_at
+          ) VALUES (
+            ${message.id}, ${message.id}, 'user', ${message.text}, ${message.attachments}, 0,
+            '2026-09-05T00:00:00.000Z', '2026-09-05T00:00:00.000Z'
+          )
+        `;
+        yield* sql`
+          INSERT INTO projection_turns (
+            thread_id, pending_message_id, state, requested_at, checkpoint_files_json
+          ) VALUES (
+            ${message.id}, ${message.id}, 'pending', '2026-09-05T00:00:00.000Z', '[]'
+          )
+        `;
+      }
+
+      yield* runMigrations({ toMigrationInclusive: 48 });
+      const rows = yield* sql<{ readonly id: string; readonly kind: string | null }>`
+        SELECT pending_message_id AS id, operation_kind AS kind
+        FROM projection_turns ORDER BY pending_message_id
+      `;
+      assert.deepStrictEqual(rows, [
+        { id: "arguments", kind: "turn" },
+        { id: "attachment", kind: "turn" },
+        { id: "compact", kind: "compact" },
+        { id: "ordinary", kind: "turn" },
+      ]);
+
+      // Old servers can still insert rows without the new column.
+      yield* sql`
+        INSERT INTO projection_turns (
+          thread_id, pending_message_id, state, requested_at, checkpoint_files_json
+        ) VALUES ('downgrade', 'compact', 'pending', '2026-09-05T00:00:01.000Z', '[]')
+      `;
+      const legacyRows = yield* sql<{ readonly kind: string | null }>`
+        SELECT operation_kind AS kind FROM projection_turns WHERE thread_id = 'downgrade'
+      `;
+      assert.deepStrictEqual(legacyRows, [{ kind: null }]);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/048_ProjectionPendingOperation.ts
+++ b/apps/server/src/persistence/Migrations/048_ProjectionPendingOperation.ts
@@ -1,0 +1,31 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  // Null identifies pending rows written by an older server after a downgrade.
+  yield* sql`ALTER TABLE projection_turns ADD COLUMN operation_kind TEXT`;
+
+  const pendingMessages = yield* sql<{
+    readonly rowId: number;
+    readonly text: string;
+    readonly hasAttachments: number;
+  }>`
+    SELECT turns.row_id AS "rowId", messages.text,
+      COALESCE(json_array_length(messages.attachments_json), 0) > 0 AS "hasAttachments"
+    FROM projection_turns turns
+    JOIN projection_thread_messages messages
+      ON messages.message_id = turns.pending_message_id
+      AND messages.thread_id = turns.thread_id
+    WHERE turns.turn_id IS NULL AND turns.state = 'pending'
+      AND turns.checkpoint_turn_count IS NULL AND messages.role = 'user'
+  `;
+  for (const message of pendingMessages) {
+    const kind =
+      message.hasAttachments === 0 && message.text.trim().toLowerCase() === "/compact"
+        ? "compact"
+        : "turn";
+    yield* sql`UPDATE projection_turns SET operation_kind = ${kind} WHERE row_id = ${message.rowId}`;
+  }
+});


### PR DESCRIPTION
Compaction and rewind need ordered database migrations. Rewind must not install migration 49 before the operation-state column in migration 48 exists.

Add the nullable `operation_kind` column and classify existing pending messages. Old writers can still omit the column. This PR does not change runtime behavior. This PR starts the dependency chain for compaction lifecycle and rewind.

The focused migration test passed. It covers mixed-case commands, whitespace, arguments, attachments, and old writers after the upgrade. Independent source review confirmed that this migration is additive and compatible with old writers.

Created with GPT-6 Astra in Codex. Recovery and verification continued in Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add migration 048 to backfill `operation_kind` on pending projection turns
> - Adds a nullable `operation_kind` column to projection turns via [048_ProjectionPendingOperation.ts](https://github.com/pingdotgg/t3code/pull/10291/files#diff-646bf7895ccc67b8c522b74e87639136753774c7facaf794f4e2c94e7dad4fcf)
> - Selects pending user turns without a turn ID or checkpoint count, joins them to their same-thread messages, and classifies each row as `compact` when the message has no attachments and its trimmed text matches the compact command; all other eligible rows are classified as `ordinary` turns
> - Registers migration 048 in the [migration registry](https://github.com/pingdotgg/t3code/pull/10291/files#diff-87557f6881a7a3dd24fa7e31f895b009cc6ede9a3571779088a10c5093110707) and adds test coverage in [048_ProjectionPendingOperation.test.ts](https://github.com/pingdotgg/t3code/pull/10291/files#diff-5055892ffb8c0b9e57a40d94e65b87401436523bfcaf1670068154993a946d84) covering compact/ordinary classification, attachments, row ordering, and nullable values for legacy inserts after downgrade
> - Behavioral Change: rows written by an older server after downgrade will have a null `operation_kind`; readers must tolerate null values in this column
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d858532.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->