### PR TITLE
fix(web): keep pull request state consistent across views

### DIFF
--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -3254,7 +3254,7 @@ it.effect(
       });
       assert.strictEqual(activityCalls, 1);
 
-      yield* service.invalidate({ reference });
+      yield* service.invalidate({ reference: { ...reference, repository: "Acme/WEB" } });
       yield* service.activity(reference);
       assert.strictEqual(activityCalls, 2);
     }),

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -2133,7 +2133,8 @@ export const make = Effect.gen(function* () {
   let turnRefreshEpoch = 0;
   const refEpochs = new Map<string, number>();
   const REF_EPOCH_CAPACITY = 2_048;
-  const refScope = (ref: PullRequestRef) => `${ref.projectId} ${ref.repository} ${ref.number}`;
+  const refScope = (ref: PullRequestRef) =>
+    `${ref.projectId} ${ref.repository.toLowerCase()} ${ref.number}`;
   const refEpoch = (ref: PullRequestRef) =>
     Math.max(turnRefreshEpoch, refEpochs.get(refScope(ref)) ?? 0);
   const refCacheKey = (ref: PullRequestRef) =>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -185,7 +185,7 @@ import { isThreadOwnPullRequest } from "./pullRequest/pullRequestDetail.logic";
 import { PullRequestDetailPanel } from "./pullRequest/PullRequestDetailPanel";
 import { PullRequestDetailGhost } from "./pullRequest/PullRequestGhosts";
 import { PullRequestsUnavailableState } from "./pullRequest/PullRequestsUnavailableState";
-import { RightPanelTabs, type PullRequestTabStatus } from "./RightPanelTabs";
+import { RightPanelTabs } from "./RightPanelTabs";
 import { AgentsPanel } from "./AgentsPanel";
 import {
   deriveAgentPanelModel,
@@ -278,6 +278,7 @@ import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../termina
 import { useKnownTerminalSessions, useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
+import { useSharedThreadPullRequest } from "../state/pullRequests";
 import {
   environmentServerConfigsAtom,
   primaryServerAvailableEditorsAtom,
@@ -1856,8 +1857,6 @@ export default function ChatView(props: ChatViewProps) {
   const activeRightPanelSurface = useRightPanelStore((state) =>
     selectActiveRightPanelSurface(state.byThreadKey, activeThreadRef),
   );
-  const refreshVcsStatus = useAtomCommand(vcsEnvironment.refreshStatus, { reportFailure: false });
-  const sidebarPrRefreshKeyRef = useRef<string | null>(null);
   const threadPrRelinkKeysRef = useRef(new Map<string, string>());
   const threadPrRelinkWriteRef = useRef(Promise.resolve());
   const activePreviewState = useThreadPreviewState(activeThreadRef);
@@ -5152,7 +5151,7 @@ export default function ChatView(props: ChatViewProps) {
       resizeObserver.disconnect();
     };
   }, [composerOverlayElement, publishComposerOverlayHeight]);
-  const activeThreadPr =
+  const detectedThreadPr =
     replacementLinkedThreadPullRequest !== null
       ? (gitStatusQuery.data?.pr ?? null)
       : resolveDisplayedThreadPr({
@@ -5163,38 +5162,10 @@ export default function ChatView(props: ChatViewProps) {
           linkedPullRequest: linkedThreadPullRequest,
           linkedPullRequestStatus: persistedLinkedThreadPullRequestStatus,
         });
-  const handlePullRequestTabStatusChange = useCallback(
-    (status: Pick<PullRequestTabStatus, "repository" | "number" | "state">) => {
-      if (
-        threadRepository?.toLowerCase() !== status.repository.toLowerCase() ||
-        activeThreadPr?.number !== status.number ||
-        activeThreadPr.state === status.state
-      ) {
-        sidebarPrRefreshKeyRef.current = null;
-        return;
-      }
-      const refreshKey = `${activeThreadKey}:vcs:${status.repository}#${status.number}:${status.state}`;
-      if (sidebarPrRefreshKeyRef.current === refreshKey) return;
-      sidebarPrRefreshKeyRef.current = refreshKey;
-      if (activeThreadRef === null || gitCwd === null) return;
-      void refreshVcsStatus({
-        environmentId: activeThreadRef.environmentId,
-        input: { cwd: gitCwd },
-      }).then(() => {
-        if (sidebarPrRefreshKeyRef.current === refreshKey) {
-          sidebarPrRefreshKeyRef.current = null;
-        }
-      });
-    },
-    [
-      activeThreadKey,
-      activeThreadPr?.number,
-      activeThreadPr?.state,
-      activeThreadRef,
-      gitCwd,
-      refreshVcsStatus,
-      threadRepository,
-    ],
+  const activeThreadPr = useSharedThreadPullRequest(
+    activeThreadRef?.environmentId ?? null,
+    activeProject?.id ?? null,
+    detectedThreadPr,
   );
   const openPanelPullRequestUrl = useOpenPanelPullRequestUrl(activeThreadRef);
   const activeThreadReferenceCopyTarget = useMemo(
@@ -7784,9 +7755,6 @@ export default function ChatView(props: ChatViewProps) {
             : "page"
         }
         composerDraftTarget={composerDraftTarget}
-        {...(linkedThreadPullRequest === null
-          ? { onStateChange: handlePullRequestTabStatusChange }
-          : {})}
       />
     ) : renderedRightPanelSurface?.kind === "agents" ? (
       <AgentsPanel

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -117,6 +117,7 @@ import { useDesktopUpdateState } from "../state/desktopUpdate";
 import { useThreadActions } from "../hooks/useThreadActions";
 import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
+import { useSharedThreadPullRequest } from "../state/pullRequests";
 import { threadEnvironment, useEnvironmentThread } from "../state/threads";
 import { vcsEnvironment } from "../state/vcs";
 import { useEnvironment, useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
@@ -482,10 +483,13 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
       : JSON.stringify([thread.environmentId, thread.linkedPullRequest]),
     linkedPullRequestStatus,
   );
-  const pr =
+  const pr = useSharedThreadPullRequest(
+    thread.environmentId,
+    thread.projectId,
     thread.linkedPullRequest == null
       ? resolveThreadPr({ threadBranch: thread.branch, gitStatus: visibleGitStatus })
-      : (visibleLinkedPullRequestStatus?.pr ?? null);
+      : (visibleLinkedPullRequestStatus?.pr ?? null),
+  );
   const prStatus = prStatusIndicator(
     pr,
     visibleLinkedPullRequestStatus?.sourceControlProvider ??

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -54,8 +54,7 @@ import { ScrollArea } from "~/components/ui/scroll-area";
 import { PanelTabCloseButton } from "~/components/ui/panel-tab-close-button";
 import { faviconUrlForOrigin } from "~/lib/favicon";
 import { useTheme } from "~/hooks/useTheme";
-import { pullRequestEnvironment } from "~/state/pullRequests";
-import { useEnvironmentQuery } from "~/state/query";
+import { usePullRequestDetail } from "~/state/pullRequests";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 
 import { PreviewPanelShell, type PreviewPanelMode } from "./preview/PreviewPanelShell";
@@ -699,17 +698,17 @@ function PullRequestSurfaceIcon({
 }) {
   const resolvedEnvironmentId =
     (surface.environmentId as EnvironmentId | undefined) ?? environmentId;
-  const detail = useEnvironmentQuery(
+  const detail = usePullRequestDetail(
     resolvedEnvironmentId === null
       ? null
-      : pullRequestEnvironment.detail({
+      : {
           environmentId: resolvedEnvironmentId,
           input: {
             projectId: surface.projectId as ProjectId,
             repository: surface.repository,
             number: surface.number,
           },
-        }),
+        },
   ).data;
   // Only state and draft reach the tab. A list seed cannot know mergeability, so feeding the
   // full detail would flip an open tab to the conflict glyph the moment its read lands.

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -125,6 +125,7 @@ import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../s
 import { vcsEnvironment } from "../state/vcs";
 import { threadEnvironment } from "../state/threads";
 import { useEnvironmentQuery } from "../state/query";
+import { useSharedThreadPullRequest } from "../state/pullRequests";
 import { useAtomCommand } from "../state/use-atom-command";
 import {
   buildThreadRouteParams,
@@ -871,14 +872,18 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     gitStatus.data,
   );
   const retainTerminalOnBranchMismatch = thread.worktreePath === null;
-  const pr = resolveDisplayedThreadPr({
-    threadBranch: thread.branch,
-    gitStatus: visibleGitStatus,
-    snapshot: changeRequestSnapshot,
-    retainTerminalOnBranchMismatch,
-    linkedPullRequest: thread.linkedPullRequest,
-    linkedPullRequestStatus,
-  });
+  const pr = useSharedThreadPullRequest(
+    thread.environmentId,
+    thread.projectId,
+    resolveDisplayedThreadPr({
+      threadBranch: thread.branch,
+      gitStatus: visibleGitStatus,
+      snapshot: changeRequestSnapshot,
+      retainTerminalOnBranchMismatch,
+      linkedPullRequest: thread.linkedPullRequest,
+      linkedPullRequestStatus,
+    }),
+  );
 
   // Same semantics as the legacy sidebar (never-visited counts as read):
   // switching sidebars must not light up every historical thread as unread.
@@ -991,9 +996,15 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       linkedPullRequestStatus,
     });
     if (nextSnapshot === undefined) return;
-    onChangeRequestSnapshot(threadKey, nextSnapshot);
+    onChangeRequestSnapshot(
+      threadKey,
+      nextSnapshot !== null && pr !== null && nextSnapshot.pr.url === pr.url
+        ? { ...nextSnapshot, pr }
+        : nextSnapshot,
+    );
   }, [
     changeRequestSnapshot,
+    pr,
     visibleGitStatus,
     linkedPullRequestStatus,
     onChangeRequestSnapshot,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -125,7 +125,7 @@ import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../s
 import { vcsEnvironment } from "../state/vcs";
 import { threadEnvironment } from "../state/threads";
 import { useEnvironmentQuery } from "../state/query";
-import { useSharedThreadPullRequest } from "../state/pullRequests";
+import { samePullRequestUrl, useSharedThreadPullRequest } from "../state/pullRequests";
 import { useAtomCommand } from "../state/use-atom-command";
 import {
   buildThreadRouteParams,
@@ -998,7 +998,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     if (nextSnapshot === undefined) return;
     onChangeRequestSnapshot(
       threadKey,
-      nextSnapshot !== null && pr !== null && nextSnapshot.pr.url === pr.url
+      nextSnapshot !== null && pr !== null && samePullRequestUrl(nextSnapshot.pr.url, pr.url)
         ? { ...nextSnapshot, pr }
         : nextSnapshot,
     );

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -18,7 +18,11 @@ import { useEnvironment, usePrimaryEnvironmentId } from "../state/environments";
 import { EnvironmentMachineIcon } from "./EnvironmentMachineIcon";
 import { useProject } from "../state/entities";
 import { useEnvironmentQuery } from "../state/query";
-import { linkedPullRequestDetailAtom, useSharedPullRequestSummary } from "../state/pullRequests";
+import {
+  linkedPullRequestDetailAtom,
+  useSharedPullRequestSummary,
+  useSharedThreadPullRequest,
+} from "../state/pullRequests";
 import { useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { vcsEnvironment } from "../state/vcs";
 import { useUiStateStore } from "../uiStateStore";
@@ -573,10 +577,13 @@ export function ThreadRowLeadingStatus({ thread }: { thread: SidebarThreadSummar
         })
       : null,
   );
-  const pr =
+  const pr = useSharedThreadPullRequest(
+    thread.environmentId,
+    thread.projectId,
     thread.linkedPullRequest == null
       ? resolveThreadPr({ threadBranch: thread.branch, gitStatus: gitStatus.data })
-      : (linkedPullRequest?.pr ?? null);
+      : (linkedPullRequest?.pr ?? null),
+  );
   const prStatus = prStatusIndicator(
     pr,
     linkedPullRequest?.sourceControlProvider ?? gitStatus.data?.sourceControlProvider,

--- a/apps/web/src/components/pullRequest/PullRequestChecksPopover.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestChecksPopover.tsx
@@ -8,8 +8,7 @@ import type {
 
 import { useOpenLink } from "~/browser/useOpenLink";
 import { cn } from "~/lib/utils";
-import { pullRequestEnvironment } from "~/state/pullRequests";
-import { useEnvironmentQuery } from "~/state/query";
+import { usePullRequestDetail } from "~/state/pullRequests";
 
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
@@ -35,9 +34,7 @@ function LazyChecksBody({
   reference: PullRequestRef;
   threadRef: ScopedThreadRef | null;
 }) {
-  const detailQuery = useEnvironmentQuery(
-    pullRequestEnvironment.detail({ environmentId, input: reference }),
-  );
+  const detailQuery = usePullRequestDetail({ environmentId, input: reference });
   if (detailQuery.error !== null) {
     return <p className="text-muted-foreground text-xs">{detailQuery.error}</p>;
   }

--- a/apps/web/src/components/pullRequest/PullRequestChecksPopover.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestChecksPopover.tsx
@@ -35,7 +35,7 @@ function LazyChecksBody({
   threadRef: ScopedThreadRef | null;
 }) {
   const detailQuery = usePullRequestDetail({ environmentId, input: reference });
-  if (detailQuery.error !== null) {
+  if (detailQuery.error !== null && detailQuery.data === null) {
     return <p className="text-muted-foreground text-xs">{detailQuery.error}</p>;
   }
   if (detailQuery.data === null) {

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -8,7 +8,6 @@ import {
   type PullRequestListEntry,
   type PullRequestUpdateMethod,
   type PullRequestRef,
-  type PullRequestState,
   resolveEnvironmentMachineKind,
   type ScopedThreadRef,
 } from "@t3tools/contracts";
@@ -67,7 +66,9 @@ import { useLiveRefresh } from "~/hooks/useLiveRefresh";
 import {
   pullRequestEnvironment,
   usePullRequestTurnRefresh,
-  useSharedPullRequestSummary,
+  usePullRequestDetail,
+  refreshPullRequest,
+  refreshPullRequestFromHost,
 } from "~/state/pullRequests";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { vcsEnvironment } from "~/state/vcs";
@@ -126,13 +127,9 @@ import {
   pullRequestFindingKey,
   pullRequestHandoffLabels,
   readableFailure,
-  readPullRequestDetailSnapshot,
-  resolveDisplayedPullRequestDetail,
   resolvePullRequestPrimaryControl,
   resolveBaseFreshness,
   type PullRequestFinding,
-  shouldRefreshPullRequestActivity,
-  writePullRequestDetailSnapshot,
 } from "./pullRequestDetail.logic";
 import { canEditPullRequestChangeRequest } from "./pullRequestEditing.logic";
 import {
@@ -451,10 +448,8 @@ export function PullRequestDetailPanel({
   threadRef = null,
   reference,
   listEntry = null,
-  refreshToken: forcedRefreshToken = 0,
   onActed,
   onClose,
-  onStateChange,
   context = "page",
   composerDraftTarget,
 }: {
@@ -470,20 +465,12 @@ export function PullRequestDetailPanel({
   /** Row fields already loaded by the pull-request list, used while richer detail arrives. */
   listEntry?: PullRequestListEntry | null;
   /**
-   * Bumped by whatever holds the panel when a reader asks for everything on screen to be read
-   * again. The panel owns its own reads, so the page cannot refresh them for it — it says when,
-   * and this says it.
-   */
-  refreshToken?: number;
-  /**
    * An action changed this pull request on the host, so a list showing it is now out of date.
    * Told rather than assumed: only the page knows whether it is showing one.
    */
   onActed?: () => void;
   /** Page-owned detail columns use this to clear the selected pull request. */
   onClose?: () => void;
-  /** Keeps surrounding inferred thread state in step with refreshed host state. */
-  onStateChange?: (status: { repository: string; number: number; state: PullRequestState }) => void;
   /**
    * Beside a thread, the checkout affordance disappears: the panel is showing that thread's
    * own pull request, so the branch is already under the reader's feet — and checking it out
@@ -574,73 +561,21 @@ export function PullRequestDetailPanel({
   // Which handoff is preparing, keyed so a per-finding button can say "Preparing..." on itself
   // alone. One at a time whatever the key: they all check the same pull request out.
   const [handoff, setHandoff] = useState<string | null>(null);
-  const detailQuery = useEnvironmentQuery(
-    pullRequestEnvironment.detail({ environmentId, input: reference }),
+  const target = useMemo(
+    () => ({
+      environmentId,
+      input: {
+        projectId: reference.projectId,
+        repository: reference.repository.toLowerCase(),
+        number: reference.number,
+      },
+    }),
+    [environmentId, reference.projectId, reference.repository, reference.number],
   );
-  const activityQuery = useEnvironmentQuery(
-    pullRequestEnvironment.activity({ environmentId, input: reference }),
-  );
+  const detailQuery = usePullRequestDetail(target);
+  const activityQuery = useEnvironmentQuery(pullRequestEnvironment.activity(target));
   const turnRefresh = usePullRequestTurnRefresh(environmentId);
-  const [cachedDetail, setCachedDetail] = useState(() =>
-    readPullRequestDetailSnapshot(
-      typeof window === "undefined" ? undefined : window.localStorage,
-      environmentId,
-      reference,
-    ),
-  );
-  useEffect(() => {
-    setCachedDetail(
-      readPullRequestDetailSnapshot(
-        typeof window === "undefined" ? undefined : window.localStorage,
-        environmentId,
-        reference,
-      ),
-    );
-  }, [environmentId, pullRequestKey, reference.projectId, reference.repository, reference.number]);
-  useEffect(() => {
-    if (detailQuery.data === null) return;
-    writePullRequestDetailSnapshot(
-      typeof window === "undefined" ? undefined : window.localStorage,
-      environmentId,
-      reference,
-      detailQuery.data,
-    );
-    setCachedDetail(detailQuery.data);
-  }, [
-    detailQuery.data,
-    environmentId,
-    pullRequestKey,
-    reference.projectId,
-    reference.repository,
-    reference.number,
-  ]);
-  const resolvedCoreDetail = resolveDisplayedPullRequestDetail({
-    live: detailQuery.data,
-    cached: cachedDetail,
-    reference,
-  });
-  const sharedSummary = useSharedPullRequestSummary(environmentId, reference, resolvedCoreDetail);
-  const coreDetail = useMemo(
-    () =>
-      resolvedCoreDetail === null || sharedSummary === null || sharedSummary === resolvedCoreDetail
-        ? resolvedCoreDetail
-        : {
-            ...resolvedCoreDetail,
-            ...sharedSummary,
-            closedAt:
-              sharedSummary.closedAt === undefined
-                ? resolvedCoreDetail.closedAt
-                : sharedSummary.closedAt,
-            mergedAt:
-              sharedSummary.mergedAt === undefined
-                ? resolvedCoreDetail.mergedAt
-                : sharedSummary.mergedAt,
-            // A summary may come from an older server that does not report draft state. Keep the
-            // detail's required value instead of making the complete detail shape partial.
-            isDraft: sharedSummary.isDraft ?? resolvedCoreDetail.isDraft,
-          },
-    [resolvedCoreDetail, sharedSummary],
-  );
+  const coreDetail = detailQuery.data;
   const activity = activityQuery.data;
   const detail = useMemo(
     () =>
@@ -696,32 +631,8 @@ export function PullRequestDetailPanel({
     isStackedPullRequestBase(detail.baseBranch, branchRefsQuery.data?.refs ?? []);
   const activityPending = activityQuery.isPending && activity === null;
   const activityError = activity === null ? activityQuery.error : null;
-  const refreshDetail = useCallback(() => {
-    detailQuery.refresh();
-    activityQuery.refresh();
-  }, [activityQuery.refresh, detailQuery.refresh]);
-  const [refreshToken, setRefreshToken] = useState(0);
-  const codeRefreshToken = refreshToken + (turnRefresh ?? 0);
-  const activityRevision = useRef<{ readonly key: string; readonly updatedAt: string } | null>(
-    null,
-  );
-  useEffect(() => {
-    if (!coreDetail) return;
-    const next = { key: tabScopeKey, updatedAt: coreDetail.updatedAt };
-    if (shouldRefreshPullRequestActivity(activityRevision.current, next)) {
-      activityQuery.refresh();
-      setRefreshToken((token) => token + 1);
-    }
-    activityRevision.current = next;
-  }, [activityQuery.refresh, coreDetail, tabScopeKey]);
-  useLayoutEffect(() => {
-    if (!resolvedCoreDetail) return;
-    onStateChange?.({
-      repository: resolvedCoreDetail.repository,
-      number: resolvedCoreDetail.number,
-      state: resolvedCoreDetail.state,
-    });
-  }, [onStateChange, resolvedCoreDetail]);
+  const refreshDetail = useCallback(() => refreshPullRequest(target), [target]);
+  const codeRefreshToken = detailQuery.revision + (turnRefresh ?? 0);
   // Reuse activity and diff until core detail reports a changed revision. Keyed by
   // the pull request rather than by the panel, because this one panel shows a different pull
   // request every time it is opened.
@@ -731,29 +642,15 @@ export function PullRequestDetailPanel({
     },
     { key: `pull-request:${environmentId}:${pullRequestKey}` },
   );
-  // The button, on the other hand, goes around the server's cache rather than through it: it is
-  // the answer for a reader who can see that what they are looking at is behind. The
-  // invalidation goes first so the re-reads miss that cache; if it fails, the reads still run
-  // and at worst answer from it.
-  const invalidate = useAtomCommand(pullRequestEnvironment.invalidate, { reportFailure: false });
   const [isInvalidating, setIsInvalidating] = useState(false);
   const refreshFromHost = useCallback(async () => {
     setIsInvalidating(true);
     try {
-      await invalidate({ environmentId, input: { reference } });
-      refreshDetail();
-      setRefreshToken((token) => token + 1);
+      await refreshPullRequestFromHost(target);
     } finally {
       setIsInvalidating(false);
     }
-  }, [environmentId, invalidate, reference, refreshDetail]);
-  // A refresh asked for by the page: the detail, and through the token below, the diff with it.
-  const appliedForcedToken = useRef(forcedRefreshToken);
-  useEffect(() => {
-    if (appliedForcedToken.current === forcedRefreshToken) return;
-    appliedForcedToken.current = forcedRefreshToken;
-    void refreshFromHost();
-  }, [forcedRefreshToken, refreshFromHost]);
+  }, [target]);
   const runAction = useAtomCommand(pullRequestEnvironment.runAction, { reportFailure: false });
   const postComment = useAtomCommand(pullRequestEnvironment.comment, { reportFailure: false });
   // Which action is in flight, not merely that one is: every control here is disabled while any

--- a/apps/web/src/components/pullRequest/PullRequestLinkPreview.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestLinkPreview.tsx
@@ -3,9 +3,8 @@ import type { EnvironmentId, PullRequestRef } from "@t3tools/contracts";
 import { cloneElement, useState, type ComponentPropsWithoutRef, type ReactElement } from "react";
 
 import { formatRelativeTimeLabel } from "~/timestampFormat";
-import { pullRequestEnvironment } from "~/state/pullRequests";
+import { pullRequestEnvironment, usePullRequestDetail } from "~/state/pullRequests";
 import { useAtomQueryRunner } from "~/state/use-atom-query-runner";
-import { useEnvironmentQuery } from "~/state/query";
 
 import { PreviewCard, PreviewCardPopup, PreviewCardTrigger } from "../ui/preview-card";
 import { PullRequestActorAvatar, resolvePullRequestState } from "./pullRequestPresentation";
@@ -34,14 +33,7 @@ export function PullRequestLinkPreview({
 }) {
   const [open, setOpen] = useState(false);
   const [resolvingClick, setResolvingClick] = useState(false);
-  const detailQuery = useEnvironmentQuery(
-    open
-      ? pullRequestEnvironment.detail({
-          environmentId: target.environmentId,
-          input: target.input,
-        })
-      : null,
-  );
+  const detailQuery = usePullRequestDetail(open ? target : null);
   const readDetail = useAtomQueryRunner(pullRequestEnvironment.detail, {
     reportFailure: false,
     reportDefect: false,

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -36,9 +36,7 @@ import {
   PULL_REQUEST_DETAIL_SNAPSHOT_MAX_ENTRIES,
   readableFailure,
   readPullRequestDetailSnapshot,
-  resolveDisplayedPullRequestDetail,
   resolvePullRequestPrimaryControl,
-  shouldRefreshPullRequestActivity,
   resolveBaseFreshness,
   buildPullRequestTimeline,
   editPullRequestThreadComment,
@@ -88,32 +86,6 @@ const TIMELINE_SOURCE: Pick<
   closedAt: null,
 };
 
-describe("pull request activity refresh", () => {
-  const first = {
-    key: "project:acme/web#7",
-    updatedAt: "2026-08-13T13:00:00Z",
-  };
-
-  it("refreshes activity only after the same pull request changes", () => {
-    expect(
-      shouldRefreshPullRequestActivity(first, {
-        ...first,
-        updatedAt: "2026-08-13T13:01:00Z",
-      }),
-    ).toBe(true);
-  });
-
-  it("does not duplicate the first activity read or carry a revision across pull requests", () => {
-    expect(shouldRefreshPullRequestActivity(null, first)).toBe(false);
-    expect(shouldRefreshPullRequestActivity(first, first)).toBe(false);
-    expect(
-      shouldRefreshPullRequestActivity(first, {
-        key: "project:acme/web#8",
-        updatedAt: "2026-08-13T13:01:00Z",
-      }),
-    ).toBe(false);
-  });
-});
 describe("review thread comment pages", () => {
   it("appends new comments once and keeps refreshed base comments", () => {
     expect(
@@ -1620,26 +1592,6 @@ describe("cached pull request detail", () => {
     );
     expect(readPullRequestDetailSnapshot(storage, "env-1", reference)).toBeNull();
     expect(storage.entries().filter(([key]) => key.startsWith(snapshotPrefix))).toHaveLength(0);
-  });
-
-  it("keeps a cached tab painted while the live read replaces the counts", () => {
-    const cached = detail();
-    const live = detail({ additions: 40, deletions: 9, title: "Cache the title" });
-    expect(resolveDisplayedPullRequestDetail({ live, cached, reference })?.additions).toBe(40);
-    expect(resolveDisplayedPullRequestDetail({ live: null, cached, reference })?.additions).toBe(
-      12,
-    );
-  });
-
-  it("does not paint another change request's snapshot", () => {
-    expect(
-      resolveDisplayedPullRequestDetail({
-        live: null,
-        cached: detail({ number: 8 }),
-        reference,
-      }),
-    ).toBeNull();
-    expect(readPullRequestDetailSnapshot(makeStorage(), "env-2", reference)).toBeNull();
   });
 
   it("tolerates corrupt, denied, missing, and non-evictable storage", () => {

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -2,6 +2,7 @@ import * as Schema from "effect/Schema";
 
 import {
   PullRequestDetail,
+  PullRequestSummary,
   type PullRequestAction,
   type PullRequestActor,
   type PullRequestBaseComparison,
@@ -91,13 +92,6 @@ export function pullRequestCheckoutCommand(
   }
 }
 
-/** Activity changes only when the same host resource reports a newer revision. */
-export function shouldRefreshPullRequestActivity(
-  previous: { readonly key: string; readonly updatedAt: string } | null,
-  next: { readonly key: string; readonly updatedAt: string },
-): boolean {
-  return previous !== null && previous.key === next.key && previous.updatedAt !== next.updatedAt;
-}
 /** Appends fetched pages without replacing fresher comments already in the activity response. */
 export function mergePullRequestThreadComments<T extends { readonly id: string }>(
   base: ReadonlyArray<T>,
@@ -1076,14 +1070,19 @@ const pullRequestDetailSnapshotKey = (
     reference.number,
   ])}`;
 
-const decodeDetailSnapshot = Schema.decodeUnknownOption(PullRequestDetail);
+const PullRequestDetailSnapshot = Schema.Struct({
+  ...PullRequestDetail.fields,
+  observedSummary: Schema.optional(PullRequestSummary),
+});
+type PullRequestDetailSnapshot = typeof PullRequestDetailSnapshot.Type;
+const decodeDetailSnapshot = Schema.decodeUnknownOption(PullRequestDetailSnapshot);
 
 /** Hydrates one recent detail after a reload while the live query refreshes it. */
 export function readPullRequestDetailSnapshot(
   storage: SnapshotStorage | undefined,
   environmentId: string,
   reference: PullRequestDetailSnapshotRef,
-): PullRequestDetail | null {
+): PullRequestDetailSnapshot | null {
   try {
     if (!storage) return null;
     const key = pullRequestDetailSnapshotKey(environmentId, reference);
@@ -1114,7 +1113,7 @@ export function writePullRequestDetailSnapshot(
   storage: SnapshotStorage | undefined,
   environmentId: string,
   reference: PullRequestDetailSnapshotRef,
-  detail: PullRequestDetail,
+  detail: PullRequestDetailSnapshot,
 ): void {
   try {
     // Stores without eviction support remain readable but cannot grow this cache.
@@ -1160,22 +1159,4 @@ export function writePullRequestDetailSnapshot(
   } catch {
     // Quota or denied storage: the next open can still use the live query.
   }
-}
-
-/** Live host state wins; a snapshot is only the same change request, never a neighbour's. */
-export function resolveDisplayedPullRequestDetail(input: {
-  readonly live: PullRequestDetail | null;
-  readonly cached: PullRequestDetail | null;
-  readonly reference: PullRequestDetailSnapshotRef;
-}): PullRequestDetail | null {
-  if (input.live !== null) return input.live;
-  if (
-    input.cached !== null &&
-    input.cached.projectId === input.reference.projectId &&
-    input.cached.repository.toLowerCase() === input.reference.repository.toLowerCase() &&
-    input.cached.number === input.reference.number
-  ) {
-    return input.cached;
-  }
-  return null;
 }

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -1,6 +1,8 @@
 import * as Schema from "effect/Schema";
 
 import {
+  EnvironmentId,
+  ProjectId,
   PullRequestDetail,
   PullRequestSummary,
   type PullRequestAction,
@@ -1077,6 +1079,37 @@ const PullRequestDetailSnapshot = Schema.Struct({
 type PullRequestDetailSnapshot = typeof PullRequestDetailSnapshot.Type;
 const decodeDetailSnapshot = Schema.decodeUnknownOption(PullRequestDetailSnapshot);
 
+const decodeDetailSnapshotReference = Schema.decodeUnknownOption(
+  Schema.Tuple([EnvironmentId, ProjectId, Schema.String, Schema.Number]),
+);
+
+/** Recover URL references from the bounded detail cache, without retaining another payload copy. */
+export function readPullRequestDetailSnapshotReferences(storage: SnapshotStorage | undefined) {
+  if (!storage) return [];
+  return readDetailSnapshotIndex(storage).flatMap((entry) => {
+    try {
+      const ref = decodeDetailSnapshotReference(
+        JSON.parse(entry.key.slice(DETAIL_SNAPSHOT_PREFIX.length)),
+      );
+      if (ref._tag === "None") return [];
+      const [environmentId, projectId, repository, number] = ref.value;
+      const raw = storage.getItem(entry.key);
+      if (!raw || entry.bytes !== 2 * (entry.key.length + raw.length)) return [];
+      const detail = decodeDetailSnapshot(JSON.parse(raw));
+      if (
+        detail._tag === "None" ||
+        detail.value.projectId !== projectId ||
+        detail.value.repository.toLowerCase() !== repository.toLowerCase() ||
+        detail.value.number !== number
+      )
+        return [];
+      return [{ environmentId, input: { projectId, repository, number }, url: detail.value.url }];
+    } catch {
+      return [];
+    }
+  });
+}
+
 /** Hydrates one recent detail after a reload while the live query refreshes it. */
 export function readPullRequestDetailSnapshot(
   storage: SnapshotStorage | undefined,
@@ -1085,10 +1118,29 @@ export function readPullRequestDetailSnapshot(
 ): PullRequestDetailSnapshot | null {
   try {
     if (!storage) return null;
-    const key = pullRequestDetailSnapshotKey(environmentId, reference);
+    const requestedKey = pullRequestDetailSnapshotKey(environmentId, reference);
     const index = readDetailSnapshotIndex(storage);
-    const entry = index.find((entry) => entry.key === key);
+    const entry =
+      index.find((entry) => entry.key === requestedKey) ??
+      index.find((entry) => {
+        try {
+          const decoded = decodeDetailSnapshotReference(
+            JSON.parse(entry.key.slice(DETAIL_SNAPSHOT_PREFIX.length)),
+          );
+          if (decoded._tag === "None") return false;
+          const [savedEnvironment, projectId, repository, number] = decoded.value;
+          return (
+            savedEnvironment === environmentId &&
+            projectId === reference.projectId &&
+            repository.toLowerCase() === reference.repository.toLowerCase() &&
+            number === reference.number
+          );
+        } catch {
+          return false;
+        }
+      });
     if (!entry) return null;
+    const key = entry.key;
     const raw = storage.getItem(key);
     if (!raw || entry.bytes !== 2 * (key.length + raw.length)) return null;
     const decoded = decodeDetailSnapshot(JSON.parse(raw));

--- a/apps/web/src/hooks/useOpenPanelPullRequestUrl.ts
+++ b/apps/web/src/hooks/useOpenPanelPullRequestUrl.ts
@@ -1,16 +1,10 @@
 import { scopeProjectRef } from "@t3tools/client-runtime/environment";
 import { EnvironmentId, ProjectId, type ScopedThreadRef } from "@t3tools/contracts";
-import { useMemo } from "react";
 
-import {
-  readPullRequestDetailSnapshot,
-  resolveDisplayedPullRequestDetail,
-} from "../components/pullRequest/pullRequestDetail.logic";
 import { gitHubPullRequestBrowserUrl } from "../lib/openPullRequestLink";
 import { selectActiveRightPanelSurface, useRightPanelStore } from "../rightPanelStore";
 import { useProject } from "../state/entities";
-import { pullRequestEnvironment } from "../state/pullRequests";
-import { useEnvironmentQuery } from "../state/query";
+import { usePullRequestDetail } from "../state/pullRequests";
 
 export function useOpenPanelPullRequestUrl(threadRef: ScopedThreadRef | null) {
   const surface = useRightPanelStore((state) =>
@@ -25,31 +19,20 @@ export function useOpenPanelPullRequestUrl(threadRef: ScopedThreadRef | null) {
       ? scopeProjectRef(environmentId, ProjectId.make(reference.projectId))
       : null,
   );
-  const detail = useEnvironmentQuery(
+  const detail = usePullRequestDetail(
     reference && environmentId
-      ? pullRequestEnvironment.detail({
+      ? {
           environmentId,
           input: {
             projectId: ProjectId.make(reference.projectId),
             repository: reference.repository,
             number: reference.number,
           },
-        })
+        }
       : null,
   ).data;
-  const cachedDetail = useMemo(
-    () =>
-      reference && environmentId
-        ? readPullRequestDetailSnapshot(
-            typeof window === "undefined" ? undefined : window.localStorage,
-            environmentId,
-            reference,
-          )
-        : null,
-    [environmentId, reference],
-  );
   return reference
-    ? (resolveDisplayedPullRequestDetail({ live: detail, cached: cachedDetail, reference })?.url ??
+    ? (detail?.url ??
         gitHubPullRequestBrowserUrl(
           project?.repositoryIdentity,
           reference.repository,

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -60,12 +60,10 @@ import {
   rankPullRequestMatches,
   sortPullRequestGroups,
   pullRequestEnvironmentSetKey,
-  readPullRequestListSnapshot,
   resolveProjectScope,
   resolveQueryEnvironmentIds,
   resolveSelectedEnvironmentId,
   withDiffStat,
-  writePullRequestListSnapshot,
   scorePullRequestMatch,
   pullRequestStatsRefreshBatches,
   pullRequestStatsRequestBatches,
@@ -76,7 +74,6 @@ import {
   type PullRequestStatsBatch,
   type PullRequestStatsPolicy,
   type PullRequestStatsScope,
-  type PullRequestPartitionsSnapshot,
 } from "../components/pullRequest/pullRequestList.logic";
 import {
   pullRequestListPreferences,
@@ -134,6 +131,9 @@ import { useAllEnvironmentShellsBootstrapped, useProjects } from "../state/entit
 import { useEnvironments } from "../state/environments";
 import {
   pullRequestEnvironment,
+  refreshPullRequestFromHost,
+  useObservedPullRequestEntries,
+  useRetainedPullRequestList,
   usePullRequestList,
   usePullRequestListStats,
   usePullRequestTurnRefreshes,
@@ -193,6 +193,7 @@ const SORT_OPTIONS = [
 
 /** Long enough that a keystroke does not become a request, short enough to feel answered. */
 const SEARCH_DEBOUNCE_MS = 250;
+const EMPTY_ENTRIES: ReadonlyArray<EnvironmentPullRequestEntry> = [];
 /** What `scorePullRequestMatch` gives a row none of whose own fields carry the search text. */
 const MATCHED_ELSEWHERE_SCORE = 10;
 /**
@@ -802,10 +803,6 @@ function PullRequestsRouteView() {
   // The header's refresh punches through the server's cache before re-reading; the error and
   // empty states retry plainly, because a failure is never cached.
   const invalidate = useAtomCommand(pullRequestEnvironment.invalidate, { reportFailure: false });
-  // What the reader pressed refresh for is everything they can see, not the one query that
-  // happens to be theirs: the list, the counts beside its rows, and whatever the panel is
-  // showing. The panel owns its own reads, so it is told to redo them rather than reached into.
-  const [detailRefreshToken, setDetailRefreshToken] = useState(0);
   // The queries only go pending once the invalidation has come back, so refreshing is tracked
   // from the first moment rather than the second: a button that stays live through the slow half
   // of its own work is a button that gets pressed again, and buys the whole cascade twice.
@@ -835,22 +832,19 @@ function PullRequestsRouteView() {
       setStatsTargetState({ key: requestedStatsScope.key, batches });
       statsQuery.refresh(batches.map(({ environmentId, input }) => ({ environmentId, input })));
     }
-    if (includeDetail) setDetailRefreshToken((token) => token + 1);
+    if (includeDetail && panelEnvironmentId !== null && renderedPullRequestSurface !== null) {
+      void refreshPullRequestFromHost({
+        environmentId: panelEnvironmentId,
+        input: {
+          projectId: renderedPullRequestSurface.projectId as ProjectId,
+          repository: renderedPullRequestSurface.repository,
+          number: renderedPullRequestSurface.number,
+        },
+      });
+    }
   };
   const refreshing = invalidating || listQuery.isPending;
 
-  // Every page size and every search is its own query, and a new one starts empty. The last
-  // answer for these filters is held so the page grows and narrows in place rather than blanking
-  // out: a longer page reads as growth, and a search shows the rows it already has, narrowed
-  // here, until the hosts answer for themselves.
-  const [loaded, setLoaded] = useState<{
-    environmentKey: string;
-    scope: string;
-    query: string;
-    data: MergedPullRequestList;
-    /** The priority groups' own answers, carried so a cold start has whole groups too. */
-    partitions?: PullRequestPartitionsSnapshot;
-  } | null>(null);
   // A longer page is the same list with more on the end, so the rows already read stay where
   // they were read: each answer is merged onto the last rather than replacing it, and anything
   // new lands at the bottom. Only a different question — other filters, another search — starts
@@ -860,98 +854,16 @@ function PullRequestsRouteView() {
     key: string;
     entries: ReadonlyArray<EnvironmentPullRequestEntry>;
   } | null>(null);
-  // A reload recreates the registry the queries live in, so with nothing held the page would
-  // cold-start into skeletons even though almost every row is unchanged. The last answer for
-  // this set of environments is kept across reloads and hydrated here as the carried rows: they
-  // render at once — narrowed to the current filters like any carried answer — and the live read
-  // reconciles them in place by key rather than replacing them with ghosts.
-  useEffect(() => {
-    if (environmentKey.length === 0) return;
-    setLoaded((current) => {
-      // Rows read from a different set of environments cannot even be narrowed — one of them may
-      // no longer be connected at all — so that set's own snapshot beats holding them.
-      if (current !== null && current.environmentKey === environmentKey) return current;
-      const snapshot = readPullRequestListSnapshot(
-        typeof window === "undefined" ? undefined : window.localStorage,
-        environmentKey,
-      );
-      if (snapshot === null) return null;
-      return {
-        environmentKey,
-        scope: snapshot.scope,
-        query: "",
-        data: snapshot.data,
-        ...(snapshot.partitions === undefined ? {} : { partitions: snapshot.partitions }),
-      };
-    });
-  }, [environmentKey]);
-  useEffect(() => {
-    // Only once this query has settled. While a search is being swapped in or out the text has
-    // already changed and the data has not, so recording them together would file the previous
-    // answer under the new question — which is how a search's answer came to speak for the
-    // workspace after the search was cleared.
-    if (!listQuery.data || listQuery.isPending) return;
-    const data = listQuery.data;
-    setLoaded((current) => {
-      // The partitions arrive on their own clock, so this records whichever have landed by
-      // now and runs again when the rest do. Until then the ones already held for this scope
-      // stay — hydrated or previously answered — rather than being dropped for a feed that
-      // merely settled first.
-      const partitions =
-        partitionsWanted && authoredQuery.data !== null && reviewingQuery.data !== null
-          ? { authored: authoredQuery.data.entries, reviewing: reviewingQuery.data.entries }
-          : current !== null &&
-              current.environmentKey === environmentKey &&
-              current.scope === scopeKey
-            ? current.partitions
-            : undefined;
-      // A search's answer is the search's, not the workspace's, so only unsearched lists
-      // persist. Written here where the held partitions are in reach, so a feed settling
-      // ahead of them cannot overwrite a stored snapshot that already had both groups.
-      //
-      // What is written is what the reader is actually looking at, not this round's own
-      // answer: a continuation only asks the environments still paging, so its answer alone is
-      // missing both the rows read on earlier pages and the hosts of whichever environment had
-      // already run out of cursors. `ordered` carries the accumulated rows, and the baseline
-      // read — which never drops an environment for lack of a cursor — carries the full hosts.
-      if (environmentKey.length > 0 && sentQuery.length === 0) {
-        const accumulatedEntries = ordered?.key === filterKey ? ordered.entries : data.entries;
-        writePullRequestListSnapshot(
-          typeof window === "undefined" ? undefined : window.localStorage,
-          environmentKey,
-          {
-            scope: scopeKey,
-            data: {
-              ...data,
-              entries: accumulatedEntries,
-              viewers: baselineQuery.data?.viewers ?? data.viewers,
-              providers: baselineQuery.data?.providers ?? data.providers,
-            },
-            ...(partitions === undefined ? {} : { partitions }),
-          },
-        );
-      }
-      return {
-        environmentKey,
-        scope: scopeKey,
-        query: sentQuery,
-        data: { ...data, entries: ordered?.key === filterKey ? ordered.entries : data.entries },
-        ...(partitions === undefined ? {} : { partitions }),
-      };
-    });
-  }, [
+  const loaded = useRetainedPullRequestList({
     environmentKey,
-    scopeKey,
-    sentQuery,
-    listQuery.data,
-    listQuery.isPending,
-    partitionsWanted,
-    authoredQuery.data,
-    reviewingQuery.data,
-    ordered,
-    filterKey,
-    baselineQuery.data,
-  ]);
+    scope: scopeKey,
+    query: sentQuery,
+    live: listQuery,
+    baseline: baselineQuery.data,
+    orderedEntries: ordered?.key === filterKey ? ordered.entries : null,
+    authored: partitionsWanted ? authoredQuery.data : null,
+    reviewing: partitionsWanted ? reviewingQuery.data : null,
+  });
   // Changing a filter asks a question nothing has answered yet, and the page is already holding
   // perfectly good rows for the last one. Rather than blank out for the round trip, those rows
   // are narrowed to the new filters and stay until the answer lands — a subset of it, never a
@@ -1144,8 +1056,15 @@ function PullRequestsRouteView() {
     [baselineQuery.data?.providers, listData?.providers],
   );
 
+  const observedEntries = useObservedPullRequestEntries(
+    ordered?.key === filterKey ? ordered.entries : (listData?.entries ?? EMPTY_ENTRIES),
+  );
   const entries = useMemo(() => {
-    const known = ordered?.key === filterKey ? ordered.entries : (listData?.entries ?? []);
+    const known = narrowPullRequestsToFilters(observedEntries, {
+      state: search.state,
+      projectId: scopedProjectId,
+      host: search.host,
+    });
     const involvementEntries = filterPullRequestsByInvolvement(known, viewers, search.involvement);
     // The hosts search more than the row shows — a body, a review, a commit message — so once
     // their answer is in, narrowing it again here would throw away matches the reader asked for.
@@ -1175,13 +1094,14 @@ function PullRequestsRouteView() {
         matchesPullRequestQuery(entry, typedParsed.text),
     );
   }, [
-    filterKey,
     hasLocalFilters,
     localFilters,
-    listData,
-    ordered,
+    observedEntries,
     querySettled,
     search.involvement,
+    search.state,
+    search.host,
+    scopedProjectId,
     searchingHosts,
     showingCarried,
     typedParsed.text,
@@ -1211,46 +1131,52 @@ function PullRequestsRouteView() {
    * listing leaves them out and they arrive a moment later, into rows that already draw without
    * them. Keyed by the rows being shown, so scrolling further asks only about what is new.
    */
+  const heldPartitions =
+    loaded !== null && loaded.environmentKey === environmentKey && loaded.scope === scopeKey
+      ? loaded.partitions
+      : undefined;
+  const authoredEntries = partitionsWanted
+    ? (authoredQuery.data?.entries ?? heldPartitions?.authored)
+    : undefined;
+  const reviewingEntries = partitionsWanted
+    ? (reviewingQuery.data?.entries ?? heldPartitions?.reviewing)
+    : undefined;
+  const observedAuthored = useObservedPullRequestEntries(authoredEntries ?? EMPTY_ENTRIES);
+  const observedReviewing = useObservedPullRequestEntries(reviewingEntries ?? EMPTY_ENTRIES);
   const groups = useMemo(() => {
     if (search.involvement !== "all") return [{ key: "others" as const, label: "", entries }];
-    // Until both partitions have answered, the snapshot's stand in — they are yesterday's
-    // groups, but whole ones, where grouping the feed's first page locally loses every
-    // authored row older than it. Once the live reads land they take over; with neither,
-    // the local grouping is still better than nothing.
-    const held =
-      loaded !== null && loaded.environmentKey === environmentKey && loaded.scope === scopeKey
-        ? loaded.partitions
-        : undefined;
-    // The priority reads answer the same question the feed does, so they take the same local
-    // narrowing: a host that cannot filter for itself would otherwise put rows into Authored
-    // that the filters above just took out of the feed.
-    const narrow = (rows: ReadonlyArray<EnvironmentPullRequestEntry> | undefined) =>
-      rows === undefined || !hasLocalFilters
-        ? rows
-        : rows.filter((entry) =>
-            matchesPullRequestFilters(entry, localFilters, pullRequestEntryViewer(entry, viewers)),
-          );
-    const authored = narrow(
-      partitionsWanted ? (authoredQuery.data?.entries ?? held?.authored) : undefined,
-    );
-    const reviewing = narrow(
-      partitionsWanted ? (reviewingQuery.data?.entries ?? held?.reviewing) : undefined,
-    );
-    if (authored === undefined || reviewing === undefined) {
+    if (authoredEntries === undefined || reviewingEntries === undefined) {
       return groupPullRequestsByInvolvement(entries, viewers);
     }
-    return partitionPullRequestsWithPriority(entries, authored, reviewing);
+    const narrow = (rows: ReadonlyArray<EnvironmentPullRequestEntry>) => {
+      const scoped = narrowPullRequestsToFilters(rows, {
+        state: search.state,
+        projectId: scopedProjectId,
+        host: search.host,
+      });
+      return hasLocalFilters
+        ? scoped.filter((entry) =>
+            matchesPullRequestFilters(entry, localFilters, pullRequestEntryViewer(entry, viewers)),
+          )
+        : scoped;
+    };
+    return partitionPullRequestsWithPriority(
+      entries,
+      narrow(observedAuthored),
+      narrow(observedReviewing),
+    );
   }, [
+    authoredEntries,
+    reviewingEntries,
     hasLocalFilters,
     localFilters,
-    authoredQuery.data?.entries,
     entries,
-    environmentKey,
-    loaded,
-    partitionsWanted,
-    reviewingQuery.data?.entries,
-    scopeKey,
+    observedAuthored,
+    observedReviewing,
+    scopedProjectId,
     search.involvement,
+    search.state,
+    search.host,
     viewers,
   ]);
 
@@ -1937,7 +1863,6 @@ function PullRequestsRouteView() {
                   pullRequestListEntryId(renderedPullRequestSurface),
                 ) ?? null
               }
-              refreshToken={detailRefreshToken}
               // Host actions can change both readiness and diff size, so refresh the counts
               // alongside the list. The panel already refreshes itself after each action.
               onActed={() => {

--- a/apps/web/src/state/pullRequests.test.tsx
+++ b/apps/web/src/state/pullRequests.test.tsx
@@ -1,0 +1,579 @@
+import {
+  EnvironmentId,
+  ProjectId,
+  type PullRequestDetail,
+  type PullRequestSummary,
+  type VcsStatusResult,
+} from "@t3tools/contracts";
+import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
+import { act, useLayoutEffect } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  readPullRequestDetailSnapshot,
+  writePullRequestDetailSnapshot,
+} from "../components/pullRequest/pullRequestDetail.logic";
+import {
+  narrowPullRequestsToFilters,
+  readPullRequestListSnapshot,
+  writePullRequestListSnapshot,
+  type EnvironmentPullRequestEntry,
+  type MergedPullRequestList,
+} from "../components/pullRequest/pullRequestList.logic";
+import { AppAtomRegistryProvider, appAtomRegistry } from "../rpc/atomRegistry";
+import {
+  createPullRequestState,
+  pullRequestEnvironment,
+  pullRequestState,
+  refreshPullRequestFromHost,
+  resolveSharedThreadPullRequest,
+  useObservedPullRequestEntries,
+  usePullRequestDetail,
+  useRetainedPullRequestList,
+  useSharedPullRequestSummary,
+  useSharedThreadPullRequest,
+} from "./pullRequests";
+
+const environmentId = EnvironmentId.make("environment-1");
+const otherEnvironmentId = EnvironmentId.make("environment-2");
+const reference = { projectId: ProjectId.make("project-1"), repository: "acme/web", number: 7 };
+const target = { environmentId, input: reference };
+
+function detail(overrides: Partial<PullRequestDetail> = {}): PullRequestDetail {
+  return {
+    provider: "github",
+    capabilities: {
+      diff: true,
+      comment: true,
+      actions: ["merge"],
+      mergeMethods: ["merge"],
+      search: true,
+      review: { inlineComment: true, reply: true, resolve: true, verdicts: ["comment"] },
+      reviewers: { request: true, listCandidates: true },
+    },
+    viewerPermissions: {
+      actions: ["merge"],
+      comment: true,
+      resolve: true,
+      verdicts: ["comment"],
+      requestReviewers: true,
+    },
+    ...reference,
+    projectTitle: "web",
+    workspaceRoot: "/repo",
+    title: "Open PR",
+    body: "Current description",
+    url: "https://github.com/acme/web/pull/7",
+    author: null,
+    viewer: "reader",
+    state: "open",
+    isDraft: false,
+    mergeability: "mergeable",
+    additions: 12,
+    deletions: 3,
+    changedFiles: 2,
+    headBranch: "feature",
+    baseBranch: "main",
+    createdAt: "2026-09-01T00:00:00.000Z",
+    updatedAt: "2026-09-02T00:00:00.000Z",
+    mergedAt: null,
+    closedAt: null,
+    reviewers: [],
+    labels: [],
+    checks: [],
+    mergeCapabilities: { merge: true, squash: true, rebase: true },
+    ...overrides,
+  };
+}
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => {
+      values.set(key, value);
+    },
+    removeItem: (key) => {
+      values.delete(key);
+    },
+    key: (index) => [...values.keys()][index] ?? null,
+    clear: () => {
+      values.clear();
+    },
+  };
+}
+
+function listEntry(
+  overrides: Partial<EnvironmentPullRequestEntry> = {},
+): EnvironmentPullRequestEntry {
+  return {
+    ...detail(),
+    environmentId,
+    host: "github.com",
+    viewerReviewRequested: true,
+    ...overrides,
+  };
+}
+
+function list(entries: ReadonlyArray<EnvironmentPullRequestEntry>): MergedPullRequestList {
+  return {
+    entries,
+    viewers: { [`${environmentId} github.com`]: "reader" },
+    providers: [],
+    errors: [],
+    truncated: false,
+    nextCursors: {},
+    truncatedEnvironments: [],
+  };
+}
+
+describe("scoped pull request state", () => {
+  let registry: AtomRegistry.AtomRegistry;
+  let storage: Storage;
+  const revised = vi.fn();
+  let state: ReturnType<typeof createPullRequestState>;
+
+  beforeEach(() => {
+    registry = AtomRegistry.make();
+    storage = memoryStorage();
+    revised.mockReset();
+    state = createPullRequestState(registry, {
+      storage: () => storage,
+      onRevisionChanged: revised,
+    });
+  });
+  afterEach(() => registry.dispose());
+
+  it("retains newer detail and a confirmed merge when an older response arrives", () => {
+    const current = detail({
+      title: "Merged PR",
+      state: "merged",
+      updatedAt: "2026-09-03T00:00:00.000Z",
+    });
+    state.observeDetail(target, current);
+    state.observeDetail(target, detail({ body: "Old description" }));
+    expect(registry.get(state.snapshot(target)).detail).toBe(current);
+    expect(registry.get(state.snapshot(target)).summary?.state).toBe("merged");
+    expect(readPullRequestDetailSnapshot(storage, environmentId, reference)?.title).toBe(
+      "Merged PR",
+    );
+    expect(revised).not.toHaveBeenCalled();
+  });
+
+  it("stores summary fields without copying detail permissions or content", () => {
+    const current = detail();
+    state.observeDetail(target, current);
+    state.observeSummary(
+      target,
+      detail({
+        title: "New title",
+        updatedAt: "2026-09-03T00:00:00.000Z",
+        body: "A summary must not replace the body",
+        viewer: "another-reader",
+        viewerPermissions: { ...current.viewerPermissions, actions: [] },
+      }),
+    );
+    const snapshot = registry.get(state.snapshot(target));
+    expect(snapshot.detail).toBe(current);
+    expect(snapshot.summary?.title).toBe("New title");
+    expect(snapshot.summary).not.toHaveProperty("body");
+    expect(snapshot.summary).not.toHaveProperty("viewerPermissions");
+    const persisted = readPullRequestDetailSnapshot(storage, environmentId, reference);
+    expect(persisted?.observedSummary?.title).toBe("New title");
+    expect(persisted?.updatedAt).toBe(current.updatedAt);
+    expect(persisted?.body).toBe(current.body);
+    expect(persisted?.viewer).toBe(current.viewer);
+    expect(persisted?.viewerPermissions).toEqual(current.viewerPermissions);
+  });
+
+  it("refreshes once per accepted revision and accepts later merged metadata", () => {
+    const first = detail({ state: "merged" });
+    state.observeDetail(target, first);
+    const next = detail({
+      state: "merged",
+      title: "Updated after merge",
+      updatedAt: "2026-09-03T00:00:00.000Z",
+    });
+    state.observeSummary(target, next);
+    state.observeSummary(target, next);
+    state.observeDetail(target, next);
+    state.observeSummary(target, first);
+    expect(registry.get(state.snapshot(target)).summary?.title).toBe(next.title);
+    expect(registry.get(state.snapshot(target)).revision).toBe(1);
+    expect(revised).toHaveBeenCalledExactlyOnceWith(target);
+    state.invalidate(target);
+    expect(registry.get(state.snapshot(target)).revision).toBe(2);
+  });
+
+  it("keeps detail and summary timestamps separate across a reload", () => {
+    state.observeDetail(target, detail({ body: "Body A" }));
+    state.observeSummary(
+      target,
+      detail({ title: "Latest title", updatedAt: "2026-09-04T00:00:00.000Z" }),
+    );
+    registry.reset();
+    state.observeDetail(target, detail({ body: "Body B", updatedAt: "2026-09-03T00:00:00.000Z" }));
+    const snapshot = registry.get(state.snapshot(target));
+    expect(snapshot.detail?.body).toBe("Body B");
+    expect(snapshot.detail?.updatedAt).toBe("2026-09-03T00:00:00.000Z");
+    expect(snapshot.summary?.title).toBe("Latest title");
+    const stored = readPullRequestDetailSnapshot(storage, environmentId, reference);
+    expect(stored?.updatedAt).toBe("2026-09-03T00:00:00.000Z");
+    expect(stored?.observedSummary?.updatedAt).toBe("2026-09-04T00:00:00.000Z");
+  });
+
+  it("keeps the current viewer's permissions even when the PR timestamp goes backward", () => {
+    state.observeDetail(target, detail({ updatedAt: "2026-09-04T00:00:00.000Z" }));
+    const currentViewer = detail({
+      viewer: "new-reader",
+      viewerPermissions: {
+        actions: [],
+        comment: false,
+        resolve: false,
+        verdicts: [],
+        requestReviewers: false,
+      },
+    });
+    state.observeDetail(target, currentViewer);
+    expect(registry.get(state.snapshot(target)).detail?.viewer).toBe("new-reader");
+    expect(registry.get(state.snapshot(target)).detail?.viewerPermissions.actions).toEqual([]);
+  });
+
+  it("retains a known draft value when an older server omits it and accepts a ready update", () => {
+    state.observeDetail(target, detail({ isDraft: true }));
+    state.observeSummary(target, {
+      ...detail({ updatedAt: "2026-09-03T00:00:00.000Z" }),
+      isDraft: undefined,
+    });
+    expect(registry.get(state.snapshot(target)).summary?.isDraft).toBe(true);
+    state.observeSummary(target, detail({ isDraft: false, updatedAt: "2026-09-04T00:00:00.000Z" }));
+    expect(registry.get(state.snapshot(target)).summary?.isDraft).toBe(false);
+  });
+
+  it("shares a merge with a detected PR but not another environment, project, or host", () => {
+    const merged = detail({ state: "merged" });
+    state.observeDetail(target, merged);
+    const observed = registry.get(
+      state.summaryByUrl(environmentId, reference.projectId, merged.url),
+    );
+    const detected: NonNullable<VcsStatusResult["pr"]> = {
+      number: 7,
+      title: "Open PR",
+      url: merged.url,
+      baseRef: "main",
+      headRef: "feature",
+      state: "open",
+    };
+    expect(resolveSharedThreadPullRequest(detected, observed)?.state).toBe("merged");
+    expect(
+      registry.get(state.summaryByUrl(otherEnvironmentId, reference.projectId, merged.url)),
+    ).toBeNull();
+    expect(
+      registry.get(state.summaryByUrl(environmentId, ProjectId.make("other-project"), merged.url)),
+    ).toBeNull();
+    expect(
+      resolveSharedThreadPullRequest(
+        { ...detected, url: "https://github.enterprise.test/acme/web/pull/7" },
+        observed,
+      )?.state,
+    ).toBe("open");
+  });
+
+  it("keeps newer merged VCS metadata when a merged summary is older", () => {
+    const current: NonNullable<VcsStatusResult["pr"]> = {
+      number: 7,
+      title: "New title",
+      url: detail().url,
+      baseRef: "main",
+      headRef: "feature",
+      state: "merged",
+      updatedAt: "2026-09-04T00:00:00.000Z",
+    };
+    expect(resolveSharedThreadPullRequest(current, detail({ state: "merged" }))).toBe(current);
+    expect(
+      resolveSharedThreadPullRequest(
+        current,
+        detail({ state: "merged", title: "Latest title", updatedAt: "2026-09-05T00:00:00.000Z" }),
+      )?.title,
+    ).toBe("Latest title");
+  });
+
+  it("rehydrates accepted state after registry disposal and tolerates denied storage access", () => {
+    state.observeDetail(target, detail());
+    state.observeSummary(
+      target,
+      detail({ state: "merged", updatedAt: "2026-09-03T00:00:00.000Z" }),
+    );
+    registry.reset();
+    expect(registry.get(state.snapshot(target)).summary?.state).toBe("merged");
+    expect(
+      registry.get(state.snapshot({ ...target, environmentId: otherEnvironmentId })).detail,
+    ).toBeNull();
+    const denied = createPullRequestState(registry, {
+      storage: () => {
+        throw new Error("Storage denied");
+      },
+      onRevisionChanged: revised,
+    });
+    denied.observeDetail(target, detail());
+    expect(registry.get(denied.snapshot(target)).detail?.title).toBe("Open PR");
+  });
+});
+
+describe("pull request readers", () => {
+  let renderer: ReactTestRenderer | undefined;
+  let latest: ReturnType<typeof usePullRequestDetail>;
+  let linked: PullRequestSummary | null;
+  let linkedQuery: PullRequestSummary | null;
+  let detected: VcsStatusResult["pr"];
+  let paints: Array<{ environmentId: EnvironmentId; title: string | null }>;
+  let queries = Atom.family((_key: string) =>
+    Atom.make<AsyncResult.AsyncResult<PullRequestDetail>>(AsyncResult.initial()),
+  );
+
+  function Probe({ selected }: { selected: EnvironmentId }) {
+    const current = usePullRequestDetail({ environmentId: selected, input: reference });
+    const currentLinked = useSharedPullRequestSummary(
+      selected,
+      { ...reference, ...(linkedQuery === null ? {} : { url: linkedQuery.url }) },
+      linkedQuery,
+    );
+    const currentDetected = useSharedThreadPullRequest(selected, reference.projectId, {
+      number: reference.number,
+      url: detail().url,
+      title: "Open PR",
+      state: "open",
+      baseRef: "main",
+      headRef: "feature",
+    });
+    useLayoutEffect(() => {
+      latest = current;
+      linked = currentLinked;
+      detected = currentDetected;
+      paints.push({ environmentId: selected, title: current.data?.title ?? null });
+    }, [current, currentLinked, currentDetected, selected]);
+    return null;
+  }
+
+  const render = (selected: EnvironmentId) => (
+    <AppAtomRegistryProvider>
+      <Probe selected={selected} />
+    </AppAtomRegistryProvider>
+  );
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal("window", { localStorage: memoryStorage() });
+    appAtomRegistry.reset();
+    paints = [];
+    linkedQuery = null;
+    queries = Atom.family((_key: string) =>
+      Atom.make<AsyncResult.AsyncResult<PullRequestDetail>>(AsyncResult.initial()),
+    );
+    vi.spyOn(pullRequestEnvironment, "detail").mockImplementation(({ environmentId }) =>
+      queries(environmentId),
+    );
+    vi.spyOn(pullRequestEnvironment, "activity").mockReturnValue(Atom.make(AsyncResult.initial()));
+  });
+
+  afterEach(async () => {
+    await act(() => renderer?.unmount());
+    renderer = undefined;
+    appAtomRegistry.reset();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("never renders or publishes the previous environment's snapshot after a switch", async () => {
+    writePullRequestDetailSnapshot(
+      window.localStorage,
+      environmentId,
+      reference,
+      detail({ title: "First environment" }),
+    );
+    await act(() => {
+      renderer = create(render(environmentId));
+    });
+    expect(latest.data?.title).toBe("First environment");
+    paints = [];
+    await act(() => renderer?.update(render(otherEnvironmentId)));
+    expect(paints.length).toBeGreaterThan(0);
+    expect(
+      paints.every((paint) => paint.environmentId === otherEnvironmentId && paint.title === null),
+    ).toBe(true);
+    expect(linked).toBeNull();
+    expect(
+      appAtomRegistry.get(
+        pullRequestState.snapshot({ ...target, environmentId: otherEnvironmentId }),
+      ).summary,
+    ).toBeNull();
+  });
+
+  it("updates detail, linked, and detected readers from one confirmed merge", async () => {
+    await act(() => {
+      renderer = create(render(environmentId));
+    });
+    await act(() => appAtomRegistry.set(queries(environmentId), AsyncResult.success(detail())));
+    await act(() =>
+      appAtomRegistry.set(
+        queries(environmentId),
+        AsyncResult.success(
+          detail({ state: "merged", title: "Merged PR", updatedAt: "2026-09-03T00:00:00.000Z" }),
+        ),
+      ),
+    );
+    expect(latest.data?.state).toBe("merged");
+    expect(linked?.state).toBe("merged");
+    expect(detected?.state).toBe("merged");
+    await act(() => appAtomRegistry.set(queries(environmentId), AsyncResult.success(detail())));
+    expect(latest.data?.state).toBe("merged");
+    expect(latest.data?.title).toBe("Merged PR");
+    expect(detected?.state).toBe("merged");
+  });
+
+  it("does not republish a held linked summary when detail changes at the same timestamp", async () => {
+    linkedQuery = detail({ isDraft: true });
+    await act(() => {
+      renderer = create(render(environmentId));
+    });
+    await act(() =>
+      appAtomRegistry.set(queries(environmentId), AsyncResult.success(detail({ isDraft: false }))),
+    );
+    expect(latest.data?.isDraft).toBe(false);
+    expect(linked?.isDraft).toBe(false);
+    expect(appAtomRegistry.get(pullRequestState.snapshot(target)).summary?.isDraft).toBe(false);
+  });
+
+  it("does not let held detail undo a same-timestamp summary update", async () => {
+    await act(() => {
+      renderer = create(render(environmentId));
+    });
+    await act(() =>
+      appAtomRegistry.set(queries(environmentId), AsyncResult.success(detail({ isDraft: true }))),
+    );
+    await act(() => pullRequestState.observeSummary(target, detail({ isDraft: false })));
+    expect(latest.data?.isDraft).toBe(false);
+    expect(linked?.isDraft).toBe(false);
+  });
+
+  it("does not let a mounted old-host linked summary replace current detail", async () => {
+    linkedQuery = detail({ title: "Old host" });
+    await act(() => {
+      renderer = create(render(environmentId));
+    });
+    const currentHost = detail({
+      title: "Current host",
+      url: "https://github.enterprise.test/acme/web/pull/7",
+    });
+    await act(() => appAtomRegistry.set(queries(environmentId), AsyncResult.success(currentHost)));
+    expect(latest.data?.title).toBe("Current host");
+    expect(appAtomRegistry.get(pullRequestState.snapshot(target)).detail).toBe(currentHost);
+    await act(() => pullRequestState.observeSummary(target, detail({ state: "merged" })));
+    expect(appAtomRegistry.get(pullRequestState.snapshot(target)).detail).toBe(currentHost);
+  });
+
+  it("invalidates the selected host before re-reading and keeps a later environment switch separate", async () => {
+    let finishInvalidation = () => {};
+    const invalidation = new Promise<
+      Awaited<ReturnType<typeof pullRequestEnvironment.invalidate.run>>
+    >((resolve) => {
+      finishInvalidation = () => resolve(AsyncResult.success(undefined));
+    });
+    vi.spyOn(pullRequestEnvironment.invalidate, "run").mockReturnValue(invalidation);
+    await act(() => {
+      renderer = create(render(environmentId));
+    });
+    const refresh = refreshPullRequestFromHost(target);
+    expect(appAtomRegistry.get(pullRequestState.snapshot(target)).revision).toBe(0);
+    await act(() => renderer?.update(render(otherEnvironmentId)));
+    await act(async () => {
+      finishInvalidation();
+      await refresh;
+    });
+    expect(appAtomRegistry.get(pullRequestState.snapshot(target)).revision).toBe(1);
+    expect(latest.revision).toBe(0);
+  });
+
+  it("applies observed state before list filters without changing host or viewer fields", async () => {
+    const rows = [listEntry(), listEntry({ environmentId: otherEnvironmentId })];
+    let shown: ReadonlyArray<EnvironmentPullRequestEntry> = [];
+    function ListProbe() {
+      const entries = useObservedPullRequestEntries(rows);
+      useLayoutEffect(() => {
+        shown = entries;
+      }, [entries]);
+      return null;
+    }
+    await act(() => {
+      renderer = create(
+        <AppAtomRegistryProvider>
+          <ListProbe />
+        </AppAtomRegistryProvider>,
+      );
+    });
+    await act(() =>
+      pullRequestState.observeSummary(
+        target,
+        detail({ state: "merged", updatedAt: "2026-09-03T00:00:00.000Z" }),
+      ),
+    );
+    expect(shown[0]?.state).toBe("merged");
+    expect(shown[0]?.host).toBe("github.com");
+    expect(shown[0]?.viewerReviewRequested).toBe(true);
+    expect(shown[1]).toBe(rows[1]);
+    expect(
+      narrowPullRequestsToFilters(shown, { state: "open", projectId: undefined, host: undefined }),
+    ).toEqual([rows[1]]);
+  });
+
+  it("hydrates only the selected environment's list and does not persist search results", async () => {
+    const saved = list([listEntry()]);
+    writePullRequestListSnapshot(window.localStorage, environmentId, { scope: "all", data: saved });
+    const held: { current: ReturnType<typeof useRetainedPullRequestList> } = { current: null };
+    const renderedTitles: Array<string | undefined> = [];
+    function ListProbe({
+      selected,
+      live = null,
+      query = "",
+    }: {
+      selected: EnvironmentId;
+      live?: MergedPullRequestList | null;
+      query?: string;
+    }) {
+      const current = useRetainedPullRequestList({
+        environmentKey: selected,
+        scope: "all",
+        query,
+        live: { data: live, isPending: live === null },
+        baseline: null,
+        orderedEntries: null,
+        authored: null,
+        reviewing: null,
+      });
+      useLayoutEffect(() => {
+        held.current = current;
+        renderedTitles.push(current?.data.entries[0]?.title);
+      }, [current]);
+      return null;
+    }
+    await act(() => {
+      renderer = create(<ListProbe selected={environmentId} />);
+    });
+    expect(held.current?.data.entries[0]?.title).toBe("Open PR");
+    renderedTitles.length = 0;
+    await act(() => renderer?.update(<ListProbe selected={otherEnvironmentId} />));
+    expect(renderedTitles.every((title) => title === undefined)).toBe(true);
+    const searchResult = list([listEntry({ title: "Search result" })]);
+    await act(() =>
+      renderer?.update(<ListProbe selected={environmentId} live={searchResult} query="search" />),
+    );
+    expect(held.current?.data.entries[0]?.title).toBe("Search result");
+    expect(
+      readPullRequestListSnapshot(window.localStorage, environmentId)?.data.entries[0]?.title,
+    ).toBe("Open PR");
+  });
+});

--- a/apps/web/src/state/pullRequests.test.tsx
+++ b/apps/web/src/state/pullRequests.test.tsx
@@ -2,6 +2,7 @@ import {
   EnvironmentId,
   ProjectId,
   type PullRequestDetail,
+  type PullRequestListResult,
   type PullRequestSummary,
   type VcsStatusResult,
 } from "@t3tools/contracts";
@@ -30,6 +31,7 @@ import {
   resolveSharedThreadPullRequest,
   useObservedPullRequestEntries,
   usePullRequestDetail,
+  usePullRequestList,
   useRetainedPullRequestList,
   useSharedPullRequestSummary,
   useSharedThreadPullRequest,
@@ -164,6 +166,13 @@ describe("scoped pull request state", () => {
     expect(revised).not.toHaveBeenCalled();
   });
 
+  it("can hydrate detail from an object already observed as a summary", () => {
+    const current = detail();
+    state.observeSummary(target, current);
+    state.observeDetail(target, current);
+    expect(registry.get(state.snapshot(target)).detail).toBe(current);
+  });
+
   it("stores summary fields without copying detail permissions or content", () => {
     const current = detail();
     state.observeDetail(target, current);
@@ -243,15 +252,20 @@ describe("scoped pull request state", () => {
     expect(registry.get(state.snapshot(target)).detail?.viewerPermissions.actions).toEqual([]);
   });
 
-  it("retains a known draft value when an older server omits it and accepts a ready update", () => {
-    state.observeDetail(target, detail({ isDraft: true }));
+  it("retains optional summary fields from older servers and accepts explicit reopen values", () => {
+    const closedAt = "2026-09-02T00:00:00.000Z";
+    state.observeDetail(target, detail({ state: "closed", isDraft: true, closedAt }));
     state.observeSummary(target, {
-      ...detail({ updatedAt: "2026-09-03T00:00:00.000Z" }),
+      ...detail({ state: "closed", updatedAt: "2026-09-03T00:00:00.000Z" }),
       isDraft: undefined,
+      closedAt: undefined,
+      mergedAt: undefined,
     });
     expect(registry.get(state.snapshot(target)).summary?.isDraft).toBe(true);
+    expect(registry.get(state.snapshot(target)).summary?.closedAt).toBe(closedAt);
     state.observeSummary(target, detail({ isDraft: false, updatedAt: "2026-09-04T00:00:00.000Z" }));
     expect(registry.get(state.snapshot(target)).summary?.isDraft).toBe(false);
+    expect(registry.get(state.snapshot(target)).summary?.closedAt).toBeNull();
   });
 
   it("shares a merge with a detected PR but not another environment, project, or host", () => {
@@ -332,7 +346,9 @@ describe("pull request readers", () => {
   let detected: VcsStatusResult["pr"];
   let paints: Array<{ environmentId: EnvironmentId; title: string | null }>;
   let queries = Atom.family((_key: string) =>
-    Atom.make<AsyncResult.AsyncResult<PullRequestDetail>>(AsyncResult.initial()),
+    Atom.make<AsyncResult.AsyncResult<PullRequestDetail>>(AsyncResult.initial()).pipe(
+      Atom.keepAlive,
+    ),
   );
 
   function Probe({ selected }: { selected: EnvironmentId }) {
@@ -372,7 +388,9 @@ describe("pull request readers", () => {
     paints = [];
     linkedQuery = null;
     queries = Atom.family((_key: string) =>
-      Atom.make<AsyncResult.AsyncResult<PullRequestDetail>>(AsyncResult.initial()),
+      Atom.make<AsyncResult.AsyncResult<PullRequestDetail>>(AsyncResult.initial()).pipe(
+        Atom.keepAlive,
+      ),
     );
     vi.spyOn(pullRequestEnvironment, "detail").mockImplementation(({ environmentId }) =>
       queries(environmentId),
@@ -446,6 +464,11 @@ describe("pull request readers", () => {
     expect(latest.data?.isDraft).toBe(false);
     expect(linked?.isDraft).toBe(false);
     expect(appAtomRegistry.get(pullRequestState.snapshot(target)).summary?.isDraft).toBe(false);
+    await act(() => renderer?.unmount());
+    await act(() => {
+      renderer = create(render(environmentId));
+    });
+    expect(linked?.isDraft).toBe(false);
   });
 
   it("does not let held detail undo a same-timestamp summary update", async () => {
@@ -458,6 +481,11 @@ describe("pull request readers", () => {
     await act(() => pullRequestState.observeSummary(target, detail({ isDraft: false })));
     expect(latest.data?.isDraft).toBe(false);
     expect(linked?.isDraft).toBe(false);
+    await act(() => renderer?.unmount());
+    await act(() => {
+      renderer = create(render(environmentId));
+    });
+    expect(latest.data?.isDraft).toBe(false);
   });
 
   it("does not let a mounted old-host linked summary replace current detail", async () => {
@@ -528,6 +556,57 @@ describe("pull request readers", () => {
     expect(
       narrowPullRequestsToFilters(shown, { state: "open", projectId: undefined, host: undefined }),
     ).toEqual([rows[1]]);
+  });
+
+  it("does not replay a held list answer when another environment answers or refresh starts", async () => {
+    const lists = Atom.family((_key: string) =>
+      Atom.make<AsyncResult.AsyncResult<PullRequestListResult>>(AsyncResult.initial()),
+    );
+    vi.spyOn(pullRequestEnvironment, "list").mockImplementation(({ environmentId }) =>
+      lists(environmentId),
+    );
+    const first: PullRequestListResult = {
+      entries: [listEntry({ state: "closed", isDraft: true })],
+      viewers: {},
+      providers: [],
+      errors: [],
+      truncated: false,
+      nextCursors: {},
+    };
+    function ListProbe() {
+      usePullRequestList([
+        { environmentId, input: { state: "all" } },
+        { environmentId: otherEnvironmentId, input: { state: "all" } },
+      ]);
+      return <Probe selected={environmentId} />;
+    }
+    await act(() => {
+      appAtomRegistry.set(lists(environmentId), AsyncResult.success(first));
+      renderer = create(
+        <AppAtomRegistryProvider>
+          <ListProbe />
+        </AppAtomRegistryProvider>,
+      );
+    });
+    await act(() =>
+      appAtomRegistry.set(
+        queries(environmentId),
+        AsyncResult.success(detail({ state: "open", isDraft: false })),
+      ),
+    );
+    await act(() =>
+      appAtomRegistry.set(
+        lists(otherEnvironmentId),
+        AsyncResult.success({ ...first, entries: [] }),
+      ),
+    );
+    expect(latest.data?.state).toBe("open");
+    expect(latest.data?.isDraft).toBe(false);
+    await act(() =>
+      appAtomRegistry.set(lists(environmentId), AsyncResult.success(first, { waiting: true })),
+    );
+    expect(latest.data?.state).toBe("open");
+    expect(latest.data?.isDraft).toBe(false);
   });
 
   it("hydrates only the selected environment's list and does not persist search results", async () => {

--- a/apps/web/src/state/pullRequests.test.tsx
+++ b/apps/web/src/state/pullRequests.test.tsx
@@ -173,6 +173,106 @@ describe("scoped pull request state", () => {
     expect(registry.get(state.snapshot(target)).detail).toBe(current);
   });
 
+  it.each([false, true])(
+    "confirms equal-time detail conflicts with fresh draft=%s",
+    async (isDraft) => {
+      const fresh = detail({ isDraft });
+      let confirm = (_value: PullRequestDetail | null) => {};
+      const answer = new Promise<PullRequestDetail | null>((resolve) => {
+        confirm = resolve;
+      });
+      const readFreshDetail = vi.fn(() => answer);
+      state = createPullRequestState(registry, {
+        storage: () => storage,
+        onRevisionChanged: revised,
+        readFreshDetail,
+      });
+      state.observeSummary(target, detail({ isDraft: !isDraft }));
+      state.observeDetail(target, fresh);
+      state.observeDetail(target, { ...fresh });
+      expect(registry.get(state.snapshot(target)).summary?.isDraft).toBe(!isDraft);
+      expect(registry.get(state.snapshot(target)).detail?.body).toBe(fresh.body);
+      expect(readFreshDetail).toHaveBeenCalledExactlyOnceWith(target, expect.any(AbortSignal));
+      confirm(fresh);
+      await answer;
+      expect(registry.get(state.snapshot(target)).summary?.isDraft).toBe(isDraft);
+    },
+  );
+
+  it("does not let a conflict confirmation undo a newer summary", async () => {
+    let confirm = (_value: PullRequestDetail | null) => {};
+    const answer = new Promise<PullRequestDetail | null>((resolve) => {
+      confirm = resolve;
+    });
+    state = createPullRequestState(registry, {
+      storage: () => storage,
+      onRevisionChanged: revised,
+      readFreshDetail: () => answer,
+    });
+    state.observeSummary(target, detail({ isDraft: false }));
+    state.observeDetail(target, detail({ isDraft: true }));
+    state.observeSummary(
+      target,
+      detail({ title: "Later title", isDraft: false, updatedAt: "2026-09-03T00:00:00.000Z" }),
+    );
+    confirm(detail({ isDraft: true }));
+    await answer;
+    expect(registry.get(state.snapshot(target)).summary?.title).toBe("Later title");
+    expect(registry.get(state.snapshot(target)).summary?.isDraft).toBe(false);
+  });
+
+  it("confirms an unseen old summary without undoing accepted detail", async () => {
+    const fresh = detail({ isDraft: false });
+    const answer = Promise.resolve(fresh);
+    const readFreshDetail = vi.fn(() => answer);
+    state = createPullRequestState(registry, {
+      storage: () => storage,
+      onRevisionChanged: revised,
+      readFreshDetail,
+    });
+    state.observeDetail(target, fresh);
+    state.observeSummary(target, detail({ isDraft: true }));
+    expect(registry.get(state.snapshot(target)).summary?.isDraft).toBe(false);
+    await answer;
+    expect(registry.get(state.snapshot(target)).summary?.isDraft).toBe(false);
+    expect(readFreshDetail).toHaveBeenCalledOnce();
+  });
+
+  it("finds a saved detail written with different repository casing", () => {
+    writePullRequestDetailSnapshot(
+      storage,
+      environmentId,
+      { ...reference, repository: "ACME/Web" },
+      detail({ state: "merged" }),
+    );
+    expect(
+      registry.get(state.summaryByUrl(environmentId, reference.projectId, detail().url))?.state,
+    ).toBe("merged");
+  });
+
+  it("aborts conflict confirmation on reset and rejects its late answer", async () => {
+    let confirm = (_value: PullRequestDetail | null) => {};
+    const answer = new Promise<PullRequestDetail | null>((resolve) => {
+      confirm = resolve;
+    });
+    const readFreshDetail = vi.fn((_target: typeof target, _signal: AbortSignal) => answer);
+    state = createPullRequestState(registry, {
+      storage: () => storage,
+      onRevisionChanged: revised,
+      readFreshDetail,
+    });
+    state.observeSummary(target, detail({ isDraft: false }));
+    state.observeDetail(target, detail({ isDraft: true }));
+    const signal = readFreshDetail.mock.calls[0]![1];
+    registry.reset();
+    expect(signal.aborted).toBe(true);
+    confirm(detail({ isDraft: true }));
+    await answer;
+    expect(registry.get(state.snapshot(target)).summary?.isDraft).toBe(false);
+    state.observeDetail(target, detail({ isDraft: true }));
+    expect(readFreshDetail).toHaveBeenCalledTimes(2);
+  });
+
   it("stores summary fields without copying detail permissions or content", () => {
     const current = detail();
     state.observeDetail(target, current);
@@ -323,6 +423,25 @@ describe("scoped pull request state", () => {
       detail({ state: "merged", updatedAt: "2026-09-03T00:00:00.000Z" }),
     );
     registry.reset();
+    // The detected sidebar has only a URL and must not depend on another reader mounting first.
+    expect(
+      registry.get(
+        state.summaryByUrl(
+          environmentId,
+          reference.projectId,
+          "https://GITHUB.com/ACME/WEB/pull/7/?view=checks#top",
+        ),
+      )?.state,
+    ).toBe("merged");
+    expect(
+      registry.get(
+        state.summaryByUrl(
+          environmentId,
+          reference.projectId,
+          "https://github.enterprise.test/acme/web/pull/7",
+        ),
+      ),
+    ).toBeNull();
     expect(registry.get(state.snapshot(target)).summary?.state).toBe("merged");
     expect(
       registry.get(state.snapshot({ ...target, environmentId: otherEnvironmentId })).detail,
@@ -338,6 +457,17 @@ describe("scoped pull request state", () => {
   });
 });
 
+function retainedDetailQuery() {
+  let current: AsyncResult.AsyncResult<PullRequestDetail> = AsyncResult.initial();
+  return Atom.writable(
+    () => current,
+    (context, value: AsyncResult.AsyncResult<PullRequestDetail>) => {
+      current = value;
+      context.setSelf(value);
+    },
+  ).pipe(Atom.keepAlive);
+}
+
 describe("pull request readers", () => {
   let renderer: ReactTestRenderer | undefined;
   let latest: ReturnType<typeof usePullRequestDetail>;
@@ -345,11 +475,7 @@ describe("pull request readers", () => {
   let linkedQuery: PullRequestSummary | null;
   let detected: VcsStatusResult["pr"];
   let paints: Array<{ environmentId: EnvironmentId; title: string | null }>;
-  let queries = Atom.family((_key: string) =>
-    Atom.make<AsyncResult.AsyncResult<PullRequestDetail>>(AsyncResult.initial()).pipe(
-      Atom.keepAlive,
-    ),
-  );
+  let queries = Atom.family((_key: string) => retainedDetailQuery());
 
   function Probe({ selected }: { selected: EnvironmentId }) {
     const current = usePullRequestDetail({ environmentId: selected, input: reference });
@@ -387,10 +513,9 @@ describe("pull request readers", () => {
     appAtomRegistry.reset();
     paints = [];
     linkedQuery = null;
-    queries = Atom.family((_key: string) =>
-      Atom.make<AsyncResult.AsyncResult<PullRequestDetail>>(AsyncResult.initial()).pipe(
-        Atom.keepAlive,
-      ),
+    queries = Atom.family((_key: string) => retainedDetailQuery());
+    vi.spyOn(pullRequestEnvironment.invalidate, "run").mockResolvedValue(
+      AsyncResult.success(undefined),
     );
     vi.spyOn(pullRequestEnvironment, "detail").mockImplementation(({ environmentId }) =>
       queries(environmentId),
@@ -458,9 +583,9 @@ describe("pull request readers", () => {
     await act(() => {
       renderer = create(render(environmentId));
     });
-    await act(() =>
-      appAtomRegistry.set(queries(environmentId), AsyncResult.success(detail({ isDraft: false }))),
-    );
+    await act(async () => {
+      appAtomRegistry.set(queries(environmentId), AsyncResult.success(detail({ isDraft: false })));
+    });
     expect(latest.data?.isDraft).toBe(false);
     expect(linked?.isDraft).toBe(false);
     expect(appAtomRegistry.get(pullRequestState.snapshot(target)).summary?.isDraft).toBe(false);
@@ -472,15 +597,27 @@ describe("pull request readers", () => {
   });
 
   it("does not let held detail undo a same-timestamp summary update", async () => {
+    let invalidate = () => {};
+    vi.mocked(pullRequestEnvironment.invalidate.run).mockReturnValueOnce(
+      new Promise((resolve) => {
+        invalidate = () => resolve(AsyncResult.success(undefined));
+      }),
+    );
+    const held = detail({ isDraft: true });
     await act(() => {
       renderer = create(render(environmentId));
     });
-    await act(() =>
-      appAtomRegistry.set(queries(environmentId), AsyncResult.success(detail({ isDraft: true }))),
-    );
+    await act(() => appAtomRegistry.set(queries(environmentId), AsyncResult.success(held)));
     await act(() => pullRequestState.observeSummary(target, detail({ isDraft: false })));
+    // Conflicting equal timestamps keep the accepted state until a fresh host answer arrives.
+    expect(latest.data?.isDraft).toBe(true);
+    await act(async () => {
+      appAtomRegistry.set(queries(environmentId), AsyncResult.success(detail({ isDraft: false })));
+      invalidate();
+    });
     expect(latest.data?.isDraft).toBe(false);
     expect(linked?.isDraft).toBe(false);
+    await act(() => appAtomRegistry.set(queries(environmentId), AsyncResult.success(held)));
     await act(() => renderer?.unmount());
     await act(() => {
       renderer = create(render(environmentId));
@@ -588,12 +725,12 @@ describe("pull request readers", () => {
         </AppAtomRegistryProvider>,
       );
     });
-    await act(() =>
+    await act(async () => {
       appAtomRegistry.set(
         queries(environmentId),
         AsyncResult.success(detail({ state: "open", isDraft: false })),
-      ),
-    );
+      );
+    });
     await act(() =>
       appAtomRegistry.set(
         lists(otherEnvironmentId),

--- a/apps/web/src/state/pullRequests.ts
+++ b/apps/web/src/state/pullRequests.ts
@@ -199,6 +199,11 @@ export function createPullRequestState(
       return undefined;
     }
   };
+  // Query atoms can keep the same answer across refreshes and remounts. Each answer
+  // can update a PR once per observation kind, even when its timestamp is unchanged.
+  const observations = Atom.make(() => new WeakMap<PullRequestSummary, Set<string>>()).pipe(
+    Atom.keepAlive,
+  );
   const snapshots = Atom.family((key: string) =>
     Atom.writable(
       (): PullRequestSnapshot => {
@@ -246,6 +251,15 @@ export function createPullRequestState(
     if (!matchesPullRequest(target.input, value)) return;
     const atom = snapshot(target);
     const previous = registry.get(atom);
+    const seen = registry.get(observations);
+    const sourceKey = JSON.stringify([pullRequestKey(target), detail !== null]);
+    const accepted = seen.get(value);
+    if (previous.summary !== null && accepted?.has(sourceKey)) {
+      registerReference(target, value);
+      return;
+    }
+    if (accepted === undefined) seen.set(value, new Set([sourceKey]));
+    else accepted.add(sourceKey);
     const next = resolvePullRequestSnapshot(previous, value, detail);
     if (next !== previous) {
       registry.set(atom, next);
@@ -595,7 +609,7 @@ function createMergedEnvironmentQuery<Input, A>(
 
 const usePullRequestListsQuery = createMergedEnvironmentQuery(
   "web-pull-requests:list",
-  pullRequestEnvironment.list,
+  (target: EnvironmentQueryTarget<PullRequestListInput>) => pullRequestEnvironment.list(target),
 );
 
 const usePullRequestStatsQuery = createMergedEnvironmentQuery(
@@ -636,17 +650,22 @@ export function usePullRequestList(
   const query = usePullRequestListsQuery(targets);
   const data = useMemo(() => mergePullRequestLists(query.values), [query.values]);
   useLayoutEffect(() => {
-    if (data === null) return;
-    for (const entry of data.entries) {
-      pullRequestState.observeSummary(
-        {
-          environmentId: entry.environmentId,
-          input: { projectId: entry.projectId, repository: entry.repository, number: entry.number },
-        },
-        entry,
-      );
+    for (const [environmentId, result] of query.values) {
+      for (const entry of result.entries) {
+        pullRequestState.observeSummary(
+          {
+            environmentId,
+            input: {
+              projectId: entry.projectId,
+              repository: entry.repository,
+              number: entry.number,
+            },
+          },
+          entry,
+        );
+      }
     }
-  }, [data]);
+  }, [query.values]);
   return { data, error: query.error, isPending: query.isPending, refresh: query.refresh };
 }
 

--- a/apps/web/src/state/pullRequests.ts
+++ b/apps/web/src/state/pullRequests.ts
@@ -5,23 +5,34 @@ import {
 } from "@t3tools/client-runtime/state/pull-requests";
 import type {
   EnvironmentId,
+  ProjectId,
+  PullRequestDetail,
   PullRequestListInput,
   PullRequestListStatsInput,
   PullRequestRef,
   PullRequestSummary,
+  VcsStatusResult,
 } from "@t3tools/contracts";
 import * as Option from "effect/Option";
-import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { useCallback, useLayoutEffect, useMemo } from "react";
+import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
 
 import { connectionAtomRuntime } from "../connection/runtime";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import {
   mergePullRequestLists,
+  readPullRequestListSnapshot,
+  writePullRequestListSnapshot,
+  type PullRequestPartitionsSnapshot,
   type EnvironmentPullRequestStat,
   type MergedPullRequestList,
+  type EnvironmentPullRequestEntry,
 } from "../components/pullRequest/pullRequestList.logic";
-import { formatEnvironmentQueryError } from "./query";
+import {
+  readPullRequestDetailSnapshot,
+  writePullRequestDetailSnapshot,
+} from "../components/pullRequest/pullRequestDetail.logic";
+import { formatEnvironmentQueryError, useEnvironmentQuery } from "./query";
 
 export const pullRequestEnvironment = createPullRequestEnvironmentAtoms(connectionAtomRuntime);
 export const linkedPullRequestDetailAtom = createLinkedPullRequestSummaryAtomFamily(
@@ -29,48 +40,490 @@ export const linkedPullRequestDetailAtom = createLinkedPullRequestSummaryAtomFam
   pullRequestEnvironment.refreshes,
 );
 
-const observedPullRequestSummaryAtom = Atom.family((key: string) =>
-  Atom.make<PullRequestSummary | null>(null).pipe(
-    Atom.setIdleTTL(5 * 60_000),
-    Atom.withLabel(`web-pull-requests:observed-summary:${key}`),
-  ),
-);
+type PullRequestTarget = EnvironmentQueryTarget<PullRequestRef>;
+
+interface PullRequestSnapshot {
+  readonly detail: PullRequestDetail | null;
+  readonly summary: PullRequestSummary | null;
+  readonly revision: number;
+}
+
+function pullRequestKey({ environmentId, input }: PullRequestTarget): string {
+  return JSON.stringify([
+    environmentId,
+    input.projectId,
+    input.repository.toLowerCase(),
+    input.number,
+  ]);
+}
+
+function normalizedPullRequestUrl(url: string): string {
+  return url.split(/[?#]/u)[0]!.replace(/\/$/u, "").toLowerCase();
+}
+
+function pullRequestUrlKey(environmentId: EnvironmentId, projectId: ProjectId, url: string) {
+  return JSON.stringify([environmentId, projectId, normalizedPullRequestUrl(url)]);
+}
+
+function targetFromKey(key: string): PullRequestTarget {
+  const [environmentId, projectId, repository, number] = JSON.parse(key) as [
+    EnvironmentId,
+    ProjectId,
+    string,
+    number,
+  ];
+  return { environmentId, input: { projectId, repository, number } };
+}
+
+function matchesPullRequest(
+  reference: PullRequestRef & { readonly url?: string },
+  value: PullRequestSummary,
+): boolean {
+  return (
+    reference.projectId === value.projectId &&
+    reference.repository.toLowerCase() === value.repository.toLowerCase() &&
+    reference.number === value.number &&
+    (reference.url === undefined ||
+      normalizedPullRequestUrl(reference.url) === normalizedPullRequestUrl(value.url))
+  );
+}
+
+function samePullRequest(left: PullRequestSummary, right: PullRequestSummary): boolean {
+  return matchesPullRequest(left, right) && left.provider === right.provider;
+}
+
+/** Store only summary fields. A typed detail value still has its other fields at runtime. */
+function pullRequestSummary(value: PullRequestSummary): PullRequestSummary {
+  return {
+    provider: value.provider,
+    projectId: value.projectId,
+    repository: value.repository,
+    number: value.number,
+    title: value.title,
+    url: value.url,
+    state: value.state,
+    ...(value.isDraft === undefined ? {} : { isDraft: value.isDraft }),
+    headBranch: value.headBranch,
+    baseBranch: value.baseBranch,
+    ...(value.closedAt === undefined ? {} : { closedAt: value.closedAt }),
+    ...(value.mergedAt === undefined ? {} : { mergedAt: value.mergedAt }),
+    updatedAt: value.updatedAt,
+  };
+}
+
+function observedPullRequestIsNewer(
+  current: Pick<NonNullable<VcsStatusResult["pr"]>, "state" | "updatedAt">,
+  observed: Pick<PullRequestSummary, "state" | "updatedAt">,
+): boolean {
+  if (current.state === "merged" && observed.state !== "merged") return false;
+  if (observed.state === "merged" && current.state !== "merged") return true;
+  return (
+    current.updatedAt == null || Date.parse(observed.updatedAt) >= Date.parse(current.updatedAt)
+  );
+}
 
 export function newestPullRequestSummary(
   current: PullRequestSummary | null,
   observed: PullRequestSummary | null,
 ): PullRequestSummary | null {
   if (current === null) return observed;
-  if (observed === null) return current;
-  if (current.state === "merged") return current;
-  if (observed.state === "merged") return observed;
-  return Date.parse(observed.updatedAt) >= Date.parse(current.updatedAt) ? observed : current;
+  if (observed === null || !samePullRequest(current, observed)) return current;
+  return observedPullRequestIsNewer(current, observed) ? observed : current;
 }
+
+function applyPullRequestSummary<T extends PullRequestSummary>(
+  current: T,
+  observed: PullRequestSummary | null,
+): T {
+  const newest = newestPullRequestSummary(current, observed);
+  if (newest === null || newest === current) return current;
+  const summary = pullRequestSummary(newest);
+  if (Object.entries(summary).every(([key, value]) => current[key as keyof T] === value)) {
+    return current;
+  }
+  return { ...current, ...summary };
+}
+
+function resolvePullRequestSnapshot(
+  previous: PullRequestSnapshot,
+  observation: PullRequestSummary,
+  detail: PullRequestDetail | null,
+): PullRequestSnapshot {
+  const sameIdentity = previous.summary === null || samePullRequest(previous.summary, observation);
+  if (!sameIdentity && detail === null && previous.detail !== null) return previous;
+  const previousDetail = sameIdentity ? previous.detail : null;
+  // Viewer permissions belong to the latest viewer, not to the PR's update timestamp.
+  const nextDetail =
+    detail !== null &&
+    (previousDetail === null ||
+      detail.viewer !== previousDetail.viewer ||
+      Date.parse(detail.updatedAt) >= Date.parse(previousDetail.updatedAt))
+      ? detail
+      : previousDetail;
+  const newest =
+    newestPullRequestSummary(sameIdentity ? previous.summary : null, observation) ?? observation;
+  const summary = {
+    ...(sameIdentity ? previous.summary : null),
+    ...pullRequestSummary(newest),
+  };
+  const previousSummary = previous.summary;
+  const changedRevision =
+    previousSummary !== null &&
+    (!sameIdentity ||
+      summary.updatedAt !== previousSummary.updatedAt ||
+      summary.state !== previousSummary.state);
+  if (
+    nextDetail === previous.detail &&
+    previousSummary !== null &&
+    Object.entries(summary).every(
+      ([key, value]) => previousSummary[key as keyof PullRequestSummary] === value,
+    )
+  ) {
+    return previous;
+  }
+  return { detail: nextDetail, summary, revision: previous.revision + Number(changedRevision) };
+}
+
+/** Own accepted detail, summary, and refresh revisions for each environment and PR reference. */
+export function createPullRequestState(
+  registry: AtomRegistry.AtomRegistry,
+  options: {
+    readonly storage: () => Storage | undefined;
+    readonly onRevisionChanged: (target: PullRequestTarget) => void;
+  },
+) {
+  const storage = () => {
+    try {
+      return options.storage();
+    } catch {
+      return undefined;
+    }
+  };
+  const snapshots = Atom.family((key: string) =>
+    Atom.writable(
+      (): PullRequestSnapshot => {
+        const { environmentId, input: reference } = targetFromKey(key);
+        const stored = readPullRequestDetailSnapshot(storage(), environmentId, reference);
+        if (stored === null || !matchesPullRequest(reference, stored)) {
+          return { detail: null, summary: null, revision: 0 };
+        }
+        const { observedSummary, ...detail } = stored;
+        return {
+          detail,
+          summary: pullRequestSummary(
+            newestPullRequestSummary(detail, observedSummary ?? null) ?? detail,
+          ),
+          revision: 0,
+        };
+      },
+      (context, value: PullRequestSnapshot) => context.setSelf(value),
+    ).pipe(Atom.setIdleTTL(5 * 60_000), Atom.withLabel(`web-pull-requests:snapshot:${key}`)),
+  );
+  // Detected VCS PRs carry a URL, not the host's repository reference. This index points at
+  // the same snapshot and never copies its status or shares it across projects.
+  const referencesByUrl = Atom.family((_key: string) =>
+    Atom.make<PullRequestTarget | null>(null).pipe(Atom.setIdleTTL(5 * 60_000)),
+  );
+  const summariesByUrl = Atom.family((key: string) =>
+    Atom.make((get) => {
+      const target = get(referencesByUrl(key));
+      return target === null ? null : get(snapshots(pullRequestKey(target))).summary;
+    }).pipe(Atom.setIdleTTL(5 * 60_000)),
+  );
+  const snapshot = (target: PullRequestTarget) => snapshots(pullRequestKey(target));
+  const registerReference = (target: PullRequestTarget, value: PullRequestSummary) => {
+    if (!matchesPullRequest(target.input, value)) return;
+    const urlReference = referencesByUrl(
+      pullRequestUrlKey(target.environmentId, target.input.projectId, value.url),
+    );
+    if (registry.get(urlReference) === null) registry.set(urlReference, target);
+  };
+  const observe = (
+    target: PullRequestTarget,
+    value: PullRequestSummary,
+    detail: PullRequestDetail | null = null,
+  ) => {
+    if (!matchesPullRequest(target.input, value)) return;
+    const atom = snapshot(target);
+    const previous = registry.get(atom);
+    const next = resolvePullRequestSnapshot(previous, value, detail);
+    if (next !== previous) {
+      registry.set(atom, next);
+      if (next.detail !== null) {
+        writePullRequestDetailSnapshot(
+          storage(),
+          target.environmentId,
+          targetFromKey(pullRequestKey(target)).input,
+          {
+            ...next.detail,
+            ...(next.summary === null ? {} : { observedSummary: next.summary }),
+          },
+        );
+      }
+      if (next.revision !== previous.revision)
+        options.onRevisionChanged(targetFromKey(pullRequestKey(target)));
+    }
+    registerReference(target, value);
+  };
+  return {
+    snapshot,
+    registerReference,
+    observeSummary: (target: PullRequestTarget, value: PullRequestSummary) =>
+      observe(target, value),
+    observeDetail: (target: PullRequestTarget, value: PullRequestDetail) =>
+      observe(target, value, value),
+    summaryByUrl: (environmentId: EnvironmentId, projectId: ProjectId, url: string) =>
+      summariesByUrl(pullRequestUrlKey(environmentId, projectId, url)),
+    invalidate: (target: PullRequestTarget) =>
+      registry.update(snapshot(target), (previous) => ({
+        ...previous,
+        revision: previous.revision + 1,
+      })),
+  };
+}
+
+function pullRequestSnapshotStorage(): Storage | undefined {
+  try {
+    return typeof window === "undefined" ? undefined : window.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+export const pullRequestState = createPullRequestState(appAtomRegistry, {
+  storage: pullRequestSnapshotStorage,
+  onRevisionChanged: (target) => appAtomRegistry.refresh(pullRequestEnvironment.activity(target)),
+});
+
+const emptyPullRequestSnapshot = Atom.make<PullRequestSnapshot>({
+  detail: null,
+  summary: null,
+  revision: 0,
+});
+const emptyPullRequestSummary = Atom.make<PullRequestSummary | null>(null);
 
 export function useSharedPullRequestSummary(
   environmentId: EnvironmentId | null,
-  reference: PullRequestRef | null,
+  reference: (PullRequestRef & { readonly url?: string }) | null,
   current: PullRequestSummary | null,
 ): PullRequestSummary | null {
   const key =
     environmentId === null || reference === null
-      ? "none"
-      : JSON.stringify([
-          environmentId,
-          reference.projectId,
-          reference.repository.toLowerCase(),
-          reference.number,
-        ]);
-  const atom = observedPullRequestSummaryAtom(key);
-  const observed = useAtomValue(atom);
+      ? null
+      : pullRequestKey({ environmentId, input: reference });
+  const target = useMemo(() => (key === null ? null : targetFromKey(key)), [key]);
+  const observed = useAtomValue(
+    target === null ? emptyPullRequestSnapshot : pullRequestState.snapshot(target),
+  );
+  const matching =
+    reference !== null && current !== null && matchesPullRequest(reference, current)
+      ? current
+      : null;
+  const shared =
+    reference !== null &&
+    observed.summary !== null &&
+    matchesPullRequest(reference, observed.summary)
+      ? observed.summary
+      : null;
   useLayoutEffect(() => {
-    if (environmentId === null || current === null) return;
-    appAtomRegistry.modify(atom, (previous) => {
-      const next = newestPullRequestSummary(previous, current);
-      return next === previous ? [false, previous] : [true, next];
+    if (target !== null && matching !== null) pullRequestState.observeSummary(target, matching);
+  }, [matching, target]);
+  useLayoutEffect(() => {
+    if (target !== null && shared !== null) pullRequestState.registerReference(target, shared);
+  }, [shared, target]);
+  return target === null ? null : newestPullRequestSummary(matching, shared);
+}
+
+/** Apply a confirmed PR observation after checkout/branch association has been resolved. */
+export function resolveSharedThreadPullRequest(
+  current: VcsStatusResult["pr"],
+  summary: PullRequestSummary | null,
+): VcsStatusResult["pr"] {
+  if (current === null || summary === null) return current;
+  if (normalizedPullRequestUrl(current.url) !== normalizedPullRequestUrl(summary.url))
+    return current;
+  if (!observedPullRequestIsNewer(current, summary)) return current;
+  return {
+    ...current,
+    title: summary.title,
+    state: summary.state,
+    ...(summary.isDraft === undefined ? {} : { isDraft: summary.isDraft }),
+    headRef: summary.headBranch,
+    baseRef: summary.baseBranch,
+    updatedAt: summary.updatedAt,
+  };
+}
+
+export function useSharedThreadPullRequest(
+  environmentId: EnvironmentId | null,
+  projectId: ProjectId | null,
+  current: VcsStatusResult["pr"],
+): VcsStatusResult["pr"] {
+  const summary = useAtomValue(
+    environmentId === null || projectId === null || current === null
+      ? emptyPullRequestSummary
+      : pullRequestState.summaryByUrl(environmentId, projectId, current.url),
+  );
+  return useMemo(() => resolveSharedThreadPullRequest(current, summary), [current, summary]);
+}
+
+/** The same scoped detail is used by the panel, tab icon, and copy-link action. */
+export function usePullRequestDetail(target: PullRequestTarget | null) {
+  const key = target === null ? null : pullRequestKey(target);
+  const stableTarget = useMemo(() => (key === null ? null : targetFromKey(key)), [key]);
+  const query = useEnvironmentQuery(
+    stableTarget === null ? null : pullRequestEnvironment.detail(stableTarget),
+  );
+  const snapshot = useAtomValue(
+    stableTarget === null ? emptyPullRequestSnapshot : pullRequestState.snapshot(stableTarget),
+  );
+  const resolved = useMemo(() => {
+    // A shared summary changing does not make the stored query value a new observation.
+    if (
+      query.data === snapshot.detail ||
+      query.data === null ||
+      stableTarget === null ||
+      !matchesPullRequest(stableTarget.input, query.data)
+    )
+      return snapshot;
+    return resolvePullRequestSnapshot(snapshot, query.data, query.data);
+  }, [query.data, snapshot, stableTarget]);
+  useLayoutEffect(() => {
+    if (stableTarget !== null && query.data !== null)
+      pullRequestState.observeDetail(stableTarget, query.data);
+  }, [query.data, stableTarget]);
+  useLayoutEffect(() => {
+    if (stableTarget !== null && snapshot.summary !== null)
+      pullRequestState.registerReference(stableTarget, snapshot.summary);
+  }, [snapshot.summary, stableTarget]);
+  const data = useMemo(
+    () =>
+      resolved.detail === null ? null : applyPullRequestSummary(resolved.detail, resolved.summary),
+    [resolved.detail, resolved.summary],
+  );
+  return { ...query, data, revision: snapshot.revision };
+}
+
+export function refreshPullRequest(target: PullRequestTarget, includeDiff = false): void {
+  const queryTarget = targetFromKey(pullRequestKey(target));
+  appAtomRegistry.refresh(pullRequestEnvironment.detail(queryTarget));
+  appAtomRegistry.refresh(pullRequestEnvironment.activity(queryTarget));
+  if (includeDiff) pullRequestState.invalidate(target);
+}
+
+export async function refreshPullRequestFromHost(target: PullRequestTarget): Promise<void> {
+  await pullRequestEnvironment.invalidate.run(appAtomRegistry, {
+    environmentId: target.environmentId,
+    input: { reference: target.input },
+  });
+  refreshPullRequest(target, true);
+}
+
+/** Keep local list order and account fields while applying newer PR observations. */
+export function useObservedPullRequestEntries(entries: ReadonlyArray<EnvironmentPullRequestEntry>) {
+  const atom = useMemo(
+    () =>
+      Atom.make((get) =>
+        entries.map((entry) =>
+          applyPullRequestSummary(
+            entry,
+            get(
+              pullRequestState.snapshot({
+                environmentId: entry.environmentId,
+                input: {
+                  projectId: entry.projectId,
+                  repository: entry.repository,
+                  number: entry.number,
+                },
+              }),
+            ).summary,
+          ),
+        ),
+      ),
+    [entries],
+  );
+  return useAtomValue(atom);
+}
+
+interface RetainedPullRequestList {
+  readonly environmentKey: string;
+  readonly scope: string;
+  readonly query: string;
+  readonly data: MergedPullRequestList;
+  readonly partitions?: PullRequestPartitionsSnapshot | undefined;
+}
+
+/** Hydrate only the selected environment set and persist complete, unsearched list answers. */
+export function useRetainedPullRequestList({
+  environmentKey,
+  scope,
+  query,
+  live,
+  baseline,
+  orderedEntries,
+  authored,
+  reviewing,
+}: {
+  readonly environmentKey: string;
+  readonly scope: string;
+  readonly query: string;
+  readonly live: Pick<MergedPullRequestListView, "data" | "isPending">;
+  readonly baseline: MergedPullRequestList | null;
+  readonly orderedEntries: ReadonlyArray<EnvironmentPullRequestEntry> | null;
+  readonly authored: MergedPullRequestList | null;
+  readonly reviewing: MergedPullRequestList | null;
+}): RetainedPullRequestList | null {
+  const snapshot = useMemo((): RetainedPullRequestList | null => {
+    if (environmentKey.length === 0) return null;
+    const stored = readPullRequestListSnapshot(pullRequestSnapshotStorage(), environmentKey);
+    return stored === null ? null : { ...stored, environmentKey, query: "" };
+  }, [environmentKey]);
+  const [held, setHeld] = useState<RetainedPullRequestList | null>(null);
+  const loaded = held?.environmentKey === environmentKey ? held : snapshot;
+  useEffect(() => {
+    const liveData = live.data;
+    if (liveData === null || live.isPending) return;
+    setHeld((current) => {
+      const previous = current?.environmentKey === environmentKey ? current : snapshot;
+      const partitions =
+        authored !== null && reviewing !== null
+          ? { authored: authored.entries, reviewing: reviewing.entries }
+          : previous?.scope === scope
+            ? previous.partitions
+            : undefined;
+      const data = { ...liveData, entries: orderedEntries ?? liveData.entries };
+      if (environmentKey.length > 0 && query.length === 0) {
+        writePullRequestListSnapshot(pullRequestSnapshotStorage(), environmentKey, {
+          scope,
+          data: {
+            ...data,
+            viewers: baseline?.viewers ?? data.viewers,
+            providers: baseline?.providers ?? data.providers,
+          },
+          ...(partitions === undefined ? {} : { partitions }),
+        });
+      }
+      return {
+        environmentKey,
+        scope,
+        query,
+        data,
+        ...(partitions === undefined ? {} : { partitions }),
+      };
     });
-  }, [atom, current, environmentId]);
-  return newestPullRequestSummary(current, observed);
+  }, [
+    authored,
+    baseline,
+    environmentKey,
+    live.data,
+    live.isPending,
+    orderedEntries,
+    query,
+    reviewing,
+    scope,
+    snapshot,
+  ]);
+  return loaded;
 }
 
 export interface EnvironmentQueryTarget<Input> {
@@ -182,6 +635,18 @@ export function usePullRequestList(
 ): MergedPullRequestListView {
   const query = usePullRequestListsQuery(targets);
   const data = useMemo(() => mergePullRequestLists(query.values), [query.values]);
+  useLayoutEffect(() => {
+    if (data === null) return;
+    for (const entry of data.entries) {
+      pullRequestState.observeSummary(
+        {
+          environmentId: entry.environmentId,
+          input: { projectId: entry.projectId, repository: entry.repository, number: entry.number },
+        },
+        entry,
+      );
+    }
+  }, [data]);
   return { data, error: query.error, isPending: query.isPending, refresh: query.refresh };
 }
 

--- a/apps/web/src/state/pullRequests.ts
+++ b/apps/web/src/state/pullRequests.ts
@@ -3,6 +3,7 @@ import {
   createLinkedPullRequestSummaryAtomFamily,
   createPullRequestEnvironmentAtoms,
 } from "@t3tools/client-runtime/state/pull-requests";
+import { executeAtomQuery } from "@t3tools/client-runtime/state/runtime";
 import type {
   EnvironmentId,
   ProjectId,
@@ -29,7 +30,9 @@ import {
   type EnvironmentPullRequestEntry,
 } from "../components/pullRequest/pullRequestList.logic";
 import {
+  PULL_REQUEST_DETAIL_SNAPSHOT_MAX_ENTRIES,
   readPullRequestDetailSnapshot,
+  readPullRequestDetailSnapshotReferences,
   writePullRequestDetailSnapshot,
 } from "../components/pullRequest/pullRequestDetail.logic";
 import { formatEnvironmentQueryError, useEnvironmentQuery } from "./query";
@@ -61,6 +64,10 @@ function normalizedPullRequestUrl(url: string): string {
   return url.split(/[?#]/u)[0]!.replace(/\/$/u, "").toLowerCase();
 }
 
+export function samePullRequestUrl(left: string, right: string): boolean {
+  return normalizedPullRequestUrl(left) === normalizedPullRequestUrl(right);
+}
+
 function pullRequestUrlKey(environmentId: EnvironmentId, projectId: ProjectId, url: string) {
   return JSON.stringify([environmentId, projectId, normalizedPullRequestUrl(url)]);
 }
@@ -83,8 +90,7 @@ function matchesPullRequest(
     reference.projectId === value.projectId &&
     reference.repository.toLowerCase() === value.repository.toLowerCase() &&
     reference.number === value.number &&
-    (reference.url === undefined ||
-      normalizedPullRequestUrl(reference.url) === normalizedPullRequestUrl(value.url))
+    (reference.url === undefined || samePullRequestUrl(reference.url, value.url))
   );
 }
 
@@ -144,10 +150,45 @@ function applyPullRequestSummary<T extends PullRequestSummary>(
   return { ...current, ...summary };
 }
 
+function sameSummary(left: PullRequestSummary | null, right: PullRequestSummary | null): boolean {
+  return (
+    left === right ||
+    (left !== null &&
+      right !== null &&
+      Object.entries(left).every(
+        ([key, value]) => right[key as keyof PullRequestSummary] === value,
+      ) &&
+      Object.entries(right).every(
+        ([key, value]) => left[key as keyof PullRequestSummary] === value,
+      ))
+  );
+}
+
+function hasEqualTimeSummaryConflict(
+  current: PullRequestSummary | null,
+  detail: PullRequestSummary,
+): boolean {
+  if (
+    current === null ||
+    !samePullRequest(current, detail) ||
+    current.state === "merged" ||
+    detail.state === "merged" ||
+    Date.parse(current.updatedAt) !== Date.parse(detail.updatedAt)
+  )
+    return false;
+  return (
+    ["title", "state", "isDraft", "headBranch", "baseBranch", "closedAt", "mergedAt"] as const
+  ).some(
+    (key) =>
+      current[key] !== undefined && detail[key] !== undefined && current[key] !== detail[key],
+  );
+}
+
 function resolvePullRequestSnapshot(
   previous: PullRequestSnapshot,
   observation: PullRequestSummary,
   detail: PullRequestDetail | null,
+  freshDetail = false,
 ): PullRequestSnapshot {
   const sameIdentity = previous.summary === null || samePullRequest(previous.summary, observation);
   if (!sameIdentity && detail === null && previous.detail !== null) return previous;
@@ -160,25 +201,27 @@ function resolvePullRequestSnapshot(
       Date.parse(detail.updatedAt) >= Date.parse(previousDetail.updatedAt))
       ? detail
       : previousDetail;
+  // Equal host timestamps cannot order independent summary and held-detail responses.
+  // Keep the accepted summary until a read after explicit host invalidation confirms it.
   const newest =
-    newestPullRequestSummary(sameIdentity ? previous.summary : null, observation) ?? observation;
-  const summary = {
+    !freshDetail && hasEqualTimeSummaryConflict(previous.summary, observation)
+      ? previous.summary!
+      : (newestPullRequestSummary(sameIdentity ? previous.summary : null, observation) ??
+        observation);
+  const candidateSummary = {
     ...(sameIdentity ? previous.summary : null),
     ...pullRequestSummary(newest),
   };
+  const summary = sameSummary(previous.summary, candidateSummary)
+    ? previous.summary!
+    : candidateSummary;
   const previousSummary = previous.summary;
   const changedRevision =
     previousSummary !== null &&
     (!sameIdentity ||
       summary.updatedAt !== previousSummary.updatedAt ||
       summary.state !== previousSummary.state);
-  if (
-    nextDetail === previous.detail &&
-    previousSummary !== null &&
-    Object.entries(summary).every(
-      ([key, value]) => previousSummary[key as keyof PullRequestSummary] === value,
-    )
-  ) {
+  if (nextDetail === previous.detail && summary === previous.summary) {
     return previous;
   }
   return { detail: nextDetail, summary, revision: previous.revision + Number(changedRevision) };
@@ -190,6 +233,10 @@ export function createPullRequestState(
   options: {
     readonly storage: () => Storage | undefined;
     readonly onRevisionChanged: (target: PullRequestTarget) => void;
+    readonly readFreshDetail?: (
+      target: PullRequestTarget,
+      signal: AbortSignal,
+    ) => Promise<PullRequestDetail | null>;
   },
 ) {
   const storage = () => {
@@ -224,15 +271,33 @@ export function createPullRequestState(
       (context, value: PullRequestSnapshot) => context.setSelf(value),
     ).pipe(Atom.setIdleTTL(5 * 60_000), Atom.withLabel(`web-pull-requests:snapshot:${key}`)),
   );
+  // Read the bounded saved index once so detected-only sidebars can hydrate after a reload.
+  const savedReferences = Atom.make(
+    () =>
+      new Map(
+        readPullRequestDetailSnapshotReferences(storage()).map(({ environmentId, input, url }) => [
+          pullRequestUrlKey(environmentId, input.projectId, url),
+          { environmentId, input },
+        ]),
+      ),
+  ).pipe(Atom.keepAlive);
   // Detected VCS PRs carry a URL, not the host's repository reference. This index points at
   // the same snapshot and never copies its status or shares it across projects.
-  const referencesByUrl = Atom.family((_key: string) =>
-    Atom.make<PullRequestTarget | null>(null).pipe(Atom.setIdleTTL(5 * 60_000)),
+  const referencesByUrl = Atom.family((key: string) =>
+    Atom.writable(
+      (get): PullRequestTarget | null => get(savedReferences).get(key) ?? null,
+      (context, value: PullRequestTarget) => context.setSelf(value),
+    ).pipe(Atom.setIdleTTL(5 * 60_000)),
   );
   const summariesByUrl = Atom.family((key: string) =>
     Atom.make((get) => {
       const target = get(referencesByUrl(key));
-      return target === null ? null : get(snapshots(pullRequestKey(target))).summary;
+      if (target === null) return null;
+      const summary = get(snapshots(pullRequestKey(target))).summary;
+      return summary !== null &&
+        pullRequestUrlKey(target.environmentId, target.input.projectId, summary.url) === key
+        ? summary
+        : null;
     }).pipe(Atom.setIdleTTL(5 * 60_000)),
   );
   const snapshot = (target: PullRequestTarget) => snapshots(pullRequestKey(target));
@@ -243,10 +308,18 @@ export function createPullRequestState(
     );
     if (registry.get(urlReference) === null) registry.set(urlReference, target);
   };
+  const confirmations = Atom.make((get) => {
+    const pending = new Map<string, AbortController>();
+    get.addFinalizer(() => {
+      for (const controller of pending.values()) controller.abort();
+    });
+    return pending;
+  }).pipe(Atom.keepAlive);
   const observe = (
     target: PullRequestTarget,
     value: PullRequestSummary,
     detail: PullRequestDetail | null = null,
+    freshDetail = false,
   ) => {
     if (!matchesPullRequest(target.input, value)) return;
     const atom = snapshot(target);
@@ -254,13 +327,13 @@ export function createPullRequestState(
     const seen = registry.get(observations);
     const sourceKey = JSON.stringify([pullRequestKey(target), detail !== null]);
     const accepted = seen.get(value);
-    if (previous.summary !== null && accepted?.has(sourceKey)) {
+    if (!freshDetail && previous.summary !== null && accepted?.has(sourceKey)) {
       registerReference(target, value);
       return;
     }
     if (accepted === undefined) seen.set(value, new Set([sourceKey]));
     else accepted.add(sourceKey);
-    const next = resolvePullRequestSnapshot(previous, value, detail);
+    const next = resolvePullRequestSnapshot(previous, value, detail, freshDetail);
     if (next !== previous) {
       registry.set(atom, next);
       if (next.detail !== null) {
@@ -273,9 +346,48 @@ export function createPullRequestState(
             ...(next.summary === null ? {} : { observedSummary: next.summary }),
           },
         );
+        const saved = registry.get(savedReferences);
+        const urlKey = pullRequestUrlKey(
+          target.environmentId,
+          target.input.projectId,
+          next.detail.url,
+        );
+        saved.delete(urlKey);
+        saved.set(urlKey, target);
+        if (saved.size > PULL_REQUEST_DETAIL_SNAPSHOT_MAX_ENTRIES) {
+          const oldest = saved.keys().next().value;
+          if (oldest !== undefined) saved.delete(oldest);
+        }
       }
       if (next.revision !== previous.revision)
         options.onRevisionChanged(targetFromKey(pullRequestKey(target)));
+    }
+    const pending = registry.get(confirmations);
+    if (
+      !freshDetail &&
+      hasEqualTimeSummaryConflict(previous.summary, value) &&
+      options.readFreshDetail !== undefined &&
+      !pending.has(pullRequestKey(target))
+    ) {
+      const key = pullRequestKey(target);
+      const expectedSummary = next.summary;
+      // The in-flight map holds only active reads. Multiple mounted readers share this request.
+      const controller = new AbortController();
+      pending.set(key, controller);
+      void options
+        .readFreshDetail(target, controller.signal)
+        .then((fresh) => {
+          if (
+            !controller.signal.aborted &&
+            fresh !== null &&
+            registry.get(atom).summary === expectedSummary
+          )
+            observe(target, fresh, fresh, true);
+        })
+        .catch(() => {
+          // Keep the accepted summary if the host is unavailable. A later new response can retry.
+        })
+        .finally(() => pending.delete(key));
     }
     registerReference(target, value);
   };
@@ -307,6 +419,17 @@ function pullRequestSnapshotStorage(): Storage | undefined {
 export const pullRequestState = createPullRequestState(appAtomRegistry, {
   storage: pullRequestSnapshotStorage,
   onRevisionChanged: (target) => appAtomRegistry.refresh(pullRequestEnvironment.activity(target)),
+  readFreshDetail: async (target, signal) => {
+    const invalidated = await pullRequestEnvironment.invalidate.run(appAtomRegistry, {
+      environmentId: target.environmentId,
+      input: { reference: target.input },
+    });
+    if (signal.aborted || !AsyncResult.isSuccess(invalidated)) return null;
+    const query = pullRequestEnvironment.detail(target);
+    appAtomRegistry.refresh(query);
+    const result = await executeAtomQuery(appAtomRegistry, query, { signal });
+    return AsyncResult.isSuccess(result) ? result.value : null;
+  },
 });
 
 const emptyPullRequestSnapshot = Atom.make<PullRequestSnapshot>({
@@ -354,8 +477,7 @@ export function resolveSharedThreadPullRequest(
   summary: PullRequestSummary | null,
 ): VcsStatusResult["pr"] {
   if (current === null || summary === null) return current;
-  if (normalizedPullRequestUrl(current.url) !== normalizedPullRequestUrl(summary.url))
-    return current;
+  if (!samePullRequestUrl(current.url, summary.url)) return current;
   if (!observedPullRequestIsNewer(current, summary)) return current;
   return {
     ...current,

--- a/packages/client-runtime/src/state/pullRequests.test.ts
+++ b/packages/client-runtime/src/state/pullRequests.test.ts
@@ -133,7 +133,13 @@ it.effect("refreshes pull request activity after a comment is updated", () =>
       const update = yield* Effect.promise(() =>
         atoms.updateComment.run(registry, {
           environmentId: TARGET.environmentId,
-          input: { ...reference, commentId: "comment-1", kind: "issue-comment", body: "updated" },
+          input: {
+            ...reference,
+            repository: "Acme/WEB",
+            commentId: "comment-1",
+            kind: "issue-comment",
+            body: "updated",
+          },
         }),
       );
 

--- a/packages/client-runtime/src/state/pullRequests.ts
+++ b/packages/client-runtime/src/state/pullRequests.ts
@@ -1,6 +1,8 @@
 import {
   WS_METHODS,
+  type EnvironmentId,
   type PullRequestDetail,
+  type PullRequestRef,
   type PullRequestDiffInput,
   type PullRequestSummary,
   type VcsStatusResult,
@@ -45,12 +47,29 @@ function createPullRequestRefreshAtomFamily<R, E>(
   });
 }
 
+type PullRequestTarget = { readonly environmentId: EnvironmentId; readonly input: PullRequestRef };
+
+/** Extra URL/list fields and repository case must not split reads for the same PR. */
+function normalizePullRequestTarget({
+  environmentId,
+  input,
+}: PullRequestTarget): PullRequestTarget {
+  return {
+    environmentId,
+    input: {
+      projectId: input.projectId,
+      repository: input.repository.toLowerCase(),
+      number: input.number,
+    },
+  };
+}
+
 /** Refresh only the live fields a linked thread renders. */
 export function createLinkedPullRequestSummaryAtomFamily<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | R, E>,
   refreshes = createPullRequestRefreshAtomFamily(runtime),
 ) {
-  return createEnvironmentRpcQueryAtomFamily(runtime, {
+  const query = createEnvironmentRpcQueryAtomFamily(runtime, {
     label: "environment-data:pull-requests:linked-summary",
     tag: WS_METHODS.pullRequestsSummary,
     staleTimeMs: 60_000,
@@ -58,6 +77,7 @@ export function createLinkedPullRequestSummaryAtomFamily<R, E>(
     idleTtlMs: LINKED_PULL_REQUEST_IDLE_TTL_MS,
     refreshTrigger: ({ environmentId }) => refreshes({ environmentId, input: {} }),
   });
+  return (target: PullRequestTarget) => query(normalizePullRequestTarget(target));
 }
 
 export function pullRequestDetailToVcsStatus(
@@ -89,9 +109,16 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     mode: "serial",
     key: ({ environmentId }: { readonly environmentId: string }) => environmentId,
   } as const;
-  const activity = createEnvironmentRpcQueryAtomFamily(runtime, {
+  const activityQuery = createEnvironmentRpcQueryAtomFamily(runtime, {
     label: "environment-data:pull-requests:activity",
     tag: WS_METHODS.pullRequestsActivity,
+    staleTimeMs: 60_000,
+    refreshTrigger: ({ environmentId }) => refreshes({ environmentId, input: {} }),
+  });
+  const activity = (target: PullRequestTarget) => activityQuery(normalizePullRequestTarget(target));
+  const detailQuery = createEnvironmentRpcQueryAtomFamily(runtime, {
+    label: "environment-data:pull-requests:detail",
+    tag: WS_METHODS.pullRequestsDetail,
     staleTimeMs: 60_000,
     refreshTrigger: ({ environmentId }) => refreshes({ environmentId, input: {} }),
   });
@@ -116,12 +143,7 @@ export function createPullRequestEnvironmentAtoms<R, E>(
       staleTimeMs: 60_000,
       refreshTrigger: ({ environmentId }) => refreshes({ environmentId, input: {} }),
     }),
-    detail: createEnvironmentRpcQueryAtomFamily(runtime, {
-      label: "environment-data:pull-requests:detail",
-      tag: WS_METHODS.pullRequestsDetail,
-      staleTimeMs: 60_000,
-      refreshTrigger: ({ environmentId }) => refreshes({ environmentId, input: {} }),
-    }),
+    detail: (target: PullRequestTarget) => detailQuery(normalizePullRequestTarget(target)),
     activity,
     threadComments: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:thread-comments",


### PR DESCRIPTION
PR detail, list, sidebar, and tab readers could show different states. Each reader kept its own saved detail and refresh rules. Reopening a reader could let an old response replace a newer observation with the same timestamp.

Give the web PR state one owner for saved detail, accepted summaries, and refresh revisions. Keep list pagination local. Normalize query identity and share accepted state across the list, both sidebars, detail panel, tab, and copy-link action. Retained response objects can update a PR only once per observation kind. Conflicting equal-time summaries trigger one uncached host read before replacing accepted state. Resetting the client cancels that confirmation.

Environment, project, repository, host URL, and viewer permissions stay separate. Preserve optional fields from older servers and current terminal timestamps. Desktop uses the same web readers. Mobile gets only normalized shared query keys. Server invalidation now uses one epoch across repository casing variants.

Depends on [#10109](https://github.com/pingdotgg/t3code/pull/10109). Merge that PR first.

Verified:

- 130 focused client tests pass, including both equal-time response orders, confirmation reset, environment switches, same-timestamp remounts, list filtering, saved detail, and denied storage.
- 104 PullRequestService tests pass, including invalidation across repository casing.
- Three held-response cases fail with the acceptance guard removed and pass with it restored.
- Web and client-runtime typechecks pass. Scoped lint passes with existing or moved React warnings.
- Independent source review verified the held-response fix and the equal-time confirmation fixes.

## Client check

A disposable integrated web client received merged list and summary responses while detail still returned its earlier open state. List and detail kept merged state after the next detail refresh failed. The list checks popup kept its saved check.

The sidebar was linked again after the error stage and matched the saved merged state. This did not test the sidebar through every phase. These were client-only read fixtures, not provider or hosting tests. The fixture sent no server write. No live app or data was used.

Initial open state:

![Initial open PR state](https://files.tslop.org/2026/09/pr-state-open-8c8246ff.png)

After the merged summary and failed detail refresh. The sidebar was linked again at this stage:

![Merged list, detail, and sidebar with saved checks after a failed detail refresh](https://files.tslop.org/2026/09/pr-state-refresh-error-saved-checks-fbe83d71.png)

Created with GPT-6 Astra in Codex. Follow-up fixes and current-main integration completed with Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add shared pull-request state layer to keep PR data consistent across views
> - Introduces a central pull-request state factory in [pullRequests.ts](https://github.com/pingdotgg/t3code/pull/10293/files#diff-7129ea4b7244d6e4a694b6a19c0a0d3485c311cb6c3f967257a7d493b6b38fed) that persists detail snapshots to local storage, normalizes URLs and repository casing, resolves equal-timestamp conflicts via confirmation reads, and deduplicates observations by identity.
> - Adds shared hooks (`usePullRequestDetail`, `useSharedPullRequestSummary`, `useSharedThreadPullRequest`, `useObservedPullRequestEntries`, `useRetainedPullRequestList`) and migrates `PullRequestDetailPanel`, `PullRequestLinkPreview`, `ChatView`, `Sidebar`, `LegacySidebar`, `RightPanelTabs`, and the Pull Requests route to consume them instead of per-component environment queries and local-storage fallbacks.
> - Normalizes query targets in [client-runtime pullRequests.ts](https://github.com/pingdotgg/t3code/pull/10293/files#diff-2d91060574375b3bf673fd9485f3426ac3aa80b2c3441aeb87d6786c49607879) and lowercases repository names in server-side epoch scoping in [PullRequestService.ts](https://github.com/pingdotgg/t3code/pull/10293/files#diff-6dc74968ebcf535ce84fea9f44369080aa5246f4a8c9d10824bf988651c4f0bf) so repository casing no longer creates separate cache entries or invalidation scopes.
> - Risk: `PullRequestDetailPanel` removes `refreshToken` and `onStateChange` props and now delegates all refresh to state-layer helpers; any callers still passing those props will break. Snapshot schema in [pullRequestDetail.logic.ts](https://github.com/pingdotgg/t3code/pull/10293/files#diff-2c5f917dba9decc3bd48ec3231f7b0db073e8b642379cf000265960a03718c18) adds an optional `observedSummary` field to persisted detail payloads, so older snapshots without it are tolerated but will not carry summary data until re-observed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7b7838.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->