### PR TITLE
fix(threads): tie compaction state to its request

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -302,6 +302,30 @@ function makeThread(
 }
 
 describe("buildThreadFeed", () => {
+  it.each(["provider.turn.start.accepted", "provider.turn.start.interrupted"])(
+    "hides the internal %s activity",
+    (kind) => {
+      const thread = makeThread({
+        id: ThreadId.make("thread-acceptance"),
+        projectId: ProjectId.make("project-1"),
+        title: "Acceptance",
+        activities: [
+          makeActivity({
+            id: EventId.make(kind),
+            kind,
+            summary: "Provider request",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            payload: { timelineBypass: true },
+          }),
+        ],
+      });
+      expect(
+        buildThreadFeed(thread).flatMap((entry) =>
+          entry.type === "activity-group" ? entry.activities : [],
+        ),
+      ).toEqual([]);
+    },
+  );
   it("reuses unchanged feed and presentation rows during an assistant text update", () => {
     const completedTurnId = TurnId.make("completed-turn");
     const activeTurnId = TurnId.make("active-turn");

--- a/apps/mobile/src/state/use-thread-composer-state.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.ts
@@ -6,6 +6,8 @@ import * as Cause from "effect/Cause";
 import {
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
+  getThreadPendingOperation,
+  isContextCompactionMessage,
   MessageId,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   type EnvironmentId,
@@ -179,39 +181,15 @@ export function useThreadComposerState() {
   }, [selectedThreadDetail, selectedThreadShell]);
 
   const isCompacting = useMemo(() => {
+    if (getThreadPendingOperation(selectedThread)?.kind === "compact") return true;
     const queuedMessage = selectedThreadQueuedMessages.findLast(
       (message) =>
         message.messageId === dispatchingQueuedMessageId &&
-        message.text.trim().toLowerCase() === "/compact" &&
-        message.attachments.length === 0,
+        isContextCompactionMessage({ ...message, role: "user" }),
     );
-    const latestCompactMessage = selectedThreadDetail?.messages.findLast(
-      (message) =>
-        message.role === "user" &&
-        message.text.trim().toLowerCase() === "/compact" &&
-        !message.attachments?.length,
-    );
-    const compactRequestIsActive =
-      latestCompactMessage !== undefined &&
-      (latestCompactMessage.createdAt >
-        (selectedThread?.latestTurn?.requestedAt ?? latestCompactMessage.createdAt) ||
-        (selectedThread?.latestTurn?.state === "running" &&
-          latestCompactMessage.createdAt === selectedThread.latestTurn.requestedAt));
-    const compactionSettled = selectedThreadDetail?.activities.some((activity) => {
-      if (!["context-compaction", "provider.turn.start.failed"].includes(activity.kind))
-        return false;
-      const payload =
-        typeof activity.payload === "object" && activity.payload !== null
-          ? (activity.payload as { readonly requestId?: unknown })
-          : null;
-      return payload?.requestId === latestCompactMessage?.id;
-    });
     return (
-      queuedMessage !== undefined ||
-      ((selectedThread?.session?.status === "starting" ||
-        selectedThread?.session?.status === "running") &&
-        compactRequestIsActive &&
-        !compactionSettled)
+      queuedMessage !== undefined &&
+      !selectedThreadDetail?.messages.some((message) => message.id === queuedMessage.messageId)
     );
   }, [
     dispatchingQueuedMessageId,

--- a/apps/mobile/src/state/use-thread-selection.ts
+++ b/apps/mobile/src/state/use-thread-selection.ts
@@ -56,6 +56,7 @@ function threadDetailToShell(
     worktreePath: thread.worktreePath,
     linkedPullRequest: thread.linkedPullRequest ?? null,
     latestTurn: thread.latestTurn,
+    pendingOperation: thread.pendingOperation,
     createdAt: thread.createdAt,
     updatedAt: thread.updatedAt,
     archivedAt: thread.archivedAt,

--- a/apps/server/integration/TransferBudgetReport.integration.ts
+++ b/apps/server/integration/TransferBudgetReport.integration.ts
@@ -50,7 +50,8 @@ interface ProviderTransferBudget {
 // orders of magnitude. The CI report preserves exact values for review.
 const TRANSFER_BUDGET = {
   totalWireBytes: 15_500,
-  threadSnapshotWireBytes: 7_500,
+  // Ten history turns include request bindings for send acceptance.
+  threadSnapshotWireBytes: 8_000,
   measuredTurnWebSocketWireBytes: 8_000,
   measuredTurnWebSocketDecodedBytes: 68_000,
   measuredTurnWebSocketMessages: 21,

--- a/apps/server/src/orchestration/Errors.ts
+++ b/apps/server/src/orchestration/Errors.ts
@@ -56,7 +56,7 @@ export class OrchestrationOperationSupersededError extends Schema.TaggedErrorCla
   "OrchestrationOperationSupersededError",
   {
     requestId: MessageId,
-    currentRequestId: MessageId,
+    currentRequestId: Schema.NullOr(MessageId),
   },
 ) {
   override get message(): string {

--- a/apps/server/src/orchestration/Errors.ts
+++ b/apps/server/src/orchestration/Errors.ts
@@ -1,4 +1,4 @@
-import { ThreadId } from "@t3tools/contracts";
+import { MessageId, ThreadId } from "@t3tools/contracts";
 import * as SchemaIssue from "effect/SchemaIssue";
 import * as Schema from "effect/Schema";
 
@@ -52,9 +52,22 @@ export class OrchestrationThreadSettleBlockedError extends Schema.TaggedErrorCla
   }
 }
 
+export class OrchestrationOperationSupersededError extends Schema.TaggedErrorClass<OrchestrationOperationSupersededError>()(
+  "OrchestrationOperationSupersededError",
+  {
+    requestId: MessageId,
+    currentRequestId: MessageId,
+  },
+) {
+  override get message(): string {
+    return "The operation result belongs to an older request.";
+  }
+}
+
 export const OrchestrationCommandRejection = Schema.Union([
   OrchestrationCommandInvariantError,
   OrchestrationThreadSettleBlockedError,
+  OrchestrationOperationSupersededError,
 ]);
 export type OrchestrationCommandRejection = typeof OrchestrationCommandRejection.Type;
 export const isOrchestrationCommandRejection = Schema.is(OrchestrationCommandRejection);

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -10,6 +10,7 @@ import {
   ThreadId,
   TurnId,
   ProviderInstanceId,
+  type OrchestrationPendingOperation,
 } from "@t3tools/contracts";
 import * as Option from "effect/Option";
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -17,6 +18,7 @@ import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Stream from "effect/Stream";
 import * as Path from "effect/Path";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
@@ -42,6 +44,7 @@ import * as ThreadPlanProgress from "../ThreadPlanProgress.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { OrchestrationProjectionPipeline } from "../Services/ProjectionPipeline.ts";
 import { ServerConfig } from "../../config.ts";
+import { createEmptyReadModel, projectEvent } from "../projector.ts";
 
 const makeProjectionPipelinePrefixedTestLayer = (prefix: string) =>
   OrchestrationProjectionPipelineLive.pipe(
@@ -3699,103 +3702,109 @@ it.layer(makeProjectionPipelinePrefixedTestLayer("t3-pending-turn-terminal-test-
   },
 );
 
-it.effect("restores pending turn-start metadata across projection pipeline restart", () =>
-  Effect.gen(function* () {
-    const { dbPath } = yield* ServerConfig;
-    const persistenceLayer = makeSqlitePersistenceLive(dbPath);
-    const firstProjectionLayer = OrchestrationProjectionPipelineLive.pipe(
-      Layer.provideMerge(OrchestrationEventStoreLive),
-      Layer.provideMerge(persistenceLayer),
-    );
-    const secondProjectionLayer = OrchestrationProjectionPipelineLive.pipe(
-      Layer.provideMerge(OrchestrationEventStoreLive),
-      Layer.provideMerge(persistenceLayer),
-    );
+it.effect.each(["turn", "compact"] as const)(
+  "restores pending %s metadata across projection pipeline restart",
+  (operation) =>
+    Effect.gen(function* () {
+      const { dbPath } = yield* ServerConfig;
+      const persistenceLayer = makeSqlitePersistenceLive(dbPath);
+      const firstProjectionLayer = OrchestrationProjectionPipelineLive.pipe(
+        Layer.provideMerge(OrchestrationEventStoreLive),
+        Layer.provideMerge(persistenceLayer),
+      );
+      const secondProjectionLayer = OrchestrationProjectionPipelineLive.pipe(
+        Layer.provideMerge(OrchestrationEventStoreLive),
+        Layer.provideMerge(persistenceLayer),
+      );
 
-    const threadId = ThreadId.make("thread-restart");
-    const turnId = TurnId.make("turn-restart");
-    const messageId = MessageId.make("message-restart");
-    const sourcePlanThreadId = ThreadId.make("thread-plan-source");
-    const sourcePlanId = "plan-source";
-    const turnStartedAt = "2026-02-26T14:00:00.000Z";
-    const sessionSetAt = "2026-02-26T14:00:05.000Z";
+      const threadId = ThreadId.make("thread-restart");
+      const turnId = TurnId.make("turn-restart");
+      const messageId = MessageId.make("message-restart");
+      const sourcePlanThreadId = ThreadId.make("thread-plan-source");
+      const sourcePlanId = "plan-source";
+      const turnStartedAt = "2026-02-26T14:00:00.000Z";
+      const sessionSetAt = "2026-02-26T14:00:05.000Z";
 
-    yield* Effect.gen(function* () {
-      const eventStore = yield* OrchestrationEventStore;
-      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      yield* Effect.gen(function* () {
+        const eventStore = yield* OrchestrationEventStore;
+        const projectionPipeline = yield* OrchestrationProjectionPipeline;
 
-      yield* eventStore.append({
-        type: "thread.turn-start-requested",
-        eventId: EventId.make("evt-restart-1"),
-        aggregateKind: "thread",
-        aggregateId: threadId,
-        occurredAt: turnStartedAt,
-        commandId: CommandId.make("cmd-restart-1"),
-        causationEventId: null,
-        correlationId: CorrelationId.make("cmd-restart-1"),
-        metadata: {},
-        payload: {
-          threadId,
-          messageId,
-          sourceProposedPlan: {
-            threadId: sourcePlanThreadId,
-            planId: sourcePlanId,
-          },
-          runtimeMode: "approval-required",
-          createdAt: turnStartedAt,
-        },
-      });
-
-      yield* projectionPipeline.bootstrap;
-    }).pipe(Effect.provide(firstProjectionLayer));
-
-    const turnRows = yield* Effect.gen(function* () {
-      const eventStore = yield* OrchestrationEventStore;
-      const projectionPipeline = yield* OrchestrationProjectionPipeline;
-      const sql = yield* SqlClient.SqlClient;
-
-      yield* eventStore.append({
-        type: "thread.session-set",
-        eventId: EventId.make("evt-restart-2"),
-        aggregateKind: "thread",
-        aggregateId: threadId,
-        occurredAt: sessionSetAt,
-        commandId: CommandId.make("cmd-restart-2"),
-        causationEventId: null,
-        correlationId: CorrelationId.make("cmd-restart-2"),
-        metadata: {},
-        payload: {
-          threadId,
-          session: {
+        yield* eventStore.append({
+          type: "thread.turn-start-requested",
+          eventId: EventId.make("evt-restart-1"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: turnStartedAt,
+          commandId: CommandId.make("cmd-restart-1"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-restart-1"),
+          metadata: {},
+          payload: {
             threadId,
-            status: "running",
-            providerName: "codex",
+            messageId,
+            operation,
+            sourceProposedPlan: {
+              threadId: sourcePlanThreadId,
+              planId: sourcePlanId,
+            },
             runtimeMode: "approval-required",
-            activeTurnId: turnId,
-            lastError: null,
-            updatedAt: sessionSetAt,
+            createdAt: turnStartedAt,
           },
-        },
-      });
+        });
 
-      yield* projectionPipeline.bootstrap;
+        yield* projectionPipeline.bootstrap;
+      }).pipe(Effect.provide(firstProjectionLayer));
 
-      const pendingRows = yield* sql<{ readonly threadId: string }>`
+      const turnRows = yield* Effect.gen(function* () {
+        const eventStore = yield* OrchestrationEventStore;
+        const projectionPipeline = yield* OrchestrationProjectionPipeline;
+        const sql = yield* SqlClient.SqlClient;
+
+        yield* eventStore.append({
+          type: "thread.session-set",
+          eventId: EventId.make("evt-restart-2"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: sessionSetAt,
+          commandId: CommandId.make("cmd-restart-2"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-restart-2"),
+          metadata: {},
+          payload: {
+            threadId,
+            session: {
+              threadId,
+              status: "running",
+              providerName: "codex",
+              runtimeMode: "approval-required",
+              activeTurnId: turnId,
+              lastError: null,
+              updatedAt: sessionSetAt,
+            },
+          },
+        });
+
+        yield* projectionPipeline.bootstrap;
+
+        const pendingRows = yield* sql<{ readonly threadId: string }>`
         SELECT thread_id AS "threadId"
         FROM projection_turns
         WHERE thread_id = ${threadId}
           AND turn_id IS NULL
           AND state = 'pending'
       `;
-      assert.deepEqual(pendingRows, []);
+        assert.deepEqual(
+          pendingRows,
+          operation === "compact" ? [{ threadId: "thread-restart" }] : [],
+        );
 
-      return yield* sql<{
-        readonly turnId: string;
-        readonly userMessageId: string | null;
-        readonly sourceProposedPlanThreadId: string | null;
-        readonly sourceProposedPlanId: string | null;
-        readonly startedAt: string;
-      }>`
+        return yield* sql<{
+          readonly turnId: string;
+          readonly userMessageId: string | null;
+          readonly sourceProposedPlanThreadId: string | null;
+          readonly sourceProposedPlanId: string | null;
+          readonly startedAt: string;
+        }>`
         SELECT
           turn_id AS "turnId",
           pending_message_id AS "userMessageId",
@@ -3805,27 +3814,27 @@ it.effect("restores pending turn-start metadata across projection pipeline resta
         FROM projection_turns
         WHERE turn_id = ${turnId}
       `;
-    }).pipe(Effect.provide(secondProjectionLayer));
+      }).pipe(Effect.provide(secondProjectionLayer));
 
-    assert.deepEqual(turnRows, [
-      {
-        turnId: "turn-restart",
-        userMessageId: "message-restart",
-        sourceProposedPlanThreadId: "thread-plan-source",
-        sourceProposedPlanId: "plan-source",
-        startedAt: turnStartedAt,
-      },
-    ]);
-  }).pipe(
-    Effect.provide(
-      Layer.provideMerge(
-        ServerConfig.layerTest(process.cwd(), {
-          prefix: "t3-projection-pipeline-restart-",
-        }),
-        NodeServices.layer,
+      assert.deepEqual(turnRows, [
+        {
+          turnId: "turn-restart",
+          userMessageId: "message-restart",
+          sourceProposedPlanThreadId: "thread-plan-source",
+          sourceProposedPlanId: "plan-source",
+          startedAt: turnStartedAt,
+        },
+      ]);
+    }).pipe(
+      Effect.provide(
+        Layer.provideMerge(
+          ServerConfig.layerTest(process.cwd(), {
+            prefix: "t3-projection-pipeline-restart-",
+          }),
+          NodeServices.layer,
+        ),
       ),
     ),
-  ),
 );
 
 const engineLayer = it.layer(
@@ -4215,6 +4224,169 @@ engineLayer("OrchestrationProjectionPipeline via engine dispatch", (it) => {
         WHERE command_id = ${cleanupFailureCommandId}
       `;
       assert.deepEqual(cleanupFailureReceipts, [{ status: "accepted" }]);
+    }),
+  );
+});
+
+engineLayer("pending operation facts", (it) => {
+  it.effect("keeps SQL snapshots and event replay consistent for delayed compaction results", () =>
+    Effect.gen(function* () {
+      const engine = yield* OrchestrationEngineService;
+      const snapshots = yield* ProjectionSnapshotQuery;
+      const sql = yield* SqlClient.SqlClient;
+      const threadId = ThreadId.make("thread-operation-facts");
+      const projectId = ProjectId.make("project-operation-facts");
+      const now = "2026-09-05T00:00:00.000Z";
+      yield* engine.dispatch({
+        type: "project.create",
+        commandId: CommandId.make("operation-project"),
+        projectId,
+        title: "Operation facts",
+        workspaceRoot: "/tmp/operation-facts",
+        createdAt: now,
+      });
+      yield* engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.make("operation-thread"),
+        threadId,
+        projectId,
+        title: "Compaction",
+        modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5-codex" },
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        branch: null,
+        worktreePath: null,
+        createdAt: now,
+      });
+      const start = (id: string, text: string) =>
+        engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make(`operation-start-${id}`),
+          threadId,
+          message: { messageId: MessageId.make(id), role: "user", text, attachments: [] },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          createdAt: now,
+        });
+      const session = {
+        threadId,
+        status: "ready" as const,
+        providerName: "codex",
+        runtimeMode: "full-access" as const,
+        activeTurnId: null,
+        lastError: null,
+        updatedAt: now,
+      };
+      const check = Effect.fn("checkPendingOperation")(function* (
+        expected: OrchestrationPendingOperation | null,
+      ) {
+        const detail = Option.getOrThrow(yield* snapshots.getThreadDetailById(threadId));
+        const shell = Option.getOrThrow(yield* snapshots.getThreadShellById(threadId));
+        assert.deepEqual(detail.pendingOperation, expected);
+        assert.deepEqual(shell.pendingOperation, expected);
+        const events = yield* Stream.runCollect(engine.readEvents(0));
+        let model = createEmptyReadModel(now);
+        for (const event of events) {
+          if (event.aggregateId === threadId) model = yield* projectEvent(model, event);
+        }
+        assert.deepEqual(model.threads[0]?.pendingOperation, expected);
+      });
+
+      yield* start("initial-message", "hello");
+      yield* engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("initial-turn-started"),
+        threadId,
+        session: { ...session, status: "running", activeTurnId: TurnId.make("initial-turn") },
+        createdAt: now,
+      });
+      yield* start("first-compact", " /CoMpAcT ");
+      const pending = { kind: "compact", requestId: MessageId.make("first-compact") } as const;
+      yield* check(pending);
+      for (const snapshot of [
+        yield* snapshots.getSnapshot(),
+        yield* snapshots.getCommandReadModel(),
+        yield* snapshots.getShellSnapshot(),
+      ]) {
+        assert.deepEqual(
+          snapshot.threads.find((thread) => thread.id === threadId)?.pendingOperation,
+          pending,
+        );
+      }
+
+      // This is a session preparation update, despite its old command prefix.
+      yield* engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("server:provider-session-set:prepare"),
+        threadId,
+        session,
+        createdAt: now,
+      });
+      yield* start("rejected-during-compact", "another message");
+      yield* engine.dispatch({
+        type: "thread.activity.append",
+        commandId: CommandId.make("operation-rejected-send"),
+        threadId,
+        operationResult: {
+          requestId: MessageId.make("rejected-during-compact"),
+          outcome: "failed",
+        },
+        activity: {
+          id: EventId.make("operation-rejected-send"),
+          kind: "provider.turn.start.failed",
+          tone: "error",
+          summary: "Wait for compaction",
+          payload: { requestId: "rejected-during-compact" },
+          turnId: null,
+          createdAt: now,
+        },
+        createdAt: now,
+      });
+      yield* check(pending);
+      yield* engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("operation-finished-without-magic-prefix"),
+        threadId,
+        session,
+        operationResult: { requestId: pending.requestId, outcome: "completed" },
+        createdAt: now,
+      });
+      yield* check(null);
+
+      yield* start("second-compact", "/compact");
+      yield* engine.dispatch({
+        type: "thread.activity.append",
+        commandId: CommandId.make("operation-late-completion"),
+        threadId,
+        operationResult: { requestId: pending.requestId, outcome: "completed" },
+        activity: {
+          id: EventId.make("operation-late-completion"),
+          kind: "context-compaction",
+          tone: "info",
+          summary: "Context compacted",
+          payload: { requestId: "first-compact" },
+          turnId: null,
+          createdAt: now,
+        },
+        createdAt: now,
+      });
+      yield* check({ kind: "compact", requestId: MessageId.make("second-compact") });
+      // Older versions omit this column when writing a pending row after a downgrade.
+      yield* sql`UPDATE projection_turns SET operation_kind = NULL WHERE thread_id = ${threadId} AND turn_id IS NULL`;
+      yield* check({ kind: "compact", requestId: MessageId.make("second-compact") });
+      assert.deepEqual(
+        (yield* snapshots.getCommandReadModel()).threads.find((thread) => thread.id === threadId)
+          ?.pendingOperation,
+        { kind: "compact", requestId: "second-compact" },
+      );
+      yield* engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("operation-interrupted"),
+        threadId,
+        session: { ...session, status: "interrupted" },
+        createdAt: now,
+      });
+      yield* check(null);
     }),
   );
 });

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -4322,6 +4322,14 @@ engineLayer("pending operation facts", (it) => {
         session,
         createdAt: now,
       });
+      yield* engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("native-compact-turn-started"),
+        threadId,
+        session: { ...session, status: "running", activeTurnId: TurnId.make("compact-turn") },
+        createdAt: now,
+      });
+      yield* check(pending);
       yield* start("rejected-during-compact", "another message");
       yield* engine.dispatch({
         type: "thread.activity.append",
@@ -4343,6 +4351,23 @@ engineLayer("pending operation facts", (it) => {
         createdAt: now,
       });
       yield* check(pending);
+      yield* engine.dispatch({
+        type: "thread.activity.append",
+        commandId: CommandId.make("compact-result-before-session-restore"),
+        threadId,
+        operationResult: { requestId: pending.requestId, outcome: "completed" },
+        activity: {
+          id: EventId.make("compact-result-before-session-restore"),
+          kind: "context-compaction",
+          tone: "info",
+          summary: "Context compacted",
+          payload: {},
+          turnId: TurnId.make("compact-turn"),
+          createdAt: now,
+        },
+        createdAt: now,
+      });
+      yield* check(null);
       yield* engine.dispatch({
         type: "thread.session.set",
         commandId: CommandId.make("operation-finished-without-magic-prefix"),

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -4348,7 +4348,7 @@ engineLayer("pending operation facts", (it) => {
 
         // B's response arrives before turn.started. No public running state is invented.
         yield* accept("b", "turn-b");
-        yield* check(null, "a");
+        yield* check("b", "a");
         const waiting =
           yield* sql`SELECT state, started_at FROM projection_turns WHERE thread_id = ${threadId} AND turn_id = 'turn-b'`;
         assert.deepEqual(waiting, [{ state: "pending", started_at: null }]);
@@ -4375,7 +4375,7 @@ engineLayer("pending operation facts", (it) => {
           reconnect.activities
             .filter((activity) => activity.turnId === "turn-c")
             .map((activity) => turnStartAcceptance(activity)?.requestId),
-          ["d", "c"],
+          [MessageId.make("d"), MessageId.make("c")],
         );
         yield* session("running", "turn-c");
         yield* check(null, "d");

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -11,6 +11,7 @@ import {
   TurnId,
   ProviderInstanceId,
   type OrchestrationPendingOperation,
+  turnStartAcceptance,
 } from "@t3tools/contracts";
 import * as Option from "effect/Option";
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -4229,6 +4230,157 @@ engineLayer("OrchestrationProjectionPipeline via engine dispatch", (it) => {
 });
 
 engineLayer("pending operation facts", (it) => {
+  it.effect(
+    "binds accepted requests without letting old lifecycle updates consume a newer request",
+    () =>
+      Effect.gen(function* () {
+        const engine = yield* OrchestrationEngineService;
+        const snapshots = yield* ProjectionSnapshotQuery;
+        const sql = yield* SqlClient.SqlClient;
+        const threadId = ThreadId.make("thread-acceptance");
+        const projectId = ProjectId.make("project-acceptance");
+        const now = "2026-09-05T00:00:00.000Z";
+        yield* engine.dispatch({
+          type: "project.create",
+          commandId: CommandId.make("acceptance-project"),
+          projectId,
+          title: "Acceptance",
+          workspaceRoot: "/tmp/acceptance",
+          createdAt: now,
+        });
+        yield* engine.dispatch({
+          type: "thread.create",
+          commandId: CommandId.make("acceptance-thread"),
+          threadId,
+          projectId,
+          title: "Acceptance",
+          modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5-codex" },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt: now,
+        });
+        const start = (id: string) =>
+          engine.dispatch({
+            type: "thread.turn.start",
+            commandId: CommandId.make(`acceptance-start-${id}`),
+            threadId,
+            message: {
+              messageId: MessageId.make(id),
+              role: "user",
+              text: "hello",
+              attachments: [],
+            },
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            createdAt: now,
+          });
+        let next = 0;
+        const session = (
+          status: "running" | "ready" | "error" | "interrupted",
+          turnId: string | null,
+        ) =>
+          engine.dispatch({
+            type: "thread.session.set",
+            commandId: CommandId.make(`acceptance-session-${next++}`),
+            threadId,
+            session: {
+              threadId,
+              status,
+              providerName: "codex",
+              runtimeMode: "full-access",
+              activeTurnId: turnId === null ? null : TurnId.make(turnId),
+              lastError: null,
+              updatedAt: now,
+            },
+            createdAt: now,
+          });
+        const accept = (id: string, turnId: string) =>
+          engine.dispatch({
+            type: "thread.activity.append",
+            commandId: CommandId.make(`acceptance-${id}`),
+            threadId,
+            operationResult: { requestId: MessageId.make(id), outcome: "completed" },
+            activity: {
+              id: EventId.make(`acceptance-${id}`),
+              kind: "provider.turn.start.accepted",
+              tone: "info",
+              summary: "Provider accepted the request",
+              turnId: TurnId.make(turnId),
+              createdAt: now,
+              payload: { requestId: id, turnId, requestedAt: now, timelineBypass: true },
+            },
+            createdAt: now,
+          });
+        const check = Effect.fn("checkAcceptance")(function* (
+          pendingId: string | null,
+          requestId: string | undefined,
+        ) {
+          const detail = Option.getOrThrow(yield* snapshots.getThreadDetailById(threadId));
+          let replay = createEmptyReadModel(now);
+          for (const event of yield* Stream.runCollect(engine.readEvents(0))) {
+            if (event.aggregateId === threadId) replay = yield* projectEvent(replay, event);
+          }
+          const expected = pendingId === null ? null : { kind: "turn", requestId: pendingId };
+          assert.deepEqual(detail.pendingOperation, expected);
+          assert.deepEqual(replay.threads[0]?.pendingOperation, expected);
+          assert.equal(detail.latestTurn?.requestId, requestId);
+          assert.equal(replay.threads[0]?.latestTurn?.requestId, requestId);
+          assert.equal(replay.threads[0]?.latestTurn?.state, detail.latestTurn?.state);
+        });
+
+        yield* start("a");
+        yield* start("b");
+        yield* session("running", "turn-a");
+        yield* check("b", undefined);
+        for (const status of ["error", "interrupted", "ready"] as const) {
+          yield* session(status, null);
+          yield* check("b", undefined);
+        }
+        // A finished before its send response arrived. It must stay finished.
+        yield* accept("a", "turn-a");
+        yield* check("b", "a");
+        assert.equal(
+          Option.getOrThrow(yield* snapshots.getThreadDetailById(threadId)).latestTurn?.state,
+          "error",
+        );
+
+        // B's response arrives before turn.started. No public running state is invented.
+        yield* accept("b", "turn-b");
+        yield* check(null, "a");
+        const waiting =
+          yield* sql`SELECT state, started_at FROM projection_turns WHERE thread_id = ${threadId} AND turn_id = 'turn-b'`;
+        assert.deepEqual(waiting, [{ state: "pending", started_at: null }]);
+        yield* session("running", "turn-b");
+        yield* check(null, "b");
+
+        // Steering can return the same turn without another turn.started event.
+        yield* start("steer");
+        yield* accept("steer", "turn-b");
+        yield* check(null, "b");
+        const bindings =
+          yield* sql`SELECT turn_id, pending_message_id FROM projection_turns WHERE thread_id = ${threadId} ORDER BY turn_id`;
+        assert.deepEqual(bindings, [
+          { turn_id: "turn-a", pending_message_id: "a" },
+          { turn_id: "turn-b", pending_message_id: "b" },
+        ]);
+        // First accepted wins even if both replies arrive before the same turn starts.
+        yield* start("c");
+        yield* start("d");
+        yield* accept("d", "turn-c");
+        yield* accept("c", "turn-c");
+        const reconnect = Option.getOrThrow(yield* snapshots.getThreadDetailById(threadId));
+        assert.deepEqual(
+          reconnect.activities
+            .filter((activity) => activity.turnId === "turn-c")
+            .map((activity) => turnStartAcceptance(activity)?.requestId),
+          ["d", "c"],
+        );
+        yield* session("running", "turn-c");
+        yield* check(null, "d");
+      }),
+  );
   it.effect("keeps SQL snapshots and event replay consistent for delayed compaction results", () =>
     Effect.gen(function* () {
       const engine = yield* OrchestrationEngineService;
@@ -4408,6 +4560,7 @@ engineLayer("pending operation facts", (it) => {
         type: "thread.session.set",
         commandId: CommandId.make("operation-interrupted"),
         threadId,
+        operationResult: { requestId: MessageId.make("second-compact"), outcome: "interrupted" },
         session: { ...session, status: "interrupted" },
         createdAt: now,
       });

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -4309,7 +4309,13 @@ engineLayer("pending operation facts", (it) => {
               summary: "Provider accepted the request",
               turnId: TurnId.make(turnId),
               createdAt: now,
-              payload: { requestId: id, turnId, requestedAt: now, timelineBypass: true },
+              payload: {
+                requestId: id,
+                turnId,
+                requestedAt: now,
+                timelineBypass: true,
+                sourceProposedPlan: { threadId, planId: `plan-${id}` },
+              },
             },
             createdAt: now,
           });
@@ -4328,8 +4334,29 @@ engineLayer("pending operation facts", (it) => {
           assert.equal(detail.latestTurn?.requestId, requestId);
           assert.equal(replay.threads[0]?.latestTurn?.requestId, requestId);
           assert.equal(replay.threads[0]?.latestTurn?.state, detail.latestTurn?.state);
+          assert.deepEqual(
+            replay.threads[0]?.latestTurn?.sourceProposedPlan,
+            detail.latestTurn?.sourceProposedPlan,
+          );
+          if (requestId !== undefined)
+            assert.equal(detail.latestTurn?.sourceProposedPlan?.planId, `plan-${requestId}`);
         });
 
+        yield* start("lost-start");
+        yield* accept("lost-start", "recovered-turn");
+        yield* engine.dispatch({
+          type: "thread.turn.diff.complete",
+          commandId: CommandId.make("recovered-checkpoint"),
+          threadId,
+          turnId: TurnId.make("recovered-turn"),
+          checkpointRef: CheckpointRef.make("refs/t3/checkpoints/recovered"),
+          checkpointTurnCount: 1,
+          status: "ready",
+          files: [],
+          completedAt: now,
+          createdAt: now,
+        });
+        yield* check(null, "lost-start");
         yield* start("a");
         yield* start("b");
         yield* session("running", "turn-a");
@@ -4348,7 +4375,7 @@ engineLayer("pending operation facts", (it) => {
 
         // B's response arrives before turn.started. No public running state is invented.
         yield* accept("b", "turn-b");
-        yield* check("b", "a");
+        yield* check(null, "a");
         const waiting =
           yield* sql`SELECT state, started_at FROM projection_turns WHERE thread_id = ${threadId} AND turn_id = 'turn-b'`;
         assert.deepEqual(waiting, [{ state: "pending", started_at: null }]);
@@ -4362,6 +4389,7 @@ engineLayer("pending operation facts", (it) => {
         const bindings =
           yield* sql`SELECT turn_id, pending_message_id FROM projection_turns WHERE thread_id = ${threadId} ORDER BY turn_id`;
         assert.deepEqual(bindings, [
+          { turn_id: "recovered-turn", pending_message_id: "lost-start" },
           { turn_id: "turn-a", pending_message_id: "a" },
           { turn_id: "turn-b", pending_message_id: "b" },
         ]);
@@ -4379,6 +4407,12 @@ engineLayer("pending operation facts", (it) => {
         );
         yield* session("running", "turn-c");
         yield* check(null, "d");
+        yield* start("e");
+        yield* start("f");
+        yield* accept("e", "turn-e");
+        yield* accept("f", "turn-e");
+        yield* session("running", "turn-e");
+        yield* check(null, "e");
       }),
   );
   it.effect("keeps SQL snapshots and event replay consistent for delayed compaction results", () =>

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1236,11 +1236,13 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
 
         case "thread.activity-appended": {
           const accepted = turnStartAcceptance(event.payload.activity);
+          let acceptedTurnStarted = false;
           if (accepted) {
             const current = yield* projectionTurnRepository.getByTurnId({
               threadId: event.payload.threadId,
               turnId: accepted.turnId,
             });
+            acceptedTurnStarted = Option.isSome(current) && current.value.state !== "pending";
             if (Option.isNone(current) || current.value.pendingMessageId === null) {
               yield* projectionTurnRepository.upsertByTurnId({
                 ...(Option.isSome(current)
@@ -1271,26 +1273,49 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           );
           if (Option.isNone(existing)) return;
           const pending = yield* resolvePendingOperation(existing.value);
-          if (pendingOperationAfterEvent(pending, event) === null) {
+          if (
+            pendingOperationAfterEvent(
+              pending,
+              event,
+              undefined,
+              accepted && acceptedTurnStarted ? accepted.requestId : undefined,
+            ) === null
+          ) {
             yield* projectionTurnRepository.deletePendingTurnStartByThreadId(event.payload);
           }
           return;
         }
 
         case "thread.session-set": {
+          const turnId = event.payload.session.activeTurnId;
+          const acceptedTurn =
+            turnId !== null && event.payload.session.status === "running"
+              ? yield* projectionTurnRepository.getByTurnId({
+                  threadId: event.payload.threadId,
+                  turnId,
+                })
+              : Option.none();
           const pending = yield* projectionTurnRepository.getPendingTurnStartByThreadId({
             threadId: event.payload.threadId,
           });
           if (Option.isSome(pending)) {
             const operation = yield* resolvePendingOperation(pending.value);
-            if (pendingOperationAfterEvent(operation, event) === null) {
+            if (
+              pendingOperationAfterEvent(
+                operation,
+                event,
+                undefined,
+                Option.isSome(acceptedTurn)
+                  ? (acceptedTurn.value.pendingMessageId ?? undefined)
+                  : undefined,
+              ) === null
+            ) {
               yield* projectionTurnRepository.deletePendingTurnStartByThreadId(event.payload);
             }
           }
           // Only old logs infer a request binding from the next running session.
           const pendingTurnStart =
             event.payload.operationResult === undefined ? pending : Option.none();
-          const turnId = event.payload.session.activeTurnId;
           if (turnId === null || event.payload.session.status !== "running") {
             // Leaving the "running" session status is the turn-end signal:
             // settle still-running turns so their duration reflects the whole
@@ -1343,10 +1368,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             { concurrency: 1 },
           );
 
-          const existingTurn = yield* projectionTurnRepository.getByTurnId({
-            threadId: event.payload.threadId,
-            turnId,
-          });
+          const existingTurn = acceptedTurn;
           if (Option.isSome(existingTurn)) {
             const nextState =
               existingTurn.value.state === "completed" || existingTurn.value.state === "error"

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -4,6 +4,7 @@ import {
   isImportedAgentSessionMessageId,
   isContextCompactionMessage,
   pendingOperationAfterEvent,
+  turnStartAcceptance,
   type ChatAttachment,
   type OrchestrationEvent,
   type OrchestrationSessionStatus,
@@ -1113,9 +1114,11 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             kind: event.payload.activity.kind,
             summary: event.payload.activity.summary,
             payload: event.payload.activity.payload,
-            ...(event.payload.activity.sequence !== undefined
-              ? { sequence: event.payload.activity.sequence }
-              : {}),
+            ...(event.payload.activity.kind === "provider.turn.start.accepted"
+              ? { sequence: event.sequence }
+              : event.payload.activity.sequence !== undefined
+                ? { sequence: event.payload.activity.sequence }
+                : {}),
             createdAt: event.payload.activity.createdAt,
           });
           return;
@@ -1232,6 +1235,36 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         }
 
         case "thread.activity-appended": {
+          const accepted = turnStartAcceptance(event.payload.activity);
+          if (accepted) {
+            const current = yield* projectionTurnRepository.getByTurnId({
+              threadId: event.payload.threadId,
+              turnId: accepted.turnId,
+            });
+            if (Option.isNone(current) || current.value.pendingMessageId === null) {
+              yield* projectionTurnRepository.upsertByTurnId({
+                ...(Option.isSome(current)
+                  ? current.value
+                  : {
+                      turnId: accepted.turnId,
+                      threadId: event.payload.threadId,
+                      assistantMessageId: null,
+                      state: "pending" as const,
+                      startedAt: null,
+                      completedAt: null,
+                      checkpointTurnCount: null,
+                      checkpointRef: null,
+                      checkpointStatus: null,
+                      checkpointFiles: [],
+                    }),
+                operation: "turn",
+                pendingMessageId: accepted.requestId,
+                requestedAt: accepted.requestedAt,
+                sourceProposedPlanThreadId: accepted.sourceProposedPlan?.threadId ?? null,
+                sourceProposedPlanId: accepted.sourceProposedPlan?.planId ?? null,
+              });
+            }
+          }
           if (event.payload.operationResult === null) return;
           const existing = yield* projectionTurnRepository.getPendingTurnStartByThreadId(
             event.payload,
@@ -1245,15 +1278,18 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         }
 
         case "thread.session-set": {
-          const pendingTurnStart = yield* projectionTurnRepository.getPendingTurnStartByThreadId({
+          const pending = yield* projectionTurnRepository.getPendingTurnStartByThreadId({
             threadId: event.payload.threadId,
           });
-          if (Option.isSome(pendingTurnStart)) {
-            const pending = yield* resolvePendingOperation(pendingTurnStart.value);
-            if (pendingOperationAfterEvent(pending, event) === null) {
+          if (Option.isSome(pending)) {
+            const operation = yield* resolvePendingOperation(pending.value);
+            if (pendingOperationAfterEvent(operation, event) === null) {
               yield* projectionTurnRepository.deletePendingTurnStartByThreadId(event.payload);
             }
           }
+          // Only old logs infer a request binding from the next running session.
+          const pendingTurnStart =
+            event.payload.operationResult === undefined ? pending : Option.none();
           const turnId = event.payload.session.activeTurnId;
           if (turnId === null || event.payload.session.status !== "running") {
             // Leaving the "running" session status is the turn-end signal:

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1236,13 +1236,11 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
 
         case "thread.activity-appended": {
           const accepted = turnStartAcceptance(event.payload.activity);
-          let acceptedTurnStarted = false;
           if (accepted) {
             const current = yield* projectionTurnRepository.getByTurnId({
               threadId: event.payload.threadId,
               turnId: accepted.turnId,
             });
-            acceptedTurnStarted = Option.isSome(current) && current.value.state !== "pending";
             if (Option.isNone(current) || current.value.pendingMessageId === null) {
               yield* projectionTurnRepository.upsertByTurnId({
                 ...(Option.isSome(current)
@@ -1273,49 +1271,26 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           );
           if (Option.isNone(existing)) return;
           const pending = yield* resolvePendingOperation(existing.value);
-          if (
-            pendingOperationAfterEvent(
-              pending,
-              event,
-              undefined,
-              accepted && acceptedTurnStarted ? accepted.requestId : undefined,
-            ) === null
-          ) {
+          if (pendingOperationAfterEvent(pending, event) === null) {
             yield* projectionTurnRepository.deletePendingTurnStartByThreadId(event.payload);
           }
           return;
         }
 
         case "thread.session-set": {
-          const turnId = event.payload.session.activeTurnId;
-          const acceptedTurn =
-            turnId !== null && event.payload.session.status === "running"
-              ? yield* projectionTurnRepository.getByTurnId({
-                  threadId: event.payload.threadId,
-                  turnId,
-                })
-              : Option.none();
           const pending = yield* projectionTurnRepository.getPendingTurnStartByThreadId({
             threadId: event.payload.threadId,
           });
           if (Option.isSome(pending)) {
             const operation = yield* resolvePendingOperation(pending.value);
-            if (
-              pendingOperationAfterEvent(
-                operation,
-                event,
-                undefined,
-                Option.isSome(acceptedTurn)
-                  ? (acceptedTurn.value.pendingMessageId ?? undefined)
-                  : undefined,
-              ) === null
-            ) {
+            if (pendingOperationAfterEvent(operation, event) === null) {
               yield* projectionTurnRepository.deletePendingTurnStartByThreadId(event.payload);
             }
           }
           // Only old logs infer a request binding from the next running session.
           const pendingTurnStart =
             event.payload.operationResult === undefined ? pending : Option.none();
+          const turnId = event.payload.session.activeTurnId;
           if (turnId === null || event.payload.session.status !== "running") {
             // Leaving the "running" session status is the turn-end signal:
             // settle still-running turns so their duration reflects the whole
@@ -1368,7 +1343,10 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             { concurrency: 1 },
           );
 
-          const existingTurn = acceptedTurn;
+          const existingTurn = yield* projectionTurnRepository.getByTurnId({
+            threadId: event.payload.threadId,
+            turnId,
+          });
           if (Option.isSome(existingTurn)) {
             const nextState =
               existingTurn.value.state === "completed" || existingTurn.value.state === "error"

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -2,6 +2,8 @@ import { isRequestResponseStale } from "@t3tools/shared/requestActivity";
 import {
   ApprovalRequestId,
   isImportedAgentSessionMessageId,
+  isContextCompactionMessage,
+  pendingOperationAfterEvent,
   type ChatAttachment,
   type OrchestrationEvent,
   type OrchestrationSessionStatus,
@@ -34,6 +36,7 @@ import {
 import { ProjectionThreadSessionRepository } from "../../persistence/Services/ProjectionThreadSessions.ts";
 import {
   type ProjectionTurn,
+  type ProjectionPendingTurnStart,
   ProjectionTurnRepository,
 } from "../../persistence/Services/ProjectionTurns.ts";
 import { ProjectionThreadRepository } from "../../persistence/Services/ProjectionThreads.ts";
@@ -1173,6 +1176,20 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
       });
     });
 
+    const resolvePendingOperation = Effect.fn("resolvePendingOperation")(function* (
+      pending: ProjectionPendingTurnStart,
+    ) {
+      let kind = pending.operation;
+      if (kind == null) {
+        const message = yield* projectionThreadMessageRepository.getByMessageId({
+          messageId: pending.messageId,
+        });
+        kind =
+          Option.isSome(message) && isContextCompactionMessage(message.value) ? "compact" : "turn";
+      }
+      return { kind, requestId: pending.messageId };
+    });
+
     const applyThreadTurnsProjection: ProjectorDefinition["apply"] = Effect.fn(
       "applyThreadTurnsProjection",
     )(function* (event, _attachmentSideEffects) {
@@ -1184,25 +1201,29 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           return;
 
         case "thread.turn-start-requested": {
-          const pendingTurnStart = yield* projectionTurnRepository.getPendingTurnStartByThreadId({
+          const existing = yield* projectionTurnRepository.getPendingTurnStartByThreadId({
             threadId: event.payload.threadId,
           });
-          if (Option.isSome(pendingTurnStart)) {
-            const pendingMessage = yield* projectionThreadMessageRepository.getByMessageId({
-              messageId: pendingTurnStart.value.messageId,
-            });
-            if (
-              Option.isSome(pendingMessage) &&
-              pendingMessage.value.role === "user" &&
-              (pendingMessage.value.attachments?.length ?? 0) === 0 &&
-              pendingMessage.value.text.trim().toLowerCase() === "/compact"
-            ) {
-              return;
-            }
-          }
+          const pending = Option.isSome(existing)
+            ? yield* resolvePendingOperation(existing.value)
+            : null;
+          if (pending?.kind === "compact") return;
+          const legacyMessage =
+            event.payload.operation === undefined
+              ? yield* projectionThreadMessageRepository.getByMessageId({
+                  messageId: event.payload.messageId,
+                })
+              : Option.none();
+          const next = pendingOperationAfterEvent(
+            pending,
+            event,
+            Option.getOrUndefined(legacyMessage),
+          );
+          if (next === null) return;
           yield* projectionTurnRepository.replacePendingTurnStart({
             threadId: event.payload.threadId,
             messageId: event.payload.messageId,
+            operation: next.kind,
             sourceProposedPlanThreadId: event.payload.sourceProposedPlan?.threadId ?? null,
             sourceProposedPlanId: event.payload.sourceProposedPlan?.planId ?? null,
             requestedAt: event.payload.createdAt,
@@ -1211,49 +1232,30 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         }
 
         case "thread.activity-appended": {
-          if (event.payload.activity.kind === "context-compaction") {
-            const pendingTurnStart = yield* projectionTurnRepository.getPendingTurnStartByThreadId(
-              event.payload,
-            );
-            if (
-              Option.isNone(pendingTurnStart) ||
-              String(pendingTurnStart.value.messageId) !==
-                extractActivityRequestId(event.payload.activity.payload)
-            ) {
-              return;
-            }
-            yield* projectionTurnRepository.deletePendingTurnStartByThreadId(event.payload);
-            return;
-          }
-          if (event.payload.activity.kind !== "provider.turn.start.failed") return;
-          const pendingTurnStart = yield* projectionTurnRepository.getPendingTurnStartByThreadId(
+          if (event.payload.operationResult === null) return;
+          const existing = yield* projectionTurnRepository.getPendingTurnStartByThreadId(
             event.payload,
           );
-          if (
-            Option.isNone(pendingTurnStart) ||
-            String(pendingTurnStart.value.messageId) !==
-              extractActivityRequestId(event.payload.activity.payload)
-          ) {
-            return;
+          if (Option.isNone(existing)) return;
+          const pending = yield* resolvePendingOperation(existing.value);
+          if (pendingOperationAfterEvent(pending, event) === null) {
+            yield* projectionTurnRepository.deletePendingTurnStartByThreadId(event.payload);
           }
-          yield* projectionTurnRepository.deletePendingTurnStartByThreadId(event.payload);
           return;
         }
 
         case "thread.session-set": {
+          const pendingTurnStart = yield* projectionTurnRepository.getPendingTurnStartByThreadId({
+            threadId: event.payload.threadId,
+          });
+          if (Option.isSome(pendingTurnStart)) {
+            const pending = yield* resolvePendingOperation(pendingTurnStart.value);
+            if (pendingOperationAfterEvent(pending, event) === null) {
+              yield* projectionTurnRepository.deletePendingTurnStartByThreadId(event.payload);
+            }
+          }
           const turnId = event.payload.session.activeTurnId;
           if (turnId === null || event.payload.session.status !== "running") {
-            if (
-              (event.payload.session.status === "ready" &&
-                event.commandId?.startsWith("server:provider-session-set:") === true) ||
-              event.payload.session.status === "error" ||
-              event.payload.session.status === "stopped" ||
-              event.payload.session.status === "interrupted"
-            ) {
-              yield* projectionTurnRepository.deletePendingTurnStartByThreadId({
-                threadId: event.payload.threadId,
-              });
-            }
             // Leaving the "running" session status is the turn-end signal:
             // settle still-running turns so their duration reflects the whole
             // turn rather than the last assistant message.
@@ -1308,9 +1310,6 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           const existingTurn = yield* projectionTurnRepository.getByTurnId({
             threadId: event.payload.threadId,
             turnId,
-          });
-          const pendingTurnStart = yield* projectionTurnRepository.getPendingTurnStartByThreadId({
-            threadId: event.payload.threadId,
           });
           if (Option.isSome(existingTurn)) {
             const nextState =
@@ -1373,9 +1372,6 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             });
           }
 
-          yield* projectionTurnRepository.deletePendingTurnStartByThreadId({
-            threadId: event.payload.threadId,
-          });
           return;
         }
 

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1318,6 +1318,9 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
                 : "running";
             yield* projectionTurnRepository.upsertByTurnId({
               ...existingTurn.value,
+              ...(Option.isSome(pendingTurnStart)
+                ? { operation: (yield* resolvePendingOperation(pendingTurnStart.value)).kind }
+                : {}),
               state: nextState,
               pendingMessageId:
                 existingTurn.value.pendingMessageId ??
@@ -1347,6 +1350,9 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             yield* projectionTurnRepository.upsertByTurnId({
               turnId,
               threadId: event.payload.threadId,
+              operation: Option.isSome(pendingTurnStart)
+                ? (yield* resolvePendingOperation(pendingTurnStart.value)).kind
+                : "turn",
               pendingMessageId: Option.isSome(pendingTurnStart)
                 ? pendingTurnStart.value.messageId
                 : null,

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -2288,6 +2288,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery windowed thread detail", (it) =
     const sql = yield* SqlClient.SqlClient;
 
     // Tests in this block share one in-memory database; reset before seeding.
+    yield* sql`DELETE FROM projection_thread_sessions`;
     yield* sql`DELETE FROM projection_projects`;
     yield* sql`DELETE FROM projection_threads`;
     yield* sql`DELETE FROM projection_turns`;
@@ -2674,6 +2675,55 @@ projectionSnapshotLayer("ProjectionSnapshotQuery windowed thread detail", (it) =
       assert.equal(new Set(seenActivities).size, seenActivities.length);
       assert.equal(seenMessages.length, 9);
       assert.equal(seenActivities.length, 6);
+    }),
+  );
+
+  it.effect("recovers only an active unfinished legacy compaction from its adopted turn", () =>
+    Effect.gen(function* () {
+      yield* seedFanOutThread();
+      const snapshotQuery = yield* ProjectionSnapshotQuery;
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        UPDATE projection_thread_messages SET text = '	 /CoMpAcT
+'
+        WHERE message_id = 'user-msg-5'
+      `;
+      yield* sql`
+        UPDATE projection_turns SET state = 'running', completed_at = NULL
+        WHERE turn_id = 'turn-5'
+      `;
+      yield* sql`
+        INSERT OR REPLACE INTO projection_thread_sessions (
+          thread_id, status, provider_name, runtime_mode, active_turn_id, updated_at
+        ) VALUES ('thread-w', 'running', 'codex', 'full-access', 'turn-5', '2026-03-01T00:04:00.000Z')
+      `;
+      assert.deepEqual((yield* snapshotQuery.getShellSnapshot()).threads[0]?.pendingOperation, {
+        kind: "compact",
+        requestId: "user-msg-5",
+      });
+      yield* sql`
+        INSERT INTO projection_thread_activities (
+          activity_id, thread_id, turn_id, tone, kind, summary, payload_json, created_at
+        ) VALUES ('legacy-compact-done', 'thread-w', 'turn-5', 'info', 'context-compaction',
+          'Compacted', '{"requestId":"user-msg-5"}', '2026-03-01T00:04:01.000Z')
+      `;
+      assert.equal((yield* snapshotQuery.getShellSnapshot()).threads[0]?.pendingOperation, null);
+      yield* sql`DELETE FROM projection_thread_activities WHERE activity_id = 'legacy-compact-done'`;
+      yield* sql`UPDATE projection_turns SET operation_kind = 'compact' WHERE turn_id = 'turn-5'`;
+      assert.equal((yield* snapshotQuery.getShellSnapshot()).threads[0]?.pendingOperation, null);
+      yield* sql`UPDATE projection_turns SET operation_kind = NULL WHERE turn_id = 'turn-5'`;
+      yield* sql`UPDATE projection_thread_sessions SET active_turn_id = NULL WHERE thread_id = 'thread-w'`;
+      assert.equal((yield* snapshotQuery.getShellSnapshot()).threads[0]?.pendingOperation, null);
+      yield* sql`UPDATE projection_thread_sessions SET active_turn_id = 'turn-5' WHERE thread_id = 'thread-w'`;
+      yield* sql`
+        INSERT INTO projection_turns (
+          thread_id, pending_message_id, operation_kind, state, requested_at, checkpoint_files_json
+        ) VALUES ('thread-w', 'next-request', 'turn', 'pending', '2026-03-01T00:04:02.000Z', '[]')
+      `;
+      assert.deepEqual((yield* snapshotQuery.getShellSnapshot()).threads[0]?.pendingOperation, {
+        kind: "turn",
+        requestId: "next-request",
+      });
     }),
   );
 

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -349,6 +349,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           pinnedAt: "2026-02-24T00:00:01.000Z",
           pinOrderKey: "gm",
           titleRegeneration: null,
+          pendingOperation: null,
           deletedAt: null,
           messages: [
             {
@@ -477,6 +478,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           pinnedAt: "2026-02-24T00:00:01.000Z",
           pinOrderKey: "gm",
           titleRegeneration: null,
+          pendingOperation: null,
           session: {
             threadId: ThreadId.make("thread-1"),
             status: "running",

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -130,6 +130,7 @@ const ProjectionThreadDbRowSchema = ProjectionThread.mapFields(
         OrchestrationPendingOperation.mapFields(
           Struct.assign({
             kind: Schema.NullOr(OrchestrationOperationKind),
+            legacyActive: Schema.optional(Schema.Boolean),
             legacyMessage: Schema.NullOr(
               Schema.Struct({
                 role: Schema.String,
@@ -385,14 +386,13 @@ function mapPendingOperation(row: Schema.Schema.Type<typeof ProjectionThreadDbRo
   if (pending === null) return null;
   // An older server can write an untyped row after this migration has run.
   // Resolve it here so lightweight snapshots do not need message history.
-  return {
-    kind:
-      pending.kind ??
-      (pending.legacyMessage !== null && isContextCompactionMessage(pending.legacyMessage)
-        ? "compact"
-        : "turn"),
-    requestId: pending.requestId,
-  };
+  const kind =
+    pending.kind ??
+    (pending.legacyMessage !== null && isContextCompactionMessage(pending.legacyMessage)
+      ? "compact"
+      : "turn");
+  if (pending.legacyActive && kind !== "compact") return null;
+  return { kind, requestId: pending.requestId };
 }
 
 function mapSessionRow(
@@ -528,7 +528,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
   });
 
   const pendingOperationSql = sql`
-    (
+    COALESCE((
       SELECT json_object(
         'kind', pending.operation_kind,
         'requestId', pending.pending_message_id,
@@ -551,7 +551,33 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         AND pending.checkpoint_turn_count IS NULL
       ORDER BY pending.requested_at DESC
       LIMIT 1
-    )
+    ), (
+      SELECT json_object(
+        'kind', NULL,
+        'requestId', active.pending_message_id,
+        'legacyActive', json('true'),
+        'legacyMessage', json_object(
+          'role', messages.role, 'text', messages.text,
+          'attachments', json(COALESCE(messages.attachments_json, '[]'))
+        )
+      )
+      FROM projection_thread_sessions session
+      JOIN projection_turns active
+        ON active.thread_id = session.thread_id AND active.turn_id = session.active_turn_id
+      JOIN projection_thread_messages messages
+        ON messages.thread_id = active.thread_id AND messages.message_id = active.pending_message_id
+      WHERE session.thread_id = projection_threads.thread_id
+        AND session.status IN ('starting', 'running')
+        AND active.operation_kind IS NULL
+        AND active.state = 'running'
+        AND NOT EXISTS (
+          SELECT 1 FROM projection_thread_activities activity
+          WHERE activity.thread_id = active.thread_id
+            AND activity.kind IN ('context-compaction', 'provider.turn.start.failed')
+            AND json_extract(activity.payload_json, '$.requestId') = active.pending_message_id
+        )
+      LIMIT 1
+    ))
   `;
 
   const listThreadRows = SqlSchema.findAll({

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -4,6 +4,9 @@ import {
 } from "@t3tools/shared/requestActivity";
 import * as Predicate from "effect/Predicate";
 import {
+  OrchestrationOperationKind,
+  OrchestrationPendingOperation,
+  isContextCompactionMessage,
   AgentSessionImportSource,
   ApprovalRequestId,
   EventId,
@@ -122,6 +125,22 @@ const ProjectionThreadDbRowSchema = ProjectionThread.mapFields(
   Struct.assign({
     modelSelection: Schema.fromJsonString(ModelSelection),
     linkedPullRequest: Schema.NullOr(Schema.fromJsonString(ThreadLinkedPullRequest)),
+    pendingOperation: Schema.NullOr(
+      Schema.fromJsonString(
+        OrchestrationPendingOperation.mapFields(
+          Struct.assign({
+            kind: Schema.NullOr(OrchestrationOperationKind),
+            legacyMessage: Schema.NullOr(
+              Schema.Struct({
+                role: Schema.String,
+                text: Schema.String,
+                attachments: Schema.Array(Schema.Unknown),
+              }),
+            ),
+          }),
+        ),
+      ),
+    ),
   }),
 );
 const ProjectionThreadActivityDbRowSchema = ProjectionThreadActivity.mapFields(
@@ -147,6 +166,7 @@ const ProjectionCheckpointDbRowSchema = ProjectionCheckpoint.mapFields(
 const ProjectionLatestTurnDbRowSchema = Schema.Struct({
   threadId: ProjectionThread.fields.threadId,
   turnId: TurnId,
+  requestId: Schema.NullOr(MessageId),
   state: Schema.String,
   requestedAt: IsoDateTime,
   startedAt: Schema.NullOr(IsoDateTime),
@@ -327,6 +347,7 @@ function mapLatestTurn(
 ): OrchestrationLatestTurn {
   return {
     turnId: row.turnId,
+    ...(row.requestId !== null ? { requestId: row.requestId } : {}),
     state:
       row.state === "error"
         ? "error"
@@ -357,6 +378,21 @@ function mapTitleRegeneration(row: Schema.Schema.Type<typeof ProjectionThreadDbR
         startedAt: row.titleRegenerationStartedAt,
       }
     : null;
+}
+
+function mapPendingOperation(row: Schema.Schema.Type<typeof ProjectionThreadDbRowSchema>) {
+  const pending = row.pendingOperation;
+  if (pending === null) return null;
+  // An older server can write an untyped row after this migration has run.
+  // Resolve it here so lightweight snapshots do not need message history.
+  return {
+    kind:
+      pending.kind ??
+      (pending.legacyMessage !== null && isContextCompactionMessage(pending.legacyMessage)
+        ? "compact"
+        : "turn"),
+    requestId: pending.requestId,
+  };
 }
 
 function mapSessionRow(
@@ -491,6 +527,33 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       `,
   });
 
+  const pendingOperationSql = sql`
+    (
+      SELECT json_object(
+        'kind', pending.operation_kind,
+        'requestId', pending.pending_message_id,
+        'legacyMessage', CASE
+          WHEN pending.operation_kind IS NULL AND messages.message_id IS NOT NULL THEN
+            json_object('role', messages.role, 'text', messages.text,
+              'attachments', json(COALESCE(messages.attachments_json, '[]')))
+          ELSE NULL
+        END
+      )
+      FROM projection_turns pending
+      LEFT JOIN projection_thread_messages messages
+        ON pending.operation_kind IS NULL
+        AND messages.thread_id = pending.thread_id
+        AND messages.message_id = pending.pending_message_id
+      WHERE pending.thread_id = projection_threads.thread_id
+        AND pending.turn_id IS NULL
+        AND pending.state = 'pending'
+        AND pending.pending_message_id IS NOT NULL
+        AND pending.checkpoint_turn_count IS NULL
+      ORDER BY pending.requested_at DESC
+      LIMIT 1
+    )
+  `;
+
   const listThreadRows = SqlSchema.findAll({
     Request: Schema.Void,
     Result: ProjectionThreadDbRowSchema,
@@ -507,6 +570,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           worktree_path AS "worktreePath",
           linked_pull_request_json AS "linkedPullRequest",
           latest_turn_id AS "latestTurnId",
+          ${pendingOperationSql} AS "pendingOperation",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
           archived_at AS "archivedAt",
@@ -545,6 +609,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           worktree_path AS "worktreePath",
           linked_pull_request_json AS "linkedPullRequest",
           latest_turn_id AS "latestTurnId",
+          ${pendingOperationSql} AS "pendingOperation",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
           archived_at AS "archivedAt",
@@ -585,6 +650,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           worktree_path AS "worktreePath",
           linked_pull_request_json AS "linkedPullRequest",
           latest_turn_id AS "latestTurnId",
+          ${pendingOperationSql} AS "pendingOperation",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
           archived_at AS "archivedAt",
@@ -771,6 +837,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           turns.thread_id AS "threadId",
           turns.turn_id AS "turnId",
+          turns.pending_message_id AS "requestId",
           turns.state,
           turns.requested_at AS "requestedAt",
           turns.started_at AS "startedAt",
@@ -795,6 +862,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           turns.thread_id AS "threadId",
           turns.turn_id AS "turnId",
+          turns.pending_message_id AS "requestId",
           turns.state,
           turns.requested_at AS "requestedAt",
           turns.started_at AS "startedAt",
@@ -821,6 +889,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           turns.thread_id AS "threadId",
           turns.turn_id AS "turnId",
+          turns.pending_message_id AS "requestId",
           turns.state,
           turns.requested_at AS "requestedAt",
           turns.started_at AS "startedAt",
@@ -1074,6 +1143,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           worktree_path AS "worktreePath",
           linked_pull_request_json AS "linkedPullRequest",
           latest_turn_id AS "latestTurnId",
+          ${pendingOperationSql} AS "pendingOperation",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
           archived_at AS "archivedAt",
@@ -1415,6 +1485,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           turns.thread_id AS "threadId",
           turns.turn_id AS "turnId",
+          turns.pending_message_id AS "requestId",
           turns.state,
           turns.requested_at AS "requestedAt",
           turns.started_at AS "startedAt",
@@ -2016,29 +2087,7 @@ pending_approval_requests AS (
                 if (latestTurnByThread.has(row.threadId)) {
                   continue;
                 }
-                latestTurnByThread.set(row.threadId, {
-                  turnId: row.turnId,
-                  state:
-                    row.state === "error"
-                      ? "error"
-                      : row.state === "interrupted"
-                        ? "interrupted"
-                        : row.state === "completed"
-                          ? "completed"
-                          : "running",
-                  requestedAt: row.requestedAt,
-                  startedAt: row.startedAt,
-                  completedAt: row.completedAt,
-                  assistantMessageId: row.assistantMessageId,
-                  ...(row.sourceProposedPlanThreadId !== null && row.sourceProposedPlanId !== null
-                    ? {
-                        sourceProposedPlan: {
-                          threadId: row.sourceProposedPlanThreadId,
-                          planId: row.sourceProposedPlanId,
-                        },
-                      }
-                    : {}),
-                });
+                latestTurnByThread.set(row.threadId, mapLatestTurn(row));
               }
 
               for (const row of sessionRows) {
@@ -2102,6 +2151,7 @@ pending_approval_requests AS (
                 pinnedAt: row.pinnedAt,
                 pinOrderKey: row.pinOrderKey ?? null,
                 titleRegeneration: mapTitleRegeneration(row),
+                pendingOperation: mapPendingOperation(row),
                 deletedAt: row.deletedAt,
                 messages: messagesByThread.get(row.threadId) ?? [],
                 proposedPlans: proposedPlansByThread.get(row.threadId) ?? [],
@@ -2315,6 +2365,7 @@ pending_approval_requests AS (
                   pinnedAt: row.pinnedAt,
                   pinOrderKey: row.pinOrderKey ?? null,
                   titleRegeneration: mapTitleRegeneration(row),
+                  pendingOperation: mapPendingOperation(row),
                   deletedAt: row.deletedAt,
                   messages: [],
                   proposedPlans: proposedPlansByThread.get(row.threadId) ?? [],
@@ -2455,6 +2506,7 @@ pending_approval_requests AS (
                       pinnedAt: row.pinnedAt,
                       pinOrderKey: row.pinOrderKey ?? null,
                       titleRegeneration: mapTitleRegeneration(row),
+                      pendingOperation: mapPendingOperation(row),
                       session: sessionByThread.get(row.threadId) ?? null,
                       latestUserMessageAt: row.latestUserMessageAt,
                       hasPendingApprovals: row.pendingApprovalCount > 0,
@@ -2603,6 +2655,7 @@ pending_approval_requests AS (
                 pinnedAt: row.pinnedAt,
                 pinOrderKey: row.pinOrderKey ?? null,
                 titleRegeneration: mapTitleRegeneration(row),
+                pendingOperation: mapPendingOperation(row),
                 session: sessionByThread.get(row.threadId) ?? null,
                 latestUserMessageAt: row.latestUserMessageAt,
                 hasPendingApprovals: row.pendingApprovalCount > 0,
@@ -2924,6 +2977,7 @@ pending_approval_requests AS (
         pinnedAt: threadRow.value.pinnedAt,
         pinOrderKey: threadRow.value.pinOrderKey ?? null,
         titleRegeneration: mapTitleRegeneration(threadRow.value),
+        pendingOperation: mapPendingOperation(threadRow.value),
         session: Option.isSome(sessionRow) ? mapSessionRow(sessionRow.value) : null,
         latestUserMessageAt: threadRow.value.latestUserMessageAt,
         hasPendingApprovals: threadRow.value.pendingApprovalCount > 0,
@@ -3289,6 +3343,7 @@ pending_approval_requests AS (
         pinnedAt: threadRow.value.pinnedAt,
         pinOrderKey: threadRow.value.pinOrderKey ?? null,
         titleRegeneration: mapTitleRegeneration(threadRow.value),
+        pendingOperation: mapPendingOperation(threadRow.value),
         deletedAt: null,
         messages: messageRows.map((row) => {
           const message = {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1074,16 +1074,108 @@ describe("ProviderCommandReactor", () => {
     engine: OrchestrationEngineService["Service"],
     id: string,
     text: string,
+    sourceProposedPlan?: { threadId: ThreadId; planId: string },
   ) =>
     engine.dispatch({
       type: "thread.turn.start",
       commandId: CommandId.make(`cmd-${id}`),
+      ...(sourceProposedPlan ? { sourceProposedPlan } : {}),
       threadId: ThreadId.make("thread-1"),
       message: { messageId: MessageId.make(id), role: "user", text, attachments: [] },
       runtimeMode: "approval-required",
       interactionMode: "default",
       createdAt: "2026-01-01T00:00:00.000Z",
     });
+
+  effectIt.effect.each(["accepted", "interrupted"] as const)(
+    "clears only the request returned by an %s send",
+    (outcome) =>
+      Effect.gen(function* () {
+        const harness = yield* Effect.promise(() => createHarness());
+        const createdAt = "2026-01-01T00:00:00.000Z";
+        yield* harness.engine.dispatch({
+          type: "thread.proposed-plan.upsert",
+          commandId: CommandId.make("plan-for-send"),
+          threadId: ThreadId.make("thread-1"),
+          proposedPlan: {
+            id: "source-plan",
+            turnId: null,
+            planMarkdown: "# Plan",
+            implementedAt: null,
+            implementationThreadId: null,
+            createdAt,
+            updatedAt: createdAt,
+          },
+          createdAt,
+        });
+        const sendStarted = yield* Deferred.make<void>();
+        const finishSend = yield* Deferred.make<void>();
+        harness.sendTurn.mockImplementation(() =>
+          Effect.gen(function* () {
+            yield* Deferred.succeed(sendStarted, undefined);
+            yield* Deferred.await(finishSend);
+            if (outcome === "interrupted") return yield* Effect.interrupt;
+            return { threadId: ThreadId.make("thread-1"), turnId: TurnId.make("returned-turn") };
+          }),
+        );
+        const events = yield* harness.engine.subscribeDomainEvents;
+        const result = yield* events.pipe(
+          Stream.filter(
+            (event) =>
+              (event.type === "thread.activity-appended" &&
+                event.payload.operationResult?.requestId === "correlated-send") ||
+              (event.type === "thread.proposed-plan-upserted" &&
+                event.payload.proposedPlan.implementedAt !== null),
+          ),
+          Stream.take(outcome === "accepted" ? 2 : 1),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        yield* dispatchTestTurn(harness.engine, "correlated-send", "hello", {
+          threadId: ThreadId.make("thread-1"),
+          planId: "source-plan",
+        });
+        yield* Deferred.await(sendStarted);
+        expect(
+          (yield* Effect.promise(() => harness.readModel())).threads[0]?.pendingOperation,
+        ).toEqual({ kind: "turn", requestId: "correlated-send" });
+        expect(
+          (yield* Effect.promise(() => harness.readModel())).threads[0]?.proposedPlans[0]
+            ?.implementedAt,
+        ).toBeNull();
+        yield* Deferred.succeed(finishSend, undefined);
+        const receipts = yield* Fiber.join(result);
+        expect(receipts[0]).toMatchObject({
+          payload: {
+            operationResult: {
+              requestId: "correlated-send",
+              outcome: outcome === "accepted" ? "completed" : "interrupted",
+            },
+            activity: { payload: { timelineBypass: true } },
+          },
+        });
+        expect(
+          (yield* Effect.promise(() => harness.readModel())).threads[0]?.pendingOperation,
+        ).toBeNull();
+        expect(
+          (yield* Effect.promise(() => harness.readModel())).threads[0]?.proposedPlans[0]
+            ?.implementedAt,
+        ).toBe(outcome === "accepted" ? createdAt : null);
+        if (outcome === "accepted") {
+          expect(receipts[0]).toMatchObject({
+            payload: {
+              activity: {
+                payload: {
+                  requestId: "correlated-send",
+                  turnId: "returned-turn",
+                  requestedAt: "2026-01-01T00:00:00.000Z",
+                },
+              },
+            },
+          });
+        }
+      }),
+  );
 
   const readyAfterTestTurn = (engine: OrchestrationEngineService["Service"], requestId: string) =>
     engine.dispatch({
@@ -1307,6 +1399,10 @@ describe("ProviderCommandReactor", () => {
             type: "thread.session.set",
             commandId: CommandId.make("terminal-before-queued-restore"),
             threadId: ThreadId.make("thread-1"),
+            operationResult: {
+              requestId: MessageId.make("queued-restore"),
+              outcome: terminalStatus === "error" ? "failed" : "interrupted",
+            },
             session: {
               threadId: ThreadId.make("thread-1"),
               status: terminalStatus,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -180,6 +180,7 @@ describe("ProviderCommandReactor", () => {
     readonly titleRegenerationBeforeStart?: "one" | "two";
     readonly serverActivation?: Effect.Effect<void>;
     readonly beforeReadySessionDispatch?: () => Effect.Effect<void>;
+    readonly beforeErrorSessionDispatch?: () => Effect.Effect<void>;
     readonly compactThreadEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
     readonly interruptTurnEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
     readonly stopSessionEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
@@ -446,7 +447,9 @@ describe("ProviderCommandReactor", () => {
             return (
               command.type === "thread.session.set" && command.session.status === "ready"
                 ? (input?.beforeReadySessionDispatch?.() ?? Effect.void)
-                : Effect.void
+                : command.type === "thread.session.set" && command.session.status === "error"
+                  ? (input?.beforeErrorSessionDispatch?.() ?? Effect.void)
+                  : Effect.void
             ).pipe(Effect.andThen(engine.dispatch(command)));
           },
           get streamDomainEvents() {
@@ -1156,7 +1159,7 @@ describe("ProviderCommandReactor", () => {
         });
         expect(
           (yield* Effect.promise(() => harness.readModel())).threads[0]?.pendingOperation,
-        ).toEqual(outcome === "accepted" ? { kind: "turn", requestId: "correlated-send" } : null);
+        ).toBeNull();
         if (outcome === "accepted") {
           yield* harness.engine.dispatch({
             type: "thread.session.set",
@@ -1350,14 +1353,30 @@ describe("ProviderCommandReactor", () => {
     }),
   );
 
-  effectIt.effect.each([false, true])(
-    "ignores older send failure after newer acceptance, with start: %s",
-    (secondStarted) =>
+  effectIt.effect.each([
+    { secondStarted: false, pauseErrorDispatch: false },
+    { secondStarted: true, pauseErrorDispatch: false },
+    { secondStarted: false, pauseErrorDispatch: true },
+    { secondStarted: true, pauseErrorDispatch: true },
+  ])(
+    "ignores older send failure after newer acceptance, with start $secondStarted and paused dispatch $pauseErrorDispatch",
+    ({ secondStarted, pauseErrorDispatch }) =>
       Effect.gen(function* () {
         const firstStarted = yield* Deferred.make<Fiber.Fiber<unknown, unknown>>();
         const failFirst = yield* Deferred.make<void>();
         const secondSent = yield* Deferred.make<void>();
-        const harness = yield* Effect.promise(() => createHarness());
+        const errorDispatchPaused = yield* Deferred.make<void>();
+        const releaseErrorDispatch = yield* Deferred.make<void>();
+        const harness = yield* Effect.promise(() =>
+          createHarness({
+            beforeErrorSessionDispatch: () =>
+              pauseErrorDispatch
+                ? Deferred.succeed(errorDispatchPaused, undefined).pipe(
+                    Effect.andThen(Deferred.await(releaseErrorDispatch)),
+                  )
+                : Effect.void,
+          }),
+        );
         harness.sendTurn
           .mockImplementationOnce(() =>
             Effect.gen(function* () {
@@ -1380,6 +1399,10 @@ describe("ProviderCommandReactor", () => {
           );
         yield* dispatchTestTurn(harness.engine, "first-send", "first");
         const firstFiber = yield* Deferred.await(firstStarted);
+        if (pauseErrorDispatch) {
+          yield* Deferred.succeed(failFirst, undefined);
+          yield* Deferred.await(errorDispatchPaused);
+        }
         const events = yield* harness.engine.subscribeDomainEvents;
         const accepted = yield* events.pipe(
           Stream.filter(
@@ -1412,12 +1435,11 @@ describe("ProviderCommandReactor", () => {
             createdAt: "2026-01-01T00:00:00.000Z",
           });
         yield* Deferred.succeed(failFirst, undefined);
+        yield* Deferred.succeed(releaseErrorDispatch, undefined);
         yield* Fiber.await(firstFiber);
         const thread = (yield* Effect.promise(() => harness.readModel())).threads[0];
         expect(thread?.latestTurn?.requestId).toBe(secondStarted ? "second-send" : undefined);
-        expect(thread?.pendingOperation).toEqual(
-          secondStarted ? null : { kind: "turn", requestId: "second-send" },
-        );
+        expect(thread?.pendingOperation).toBeNull();
         expect(thread?.session).toMatchObject({
           status: secondStarted ? "running" : "starting",
           activeTurnId: secondStarted ? "second-turn" : null,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1156,12 +1156,56 @@ describe("ProviderCommandReactor", () => {
         });
         expect(
           (yield* Effect.promise(() => harness.readModel())).threads[0]?.pendingOperation,
-        ).toBeNull();
+        ).toEqual(outcome === "accepted" ? { kind: "turn", requestId: "correlated-send" } : null);
+        if (outcome === "accepted") {
+          yield* harness.engine.dispatch({
+            type: "thread.session.set",
+            commandId: CommandId.make("correlated-turn-started"),
+            threadId: ThreadId.make("thread-1"),
+            session: {
+              threadId: ThreadId.make("thread-1"),
+              status: "running",
+              providerName: "codex",
+              runtimeMode: "approval-required",
+              activeTurnId: TurnId.make("returned-turn"),
+              lastError: null,
+              updatedAt: createdAt,
+            },
+            createdAt,
+          });
+          expect(
+            (yield* Effect.promise(() => harness.readModel())).threads[0]?.pendingOperation,
+          ).toBeNull();
+        }
         expect(
           (yield* Effect.promise(() => harness.readModel())).threads[0]?.proposedPlans[0]
             ?.implementedAt,
         ).toBe(outcome === "accepted" ? createdAt : null);
         if (outcome === "accepted") {
+          // Another sender can have read the unimplemented plan before this send finished.
+          yield* harness.engine.dispatch({
+            type: "thread.proposed-plan.upsert",
+            commandId: CommandId.make("late-source-plan-claim"),
+            threadId: ThreadId.make("thread-1"),
+            onlyIfUnimplemented: true,
+            proposedPlan: {
+              id: "source-plan",
+              turnId: null,
+              planMarkdown: "stale copy",
+              implementedAt: "2026-01-01T00:00:01.000Z",
+              implementationThreadId: ThreadId.make("other-thread"),
+              createdAt,
+              updatedAt: "2026-01-01T00:00:01.000Z",
+            },
+            createdAt,
+          });
+          expect(
+            (yield* Effect.promise(() => harness.readModel())).threads[0]?.proposedPlans[0],
+          ).toMatchObject({
+            implementationThreadId: "thread-1",
+            implementedAt: createdAt,
+            planMarkdown: "# Plan",
+          });
           expect(receipts[0]).toMatchObject({
             payload: {
               activity: {
@@ -1254,55 +1298,131 @@ describe("ProviderCommandReactor", () => {
       }),
   );
 
-  effectIt.effect("does not let an older send failure stop an adopted newer request", () =>
+  effectIt.effect("clears pending compaction when a native sign-out stops the session", () =>
     Effect.gen(function* () {
-      const firstStarted = yield* Deferred.make<Fiber.Fiber<unknown, unknown>>();
-      const failFirst = yield* Deferred.make<void>();
-      const secondSent = yield* Deferred.make<void>();
-      const harness = yield* Effect.promise(() => createHarness());
-      harness.sendTurn
-        .mockImplementationOnce(() =>
-          Effect.gen(function* () {
-            yield* Deferred.succeed(firstStarted, yield* Effect.fiber);
-            yield* Deferred.await(failFirst);
-            return yield* new ProviderAdapterRequestError({
-              provider: "codex",
-              method: "turn.start",
-              detail: "first send failed late",
-            });
-          }),
-        )
-        .mockImplementationOnce(() =>
-          Deferred.succeed(secondSent, undefined).pipe(
-            Effect.as({ threadId: ThreadId.make("thread-1"), turnId: TurnId.make("second-turn") }),
-          ),
-        );
-      yield* dispatchTestTurn(harness.engine, "first-send", "first");
-      const firstFiber = yield* Deferred.await(firstStarted);
-      yield* dispatchTestTurn(harness.engine, "second-send", "second");
-      yield* Deferred.await(secondSent);
-      yield* harness.engine.dispatch({
-        type: "thread.session.set",
-        commandId: CommandId.make("second-send-started"),
-        threadId: ThreadId.make("thread-1"),
-        session: {
-          threadId: ThreadId.make("thread-1"),
-          status: "running",
-          providerName: "codex",
-          providerInstanceId: ProviderInstanceId.make("codex"),
-          runtimeMode: "approval-required",
-          activeTurnId: TurnId.make("second-turn"),
-          lastError: null,
-          updatedAt: "2026-01-01T00:00:00.000Z",
-        },
-        createdAt: "2026-01-01T00:00:00.000Z",
-      });
-      yield* Deferred.succeed(failFirst, undefined);
-      yield* Fiber.await(firstFiber);
-      const thread = (yield* Effect.promise(() => harness.readModel())).threads[0];
-      expect(thread?.latestTurn?.requestId).toBe("second-send");
-      expect(thread?.session).toMatchObject({ status: "running", activeTurnId: "second-turn" });
+      const compactStarted = yield* Deferred.make<Fiber.Fiber<unknown, unknown>>();
+      const finishCompact = yield* Deferred.make<void>();
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          compactThreadEffect: () =>
+            Effect.gen(function* () {
+              yield* Deferred.succeed(compactStarted, yield* Effect.fiber);
+              yield* Deferred.await(finishCompact);
+            }),
+          tryHandlePromptCommandEffect: ({ text }) => Effect.succeed(text === "/logout"),
+        }),
+      );
+      const events = yield* harness.engine.subscribeDomainEvents;
+      const accepted = yield* events.pipe(
+        Stream.filter(
+          (event) =>
+            event.type === "thread.activity-appended" &&
+            event.payload.operationResult?.requestId === "before-sign-out",
+        ),
+        Stream.take(1),
+        Stream.runDrain,
+        Effect.forkChild,
+      );
+      yield* dispatchTestTurn(harness.engine, "before-sign-out", "hello");
+      yield* Fiber.join(accepted);
+      yield* readyAfterTestTurn(harness.engine, "before-sign-out");
+      yield* dispatchTestTurn(harness.engine, "compact-sign-out", "/compact");
+      const compactFiber = yield* Deferred.await(compactStarted);
+      const stopped = yield* events.pipe(
+        Stream.filter(
+          (event) =>
+            event.type === "thread.session-set" && event.payload.session.status === "stopped",
+        ),
+        Stream.take(1),
+        Stream.runDrain,
+        Effect.forkChild,
+      );
+      yield* dispatchTestTurn(harness.engine, "sign-out", "/logout");
+      yield* Fiber.join(stopped);
+      const signedOut = (yield* Effect.promise(() => harness.readModel())).threads[0];
+      expect(signedOut?.pendingOperation).toBeNull();
+      expect(signedOut?.session?.status).toBe("stopped");
+      yield* Deferred.succeed(finishCompact, undefined);
+      yield* Fiber.await(compactFiber);
+      const finished = (yield* Effect.promise(() => harness.readModel())).threads[0];
+      expect(finished?.pendingOperation).toBeNull();
+      expect(finished?.session?.status).toBe("stopped");
     }),
+  );
+
+  effectIt.effect.each([false, true])(
+    "ignores older send failure after newer acceptance, with start: %s",
+    (secondStarted) =>
+      Effect.gen(function* () {
+        const firstStarted = yield* Deferred.make<Fiber.Fiber<unknown, unknown>>();
+        const failFirst = yield* Deferred.make<void>();
+        const secondSent = yield* Deferred.make<void>();
+        const harness = yield* Effect.promise(() => createHarness());
+        harness.sendTurn
+          .mockImplementationOnce(() =>
+            Effect.gen(function* () {
+              yield* Deferred.succeed(firstStarted, yield* Effect.fiber);
+              yield* Deferred.await(failFirst);
+              return yield* new ProviderAdapterRequestError({
+                provider: "codex",
+                method: "turn.start",
+                detail: "first send failed late",
+              });
+            }),
+          )
+          .mockImplementationOnce(() =>
+            Deferred.succeed(secondSent, undefined).pipe(
+              Effect.as({
+                threadId: ThreadId.make("thread-1"),
+                turnId: TurnId.make("second-turn"),
+              }),
+            ),
+          );
+        yield* dispatchTestTurn(harness.engine, "first-send", "first");
+        const firstFiber = yield* Deferred.await(firstStarted);
+        const events = yield* harness.engine.subscribeDomainEvents;
+        const accepted = yield* events.pipe(
+          Stream.filter(
+            (event) =>
+              event.type === "thread.activity-appended" &&
+              event.payload.operationResult?.requestId === "second-send",
+          ),
+          Stream.take(1),
+          Stream.runDrain,
+          Effect.forkChild,
+        );
+        yield* dispatchTestTurn(harness.engine, "second-send", "second");
+        yield* Deferred.await(secondSent);
+        yield* Fiber.join(accepted);
+        if (secondStarted)
+          yield* harness.engine.dispatch({
+            type: "thread.session.set",
+            commandId: CommandId.make("second-send-started"),
+            threadId: ThreadId.make("thread-1"),
+            session: {
+              threadId: ThreadId.make("thread-1"),
+              status: "running",
+              providerName: "codex",
+              providerInstanceId: ProviderInstanceId.make("codex"),
+              runtimeMode: "approval-required",
+              activeTurnId: TurnId.make("second-turn"),
+              lastError: null,
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+            createdAt: "2026-01-01T00:00:00.000Z",
+          });
+        yield* Deferred.succeed(failFirst, undefined);
+        yield* Fiber.await(firstFiber);
+        const thread = (yield* Effect.promise(() => harness.readModel())).threads[0];
+        expect(thread?.latestTurn?.requestId).toBe(secondStarted ? "second-send" : undefined);
+        expect(thread?.pendingOperation).toEqual(
+          secondStarted ? null : { kind: "turn", requestId: "second-send" },
+        );
+        expect(thread?.session).toMatchObject({
+          status: secondStarted ? "running" : "starting",
+          activeTurnId: secondStarted ? "second-turn" : null,
+        });
+      }),
   );
 
   effectIt.effect.each(["/COMPACT", "queued message"])(

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -27,6 +27,7 @@ import { serializeAssistantCitation } from "@t3tools/shared/assistantCitations";
 import * as Effect from "effect/Effect";
 import * as Deferred from "effect/Deferred";
 import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as Option from "effect/Option";
@@ -265,7 +266,7 @@ describe("ProviderCommandReactor", () => {
         ),
       );
     });
-    const sendTurn = vi.fn((_: unknown) =>
+    const sendTurn = vi.fn<ProviderServiceShape["sendTurn"]>((_) =>
       Effect.succeed({
         threadId: ThreadId.make("thread-1"),
         turnId: asTurnId("turn-1"),
@@ -1034,6 +1035,17 @@ describe("ProviderCommandReactor", () => {
   effectIt.effect("rejects /compact without conversation context", () =>
     Effect.gen(function* () {
       const harness = yield* Effect.promise(() => createHarness());
+      const events = yield* harness.engine.subscribeDomainEvents;
+      const rejected = yield* events.pipe(
+        Stream.filter(
+          (event) =>
+            event.type === "thread.activity-appended" &&
+            event.payload.operationResult?.requestId === "user-message-empty-compact",
+        ),
+        Stream.take(1),
+        Stream.runDrain,
+        Effect.forkChild,
+      );
       yield* harness.engine.dispatch({
         type: "thread.turn.start",
         commandId: CommandId.make("cmd-empty-compact"),
@@ -1048,9 +1060,208 @@ describe("ProviderCommandReactor", () => {
         runtimeMode: "approval-required",
         createdAt: "2026-01-01T00:00:00.000Z",
       });
+      yield* Fiber.join(rejected);
       yield* Effect.promise(() => harness.drain());
       expect(harness.compactThread).not.toHaveBeenCalled();
+      const thread = (yield* Effect.promise(() => harness.readModel())).threads.find(
+        (entry) => entry.id === "thread-1",
+      );
+      expect(thread?.pendingOperation).toBeNull();
     }),
+  );
+
+  const dispatchTestTurn = (
+    engine: OrchestrationEngineService["Service"],
+    id: string,
+    text: string,
+  ) =>
+    engine.dispatch({
+      type: "thread.turn.start",
+      commandId: CommandId.make(`cmd-${id}`),
+      threadId: ThreadId.make("thread-1"),
+      message: { messageId: MessageId.make(id), role: "user", text, attachments: [] },
+      runtimeMode: "approval-required",
+      interactionMode: "default",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+
+  const readyAfterTestTurn = (engine: OrchestrationEngineService["Service"], requestId: string) =>
+    engine.dispatch({
+      type: "thread.session.set",
+      commandId: CommandId.make(`ready-${requestId}`),
+      threadId: ThreadId.make("thread-1"),
+      operationResult: { requestId: MessageId.make(requestId), outcome: "completed" },
+      session: {
+        threadId: ThreadId.make("thread-1"),
+        status: "ready",
+        providerName: "codex",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        runtimeMode: "approval-required",
+        activeTurnId: null,
+        lastError: null,
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+
+  effectIt.effect(
+    "retains the compaction result while a failed stop owns session restoration",
+    () =>
+      Effect.gen(function* () {
+        const initialSent = yield* Deferred.make<void>();
+        const compactStarted = yield* Deferred.make<Fiber.Fiber<unknown, unknown>>();
+        const finishCompact = yield* Deferred.make<void>();
+        const stopStarted = yield* Deferred.make<void>();
+        const failStop = yield* Deferred.make<void>();
+        const harness = yield* Effect.promise(() =>
+          createHarness({
+            compactThreadEffect: () =>
+              Effect.gen(function* () {
+                yield* Deferred.succeed(compactStarted, yield* Effect.fiber);
+                yield* Deferred.await(finishCompact);
+              }),
+            stopSessionEffect: () =>
+              Deferred.succeed(stopStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(failStop)),
+                Effect.andThen(
+                  Effect.fail(
+                    new ProviderAdapterRequestError({
+                      provider: "codex",
+                      method: "session.stop",
+                      detail: "stop failed",
+                    }),
+                  ),
+                ),
+              ),
+          }),
+        );
+        harness.sendTurn.mockImplementation(() =>
+          Deferred.succeed(initialSent, undefined).pipe(
+            Effect.as({ threadId: ThreadId.make("thread-1"), turnId: TurnId.make("initial") }),
+          ),
+        );
+        yield* dispatchTestTurn(harness.engine, "before-stop-race", "hello");
+        yield* Deferred.await(initialSent);
+        yield* readyAfterTestTurn(harness.engine, "before-stop-race");
+        yield* dispatchTestTurn(harness.engine, "compact-stop-race", "/compact");
+        const compactFiber = yield* Deferred.await(compactStarted);
+        yield* harness.engine.dispatch({
+          type: "thread.session.stop",
+          commandId: CommandId.make("stop-race"),
+          threadId: ThreadId.make("thread-1"),
+          createdAt: "2026-01-01T00:00:00.000Z",
+        });
+        yield* Deferred.await(stopStarted);
+        yield* Deferred.succeed(finishCompact, undefined);
+        yield* Fiber.await(compactFiber);
+        yield* Deferred.succeed(failStop, undefined);
+        yield* Effect.promise(() => harness.drain());
+        const thread = (yield* Effect.promise(() => harness.readModel())).threads[0];
+        expect(thread?.session?.status).toBe("ready");
+        expect(thread?.pendingOperation).toBeNull();
+      }),
+  );
+
+  effectIt.effect("does not let an older send failure stop an adopted newer request", () =>
+    Effect.gen(function* () {
+      const firstStarted = yield* Deferred.make<Fiber.Fiber<unknown, unknown>>();
+      const failFirst = yield* Deferred.make<void>();
+      const secondSent = yield* Deferred.make<void>();
+      const harness = yield* Effect.promise(() => createHarness());
+      harness.sendTurn
+        .mockImplementationOnce(() =>
+          Effect.gen(function* () {
+            yield* Deferred.succeed(firstStarted, yield* Effect.fiber);
+            yield* Deferred.await(failFirst);
+            return yield* new ProviderAdapterRequestError({
+              provider: "codex",
+              method: "turn.start",
+              detail: "first send failed late",
+            });
+          }),
+        )
+        .mockImplementationOnce(() =>
+          Deferred.succeed(secondSent, undefined).pipe(
+            Effect.as({ threadId: ThreadId.make("thread-1"), turnId: TurnId.make("second-turn") }),
+          ),
+        );
+      yield* dispatchTestTurn(harness.engine, "first-send", "first");
+      const firstFiber = yield* Deferred.await(firstStarted);
+      yield* dispatchTestTurn(harness.engine, "second-send", "second");
+      yield* Deferred.await(secondSent);
+      yield* harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("second-send-started"),
+        threadId: ThreadId.make("thread-1"),
+        session: {
+          threadId: ThreadId.make("thread-1"),
+          status: "running",
+          providerName: "codex",
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          runtimeMode: "approval-required",
+          activeTurnId: TurnId.make("second-turn"),
+          lastError: null,
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+      yield* Deferred.succeed(failFirst, undefined);
+      yield* Fiber.await(firstFiber);
+      const thread = (yield* Effect.promise(() => harness.readModel())).threads[0];
+      expect(thread?.latestTurn?.requestId).toBe("second-send");
+      expect(thread?.session).toMatchObject({ status: "running", activeTurnId: "second-turn" });
+    }),
+  );
+
+  effectIt.effect(
+    "rejects a compaction that did not get a pending record before the prior one finished",
+    () =>
+      Effect.gen(function* () {
+        const initialSent = yield* Deferred.make<void>();
+        const firstCompactStarted = yield* Deferred.make<Fiber.Fiber<unknown, unknown>>();
+        const finishFirst = yield* Deferred.make<void>();
+        const secondPaused = yield* Deferred.make<void>();
+        const releaseSecond = yield* Deferred.make<void>();
+        const harness = yield* Effect.promise(() =>
+          createHarness({
+            compactThreadEffect: () =>
+              Effect.gen(function* () {
+                yield* Deferred.succeed(firstCompactStarted, yield* Effect.fiber);
+                yield* Deferred.await(finishFirst);
+              }),
+            tryHandlePromptCommandEffect: ({ text }) =>
+              text === "/COMPACT"
+                ? Deferred.succeed(secondPaused, undefined).pipe(
+                    Effect.andThen(Deferred.await(releaseSecond)),
+                    Effect.as(false),
+                  )
+                : Effect.succeed(false),
+          }),
+        );
+        harness.sendTurn.mockImplementation(() =>
+          Deferred.succeed(initialSent, undefined).pipe(
+            Effect.as({ threadId: ThreadId.make("thread-1"), turnId: TurnId.make("initial") }),
+          ),
+        );
+        yield* dispatchTestTurn(harness.engine, "before-admission-race", "hello");
+        yield* Deferred.await(initialSent);
+        yield* readyAfterTestTurn(harness.engine, "before-admission-race");
+        yield* dispatchTestTurn(harness.engine, "first-compact", "/compact");
+        const firstFiber = yield* Deferred.await(firstCompactStarted);
+        yield* dispatchTestTurn(harness.engine, "second-compact", "/COMPACT");
+        yield* Deferred.await(secondPaused);
+        yield* Deferred.succeed(finishFirst, undefined);
+        yield* Fiber.await(firstFiber);
+        yield* Deferred.succeed(releaseSecond, undefined);
+        yield* Effect.promise(() => harness.drain());
+        expect(harness.compactThread).toHaveBeenCalledTimes(1);
+        const thread = (yield* Effect.promise(() => harness.readModel())).threads[0];
+        expect(thread?.pendingOperation).toBeNull();
+        expect(
+          thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed")
+            ?.payload,
+        ).toMatchObject({ requestId: "second-compact" });
+      }),
   );
 
   effectIt.effect("keeps turns blocked until compaction restores the session", () =>

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -636,13 +636,16 @@ describe("ProviderCommandReactor", () => {
     };
   }
 
-  effectIt.effect.each(["thread.turn.interrupt", "thread.session.stop"] as const)(
-    "still dispatches %s when a queued cancellation activity cannot be saved",
-    (type) =>
+  effectIt.effect.each([
+    { type: "thread.turn.interrupt", failCancellationActivity: false },
+    { type: "thread.session.stop", failCancellationActivity: false },
+    { type: "thread.turn.interrupt", failCancellationActivity: true },
+    { type: "thread.session.stop", failCancellationActivity: true },
+  ] as const)(
+    "dispatches $type after queued cancellation with save failure: $failCancellationActivity",
+    ({ type, failCancellationActivity }) =>
       Effect.gen(function* () {
-        const harness = yield* Effect.promise(() =>
-          createHarness({ failCancellationActivity: true }),
-        );
+        const harness = yield* Effect.promise(() => createHarness({ failCancellationActivity }));
         const threadId = ThreadId.make("thread-1");
         const createdAt = "2026-01-01T00:00:00.000Z";
         yield* harness.engine.dispatch({
@@ -685,6 +688,10 @@ describe("ProviderCommandReactor", () => {
           createdAt,
         });
         yield* Effect.promise(harness.drain);
+        expect((yield* Effect.promise(harness.readModel)).threads[0]?.pendingOperation).toEqual({
+          kind: "turn",
+          requestId: MessageId.make("cancellation-failure-message"),
+        });
         yield* harness.engine.dispatch({
           type,
           commandId: CommandId.make("cancellation-failure-stop"),
@@ -696,6 +703,13 @@ describe("ProviderCommandReactor", () => {
           type === "thread.turn.interrupt" ? harness.interruptTurn : harness.stopSession,
         ).toHaveBeenCalledOnce();
         expect(harness.sendTurn).not.toHaveBeenCalled();
+        if (!failCancellationActivity) {
+          expect(
+            (yield* Effect.promise(harness.readModel)).threads[0]?.pendingOperation,
+          ).toBeNull();
+          const reloaded = yield* harness.snapshotQuery.getCommandReadModel();
+          expect(reloaded.threads[0]?.pendingOperation).toBeNull();
+        }
         yield* harness.checkpointCapture.complete(terminal, "captured");
       }),
   );

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1966,6 +1966,7 @@ describe("ProviderCommandReactor", () => {
       let readModel = yield* Effect.promise(() => harness.readModel());
       let thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
       expect(thread?.session?.lastError).toContain("deterministic startup failure");
+      expect(thread?.pendingOperation).toBeNull();
       expect(harness.sendTurn).not.toHaveBeenCalled();
 
       failStartup = false;

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1213,9 +1213,9 @@ describe("ProviderCommandReactor", () => {
     }),
   );
 
-  effectIt.effect(
-    "rejects a compaction that did not get a pending record before the prior one finished",
-    () =>
+  effectIt.effect.each(["/COMPACT", "queued message"])(
+    "rejects %s without a pending record when the prior compaction finishes",
+    (secondMessage) =>
       Effect.gen(function* () {
         const initialSent = yield* Deferred.make<void>();
         const firstCompactStarted = yield* Deferred.make<Fiber.Fiber<unknown, unknown>>();
@@ -1230,7 +1230,7 @@ describe("ProviderCommandReactor", () => {
                 yield* Deferred.await(finishFirst);
               }),
             tryHandlePromptCommandEffect: ({ text }) =>
-              text === "/COMPACT"
+              text === secondMessage
                 ? Deferred.succeed(secondPaused, undefined).pipe(
                     Effect.andThen(Deferred.await(releaseSecond)),
                     Effect.as(false),
@@ -1248,19 +1248,86 @@ describe("ProviderCommandReactor", () => {
         yield* readyAfterTestTurn(harness.engine, "before-admission-race");
         yield* dispatchTestTurn(harness.engine, "first-compact", "/compact");
         const firstFiber = yield* Deferred.await(firstCompactStarted);
-        yield* dispatchTestTurn(harness.engine, "second-compact", "/COMPACT");
+        yield* dispatchTestTurn(harness.engine, "second-compact", secondMessage);
         yield* Deferred.await(secondPaused);
         yield* Deferred.succeed(finishFirst, undefined);
         yield* Fiber.await(firstFiber);
         yield* Deferred.succeed(releaseSecond, undefined);
         yield* Effect.promise(() => harness.drain());
         expect(harness.compactThread).toHaveBeenCalledTimes(1);
+        expect(harness.sendTurn).toHaveBeenCalledTimes(1);
         const thread = (yield* Effect.promise(() => harness.readModel())).threads[0];
         expect(thread?.pendingOperation).toBeNull();
         expect(
           thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed")
             ?.payload,
         ).toMatchObject({ requestId: "second-compact" });
+      }),
+  );
+
+  effectIt.effect.each(["stopped", "interrupted", "error"] as const)(
+    "keeps %s when a compaction restore was already queued",
+    (terminalStatus) =>
+      Effect.gen(function* () {
+        const initialSent = yield* Deferred.make<void>();
+        const restoreStarted = yield* Deferred.make<Fiber.Fiber<unknown, unknown>>();
+        const releaseRestore = yield* Deferred.make<void>();
+        let blockRestore = false;
+        const harness = yield* Effect.promise(() =>
+          createHarness({
+            beforeReadySessionDispatch: () =>
+              blockRestore
+                ? Effect.gen(function* () {
+                    yield* Deferred.succeed(restoreStarted, yield* Effect.fiber);
+                    yield* Deferred.await(releaseRestore);
+                  })
+                : Effect.void,
+          }),
+        );
+        harness.sendTurn.mockImplementation(() =>
+          Deferred.succeed(initialSent, undefined).pipe(
+            Effect.as({ threadId: ThreadId.make("thread-1"), turnId: TurnId.make("initial") }),
+          ),
+        );
+        yield* dispatchTestTurn(harness.engine, "before-queued-restore", "hello");
+        yield* Deferred.await(initialSent);
+        yield* readyAfterTestTurn(harness.engine, "before-queued-restore");
+        blockRestore = true;
+        yield* dispatchTestTurn(harness.engine, "queued-restore", "/compact");
+        const restoreFiber = yield* Deferred.await(restoreStarted);
+        if (terminalStatus === "stopped") {
+          yield* harness.engine.dispatch({
+            type: "thread.session.stop",
+            commandId: CommandId.make("stop-before-queued-restore"),
+            threadId: ThreadId.make("thread-1"),
+            createdAt: "2026-01-01T00:00:01.000Z",
+          });
+        } else {
+          yield* harness.engine.dispatch({
+            type: "thread.session.set",
+            commandId: CommandId.make("terminal-before-queued-restore"),
+            threadId: ThreadId.make("thread-1"),
+            session: {
+              threadId: ThreadId.make("thread-1"),
+              status: terminalStatus,
+              providerName: "codex",
+              providerInstanceId: ProviderInstanceId.make("codex"),
+              runtimeMode: "approval-required",
+              activeTurnId: null,
+              lastError: terminalStatus === "error" ? "Provider failed" : null,
+              updatedAt: "2026-01-01T00:00:01.000Z",
+            },
+            createdAt: "2026-01-01T00:00:01.000Z",
+          });
+        }
+        yield* Effect.promise(() => harness.drain());
+        const stopped = (yield* Effect.promise(() => harness.readModel())).threads[0];
+        expect(stopped?.session?.status).toBe(terminalStatus);
+        yield* Deferred.succeed(releaseRestore, undefined);
+        yield* Fiber.await(restoreFiber);
+        const thread = (yield* Effect.promise(() => harness.readModel())).threads[0];
+        expect(thread?.session?.status).toBe(terminalStatus);
+        expect(thread?.pendingOperation).toBeNull();
       }),
   );
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -399,6 +399,7 @@ const make = Effect.gen(function* () {
     readonly threadId: ThreadId;
     readonly session: OrchestrationSession;
     readonly operationResult?: OrchestrationOperationResult | null;
+    readonly expectedPendingRequestId?: MessageId;
     readonly createdAt: string;
   }) =>
     serverCommandId("provider-session-set").pipe(
@@ -409,6 +410,9 @@ const make = Effect.gen(function* () {
           threadId: input.threadId,
           session: input.session,
           operationResult: input.operationResult ?? null,
+          ...(input.expectedPendingRequestId
+            ? { expectedPendingRequestId: input.expectedPendingRequestId }
+            : {}),
           createdAt: input.createdAt,
         }),
       ),
@@ -425,11 +429,12 @@ const make = Effect.gen(function* () {
     if (!thread) {
       return;
     }
-    if (thread.pendingOperation && thread.pendingOperation.requestId !== input.requestId) return;
+    if (thread.pendingOperation?.requestId !== input.requestId) return;
     const session = thread.session;
     yield* setThreadSession({
       threadId: input.threadId,
       operationResult: { requestId: input.requestId, outcome: "failed" },
+      expectedPendingRequestId: input.requestId,
       session: {
         ...(session ?? {
           threadId: input.threadId,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -3,6 +3,7 @@ import {
   type ApprovalRequestId,
   type ProviderRequestFailureReason,
   OrchestrationRequestResponseFailedPayload,
+  OrchestrationProposedPlanId,
   CommandId,
   EventId,
   isContextCompactionMessage,
@@ -49,6 +50,8 @@ import { ProviderAuthService } from "../../provider/Services/ProviderAuthService
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProviderRegistry } from "../../provider/Services/ProviderRegistry.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
+import { ProjectionThreadProposedPlanRepository } from "../../persistence/Services/ProjectionThreadProposedPlans.ts";
+import { ProjectionThreadProposedPlanRepositoryLive } from "../../persistence/Layers/ProjectionThreadProposedPlans.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
 import {
   ProviderCommandReactor,
@@ -292,6 +295,7 @@ const make = Effect.gen(function* () {
   const crypto = yield* Crypto.Crypto;
   const orchestrationEngine = yield* OrchestrationEngineService;
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
+  const projectionThreadProposedPlans = yield* ProjectionThreadProposedPlanRepository;
   const providerAuthService = yield* ProviderAuthService;
   const providerService = yield* ProviderService;
   const checkpointCapture = yield* TurnCheckpointCapture.TurnCheckpointCapture;
@@ -1201,8 +1205,14 @@ const make = Effect.gen(function* () {
   ) {
     const source = event.payload.sourceProposedPlan;
     if (!source) return;
-    const sourceThread = yield* resolveThreadDetail(source.threadId);
-    const sourcePlan = sourceThread?.proposedPlans.find((plan) => plan.id === source.planId);
+    const sourceThread = yield* resolveThreadShell(source.threadId);
+    if (!sourceThread) return;
+    const sourcePlan = Option.getOrUndefined(
+      yield* projectionThreadProposedPlans.getByPlanId({
+        threadId: source.threadId,
+        planId: OrchestrationProposedPlanId.make(source.planId),
+      }),
+    );
     if (!sourcePlan || sourcePlan.implementedAt !== null) return;
     yield* orchestrationEngine.dispatch({
       type: "thread.proposed-plan.upsert",
@@ -1210,7 +1220,10 @@ const make = Effect.gen(function* () {
       threadId: source.threadId,
       onlyIfUnimplemented: true,
       proposedPlan: {
-        ...sourcePlan,
+        id: sourcePlan.planId,
+        turnId: sourcePlan.turnId,
+        planMarkdown: sourcePlan.planMarkdown,
+        createdAt: sourcePlan.createdAt,
         implementedAt: event.payload.createdAt,
         implementationThreadId: event.payload.threadId,
         updatedAt: event.payload.createdAt,
@@ -1908,6 +1921,7 @@ const make = Effect.gen(function* () {
               detail: "This message was cancelled before the previous turn's checkpoint finished.",
               turnId: null,
               requestId: request.payload.messageId,
+              operationResult: { requestId: request.payload.messageId, outcome: "interrupted" },
               createdAt: event.occurredAt,
             }).pipe(
               Effect.catchCause((cause) =>
@@ -2067,4 +2081,6 @@ const make = Effect.gen(function* () {
   } satisfies ProviderCommandReactorShape;
 });
 
-export const ProviderCommandReactorLive = Layer.effect(ProviderCommandReactor, make);
+export const ProviderCommandReactorLive = Layer.effect(ProviderCommandReactor, make).pipe(
+  Layer.provide(ProjectionThreadProposedPlanRepositoryLive),
+);

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1203,6 +1203,7 @@ const make = Effect.gen(function* () {
       type: "thread.proposed-plan.upsert",
       commandId: CommandId.make(`server:source-plan-accepted:${event.eventId}`),
       threadId: source.threadId,
+      onlyIfUnimplemented: true,
       proposedPlan: {
         ...sourcePlan,
         implementedAt: event.payload.createdAt,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -5,6 +5,9 @@ import {
   OrchestrationRequestResponseFailedPayload,
   CommandId,
   EventId,
+  isContextCompactionMessage,
+  type MessageId,
+  type OrchestrationOperationResult,
   type ModelSelection,
   type OrchestrationEvent,
   ProviderDriverKind,
@@ -95,10 +98,6 @@ function toNonEmptyProviderInput(value: string | undefined): string | undefined 
   return normalized && normalized.length > 0 ? normalized : undefined;
 }
 
-const isCompactCommandMessage = (message: ThreadTitleMessage): boolean =>
-  message.role === "user" &&
-  (message.attachments?.length ?? 0) === 0 &&
-  message.text.trim().toLowerCase() === "/compact";
 function mapProviderSessionStatusToOrchestrationStatus(
   status: "connecting" | "ready" | "running" | "error" | "closed",
 ): OrchestrationSession["status"] {
@@ -318,7 +317,7 @@ const make = Effect.gen(function* () {
     );
 
   const threadModelSelections = new Map<string, ModelSelection>();
-  const compactingThreadIds = new Set<ThreadId>();
+  const compactingThreads = new Map<ThreadId, OrchestrationOperationResult | null>();
   const stoppingThreadIds = new Set<ThreadId>();
   const delayedTurnStarts = new Map<ThreadId, Set<TurnStartRequestedEvent>>();
 
@@ -329,6 +328,7 @@ const make = Effect.gen(function* () {
       readonly detail: string;
       readonly turnId: TurnId | null;
       readonly createdAt: string;
+      readonly operationResult?: OrchestrationOperationResult;
     } & (
       | {
           readonly kind: "provider.approval.respond.failed" | "provider.user-input.respond.failed";
@@ -354,6 +354,7 @@ const make = Effect.gen(function* () {
           type: "thread.activity.append",
           commandId,
           threadId: input.threadId,
+          operationResult: input.operationResult ?? null,
           activity: {
             id: eventId,
             tone: "error",
@@ -396,6 +397,7 @@ const make = Effect.gen(function* () {
   const setThreadSession = (input: {
     readonly threadId: ThreadId;
     readonly session: OrchestrationSession;
+    readonly operationResult?: OrchestrationOperationResult | null;
     readonly createdAt: string;
   }) =>
     serverCommandId("provider-session-set").pipe(
@@ -405,13 +407,16 @@ const make = Effect.gen(function* () {
           commandId,
           threadId: input.threadId,
           session: input.session,
+          operationResult: input.operationResult ?? null,
           createdAt: input.createdAt,
         }),
       ),
+      Effect.catchTag("OrchestrationOperationSupersededError", () => Effect.void),
     );
 
   const setThreadSessionErrorOnTurnStartFailure = Effect.fnUntraced(function* (input: {
     readonly threadId: ThreadId;
+    readonly requestId: MessageId;
     readonly detail: string;
     readonly createdAt: string;
   }) {
@@ -419,9 +424,11 @@ const make = Effect.gen(function* () {
     if (!thread) {
       return;
     }
+    if (thread.pendingOperation && thread.pendingOperation.requestId !== input.requestId) return;
     const session = thread.session;
     yield* setThreadSession({
       threadId: input.threadId,
+      operationResult: { requestId: input.requestId, outcome: "failed" },
       session: {
         ...(session ?? {
           threadId: input.threadId,
@@ -438,13 +445,25 @@ const make = Effect.gen(function* () {
     });
   });
 
-  const restoreCompaction = Effect.fnUntraced(function* (threadId: ThreadId, fromRunning = false) {
+  const restoreCompaction = Effect.fnUntraced(function* (
+    threadId: ThreadId,
+    operationResult: OrchestrationOperationResult | null,
+    fromRunning = false,
+  ) {
+    if (operationResult !== null && compactingThreads.has(threadId)) {
+      compactingThreads.set(threadId, operationResult);
+    }
     if (stoppingThreadIds.has(threadId)) {
-      compactingThreadIds.delete(threadId);
       return;
     }
     const thread = yield* resolveThreadShell(threadId);
     if (!thread?.session) return;
+    if (
+      operationResult !== null &&
+      thread.pendingOperation &&
+      thread.pendingOperation.requestId !== operationResult.requestId
+    )
+      return;
     if (
       thread.session.status !== "starting" &&
       thread.session.status !== "ready" &&
@@ -453,11 +472,11 @@ const make = Effect.gen(function* () {
       return;
     const completedAt = DateTime.formatIso(yield* DateTime.now);
     if (stoppingThreadIds.has(threadId)) {
-      compactingThreadIds.delete(threadId);
       return;
     }
     yield* setThreadSession({
       threadId,
+      operationResult,
       session: {
         ...thread.session,
         status: "ready",
@@ -1210,6 +1229,7 @@ const make = Effect.gen(function* () {
         turnId: null,
         createdAt: event.payload.createdAt,
         requestId: event.payload.messageId,
+        operationResult: { requestId: event.payload.messageId, outcome: "failed" },
       });
       return;
     }
@@ -1223,6 +1243,7 @@ const make = Effect.gen(function* () {
         turnId: null,
         createdAt: event.payload.createdAt,
         requestId: event.payload.messageId,
+        operationResult: { requestId: event.payload.messageId, outcome: "failed" },
       });
 
     const handleTurnStartFailure = (cause: Cause.Cause<unknown>) => {
@@ -1232,6 +1253,7 @@ const make = Effect.gen(function* () {
       const detail = formatFailureDetail(cause);
       return setThreadSessionErrorOnTurnStartFailure({
         threadId: event.payload.threadId,
+        requestId: event.payload.messageId,
         detail,
         createdAt: event.payload.createdAt,
       }).pipe(
@@ -1305,7 +1327,9 @@ const make = Effect.gen(function* () {
 
     yield* ensureThreadWorktree(thread);
 
-    const isCompactCommand = isCompactCommandMessage(message);
+    const isCompactCommand =
+      (event.payload.operation ?? (isContextCompactionMessage(message) ? "compact" : "turn")) ===
+      "compact";
     if (!hasOtherUserMessages && !isCompactCommand) {
       const project = yield* resolveProject(thread.projectId);
       const generationCwd =
@@ -1341,9 +1365,16 @@ const make = Effect.gen(function* () {
         return Effect.void;
       }
       const detail = formatFailureDetail(cause);
+      if (compactingThreads.has(event.payload.threadId)) {
+        compactingThreads.set(event.payload.threadId, {
+          requestId: event.payload.messageId,
+          outcome: "failed",
+        });
+      }
       if (!compactionSessionEnsured) {
         return setThreadSessionErrorOnTurnStartFailure({
           threadId: event.payload.threadId,
+          requestId: event.payload.messageId,
           detail,
           createdAt: event.payload.createdAt,
         }).pipe(
@@ -1353,7 +1384,10 @@ const make = Effect.gen(function* () {
       }
       return appendTurnStartFailure("Context compaction failed", detail).pipe(
         Effect.ensuring(
-          restoreCompaction(event.payload.threadId).pipe(
+          restoreCompaction(event.payload.threadId, {
+            requestId: event.payload.messageId,
+            outcome: "failed",
+          }).pipe(
             Effect.catchCause((restoreCause) =>
               Effect.logWarning("failed to restore provider session after compaction failure", {
                 threadId: event.payload.threadId,
@@ -1377,6 +1411,15 @@ const make = Effect.gen(function* () {
         ),
       );
     if (isCompactCommand) {
+      if (
+        event.payload.operation !== undefined &&
+        thread.pendingOperation?.requestId !== event.payload.messageId
+      ) {
+        return yield* appendTurnStartFailure(
+          "Context compaction failed",
+          "This compaction request was not admitted. Wait for the current operation to finish and retry.",
+        );
+      }
       if (!hasOtherUserMessages) {
         return yield* appendTurnStartFailure(
           "Context compaction failed",
@@ -1385,7 +1428,7 @@ const make = Effect.gen(function* () {
       }
       const latestThread = yield* resolveThreadShell(event.payload.threadId);
       if (
-        compactingThreadIds.has(event.payload.threadId) ||
+        compactingThreads.has(event.payload.threadId) ||
         latestThread?.session?.status === "starting" ||
         latestThread?.session?.status === "running"
       ) {
@@ -1395,7 +1438,7 @@ const make = Effect.gen(function* () {
         );
         return;
       }
-      compactingThreadIds.add(event.payload.threadId);
+      compactingThreads.set(event.payload.threadId, null);
       yield* Effect.gen(function* () {
         yield* ensureSessionForThread(
           event.payload.threadId,
@@ -1414,14 +1457,28 @@ const make = Effect.gen(function* () {
           event.payload.messageId,
         );
       }).pipe(
-        Effect.andThen(restoreCompaction(event.payload.threadId, true)),
+        Effect.andThen(
+          restoreCompaction(
+            event.payload.threadId,
+            {
+              requestId: event.payload.messageId,
+              outcome: "completed",
+            },
+            true,
+          ),
+        ),
         Effect.catchCause(recoverCompactionFailure),
-        Effect.ensuring(Effect.sync(() => void compactingThreadIds.delete(event.payload.threadId))),
+        Effect.ensuring(
+          Effect.sync(() => {
+            if (!stoppingThreadIds.has(event.payload.threadId))
+              compactingThreads.delete(event.payload.threadId);
+          }),
+        ),
         Effect.forkScoped,
       );
       return;
     }
-    if (compactingThreadIds.has(event.payload.threadId)) {
+    if (compactingThreads.has(event.payload.threadId)) {
       return yield* appendTurnStartFailure(
         "Provider turn start failed",
         "Wait for context compaction to finish before sending another message.",
@@ -1666,9 +1723,11 @@ const make = Effect.gen(function* () {
     }
 
     const now = event.payload.createdAt;
-    const wasCompacting = compactingThreadIds.has(thread.id);
     stoppingThreadIds.add(thread.id);
-    const clearStopping = Effect.sync(() => void stoppingThreadIds.delete(thread.id));
+    const clearStopping = Effect.sync(() => {
+      stoppingThreadIds.delete(thread.id);
+      if (compactingThreads.get(thread.id) !== null) compactingThreads.delete(thread.id);
+    });
     yield* (
       thread.session && thread.session.status !== "stopped"
         ? providerService.stopSession({ threadId: thread.id })
@@ -1682,10 +1741,16 @@ const make = Effect.gen(function* () {
           const detail = formatFailureDetail(cause);
           return Effect.sync(() => {
             stoppingThreadIds.delete(thread.id);
-            return wasCompacting && !compactingThreadIds.has(thread.id);
+            return compactingThreads.get(thread.id);
           }).pipe(
-            Effect.flatMap((compactionSettled) =>
-              compactionSettled ? restoreCompaction(thread.id) : Effect.void,
+            Effect.flatMap((operationResult) =>
+              operationResult
+                ? restoreCompaction(
+                    thread.id,
+                    operationResult,
+                    operationResult.outcome === "completed",
+                  )
+                : Effect.void,
             ),
             Effect.andThen(
               appendProviderFailureActivity({

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1324,6 +1324,15 @@ const make = Effect.gen(function* () {
     if (authCommandHandled) {
       return;
     }
+    if (
+      thread.pendingOperation?.kind === "compact" &&
+      thread.pendingOperation.requestId !== event.payload.messageId
+    ) {
+      return yield* appendTurnStartFailure(
+        "Provider turn start failed",
+        "Wait for context compaction to finish before sending another message.",
+      );
+    }
 
     yield* ensureThreadWorktree(thread);
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -8,6 +8,7 @@ import {
   isContextCompactionMessage,
   type MessageId,
   type OrchestrationOperationResult,
+  type OrchestrationTurnStartAcceptance,
   type ModelSelection,
   type OrchestrationEvent,
   ProviderDriverKind,
@@ -411,7 +412,7 @@ const make = Effect.gen(function* () {
           createdAt: input.createdAt,
         }),
       ),
-      Effect.catchTag("OrchestrationOperationSupersededError", () => Effect.void),
+      Effect.catchTags({ OrchestrationOperationSupersededError: () => Effect.void }),
     );
 
   const setThreadSessionErrorOnTurnStartFailure = Effect.fnUntraced(function* (input: {
@@ -1190,6 +1191,28 @@ const make = Effect.gen(function* () {
     processThreadTitleRegenerationSafely,
   );
 
+  const markAcceptedSourcePlan = Effect.fn("markAcceptedSourcePlan")(function* (
+    event: Extract<ProviderIntentEvent, { type: "thread.turn-start-requested" }>,
+  ) {
+    const source = event.payload.sourceProposedPlan;
+    if (!source) return;
+    const sourceThread = yield* resolveThreadDetail(source.threadId);
+    const sourcePlan = sourceThread?.proposedPlans.find((plan) => plan.id === source.planId);
+    if (!sourcePlan || sourcePlan.implementedAt !== null) return;
+    yield* orchestrationEngine.dispatch({
+      type: "thread.proposed-plan.upsert",
+      commandId: CommandId.make(`server:source-plan-accepted:${event.eventId}`),
+      threadId: source.threadId,
+      proposedPlan: {
+        ...sourcePlan,
+        implementedAt: event.payload.createdAt,
+        implementationThreadId: event.payload.threadId,
+        updatedAt: event.payload.createdAt,
+      },
+      createdAt: event.payload.createdAt,
+    });
+  });
+
   const processTurnStartRequested = Effect.fn("processTurnStartRequested")(function* (
     event: Extract<ProviderIntentEvent, { type: "thread.turn-start-requested" }>,
   ) {
@@ -1248,7 +1271,24 @@ const make = Effect.gen(function* () {
 
     const handleTurnStartFailure = (cause: Cause.Cause<unknown>) => {
       if (Cause.hasInterruptsOnly(cause)) {
-        return Effect.void;
+        return orchestrationEngine
+          .dispatch({
+            type: "thread.activity.append",
+            commandId: CommandId.make(`server:turn-start-interrupted:${event.eventId}`),
+            threadId: event.payload.threadId,
+            operationResult: { requestId: event.payload.messageId, outcome: "interrupted" },
+            activity: {
+              id: EventId.make(`turn-start-interrupted:${event.eventId}`),
+              kind: "provider.turn.start.interrupted",
+              tone: "info",
+              summary: "Provider request interrupted",
+              payload: { timelineBypass: true },
+              turnId: null,
+              createdAt: event.payload.createdAt,
+            },
+            createdAt: event.payload.createdAt,
+          })
+          .pipe(Effect.asVoid);
       }
       const detail = formatFailureDetail(cause);
       return setThreadSessionErrorOnTurnStartFailure({
@@ -1509,9 +1549,48 @@ const make = Effect.gen(function* () {
 
     if (Option.isNone(sendTurnRequest)) return;
 
-    yield* providerService
-      .sendTurn(sendTurnRequest.value)
-      .pipe(Effect.asVoid, Effect.catchCause(recoverTurnStartFailure), Effect.forkScoped);
+    yield* providerService.sendTurn(sendTurnRequest.value).pipe(
+      Effect.flatMap((result) =>
+        orchestrationEngine.dispatch({
+          type: "thread.activity.append",
+          commandId: CommandId.make(`server:turn-start-accepted:${event.eventId}`),
+          threadId: event.payload.threadId,
+          operationResult: { requestId: event.payload.messageId, outcome: "completed" },
+          activity: {
+            id: EventId.make(`turn-start-accepted:${event.eventId}`),
+            kind: "provider.turn.start.accepted",
+            tone: "info",
+            summary: "Provider accepted the request",
+            payload: {
+              timelineBypass: true,
+              ...({
+                requestId: event.payload.messageId,
+                turnId: result.turnId,
+                requestedAt: event.payload.createdAt,
+                ...(event.payload.sourceProposedPlan
+                  ? { sourceProposedPlan: event.payload.sourceProposedPlan }
+                  : {}),
+              } satisfies OrchestrationTurnStartAcceptance),
+            },
+            turnId: result.turnId,
+            createdAt: event.payload.createdAt,
+          },
+          createdAt: event.payload.createdAt,
+        }),
+      ),
+      Effect.andThen(
+        markAcceptedSourcePlan(event).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("provider command reactor failed to mark source plan", {
+              cause: Cause.pretty(cause),
+            }),
+          ),
+        ),
+      ),
+      Effect.asVoid,
+      Effect.catchCause(recoverTurnStartFailure),
+      Effect.forkScoped,
+    );
   });
 
   const processTurnInterruptRequested = Effect.fn("processTurnInterruptRequested")(function* (

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -1798,8 +1798,21 @@ describe("ProviderRuntimeIngestion", () => {
       implementedAt: null,
       implementationThreadId: null,
     });
-    const implementedPlan = sourceThreadAfterStart.proposedPlans.find(
-      (entry) => entry.id === sourcePlan.id,
+    const implementedAt = "2026-01-01T00:00:30.000Z";
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.proposed-plan.upsert",
+        commandId: CommandId.make("cmd-source-plan-accepted"),
+        threadId: sourceThreadId,
+        onlyIfUnimplemented: true,
+        proposedPlan: {
+          ...sourcePlan,
+          implementedAt,
+          implementationThreadId: targetThreadId,
+          updatedAt: implementedAt,
+        },
+        createdAt: implementedAt,
+      }),
     );
     await harness.emitAndDrain([
       {
@@ -1820,7 +1833,7 @@ describe("ProviderRuntimeIngestion", () => {
     ).toMatchObject({
       planMarkdown: "# Source plan with late details",
       createdAt: sourcePlan.createdAt,
-      implementedAt: implementedPlan?.implementedAt,
+      implementedAt,
       implementationThreadId: targetThreadId,
     });
   });

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3888,81 +3888,87 @@ describe("ProviderRuntimeIngestion", () => {
     });
   });
 
-  it("projects compacted thread state into context compaction activities", async () => {
-    const harness = await createHarness();
-    const now = "2026-01-01T00:00:00.000Z";
+  it.each(["manual", "automatic"] as const)(
+    "projects %s compaction without guessing request identity",
+    async (mode) => {
+      const harness = await createHarness();
+      const now = "2026-01-01T00:00:00.000Z";
 
-    const compactCommand = {
-      type: "thread.turn.start",
-      commandId: CommandId.make("cmd-thread-compact"),
-      threadId: asThreadId("thread-1"),
-      message: {
-        messageId: asMessageId("message-compact"),
-        role: "user",
-        text: "/compact",
-        attachments: [],
-      },
-      interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-      runtimeMode: "approval-required",
-      createdAt: now,
-    } satisfies OrchestrationCommand;
-    await harness.dispatch(compactCommand);
-    harness.emit({
-      type: "session.state.changed",
-      eventId: asEventId("evt-session-starting-compact"),
-      provider: ProviderDriverKind.make("codex"),
-      providerInstanceId: ProviderInstanceId.make("codex"),
-      createdAt: now,
-      threadId: asThreadId("thread-1"),
-      payload: { state: "starting" },
-    });
-    await waitForThread(harness.readModel, (entry) => entry.session?.status === "starting");
-
-    for (const [index, usedTokens] of [899_000, 0].entries()) {
-      harness.emit({
-        type: "thread.token-usage.updated",
-        eventId: asEventId(`evt-thread-token-usage-${index}`),
-        provider: ProviderDriverKind.make("codex"),
-        createdAt: now,
+      const compactCommand = {
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-thread-compact"),
         threadId: asThreadId("thread-1"),
-        payload: { usage: { usedTokens } },
-      });
-    }
-    await waitForThread(
-      harness.readModel,
-      (entry) =>
-        entry.activities.filter(
-          (activity: ProviderRuntimeTestActivity) => activity.kind === "context-window.updated",
-        ).length === 2,
-    );
+        message: {
+          messageId: asMessageId("message-compact"),
+          role: "user",
+          text: "/compact",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      } satisfies OrchestrationCommand;
+      await harness.dispatch(compactCommand);
+      await harness.emitAndDrain([
+        {
+          type: "session.state.changed",
+          eventId: asEventId("evt-session-starting-compact"),
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          createdAt: now,
+          threadId: asThreadId("thread-1"),
+          payload: { state: "starting" },
+        },
+      ]);
 
-    harness.emit({
-      type: "thread.state.changed",
-      eventId: asEventId("evt-thread-compacted"),
-      provider: ProviderDriverKind.make("codex"),
-      providerInstanceId: ProviderInstanceId.make("codex"),
-      createdAt: now,
-      threadId: asThreadId("thread-1"),
-      turnId: asTurnId("turn-1"),
-      payload: {
-        state: "compacted",
-        detail: { source: "provider" },
-      },
-    });
+      for (const [index, usedTokens] of [899_000, 0].entries()) {
+        await harness.emitAndDrain([
+          {
+            type: "thread.token-usage.updated",
+            eventId: asEventId(`evt-thread-token-usage-${index}`),
+            provider: ProviderDriverKind.make("codex"),
+            createdAt: now,
+            threadId: asThreadId("thread-1"),
+            payload: { usage: { usedTokens } },
+          },
+        ]);
+      }
 
-    const thread = await waitForThread(harness.readModel, (entry) =>
-      entry.activities.some(
-        (activity: ProviderRuntimeTestActivity) => activity.id === "evt-thread-compacted",
-      ),
-    );
+      await harness.emitAndDrain([
+        {
+          type: "thread.state.changed",
+          ...(mode === "manual" ? { requestId: RuntimeRequestId.make("message-compact") } : {}),
+          eventId: asEventId("evt-thread-compacted"),
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          createdAt: now,
+          threadId: asThreadId("thread-1"),
+          turnId: asTurnId("turn-1"),
+          payload: {
+            state: "compacted",
+            detail: { source: "provider" },
+          },
+        },
+      ]);
 
-    const activity = thread.activities.find(
-      (candidate: ProviderRuntimeTestActivity) => candidate.id === "evt-thread-compacted",
-    );
-    expect(activity?.summary).toBe("Compacted context 899K → 0 tokens");
-    expect(activity?.tone).toBe("info");
-    expect(activity?.payload).toMatchObject({ requestId: "message-compact" });
-  });
+      const thread = (await harness.readModel()).threads.find((entry) => entry.id === "thread-1");
+      expect(thread?.pendingOperation).toEqual(
+        mode === "manual" ? null : { kind: "compact", requestId: "message-compact" },
+      );
+      if (!thread) throw new Error("Expected the compacting thread");
+
+      const activity = thread.activities.find(
+        (candidate: ProviderRuntimeTestActivity) => candidate.id === "evt-thread-compacted",
+      );
+      expect(activity?.summary).toBe("Compacted context 899K → 0 tokens");
+      expect(activity?.tone).toBe("info");
+      if (mode === "manual") {
+        expect(activity?.payload).toMatchObject({ requestId: "message-compact" });
+      } else {
+        expect(activity?.payload).not.toHaveProperty("requestId");
+      }
+    },
+  );
 
   it("projects Codex task lifecycle chunks into thread activities", async () => {
     const harness = await createHarness();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -823,6 +823,61 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.lastError).toBeNull();
   });
 
+  it.each(
+    (["turn", "compact"] as const).flatMap((kind) =>
+      [undefined, "older-request", "current-request"].map((errorRequestId) => ({
+        kind,
+        errorRequestId,
+      })),
+    ),
+  )(
+    "preserves pending $kind state unless a session error names it: $errorRequestId",
+    async ({ kind, errorRequestId }) => {
+      const harness = await createHarness();
+      const threadId = asThreadId("thread-1");
+      const requestId = asMessageId("current-request");
+      const createdAt = "2026-01-01T00:00:01.000Z";
+      await harness.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("session-error-pending-start"),
+        threadId,
+        message: {
+          messageId: requestId,
+          role: "user",
+          text: kind === "compact" ? "/compact" : "Start the current request.",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt,
+      });
+      const sessionBeforeError = (await harness.readModel()).threads[0]?.session;
+      await harness.emitAndDrain([
+        {
+          type: "session.state.changed",
+          eventId: asEventId("session-error-after-pending-start"),
+          provider: ProviderDriverKind.make("codex"),
+          threadId,
+          ...(errorRequestId !== undefined ? { requestId: errorRequestId } : {}),
+          createdAt: "2026-01-01T00:00:02.000Z",
+          payload: { state: "error", reason: "Provider session error" },
+        },
+      ]);
+
+      const expectedPending = errorRequestId === requestId ? null : { kind, requestId };
+      const thread = (await harness.readModel()).threads[0];
+      const shell = await harness.readThreadShell();
+      expect(thread?.pendingOperation).toEqual(expectedPending);
+      expect(shell.pendingOperation).toEqual(expectedPending);
+      if (errorRequestId !== requestId) {
+        expect(thread?.session).toEqual(sessionBeforeError);
+        expect(shell.session).toEqual(sessionBeforeError);
+      } else {
+        expect(thread?.session?.status).toBe("error");
+      }
+    },
+  );
+
   it("clears active turn when provider session becomes ready", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -696,6 +696,27 @@ describe("ProviderRuntimeIngestion", () => {
       expect(completedThread?.latestTurn).toMatchObject({ turnId: nextTurnId, state: "completed" });
     }
 
+    await harness.dispatch({
+      type: "thread.activity.append",
+      commandId: CommandId.make("opencode-pending-accepted"),
+      threadId,
+      operationResult: { requestId: asMessageId("opencode-pending-message"), outcome: "completed" },
+      activity: {
+        id: asEventId("opencode-pending-accepted"),
+        kind: "provider.turn.start.accepted",
+        tone: "info",
+        summary: "Provider accepted the request",
+        turnId: asTurnId("opencode-pending-turn"),
+        createdAt: pendingAt,
+        payload: {
+          requestId: "opencode-pending-message",
+          turnId: "opencode-pending-turn",
+          requestedAt: pendingAt,
+          timelineBypass: true,
+        },
+      },
+      createdAt: pendingAt,
+    });
     harness.emit({
       ...base,
       type: "turn.started",
@@ -1600,7 +1621,7 @@ describe("ProviderRuntimeIngestion", () => {
     );
   });
 
-  it("marks the source proposed plan implemented only after the target turn starts", async () => {
+  it("does not infer source plan acceptance from a provider turn start", async () => {
     const harness = await createHarness();
     const sourceThreadId = asThreadId("thread-plan");
     const targetThreadId = asThreadId("thread-implement");
@@ -1767,22 +1788,15 @@ describe("ProviderRuntimeIngestion", () => {
       turnId: targetTurnId,
     });
 
-    const sourceThreadAfterStart = await waitForThread(
-      harness.readModel,
-      (thread) =>
-        thread.proposedPlans.some(
-          (proposedPlan: ProviderRuntimeTestProposedPlan) =>
-            proposedPlan.id === sourcePlan.id &&
-            proposedPlan.implementedAt !== null &&
-            proposedPlan.implementationThreadId === targetThreadId,
-        ),
-      2_000,
-      sourceThreadId,
+    await harness.drain();
+    const sourceThreadAfterStart = (await harness.readModel()).threads.find(
+      (thread) => thread.id === sourceThreadId,
     );
     expect(
-      sourceThreadAfterStart.proposedPlans.find((entry) => entry.id === sourcePlan.id),
+      sourceThreadAfterStart?.proposedPlans.find((entry) => entry.id === sourcePlan.id),
     ).toMatchObject({
-      implementationThreadId: "thread-implement",
+      implementedAt: null,
+      implementationThreadId: null,
     });
     const implementedPlan = sourceThreadAfterStart.proposedPlans.find(
       (entry) => entry.id === sourcePlan.id,
@@ -1964,91 +1978,109 @@ describe("ProviderRuntimeIngestion", () => {
     expect(targetThreadAfterRejectedStart?.session?.activeTurnId).toBe(activeTurnId);
   });
 
-  it("accepts a conflicting turn.started for a pending turn start when the provider expects that turn", async () => {
-    // Steering a running turn: the server requests a new turn while the old
-    // one is still active, and providers like opencode open the new turn
-    // without ever completing the superseded one. The new turn.started must
-    // replace the active turn instead of being rejected as stale.
-    const harness = await createHarness();
-    const threadId = asThreadId("thread-1");
-    const oldTurnId = asTurnId("turn-steered-over");
-    const newTurnId = asTurnId("turn-from-steer");
-    const createdAt = "2026-01-01T00:00:00.000Z";
+  it.each([false, true])(
+    "accepts provider-confirmed steering with an early send response: %s",
+    async (acceptedBeforeStart) => {
+      // Steering a running turn: the server requests a new turn while the old
+      // one is still active, and providers like opencode open the new turn
+      // without ever completing the superseded one. The new turn.started must
+      // replace the active turn instead of being rejected as stale.
+      const harness = await createHarness();
+      const threadId = asThreadId("thread-1");
+      const oldTurnId = asTurnId("turn-steered-over");
+      const newTurnId = asTurnId("turn-from-steer");
+      const createdAt = "2026-01-01T00:00:00.000Z";
 
-    harness.setProviderSession({
-      provider: ProviderDriverKind.make("codex"),
-      status: "running",
-      runtimeMode: "approval-required",
-      threadId,
-      createdAt,
-      updatedAt: createdAt,
-      activeTurnId: oldTurnId,
-    });
-    harness.emit({
-      type: "turn.started",
-      eventId: asEventId("evt-turn-started-steered-over"),
-      provider: ProviderDriverKind.make("codex"),
-      createdAt,
-      threadId,
-      turnId: oldTurnId,
-    });
-    await waitForThread(
-      harness.readModel,
-      (thread) =>
-        thread.session?.status === "running" && thread.session?.activeTurnId === oldTurnId,
-      2_000,
-      threadId,
-    );
-
-    // The steer: a user-requested turn start while the old turn still runs.
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.turn.start",
-        commandId: CommandId.make("cmd-turn-start-steer"),
-        threadId,
-        message: {
-          messageId: asMessageId("msg-steer"),
-          role: "user",
-          text: "actually, do 15 instead",
-          attachments: [],
-        },
-        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+      harness.setProviderSession({
+        provider: ProviderDriverKind.make("codex"),
+        status: "running",
         runtimeMode: "approval-required",
+        threadId,
         createdAt,
-      }),
-    );
+        updatedAt: createdAt,
+        activeTurnId: oldTurnId,
+      });
+      harness.emit({
+        type: "turn.started",
+        eventId: asEventId("evt-turn-started-steered-over"),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt,
+        threadId,
+        turnId: oldTurnId,
+      });
+      await harness.drain();
 
-    // The provider session tracks the new turn before emitting turn.started
-    // (sendTurn updates the session first).
-    harness.setProviderSession({
-      provider: ProviderDriverKind.make("codex"),
-      status: "running",
-      runtimeMode: "approval-required",
-      threadId,
-      createdAt,
-      updatedAt: createdAt,
-      activeTurnId: newTurnId,
-    });
-    harness.emit({
-      type: "turn.started",
-      eventId: asEventId("evt-turn-started-from-steer"),
-      provider: ProviderDriverKind.make("codex"),
-      createdAt,
-      threadId,
-      turnId: newTurnId,
-    });
+      // The steer: a user-requested turn start while the old turn still runs.
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make("cmd-turn-start-steer"),
+          threadId,
+          message: {
+            messageId: asMessageId("msg-steer"),
+            role: "user",
+            text: "actually, do 15 instead",
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt,
+        }),
+      );
 
-    const threadAfterSteer = await waitForThread(
-      harness.readModel,
-      (thread) =>
-        thread.session?.status === "running" && thread.session?.activeTurnId === newTurnId,
-      2_000,
-      threadId,
-    );
-    expect(threadAfterSteer.session?.activeTurnId).toBe(newTurnId);
-    expect(threadAfterSteer.latestTurn?.turnId).toBe(newTurnId);
-    expect(threadAfterSteer.latestTurn?.state).toBe("running");
-  });
+      if (acceptedBeforeStart) {
+        await harness.dispatch({
+          type: "thread.activity.append",
+          commandId: CommandId.make("steer-accepted"),
+          threadId,
+          operationResult: { requestId: asMessageId("msg-steer"), outcome: "completed" },
+          activity: {
+            id: asEventId("steer-accepted"),
+            kind: "provider.turn.start.accepted",
+            tone: "info",
+            summary: "Provider accepted the request",
+            turnId: newTurnId,
+            createdAt,
+            payload: {
+              requestId: "msg-steer",
+              turnId: newTurnId,
+              requestedAt: createdAt,
+              timelineBypass: true,
+            },
+          },
+          createdAt,
+        });
+      }
+
+      // The provider session tracks the new turn before emitting turn.started
+      // (sendTurn updates the session first).
+      harness.setProviderSession({
+        provider: ProviderDriverKind.make("codex"),
+        status: "running",
+        runtimeMode: "approval-required",
+        threadId,
+        createdAt,
+        updatedAt: createdAt,
+        activeTurnId: newTurnId,
+      });
+      harness.emit({
+        type: "turn.started",
+        eventId: asEventId("evt-turn-started-from-steer"),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt,
+        threadId,
+        turnId: newTurnId,
+      });
+
+      await harness.drain();
+      const threadAfterSteer = (await harness.readModel()).threads.find(
+        (thread) => thread.id === threadId,
+      )!;
+      expect(threadAfterSteer.session?.activeTurnId).toBe(newTurnId);
+      expect(threadAfterSteer.latestTurn?.turnId).toBe(newTurnId);
+      expect(threadAfterSteer.latestTurn?.state).toBe("running");
+    },
+  );
 
   it("does not mark the source proposed plan implemented for an unrelated turn.started when no thread active turn is tracked", async () => {
     const harness = await createHarness();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1390,87 +1390,11 @@ const make = Effect.gen(function* () {
       ).pipe(Effect.asVoid);
     });
 
-  const getSourceProposedPlanReferenceForPendingTurnStart = Effect.fn(
-    "getSourceProposedPlanReferenceForPendingTurnStart",
-  )(function* (threadId: ThreadId) {
-    const pendingTurnStart = yield* projectionTurnRepository.getPendingTurnStartByThreadId({
-      threadId,
-    });
-    if (Option.isNone(pendingTurnStart)) {
-      return null;
-    }
-
-    const sourceThreadId = pendingTurnStart.value.sourceProposedPlanThreadId;
-    const sourcePlanId = pendingTurnStart.value.sourceProposedPlanId;
-    if (sourceThreadId === null || sourcePlanId === null) {
-      return null;
-    }
-
-    return {
-      sourceThreadId,
-      sourcePlanId,
-    } as const;
-  });
-
   const getExpectedProviderTurnIdForThread = Effect.fn("getExpectedProviderTurnIdForThread")(
     function* (threadId: ThreadId) {
       const sessions = yield* providerService.listSessions();
       const session = sessions.find((entry) => entry.threadId === threadId);
       return session?.activeTurnId;
-    },
-  );
-
-  const getSourceProposedPlanReferenceForAcceptedTurnStart = Effect.fn(
-    "getSourceProposedPlanReferenceForAcceptedTurnStart",
-  )(function* (threadId: ThreadId, eventTurnId: TurnId | undefined) {
-    if (eventTurnId === undefined) {
-      return null;
-    }
-
-    const expectedTurnId = yield* getExpectedProviderTurnIdForThread(threadId);
-    if (!sameId(expectedTurnId, eventTurnId)) {
-      return null;
-    }
-
-    return yield* getSourceProposedPlanReferenceForPendingTurnStart(threadId);
-  });
-
-  const markSourceProposedPlanImplemented = Effect.fn("markSourceProposedPlanImplemented")(
-    function* (
-      sourceThreadId: ThreadId,
-      sourcePlanId: OrchestrationProposedPlanId,
-      implementationThreadId: ThreadId,
-      implementedAt: string,
-    ) {
-      const sourceThread = yield* resolveThreadRuntimeContext(sourceThreadId);
-      const sourcePlan = Option.getOrUndefined(
-        yield* projectionThreadProposedPlans.getByPlanId({
-          threadId: sourceThreadId,
-          planId: sourcePlanId,
-        }),
-      );
-      if (!sourceThread || !sourcePlan || sourcePlan.implementedAt !== null) {
-        return;
-      }
-
-      const commandUuid = yield* crypto.randomUUIDv4;
-      yield* orchestrationEngine.dispatch({
-        type: "thread.proposed-plan.upsert",
-        commandId: CommandId.make(
-          `provider:source-proposed-plan-implemented:${implementationThreadId}:${commandUuid}`,
-        ),
-        threadId: sourceThreadId,
-        proposedPlan: {
-          id: sourcePlan.planId,
-          turnId: sourcePlan.turnId,
-          planMarkdown: sourcePlan.planMarkdown,
-          createdAt: sourcePlan.createdAt,
-          implementedAt,
-          implementationThreadId,
-          updatedAt: implementedAt,
-        },
-        createdAt: implementedAt,
-      });
     },
   );
 
@@ -1514,7 +1438,21 @@ const make = Effect.gen(function* () {
       const conflictingTurnStartIsPendingTurnStart =
         event.type === "turn.started" && conflictsWithActiveTurn
           ? sameId(yield* getExpectedProviderTurnIdForThread(thread.id), eventTurnId) &&
-            Option.isSome(pendingTurnStart)
+            (Option.isSome(pendingTurnStart) ||
+              (eventTurnId !== undefined &&
+                (yield* projectionTurnRepository
+                  .getByTurnId({
+                    threadId: thread.id,
+                    turnId: eventTurnId,
+                  })
+                  .pipe(
+                    Effect.map(
+                      (turn) =>
+                        Option.isSome(turn) &&
+                        turn.value.state === "pending" &&
+                        turn.value.pendingMessageId !== null,
+                    ),
+                  ))))
           : false;
 
       const shouldApplyThreadLifecycle = (() => {
@@ -1546,10 +1484,6 @@ const make = Effect.gen(function* () {
             return true;
         }
       })();
-      const acceptedTurnStartedSourcePlan =
-        event.type === "turn.started" && shouldApplyThreadLifecycle
-          ? yield* getSourceProposedPlanReferenceForAcceptedTurnStart(thread.id, eventTurnId)
-          : null;
 
       if (
         event.type === "session.started" ||
@@ -1604,30 +1538,16 @@ const make = Effect.gen(function* () {
                 : (thread.session?.lastError ?? null);
 
         if (shouldApplyThreadLifecycle) {
-          if (event.type === "turn.started" && acceptedTurnStartedSourcePlan !== null) {
-            yield* markSourceProposedPlanImplemented(
-              acceptedTurnStartedSourcePlan.sourceThreadId,
-              acceptedTurnStartedSourcePlan.sourcePlanId,
-              thread.id,
-              now,
-            ).pipe(
-              Effect.catchCause((cause) =>
-                Effect.logWarning(
-                  "provider runtime ingestion failed to mark source proposed plan",
-                  {
-                    eventId: event.eventId,
-                    eventType: event.type,
-                    cause: Cause.pretty(cause),
-                  },
-                ),
-              ),
-            );
-          }
-
           yield* orchestrationEngine.dispatch({
             type: "thread.session.set",
             commandId: yield* providerCommandId(event, "thread-session-set"),
             threadId: thread.id,
+            operationResult:
+              event.type === "session.state.changed" &&
+              event.payload.state === "error" &&
+              Option.isSome(pendingTurnStart)
+                ? { requestId: pendingTurnStart.value.messageId, outcome: "failed" }
+                : null,
             session: {
               threadId: thread.id,
               status,

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -16,7 +16,6 @@ import {
   type OrchestrationCheckpointSummary,
   type OrchestrationThreadActivity,
   type ProviderRuntimeEvent,
-  RuntimeRequestId,
 } from "@t3tools/contracts";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
@@ -1488,16 +1487,13 @@ const make = Effect.gen(function* () {
       const eventTurnId = toTurnId(event.turnId);
       const activeTurnId = thread.session?.activeTurnId ?? null;
       const isTerminalTurn = event.type === "turn.completed" || event.type === "turn.aborted";
-      const isCompactedThreadState =
-        event.type === "thread.state.changed" && event.payload.state === "compacted";
       const pendingTurnStart =
         event.type === "session.started" ||
         event.type === "session.state.changed" ||
         event.type === "session.exited" ||
         event.type === "thread.started" ||
         event.type === "turn.started" ||
-        isTerminalTurn ||
-        isCompactedThreadState
+        isTerminalTurn
           ? yield* projectionTurnRepository.getPendingTurnStartByThreadId({
               threadId: thread.id,
             })
@@ -2080,34 +2076,6 @@ const make = Effect.gen(function* () {
 
       let activityEvent = event;
       if (
-        isCompactedThreadState &&
-        event.requestId === undefined &&
-        Option.isSome(pendingTurnStart) &&
-        thread.session?.status === "starting" &&
-        activeTurnId === null &&
-        sameId(thread.session.providerName, event.provider) &&
-        sameId(thread.session.providerInstanceId, event.providerInstanceId) &&
-        DateTime.isGreaterThanOrEqualTo(
-          DateTime.makeUnsafe(event.createdAt),
-          DateTime.makeUnsafe(pendingTurnStart.value.requestedAt),
-        )
-      ) {
-        const pendingMessage = yield* getThreadMessageById(
-          thread.id,
-          pendingTurnStart.value.messageId,
-        );
-        if (
-          pendingMessage?.role === "user" &&
-          (pendingMessage.attachments?.length ?? 0) === 0 &&
-          pendingMessage.text.trim().toLowerCase() === "/compact"
-        ) {
-          activityEvent = {
-            ...event,
-            requestId: RuntimeRequestId.make(String(pendingTurnStart.value.messageId)),
-          };
-        }
-      }
-      if (
         activityEvent.type === "thread.state.changed" &&
         activityEvent.payload.state === "compacted" &&
         (activityEvent.payload.beforeTokens === undefined ||
@@ -2141,6 +2109,12 @@ const make = Effect.gen(function* () {
               commandId,
               threadId: thread.id,
               activity,
+              operationResult:
+                event.type === "thread.state.changed" &&
+                event.payload.state === "compacted" &&
+                event.requestId !== undefined
+                  ? { requestId: MessageId.make(String(event.requestId)), outcome: "completed" }
+                  : null,
               createdAt: activity.createdAt,
             }),
           ),

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -20,7 +20,6 @@ import {
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
-import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -1424,6 +1423,13 @@ const make = Effect.gen(function* () {
           : Option.none();
       const hasPendingTurnStart =
         Option.isSome(pendingTurnStart) && thread.session?.status === "starting";
+      const failedPendingRequestId =
+        event.type === "session.state.changed" &&
+        event.payload.state === "error" &&
+        Option.isSome(pendingTurnStart) &&
+        sameId(event.requestId, pendingTurnStart.value.messageId)
+          ? pendingTurnStart.value.messageId
+          : undefined;
 
       const conflictsWithActiveTurn =
         activeTurnId !== null && eventTurnId !== undefined && !sameId(activeTurnId, eventTurnId);
@@ -1460,6 +1466,14 @@ const make = Effect.gen(function* () {
           return true;
         }
         switch (event.type) {
+          case "session.state.changed":
+            // The command reactor settles pending work from its own send result.
+            // An unrelated session error must not block that request's recovery.
+            return (
+              event.payload.state !== "error" ||
+              Option.isNone(pendingTurnStart) ||
+              failedPendingRequestId !== undefined
+            );
           case "session.exited":
             return true;
           case "session.started":
@@ -1542,11 +1556,12 @@ const make = Effect.gen(function* () {
             type: "thread.session.set",
             commandId: yield* providerCommandId(event, "thread-session-set"),
             threadId: thread.id,
+            ...(failedPendingRequestId !== undefined
+              ? { expectedPendingRequestId: failedPendingRequestId }
+              : {}),
             operationResult:
-              event.type === "session.state.changed" &&
-              event.payload.state === "error" &&
-              Option.isSome(pendingTurnStart)
-                ? { requestId: pendingTurnStart.value.messageId, outcome: "failed" }
+              failedPendingRequestId !== undefined
+                ? { requestId: failedPendingRequestId, outcome: "failed" }
                 : null,
             session: {
               threadId: thread.id,

--- a/apps/server/src/orchestration/ThreadSettlementPolicy.test.ts
+++ b/apps/server/src/orchestration/ThreadSettlementPolicy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   ProviderInstanceId,
+  MessageId,
   ThreadId,
   ProjectId,
   TurnId,
@@ -48,6 +49,25 @@ const decide = (
   }) !== null;
 
 describe("resolveAutoSettlementAt", () => {
+  it("uses typed pending results instead of a compaction message timestamp", () => {
+    expect(
+      decide(
+        makeThread({
+          pendingOperation: { kind: "compact", requestId: MessageId.make("compact") },
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      decide(
+        makeThread({
+          latestUserMessageAt: NOW,
+          pendingOperation: null,
+        }),
+        { state: "closed", updatedAt: NOW },
+      ),
+    ).toBe(true);
+  });
+
   it("returns the last activity time for persisted settlement", () => {
     expect(
       resolveAutoSettlementAt({

--- a/apps/server/src/orchestration/ThreadSettlementPolicy.test.ts
+++ b/apps/server/src/orchestration/ThreadSettlementPolicy.test.ts
@@ -63,7 +63,7 @@ describe("resolveAutoSettlementAt", () => {
           latestUserMessageAt: NOW,
           pendingOperation: null,
         }),
-        { state: "closed", updatedAt: NOW },
+        { state: "closed", closedAt: NOW },
       ),
     ).toBe(true);
   });

--- a/apps/server/src/orchestration/ThreadSettlementPolicy.ts
+++ b/apps/server/src/orchestration/ThreadSettlementPolicy.ts
@@ -24,13 +24,15 @@ function latestTimestamp(values: ReadonlyArray<string | null | undefined>): stri
   return latest;
 }
 
-/** A recent user message stays queued until a turn adopts its timestamp.
- * Absolute age bounds client clock skew in both directions and stops stale
- * pre-adoption data from blocking the thread forever. */
+/** Reads typed pending state, with bounded timestamp matching for older snapshots. */
 export function threadHasQueuedTurnStart(
-  thread: Pick<OrchestrationThreadShell, "latestUserMessageAt" | "latestTurn" | "session">,
+  thread: Pick<
+    OrchestrationThreadShell,
+    "pendingOperation" | "latestUserMessageAt" | "latestTurn" | "session"
+  >,
   now: string,
 ): boolean {
+  if (thread.pendingOperation !== undefined) return thread.pendingOperation !== null;
   if (thread.latestUserMessageAt === null || thread.session?.status === "error") return false;
   const messageAt = Date.parse(thread.latestUserMessageAt);
   const age = Date.parse(now) - messageAt;

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1235,10 +1235,16 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           thread.latestTurn?.turnId === thread.session.activeTurnId
             ? thread.latestTurn.requestId
             : undefined);
-        if (currentRequestId !== undefined && currentRequestId !== result.requestId) {
+        if (
+          (currentRequestId !== undefined && currentRequestId !== result.requestId) ||
+          (currentRequestId === undefined &&
+            (thread.session?.status === "stopped" ||
+              thread.session?.status === "interrupted" ||
+              thread.session?.status === "error"))
+        ) {
           return yield* new OrchestrationOperationSupersededError({
             requestId: result.requestId,
-            currentRequestId,
+            currentRequestId: currentRequestId ?? null,
           });
         }
       }

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1433,11 +1433,17 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
     }
 
     case "thread.proposed-plan.upsert": {
-      yield* requireThread({
+      const thread = yield* requireThread({
         readModel,
         command,
         threadId: command.threadId,
       });
+      const existing = thread.proposedPlans.find((plan) => plan.id === command.proposedPlan.id);
+      if (command.onlyIfUnimplemented && !existing)
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: "Source plan no longer exists.",
+        });
       return {
         ...(yield* withEventBase({
           aggregateKind: "thread",
@@ -1448,7 +1454,17 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         type: "thread.proposed-plan-upserted",
         payload: {
           threadId: command.threadId,
-          proposedPlan: command.proposedPlan,
+          proposedPlan:
+            command.onlyIfUnimplemented && existing
+              ? existing.implementedAt !== null
+                ? existing
+                : {
+                    ...existing,
+                    implementedAt: command.proposedPlan.implementedAt,
+                    implementationThreadId: command.proposedPlan.implementationThreadId,
+                    updatedAt: command.proposedPlan.updatedAt,
+                  }
+              : command.proposedPlan,
         },
       };
     }

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1226,6 +1226,15 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         threadId: command.threadId,
       });
+      if (
+        command.expectedPendingRequestId !== undefined &&
+        thread.pendingOperation?.requestId !== command.expectedPendingRequestId
+      ) {
+        return yield* new OrchestrationOperationSupersededError({
+          requestId: command.expectedPendingRequestId,
+          currentRequestId: thread.pendingOperation?.requestId ?? null,
+        });
+      }
       const result = command.operationResult;
       if (result != null) {
         const currentRequestId =

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -956,8 +956,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         payload: {
           threadId: command.threadId,
           messageId: command.message.messageId,
-          operation:
-            command.operation ?? (isContextCompactionMessage(command.message) ? "compact" : "turn"),
+          operation: isContextCompactionMessage(command.message) ? "compact" : "turn",
           ...(command.modelSelection !== undefined
             ? { modelSelection: command.modelSelection }
             : {}),

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -3,6 +3,7 @@ import {
   EventId,
   MessageId,
   UserInputRequestedPayload,
+  isContextCompactionMessage,
   isImportedAgentSessionMessageId,
   type OrchestrationCommand,
   type OrchestrationEvent,
@@ -21,6 +22,7 @@ import type * as PlatformError from "effect/PlatformError";
 
 import {
   OrchestrationCommandInvariantError,
+  OrchestrationOperationSupersededError,
   OrchestrationThreadSettleBlockedError,
   type OrchestrationCommandRejection,
 } from "./Errors.ts";
@@ -72,9 +74,10 @@ function hasOpenBlockingRequest(thread: {
 
 /** Apply the shared shell-level rule to the detailed command read model. */
 function hasQueuedTurnStartForThread(
-  thread: Pick<OrchestrationThread, "messages" | "latestTurn" | "session">,
+  thread: Pick<OrchestrationThread, "pendingOperation" | "messages" | "latestTurn" | "session">,
   now: string,
 ): boolean {
+  if (thread.pendingOperation !== undefined) return thread.pendingOperation !== null;
   let latestUserMessageAt: string | null = null;
   let latestUserMessageAtMs = Number.NEGATIVE_INFINITY;
   for (const message of thread.messages) {
@@ -953,6 +956,8 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         payload: {
           threadId: command.threadId,
           messageId: command.message.messageId,
+          operation:
+            command.operation ?? (isContextCompactionMessage(command.message) ? "compact" : "turn"),
           ...(command.modelSelection !== undefined
             ? { modelSelection: command.modelSelection }
             : {}),
@@ -1222,6 +1227,21 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         threadId: command.threadId,
       });
+      const result = command.operationResult;
+      if (result != null) {
+        const currentRequestId =
+          thread.pendingOperation?.requestId ??
+          (thread.session?.activeTurnId != null &&
+          thread.latestTurn?.turnId === thread.session.activeTurnId
+            ? thread.latestTurn.requestId
+            : undefined);
+        if (currentRequestId !== undefined && currentRequestId !== result.requestId) {
+          return yield* new OrchestrationOperationSupersededError({
+            requestId: result.requestId,
+            currentRequestId,
+          });
+        }
+      }
       const sessionSetEvent: Omit<OrchestrationEvent, "sequence"> = {
         ...(yield* withEventBase({
           aggregateKind: "thread",
@@ -1234,6 +1254,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         payload: {
           threadId: command.threadId,
           session: command.session,
+          operationResult: command.operationResult ?? null,
         },
       };
       // Only a session coming alive is activity worth waking a settled thread
@@ -1501,6 +1522,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         payload: {
           threadId: command.threadId,
           activity: command.activity,
+          operationResult: command.operationResult ?? null,
         },
       };
       // An approval or user-input request is blocked-on-you work — it must

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -88,6 +88,7 @@ describe("orchestration projector", () => {
         branch: null,
         worktreePath: null,
         latestTurn: null,
+        pendingOperation: null,
         createdAt: now,
         updatedAt: now,
         archivedAt: null,

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -4,6 +4,7 @@ import {
   isImportedAgentSessionMessageId,
   getThreadPendingOperation,
   pendingOperationAfterEvent,
+  acceptedRequestIdForEvent,
   bindAcceptedTurn,
   bindTurnFromActivities,
   turnStartAcceptance,
@@ -675,7 +676,12 @@ export function projectEvent(
           ...nextBase,
           threads: updateThread(nextBase.threads, payload.threadId, {
             session,
-            pendingOperation: pendingOperationAfterEvent(getThreadPendingOperation(thread), event),
+            pendingOperation: pendingOperationAfterEvent(
+              getThreadPendingOperation(thread),
+              event,
+              undefined,
+              acceptedRequestIdForEvent(thread, event),
+            ),
             latestTurn: bindTurnFromActivities(
               session.status === "running" && session.activeTurnId !== null
                 ? {
@@ -927,6 +933,8 @@ export function projectEvent(
               pendingOperation: pendingOperationAfterEvent(
                 getThreadPendingOperation(thread),
                 event,
+                undefined,
+                acceptedRequestIdForEvent(thread, event),
               ),
               updatedAt: event.occurredAt,
             }),

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -2,6 +2,9 @@ import { isRequestResponseStale } from "@t3tools/shared/requestActivity";
 import type { OrchestrationEvent, OrchestrationReadModel, ThreadId } from "@t3tools/contracts";
 import {
   isImportedAgentSessionMessageId,
+  getThreadPendingOperation,
+  pendingOperationAfterEvent,
+  ThreadTurnStartRequestedPayload,
   OrchestrationCheckpointSummary,
   OrchestrationMessage,
   OrchestrationSession,
@@ -349,6 +352,7 @@ export function projectEvent(
             branch: payload.branch,
             worktreePath: payload.worktreePath,
             latestTurn: null,
+            pendingOperation: null,
             createdAt: payload.createdAt,
             updatedAt: payload.updatedAt,
             archivedAt: null,
@@ -615,6 +619,32 @@ export function projectEvent(
         };
       });
 
+    case "thread.turn-start-requested":
+      return decodeForEvent(
+        ThreadTurnStartRequestedPayload,
+        event.payload,
+        event.type,
+        "payload",
+      ).pipe(
+        Effect.map((payload) => {
+          const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+          if (!thread) return nextBase;
+          return {
+            ...nextBase,
+            threads: updateThread(nextBase.threads, payload.threadId, {
+              pendingOperation: pendingOperationAfterEvent(
+                getThreadPendingOperation(thread),
+                event,
+                payload.operation === undefined
+                  ? thread.messages.find((message) => message.id === payload.messageId)
+                  : undefined,
+              ),
+              updatedAt: event.occurredAt,
+            }),
+          };
+        }),
+      );
+
     case "thread.session-set":
       return Effect.gen(function* () {
         const payload = yield* decodeForEvent(
@@ -642,10 +672,16 @@ export function projectEvent(
           ...nextBase,
           threads: updateThread(nextBase.threads, payload.threadId, {
             session,
+            pendingOperation: pendingOperationAfterEvent(getThreadPendingOperation(thread), event),
             latestTurn:
               session.status === "running" && session.activeTurnId !== null
                 ? {
                     turnId: session.activeTurnId,
+                    requestId:
+                      thread.latestTurn?.turnId === session.activeTurnId
+                        ? (thread.latestTurn.requestId ??
+                          getThreadPendingOperation(thread)?.requestId)
+                        : getThreadPendingOperation(thread)?.requestId,
                     state: "running",
                     requestedAt:
                       thread.latestTurn?.turnId === session.activeTurnId
@@ -768,6 +804,9 @@ export function projectEvent(
               ? thread.latestTurn
               : {
                   turnId: payload.turnId,
+                  ...(thread.latestTurn?.turnId === payload.turnId
+                    ? { requestId: thread.latestTurn.requestId }
+                    : {}),
                   state:
                     thread.latestTurn?.turnId === payload.turnId &&
                     thread.latestTurn.state === "interrupted"
@@ -834,6 +873,7 @@ export function projectEvent(
               proposedPlans,
               activities,
               latestTurn,
+              pendingOperation: null,
               updatedAt: event.occurredAt,
             }),
           };
@@ -864,6 +904,10 @@ export function projectEvent(
             ...nextBase,
             threads: updateThread(nextBase.threads, payload.threadId, {
               activities,
+              pendingOperation: pendingOperationAfterEvent(
+                getThreadPendingOperation(thread),
+                event,
+              ),
               updatedAt: event.occurredAt,
             }),
           };

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -4,7 +4,6 @@ import {
   isImportedAgentSessionMessageId,
   getThreadPendingOperation,
   pendingOperationAfterEvent,
-  acceptedRequestIdForEvent,
   bindAcceptedTurn,
   bindTurnFromActivities,
   turnStartAcceptance,
@@ -676,12 +675,7 @@ export function projectEvent(
           ...nextBase,
           threads: updateThread(nextBase.threads, payload.threadId, {
             session,
-            pendingOperation: pendingOperationAfterEvent(
-              getThreadPendingOperation(thread),
-              event,
-              undefined,
-              acceptedRequestIdForEvent(thread, event),
-            ),
+            pendingOperation: pendingOperationAfterEvent(getThreadPendingOperation(thread), event),
             latestTurn: bindTurnFromActivities(
               session.status === "running" && session.activeTurnId !== null
                 ? {
@@ -821,27 +815,35 @@ export function projectEvent(
             checkpoints,
             latestTurn: turnStillRunning
               ? thread.latestTurn
-              : {
-                  turnId: payload.turnId,
-                  ...(thread.latestTurn?.turnId === payload.turnId
-                    ? { requestId: thread.latestTurn.requestId }
-                    : {}),
-                  state:
-                    thread.latestTurn?.turnId === payload.turnId &&
-                    thread.latestTurn.state === "interrupted"
-                      ? "interrupted"
-                      : checkpointStatusToLatestTurnState(payload.status),
-                  requestedAt:
-                    thread.latestTurn?.turnId === payload.turnId
-                      ? thread.latestTurn.requestedAt
-                      : payload.completedAt,
-                  startedAt:
-                    thread.latestTurn?.turnId === payload.turnId
-                      ? (thread.latestTurn.startedAt ?? payload.completedAt)
-                      : payload.completedAt,
-                  completedAt: payload.completedAt,
-                  assistantMessageId: payload.assistantMessageId,
-                },
+              : bindTurnFromActivities(
+                  {
+                    turnId: payload.turnId,
+                    ...(thread.latestTurn?.turnId === payload.turnId
+                      ? {
+                          requestId: thread.latestTurn.requestId,
+                          ...(thread.latestTurn.sourceProposedPlan
+                            ? { sourceProposedPlan: thread.latestTurn.sourceProposedPlan }
+                            : {}),
+                        }
+                      : {}),
+                    state:
+                      thread.latestTurn?.turnId === payload.turnId &&
+                      thread.latestTurn.state === "interrupted"
+                        ? "interrupted"
+                        : checkpointStatusToLatestTurnState(payload.status),
+                    requestedAt:
+                      thread.latestTurn?.turnId === payload.turnId
+                        ? thread.latestTurn.requestedAt
+                        : payload.completedAt,
+                    startedAt:
+                      thread.latestTurn?.turnId === payload.turnId
+                        ? (thread.latestTurn.startedAt ?? payload.completedAt)
+                        : payload.completedAt,
+                    completedAt: payload.completedAt,
+                    assistantMessageId: payload.assistantMessageId,
+                  },
+                  thread.activities,
+                ),
             updatedAt: event.occurredAt,
           }),
         };
@@ -933,8 +935,6 @@ export function projectEvent(
               pendingOperation: pendingOperationAfterEvent(
                 getThreadPendingOperation(thread),
                 event,
-                undefined,
-                acceptedRequestIdForEvent(thread, event),
               ),
               updatedAt: event.occurredAt,
             }),

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -4,6 +4,9 @@ import {
   isImportedAgentSessionMessageId,
   getThreadPendingOperation,
   pendingOperationAfterEvent,
+  bindAcceptedTurn,
+  bindTurnFromActivities,
+  turnStartAcceptance,
   ThreadTurnStartRequestedPayload,
   OrchestrationCheckpointSummary,
   OrchestrationMessage,
@@ -673,15 +676,23 @@ export function projectEvent(
           threads: updateThread(nextBase.threads, payload.threadId, {
             session,
             pendingOperation: pendingOperationAfterEvent(getThreadPendingOperation(thread), event),
-            latestTurn:
+            latestTurn: bindTurnFromActivities(
               session.status === "running" && session.activeTurnId !== null
                 ? {
                     turnId: session.activeTurnId,
                     requestId:
                       thread.latestTurn?.turnId === session.activeTurnId
                         ? (thread.latestTurn.requestId ??
-                          getThreadPendingOperation(thread)?.requestId)
-                        : getThreadPendingOperation(thread)?.requestId,
+                          (event.payload.operationResult === undefined
+                            ? getThreadPendingOperation(thread)?.requestId
+                            : undefined))
+                        : event.payload.operationResult === undefined
+                          ? getThreadPendingOperation(thread)?.requestId
+                          : undefined,
+                    ...(thread.latestTurn?.turnId === session.activeTurnId &&
+                    thread.latestTurn.sourceProposedPlan
+                      ? { sourceProposedPlan: thread.latestTurn.sourceProposedPlan }
+                      : {}),
                     state: "running",
                     requestedAt:
                       thread.latestTurn?.turnId === session.activeTurnId
@@ -709,6 +720,8 @@ export function projectEvent(
                       completedAt: session.updatedAt,
                     }
                   : thread.latestTurn,
+              thread.activities,
+            ),
             updatedAt: event.occurredAt,
           }),
         };
@@ -893,17 +906,24 @@ export function projectEvent(
             return nextBase;
           }
 
+          const activity =
+            payload.activity.kind === "provider.turn.start.accepted"
+              ? { ...payload.activity, sequence: event.sequence }
+              : payload.activity;
           const activities = retainThreadActivities(
-            [
-              ...thread.activities.filter((entry) => entry.id !== payload.activity.id),
-              payload.activity,
-            ].toSorted(compareThreadActivities),
+            [...thread.activities.filter((entry) => entry.id !== activity.id), activity].toSorted(
+              compareThreadActivities,
+            ),
           );
 
           return {
             ...nextBase,
             threads: updateThread(nextBase.threads, payload.threadId, {
               activities,
+              latestTurn: bindAcceptedTurn(
+                thread.latestTurn,
+                turnStartAcceptance(payload.activity),
+              ),
               pendingOperation: pendingOperationAfterEvent(
                 getThreadPendingOperation(thread),
                 event,

--- a/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
@@ -18,6 +18,8 @@ import * as Statement from "effect/unstable/sql/Statement";
 import { SqlitePersistenceMemory } from "./Sqlite.ts";
 import { ProjectionProjectRepositoryLive } from "./ProjectionProjects.ts";
 import { ProjectionThreadRepositoryLive } from "./ProjectionThreads.ts";
+import { ProjectionTurnRepositoryLive } from "./ProjectionTurns.ts";
+import { ProjectionTurnRepository } from "../Services/ProjectionTurns.ts";
 import { ProjectionThreadActivityRepositoryLive } from "./ProjectionThreadActivities.ts";
 import { ProjectionThreadProposedPlanRepositoryLive } from "./ProjectionThreadProposedPlans.ts";
 import { ProjectionProjectRepository } from "../Services/ProjectionProjects.ts";
@@ -29,6 +31,7 @@ const projectionRepositoriesLayer = it.layer(
   Layer.mergeAll(
     ProjectionProjectRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
     ProjectionThreadRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
+    ProjectionTurnRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
     ProjectionThreadActivityRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
     ProjectionThreadProposedPlanRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
     SqlitePersistenceMemory,
@@ -451,6 +454,40 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
           }),
         ),
       );
+    }),
+  );
+
+  it.effect("reads concrete turn operation kinds and legacy nulls", () =>
+    Effect.gen(function* () {
+      const turns = yield* ProjectionTurnRepository;
+      const sql = yield* SqlClient.SqlClient;
+      const threadId = ThreadId.make("operation-roundtrip");
+      for (const operation of [undefined, "turn", "compact"] as const) {
+        const turnId = TurnId.make(`operation-${operation ?? "legacy"}`);
+        yield* turns.upsertByTurnId({
+          threadId,
+          turnId,
+          ...(operation ? { operation } : {}),
+          pendingMessageId: null,
+          sourceProposedPlanThreadId: null,
+          sourceProposedPlanId: null,
+          assistantMessageId: null,
+          state: "completed",
+          requestedAt: "2026-04-01T00:00:00.000Z",
+          startedAt: null,
+          completedAt: "2026-04-01T00:00:01.000Z",
+          checkpointTurnCount: null,
+          checkpointRef: null,
+          checkpointStatus: null,
+          checkpointFiles: [],
+        });
+        if (operation === undefined) {
+          // Rows written before migration 48 can have no operation kind.
+          yield* sql`UPDATE projection_turns SET operation_kind = NULL WHERE thread_id = ${threadId} AND turn_id = ${turnId}`;
+        }
+        const persisted = Option.getOrThrow(yield* turns.getByTurnId({ threadId, turnId }));
+        assert.equal(persisted.operation, operation ?? null);
+      }
     }),
   );
 

--- a/apps/server/src/persistence/Layers/ProjectionTurns.ts
+++ b/apps/server/src/persistence/Layers/ProjectionTurns.ts
@@ -116,6 +116,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           thread_id,
           turn_id,
           pending_message_id,
+          operation_kind,
           source_proposed_plan_thread_id,
           source_proposed_plan_id,
           assistant_message_id,
@@ -132,6 +133,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           ${row.threadId},
           NULL,
           ${row.messageId},
+          ${row.operation ?? null},
           ${row.sourceProposedPlanThreadId},
           ${row.sourceProposedPlanId},
           NULL,
@@ -155,6 +157,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
         SELECT
           thread_id AS "threadId",
           pending_message_id AS "messageId",
+          operation_kind AS "operation",
           source_proposed_plan_thread_id AS "sourceProposedPlanThreadId",
           source_proposed_plan_id AS "sourceProposedPlanId",
           requested_at AS "requestedAt"

--- a/apps/server/src/persistence/Layers/ProjectionTurns.ts
+++ b/apps/server/src/persistence/Layers/ProjectionTurns.ts
@@ -51,6 +51,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           thread_id,
           turn_id,
           pending_message_id,
+          operation_kind,
           source_proposed_plan_thread_id,
           source_proposed_plan_id,
           assistant_message_id,
@@ -67,6 +68,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           ${row.threadId},
           ${row.turnId},
           ${row.pendingMessageId},
+          ${row.operation ?? "turn"},
           ${row.sourceProposedPlanThreadId},
           ${row.sourceProposedPlanId},
           ${row.assistantMessageId},
@@ -82,6 +84,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
         ON CONFLICT (thread_id, turn_id)
         DO UPDATE SET
           pending_message_id = excluded.pending_message_id,
+          operation_kind = COALESCE(${row.operation ?? null}, projection_turns.operation_kind),
           source_proposed_plan_thread_id = excluded.source_proposed_plan_thread_id,
           source_proposed_plan_id = excluded.source_proposed_plan_id,
           assistant_message_id = excluded.assistant_message_id,

--- a/apps/server/src/persistence/Layers/ProjectionTurns.ts
+++ b/apps/server/src/persistence/Layers/ProjectionTurns.ts
@@ -217,6 +217,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           thread_id AS "threadId",
           turn_id AS "turnId",
           pending_message_id AS "pendingMessageId",
+          operation_kind AS "operation",
           source_proposed_plan_thread_id AS "sourceProposedPlanThreadId",
           source_proposed_plan_id AS "sourceProposedPlanId",
           assistant_message_id AS "assistantMessageId",

--- a/apps/server/src/persistence/Services/ProjectionTurns.ts
+++ b/apps/server/src/persistence/Services/ProjectionTurns.ts
@@ -56,7 +56,7 @@ export const ProjectionTurnById = Schema.Struct({
   threadId: ThreadId,
   turnId: TurnId,
   pendingMessageId: Schema.NullOr(MessageId),
-  operation: Schema.optional(OrchestrationOperationKind),
+  operation: Schema.optional(Schema.NullOr(OrchestrationOperationKind)),
   sourceProposedPlanThreadId: Schema.NullOr(ThreadId),
   sourceProposedPlanId: Schema.NullOr(OrchestrationProposedPlanId),
   assistantMessageId: Schema.NullOr(MessageId),

--- a/apps/server/src/persistence/Services/ProjectionTurns.ts
+++ b/apps/server/src/persistence/Services/ProjectionTurns.ts
@@ -14,6 +14,7 @@ import {
   OrchestrationProposedPlanId,
   OrchestrationCheckpointFile,
   OrchestrationCheckpointStatus,
+  OrchestrationOperationKind,
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
@@ -72,6 +73,7 @@ export type ProjectionTurnById = typeof ProjectionTurnById.Type;
 export const ProjectionPendingTurnStart = Schema.Struct({
   threadId: ThreadId,
   messageId: MessageId,
+  operation: Schema.optional(Schema.NullOr(OrchestrationOperationKind)),
   sourceProposedPlanThreadId: Schema.NullOr(ThreadId),
   sourceProposedPlanId: Schema.NullOr(OrchestrationProposedPlanId),
   requestedAt: IsoDateTime,

--- a/apps/server/src/persistence/Services/ProjectionTurns.ts
+++ b/apps/server/src/persistence/Services/ProjectionTurns.ts
@@ -56,6 +56,7 @@ export const ProjectionTurnById = Schema.Struct({
   threadId: ThreadId,
   turnId: TurnId,
   pendingMessageId: Schema.NullOr(MessageId),
+  operation: Schema.optional(OrchestrationOperationKind),
   sourceProposedPlanThreadId: Schema.NullOr(ThreadId),
   sourceProposedPlanId: Schema.NullOr(OrchestrationProposedPlanId),
   assistantMessageId: Schema.NullOr(MessageId),

--- a/apps/server/src/project/AgentSessionImporter.test.ts
+++ b/apps/server/src/project/AgentSessionImporter.test.ts
@@ -575,7 +575,7 @@ const integrationLayer = Layer.mergeAll(
   Layer.provide(OrchestrationEventStoreLive),
   Layer.provide(OrchestrationCommandReceiptRepositoryLive),
   Layer.provide(RepositoryIdentityResolver.layer),
-  Layer.provide(SqlitePersistenceMemory),
+  Layer.provideMerge(SqlitePersistenceMemory),
   Layer.provideMerge(integrationServerConfig),
   Layer.provideMerge(NodeServices.layer),
 );

--- a/apps/server/src/serverRuntimeStartup.reconcile.test.ts
+++ b/apps/server/src/serverRuntimeStartup.reconcile.test.ts
@@ -1,6 +1,8 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import {
   type OrchestrationCommand,
+  type OrchestrationPendingOperation,
+  MessageId,
   type OrchestrationSessionStatus,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -72,14 +74,19 @@ const makeProviderService = (liveThreadIds: ReadonlyArray<ThreadId> = []) =>
     streamEvents: Stream.empty,
   }) satisfies ProviderService.ProviderService["Service"];
 
-const queryWithThreads = (threads: ReadonlyArray<ReturnType<typeof makeThread>>) =>
+type ReconciliationThread = Omit<ReturnType<typeof makeThread>, "session"> & {
+  readonly session: ReturnType<typeof makeThread>["session"] | null;
+  readonly pendingOperation?: OrchestrationPendingOperation;
+};
+
+const queryWithThreads = (threads: ReadonlyArray<ReconciliationThread>) =>
   ({
     getUserInputActivity: () => Effect.die("unused"),
     getCommandReadModel: () => Effect.succeed({ threads } as never),
   }) as unknown as ProjectionSnapshotQuery.ProjectionSnapshotQuery["Service"];
 
 const runReconciliation = (input: {
-  readonly threads: ReadonlyArray<ReturnType<typeof makeThread>>;
+  readonly threads: ReadonlyArray<ReconciliationThread>;
   readonly continueAfterRestart?: boolean;
   readonly liveThreadIds?: ReadonlyArray<ThreadId>;
   readonly providerService?: ProviderService.ProviderService["Service"];
@@ -986,3 +993,54 @@ it.effect("settles failed opt-in recovery without retrying the provider turn", (
     });
   }),
 );
+
+it.effect("interrupts orphaned pending operations even before a provider session starts", () => {
+  const pending = {
+    kind: "compact",
+    requestId: MessageId.make("unstarted-compact"),
+  } as const;
+  const ready = { ...makeThread("pending-ready", "ready"), pendingOperation: pending };
+  const unstarted = {
+    ...makeThread("pending-without-session", "ready"),
+    session: null,
+    pendingOperation: pending,
+  };
+  const live = { ...makeThread("pending-live", "starting"), pendingOperation: pending };
+  const commands: OrchestrationCommand[] = [];
+  return runReconciliation({
+    threads: [ready, unstarted, live],
+    liveThreadIds: [live.id],
+    directory: {
+      getBinding: () => Effect.die("Idle pending work has no provider binding to reconcile"),
+      upsert: () => Effect.die("unused"),
+      recordImportedTranscript: () => Effect.die("unused"),
+      getProvider: () => Effect.die("unused"),
+      listThreadIds: () => Effect.die("unused"),
+      listBindings: () => Effect.succeed([]),
+    },
+    dispatch: (command) =>
+      Effect.sync(() => {
+        commands.push(command);
+        return { sequence: commands.length };
+      }),
+  }).pipe(
+    Effect.tap(() =>
+      Effect.sync(() => {
+        assert.deepEqual(
+          commands.map((command) =>
+            command.type === "thread.activity.append"
+              ? {
+                  threadId: command.threadId,
+                  result: command.operationResult,
+                }
+              : null,
+          ),
+          [ready, unstarted].map((thread) => ({
+            threadId: thread.id,
+            result: { requestId: pending.requestId, outcome: "interrupted" as const },
+          })),
+        );
+      }),
+    ),
+  );
+});

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -1,6 +1,7 @@
 import {
   CommandId,
   DEFAULT_MODEL,
+  EventId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   DEFAULT_SERVER_SETTINGS,
   type ModelSelection,
@@ -521,6 +522,47 @@ export const reconcileProviderSessions = Effect.gen(function* () {
       )
       .map((binding) => binding.threadId),
   );
+  // Pending operations are not resumed by the reactor's live event subscription.
+  // Close even requests that persisted before a provider session was started.
+  for (const thread of threads) {
+    const pending = thread.pendingOperation;
+    if (!pending || liveThreadIds.has(thread.id)) continue;
+    const completedAt = DateTime.formatIso(yield* DateTime.now);
+    yield* orchestrationEngine
+      .dispatch({
+        type: "thread.activity.append",
+        commandId: CommandId.make(yield* crypto.randomUUIDv4),
+        threadId: thread.id,
+        operationResult: { requestId: pending.requestId, outcome: "interrupted" },
+        activity: {
+          id: EventId.make(yield* crypto.randomUUIDv4),
+          kind: "provider.turn.start.failed",
+          tone: "error",
+          summary:
+            pending.kind === "compact"
+              ? "Context compaction interrupted"
+              : "Provider turn start interrupted",
+          payload: {
+            requestId: pending.requestId,
+            detail: "The server restarted before this operation finished. Send the request again.",
+          },
+          turnId: null,
+          createdAt: completedAt,
+        },
+        createdAt: completedAt,
+      })
+      .pipe(
+        Effect.retry({ times: 1 }),
+        Effect.catchCause((cause) =>
+          Cause.hasInterrupts(cause)
+            ? Effect.failCause(cause)
+            : Effect.logWarning("failed to settle orphaned pending operation", {
+                threadId: thread.id,
+                cause,
+              }),
+        ),
+      );
+  }
   const orphanedThreads = threads.filter(
     (thread) =>
       thread.session !== null &&
@@ -634,6 +676,7 @@ export const reconcileProviderSessions = Effect.gen(function* () {
 
     if (
       Option.isSome(binding) &&
+      thread.pendingOperation?.kind !== "compact" &&
       (continuationMarked || interruptedByRestart) &&
       (session.status === "running" || session.status === "starting" || preparedWhileReady) &&
       binding.value.resumeCursor != null &&

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -12,6 +12,8 @@ import {
   type ApprovalRequestId,
   type ChatFileAttachment,
   DEFAULT_MODEL,
+  getThreadPendingOperation,
+  isContextCompactionMessage,
   type EnvironmentId,
   type MessageId,
   type ModelSelection,
@@ -643,11 +645,6 @@ function formatOutgoingPrompt(params: {
 }
 const SCRIPT_TERMINAL_COLS = 120;
 const SCRIPT_TERMINAL_ROWS = 30;
-
-function isCompactCommandMessage(message: ChatMessage): boolean {
-  const text = message.text.trim().toLowerCase();
-  return message.role === "user" && text === "/compact" && !message.attachments?.length;
-}
 
 type ChatViewProps =
   | {
@@ -2766,30 +2763,12 @@ export default function ChatView(props: ChatViewProps) {
     threadError,
   });
   const optimisticCompactionMessage = optimisticUserMessages.at(-1);
-  const pendingCompactionMessage =
-    isSendBusy &&
-    optimisticCompactionMessage !== undefined &&
-    isCompactCommandMessage(optimisticCompactionMessage)
-      ? optimisticCompactionMessage
-      : activeThread?.messages.findLast(isCompactCommandMessage);
-  const compactRequestIsActive =
-    pendingCompactionMessage !== undefined &&
-    (pendingCompactionMessage.createdAt >
-      (activeLatestTurn?.requestedAt ?? pendingCompactionMessage.createdAt) ||
-      (activeLatestTurn?.state === "running" &&
-        pendingCompactionMessage.createdAt === activeLatestTurn.requestedAt));
-  const compactionSettled =
-    pendingCompactionMessage !== undefined &&
-    (latestTurnStartFailureId(activeThread, pendingCompactionMessage.id) !== null ||
-      activeThread?.activities.some((activity) => {
-        if (activity.kind !== "context-compaction") return false;
-        const payload = activity.payload as { readonly requestId?: unknown } | null | undefined;
-        return payload?.requestId === pendingCompactionMessage.id;
-      }));
   const isCompacting =
-    (isSendBusy || phase === "connecting" || phase === "running") &&
-    compactRequestIsActive &&
-    !compactionSettled;
+    getThreadPendingOperation(activeThread)?.kind === "compact" ||
+    (isSendBusy &&
+      optimisticCompactionMessage !== undefined &&
+      isContextCompactionMessage(optimisticCompactionMessage) &&
+      !activeThread?.messages.some((message) => message.id === optimisticCompactionMessage.id));
   const isWorking =
     phase === "running" || isSendBusy || isConnecting || isRevertingCheckpoint || isCompacting;
   const activeWorkStartedAt = deriveActiveWorkStartedAt(
@@ -5732,7 +5711,7 @@ export default function ChatView(props: ChatViewProps) {
       : null;
   const activeThreadHasCompactableConversation =
     activeThread?.messages.some(
-      (message) => message.role === "user" && !isCompactCommandMessage(message),
+      (message) => message.role === "user" && !isContextCompactionMessage(message),
     ) ?? false;
   const compactThreadUnavailable =
     !activeThread ||

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -2299,17 +2299,20 @@ describe("deriveWorkLogEntries quiet-timeline guarantee", () => {
     expect(entries[0]!.agentSpawn?.agentTaskIds).toEqual(["child-1", "child-2"]);
   });
 
-  it("timelineBypass non-agent rows (background shells) stay suppressed", () => {
-    const entries = deriveWorkLogEntries([
-      makeActivity({
-        kind: "task.progress",
-        summary: "stall",
-        tone: "info",
-        payload: { taskId: "sh-1", taskType: "local_bash", timelineBypass: true },
-      }),
-    ]);
-    expect(entries).toHaveLength(0);
-  });
+  it.each(["task.progress", "provider.turn.start.accepted", "provider.turn.start.interrupted"])(
+    "hides the internal %s activity",
+    (kind) => {
+      const entries = deriveWorkLogEntries([
+        makeActivity({
+          kind,
+          summary: "stall",
+          tone: "info",
+          payload: { taskId: "sh-1", taskType: "local_bash", timelineBypass: true },
+        }),
+      ]);
+      expect(entries).toHaveLength(0);
+    },
+  );
 
   it("drops task.updated and tool.progress from the work log (fold input only)", () => {
     const entries = deriveWorkLogEntries([

--- a/packages/client-runtime/src/operations/commands.ts
+++ b/packages/client-runtime/src/operations/commands.ts
@@ -1,5 +1,6 @@
 import {
   CommandId,
+  isContextCompactionMessage,
   ORCHESTRATION_WS_METHODS,
   type ClientOrchestrationCommand,
 } from "@t3tools/contracts";
@@ -270,6 +271,7 @@ export const startThreadTurn: (input: StartThreadTurnInput) => CommandEffect = E
   return yield* dispatch({
     ...input,
     type: "thread.turn.start",
+    operation: input.operation ?? (isContextCompactionMessage(input.message) ? "compact" : "turn"),
     commandId: metadata.commandId,
     createdAt: metadata.createdAt,
   });

--- a/packages/client-runtime/src/operations/commands.ts
+++ b/packages/client-runtime/src/operations/commands.ts
@@ -1,6 +1,5 @@
 import {
   CommandId,
-  isContextCompactionMessage,
   ORCHESTRATION_WS_METHODS,
   type ClientOrchestrationCommand,
 } from "@t3tools/contracts";
@@ -271,7 +270,6 @@ export const startThreadTurn: (input: StartThreadTurnInput) => CommandEffect = E
   return yield* dispatch({
     ...input,
     type: "thread.turn.start",
-    operation: input.operation ?? (isContextCompactionMessage(input.message) ? "compact" : "turn"),
     commandId: metadata.commandId,
     createdAt: metadata.createdAt,
   });

--- a/packages/client-runtime/src/state/entities.test.ts
+++ b/packages/client-runtime/src/state/entities.test.ts
@@ -1,5 +1,6 @@
 import {
   EnvironmentId,
+  MessageId,
   ProjectId,
   ProviderInstanceId,
   ThreadId,
@@ -206,6 +207,7 @@ describe("environment entity projections", () => {
       ...THREAD_SHELL,
       environmentId: ENVIRONMENT_ID,
       title: "Cached thread",
+      pendingOperation: { kind: "compact", requestId: MessageId.make("cached-compact") },
       branch: "stale-branch",
       worktreePath: "/repo/stale-worktree",
       deletedAt: null,
@@ -218,6 +220,7 @@ describe("environment entity projections", () => {
       ...THREAD_SHELL,
       environmentId: ENVIRONMENT_ID,
       title: "Current thread",
+      pendingOperation: null,
       branch: "current-branch",
       worktreePath: "/repo/current-worktree",
     };
@@ -230,6 +233,10 @@ describe("environment entity projections", () => {
       worktreePath: "/repo/current-worktree",
     });
     expect(merged?.messages).toBe(messages);
+    expect(merged?.pendingOperation).toBeNull();
+    expect(
+      mergeEnvironmentThread(detail, { ...shell, pendingOperation: undefined })?.pendingOperation,
+    ).toEqual(detail.pendingOperation);
   });
 
   it("preserves untouched project and thread identities across unrelated shell updates", () => {

--- a/packages/client-runtime/src/state/threadDetail.ts
+++ b/packages/client-runtime/src/state/threadDetail.ts
@@ -53,6 +53,8 @@ export function mergeEnvironmentThread(
     branch: shell.branch,
     worktreePath: shell.worktreePath,
     latestTurn: shell.latestTurn,
+    pendingOperation:
+      shell.pendingOperation !== undefined ? shell.pendingOperation : detail.pendingOperation,
     createdAt: shell.createdAt,
     updatedAt: shell.updatedAt,
     archivedAt: shell.archivedAt,

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -4,13 +4,14 @@ import {
   CheckpointRef,
   CommandId,
   EventId,
+  getThreadPendingOperation,
   MessageId,
   ProjectId,
   ProviderInstanceId,
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
-import type { OrchestrationThread } from "@t3tools/contracts";
+import type { OrchestrationEvent, OrchestrationThread } from "@t3tools/contracts";
 
 import { applyThreadDetailEvent } from "./threadReducer.ts";
 
@@ -46,6 +47,87 @@ const baseThread: OrchestrationThread = {
 };
 
 describe("applyThreadDetailEvent", () => {
+  it("tracks compaction by request identity without message history or timestamps", () => {
+    let thread: OrchestrationThread = { ...baseThread, pendingOperation: null };
+    const fields = {
+      ...baseEventFields,
+      sequence: 1,
+      occurredAt: baseThread.createdAt,
+      aggregateKind: "thread" as const,
+      aggregateId: baseThread.id,
+    };
+    const apply = (event: OrchestrationEvent) => {
+      const result = applyThreadDetailEvent(thread, event);
+      if (result.kind !== "updated") throw new Error("Expected a thread update");
+      thread = result.thread;
+    };
+    const start = (requestId: string) =>
+      apply({
+        ...fields,
+        type: "thread.turn-start-requested",
+        payload: {
+          threadId: thread.id,
+          messageId: MessageId.make(requestId),
+          operation: "compact",
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          createdAt: fields.occurredAt,
+        },
+      });
+    const result = (requestId: string | null) =>
+      apply({
+        ...fields,
+        type: "thread.activity-appended",
+        payload: {
+          threadId: thread.id,
+          operationResult:
+            requestId === null
+              ? null
+              : { requestId: MessageId.make(requestId), outcome: "completed" },
+          activity: {
+            id: EventId.make(`activity-${requestId ?? "automatic"}`),
+            kind: "context-compaction",
+            tone: "info",
+            summary: "Context compacted",
+            payload: { requestId: "first" },
+            turnId: null,
+            createdAt: fields.occurredAt,
+          },
+        },
+      });
+    start("first");
+    const first = { kind: "compact", requestId: "first" };
+    expect(getThreadPendingOperation(thread)).toEqual(first);
+    apply({
+      ...fields,
+      type: "thread.session-set",
+      payload: {
+        threadId: thread.id,
+        operationResult: null,
+        session: {
+          threadId: thread.id,
+          status: "running",
+          providerName: "claudeAgent",
+          runtimeMode: "full-access",
+          activeTurnId: TurnId.make("native-command-turn"),
+          lastError: null,
+          updatedAt: fields.occurredAt,
+        },
+      },
+    });
+    expect(thread.latestTurn?.requestId).toBe("first");
+    expect(getThreadPendingOperation({ ...thread, messages: [], activities: [] })).toEqual(first);
+    result(null);
+    expect(thread.pendingOperation).toEqual(first);
+    result("first");
+    expect(thread.pendingOperation).toBeNull();
+    start("second");
+    result("first");
+    expect(thread.pendingOperation).toEqual({ kind: "compact", requestId: "second" });
+    result("second");
+    expect(thread.pendingOperation).toBeNull();
+  });
+
   describe("project events", () => {
     it("returns unchanged for project.created", () => {
       const result = applyThreadDetailEvent(baseThread, {

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -47,6 +47,70 @@ const baseThread: OrchestrationThread = {
 };
 
 describe("applyThreadDetailEvent", () => {
+  it.each([
+    {
+      messageAt: "2026-04-01T02:00:00+02:00",
+      turnAt: "2026-04-01T00:00:00Z",
+      state: "completed",
+      pending: false,
+    },
+    {
+      messageAt: "2026-04-01T03:00:00+04:00",
+      turnAt: "2026-04-01T00:00:00Z",
+      state: "completed",
+      pending: false,
+    },
+    {
+      messageAt: "2026-04-01T00:00:00Z",
+      turnAt: "2026-04-01T01:00:00+02:00",
+      state: "completed",
+      pending: true,
+    },
+    {
+      messageAt: "2026-04-01T02:00:00+02:00",
+      turnAt: "2026-04-01T00:00:00Z",
+      state: "running",
+      pending: true,
+    },
+  ] as const)(
+    "compares legacy compaction timestamps as instants: %j",
+    ({ messageAt, turnAt, state, pending }) => {
+      const requestId = MessageId.make("legacy-compact");
+      const operation = getThreadPendingOperation({
+        ...baseThread,
+        messages: [
+          {
+            id: requestId,
+            role: "user",
+            text: "/compact",
+            createdAt: messageAt,
+            updatedAt: messageAt,
+            turnId: null,
+            streaming: false,
+          },
+        ],
+        latestTurn: {
+          turnId: TurnId.make("prior-turn"),
+          state,
+          requestedAt: turnAt,
+          startedAt: turnAt,
+          completedAt: state === "completed" ? turnAt : null,
+          assistantMessageId: null,
+        },
+        session: {
+          threadId: baseThread.id,
+          status: "starting",
+          providerName: "codex",
+          runtimeMode: "full-access",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: turnAt,
+        },
+      });
+      expect(operation).toEqual(pending ? { kind: "compact", requestId } : null);
+    },
+  );
+
   it.each([true, false])(
     "keeps request bindings when acceptance precedes start: %s",
     (beforeStart) => {

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -47,6 +47,115 @@ const baseThread: OrchestrationThread = {
 };
 
 describe("applyThreadDetailEvent", () => {
+  it.each([true, false])(
+    "keeps request bindings when acceptance precedes start: %s",
+    (beforeStart) => {
+      let thread: OrchestrationThread = { ...baseThread, pendingOperation: null };
+      const fields = {
+        ...baseEventFields,
+        sequence: 1,
+        occurredAt: baseThread.createdAt,
+        aggregateKind: "thread" as const,
+        aggregateId: baseThread.id,
+      };
+      let sequence = 0;
+      const apply = (event: OrchestrationEvent) => {
+        const result = applyThreadDetailEvent(thread, { ...event, sequence: ++sequence });
+        if (result.kind !== "updated") throw new Error("Expected a thread update");
+        thread = result.thread;
+      };
+      const start = (id: string) =>
+        apply({
+          ...fields,
+          type: "thread.turn-start-requested",
+          payload: {
+            threadId: thread.id,
+            messageId: MessageId.make(id),
+            operation: "turn",
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            createdAt: fields.occurredAt,
+          },
+        });
+      const accept = (id: string) =>
+        apply({
+          ...fields,
+          type: "thread.activity-appended",
+          payload: {
+            threadId: thread.id,
+            operationResult: { requestId: MessageId.make(id), outcome: "completed" },
+            activity: {
+              id: EventId.make(`accepted-${id}`),
+              kind: "provider.turn.start.accepted",
+              tone: "info",
+              summary: "Provider accepted the request",
+              turnId: TurnId.make("turn-a"),
+              createdAt: fields.occurredAt,
+              payload: {
+                requestId: id,
+                turnId: "turn-a",
+                requestedAt: fields.occurredAt,
+                timelineBypass: true,
+                sourceProposedPlan: { threadId: thread.id, planId: `plan-${id}` },
+              },
+            },
+          },
+        });
+      const session = (status: "running" | "interrupted") =>
+        apply({
+          ...fields,
+          type: "thread.session-set",
+          payload: {
+            threadId: thread.id,
+            operationResult: null,
+            session: {
+              threadId: thread.id,
+              status,
+              providerName: "codex",
+              runtimeMode: "full-access",
+              activeTurnId: status === "running" ? TurnId.make("turn-a") : null,
+              lastError: null,
+              updatedAt: fields.occurredAt,
+            },
+          },
+        });
+      start("a");
+      if (beforeStart) {
+        accept("a");
+        expect(thread.latestTurn).toBeNull();
+      }
+      session("running");
+      start("b");
+      session("interrupted");
+      if (!beforeStart) accept("a");
+      expect(thread.pendingOperation).toEqual({ kind: "turn", requestId: "b" });
+      expect(thread.latestTurn).toMatchObject({
+        requestId: "a",
+        state: "interrupted",
+        sourceProposedPlan: { planId: "plan-a" },
+      });
+      const completedAt = thread.latestTurn?.completedAt;
+      // A second request can steer the same provider turn without replacing its start metadata.
+      accept("b");
+      expect(thread.pendingOperation).toBeNull();
+      expect(thread.latestTurn).toMatchObject({
+        requestId: "a",
+        state: "interrupted",
+        completedAt,
+        sourceProposedPlan: { planId: "plan-a" },
+      });
+      session("running");
+      expect(thread.latestTurn?.sourceProposedPlan?.planId).toBe("plan-a");
+
+      thread = { ...baseThread, pendingOperation: null };
+      start("a");
+      start("b");
+      accept("b");
+      accept("a");
+      session("running");
+      expect(thread.latestTurn?.requestId).toBe("b");
+    },
+  );
   it("tracks compaction by request identity without message history or timestamps", () => {
     let thread: OrchestrationThread = { ...baseThread, pendingOperation: null };
     const fields = {
@@ -115,7 +224,7 @@ describe("applyThreadDetailEvent", () => {
         },
       },
     });
-    expect(thread.latestTurn?.requestId).toBe("first");
+    expect(thread.latestTurn?.requestId).toBeUndefined();
     expect(getThreadPendingOperation({ ...thread, messages: [], activities: [] })).toEqual(first);
     result(null);
     expect(thread.pendingOperation).toEqual(first);

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -146,6 +146,21 @@ describe("applyThreadDetailEvent", () => {
       });
       session("running");
       expect(thread.latestTurn?.sourceProposedPlan?.planId).toBe("plan-a");
+      apply({
+        ...fields,
+        type: "thread.message-sent",
+        payload: {
+          threadId: thread.id,
+          messageId: MessageId.make("assistant-reply"),
+          role: "assistant",
+          text: "Working",
+          turnId: TurnId.make("turn-a"),
+          streaming: true,
+          createdAt: fields.occurredAt,
+          updatedAt: fields.occurredAt,
+        },
+      });
+      expect(thread.latestTurn?.sourceProposedPlan?.planId).toBe("plan-a");
 
       thread = { ...baseThread, pendingOperation: null };
       start("a");
@@ -154,6 +169,56 @@ describe("applyThreadDetailEvent", () => {
       accept("a");
       session("running");
       expect(thread.latestTurn?.requestId).toBe("b");
+      expect(thread.pendingOperation).toBeNull();
+      thread = { ...baseThread, pendingOperation: null };
+      start("a");
+      start("b");
+      accept("a");
+      accept("b");
+      session("running");
+      expect(thread.latestTurn?.requestId).toBe("a");
+      expect(thread.pendingOperation).toBeNull();
+      // Named completions can recover a turn whose start event was lost.
+      thread = { ...baseThread, pendingOperation: null };
+      start("a");
+      accept("a");
+      if (beforeStart) {
+        apply({
+          ...fields,
+          type: "thread.message-sent",
+          payload: {
+            threadId: thread.id,
+            messageId: MessageId.make("recovered-reply"),
+            role: "assistant",
+            text: "Done",
+            turnId: TurnId.make("turn-a"),
+            streaming: false,
+            createdAt: fields.occurredAt,
+            updatedAt: fields.occurredAt,
+          },
+        });
+        expect(thread.latestTurn?.requestId).toBe("a");
+        expect(thread.latestTurn?.sourceProposedPlan?.planId).toBe("plan-a");
+      }
+      apply({
+        ...fields,
+        type: "thread.turn-diff-completed",
+        payload: {
+          threadId: thread.id,
+          turnId: TurnId.make("turn-a"),
+          checkpointRef: CheckpointRef.make("refs/t3/checkpoints/recovered"),
+          checkpointTurnCount: 1,
+          status: "ready",
+          files: [],
+          assistantMessageId: null,
+          completedAt: fields.occurredAt,
+        },
+      });
+      expect(thread.latestTurn).toMatchObject({
+        requestId: "a",
+        state: "completed",
+        sourceProposedPlan: { planId: "plan-a" },
+      });
     },
   );
   it("tracks compaction by request identity without message history or timestamps", () => {

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -16,6 +16,7 @@ import {
   isImportedAgentSessionMessageId,
   getThreadPendingOperation,
   pendingOperationAfterEvent,
+  acceptedRequestIdForEvent,
   bindAcceptedTurn,
   bindTurnFromActivities,
   turnStartAcceptance,
@@ -482,7 +483,12 @@ export function applyThreadDetailEvent(
         thread: {
           ...thread,
           session: event.payload.session,
-          pendingOperation: pendingOperationAfterEvent(getThreadPendingOperation(thread), event),
+          pendingOperation: pendingOperationAfterEvent(
+            getThreadPendingOperation(thread),
+            event,
+            undefined,
+            acceptedRequestIdForEvent(thread, event),
+          ),
           latestTurn,
           updatedAt: event.occurredAt,
         },
@@ -639,7 +645,12 @@ export function applyThreadDetailEvent(
         event.payload.activity.kind === "provider.turn.start.accepted"
           ? { ...event.payload.activity, sequence: event.sequence }
           : event.payload.activity;
-      const pendingOperation = pendingOperationAfterEvent(getThreadPendingOperation(thread), event);
+      const pendingOperation = pendingOperationAfterEvent(
+        getThreadPendingOperation(thread),
+        event,
+        undefined,
+        acceptedRequestIdForEvent(thread, event),
+      );
       const latestTurn = bindAcceptedTurn(thread.latestTurn, turnStartAcceptance(activity));
       // A resolvable context-window update supersedes earlier resolvable ones
       // for the same turn: consumers only read the latest value (walking the

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -16,7 +16,6 @@ import {
   isImportedAgentSessionMessageId,
   getThreadPendingOperation,
   pendingOperationAfterEvent,
-  acceptedRequestIdForEvent,
   bindAcceptedTurn,
   bindTurnFromActivities,
   turnStartAcceptance,
@@ -370,33 +369,41 @@ export function applyThreadDetailEvent(
         event.payload.role === "assistant" &&
           event.payload.turnId !== null &&
           (thread.latestTurn === null || thread.latestTurn.turnId === event.payload.turnId)
-          ? {
-              turnId: event.payload.turnId,
-              ...(thread.latestTurn?.turnId === event.payload.turnId
-                ? { requestId: thread.latestTurn.requestId }
-                : {}),
-              state: settlesTurn
-                ? thread.latestTurn?.state === "interrupted"
-                  ? "interrupted"
-                  : thread.latestTurn?.state === "error"
-                    ? "error"
-                    : "completed"
-                : "running",
-              requestedAt:
-                thread.latestTurn?.turnId === event.payload.turnId
-                  ? thread.latestTurn.requestedAt
-                  : event.payload.createdAt,
-              startedAt:
-                thread.latestTurn?.turnId === event.payload.turnId
-                  ? (thread.latestTurn.startedAt ?? event.payload.createdAt)
-                  : event.payload.createdAt,
-              completedAt: settlesTurn
-                ? event.payload.updatedAt
-                : thread.latestTurn?.turnId === event.payload.turnId
-                  ? (thread.latestTurn.completedAt ?? null)
-                  : null,
-              assistantMessageId: event.payload.messageId,
-            }
+          ? bindTurnFromActivities(
+              {
+                turnId: event.payload.turnId,
+                ...(thread.latestTurn?.turnId === event.payload.turnId
+                  ? {
+                      requestId: thread.latestTurn.requestId,
+                      ...(thread.latestTurn.sourceProposedPlan
+                        ? { sourceProposedPlan: thread.latestTurn.sourceProposedPlan }
+                        : {}),
+                    }
+                  : {}),
+                state: settlesTurn
+                  ? thread.latestTurn?.state === "interrupted"
+                    ? "interrupted"
+                    : thread.latestTurn?.state === "error"
+                      ? "error"
+                      : "completed"
+                  : "running",
+                requestedAt:
+                  thread.latestTurn?.turnId === event.payload.turnId
+                    ? thread.latestTurn.requestedAt
+                    : event.payload.createdAt,
+                startedAt:
+                  thread.latestTurn?.turnId === event.payload.turnId
+                    ? (thread.latestTurn.startedAt ?? event.payload.createdAt)
+                    : event.payload.createdAt,
+                completedAt: settlesTurn
+                  ? event.payload.updatedAt
+                  : thread.latestTurn?.turnId === event.payload.turnId
+                    ? (thread.latestTurn.completedAt ?? null)
+                    : null,
+                assistantMessageId: event.payload.messageId,
+              },
+              thread.activities,
+            )
           : thread.latestTurn,
       );
 
@@ -483,12 +490,7 @@ export function applyThreadDetailEvent(
         thread: {
           ...thread,
           session: event.payload.session,
-          pendingOperation: pendingOperationAfterEvent(
-            getThreadPendingOperation(thread),
-            event,
-            undefined,
-            acceptedRequestIdForEvent(thread, event),
-          ),
+          pendingOperation: pendingOperationAfterEvent(getThreadPendingOperation(thread), event),
           latestTurn,
           updatedAt: event.occurredAt,
         },
@@ -562,20 +564,28 @@ export function applyThreadDetailEvent(
       const latestTurn =
         !diffTurnStillRunning &&
         (thread.latestTurn === null || thread.latestTurn.turnId === event.payload.turnId)
-          ? {
-              turnId: event.payload.turnId,
-              ...(thread.latestTurn?.turnId === event.payload.turnId
-                ? { requestId: thread.latestTurn.requestId }
-                : {}),
-              state:
-                thread.latestTurn?.state === "interrupted"
-                  ? "interrupted"
-                  : checkpointStatusToTurnState(event.payload.status),
-              requestedAt: thread.latestTurn?.requestedAt ?? event.payload.completedAt,
-              startedAt: thread.latestTurn?.startedAt ?? event.payload.completedAt,
-              completedAt: event.payload.completedAt,
-              assistantMessageId: event.payload.assistantMessageId,
-            }
+          ? bindTurnFromActivities(
+              {
+                turnId: event.payload.turnId,
+                ...(thread.latestTurn?.turnId === event.payload.turnId
+                  ? {
+                      requestId: thread.latestTurn.requestId,
+                      ...(thread.latestTurn.sourceProposedPlan
+                        ? { sourceProposedPlan: thread.latestTurn.sourceProposedPlan }
+                        : {}),
+                    }
+                  : {}),
+                state:
+                  thread.latestTurn?.state === "interrupted"
+                    ? "interrupted"
+                    : checkpointStatusToTurnState(event.payload.status),
+                requestedAt: thread.latestTurn?.requestedAt ?? event.payload.completedAt,
+                startedAt: thread.latestTurn?.startedAt ?? event.payload.completedAt,
+                completedAt: event.payload.completedAt,
+                assistantMessageId: event.payload.assistantMessageId,
+              },
+              thread.activities,
+            )
           : thread.latestTurn;
 
       return {
@@ -645,12 +655,7 @@ export function applyThreadDetailEvent(
         event.payload.activity.kind === "provider.turn.start.accepted"
           ? { ...event.payload.activity, sequence: event.sequence }
           : event.payload.activity;
-      const pendingOperation = pendingOperationAfterEvent(
-        getThreadPendingOperation(thread),
-        event,
-        undefined,
-        acceptedRequestIdForEvent(thread, event),
-      );
+      const pendingOperation = pendingOperationAfterEvent(getThreadPendingOperation(thread), event);
       const latestTurn = bindAcceptedTurn(thread.latestTurn, turnStartAcceptance(activity));
       // A resolvable context-window update supersedes earlier resolvable ones
       // for the same turn: consumers only read the latest value (walking the

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -12,7 +12,11 @@ import type {
   OrchestrationThreadActivity,
   TurnId,
 } from "@t3tools/contracts";
-import { isImportedAgentSessionMessageId } from "@t3tools/contracts";
+import {
+  isImportedAgentSessionMessageId,
+  getThreadPendingOperation,
+  pendingOperationAfterEvent,
+} from "@t3tools/contracts";
 import { compareDateTimeStrings } from "@t3tools/shared/dateTime";
 
 export type ThreadDetailReducerResult =
@@ -98,6 +102,7 @@ export function applyThreadDetailEvent(
           branch: event.payload.branch,
           worktreePath: event.payload.worktreePath,
           latestTurn: null,
+          pendingOperation: null,
           createdAt: event.payload.createdAt,
           updatedAt: event.payload.updatedAt,
           archivedAt: null,
@@ -270,6 +275,13 @@ export function applyThreadDetailEvent(
         kind: "updated",
         thread: {
           ...thread,
+          pendingOperation: pendingOperationAfterEvent(
+            getThreadPendingOperation(thread),
+            event,
+            event.payload.operation === undefined
+              ? thread.messages.find((message) => message.id === event.payload.messageId)
+              : undefined,
+          ),
           ...(event.payload.modelSelection !== undefined
             ? { modelSelection: event.payload.modelSelection }
             : {}),
@@ -356,6 +368,9 @@ export function applyThreadDetailEvent(
           (thread.latestTurn === null || thread.latestTurn.turnId === event.payload.turnId)
           ? {
               turnId: event.payload.turnId,
+              ...(thread.latestTurn?.turnId === event.payload.turnId
+                ? { requestId: thread.latestTurn.requestId }
+                : {}),
               state: settlesTurn
                 ? thread.latestTurn?.state === "interrupted"
                   ? "interrupted"
@@ -414,6 +429,10 @@ export function applyThreadDetailEvent(
         event.payload.session.status === "running" && event.payload.session.activeTurnId !== null
           ? {
               turnId: event.payload.session.activeTurnId,
+              requestId:
+                thread.latestTurn?.turnId === event.payload.session.activeTurnId
+                  ? (thread.latestTurn.requestId ?? getThreadPendingOperation(thread)?.requestId)
+                  : getThreadPendingOperation(thread)?.requestId,
               state: "running",
               requestedAt:
                 thread.latestTurn?.turnId === event.payload.session.activeTurnId
@@ -448,6 +467,7 @@ export function applyThreadDetailEvent(
         thread: {
           ...thread,
           session: event.payload.session,
+          pendingOperation: pendingOperationAfterEvent(getThreadPendingOperation(thread), event),
           latestTurn,
           updatedAt: event.occurredAt,
         },
@@ -523,6 +543,9 @@ export function applyThreadDetailEvent(
         (thread.latestTurn === null || thread.latestTurn.turnId === event.payload.turnId)
           ? {
               turnId: event.payload.turnId,
+              ...(thread.latestTurn?.turnId === event.payload.turnId
+                ? { requestId: thread.latestTurn.requestId }
+                : {}),
               state:
                 thread.latestTurn?.state === "interrupted"
                   ? "interrupted"
@@ -572,6 +595,7 @@ export function applyThreadDetailEvent(
         kind: "updated",
         thread: {
           ...thread,
+          pendingOperation: null,
           checkpoints,
           messages,
           proposedPlans,
@@ -597,6 +621,7 @@ export function applyThreadDetailEvent(
     // ── Activities ──────────────────────────────────────────────────
     case "thread.activity-appended": {
       const activity = event.payload.activity;
+      const pendingOperation = pendingOperationAfterEvent(getThreadPendingOperation(thread), event);
       // A resolvable context-window update supersedes earlier resolvable ones
       // for the same turn: consumers only read the latest value (walking the
       // array backwards), and providers stream these updates continuously, so
@@ -627,6 +652,7 @@ export function applyThreadDetailEvent(
           thread: {
             ...thread,
             activities,
+            pendingOperation,
             updatedAt: event.occurredAt,
           },
         };
@@ -649,7 +675,7 @@ export function applyThreadDetailEvent(
 
       return {
         kind: "updated",
-        thread: { ...thread, activities, updatedAt: event.occurredAt },
+        thread: { ...thread, activities, pendingOperation, updatedAt: event.occurredAt },
       };
     }
 
@@ -715,6 +741,7 @@ function reuseLatestTurn(
     return next;
   }
   return previous.turnId === next.turnId &&
+    previous.requestId === next.requestId &&
     previous.state === next.state &&
     previous.requestedAt === next.requestedAt &&
     previous.startedAt === next.startedAt &&

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -16,6 +16,9 @@ import {
   isImportedAgentSessionMessageId,
   getThreadPendingOperation,
   pendingOperationAfterEvent,
+  bindAcceptedTurn,
+  bindTurnFromActivities,
+  turnStartAcceptance,
 } from "@t3tools/contracts";
 import { compareDateTimeStrings } from "@t3tools/shared/dateTime";
 
@@ -426,40 +429,52 @@ export function applyThreadDetailEvent(
       const settledTurnState = settledTurnStateForSessionStatus(event.payload.session.status);
       const latestTurn = reuseLatestTurn(
         thread.latestTurn,
-        event.payload.session.status === "running" && event.payload.session.activeTurnId !== null
-          ? {
-              turnId: event.payload.session.activeTurnId,
-              requestId:
-                thread.latestTurn?.turnId === event.payload.session.activeTurnId
-                  ? (thread.latestTurn.requestId ?? getThreadPendingOperation(thread)?.requestId)
-                  : getThreadPendingOperation(thread)?.requestId,
-              state: "running",
-              requestedAt:
-                thread.latestTurn?.turnId === event.payload.session.activeTurnId
-                  ? thread.latestTurn.requestedAt
-                  : event.payload.session.updatedAt,
-              startedAt:
-                thread.latestTurn?.turnId === event.payload.session.activeTurnId
-                  ? (thread.latestTurn.startedAt ?? event.payload.session.updatedAt)
-                  : event.payload.session.updatedAt,
-              completedAt: null,
-              assistantMessageId:
-                thread.latestTurn?.turnId === event.payload.session.activeTurnId
-                  ? thread.latestTurn.assistantMessageId
-                  : null,
-            }
-          : thread.latestTurn !== null &&
-              thread.latestTurn.state === "running" &&
-              settledTurnState !== null
+        bindTurnFromActivities(
+          event.payload.session.status === "running" && event.payload.session.activeTurnId !== null
             ? {
-                ...thread.latestTurn,
-                state: settledTurnState,
-                // A running turn's completedAt can only hold a mid-turn
-                // placeholder checkpoint timestamp — the session leaving
-                // "running" is the authoritative turn end.
-                completedAt: event.payload.session.updatedAt,
+                turnId: event.payload.session.activeTurnId,
+                requestId:
+                  thread.latestTurn?.turnId === event.payload.session.activeTurnId
+                    ? (thread.latestTurn.requestId ??
+                      (event.payload.operationResult === undefined
+                        ? getThreadPendingOperation(thread)?.requestId
+                        : undefined))
+                    : event.payload.operationResult === undefined
+                      ? getThreadPendingOperation(thread)?.requestId
+                      : undefined,
+                ...(thread.latestTurn?.turnId === event.payload.session.activeTurnId &&
+                thread.latestTurn.sourceProposedPlan
+                  ? { sourceProposedPlan: thread.latestTurn.sourceProposedPlan }
+                  : {}),
+                state: "running",
+                requestedAt:
+                  thread.latestTurn?.turnId === event.payload.session.activeTurnId
+                    ? thread.latestTurn.requestedAt
+                    : event.payload.session.updatedAt,
+                startedAt:
+                  thread.latestTurn?.turnId === event.payload.session.activeTurnId
+                    ? (thread.latestTurn.startedAt ?? event.payload.session.updatedAt)
+                    : event.payload.session.updatedAt,
+                completedAt: null,
+                assistantMessageId:
+                  thread.latestTurn?.turnId === event.payload.session.activeTurnId
+                    ? thread.latestTurn.assistantMessageId
+                    : null,
               }
-            : thread.latestTurn,
+            : thread.latestTurn !== null &&
+                thread.latestTurn.state === "running" &&
+                settledTurnState !== null
+              ? {
+                  ...thread.latestTurn,
+                  state: settledTurnState,
+                  // A running turn's completedAt can only hold a mid-turn
+                  // placeholder checkpoint timestamp — the session leaving
+                  // "running" is the authoritative turn end.
+                  completedAt: event.payload.session.updatedAt,
+                }
+              : thread.latestTurn,
+          thread.activities,
+        ),
       );
 
       return {
@@ -620,8 +635,12 @@ export function applyThreadDetailEvent(
 
     // ── Activities ──────────────────────────────────────────────────
     case "thread.activity-appended": {
-      const activity = event.payload.activity;
+      const activity =
+        event.payload.activity.kind === "provider.turn.start.accepted"
+          ? { ...event.payload.activity, sequence: event.sequence }
+          : event.payload.activity;
       const pendingOperation = pendingOperationAfterEvent(getThreadPendingOperation(thread), event);
+      const latestTurn = bindAcceptedTurn(thread.latestTurn, turnStartAcceptance(activity));
       // A resolvable context-window update supersedes earlier resolvable ones
       // for the same turn: consumers only read the latest value (walking the
       // array backwards), and providers stream these updates continuously, so
@@ -652,6 +671,7 @@ export function applyThreadDetailEvent(
           thread: {
             ...thread,
             activities,
+            latestTurn,
             pendingOperation,
             updatedAt: event.occurredAt,
           },
@@ -675,7 +695,13 @@ export function applyThreadDetailEvent(
 
       return {
         kind: "updated",
-        thread: { ...thread, activities, pendingOperation, updatedAt: event.occurredAt },
+        thread: {
+          ...thread,
+          activities,
+          latestTurn,
+          pendingOperation,
+          updatedAt: event.occurredAt,
+        },
       };
     }
 

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -1,29 +1,19 @@
 // @effect-diagnostics globalDate:off -- UI snooze presets use local calendar boundaries and Intl labels.
 import type { OrchestrationThreadShell } from "@t3tools/contracts";
 
-/**
- * A queued turn start lives for at most this long: session adoption takes
- * seconds, so a user message still unadopted after the grace window is a
- * failed start (or stale data — shells from older servers can carry user
- * messages with no latestTurn at all), not pending work. Without this bound
- * such threads would be permanently unsettleable.
- */
+/** Bounds the timestamp fallback for snapshots from older servers. */
 export const QUEUED_TURN_START_GRACE_MS = 2 * 60 * 1_000;
 const DAY_MS = 24 * 60 * 60 * 1_000;
 
-/**
- * A user message no turn has picked up yet: the turn.start command was
- * dispatched (message-sent + turn-start-requested) but no session has
- * adopted it, so `session` is still null and the pending work is invisible
- * to the session-status checks. Detectable as a user message strictly newer
- * than every timestamp on the latest turn — on adoption the new turn's
- * requestedAt equals the message time, clearing the condition — and only
- * within the adoption grace window.
- */
+/** Reads typed pending state, with bounded timestamp matching for older snapshots. */
 export function hasQueuedTurnStart(
-  shell: Pick<OrchestrationThreadShell, "latestUserMessageAt" | "latestTurn" | "session">,
+  shell: Pick<
+    OrchestrationThreadShell,
+    "pendingOperation" | "latestUserMessageAt" | "latestTurn" | "session"
+  >,
   options: { readonly now: string },
 ): boolean {
+  if (shell.pendingOperation !== undefined) return shell.pendingOperation !== null;
   if (shell.latestUserMessageAt == null) return false;
   // A failed session start clears the queued state: the failure is already
   // visible (status edge / error).

--- a/packages/client-runtime/src/state/threadSnoozed.test.ts
+++ b/packages/client-runtime/src/state/threadSnoozed.test.ts
@@ -1,5 +1,5 @@
 // @effect-diagnostics globalDate:off -- Tests exercise local calendar snooze boundaries.
-import { ThreadId } from "@t3tools/contracts";
+import { ThreadId, MessageId } from "@t3tools/contracts";
 import { TurnId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
@@ -214,6 +214,21 @@ describe("canSnooze", () => {
 });
 
 describe("hasQueuedTurnStart", () => {
+  it("uses typed pending results even when message timestamps have not changed", () => {
+    const shell = { latestUserMessageAt: NOW, latestTurn: null, session: null };
+    expect(hasQueuedTurnStart({ ...shell, pendingOperation: null }, { now: NOW })).toBe(false);
+    expect(
+      hasQueuedTurnStart(
+        {
+          ...shell,
+          latestUserMessageAt: null,
+          pendingOperation: { kind: "compact", requestId: MessageId.make("compact") },
+        },
+        { now: NOW },
+      ),
+    ).toBe(true);
+  });
+
   it("expires queued state after two minutes", () => {
     const thread = makeQueuedTurnShell({
       latestUserMessageAt: "2026-04-10T11:57:59.000Z",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -25,6 +25,7 @@ export * from "./vcs.ts";
 export * from "./sourceControl.ts";
 export * from "./pullRequest.ts";
 export * from "./orchestration.ts";
+export * from "./orchestrationOperations.ts";
 export * from "./t3ProjectFile.ts";
 export * from "./editor.ts";
 export * from "./project.ts";

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -249,6 +249,24 @@ it.effect("decodes thread.turn.start defaults for provider and runtime mode", ()
   }),
 );
 
+it.effect("does not accept a client operation override for turn input", () =>
+  Effect.gen(function* () {
+    for (const decode of [decodeClientOrchestrationCommand, decodeThreadTurnStartCommand]) {
+      const command = yield* decode({
+        type: "thread.turn.start",
+        commandId: "cmd-turn-operation-override",
+        threadId: "thread-1",
+        operation: "compact",
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        message: { messageId: "msg-1", role: "user", text: "hello", attachments: [] },
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+      assert.strictEqual("operation" in command, false);
+    }
+  }),
+);
+
 it.effect("accepts inline images, uploaded images, and uploaded files from clients", () =>
   Effect.gen(function* () {
     const command = yield* decodeClientOrchestrationCommand({

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -379,7 +379,7 @@ export const OrchestrationProposedPlan = Schema.Struct({
 });
 export type OrchestrationProposedPlan = typeof OrchestrationProposedPlan.Type;
 
-const SourceProposedPlanReference = Schema.Struct({
+export const SourceProposedPlanReference = Schema.Struct({
   threadId: ThreadId,
   planId: OrchestrationProposedPlanId,
 });
@@ -991,7 +991,6 @@ export const ThreadTurnStartCommand = Schema.Struct({
   type: Schema.Literal("thread.turn.start"),
   commandId: CommandId,
   threadId: ThreadId,
-  operation: Schema.optional(OrchestrationOperationKind),
   message: Schema.Struct({
     messageId: MessageId,
     role: Schema.Literal("user"),
@@ -1013,7 +1012,6 @@ const ClientThreadTurnStartCommand = Schema.Struct({
   type: Schema.Literal("thread.turn.start"),
   commandId: CommandId,
   threadId: ThreadId,
-  operation: Schema.optional(OrchestrationOperationKind),
   message: Schema.Struct({
     messageId: MessageId,
     role: Schema.Literal("user"),

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -473,6 +473,7 @@ export type OrchestrationLatestTurnState = typeof OrchestrationLatestTurnState.T
 
 export const OrchestrationLatestTurn = Schema.Struct({
   turnId: TurnId,
+  requestId: Schema.optional(MessageId),
   state: OrchestrationLatestTurnState,
   requestedAt: IsoDateTime,
   startedAt: Schema.NullOr(IsoDateTime),
@@ -481,6 +482,21 @@ export const OrchestrationLatestTurn = Schema.Struct({
   sourceProposedPlan: Schema.optional(SourceProposedPlanReference),
 });
 export type OrchestrationLatestTurn = typeof OrchestrationLatestTurn.Type;
+
+export const OrchestrationOperationKind = Schema.Literals(["turn", "compact"]);
+export type OrchestrationOperationKind = typeof OrchestrationOperationKind.Type;
+
+export const OrchestrationPendingOperation = Schema.Struct({
+  kind: OrchestrationOperationKind,
+  requestId: MessageId,
+});
+export type OrchestrationPendingOperation = typeof OrchestrationPendingOperation.Type;
+
+export const OrchestrationOperationResult = Schema.Struct({
+  requestId: MessageId,
+  outcome: Schema.Literals(["completed", "failed", "interrupted"]),
+});
+export type OrchestrationOperationResult = typeof OrchestrationOperationResult.Type;
 
 export const ThreadTitleRegeneration = Schema.Struct({
   requestId: CommandId,
@@ -509,6 +525,8 @@ export const OrchestrationThread = Schema.Struct({
   worktreePath: Schema.NullOr(TrimmedNonEmptyString),
   linkedPullRequest: Schema.optional(Schema.NullOr(ThreadLinkedPullRequest)),
   latestTurn: Schema.NullOr(OrchestrationLatestTurn),
+  // Missing means an older server has not projected operation state.
+  pendingOperation: Schema.optional(Schema.NullOr(OrchestrationPendingOperation)),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
   archivedAt: Schema.NullOr(IsoDateTime).pipe(Schema.withDecodingDefault(Effect.succeed(null))),
@@ -587,6 +605,7 @@ export const OrchestrationThreadShell = Schema.Struct({
   worktreePath: Schema.NullOr(TrimmedNonEmptyString),
   linkedPullRequest: Schema.optional(Schema.NullOr(ThreadLinkedPullRequest)),
   latestTurn: Schema.NullOr(OrchestrationLatestTurn),
+  pendingOperation: Schema.optional(Schema.NullOr(OrchestrationPendingOperation)),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
   archivedAt: Schema.NullOr(IsoDateTime).pipe(Schema.withDecodingDefault(Effect.succeed(null))),
@@ -972,6 +991,7 @@ export const ThreadTurnStartCommand = Schema.Struct({
   type: Schema.Literal("thread.turn.start"),
   commandId: CommandId,
   threadId: ThreadId,
+  operation: Schema.optional(OrchestrationOperationKind),
   message: Schema.Struct({
     messageId: MessageId,
     role: Schema.Literal("user"),
@@ -993,6 +1013,7 @@ const ClientThreadTurnStartCommand = Schema.Struct({
   type: Schema.Literal("thread.turn.start"),
   commandId: CommandId,
   threadId: ThreadId,
+  operation: Schema.optional(OrchestrationOperationKind),
   message: Schema.Struct({
     messageId: MessageId,
     role: Schema.Literal("user"),
@@ -1115,6 +1136,7 @@ const ThreadSessionSetCommand = Schema.Struct({
   commandId: CommandId,
   threadId: ThreadId,
   session: OrchestrationSession,
+  operationResult: Schema.optional(Schema.NullOr(OrchestrationOperationResult)),
   createdAt: IsoDateTime,
 });
 
@@ -1178,6 +1200,7 @@ const ThreadActivityAppendCommand = Schema.Struct({
   commandId: CommandId,
   threadId: ThreadId,
   activity: OrchestrationThreadActivity,
+  operationResult: Schema.optional(Schema.NullOr(OrchestrationOperationResult)),
   createdAt: IsoDateTime,
 });
 
@@ -1413,6 +1436,7 @@ export const ThreadMessageSentPayload = Schema.Struct({
 export const ThreadTurnStartRequestedPayload = Schema.Struct({
   threadId: ThreadId,
   messageId: MessageId,
+  operation: Schema.optional(OrchestrationOperationKind),
   modelSelection: Schema.optional(ModelSelection),
   titleSeed: Schema.optional(TrimmedNonEmptyString),
   runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_RUNTIME_MODE))),
@@ -1462,6 +1486,8 @@ export const ThreadSessionStopRequestedPayload = Schema.Struct({
 export const ThreadSessionSetPayload = Schema.Struct({
   threadId: ThreadId,
   session: OrchestrationSession,
+  // Null is an explicit non-result. Missing is reserved for old events.
+  operationResult: Schema.optional(Schema.NullOr(OrchestrationOperationResult)),
 });
 
 export const ThreadProposedPlanUpsertedPayload = Schema.Struct({
@@ -1483,6 +1509,7 @@ export const ThreadTurnDiffCompletedPayload = Schema.Struct({
 export const ThreadActivityAppendedPayload = Schema.Struct({
   threadId: ThreadId,
   activity: OrchestrationThreadActivity,
+  operationResult: Schema.optional(Schema.NullOr(OrchestrationOperationResult)),
 });
 
 /**

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1135,6 +1135,7 @@ const ThreadSessionSetCommand = Schema.Struct({
   threadId: ThreadId,
   session: OrchestrationSession,
   operationResult: Schema.optional(Schema.NullOr(OrchestrationOperationResult)),
+  expectedPendingRequestId: Schema.optional(MessageId),
   createdAt: IsoDateTime,
 });
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1176,6 +1176,7 @@ const ThreadProposedPlanUpsertCommand = Schema.Struct({
   commandId: CommandId,
   threadId: ThreadId,
   proposedPlan: OrchestrationProposedPlan,
+  onlyIfUnimplemented: Schema.optional(Schema.Literal(true)),
   createdAt: IsoDateTime,
 });
 

--- a/packages/contracts/src/orchestrationOperations.ts
+++ b/packages/contracts/src/orchestrationOperations.ts
@@ -169,12 +169,13 @@ export function getThreadPendingOperation(
     return null;
   }
   const message = thread.messages?.findLast(isContextCompactionMessage);
+  if (!message) return null;
+  const messageCreatedAt = Date.parse(message.createdAt);
+  const turnRequestedAt = Date.parse(thread.latestTurn?.requestedAt ?? message.createdAt);
   if (
-    !message ||
     !(
-      message.createdAt > (thread.latestTurn?.requestedAt ?? message.createdAt) ||
-      (thread.latestTurn?.state === "running" &&
-        message.createdAt === thread.latestTurn.requestedAt)
+      messageCreatedAt > turnRequestedAt ||
+      (thread.latestTurn?.state === "running" && messageCreatedAt === turnRequestedAt)
     )
   ) {
     return null;

--- a/packages/contracts/src/orchestrationOperations.ts
+++ b/packages/contracts/src/orchestrationOperations.ts
@@ -75,6 +75,30 @@ export function bindTurnFromActivities(
   return turn;
 }
 
+/** Identifies a request only after its accepted provider turn is visible. */
+export function acceptedRequestIdForEvent(
+  thread: Pick<OrchestrationThread, "latestTurn" | "activities">,
+  event: OrchestrationEvent,
+): MessageId | undefined {
+  if (event.type === "thread.activity-appended") {
+    const accepted = turnStartAcceptance(event.payload.activity);
+    return accepted && thread.latestTurn?.turnId === accepted.turnId
+      ? accepted.requestId
+      : undefined;
+  }
+  if (event.type !== "thread.session-set" || event.payload.session.status !== "running")
+    return undefined;
+  const turnId = event.payload.session.activeTurnId;
+  if (thread.latestTurn?.turnId === turnId && thread.latestTurn.requestId !== undefined)
+    return thread.latestTurn.requestId;
+  for (const activity of thread.activities) {
+    if (activity.turnId !== turnId) continue;
+    const accepted = turnStartAcceptance(activity);
+    if (accepted) return accepted.requestId;
+  }
+  return undefined;
+}
+
 function operationResultForEvent(
   pending: OrchestrationPendingOperation,
   event: OrchestrationEvent,
@@ -112,6 +136,7 @@ export function pendingOperationAfterEvent(
   pending: OrchestrationPendingOperation | null,
   event: OrchestrationEvent,
   legacyMessage?: CommandMessage,
+  acceptedRequestId?: MessageId,
 ): OrchestrationPendingOperation | null {
   switch (event.type) {
     case "thread.created":
@@ -133,6 +158,12 @@ export function pendingOperationAfterEvent(
       if (pending === null) return null;
       const result = operationResultForEvent(pending, event);
       if (result !== null) {
+        if (
+          event.type === "thread.activity-appended" &&
+          turnStartAcceptance(event.payload.activity) &&
+          acceptedRequestId !== result.requestId
+        )
+          return pending;
         return result.requestId === pending.requestId ? null : pending;
       }
       if (event.type === "thread.session-set") {
@@ -140,6 +171,7 @@ export function pendingOperationAfterEvent(
         // A stopped session ends all requests. Other modern lifecycle updates
         // can belong to an older turn and cannot identify the pending request.
         if (session.status === "stopped") return null;
+        if (session.status === "running" && acceptedRequestId === pending.requestId) return null;
         if (event.payload.operationResult !== undefined) return pending;
         if (
           session.status === "error" ||

--- a/packages/contracts/src/orchestrationOperations.ts
+++ b/packages/contracts/src/orchestrationOperations.ts
@@ -1,12 +1,15 @@
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 
-import { MessageId } from "./baseSchemas.ts";
+import { IsoDateTime, MessageId, TurnId } from "./baseSchemas.ts";
+import { SourceProposedPlanReference } from "./orchestration.ts";
 import type {
   OrchestrationEvent,
   OrchestrationOperationResult,
   OrchestrationPendingOperation,
   OrchestrationThread,
+  OrchestrationLatestTurn,
+  OrchestrationThreadActivity,
 } from "./orchestration.ts";
 
 type CommandMessage = {
@@ -25,6 +28,52 @@ export function isContextCompactionMessage(message: CommandMessage): boolean {
 }
 
 const decodeLegacyRequest = Schema.decodeUnknownOption(Schema.Struct({ requestId: MessageId }));
+
+export const OrchestrationTurnStartAcceptance = Schema.Struct({
+  requestId: MessageId,
+  turnId: TurnId,
+  requestedAt: IsoDateTime,
+  sourceProposedPlan: Schema.optional(SourceProposedPlanReference),
+});
+export type OrchestrationTurnStartAcceptance = typeof OrchestrationTurnStartAcceptance.Type;
+const decodeTurnStartAcceptance = Schema.decodeUnknownOption(OrchestrationTurnStartAcceptance);
+
+/** Reads the request binding returned by sendTurn, not a provider lifecycle guess. */
+export function turnStartAcceptance(activity: OrchestrationThreadActivity) {
+  return activity.kind === "provider.turn.start.accepted"
+    ? Option.getOrNull(decodeTurnStartAcceptance(activity.payload))
+    : null;
+}
+
+/** Keeps original turn metadata when steering reuses an already accepted turn. */
+export function bindAcceptedTurn(
+  turn: OrchestrationLatestTurn | null,
+  accepted: OrchestrationTurnStartAcceptance | null,
+): OrchestrationLatestTurn | null {
+  if (!turn || !accepted || turn.turnId !== accepted.turnId || turn.requestId !== undefined) {
+    return turn;
+  }
+  return {
+    ...turn,
+    requestId: accepted.requestId,
+    requestedAt: accepted.requestedAt,
+    ...(accepted.sourceProposedPlan ? { sourceProposedPlan: accepted.sourceProposedPlan } : {}),
+  };
+}
+
+/** Acceptance can precede turn.started, so replay retains it in the hidden activity. */
+export function bindTurnFromActivities(
+  turn: OrchestrationLatestTurn | null,
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): OrchestrationLatestTurn | null {
+  if (!turn || turn.requestId !== undefined) return turn;
+  for (const activity of activities) {
+    if (activity.turnId !== turn.turnId) continue;
+    const accepted = turnStartAcceptance(activity);
+    if (accepted) return bindAcceptedTurn(turn, accepted);
+  }
+  return turn;
+}
 
 function operationResultForEvent(
   pending: OrchestrationPendingOperation,
@@ -88,9 +137,12 @@ export function pendingOperationAfterEvent(
       }
       if (event.type === "thread.session-set") {
         const session = event.payload.session;
+        // A stopped session ends all requests. Other modern lifecycle updates
+        // can belong to an older turn and cannot identify the pending request.
+        if (session.status === "stopped") return null;
+        if (event.payload.operationResult !== undefined) return pending;
         if (
           session.status === "error" ||
-          session.status === "stopped" ||
           session.status === "interrupted" ||
           (pending.kind === "turn" && session.status === "running" && session.activeTurnId !== null)
         ) {

--- a/packages/contracts/src/orchestrationOperations.ts
+++ b/packages/contracts/src/orchestrationOperations.ts
@@ -75,30 +75,6 @@ export function bindTurnFromActivities(
   return turn;
 }
 
-/** Identifies a request only after its accepted provider turn is visible. */
-export function acceptedRequestIdForEvent(
-  thread: Pick<OrchestrationThread, "latestTurn" | "activities">,
-  event: OrchestrationEvent,
-): MessageId | undefined {
-  if (event.type === "thread.activity-appended") {
-    const accepted = turnStartAcceptance(event.payload.activity);
-    return accepted && thread.latestTurn?.turnId === accepted.turnId
-      ? accepted.requestId
-      : undefined;
-  }
-  if (event.type !== "thread.session-set" || event.payload.session.status !== "running")
-    return undefined;
-  const turnId = event.payload.session.activeTurnId;
-  if (thread.latestTurn?.turnId === turnId && thread.latestTurn.requestId !== undefined)
-    return thread.latestTurn.requestId;
-  for (const activity of thread.activities) {
-    if (activity.turnId !== turnId) continue;
-    const accepted = turnStartAcceptance(activity);
-    if (accepted) return accepted.requestId;
-  }
-  return undefined;
-}
-
 function operationResultForEvent(
   pending: OrchestrationPendingOperation,
   event: OrchestrationEvent,
@@ -136,7 +112,6 @@ export function pendingOperationAfterEvent(
   pending: OrchestrationPendingOperation | null,
   event: OrchestrationEvent,
   legacyMessage?: CommandMessage,
-  acceptedRequestId?: MessageId,
 ): OrchestrationPendingOperation | null {
   switch (event.type) {
     case "thread.created":
@@ -158,12 +133,6 @@ export function pendingOperationAfterEvent(
       if (pending === null) return null;
       const result = operationResultForEvent(pending, event);
       if (result !== null) {
-        if (
-          event.type === "thread.activity-appended" &&
-          turnStartAcceptance(event.payload.activity) &&
-          acceptedRequestId !== result.requestId
-        )
-          return pending;
         return result.requestId === pending.requestId ? null : pending;
       }
       if (event.type === "thread.session-set") {
@@ -171,7 +140,6 @@ export function pendingOperationAfterEvent(
         // A stopped session ends all requests. Other modern lifecycle updates
         // can belong to an older turn and cannot identify the pending request.
         if (session.status === "stopped") return null;
-        if (session.status === "running" && acceptedRequestId === pending.requestId) return null;
         if (event.payload.operationResult !== undefined) return pending;
         if (
           session.status === "error" ||

--- a/packages/contracts/src/orchestrationOperations.ts
+++ b/packages/contracts/src/orchestrationOperations.ts
@@ -1,0 +1,138 @@
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+
+import { MessageId } from "./baseSchemas.ts";
+import type {
+  OrchestrationEvent,
+  OrchestrationOperationResult,
+  OrchestrationPendingOperation,
+  OrchestrationThread,
+} from "./orchestration.ts";
+
+type CommandMessage = {
+  readonly role: string;
+  readonly text: string;
+  readonly attachments?: ReadonlyArray<unknown> | undefined;
+};
+
+/** Classifies slash-command input before it becomes a typed operation. */
+export function isContextCompactionMessage(message: CommandMessage): boolean {
+  return (
+    message.role === "user" &&
+    (message.attachments?.length ?? 0) === 0 &&
+    message.text.trim().toLowerCase() === "/compact"
+  );
+}
+
+const decodeLegacyRequest = Schema.decodeUnknownOption(Schema.Struct({ requestId: MessageId }));
+
+function operationResultForEvent(
+  pending: OrchestrationPendingOperation,
+  event: OrchestrationEvent,
+): OrchestrationOperationResult | null {
+  if (event.type !== "thread.session-set" && event.type !== "thread.activity-appended") {
+    return null;
+  }
+  if (event.payload.operationResult !== undefined) {
+    return event.payload.operationResult;
+  }
+
+  // Old event logs and older remote servers do not carry typed results.
+  // New producers emit null when an event does not resolve an operation.
+  if (event.type === "thread.session-set") {
+    return event.payload.session.status === "ready" &&
+      event.commandId?.startsWith("server:provider-session-set:") === true
+      ? { requestId: pending.requestId, outcome: "completed" }
+      : null;
+  }
+  const activity = event.payload.activity;
+  if (activity.kind !== "context-compaction" && activity.kind !== "provider.turn.start.failed") {
+    return null;
+  }
+  const request = decodeLegacyRequest(activity.payload);
+  return Option.isSome(request)
+    ? {
+        requestId: request.value.requestId,
+        outcome: activity.kind === "context-compaction" ? "completed" : "failed",
+      }
+    : null;
+}
+
+/** Projects the pending request independently of provider turn IDs. */
+export function pendingOperationAfterEvent(
+  pending: OrchestrationPendingOperation | null,
+  event: OrchestrationEvent,
+  legacyMessage?: CommandMessage,
+): OrchestrationPendingOperation | null {
+  switch (event.type) {
+    case "thread.created":
+    case "thread.reverted":
+      return null;
+    case "thread.turn-start-requested":
+      return pending?.kind === "compact"
+        ? pending
+        : {
+            kind:
+              event.payload.operation ??
+              (legacyMessage !== undefined && isContextCompactionMessage(legacyMessage)
+                ? "compact"
+                : "turn"),
+            requestId: event.payload.messageId,
+          };
+    case "thread.session-set":
+    case "thread.activity-appended": {
+      if (pending === null) return null;
+      const result = operationResultForEvent(pending, event);
+      if (result !== null) {
+        return result.requestId === pending.requestId ? null : pending;
+      }
+      if (event.type === "thread.session-set") {
+        const session = event.payload.session;
+        if (
+          session.status === "error" ||
+          session.status === "stopped" ||
+          session.status === "interrupted" ||
+          (pending.kind === "turn" && session.status === "running" && session.activeTurnId !== null)
+        ) {
+          return null;
+        }
+      }
+      return pending;
+    }
+    default:
+      return pending;
+  }
+}
+
+type OperationThread = Pick<OrchestrationThread, "pendingOperation" | "latestTurn" | "session"> &
+  Partial<Pick<OrchestrationThread, "messages" | "activities">>;
+
+/** Reads current operation state, with a fallback for snapshots from older servers. */
+export function getThreadPendingOperation(
+  thread: OperationThread | null | undefined,
+): OrchestrationPendingOperation | null {
+  if (!thread) return null;
+  if (thread.pendingOperation !== undefined) return thread.pendingOperation;
+  if (thread.session?.status !== "starting" && thread.session?.status !== "running") {
+    return null;
+  }
+  const message = thread.messages?.findLast(isContextCompactionMessage);
+  if (
+    !message ||
+    !(
+      message.createdAt > (thread.latestTurn?.requestedAt ?? message.createdAt) ||
+      (thread.latestTurn?.state === "running" &&
+        message.createdAt === thread.latestTurn.requestedAt)
+    )
+  ) {
+    return null;
+  }
+  const settled = thread.activities?.some((activity) => {
+    if (activity.kind !== "context-compaction" && activity.kind !== "provider.turn.start.failed") {
+      return false;
+    }
+    const request = decodeLegacyRequest(activity.payload);
+    return Option.isSome(request) && request.value.requestId === message.id;
+  });
+  return settled ? null : { kind: "compact", requestId: message.id };
+}


### PR DESCRIPTION
Clients and server projections infer compaction state from message text, timestamps, and command IDs. A late provider update can clear a newer request or restore a stopped session.

Track pending operations by kind and request ID. Derive the kind on the server. Bind normal requests to the send response, not an uncorrelated turn-start event. Keep accepted request metadata in one hidden activity per send so SQL snapshots, replay, and clients agree. Reject stale failure writes in the serialized decider. Preserve terminal state, source-plan ownership, and same-turn steering. Keep the legacy reader for older events and snapshots.

Depends on [#10297](https://github.com/pingdotgg/t3code/pull/10297), which includes the migration, request-closure, and targeted-query prerequisites. Merge that dependency chain first.

Verified on the final published commit with 729 tests across 17 files. The focused HTTP/WebSocket transfer test also passed after the dependency rebase. Server, web, mobile, and client-runtime typechecks passed. Scoped lint, format, and independent source review passed. The 15,500-byte total transfer cap is unchanged. The snapshot cap is 8,000 bytes to include ten retained send-acceptance records.

The final branch includes correlated results for checkpoint-delayed cancellation and a targeted source-plan lookup. A session error cannot change pending work unless it names that request. The follow-up passed 185 reactor, runtime ingestion, and projection tests, plus server typecheck and scoped lint. Real startup failures still clear pending state and allow retry. The lifecycle client code matches the fixed integration build used below. No live app or data was used. Current-head CI, correctness, Effect, and UI checks passed. The approval check requires human review because this changes behavior across layers. Primary cross-PR review remains.

## Client check

Both images use the fixed integration build `2c3db32243` with a client stream fixture on a disposable local server. No provider turn or compaction command was sent. The fixture blocked provider refresh. This checks client state and controls, not native provider compaction.

An old result leaves the current request pending with "Compacting…" visible and `/compact` unavailable. The matching result clears pending state and makes `/compact` available. A duplicate result after a stopped session leaves it stopped, with no compacting label.

![Current request remains pending after an older result](https://files.tslop.org/2026/09/lifecycle-client-pending-802d7f37.png)

![Matching result clears the current request](https://files.tslop.org/2026/09/lifecycle-client-complete-95af73d5.png)

Created with GPT-6 Astra in Codex. Recovery and verification continued in Codex.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tie compaction and turn pending state to request identifiers across orchestration layers
> - Replaces the set of compacting thread IDs in `ProviderCommandReactor` with a map that records operation results per request, so stale results from an older request cannot settle a newer pending operation
> - Adds `OrchestrationPendingOperation` and `OrchestrationOperationResult` contract types carrying an operation kind (normal turn vs compaction) and a request identifier; these flow through turn-start, activity-append, and session-set commands and payloads
> - Projection pipeline, snapshot queries, and client reducers now persist and replay pending-operation state by request ID, including legacy recovery that infers compaction from `/compact` message content for older records
> - `reconcileProviderSessions` now dispatches an interrupted activity for every orphaned pending operation on a non-live thread at startup, including threads without a provider session
> - Mobile and web clients use the persisted `pendingOperation` field for compaction and queued-turn detection instead of inferring from message timing and activity history
> - Risk: legacy turns written before the migration store SQL `null` for the operation kind; `mapPendingOperation` in [ProjectionSnapshotQuery.ts](https://github.com/pingdotgg/t3code/pull/10294/files#diff-7f517291c1a9a2bf839691915f2f1c92d2553a298bd2d6144574615878e82209) infers compaction from message content only for active unfinished records, and a newer typed pending request takes precedence. Session-error handling in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/10294/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) now ignores errors that do not name the current pending request ID, so unrelated session errors no longer clear pending state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1900f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->