### PR TITLE
fix(web): keep background shells visible until they exit

### DIFF
--- a/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
@@ -168,6 +168,28 @@ describe("projectActivityPayload", () => {
     expect(JSON.stringify(openCode.payload).length).toBeLessThan(200);
   });
 
+  it("keeps the Claude run_in_background launch flag", () => {
+    const projected = projectActivityPayload(
+      activity({
+        itemType: "command_execution",
+        toolCallId: "claude-call-bg",
+        data: {
+          toolName: "Bash",
+          input: { command: "sleep 600", run_in_background: true },
+          result: { type: "tool_result", content: "Command running in background with ID: b1" },
+        },
+      }),
+    );
+    expect(projected.payload).toMatchObject({
+      data: { command: "sleep 600", runInBackground: true },
+    });
+    expect(JSON.stringify(projected.payload)).not.toContain('"input"');
+    // Thread snapshots are projected twice before they reach a client.
+    expect(projectActivityPayload(projected).payload).toMatchObject({
+      data: { runInBackground: true },
+    });
+  });
+
   it("keeps full Claude Read image paths through repeated projection", () => {
     const imagePath = `/workspace/${"nested folder/".repeat(16)}reference image.webp`;
     const projected = projectActivityPayload(

--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -390,6 +390,13 @@ export function projectActivityPayload(
   if (command !== undefined) {
     projectedData.command = command;
   }
+  // Claude's Bash `run_in_background` launch flag. The raw input does not
+  // survive slimming, and the web client needs it to hold the tool row open
+  // until the launched shell's task rows settle. Re-read the projected key
+  // too: snapshots are projected again on the way out.
+  if (asRecord(data.input)?.run_in_background === true || data.runInBackground === true) {
+    projectedData.runInBackground = true;
+  }
   const imagePath = projectViewedImagePath(data);
   if (imagePath) {
     projectedData.imagePath = imagePath;

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1619,6 +1619,77 @@ describe("deriveMessagesTimelineRows", () => {
     expect(rows.at(-1)).toMatchObject({ kind: "thinking" });
   });
 
+  it("keeps the thinking indicator when an older turn's background shell is still running", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "work-entry-1",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:05Z",
+          entry: {
+            id: "work-1",
+            createdAt: "2026-01-01T00:00:05Z",
+            turnId: "turn-1" as never,
+            label: "Command run",
+            tone: "tool" as const,
+            command: "sleep 600",
+            itemType: "command_execution" as const,
+            toolCallId: "call-1",
+            sourceActivityKind: "tool.completed" as const,
+            toolLifecycleStatus: "inProgress" as const,
+            backgroundTaskRunning: true,
+          },
+        },
+        {
+          id: "assistant-final-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:20Z",
+          message: {
+            id: "assistant-final" as never,
+            role: "assistant",
+            text: "Watching in the background.",
+            turnId: "turn-1" as never,
+            createdAt: "2026-01-01T00:00:20Z",
+            updatedAt: "2026-01-01T00:00:22Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "user-followup-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:01:00Z",
+          message: {
+            id: "user-followup" as never,
+            role: "user",
+            text: "and now?",
+            turnId: null,
+            createdAt: "2026-01-01T00:01:00Z",
+            updatedAt: "2026-01-01T00:01:00Z",
+            streaming: false,
+          },
+        },
+      ],
+      latestTurn: {
+        turnId: "turn-1" as never,
+        state: "completed",
+        startedAt: "2026-01-01T00:00:00Z",
+        completedAt: "2026-01-01T00:00:22Z",
+      },
+      isWorking: true,
+      activeTurnStartedAt: "2026-01-01T00:01:00Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual([
+      "work-live",
+      "message",
+      "message",
+      "working",
+      "thinking",
+    ]);
+  });
+
   it("does not fold the active in-progress turn", () => {
     const rows = deriveMessagesTimelineRows({
       timelineEntries: [

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1181,6 +1181,83 @@ describe("deriveMessagesTimelineRows", () => {
     ).toBeDefined();
   });
 
+  it("keeps a running background shell live outside the fold of its settled turn", () => {
+    const timelineEntries = [
+      {
+        id: "user-entry",
+        kind: "message" as const,
+        createdAt: "2026-01-01T00:00:00Z",
+        message: {
+          id: "user-1" as never,
+          role: "user" as const,
+          text: "Watch CI",
+          turnId: null,
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+          streaming: false,
+        },
+      },
+      {
+        id: "work-entry-1",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:05Z",
+        entry: {
+          id: "work-1",
+          createdAt: "2026-01-01T00:00:05Z",
+          turnId: "turn-1" as never,
+          label: "Read file",
+          tone: "tool" as const,
+          toolLifecycleStatus: "completed" as const,
+        },
+      },
+      {
+        id: "work-entry-2",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:08Z",
+        entry: {
+          id: "work-2",
+          createdAt: "2026-01-01T00:00:08Z",
+          turnId: "turn-1" as never,
+          label: "Command run",
+          tone: "tool" as const,
+          command: "sleep 600",
+          itemType: "command_execution" as const,
+          toolCallId: "call-1",
+          sourceActivityKind: "tool.completed" as const,
+          toolLifecycleStatus: "inProgress" as const,
+          backgroundTaskRunning: true,
+        },
+      },
+      {
+        id: "assistant-final-entry",
+        kind: "message" as const,
+        createdAt: "2026-01-01T00:00:20Z",
+        message: {
+          id: "assistant-final" as never,
+          role: "assistant" as const,
+          text: "Watching in the background.",
+          turnId: "turn-1" as never,
+          createdAt: "2026-01-01T00:00:20Z",
+          updatedAt: "2026-01-01T00:00:22Z",
+          streaming: false,
+        },
+      },
+    ];
+
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries,
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual(["message", "turn-fold", "work-live", "message"]);
+    const liveRow = rows.find((row) => row.kind === "work-live");
+    expect(liveRow).toMatchObject({ active: true, entry: { id: "work-2" } });
+    expect(liveWorkEntryLabel(liveRow!.entry, undefined, liveRow!.active)).toBe("Running sleep");
+  });
+
   it("keeps a tool group after the terminal response visible when the turn is folded", () => {
     const turnId = TurnId.make("turn-1");
     const timelineEntries = [

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -629,10 +629,13 @@ function deriveTurnFolds(input: {
       if (!isCompaction && index > terminalEntryIndex && !isSingleTrailingActivity) {
         continue;
       }
-      // Agent-spawn CTA rows never fold: workflows outlive their launching
-      // turn (dynamic spawns, background execution), and folding the CTA
-      // when the turn settles makes a still-running fleet invisible.
-      if (entry.kind === "work" && entry.entry.agentSpawn !== undefined) {
+      // Agent-spawn CTA rows and running background shells never fold: both
+      // outlive their launching turn, and folding them when the turn settles
+      // makes a still-running fleet or shell invisible.
+      if (
+        entry.kind === "work" &&
+        (entry.entry.agentSpawn !== undefined || entry.entry.backgroundTaskRunning === true)
+      ) {
         continue;
       }
       hiddenEntryIds.add(entry.id);
@@ -826,11 +829,14 @@ export function deriveMessagesTimelineRows(input: {
     input.isWorking &&
     index >= activeTurnHeaderIndex &&
     (unsettledTurnId === null || timelineEntryTurnId(entry) === unsettledTurnId);
+  // A background shell keeps its live row after its turn settles, the same
+  // row an in-progress tool gets during the active turn.
   const workEntryIsInActiveRun = (entry: WorkLogEntry) =>
-    input.isWorking &&
-    unsettledTurnId !== null &&
-    entry.toolLifecycleStatus === "inProgress" &&
-    entry.turnId === unsettledTurnId;
+    entry.backgroundTaskRunning === true ||
+    (input.isWorking &&
+      unsettledTurnId !== null &&
+      entry.toolLifecycleStatus === "inProgress" &&
+      entry.turnId === unsettledTurnId);
   const activeToolEntries: Array<Extract<TimelineEntry, { kind: "work" }>> = [];
   for (let index = input.timelineEntries.length - 1; index >= activeTurnHeaderIndex; index -= 1) {
     const entry = input.timelineEntries[index]!;

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -829,14 +829,17 @@ export function deriveMessagesTimelineRows(input: {
     input.isWorking &&
     index >= activeTurnHeaderIndex &&
     (unsettledTurnId === null || timelineEntryTurnId(entry) === unsettledTurnId);
+  const workEntryIsInActiveTurnRun = (entry: WorkLogEntry) =>
+    input.isWorking &&
+    unsettledTurnId !== null &&
+    entry.toolLifecycleStatus === "inProgress" &&
+    entry.turnId === unsettledTurnId;
   // A background shell keeps its live row after its turn settles, the same
-  // row an in-progress tool gets during the active turn.
+  // row an in-progress tool gets during the active turn. Only the latter
+  // stands in for the thinking indicator: an older shell says nothing about
+  // whether the current turn is making progress.
   const workEntryIsInActiveRun = (entry: WorkLogEntry) =>
-    entry.backgroundTaskRunning === true ||
-    (input.isWorking &&
-      unsettledTurnId !== null &&
-      entry.toolLifecycleStatus === "inProgress" &&
-      entry.turnId === unsettledTurnId);
+    entry.backgroundTaskRunning === true || workEntryIsInActiveTurnRun(entry);
   const activeToolEntries: Array<Extract<TimelineEntry, { kind: "work" }>> = [];
   for (let index = input.timelineEntries.length - 1; index >= activeTurnHeaderIndex; index -= 1) {
     const entry = input.timelineEntries[index]!;
@@ -1019,7 +1022,7 @@ export function deriveMessagesTimelineRows(input: {
             expanded,
             active: true,
           });
-          hasActivityRow = true;
+          hasActivityRow ||= activeInProgressToolEntries.some(workEntryIsInActiveTurnRun);
           if (expanded) {
             nextRows.push(
               expandedWorkGroupRow(groupId, timelineEntry.createdAt, visibleGroupedEntries),

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -2727,6 +2727,123 @@ describe("deriveWorkLogEntries quiet-timeline guarantee", () => {
   });
 });
 
+describe("background shells", () => {
+  // Claude's Bash tool returns as soon as a shell is backgrounded, so the
+  // tool rows settle immediately while the task rows carry the real state.
+  const shellStarted = makeActivity({
+    id: "shell-start",
+    createdAt: "2026-02-23T00:00:01.000Z",
+    turnId: "turn-1",
+    kind: "task.started",
+    summary: "local_bash task started",
+    tone: "info",
+    payload: { taskId: "sh-1", taskType: "local_bash", toolUseId: "call-1", title: "Watch CI" },
+  });
+  const toolRows = (runInBackground: boolean) => [
+    makeActivity({
+      id: "shell-tool-progress",
+      createdAt: "2026-02-23T00:00:02.000Z",
+      turnId: "turn-1",
+      kind: "tool.updated",
+      summary: "Command run",
+      payload: {
+        itemType: "command_execution",
+        toolCallId: "call-1",
+        status: "inProgress",
+        data: { command: "sleep 600" },
+      },
+    }),
+    makeActivity({
+      id: "shell-tool-complete",
+      createdAt: "2026-02-23T00:00:03.000Z",
+      turnId: "turn-1",
+      kind: "tool.completed",
+      summary: "Command run",
+      payload: {
+        itemType: "command_execution",
+        toolCallId: "call-1",
+        status: "completed",
+        data: {
+          toolName: "Bash",
+          command: "sleep 600",
+          ...(runInBackground ? { runInBackground: true } : {}),
+        },
+      },
+    }),
+  ];
+  const shellCompleted = (status: string) =>
+    makeActivity({
+      id: "shell-complete",
+      createdAt: "2026-02-23T00:10:00.000Z",
+      kind: "task.completed",
+      summary: "Task completed",
+      tone: "info",
+      payload: {
+        taskId: "sh-1",
+        taskType: "local_bash",
+        toolUseId: "call-1",
+        status,
+        summary: `Background command "Watch CI" ${status}`,
+      },
+    });
+
+  it("keeps a run_in_background shell's tool row in progress until its task ends", () => {
+    const entries = deriveWorkLogEntries([shellStarted, ...toolRows(true)]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "shell-tool-complete",
+      command: "sleep 600",
+      toolLifecycleStatus: "inProgress",
+      backgroundTaskRunning: true,
+    });
+  });
+
+  it("settles the tool row from the task's terminal status, even after the turn ended", () => {
+    const entries = deriveWorkLogEntries([
+      shellStarted,
+      ...toolRows(true),
+      shellCompleted("failed"),
+    ]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ id: "shell-tool-complete", toolLifecycleStatus: "failed" });
+    expect(entries[0]?.backgroundTaskRunning).toBeUndefined();
+  });
+
+  it("holds a foreground shell moved to the background at its timeout", () => {
+    const backgrounded = makeActivity({
+      id: "shell-backgrounded",
+      createdAt: "2026-02-23T00:00:04.000Z",
+      turnId: "turn-1",
+      kind: "task.updated",
+      summary: "Task updated",
+      tone: "info",
+      payload: {
+        taskId: "sh-1",
+        taskType: "local_bash",
+        toolUseId: "call-1",
+        isBackgrounded: true,
+      },
+    });
+    const entries = deriveWorkLogEntries([shellStarted, ...toolRows(false), backgrounded]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      toolLifecycleStatus: "inProgress",
+      backgroundTaskRunning: true,
+    });
+  });
+
+  it("leaves foreground shells alone", () => {
+    const entries = deriveWorkLogEntries([
+      shellStarted,
+      ...toolRows(false),
+      shellCompleted("completed"),
+    ]);
+    expect(entries.map((entry) => entry.id)).toEqual(["shell-tool-complete", "shell-complete"]);
+    expect(entries[0]?.toolLifecycleStatus).toBe("completed");
+    expect(entries[0]?.backgroundTaskRunning).toBeUndefined();
+  });
+});
+
 describe("rerun workflows", () => {
   it("turn-less direct spawns do not collapse into one global batch", () => {
     // Rows that lost their turn id (defensive path) group per task, so two

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -2832,6 +2832,21 @@ describe("background shells", () => {
     });
   });
 
+  it("settles a killed shell from its terminal task.updated status", () => {
+    const killed = makeActivity({
+      id: "shell-killed",
+      createdAt: "2026-02-23T00:05:00.000Z",
+      kind: "task.updated",
+      summary: "Task updated",
+      tone: "info",
+      payload: { taskId: "sh-1", taskType: "local_bash", toolUseId: "call-1", status: "cancelled" },
+    });
+    const entries = deriveWorkLogEntries([shellStarted, ...toolRows(true), killed]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.toolLifecycleStatus).toBe("stopped");
+    expect(entries[0]?.backgroundTaskRunning).toBeUndefined();
+  });
+
   it("leaves foreground shells alone", () => {
     const entries = deriveWorkLogEntries([
       shellStarted,

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -73,6 +73,13 @@ export interface WorkLogEntry {
   /** Agent role (subagent_type) for labeled timeline rows. */
   agentRole?: string;
   /**
+   * The tool call launched a background shell (`run_in_background`, or moved
+   * to the background at its timeout) that is still running. The row stays in
+   * progress after the tool call returns and after its turn settles, until
+   * the task's terminal row arrives.
+   */
+  backgroundTaskRunning?: boolean;
+  /**
    * Present on agent-spawn CTA rows: one per workflow run or per-turn batch
    * of direct spawns. The row renders as a call-to-action ("Kicked off N
    * subagents") whose live status is derived from the agent panel model at
@@ -739,6 +746,94 @@ function isAgentTaskStartedActivity(activity: OrchestrationThreadActivity): bool
   return !isBackgroundTaskActivity(payload);
 }
 
+/**
+ * Status the launching tool row should show for each background shell, keyed
+ * by tool call id. Only shells that outlive their tool call count: a
+ * `run_in_background` launch (the server projects the flag as
+ * `data.runInBackground`) or a foreground command moved to the background at
+ * its timeout (task.updated `isBackgrounded`). Every
+ * Claude shell emits task rows, but foreground ones settle before the tool
+ * result arrives and are left alone. Order-independent: the terminal row wins
+ * whenever it is present, so a late or out-of-order delivery cannot reopen a
+ * finished shell.
+ */
+function deriveBackgroundShellStatusByToolCallId(
+  ordered: ReadonlyArray<OrchestrationThreadActivity>,
+): ReadonlyMap<string, WorkLogToolLifecycleStatus> {
+  const toolRowCallIds = new Set<string>();
+  const backgroundToolCallIds = new Set<string>();
+  const startedToolCallIds = new Set<string>();
+  const terminalStatusByToolCallId = new Map<string, WorkLogToolLifecycleStatus>();
+  for (const activity of ordered) {
+    const payload = asRecord(activity.payload);
+    if (!payload) continue;
+    switch (activity.kind) {
+      case "tool.updated":
+      case "tool.completed": {
+        const toolCallId = extractToolCallId(payload);
+        if (!toolCallId) break;
+        toolRowCallIds.add(toolCallId);
+        if (asRecord(payload.data)?.runInBackground === true) {
+          backgroundToolCallIds.add(toolCallId);
+        }
+        break;
+      }
+      case "task.started":
+      case "task.updated":
+      case "task.completed": {
+        if (!isBackgroundTaskActivity(payload)) break;
+        const toolCallId = asTrimmedString(payload.toolUseId);
+        if (!toolCallId) break;
+        if (activity.kind === "task.started") {
+          startedToolCallIds.add(toolCallId);
+        } else if (activity.kind === "task.updated") {
+          if (payload.isBackgrounded === true) backgroundToolCallIds.add(toolCallId);
+        } else {
+          terminalStatusByToolCallId.set(toolCallId, backgroundShellTerminalStatus(payload.status));
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  const statusByToolCallId = new Map<string, WorkLogToolLifecycleStatus>();
+  for (const toolCallId of backgroundToolCallIds) {
+    if (!toolRowCallIds.has(toolCallId)) continue;
+    const terminalStatus = terminalStatusByToolCallId.get(toolCallId);
+    if (terminalStatus !== undefined) {
+      statusByToolCallId.set(toolCallId, terminalStatus);
+    } else if (startedToolCallIds.has(toolCallId)) {
+      statusByToolCallId.set(toolCallId, "inProgress");
+    }
+  }
+  return statusByToolCallId;
+}
+
+/** task.completed `status` (RuntimeTaskStatus) → the tool row vocabulary. */
+function backgroundShellTerminalStatus(status: unknown): WorkLogToolLifecycleStatus {
+  switch (status) {
+    case "failed":
+      return "failed";
+    case "cancelled":
+    case "interrupted":
+    case "stopped":
+      return "stopped";
+    default:
+      return "completed";
+  }
+}
+
+/** True for a background shell's task.completed row that folds into its tool row. */
+function isFoldedBackgroundShellCompletion(
+  activity: OrchestrationThreadActivity,
+  statusByToolCallId: ReadonlyMap<string, WorkLogToolLifecycleStatus>,
+): boolean {
+  if (activity.kind !== "task.completed") return false;
+  const toolCallId = asTrimmedString(asRecord(activity.payload)?.toolUseId);
+  return toolCallId ? statusByToolCallId.has(toolCallId) : false;
+}
+
 function isAgentInternalActivity(activity: OrchestrationThreadActivity): boolean {
   const payload =
     activity.payload && typeof activity.payload === "object"
@@ -782,10 +877,14 @@ export function deriveWorkLogEntries(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): WorkLogEntry[] {
   const ordered = [...activities].toSorted(compareActivitiesByOrder);
+  const backgroundShellStatusByToolCallId = deriveBackgroundShellStatusByToolCallId(ordered);
   const entries: DerivedWorkLogEntry[] = [];
   for (const activity of ordered) {
     if (activity.tone !== "error" && isWorktreeSetupActivity(activity.kind)) continue;
     if (activity.kind === "tool.started") continue;
+    // A background shell's completion lands on its tool row instead of
+    // rendering as a separate "Background command ... completed" row.
+    if (isFoldedBackgroundShellCompletion(activity, backgroundShellStatusByToolCallId)) continue;
     // Agent task.started rows are CTA seeds: they carry the true spawn turn,
     // which is the batch key (completions of background subagents arrive
     // under later synthetic turns and must not start new batches). They
@@ -801,7 +900,22 @@ export function deriveWorkLogEntries(
     if (isAgentInternalActivity(activity)) continue;
     entries.push(toDerivedWorkLogEntry(activity));
   }
-  return collapseDerivedWorkLogEntries(entries);
+  const collapsed = collapseDerivedWorkLogEntries(entries);
+  if (backgroundShellStatusByToolCallId.size === 0) return collapsed;
+  // The Bash tool call returns as soon as the shell is backgrounded, so its
+  // own lifecycle says "completed" while the process still runs. The task
+  // rows carry the real state; apply it after collapse so it also covers a
+  // row merged from tool.updated + tool.completed.
+  return collapsed.map((entry) => {
+    const status =
+      entry.toolCallId === undefined
+        ? undefined
+        : backgroundShellStatusByToolCallId.get(entry.toolCallId);
+    if (status === undefined) return entry;
+    return status === "inProgress"
+      ? { ...entry, toolLifecycleStatus: status, backgroundTaskRunning: true }
+      : { ...entry, toolLifecycleStatus: status };
+  });
 }
 
 /** Adapters forward unknown wire-only SDK messages (background_tasks_changed,

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -786,10 +786,16 @@ function deriveBackgroundShellStatusByToolCallId(
         if (!toolCallId) break;
         if (activity.kind === "task.started") {
           startedToolCallIds.add(toolCallId);
-        } else if (activity.kind === "task.updated") {
-          if (payload.isBackgrounded === true) backgroundToolCallIds.add(toolCallId);
-        } else {
-          terminalStatusByToolCallId.set(toolCallId, backgroundShellTerminalStatus(payload.status));
+          break;
+        }
+        if (activity.kind === "task.updated" && payload.isBackgrounded === true) {
+          backgroundToolCallIds.add(toolCallId);
+        }
+        // A killed shell ends with a terminal task.updated and no
+        // task.completed, so status patches settle the row too.
+        const terminalStatus = backgroundShellTerminalStatus(payload.status);
+        if (activity.kind === "task.completed" || terminalStatus !== undefined) {
+          terminalStatusByToolCallId.set(toolCallId, terminalStatus ?? "completed");
         }
         break;
       }
@@ -810,9 +816,11 @@ function deriveBackgroundShellStatusByToolCallId(
   return statusByToolCallId;
 }
 
-/** task.completed `status` (RuntimeTaskStatus) → the tool row vocabulary. */
-function backgroundShellTerminalStatus(status: unknown): WorkLogToolLifecycleStatus {
+/** Terminal task `status` (RuntimeTaskStatus) → the tool row vocabulary; undefined while live. */
+function backgroundShellTerminalStatus(status: unknown): WorkLogToolLifecycleStatus | undefined {
   switch (status) {
+    case "completed":
+      return "completed";
     case "failed":
       return "failed";
     case "cancelled":
@@ -820,7 +828,7 @@ function backgroundShellTerminalStatus(status: unknown): WorkLogToolLifecycleSta
     case "stopped":
       return "stopped";
     default:
-      return "completed";
+      return undefined;
   }
 }
 


### PR DESCRIPTION
A Claude shell started with `run_in_background: true` vanished from the UI while it ran. The Bash tool call returns in about 20 ms, so its row settled at once, the shell's task rows were filtered out of the work log, and nothing on screen showed a process that could live for an hour. Reproduced on nightly 0.0.39-nightly.20260906.1292 with Claude Code 2.1.263; the drop lives in the web client, so it is the same on every OS.

Now the shell's task rows fold into the tool row that launched it. The row stays in progress until the terminal task row arrives, keeps that state after its turn settles, stays out of the "Worked for" fold, and then shows the task's final status. Foreground shells are untouched: they emit the same task rows but settle before the tool result. A command Claude moves to the background at its timeout gets the same treatment through the `isBackgrounded` patch.

The server strips tool input before rows reach clients, so the payload projection now keeps Claude's `run_in_background` flag as `data.runInBackground`. Web only. The mobile work log drops the same rows and can take the same fold in a follow-up.

Closes #9107

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/ishaanko/t3code/3d440c090026725f9a5fb99c1faf5643bbcf564c/before.png) | ![after](https://raw.githubusercontent.com/ishaanko/t3code/3d440c090026725f9a5fb99c1faf5643bbcf564c/after.png) |

A background `sleep` after its turn settled. The row expands to the rest of the group as before.

Written by Claude Fable 5.1 in Claude Code, driven from T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep background shells visible in chat timeline until they exit
> - [ActivityPayloadProjection.ts](https://github.com/pingdotgg/t3code/pull/10295/files#diff-debcaf6e868575f9d95bb6918b9983c3a8929d664039039b54e9e1c7ea3b4130) projection now retains the `runInBackground` marker across repeated passes without exposing the raw `input`.
> - [session-logic.ts](https://github.com/pingdotgg/t3code/pull/10295/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) keeps the launching tool row in progress for background shells and folds terminal task statuses into that row.
> - [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/10295/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe) renders running background shells as live rows outside settled turn folds, while only current-turn tools drive the thinking indicator.
> - Behavioral Change: `task.completed` rows for background shells are skipped as standalone work-log entries, and only current-turn in-progress tools mark the timeline row as active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd82875.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->