### PR TITLE
feat(usage): pool subscription limits per provider across accounts and environments

### DIFF
--- a/apps/server/src/usage/cliproxyUsageLimits.test.ts
+++ b/apps/server/src/usage/cliproxyUsageLimits.test.ts
@@ -102,6 +102,22 @@ describe("cliproxyStatusToAccounts", () => {
       },
     ]);
   });
+
+  it("names a Codex five-hour window `primary`, as the Codex driver does", () => {
+    const accounts = cliproxyStatusToAccounts(
+      {
+        accounts: {
+          "codex-abc-someone@example.com-pro.json": {
+            provider: "codex",
+            plan: "pro",
+            five_hour: { hard_limited: false, known: true, used_percent: 40 },
+          },
+        },
+      },
+      checkedAt,
+    );
+    expect(accounts[0]?.usageLimits.windows.map((window) => window.id)).toEqual(["primary"]);
+  });
 });
 
 describe("accountEmailFromAuthFile", () => {

--- a/apps/server/src/usage/cliproxyUsageLimits.ts
+++ b/apps/server/src/usage/cliproxyUsageLimits.ts
@@ -124,7 +124,9 @@ export function cliproxyAccountToUsageLimits(
     if (!window || window.known === false) continue;
     const resetsAt = isoFromHub(window.reset_at);
     windows.push({
-      id: spec.id,
+      // Codex names its five-hour window by position, so a hub row and a
+      // native row for the same account pool together.
+      id: spec.key === "five_hour" && account.provider === "codex" ? "primary" : spec.id,
       kind: spec.kind,
       label: spec.label,
       windowDurationMins: spec.windowDurationMins,

--- a/apps/web/src/components/usage/UsageLimits.tsx
+++ b/apps/web/src/components/usage/UsageLimits.tsx
@@ -5,21 +5,16 @@ import {
   ServerProvider,
   ServerProviderResetCredits,
   ServerProviderUsageWindow,
-  UsageLimitSourceAccount,
-  UsageLimitSourceSnapshot,
   UsageProviderKind,
 } from "@t3tools/contracts";
 import { useAtomValue } from "@effect/atom-react";
 import {
-  collectLimitSources,
-  collectLimitsGroups,
+  collectLimitAccounts,
   elapsedShare,
   formatDuration,
   formatResetsIn,
-  limitsNotice,
   type LimitPace,
   paceOf,
-  providerLimitsLabel,
   remainingPercent,
 } from "@t3tools/shared/usageLimits";
 import { GaugeIcon, TrendingDownIcon, TrendingUpIcon } from "lucide-react";
@@ -30,9 +25,6 @@ import { environmentPresentations } from "../../state/presentation";
 import { serverEnvironment } from "../../state/server";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { formatUpcomingTimestamp } from "../../timestampFormat";
-import { ProviderInstanceIcon } from "../chat/ProviderInstanceIcon";
-import { getDriverOption } from "../settings/providerDriverMeta";
-import { RedactedSensitiveText } from "../settings/RedactedSensitiveText";
 import {
   AlertDialog,
   AlertDialogClose,
@@ -44,6 +36,8 @@ import {
 } from "../ui/alert-dialog";
 import { Button } from "../ui/button";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import type { makeLimitsFixture } from "./usageLimitsFixture";
+import { UsageLimitsPooled } from "./UsageLimitsPooled";
 import { PROVIDER_PRESENTATION } from "./usageProviders";
 
 const PACE: Record<LimitPace, { readonly label: string; readonly icon: typeof GaugeIcon }> = {
@@ -53,14 +47,14 @@ const PACE: Record<LimitPace, { readonly label: string; readonly icon: typeof Ga
 };
 
 /** The series colour the cost chart uses for this driver, so the two views read as one. */
-function barColor(driver: ServerProvider["driver"]): string {
+export function barColor(driver: ServerProvider["driver"]): string {
   const kind: UsageProviderKind | undefined =
     driver === "codex" ? "codex" : driver === "claudeAgent" ? "claude" : undefined;
   return kind ? PROVIDER_PRESENTATION[kind].color : "var(--foreground)";
 }
 
 /** Pace as a glyph with the words on hover. */
-function PaceIcon({ pace }: { readonly pace: LimitPace }) {
+export function PaceIcon({ pace }: { readonly pace: LimitPace }) {
   const Icon = PACE[pace].icon;
   return (
     <Tooltip>
@@ -202,94 +196,6 @@ export function LimitWindows({
   );
 }
 
-/**
- * Heading shared by local providers and source accounts: icon, driver, instance, plan,
- * and the signed-in email blurred until clicked, as provider settings do.
- */
-function AccountHeading({
-  driver,
-  label,
-  instanceLabel,
-  plan,
-  email,
-  accentColor,
-}: {
-  readonly driver: ServerProvider["driver"];
-  readonly label: string;
-  readonly instanceLabel: string;
-  readonly plan: string | undefined;
-  readonly email: string | undefined;
-  readonly accentColor?: string | undefined;
-}) {
-  return (
-    <h2 className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-sm font-medium text-foreground">
-      <ProviderInstanceIcon
-        driverKind={driver}
-        displayName={instanceLabel}
-        accentColor={accentColor}
-        showBadge={Boolean(accentColor)}
-        indicatorBackground="var(--background)"
-        className="size-5"
-        iconClassName="size-4 text-foreground/80"
-      />
-      <span className="truncate">{label}</span>
-      {instanceLabel !== label ? (
-        <span className="min-w-0 truncate text-xs font-normal text-muted-foreground">
-          · {instanceLabel}
-        </span>
-      ) : null}
-      {plan ? <span className="font-normal text-muted-foreground">· {plan}</span> : null}
-      {email ? (
-        <RedactedSensitiveText
-          value={email}
-          ariaLabel="Toggle account email visibility"
-          revealTooltip="Click to reveal email"
-          hideTooltip="Click to hide email"
-        />
-      ) : null}
-    </h2>
-  );
-}
-
-function ProviderLimits({
-  provider,
-  environmentId,
-  now,
-}: {
-  readonly provider: ServerProvider;
-  readonly environmentId: EnvironmentId;
-  readonly now: number;
-}) {
-  const limits = provider.usageLimits;
-  if (!limits) return null;
-  const notice = limitsNotice(limits);
-  return (
-    <section className="flex flex-col gap-3">
-      <AccountHeading
-        driver={provider.driver}
-        label={getDriverOption(provider.driver)?.label ?? String(provider.driver)}
-        instanceLabel={providerLimitsLabel(provider, (driver) => getDriverOption(driver)?.label)}
-        plan={provider.auth.label}
-        email={provider.auth.email}
-        accentColor={provider.accentColor}
-      />
-      {notice ? (
-        <span className="text-xs text-muted-foreground">{notice}</span>
-      ) : (
-        <LimitWindows driver={provider.driver} windows={limits.windows} now={now} />
-      )}
-      {limits.resetCredits ? (
-        <ResetCredits
-          environmentId={environmentId}
-          instanceId={provider.instanceId}
-          credits={limits.resetCredits}
-          now={now}
-        />
-      ) : null}
-    </section>
-  );
-}
-
 const OUTCOME_TEXT: Record<ProviderConsumeResetCreditOutcome, string> = {
   reset: "Reset applied. Your windows have cleared.",
   nothingToReset: "Nothing to reset right now.",
@@ -297,36 +203,12 @@ const OUTCOME_TEXT: Record<ProviderConsumeResetCreditOutcome, string> = {
   alreadyRedeemed: "That credit was already redeemed.",
 };
 
-/**
- * Banked reset credits with a confirmed redeem action. Redeeming spends a
- * credit the provider granted the user, so it never fires on a bare click.
- */
-export function ResetCredits({
-  environmentId,
-  instanceId,
-  credits,
-  now,
-}: {
-  readonly environmentId: EnvironmentId;
-  readonly instanceId: ProviderInstanceId;
-  readonly credits: ServerProviderResetCredits;
-  readonly now: number;
-}) {
+/** Everything a redeem needs: where to send it and what to say afterwards. */
+export function useResetCredit(environmentId: EnvironmentId, instanceId: ProviderInstanceId) {
   const consume = useAtomCommand(serverEnvironment.consumeResetCredit, { reportFailure: false });
   const [confirming, setConfirming] = useState(false);
   const [busy, setBusy] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
-  if (credits.availableCount === 0 && status === null) return null;
-
-  const expiresIn = credits.nextExpiresAt
-    ? formatDuration(Date.parse(credits.nextExpiresAt) - now)
-    : null;
-  const summary =
-    credits.availableCount === 0
-      ? "No reset credits banked"
-      : `${credits.availableCount} ${credits.availableCount === 1 ? "reset credit" : "reset credits"} banked${
-          expiresIn ? ` · next expires in ${expiresIn}` : ""
-        }`;
 
   const redeem = async () => {
     setConfirming(false);
@@ -345,138 +227,115 @@ export function ResetCredits({
     );
   };
 
+  return { confirming, setConfirming, busy, status, redeem };
+}
+
+/**
+ * The confirm for a redeem. Redeeming spends a credit the provider granted the
+ * user, so it never fires on a bare click. Mount it outside any popover that
+ * holds the button: dialogs stack under popovers, and closing the popover
+ * would unmount a dialog rendered inside it.
+ */
+export function ResetCreditDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+}: {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogPopup>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Use a reset credit?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This redeems one credit on your account and clears the current rate-limit windows. It
+            cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
+          <Button onClick={onConfirm}>Use credit</Button>
+        </AlertDialogFooter>
+      </AlertDialogPopup>
+    </AlertDialog>
+  );
+}
+
+/** `2 reset credits banked · next expires in 27d 23h`, or the short form for a popover. */
+export function resetCreditsSummary(
+  credits: ServerProviderResetCredits,
+  now: number,
+  compact = false,
+): string {
+  const expiresIn = credits.nextExpiresAt
+    ? formatDuration(Date.parse(credits.nextExpiresAt) - now)
+    : null;
+  if (credits.availableCount === 0) return "No reset credits banked";
+  if (compact)
+    return `${credits.availableCount} banked${expiresIn ? ` · expires in ${expiresIn}` : ""}`;
+  return `${credits.availableCount} ${credits.availableCount === 1 ? "reset credit" : "reset credits"} banked${
+    expiresIn ? ` · next expires in ${expiresIn}` : ""
+  }`;
+}
+
+/** Banked reset credits with the redeem button and its confirm, self-contained. */
+export function ResetCredits({
+  environmentId,
+  instanceId,
+  credits,
+  now,
+}: {
+  readonly environmentId: EnvironmentId;
+  readonly instanceId: ProviderInstanceId;
+  readonly credits: ServerProviderResetCredits;
+  readonly now: number;
+}) {
+  const { confirming, setConfirming, busy, status, redeem } = useResetCredit(
+    environmentId,
+    instanceId,
+  );
+  if (credits.availableCount === 0 && status === null) return null;
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-      <span className="tabular-nums">{summary}</span>
+      <span className="tabular-nums">{resetCreditsSummary(credits, now)}</span>
       {credits.availableCount > 0 ? (
         <Button size="xs" variant="outline" disabled={busy} onClick={() => setConfirming(true)}>
           {busy ? "Using…" : "Use reset"}
         </Button>
       ) : null}
       {status ? <span className="text-foreground">{status}</span> : null}
-      <AlertDialog open={confirming} onOpenChange={setConfirming}>
-        <AlertDialogPopup>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Use a reset credit?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This redeems one credit on your account and clears the current rate-limit windows. It
-              cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
-            <Button onClick={() => void redeem()}>Use credit</Button>
-          </AlertDialogFooter>
-        </AlertDialogPopup>
-      </AlertDialog>
-    </div>
-  );
-}
-
-/** One account pooled by a usage-limit source, drawn like a provider row. */
-function SourceAccountLimits({
-  account,
-  sourceKind,
-  now,
-}: {
-  readonly account: UsageLimitSourceAccount;
-  readonly sourceKind: string;
-  readonly now: number;
-}) {
-  const notice = limitsNotice(account.usageLimits);
-  return (
-    <section className="flex flex-col gap-3">
-      <AccountHeading
-        driver={account.driver}
-        label={getDriverOption(account.driver)?.label ?? String(account.driver)}
-        instanceLabel={sourceKind}
-        plan={account.plan}
-        email={account.email}
+      <ResetCreditDialog
+        open={confirming}
+        onOpenChange={setConfirming}
+        onConfirm={() => void redeem()}
       />
-      {notice ? (
-        <span className="text-xs text-muted-foreground">{notice}</span>
-      ) : (
-        <LimitWindows driver={account.driver} windows={account.usageLimits.windows} now={now} />
-      )}
-    </section>
-  );
-}
-
-const SOURCE_KIND_LABEL: Record<UsageLimitSourceSnapshot["kind"], string> = {
-  cliproxy: "CLI Proxy",
-};
-
-type LimitsSource = ReturnType<typeof collectLimitSources>[number];
-
-/** Read-only accounts pooled by a configured usage source. */
-function SourceLimits({ source, now }: { readonly source: LimitsSource; readonly now: number }) {
-  const kind = SOURCE_KIND_LABEL[source.kind];
-  return (
-    <div className="flex flex-col gap-6">
-      {source.error ? (
-        <span className="text-xs text-muted-foreground">{source.error}</span>
-      ) : source.accounts.length === 0 ? (
-        <span className="text-xs text-muted-foreground">
-          {source.hiddenAccountCount > 0
-            ? "All accounts are shown by connected providers."
-            : "No accounts reported."}
-        </span>
-      ) : (
-        source.accounts.map((account) => (
-          <SourceAccountLimits key={account.id} account={account} sourceKind={kind} now={now} />
-        ))
-      )}
     </div>
   );
 }
 
 /**
- * Subscription quota windows from every connected environment's providers.
- * Countdowns anchor to render time rather than ticking: a live clock would
- * repaint the page every minute for no decision-changing gain.
+ * Subscription quota across every connected environment's providers and hubs,
+ * pooled per provider. Countdowns anchor to render time rather than ticking: a
+ * live clock would repaint the page every minute for no decision-changing gain.
  */
 export function UsageLimitsSection({
   selectedEnvironmentIds,
+  fixture = null,
 }: {
   readonly selectedEnvironmentIds: ReadonlySet<EnvironmentId> | null;
+  /** Dev-only synthetic presentations standing in for the live ones. */
+  readonly fixture?: ReturnType<typeof makeLimitsFixture> | null;
 }) {
-  const presentations = useAtomValue(environmentPresentations.presentationsAtom);
+  const live = useAtomValue(environmentPresentations.presentationsAtom);
+  // Anchored once per mount on purpose: countdowns must not tick (see above).
+  const [now] = useState(() => Date.now());
+  const presentations: Parameters<typeof collectLimitAccounts>[0] = fixture ?? live;
   const selected =
     selectedEnvironmentIds === null
       ? presentations
       : new Map([...presentations].filter(([id]) => selectedEnvironmentIds.has(id)));
-  const groups = collectLimitsGroups(selected);
-  const sources = collectLimitSources(selected);
-  // Anchored once per mount on purpose: countdowns must not tick (see below).
-  const [now] = useState(() => Date.now());
-
-  return (
-    <div className="flex flex-col gap-8">
-      {groups.length === 0 && sources.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          No provider on the selected environments reports subscription limits.
-        </p>
-      ) : null}
-      {sources.map((source) => (
-        <SourceLimits key={source.key} source={source} now={now} />
-      ))}
-      {groups.map((group) => (
-        <div key={group.environmentId} className="flex flex-col gap-6">
-          {group.environmentLabel ? (
-            <h2 className="text-xs tracking-wide text-muted-foreground uppercase">
-              {group.environmentLabel}
-            </h2>
-          ) : null}
-          {group.providers.map((provider) => (
-            <ProviderLimits
-              key={provider.instanceId}
-              provider={provider}
-              environmentId={group.environmentId}
-              now={now}
-            />
-          ))}
-        </div>
-      ))}
-    </div>
-  );
+  return <UsageLimitsPooled presentations={selected} now={now} />;
 }

--- a/apps/web/src/components/usage/UsageLimitsPooled.tsx
+++ b/apps/web/src/components/usage/UsageLimitsPooled.tsx
@@ -92,7 +92,7 @@ function AccountAvatar({
  * is one, else a two-letter chip. The address itself is revealed on demand in
  * the segment's popover.
  */
-export function AccountName({
+function AccountName({
   account,
   className,
 }: {
@@ -480,7 +480,7 @@ export function UsageLimitsPooled({
 }
 
 /** Sources and providers that could not be read, so a missing bar is not mistaken for a full one. */
-export function LimitNotices({ notices }: { readonly notices: readonly string[] }) {
+function LimitNotices({ notices }: { readonly notices: readonly string[] }) {
   if (notices.length === 0) return null;
   return (
     <ul className="flex flex-col gap-1 text-xs text-muted-foreground">

--- a/apps/web/src/components/usage/UsageLimitsPooled.tsx
+++ b/apps/web/src/components/usage/UsageLimitsPooled.tsx
@@ -222,12 +222,15 @@ function PoolSegment({
   reset,
   color,
   now,
+  index,
 }: {
   readonly account: LimitAccount;
   readonly window: LimitPoolMember["window"];
   readonly reset: LimitPoolWindow["resets"][number] | undefined;
   readonly color: string;
   readonly now: number;
+  /** 1-based position in the bar, shown on the strip and its legend row to tie them together. */
+  readonly index: number;
 }) {
   const [open, setOpen] = useState(false);
   const remaining = remainingPercent(window);
@@ -240,8 +243,9 @@ function PoolSegment({
         render={
           <button
             type="button"
+            style={{ gridColumn: index, gridRow: 1 }}
             aria-label={`${account.displayName ?? (account.email ? accountInitials(account.email) : account.driver)}: ${remaining}% left${resetsIn ? `, ${resetsIn}` : ""}${credits ? `, ${credits} reset ${credits === 1 ? "credit" : "credits"} banked` : ""}`}
-            className="relative h-8 min-w-0 cursor-pointer overflow-hidden rounded-md bg-muted text-start outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[popup-open]:ring-1 data-[popup-open]:ring-border"
+            className="relative h-5 min-w-0 cursor-pointer overflow-hidden rounded-md bg-muted text-start outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[popup-open]:ring-1 data-[popup-open]:ring-border @2xl/pool:h-8"
           />
         }
       >
@@ -262,7 +266,13 @@ function PoolSegment({
             }}
           />
         ) : null}
-        <div className="relative flex h-full min-w-0 items-center gap-1.5 px-2 text-xs">
+        <span
+          aria-hidden
+          className="absolute inset-0 flex items-center justify-center text-[10px] leading-none font-semibold text-foreground/80 tabular-nums @2xl/pool:hidden"
+        >
+          {index}
+        </span>
+        <div className="relative hidden h-full min-w-0 items-center gap-1.5 px-2 text-xs @2xl/pool:flex">
           <AccountName account={account} className="min-w-0 truncate font-medium text-foreground" />
           <span className="shrink-0 font-semibold text-foreground tabular-nums">{remaining}%</span>
           {/* Countdown and badge get their own plate: fill and hatching run under them otherwise. */}
@@ -284,6 +294,7 @@ function PoolSegment({
           </span>
         </div>
       </PopoverTrigger>
+      <LegendRow account={account} window={window} color={color} now={now} index={index} />
       {account.redeem ? (
         <RedeemableSegmentPopup
           account={account}
@@ -306,6 +317,65 @@ function PoolSegment({
         </PopoverPopup>
       )}
     </Popover>
+  );
+}
+
+/**
+ * Below the strip at narrow widths: one row per account in bar order, carrying
+ * the text the segment has no room for. Tapping a row opens the same popover
+ * as its segment, so the two are one control with two handles.
+ */
+function LegendRow({
+  account,
+  window,
+  color,
+  now,
+  index,
+}: {
+  readonly account: LimitAccount;
+  readonly window: LimitPoolMember["window"];
+  readonly color: string;
+  readonly now: number;
+  readonly index: number;
+}) {
+  const remaining = remainingPercent(window);
+  const resetsIn = formatResetsIn(window, now);
+  const credits = account.redeem ? (account.limits.resetCredits?.availableCount ?? 0) : 0;
+  return (
+    <PopoverTrigger
+      style={{ gridColumn: "1 / -1", gridRow: index + 1 }}
+      className="flex min-h-7 min-w-0 cursor-pointer items-center gap-2 rounded-md px-1 py-0.5 text-start text-xs outline-none focus-visible:ring-2 focus-visible:ring-ring @2xl/pool:hidden"
+    >
+      <span className="relative inline-flex size-4 shrink-0 items-center justify-center rounded-sm text-[10px] leading-none font-semibold text-foreground/80 tabular-nums">
+        <span
+          aria-hidden
+          className="absolute inset-0 rounded-sm opacity-35"
+          style={{ backgroundColor: color }}
+        />
+        <span className="sr-only">Segment </span>
+        <span className="relative">{index}</span>
+      </span>
+      <AccountName account={account} className="min-w-0 truncate font-medium text-foreground" />
+      <span className="shrink-0 font-semibold text-foreground tabular-nums">{remaining}%</span>
+      <span className="ms-auto flex shrink-0 items-center gap-1.5 text-[11px] text-muted-foreground tabular-nums">
+        {resetsIn?.replace("resets in ", "↻ ") ?? ""}
+        {credits ? (
+          <>
+            {resetsIn ? <span aria-hidden>·</span> : null}
+            <span
+              aria-hidden
+              className="inline-flex items-center gap-0.5 font-semibold text-foreground"
+            >
+              <TicketIcon className="size-3" aria-hidden />
+              {credits}
+            </span>
+            <span className="sr-only">
+              {credits} reset {credits === 1 ? "credit" : "credits"} banked
+            </span>
+          </>
+        ) : null}
+      </span>
+    </PopoverTrigger>
   );
 }
 
@@ -360,6 +430,10 @@ function RedeemableSegmentPopup({
  * One pooled window as equal-width segments, one per account, each filled by
  * the share of that account's quota still open. Equal widths are honest: every
  * account contributes the same share of the pool, whatever its plan.
+ *
+ * Wide, each segment carries its own label. Narrow, the bar is a bare strip
+ * and a legend below lists the accounts in the same order; both open the
+ * same popover.
  */
 function PoolBar({
   pool,
@@ -372,20 +446,23 @@ function PoolBar({
 }) {
   const restores = new Map(pool.resets.map((reset) => [reset.member.account.key, reset]));
   return (
-    <div
-      className="grid gap-1"
-      style={{ gridTemplateColumns: `repeat(${pool.members.length}, minmax(0, 1fr))` }}
-    >
-      {pool.members.map(({ account, window }) => (
-        <PoolSegment
-          key={account.key}
-          account={account}
-          window={window}
-          reset={restores.get(account.key)}
-          color={color}
-          now={now}
-        />
-      ))}
+    <div className="@container/pool min-w-0">
+      <div
+        className="grid gap-x-1 gap-y-1"
+        style={{ gridTemplateColumns: `repeat(${pool.members.length}, minmax(0, 1fr))` }}
+      >
+        {pool.members.map(({ account, window }, position) => (
+          <PoolSegment
+            key={account.key}
+            account={account}
+            window={window}
+            reset={restores.get(account.key)}
+            color={color}
+            now={now}
+            index={position + 1}
+          />
+        ))}
+      </div>
     </div>
   );
 }
@@ -393,7 +470,7 @@ function PoolBar({
 /**
  * Big pooled number and the segment bar. The bar is sorted by reset, so who
  * refills next is its left edge; the exact time and share restored live in
- * each segment's tooltip rather than a list restating the bar.
+ * each segment's popover rather than a list restating the bar.
  */
 function PoolWindowCard({
   pool,

--- a/apps/web/src/components/usage/UsageLimitsPooled.tsx
+++ b/apps/web/src/components/usage/UsageLimitsPooled.tsx
@@ -49,7 +49,8 @@ function AccountChip({ email }: { readonly email: string }) {
   const hue = accountHue(email);
   return (
     <span
-      aria-hidden
+      role="img"
+      aria-label={`Account ${accountInitials(email)}`}
       className="inline-flex size-4 shrink-0 items-center justify-center rounded-full text-[9px] leading-none font-semibold"
       style={{ backgroundColor: `oklch(0.85 0.08 ${hue})`, color: `oklch(0.35 0.1 ${hue})` }}
     >

--- a/apps/web/src/components/usage/UsageLimitsPooled.tsx
+++ b/apps/web/src/components/usage/UsageLimitsPooled.tsx
@@ -1,0 +1,492 @@
+import {
+  collectLimitAccounts,
+  collectLimitNotices,
+  collectLimitPools,
+  formatDuration,
+  formatResetsIn,
+  type LimitAccount,
+  type LimitPool,
+  type LimitPoolMember,
+  type LimitPoolWindow,
+  remainingPercent,
+} from "@t3tools/shared/usageLimits";
+import { TicketIcon } from "lucide-react";
+import { type ReactNode, useState } from "react";
+
+import { usePrimarySettings } from "../../hooks/useSettings";
+import { cn } from "../../lib/utils";
+import { formatUpcomingTimestamp } from "../../timestampFormat";
+import { ProviderInstanceIcon } from "../chat/ProviderInstanceIcon";
+import { getDriverOption } from "../settings/providerDriverMeta";
+import { RedactedSensitiveText } from "../settings/RedactedSensitiveText";
+import { Button } from "../ui/button";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+import {
+  PaceIcon,
+  ResetCreditDialog,
+  barColor,
+  resetCreditsSummary,
+  useResetCredit,
+} from "./UsageLimits";
+
+/** `someone@example.com` → `SE`: enough to tell accounts apart, too little to identify one. */
+function accountInitials(email: string): string {
+  const [local = "", domain = ""] = email.split("@");
+  return `${local[0] ?? ""}${domain[0] ?? ""}`.toUpperCase() || "?";
+}
+
+/** A stable hue per email, so the same account gets the same chip on every visit. */
+function accountHue(email: string): number {
+  let hash = 0;
+  for (let index = 0; index < email.length; index += 1) {
+    hash = (hash * 31 + email.charCodeAt(index)) | 0;
+  }
+  return Math.abs(hash) % 360;
+}
+
+/** The two-letter chip for an email, coloured by a stable hue per address. */
+function AccountChip({ email }: { readonly email: string }) {
+  const hue = accountHue(email);
+  return (
+    <span
+      aria-hidden
+      className="inline-flex size-4 shrink-0 items-center justify-center rounded-full text-[9px] leading-none font-semibold"
+      style={{ backgroundColor: `oklch(0.85 0.08 ${hue})`, color: `oklch(0.35 0.1 ${hue})` }}
+    >
+      {accountInitials(email)}
+    </span>
+  );
+}
+
+/**
+ * The same mark the model picker uses for a native instance (provider glyph,
+ * initials badge, accent); hub accounts have no instance, so they get the chip.
+ */
+function AccountAvatar({
+  account,
+  className,
+}: {
+  readonly account: LimitAccount;
+  readonly className?: string;
+}) {
+  if (account.redeem) {
+    return (
+      <ProviderInstanceIcon
+        driverKind={account.driver}
+        displayName={
+          account.displayName ?? getDriverOption(account.driver)?.label ?? String(account.driver)
+        }
+        accentColor={account.accentColor}
+        showBadge={Boolean(account.displayName)}
+        indicatorBackground="var(--popover)"
+        className={cn("size-5", className)}
+        iconClassName="size-4 text-foreground/80"
+      />
+    );
+  }
+  return account.email ? <AccountChip email={account.email} /> : null;
+}
+
+/**
+ * Who an account is, without printing the email: the instance name when there
+ * is one, else a two-letter chip. The address itself is revealed on demand in
+ * the segment's popover.
+ */
+export function AccountName({
+  account,
+  className,
+}: {
+  readonly account: LimitAccount;
+  readonly className?: string;
+}) {
+  if (account.displayName) return <span className={className}>{account.displayName}</span>;
+  if (account.email) {
+    return (
+      <span className={cn("inline-flex min-w-0 items-center", className)}>
+        <AccountChip email={account.email} />
+      </span>
+    );
+  }
+  return (
+    <span className={className}>
+      {getDriverOption(account.driver)?.label ?? String(account.driver)}
+    </span>
+  );
+}
+
+function Row({ label, children }: { readonly label: string; readonly children: ReactNode }) {
+  return (
+    <div className="grid grid-cols-[4.5rem_minmax(0,1fr)] gap-x-3">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="min-w-0 text-foreground tabular-nums">{children}</span>
+    </div>
+  );
+}
+
+/**
+ * Everything about one account in one window: plan, where it is signed in,
+ * the email on request, reset time and share of the pool it restores, and the
+ * reset-credit action. Opens on hover for a glance, on click to act.
+ */
+function SegmentPopover({
+  account,
+  window,
+  reset,
+  now,
+  redeem,
+  onRedeem,
+}: {
+  readonly account: LimitAccount;
+  readonly window: LimitPoolMember["window"];
+  readonly reset: LimitPoolWindow["resets"][number] | undefined;
+  readonly now: number;
+  /** Redeem state owned by the segment, since the confirm lives outside this popover. */
+  readonly redeem: ReturnType<typeof useResetCredit> | null;
+  readonly onRedeem: () => void;
+}) {
+  const timestampFormat = usePrimarySettings((settings) => settings.timestampFormat);
+  const remaining = remainingPercent(window);
+  const resetsIn = formatResetsIn(window, now);
+  const where =
+    account.environments.length > 0
+      ? account.environments.map((environment) => environment.label).join(", ")
+      : account.sourceLabel;
+  const credits =
+    redeem && account.limits.resetCredits?.availableCount ? account.limits.resetCredits : null;
+  return (
+    <div className="flex w-72 flex-col gap-2.5 text-xs">
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="flex items-center gap-2 text-sm font-medium text-foreground">
+          <AccountAvatar account={account} />
+          <span className="truncate">
+            {account.displayName ?? getDriverOption(account.driver)?.label ?? account.driver}
+          </span>
+        </span>
+        {account.email ? (
+          <RedactedSensitiveText
+            value={account.email}
+            ariaLabel="Toggle account email visibility"
+            revealTooltip="Click to reveal email"
+            hideTooltip="Click to hide email"
+            className="w-fit"
+          />
+        ) : null}
+      </div>
+      <div className="flex flex-col gap-1 border-t border-border/60 pt-2.5">
+        {account.plan ? <Row label="Plan">{account.plan}</Row> : null}
+        {where ? (
+          <Row label={account.environments.length > 0 ? "Signed in" : "Via"}>{where}</Row>
+        ) : null}
+      </div>
+      <div className="flex flex-col gap-1 border-t border-border/60 pt-2.5">
+        <Row label="Left">{remaining}%</Row>
+        {window.resetsAt ? (
+          <Row label="Resets">
+            {formatUpcomingTimestamp(window.resetsAt, timestampFormat, now)}
+            {resetsIn ? ` · ${resetsIn.replace("resets in ", "in ")}` : ""}
+          </Row>
+        ) : null}
+        {reset && reset.restoresPercent > 0 ? (
+          <Row label="Restores">+{reset.restoresPercent}% of pool</Row>
+        ) : null}
+      </div>
+      {credits && redeem ? (
+        <div className="border-t border-border/60 pt-2.5 text-muted-foreground">
+          <span className="flex items-center gap-3">
+            <span className="tabular-nums">{resetCreditsSummary(credits, now, true)}</span>
+            <Button
+              size="xs"
+              variant="outline"
+              disabled={redeem.busy}
+              className="ms-auto"
+              onClick={onRedeem}
+            >
+              {redeem.busy ? "Using…" : "Use reset"}
+            </Button>
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * One account's share of one pooled window: the segment, its popover, and the
+ * reset confirm. The confirm is a sibling of the popover, not a child: dialogs
+ * stack under popovers, and the popover closes as the confirm opens.
+ */
+function PoolSegment({
+  account,
+  window,
+  reset,
+  color,
+  now,
+}: {
+  readonly account: LimitAccount;
+  readonly window: LimitPoolMember["window"];
+  readonly reset: LimitPoolWindow["resets"][number] | undefined;
+  readonly color: string;
+  readonly now: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const remaining = remainingPercent(window);
+  const resetsIn = formatResetsIn(window, now);
+  const credits = account.redeem ? (account.limits.resetCredits?.availableCount ?? 0) : 0;
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        openOnHover
+        render={
+          <button
+            type="button"
+            aria-label={`${account.displayName ?? (account.email ? accountInitials(account.email) : account.driver)}: ${remaining}% left${resetsIn ? `, ${resetsIn}` : ""}${credits ? `, ${credits} reset ${credits === 1 ? "credit" : "credits"} banked` : ""}`}
+            className="relative h-8 min-w-0 cursor-pointer overflow-hidden rounded-md bg-muted text-start outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[popup-open]:ring-1 data-[popup-open]:ring-border"
+          />
+        }
+      >
+        {/* Translucent so the label reads over the fill for any provider colour and theme. */}
+        <div
+          aria-hidden
+          className="absolute inset-y-0 left-0 rounded-md opacity-35"
+          style={{ width: `${remaining}%`, backgroundColor: color }}
+        />
+        {/* The spent share is hatched, not blank: it is what the countdown restores. */}
+        {remaining < 100 && reset ? (
+          <div
+            aria-hidden
+            className="absolute inset-y-0 right-0 opacity-20"
+            style={{
+              width: `${100 - remaining}%`,
+              backgroundImage: `repeating-linear-gradient(135deg, ${color} 0 1px, transparent 1px 5px)`,
+            }}
+          />
+        ) : null}
+        <div className="relative flex h-full min-w-0 items-center gap-1.5 px-2 text-xs">
+          <AccountName account={account} className="min-w-0 truncate font-medium text-foreground" />
+          <span className="shrink-0 font-semibold text-foreground tabular-nums">{remaining}%</span>
+          {/* Countdown and badge get their own plate: fill and hatching run under them otherwise. */}
+          <span className="ms-auto flex shrink-0 items-center gap-1.5 rounded-sm bg-background/85 px-1.5 py-0.5 text-[11px] text-foreground tabular-nums">
+            {resetsIn?.replace("resets in ", "↻ ") ?? ""}
+            {credits ? (
+              <>
+                {resetsIn ? (
+                  <span aria-hidden className="text-muted-foreground">
+                    ·
+                  </span>
+                ) : null}
+                <span aria-hidden className="inline-flex items-center gap-0.5 font-semibold">
+                  <TicketIcon className="size-3" aria-hidden />
+                  {credits}
+                </span>
+              </>
+            ) : null}
+          </span>
+        </div>
+      </PopoverTrigger>
+      {account.redeem ? (
+        <RedeemableSegmentPopup
+          account={account}
+          window={window}
+          reset={reset}
+          now={now}
+          redeemAt={account.redeem}
+          closePopover={() => setOpen(false)}
+        />
+      ) : (
+        <PopoverPopup side="top" sideOffset={6}>
+          <SegmentPopover
+            account={account}
+            window={window}
+            reset={reset}
+            now={now}
+            redeem={null}
+            onRedeem={() => {}}
+          />
+        </PopoverPopup>
+      )}
+    </Popover>
+  );
+}
+
+/** Split out so the redeem hook only runs for accounts that can redeem. */
+function RedeemableSegmentPopup({
+  account,
+  window,
+  reset,
+  now,
+  redeemAt,
+  closePopover,
+}: {
+  readonly account: LimitAccount;
+  readonly window: LimitPoolMember["window"];
+  readonly reset: LimitPoolWindow["resets"][number] | undefined;
+  readonly now: number;
+  readonly redeemAt: NonNullable<LimitAccount["redeem"]>;
+  readonly closePopover: () => void;
+}) {
+  const redeem = useResetCredit(redeemAt.environmentId, redeemAt.instanceId);
+  return (
+    <>
+      <PopoverPopup side="top" sideOffset={6}>
+        <SegmentPopover
+          account={account}
+          window={window}
+          reset={reset}
+          now={now}
+          redeem={redeem}
+          onRedeem={() => {
+            closePopover();
+            redeem.setConfirming(true);
+          }}
+        />
+      </PopoverPopup>
+      <ResetCreditDialog
+        open={redeem.confirming}
+        onOpenChange={redeem.setConfirming}
+        onConfirm={() => void redeem.redeem()}
+      />
+      {/* The popover closed before the confirm, so the outcome needs a home outside it. */}
+      {redeem.status ? (
+        <span role="status" className="col-span-full text-xs text-muted-foreground">
+          <AccountName account={account} className="font-medium text-foreground" /> {redeem.status}
+        </span>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * One pooled window as equal-width segments, one per account, each filled by
+ * the share of that account's quota still open. Equal widths are honest: every
+ * account contributes the same share of the pool, whatever its plan.
+ */
+function PoolBar({
+  pool,
+  color,
+  now,
+}: {
+  readonly pool: LimitPoolWindow;
+  readonly color: string;
+  readonly now: number;
+}) {
+  const restores = new Map(pool.resets.map((reset) => [reset.member.account.key, reset]));
+  return (
+    <div
+      className="grid gap-1"
+      style={{ gridTemplateColumns: `repeat(${pool.members.length}, minmax(0, 1fr))` }}
+    >
+      {pool.members.map(({ account, window }) => (
+        <PoolSegment
+          key={account.key}
+          account={account}
+          window={window}
+          reset={restores.get(account.key)}
+          color={color}
+          now={now}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Big pooled number and the segment bar. The bar is sorted by reset, so who
+ * refills next is its left edge; the exact time and share restored live in
+ * each segment's tooltip rather than a list restating the bar.
+ */
+function PoolWindowCard({
+  pool,
+  color,
+  now,
+}: {
+  readonly pool: LimitPoolWindow;
+  readonly color: string;
+  readonly now: number;
+}) {
+  // The soonest reset that hands anything back; an untouched account resets to no effect.
+  const nextRefill = pool.resets.find((reset) => reset.restoresPercent > 0);
+  return (
+    <div className="grid items-center gap-x-6 gap-y-3 rounded-lg border border-border/60 p-4 md:grid-cols-[11rem_minmax(0,1fr)]">
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-medium text-foreground">{pool.label}</span>
+        <span className="flex items-baseline gap-2">
+          <span className="text-3xl font-semibold text-foreground tabular-nums">
+            {pool.remainingPercent}%
+          </span>
+          <span className="text-sm text-muted-foreground">left</span>
+          {pool.pace ? <PaceIcon pace={pool.pace} /> : null}
+        </span>
+        {nextRefill ? (
+          <span className="text-xs text-muted-foreground tabular-nums">
+            <span className="font-medium text-foreground">↻ +{nextRefill.restoresPercent}%</span>{" "}
+            {nextRefill.at <= now ? "now" : `in ${formatDuration(nextRefill.at - now)}`}
+          </span>
+        ) : null}
+      </div>
+      <PoolBar pool={pool} color={color} now={now} />
+    </div>
+  );
+}
+
+function PoolSection({ pool, now }: { readonly pool: LimitPool; readonly now: number }) {
+  const color = barColor(pool.driver);
+  const label = getDriverOption(pool.driver)?.label ?? String(pool.driver);
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="flex items-center gap-2 text-sm font-medium text-foreground">
+        <ProviderInstanceIcon
+          driverKind={pool.driver}
+          displayName={label}
+          indicatorBackground="var(--background)"
+          className="size-5"
+          iconClassName="size-4 text-foreground/80"
+        />
+        {label}
+      </h2>
+      {pool.windows.map((window) => (
+        <PoolWindowCard key={`${window.kind}:${window.id}`} pool={window} color={color} now={now} />
+      ))}
+    </section>
+  );
+}
+
+/**
+ * Accounts pooled per provider: what is open across all of them, who resets
+ * next, and how much of the pool that hands back. Answers "can I keep going"
+ * before "on which account".
+ */
+export function UsageLimitsPooled({
+  presentations,
+  now,
+}: {
+  readonly presentations: Parameters<typeof collectLimitAccounts>[0];
+  readonly now: number;
+}) {
+  const pools = collectLimitPools(collectLimitAccounts(presentations), now);
+  const notices = collectLimitNotices(presentations);
+  return (
+    <div className="flex flex-col gap-8">
+      {pools.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No provider on the selected environments reports subscription limits.
+        </p>
+      ) : null}
+      {pools.map((pool) => (
+        <PoolSection key={pool.driver} pool={pool} now={now} />
+      ))}
+      <LimitNotices notices={notices} />
+    </div>
+  );
+}
+
+/** Sources and providers that could not be read, so a missing bar is not mistaken for a full one. */
+export function LimitNotices({ notices }: { readonly notices: readonly string[] }) {
+  if (notices.length === 0) return null;
+  return (
+    <ul className="flex flex-col gap-1 text-xs text-muted-foreground">
+      {notices.map((notice) => (
+        <li key={notice}>{notice}</li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/src/components/usage/UsageLimitsPooled.tsx
+++ b/apps/web/src/components/usage/UsageLimitsPooled.tsx
@@ -155,7 +155,7 @@ function SegmentPopover({
   const credits =
     redeem && account.limits.resetCredits?.availableCount ? account.limits.resetCredits : null;
   return (
-    <div className="flex w-72 flex-col gap-2.5 text-xs">
+    <div className="flex w-72 max-w-[calc(100vw-3rem)] flex-col gap-2.5 text-xs">
       <div className="flex min-w-0 flex-col gap-0.5">
         <span className="flex items-center gap-2 text-sm font-medium text-foreground">
           <AccountAvatar account={account} />

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -59,6 +59,7 @@ import {
 import { WorkspacePageContainer } from "../WorkspacePageContainer";
 import { WorkspacePageHeader } from "../WorkspacePageHeader";
 import { UsageLimitsSection } from "./UsageLimits";
+import { makeLimitsFixture } from "./usageLimitsFixture";
 import { UsagePriceOverrides } from "./UsagePriceOverrides";
 import { UsageProviderChart, type UsageChartMetric } from "./UsageProviderChart";
 import { PROVIDER_ORDER, PROVIDER_PRESENTATION, providersWithUsage } from "./usageProviders";
@@ -95,10 +96,33 @@ export function UsagePage() {
     useState<ReadonlySet<EnvironmentId> | null>(null);
   const { days: windowDays, window } = windowSelection;
   const isPast24Hours = windowDays === 1;
-  const { merged, environments, selectedEnvironments, isPending, isPartial, refresh } = useUsage(
-    window,
-    selectedEnvironmentIds,
-  );
+  const usage = useUsage(window, selectedEnvironmentIds);
+  // Dev only: `/usage?limitsFixture=<name>` lists synthetic environments in the
+  // picker and feeds the Limits view from them, so merge rules can be eyeballed.
+  const [fixture] = useState(() => {
+    if (!import.meta.env.DEV) return null;
+    const name = new URLSearchParams(globalThis.location.search).get("limitsFixture");
+    return name ? makeLimitsFixture(name, Date.now()) : null;
+  });
+  const { merged, environments, selectedEnvironments, isPending, isPartial, refresh } =
+    useMemo(() => {
+      if (!fixture || !showingLimits) return usage;
+      const all = [...fixture].map(([environmentId, presentation]) => ({
+        environmentId,
+        label: presentation.entry.target.label,
+        isPending: false,
+        error: null,
+        summary: null,
+      }));
+      return {
+        ...usage,
+        environments: all,
+        selectedEnvironments:
+          selectedEnvironmentIds === null
+            ? all
+            : all.filter((environment) => selectedEnvironmentIds.has(environment.environmentId)),
+      };
+    }, [fixture, selectedEnvironmentIds, showingLimits, usage]);
   const presentations = useAtomValue(environmentPresentations.presentationsAtom);
   const refreshProviders = useAtomCommand(serverEnvironment.refreshProviders, {
     reportFailure: false,
@@ -143,6 +167,8 @@ export function UsagePage() {
     if (refreshingRef.current) return;
 
     if (showingLimits) {
+      // Synthetic data has nothing to re-read.
+      if (fixture) return;
       refreshingRef.current = true;
       setIsRefreshing(true);
       void Promise.all(
@@ -326,7 +352,10 @@ export function UsagePage() {
                   : `Select an environment to see ${showingLimits ? "limits" : "usage"}.`}
               </p>
             ) : showingLimits ? (
-              <UsageLimitsSection selectedEnvironmentIds={selectedEnvironmentIds} />
+              <UsageLimitsSection
+                selectedEnvironmentIds={selectedEnvironmentIds}
+                fixture={fixture}
+              />
             ) : isPending ? (
               <UsageSkeleton />
             ) : (

--- a/apps/web/src/components/usage/usageLimitsFixture.ts
+++ b/apps/web/src/components/usage/usageLimitsFixture.ts
@@ -1,0 +1,413 @@
+/**
+ * Dev-only stand-ins for `environmentPresentations` that exercise the pooled
+ * Limits view's merge rules, one scenario per named fixture. Reached with
+ * `/usage?limitsFixture=<name>` on a dev build; never bundled otherwise.
+ */
+import {
+  EnvironmentId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  type ServerProvider,
+  type ServerProviderUsageWindow,
+  type UsageLimitSourceSnapshot,
+  UsageLimitSourceId,
+} from "@t3tools/contracts";
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+interface Presentation {
+  readonly entry: { readonly target: { readonly label: string } };
+  readonly serverConfig: {
+    readonly providers: readonly ServerProvider[];
+    readonly usageLimitSources: readonly UsageLimitSourceSnapshot[];
+  };
+}
+
+type Fixture = ReadonlyMap<EnvironmentId, Presentation>;
+
+const codex = ProviderDriverKind.make("codex");
+const claude = ProviderDriverKind.make("claudeAgent");
+
+function makeHelpers(now: number) {
+  const at = (ms: number) => new Date(now + ms).toISOString();
+  const checked = (agoMs: number) => new Date(now - agoMs).toISOString();
+
+  const session = (used: number, resetsInMs: number): ServerProviderUsageWindow => ({
+    id: "five_hour",
+    kind: "session",
+    label: "Session",
+    usedPercent: used,
+    windowDurationMins: 300,
+    resetsAt: at(resetsInMs),
+  });
+  const weekly = (
+    id: string,
+    label: string,
+    used: number,
+    resetsInMs: number,
+  ): ServerProviderUsageWindow => ({
+    id,
+    kind: "weekly",
+    label,
+    usedPercent: used,
+    windowDurationMins: 7 * 24 * 60,
+    resetsAt: at(resetsInMs),
+  });
+  /** Codex names its five-hour window `primary` and its weekly one `secondary`. */
+  const codexSession = (used: number, resetsInMs: number): ServerProviderUsageWindow => ({
+    ...session(used, resetsInMs),
+    id: "primary",
+  });
+  const codexWeekly = (used: number, resetsInMs: number) =>
+    weekly("secondary", "Weekly", used, resetsInMs);
+
+  const provider = (
+    overrides: Partial<ServerProvider> & Pick<ServerProvider, "instanceId" | "driver">,
+  ): ServerProvider => ({
+    enabled: true,
+    installed: true,
+    version: null,
+    status: "ready",
+    auth: { status: "authenticated" },
+    checkedAt: checked(0),
+    models: [],
+    slashCommands: [],
+    skills: [],
+    ...overrides,
+  });
+
+  const codexInstance = (input: {
+    readonly instanceId: string;
+    readonly displayName?: string;
+    readonly accentColor?: string;
+    readonly email: string;
+    readonly plan?: string;
+    readonly checkedAgoMs?: number;
+    readonly windows: readonly ServerProviderUsageWindow[];
+    readonly credits?: number;
+  }) =>
+    provider({
+      instanceId: ProviderInstanceId.make(input.instanceId),
+      driver: codex,
+      ...(input.displayName ? { displayName: input.displayName } : {}),
+      ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+      auth: {
+        status: "authenticated",
+        label: input.plan ?? "ChatGPT Pro 20x Subscription",
+        email: input.email,
+      },
+      usageLimits: {
+        checkedAt: checked(input.checkedAgoMs ?? MINUTE),
+        windows: input.windows,
+        ...(input.credits
+          ? { resetCredits: { availableCount: input.credits, nextExpiresAt: at(28 * DAY) } }
+          : {}),
+      },
+    });
+
+  const claudeHubAccount = (
+    email: string | null,
+    windows: readonly ServerProviderUsageWindow[],
+    checkedAgoMs = 4 * MINUTE,
+  ): UsageLimitSourceSnapshot["accounts"][number] => ({
+    id: email ? `claude-${email}.json` : "claude-team-seat.json",
+    driver: claude,
+    ...(email ? { email } : {}),
+    plan: "Claude Subscription",
+    usageLimits: { checkedAt: checked(checkedAgoMs), windows },
+  });
+
+  const hub = (
+    id: string,
+    label: string,
+    accounts: UsageLimitSourceSnapshot["accounts"],
+    error?: string,
+  ): UsageLimitSourceSnapshot => ({
+    id: UsageLimitSourceId.make(id),
+    kind: "cliproxy",
+    label,
+    checkedAt: checked(2 * MINUTE),
+    accounts,
+    ...(error ? { error } : {}),
+  });
+
+  const environment = (
+    id: string,
+    label: string,
+    providers: readonly ServerProvider[],
+    usageLimitSources: readonly UsageLimitSourceSnapshot[] = [],
+  ): readonly [EnvironmentId, Presentation] => [
+    EnvironmentId.make(id),
+    { entry: { target: { label } }, serverConfig: { providers, usageLimitSources } },
+  ];
+
+  return {
+    at,
+    checked,
+    session,
+    weekly,
+    codexSession,
+    codexWeekly,
+    provider,
+    codexInstance,
+    claudeHubAccount,
+    hub,
+    environment,
+  };
+}
+
+const FIXTURES: Record<string, (now: number) => Fixture> = {
+  /**
+   * The same Codex account signed in on two machines with different snapshot
+   * ages, plus a hub that also reports it. Must collapse to one segment with
+   * the freshest figures and both machines listed.
+   */
+  "same-account": (now) => {
+    const h = makeHelpers(now);
+    const email = "main@example.com";
+    const hubAccounts: UsageLimitSourceSnapshot["accounts"] = [
+      {
+        id: `codex-abc-${email}-pro.json`,
+        driver: codex,
+        email,
+        plan: "ChatGPT Pro 20x Subscription",
+        usageLimits: { checkedAt: h.checked(14 * MINUTE), windows: [h.codexWeekly(70, 5 * DAY)] },
+      },
+    ];
+    return new Map([
+      h.environment(
+        "env-macbook",
+        "MacBook Pro",
+        [
+          h.codexInstance({
+            instanceId: "codex",
+            displayName: "Codex Personal",
+            accentColor: "#6366f1",
+            email,
+            windows: [h.codexSession(10, 3 * HOUR), h.codexWeekly(66, 5 * DAY)],
+            credits: 2,
+          }),
+        ],
+        [h.hub("cliproxy-nucbox", "CLI Proxy", hubAccounts)],
+      ),
+      h.environment("env-nucbox", "nucbox-1", [
+        h.codexInstance({
+          instanceId: "codex",
+          email,
+          checkedAgoMs: 9 * MINUTE,
+          windows: [h.codexSession(30, 3 * HOUR), h.codexWeekly(60, 5 * DAY)],
+          credits: 2,
+        }),
+      ]),
+    ]);
+  },
+
+  /**
+   * Three machines, no two alike: one has only Codex, one only Claude via a
+   * hub, one has both natively. Filtering to any single environment should
+   * drop whole provider sections.
+   */
+  "uneven-environments": (now) => {
+    const h = makeHelpers(now);
+    return new Map([
+      h.environment("env-macbook", "MacBook Pro", [
+        h.codexInstance({
+          instanceId: "codex",
+          displayName: "Codex Personal",
+          accentColor: "#6366f1",
+          email: "main@example.com",
+          windows: [h.codexSession(10, 3 * HOUR), h.codexWeekly(66, 5 * DAY)],
+          credits: 2,
+        }),
+        h.provider({
+          instanceId: ProviderInstanceId.make("claude"),
+          driver: claude,
+          auth: { status: "authenticated", label: "Claude Max", email: "main@example.com" },
+          usageLimits: {
+            checkedAt: h.checked(MINUTE),
+            windows: [
+              h.session(2, 4 * HOUR),
+              h.weekly("seven_day", "Weekly", 38, 4 * DAY),
+              h.weekly("seven_day_fable", "Weekly · Fable", 69, 4 * DAY),
+            ],
+          },
+        }),
+      ]),
+      h.environment(
+        "env-nucbox",
+        "nucbox-1",
+        [],
+        [
+          h.hub("cliproxy-nucbox", "CLI Proxy", [
+            h.claudeHubAccount("personal@example.com", [
+              h.session(100, 4 * HOUR),
+              h.weekly("seven_day", "Weekly", 50, DAY),
+              h.weekly("seven_day_fable", "Weekly · Fable", 96, DAY),
+            ]),
+            h.claudeHubAccount("second@example.org", [
+              h.session(63, 2 * HOUR),
+              h.weekly("seven_day", "Weekly", 37, 4 * DAY),
+              h.weekly("seven_day_fable", "Weekly · Fable", 72, 4 * DAY),
+            ]),
+          ]),
+        ],
+      ),
+      h.environment("env-macmini", "Mac Mini", [
+        h.codexInstance({
+          instanceId: "codex",
+          displayName: "Codex Work",
+          email: "work@example.com",
+          windows: [h.codexSession(0, 5 * HOUR), h.codexWeekly(95, 5 * DAY)],
+          credits: 1,
+        }),
+      ]),
+    ]);
+  },
+
+  /**
+   * Codex plans that report only one window (Go reports a monthly allowance;
+   * a hub often has no five-hour figure for an account) mixed with a plan that
+   * reports both. Each pool lists only the accounts that have that window.
+   */
+  "codex-window-mix": (now) => {
+    const h = makeHelpers(now);
+    return new Map([
+      h.environment(
+        "env-macbook",
+        "MacBook Pro",
+        [
+          h.codexInstance({
+            instanceId: "codex",
+            displayName: "Codex Personal",
+            accentColor: "#6366f1",
+            email: "main@example.com",
+            windows: [h.codexSession(40, 2 * HOUR), h.codexWeekly(55, 3 * DAY)],
+            credits: 2,
+          }),
+          h.codexInstance({
+            instanceId: "codex-go",
+            displayName: "Codex Go",
+            accentColor: "#10b981",
+            email: "go@example.com",
+            plan: "ChatGPT Go Subscription",
+            windows: [
+              {
+                id: "primary",
+                kind: "monthly",
+                label: "Monthly",
+                usedPercent: 82,
+                windowDurationMins: 30 * 24 * 60,
+                resetsAt: h.at(11 * DAY),
+              },
+            ],
+          }),
+        ],
+        [
+          h.hub("cliproxy-nucbox", "CLI Proxy", [
+            {
+              id: "codex-def-work@example.com-pro.json",
+              driver: codex,
+              email: "work@example.com",
+              plan: "ChatGPT Pro 20x Subscription",
+              usageLimits: {
+                checkedAt: h.checked(3 * MINUTE),
+                windows: [h.codexWeekly(88, 6 * DAY)],
+              },
+            },
+            {
+              id: "codex-ghi-team@example.net-plus.json",
+              driver: codex,
+              email: "team@example.net",
+              plan: "ChatGPT Plus Subscription",
+              usageLimits: {
+                checkedAt: h.checked(3 * MINUTE),
+                windows: [h.codexWeekly(12, DAY)],
+              },
+            },
+          ]),
+        ],
+      ),
+    ]);
+  },
+
+  /**
+   * A hub configured on two environments, a hub that is down, a provider
+   * whose probe failed, an API-key account, and a hub account with no email.
+   */
+  "failures-and-strays": (now) => {
+    const h = makeHelpers(now);
+    const hubAccounts: UsageLimitSourceSnapshot["accounts"] = [
+      h.claudeHubAccount("main@example.com", [
+        h.session(2, 4 * HOUR),
+        h.weekly("seven_day", "Weekly", 38, 4 * DAY),
+        h.weekly("seven_day_fable", "Weekly · Fable", 69, 4 * DAY),
+      ]),
+      h.claudeHubAccount(null, [
+        h.session(40, 2 * HOUR),
+        h.weekly("seven_day", "Weekly", 20, 6 * DAY),
+      ]),
+    ];
+    return new Map([
+      h.environment(
+        "env-macbook",
+        "MacBook Pro",
+        [
+          h.provider({
+            instanceId: ProviderInstanceId.make("claude"),
+            driver: claude,
+            auth: { status: "authenticated", label: "Claude API Key" },
+            usageLimits: {
+              checkedAt: h.checked(MINUTE),
+              windows: [],
+              unavailable: {
+                reason: "unsupported",
+                message: "This account has no subscription limits.",
+              },
+            },
+          }),
+        ],
+        [h.hub("cliproxy-nucbox", "CLI Proxy", hubAccounts)],
+      ),
+      h.environment(
+        "env-nucbox",
+        "nucbox-1",
+        [],
+        [h.hub("cliproxy-nucbox", "CLI Proxy", hubAccounts)],
+      ),
+      h.environment(
+        "env-macmini",
+        "Mac Mini",
+        [
+          h.provider({
+            instanceId: ProviderInstanceId.make("claude"),
+            driver: claude,
+            auth: {
+              status: "authenticated",
+              label: "Claude Max",
+              email: "work@example.com",
+            },
+            usageLimits: {
+              checkedAt: h.checked(MINUTE),
+              windows: [],
+              unavailable: { reason: "probeFailed", message: "Claude timed out reading usage." },
+            },
+          }),
+        ],
+        [
+          h.hub(
+            "cliproxy-aws",
+            "AWS proxy",
+            [],
+            "fetch failed: connect ECONNREFUSED 10.0.0.4:8318",
+          ),
+        ],
+      ),
+    ]);
+  },
+};
+
+export function makeLimitsFixture(name: string, now: number): Fixture | null {
+  return FIXTURES[name]?.(now) ?? null;
+}

--- a/apps/web/src/components/usage/usageLimitsFixture.ts
+++ b/apps/web/src/components/usage/usageLimitsFixture.ts
@@ -409,5 +409,5 @@ const FIXTURES: Record<string, (now: number) => Fixture> = {
 };
 
 export function makeLimitsFixture(name: string, now: number): Fixture | null {
-  return FIXTURES[name]?.(now) ?? null;
+  return Object.hasOwn(FIXTURES, name) ? FIXTURES[name]!(now) : null;
 }

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -39,9 +39,16 @@ the dialog.
 
 ## Track subscription limits
 
-**Usage → Limits** shows how much quota is left in each window and when it resets, for Codex and
-Claude subscriptions. For windows with timing data, each bar also marks how much of the window is
-left, so you can judge your pace before the next reset.
+**Usage → Limits** pools every subscription account it can see per provider, so with several Codex
+or Claude accounts across your environments and hubs you read one number per window rather than a
+list. Each window card shows how much of the pool is left, when the next reset lands and how much it
+hands back, and a bar with one segment per account, ordered by which resets soonest. The hatched
+part of a segment is what that reset restores. Hover a segment for the account's plan, where it is
+signed in, and its reset time; Codex accounts with banked reset credits show a ticket count on the
+segment and the **Use reset** action in that popover.
+
+The same account signed in on more than one environment, or reported by a hub as well, counts once.
+Filter with the environment dropdown to see what a single machine has.
 
 If a window looks stale, refresh Limits to re-check every provider and hub.
 

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -44,9 +44,10 @@ or Claude accounts across your environments and hubs you read one number per win
 list. Each window card shows how much of the pool is left and a bar with one segment per account,
 ordered by which resets soonest; when the provider reports reset times, the card also says when
 the next reset lands and how much it hands back. The hatched
-part of a segment is what that reset restores. Hover a segment for the account's plan, where it is
+part of a segment is what that reset restores. Tap or hover a segment for the account's plan, where it is
 signed in, and its reset time; Codex accounts with banked reset credits show a ticket count on the
-segment and the **Use reset** action in that popover.
+segment and the **Use reset** action in that popover. On narrow screens, numbered rows below
+the bar show each account's quota, countdown, and credits. Tap a row to open its details.
 
 The same account signed in on more than one environment, or reported by a hub as well, counts once.
 Filter with the environment dropdown to see what a single machine has.

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -39,7 +39,7 @@ the dialog.
 
 ## Track subscription limits
 
-**Usage → Limits** pools every subscription account it can see per provider, so with several Codex
+On web and desktop, **Usage → Limits** pools every subscription account it can see per provider, so with several Codex
 or Claude accounts across your environments and hubs you read one number per window rather than a
 list. Each window card shows how much of the pool is left and a bar with one segment per account,
 ordered by which resets soonest; when the provider reports reset times, the card also says when

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -41,8 +41,9 @@ the dialog.
 
 **Usage → Limits** pools every subscription account it can see per provider, so with several Codex
 or Claude accounts across your environments and hubs you read one number per window rather than a
-list. Each window card shows how much of the pool is left, when the next reset lands and how much it
-hands back, and a bar with one segment per account, ordered by which resets soonest. The hatched
+list. Each window card shows how much of the pool is left and a bar with one segment per account,
+ordered by which resets soonest; when the provider reports reset times, the card also says when
+the next reset lands and how much it hands back. The hatched
 part of a segment is what that reset restores. Hover a segment for the account's plan, where it is
 signed in, and its reset time; Codex accounts with banked reset credits show a ticket count on the
 segment and the **Use reset** action in that popover.

--- a/packages/shared/src/usageLimits.test.ts
+++ b/packages/shared/src/usageLimits.test.ts
@@ -377,7 +377,8 @@ describe("pools", () => {
     expect(accounts[0]).toMatchObject({
       key: "env-a:claude",
       sourceLabel: null,
-      redeem: { environmentId: "env-a", instanceId: "claude" },
+      // Desktop's read is fresher, so its credits and its redeem are the ones on show.
+      redeem: { environmentId: "env-b", instanceId: "claude" },
       environments: [
         { environmentId: "env-a", label: "Laptop" },
         { environmentId: "env-b", label: "Desktop" },
@@ -385,6 +386,80 @@ describe("pools", () => {
     });
     // The fresher native snapshot wins; the hub row is pre-filtered by email.
     expect(accounts[0]?.limits.windows[0]?.usedPercent).toBe(55);
+  });
+
+  it("takes windows from a fresher hub read but credits and redeem from the native instance", () => {
+    const native = provider({
+      driver: claude,
+      instanceId: ProviderInstanceId.make("claude"),
+      auth: { status: "authenticated", email: "same@example.com" },
+      usageLimits: {
+        checkedAt,
+        windows: [{ ...window, usedPercent: 40 }],
+        resetCredits: { availableCount: 2 },
+      },
+    });
+    const input = new Map([
+      [
+        EnvironmentId.make("env-a"),
+        {
+          ...laptop,
+          serverConfig: {
+            providers: [native],
+            usageLimitSources: [
+              {
+                ...source,
+                accounts: [
+                  {
+                    id: "claude-same@example.com.json",
+                    driver: claude,
+                    email: "same@example.com",
+                    usageLimits: {
+                      checkedAt: "2026-09-03T11:30:00.000Z",
+                      windows: [{ ...window, usedPercent: 55 }],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    ]);
+    const [account] = collectLimitAccounts(input);
+    expect(account?.limits.windows[0]?.usedPercent).toBe(55);
+    expect(account?.limits.resetCredits?.availableCount).toBe(2);
+    expect(account?.redeem).toEqual({ environmentId: "env-a", instanceId: "claude" });
+    expect(account?.environments).toEqual([{ environmentId: "env-a", label: "Laptop" }]);
+  });
+
+  it("redeems on the environment whose snapshot supplied the credits on show", () => {
+    const stale = provider({
+      auth: { status: "authenticated", email: "same@example.com" },
+      usageLimits: {
+        checkedAt,
+        windows: [window],
+        resetCredits: { availableCount: 0 },
+      },
+    });
+    const fresh = {
+      ...stale,
+      usageLimits: {
+        checkedAt: "2026-09-03T11:30:00.000Z",
+        windows: [window],
+        resetCredits: { availableCount: 2 },
+      },
+    };
+    const input = new Map([
+      [EnvironmentId.make("env-a"), { ...laptop, serverConfig: { providers: [stale] } }],
+      [
+        EnvironmentId.make("env-b"),
+        { entry: { target: { label: "Desktop" } }, serverConfig: { providers: [fresh] } },
+      ],
+    ]);
+    const [account] = collectLimitAccounts(input);
+    expect(account?.limits.resetCredits?.availableCount).toBe(2);
+    expect(account?.redeem).toEqual({ environmentId: "env-b", instanceId: "codex" });
   });
 
   it("names an environment once however many of its instances share the account", () => {

--- a/packages/shared/src/usageLimits.test.ts
+++ b/packages/shared/src/usageLimits.test.ts
@@ -13,6 +13,9 @@ import {
   collectProviderUsageLimits,
   sameUsageLimitCommandCoverage,
   withUsageLimitsCommands,
+  collectLimitAccounts,
+  collectLimitNotices,
+  collectLimitPools,
   collectLimitSources,
   collectLimitsGroups,
   elapsedShare,
@@ -307,6 +310,289 @@ describe("collectLimitSources", () => {
       "Laptop · hub",
       "Desktop · hub",
     ]);
+  });
+});
+
+describe("pools", () => {
+  const checkedAt = "2026-09-03T11:00:00.000Z";
+  const weekly = {
+    id: "seven_day",
+    kind: "weekly",
+    label: "Weekly",
+    windowDurationMins: 7 * 24 * 60,
+    resetsAt: "2026-09-06T12:00:00.000Z",
+  } as const;
+  const claude = ProviderDriverKind.make("claudeAgent");
+  const source = {
+    id: UsageLimitSourceId.make("hub"),
+    kind: "cliproxy" as const,
+    label: "hub",
+    checkedAt,
+  };
+  const laptop = { entry: { target: { label: "Laptop" } } };
+
+  it("merges one account reported natively on two environments and by a hub into one entry", () => {
+    const native = provider({
+      driver: claude,
+      instanceId: ProviderInstanceId.make("claude"),
+      auth: { status: "authenticated", email: "Same@example.com" },
+      usageLimits: { checkedAt, windows: [{ ...window, usedPercent: 40 }] },
+    });
+    const input = new Map([
+      [EnvironmentId.make("env-a"), { ...laptop, serverConfig: { providers: [native] } }],
+      [
+        EnvironmentId.make("env-b"),
+        {
+          entry: { target: { label: "Desktop" } },
+          serverConfig: {
+            providers: [
+              {
+                ...native,
+                usageLimits: {
+                  checkedAt: "2026-09-03T11:30:00.000Z",
+                  windows: [{ ...window, usedPercent: 55 }],
+                },
+              },
+            ],
+            usageLimitSources: [
+              {
+                ...source,
+                accounts: [
+                  {
+                    id: "claude-same@example.com.json",
+                    driver: claude,
+                    email: "same@example.com",
+                    plan: "Claude Subscription",
+                    usageLimits: { checkedAt, windows: [{ ...window, usedPercent: 10 }] },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    ]);
+    const accounts = collectLimitAccounts(input);
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0]).toMatchObject({
+      key: "env-a:claude",
+      sourceLabel: null,
+      redeem: { environmentId: "env-a", instanceId: "claude" },
+      environments: [
+        { environmentId: "env-a", label: "Laptop" },
+        { environmentId: "env-b", label: "Desktop" },
+      ],
+    });
+    // The fresher native snapshot wins; the hub row is pre-filtered by email.
+    expect(accounts[0]?.limits.windows[0]?.usedPercent).toBe(55);
+  });
+
+  it("names an environment once however many of its instances share the account", () => {
+    const shared = provider({
+      auth: { status: "authenticated", email: "same@example.com" },
+      usageLimits: { checkedAt, windows: [window] },
+    });
+    const input = new Map([
+      [
+        EnvironmentId.make("env-a"),
+        {
+          ...laptop,
+          serverConfig: {
+            providers: [shared, { ...shared, instanceId: ProviderInstanceId.make("work") }],
+          },
+        },
+      ],
+    ]);
+    expect(collectLimitAccounts(input)[0]?.environments).toEqual([
+      { environmentId: "env-a", label: "Laptop" },
+    ]);
+  });
+
+  it("keys a hub account without an email by hub, so two environments on one hub share it", () => {
+    const seat = {
+      id: "claude-team-seat.json",
+      driver: claude,
+      usageLimits: { checkedAt, windows: [window] },
+    };
+    const hub = { ...source, accounts: [seat] };
+    const input = new Map([
+      [EnvironmentId.make("env-a"), { ...laptop, serverConfig: { usageLimitSources: [hub] } }],
+      [
+        EnvironmentId.make("env-b"),
+        { entry: { target: { label: "Desktop" } }, serverConfig: { usageLimitSources: [hub] } },
+      ],
+    ]);
+    const accounts = collectLimitAccounts(input);
+    expect(accounts.map((account) => account.key)).toEqual(["hub:claude-team-seat.json"]);
+    expect(accounts[0]?.displayName).toBe("claude-team-seat");
+  });
+
+  it("pools windows by id across accounts and orders resets by when they land", () => {
+    const input = new Map([
+      [
+        EnvironmentId.make("env-a"),
+        {
+          ...laptop,
+          serverConfig: {
+            providers: [],
+            usageLimitSources: [
+              {
+                ...source,
+                accounts: [
+                  {
+                    id: "a",
+                    driver: claude,
+                    usageLimits: {
+                      checkedAt,
+                      windows: [
+                        { ...window, usedPercent: 80, resetsAt: "2026-09-03T13:00:00.000Z" },
+                        { ...weekly, usedPercent: 20 },
+                      ],
+                    },
+                  },
+                  {
+                    id: "b",
+                    driver: claude,
+                    usageLimits: {
+                      checkedAt,
+                      windows: [{ ...window, usedPercent: 40 }],
+                    },
+                  },
+                  {
+                    id: "c",
+                    driver: ProviderDriverKind.make("codex"),
+                    usageLimits: { checkedAt, windows: [{ ...weekly, usedPercent: 50 }] },
+                  },
+                  {
+                    id: "unsupported",
+                    driver: claude,
+                    usageLimits: {
+                      checkedAt,
+                      windows: [],
+                      unavailable: { reason: "unsupported" as const },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    ]);
+    const pools = collectLimitPools(collectLimitAccounts(input), now);
+    expect(pools.map((pool) => [pool.driver, pool.accounts.length])).toEqual([
+      ["claudeAgent", 2],
+      ["codex", 1],
+    ]);
+    const [session, week] = pools[0]!.windows;
+    // a is 80% through its window and b 60%: the pool is 70% elapsed, 60% used.
+    expect(session).toMatchObject({
+      id: "five_hour",
+      remainingPercent: 40,
+      usedPercent: 60,
+      pace: "under",
+    });
+    expect(
+      session?.resets.map((reset) => [reset.member.account.key, reset.restoresPercent]),
+    ).toEqual([
+      ["hub:a", 40],
+      ["hub:b", 20],
+    ]);
+    expect(week).toMatchObject({ id: "seven_day", remainingPercent: 80, members: [{}] });
+    // Codex reports `primary` for both its five-hour and (on Go) monthly window.
+    const mixed = collectLimitPools(
+      [
+        ...collectLimitAccounts(input),
+        {
+          key: "go",
+          driver: claude,
+          displayName: "Go",
+          email: undefined,
+          plan: undefined,
+          accentColor: undefined,
+          environments: [],
+          sourceLabel: null,
+          redeem: null,
+          limits: {
+            checkedAt,
+            windows: [
+              {
+                id: "five_hour",
+                kind: "monthly",
+                label: "Monthly",
+                usedPercent: 82,
+                windowDurationMins: 30 * 24 * 60,
+                resetsAt: "2026-09-14T12:00:00.000Z",
+              },
+            ],
+          },
+        },
+      ],
+      now,
+    );
+    expect(mixed[0]?.windows.map((window) => [window.kind, window.members.length])).toEqual([
+      ["session", 2],
+      ["weekly", 1],
+      ["monthly", 1],
+    ]);
+    // Segments read left to right as "who refills next", matching the reset list.
+    expect(session?.members.map((member) => member.account.key)).toEqual(["hub:a", "hub:b"]);
+    expect(pools[0]?.accounts.map((account) => account.key)).toEqual(["hub:a", "hub:b"]);
+  });
+});
+
+describe("collectLimitNotices", () => {
+  const checkedAt = "2026-09-03T11:00:00.000Z";
+  const claude = ProviderDriverKind.make("claudeAgent");
+  const laptop = { entry: { target: { label: "Laptop" } } };
+  const hub = {
+    id: UsageLimitSourceId.make("hub"),
+    kind: "cliproxy" as const,
+    label: "hub",
+    checkedAt,
+    accounts: [],
+  };
+
+  it("names failures and silence, skips unsupported accounts, and labels environments only when several", () => {
+    const failed = provider({
+      instanceId: ProviderInstanceId.make("claude"),
+      driver: claude,
+      displayName: "Claude Max",
+      usageLimits: { checkedAt, windows: [], unavailable: { reason: "probeFailed" } },
+    });
+    const apiKey = provider({
+      instanceId: ProviderInstanceId.make("api"),
+      driver: claude,
+      usageLimits: { checkedAt, windows: [], unavailable: { reason: "unsupported" } },
+    });
+    const silent = provider({ usageLimits: { checkedAt, windows: [] } });
+    const one = new Map([
+      [
+        EnvironmentId.make("env-a"),
+        {
+          ...laptop,
+          serverConfig: {
+            providers: [failed, apiKey, silent],
+            usageLimitSources: [
+              hub,
+              { ...hub, id: UsageLimitSourceId.make("down"), label: "down", error: "ECONNREFUSED" },
+            ],
+          },
+        },
+      ],
+    ]);
+    expect(collectLimitNotices(one)).toEqual([
+      "Claude Max: Could not read limits.",
+      "codex: No limits reported.",
+      "hub: No accounts reported.",
+      "down: ECONNREFUSED",
+    ]);
+
+    one.set(EnvironmentId.make("env-b"), {
+      entry: { target: { label: "Desktop" } },
+      serverConfig: { providers: [], usageLimitSources: [] },
+    });
+    expect(collectLimitNotices(one)[0]).toBe("Laptop · Claude Max: Could not read limits.");
   });
 });
 

--- a/packages/shared/src/usageLimits.test.ts
+++ b/packages/shared/src/usageLimits.test.ts
@@ -485,6 +485,23 @@ describe("pools", () => {
       ["codex", 1],
     ]);
     const [session, week] = pools[0]!.windows;
+    // A member with no reset has no clock, so it does not vote on pace.
+    const untimed = collectLimitPools(
+      collectLimitAccounts(input).map((account) =>
+        account.key === "hub:b"
+          ? {
+              ...account,
+              limits: {
+                ...account.limits,
+                windows: account.limits.windows.map((w) => ({ ...w, resetsAt: undefined })),
+              },
+            }
+          : account,
+      ),
+      now,
+    );
+    // Only a votes: 80% used, 80% elapsed.
+    expect(untimed[0]?.windows[0]?.pace).toBe("on");
     // a is 80% through its window and b 60%: the pool is 70% elapsed, 60% used.
     expect(session).toMatchObject({
       id: "five_hour",

--- a/packages/shared/src/usageLimits.ts
+++ b/packages/shared/src/usageLimits.ts
@@ -58,7 +58,9 @@ export function collectLimitsGroups(
     EnvironmentId,
     {
       readonly entry: { readonly target: { readonly label: string } };
-      readonly serverConfig: { readonly providers: readonly ServerProvider[] } | null;
+      readonly serverConfig: {
+        readonly providers?: readonly ServerProvider[] | undefined;
+      } | null;
     }
   >,
 ): readonly LimitsGroup[] {
@@ -147,6 +149,279 @@ function accountKey(driver: ServerProvider["driver"], email: string | undefined)
   return normalizedEmail ? `${driver}:${normalizedEmail}` : null;
 }
 
+/**
+ * One subscription account as the pooled views see it, whichever way it was
+ * reported. The same email signed in natively on two environments, or reported
+ * by a hub as well as natively, is one account: its quota is one bucket, so
+ * counting it twice would misstate what is left.
+ */
+export interface LimitAccount {
+  readonly key: string;
+  readonly driver: ServerProvider["driver"];
+  /** The instance's configured name, which is not sensitive; null for hub accounts. */
+  readonly displayName: string | null;
+  readonly email: string | undefined;
+  readonly plan: string | undefined;
+  readonly accentColor: string | undefined;
+  /** Environments the account is signed in on; empty when only a hub reports it. */
+  readonly environments: ReadonlyArray<{
+    readonly environmentId: EnvironmentId;
+    readonly label: string;
+  }>;
+  /** The hub that reported it, when no environment has it natively. */
+  readonly sourceLabel: string | null;
+  /** Where a reset credit can be redeemed; only native instances can. */
+  readonly redeem: {
+    readonly environmentId: EnvironmentId;
+    readonly instanceId: ProviderInstanceId;
+  } | null;
+  readonly limits: ServerProviderUsageLimits;
+}
+
+/**
+ * Every account with usable windows across the connected environments, one
+ * entry per distinct account. Native instances win over hub reports, and the
+ * freshest snapshot wins when the same account is reported twice.
+ */
+export function collectLimitAccounts(
+  presentations: Parameters<typeof collectLimitSources>[0],
+): readonly LimitAccount[] {
+  const accounts = new Map<string, LimitAccount>();
+  const merge = (key: string, next: LimitAccount) => {
+    const previous = accounts.get(key);
+    if (!previous) {
+      accounts.set(key, next);
+      return;
+    }
+    const fresher = Date.parse(next.limits.checkedAt) > Date.parse(previous.limits.checkedAt);
+    // Two instances on one machine sharing an account still name it once.
+    const environments = [
+      ...previous.environments,
+      ...next.environments.filter(
+        (candidate) =>
+          !previous.environments.some((seen) => seen.environmentId === candidate.environmentId),
+      ),
+    ];
+    accounts.set(key, {
+      ...previous,
+      displayName: previous.displayName ?? next.displayName,
+      plan: previous.plan ?? next.plan,
+      accentColor: previous.accentColor ?? next.accentColor,
+      environments,
+      // A hub only names the account when no environment has it natively.
+      sourceLabel: environments.length > 0 ? null : (previous.sourceLabel ?? next.sourceLabel),
+      redeem: previous.redeem ?? next.redeem,
+      limits: fresher ? next.limits : previous.limits,
+    });
+  };
+  for (const [environmentId, presentation] of presentations) {
+    const label = presentation.entry.target.label;
+    for (const provider of providersWithLimits(presentation.serverConfig?.providers ?? [])) {
+      if (!provider.usageLimits || limitsNotice(provider.usageLimits) !== null) continue;
+      merge(
+        accountKey(provider.driver, provider.auth.email) ??
+          `${environmentId}:${provider.instanceId}`,
+        {
+          key: `${environmentId}:${provider.instanceId}`,
+          driver: provider.driver,
+          displayName: provider.displayName?.trim() || null,
+          email: provider.auth.email,
+          plan: provider.auth.label,
+          accentColor: provider.accentColor,
+          environments: [{ environmentId, label }],
+          sourceLabel: null,
+          redeem: { environmentId, instanceId: provider.instanceId },
+          limits: provider.usageLimits,
+        },
+      );
+    }
+  }
+  for (const source of collectLimitSources(presentations)) {
+    for (const account of source.accounts) {
+      if (limitsNotice(account.usageLimits) !== null) continue;
+      // Without an email the auth file name is the identity, keyed by source
+      // id so the same hub configured on two environments with the same URL
+      // yields one account. The id derives from the URL as typed, so a hub
+      // reached by two different hosts still counts twice.
+      merge(accountKey(account.driver, account.email) ?? `${source.id}:${account.id}`, {
+        key: `${source.id}:${account.id}`,
+        driver: account.driver,
+        displayName: account.email ? null : account.id.replace(/\.json$/i, ""),
+        email: account.email,
+        plan: account.plan,
+        accentColor: undefined,
+        environments: [],
+        sourceLabel: source.label,
+        redeem: null,
+        limits: account.usageLimits,
+      });
+    }
+  }
+  return [...accounts.values()];
+}
+
+/**
+ * What the pooled views cannot draw as a bar: a hub that failed to read, a
+ * provider whose probe failed. Accounts that can never report (API keys)
+ * are left out; there is nothing for the user to act on. The environment
+ * is named only when more than one is connected.
+ */
+export function collectLimitNotices(
+  presentations: Parameters<typeof collectLimitSources>[0],
+): readonly string[] {
+  const label = (environmentLabel: string, subject: string) =>
+    presentations.size > 1 ? `${environmentLabel} · ${subject}` : subject;
+  const notices: string[] = [];
+  for (const presentation of presentations.values()) {
+    const environmentLabel = presentation.entry.target.label;
+    for (const provider of providersWithLimits(presentation.serverConfig?.providers ?? [])) {
+      // An account that can never report (API key) is left out; one that
+      // failed, or reported nothing at all, is worth a line.
+      if (provider.usageLimits?.unavailable?.reason === "unsupported") continue;
+      const notice = provider.usageLimits ? limitsNotice(provider.usageLimits) : null;
+      const name = provider.displayName?.trim() || String(provider.driver);
+      if (notice) notices.push(`${label(environmentLabel, name)}: ${notice}`);
+    }
+    for (const source of presentation.serverConfig?.usageLimitSources ?? []) {
+      if (source.error) {
+        notices.push(`${label(environmentLabel, source.label)}: ${source.error}`);
+      } else if (source.accounts.length === 0) {
+        notices.push(`${label(environmentLabel, source.label)}: No accounts reported.`);
+      }
+    }
+  }
+  return notices;
+}
+
+export interface LimitPoolMember {
+  readonly account: LimitAccount;
+  readonly window: ServerProviderUsageWindow;
+}
+
+/**
+ * One window id across every account that reports it: the pooled share left,
+ * pace against the clock, and the resets in the order they will land, each
+ * with the share of the pool it hands back.
+ */
+export interface LimitPoolWindow {
+  readonly id: string;
+  readonly kind: ServerProviderUsageWindow["kind"];
+  readonly label: string;
+  readonly members: readonly LimitPoolMember[];
+  readonly remainingPercent: number;
+  readonly usedPercent: number;
+  readonly pace: LimitPace | null;
+  readonly resets: ReadonlyArray<{
+    readonly member: LimitPoolMember;
+    readonly at: number;
+    /** Points of the pool the reset restores: the member's used share over the member count. */
+    readonly restoresPercent: number;
+  }>;
+}
+
+export interface LimitPool {
+  readonly driver: ServerProvider["driver"];
+  readonly accounts: readonly LimitAccount[];
+  readonly windows: readonly LimitPoolWindow[];
+}
+
+const WINDOW_KIND_ORDER: Record<ServerProviderUsageWindow["kind"], number> = {
+  session: 0,
+  weekly: 1,
+  monthly: 2,
+  other: 3,
+};
+
+/**
+ * Accounts grouped by driver, each with its windows pooled by kind and id.
+ * Window ids are stable per provider, so a hub row and a native row for the
+ * same window land in the same pool; the kind is part of the key because
+ * Codex's `primary` is a position, not a duration (five hours on paid plans,
+ * a month on Free/Go), and a monthly allowance must not average into a
+ * five-hour pool. Pools order by kind, then first appearance.
+ *
+ * `accounts` is the table order: instances the user can act on (native,
+ * named) before hub-only accounts, each group alphabetical. Each window's
+ * `members` sort by reset instead, soonest first, so a bar reads left to
+ * right as "who refills next" and matches the reset list under it.
+ */
+export function collectLimitPools(
+  accounts: readonly LimitAccount[],
+  now: number,
+): readonly LimitPool[] {
+  const byDriver = new Map<ServerProvider["driver"], LimitAccount[]>();
+  for (const account of accounts) {
+    const list = byDriver.get(account.driver);
+    if (list) list.push(account);
+    else byDriver.set(account.driver, [account]);
+  }
+  return [...byDriver].map(([driver, members]) => {
+    const sorted = members.toSorted(
+      (left, right) =>
+        Number(left.redeem === null) - Number(right.redeem === null) ||
+        accountSortName(left).localeCompare(accountSortName(right)),
+    );
+    return { driver, accounts: sorted, windows: poolWindows(sorted, now) };
+  });
+}
+
+function accountSortName(account: LimitAccount): string {
+  return (account.displayName ?? account.email ?? account.key).toLowerCase();
+}
+
+function poolWindows(accounts: readonly LimitAccount[], now: number): readonly LimitPoolWindow[] {
+  const byKey = new Map<string, LimitPoolMember[]>();
+  for (const account of accounts) {
+    for (const window of account.limits.windows) {
+      const key = `${window.kind}:${window.id}`;
+      const list = byKey.get(key);
+      if (list) list.push({ account, window });
+      else byKey.set(key, [{ account, window }]);
+    }
+  }
+  const pools = [...byKey.values()].map((unordered): LimitPoolWindow => {
+    const members = unordered.toSorted(
+      (left, right) =>
+        (resetMillis(left.window) ?? Number.POSITIVE_INFINITY) -
+        (resetMillis(right.window) ?? Number.POSITIVE_INFINITY),
+    );
+    const first = members[0]!.window;
+    const usedPercent = members.reduce((sum, m) => sum + m.window.usedPercent, 0) / members.length;
+    const elapsed = members
+      .map((m) => elapsedShare(m.window, now))
+      .filter((share): share is number => share !== null);
+    const meanElapsed =
+      elapsed.length > 0 ? elapsed.reduce((sum, share) => sum + share, 0) / elapsed.length : null;
+    const resets = members
+      .flatMap((member) => {
+        const at = resetMillis(member.window);
+        return at === null
+          ? []
+          : [
+              {
+                member,
+                at,
+                restoresPercent: Math.round(member.window.usedPercent / members.length),
+              },
+            ];
+      })
+      .toSorted((left, right) => left.at - right.at);
+    return {
+      id: first.id,
+      kind: first.kind,
+      label: first.label,
+      members,
+      usedPercent: Math.round(usedPercent),
+      remainingPercent: Math.round(100 - usedPercent),
+      pace: meanElapsed === null ? null : paceOfShares(usedPercent, meanElapsed),
+      resets,
+    };
+  });
+  return pools.toSorted(
+    (left, right) => WINDOW_KIND_ORDER[left.kind] - WINDOW_KIND_ORDER[right.kind],
+  );
+}
+
 /** The instance's configured name, else the driver's, else its raw kind. */
 export function providerLimitsLabel(
   provider: Pick<ServerProvider, "driver" | "displayName">,
@@ -195,8 +470,11 @@ export type LimitPace = "ahead" | "on" | "under";
  */
 export function paceOf(window: ServerProviderUsageWindow, now: number): LimitPace | null {
   const elapsed = elapsedShare(window, now);
-  if (elapsed === null) return null;
-  const gap = window.usedPercent - elapsed * 100;
+  return elapsed === null ? null : paceOfShares(window.usedPercent, elapsed);
+}
+
+function paceOfShares(usedPercent: number, elapsed: number): LimitPace {
+  const gap = usedPercent - elapsed * 100;
   if (gap > 5) return "ahead";
   if (gap < -5) return "under";
   return "on";

--- a/packages/shared/src/usageLimits.ts
+++ b/packages/shared/src/usageLimits.ts
@@ -387,11 +387,16 @@ function poolWindows(accounts: readonly LimitAccount[], now: number): readonly L
     );
     const first = members[0]!.window;
     const usedPercent = members.reduce((sum, m) => sum + m.window.usedPercent, 0) / members.length;
-    const elapsed = members
-      .map((m) => elapsedShare(m.window, now))
-      .filter((share): share is number => share !== null);
+    // Pace compares spend against the clock, so it is judged only over the
+    // members that have a clock; a window with no reset would otherwise
+    // count as spend with no time elapsed and skew the verdict.
+    const timed = members.flatMap((m) => {
+      const share = elapsedShare(m.window, now);
+      return share === null ? [] : [{ used: m.window.usedPercent, elapsed: share }];
+    });
+    const timedUsed = timed.reduce((sum, t) => sum + t.used, 0) / timed.length;
     const meanElapsed =
-      elapsed.length > 0 ? elapsed.reduce((sum, share) => sum + share, 0) / elapsed.length : null;
+      timed.length > 0 ? timed.reduce((sum, t) => sum + t.elapsed, 0) / timed.length : null;
     const resets = members
       .flatMap((member) => {
         const at = resetMillis(member.window);
@@ -413,7 +418,7 @@ function poolWindows(accounts: readonly LimitAccount[], now: number): readonly L
       members,
       usedPercent: Math.round(usedPercent),
       remainingPercent: Math.round(100 - usedPercent),
-      pace: meanElapsed === null ? null : paceOfShares(usedPercent, meanElapsed),
+      pace: meanElapsed === null ? null : paceOfShares(timedUsed, meanElapsed),
       resets,
     };
   });

--- a/packages/shared/src/usageLimits.ts
+++ b/packages/shared/src/usageLimits.ts
@@ -202,6 +202,14 @@ export function collectLimitAccounts(
           !previous.environments.some((seen) => seen.environmentId === candidate.environmentId),
       ),
     ];
+    const winner = fresher ? next : previous;
+    // Windows come from the freshest snapshot, wherever it was read. Reset
+    // credits only ever come from a native instance, and the redeem must go
+    // to the instance whose credits are on show, so the two travel together:
+    // the freshest native snapshot supplies both, or neither.
+    const native = [previous, next]
+      .filter((candidate) => candidate.redeem !== null)
+      .toSorted((a, b) => Date.parse(b.limits.checkedAt) - Date.parse(a.limits.checkedAt))[0];
     accounts.set(key, {
       ...previous,
       displayName: previous.displayName ?? next.displayName,
@@ -210,8 +218,13 @@ export function collectLimitAccounts(
       environments,
       // A hub only names the account when no environment has it natively.
       sourceLabel: environments.length > 0 ? null : (previous.sourceLabel ?? next.sourceLabel),
-      redeem: previous.redeem ?? next.redeem,
-      limits: fresher ? next.limits : previous.limits,
+      redeem: native?.redeem ?? null,
+      limits: {
+        ...winner.limits,
+        ...(native?.limits.resetCredits
+          ? { resetCredits: native.limits.resetCredits }
+          : { resetCredits: undefined }),
+      },
     });
   };
   for (const [environmentId, presentation] of presentations) {
@@ -236,25 +249,30 @@ export function collectLimitAccounts(
       );
     }
   }
-  for (const source of collectLimitSources(presentations)) {
-    for (const account of source.accounts) {
-      if (limitsNotice(account.usageLimits) !== null) continue;
-      // Without an email the auth file name is the identity, keyed by source
-      // id so the same hub configured on two environments with the same URL
-      // yields one account. The id derives from the URL as typed, so a hub
-      // reached by two different hosts still counts twice.
-      merge(accountKey(account.driver, account.email) ?? `${source.id}:${account.id}`, {
-        key: `${source.id}:${account.id}`,
-        driver: account.driver,
-        displayName: account.email ? null : account.id.replace(/\.json$/i, ""),
-        email: account.email,
-        plan: account.plan,
-        accentColor: undefined,
-        environments: [],
-        sourceLabel: source.label,
-        redeem: null,
-        limits: account.usageLimits,
-      });
+  // Every hub account, including those a native instance also knows: the hub
+  // may hold a fresher read of the same subscription, and the merge above
+  // keeps the redeem target consistent with whichever snapshot wins.
+  const labelEnvironment = presentations.size > 1;
+  for (const presentation of presentations.values()) {
+    for (const source of presentation.serverConfig?.usageLimitSources ?? []) {
+      const sourceLabel = labelEnvironment
+        ? `${presentation.entry.target.label} · ${source.label}`
+        : source.label;
+      for (const account of source.accounts) {
+        if (limitsNotice(account.usageLimits) !== null) continue;
+        merge(accountKey(account.driver, account.email) ?? `${source.id}:${account.id}`, {
+          key: `${source.id}:${account.id}`,
+          driver: account.driver,
+          displayName: account.email ? null : account.id.replace(/\.json$/i, ""),
+          email: account.email,
+          plan: account.plan,
+          accentColor: undefined,
+          environments: [],
+          sourceLabel,
+          redeem: null,
+          limits: account.usageLimits,
+        });
+      }
     }
   }
   return [...accounts.values()];


### PR DESCRIPTION
Usage → Limits repeated the same subscription across environments and made people add separate account quotas mentally. This change merges accounts by provider and email, then shows one segmented bar per window. Segments sort by reset time; each account contributes equally to the pooled percentage.

The freshest snapshot supplies the usage figures. Reset credits and their action come together from the freshest native instance. Filtering environments recomputes the pools, and accounts contribute only to windows they report, keeping monthly allowances separate from session and weekly limits.

Below 672px of available bar width, numbered segments map to tappable account rows. Wider bars retain inline labels. Tap or hover for account details, blurred email, plan, environments, and reset credits. Use reset closes the popover before opening its confirmation. Popovers fit down to 320px.

The CLIProxy adapter maps Codex five-hour windows to `primary`, matching native Codex. No wire contract changes. Web and Electron share this UI; the native mobile app retains its existing per-account view for the next pass.

## Before and after

The base renderer at `eee05575eb` and current implementation use the same `uneven-environments` synthetic snapshot and matching viewports, scroll, and dark theme. The base renderer receives the fixture at its data boundary; its rendering code is unchanged.

Phone, 390 × 844:

| Before | After |
|---|---|
| ![Before: per-account limits at phone width](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/08d52237341d3e15/base-phone.png) | ![After: pooled account bars at phone width](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4565a13baa49d097/head-phone.png) |

Tablet, 768 × 1024, sidebar open:

| Before | After |
|---|---|
| ![Before: per-account limits at tablet width](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/cec043cdc062590a/base-tablet.png) | ![After: pooled account bars at tablet width](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/b3f618c3b47f62e3/head-tablet.png) |

Desktop, 1280 × 820:

| Before | After |
|---|---|
| ![Before: per-account limits at desktop width](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/f0f60eb0fffdce83/base-desktop.png) | ![After: pooled account bars at desktop width](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/7ef55303631668f4/head-desktop.png) |

## Interaction and edge-case demos

These recordings use synthetic accounts and environments through the real environment picker. No reset credit is consumed.

Phone: account details, reset confirmation and cancellation, then MacBook Pro with Codex and Claude, nucbox-1 with Claude only, Mac Mini with Codex only, and back to all.

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/826d604f8673b9a6/uneven-environments.mp4

Tablet: one Codex account reported natively on two machines and by a hub. Filtering shows the selected machine’s snapshot without double-counting the account.

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/06e0627a575514cd/same-account.mp4

Phone: session and weekly on one account, monthly only on another, and weekly-only hub accounts. Includes the empty environment selection.

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/9e40a21ffd400d86/codex-window-mix.mp4

Tablet: duplicate hub configuration, a hub account without email, an unsupported API-key account, a failed probe, and an unavailable hub. Filtering to the failed environment shows notices instead of bars.

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/e7f1237352296639/failures-and-strays.mp4

Account details and reset confirmation:

| Details | Confirmation |
|---|---|
| ![Phone account detail popover](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/0478b09fd626742e/head-popover.png) | ![Reset confirmation after the account popover closes](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/be7657bc3b11c3e0/head-confirm.png) |

![Account details fit within a 320px phone in light mode](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/b995961f969278d2/320-popover.png)

## Verification

- 38 focused tests pass across shared usage-limit logic and the CLIProxy adapter.
- Web typecheck and targeted lint pass. React Doctor reported no correctness errors; its six warnings concern complexity, shared exports, and memoization.
- Browser verification covers 320px light mode, 390px phones, 768px tablets, and desktop widths; filtering, partial window availability, reset confirmation/cancellation, and both trigger handles.
- Keyboard checks confirm each handle positions the popover relative to itself and receives focus back after dismissal. The final 320px check reports a 320px document width and a 306px popup.
- Whole-PR source review includes the shared collectors, adapter, composer reset-credit callers, and unchanged native mobile consumers. Connection modes use existing environment state and commands.

Pooling is an unweighted mean because the contract has no comparable plan-capacity units. Accounts without email use source identity, so the same hub reached through different configured identities can still count twice.

Initial implementation: Claude Fable 5 in Claude Code. Web completion: GPT-6 in Codex, via T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pooled subscription limits across accounts and environments
> - Aggregates accounts across native providers and hubs into provider pools via `collectLimitAccounts` and `collectLimitPools`, preferring the freshest usage snapshot and merging duplicate environments
> - Adds `UsageLimitsPooled` and related components to render interactive segment bars, account detail popovers, and aggregate quota summaries per provider
> - Fixes Codex `five_hour` quota mapping to use the `primary` window identifier in `cliproxyAccountToUsageLimits`, aligning it with native Codex rows
> - Adds development fixture support via `limitsFixture` query parameter in `UsagePage` to test pooled views with synthetic data
> - Risk: `UsageLimitsSection` in [UsageLimits.tsx](https://github.com/pingdotgg/t3code/pull/10300/files#diff-2764f260dc4f879cad990f9601cd2a8d41a4af19eea6398254e9bbf00bdad23a) removes prior local-provider and source-account group rendering; out-of-tree consumers expecting the old layout will break
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83eaf1b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->