### PR TITLE
test(desktop): exercise WSL cache safety through public scripts

### DIFF
--- a/apps/desktop/src/wsl/DesktopWslEnvironment.test.ts
+++ b/apps/desktop/src/wsl/DesktopWslEnvironment.test.ts
@@ -12,21 +12,17 @@ import * as TestClock from "effect/testing/TestClock";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
-  buildWslNodeEnvPreamble,
   buildWslRuntimeInstallScript,
   buildWslRuntimeInvalidateScript,
   buildWslRuntimePruneScript,
   DesktopWslDistroListError,
   formatMissingToolsReason,
-  formatNodePtyProbeFailureReason,
-  formatWslShellTransportFailureReason,
   parseNodePath,
   parseNodeVersion,
   parseResolvedPath,
   parseToolchainReport,
   parseWslRuntimeRoot,
   probeWslDistros,
-  sanitizeWslRuntimeId,
 } from "./DesktopWslEnvironment.ts";
 
 const encoder = new TextEncoder();
@@ -144,46 +140,19 @@ describe("probeWslDistros", () => {
   });
 });
 
-describe("formatNodePtyProbeFailureReason", () => {
-  it("identifies a packaged build that omitted the Linux node-pty prebuild", () => {
-    const reason = formatNodePtyProbeFailureReason(4);
-
-    expect(reason).toContain("packaged Linux node-pty binary was not included");
-    expect(reason).toContain("--wsl-prebuild");
-  });
-
-  it("leaves other node-pty load failures to the compatibility diagnostic", () => {
-    expect(formatNodePtyProbeFailureReason(1)).toBeNull();
-  });
-});
-
-describe("formatWslShellTransportFailureReason", () => {
-  it("distinguishes timeouts and spawn failures from normal shell exit codes", () => {
-    expect(formatWslShellTransportFailureReason("timeout")).toContain("timed out");
-    expect(formatWslShellTransportFailureReason("spawn")).toContain("could not start wsl.exe");
-    expect(formatWslShellTransportFailureReason("process")).toContain("lost communication");
-    expect(formatWslShellTransportFailureReason(null)).toBeNull();
-  });
-});
-
-describe("buildWslNodeEnvPreamble", () => {
-  it("passes the required Node engine range into the shared resolver", () => {
-    const preamble = buildWslNodeEnvPreamble("^22.16 || ^23.11 || >=24.10");
-
-    expect(preamble).toContain("T3_NODE_ENGINE_RANGE='^22.16 || ^23.11 || >=24.10'");
-    expect(preamble.indexOf("T3_NODE_ENGINE_RANGE=")).toBeLessThan(
-      preamble.lastIndexOf("ensure_remote_node_path || true"),
-    );
-  });
-
-  it("keeps the shared resolver permissive when no Node engine range is provided", () => {
-    expect(buildWslNodeEnvPreamble()).toContain("T3_NODE_ENGINE_RANGE=''");
-  });
-});
-
 describe("WSL runtime cache", () => {
-  it("sanitizes cache ids before interpolating them into Linux paths", () => {
-    expect(sanitizeWslRuntimeId("1.2.3/x64; touch /tmp/nope")).toBe("1.2.3_x64__touch__tmp_nope");
+  it.each([
+    [
+      "install",
+      (id: string) => buildWslRuntimeInstallScript("/runtime.tar.gz", id, "b".repeat(64)),
+    ],
+    ["prune", buildWslRuntimePruneScript],
+    ["invalidate", buildWslRuntimeInvalidateScript],
+  ] as const)("sanitizes cache ids in the %s script", (_, buildScript) => {
+    const runtimeId = "1.2.3/x64; touch /tmp/nope";
+    const script = buildScript(runtimeId);
+    expect(script).toContain("/1.2.3_x64__touch__tmp_nope");
+    expect(script).not.toContain(runtimeId);
   });
 
   it("installs through a temporary directory and only reuses valid completed caches", () => {

--- a/apps/desktop/src/wsl/DesktopWslEnvironment.ts
+++ b/apps/desktop/src/wsl/DesktopWslEnvironment.ts
@@ -147,7 +147,7 @@ const TIMEOUT_RESULT: ShellResult = {
   transportFailure: "timeout",
 };
 
-export const formatWslShellTransportFailureReason = (
+const formatWslShellTransportFailureReason = (
   failure: ShellResult["transportFailure"],
 ): string | null => {
   switch (failure) {
@@ -165,7 +165,7 @@ export const formatWslShellTransportFailureReason = (
 // Reuse the SSH remote resolver so WSL and SSH discover version-managed Node
 // the same way. Passing the engine range lets the resolver fall through to
 // version managers like nvm when a system node exists but is too old.
-export const buildWslNodeEnvPreamble = (
+const buildWslNodeEnvPreamble = (
   nodeEngineRange?: string | null,
 ): string => `${buildRemoteNodeEnvScript({ nodeEngineRange: nodeEngineRange ?? null })}
 ensure_remote_node_path || true
@@ -263,8 +263,7 @@ const WSL_RUNTIME_READY_MARKER = ".t3code-wsl-runtime-ready";
 const WSL_RUNTIME_SELECTED_MARKER = ".t3code-wsl-runtime-selected";
 const WSL_RUNTIME_SELECTION_GRACE_MINUTES = 5;
 
-export const sanitizeWslRuntimeId = (value: string): string =>
-  value.replace(/[^A-Za-z0-9._-]/g, "_");
+const sanitizeWslRuntimeId = (value: string): string => value.replace(/[^A-Za-z0-9._-]/g, "_");
 
 // `archiveSha256` is the digest the build recorded alongside the archive. The
 // install verifies the bytes before extracting, so an archive can never be
@@ -491,7 +490,7 @@ export const parseWslRuntimeRoot = (stdout: string): string | null => {
 
 const NODE_PTY_PREBUILD_MISSING_EXIT_CODE = 4;
 
-export const formatNodePtyProbeFailureReason = (exitCode: number): string | null =>
+const formatNodePtyProbeFailureReason = (exitCode: number): string | null =>
   exitCode === NODE_PTY_PREBUILD_MISSING_EXIT_CODE
     ? "WSL support is missing from this T3 Code build: the packaged Linux node-pty binary was not included. Rebuild the Windows artifact with `--wsl-prebuild <path-to-linux-pty.node>` or install a build that includes WSL support."
     : null;


### PR DESCRIPTION
Four WSL helpers were exported only for direct unit tests. Make them private and remove five tests of diagnostic wording and a thin shared Node resolver wrapper.

Cache ID sanitization remains covered through the public install, prune, and invalidate script builders. Existing executed-shell, cache lifecycle, transport, and parser tests remain.

Verification: 60 WSL and SSH tests pass, plus desktop typecheck and changed-file lint/format checks. No runtime behavior changes.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make WSL cache and diagnostic helpers module-private and test cache safety through public scripts
> - Converts `formatWslShellTransportFailureReason`, `buildWslNodeEnvPreamble`, `sanitizeWslRuntimeId`, and `formatNodePtyProbeFailureReason` from exported functions to module-private constants in [DesktopWslEnvironment.ts](https://github.com/pingdotgg/t3code/pull/10301/files#diff-eb443cdb82c5c1542b51d3b5bd796cd760f44161c7cd5f8ead2affd539c22d1d), reducing the module's public surface.
> - Replaces direct tests of those internal helpers with a parameterized test in [DesktopWslEnvironment.test.ts](https://github.com/pingdotgg/t3code/pull/10301/files#diff-55ea5641219aba2cbb061e278698fc36a0935306c50420e84b35c966ebb91b77) that checks cache-ID sanitization across the install, prune, and invalidate script builders.
> - Risk: external callers importing any of the four now-private helpers will break at compile time; no in-tree imports were affected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55360c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->