### PR TITLE
test(web): focus command palette tests on search behavior

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -2,45 +2,14 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
 import type { Thread } from "../types";
 import {
-  browseInputEndPaddingClass,
   buildBrowseGroups,
   buildThreadActionItems,
   enumerateCommandPaletteItems,
   filterPinnedBrowseEntries,
   filterCommandPaletteGroups,
-  normalizeSearchText,
   reduceCommandPaletteUiState,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
-
-describe("browseInputEndPaddingClass", () => {
-  it("reserves the widest space for the create action", () => {
-    expect(
-      browseInputEndPaddingClass({
-        willCreateProjectPath: true,
-        hasHighlightedBrowseItem: false,
-      }),
-    ).toContain("pe-38");
-  });
-
-  it("reserves space for the wider highlighted-item shortcut", () => {
-    expect(
-      browseInputEndPaddingClass({
-        willCreateProjectPath: false,
-        hasHighlightedBrowseItem: true,
-      }),
-    ).toContain("pe-30");
-  });
-
-  it("keeps the compact reserve for the normal add action", () => {
-    expect(
-      browseInputEndPaddingClass({
-        willCreateProjectPath: false,
-        hasHighlightedBrowseItem: false,
-      }),
-    ).toContain("pe-24");
-  });
-});
 
 describe("reduceCommandPaletteUiState", () => {
   const closedState = { open: false, mode: "command", openIntent: null } as const;
@@ -333,10 +302,33 @@ describe("buildThreadActionItems", () => {
   });
 
   it("normalizes case independently of the host locale", () => {
-    const localeLowerCase = vi.spyOn(String.prototype, "toLocaleLowerCase").mockReturnValue("gıt");
+    const toLocaleLowerCase = String.prototype.toLocaleLowerCase;
+    const localeLowerCase = vi
+      .spyOn(String.prototype, "toLocaleLowerCase")
+      .mockImplementation(function (this: string) {
+        return toLocaleLowerCase.call(this, "tr");
+      });
     try {
-      expect(normalizeSearchText("GIT")).toBe("git");
-      expect(localeLowerCase).not.toHaveBeenCalled();
+      const groups = filterCommandPaletteGroups({
+        activeGroups: [],
+        query: "GIT",
+        isInSubmenu: false,
+        projectSearchItems: [],
+        threadSearchItems: [],
+        settingsSearchItems: [
+          {
+            kind: "action",
+            value: "setting:version-control",
+            title: "Version control",
+            searchTerms: ["git"],
+            icon: null,
+            run: async () => undefined,
+          },
+        ],
+      });
+      expect(groups.flatMap((group) => group.items.map((item) => item.value))).toEqual([
+        "setting:version-control",
+      ]);
     } finally {
       localeLowerCase.mockRestore();
     }

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -13,8 +13,6 @@ import { normalizeSearchText } from "../lib/utils";
 import { formatRelativeTimeLabel } from "../timestampFormat";
 import { type Project, type SidebarThreadSummary, type Thread } from "../types";
 
-export { normalizeSearchText } from "../lib/utils";
-
 export const RECENT_THREAD_LIMIT = 12;
 export const ITEM_ICON_CLASS = "size-4 text-icon-muted";
 export const ADDON_ICON_CLASS = "size-4";


### PR DESCRIPTION
Command palette tests asserted padding class strings and imported a shared normalization helper through a test-only re-export. Remove those three styling assertions and the re-export, and check locale-independent search through the returned command groups.

Verification: all 17 remaining command palette tests pass; web typecheck and changed-file lint/format pass. Runtime behavior is unchanged.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor command palette tests to focus on search behavior
> - Removes direct tests for `browseInputEndPaddingClass` (create-project, highlighted-item, normal add) and `normalizeSearchText` from [CommandPalette.logic.test.ts](https://github.com/pingdotgg/t3code/pull/10302/files#diff-7e27ce8f14aaa0d915ad6b3770ec03d8acaa092915823abfb90caaec3cb00e34)
> - Replaces the direct `normalizeSearchText` unit test with an integration test through `filterCommandPaletteGroups`, forcing Turkish locale and verifying `GIT` matches `git`
> - Removes the re-export of `normalizeSearchText` from [CommandPalette.logic.ts](https://github.com/pingdotgg/t3code/pull/10302/files#diff-55f82e14ac05e7221288a697ea63ead189293a840ab2676cf127368f874e4d0e)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd34d63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->