### PR TITLE
docs: link the repository security reporting policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,8 @@
+# Security policy
+
+Report security vulnerabilities affecting T3 Code or T3 Tools-operated infrastructure to
+[security@ping.gg](mailto:security@ping.gg). Please do not disclose them publicly until we have had
+a reasonable opportunity to investigate and remediate them.
+
+See the [full security policy](https://t3.codes/security-policy) for reporting details, scope,
+and safe harbor terms for good-faith research.


### PR DESCRIPTION
## What Changed

Add `.github/SECURITY.md` with the published reporting address and a link to the existing security policy.

## Why

Researchers browsing the repository cannot find the private vulnerability reporting channel.

Closes #9881.

## Testing

- Verified the address and policy URL against the marketing site's security policy source.
- Targeted formatting and `git diff --check` pass. No runtime code changed.

## Checklist

- [x] One focused change
- [x] Explained what changed and why
- [x] Verified the existing reporting policy
- [x] No UI layout or animation changes

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add repository security policy in `.github/SECURITY.md`
> Adds a security policy document directing users to report vulnerabilities affecting T3 Code or T3 Tools-operated infrastructure to the security email address. The policy asks reporters to avoid public disclosure during investigation and links to the full policy for reporting details, scope, and safe-harbor terms.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 94db614.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
