### PR TITLE
test(web): cover file classification through diff ordering

### DIFF
--- a/apps/web/src/components/pullRequest/pullRequestFileOrder.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestFileOrder.logic.test.ts
@@ -1,7 +1,7 @@
 import type { FileDiffMetadata } from "@pierre/diffs";
 import { describe, expect, it } from "vite-plus/test";
 
-import { diffFileTier, orderDiffFiles } from "./pullRequestFileOrder.logic";
+import { orderDiffFiles } from "./pullRequestFileOrder.logic";
 
 /** Only the path and the patch's own lines matter here; the viewer fills the rest in. */
 function file(name: string, additionLines: ReadonlyArray<string> = []): FileDiffMetadata {
@@ -12,34 +12,31 @@ function order(files: ReadonlyArray<FileDiffMetadata>): Array<string> {
   return orderDiffFiles(files).map((entry) => entry.name);
 }
 
-describe("diffFileTier", () => {
-  it("puts lockfiles, snapshots and build output last", () => {
-    expect(diffFileTier("pnpm-lock.yaml")).toBe("generated");
-    expect(diffFileTier("apps/web/package-lock.json")).toBe("generated");
-    expect(diffFileTier("src/__snapshots__/app.ts")).toBe("generated");
-    expect(diffFileTier("src/app.test.ts.snap")).toBe("generated");
-    expect(diffFileTier("src/api.generated.ts")).toBe("generated");
-    expect(diffFileTier("public/app.min.js")).toBe("generated");
-    expect(diffFileTier("dist/app.js")).toBe("generated");
-    expect(diffFileTier("packages/core/vendor/lib.js")).toBe("generated");
-  });
-
-  it("recognises a test by its name or by the directory holding it", () => {
-    expect(diffFileTier("src/app.test.ts")).toBe("test");
-    expect(diffFileTier("src/app.spec.tsx")).toBe("test");
-    expect(diffFileTier("src/__tests__/app.ts")).toBe("test");
-    expect(diffFileTier("test/app.ts")).toBe("test");
-    expect(diffFileTier("tests/helpers/app.ts")).toBe("test");
-  });
-
-  it("treats everything else as source, including files merely named like a directory", () => {
-    expect(diffFileTier("src/app.ts")).toBe("source");
-    expect(diffFileTier("src/testing.ts")).toBe("source");
-    expect(diffFileTier("src/dist.ts")).toBe("source");
-  });
-});
-
 describe("orderDiffFiles", () => {
+  it("places source before tests and generated files across path conventions", () => {
+    const source = ["src/app.ts", "src/dist.ts", "src/testing.ts"];
+    const tests = [
+      "src/__tests__/app.ts",
+      "src/app.spec.tsx",
+      "src/app.test.ts",
+      "test/app.ts",
+      "tests/helpers/app.ts",
+    ];
+    const generated = [
+      "apps/web/package-lock.json",
+      "dist/app.js",
+      "packages/core/vendor/lib.js",
+      "pnpm-lock.yaml",
+      "public/app.min.js",
+      "src/__snapshots__/app.ts",
+      "src/api.generated.ts",
+      "src/app.test.ts.snap",
+    ];
+    expect(
+      order([...generated, ...tests, ...source].toReversed().map((path) => file(path))),
+    ).toEqual([...source, ...tests, ...generated]);
+  });
+
   it("answers an empty diff with an empty order", () => {
     expect(order([])).toEqual([]);
   });

--- a/apps/web/src/components/pullRequest/pullRequestFileOrder.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestFileOrder.logic.ts
@@ -31,7 +31,7 @@ const GENERATED_DIRECTORIES = new Set([
 const TEST_DIRECTORIES = new Set(["__tests__", "tests", "test"]);
 const MODULE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
 
-export function diffFileTier(path: string): DiffFileTier {
+function diffFileTier(path: string): DiffFileTier {
   const segments = path.split("/");
   const name = segments.at(-1) ?? "";
   if (


### PR DESCRIPTION
The diff file classifier was exported only so tests could assert its intermediate tier labels. Make it private and consolidate those tests into a check of the public file ordering result.

The ordering test retains all 16 source, test, lockfile, snapshot, and generated-path examples. Existing dependency-ordering and cycle coverage remains.

Verification: all 15 diff ordering tests pass; web typecheck and changed-file lint/format pass.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cover file classification via `orderDiffFiles` tests and make `diffFileTier` private
> Tests now verify file classification by checking `orderDiffFiles` output instead of testing `diffFileTier` directly. `diffFileTier` is made module-private in [pullRequestFileOrder.logic.ts](https://github.com/pingdotgg/t3code/pull/10304/files#diff-463186f69e6df2f0cb54e71d9b22ac10b472493e600fb37eca1012720f6b2aa7). Existing tests are grouped under the `orderDiffFiles` describe block.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ab7521.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->