### PR TITLE
fix(marketing): show a real preview card when t3.codes is shared

### DIFF
--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from "astro/config";
 
 export default defineConfig({
+  site: "https://t3.codes",
   server: {
     port: Number(process.env.PORT ?? 4173),
   },

--- a/apps/marketing/src/layouts/Layout.astro
+++ b/apps/marketing/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
-import { Image } from "astro:assets";
+import { getImage, Image } from "astro:assets";
 import appIcon from "../assets/icon.webp";
+import desktopScreenshot from "../assets/app-desktop.webp";
 import dmSansLatinUrl from "../assets/fonts/dm-sans-latin.woff2?url";
 import "../styles/fonts.css";
 import {
@@ -21,6 +22,21 @@ const {
   description = "T3 Code. The open-source control plane for coding agents.",
   pageClass,
 } = Astro.props;
+
+// Social preview card. Link unfurlers (Instagram, iMessage, X, Slack) want a
+// 1200x630 jpg or png at an absolute URL. Built from the hero screenshot so it
+// stays in sync with the homepage.
+const socialImage = await getImage({
+  src: desktopScreenshot,
+  width: 1200,
+  height: 630,
+  fit: "cover",
+  position: "top",
+  format: "jpg",
+  quality: 90,
+});
+const socialImageUrl = new URL(socialImage.src, Astro.site);
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
 ---
 
 <html lang="en">
@@ -28,6 +44,21 @@ const {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
+    <link rel="canonical" href={canonicalUrl} />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="T3 Code" />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:image" content={socialImageUrl} />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="The T3 Code desktop app with a thread open." />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@t3dotgg" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={socialImageUrl} />
     <link
       rel="preload"
       href={dmSansLatinUrl}


### PR DESCRIPTION
Sharing t3.codes in Instagram, iMessage, or X showed a tiny black-and-gray square. The site had no Open Graph or Twitter meta tags, so unfurlers fell back to the 180px apple-touch-icon and letterboxed it.

The shared layout now emits Open Graph and Twitter card tags on every page, with a canonical URL. The preview image is a 1200x630 jpg that Astro builds from the hero screenshot at build time, so it stays in sync with the homepage. Set `site` in the Astro config so the image and canonical URLs are absolute, which unfurlers require.

Verified with a local build: every page has the tags, and the generated image is 1200x630.

Created with Claude Fable 5.1 in Claude Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Open Graph and Twitter preview cards to marketing site layout
> - Sets the canonical site URL to `https://t3.codes` in [astro.config.mjs](https://github.com/pingdotgg/t3code/pull/10305/files#diff-fef56f737a189b6e431254fae768a0c3026c90e25da8f427f8182f295896ea68) so Astro can generate absolute URLs
> - Generates a 1200x630 JPEG social preview image by cropping the desktop screenshot from the top at quality 90 in [Layout.astro](https://github.com/pingdotgg/t3code/pull/10305/files#diff-cd40546c5d1667e6a791b4befdf6583020a7cfd7a6bbe78583471acd1618eaba)\n- Adds canonical, Open Graph, and Twitter metadata to all pages using the layout, built from the page title, description, configured site URL, and generated image URL
> - Risk: every page now triggers an async `getImage` call at build time, which increases build duration for the marketing site
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9117126.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->