### PR TITLE
test(web): keep Markdown gutter styling private

### DIFF
--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -60,7 +60,6 @@ vi.mock("~/lib/openPullRequestLink", () => ({
 import ChatMarkdown, {
   canUseMarkdownFileShellActions,
   hasMarkdownFilePrimaryAction,
-  orderedListGutterStyle,
   shouldUseMarkdownFileBrowserPrimaryAction,
 } from "./ChatMarkdown";
 
@@ -637,47 +636,6 @@ describe("shouldUseMarkdownFileBrowserPrimaryAction", () => {
         canOpenInPanel: true,
       }),
     ).toBe(true);
-  });
-});
-
-describe("orderedListGutterStyle", () => {
-  it("leaves the default gutter alone for single-digit lists", () => {
-    expect(orderedListGutterStyle(9, undefined)).toBeUndefined();
-  });
-
-  it("widens the gutter for two-digit lists", () => {
-    expect(orderedListGutterStyle(99, undefined)).toEqual({ "--list-gutter": "3ch" });
-  });
-
-  it("widens the gutter for a two-digit list that starts above 1", () => {
-    // start=50 + 49 items => last marker is "98", still two digits.
-    expect(orderedListGutterStyle(49, 50)).toEqual({ "--list-gutter": "3ch" });
-  });
-
-  it("widens the gutter once the last marker reaches three digits", () => {
-    // item 100 is the bug from #6512: a 100-item list starting at 1.
-    expect(orderedListGutterStyle(100, undefined)).toEqual({ "--list-gutter": "4ch" });
-  });
-
-  it("accounts for a non-default start attribute", () => {
-    // start=95 + 9 items => last marker is "103", three digits.
-    expect(orderedListGutterStyle(9, 95)).toEqual({ "--list-gutter": "4ch" });
-    expect(orderedListGutterStyle(5, "999995")).toEqual({ "--list-gutter": "7ch" });
-  });
-
-  it("scales further for four-digit markers", () => {
-    expect(orderedListGutterStyle(1000, undefined)).toEqual({ "--list-gutter": "5ch" });
-  });
-
-  it("uses the widest marker and includes a negative start's minus sign", () => {
-    expect(orderedListGutterStyle(1001, -1000)).toEqual({ "--list-gutter": "6ch" });
-    expect(orderedListGutterStyle(3, -15)).toEqual({ "--list-gutter": "4ch" });
-    expect(orderedListGutterStyle(3, -5)).toEqual({ "--list-gutter": "3ch" });
-  });
-
-  it("treats a missing/zero item count as a single item", () => {
-    expect(orderedListGutterStyle(0, undefined)).toBeUndefined();
-    expect(orderedListGutterStyle(0, 100)).toEqual({ "--list-gutter": "4ch" });
   });
 });
 

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -340,7 +340,7 @@ function findTaskListMarkerOffset(markdown: string, listItemStart: number): numb
  * message's overflow. Widen the gutter to fit the widest marker, including a
  * negative marker's minus sign.
  */
-export function orderedListGutterStyle(
+function orderedListGutterStyle(
   itemCount: number,
   start: unknown,
 ): { "--list-gutter": string } | undefined {


### PR DESCRIPTION
The Markdown list gutter helper was exported only for eight tests asserting exact CSS custom-property values. Keep the helper private and remove those styling implementation tests.

This deliberately drops direct coverage of the gutter formula; its implementation and renderer usage are unchanged. No static-markup replacements are added.

Verification: all 43 remaining ChatMarkdown tests pass; web typecheck and formatting pass. Lint reports only two existing effect warnings outside the change.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `orderedListGutterStyle` private in `ChatMarkdown`
> Removes the `export` modifier from the `orderedListGutterStyle` helper in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/10306/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05), keeping it module-internal. Deletes the corresponding test suite in [ChatMarkdown.test.tsx](https://github.com/pingdotgg/t3code/pull/10306/files#diff-c672cad8956ca6dade2db0386173cecd0d0e003ce008ec7fc6484e962b3562da) that relied on the named import. The gutter calculation logic itself is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f095a4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->