### PR TITLE
test(web): keep settings viewport comparison private

### DIFF
--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -14,7 +14,6 @@ import {
   formatDiagnosticsDescription,
   getChangedBrowserSettingLabels,
   getChangedTypographySettingLabels,
-  isSamePreviewViewport,
   hasChangedBackgroundActivitySettings,
   isProjectGroupingEnabled,
   projectGroupingModeFromToggle,
@@ -280,27 +279,5 @@ describe("getChangedBrowserSettingLabels", () => {
       "Open links in",
       "Floating preview",
     ]);
-  });
-});
-
-describe("isSamePreviewViewport", () => {
-  it("separates presets that share a size", () => {
-    // Two presets can agree on width and height and still be different
-    // entries in the picker, so the id has to take part in the comparison.
-    expect(
-      isSamePreviewViewport(
-        { _tag: "preset", width: 390, height: 844, presetId: "iphone-12-pro" },
-        { _tag: "preset", width: 390, height: 844, presetId: "ipad-mini" },
-      ),
-    ).toBe(false);
-  });
-
-  it("separates a freeform viewport from a preset of the same size", () => {
-    expect(
-      isSamePreviewViewport(
-        { _tag: "freeform", width: 390, height: 844 },
-        { _tag: "preset", width: 390, height: 844, presetId: "iphone-12-pro" },
-      ),
-    ).toBe(false);
   });
 });

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -126,7 +126,7 @@ export type BrowserDefaultSettings = Pick<
  * reports every stored viewport as changed — including one that matches the
  * default.
  */
-export function isSamePreviewViewport(
+function isSamePreviewViewport(
   left: PreviewViewportSetting,
   right: PreviewViewportSetting,
 ): boolean {


### PR DESCRIPTION
The settings viewport comparator was exported only for direct helper tests. Keep it private and remove those two comparator tests.

The public changed-settings tests still cover defaults, a freshly decoded equivalent viewport, and changed viewport labels. The comparison implementation is unchanged.

Verification: all 16 remaining settings logic tests pass; web typecheck and changed-file lint/format pass.

Model: gpt-6 astra. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `isSamePreviewViewport` module-private in settings panels
> Changes `isSamePreviewViewport` from an exported function to a module-private function in [SettingsPanels.logic.ts](https://github.com/pingdotgg/t3code/pull/10307/files#diff-bad687287a18d0a58c30735640fef99f0f90283727a66f89de22cffd8cb302c4). Removes the `isSamePreviewViewport` import and its two test cases from [SettingsPanels.logic.test.ts](https://github.com/pingdotgg/t3code/pull/10307/files#diff-13778009ccc3ad26b09e392a67d8d5c31f94c8caaea4dc191b3952ec708c7977). Comparison logic is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a42f4b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->