### PR TITLE
fix(server): preserve Codex reset credits during usage updates

### DIFF
--- a/apps/server/src/provider/providerUsageLimits.test.ts
+++ b/apps/server/src/provider/providerUsageLimits.test.ts
@@ -61,6 +61,21 @@ describe("applyUsageLimitsUpdate", () => {
       applyUsageLimitsUpdate({ previous: published, checkedAt, update: { windows: [] } }),
     ).toBe(published);
   });
+
+  it("preserves reset credits when a streamed window update changes usage", () => {
+    const resetCredits = { availableCount: 2, nextExpiresAt: "2026-10-01T00:00:00.000Z" };
+    const next = applyUsageLimitsUpdate({
+      previous: { ...published, resetCredits },
+      checkedAt: "2026-09-03T12:00:05.000Z",
+      update: { windows: [{ ...session, usedPercent: 55 }] },
+    });
+
+    expect(next).toEqual({
+      checkedAt: "2026-09-03T12:00:05.000Z",
+      windows: [{ ...session, usedPercent: 55 }, weekly],
+      resetCredits,
+    });
+  });
 });
 
 describe("resolveUsageLimitsAfterProbe", () => {

--- a/apps/server/src/provider/providerUsageLimits.ts
+++ b/apps/server/src/provider/providerUsageLimits.ts
@@ -91,7 +91,10 @@ export function applyUsageLimitsUpdate(input: {
   if (!changed && previous !== undefined && previous.unavailable === undefined) {
     return previous;
   }
-  return makeUsageLimits({ checkedAt: input.checkedAt, windows: merged.values() });
+  return {
+    ...makeUsageLimits({ checkedAt: input.checkedAt, windows: merged.values() }),
+    ...(previous?.resetCredits !== undefined ? { resetCredits: previous.resetCredits } : {}),
+  };
 }
 
 function usageWindowEquals(a: ServerProviderUsageWindow, b: ServerProviderUsageWindow): boolean {


### PR DESCRIPTION
## What Changed

Preserve Codex reset credits when merging streamed rate-limit window updates. A later full account probe can still replace or remove the credits.

## Why

Sparse usage updates rebuild the limits snapshot and discard the credits returned by the last probe, making reset credits disappear from Usage → Limits during a turn.

## Testing

- `providerUsageLimits.test.ts` passes, 5/5, including a streamed-update regression.
- Server typecheck, targeted lint, and formatting pass.

## Checklist

- [x] One focused change
- [x] Explained what changed and why
- [x] Added regression coverage for the changed behavior
- [x] No UI layout or animation changes

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve `resetCredits` in `provider.applyUsageLimitsUpdate`
> Streamed usage-limit updates were dropping the `resetCredits` metadata from the prior snapshot. The merger now carries forward `previous.resetCredits` while still applying the new window data and updated check timestamp.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1050bfa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
