### PR TITLE
fix(desktop): bundle the resource monitor for WSL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -327,7 +327,7 @@ jobs:
   # cross-compiling and no first-launch compiler/node-gyp/network on the user's
   # machine. node-pty is N-API, so one binary works across all WSL Node versions.
   build_wsl_node_pty:
-    name: Build WSL node-pty (linux-x64)
+    name: Build WSL native binaries (linux-x64)
     # Same gating as relay_public_config: only the commit SHA is needed, so this
     # runs alongside preflight. See the condition comment there.
     needs: [check_changes]
@@ -374,6 +374,21 @@ jobs:
         with:
           name: wsl-node-pty-x64
           path: wsl-prebuild/pty.node
+          if-no-files-found: error
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Build WSL resource monitor
+        run: cargo build --locked --release --manifest-path native/resource-monitor/Cargo.toml --target x86_64-unknown-linux-gnu
+
+      - name: Upload WSL resource monitor
+        uses: actions/upload-artifact@v7
+        with:
+          name: wsl-resource-monitor-x64
+          path: native/resource-monitor/target/x86_64-unknown-linux-gnu/release/t3-resource-monitor
           if-no-files-found: error
 
   build:
@@ -511,6 +526,13 @@ jobs:
         with:
           name: wsl-node-pty-x64
           path: wsl-prebuild
+
+      - name: Download WSL resource monitor
+        if: matrix.platform == 'win'
+        uses: actions/download-artifact@v8
+        with:
+          name: wsl-resource-monitor-x64
+          path: native/resource-monitor/target/x86_64-unknown-linux-gnu/release
 
       - name: Install Spectre-mitigated MSVC libs
         if: matrix.platform == 'win'

--- a/apps/desktop/src/wsl/DesktopWslEnvironment.test.ts
+++ b/apps/desktop/src/wsl/DesktopWslEnvironment.test.ts
@@ -436,7 +436,7 @@ describe.skipIf(posixShellRunner === null)("WSL runtime install script (executed
     fixtures.length = 0;
   });
 
-  const createFixture = () => {
+  const createFixture = (includeMonitor = false) => {
     const result = runShell(
       [
         "set -eu",
@@ -447,6 +447,13 @@ describe.skipIf(posixShellRunner === null)("WSL runtime install script (executed
         `printf '%s' '{"name":"node-pty","version":"0.0.0-test"}' > "$stage/node_modules/node-pty/package.json"`,
         `printf '%s' 'pty-native-payload' > "$stage/node_modules/node-pty/prebuilds/linux-x64/pty.node"`,
         `printf '%s' '{"arch":"x64"}' > "$stage/node_modules/node-pty/prebuilds/linux-x64/t3code-wsl-node-pty.json"`,
+        ...(includeMonitor
+          ? [
+              'mkdir -p "$stage/apps/server/dist/resource-monitor/linux-x64"',
+              `printf '%s' ${sh("#!/bin/sh\nprintf monitor-ready\n")} > "$stage/apps/server/dist/resource-monitor/linux-x64/t3-resource-monitor"`,
+              'chmod 644 "$stage/apps/server/dist/resource-monitor/linux-x64/t3-resource-monitor"',
+            ]
+          : []),
         `tar -czf "$work/wsl-runtime.tar.gz" -C "$stage" apps/server/dist node_modules`,
         `printf 'work:%s\\n' "$work"`,
         `printf 'archiveSha:%s\\n' "$(sha256sum "$work/wsl-runtime.tar.gz" | cut -d ' ' -f 1)"`,
@@ -479,6 +486,17 @@ describe.skipIf(posixShellRunner === null)("WSL runtime install script (executed
       install: (archive?: string, sha?: string) => runShell(installScript(archive, sha)),
     };
   };
+
+  it("makes a monitor archived without execute permission runnable inside WSL", () => {
+    const fixture = createFixture(true);
+    const installed = fixture.install();
+    expect(installed.status, installed.stderr).toBe(0);
+
+    const monitor = `${fixture.runtimeRoot}/apps/server/dist/resource-monitor/linux-x64/t3-resource-monitor`;
+    const launched = runShell(`set -eu\ntest -x ${sh(monitor)}\n${sh(monitor)}`);
+    expect(launched.status, launched.stderr).toBe(0);
+    expect(launched.stdout).toBe("monitor-ready");
+  });
 
   it("reuses a warm cache without touching the archive", () => {
     const fixture = createFixture();

--- a/apps/desktop/src/wsl/DesktopWslEnvironment.ts
+++ b/apps/desktop/src/wsl/DesktopWslEnvironment.ts
@@ -372,6 +372,10 @@ export const buildWslRuntimeInstallScript = (
     'cleanup_runtime_install() { rm -rf "$runtime_tmp"; }',
     "trap cleanup_runtime_install EXIT",
     `tar -xzf ${shellQuote(linuxArchivePath)} -C "$runtime_tmp"`,
+    // Windows cannot record Unix execute bits when staging the archive.
+    'for monitor in "$runtime_tmp"/apps/server/dist/resource-monitor/linux-*/t3-resource-monitor; do',
+    '  [ ! -f "$monitor" ] || chmod 755 "$monitor"',
+    "done",
     'test -f "$runtime_tmp/apps/server/dist/bin.mjs"',
     'test -f "$runtime_tmp/node_modules/node-pty/package.json"',
 

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -1897,6 +1897,22 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         const hashPath = `${archivePath}.sha256`;
         yield* stageWslRuntimeTreeFixture(sourceDir, "export const serve = 1;\n");
 
+        const monitorPath = path.join(
+          root,
+          "native/resource-monitor/target/x86_64-unknown-linux-gnu/release/t3-resource-monitor",
+        );
+        yield* fs.makeDirectory(path.dirname(monitorPath), { recursive: true });
+        yield* fs.writeFileString(monitorPath, "linux monitor");
+        yield* fs.chmod(monitorPath, 0o644);
+        yield* stageResourceMonitor({
+          repoRoot: root,
+          stageResourcesDir: path.join(sourceDir, "apps/server/dist"),
+          platform: "linux",
+          arch: "x64",
+          verbose: false,
+          reuseExisting: true,
+        });
+
         const members = [
           "node_modules/node-pty/prebuilds/darwin-x64/pty.node",
           "node_modules/node-pty/prebuilds/win32-x64/pty.node",
@@ -1943,6 +1959,21 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         assert.equal(Number(yield* process.exitCode), 0);
 
         assert.include(listing, "apps/server/dist/bin.mjs");
+        assert.include(listing, "apps/server/dist/resource-monitor/t3-resource-monitor");
+        const extractedDir = path.join(root, "extracted");
+        yield* fs.makeDirectory(extractedDir);
+        const extract = yield* spawner.spawn(
+          ChildProcess.make("tar", ["-xzf", archivePath, "-C", extractedDir]),
+        );
+        assert.equal(Number(yield* extract.exitCode), 0);
+        const extractedMonitor = path.join(
+          extractedDir,
+          "apps/server/dist/resource-monitor/t3-resource-monitor",
+        );
+        assert.equal(yield* fs.readFileString(extractedMonitor), "linux monitor");
+        if ((yield* HostProcessPlatform) !== "win32") {
+          assert.equal((yield* fs.stat(extractedMonitor)).mode & 0o111, 0o111);
+        }
         assert.include(listing, "node_modules/node-pty/prebuilds/linux-x64/pty.node");
         assert.include(listing, "node_modules/@ff-labs/fff-bin-linux-x64-gnu/libfff.so");
         assert.include(listing, "node_modules/@yuuang/ffi-rs-linux-x64-gnu/libffi.so");

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -1904,14 +1904,17 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         yield* fs.makeDirectory(path.dirname(monitorPath), { recursive: true });
         yield* fs.writeFileString(monitorPath, "linux monitor");
         yield* fs.chmod(monitorPath, 0o644);
-        yield* stageResourceMonitor({
+        const stagedMonitor = yield* stageResourceMonitor({
           repoRoot: root,
-          stageResourcesDir: path.join(sourceDir, "apps/server/dist"),
+          stageResourcesDir: path.join(root, "wsl-monitor"),
           platform: "linux",
           arch: "x64",
           verbose: false,
           reuseExisting: true,
         });
+        const monitorDir = path.join(sourceDir, "apps/server/dist/resource-monitor/linux-x64");
+        yield* fs.makeDirectory(monitorDir, { recursive: true });
+        yield* fs.copyFile(stagedMonitor, path.join(monitorDir, "t3-resource-monitor"));
 
         const members = [
           "node_modules/node-pty/prebuilds/darwin-x64/pty.node",
@@ -1959,7 +1962,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         assert.equal(Number(yield* process.exitCode), 0);
 
         assert.include(listing, "apps/server/dist/bin.mjs");
-        assert.include(listing, "apps/server/dist/resource-monitor/t3-resource-monitor");
+        assert.include(listing, "apps/server/dist/resource-monitor/linux-x64/t3-resource-monitor");
         const extractedDir = path.join(root, "extracted");
         yield* fs.makeDirectory(extractedDir);
         const extract = yield* spawner.spawn(
@@ -1968,7 +1971,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         assert.equal(Number(yield* extract.exitCode), 0);
         const extractedMonitor = path.join(
           extractedDir,
-          "apps/server/dist/resource-monitor/t3-resource-monitor",
+          "apps/server/dist/resource-monitor/linux-x64/t3-resource-monitor",
         );
         assert.equal(yield* fs.readFileString(extractedMonitor), "linux monitor");
         if ((yield* HostProcessPlatform) !== "win32") {

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -2222,6 +2222,7 @@ export const stageResourceMonitor = Effect.fn("stageResourceMonitor")(function* 
   if (input.platform !== "win") {
     yield* fs.chmod(destinationPath, 0o755);
   }
+  return destinationPath;
 });
 
 export const stageBrowserSecret = Effect.fn("stageBrowserSecret")(function* (input: {
@@ -2983,14 +2984,21 @@ export const stageWindowsServerSidecar = Effect.fn("stageWindowsServerSidecar")(
   // extract and reject on every launch. The desktop app treats a missing
   // archive as "no WSL-local runtime" and goes straight to the mounted tree.
   if (bundlesWslRuntime({ arch: input.arch, prebuildPath: input.wslPrebuildPath })) {
-    yield* stageResourceMonitor({
+    const monitorPath = yield* stageResourceMonitor({
       repoRoot: input.repoRoot,
-      stageResourcesDir: path.join(serverStageDir, "apps/server/dist"),
+      stageResourcesDir: path.join(input.stageRoot, "wsl-monitor"),
       platform: "linux",
       arch: input.arch,
       verbose: input.verbose,
       reuseExisting: true,
     });
+    const monitorDir = path.join(
+      serverStageDir,
+      "apps/server/dist/resource-monitor",
+      `linux-${input.arch}`,
+    );
+    yield* fs.makeDirectory(monitorDir, { recursive: true });
+    yield* fs.copyFile(monitorPath, path.join(monitorDir, "t3-resource-monitor"));
     yield* stageWslRuntimeArchive({
       sourceDir: serverStageDir,
       archivePath: input.wslRuntimeArchivePath,

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -2144,15 +2144,18 @@ export const stageResourceMonitor = Effect.fn("stageResourceMonitor")(function* 
   readonly platform: typeof BuildPlatform.Type;
   readonly arch: typeof BuildArch.Type;
   readonly verbose: boolean;
+  readonly reuseExisting?: boolean;
 }) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const manifestPath = path.join(input.repoRoot, "native/resource-monitor/Cargo.toml");
   const executableName = resourceMonitorExecutableName(input.platform);
   const rustTargets = resolveResourceMonitorRustTargets(input.platform, input.arch);
-  const reuseResourceMonitor = yield* Config.boolean("T3CODE_DESKTOP_REUSE_RESOURCE_MONITOR").pipe(
-    Config.withDefault(false),
-  );
+  const reuseResourceMonitor =
+    input.reuseExisting ??
+    (yield* Config.boolean("T3CODE_DESKTOP_REUSE_RESOURCE_MONITOR").pipe(
+      Config.withDefault(false),
+    ));
   const builtBinaries: string[] = [];
 
   for (const rustTarget of rustTargets) {
@@ -2980,6 +2983,14 @@ export const stageWindowsServerSidecar = Effect.fn("stageWindowsServerSidecar")(
   // extract and reject on every launch. The desktop app treats a missing
   // archive as "no WSL-local runtime" and goes straight to the mounted tree.
   if (bundlesWslRuntime({ arch: input.arch, prebuildPath: input.wslPrebuildPath })) {
+    yield* stageResourceMonitor({
+      repoRoot: input.repoRoot,
+      stageResourcesDir: path.join(serverStageDir, "apps/server/dist"),
+      platform: "linux",
+      arch: input.arch,
+      verbose: input.verbose,
+      reuseExisting: true,
+    });
     yield* stageWslRuntimeArchive({
       sourceDir: serverStageDir,
       archivePath: input.wslRuntimeArchivePath,


### PR DESCRIPTION
## What Changed

Build the Linux resource monitor alongside the WSL terminal prebuild and copy it into `resource-monitor/linux-x64` before creating the WSL archive.

Reuse monitor staging in a temporary directory, then copy only the Linux binary so existing monitor directories remain intact. Packaging fails if the required prebuilt binary is missing.

Restore the monitor's execute permission inside the Linux installer after extraction, because Windows archive creation does not preserve it reliably. Older archives without a monitor retain their existing installation behavior.

## Why

Windows desktop releases omit the Linux monitor from their WSL runtime, so Resource Monitor reports that its binary was not found. The npm package receives those binaries only after desktop packaging finishes.

Fixes #9837.

## Testing

- Focused archive and cached-monitor tests pass, including archive extraction, monitor contents, and executable permissions.
- All 51 `DesktopWslEnvironment` tests pass, including an executed shell regression that installs a monitor archived with mode `0644` and verifies it can run.
- Scripts and desktop typechecks, targeted lint, and formatting pass.
- A Windows release build was not run locally.

## Checklist

- [x] One focused change
- [x] Explained what changed and why
- [x] Added regression coverage for the changed behavior
- [x] No UI layout or animation changes

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bundle Linux resource-monitor executable in WSL runtime archive
> - The release workflow builds the Rust `resource-monitor` for the GNU x64 target in `build_wsl_node_pty`, uploads it as an artifact, and the Windows packaging job downloads it into the expected Rust release target directory before creating the sidecar
> - `stageWindowsServerSidecar` now stages the Linux resource monitor in reuse-existing mode and copies it into the architecture-specific directory inside the server distribution before building the WSL runtime archive
> - `buildWslRuntimeInstallScript` adds an extraction-time loop that finds Linux resource-monitor executables in the temp runtime tree and sets executable permissions before the runtime is validated and promoted
> - Tests in [DesktopWslEnvironment.test.ts](https://github.com/pingdotgg/t3code/pull/10309/files#diff-55ea5641219aba2cbb061e278698fc36a0935306c50420e84b35c966ebb91b77) and [build-desktop-artifact.test.ts](https://github.com/pingdotgg/t3code/pull/10309/files#diff-a199d37af35c35dd3b48cf71436cb06b23acccd6857a9fe74db6d48cb73c7663) verify the monitor is present in the archive, preserves executable mode, and becomes runnable after install
> - Risk: WSL runtime installs that previously lacked a resource monitor now require one; if the staged binary is missing or not executable after the permission loop, `buildWslRuntimeInstallScript` will fail at validation in [DesktopWslEnvironment.ts](https://github.com/pingdotgg/t3code/pull/10309/files#diff-eb443cdb82c5c1542b51d3b5bd796cd760f44161c7cd5f8ead2affd539c22d1d)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 16f940e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WSL runtime installation so the Linux resource monitor is executable after extraction.
  - Fixed WSL-based resource monitoring in packaged desktop builds by bundling the required Linux binary.
  - Added validation to ensure the monitor is included in runtime archives and runs successfully inside WSL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->