### PR TITLE
fix(server): honor disabled usage hub polling

### DIFF
--- a/apps/server/src/usage/UsageLimitSources.test.ts
+++ b/apps/server/src/usage/UsageLimitSources.test.ts
@@ -1,0 +1,76 @@
+import { assert, describe, it } from "@effect/vitest";
+import { UsageLimitSourceId } from "@t3tools/contracts";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
+import { TestClock } from "effect/testing";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+
+import { BackgroundPolicy } from "../background/BackgroundPolicy.ts";
+import { layerTest } from "../serverSettings.ts";
+import * as UsageLimitSources from "./UsageLimitSources.ts";
+
+const backgroundPolicy = Layer.succeed(BackgroundPolicy, {
+  reportClientActivity: () => Effect.void,
+  removeRpcClient: () => Effect.void,
+  reportHostPowerState: () => Effect.void,
+  snapshot: Effect.die("unused"),
+  streamChanges: Stream.empty,
+  subscribe: Effect.die("unused"),
+  hasDemand: () => Effect.succeed(true),
+  shouldRunScopeWork: () => Effect.succeed(true),
+  shouldRunOpportunisticWork: Effect.succeed(true),
+});
+
+describe("UsageLimitSources refresh interval", () => {
+  it.effect.each([
+    { interval: Duration.seconds(0), expectedReads: 1 },
+    { interval: Duration.minutes(1), expectedReads: 2 },
+  ])("polls only when enabled: $expectedReads reads", ({ interval, expectedReads }) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const reads = yield* Ref.make(0);
+        const httpClient = Layer.succeed(
+          HttpClient.HttpClient,
+          HttpClient.make((request) =>
+            Ref.update(reads, (count) => count + 1).pipe(
+              Effect.as(HttpClientResponse.fromWeb(request, Response.json({ accounts: {} }))),
+            ),
+          ),
+        );
+        const sources = yield* UsageLimitSources.make.pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              backgroundPolicy,
+              httpClient,
+              layerTest({
+                providerHealthRefreshInterval: interval,
+                usageLimitSources: {
+                  [UsageLimitSourceId.make("hub")]: {
+                    kind: "cliproxy",
+                    url: "https://hub.example.com",
+                    managementKey: "test-key",
+                    enabled: true,
+                  },
+                },
+              }),
+            ),
+          ),
+        );
+        yield* sources.streamChanges.pipe(
+          Stream.filter((snapshots) => snapshots.length === 1),
+          Stream.runHead,
+        );
+        assert.strictEqual(yield* Ref.get(reads), 1);
+
+        yield* TestClock.adjust("61 seconds");
+        assert.strictEqual(yield* Ref.get(reads), expectedReads);
+
+        yield* sources.refresh;
+        assert.strictEqual(yield* Ref.get(reads), expectedReads + 1);
+      }),
+    ).pipe(Effect.provide(TestClock.layer())),
+  );
+});

--- a/apps/server/src/usage/UsageLimitSources.ts
+++ b/apps/server/src/usage/UsageLimitSources.ts
@@ -172,9 +172,16 @@ export const make = Effect.gen(function* () {
   yield* Effect.forever(
     interval.pipe(
       Effect.flatMap((wait) =>
-        Effect.sleep(Duration.toMillis(Duration.fromInputUnsafe(wait)) <= 0 ? "60 seconds" : wait),
+        Effect.sleep(
+          Duration.toMillis(Duration.fromInputUnsafe(wait)) <= 0 ? "60 seconds" : wait,
+        ).pipe(
+          Effect.andThen(
+            Duration.toMillis(Duration.fromInputUnsafe(wait)) > 0
+              ? backgroundPolicy.shouldRunScopeWork({ type: "provider-status" })
+              : Effect.succeed(false),
+          ),
+        ),
       ),
-      Effect.andThen(backgroundPolicy.shouldRunScopeWork({ type: "provider-status" })),
       Effect.flatMap((shouldRun) => (shouldRun ? refresh : Effect.void)),
       Effect.ignoreCause({ log: true }),
     ),


### PR DESCRIPTION
## What Changed

Skip periodic usage hub refreshes when the provider health-check interval is disabled. Startup, settings changes, and explicit refresh still fetch the current limits.

## Why

An interval of zero still polls configured CLIProxyAPI usage hubs once per minute while the Limits view is active. The loop substitutes a one-minute sleep, then fetches anyway.

## Testing

- `UsageLimitSources.test.ts` passes, 2/2.
- Deterministic TestClock cases cover enabled and disabled polling and explicit refresh.
- Server typecheck, targeted lint, and formatting pass.

## Checklist

- [x] One focused change
- [x] Explained what changed and why
- [x] Added regression coverage for the changed behavior
- [x] No UI layout or animation changes

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 'UsageLimitSources.make' to honor disabled polling for non-positive intervals
> - `UsageLimitSources.make` now skips scheduled provider-status refreshes when the configured interval is zero or negative. It retains a 60-second sleep to avoid tight looping but skips the `BackgroundPolicy` check.
> - The initial forked refresh and explicit refresh requests remain unchanged.
> - Adds a test-only `BackgroundPolicy` fixture and parameterized tests to verify read counts for zero and one-minute refresh intervals.
> - Behavioral Change: Setting the refresh interval to `0` or a negative value now disables scheduled polling instead of falling back to periodic refreshes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c566bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
