### PR TITLE
fix(shared): classify workspace previews by literal filenames

### DIFF
--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -573,6 +573,49 @@ describe("AssetAccess", () => {
     }).pipe(Effect.provide(testLayer)),
   );
 
+  it.effect("previews workspace files with literal fragment characters in their paths", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-preview-literal-" });
+      const directory = path.join(root, "assets#archive");
+      yield* fileSystem.makeDirectory(directory);
+
+      for (const name of ["icon#v2.png", "report#draft.pdf"]) {
+        const filePath = path.join(directory, name);
+        yield* fileSystem.writeFileString(filePath, "preview fixture");
+        const canonicalFile = yield* fileSystem.realPath(filePath);
+        const result = yield* issueAssetUrl({
+          resource: {
+            _tag: "workspace-file",
+            threadId: ThreadId.make("thread-1"),
+            path: filePath,
+          },
+          workspaceRoot: root,
+        });
+        const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+        const token = suffix.slice(0, suffix.indexOf("/"));
+
+        expect(yield* resolveAsset(token, name)).toEqual({ kind: "file", path: canonicalFile });
+        if (name.endsWith(".png")) {
+          expect(yield* resolveAsset(token, "other.png")).toBeNull();
+        }
+      }
+
+      const disguisedPath = path.join(root, "image.png#notes.txt");
+      yield* fileSystem.writeFileString(disguisedPath, "not an image");
+      const error = yield* issueAssetUrl({
+        resource: {
+          _tag: "workspace-file",
+          threadId: ThreadId.make("thread-1"),
+          path: disguisedPath,
+        },
+        workspaceRoot: root,
+      }).pipe(Effect.flip);
+      expect(error).toBeInstanceOf(AssetPreviewTypeValidationError);
+    }).pipe(Effect.provide(testLayer)),
+  );
+
   it.effect("issues exact attachment capabilities by attachment id", () =>
     Effect.gen(function* () {
       const config = yield* ServerConfig.ServerConfig;

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -134,5 +134,8 @@ On web and desktop, HTML and PDF files open as rendered pages. Switch an HTML
 file to source view to read its markup; a link to a specific line opens source
 automatically. HTML previews cannot access your T3 Code session.
 
+The file viewer recognizes images, HTML, and PDF files by their filename extension,
+including filenames or folders containing `#` or `?`.
+
 On mobile, select a PDF attachment or link to open it. iOS uses the native viewer;
 Android opens the system chooser.

--- a/packages/shared/src/filePreview.test.ts
+++ b/packages/shared/src/filePreview.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./filePreview.ts";
 
 describe("workspace file previews", () => {
-  it.each(["report.html", "report.HTM", "document.pdf?download=1"])(
+  it.each(["report.html", "report.HTM", "document#draft.pdf", "reports?old/document.pdf"])(
     "recognizes browser preview path %s",
     (path) => {
       expect(isWorkspaceBrowserPreviewPath(path)).toBe(true);
@@ -21,7 +21,9 @@ describe("workspace file previews", () => {
     "icon.png",
     "photo.JPEG",
     "animation.gif",
-    "vector.svg#mark",
+    "vector#mark.svg",
+    "photo?edited.JPEG",
+    "images#archive/icon.png",
     "texture.webp",
     "image.avif",
   ])("recognizes image preview path %s", (path) => {
@@ -29,12 +31,19 @@ describe("workspace file previews", () => {
     expect(isWorkspacePreviewEntryPath(path)).toBe(true);
   });
 
-  it.each(["README.md", "src/index.ts", "image.png.ts", "png"])(
-    "rejects non-preview path %s",
-    (path) => {
-      expect(isWorkspacePreviewEntryPath(path)).toBe(false);
-    },
-  );
+  it.each([
+    "README.md",
+    "src/index.ts",
+    "image.png.ts",
+    "png",
+    "image.png#notes.txt",
+    "image.svg?notes.txt",
+    "document.pdf?download=1",
+    "report.html#notes.txt",
+    "image%2Epng",
+  ])("rejects non-preview path %s", (path) => {
+    expect(isWorkspacePreviewEntryPath(path)).toBe(false);
+  });
 });
 
 describe("media path parsing", () => {

--- a/packages/shared/src/filePreview.ts
+++ b/packages/shared/src/filePreview.ts
@@ -81,8 +81,8 @@ export function mediaKindFromPath(path: string): "image" | "video" | null {
 }
 
 function hasPreviewExtension(path: string, extensions: ReadonlyArray<string>): boolean {
-  const pathWithoutQuery = path.split(/[?#]/, 1)[0]?.toLowerCase() ?? "";
-  return extensions.some((extension) => pathWithoutQuery.endsWith(extension));
+  const literalPath = path.toLowerCase();
+  return extensions.some((extension) => literalPath.endsWith(extension));
 }
 
 export function isWorkspaceBrowserPreviewPath(path: string): boolean {


### PR DESCRIPTION
## What Changed

Classify workspace images and browser documents by their literal filename extension, matching the existing video viewer behavior. Authored Markdown and media URLs retain their separate URL-aware parser.

The shared fix covers server asset validation and image search, web and desktop file viewers, mobile file previews, and provider image-read activity.

## Why

Workspace previews strip literal `#` and `?` characters as URL suffixes. This rejects files such as `assets#archive/icon#v2.png` and accepts non-image filenames such as `image.png#notes.txt`.

## Testing

- File preview and video tests pass, 39/39; the new classification regressions fail on main.
- Asset access tests pass, 28/28, including issuing and resolving real workspace URLs while preserving exact image access.
- Shared package typecheck, targeted lint and formatting, and `git diff --check` pass.
- No UI layout changes or browser testing.

## Checklist

- [x] One focused change
- [x] Explained what changed and why
- [x] Added regression coverage for the changed behavior
- [x] No UI layout or animation changes

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add regression test for workspace asset previews with literal `#` and `?` filenames
> Adds an effect-based test in [AssetAccess.test.ts](https://github.com/pingdotgg/t3code/pull/10311/files#diff-3e248bf73b1190cf86ee6fda71efa01343c3a1f70aa874b545ec1e7184157710) that creates workspace files with literal `#` or `?` in their path and verifies issued asset URLs resolve correctly. Also checks rejection of sibling files and filenames with image-like prefixes followed by non-image suffixes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f008404.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace file preview detection for image, HTML, and PDF files.
  * Filenames containing `#` or `?` are now recognized when the extension appears at the end of the filename.
  * Files with trailing fragments, query parameters, or encoded extensions are no longer incorrectly treated as previewable files.
  * Preview access now correctly prevents similarly named or non-previewable assets from being opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->