### PR TITLE
fix(server): recover the login shell SSH agent

### DIFF
--- a/apps/server/src/os-jank.test.ts
+++ b/apps/server/src/os-jank.test.ts
@@ -1,7 +1,56 @@
 import * as NodeOS from "node:os";
 import { assert, it } from "vite-plus/test";
 
-import { hydratePosixHome } from "./os-jank.ts";
+import { hydratePosixEnvironment, hydratePosixHome } from "./os-jank.ts";
+
+it.each(["linux", "darwin"] as const)(
+  "hydrates the SSH agent and merges PATH from the login shell on %s",
+  (platform) => {
+    const env: NodeJS.ProcessEnv = { PATH: "/usr/bin:/service/bin", SHELL: "/bin/bash" };
+
+    hydratePosixEnvironment(env, platform, () => ({
+      PATH: "/shell/bin:/usr/bin",
+      SSH_AUTH_SOCK: "/opt/orbstack-guest/run/host-ssh-agent.sock",
+    }));
+
+    assert.equal(env.SSH_AUTH_SOCK, "/opt/orbstack-guest/run/host-ssh-agent.sock");
+    assert.equal(env.PATH, "/shell/bin:/usr/bin:/service/bin");
+  },
+);
+
+it("preserves an explicitly forwarded SSH agent", () => {
+  const env: NodeJS.ProcessEnv = { SSH_AUTH_SOCK: "/forwarded/agent.sock" };
+
+  hydratePosixEnvironment(env, "linux", () => ({
+    PATH: "/usr/bin",
+    SSH_AUTH_SOCK: "/login/agent.sock",
+  }));
+
+  assert.equal(env.SSH_AUTH_SOCK, "/forwarded/agent.sock");
+});
+
+it("leaves the SSH agent unset when the login shell has none", () => {
+  const env: NodeJS.ProcessEnv = { PATH: "/service/bin" };
+
+  hydratePosixEnvironment(env, "linux", () => ({ PATH: "/usr/bin" }));
+
+  assert.equal(env.SSH_AUTH_SOCK, undefined);
+  assert.equal(env.PATH, "/usr/bin:/service/bin");
+});
+
+it("reads the current agent socket for each fresh service environment", () => {
+  const first: NodeJS.ProcessEnv = {};
+  const next: NodeJS.ProcessEnv = {};
+  let socket = "/run/user/1000/agent-first.sock";
+  const readShellEnvironment = () => ({ PATH: "/usr/bin", SSH_AUTH_SOCK: socket });
+
+  hydratePosixEnvironment(first, "linux", readShellEnvironment);
+  socket = "/run/user/1000/agent-next.sock";
+  hydratePosixEnvironment(next, "linux", readShellEnvironment);
+
+  assert.equal(first.SSH_AUTH_SOCK, "/run/user/1000/agent-first.sock");
+  assert.equal(next.SSH_AUTH_SOCK, "/run/user/1000/agent-next.sock");
+});
 
 it("hydrates HOME for minimal service environments from the user account", () => {
   const env: NodeJS.ProcessEnv = {};

--- a/apps/server/src/os-jank.test.ts
+++ b/apps/server/src/os-jank.test.ts
@@ -29,6 +29,19 @@ it("preserves an explicitly forwarded SSH agent", () => {
   assert.equal(env.SSH_AUTH_SOCK, "/forwarded/agent.sock");
 });
 
+it("takes the agent from the accepted shell when an earlier candidate has no PATH", () => {
+  const env: NodeJS.ProcessEnv = { SHELL: "/custom/shell-without-path" };
+
+  hydratePosixEnvironment(env, "linux", (shell) =>
+    shell === env.SHELL
+      ? { SSH_AUTH_SOCK: "/stale/agent.sock" }
+      : { PATH: "/usr/bin", SSH_AUTH_SOCK: "/current/agent.sock" },
+  );
+
+  assert.equal(env.SSH_AUTH_SOCK, "/current/agent.sock");
+  assert.equal(env.PATH, "/usr/bin");
+});
+
 it("leaves the SSH agent unset when the login shell has none", () => {
   const env: NodeJS.ProcessEnv = { PATH: "/service/bin" };
 

--- a/apps/server/src/os-jank.ts
+++ b/apps/server/src/os-jank.ts
@@ -28,7 +28,7 @@ export function hydratePosixEnvironment(
     try {
       const shellEnvironment = readShellEnvironment(shell, ["PATH", "SSH_AUTH_SOCK"]);
       shellPath = shellEnvironment.PATH;
-      if (!env.SSH_AUTH_SOCK && shellEnvironment.SSH_AUTH_SOCK) {
+      if (shellPath && !env.SSH_AUTH_SOCK && shellEnvironment.SSH_AUTH_SOCK) {
         env.SSH_AUTH_SOCK = shellEnvironment.SSH_AUTH_SOCK;
       }
     } catch (error) {

--- a/apps/server/src/os-jank.ts
+++ b/apps/server/src/os-jank.ts
@@ -2,9 +2,10 @@ import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hos
 import {
   listLoginShellCandidates,
   mergePathEntries,
-  readPathFromLoginShell,
+  readEnvironmentFromLoginShell,
   readPathFromLaunchctl,
   resolveWindowsEnvironment,
+  type ShellEnvironmentReader,
 } from "@t3tools/shared/shell";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -17,13 +18,21 @@ function logPathHydrationWarning(message: string, error?: unknown): void {
   );
 }
 
-function hydratePosixPath(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): void {
+export function hydratePosixEnvironment(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+  readShellEnvironment: ShellEnvironmentReader = readEnvironmentFromLoginShell,
+): void {
   let shellPath: string | undefined;
   for (const shell of listLoginShellCandidates(platform, env.SHELL)) {
     try {
-      shellPath = readPathFromLoginShell(shell);
+      const shellEnvironment = readShellEnvironment(shell, ["PATH", "SSH_AUTH_SOCK"]);
+      shellPath = shellEnvironment.PATH;
+      if (!env.SSH_AUTH_SOCK && shellEnvironment.SSH_AUTH_SOCK) {
+        env.SSH_AUTH_SOCK = shellEnvironment.SSH_AUTH_SOCK;
+      }
     } catch (error) {
-      logPathHydrationWarning(`Failed to read PATH from login shell ${shell}.`, error);
+      logPathHydrationWarning(`Failed to read environment from login shell ${shell}.`, error);
     }
 
     if (shellPath) break;
@@ -82,10 +91,10 @@ export const fixPath = Effect.fn("fixPath")(function* (): Effect.fn.Return<
       }),
     ),
   );
-  yield* Effect.sync(() => hydratePosixPath(env, platform)).pipe(
+  yield* Effect.sync(() => hydratePosixEnvironment(env, platform)).pipe(
     Effect.catchDefect((defect) =>
       Effect.sync(() => {
-        logPathHydrationWarning("Failed to hydrate PATH from the user environment.", defect);
+        logPathHydrationWarning("Failed to hydrate the login-shell environment.", defect);
       }),
     ),
   );


### PR DESCRIPTION
## What Changed

Recover `SSH_AUTH_SOCK` during the existing startup login-shell probe when the server has no explicit agent socket. Only accept it from a shell that also provides a usable PATH.

Each server start resolves the current shell environment, so no socket path is stored in the service unit. Existing forwarded sockets remain unchanged.

## Why

Linux background services and WSL backends recover PATH but drop the SSH agent socket. Git fetches and SSH-signed commits then fail despite a working agent in the user's shell.

Fixes #10179. Fixes #5740.

## Testing

- The os-jank and shared shell tests pass, 42/42, including the fallback-shell case raised in review.
- Server typecheck, targeted lint, and formatting pass.
- No OrbStack or WSL machine was available for an end-to-end SSH check.

## Checklist

- [x] One focused change
- [x] Explained what changed and why
- [x] Added regression coverage for the changed behavior
- [x] No UI layout or animation changes

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix login-shell SSH agent hydration in `hydratePosixEnvironment`
> - `hydratePosixEnvironment` now requests `SSH_AUTH_SOCK` alongside `PATH` from each login-shell candidate and copies the socket into the service environment when it is not already set and the candidate supplies a `PATH`.
> - `fixPath` updated to call the renamed hydrator; failure logging now refers to login-shell environment reads rather than `PATH`-only reads.
> - Adds tests covering `PATH` merging with `SSH_AUTH_SOCK` on Linux and macOS, explicit-socket preservation, multi-candidate selection, missing-agent handling, and per-call freshness of the socket value.
> - Behavioral Change: on Linux and macOS, services without an explicit `SSH_AUTH_SOCK` now inherit the accepted login shell's agent socket; services that already define `SSH_AUTH_SOCK` remain unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 863f077.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
