### PR TITLE
fix(cursor): reject incomplete skill file reads

### DIFF
--- a/apps/server/src/provider/Drivers/CursorSkills.ts
+++ b/apps/server/src/provider/Drivers/CursorSkills.ts
@@ -164,10 +164,12 @@ const discoverSkillsInRoot = Effect.fn("discoverCursorSkillsInRoot")(function* (
     if (skillInfo?.type === "File") {
       let frontmatter: CursorSkillFrontmatter | undefined = { cliVisible: true };
       if (skillInfo.size <= MAX_SKILL_BYTES && skillInfo.size <= input.budget.remainingBytes) {
-        const contents = yield* orUndefined(fileSystem.readFileString(skillPath));
+        const contents = yield* orUndefined(fileSystem.readFileString(skillPath), input.budget);
         if (contents !== undefined) {
           input.budget.remainingBytes -= skillInfo.size;
           frontmatter = parseSkillFrontmatter(contents);
+        } else {
+          frontmatter = undefined;
         }
       }
       const name = path.basename(directory).trim();

--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -5,6 +5,7 @@ import type * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
 import type * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import { describe, expect, it } from "vite-plus/test";
 import type * as EffectAcpSchema from "effect-acp/schema";
@@ -316,6 +317,63 @@ const cursorCliCommandMissingMessage = [
 ].join(" ");
 
 describe("Cursor skills", () => {
+  it("rejects an unreadable skill catalog and recovers its metadata on retry", async () =>
+    await runNode(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const temporary = yield* fileSystem.makeTempDirectoryScoped({ prefix: "cursor-skills-" });
+          const workspace = yield* fileSystem.realPath(temporary);
+          const skillDirectory = path.join(workspace, ".cursor", "skills", "review");
+          const skillPath = path.join(skillDirectory, "SKILL.md");
+          yield* fileSystem.makeDirectory(skillDirectory, { recursive: true });
+          yield* fileSystem.writeFileString(
+            skillPath,
+            "---\ndescription: Review changes\nuser-invocable: false\n---\n",
+          );
+          const unreadableFileSystem = FileSystem.FileSystem.of({
+            ...fileSystem,
+            readFileString: (target, ...args) =>
+              target === skillPath
+                ? Effect.fail(
+                    PlatformError.systemError({
+                      _tag: "PermissionDenied",
+                      module: "FileSystem",
+                      method: "readFileString",
+                      pathOrDescriptor: target,
+                    }),
+                  )
+                : fileSystem.readFileString(target, ...args),
+          });
+          const environment = { HOME: path.join(workspace, "home") };
+          const failed = yield* probeCursorSkills(workspace, environment).pipe(
+            Effect.provideService(FileSystem.FileSystem, unreadableFileSystem),
+            Effect.result,
+          );
+          expect(failed._tag).toBe("Failure");
+          if (failed._tag === "Failure") {
+            expect(failed.failure.reason).toBe("filesystem-error");
+          }
+          expect(
+            yield* discoverCursorSkills(workspace, environment).pipe(
+              Effect.provideService(FileSystem.FileSystem, unreadableFileSystem),
+            ),
+          ).toEqual([]);
+          expect(yield* probeCursorSkills(workspace, environment)).toEqual([
+            {
+              name: "review",
+              path: skillPath,
+              scope: "project",
+              enabled: true,
+              description: "Review changes",
+              userInvocable: false,
+            },
+          ]);
+        }),
+      ),
+    ));
+
   it("discovers recursive project skills with project precedence", async () =>
     await runNode(
       Effect.gen(function* () {


### PR DESCRIPTION
## What Changed

Treat Cursor skill-file read failures as incomplete discovery, consistent with directory and stat failures. Omit unreadable entries from best-effort discovery and fail the workspace probe so callers can retry.

## Why

An unreadable SKILL.md currently becomes an enabled skill with no metadata. The probe reports success, so an incomplete catalog can be cached and flags such as `user-invocable: false` are lost.

## Testing

- Five focused Cursor skill tests pass.
- The unreadable-file regression fails against the original implementation and passes with the fix, including metadata recovery after retry.
- Server typecheck, targeted lint, and formatting pass.

## Checklist

- [x] One focused change
- [x] Explained what changed and why
- [x] Added regression coverage for the changed behavior
- [x] No UI layout or animation changes

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `discoverSkillsInRoot` to reject skills with unreadable `SKILL.md`
> - When a `SKILL.md` read returns no contents (e.g. permission error), the scanner now clears the default frontmatter so the directory is skipped instead of being emitted with default metadata.
> - The read is routed through the scan-budget-aware path, matching other reads.
> - Default frontmatter is still retained for files skipped by size or remaining-byte checks.
> - Adds a test simulating a `PermissionDenied` failure and verifying recovery on a subsequent normal probe.
> - Risk: skills whose `SKILL.md` is present but unreadable at scan time will no longer appear in the CLI catalog; check `discoverSkillsInRoot` in [CursorSkills.ts](https://github.com/pingdotgg/t3code/pull/10314/files#diff-528e28e34e83cfb127b20e204b245df257b3295b01f91ac1ceed4d8219baf928) if missing skills are expected.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0a5fb20. 1 file reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/provider/Drivers/CursorSkills.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 167](https://github.com/pingdotgg/t3code/blob/0a5fb200c2be6effc01c5e8cf0d2f40fd358adc6/apps/server/src/provider/Drivers/CursorSkills.ts#L167): When `SKILL.md` is removed or renamed after the successful `stat` at line 163 but before this read, `readFileString` fails with `NotFound`. `orUndefined` deliberately does not set `budget.incomplete` for `NotFound`, while the new branch omits the skill, so `probeCursorSkills` returns a successful but incomplete catalog rather than triggering a retry. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
