### PR TITLE
fix(shared): keep the newest shared usage scan

### DIFF
--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -146,6 +146,26 @@ describe("mergeUsage", () => {
     ).toEqual({ claude: 1, codex: 1 });
   });
 
+  it("uses the newest scan when environments share the same transcript directory", () => {
+    const source = { provider: "claude" as const, hostId: "mac", homePath: "/home/theo/.claude" };
+    const environments = [
+      environment("env-a", summary([bucket({ costUsd: 4, records: 2 })], [source])),
+      environment("env-b", {
+        ...summary([bucket()], [source]),
+        readAt: "2026-08-07T01:00:00.000Z",
+      }),
+    ];
+
+    for (const ordered of [environments, environments.toReversed()]) {
+      const merged = mergeUsage(ordered, USAGE_CONTRACT_VERSION);
+      expect(merged.costUsd).toBe(10);
+      expect(merged.records).toBe(5);
+      expect(merged.sessions).toBe(1);
+      expect(merged.contributingEnvironments).toEqual(["env-b"]);
+      expect(merged.duplicateSources).toEqual(["env-a: /home/theo/.claude"]);
+    }
+  });
+
   it("excludes an environment reporting an older contract version", () => {
     const merged = mergeUsage(
       [

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -105,9 +105,9 @@ function fingerprintKey(fingerprint: UsageSourceFingerprint): string {
  *
  * Several environments on one machine (worktree servers, for instance) resolve
  * the same provider home and would otherwise double count every token. The
- * first environment in a stable order claims a fingerprint; the rest have that
- * provider's buckets dropped. Environments are sorted by id so the winner does
- * not change between renders.
+ * most recently read summary claims a fingerprint; the rest have that provider's
+ * buckets dropped. Environment ids break ties so the winner is stable when
+ * summaries have the same read time.
  */
 function claimSources(environments: readonly EnvironmentUsage[]): {
   readonly ownerByFingerprint: ReadonlyMap<string, EnvironmentId>;
@@ -116,7 +116,11 @@ function claimSources(environments: readonly EnvironmentUsage[]): {
   const ownerByFingerprint = new Map<string, EnvironmentId>();
   const duplicates: string[] = [];
 
-  const ordered = [...environments].sort((a, b) => a.environmentId.localeCompare(b.environmentId));
+  const ordered = [...environments].sort(
+    (a, b) =>
+      (Date.parse(b.summary.readAt) || 0) - (Date.parse(a.summary.readAt) || 0) ||
+      a.environmentId.localeCompare(b.environmentId),
+  );
 
   for (const environment of ordered) {
     for (const source of environment.summary.sources) {


### PR DESCRIPTION
## What Changed

Choose the most recently read usage summary for each shared transcript directory. Use environment IDs to break ties so selection remains stable.

## Why

When two environments read the same directory, the merge always keeps the environment with the smallest ID. An older cached response can therefore hide tokens and costs present in a newer response, including while the older environment is failing to refresh.

The shared merge serves web, desktop, and mobile.

## Testing

- `usageMerge.test.ts` passes, 13/13.
- The regression returns the stale $4 total before the fix and the current $10 total afterward, regardless of response order.
- Shared package typecheck, targeted lint, and formatting pass.

## Checklist

- [x] One focused change
- [x] Explained what changed and why
- [x] Added regression coverage for the changed behavior
- [x] No UI layout or animation changes

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `claimSources` to keep newest shared usage scan by `readAt`
> When environments report the same physical transcript directory, `mergeUsage` now keeps the provider buckets from the environment with the newest summary `readAt` time instead of using environment-id order.
>
> - Changes source ownership ordering in [usageMerge.ts](https://github.com/pingdotgg/t3code/pull/10315/files#diff-143d7ed21cccd3774754bd4f261d302d61b7997008db82ed56a3920e176a57b3) to descending parsed `readAt`, with environment id as tie-breaker; invalid or absent dates fall back to zero for ordering.
> - Adds a regression test in [usageMerge.test.ts](https://github.com/pingdotgg/t3code/pull/10315/files#diff-631b86919e76226dd336b2a3fa48a9881ada3f0eaf3c73ac2731182dd879b579) verifying the newer environment supplies merged totals regardless of input order.
> - Risk: environments with missing or unparseable `readAt` dates order as zero and may lose ownership to any environment with a valid date.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78eded7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Usage data from duplicate environment scans now consistently prioritizes the most recently read summary.
  * Duplicate-source reporting is now deterministic, regardless of input order.
  * Ties are resolved consistently using the environment identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->