### PR TITLE
fix(server): finish short workspace file reads

### DIFF
--- a/apps/server/src/workspace/WorkspaceFileSystem.test.ts
+++ b/apps/server/src/workspace/WorkspaceFileSystem.test.ts
@@ -1,5 +1,6 @@
-// @effect-diagnostics nodeBuiltinImport:off - FileSystem cannot create a FIFO.
+// @effect-diagnostics nodeBuiltinImport:off - tests inject short reads and create a FIFO.
 import * as NodeChildProcess from "node:child_process";
+import * as NodeFSP from "node:fs/promises";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it, describe, expect } from "@effect/vitest";
@@ -7,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
+import { vi } from "vite-plus/test";
 
 import * as ServerConfig from "../config.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
@@ -16,6 +18,11 @@ import * as WorkspaceFileSystem from "./WorkspaceFileSystem.ts";
 import * as WorkspacePaths from "./WorkspacePaths.ts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { symlinksSupported } from "@t3tools/shared/testing/symlinks";
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFSP>();
+  return { ...actual, open: vi.fn(actual.open) };
+});
 
 const ProjectLayer = WorkspaceFileSystem.layer.pipe(
   Layer.provide(WorkspacePaths.layer),
@@ -58,6 +65,93 @@ const writeTextFile = Effect.fn("writeTextFile")(function* (
 
 it.layer(TestLayer, { excludeTestServices: true })("WorkspaceFileSystemLive", (it) => {
   describe("readFile", () => {
+    it.effect("fills the preview across short reads before decoding UTF-8", () =>
+      Effect.gen(function* () {
+        const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;
+        const cwd = yield* makeTempDir;
+        const contents = "a\u{1F680}b\nmore contents\n";
+        yield* writeTextFile(cwd, "short.txt", contents);
+        const actual = yield* Effect.promise(() =>
+          vi.importActual<typeof NodeFSP>("node:fs/promises"),
+        );
+        vi.mocked(NodeFSP.open).mockImplementationOnce(async (...args) => {
+          const handle = await actual.open(...args);
+          return {
+            stat: handle.stat.bind(handle),
+            close: handle.close.bind(handle),
+            read: (buffer: Buffer, offset: number, length: number, position: number) =>
+              handle.read(buffer, offset, Math.min(length, 2), position),
+          } as unknown as NodeFSP.FileHandle;
+        });
+
+        expect(yield* workspaceFileSystem.readFile({ cwd, relativePath: "short.txt" })).toEqual({
+          relativePath: "short.txt",
+          contents,
+          byteLength: Buffer.byteLength(contents),
+          truncated: false,
+        });
+      }),
+    );
+
+    it.effect("marks a preview incomplete when EOF arrives before the stat size", () =>
+      Effect.gen(function* () {
+        const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "shrinking.txt", "before truncate");
+        const actual = yield* Effect.promise(() =>
+          vi.importActual<typeof NodeFSP>("node:fs/promises"),
+        );
+        vi.mocked(NodeFSP.open).mockImplementationOnce(async (...args) => {
+          const handle = await actual.open(...args);
+          return {
+            stat: async () => {
+              const stat = await handle.stat();
+              await actual.truncate(args[0], 3);
+              return stat;
+            },
+            close: handle.close.bind(handle),
+            read: handle.read.bind(handle),
+          } as unknown as NodeFSP.FileHandle;
+        });
+
+        expect(yield* workspaceFileSystem.readFile({ cwd, relativePath: "shrinking.txt" })).toEqual(
+          {
+            relativePath: "shrinking.txt",
+            contents: "bef",
+            byteLength: 15,
+            truncated: true,
+          },
+        );
+      }),
+    );
+
+    it.effect("keeps the one-megabyte preview limit across short reads", () =>
+      Effect.gen(function* () {
+        const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;
+        const cwd = yield* makeTempDir;
+        const limit = 1024 * 1024;
+        yield* writeTextFile(cwd, "large.txt", "a".repeat(limit + 1));
+        const actual = yield* Effect.promise(() =>
+          vi.importActual<typeof NodeFSP>("node:fs/promises"),
+        );
+        vi.mocked(NodeFSP.open).mockImplementationOnce(async (...args) => {
+          const handle = await actual.open(...args);
+          return {
+            stat: handle.stat.bind(handle),
+            close: handle.close.bind(handle),
+            read: (buffer: Buffer, offset: number, length: number, position: number) =>
+              handle.read(buffer, offset, Math.min(length, 64 * 1024), position),
+          } as unknown as NodeFSP.FileHandle;
+        });
+
+        const result = yield* workspaceFileSystem.readFile({ cwd, relativePath: "large.txt" });
+        expect(result.contents).toHaveLength(limit);
+        expect(result.contents).toBe("a".repeat(limit));
+        expect(result.byteLength).toBe(limit + 1);
+        expect(result.truncated).toBe(true);
+      }),
+    );
+
     it.effect("reads UTF-8 files relative to the workspace root", () =>
       Effect.gen(function* () {
         const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;

--- a/apps/server/src/workspace/WorkspaceFileSystem.ts
+++ b/apps/server/src/workspace/WorkspaceFileSystem.ts
@@ -257,18 +257,23 @@ export const make = Effect.gen(function* () {
 
           const bytesToRead = Math.min(stat.size, PROJECT_READ_FILE_MAX_BYTES);
           const buffer = Buffer.alloc(bytesToRead);
-          const { bytesRead } = yield* Effect.tryPromise({
-            try: () => handle.read(buffer, 0, bytesToRead, 0),
-            catch: (cause) =>
-              new WorkspaceFileSystemOperationError({
-                workspaceRoot: input.cwd,
-                relativePath: input.relativePath,
-                resolvedPath: realTargetPath,
-                operationPath: realTargetPath,
-                operation: "read",
-                cause,
-              }),
-          });
+          let bytesRead = 0;
+          while (bytesRead < bytesToRead) {
+            const chunk = yield* Effect.tryPromise({
+              try: () => handle.read(buffer, bytesRead, bytesToRead - bytesRead, bytesRead),
+              catch: (cause) =>
+                new WorkspaceFileSystemOperationError({
+                  workspaceRoot: input.cwd,
+                  relativePath: input.relativePath,
+                  resolvedPath: realTargetPath,
+                  operationPath: realTargetPath,
+                  operation: "read",
+                  cause,
+                }),
+            });
+            if (chunk.bytesRead === 0) break;
+            bytesRead += chunk.bytesRead;
+          }
           const fileBytes = buffer.subarray(0, bytesRead);
           if (fileBytes.includes(0)) {
             return yield* new WorkspaceBinaryFileError({
@@ -282,7 +287,7 @@ export const make = Effect.gen(function* () {
             relativePath: target.relativePath,
             contents: new TextDecoder("utf-8").decode(fileBytes),
             byteLength: stat.size,
-            truncated: stat.size > PROJECT_READ_FILE_MAX_BYTES,
+            truncated: bytesRead < stat.size,
           };
         }),
       (handle) =>


### PR DESCRIPTION
## What Changed

Continue reading workspace files from the returned byte offset until the bounded preview is filled or EOF is reached. Decode UTF-8 after collecting the bytes, and mark previews incomplete when fewer bytes arrive than the earlier stat size.

The server keeps the one-megabyte memory cap and existing file-handle cleanup. No client layout or contract changes.

## Why

A single read can return fewer bytes than requested. The current reader treats that partial text as complete, potentially sending a broken UTF-8 character and `truncated: false` to the editable file viewer.

[Node's filehandle.read documentation](https://nodejs.org/api/fs.html#filehandlereadbuffer-offset-length-position) specifies the returned byte count and a zero-byte read at EOF.

## Testing

- `WorkspaceFileSystem.test.ts` passes, 15/15.
- All three new regressions fail on main: short reads, a file shrinking between stat and read, and the preview limit across multiple reads.
- Server typecheck passes with existing Effect suggestions only.
- Targeted lint, formatting, and `git diff --check` pass.

## Checklist

- [x] One focused change
- [x] Explained what changed and why
- [x] Added regression coverage for the changed behavior
- [x] No UI layout or animation changes

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `WorkspaceFileSystem.readFile` to loop over short reads
> - `readFile` now loops, requesting remaining bytes until the preview buffer fills or a zero-byte read signals EOF, advancing both buffer offset and file position by bytes actually read.
> - The `truncated` flag now compares total `bytesRead` against `stat.size` instead of only checking whether `stat.size` exceeds the preview limit, so an early EOF on a file that shrank after `stat` is correctly marked truncated.
> - Adds tests for short reads (two-byte chunks with four-byte UTF-8 characters), early EOF after truncation, and preview-limit enforcement with 64 KiB chunks.
> - Risk: `truncated` semantics change for files that shrink between `stat` and read — callers relying on the old preview-limit-only comparison may see `truncated` become `true` where it was previously `false`; check consumers of `WorkspaceFileSystem.readFile` results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8aa59e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
