### PR TITLE
fix(server): canonicalize usage transcript sources

### DIFF
--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -7,7 +7,13 @@ import * as NodePath from "node:path";
 import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
-import { UsageDay, type UsageSummaryInput } from "@t3tools/contracts";
+import {
+  EnvironmentId,
+  USAGE_CONTRACT_VERSION,
+  UsageDay,
+  type UsageSummaryInput,
+} from "@t3tools/contracts";
+import { mergeUsage } from "@t3tools/shared/usageMerge";
 import * as Duration from "effect/Duration";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
@@ -98,6 +104,50 @@ function totalOutputTokens(summary: { buckets: readonly { totals: { outputTokens
 }
 
 describe("UsageService", () => {
+  it.live("counts a transcript home once when another environment uses a directory alias", () =>
+    Effect.gen(function* () {
+      const { transcript, settings, home } = yield* setup;
+      yield* Effect.promise(() => NodeFSP.writeFile(transcript, claudeLine(1, 5)));
+      const alias = NodePath.join(home, "claude-alias");
+      yield* Effect.promise(() =>
+        NodeFSP.symlink(settings.providers.claudeAgent.homePath, alias, "junction"),
+      );
+
+      const direct = yield* UsageService.make.pipe(
+        Effect.provide(serviceLayers({ prefix: "usage-direct-home", home, settings })),
+      );
+      const linked = yield* UsageService.make.pipe(
+        Effect.provide(
+          serviceLayers({
+            prefix: "usage-linked-home",
+            home,
+            settings: {
+              providers: { ...settings.providers, claudeAgent: { homePath: alias } },
+            },
+          }),
+        ),
+      );
+      const directSummary = yield* direct.readSummary(WINDOW);
+      const linkedSummary = yield* linked.readSummary(WINDOW);
+      const merged = mergeUsage(
+        [
+          { environmentId: EnvironmentId.make("direct"), label: "Direct", summary: directSummary },
+          { environmentId: EnvironmentId.make("linked"), label: "Linked", summary: linkedSummary },
+        ],
+        USAGE_CONTRACT_VERSION,
+      );
+
+      assert.strictEqual(merged.outputTokens, 5);
+      assert.strictEqual(merged.sessions, 1);
+      assert.deepStrictEqual(
+        directSummary.sources.find((source) => source.fingerprint.provider === "claude")
+          ?.fingerprint,
+        linkedSummary.sources.find((source) => source.fingerprint.provider === "claude")
+          ?.fingerprint,
+      );
+    }).pipe(Effect.scoped),
+  );
+
   it.live("reprices unchanged transcripts when custom prices are added, edited, or removed", () =>
     Effect.gen(function* () {
       const { transcript, settings, home } = yield* setup;

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -388,7 +388,10 @@ export const make = Effect.gen(function* () {
       Effect.provideService(Path.Path, path),
     );
     const scanned: ScannedDir[] = [];
-    for (const { provider, dir, fileName } of dirs) {
+    for (const { provider, dir: configuredDir, fileName } of dirs) {
+      const dir = yield* fileSystem
+        .realPath(configuredDir)
+        .pipe(Effect.orElseSucceed(() => configuredDir));
       const volumeId = yield* Effect.promise(() => readDirectoryVolumeId(dir));
       const exists = yield* fileSystem
         .exists(dir)


### PR DESCRIPTION
## What Changed

Resolve existing Claude, Codex, and Grok transcript directories to their real paths before scanning and building source fingerprints. Missing or inaccessible directories keep their configured paths and existing handling.

## Why

Two environments configured through different paths to the same transcript directory produce different fingerprints. A symlinked provider home makes the usage page count the same tokens and sessions twice even though the filesystem identity matches.

## Testing

- `UsageService.test.ts` passes, 7/7.
- A real directory alias scanned through two service instances reproduces 10 output tokens instead of 5 before the fix; afterward the transcript and session count once.
- Server typecheck, targeted lint, and formatting pass.

## Checklist

- [x] One focused change
- [x] Explained what changed and why
- [x] Added regression coverage for the changed behavior
- [x] No UI layout or animation changes

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Canonicalize transcript directory paths via real-path resolution in `UsageService.collectDirs`
> `UsageService.collectDirs` now resolves each configured transcript directory through `fs.realpath` before scanning, so a direct path and a directory alias (e.g. a junction) yield the same source fingerprint for usage merging. When real-path resolution fails, it falls back to the original configured path. A live test confirms that merging summaries from direct and aliased Claude transcript homes produces no duplicate token or session counts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f17728.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
