### PR TITLE
fix(orchestration): preserve conversation order across clock rollback

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -416,6 +416,149 @@ function makeThread(
 }
 
 describe("buildThreadFeed", () => {
+  it("keeps anchored local feedback before the next persisted event despite a backward clock", () => {
+    const later = {
+      id: MessageId.make("later"),
+      role: "assistant" as const,
+      text: "Done",
+      turnId: null,
+      streaming: false,
+      createdSequence: 11,
+      createdAt: "2026-09-06T01:00:00.000Z",
+      updatedAt: "2026-09-06T01:00:00.000Z",
+    };
+    const submission = {
+      id: MessageId.make("local-feedback"),
+      command: "/feedback issue",
+      status: "sent" as const,
+      feedbackId: "feedback",
+      createdSequence: 11,
+      createdAt: "2026-09-06T12:00:00.000Z",
+    };
+    const thread = makeThread({
+      id: ThreadId.make("clock"),
+      projectId: ProjectId.make("project"),
+      title: "Clock",
+      messages: [later],
+    });
+    expect(
+      buildThreadFeed(thread, {
+        localMessages: [
+          codexFeedbackMessage(submission),
+          codexFeedbackMessage(submission, "assistant"),
+        ],
+      }).map((entry) => entry.id),
+    ).toEqual(["local-feedback", "local-feedback:feedback", "later"]);
+  });
+
+  it("settles a clock-corrected turn without showing a fabricated duration", () => {
+    const turnId = TurnId.make("clock-turn");
+    const before = "2026-09-06T12:00:00.000Z";
+    const after = "2026-09-06T01:00:00.000Z";
+    const thread = makeThread({
+      id: ThreadId.make("clock"),
+      projectId: ProjectId.make("project"),
+      title: "Clock",
+      latestTurn: {
+        turnId,
+        state: "completed",
+        requestedAt: before,
+        startedAt: before,
+        completedAt: after,
+        assistantMessageId: MessageId.make("clock-answer"),
+      },
+      messages: [
+        {
+          id: MessageId.make("clock-user"),
+          role: "user",
+          text: "Check",
+          turnId: null,
+          streaming: false,
+          createdAt: before,
+          updatedAt: before,
+          createdSequence: 10,
+        },
+        {
+          id: MessageId.make("clock-answer"),
+          role: "assistant",
+          text: "Done",
+          turnId,
+          streaming: false,
+          createdAt: after,
+          updatedAt: after,
+          createdSequence: 12,
+        },
+      ],
+      activities: [
+        makeActivity({
+          id: EventId.make("clock-work"),
+          kind: "tool.completed",
+          summary: "Checked",
+          turnId,
+          createdAt: after,
+          createdSequence: 11,
+        }),
+      ],
+    });
+    const rows = deriveThreadFeedPresentation(
+      buildThreadFeed(thread),
+      thread.latestTurn,
+      new Set(),
+    );
+    expect(rows.find((row) => row.type === "turn-fold")).toMatchObject({ label: "Worked" });
+    expect(rows.some((row) => row.type === "thinking")).toBe(false);
+  });
+
+  it("retains post-correction activity in a paged feed and keeps local sends last", () => {
+    const user = {
+      id: MessageId.make("clock-user"),
+      role: "user" as const,
+      text: "Run checks",
+      turnId: null,
+      streaming: false,
+      createdSequence: 10,
+      createdAt: "2026-09-06T12:00:00.000Z",
+      updatedAt: "2026-09-06T12:00:00.000Z",
+    };
+    const assistant = {
+      ...user,
+      id: MessageId.make("clock-assistant"),
+      role: "assistant" as const,
+      createdSequence: 12,
+      createdAt: "2026-09-06T01:00:01.000Z",
+    };
+    const activity = makeActivity({
+      id: EventId.make("clock-work"),
+      kind: "tool.completed",
+      createdSequence: 11,
+      createdAt: "2026-09-06T01:00:00.000Z",
+      summary: "Checked files",
+    });
+    const local = {
+      ...user,
+      id: MessageId.make("clock-local"),
+      createdSequence: undefined,
+      createdAt: "2026-09-06T00:00:00.000Z",
+    };
+    const thread = makeThread({
+      id: ThreadId.make("clock-thread"),
+      projectId: ProjectId.make("clock-project"),
+      title: "Clock correction",
+      messages: [user, assistant],
+      activities: [activity],
+    });
+    const feed = buildThreadFeed(thread, {
+      loadedMessages: [user, assistant],
+      localMessages: [local],
+    });
+    expect(feed.map((entry) => entry.id)).toEqual([
+      "clock-user",
+      "clock-work",
+      "clock-assistant",
+      "clock-local",
+    ]);
+  });
+
   it("reuses unchanged feed and presentation rows during an assistant text update", () => {
     const completedTurnId = TurnId.make("completed-turn");
     const activeTurnId = TurnId.make("active-turn");

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -13,6 +13,7 @@ import type {
   UserInputQuestion,
 } from "@t3tools/contracts";
 import { formatDuration } from "@t3tools/shared/orchestrationTiming";
+import { compareCreatedOrder } from "@t3tools/shared/chronology";
 import {
   commandDetailRepeatsCommand,
   extractCommandOutputText,
@@ -93,6 +94,7 @@ type WorkLogToolLifecycleStatus = "inProgress" | "completed" | "failed" | "decli
 export interface WorkLogEntry {
   id: string;
   createdAt: string;
+  createdSequence?: number;
   turnId: TurnId | null;
   label: string;
   detail?: string;
@@ -140,14 +142,17 @@ interface DerivedWorkLogEntry extends WorkLogEntry {
 type RawThreadFeedEntry =
   | {
       readonly type: "message";
+      readonly local?: boolean;
       readonly id: string;
       readonly createdAt: string;
+      readonly createdSequence?: number;
       readonly message: OrchestrationThread["messages"][number];
     }
   | {
       readonly type: "activity";
       readonly id: string;
       readonly createdAt: string;
+      readonly createdSequence?: number;
       readonly turnId: TurnId | null;
       readonly activity: ThreadFeedActivity;
     };
@@ -519,6 +524,9 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   const entry: DerivedWorkLogEntry = {
     id: activity.id,
     createdAt: activity.createdAt,
+    ...(activity.createdSequence !== undefined
+      ? { createdSequence: activity.createdSequence }
+      : {}),
     turnId: activity.turnId,
     ...(taskId ? { taskId } : {}),
     label: taskLabel || activity.summary,
@@ -862,6 +870,9 @@ function mergeDerivedWorkLogEntries(
     ...next,
     id: previous.id,
     createdAt: previous.createdAt,
+    ...(previous.createdSequence !== undefined
+      ? { createdSequence: previous.createdSequence }
+      : {}),
     ...(detail ? { detail } : {}),
     ...(viewedImagePath ? { viewedImagePath } : {}),
     ...(command ? { command } : {}),
@@ -1514,6 +1525,7 @@ function compareActivityLifecycleRank(kind: string): number {
 }
 
 const activityOrder = Order.combineAll<OrchestrationThreadActivity>([
+  Order.mapInput(Order.Number, (activity) => activity.createdSequence ?? 0),
   Order.mapInput(Order.Number, (activity) => activity.sequence ?? Number.MAX_SAFE_INTEGER),
   Order.mapInput(Order.String, (activity) => activity.createdAt),
   Order.mapInput(Order.Number, (activity) => compareActivityLifecycleRank(activity.kind)),
@@ -1589,7 +1601,7 @@ function computeElapsedMs(startIso: string, endIso: string): number | null {
   if (!Number.isFinite(start) || !Number.isFinite(end)) {
     return null;
   }
-  return Math.max(0, end - start);
+  return end < start ? null : end - start;
 }
 
 function maxIsoTimestamp(a: string | null, b: string | null): string | null {
@@ -2261,30 +2273,55 @@ export function buildThreadFeed(
   },
 ): ThreadFeedEntry[] {
   const loadedMessages = options?.loadedMessages ?? thread.messages;
-  const messages = options?.localMessages
-    ? [...loadedMessages, ...options.localMessages]
-    : loadedMessages;
-  const oldestLoadedMessageCreatedAt =
-    options?.loadedMessages !== undefined ? (loadedMessages[0]?.createdAt ?? null) : null;
+  const oldestLoadedMessage = options?.loadedMessages !== undefined ? loadedMessages[0] : undefined;
   const activityEntries = getThreadFeedActivityEntries(thread.activities);
-  const entries = Arr.sortWith(
-    [
-      ...messages.map((message) => {
-        let entry = messageEntriesCache.get(message);
-        if (!entry) {
-          entry = { type: "message", id: message.id, createdAt: message.createdAt, message };
-          messageEntriesCache.set(message, entry);
-        }
-        return entry;
-      }),
-      ...activityEntries.filter(
-        (entry) =>
-          oldestLoadedMessageCreatedAt === null || entry.createdAt >= oldestLoadedMessageCreatedAt,
-      ),
-    ],
-    (s) => new Date(s.createdAt),
-    Order.Date,
-  );
+  const toMessageEntry = (message: OrchestrationThread["messages"][number]) => {
+    let entry = messageEntriesCache.get(message);
+    if (!entry) {
+      entry = {
+        type: "message",
+        id: message.id,
+        createdAt: message.createdAt,
+        ...(message.createdSequence !== undefined
+          ? { createdSequence: message.createdSequence }
+          : {}),
+        message,
+      };
+      messageEntriesCache.set(message, entry);
+    }
+    return entry;
+  };
+  const hasCreatedSequences =
+    loadedMessages.some((message) => message.createdSequence !== undefined) ||
+    activityEntries.some((entry) => entry.createdSequence !== undefined);
+  const localEntries = (options?.localMessages ?? []).map((message) => ({
+    ...toMessageEntry(message),
+    local: true,
+  }));
+  const entries = [
+    ...loadedMessages.map(toMessageEntry),
+    ...localEntries.filter((entry) => !hasCreatedSequences || entry.createdSequence !== undefined),
+    ...activityEntries.filter(
+      (entry) =>
+        oldestLoadedMessage === undefined ||
+        (entry.createdSequence !== undefined || oldestLoadedMessage.createdSequence !== undefined
+          ? compareCreatedOrder(entry, oldestLoadedMessage) >= 0
+          : entry.createdAt >= oldestLoadedMessage.createdAt),
+    ),
+  ].sort((left, right) => {
+    if (left.createdSequence !== undefined || right.createdSequence !== undefined) {
+      if (left.createdSequence === right.createdSequence) {
+        const leftLocal = left.type === "message" && left.local === true;
+        const rightLocal = right.type === "message" && right.local === true;
+        if (leftLocal !== rightLocal) return leftLocal ? -1 : 1;
+        if (leftLocal && rightLocal) return 0;
+      }
+      return compareCreatedOrder(left, right);
+    }
+    return left.createdAt.localeCompare(right.createdAt);
+  });
+  if (hasCreatedSequences)
+    entries.push(...localEntries.filter((entry) => entry.createdSequence === undefined));
 
   return groupAdjacentActivities(entries);
 }
@@ -2323,6 +2360,7 @@ function toThreadFeedActivityEntry(
     type: "activity",
     id: entry.id,
     createdAt: entry.createdAt,
+    ...(entry.createdSequence !== undefined ? { createdSequence: entry.createdSequence } : {}),
     turnId: entry.turnId,
     activity: {
       id: entry.id,

--- a/apps/mobile/src/state/use-thread-composer-state.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.ts
@@ -23,6 +23,7 @@ import {
 } from "@t3tools/client-runtime/state/threads";
 import { isAtomCommandInterrupted } from "@t3tools/client-runtime/state/runtime";
 import { deriveActiveWorkStartedAt } from "@t3tools/shared/orchestrationTiming";
+import { nextLocalMessageSequence } from "@t3tools/shared/chronology";
 
 import { makeQueuedMessageMetadata } from "../lib/commandMetadata";
 import { isModelSelectionUnavailable } from "../lib/modelOptions";
@@ -299,6 +300,9 @@ export function useThreadComposerState() {
           id: MessageId.make(metadata.messageId),
           command: text,
           createdAt: metadata.createdAt,
+          createdSequence: selectedThreadDetail
+            ? nextLocalMessageSequence(selectedThreadDetail)
+            : undefined,
         },
         clearDraft: () => clearComposerDraftContent(threadKey),
         onUpdate: (submission) => {

--- a/apps/server/integration/TransferBudgetReport.integration.ts
+++ b/apps/server/integration/TransferBudgetReport.integration.ts
@@ -50,7 +50,9 @@ interface ProviderTransferBudget {
 // orders of magnitude. The CI report preserves exact values for review.
 const TRANSFER_BUDGET = {
   totalWireBytes: 15_500,
-  threadSnapshotWireBytes: 7_500,
+  // The fixture's 161 creation ordinals add 3,474 decoded bytes and 612/616
+  // gzip bytes for Codex/Claude. Reserve 650 bytes; other caps stay fixed.
+  threadSnapshotWireBytes: 7_500 + 650,
   measuredTurnWebSocketWireBytes: 8_000,
   measuredTurnWebSocketDecodedBytes: 68_000,
   measuredTurnWebSocketMessages: 21,

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -60,6 +60,332 @@ const exists = (filePath: string) =>
 
 const BaseTestLayer = makeProjectionPipelinePrefixedTestLayer("t3-projection-pipeline-test-");
 
+it.layer(Layer.fresh(makeProjectionPipelinePrefixedTestLayer("t3-clock-order-")))(
+  "OrchestrationProjectionPipeline clock rollback",
+  (it) => {
+    it.effect("only reanchors an early assistant turn when its pending prompt is associated", () =>
+      Effect.gen(function* () {
+        const pipeline = yield* OrchestrationProjectionPipeline;
+        const eventStore = yield* OrchestrationEventStore;
+        const sql = yield* SqlClient.SqlClient;
+        const threadId = ThreadId.make("clock-late-turn-identity");
+        const before = "2026-09-01T12:00:00.000Z";
+        const after = "2026-09-01T01:00:00.000Z";
+        const messageId = MessageId.make("late-identity-user");
+        const turnId = TurnId.make("late-identity-turn");
+        let eventNumber = 0;
+        const envelope = (occurredAt: string) => ({
+          eventId: EventId.make(`identity-event-${++eventNumber}`),
+          aggregateKind: "thread" as const,
+          aggregateId: threadId,
+          occurredAt,
+          commandId: CommandId.make(`identity-command-${eventNumber}`),
+          causationEventId: null,
+          correlationId: null,
+          metadata: {},
+        });
+        const project = Effect.fn("projectIdentityEvent")(function* (
+          input: Parameters<typeof eventStore.append>[0],
+        ) {
+          const event = yield* eventStore.append(input);
+          yield* pipeline.projectEvent(event);
+          return event;
+        });
+        const prompt = yield* project({
+          ...envelope(after),
+          type: "thread.message-sent",
+          payload: {
+            threadId,
+            messageId,
+            role: "user",
+            text: "New prompt",
+            turnId: null,
+            streaming: false,
+            createdAt: after,
+            updatedAt: after,
+          },
+        });
+        yield* project({
+          ...envelope(after),
+          type: "thread.turn-start-requested",
+          payload: {
+            threadId,
+            messageId,
+            runtimeMode: "full-access",
+            createdAt: after,
+          },
+        });
+        const oldDiff = yield* project({
+          ...envelope(before),
+          type: "thread.turn-diff-completed",
+          payload: {
+            threadId,
+            turnId: TurnId.make("late-unseen-old-turn"),
+            checkpointTurnCount: 1,
+            checkpointRef: CheckpointRef.make("refs/t3/checkpoints/late-old"),
+            status: "ready",
+            files: [],
+            assistantMessageId: null,
+            completedAt: before,
+          },
+        });
+        const assistant = yield* project({
+          ...envelope(after),
+          type: "thread.message-sent",
+          payload: {
+            threadId,
+            messageId: MessageId.make("late-identity-assistant"),
+            role: "assistant",
+            text: "Answer before session announcement",
+            turnId,
+            streaming: true,
+            createdAt: after,
+            updatedAt: after,
+          },
+        });
+        assert.deepEqual(
+          yield* sql`SELECT turn_id, pending_message_id, created_sequence
+          FROM projection_turns WHERE thread_id = ${threadId} AND turn_id IS NOT NULL
+          ORDER BY created_sequence`,
+          [
+            {
+              turn_id: "late-unseen-old-turn",
+              pending_message_id: null,
+              created_sequence: oldDiff.sequence,
+            },
+            { turn_id: turnId, pending_message_id: null, created_sequence: assistant.sequence },
+          ],
+        );
+        for (let index = 0; index < 2; index += 1) {
+          yield* project({
+            ...envelope(after),
+            type: "thread.session-set",
+            payload: {
+              threadId,
+              session: {
+                threadId,
+                status: "running",
+                providerName: "codex",
+                runtimeMode: "full-access",
+                activeTurnId: turnId,
+                lastError: null,
+                updatedAt: after,
+              },
+            },
+          });
+        }
+        assert.deepEqual(
+          yield* sql`SELECT turn_id, pending_message_id, created_sequence
+          FROM projection_turns WHERE thread_id = ${threadId} ORDER BY created_sequence`,
+          [
+            { turn_id: turnId, pending_message_id: messageId, created_sequence: prompt.sequence },
+            {
+              turn_id: "late-unseen-old-turn",
+              pending_message_id: null,
+              created_sequence: oldDiff.sequence,
+            },
+          ],
+        );
+      }),
+    );
+
+    it.effect("preserves creation order and resolved input through updates and full replay", () =>
+      Effect.gen(function* () {
+        const pipeline = yield* OrchestrationProjectionPipeline;
+        const eventStore = yield* OrchestrationEventStore;
+        const sql = yield* SqlClient.SqlClient;
+        const threadId = ThreadId.make("clock-order");
+        const before = "2026-09-01T12:00:00.000Z";
+        const after = "2026-09-01T01:00:00.000Z";
+        let eventNumber = 0;
+        const envelope = (occurredAt: string) => ({
+          eventId: EventId.make(`clock-event-${++eventNumber}`),
+          aggregateKind: "thread" as const,
+          aggregateId: threadId,
+          occurredAt,
+          commandId: CommandId.make(`clock-command-${eventNumber}`),
+          causationEventId: null,
+          correlationId: null,
+          metadata: {},
+        });
+        yield* eventStore.append({
+          ...envelope(before),
+          type: "thread.created",
+          payload: {
+            threadId,
+            projectId: ProjectId.make("clock-project"),
+            title: "Clock rollback",
+            modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5" },
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            branch: null,
+            worktreePath: null,
+            createdAt: before,
+            updatedAt: before,
+          },
+        });
+        const messageSequences: number[] = [];
+        for (const [index, createdAt] of [before, after].entries()) {
+          const messageId = MessageId.make(`clock-user-${index}`);
+          const turnId = TurnId.make(`clock-turn-${index}`);
+          const message = yield* eventStore.append({
+            ...envelope(createdAt),
+            type: "thread.message-sent",
+            payload: {
+              threadId,
+              messageId,
+              role: "user",
+              text: "Prompt",
+              turnId: null,
+              streaming: false,
+              createdAt,
+              updatedAt: createdAt,
+            },
+          });
+          messageSequences.push(message.sequence);
+          yield* eventStore.append({
+            ...envelope(createdAt),
+            type: "thread.turn-start-requested",
+            payload: {
+              threadId,
+              messageId,
+              runtimeMode: "full-access",
+              createdAt,
+            },
+          });
+          yield* eventStore.append({
+            ...envelope(createdAt),
+            type: "thread.session-set",
+            payload: {
+              threadId,
+              session: {
+                threadId,
+                status: "running",
+                providerName: "codex",
+                runtimeMode: "full-access",
+                activeTurnId: turnId,
+                lastError: null,
+                updatedAt: createdAt,
+              },
+            },
+          });
+        }
+        yield* pipeline.bootstrap;
+
+        const activitySequences: number[] = [];
+        for (const [index, kind] of ["user-input.requested", "user-input.resolved"].entries()) {
+          const event = yield* eventStore.append({
+            ...envelope(index === 0 ? before : after),
+            type: "thread.activity-appended",
+            payload: {
+              threadId,
+              activity: {
+                id: EventId.make(`clock-activity-${index}`),
+                tone: "info",
+                kind,
+                summary: "Question lifecycle",
+                payload: { requestId: "question" },
+                turnId: TurnId.make("clock-turn-1"),
+                sequence: index === 0 ? 100 : 1,
+                createdAt: index === 0 ? before : after,
+              },
+            },
+          });
+          activitySequences.push(event.sequence);
+          yield* pipeline.projectEvent(event);
+        }
+        const duplicate = yield* eventStore.append({
+          ...envelope(after),
+          type: "thread.activity-appended",
+          payload: {
+            threadId,
+            activity: {
+              id: EventId.make("clock-activity-0"),
+              tone: "info",
+              kind: "user-input.requested",
+              summary: "Updated question",
+              payload: { requestId: "question" },
+              turnId: TurnId.make("clock-turn-1"),
+              sequence: 200,
+              createdAt: before,
+            },
+          },
+        });
+        yield* pipeline.projectEvent(duplicate);
+        const planSequences: number[] = [];
+        for (const [index, createdAt] of [before, after, before].entries()) {
+          const event = yield* eventStore.append({
+            ...envelope(after),
+            type: "thread.proposed-plan-upserted",
+            payload: {
+              threadId,
+              proposedPlan: {
+                id: `clock-plan-${index % 2}`,
+                turnId: TurnId.make("clock-turn-1"),
+                planMarkdown: `revision-${index}`,
+                implementedAt: null,
+                implementationThreadId: null,
+                createdAt,
+                updatedAt: after,
+              },
+            },
+          });
+          if (index < 2) planSequences.push(event.sequence);
+          yield* pipeline.projectEvent(event);
+        }
+
+        const verify = Effect.gen(function* () {
+          assert.deepEqual(
+            yield* sql`SELECT message_id, created_sequence FROM projection_thread_messages
+            WHERE thread_id = ${threadId}
+            ORDER BY created_sequence`,
+            messageSequences.map((created_sequence, index) => ({
+              message_id: `clock-user-${index}`,
+              created_sequence,
+            })),
+          );
+          assert.deepEqual(
+            yield* sql`SELECT turn_id, created_sequence FROM projection_turns
+            WHERE thread_id = ${threadId}
+            ORDER BY created_sequence`,
+            messageSequences.map((created_sequence, index) => ({
+              turn_id: `clock-turn-${index}`,
+              created_sequence,
+            })),
+          );
+          assert.deepEqual(
+            yield* sql`SELECT activity_id, created_sequence FROM projection_thread_activities
+            WHERE thread_id = ${threadId}
+            ORDER BY created_sequence`,
+            activitySequences.map((created_sequence, index) => ({
+              activity_id: `clock-activity-${index}`,
+              created_sequence,
+            })),
+          );
+          assert.deepEqual(
+            yield* sql`SELECT plan_id, created_sequence FROM projection_thread_proposed_plans
+            WHERE thread_id = ${threadId}
+            ORDER BY created_sequence`,
+            planSequences.map((created_sequence, index) => ({
+              plan_id: `clock-plan-${index}`,
+              created_sequence,
+            })),
+          );
+          assert.deepEqual(
+            yield* sql`SELECT latest_user_message_at, pending_user_input_count
+            FROM projection_threads WHERE thread_id = ${threadId}`,
+            [{ latest_user_message_at: after, pending_user_input_count: 0 }],
+          );
+        });
+        yield* verify;
+        yield* sql`DELETE FROM projection_state`;
+        yield* pipeline.bootstrap;
+        yield* verify;
+      }),
+    );
+  },
+);
+
 it.layer(Layer.fresh(makeProjectionPipelinePrefixedTestLayer("t3-projection-cursor-batch-")))(
   "OrchestrationProjectionPipeline cursor batches",
   (it) => {

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -157,6 +157,7 @@ function derivePendingUserInputCountFromActivities(
   const openRequestIds = new Set<string>();
   const ordered = [...activities].toSorted(
     (left, right) =>
+      (left.createdSequence ?? 0) - (right.createdSequence ?? 0) ||
       left.createdAt.localeCompare(right.createdAt) ||
       left.activityId.localeCompare(right.activityId),
   );
@@ -203,7 +204,9 @@ function deriveHasActionableProposedPlan(input: {
 }): boolean {
   const sorted = [...input.proposedPlans].toSorted(
     (left, right) =>
-      left.updatedAt.localeCompare(right.updatedAt) || left.planId.localeCompare(right.planId),
+      (left.createdSequence ?? 0) - (right.createdSequence ?? 0) ||
+      left.updatedAt.localeCompare(right.updatedAt) ||
+      left.planId.localeCompare(right.planId),
   );
 
   let latestForTurn: ProjectionThreadProposedPlan | null = null;
@@ -276,6 +279,7 @@ function retainProjectionMessagesAfterRevert(
       )
       .toSorted(
         (left, right) =>
+          (left.createdSequence ?? 0) - (right.createdSequence ?? 0) ||
           compareDateTimeStrings(left.createdAt, right.createdAt) ||
           left.messageId.localeCompare(right.messageId),
       )
@@ -302,6 +306,7 @@ function retainProjectionMessagesAfterRevert(
       )
       .toSorted(
         (left, right) =>
+          (left.createdSequence ?? 0) - (right.createdSequence ?? 0) ||
           compareDateTimeStrings(left.createdAt, right.createdAt) ||
           left.messageId.localeCompare(right.messageId),
       )
@@ -895,9 +900,8 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           return;
         }
 
-        // A message cannot change any summary field except latestUserMessageAt,
-        // which is a monotonic maximum that folds in directly. The full refresh
-        // would re-read every message body in the thread per user message.
+        // Read only the indexed latest user timestamp, not every message body.
+        // Event order stays authoritative when the host clock moves backward.
         case "thread.message-sent": {
           const existingRow = yield* projectionThreadRepository.getById({
             threadId: event.payload.threadId,
@@ -905,16 +909,17 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           if (Option.isNone(existingRow)) {
             return;
           }
-          const previousLatest = existingRow.value.latestUserMessageAt;
+          const latestUserMessageAt =
+            event.payload.role === "user" &&
+            !isImportedAgentSessionMessageId(event.payload.messageId)
+              ? yield* projectionThreadMessageRepository.getLatestUserMessageAt({
+                  threadId: event.payload.threadId,
+                })
+              : existingRow.value.latestUserMessageAt;
           yield* projectionThreadRepository.upsert({
             ...existingRow.value,
             updatedAt: event.occurredAt,
-            latestUserMessageAt:
-              event.payload.role === "user" &&
-              !isImportedAgentSessionMessageId(event.payload.messageId) &&
-              (previousLatest === null || event.payload.createdAt > previousLatest)
-                ? event.payload.createdAt
-                : previousLatest,
+            latestUserMessageAt,
           });
           return;
         }
@@ -1044,6 +1049,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
               text: event.payload.text,
               ...(attachments !== undefined ? { attachments: [...attachments] } : {}),
               createdAt: event.payload.createdAt,
+              createdSequence: event.sequence,
               updatedAt: event.payload.updatedAt,
             });
             return;
@@ -1073,6 +1079,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             ...(nextAttachments !== undefined ? { attachments: [...nextAttachments] } : {}),
             isStreaming: false,
             createdAt: previousMessage?.createdAt ?? event.payload.createdAt,
+            createdSequence: previousMessage?.createdSequence ?? event.sequence,
             updatedAt: event.payload.updatedAt,
           });
           return;
@@ -1135,6 +1142,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             implementedAt: event.payload.proposedPlan.implementedAt,
             implementationThreadId: event.payload.proposedPlan.implementationThreadId,
             createdAt: event.payload.proposedPlan.createdAt,
+            createdSequence: event.sequence,
             updatedAt: event.payload.proposedPlan.updatedAt,
           });
           return;
@@ -1196,6 +1204,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
               ? { sequence: event.payload.activity.sequence }
               : {}),
             createdAt: event.payload.activity.createdAt,
+            createdSequence: event.sequence,
           });
           return;
 
@@ -1282,12 +1291,16 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
               return;
             }
           }
+          const message = yield* projectionThreadMessageRepository.getByMessageId({
+            messageId: event.payload.messageId,
+          });
           yield* projectionTurnRepository.replacePendingTurnStart({
             threadId: event.payload.threadId,
             messageId: event.payload.messageId,
             sourceProposedPlanThreadId: event.payload.sourceProposedPlan?.threadId ?? null,
             sourceProposedPlanId: event.payload.sourceProposedPlan?.planId ?? null,
             requestedAt: event.payload.createdAt,
+            createdSequence: Option.getOrUndefined(message)?.createdSequence ?? event.sequence,
           });
           return;
         }
@@ -1399,9 +1412,14 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
               existingTurn.value.state === "completed" || existingTurn.value.state === "error"
                 ? existingTurn.value.state
                 : "running";
+            const pendingCreatedSequence = Option.getOrUndefined(pendingTurnStart)?.createdSequence;
             yield* projectionTurnRepository.upsertByTurnId({
               ...existingTurn.value,
               state: nextState,
+              ...(existingTurn.value.pendingMessageId === null &&
+              pendingCreatedSequence !== undefined
+                ? { createdSequence: pendingCreatedSequence }
+                : {}),
               pendingMessageId:
                 existingTurn.value.pendingMessageId ??
                 (Option.isSome(pendingTurnStart) ? pendingTurnStart.value.messageId : null),
@@ -1441,6 +1459,8 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
                 : null,
               assistantMessageId: null,
               state: "running",
+              createdSequence:
+                Option.getOrUndefined(pendingTurnStart)?.createdSequence ?? event.sequence,
               requestedAt: Option.isSome(pendingTurnStart)
                 ? pendingTurnStart.value.requestedAt
                 : event.occurredAt,
@@ -1509,6 +1529,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             sourceProposedPlanId: null,
             assistantMessageId: event.payload.messageId,
             state: settlesTurn ? "completed" : "running",
+            createdSequence: event.sequence,
             requestedAt: event.payload.createdAt,
             startedAt: event.payload.createdAt,
             completedAt: settlesTurn ? event.payload.updatedAt : null,
@@ -1546,6 +1567,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             sourceProposedPlanId: null,
             assistantMessageId: null,
             state: "interrupted",
+            createdSequence: event.sequence,
             requestedAt: event.payload.createdAt,
             startedAt: event.payload.createdAt,
             completedAt: event.payload.createdAt,
@@ -1604,6 +1626,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             sourceProposedPlanId: null,
             assistantMessageId: event.payload.assistantMessageId,
             state: turnStillRunning ? "running" : nextState,
+            createdSequence: event.sequence,
             requestedAt: event.payload.completedAt,
             startedAt: event.payload.completedAt,
             completedAt: event.payload.completedAt,

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -1,5 +1,6 @@
 import {
   type AgentSessionImportSource,
+  ApprovalRequestId,
   CheckpointRef,
   EventId,
   MessageId,
@@ -13,6 +14,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
+import * as Tracer from "effect/Tracer";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
@@ -1295,6 +1297,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           )
       `;
 
+      yield* sql`UPDATE projection_thread_activities SET created_sequence = sequence WHERE thread_id = 'thread-1'`;
       const snapshot = yield* snapshotQuery.getSnapshot();
       const threadDetail = yield* snapshotQuery.getThreadDetailById(ThreadId.make("thread-1"));
 
@@ -1321,6 +1324,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           payload: { source: "sequence-1" },
           turnId: null,
           sequence: 1,
+          createdSequence: 1,
           createdAt: "2026-04-01T00:00:05.000Z",
         },
         {
@@ -1331,6 +1335,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           payload: { source: "sequence-2" },
           turnId: null,
           sequence: 2,
+          createdSequence: 2,
           createdAt: "2026-04-01T00:00:04.000Z",
         },
       ]);
@@ -2254,6 +2259,156 @@ projectionSnapshotLayer("ProjectionSnapshotQuery windowed thread detail", (it) =
     snapshot.thread.messages.map((message) => message.id).toSorted();
   const activityIds = (snapshot: { thread: { activities: ReadonlyArray<{ id: string }> } }) =>
     snapshot.thread.activities.map((activity) => activity.id).toSorted();
+
+  it.effect("pages by creation sequence across a clock rollback and accepts legacy cursors", () =>
+    Effect.gen(function* () {
+      yield* seedFanOutThread();
+      const sql = yield* SqlClient.SqlClient;
+      for (let index = 1; index <= 5; index += 1) {
+        yield* sql`UPDATE projection_turns SET created_sequence = ${index * 10} WHERE turn_id = ${"turn-" + index}`;
+        yield* sql`UPDATE projection_thread_messages SET created_sequence = ${index * 10} WHERE message_id = ${"user-msg-" + index}`;
+        yield* sql`UPDATE projection_thread_messages SET created_sequence = ${index * 10 + 1} WHERE message_id = ${"turn-" + index + "-reply"}`;
+        yield* sql`UPDATE projection_thread_activities SET created_sequence = ${index * 10 + 2} WHERE turn_id = ${"turn-" + index}`;
+      }
+      yield* sql`UPDATE projection_thread_messages SET created_sequence = 45 WHERE message_id = 'user-msg-straggler'`;
+      yield* sql`UPDATE projection_thread_activities SET created_sequence = 46 WHERE activity_id = 'turnless-activity'`;
+      yield* sql`UPDATE projection_turns SET requested_at = '2027-01-01T00:00:00.000Z' WHERE turn_id = 'turn-1'`;
+      yield* sql`UPDATE projection_thread_messages SET created_at = '2027-01-01T00:00:00.000Z' WHERE message_id IN ('user-msg-1', 'turn-1-reply')`;
+      // The pending prompt predates its turn request but shares its anchor sequence.
+      yield* sql`UPDATE projection_turns SET requested_at = '2026-03-01T00:03:01.000Z' WHERE turn_id = 'turn-4'`;
+      const snapshotQuery = yield* ProjectionSnapshotQuery;
+      const recent = yield* snapshotQuery.getThreadDetailSnapshot(threadW, { turnLimit: 2 });
+      assert.equal(recent._tag, "Some");
+      if (recent._tag !== "Some") return;
+      assert.deepEqual(
+        recent.value.thread.messages.map((message) => message.id),
+        ["user-msg-4", "turn-4-reply", "user-msg-straggler", "user-msg-5", "turn-5-reply"],
+      );
+      assert.deepEqual(
+        recent.value.thread.activities.map((activity) => activity.id),
+        ["turn-4-activity", "turnless-activity", "turn-5-activity"],
+      );
+      const cursor = recent.value.page?.beforeCursor;
+      assert.isString(cursor);
+      if (!cursor) return;
+      const legacyCursor = encodeThreadDetailPageCursor({
+        threadId: threadW,
+        beforeAnchorAt: "2026-03-01T00:03:01.000Z",
+        beforeTurnId: "turn-4",
+      });
+      for (const beforeCursor of [cursor, legacyCursor]) {
+        const older = yield* snapshotQuery.getThreadDetailSnapshot(threadW, {
+          turnLimit: 2,
+          beforeCursor,
+        });
+        assert.equal(older._tag, "Some");
+        if (older._tag !== "Some") continue;
+        assert.deepEqual(
+          older.value.thread.messages.map((message) => message.id),
+          ["user-msg-1", "turn-1-reply", "turn-2-reply", "turn-3-reply"],
+        );
+        assert.equal(older.value.page?.hasMore, false);
+      }
+      const complete = yield* snapshotQuery.getThreadDetailSnapshot(threadW);
+      assert.equal(complete._tag, "Some");
+      if (complete._tag === "Some") {
+        assert.equal(complete.value.thread.messages[0]?.id, "user-msg-1");
+        assert.equal(complete.value.thread.messages.at(-1)?.id, "turn-5-reply");
+      }
+    }),
+  );
+
+  it.effect("selects a bounded turn page through the creation-sequence index", () =>
+    Effect.gen(function* () {
+      yield* seedFanOutThread();
+      const sql = yield* SqlClient.SqlClient;
+      const snapshotQuery = yield* ProjectionSnapshotQuery;
+      const spans: Tracer.NativeSpan[] = [];
+      const tracer = Tracer.make({
+        span: (options) => {
+          const span = new Tracer.NativeSpan(options);
+          spans.push(span);
+          return span;
+        },
+      });
+      yield* snapshotQuery
+        .getThreadDetailSnapshot(threadW, { turnLimit: 2 })
+        .pipe(Effect.withTracer(tracer));
+      const statement = spans
+        .map((span) => span.attributes.get("db.query.text"))
+        .find(
+          (value): value is string =>
+            typeof value === "string" && value.includes("WITH candidates AS"),
+        );
+      assert.isDefined(statement);
+      if (statement === undefined) return;
+      const plan = yield* sql.unsafe<{ id: number; parent: number; detail: string }>(
+        `EXPLAIN QUERY PLAN ${statement}`,
+        Array.from({ length: statement.split("?").length - 1 }, () => 1),
+      );
+      const candidates = plan.find((step) =>
+        /(?:CO-ROUTINE|MATERIALIZE) candidates/.test(step.detail),
+      );
+      assert.isDefined(candidates);
+      if (candidates === undefined) return;
+      const candidateSteps = plan.filter((step) => step.parent === candidates.id);
+      assert.isTrue(
+        candidateSteps.some(
+          (step) =>
+            step.detail.includes("USING INDEX idx_projection_turns_created_sequence") &&
+            step.detail.includes("<expr><?"),
+        ),
+      );
+      assert.isFalse(candidateSteps.some((step) => step.detail.includes("USE TEMP B-TREE")));
+      const hydrationStatements = spans
+        .map((span) => span.attributes.get("db.query.text"))
+        .filter(
+          (value): value is string =>
+            typeof value === "string" && value.includes("SELECT turn_id FROM projection_turns"),
+        );
+      assert.isAtLeast(hydrationStatements.length, 2);
+      for (const hydrationStatement of hydrationStatements) {
+        const hydrationPlan = yield* sql.unsafe<{ detail: string }>(
+          `EXPLAIN QUERY PLAN ${hydrationStatement}`,
+          Array.from({ length: hydrationStatement.split("?").length - 1 }, () => 1),
+        );
+        assert.isTrue(
+          hydrationPlan.some(
+            (step) =>
+              step.detail.includes("idx_projection_turns_created_sequence") &&
+              step.detail.includes("<expr>>? AND <expr><?"),
+          ),
+        );
+      }
+    }),
+  );
+
+  it.effect("keeps a user-input resolution newer than its request after a clock rollback", () =>
+    Effect.gen(function* () {
+      yield* seedFanOutThread();
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        INSERT INTO projection_thread_activities (
+          activity_id, thread_id, turn_id, tone, kind, summary, payload_json,
+          sequence, created_sequence, created_at
+        ) VALUES
+          ('request-before-rollback', 'thread-w', 'turn-5', 'info', 'user-input.requested',
+            'question', '{"requestId":"rollback-request"}', 200, 100, '2027-01-01T00:00:00.000Z'),
+          ('resolved-after-rollback', 'thread-w', 'turn-5', 'info', 'user-input.resolved',
+            'answered', '{"requestId":"rollback-request"}', 1, 101, '2026-01-01T00:00:00.000Z')
+      `;
+      const snapshotQuery = yield* ProjectionSnapshotQuery;
+      const activity = yield* snapshotQuery.getUserInputActivity({
+        threadId: threadW,
+        requestId: ApprovalRequestId.make("rollback-request"),
+      });
+      assert.equal(activity._tag, "Some");
+      if (activity._tag === "Some") {
+        assert.equal(activity.value.id, "resolved-after-rollback");
+        assert.equal(activity.value.createdSequence, 101);
+      }
+    }),
+  );
 
   it.effect("returns the full thread with no page metadata when no window is requested", () =>
     Effect.gen(function* () {

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -2318,6 +2318,30 @@ projectionSnapshotLayer("ProjectionSnapshotQuery windowed thread detail", (it) =
     }),
   );
 
+  it.effect("reports legacy cursor row decoding with query-specific context", () =>
+    Effect.gen(function* () {
+      yield* seedFanOutThread();
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`UPDATE projection_turns SET created_sequence = -1 WHERE turn_id = 'turn-4'`;
+      const snapshotQuery = yield* ProjectionSnapshotQuery;
+      const error = yield* snapshotQuery
+        .getThreadDetailSnapshot(threadW, {
+          turnLimit: 2,
+          beforeCursor: encodeThreadDetailPageCursor({
+            threadId: threadW,
+            beforeAnchorAt: "2026-03-01T00:03:00.000Z",
+            beforeTurnId: "turn-4",
+          }),
+        })
+        .pipe(Effect.flip);
+      assert.equal(error._tag, "PersistenceDecodeError");
+      assert.equal(
+        error.operation,
+        "ProjectionSnapshotQuery.getThreadDetailSnapshot:resolveLegacyTurnCursor:decodeRow",
+      );
+    }),
+  );
+
   it.effect("selects a bounded turn page through the creation-sequence index", () =>
     Effect.gen(function* () {
       yield* seedFanOutThread();

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -3281,7 +3281,14 @@ pending_approval_requests AS (
               : decodeThreadDetailPageCursor(window.beforeCursor);
           let cursor = decodedCursor?.threadId === threadId ? decodedCursor : null;
           if (cursor !== null && cursor.beforeSequence === undefined) {
-            const boundary = yield* resolveLegacyTurnCursor(cursor);
+            const boundary = yield* resolveLegacyTurnCursor(cursor).pipe(
+              Effect.mapError(
+                toPersistenceSqlOrDecodeError(
+                  "ProjectionSnapshotQuery.getThreadDetailSnapshot:resolveLegacyTurnCursor:query",
+                  "ProjectionSnapshotQuery.getThreadDetailSnapshot:resolveLegacyTurnCursor:decodeRow",
+                ),
+              ),
+            );
             cursor = Option.isSome(boundary)
               ? { ...cursor, beforeSequence: boundary.value.anchorSequence }
               : null;

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -102,10 +102,13 @@ const ProjectionProjectDbRowSchema = ProjectionProject.mapFields(
 const ProjectionThreadMessageDbRowSchema = ProjectionThreadMessage.mapFields(
   Struct.assign({
     isStreaming: Schema.Number,
+    createdSequence: Schema.NullOr(NonNegativeInt),
     attachments: Schema.NullOr(Schema.fromJsonString(Schema.Array(ChatAttachment))),
   }),
 );
-const ProjectionThreadProposedPlanDbRowSchema = ProjectionThreadProposedPlan;
+const ProjectionThreadProposedPlanDbRowSchema = ProjectionThreadProposedPlan.mapFields(
+  Struct.assign({ createdSequence: Schema.NullOr(NonNegativeInt) }),
+);
 const ProjectionThreadDbRowSchema = ProjectionThread.mapFields(
   Struct.assign({
     modelSelection: Schema.fromJsonString(ModelSelection),
@@ -116,6 +119,7 @@ const ProjectionThreadActivityDbRowSchema = ProjectionThreadActivity.mapFields(
   Struct.assign({
     payload: Schema.fromJsonString(Schema.Unknown),
     sequence: Schema.NullOr(NonNegativeInt),
+    createdSequence: Schema.NullOr(NonNegativeInt),
   }),
 );
 const ProjectionThreadActivityIdRowSchema = Schema.Struct({
@@ -137,6 +141,7 @@ const ProjectionLatestTurnDbRowSchema = Schema.Struct({
   turnId: TurnId,
   state: Schema.String,
   requestedAt: IsoDateTime,
+  createdSequence: Schema.NullOr(NonNegativeInt),
   startedAt: Schema.NullOr(IsoDateTime),
   completedAt: Schema.NullOr(IsoDateTime),
   assistantMessageId: Schema.NullOr(MessageId),
@@ -187,12 +192,11 @@ const ThreadActivityKindsLookupInput = Schema.Struct({
 const ThreadActivityIdsLookupInput = Schema.Struct({
   activityIds: Schema.Array(ProjectionThreadActivity.fields.activityId),
 });
-// Windowed reads order turns by the stable keyset (anchor, turn key), where
-// anchor is requested_at and turn key is
-// COALESCE(turn_id, ''). Both are event-derived, so cursors survive the
-// revert projector's row-id rewrite and full projection rebuilds.
+// Creation sequences preserve ingestion order when the host clock moves backward.
+// Timestamp and turn id break ties for legacy rows without a sequence.
 const ThreadTurnWindowLookupInput = Schema.Struct({
   threadId: ThreadId,
+  beforeSequence: NonNegativeInt,
   // Exclusive keyset upper bound. Sentinels "~"/"" mean unbounded ("~" sorts
   // after every ISO timestamp).
   beforeAnchorAt: Schema.String,
@@ -201,17 +205,18 @@ const ThreadTurnWindowLookupInput = Schema.Struct({
   maxRawTurns: Schema.Number,
 });
 const ProjectionTurnWindowRowSchema = Schema.Struct({
-  // The turn's timeline anchor, used to bound rows that have no turn linkage
-  // (user messages and turnless activities) to the same page window.
+  anchorSequence: NonNegativeInt,
+  // Timestamp tie-breaker for legacy turns without a creation sequence.
   anchorAt: Schema.String,
   turnKey: Schema.String,
 });
 const ThreadTurnRangeLookupInput = Schema.Struct({
   threadId: ThreadId,
+  minSequence: NonNegativeInt,
+  beforeSequence: NonNegativeInt,
   // Turn-linked rows are bounded by the keyset range [min, before) over
-  // (anchor, turn key); turnless rows by the matching [minAnchorAt,
-  // beforeAnchorAt) time range. Unbounded ends use sentinels: "" for the
-  // lower bound, "~" (sorts after ISO dates) for the upper bound.
+  // (creation sequence, anchor, turn key). Turnless rows use their creation
+  // sequence, falling back to timestamps only for legacy unsequenced rows.
   minAnchorAt: Schema.String,
   minTurnKey: Schema.String,
   beforeAnchorAt: Schema.String,
@@ -320,6 +325,7 @@ function mapLatestTurn(
             ? "completed"
             : "running",
     requestedAt: row.requestedAt,
+    ...(row.createdSequence !== null ? { createdSequence: row.createdSequence } : {}),
     startedAt: row.startedAt,
     completedAt: row.completedAt,
     assistantMessageId: row.assistantMessageId,
@@ -387,6 +393,7 @@ function mapProposedPlanRow(
     planMarkdown: row.planMarkdown,
     implementedAt: row.implementedAt,
     implementationThreadId: row.implementationThreadId,
+    ...(row.createdSequence !== null ? { createdSequence: row.createdSequence } : {}),
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -404,6 +411,7 @@ function mapThreadActivityRow(
     turnId: row.turnId,
     createdAt: row.createdAt,
     ...(row.sequence !== null ? { sequence: row.sequence } : {}),
+    ...(row.createdSequence !== null ? { createdSequence: row.createdSequence } : {}),
   };
 }
 
@@ -606,10 +614,11 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           text,
           attachments_json AS "attachments",
           is_streaming AS "isStreaming",
+          created_sequence AS "createdSequence",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
         FROM projection_thread_messages
-        ORDER BY thread_id ASC, created_at ASC, message_id ASC
+        ORDER BY thread_id ASC, COALESCE(created_sequence, 0) ASC, created_at ASC, message_id ASC
       `,
   });
 
@@ -625,10 +634,11 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           plan_markdown AS "planMarkdown",
           implemented_at AS "implementedAt",
           implementation_thread_id AS "implementationThreadId",
+          created_sequence AS "createdSequence",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
         FROM projection_thread_proposed_plans
-        ORDER BY thread_id ASC, created_at ASC, plan_id ASC
+        ORDER BY thread_id ASC, COALESCE(created_sequence, 0) ASC, created_at ASC, plan_id ASC
       `,
   });
 
@@ -646,11 +656,12 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           summary,
           payload_json AS "payload",
           sequence,
+          created_sequence AS "createdSequence",
           created_at AS "createdAt"
         FROM projection_thread_activities
         ORDER BY
           thread_id ASC,
-          sequence ASC,
+          COALESCE(created_sequence, 0) ASC,
           created_at ASC,
           activity_id ASC
       `,
@@ -757,6 +768,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           turns.turn_id AS "turnId",
           turns.state,
           turns.requested_at AS "requestedAt",
+          turns.created_sequence AS "createdSequence",
           turns.started_at AS "startedAt",
           turns.completed_at AS "completedAt",
           turns.assistant_message_id AS "assistantMessageId",
@@ -781,6 +793,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           turns.turn_id AS "turnId",
           turns.state,
           turns.requested_at AS "requestedAt",
+          turns.created_sequence AS "createdSequence",
           turns.started_at AS "startedAt",
           turns.completed_at AS "completedAt",
           turns.assistant_message_id AS "assistantMessageId",
@@ -807,6 +820,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           turns.turn_id AS "turnId",
           turns.state,
           turns.requested_at AS "requestedAt",
+          turns.created_sequence AS "createdSequence",
           turns.started_at AS "startedAt",
           turns.completed_at AS "completedAt",
           turns.assistant_message_id AS "assistantMessageId",
@@ -888,6 +902,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                   WHEN 'user' THEN 0
                   ELSE 1
                 END ASC,
+                COALESCE(messages.created_sequence, 0) DESC,
                 messages.created_at DESC,
                 messages.message_id ASC
             ) AS thread_match_rank
@@ -1130,11 +1145,12 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           text,
           attachments_json AS "attachments",
           is_streaming AS "isStreaming",
+          created_sequence AS "createdSequence",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
         FROM projection_thread_messages
         WHERE thread_id = ${threadId}
-        ORDER BY created_at ASC, message_id ASC
+        ORDER BY COALESCE(created_sequence, 0) ASC, created_at ASC, message_id ASC
       `,
   });
 
@@ -1150,11 +1166,12 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           plan_markdown AS "planMarkdown",
           implemented_at AS "implementedAt",
           implementation_thread_id AS "implementationThreadId",
+          created_sequence AS "createdSequence",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
         FROM projection_thread_proposed_plans
         WHERE thread_id = ${threadId}
-        ORDER BY created_at ASC, plan_id ASC
+        ORDER BY COALESCE(created_sequence, 0) ASC, created_at ASC, plan_id ASC
       `,
   });
 
@@ -1172,6 +1189,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           summary,
           payload_json AS "payload",
           sequence,
+          created_sequence AS "createdSequence",
           created_at AS "createdAt"
         FROM (
           SELECT
@@ -1183,17 +1201,18 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             summary,
             payload_json,
             sequence,
+            created_sequence,
             created_at
           FROM projection_thread_activities
           WHERE thread_id = ${threadId}
           ORDER BY
-            sequence DESC,
+            COALESCE(created_sequence, 0) DESC,
             created_at DESC,
             activity_id DESC
           LIMIT ${THREAD_DETAIL_ACTIVITY_LIMIT}
         ) AS recent_activities
         ORDER BY
-          sequence ASC,
+          COALESCE(created_sequence, 0) ASC,
           created_at ASC,
           activity_id ASC
       `,
@@ -1212,12 +1231,13 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         summary,
         payload_json AS "payload",
         sequence,
+        created_sequence AS "createdSequence",
         created_at AS "createdAt"
       FROM projection_thread_activities
       WHERE thread_id = ${threadId}
         AND kind IN ('user-input.requested', 'user-input.resolved')
         AND json_extract(payload_json, '$.requestId') = ${requestId}
-      ORDER BY sequence DESC, created_at DESC, activity_id DESC
+      ORDER BY COALESCE(created_sequence, 0) DESC, created_at DESC, activity_id DESC
       LIMIT 1
     `,
   });
@@ -1242,7 +1262,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         FROM projection_thread_activities
         WHERE thread_id = ${threadId}
         ORDER BY
-          sequence DESC,
+          COALESCE(created_sequence, 0) DESC,
           created_at DESC,
           activity_id DESC
         LIMIT ${THREAD_DETAIL_ACTIVITY_LIMIT}
@@ -1263,6 +1283,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           summary,
           payload_json AS "payload",
           sequence,
+          created_sequence AS "createdSequence",
           created_at AS "createdAt"
         FROM projection_thread_activities
         -- The selectors already scoped these globally unique ids to the
@@ -1285,6 +1306,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           summary,
           payload_json AS "payload",
           sequence,
+          created_sequence AS "createdSequence",
           created_at AS "createdAt"
         FROM (
           SELECT
@@ -1296,18 +1318,19 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             summary,
             payload_json,
             sequence,
+            created_sequence,
             created_at
           FROM projection_thread_activities
           WHERE thread_id = ${threadId}
             AND ${sql.in("kind", activityKinds)}
           ORDER BY
-            sequence DESC,
+            COALESCE(created_sequence, 0) DESC,
             created_at DESC,
             activity_id DESC
           LIMIT ${THREAD_DETAIL_ACTIVITY_LIMIT}
         ) AS recent_activities
         ORDER BY
-          sequence ASC,
+          COALESCE(created_sequence, 0) ASC,
           created_at ASC,
           activity_id ASC
       `,
@@ -1343,6 +1366,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           turns.turn_id AS "turnId",
           turns.state,
           turns.requested_at AS "requestedAt",
+          turns.created_sequence AS "createdSequence",
           turns.started_at AS "startedAt",
           turns.completed_at AS "completedAt",
           turns.assistant_message_id AS "assistantMessageId",
@@ -1380,19 +1404,6 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       `,
   });
 
-  // Resolves a page of recent turns for a windowed thread detail read. Walks
-  // back from the exclusive (beforeAnchorAt, beforeTurnKey) keyset boundary
-  // (sentinels "~"/"" mean unbounded, i.e. the first page) until it has seen
-  // `userTurnLimit` user-anchored turns — turns whose pending message is a
-  // user message; subagent/fan-out turns between them ride along — or hits the
-  // `maxRawTurns` ceiling that bounds pathological fan-out. The `candidates`
-  // CTE applies the keyset bound and LIMIT before the window functions run;
-  // its ORDER BY uses raw columns so the migration-037
-  // (thread_id, requested_at, turn_id) index serves both range and order with
-  // no temp B-tree — the scan is genuinely bounded by the LIMIT. (Raw
-  // turn_id DESC places NULLs exactly where COALESCE-to-'' would, below every
-  // real id.) The caller derives the continuation cursor from the oldest
-  // returned row.
   // Highest thread-DETAIL event sequence for this thread that the projection
   // has applied (bounded by the global snapshot sequence read in the same
   // transaction). This is the thread-scoped watermark a windowed page carries
@@ -1423,61 +1434,96 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       `,
   });
 
+  const resolveLegacyTurnCursor = SqlSchema.findOneOption({
+    Request: Schema.Struct({
+      threadId: ThreadId,
+      beforeTurnId: Schema.String,
+      beforeAnchorAt: Schema.String,
+    }),
+    Result: ProjectionTurnWindowRowSchema,
+    execute: ({ threadId, beforeTurnId, beforeAnchorAt }) => sql`
+      SELECT COALESCE(created_sequence, 0) AS "anchorSequence",
+        requested_at AS "anchorAt", COALESCE(turn_id, '') AS "turnKey"
+      FROM projection_turns
+      WHERE thread_id = ${threadId}
+        AND (turn_id = ${beforeTurnId} OR (turn_id IS NULL AND ${beforeTurnId} = ''))
+        AND requested_at = ${beforeAnchorAt}
+      LIMIT 1
+    `,
+  });
+
   const listTurnWindowRows = SqlSchema.findAll({
     Request: ThreadTurnWindowLookupInput,
     Result: ProjectionTurnWindowRowSchema,
-    execute: ({ threadId, beforeAnchorAt, beforeTurnKey, userTurnLimit, maxRawTurns }) =>
+    execute: ({
+      threadId,
+      beforeSequence,
+      beforeAnchorAt,
+      beforeTurnKey,
+      userTurnLimit,
+      maxRawTurns,
+    }) =>
       sql`
         WITH candidates AS (
           SELECT
+            COALESCE(turns.created_sequence, 0) AS anchor_sequence,
             turns.requested_at AS anchor_at,
             COALESCE(turns.turn_id, '') AS turn_key,
             turns.pending_message_id
           FROM projection_turns AS turns
           WHERE turns.thread_id = ${threadId}
+            AND COALESCE(turns.created_sequence, 0) <= ${beforeSequence}
             AND (
-              turns.requested_at < ${beforeAnchorAt}
+              COALESCE(turns.created_sequence, 0) < ${beforeSequence}
               OR (
-                turns.requested_at = ${beforeAnchorAt}
-                AND COALESCE(turns.turn_id, '') < ${beforeTurnKey}
+                COALESCE(turns.created_sequence, 0) = ${beforeSequence}
+                AND (
+                  turns.requested_at < ${beforeAnchorAt}
+                  OR (turns.requested_at = ${beforeAnchorAt} AND COALESCE(turns.turn_id, '') < ${beforeTurnKey})
+                )
               )
             )
-          ORDER BY turns.requested_at DESC, turns.turn_id DESC
+          ORDER BY COALESCE(turns.created_sequence, 0) DESC, turns.requested_at DESC, turns.turn_id DESC
           LIMIT ${maxRawTurns}
         ),
         walked AS (
           SELECT
+            candidates.anchor_sequence,
             candidates.anchor_at,
             candidates.turn_key,
             CASE WHEN messages.role = 'user' THEN 1 ELSE 0 END AS is_user_turn,
             SUM(CASE WHEN messages.role = 'user' THEN 1 ELSE 0 END) OVER (
-              ORDER BY candidates.anchor_at DESC, candidates.turn_key DESC
+              ORDER BY candidates.anchor_sequence DESC, candidates.anchor_at DESC, candidates.turn_key DESC
             ) AS user_turns_seen
           FROM candidates
           LEFT JOIN projection_thread_messages AS messages
             ON messages.message_id = candidates.pending_message_id
         )
         SELECT
+          anchor_sequence AS "anchorSequence",
           anchor_at AS "anchorAt",
           turn_key AS "turnKey"
         FROM walked
         WHERE user_turns_seen < ${userTurnLimit}
           OR (user_turns_seen = ${userTurnLimit} AND is_user_turn = 1)
-        ORDER BY anchor_at ASC, turn_key ASC
+        ORDER BY anchor_sequence ASC, anchor_at ASC, turn_key ASC
       `,
   });
 
-  // Windowed variants of the two heavy collections. Turn-linked rows are
-  // bounded by the page's (anchor, turn key) keyset range over
-  // projection_turns; rows with no turn linkage (user messages always, and
-  // turnless activities like pre-turn context-window updates) are bounded by
-  // the matching turn-anchor time range so they land on the same page as the
-  // turns around them. Proposed plans and checkpoints stay unwindowed: they
-  // are metadata-scale.
+  // Turn-linked rows follow the selected turn range. Turnless rows follow
+  // creation sequences, falling back to timestamps only for legacy rows.
   const listThreadMessageRowsByThreadWindow = SqlSchema.findAll({
     Request: ThreadTurnRangeLookupInput,
     Result: ProjectionThreadMessageDbRowSchema,
-    execute: ({ threadId, minAnchorAt, minTurnKey, beforeAnchorAt, beforeTurnKey }) =>
+    execute: ({
+      threadId,
+      minSequence,
+      beforeSequence,
+      minAnchorAt,
+      minTurnKey,
+      beforeAnchorAt,
+      beforeTurnKey,
+    }) =>
       sql`
         SELECT
           message_id AS "messageId",
@@ -1487,6 +1533,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           text,
           attachments_json AS "attachments",
           is_streaming AS "isStreaming",
+          created_sequence AS "createdSequence",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
         FROM projection_thread_messages
@@ -1496,28 +1543,30 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
               SELECT turn_id FROM projection_turns
               WHERE thread_id = ${threadId}
                 AND turn_id IS NOT NULL
+                AND COALESCE(created_sequence, 0) >= ${minSequence}
+                AND COALESCE(created_sequence, 0) <= ${beforeSequence}
                 AND (
-                  requested_at > ${minAnchorAt}
-                  OR (
-                    requested_at = ${minAnchorAt}
-                    AND turn_id >= ${minTurnKey}
-                  )
+                  (COALESCE(created_sequence, 0), requested_at, turn_id) >= (${minSequence}, ${minAnchorAt}, ${minTurnKey})
                 )
                 AND (
-                  requested_at < ${beforeAnchorAt}
-                  OR (
-                    requested_at = ${beforeAnchorAt}
-                    AND turn_id < ${beforeTurnKey}
-                  )
+                  (COALESCE(created_sequence, 0), requested_at, turn_id) < (${beforeSequence}, ${beforeAnchorAt}, ${beforeTurnKey})
                 )
             )
             OR (
               turn_id IS NULL
-              AND created_at >= ${minAnchorAt}
-              AND created_at < ${beforeAnchorAt}
+              AND (
+                COALESCE(created_sequence, 0) > ${minSequence}
+                OR (COALESCE(created_sequence, 0) = ${minSequence}
+                  AND (${minSequence} > 0 OR created_at >= ${minAnchorAt}))
+              )
+              AND (
+                COALESCE(created_sequence, 0) < ${beforeSequence}
+                OR (COALESCE(created_sequence, 0) = ${beforeSequence}
+                  AND ${beforeSequence} = 0 AND created_at < ${beforeAnchorAt})
+              )
             )
           )
-        ORDER BY created_at ASC, message_id ASC
+        ORDER BY COALESCE(created_sequence, 0) ASC, created_at ASC, message_id ASC
       `,
   });
 
@@ -1533,7 +1582,7 @@ pending_approval_requests AS (
             activity.activity_id,
             ROW_NUMBER() OVER (
               PARTITION BY pending.request_id
-              ORDER BY activity.created_at DESC, activity.activity_id DESC
+              ORDER BY COALESCE(activity.created_sequence, 0) DESC, activity.created_at DESC, activity.activity_id DESC
             ) AS request_order
           FROM pending_approval_requests AS pending
           CROSS JOIN projection_thread_activities AS activity
@@ -1553,7 +1602,7 @@ pending_approval_requests AS (
             activity.kind,
             ROW_NUMBER() OVER (
               PARTITION BY json_extract(activity.payload_json, '$.requestId')
-              ORDER BY activity.created_at DESC, activity.activity_id DESC
+              ORDER BY COALESCE(activity.created_sequence, 0) DESC, activity.created_at DESC, activity.activity_id DESC
             ) AS request_order
           FROM pending_user_input_thread AS pending
           CROSS JOIN projection_thread_activities AS activity
@@ -1606,11 +1655,12 @@ pending_approval_requests AS (
           activity.summary,
           activity.payload_json AS "payload",
           activity.sequence,
+          activity.created_sequence AS "createdSequence",
           activity.created_at AS "createdAt"
         FROM pinned_activity_ids AS pinned
         INNER JOIN projection_thread_activities AS activity
           ON activity.activity_id = pinned.activity_id
-        ORDER BY activity.created_at ASC, activity.activity_id ASC
+        ORDER BY COALESCE(activity.created_sequence, 0) ASC, activity.created_at ASC, activity.activity_id ASC
       `,
   });
 
@@ -1628,7 +1678,15 @@ pending_approval_requests AS (
   const listThreadActivityRowsByThreadWindow = SqlSchema.findAll({
     Request: ThreadTurnRangeLookupInput,
     Result: ProjectionThreadActivityDbRowSchema,
-    execute: ({ threadId, minAnchorAt, minTurnKey, beforeAnchorAt, beforeTurnKey }) =>
+    execute: ({
+      threadId,
+      minSequence,
+      beforeSequence,
+      minAnchorAt,
+      minTurnKey,
+      beforeAnchorAt,
+      beforeTurnKey,
+    }) =>
       sql`
         SELECT
           activity_id AS "activityId",
@@ -1639,6 +1697,7 @@ pending_approval_requests AS (
           summary,
           payload_json AS "payload",
           sequence,
+          created_sequence AS "createdSequence",
           created_at AS "createdAt"
         FROM (
           SELECT
@@ -1650,6 +1709,7 @@ pending_approval_requests AS (
             summary,
             payload_json,
             sequence,
+            created_sequence,
             created_at
           FROM projection_thread_activities
           WHERE thread_id = ${threadId}
@@ -1658,35 +1718,37 @@ pending_approval_requests AS (
                 SELECT turn_id FROM projection_turns
                 WHERE thread_id = ${threadId}
                   AND turn_id IS NOT NULL
+                  AND COALESCE(created_sequence, 0) >= ${minSequence}
+                  AND COALESCE(created_sequence, 0) <= ${beforeSequence}
                   AND (
-                    requested_at > ${minAnchorAt}
-                    OR (
-                      requested_at = ${minAnchorAt}
-                      AND turn_id >= ${minTurnKey}
-                    )
+                    (COALESCE(created_sequence, 0), requested_at, turn_id) >= (${minSequence}, ${minAnchorAt}, ${minTurnKey})
                   )
                   AND (
-                    requested_at < ${beforeAnchorAt}
-                    OR (
-                      requested_at = ${beforeAnchorAt}
-                      AND turn_id < ${beforeTurnKey}
-                    )
+                    (COALESCE(created_sequence, 0), requested_at, turn_id) < (${beforeSequence}, ${beforeAnchorAt}, ${beforeTurnKey})
                   )
               )
               OR (
                 turn_id IS NULL
-                AND created_at >= ${minAnchorAt}
-                AND created_at < ${beforeAnchorAt}
+                AND (
+                COALESCE(created_sequence, 0) > ${minSequence}
+                OR (COALESCE(created_sequence, 0) = ${minSequence}
+                  AND (${minSequence} > 0 OR created_at >= ${minAnchorAt}))
+              )
+              AND (
+                COALESCE(created_sequence, 0) < ${beforeSequence}
+                OR (COALESCE(created_sequence, 0) = ${beforeSequence}
+                  AND ${beforeSequence} = 0 AND created_at < ${beforeAnchorAt})
+              )
               )
             )
           ORDER BY
-            sequence DESC,
+            COALESCE(created_sequence, 0) DESC,
             created_at DESC,
             activity_id DESC
           LIMIT ${THREAD_DETAIL_ACTIVITY_LIMIT}
         ) AS recent_activities
         ORDER BY
-          sequence ASC,
+          COALESCE(created_sequence, 0) ASC,
           created_at ASC,
           activity_id ASC
       `,
@@ -1695,7 +1757,15 @@ pending_approval_requests AS (
   const listThreadActivityIdsByThreadWindow = SqlSchema.findAll({
     Request: ThreadTurnRangeLookupInput,
     Result: ProjectionThreadActivityIdRowSchema,
-    execute: ({ threadId, minAnchorAt, minTurnKey, beforeAnchorAt, beforeTurnKey }) =>
+    execute: ({
+      threadId,
+      minSequence,
+      beforeSequence,
+      minAnchorAt,
+      minTurnKey,
+      beforeAnchorAt,
+      beforeTurnKey,
+    }) =>
       sql`
         SELECT activity_id AS "activityId"
         FROM projection_thread_activities
@@ -1705,29 +1775,31 @@ pending_approval_requests AS (
               SELECT turn_id FROM projection_turns
               WHERE thread_id = ${threadId}
                 AND turn_id IS NOT NULL
+                AND COALESCE(created_sequence, 0) >= ${minSequence}
+                AND COALESCE(created_sequence, 0) <= ${beforeSequence}
                 AND (
-                  requested_at > ${minAnchorAt}
-                  OR (
-                    requested_at = ${minAnchorAt}
-                    AND turn_id >= ${minTurnKey}
-                  )
+                  (COALESCE(created_sequence, 0), requested_at, turn_id) >= (${minSequence}, ${minAnchorAt}, ${minTurnKey})
                 )
                 AND (
-                  requested_at < ${beforeAnchorAt}
-                  OR (
-                    requested_at = ${beforeAnchorAt}
-                    AND turn_id < ${beforeTurnKey}
-                  )
+                  (COALESCE(created_sequence, 0), requested_at, turn_id) < (${beforeSequence}, ${beforeAnchorAt}, ${beforeTurnKey})
                 )
             )
             OR (
               turn_id IS NULL
-              AND created_at >= ${minAnchorAt}
-              AND created_at < ${beforeAnchorAt}
+              AND (
+                COALESCE(created_sequence, 0) > ${minSequence}
+                OR (COALESCE(created_sequence, 0) = ${minSequence}
+                  AND (${minSequence} > 0 OR created_at >= ${minAnchorAt}))
+              )
+              AND (
+                COALESCE(created_sequence, 0) < ${beforeSequence}
+                OR (COALESCE(created_sequence, 0) = ${beforeSequence}
+                  AND ${beforeSequence} = 0 AND created_at < ${beforeAnchorAt})
+              )
             )
           )
         ORDER BY
-          sequence DESC,
+          COALESCE(created_sequence, 0) DESC,
           created_at DESC,
           activity_id DESC
         LIMIT ${THREAD_DETAIL_ACTIVITY_LIMIT}
@@ -1882,6 +1954,7 @@ pending_approval_requests AS (
                 const threadMessages = messagesByThread.get(row.threadId) ?? [];
                 threadMessages.push({
                   id: row.messageId,
+                  ...(row.createdSequence !== null ? { createdSequence: row.createdSequence } : {}),
                   role: row.role,
                   text: row.text,
                   ...(row.attachments !== null ? { attachments: row.attachments } : {}),
@@ -1898,6 +1971,7 @@ pending_approval_requests AS (
                 const threadProposedPlans = proposedPlansByThread.get(row.threadId) ?? [];
                 threadProposedPlans.push({
                   id: row.planId,
+                  ...(row.createdSequence !== null ? { createdSequence: row.createdSequence } : {}),
                   turnId: row.turnId,
                   planMarkdown: row.planMarkdown,
                   implementedAt: row.implementedAt,
@@ -1913,6 +1987,7 @@ pending_approval_requests AS (
                 const threadActivities = activitiesByThread.get(row.threadId) ?? [];
                 threadActivities.push({
                   id: row.activityId,
+                  ...(row.createdSequence !== null ? { createdSequence: row.createdSequence } : {}),
                   tone: row.tone,
                   kind: row.kind,
                   summary: row.summary,
@@ -1961,6 +2036,7 @@ pending_approval_requests AS (
                           ? "completed"
                           : "running",
                   requestedAt: row.requestedAt,
+                  ...(row.createdSequence !== null ? { createdSequence: row.createdSequence } : {}),
                   startedAt: row.startedAt,
                   completedAt: row.completedAt,
                   assistantMessageId: row.assistantMessageId,
@@ -2891,6 +2967,8 @@ pending_approval_requests AS (
   // full thread. Resolved from a window request inside the snapshot
   // transaction (see getThreadDetailSnapshot).
   interface ThreadDetailBounds {
+    readonly minSequence: number;
+    readonly beforeSequence: number;
     readonly minAnchorAt: string;
     readonly minTurnKey: string;
     readonly beforeAnchorAt: string;
@@ -2959,7 +3037,7 @@ pending_approval_requests AS (
 
     return activities.toSorted(
       (left, right) =>
-        (left.sequence ?? -1) - (right.sequence ?? -1) ||
+        (left.createdSequence ?? 0) - (right.createdSequence ?? 0) ||
         left.createdAt.localeCompare(right.createdAt) ||
         left.id.localeCompare(right.id),
     );
@@ -3014,7 +3092,7 @@ pending_approval_requests AS (
                 ]
                   .toSorted(
                     (left, right) =>
-                      (left.sequence ?? -1) - (right.sequence ?? -1) ||
+                      (left.createdSequence ?? 0) - (right.createdSequence ?? 0) ||
                       left.createdAt.localeCompare(right.createdAt) ||
                       left.activityId.localeCompare(right.activityId),
                   )
@@ -3117,6 +3195,7 @@ pending_approval_requests AS (
         messages: messageRows.map((row) => {
           const message = {
             id: row.messageId,
+            ...(row.createdSequence !== null ? { createdSequence: row.createdSequence } : {}),
             role: row.role,
             text: row.text,
             turnId: row.turnId,
@@ -3200,10 +3279,17 @@ pending_approval_requests AS (
             window.beforeCursor === undefined
               ? null
               : decodeThreadDetailPageCursor(window.beforeCursor);
-          const cursor = decodedCursor?.threadId === threadId ? decodedCursor : null;
+          let cursor = decodedCursor?.threadId === threadId ? decodedCursor : null;
+          if (cursor !== null && cursor.beforeSequence === undefined) {
+            const boundary = yield* resolveLegacyTurnCursor(cursor);
+            cursor = Option.isSome(boundary)
+              ? { ...cursor, beforeSequence: boundary.value.anchorSequence }
+              : null;
+          }
 
           const windowRows = yield* listTurnWindowRows({
             threadId,
+            beforeSequence: cursor?.beforeSequence ?? Number.MAX_SAFE_INTEGER,
             beforeAnchorAt: cursor?.beforeAnchorAt ?? ANCHOR_UNBOUNDED,
             beforeTurnKey: cursor?.beforeTurnId ?? "",
             userTurnLimit: window.turnLimit,
@@ -3222,6 +3308,7 @@ pending_approval_requests AS (
             oldest !== undefined &&
             (yield* listTurnWindowRows({
               threadId,
+              beforeSequence: oldest.anchorSequence,
               beforeAnchorAt: oldest.anchorAt,
               beforeTurnKey: oldest.turnKey,
               userTurnLimit: 1,
@@ -3245,6 +3332,8 @@ pending_approval_requests AS (
             oldest === undefined && cursor === null
               ? undefined
               : {
+                  minSequence: hasMore ? (oldest?.anchorSequence ?? 0) : 0,
+                  beforeSequence: cursor?.beforeSequence ?? Number.MAX_SAFE_INTEGER,
                   minAnchorAt: hasMore ? (oldest?.anchorAt ?? "") : "",
                   minTurnKey: hasMore ? (oldest?.turnKey ?? "") : "",
                   beforeAnchorAt: cursor?.beforeAnchorAt ?? ANCHOR_UNBOUNDED,
@@ -3253,7 +3342,14 @@ pending_approval_requests AS (
           // Empty window behind a cursor: nothing older remains.
           const emptyBounds =
             oldest === undefined && cursor !== null
-              ? { minAnchorAt: "", minTurnKey: "", beforeAnchorAt: "", beforeTurnKey: "" }
+              ? {
+                  minSequence: 0,
+                  beforeSequence: 0,
+                  minAnchorAt: "",
+                  minTurnKey: "",
+                  beforeAnchorAt: "",
+                  beforeTurnKey: "",
+                }
               : undefined;
 
           const thread = yield* getThreadDetailByIdBounded(threadId, emptyBounds ?? bounds, {
@@ -3287,6 +3383,7 @@ pending_approval_requests AS (
                 hasMore && oldest !== undefined
                   ? encodeThreadDetailPageCursor({
                       threadId,
+                      beforeSequence: oldest.anchorSequence,
                       beforeAnchorAt: oldest.anchorAt,
                       beforeTurnId: oldest.turnKey,
                     })

--- a/apps/server/src/orchestration/projector.chronology.test.ts
+++ b/apps/server/src/orchestration/projector.chronology.test.ts
@@ -148,6 +148,28 @@ function checkpoint(turnId: string, count: number, at: string): InputEvent {
 
 describe("projector chronology across clock corrections", () => {
   it.effect(
+    "keeps the running turn anchored when a late checkpoint arrives after a queued prompt",
+    () =>
+      Effect.gen(function* () {
+        const thread = yield* replay([
+          message("initiating-prompt", before, "user"),
+          session("active-turn", "running", before),
+          message("active-answer", before, "assistant", "active-turn"),
+          message("queued-prompt", after, "user"),
+          checkpoint("older-turn", 1, after),
+          session("active-turn", "running", after),
+        ]);
+        expect(thread.latestTurn).toMatchObject({
+          turnId: "active-turn",
+          createdSequence: 2,
+          requestedAt: before,
+          state: "running",
+        });
+        expect(thread.checkpoints.map((entry) => entry.turnId)).toEqual(["older-turn"]);
+      }),
+  );
+
+  it.effect(
     "associates an early assistant turn once and keeps its anchor on repeated sessions",
     () =>
       Effect.gen(function* () {

--- a/apps/server/src/orchestration/projector.chronology.test.ts
+++ b/apps/server/src/orchestration/projector.chronology.test.ts
@@ -1,0 +1,257 @@
+import { EventId, ProjectId, ThreadId, type OrchestrationEvent } from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+import { createEmptyReadModel, projectEvent } from "./projector.ts";
+
+const before = "2026-09-05T04:18:50.462Z";
+const after = "2026-09-04T17:18:56.456Z";
+const threadId = ThreadId.make("clock-thread");
+
+interface InputEvent {
+  readonly type: OrchestrationEvent["type"];
+  readonly payload: unknown;
+  readonly at: string;
+}
+
+const replay = Effect.fn("replayClockCorrection")(function* (events: ReadonlyArray<InputEvent>) {
+  let model = createEmptyReadModel(before);
+  const allEvents: ReadonlyArray<InputEvent> = [
+    {
+      type: "thread.created",
+      at: before,
+      payload: {
+        threadId,
+        projectId: ProjectId.make("clock-project"),
+        title: "Clock correction",
+        modelSelection: { instanceId: "codex", model: "gpt-5-codex" },
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        branch: null,
+        worktreePath: null,
+        createdAt: before,
+        updatedAt: before,
+      },
+    },
+    ...events,
+  ];
+  for (const [index, entry] of allEvents.entries()) {
+    model = yield* projectEvent(model, {
+      sequence: index + 1,
+      eventId: EventId.make(`clock-event-${index + 1}`),
+      aggregateKind: "thread",
+      aggregateId: threadId,
+      commandId: null,
+      causationEventId: null,
+      correlationId: null,
+      metadata: {},
+      occurredAt: entry.at,
+      type: entry.type,
+      payload: entry.payload as never,
+    } as OrchestrationEvent);
+  }
+  return model.threads[0]!;
+});
+
+function message(
+  id: string,
+  at: string,
+  role = "assistant",
+  turnId: string | null = null,
+): InputEvent {
+  return {
+    type: "thread.message-sent",
+    at,
+    payload: {
+      threadId,
+      messageId: id,
+      role,
+      text: id,
+      turnId,
+      streaming: true,
+      createdAt: at,
+      updatedAt: at,
+    },
+  };
+}
+
+function plan(id: string, at: string): InputEvent {
+  return {
+    type: "thread.proposed-plan-upserted",
+    at,
+    payload: {
+      threadId,
+      proposedPlan: { id, turnId: null, planMarkdown: id, createdAt: at, updatedAt: at },
+    },
+  };
+}
+
+function activity(id: string, at: string, sequence: number): InputEvent {
+  return {
+    type: "thread.activity-appended",
+    at,
+    payload: {
+      threadId,
+      activity: {
+        id,
+        tone: "tool",
+        kind: "tool.completed",
+        summary: id,
+        payload: {},
+        turnId: null,
+        sequence,
+        createdAt: at,
+      },
+    },
+  };
+}
+
+function session(
+  turnId: string | null,
+  status: "running" | "ready" | "interrupted",
+  at: string,
+): InputEvent {
+  return {
+    type: "thread.session-set",
+    at,
+    payload: {
+      threadId,
+      session: {
+        threadId,
+        status,
+        providerName: "codex",
+        runtimeMode: "full-access",
+        activeTurnId: turnId,
+        lastError: null,
+        updatedAt: at,
+      },
+    },
+  };
+}
+
+function checkpoint(turnId: string, count: number, at: string): InputEvent {
+  return {
+    type: "thread.turn-diff-completed",
+    at,
+    payload: {
+      threadId,
+      turnId,
+      checkpointTurnCount: count,
+      checkpointRef: `refs/t3/checkpoints/${count}`,
+      status: "ready",
+      files: [],
+      assistantMessageId: `assistant-${count}`,
+      completedAt: at,
+    },
+  };
+}
+
+describe("projector chronology across clock corrections", () => {
+  it.effect(
+    "associates an early assistant turn once and keeps its anchor on repeated sessions",
+    () =>
+      Effect.gen(function* () {
+        const thread = yield* replay([
+          message("prompt", before, "user"),
+          message("assistant-1", after, "assistant", "turn-1"),
+          checkpoint("turn-1", 1, after),
+          session("turn-1", "running", after),
+          message("queued-prompt", after, "user"),
+          session("turn-1", "running", after),
+        ]);
+        expect(thread.latestTurn).toMatchObject({ turnId: "turn-1", createdSequence: 2 });
+      }),
+  );
+
+  it.effect("does not anchor a late checkpoint to a newer queued prompt", () =>
+    Effect.gen(function* () {
+      const knownTurn = yield* replay([
+        message("assistant-1", before, "assistant", "old-turn"),
+        message("new-prompt", after, "user"),
+        checkpoint("old-turn", 1, before),
+      ]);
+      expect(knownTurn.latestTurn).toMatchObject({ turnId: "old-turn", createdSequence: 2 });
+      const unseenTurn = yield* replay([
+        message("new-prompt", after, "user"),
+        checkpoint("unseen-old-turn", 1, before),
+      ]);
+      expect(unseenTurn.latestTurn).toMatchObject({
+        turnId: "unseen-old-turn",
+        createdSequence: 3,
+      });
+    }),
+  );
+
+  it.effect("preserves first event positions through streaming and repeated upserts", () =>
+    Effect.gen(function* () {
+      const thread = yield* replay([
+        message("before-message", before),
+        plan("before-plan", before),
+        activity("before-activity", before, 100),
+        message("after-message", after),
+        plan("after-plan", after),
+        activity("after-activity", after, 1),
+        message("before-message", after),
+        plan("before-plan", after),
+        activity("before-activity", after, 101),
+      ]);
+
+      expect(thread.messages.map(({ id, createdSequence }) => [id, createdSequence])).toEqual([
+        ["before-message", 2],
+        ["after-message", 5],
+      ]);
+      expect(thread.messages[0]?.text).toBe("before-messagebefore-message");
+      expect(thread.messages[0]?.createdAt).toBe(before);
+      expect(thread.proposedPlans.map(({ id, createdSequence }) => [id, createdSequence])).toEqual([
+        ["before-plan", 3],
+        ["after-plan", 6],
+      ]);
+      expect(thread.activities.map(({ id, createdSequence }) => [id, createdSequence])).toEqual([
+        ["before-activity", 4],
+        ["after-activity", 7],
+      ]);
+    }),
+  );
+
+  it.effect("selects the new completed task after a prior turn crosses the clock correction", () =>
+    Effect.gen(function* () {
+      const thread = yield* replay([
+        message("old-prompt", before, "user"),
+        session("old-turn", "running", before),
+        session(null, "interrupted", after),
+        message("new-prompt", after, "user"),
+        session("new-turn", "running", after),
+        session(null, "ready", after),
+      ]);
+
+      expect(thread.latestTurn).toMatchObject({
+        turnId: "new-turn",
+        createdSequence: 5,
+        state: "completed",
+      });
+      expect(thread.session?.status).toBe("ready");
+      expect(thread.messages.map(({ id }) => id)).toEqual(["old-prompt", "new-prompt"]);
+    }),
+  );
+
+  it.effect("reverting keeps the initiating prompt of the retained turn", () =>
+    Effect.gen(function* () {
+      const thread = yield* replay([
+        message("old-prompt", before, "user"),
+        message("assistant-1", before, "assistant", "turn-1"),
+        checkpoint("turn-1", 1, before),
+        message("new-prompt", after, "user"),
+        message("assistant-2", after, "assistant", "turn-2"),
+        checkpoint("turn-2", 2, after),
+        { type: "thread.reverted", at: after, payload: { threadId, turnCount: 1 } },
+      ]);
+
+      expect(thread.messages.map(({ id }) => id)).toEqual(["old-prompt", "assistant-1"]);
+      expect(thread.latestTurn).toMatchObject({
+        turnId: "turn-1",
+        createdSequence: 2,
+        state: "completed",
+      });
+    }),
+  );
+});

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -6,7 +6,7 @@ import {
   OrchestrationSession,
   OrchestrationThread,
 } from "@t3tools/contracts";
-import { compareDateTimeStrings } from "@t3tools/shared/dateTime";
+import { compareCreatedOrder } from "@t3tools/shared/chronology";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import * as Predicate from "effect/Predicate";
@@ -143,11 +143,7 @@ function retainThreadMessagesAfterRevert(
           !retainedMessageIds.has(message.id) &&
           (message.turnId === null || retainedTurnIds.has(message.turnId)),
       )
-      .toSorted(
-        (left, right) =>
-          compareDateTimeStrings(left.createdAt, right.createdAt) ||
-          left.id.localeCompare(right.id),
-      )
+      .toSorted(compareCreatedOrder)
       .slice(0, missingUserCount);
     for (const message of fallbackUserMessages) {
       retainedMessageIds.add(message.id);
@@ -169,11 +165,7 @@ function retainThreadMessagesAfterRevert(
           !retainedMessageIds.has(message.id) &&
           (message.turnId === null || retainedTurnIds.has(message.turnId)),
       )
-      .toSorted(
-        (left, right) =>
-          compareDateTimeStrings(left.createdAt, right.createdAt) ||
-          left.id.localeCompare(right.id),
-      )
+      .toSorted(compareCreatedOrder)
       .slice(0, missingAssistantCount);
     for (const message of fallbackAssistantMessages) {
       retainedMessageIds.add(message.id);
@@ -205,6 +197,9 @@ function compareThreadActivities(
   left: OrchestrationThread["activities"][number],
   right: OrchestrationThread["activities"][number],
 ): number {
+  if (left.createdSequence !== undefined || right.createdSequence !== undefined) {
+    return compareCreatedOrder(left, right);
+  }
   if (left.sequence !== undefined && right.sequence !== undefined) {
     if (left.sequence !== right.sequence) {
       return left.sequence - right.sequence;
@@ -555,10 +550,12 @@ export function projectEvent(
           return nextBase;
         }
 
+        const existingMessage = thread.messages.find((entry) => entry.id === payload.messageId);
         const message: OrchestrationMessage = yield* decodeForEvent(
           OrchestrationMessage,
           {
             id: payload.messageId,
+            createdSequence: existingMessage?.createdSequence ?? event.sequence,
             role: payload.role,
             text: payload.text,
             ...(payload.attachments !== undefined ? { attachments: payload.attachments } : {}),
@@ -571,12 +568,12 @@ export function projectEvent(
           "message",
         );
 
-        const existingMessage = thread.messages.find((entry) => entry.id === message.id);
         const messages = existingMessage
           ? thread.messages.map((entry) =>
               entry.id === message.id
                 ? {
                     ...entry,
+                    createdSequence: message.createdSequence,
                     text: message.streaming
                       ? `${entry.text}${message.text}`
                       : message.text.length > 0
@@ -634,6 +631,24 @@ export function projectEvent(
               session.status === "running" && session.activeTurnId !== null
                 ? {
                     turnId: session.activeTurnId,
+                    createdSequence:
+                      thread.session?.activeTurnId === session.activeTurnId &&
+                      thread.latestTurn?.turnId === session.activeTurnId
+                        ? thread.latestTurn.createdSequence
+                        : (thread.messages.findLast(
+                            (message) =>
+                              message.role === "user" &&
+                              !isImportedAgentSessionMessageId(message.id),
+                          )?.createdSequence ??
+                          (thread.latestTurn?.turnId === session.activeTurnId
+                            ? thread.latestTurn.createdSequence
+                            : undefined) ??
+                          thread.messages.find(
+                            (message) =>
+                              message.role === "assistant" &&
+                              message.turnId === session.activeTurnId,
+                          )?.createdSequence ??
+                          event.sequence),
                     state: "running",
                     requestedAt:
                       thread.latestTurn?.turnId === session.activeTurnId
@@ -679,14 +694,17 @@ export function projectEvent(
           return nextBase;
         }
 
+        const existingPlan = thread.proposedPlans.find(
+          (entry) => entry.id === payload.proposedPlan.id,
+        );
         const proposedPlans = [
           ...thread.proposedPlans.filter((entry) => entry.id !== payload.proposedPlan.id),
-          payload.proposedPlan,
+          {
+            ...payload.proposedPlan,
+            createdSequence: existingPlan?.createdSequence ?? event.sequence,
+          },
         ]
-          .toSorted(
-            (left, right) =>
-              left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
-          )
+          .toSorted(compareCreatedOrder)
           .slice(-200);
 
         return {
@@ -756,6 +774,13 @@ export function projectEvent(
               ? thread.latestTurn
               : {
                   turnId: payload.turnId,
+                  createdSequence:
+                    thread.latestTurn?.turnId === payload.turnId
+                      ? thread.latestTurn.createdSequence
+                      : (thread.messages.find(
+                          (message) =>
+                            message.role === "assistant" && message.turnId === payload.turnId,
+                        )?.createdSequence ?? event.sequence),
                   state:
                     thread.latestTurn?.turnId === payload.turnId &&
                     thread.latestTurn.state === "interrupted"
@@ -807,6 +832,14 @@ export function projectEvent(
               ? null
               : {
                   turnId: latestCheckpoint.turnId,
+                  createdSequence:
+                    (thread.latestTurn?.turnId === latestCheckpoint.turnId
+                      ? thread.latestTurn.createdSequence
+                      : undefined) ??
+                    messages.findLast(
+                      (message) =>
+                        message.role === "user" && !isImportedAgentSessionMessageId(message.id),
+                    )?.createdSequence,
                   state: checkpointStatusToLatestTurnState(latestCheckpoint.status),
                   requestedAt: latestCheckpoint.completedAt,
                   startedAt: latestCheckpoint.completedAt,
@@ -844,7 +877,12 @@ export function projectEvent(
           const activities = retainThreadActivities(
             [
               ...thread.activities.filter((entry) => entry.id !== payload.activity.id),
-              payload.activity,
+              {
+                ...payload.activity,
+                createdSequence:
+                  thread.activities.find((entry) => entry.id === payload.activity.id)
+                    ?.createdSequence ?? event.sequence,
+              },
             ].toSorted(compareThreadActivities),
           );
 

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -1,4 +1,9 @@
-import type { OrchestrationEvent, OrchestrationReadModel, ThreadId } from "@t3tools/contracts";
+import type {
+  OrchestrationEvent,
+  OrchestrationReadModel,
+  ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
 import {
   isImportedAgentSessionMessageId,
   OrchestrationCheckpointSummary,
@@ -41,6 +46,14 @@ import {
 type ThreadPatch = Partial<Omit<OrchestrationThread, "id" | "projectId">>;
 const MAX_THREAD_MESSAGES = 2_000;
 const MAX_THREAD_CHECKPOINTS = 500;
+
+function turnCreatedSequence(thread: OrchestrationThread, turnId: TurnId, sequence: number) {
+  if (thread.latestTurn?.turnId === turnId) return thread.latestTurn.createdSequence;
+  return (
+    thread.messages.find((message) => message.role === "assistant" && message.turnId === turnId)
+      ?.createdSequence ?? sequence
+  );
+}
 
 // Async questions can stay open while the agent produces more activity.
 // Match the database snapshot's pending-question retention.
@@ -632,23 +645,14 @@ export function projectEvent(
                 ? {
                     turnId: session.activeTurnId,
                     createdSequence:
-                      thread.session?.activeTurnId === session.activeTurnId &&
-                      thread.latestTurn?.turnId === session.activeTurnId
-                        ? thread.latestTurn.createdSequence
+                      thread.session?.activeTurnId === session.activeTurnId
+                        ? turnCreatedSequence(thread, session.activeTurnId, event.sequence)
                         : (thread.messages.findLast(
                             (message) =>
                               message.role === "user" &&
                               !isImportedAgentSessionMessageId(message.id),
                           )?.createdSequence ??
-                          (thread.latestTurn?.turnId === session.activeTurnId
-                            ? thread.latestTurn.createdSequence
-                            : undefined) ??
-                          thread.messages.find(
-                            (message) =>
-                              message.role === "assistant" &&
-                              message.turnId === session.activeTurnId,
-                          )?.createdSequence ??
-                          event.sequence),
+                          turnCreatedSequence(thread, session.activeTurnId, event.sequence)),
                     state: "running",
                     requestedAt:
                       thread.latestTurn?.turnId === session.activeTurnId
@@ -765,38 +769,37 @@ export function projectEvent(
         // checkpoint, but don't settle a turn its session is still running.
         const turnStillRunning =
           thread.session?.status === "running" && thread.session.activeTurnId === payload.turnId;
+        // A delayed checkpoint must not discard the active turn's initiating anchor.
+        const latestTurnStillRunning =
+          thread.session?.status === "running" &&
+          thread.latestTurn?.turnId === thread.session.activeTurnId;
 
         return {
           ...nextBase,
           threads: updateThread(nextBase.threads, payload.threadId, {
             checkpoints,
-            latestTurn: turnStillRunning
-              ? thread.latestTurn
-              : {
-                  turnId: payload.turnId,
-                  createdSequence:
-                    thread.latestTurn?.turnId === payload.turnId
-                      ? thread.latestTurn.createdSequence
-                      : (thread.messages.find(
-                          (message) =>
-                            message.role === "assistant" && message.turnId === payload.turnId,
-                        )?.createdSequence ?? event.sequence),
-                  state:
-                    thread.latestTurn?.turnId === payload.turnId &&
-                    thread.latestTurn.state === "interrupted"
-                      ? "interrupted"
-                      : checkpointStatusToLatestTurnState(payload.status),
-                  requestedAt:
-                    thread.latestTurn?.turnId === payload.turnId
-                      ? thread.latestTurn.requestedAt
-                      : payload.completedAt,
-                  startedAt:
-                    thread.latestTurn?.turnId === payload.turnId
-                      ? (thread.latestTurn.startedAt ?? payload.completedAt)
-                      : payload.completedAt,
-                  completedAt: payload.completedAt,
-                  assistantMessageId: payload.assistantMessageId,
-                },
+            latestTurn:
+              turnStillRunning || latestTurnStillRunning
+                ? thread.latestTurn
+                : {
+                    turnId: payload.turnId,
+                    createdSequence: turnCreatedSequence(thread, payload.turnId, event.sequence),
+                    state:
+                      thread.latestTurn?.turnId === payload.turnId &&
+                      thread.latestTurn.state === "interrupted"
+                        ? "interrupted"
+                        : checkpointStatusToLatestTurnState(payload.status),
+                    requestedAt:
+                      thread.latestTurn?.turnId === payload.turnId
+                        ? thread.latestTurn.requestedAt
+                        : payload.completedAt,
+                    startedAt:
+                      thread.latestTurn?.turnId === payload.turnId
+                        ? (thread.latestTurn.startedAt ?? payload.completedAt)
+                        : payload.completedAt,
+                    completedAt: payload.completedAt,
+                    assistantMessageId: payload.assistantMessageId,
+                  },
             updatedAt: event.occurredAt,
           }),
         };

--- a/apps/server/src/orchestration/threadDetailCursor.test.ts
+++ b/apps/server/src/orchestration/threadDetailCursor.test.ts
@@ -7,6 +7,26 @@ import {
 } from "./threadDetailCursor.ts";
 
 describe("threadDetailCursor", () => {
+  it("round-trips a sequence cursor while retaining its timestamp tiebreaker", () => {
+    const cursor = {
+      threadId: ThreadId.make("thread-1"),
+      beforeSequence: 273,
+      beforeAnchorAt: "2026-09-04T17:18:56.456Z",
+      beforeTurnId: "turn-9",
+    };
+    expect(decodeThreadDetailPageCursor(encodeThreadDetailPageCursor(cursor))).toEqual(cursor);
+  });
+
+  it.each([-1, 1.5, "273", null, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects an invalid sequence boundary %j",
+    (sequence) => {
+      const encoded = Buffer.from(
+        JSON.stringify({ t: "thread-1", a: "", i: "", v: 2, s: sequence }),
+      ).toString("base64url");
+      expect(decodeThreadDetailPageCursor(encoded)).toBeNull();
+    },
+  );
+
   it("round-trips a cursor", () => {
     const cursor = {
       threadId: ThreadId.make("thread-1"),

--- a/apps/server/src/orchestration/threadDetailCursor.ts
+++ b/apps/server/src/orchestration/threadDetailCursor.ts
@@ -3,22 +3,23 @@ import type { ThreadId } from "@t3tools/contracts";
 /**
  * Opaque, exclusive cursor for windowed thread detail reads. Encodes the thread
  * id and the keyset boundary of an already-delivered page: the boundary turn's
- * anchor timestamp (`COALESCE(requested_at, started_at, '')`) and turn id.
+ * creation sequence, anchor timestamp and turn id.
  * Passing it back requests the adjacent disjoint slice of strictly older turns
- * under `(anchor, turn_id)` ordering.
+ * under `(creation sequence, anchor, turn_id)` ordering.
  *
  * The boundary is deliberately NOT a `projection_turns.row_id`: row ids are
  * rewritten by the revert projector (delete + re-upsert) and by projection
  * rebuilds, which would silently invalidate every persisted cursor with no
- * event emitted. The (anchor, turnId) pair is derived from event content, so
- * cursors survive both and no client-side refresh machinery is needed. The
- * anchor doubles as the time bound for rows with no turn linkage (straggler
- * user messages, turnless activities). The thread id is embedded so a cursor
+ * event emitted. Creation sequences and turn keys survive both rewrites.
+ * Timestamps break ties for legacy rows without a creation sequence.
+ * The thread id is embedded so a cursor
  * can never be replayed against a different thread. Clients must treat the
  * string as opaque.
  */
 export interface ThreadDetailPageCursor {
   readonly threadId: ThreadId;
+  /** Absent in legacy timestamp cursors; resolved from their boundary turn. */
+  readonly beforeSequence?: number;
   readonly beforeAnchorAt: string;
   /** Boundary turn id; "" for the rare turn row with a null turn_id. */
   readonly beforeTurnId: string;
@@ -26,7 +27,12 @@ export interface ThreadDetailPageCursor {
 
 export function encodeThreadDetailPageCursor(cursor: ThreadDetailPageCursor): string {
   return Buffer.from(
-    JSON.stringify({ t: cursor.threadId, a: cursor.beforeAnchorAt, i: cursor.beforeTurnId }),
+    JSON.stringify({
+      t: cursor.threadId,
+      a: cursor.beforeAnchorAt,
+      i: cursor.beforeTurnId,
+      ...(cursor.beforeSequence === undefined ? {} : { v: 2, s: cursor.beforeSequence }),
+    }),
   ).toString("base64url");
 }
 
@@ -48,15 +54,28 @@ export function decodeThreadDetailPageCursor(encoded: string): ThreadDetailPageC
   if (typeof record.t !== "string" || record.t.length === 0) {
     return null;
   }
-  // Empty strings are valid boundary values, not malformed input: the anchor
-  // is COALESCE(requested_at, started_at, ''), so a boundary turn with no
-  // timestamps encodes a: "" (and sorts before every real anchor, correctly
-  // ending the walk); the turn key is "" for a null turn_id.
+  // Empty strings are valid legacy boundary values; the turn key is "" for
+  // a null turn_id.
   if (typeof record.a !== "string") {
     return null;
   }
   if (typeof record.i !== "string") {
     return null;
   }
-  return { threadId: record.t as ThreadId, beforeAnchorAt: record.a, beforeTurnId: record.i };
+  if (
+    record.v !== undefined &&
+    (record.v !== 2 ||
+      typeof record.s !== "number" ||
+      !Number.isSafeInteger(record.s) ||
+      record.s < 0)
+  ) {
+    return null;
+  }
+  if (record.v === undefined && record.s !== undefined) return null;
+  return {
+    threadId: record.t as ThreadId,
+    beforeAnchorAt: record.a,
+    beforeTurnId: record.i,
+    ...(record.v === 2 ? { beforeSequence: record.s as number } : {}),
+  };
 }

--- a/apps/server/src/persistence/Layers/ProjectionThreadActivities.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadActivities.ts
@@ -20,6 +20,7 @@ const ProjectionThreadActivityDbRowSchema = ProjectionThreadActivity.mapFields(
   Struct.assign({
     payload: Schema.fromJsonString(Schema.Unknown),
     sequence: Schema.NullOr(NonNegativeInt),
+    createdSequence: Schema.NullOr(NonNegativeInt),
   }),
 );
 
@@ -36,6 +37,7 @@ const mapActivityRows = (
     payload: row.payload,
     ...(row.sequence !== null ? { sequence: row.sequence } : {}),
     createdAt: row.createdAt,
+    ...(row.createdSequence !== null ? { createdSequence: row.createdSequence } : {}),
   }));
 
 function toPersistenceSqlOrDecodeError(sqlOperation: string, decodeOperation: string) {
@@ -61,6 +63,7 @@ const makeProjectionThreadActivityRepository = Effect.gen(function* () {
               summary,
               payload_json,
               sequence,
+              created_sequence,
               created_at
             )
             VALUES (
@@ -72,6 +75,7 @@ const makeProjectionThreadActivityRepository = Effect.gen(function* () {
               ${row.summary},
               ${JSON.stringify(row.payload)},
               ${row.sequence ?? null},
+              ${row.createdSequence ?? null},
               ${row.createdAt}
             )
             ON CONFLICT (activity_id)
@@ -83,6 +87,7 @@ const makeProjectionThreadActivityRepository = Effect.gen(function* () {
               summary = excluded.summary,
               payload_json = excluded.payload_json,
               sequence = excluded.sequence,
+              created_sequence = COALESCE(projection_thread_activities.created_sequence, excluded.created_sequence),
               created_at = excluded.created_at
           `,
   });
@@ -101,12 +106,12 @@ const makeProjectionThreadActivityRepository = Effect.gen(function* () {
           summary,
           payload_json AS "payload",
           sequence,
+          created_sequence AS "createdSequence",
           created_at AS "createdAt"
         FROM projection_thread_activities
         WHERE thread_id = ${threadId}
         ORDER BY
-          CASE WHEN sequence IS NULL THEN 0 ELSE 1 END ASC,
-          sequence ASC,
+          COALESCE(created_sequence, 0) ASC,
           created_at ASC,
           activity_id ASC
       `,
@@ -126,6 +131,7 @@ const makeProjectionThreadActivityRepository = Effect.gen(function* () {
           summary,
           payload_json AS "payload",
           sequence,
+          created_sequence AS "createdSequence",
           created_at AS "createdAt"
         FROM projection_thread_activities
         WHERE thread_id = ${threadId}
@@ -135,8 +141,7 @@ const makeProjectionThreadActivityRepository = Effect.gen(function* () {
             'provider.user-input.respond.failed'
           )
         ORDER BY
-          CASE WHEN sequence IS NULL THEN 0 ELSE 1 END ASC,
-          sequence ASC,
+          COALESCE(created_sequence, 0) ASC,
           created_at ASC,
           activity_id ASC
       `,

--- a/apps/server/src/persistence/Layers/ProjectionThreadMessages.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadMessages.test.ts
@@ -12,6 +12,45 @@ const layer = it.layer(
 );
 
 layer("ProjectionThreadMessageRepository", (it) => {
+  it.effect("keeps first event order through streaming and repeated message updates", () =>
+    Effect.gen(function* () {
+      const repository = yield* ProjectionThreadMessageRepository;
+      const threadId = ThreadId.make("thread-clock-rollback");
+      const first = {
+        messageId: MessageId.make("message-before-rollback"),
+        threadId,
+        turnId: null,
+        role: "user" as const,
+        text: "first",
+        isStreaming: false,
+        createdAt: "2026-09-01T12:00:00.000Z",
+        updatedAt: "2026-09-01T12:00:00.000Z",
+        createdSequence: 10,
+      };
+      const second = {
+        ...first,
+        messageId: MessageId.make("message-after-rollback"),
+        text: "second",
+        createdAt: "2026-09-01T01:00:00.000Z",
+        updatedAt: "2026-09-01T01:00:00.000Z",
+        createdSequence: 20,
+      };
+      yield* repository.upsert(first);
+      yield* repository.appendStreaming(second);
+      yield* repository.appendStreaming({ ...second, text: " continued", createdSequence: 30 });
+      yield* repository.upsert({ ...first, text: "edited first", createdSequence: 40 });
+      const rows = yield* repository.listByThreadId({ threadId });
+      assert.deepEqual(
+        rows.map((row) => [row.messageId, row.createdSequence, row.text]),
+        [
+          [first.messageId, 10, "edited first"],
+          [second.messageId, 20, "second continued"],
+        ],
+      );
+      assert.strictEqual(yield* repository.getLatestUserMessageAt({ threadId }), second.createdAt);
+    }),
+  );
+
   it.effect("finds the latest live user-message time within one thread", () =>
     Effect.gen(function* () {
       const repository = yield* ProjectionThreadMessageRepository;

--- a/apps/server/src/persistence/Layers/ProjectionThreadMessages.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadMessages.ts
@@ -5,7 +5,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import * as Struct from "effect/Struct";
-import { ChatAttachment } from "@t3tools/contracts";
+import { ChatAttachment, NonNegativeInt } from "@t3tools/contracts";
 
 import { toPersistenceSqlError } from "../Errors.ts";
 import {
@@ -21,6 +21,7 @@ import {
 const ProjectionThreadMessageDbRowSchema = ProjectionThreadMessage.mapFields(
   Struct.assign({
     isStreaming: Schema.Number,
+    createdSequence: Schema.NullOr(NonNegativeInt),
     attachments: Schema.NullOr(Schema.fromJsonString(Schema.Array(ChatAttachment))),
   }),
 );
@@ -36,6 +37,7 @@ function toProjectionThreadMessage(
     text: row.text,
     isStreaming: row.isStreaming === 1,
     createdAt: row.createdAt,
+    ...(row.createdSequence !== null ? { createdSequence: row.createdSequence } : {}),
     updatedAt: row.updatedAt,
     ...(row.attachments !== null ? { attachments: row.attachments } : {}),
   };
@@ -58,6 +60,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           text,
           attachments_json,
           is_streaming,
+          created_sequence,
           created_at,
           updated_at
         )
@@ -76,6 +79,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
             )
           ),
           ${row.isStreaming ? 1 : 0},
+          ${row.createdSequence ?? null},
           ${row.createdAt},
           ${row.updatedAt}
         )
@@ -90,6 +94,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
             projection_thread_messages.attachments_json
           ),
           is_streaming = excluded.is_streaming,
+          created_sequence = COALESCE(projection_thread_messages.created_sequence, excluded.created_sequence),
           created_at = excluded.created_at,
           updated_at = excluded.updated_at
       `;
@@ -110,6 +115,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           text,
           attachments_json,
           is_streaming,
+          created_sequence,
           created_at,
           updated_at
         )
@@ -121,6 +127,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           ${row.text},
           ${nextAttachmentsJson},
           1,
+          ${row.createdSequence ?? null},
           ${row.createdAt},
           ${row.updatedAt}
         )
@@ -135,6 +142,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
             projection_thread_messages.attachments_json
           ),
           is_streaming = 1,
+          created_sequence = COALESCE(projection_thread_messages.created_sequence, excluded.created_sequence),
           updated_at = excluded.updated_at
       `;
     },
@@ -153,6 +161,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           text,
           attachments_json AS "attachments",
           is_streaming AS "isStreaming",
+          created_sequence AS "createdSequence",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
         FROM projection_thread_messages
@@ -174,11 +183,12 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           text,
           attachments_json AS "attachments",
           is_streaming AS "isStreaming",
+          created_sequence AS "createdSequence",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
         FROM projection_thread_messages
         WHERE thread_id = ${threadId}
-        ORDER BY created_at ASC, message_id ASC
+        ORDER BY COALESCE(created_sequence, 0) ASC, created_at ASC, message_id ASC
       `,
   });
 
@@ -188,10 +198,14 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
       latestUserMessageAt: Schema.NullOr(ProjectionThreadMessage.fields.createdAt),
     }),
     execute: ({ threadId }) => sql`
-      SELECT MAX(created_at) AS "latestUserMessageAt"
-      FROM projection_thread_messages
-      WHERE thread_id = ${threadId} AND role = 'user'
-        AND message_id NOT GLOB 'import:*'
+      SELECT (
+        SELECT created_at
+        FROM projection_thread_messages
+        WHERE thread_id = ${threadId} AND role = 'user'
+          AND message_id NOT GLOB 'import:*'
+        ORDER BY COALESCE(created_sequence, 0) DESC, created_at DESC, message_id DESC
+        LIMIT 1
+      ) AS "latestUserMessageAt"
     `,
   });
 

--- a/apps/server/src/persistence/Layers/ProjectionThreadProposedPlans.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadProposedPlans.ts
@@ -2,6 +2,9 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as SqlSchema from "effect/unstable/sql/SqlSchema";
+import { NonNegativeInt } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+import * as Struct from "effect/Struct";
 
 import { toPersistenceSqlError } from "../Errors.ts";
 import {
@@ -26,6 +29,7 @@ const makeProjectionThreadProposedPlanRepository = Effect.gen(function* () {
         implemented_at,
         implementation_thread_id,
         created_at,
+        created_sequence,
         updated_at
       )
       VALUES (
@@ -36,6 +40,7 @@ const makeProjectionThreadProposedPlanRepository = Effect.gen(function* () {
         ${row.implementedAt},
         ${row.implementationThreadId},
         ${row.createdAt},
+        ${row.createdSequence ?? null},
         ${row.updatedAt}
       )
       ON CONFLICT (plan_id)
@@ -46,13 +51,16 @@ const makeProjectionThreadProposedPlanRepository = Effect.gen(function* () {
         implemented_at = excluded.implemented_at,
         implementation_thread_id = excluded.implementation_thread_id,
         created_at = excluded.created_at,
+        created_sequence = COALESCE(projection_thread_proposed_plans.created_sequence, excluded.created_sequence),
         updated_at = excluded.updated_at
     `,
   });
 
   const listProjectionThreadProposedPlanRows = SqlSchema.findAll({
     Request: ListProjectionThreadProposedPlansInput,
-    Result: ProjectionThreadProposedPlan,
+    Result: ProjectionThreadProposedPlan.mapFields(
+      Struct.assign({ createdSequence: Schema.NullOr(NonNegativeInt) }),
+    ),
     execute: ({ threadId }) => sql`
       SELECT
         plan_id AS "planId",
@@ -62,10 +70,11 @@ const makeProjectionThreadProposedPlanRepository = Effect.gen(function* () {
         implemented_at AS "implementedAt",
         implementation_thread_id AS "implementationThreadId",
         created_at AS "createdAt",
+        created_sequence AS "createdSequence",
         updated_at AS "updatedAt"
       FROM projection_thread_proposed_plans
       WHERE thread_id = ${threadId}
-      ORDER BY created_at ASC, plan_id ASC
+      ORDER BY COALESCE(created_sequence, 0) ASC, created_at ASC, plan_id ASC
     `,
   });
 
@@ -84,6 +93,12 @@ const makeProjectionThreadProposedPlanRepository = Effect.gen(function* () {
 
   const listByThreadId: ProjectionThreadProposedPlanRepositoryShape["listByThreadId"] = (input) =>
     listProjectionThreadProposedPlanRows(input).pipe(
+      Effect.map((rows) =>
+        rows.map(({ createdSequence, ...row }) => ({
+          ...row,
+          ...(createdSequence !== null ? { createdSequence } : {}),
+        })),
+      ),
       Effect.mapError(
         toPersistenceSqlError("ProjectionThreadProposedPlanRepository.listByThreadId:query"),
       ),

--- a/apps/server/src/persistence/Layers/ProjectionTurns.ts
+++ b/apps/server/src/persistence/Layers/ProjectionTurns.ts
@@ -1,4 +1,4 @@
-import { OrchestrationCheckpointFile } from "@t3tools/contracts";
+import { NonNegativeInt, OrchestrationCheckpointFile } from "@t3tools/contracts";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as SqlSchema from "effect/unstable/sql/SqlSchema";
 import * as Effect from "effect/Effect";
@@ -24,6 +24,7 @@ import {
 const ProjectionTurnDbRowSchema = ProjectionTurn.mapFields(
   Struct.assign({
     checkpointFiles: Schema.fromJsonString(Schema.Array(OrchestrationCheckpointFile)),
+    createdSequence: Schema.NullOr(NonNegativeInt),
   }),
 );
 
@@ -32,6 +33,11 @@ const ProjectionTurnByIdDbRowSchema = ProjectionTurnById.mapFields(
     checkpointFiles: Schema.fromJsonString(Schema.Array(OrchestrationCheckpointFile)),
   }),
 );
+
+const omitNullCreatedSequence = <T extends { readonly createdSequence: number | null }>(row: T) => {
+  const { createdSequence, ...rest } = row;
+  return { ...rest, ...(createdSequence !== null ? { createdSequence } : {}) };
+};
 
 function toPersistenceSqlOrDecodeError(sqlOperation: string, decodeOperation: string) {
   return (cause: unknown) =>
@@ -56,6 +62,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           assistant_message_id,
           state,
           requested_at,
+          created_sequence,
           started_at,
           completed_at,
           checkpoint_turn_count,
@@ -72,6 +79,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           ${row.assistantMessageId},
           ${row.state},
           ${row.requestedAt},
+          ${row.createdSequence ?? null},
           ${row.startedAt},
           ${row.completedAt},
           ${row.checkpointTurnCount},
@@ -87,6 +95,11 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           assistant_message_id = excluded.assistant_message_id,
           state = excluded.state,
           requested_at = excluded.requested_at,
+          created_sequence = CASE
+            WHEN projection_turns.pending_message_id IS NULL AND excluded.pending_message_id IS NOT NULL
+              THEN COALESCE(excluded.created_sequence, projection_turns.created_sequence)
+            ELSE COALESCE(projection_turns.created_sequence, excluded.created_sequence)
+          END,
           started_at = excluded.started_at,
           completed_at = excluded.completed_at,
           checkpoint_turn_count = excluded.checkpoint_turn_count,
@@ -121,6 +134,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           assistant_message_id,
           state,
           requested_at,
+          created_sequence,
           started_at,
           completed_at,
           checkpoint_turn_count,
@@ -137,6 +151,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           NULL,
           'pending',
           ${row.requestedAt},
+          ${row.createdSequence ?? null},
           NULL,
           NULL,
           NULL,
@@ -149,7 +164,9 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
 
   const getPendingProjectionTurn = SqlSchema.findOneOption({
     Request: GetProjectionPendingTurnStartInput,
-    Result: ProjectionPendingTurnStart,
+    Result: ProjectionPendingTurnStart.mapFields(
+      Struct.assign({ createdSequence: Schema.NullOr(NonNegativeInt) }),
+    ),
     execute: ({ threadId }) =>
       sql`
         SELECT
@@ -157,14 +174,15 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           pending_message_id AS "messageId",
           source_proposed_plan_thread_id AS "sourceProposedPlanThreadId",
           source_proposed_plan_id AS "sourceProposedPlanId",
-          requested_at AS "requestedAt"
+          requested_at AS "requestedAt",
+          created_sequence AS "createdSequence"
         FROM projection_turns
         WHERE thread_id = ${threadId}
           AND turn_id IS NULL
           AND state = 'pending'
           AND pending_message_id IS NOT NULL
           AND checkpoint_turn_count IS NULL
-        ORDER BY requested_at DESC
+        ORDER BY COALESCE(created_sequence, 0) DESC, requested_at DESC
         LIMIT 1
       `,
   });
@@ -183,6 +201,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           assistant_message_id AS "assistantMessageId",
           state,
           requested_at AS "requestedAt",
+          created_sequence AS "createdSequence",
           started_at AS "startedAt",
           completed_at AS "completedAt",
           checkpoint_turn_count AS "checkpointTurnCount",
@@ -197,6 +216,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
             ELSE 0
           END ASC,
           checkpoint_turn_count ASC,
+          COALESCE(created_sequence, 0) ASC,
           requested_at ASC,
           turn_id ASC
       `,
@@ -204,7 +224,9 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
 
   const getProjectionTurnByTurnId = SqlSchema.findOneOption({
     Request: GetProjectionTurnByTurnIdInput,
-    Result: ProjectionTurnByIdDbRowSchema,
+    Result: ProjectionTurnByIdDbRowSchema.mapFields(
+      Struct.assign({ createdSequence: Schema.NullOr(NonNegativeInt) }),
+    ),
     execute: ({ threadId, turnId }) =>
       sql`
         SELECT
@@ -216,6 +238,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           assistant_message_id AS "assistantMessageId",
           state,
           requested_at AS "requestedAt",
+          created_sequence AS "createdSequence",
           started_at AS "startedAt",
           completed_at AS "completedAt",
           checkpoint_turn_count AS "checkpointTurnCount",
@@ -283,6 +306,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
   const getPendingTurnStartByThreadId: ProjectionTurnRepositoryShape["getPendingTurnStartByThreadId"] =
     (input) =>
       getPendingProjectionTurn(input).pipe(
+        Effect.map(Option.map(omitNullCreatedSequence)),
         Effect.mapError(
           toPersistenceSqlError("ProjectionTurnRepository.getPendingTurnStartByThreadId:query"),
         ),
@@ -304,7 +328,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           "ProjectionTurnRepository.listByThreadId:decodeRows",
         ),
       ),
-      Effect.map((rows) => rows as ReadonlyArray<Schema.Schema.Type<typeof ProjectionTurn>>),
+      Effect.map((rows) => rows.map(omitNullCreatedSequence)),
     );
 
   const getByTurnId: ProjectionTurnRepositoryShape["getByTurnId"] = (input) =>
@@ -318,8 +342,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
       Effect.flatMap((rowOption) =>
         Option.match(rowOption, {
           onNone: () => Effect.succeed(Option.none()),
-          onSome: (row) =>
-            Effect.succeed(Option.some(row as Schema.Schema.Type<typeof ProjectionTurnById>)),
+          onSome: (row) => Effect.succeed(Option.some(omitNullCreatedSequence(row))),
         }),
       ),
     );

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -59,6 +59,7 @@ import Migration0044 from "./Migrations/044_ClearAutomaticProjectModelDefaults.t
 import Migration0045 from "./Migrations/045_ProjectionProjectsAutoPull.ts";
 import Migration0046 from "./Migrations/046_RepairAutomaticSettlementTimestamps.ts";
 import Migration0047 from "./Migrations/047_ProjectionProjectIcon.ts";
+import Migration0048 from "./Migrations/048_ProjectionThreadCreatedSequence.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -118,6 +119,7 @@ export const migrationEntries = [
   [45, "ProjectionProjectsAutoPull", Migration0045],
   [46, "RepairAutomaticSettlementTimestamps", Migration0046],
   [47, "ProjectionProjectIcon", Migration0047],
+  [48, "ProjectionThreadCreatedSequence", Migration0048],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);

--- a/apps/server/src/persistence/Migrations/048_ProjectionThreadCreatedSequence.test.ts
+++ b/apps/server/src/persistence/Migrations/048_ProjectionThreadCreatedSequence.test.ts
@@ -1,0 +1,120 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import * as NodeSqliteClient from "@t3tools/shared/nodeSqliteClient";
+
+import { runMigrations } from "../Migrations.ts";
+
+const encodePayload = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
+
+it.layer(NodeSqliteClient.layerMemory())("048_ProjectionThreadCreatedSequence", (it) => {
+  it.effect(
+    "repairs rollback ordering without changing timestamps or matching a deleted incarnation",
+    () =>
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        yield* runMigrations({ toMigrationInclusive: 47 });
+        const before = "2026-09-01T12:00:00.000Z";
+        const after = "2026-09-01T01:00:00.000Z";
+        yield* sql`INSERT INTO projection_threads
+        (thread_id, project_id, title, model_selection_json, created_at, updated_at,
+          latest_user_message_at, pending_user_input_count, has_actionable_proposed_plan)
+        VALUES ('thread', 'project', 'clock rollback', '{"instanceId":"codex","model":"gpt-5"}',
+          ${before}, ${after}, ${before}, 1, 1)`;
+        yield* sql`INSERT INTO projection_thread_messages
+        (message_id, thread_id, turn_id, role, text, is_streaming, created_at, updated_at)
+        VALUES ('first', 'thread', NULL, 'user', 'first', 0, ${before}, ${before}),
+          ('second', 'thread', NULL, 'user', 'second', 0, ${after}, ${after}),
+          ('import:history', 'thread', NULL, 'user', 'history', 0, ${before}, ${before}),
+          ('orphan', 'thread', NULL, 'assistant', 'no retained event', 0, ${after}, ${after})`;
+        yield* sql`INSERT INTO projection_thread_proposed_plans
+        (plan_id, thread_id, turn_id, plan_markdown, created_at, updated_at, implemented_at)
+        VALUES ('plan', 'thread', NULL, 'updated plan', ${before}, ${before}, NULL),
+          ('later-plan', 'thread', NULL, 'implemented plan', ${after}, ${after}, ${after})`;
+        yield* sql`INSERT INTO projection_thread_activities
+        (activity_id, thread_id, turn_id, tone, kind, summary, payload_json, sequence, created_at)
+        VALUES ('request', 'thread', NULL, 'info', 'user-input.requested', 'question',
+          '{"requestId":"request"}', 100, ${before}),
+          ('resolve', 'thread', NULL, 'info', 'user-input.resolved', 'answer',
+          '{"requestId":"request"}', 1, ${after})`;
+        yield* sql`INSERT INTO projection_turns
+        (thread_id, turn_id, pending_message_id, state, requested_at, checkpoint_files_json)
+        VALUES ('thread', 'first-turn', 'first', 'completed', ${before}, '[]'),
+          ('thread', 'second-turn', 'second', 'running', ${after}, '[]'),
+          ('thread', 'autonomous', NULL, 'completed', ${after}, '[]'),
+          ('thread', NULL, 'missing-prompt', 'pending', ${after}, '[]')`;
+
+        const events = [
+          ["thread.created", {}],
+          ["thread.message-sent", { messageId: "first", role: "user" }],
+          ["thread.deleted", {}],
+          ["thread.created", {}],
+          ["thread.message-sent", { messageId: "first", role: "user" }],
+          ["thread.message-sent", { messageId: "second", role: "user" }],
+          ["thread.message-sent", { messageId: "second", role: "user" }],
+          ["thread.message-sent", { messageId: "import:history", role: "user" }],
+          ["thread.proposed-plan-upserted", { proposedPlan: { id: "plan" } }],
+          ["thread.proposed-plan-upserted", { proposedPlan: { id: "plan" } }],
+          ["thread.activity-appended", { activity: { id: "request" } }],
+          ["thread.activity-appended", { activity: { id: "resolve" } }],
+          ["thread.session-set", { session: { activeTurnId: "autonomous", status: "running" } }],
+          ["thread.turn-diff-completed", { turnId: "autonomous" }],
+          ["thread.turn-start-requested", { messageId: "missing-prompt" }],
+          ["thread.proposed-plan-upserted", { proposedPlan: { id: "later-plan" } }],
+        ] as const;
+        for (const [index, [type, payload]] of events.entries()) {
+          yield* sql`INSERT INTO orchestration_events
+          (event_id, aggregate_kind, stream_id, stream_version, event_type, occurred_at,
+            command_id, actor_kind, payload_json, metadata_json)
+          VALUES (${`event-${index}`}, 'thread', 'thread', ${index + 1}, ${type}, ${after},
+            ${`command-${index}`}, 'client', ${encodePayload(payload)}, '{}')`;
+        }
+
+        yield* runMigrations({ toMigrationInclusive: 48 });
+        assert.deepEqual(
+          yield* sql`SELECT message_id, created_sequence, created_at
+        FROM projection_thread_messages ORDER BY message_id`,
+          [
+            { message_id: "first", created_sequence: 5, created_at: before },
+            { message_id: "import:history", created_sequence: 8, created_at: before },
+            { message_id: "orphan", created_sequence: null, created_at: after },
+            { message_id: "second", created_sequence: 6, created_at: after },
+          ],
+        );
+        assert.deepEqual(
+          yield* sql`SELECT created_sequence FROM projection_thread_proposed_plans ORDER BY created_sequence`,
+          [{ created_sequence: 9 }, { created_sequence: 16 }],
+        );
+        assert.deepEqual(
+          yield* sql`SELECT created_sequence, sequence FROM projection_thread_activities
+        ORDER BY created_sequence`,
+          [
+            { created_sequence: 11, sequence: 100 },
+            { created_sequence: 12, sequence: 1 },
+          ],
+        );
+        assert.deepEqual(
+          yield* sql`SELECT turn_id, created_sequence FROM projection_turns
+        ORDER BY created_sequence`,
+          [
+            { turn_id: "first-turn", created_sequence: 5 },
+            { turn_id: "second-turn", created_sequence: 6 },
+            { turn_id: "autonomous", created_sequence: 13 },
+            { turn_id: null, created_sequence: 15 },
+          ],
+        );
+        assert.deepEqual(
+          yield* sql`SELECT latest_user_message_at, pending_user_input_count, has_actionable_proposed_plan
+        FROM projection_threads`,
+          [
+            {
+              latest_user_message_at: after,
+              pending_user_input_count: 0,
+              has_actionable_proposed_plan: 0,
+            },
+          ],
+        );
+      }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/048_ProjectionThreadCreatedSequence.ts
+++ b/apps/server/src/persistence/Migrations/048_ProjectionThreadCreatedSequence.ts
@@ -1,0 +1,149 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`ALTER TABLE projection_thread_messages ADD COLUMN created_sequence INTEGER`;
+  yield* sql`ALTER TABLE projection_thread_proposed_plans ADD COLUMN created_sequence INTEGER`;
+  yield* sql`ALTER TABLE projection_thread_activities ADD COLUMN created_sequence INTEGER`;
+  yield* sql`ALTER TABLE projection_turns ADD COLUMN created_sequence INTEGER`;
+
+  // Bound matches to the current thread incarnation: draft retries can reuse ids.
+  // Materialize once so backfilling a large history does not rescan its event log per row.
+  yield* sql`
+    CREATE TEMP TABLE projection_created_sequence_backfill AS
+    WITH lifetimes AS (
+      SELECT stream_id, MAX(sequence) AS sequence
+      FROM orchestration_events
+      WHERE event_type = 'thread.created'
+      GROUP BY stream_id
+    ), current_events AS MATERIALIZED (
+      SELECT events.stream_id, events.sequence, events.event_type,
+        CASE events.event_type
+          WHEN 'thread.message-sent' THEN json_extract(payload_json, '$.messageId')
+          WHEN 'thread.proposed-plan-upserted' THEN json_extract(payload_json, '$.proposedPlan.id')
+          WHEN 'thread.activity-appended' THEN json_extract(payload_json, '$.activity.id')
+          WHEN 'thread.turn-start-requested' THEN json_extract(payload_json, '$.messageId')
+        END AS item_id,
+        CASE
+          WHEN event_type = 'thread.session-set' AND json_extract(payload_json, '$.session.status') = 'running'
+            THEN json_extract(payload_json, '$.session.activeTurnId')
+          WHEN event_type = 'thread.message-sent' AND json_extract(payload_json, '$.role') = 'assistant'
+            THEN json_extract(payload_json, '$.turnId')
+          WHEN event_type IN ('thread.turn-interrupt-requested', 'thread.turn-diff-completed')
+            THEN json_extract(payload_json, '$.turnId')
+        END AS turn_id
+      FROM orchestration_events AS events
+      LEFT JOIN lifetimes ON lifetimes.stream_id = events.stream_id
+      WHERE events.aggregate_kind = 'thread'
+        AND events.sequence >= COALESCE(lifetimes.sequence, 0)
+        AND events.event_type IN ('thread.message-sent', 'thread.proposed-plan-upserted',
+          'thread.activity-appended', 'thread.turn-start-requested', 'thread.session-set',
+          'thread.turn-interrupt-requested', 'thread.turn-diff-completed')
+    ), identities AS (
+      SELECT stream_id AS thread_id, sequence,
+        CASE event_type
+          WHEN 'thread.message-sent' THEN 'message'
+          WHEN 'thread.proposed-plan-upserted' THEN 'plan'
+          WHEN 'thread.activity-appended' THEN 'activity'
+          WHEN 'thread.turn-start-requested' THEN 'pending'
+        END AS kind,
+        item_id
+      FROM current_events
+      WHERE event_type IN ('thread.message-sent', 'thread.proposed-plan-upserted',
+        'thread.activity-appended', 'thread.turn-start-requested')
+      UNION ALL
+      SELECT stream_id, sequence, 'turn', turn_id
+      FROM current_events
+      WHERE turn_id IS NOT NULL
+    )
+    SELECT thread_id, kind, item_id, MIN(sequence) AS sequence
+    FROM identities
+    WHERE item_id IS NOT NULL
+    GROUP BY thread_id, kind, item_id
+  `;
+  yield* sql`
+    CREATE UNIQUE INDEX projection_created_sequence_backfill_key
+    ON projection_created_sequence_backfill(thread_id, kind, item_id)
+  `;
+  yield* sql`
+    UPDATE projection_thread_messages AS messages SET created_sequence = (
+      SELECT sequence FROM projection_created_sequence_backfill
+      WHERE thread_id = messages.thread_id AND kind = 'message' AND item_id = messages.message_id
+    )
+  `;
+  yield* sql`
+    UPDATE projection_thread_proposed_plans AS plans SET created_sequence = (
+      SELECT sequence FROM projection_created_sequence_backfill
+      WHERE thread_id = plans.thread_id AND kind = 'plan' AND item_id = plans.plan_id
+    )
+  `;
+  yield* sql`
+    UPDATE projection_thread_activities AS activities SET created_sequence = (
+      SELECT sequence FROM projection_created_sequence_backfill
+      WHERE thread_id = activities.thread_id AND kind = 'activity' AND item_id = activities.activity_id
+    )
+  `;
+  yield* sql`
+    UPDATE projection_turns AS turns SET created_sequence = COALESCE(
+      (SELECT created_sequence FROM projection_thread_messages
+       WHERE thread_id = turns.thread_id AND message_id = turns.pending_message_id),
+      (SELECT sequence FROM projection_created_sequence_backfill
+       WHERE thread_id = turns.thread_id AND kind = 'pending' AND item_id = turns.pending_message_id),
+      (SELECT sequence FROM projection_created_sequence_backfill
+       WHERE thread_id = turns.thread_id AND kind = 'turn' AND item_id = turns.turn_id)
+    )
+  `;
+  yield* sql`DROP TABLE projection_created_sequence_backfill`;
+
+  yield* sql`CREATE INDEX idx_projection_thread_messages_created_sequence
+    ON projection_thread_messages(thread_id, COALESCE(created_sequence, 0), created_at, message_id)`;
+  yield* sql`CREATE INDEX idx_projection_thread_proposed_plans_created_sequence
+    ON projection_thread_proposed_plans(thread_id, COALESCE(created_sequence, 0), created_at, plan_id)`;
+  yield* sql`CREATE INDEX idx_projection_thread_activities_created_sequence
+    ON projection_thread_activities(thread_id, COALESCE(created_sequence, 0), created_at, activity_id)`;
+  yield* sql`CREATE INDEX idx_projection_turns_created_sequence
+    ON projection_turns(thread_id, COALESCE(created_sequence, 0), requested_at, turn_id)`;
+
+  yield* sql`
+    UPDATE projection_threads SET latest_user_message_at = (
+      SELECT created_at FROM projection_thread_messages
+      WHERE thread_id = projection_threads.thread_id
+        AND role = 'user' AND message_id NOT GLOB 'import:*'
+      ORDER BY COALESCE(created_sequence, 0) DESC, created_at DESC, message_id DESC
+      LIMIT 1
+    )
+  `;
+  yield* sql`
+    WITH lifecycle AS (
+      SELECT thread_id, kind, ROW_NUMBER() OVER (
+        PARTITION BY thread_id, json_extract(payload_json, '$.requestId')
+        ORDER BY COALESCE(created_sequence, 0) DESC, created_at DESC, activity_id DESC
+      ) AS position
+      FROM projection_thread_activities
+      WHERE json_type(payload_json, '$.requestId') = 'text'
+        AND (kind IN ('user-input.requested', 'user-input.resolved') OR (
+          kind = 'provider.user-input.respond.failed' AND (
+            lower(COALESCE(json_extract(payload_json, '$.detail'), '')) LIKE '%stale pending user-input request%'
+            OR lower(COALESCE(json_extract(payload_json, '$.detail'), '')) LIKE '%unknown pending user-input request%'
+            OR lower(COALESCE(json_extract(payload_json, '$.detail'), '')) LIKE '%unknown pending user input request%'
+            OR lower(COALESCE(json_extract(payload_json, '$.detail'), '')) LIKE '%unknown pending codex user input request%'
+          )
+        ))
+    )
+    UPDATE projection_threads SET pending_user_input_count = (
+      SELECT COUNT(*) FROM lifecycle
+      WHERE thread_id = projection_threads.thread_id AND position = 1 AND kind = 'user-input.requested'
+    )
+  `;
+  yield* sql`
+    UPDATE projection_threads SET has_actionable_proposed_plan = COALESCE((
+      SELECT implemented_at IS NULL FROM projection_thread_proposed_plans
+      WHERE thread_id = projection_threads.thread_id
+      ORDER BY CASE WHEN turn_id = projection_threads.latest_turn_id THEN 0 ELSE 1 END,
+        COALESCE(created_sequence, 0) DESC, updated_at DESC, plan_id DESC
+      LIMIT 1
+    ), 0)
+  `;
+});

--- a/apps/server/src/persistence/Services/ProjectionThreadActivities.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadActivities.ts
@@ -30,6 +30,7 @@ export const ProjectionThreadActivity = Schema.Struct({
   payload: Schema.Unknown,
   sequence: Schema.optional(NonNegativeInt),
   createdAt: IsoDateTime,
+  createdSequence: Schema.optional(NonNegativeInt),
 });
 export type ProjectionThreadActivity = typeof ProjectionThreadActivity.Type;
 
@@ -60,8 +61,7 @@ export interface ProjectionThreadActivityRepositoryShape {
   /**
    * List projected thread activity rows for a thread.
    *
-   * Returned in ascending runtime sequence order (or creation order when
-   * sequence is unavailable).
+   * Returned in persisted creation order, with timestamp ordering for legacy rows.
    */
   readonly listByThreadId: (
     input: ListProjectionThreadActivitiesInput,

--- a/apps/server/src/persistence/Services/ProjectionThreadMessages.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadMessages.ts
@@ -9,6 +9,7 @@
 import {
   ChatAttachment,
   MessageId,
+  NonNegativeInt,
   OrchestrationMessageRole,
   ThreadId,
   TurnId,
@@ -31,6 +32,7 @@ export const ProjectionThreadMessage = Schema.Struct({
   attachments: Schema.optional(Schema.Array(ChatAttachment)),
   isStreaming: Schema.Boolean,
   createdAt: IsoDateTime,
+  createdSequence: Schema.optional(NonNegativeInt),
   updatedAt: IsoDateTime,
 });
 export type ProjectionThreadMessage = typeof ProjectionThreadMessage.Type;

--- a/apps/server/src/persistence/Services/ProjectionThreadProposedPlans.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadProposedPlans.ts
@@ -1,5 +1,6 @@
 import {
   IsoDateTime,
+  NonNegativeInt,
   OrchestrationProposedPlanId,
   ThreadId,
   TrimmedNonEmptyString,
@@ -19,6 +20,7 @@ export const ProjectionThreadProposedPlan = Schema.Struct({
   implementedAt: Schema.NullOr(IsoDateTime),
   implementationThreadId: Schema.NullOr(ThreadId),
   createdAt: IsoDateTime,
+  createdSequence: Schema.optional(NonNegativeInt),
   updatedAt: IsoDateTime,
 });
 export type ProjectionThreadProposedPlan = typeof ProjectionThreadProposedPlan.Type;

--- a/apps/server/src/persistence/Services/ProjectionTurns.ts
+++ b/apps/server/src/persistence/Services/ProjectionTurns.ts
@@ -42,6 +42,7 @@ export const ProjectionTurn = Schema.Struct({
   assistantMessageId: Schema.NullOr(MessageId),
   state: ProjectionTurnState,
   requestedAt: IsoDateTime,
+  createdSequence: Schema.optional(NonNegativeInt),
   startedAt: Schema.NullOr(IsoDateTime),
   completedAt: Schema.NullOr(IsoDateTime),
   checkpointTurnCount: Schema.NullOr(NonNegativeInt),
@@ -60,6 +61,7 @@ export const ProjectionTurnById = Schema.Struct({
   assistantMessageId: Schema.NullOr(MessageId),
   state: ProjectionTurnState,
   requestedAt: IsoDateTime,
+  createdSequence: Schema.optional(NonNegativeInt),
   startedAt: Schema.NullOr(IsoDateTime),
   completedAt: Schema.NullOr(IsoDateTime),
   checkpointTurnCount: Schema.NullOr(NonNegativeInt),
@@ -75,6 +77,7 @@ export const ProjectionPendingTurnStart = Schema.Struct({
   sourceProposedPlanThreadId: Schema.NullOr(ThreadId),
   sourceProposedPlanId: Schema.NullOr(OrchestrationProposedPlanId),
   requestedAt: IsoDateTime,
+  createdSequence: Schema.optional(NonNegativeInt),
 });
 export type ProjectionPendingTurnStart = typeof ProjectionPendingTurnStart.Type;
 

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -11,9 +11,12 @@ import {
   TurnId,
 } from "@t3tools/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { Atom } from "effect/unstable/reactivity";
 
 import type { Thread, ThreadShell, TurnDiffSummary } from "../types";
-import type { TimelineEntry } from "../session-logic";
+import { deriveTimelineEntries, type TimelineEntry } from "../session-logic";
+import { appAtomRegistry } from "../rpc/atomRegistry";
+import { environmentThreadDetails } from "../state/threads";
 import { deriveProviderInstanceEntries, NO_PROVIDER_MODEL_SELECTION } from "../providerInstances";
 import type { CodexArtifactTemplate } from "@t3tools/client-runtime/codex-artifact-templates";
 import type { RightPanelSurface } from "../rightPanelStore";
@@ -37,6 +40,7 @@ import {
   hasServerAcknowledgedLocalDispatch,
   isBranchMismatchDismissedForSession,
   reconcileMountedTerminalThreadIds,
+  readLocalMessageSequenceForSend,
   reconcileRetainedMountedThreadIds,
   resolveBackgroundDraftWorkspaceOptions,
   resolveComposerInteractionMode,
@@ -591,6 +595,73 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     ...overrides,
   };
 }
+
+describe("local message order after send preparation", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("anchors after messages received while preparing the captured thread's send", async () => {
+    const startedAt = "2026-09-06T12:00:00.000Z";
+    const correctedAt = "2026-09-06T01:00:00.000Z";
+    const original = makeThread({
+      messages: [
+        {
+          id: MessageId.make("initial"),
+          role: "user",
+          text: "Run",
+          turnId: null,
+          streaming: false,
+          createdAt: startedAt,
+          updatedAt: startedAt,
+          createdSequence: 10,
+        },
+      ],
+    });
+    const threadAtom = Atom.make<Thread | null>(original);
+    const unrelatedAtom = Atom.make<Thread | null>(makeThread({ id: ThreadId.make("other") }));
+    vi.spyOn(environmentThreadDetails, "detailAtom").mockImplementation((ref) =>
+      ref.environmentId === original.environmentId && ref.threadId === original.id
+        ? threadAtom
+        : unrelatedAtom,
+    );
+    let finishPreparation: () => void = () => {};
+    const preparation = new Promise<void>((resolve) => {
+      finishPreparation = resolve;
+    });
+    const send = (async () => {
+      await preparation;
+      return readLocalMessageSequenceForSend(original);
+    })();
+    const received = {
+      ...original.messages[0]!,
+      id: MessageId.make("received"),
+      role: "assistant" as const,
+      createdAt: correctedAt,
+      createdSequence: 20,
+    };
+    appAtomRegistry.set(threadAtom, { ...original, messages: [...original.messages, received] });
+    finishPreparation();
+    const sequence = await send;
+    expect(sequence).toBe(21);
+    const optimistic = {
+      ...received,
+      id: MessageId.make("optimistic"),
+      role: "user" as const,
+      local: true,
+      createdSequence: sequence,
+    };
+    expect(
+      deriveTimelineEntries([...original.messages, received, optimistic], [], []).map(
+        (entry) => entry.id,
+      ),
+    ).toEqual(["initial", "received", "optimistic"]);
+  });
+
+  it("uses the captured thread when server detail is unavailable", () => {
+    const detail = Atom.make<Thread | null>(null);
+    vi.spyOn(environmentThreadDetails, "detailAtom").mockReturnValue(detail);
+    expect(readLocalMessageSequenceForSend(makeThread())).toBeUndefined();
+  });
+});
 
 const completedTurn = {
   turnId: TurnId.make("turn-1"),

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -23,6 +23,7 @@ import {
   type AtomCommandResult,
 } from "@t3tools/client-runtime/state/runtime";
 import { videoMimeType } from "@t3tools/shared/video";
+import { nextLocalMessageSequence } from "@t3tools/shared/chronology";
 import {
   appendCodexArtifactTemplateUsePrompt,
   codexArtifactTemplateUsePrompt,
@@ -861,6 +862,17 @@ export function getStartedThreadModelChangeBlockReason(input: {
     title: "Start a new chat to change models",
     description: "This provider does not allow switching models after a conversation has started.",
   };
+}
+
+/** Read after send preparation, which may await uploads while the thread keeps streaming. */
+export function readLocalMessageSequenceForSend(thread: Thread): number | undefined {
+  const currentThread = appAtomRegistry.get(
+    environmentThreadDetails.detailAtom({
+      environmentId: thread.environmentId,
+      threadId: thread.id,
+    }),
+  );
+  return nextLocalMessageSequence(currentThread ?? thread);
 }
 
 export async function waitForStartedServerThread(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -394,6 +394,7 @@ import {
   cloneComposerImageForRetry,
   deriveLockedProvider,
   readFileAsDataUrl,
+  readLocalMessageSequenceForSend,
   resolveFileAttachmentUrl,
   reconcileMountedTerminalThreadIds,
   resolveBackgroundDraftWorkspaceOptions,
@@ -6501,7 +6502,7 @@ export default function ChatView(props: ChatViewProps) {
           id: newMessageId(),
           command: trimmed,
           createdAt: new Date().toISOString(),
-          createdSequence: nextLocalMessageSequence(activeThread),
+          createdSequence: readLocalMessageSequenceForSend(activeThread),
         },
         clearDraft: () => {
           promptRef.current = "";
@@ -6841,12 +6842,15 @@ export default function ChatView(props: ChatViewProps) {
     } else {
       scrollToEnd();
     }
+    const messageCreatedSequence = isServerThread
+      ? readLocalMessageSequenceForSend(activeThread)
+      : nextLocalMessageSequence(activeThread);
     setOptimisticUserMessages((existing) => [
       ...existing,
       {
         id: messageIdForSend,
         role: "user",
-        createdSequence: nextLocalMessageSequence(activeThread),
+        createdSequence: messageCreatedSequence,
         text: outgoingMessageText,
         ...(optimisticAttachments.length > 0 ? { attachments: optimisticAttachments } : {}),
         turnId: null,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -37,6 +37,7 @@ import { type EnvironmentConnectionPresentation } from "@t3tools/client-runtime/
 import { wasBootstrapThreadDeleted } from "@t3tools/client-runtime/errors";
 import { type CodexArtifactTemplate } from "@t3tools/client-runtime/codex-artifact-templates";
 import { effectiveSnoozed, threadWokeAt } from "@t3tools/client-runtime/state/thread-settled";
+import { nextLocalMessageSequence } from "@t3tools/shared/chronology";
 import {
   codexFeedbackMessage,
   parseCodexFeedbackCommand,
@@ -3057,7 +3058,13 @@ export default function ChatView(props: ChatViewProps) {
     if (pendingMessages.length === 0) {
       return serverMessagesWithPreviewHandoff;
     }
-    return [...serverMessagesWithPreviewHandoff, ...pendingMessages];
+    return [
+      ...serverMessagesWithPreviewHandoff,
+      ...pendingMessages.map((message) => ({
+        ...message,
+        local: true,
+      })),
+    ];
   }, [
     attachmentPreviewHandoffByMessageId,
     displayServerMessages,
@@ -6494,6 +6501,7 @@ export default function ChatView(props: ChatViewProps) {
           id: newMessageId(),
           command: trimmed,
           createdAt: new Date().toISOString(),
+          createdSequence: nextLocalMessageSequence(activeThread),
         },
         clearDraft: () => {
           promptRef.current = "";
@@ -6838,6 +6846,7 @@ export default function ChatView(props: ChatViewProps) {
       {
         id: messageIdForSend,
         role: "user",
+        createdSequence: nextLocalMessageSequence(activeThread),
         text: outgoingMessageText,
         ...(optimisticAttachments.length > 0 ? { attachments: optimisticAttachments } : {}),
         turnId: null,

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -869,6 +869,57 @@ describe("resolveAssistantMessageCopyState", () => {
 });
 
 describe("deriveMessagesTimelineRows", () => {
+  it("settles a clock-corrected turn without showing a fabricated duration", () => {
+    const turnId = TurnId.make("clock-turn");
+    const before = "2026-09-06T12:00:00.000Z";
+    const after = "2026-09-06T01:00:00.000Z";
+    const messages: ChatMessage[] = [
+      {
+        id: MessageId.make("clock-user"),
+        role: "user",
+        text: "Check",
+        turnId: null,
+        streaming: false,
+        createdAt: before,
+        updatedAt: before,
+        createdSequence: 10,
+      },
+      {
+        id: MessageId.make("clock-answer"),
+        role: "assistant",
+        text: "Done",
+        turnId,
+        streaming: false,
+        createdAt: after,
+        updatedAt: after,
+        createdSequence: 12,
+      },
+    ];
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: deriveTimelineEntries(
+        messages,
+        [],
+        [
+          {
+            id: "clock-work",
+            tone: "tool",
+            label: "Checked",
+            turnId,
+            createdAt: after,
+            createdSequence: 11,
+          },
+        ],
+      ),
+      latestTurn: { turnId, state: "completed", startedAt: before, completedAt: after },
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+    expect(rows.find((row) => row.kind === "turn-fold")).toMatchObject({ label: "Worked" });
+    expect(rows.some((row) => row.kind === "thinking")).toBe(false);
+  });
+
   it("keeps context compaction visible outside folded work", () => {
     const rows = deriveMessagesTimelineRows({
       timelineEntries: [

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -249,7 +249,7 @@ function computeElapsedMs(startIso: string, endIso: string): number | null {
   const start = Date.parse(startIso);
   const end = Date.parse(endIso);
   if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
-  return Math.max(0, end - start);
+  return end < start ? null : end - start;
 }
 
 function maxIsoTimestamp(a: string | null, b: string | null): string | null {

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1,5 +1,6 @@
 import {
   classifyTaskAgentKind,
+  CheckpointRef,
   EventId,
   MessageId,
   ThreadId,
@@ -20,6 +21,7 @@ import {
   deriveWorkLogEntries,
   findLatestProposedPlan,
   hasActionableProposedPlan,
+  inferCheckpointTurnCountByTurnId,
   isLatestTurnSettled,
   selectHandoffImageResources,
   selectMessageImageResources,
@@ -39,6 +41,7 @@ function makeActivity(overrides: {
   payload?: Record<string, unknown>;
   turnId?: string;
   sequence?: number;
+  createdSequence?: number;
 }): OrchestrationThreadActivity {
   // Fixtures model post-ingestion rows: ingestion stamps agentKind on every
   // task.* payload. Pass an explicit agentKind to model legacy rows.
@@ -62,6 +65,9 @@ function makeActivity(overrides: {
     payload,
     turnId: overrides.turnId ? TurnId.make(overrides.turnId) : null,
     ...(overrides.sequence !== undefined ? { sequence: overrides.sequence } : {}),
+    ...(overrides.createdSequence !== undefined
+      ? { createdSequence: overrides.createdSequence }
+      : {}),
   };
 }
 
@@ -705,6 +711,29 @@ describe("deriveActivePlanState", () => {
 });
 
 describe("findLatestProposedPlan", () => {
+  it("selects the latest persisted plan after a backward clock correction", () => {
+    const first = {
+      id: "first-plan",
+      turnId: TurnId.make("turn-1"),
+      planMarkdown: "# First",
+      implementedAt: null,
+      implementationThreadId: null,
+      createdSequence: 10,
+      createdAt: "2026-09-06T12:00:00.000Z",
+      updatedAt: "2026-09-06T12:00:00.000Z",
+    };
+    const latest = {
+      ...first,
+      id: "latest-plan",
+      planMarkdown: "# Latest",
+      createdSequence: 20,
+      createdAt: "2026-09-06T01:00:00.000Z",
+      updatedAt: "2026-09-06T01:00:00.000Z",
+    };
+    expect(findLatestProposedPlan([latest, first], null)?.id).toBe("latest-plan");
+    expect(findLatestProposedPlan([latest, first], first.turnId)?.id).toBe("latest-plan");
+  });
+
   it("prefers the latest proposed plan for the active turn", () => {
     expect(
       findLatestProposedPlan(
@@ -2200,6 +2229,131 @@ describe("image asset requests", () => {
 });
 
 describe("deriveTimelineEntries", () => {
+  it("uses persisted checkpoint counts when completed timestamps run backward", () => {
+    const common = {
+      checkpointRef: CheckpointRef.make("refs/checkpoints/test"),
+      status: "ready" as const,
+      files: [],
+      assistantMessageId: null,
+    };
+    expect(
+      inferCheckpointTurnCountByTurnId([
+        {
+          ...common,
+          turnId: TurnId.make("first"),
+          checkpointTurnCount: 5,
+          completedAt: "2026-09-06T12:00:00.000Z",
+        },
+        {
+          ...common,
+          turnId: TurnId.make("second"),
+          checkpointTurnCount: 6,
+          completedAt: "2026-09-06T01:00:00.000Z",
+        },
+      ]),
+    ).toEqual({ first: 5, second: 6 });
+  });
+
+  it("keeps local feedback before a later durable message with the same captured sequence", () => {
+    const local = {
+      id: MessageId.make("z-local"),
+      role: "user" as const,
+      text: "/feedback issue",
+      turnId: null,
+      streaming: false,
+      local: true,
+      createdSequence: 11,
+      createdAt: "2026-09-06T12:00:00.000Z",
+      updatedAt: "2026-09-06T12:00:00.000Z",
+    };
+    const later = {
+      ...local,
+      id: MessageId.make("a-durable"),
+      local: false,
+      createdAt: "2026-09-06T01:00:00.000Z",
+    };
+    const first = deriveTimelineEntriesWithState([local], [], []);
+    const next = deriveTimelineEntriesWithState([local, later], [], [], first);
+    expect(next.entries.map((entry) => entry.id)).toEqual(["z-local", "a-durable"]);
+  });
+
+  it("keeps persisted order across a clock correction and incremental streaming updates", () => {
+    const user = {
+      id: MessageId.make("clock-user"),
+      role: "user" as const,
+      text: "Run checks",
+      turnId: null,
+      streaming: false,
+      createdSequence: 10,
+      createdAt: "2026-09-06T12:00:00.000Z",
+      updatedAt: "2026-09-06T12:00:00.000Z",
+    };
+    const assistant = {
+      ...user,
+      id: MessageId.make("clock-assistant"),
+      role: "assistant" as const,
+      streaming: true,
+      createdSequence: 12,
+      createdAt: "2026-09-06T01:00:00.000Z",
+    };
+    const work = [
+      {
+        id: "clock-work",
+        label: "Checking",
+        tone: "tool" as const,
+        createdSequence: 11,
+        createdAt: "2026-09-06T01:00:00.000Z",
+      },
+    ];
+    const first = deriveTimelineEntriesWithState([user], [], work);
+    const next = deriveTimelineEntriesWithState([user, assistant], [], work, first);
+    expect(next.entries.map((entry) => entry.id)).toEqual([
+      "clock-user",
+      "clock-work",
+      "clock-assistant",
+    ]);
+    expect(next.entries).toEqual(deriveTimelineEntries([user, assistant], [], work));
+    const updated = { ...assistant, text: "Checks running" };
+    const streamed = deriveTimelineEntriesWithState([user, updated], [], work, next);
+    expect(streamed.entries[0]).toBe(next.entries[0]);
+    expect(streamed.entries.map((entry) => entry.id)).toEqual(
+      next.entries.map((entry) => entry.id),
+    );
+  });
+
+  it("keeps a completed tool at its first persisted position after a clock correction", () => {
+    const work = deriveWorkLogEntries([
+      makeActivity({
+        id: "clock-tool-start",
+        kind: "tool.updated",
+        createdSequence: 20,
+        sequence: 90,
+        createdAt: "2026-09-06T12:00:00.000Z",
+        payload: {
+          toolCallId: "clock-tool",
+          itemType: "command_execution",
+          command: "vp test",
+          status: "inProgress",
+        },
+      }),
+      makeActivity({
+        id: "clock-tool-end",
+        kind: "tool.completed",
+        createdSequence: 22,
+        sequence: 1,
+        createdAt: "2026-09-06T01:00:00.000Z",
+        payload: {
+          toolCallId: "clock-tool",
+          itemType: "command_execution",
+          command: "vp test",
+          status: "completed",
+        },
+      }),
+    ]);
+    expect(work).toHaveLength(1);
+    expect(work[0]).toMatchObject({ createdSequence: 20, toolLifecycleStatus: "completed" });
+  });
+
   const streamingMessage = {
     id: MessageId.make("streaming-message"),
     role: "assistant" as const,

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -2,6 +2,7 @@ import * as Option from "effect/Option";
 import * as Arr from "effect/Array";
 import * as Schema from "effect/Schema";
 import { shallow } from "zustand/vanilla/shallow";
+import { compareCreatedOrder } from "@t3tools/shared/chronology";
 import { isBackgroundTaskActivity } from "@t3tools/client-runtime/state/subagentRuntime";
 import {
   commandDetailRepeatsCommand,
@@ -47,6 +48,7 @@ export type WorkLogToolLifecycleStatus =
 export interface WorkLogEntry {
   id: string;
   createdAt: string;
+  createdSequence?: number;
   turnId?: TurnId | null;
   /** Stable provider identity across in-progress and completed lifecycle updates. */
   toolCallId?: string;
@@ -145,18 +147,21 @@ export type TimelineEntry =
       id: string;
       kind: "message";
       createdAt: string;
+      createdSequence?: number;
       message: ChatMessage;
     }
   | {
       id: string;
       kind: "proposed-plan";
       createdAt: string;
+      createdSequence?: number;
       proposedPlan: ProposedPlan;
     }
   | {
       id: string;
       kind: "work";
       createdAt: string;
+      createdSequence?: number;
       entry: WorkLogEntry;
     };
 
@@ -688,27 +693,26 @@ export function findLatestProposedPlan(
   if (latestTurnId) {
     const matchingTurnPlan = [...proposedPlans]
       .filter((proposedPlan) => proposedPlan.turnId === latestTurnId)
-      .toSorted(
-        (left, right) =>
-          left.updatedAt.localeCompare(right.updatedAt) || left.id.localeCompare(right.id),
-      )
+      .toSorted(compareProposedPlans)
       .at(-1);
     if (matchingTurnPlan) {
       return toLatestProposedPlanState(matchingTurnPlan);
     }
   }
 
-  const latestPlan = [...proposedPlans]
-    .toSorted(
-      (left, right) =>
-        left.updatedAt.localeCompare(right.updatedAt) || left.id.localeCompare(right.id),
-    )
-    .at(-1);
+  const latestPlan = [...proposedPlans].toSorted(compareProposedPlans).at(-1);
   if (!latestPlan) {
     return null;
   }
 
   return toLatestProposedPlanState(latestPlan);
+}
+
+function compareProposedPlans(left: ProposedPlan, right: ProposedPlan): number {
+  if (left.createdSequence !== undefined || right.createdSequence !== undefined) {
+    return compareCreatedOrder(left, right);
+  }
+  return left.updatedAt.localeCompare(right.updatedAt) || left.id.localeCompare(right.id);
 }
 
 export function hasActionableProposedPlan(
@@ -886,6 +890,9 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   const toolCallId = isTaskActivity ? null : extractToolCallId(payload);
   const entry: DerivedWorkLogEntry = {
     id: activity.id,
+    ...(activity.createdSequence !== undefined
+      ? { createdSequence: activity.createdSequence }
+      : {}),
     createdAt: activity.createdAt,
     turnId: activity.turnId,
     label: taskLabel || activity.summary,
@@ -1169,6 +1176,9 @@ function mergeDerivedWorkLogEntries(
   return {
     ...previous,
     ...next,
+    ...(previous.createdSequence !== undefined
+      ? { createdSequence: previous.createdSequence }
+      : {}),
     ...(detail ? { detail } : {}),
     ...(viewedImagePath ? { viewedImagePath } : {}),
     ...(command ? { command } : {}),
@@ -1694,6 +1704,9 @@ function compareActivitiesByOrder(
   left: OrchestrationThreadActivity,
   right: OrchestrationThreadActivity,
 ): number {
+  if (left.createdSequence !== undefined || right.createdSequence !== undefined) {
+    return compareCreatedOrder(left, right);
+  }
   if (left.sequence !== undefined && right.sequence !== undefined) {
     if (left.sequence !== right.sequence) {
       return left.sequence - right.sequence;
@@ -1736,6 +1749,7 @@ function timelineEntryFromMessage(message: ChatMessage): TimelineEntry {
     id: message.id,
     kind: "message",
     createdAt: message.createdAt,
+    ...(message.createdSequence !== undefined ? { createdSequence: message.createdSequence } : {}),
     message,
   };
 }
@@ -1745,6 +1759,9 @@ function timelineEntryFromProposedPlan(proposedPlan: ProposedPlan): TimelineEntr
     id: proposedPlan.id,
     kind: "proposed-plan",
     createdAt: proposedPlan.createdAt,
+    ...(proposedPlan.createdSequence !== undefined
+      ? { createdSequence: proposedPlan.createdSequence }
+      : {}),
     proposedPlan,
   };
 }
@@ -1754,11 +1771,23 @@ function timelineEntryFromWork(workEntry: WorkLogEntry): TimelineEntry {
     id: workEntry.id,
     kind: "work",
     createdAt: workEntry.createdAt,
+    ...(workEntry.createdSequence !== undefined
+      ? { createdSequence: workEntry.createdSequence }
+      : {}),
     entry: workEntry,
   };
 }
 
-function compareTimelineEntriesByCreatedAt(left: TimelineEntry, right: TimelineEntry): number {
+function compareTimelineEntriesByOrder(left: TimelineEntry, right: TimelineEntry): number {
+  if (left.createdSequence !== undefined || right.createdSequence !== undefined) {
+    if (left.createdSequence === right.createdSequence) {
+      const leftLocal = left.kind === "message" && left.message.local === true;
+      const rightLocal = right.kind === "message" && right.message.local === true;
+      if (leftLocal !== rightLocal) return leftLocal ? -1 : 1;
+      if (leftLocal && rightLocal) return 0;
+    }
+    return compareCreatedOrder(left, right);
+  }
   return left.createdAt.localeCompare(right.createdAt);
 }
 
@@ -1774,8 +1803,8 @@ function timelineEntrySourceOrder(entry: TimelineEntry): number {
 }
 
 function shouldTakePreviousTimelineEntry(previous: TimelineEntry, suffix: TimelineEntry): boolean {
-  const createdAtComparison = compareTimelineEntriesByCreatedAt(previous, suffix);
-  if (createdAtComparison !== 0) return createdAtComparison < 0;
+  const order = compareTimelineEntriesByOrder(previous, suffix);
+  if (order !== 0) return order < 0;
   // The original full derivation sorts a source-ordered array with a stable
   // comparator. On a tie, messages precede plans, plans precede work, and an
   // older item in the same source array precedes a newly appended item.
@@ -1799,7 +1828,7 @@ function mergeTimelineEntrySuffix(
   const previousLast = previous.at(-1);
   let suffixIsOrdered = true;
   for (let index = 1; index < suffix.length; index += 1) {
-    if (compareTimelineEntriesByCreatedAt(suffix[index - 1]!, suffix[index]!) > 0) {
+    if (compareTimelineEntriesByOrder(suffix[index - 1]!, suffix[index]!) > 0) {
       suffixIsOrdered = false;
       break;
     }
@@ -1980,7 +2009,7 @@ export function deriveTimelineEntriesWithState(
       .map(timelineEntryFromProposedPlan);
     const workRows = workEntries.slice(previous.workEntries.length).map(timelineEntryFromWork);
     const suffix = [...messageRows, ...proposedPlanRows, ...workRows].toSorted(
-      compareTimelineEntriesByCreatedAt,
+      compareTimelineEntriesByOrder,
     );
     return {
       messages,
@@ -1998,7 +2027,7 @@ export function deriveTimelineEntriesWithState(
     proposedPlans,
     workEntries,
     entries: [...messageRows, ...proposedPlanRows, ...workRows].toSorted(
-      compareTimelineEntriesByCreatedAt,
+      compareTimelineEntriesByOrder,
     ),
   };
 }
@@ -2014,12 +2043,20 @@ export function deriveTimelineEntries(
 export function inferCheckpointTurnCountByTurnId(
   summaries: ReadonlyArray<TurnDiffSummary>,
 ): Record<TurnId, number> {
-  const sorted = [...summaries].toSorted((a, b) => a.completedAt.localeCompare(b.completedAt));
+  const sorted = [...summaries].toSorted((a, b) =>
+    a.checkpointTurnCount !== undefined && b.checkpointTurnCount !== undefined
+      ? a.checkpointTurnCount - b.checkpointTurnCount
+      : a.checkpointTurnCount !== undefined
+        ? 1
+        : b.checkpointTurnCount !== undefined
+          ? -1
+          : a.completedAt.localeCompare(b.completedAt),
+  );
   const result: Record<TurnId, number> = {};
   for (let index = 0; index < sorted.length; index += 1) {
     const summary = sorted[index];
     if (!summary) continue;
-    result[summary.turnId] = index + 1;
+    result[summary.turnId] = summary.checkpointTurnCount ?? index + 1;
   }
   return result;
 }

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -76,6 +76,7 @@ export function isBrowserPreviewAttachment(attachment: ChatFileAttachment): bool
 }
 
 export interface ChatMessage extends Omit<OrchestrationMessage, "attachments"> {
+  readonly local?: boolean;
   readonly attachments?: ReadonlyArray<ChatAttachment> | undefined;
 }
 

--- a/docs/internals/overview.md
+++ b/docs/internals/overview.md
@@ -41,6 +41,20 @@ Persisted events must remain decodable on replay. Changing a schema affects old 
 startup as well as live RPC traffic. Compatibility work must account for stored history, not just
 what the newest client sends.
 
+Conversation order follows persisted event sequence, not wall time: a host clock correction can
+move timestamps backward during a turn. `createdSequence` is the first event that created a timeline
+item and must survive later streaming updates. It is distinct from an activity's provider-local
+`sequence`, which can restart with a provider session. Keep timestamps for display rather than
+rewriting the event log to make them monotonic.
+
+Turn pagination uses the initiating prompt's creation sequence, since the prompt is persisted before
+the turn-start request and has no turn id yet. Using the later request sequence would put that prompt
+on the preceding page. If an assistant event creates the turn before its running session arrives,
+the session can establish that prompt anchor once; later events preserve it. See the
+[detail cursor](../../apps/server/src/orchestration/threadDetailCursor.ts)
+for legacy cursor handling. Older snapshots without creation keys retain timestamp order as a prefix
+before newly received events; see the [shared comparator](../../packages/shared/src/chronology.ts).
+
 ## Turn completion and checkpoints
 
 A turn ending and its follow-up work settling are separate milestones. The

--- a/packages/client-runtime/src/state/threadFeedback.test.ts
+++ b/packages/client-runtime/src/state/threadFeedback.test.ts
@@ -38,6 +38,7 @@ describe("submitCodexFeedback", () => {
     id: MessageId.make("feedback-message-1"),
     command: "/feedback The agent stopped early.",
     createdAt: "2026-08-23T00:00:00.000Z",
+    createdSequence: 42,
   } as const;
 
   it("shows the command and clears the draft before the upload finishes", async () => {
@@ -70,6 +71,7 @@ describe("submitCodexFeedback", () => {
       id: submission.id,
       role: "user",
       text: submission.command,
+      createdSequence: submission.createdSequence,
     });
     expect(codexFeedbackMessage(states[0]!, "assistant").text).toBe(
       "Sending feedback to OpenAI...",

--- a/packages/client-runtime/src/state/threadFeedback.ts
+++ b/packages/client-runtime/src/state/threadFeedback.ts
@@ -14,6 +14,7 @@ type CodexFeedbackSubmissionDetails = {
   readonly id: MessageId;
   readonly command: string;
   readonly createdAt: string;
+  readonly createdSequence?: number | undefined;
 };
 
 export type CodexFeedbackSubmission = CodexFeedbackSubmissionDetails &
@@ -52,6 +53,9 @@ export function codexFeedbackMessage(
     turnId: null,
     streaming: false,
     createdAt: submission.createdAt,
+    ...(submission.createdSequence !== undefined
+      ? { createdSequence: submission.createdSequence }
+      : {}),
     updatedAt: submission.createdAt,
   };
 }

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -10,7 +10,7 @@ import {
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
-import type { OrchestrationThread } from "@t3tools/contracts";
+import type { OrchestrationEvent, OrchestrationThread } from "@t3tools/contracts";
 
 import { applyThreadDetailEvent } from "./threadReducer.ts";
 
@@ -46,6 +46,158 @@ const baseThread: OrchestrationThread = {
 };
 
 describe("applyThreadDetailEvent", () => {
+  it("preserves creation keys through streaming, completion and a clock-safe revert", () => {
+    let thread = baseThread;
+    const turnId = TurnId.make("clock-turn");
+    const before = "2026-09-06T12:00:00.000Z";
+    const after = "2026-09-06T01:00:00.000Z";
+    const apply = (event: OrchestrationEvent) => {
+      const result = applyThreadDetailEvent(thread, event);
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") thread = result.thread;
+    };
+    const message = (
+      sequence: number,
+      id: string,
+      role: "user" | "assistant",
+      createdAt: string,
+      streaming = false,
+    ): OrchestrationEvent => ({
+      ...baseEventFields,
+      sequence,
+      occurredAt: createdAt,
+      aggregateKind: "thread",
+      aggregateId: thread.id,
+      type: "thread.message-sent",
+      payload: {
+        threadId: thread.id,
+        messageId: MessageId.make(id),
+        role,
+        text: "text",
+        turnId: role === "assistant" ? turnId : null,
+        streaming,
+        createdAt,
+        updatedAt: createdAt,
+      },
+    });
+    apply(message(10, "first-user", "user", before));
+    apply(message(12, "first-answer", "assistant", after, true));
+    expect(thread.latestTurn?.createdSequence).toBe(12);
+    const sessionEvent = (sequence: number, status: "running" | "ready"): OrchestrationEvent => ({
+      ...baseEventFields,
+      sequence,
+      occurredAt: after,
+      aggregateKind: "thread",
+      aggregateId: thread.id,
+      type: "thread.session-set",
+      payload: {
+        threadId: thread.id,
+        session: {
+          threadId: thread.id,
+          status,
+          providerName: "codex",
+          runtimeMode: "full-access",
+          activeTurnId: status === "running" ? turnId : null,
+          lastError: null,
+          updatedAt: after,
+        },
+      },
+    });
+    apply(sessionEvent(13, "running"));
+    expect(thread.latestTurn?.createdSequence).toBe(10);
+    apply(message(14, "first-answer", "assistant", after, true));
+    apply(message(15, "first-answer", "assistant", after));
+    apply(sessionEvent(16, "ready"));
+    expect(thread.messages.map((entry) => entry.createdSequence)).toEqual([10, 12]);
+    expect(thread.latestTurn).toMatchObject({
+      createdSequence: 10,
+      state: "completed",
+      completedAt: after,
+    });
+    apply({
+      ...baseEventFields,
+      sequence: 17,
+      occurredAt: after,
+      aggregateKind: "thread",
+      aggregateId: thread.id,
+      type: "thread.turn-diff-completed",
+      payload: {
+        threadId: thread.id,
+        turnId,
+        checkpointTurnCount: 1,
+        checkpointRef: CheckpointRef.make("refs/checkpoints/clock"),
+        status: "ready",
+        files: [],
+        assistantMessageId: MessageId.make("first-answer"),
+        completedAt: after,
+      },
+    });
+    apply(message(20, "second-user", "user", after));
+    apply({
+      ...baseEventFields,
+      sequence: 21,
+      occurredAt: after,
+      aggregateKind: "thread",
+      aggregateId: thread.id,
+      type: "thread.reverted",
+      payload: { threadId: thread.id, turnCount: 1 },
+    });
+    expect(thread.messages.map((entry) => entry.id)).toEqual(["first-user", "first-answer"]);
+    expect(thread.latestTurn?.createdSequence).toBe(10);
+  });
+
+  it("does not assign a queued prompt's creation key to a late checkpoint", () => {
+    const turnId = TurnId.make("older-turn");
+    const createdAt = "2026-09-06T01:00:00.000Z";
+    const result = applyThreadDetailEvent(
+      {
+        ...baseThread,
+        messages: [
+          {
+            id: MessageId.make("older-answer"),
+            role: "assistant",
+            text: "Done",
+            turnId,
+            streaming: false,
+            createdAt,
+            updatedAt: createdAt,
+            createdSequence: 2,
+          },
+          {
+            id: MessageId.make("queued-user"),
+            role: "user",
+            text: "Next",
+            turnId: null,
+            streaming: false,
+            createdAt,
+            updatedAt: createdAt,
+            createdSequence: 10,
+          },
+        ],
+      },
+      {
+        ...baseEventFields,
+        sequence: 20,
+        occurredAt: createdAt,
+        aggregateKind: "thread",
+        aggregateId: baseThread.id,
+        type: "thread.turn-diff-completed",
+        payload: {
+          threadId: baseThread.id,
+          turnId,
+          checkpointTurnCount: 1,
+          checkpointRef: CheckpointRef.make("refs/checkpoints/older"),
+          status: "ready",
+          files: [],
+          assistantMessageId: MessageId.make("older-answer"),
+          completedAt: createdAt,
+        },
+      },
+    );
+    expect(result.kind).toBe("updated");
+    if (result.kind === "updated") expect(result.thread.latestTurn?.createdSequence).toBe(2);
+  });
+
   describe("project events", () => {
     it("returns unchanged for project.created", () => {
       const result = applyThreadDetailEvent(baseThread, {
@@ -895,7 +1047,7 @@ describe("applyThreadDetailEvent", () => {
       }
     });
 
-    it("re-sorts when an activity arrives out of order", () => {
+    it("keeps legacy activities before newly sequenced events", () => {
       const makeActivity = (id: string, sequence: number) => ({
         id: EventId.make(id),
         tone: "tool" as const,
@@ -929,8 +1081,8 @@ describe("applyThreadDetailEvent", () => {
       if (result.kind === "updated") {
         expect(result.thread.activities.map((activity) => activity.id)).toEqual([
           "activity-a",
-          "activity-b",
           "activity-c",
+          "activity-b",
         ]);
       }
     });
@@ -972,8 +1124,8 @@ describe("applyThreadDetailEvent", () => {
       if (result.kind === "updated") {
         expect(result.thread.activities.map((activity) => activity.id)).toEqual([
           "activity-a",
-          "activity-b",
           "activity-null",
+          "activity-b",
         ]);
       }
     });

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -46,6 +46,96 @@ const baseThread: OrchestrationThread = {
 };
 
 describe("applyThreadDetailEvent", () => {
+  it("keeps a running turn's initiating anchor through a late checkpoint and session refresh", () => {
+    const before = "2026-09-06T12:00:00.000Z";
+    const after = "2026-09-06T01:00:00.000Z";
+    const turnId = TurnId.make("active-turn");
+    const latestTurn = {
+      turnId,
+      createdSequence: 2,
+      state: "running" as const,
+      requestedAt: before,
+      startedAt: before,
+      completedAt: null,
+      assistantMessageId: null,
+    };
+    const session = {
+      threadId: baseThread.id,
+      status: "running" as const,
+      activeTurnId: turnId,
+      providerName: "codex" as const,
+      runtimeMode: "full-access" as const,
+      lastError: null,
+      updatedAt: before,
+    };
+    let thread: OrchestrationThread = {
+      ...baseThread,
+      latestTurn,
+      session,
+      messages: [
+        {
+          id: MessageId.make("initiating-prompt"),
+          role: "user",
+          turnId: null,
+          text: "Start",
+          streaming: false,
+          createdSequence: 2,
+          createdAt: before,
+          updatedAt: before,
+        },
+        {
+          id: MessageId.make("queued-prompt"),
+          role: "user",
+          turnId: null,
+          text: "Next",
+          streaming: false,
+          createdSequence: 5,
+          createdAt: after,
+          updatedAt: after,
+        },
+      ],
+    };
+    const events: OrchestrationEvent[] = [
+      {
+        ...baseEventFields,
+        sequence: 6,
+        occurredAt: after,
+        aggregateKind: "thread",
+        aggregateId: thread.id,
+        type: "thread.turn-diff-completed",
+        payload: {
+          threadId: thread.id,
+          turnId: TurnId.make("older-turn"),
+          checkpointTurnCount: 1,
+          checkpointRef: CheckpointRef.make("refs/checkpoints/older"),
+          status: "ready",
+          files: [],
+          assistantMessageId: null,
+          completedAt: after,
+        },
+      },
+      {
+        ...baseEventFields,
+        sequence: 7,
+        occurredAt: after,
+        aggregateKind: "thread",
+        aggregateId: thread.id,
+        type: "thread.session-set",
+        payload: {
+          threadId: thread.id,
+          session: { ...session, updatedAt: after },
+        },
+      },
+    ];
+    for (const event of events) {
+      const result = applyThreadDetailEvent(thread, event);
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") thread = result.thread;
+      expect(thread.latestTurn).toBe(latestTurn);
+    }
+    expect(thread.checkpoints.map((entry) => entry.turnId)).toEqual(["older-turn"]);
+  });
+
   it("preserves creation keys through streaming, completion and a clock-safe revert", () => {
     let thread = baseThread;
     const turnId = TurnId.make("clock-turn");

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -13,17 +13,18 @@ import type {
   TurnId,
 } from "@t3tools/contracts";
 import { isImportedAgentSessionMessageId } from "@t3tools/contracts";
-import { compareDateTimeStrings } from "@t3tools/shared/dateTime";
+import { compareCreatedOrder } from "@t3tools/shared/chronology";
 
 export type ThreadDetailReducerResult =
   | { readonly kind: "updated"; readonly thread: OrchestrationThread }
   | { readonly kind: "deleted" }
   | { readonly kind: "unchanged" };
 
-const proposedPlanOrder = O.combine<OrchestrationThread["proposedPlans"][number]>(
+const proposedPlanOrder = O.combineAll<OrchestrationThread["proposedPlans"][number]>([
+  O.mapInput(O.Number, (p) => p.createdSequence ?? 0),
   O.mapInput(O.String, (p) => p.createdAt),
   O.mapInput(O.String, (p) => p.id),
-);
+]);
 
 const checkpointOrder = O.mapInput(
   O.Number,
@@ -32,6 +33,7 @@ const checkpointOrder = O.mapInput(
 );
 
 const activityOrder = O.combineAll<OrchestrationThreadActivity>([
+  O.mapInput(O.Number, (a) => a.createdSequence ?? 0),
   O.mapInput(O.Number, (a) => a.sequence ?? Number.MAX_SAFE_INTEGER),
   O.mapInput(O.String, (a) => a.createdAt),
   O.mapInput(O.String, (a) => a.id),
@@ -306,6 +308,7 @@ export function applyThreadDetailEvent(
     case "thread.message-sent": {
       const message: OrchestrationMessage = {
         id: event.payload.messageId,
+        createdSequence: event.sequence,
         role: event.payload.role,
         text: event.payload.text,
         ...(event.payload.attachments !== undefined
@@ -324,6 +327,7 @@ export function applyThreadDetailEvent(
               ? entry
               : {
                   ...entry,
+                  createdSequence: entry.createdSequence ?? event.sequence,
                   text: message.streaming
                     ? `${entry.text}${message.text}`
                     : message.text.length > 0
@@ -356,6 +360,7 @@ export function applyThreadDetailEvent(
           (thread.latestTurn === null || thread.latestTurn.turnId === event.payload.turnId)
           ? {
               turnId: event.payload.turnId,
+              createdSequence: turnCreatedSequence(thread, event.payload.turnId, event.sequence),
               state: settlesTurn
                 ? thread.latestTurn?.state === "interrupted"
                   ? "interrupted"
@@ -414,6 +419,14 @@ export function applyThreadDetailEvent(
         event.payload.session.status === "running" && event.payload.session.activeTurnId !== null
           ? {
               turnId: event.payload.session.activeTurnId,
+              createdSequence:
+                thread.session?.activeTurnId !== event.payload.session.activeTurnId
+                  ? (thread.messages.findLast(
+                      (message) =>
+                        message.role === "user" && !isImportedAgentSessionMessageId(message.id),
+                    )?.createdSequence ??
+                    turnCreatedSequence(thread, event.payload.session.activeTurnId, event.sequence))
+                  : turnCreatedSequence(thread, event.payload.session.activeTurnId, event.sequence),
               state: "running",
               requestedAt:
                 thread.latestTurn?.turnId === event.payload.session.activeTurnId
@@ -473,7 +486,13 @@ export function applyThreadDetailEvent(
 
     // ── Proposed plans ──────────────────────────────────────────────
     case "thread.proposed-plan-upserted": {
-      const proposedPlan = event.payload.proposedPlan;
+      const previousPlan = thread.proposedPlans.find(
+        (plan) => plan.id === event.payload.proposedPlan.id,
+      );
+      const proposedPlan = {
+        ...event.payload.proposedPlan,
+        createdSequence: previousPlan?.createdSequence ?? event.sequence,
+      };
 
       const proposedPlans = pipe(
         thread.proposedPlans,
@@ -523,6 +542,7 @@ export function applyThreadDetailEvent(
         (thread.latestTurn === null || thread.latestTurn.turnId === event.payload.turnId)
           ? {
               turnId: event.payload.turnId,
+              createdSequence: turnCreatedSequence(thread, event.payload.turnId, event.sequence),
               state:
                 thread.latestTurn?.state === "interrupted"
                   ? "interrupted"
@@ -567,6 +587,15 @@ export function applyThreadDetailEvent(
         Arr.filter((activity) => activity.turnId === null || retainedTurnIds.has(activity.turnId)),
       );
       const latestCheckpoint = checkpoints.at(-1) ?? null;
+      const revertedTurnSequence =
+        latestCheckpoint === null
+          ? undefined
+          : thread.latestTurn?.turnId === latestCheckpoint.turnId
+            ? thread.latestTurn.createdSequence
+            : messages.findLast(
+                (message) =>
+                  message.role === "user" && !isImportedAgentSessionMessageId(message.id),
+              )?.createdSequence;
 
       return {
         kind: "updated",
@@ -581,6 +610,9 @@ export function applyThreadDetailEvent(
               ? null
               : {
                   turnId: latestCheckpoint.turnId,
+                  ...(revertedTurnSequence !== undefined
+                    ? { createdSequence: revertedTurnSequence }
+                    : {}),
                   state: checkpointStatusToTurnState(
                     latestCheckpoint.status as "ready" | "missing" | "error",
                   ),
@@ -596,7 +628,14 @@ export function applyThreadDetailEvent(
 
     // ── Activities ──────────────────────────────────────────────────
     case "thread.activity-appended": {
-      const activity = event.payload.activity;
+      const previousActivity =
+        activityIdIndex.get(thread.activities)?.has(event.payload.activity.id) === false
+          ? undefined
+          : thread.activities.find((entry) => entry.id === event.payload.activity.id);
+      const activity = {
+        ...event.payload.activity,
+        createdSequence: previousActivity?.createdSequence ?? event.sequence,
+      };
       // A resolvable context-window update supersedes earlier resolvable ones
       // for the same turn: consumers only read the latest value (walking the
       // array backwards), and providers stream these updates continuously, so
@@ -702,6 +741,14 @@ function checkpointStatusToTurnState(
   }
 }
 
+function turnCreatedSequence(thread: OrchestrationThread, turnId: TurnId, sequence: number) {
+  if (thread.latestTurn?.turnId === turnId) return thread.latestTurn.createdSequence;
+  return (
+    thread.messages.find((message) => message.role === "assistant" && message.turnId === turnId)
+      ?.createdSequence ?? sequence
+  );
+}
+
 /**
  * Returns `previous` when `next` matches it field for field, otherwise `next`.
  * Streaming cases recompute the latest turn on every delta, and keeping the
@@ -715,6 +762,7 @@ function reuseLatestTurn(
     return next;
   }
   return previous.turnId === next.turnId &&
+    previous.createdSequence === next.createdSequence &&
     previous.state === next.state &&
     previous.requestedAt === next.requestedAt &&
     previous.startedAt === next.startedAt &&
@@ -776,11 +824,7 @@ function retainMessagesAfterRevert(
           !retainedMessageIds.has(message.id) &&
           (message.turnId === null || retainedTurnIds.has(message.turnId)),
       )
-      .toSorted(
-        (left, right) =>
-          compareDateTimeStrings(left.createdAt, right.createdAt) ||
-          left.id.localeCompare(right.id),
-      )
+      .toSorted(compareCreatedOrder)
       .slice(0, missingCount);
     for (const message of fallbackMessages) {
       retainedMessageIds.add(message.id);

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -353,6 +353,8 @@ export type OrchestrationMessageRole = typeof OrchestrationMessageRole.Type;
 
 export const OrchestrationMessage = Schema.Struct({
   id: MessageId,
+  // Immutable persisted event order; timestamps remain the original display time.
+  createdSequence: Schema.optional(NonNegativeInt),
   role: OrchestrationMessageRole,
   text: Schema.String,
   attachments: Schema.optional(Schema.Array(ChatAttachment)),
@@ -368,6 +370,7 @@ export type OrchestrationProposedPlanId = typeof OrchestrationProposedPlanId.Typ
 
 export const OrchestrationProposedPlan = Schema.Struct({
   id: OrchestrationProposedPlanId,
+  createdSequence: Schema.optional(NonNegativeInt),
   turnId: Schema.NullOr(TurnId),
   planMarkdown: TrimmedNonEmptyString,
   implementedAt: Schema.NullOr(IsoDateTime).pipe(Schema.withDecodingDefault(Effect.succeed(null))),
@@ -439,6 +442,7 @@ export type OrchestrationThreadActivityTone = typeof OrchestrationThreadActivity
 
 export const OrchestrationThreadActivity = Schema.Struct({
   id: EventId,
+  createdSequence: Schema.optional(NonNegativeInt),
   tone: OrchestrationThreadActivityTone,
   kind: TrimmedNonEmptyString,
   summary: TrimmedNonEmptyString,
@@ -459,6 +463,7 @@ export type OrchestrationLatestTurnState = typeof OrchestrationLatestTurnState.T
 
 export const OrchestrationLatestTurn = Schema.Struct({
   turnId: TurnId,
+  createdSequence: Schema.optional(NonNegativeInt),
   state: OrchestrationLatestTurnState,
   requestedAt: IsoDateTime,
   startedAt: Schema.NullOr(IsoDateTime),

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -275,6 +275,10 @@
       "types": "./src/hostClassification.ts",
       "import": "./src/hostClassification.ts"
     },
+    "./chronology": {
+      "types": "./src/chronology.ts",
+      "import": "./src/chronology.ts"
+    },
     "./dateTime": {
       "types": "./src/dateTime.ts",
       "import": "./src/dateTime.ts"

--- a/packages/shared/src/chronology.test.ts
+++ b/packages/shared/src/chronology.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { compareCreatedOrder, nextLocalMessageSequence } from "./chronology.ts";
+
+describe("persisted chronology", () => {
+  it("anchors local messages after all known durable sources without inventing legacy keys", () => {
+    expect(nextLocalMessageSequence({ messages: [{}], activities: [] })).toBeUndefined();
+    expect(
+      nextLocalMessageSequence({
+        messages: [{ createdSequence: 2 }],
+        activities: [{ createdSequence: 5 }],
+        proposedPlans: [{ createdSequence: 9 }],
+      }),
+    ).toBe(10);
+  });
+  it("keeps event order across a backward clock correction", () => {
+    const before = { id: "before", createdAt: "2026-09-05T04:18:50.462Z", createdSequence: 272 };
+    const after = { id: "after", createdAt: "2026-09-04T17:18:56.456Z", createdSequence: 273 };
+
+    expect([after, before].sort(compareCreatedOrder)).toEqual([before, after]);
+  });
+
+  it("keeps legacy snapshots ordered before new events without comparison cycles", () => {
+    const legacy = { id: "legacy", createdAt: "2026-09-05T04:00:00.000Z" };
+    const earlier = { id: "earlier", createdAt: "2026-09-05T03:00:00.000Z" };
+    const current = { id: "current", createdAt: "2026-09-04T17:00:00.000Z", createdSequence: 273 };
+
+    for (const entries of [
+      [current, legacy, earlier],
+      [earlier, current, legacy],
+      [legacy, earlier, current],
+    ]) {
+      expect(entries.sort(compareCreatedOrder)).toEqual([earlier, legacy, current]);
+    }
+  });
+
+  it("uses stable ids for equal timestamps in legacy history", () => {
+    const first = { id: "a", createdAt: "2026-09-04T17:00:00.000Z" };
+    const second = { ...first, id: "b" };
+
+    expect([second, first].sort(compareCreatedOrder)).toEqual([first, second]);
+  });
+});

--- a/packages/shared/src/chronology.ts
+++ b/packages/shared/src/chronology.ts
@@ -1,0 +1,33 @@
+import { compareDateTimeStrings } from "./dateTime.ts";
+
+interface CreatedEntry {
+  readonly id: string;
+  readonly createdAt: string;
+  readonly createdSequence?: number | undefined;
+}
+
+/** Legacy snapshots form a timestamp-ordered prefix before newly persisted events. */
+export function compareCreatedOrder(left: CreatedEntry, right: CreatedEntry): number {
+  return (
+    (left.createdSequence ?? 0) - (right.createdSequence ?? 0) ||
+    compareDateTimeStrings(left.createdAt, right.createdAt) ||
+    left.id.localeCompare(right.id)
+  );
+}
+
+/** Capture once when a local message is sent, before the next persisted event. */
+export function nextLocalMessageSequence(thread: {
+  readonly messages: ReadonlyArray<{ readonly createdSequence?: number | undefined }>;
+  readonly activities: ReadonlyArray<{ readonly createdSequence?: number | undefined }>;
+  readonly proposedPlans?: ReadonlyArray<{ readonly createdSequence?: number | undefined }>;
+}): number | undefined {
+  let latest: number | undefined;
+  for (const entries of [thread.messages, thread.activities, thread.proposedPlans ?? []]) {
+    for (const entry of entries) {
+      if (entry.createdSequence !== undefined) {
+        latest = Math.max(latest ?? 0, entry.createdSequence);
+      }
+    }
+  }
+  return latest === undefined ? undefined : latest + 1;
+}


### PR DESCRIPTION
## What Changed

Conversation items now keep their first persisted event sequence through streaming updates, snapshot reloads, and replay. Web, desktop, and mobile use that key to order messages, plans, and work-log entries, independently of host timestamps and provider-local sequence counters.

Migration 052 backfills keys from retained events without rewriting timestamps or payloads. Turn pagination uses the initiating prompt's key, preserves legacy cursors, and keeps indexed range reads. Pending turn-start associations survive snapshot reloads until the provider identifies the active turn. Revert retains the correct prompt-and-answer pair after a clock correction. Backward terminal timestamps render as `Worked` without inventing an elapsed duration.

## Why

When the host clock moves backward during a turn, timestamp sorting can place an answer before its prompt and newer tasks before older ones. Reloading or paging preserves the wrong order, and reverting can retain a newer prompt with an older answer.

Fixes #9772

### Proposal

Use persisted event order as the conversation's ordering key, keep timestamps for display, and anchor each paginated turn to its initiating prompt. Backfill retained history and preserve compatibility with older snapshots and cursors.

## Testing

- Focused tests pass covering contracts, migration, persistence, projection/replay, paging, web/mobile work logs, optimistic sends, and shared client state.
- Review regressions cover queued prompts before turn identification, pending-turn snapshot hydration, legacy plan rows, sequence zero, paginated optimistic sends, delayed checkpoints, and query-specific legacy cursor decode errors.
- The focused HTTP/WebSocket transfer-budget test passes. The snapshot cap allows 650 additional bytes for creation keys, measured at 612/616 compressed bytes for the Codex/Claude fixtures; total-transfer and WebSocket caps are unchanged.
- The revert regression fails on upstream `4f782beda`, retaining `new-prompt` with `assistant-1`; the branch retains `old-prompt` with `assistant-1`.
- Targeted server, web, mobile, client-runtime, contracts, and shared package typechecks pass. Existing Effect suggestions remain outside this change.
- Focused lint and formatting pass. Existing ChatView lint warnings remain outside the changed logic.
- SQLite query-plan assertions verify indexed sequence-range pagination, including hydration queries.
- Isolated browser verification compares the upstream baseline and this branch using equivalent synthetic projection fixtures with an 11-hour rollback. Reload and work-log expansion preserve the corrected order. These visual fixtures are not a substitute for the persistence/replay tests above.
- The fixtures do not run a provider turn or change the host clock. Native mobile, real provider sessions, and relay mode were not exercised in the browser pass.

### Before

The original Task 1 prompt appears after Task 2 and both answers.

![Upstream places Task 1's prompt after both answers](https://github.com/user-attachments/assets/9d506001-5503-46ab-a3ed-f2167bcb216a)

### After

Each prompt stays before its work and answer, including after reload. The first turn crosses the clock correction, so its elapsed duration is unknown.

![The fix keeps both tasks in persisted event order](https://github.com/user-attachments/assets/96aebd78-a28b-4205-b06a-7fe3783b0dc7)

### Interaction recording

Loading the saved thread and expanding both work logs in a 1280×800 Chromium client. The initial before/after pass used the app browser over Tailscale; this recording repeats the interaction locally for upload, with no page errors.

https://github.com/user-attachments/assets/01928aa6-d889-4360-9ab3-e7b6a47f2f51

## Checklist

- [x] One concern: preserve conversation order across host clock corrections
- [x] Explained what changed and why
- [x] Added regression tests and migration coverage
- [x] Included before/after screenshots
- [x] Included an interaction recording

Updated against `main` at `3138f5716`. The integration preserves structured message context, mobile answer folding, streaming row reuse, and newer PR-link state. Migration 052 follows the four migrations added since this PR opened. Focused regressions cover persisted ordering in limited task queries and plan-status selection. Server, web, mobile, shared, contracts, and client-runtime typechecks pass.

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve conversation order across clock rollback with `createdSequence`
> - Adds a persisted `createdSequence` column to projected messages, proposed plans, activities, and turns, populated from the originating event sequence and preserved across updates
> - Replaces timestamp-first ordering with creation-sequence-first ordering across projection reads, snapshot queries, keyset cursors, thread reducers, and client timeline derivation
> - Adds migration 48 to backfill `created_sequence` from thread event history and recompute summary fields (latest user message, pending input count, actionable plan)
> - Updates `threadDetailCursor` to version 2 with sequence boundaries, translating legacy cursors via a SQL lookup
> - Adds shared `compareCreatedOrder` and `nextLocalMessageSequence` helpers in `packages/shared/src/chronology.ts`, used by server, web, and mobile ordering logic
> - Risk: migration 48 backfills four projection tables from event history; rows without a matching event (orphans or prior thread incarnations) receive no sequence and sort as legacy zero — verify [048_ProjectionThreadCreatedSequence.ts](https://github.com/pingdotgg/t3code/pull/10325/files#diff-52f5ee925451848aca6f5328310553317adef42525f543f0a618bae9d615da93) event-matching bounds and the `thread.created` upper limit
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dec6232.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation ordering when device or server clocks move backward, preserving creation order.
  * Fixed thread pagination for current and legacy cursors.
  * Prevented misleading duration displays for clock-corrected turns.
  * Improved optimistic message ordering during sending and streaming.
* **Reliability**
  * Preserved turn anchors, activities, plans, and messages across updates, refreshes, replays, and reverted actions.
* **Documentation**
  * Documented conversation ordering and pagination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->