### PR TITLE
fix(settings): preview shared preference differences before applying

### DIFF
--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -46,6 +46,8 @@ import {
 import {
   filterSharedServerPatch,
   findSharedSettingsMismatches,
+  formatSharedServerSettingValue,
+  sharedServerSettingLabels,
   pickSharedServerSettings,
   supportsSharedSettingsSync,
 } from "@t3tools/client-runtime/state/shared-settings";
@@ -571,6 +573,7 @@ function AutoSettleSettingsRows() {
   const referenceSettings = reference?.serverConfig?.settings ?? null;
 
   const [daysDraft, setDaysDraft] = useState<string | null>(null);
+  const [reviewDifferences, setReviewDifferences] = useState(false);
 
   if (reference === null || referenceSettings === null) {
     return null;
@@ -645,7 +648,7 @@ function AutoSettleSettingsRows() {
         </View>
       ) : null}
       {mismatches.length > 0 ? (
-        <View className="flex-row items-center gap-4 border-t border-border-subtle p-4">
+        <View className="gap-4 border-t border-border-subtle p-4">
           <View className="min-w-0 flex-1">
             <Text className="text-lg text-foreground">Settings differ</Text>
             <Text className="text-sm text-foreground-muted">
@@ -654,30 +657,69 @@ function AutoSettleSettingsRows() {
           </View>
           <Pressable
             accessibilityRole="button"
-            onPress={() => {
-              const patch = pickSharedServerSettings(
-                referenceSettings,
-                reference.serverConfig?.environment.capabilities,
-              );
-              for (const mismatch of mismatches) {
-                const target = environments.find(
-                  (candidate) => candidate.environmentId === mismatch.environmentId,
-                );
-                void updateSettings({
-                  environmentId: mismatch.environmentId,
-                  input: {
-                    patch: filterSharedServerPatch(
-                      patch,
-                      target?.serverConfig?.environment.capabilities,
-                    ),
-                  },
-                });
-              }
-            }}
-            className="rounded-full bg-subtle px-4 py-2 active:opacity-70"
+            accessibilityState={{ expanded: reviewDifferences }}
+            onPress={() => setReviewDifferences((value) => !value)}
+            className="rounded-xl bg-subtle px-4 py-3 active:opacity-70"
           >
-            <Text className="text-base font-t3-medium text-foreground">Apply to all</Text>
+            <Text className="text-base font-t3-medium text-foreground">
+              {reviewDifferences ? "Hide differences" : "Review differences"}
+            </Text>
           </Pressable>
+          {reviewDifferences ? (
+            <View className="gap-4">
+              <Text className="text-sm text-foreground-muted">
+                Apply to all copies shared preferences from {reference.label} to the environments
+                below. These values will change; matching values stay the same.
+              </Text>
+              {mismatches.map((mismatch) => (
+                <View
+                  key={mismatch.environmentId}
+                  className="gap-3 rounded-xl border border-border-subtle p-3"
+                >
+                  <Text className="text-base font-t3-medium text-foreground">{mismatch.label}</Text>
+                  {mismatch.differences.map(({ key, currentValue, incomingValue }) => (
+                    <View key={key} className="gap-1">
+                      <Text className="text-base font-t3-medium text-foreground">
+                        {sharedServerSettingLabels[key]}
+                      </Text>
+                      <Text className="text-sm text-foreground-muted">
+                        Current: {formatSharedServerSettingValue(key, currentValue)}
+                      </Text>
+                      <Text className="text-sm text-foreground">
+                        From {reference.label}: {formatSharedServerSettingValue(key, incomingValue)}
+                      </Text>
+                    </View>
+                  ))}
+                </View>
+              ))}
+              <Pressable
+                accessibilityRole="button"
+                onPress={() => {
+                  const patch = pickSharedServerSettings(
+                    referenceSettings,
+                    reference.serverConfig?.environment.capabilities,
+                  );
+                  for (const mismatch of mismatches) {
+                    const target = environments.find(
+                      (candidate) => candidate.environmentId === mismatch.environmentId,
+                    );
+                    void updateSettings({
+                      environmentId: mismatch.environmentId,
+                      input: {
+                        patch: filterSharedServerPatch(
+                          patch,
+                          target?.serverConfig?.environment.capabilities,
+                        ),
+                      },
+                    });
+                  }
+                }}
+                className="rounded-full bg-subtle px-4 py-2 active:opacity-70"
+              >
+                <Text className="text-base font-t3-medium text-foreground">Apply to all</Text>
+              </Pressable>
+            </View>
+          ) : null}
         </View>
       ) : null}
     </>

--- a/apps/web/src/components/settings/SharedSettingsMismatchAlert.test.tsx
+++ b/apps/web/src/components/settings/SharedSettingsMismatchAlert.test.tsx
@@ -1,0 +1,41 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { EnvironmentId } from "@t3tools/contracts";
+import type { SharedSettingsMismatch } from "@t3tools/client-runtime/state/shared-settings";
+
+const state = vi.hoisted(() => ({
+  mismatches: [] as SharedSettingsMismatch[],
+  sourceLabel: "Desktop",
+  applyToAll: vi.fn(),
+}));
+
+vi.mock("../../hooks/useSettings", () => ({ useSharedSettingsSync: () => state }));
+
+import { SharedSettingsMismatchAlert } from "./SharedSettingsMismatchAlert";
+
+describe("SharedSettingsMismatchAlert", () => {
+  it("shows no warning when environments agree", () => {
+    state.mismatches = [];
+    expect(renderToStaticMarkup(<SharedSettingsMismatchAlert />)).toBe("");
+  });
+
+  it("keeps apply inside the closed review and names the source and differing values", () => {
+    state.mismatches = [
+      {
+        environmentId: EnvironmentId.make("remote"),
+        label: "Remote laptop",
+        differences: [{ key: "sidebarAutoSettleAfterDays", currentValue: 3, incomingValue: null }],
+      },
+    ];
+    const markup = renderToStaticMarkup(<SharedSettingsMismatchAlert />);
+    const review = markup.slice(markup.indexOf("<details"), markup.indexOf("</details>"));
+    expect(review).toContain("Review differences");
+    expect(review).toContain("Remote laptop");
+    expect(review).toContain("From Desktop");
+    expect(review).toContain("After 3 days");
+    expect(review).toContain("Off");
+    expect(review).toContain("Apply to all");
+    expect(review).not.toMatch(/<details[^>]*\sopen[\s=>]/);
+    expect(state.applyToAll).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/settings/SharedSettingsMismatchAlert.test.tsx
+++ b/apps/web/src/components/settings/SharedSettingsMismatchAlert.test.tsx
@@ -19,7 +19,7 @@ describe("SharedSettingsMismatchAlert", () => {
     expect(renderToStaticMarkup(<SharedSettingsMismatchAlert />)).toBe("");
   });
 
-  it("keeps apply inside the closed review and names the source and differing values", () => {
+  it("names the source and differing values inside the review", () => {
     state.mismatches = [
       {
         environmentId: EnvironmentId.make("remote"),
@@ -35,7 +35,5 @@ describe("SharedSettingsMismatchAlert", () => {
     expect(review).toContain("After 3 days");
     expect(review).toContain("Off");
     expect(review).toContain("Apply to all");
-    expect(review).not.toMatch(/<details[^>]*\sopen[\s=>]/);
-    expect(state.applyToAll).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/settings/SharedSettingsMismatchAlert.tsx
+++ b/apps/web/src/components/settings/SharedSettingsMismatchAlert.tsx
@@ -1,7 +1,11 @@
 import { TriangleAlertIcon } from "lucide-react";
+import {
+  formatSharedServerSettingValue,
+  sharedServerSettingLabels,
+} from "@t3tools/client-runtime/state/shared-settings";
 
 import { useSharedSettingsSync } from "../../hooks/useSettings";
-import { Alert, AlertAction, AlertDescription } from "../ui/alert";
+import { Alert, AlertDescription } from "../ui/alert";
 import { Button } from "../ui/button";
 
 /**
@@ -10,23 +14,57 @@ import { Button } from "../ui/button";
  * Renders nothing when every connected environment agrees.
  */
 export function SharedSettingsMismatchAlert() {
-  const { mismatches, applyToAll } = useSharedSettingsSync();
+  const { mismatches, applyToAll, sourceLabel } = useSharedSettingsSync();
   if (mismatches.length === 0) {
     return null;
   }
   const labels = mismatches.map((mismatch) => mismatch.label).join(", ");
   return (
-    <Alert variant="warning" className="mx-3 sm:mx-4">
+    <Alert variant="warning" controlAlignment="first-line" className="mx-3 sm:mx-4">
       <TriangleAlertIcon />
       <AlertDescription>
-        Settings differ on {labels}. Thread and source control preferences are meant to match on
-        every environment.
+        <p>Settings differ on {labels}.</p>
+        <details className="min-w-0">
+          <summary className="cursor-pointer rounded-sm font-medium focus-visible:outline-2 focus-visible:outline-offset-2">
+            Review differences
+          </summary>
+          <div className="mt-3 space-y-3 rounded-lg bg-card p-3 text-foreground">
+            <p className="break-words">
+              Apply to all copies shared preferences from <strong>{sourceLabel}</strong> (primary)
+              to the environments below. Only changed values are listed.
+            </p>
+            {mismatches.map((mismatch) => (
+              <section key={mismatch.environmentId} className="min-w-0 border-t border-border pt-3">
+                <h3 className="break-words font-medium">{mismatch.label}</h3>
+                <dl className="mt-2 space-y-3">
+                  {mismatch.differences.map(({ key, currentValue, incomingValue }) => (
+                    <div key={key}>
+                      <dt className="font-medium">{sharedServerSettingLabels[key]}</dt>
+                      <dd className="mt-1 grid min-w-0 gap-2 sm:grid-cols-2">
+                        <div>
+                          <span className="font-medium">Current</span>
+                          <p className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+                            {formatSharedServerSettingValue(key, currentValue)}
+                          </p>
+                        </div>
+                        <div>
+                          <span className="font-medium">From {sourceLabel} (primary)</span>
+                          <p className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+                            {formatSharedServerSettingValue(key, incomingValue)}
+                          </p>
+                        </div>
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              </section>
+            ))}
+            <Button variant="outline" size="xs" onClick={applyToAll}>
+              Apply to all
+            </Button>
+          </div>
+        </details>
       </AlertDescription>
-      <AlertAction>
-        <Button variant="outline" size="xs" onClick={applyToAll}>
-          Apply to all
-        </Button>
-      </AlertAction>
     </Alert>
   );
 }

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -546,7 +546,11 @@ export function useSharedSettingsSync() {
     }
   }, [environments, mismatches, persistServerSettings, primarySettings, primaryCapabilities]);
 
-  return { mismatches, applyToAll };
+  return {
+    mismatches,
+    applyToAll,
+    sourceLabel: primaryEnvironment?.label ?? "Primary environment",
+  };
 }
 
 export function useUpdateEnvironmentSettings(environmentId: EnvironmentId) {

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -44,8 +44,12 @@ resumed after it closed.
 Change these rules in **Settings → General**. They continue to run when your apps
 are closed. Changes apply to connected environments that support shared settings;
 offline environments and older servers keep their previous values. If connected
-environments disagree, **Apply to all** copies your current settings to those named
-in the warning. Changing a rule does not reopen already settled threads.
+environments disagree, **Review differences** shows each differing preference, its
+current value, and the value from the named source environment. **Apply to all**
+copies the source's shared preferences to the listed environments. On web and
+desktop the source is the primary environment; on mobile it is the first connected
+environment that supports shared settings. Changing a rule does not reopen already
+settled threads.
 
 ## Link a pull request
 

--- a/packages/client-runtime/src/state/sharedSettings.test.ts
+++ b/packages/client-runtime/src/state/sharedSettings.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "@effect/vitest";
 import {
   filterSharedServerPatch,
   findSharedSettingsMismatches,
+  formatSharedServerSettingValue,
   pickSharedServerSettings,
   splitSharedServerPatch,
   supportsSharedSettingsSync,
@@ -118,7 +119,19 @@ describe("findSharedSettingsMismatches", () => {
           primaryCapabilities: restartCapabilities,
           environments: [environment],
         }),
-      ).toEqual([{ environmentId: boxId, label: "Remote Box" }]);
+      ).toEqual([
+        {
+          environmentId: boxId,
+          label: "Remote Box",
+          differences: [
+            {
+              key: "continueThreadsAfterServerUpdate",
+              currentValue: !enabled,
+              incomingValue: enabled,
+            },
+          ],
+        },
+      ]);
       expect(
         findSharedSettingsMismatches({
           primaryEnvironmentId: primaryId,
@@ -170,7 +183,13 @@ describe("findSharedSettingsMismatches", () => {
             },
           ],
         }),
-      ).toEqual([{ environmentId: boxId, label: "Remote Box" }]);
+      ).toEqual([
+        {
+          environmentId: boxId,
+          label: "Remote Box",
+          differences: [{ key: "sidebarAutoSettleAfterDays", currentValue: 14, incomingValue: 7 }],
+        },
+      ]);
     },
   );
 
@@ -199,7 +218,19 @@ describe("findSharedSettingsMismatches", () => {
         },
       ],
     });
-    expect(mismatches).toEqual([{ environmentId: boxId, label: "Remote Box" }]);
+    expect(mismatches).toEqual([
+      {
+        environmentId: boxId,
+        label: "Remote Box",
+        differences: [
+          {
+            key: "sidebarAutoSettleAfterDays",
+            currentValue: DEFAULT_SERVER_SETTINGS.sidebarAutoSettleAfterDays,
+            incomingValue: 7,
+          },
+        ],
+      },
+    ]);
   });
 
   it("ignores machine-only differences", () => {
@@ -221,6 +252,43 @@ describe("findSharedSettingsMismatches", () => {
       ],
     });
     expect(mismatches).toEqual([]);
+  });
+
+  it("preserves disabled values and multiline writing styles in the overwrite preview", () => {
+    const writingStyle = {
+      ...primarySettings.sourceControlWritingStyle,
+      mode: "custom" as const,
+      customInstructions: "Use short titles.\nExplain the why.",
+    };
+    const mismatches = findSharedSettingsMismatches({
+      primaryEnvironmentId: primaryId,
+      primarySettings: {
+        ...primarySettings,
+        sidebarAutoSettleAfterDays: null,
+        sourceControlWritingStyle: writingStyle,
+      },
+      environments: [
+        {
+          environmentId: boxId,
+          label: "Remote",
+          syncEligible: true,
+          settings: primarySettings,
+        },
+      ],
+    });
+    expect(mismatches[0]?.differences).toEqual([
+      { key: "sidebarAutoSettleAfterDays", currentValue: 7, incomingValue: null },
+      {
+        key: "sourceControlWritingStyle",
+        currentValue: primarySettings.sourceControlWritingStyle,
+        incomingValue: writingStyle,
+      },
+    ]);
+    expect(formatSharedServerSettingValue("sourceControlWritingStyle", writingStyle)).toContain(
+      "Custom\nCustom instructions: Use short titles.\nExplain the why.",
+    );
+    expect(formatSharedServerSettingValue("sidebarAutoSettleAfterDays", null)).toBe("Off");
+    expect(formatSharedServerSettingValue("sidebarAutoSettleAfterDays", 1)).toBe("After 1 day");
   });
 
   it("reports nothing until the primary environment's settings are loaded", () => {

--- a/packages/client-runtime/src/state/sharedSettings.ts
+++ b/packages/client-runtime/src/state/sharedSettings.ts
@@ -30,6 +30,42 @@ const SHARED_SERVER_SETTING_KEYS = [
 
 export type SharedServerSettingKey = (typeof SHARED_SERVER_SETTING_KEYS)[number];
 
+export const sharedServerSettingLabels: Record<SharedServerSettingKey, string> = {
+  continueThreadsAfterServerUpdate: "Continue threads after server updates",
+  sidebarAutoSettleAfterDays: "Auto-settle inactive threads",
+  sidebarAutoSettleOnMerge: "Auto-settle merged threads",
+  newWorktreesStartFromOrigin: "Start new worktrees from origin",
+  sourceControlWritingStyle: "Source control writing style",
+};
+
+export function formatSharedServerSettingValue(
+  key: SharedServerSettingKey,
+  value: ServerSettings[SharedServerSettingKey],
+): string {
+  if (value === null) return "Off";
+  if (typeof value === "boolean") return value ? "On" : "Off";
+  if (typeof value === "object") {
+    const modes = {
+      conventional_commits: "Conventional commits",
+      custom: "Custom",
+      repo_conventions: "Repository conventions",
+    };
+    return `${modes[value.mode]}\nCustom instructions: ${value.customInstructions || "None"}\nFollow change request templates: ${value.followChangeRequestTemplates ? "On" : "Off"}`;
+  }
+  if (key === "sidebarAutoSettleAfterDays") return `After ${value} ${value === 1 ? "day" : "days"}`;
+  return String(value);
+}
+
+export interface SharedSettingsMismatch {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+  readonly differences: ReadonlyArray<{
+    readonly key: SharedServerSettingKey;
+    readonly currentValue: ServerSettings[SharedServerSettingKey];
+    readonly incomingValue: ServerSettings[SharedServerSettingKey];
+  }>;
+}
+
 const SHARED_KEY_SET = new Set<string>(SHARED_SERVER_SETTING_KEYS);
 
 /** Split a server patch into the keys every environment should receive and the primary-only rest. */
@@ -113,12 +149,13 @@ export function findSharedSettingsMismatches(input: {
     | Pick<ExecutionEnvironmentCapabilities, "threadRestartContinuation">
     | undefined;
   readonly environments: ReadonlyArray<SharedSettingsEnvironment>;
-}): ReadonlyArray<{ readonly environmentId: EnvironmentId; readonly label: string }> {
+}): ReadonlyArray<SharedSettingsMismatch> {
   if (input.primaryEnvironmentId === null || input.primarySettings === null) {
     return [];
   }
+  const loadedPrimarySettings = input.primarySettings;
   const primarySettings = pickSharedServerSettings(
-    input.primarySettings,
+    loadedPrimarySettings,
     input.primaryCapabilities,
   );
   return input.environments.flatMap((environment) => {
@@ -130,12 +167,22 @@ export function findSharedSettingsMismatches(input: {
       return [];
     }
     const expected = filterSharedServerPatch(primarySettings, environment.capabilities);
+    const loadedSettings = environment.settings;
     const actual = filterSharedServerPatch(
       pickSharedServerSettings(environment.settings, environment.capabilities),
       input.primaryCapabilities,
     );
-    return Equal.equals(actual, expected)
+    const differences = SHARED_SERVER_SETTING_KEYS.flatMap((key) => {
+      const currentValue = actual[key];
+      const incomingValue = expected[key];
+      return currentValue === undefined ||
+        incomingValue === undefined ||
+        Equal.equals(currentValue, incomingValue)
+        ? []
+        : [{ key, currentValue: loadedSettings[key], incomingValue: loadedPrimarySettings[key] }];
+    });
+    return differences.length === 0
       ? []
-      : [{ environmentId: environment.environmentId, label: environment.label }];
+      : [{ environmentId: environment.environmentId, label: environment.label, differences }];
   });
 }


### PR DESCRIPTION
## What Changed

Adds **Review differences** to the shared-settings warning on web, desktop, and mobile. It shows each environment's current values, the incoming values, and the source environment before **Apply to all**.

## Why

The warning identifies environments with different preferences but gives no way to see what applying will overwrite. Related discussion: https://github.com/pingdotgg/t3code/discussions/10323.

## UI Changes

Desktop screenshot using two isolated test environments:

<img width="1440" height="900" alt="Desktop settings difference review" src="https://github.com/user-attachments/assets/be777944-c952-4baa-81b6-f5f67af4e5df" />

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why.
- [x] Desktop screenshot included.
- [x] 37 focused tests and client-runtime, web, and mobile typechecks pass.
- [x] Verified General and Source Control, keyboard expansion, responsive web layouts, and applying all four seeded differences to a second server.
- [ ] Native mobile runtime verification; mobile is typechecked only.

Implemented with GPT-6 in Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preview shared setting differences before applying in settings UI
> - Adds `findSharedSettingsMismatches` per-key mismatch records with current and incoming values, plus `sharedServerSettingLabels` and `formatSharedServerSettingValue` in [sharedSettings.ts](https://github.com/pingdotgg/t3code/pull/10328/files#diff-38f5f180a1e6b08473997fcfd4ea833484eedc94dcfbe574949cee47cb522f70)
> - Replaces the single-row mismatch action on web ([SharedSettingsMismatchAlert.tsx](https://github.com/pingdotgg/t3code/pull/10328/files#diff-0705f2bccf91db619ee87b6120e5855db298294014c6a79ee04cc1124a07f757)) and mobile ([SettingsRouteScreen.tsx](https://github.com/pingdotgg/t3code/pull/10328/files#diff-2f7a2e66b652454e7fd1b30226a5146d595dfe05945b34d90ffd5f3a5037cb1e)) with an expandable review showing affected environments, each differing setting, and formatted current vs source values
> - Exposes `sourceLabel` from `useSharedSettingsSync` in [useSettings.ts](https://github.com/pingdotgg/t3code/pull/10328/files#diff-e989c3ad63c7359b2af1c2873a7ffbfea1639454ea1053c98da7f68d6946fbda) so consumers can label the primary source
> - Updates mismatch tests to assert detailed per-setting records and formatter output for disabled values, day counts, and multiline writing styles
> - Risk: callers of `findSharedSettingsMismatches` must handle the new `SharedSettingsMismatch` shape; the old environment-only record type is removed
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1db1425.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->