### PR TITLE
feat(web): image previews enhance

### DIFF
--- a/apps/web/src/components/chat/ExpandedImageDialog.tsx
+++ b/apps/web/src/components/chat/ExpandedImageDialog.tsx
@@ -10,6 +10,7 @@ import { MediaActions, type MediaActionSource } from "../media/MediaActions";
 import { MediaVideoPlayer } from "../media/MediaVideoPlayer";
 import { isContextMenuOpen } from "../../contextMenuFallback";
 import { composerFloatingLayerProps } from "./composerEventScope";
+import { ZoomableImageViewer } from "./ZoomableImageViewer";
 
 interface ExpandedImageDialogProps {
   preview: ExpandedImagePreview;
@@ -178,11 +179,9 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
               {openOriginalLink}
             </ExpandedMediaFailure>
           ) : (
-            <img
+            <ZoomableImageViewer
               src={item.src}
               alt={item.name}
-              className="max-h-[86vh] max-w-[92vw] select-none rounded-lg border border-border/70 bg-background object-contain shadow-2xl"
-              draggable={false}
               onError={() => setFailedImageSrc(item.src)}
             />
           )}

--- a/apps/web/src/components/chat/ZoomableImageViewer.tsx
+++ b/apps/web/src/components/chat/ZoomableImageViewer.tsx
@@ -1,164 +1,162 @@
-import { memo, type CSSProperties, type ReactNode } from "react";
+import { forwardRef, memo, type HTMLAttributes, type ReactNode } from "react";
 import { MinusIcon, PlusIcon, RotateCwIcon, RotateCcwIcon } from "lucide-react";
 import { Button } from "../ui/button";
 import { cn } from "../../lib/utils";
 import { useZoomableImage } from "./useZoomableImage";
 
-export interface ZoomableImageViewerProps {
+export interface ZoomableImageViewerProps extends HTMLAttributes<HTMLDivElement> {
   readonly src: string;
   readonly alt: string;
   readonly layout?: "dialog" | "panel";
-  readonly className?: string;
-  readonly style?: CSSProperties;
   readonly onError?: () => void;
   readonly onOpenOriginal?: ReactNode;
 }
 
-export const ZoomableImageViewer = memo(function ZoomableImageViewer({
-  src,
-  alt,
-  layout = "dialog",
-  className,
-  style,
-  onError,
-}: ZoomableImageViewerProps) {
-  const {
-    scale,
-    position,
-    rotation,
-    isDragging,
-    containerRef,
-    zoomIn,
-    zoomOut,
-    resetTransform,
-    rotateClockwise,
-    handleWheel,
-    handlePointerDown,
-    handlePointerMove,
-    handlePointerUp,
-    handleDoubleClick,
-    canZoomIn,
-    canZoomOut,
-    isZoomed,
-    zoomPercentage,
-  } = useZoomableImage(src);
+export const ZoomableImageViewer = memo(
+  forwardRef<HTMLDivElement, ZoomableImageViewerProps>(function ZoomableImageViewer(
+    { src, alt, layout = "dialog", className, style, onError, onOpenOriginal, ...domProps },
+    ref,
+  ) {
+    const {
+      scale,
+      position,
+      rotation,
+      isDragging,
+      containerRef,
+      zoomIn,
+      zoomOut,
+      resetTransform,
+      rotateClockwise,
+      handleWheel,
+      handlePointerDown,
+      handlePointerMove,
+      handlePointerUp,
+      handleDoubleClick,
+      canZoomIn,
+      canZoomOut,
+      isZoomed,
+      zoomPercentage,
+    } = useZoomableImage(src, { layout });
 
-  const isPanel = layout === "panel";
+    const isPanel = layout === "panel";
 
-  return (
-    <div
-      className={cn(
-        "relative flex items-center justify-center",
-        isPanel ? "h-full w-full min-h-0 flex-1 flex-col overflow-hidden" : "flex-col",
-      )}
-    >
-      {/* Zoomable Image Viewport */}
+    return (
       <div
-        ref={containerRef}
-        onWheel={handleWheel}
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onPointerCancel={handlePointerUp}
-        onDoubleClick={handleDoubleClick}
+        ref={ref}
         className={cn(
-          "relative flex items-center justify-center overflow-hidden transition-colors touch-none select-none",
-          isPanel
-            ? "h-full w-full min-h-0 flex-1 rounded-md border border-border/40 bg-muted/10"
-            : "max-h-[82vh] max-w-[92vw] rounded-lg border border-border/70 bg-background/95 shadow-2xl",
-          isDragging ? "cursor-grabbing" : isZoomed ? "cursor-grab" : "cursor-zoom-in",
+          "relative flex items-center justify-center",
+          isPanel ? "h-full w-full min-h-0 flex-1 flex-col overflow-hidden" : "flex-col",
           className,
         )}
         style={style}
+        {...domProps}
       >
-        <img
-          src={src}
-          alt={alt}
-          draggable={false}
-          onError={onError}
+        {/* Zoomable Image Viewport */}
+        <div
+          ref={containerRef}
+          onWheel={handleWheel}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+          onDoubleClick={handleDoubleClick}
           className={cn(
-            "object-contain select-none will-change-transform",
-            isPanel ? "max-h-full max-w-full" : "max-h-[82vh] max-w-[92vw]",
+            "relative flex items-center justify-center overflow-hidden transition-colors touch-none select-none",
+            isPanel
+              ? "h-full w-full min-h-0 flex-1 rounded-md border border-border/40 bg-muted/10"
+              : "max-h-[82vh] max-w-[92vw] rounded-lg border border-border/70 bg-background/95 shadow-2xl",
+            isDragging ? "cursor-grabbing" : isZoomed ? "cursor-grab" : "cursor-zoom-in",
           )}
-          style={{
-            transform: `translate3d(${position.x}px, ${position.y}px, 0) scale(${scale}) rotate(${rotation}deg)`,
-            transition: isDragging ? "none" : "transform 0.15s ease-out",
-          }}
-        />
+        >
+          <img
+            src={src}
+            alt={alt}
+            draggable={false}
+            onError={onError}
+            className={cn(
+              "object-contain select-none will-change-transform",
+              isPanel ? "max-h-full max-w-full" : "max-h-[82vh] max-w-[92vw]",
+            )}
+            style={{
+              transform: `translate3d(${position.x}px, ${position.y}px, 0) scale(${scale}) rotate(${rotation}deg)`,
+              transition: isDragging ? "none" : "transform 0.15s ease-out",
+            }}
+          />
+        </div>
+
+        {/* Floating Interactive Toolbar */}
+        <div
+          className={cn(
+            "flex items-center gap-1 rounded-full border border-border/80 bg-popover/90 px-2.5 py-1 text-foreground shadow-xl backdrop-blur-md",
+            isPanel ? "absolute bottom-4 z-10" : "mt-3",
+          )}
+          role="toolbar"
+          aria-label="Image preview controls"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            onClick={zoomOut}
+            disabled={!canZoomOut}
+            title="Zoom out (-)"
+            aria-label="Zoom out"
+            className="size-7 rounded-full text-foreground/80 hover:bg-muted hover:text-foreground"
+          >
+            <MinusIcon className="size-3.5" />
+          </Button>
+
+          <button
+            type="button"
+            onClick={resetTransform}
+            title="Reset zoom (0)"
+            aria-label={`Current zoom ${zoomPercentage}%. Click to reset.`}
+            className="min-w-12 px-1 text-center font-mono text-xs font-semibold text-foreground/90 transition-colors hover:text-foreground"
+          >
+            {zoomPercentage}%
+          </button>
+
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            onClick={zoomIn}
+            disabled={!canZoomIn}
+            title="Zoom in (+)"
+            aria-label="Zoom in"
+            className="size-7 rounded-full text-foreground/80 hover:bg-muted hover:text-foreground"
+          >
+            <PlusIcon className="size-3.5" />
+          </Button>
+
+          <div className="mx-1 h-3.5 w-px bg-border/80" />
+
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            onClick={rotateClockwise}
+            title="Rotate 90° (R)"
+            aria-label="Rotate 90 degrees"
+            className="size-7 rounded-full text-foreground/80 hover:bg-muted hover:text-foreground"
+          >
+            <RotateCwIcon className="size-3.5" />
+          </Button>
+
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            onClick={resetTransform}
+            title="Reset view (0)"
+            aria-label="Reset zoom and rotation"
+            className="size-7 rounded-full text-foreground/80 hover:bg-muted hover:text-foreground"
+          >
+            <RotateCcwIcon className="size-3.5" />
+          </Button>
+        </div>
       </div>
-
-      {/* Floating Interactive Toolbar */}
-      <div
-        className={cn(
-          "flex items-center gap-1 rounded-full border border-border/80 bg-popover/90 px-2.5 py-1 text-foreground shadow-xl backdrop-blur-md",
-          isPanel ? "absolute bottom-4 z-10" : "mt-3",
-        )}
-        role="toolbar"
-        aria-label="Image preview controls"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <Button
-          type="button"
-          size="icon-xs"
-          variant="ghost"
-          onClick={zoomOut}
-          disabled={!canZoomOut}
-          title="Zoom out (-)"
-          aria-label="Zoom out"
-          className="size-7 rounded-full text-foreground/80 hover:bg-muted hover:text-foreground"
-        >
-          <MinusIcon className="size-3.5" />
-        </Button>
-
-        <button
-          type="button"
-          onClick={resetTransform}
-          title="Reset zoom (0)"
-          aria-label={`Current zoom ${zoomPercentage}%. Click to reset.`}
-          className="min-w-12 px-1 text-center font-mono text-xs font-semibold text-foreground/90 transition-colors hover:text-foreground"
-        >
-          {zoomPercentage}%
-        </button>
-
-        <Button
-          type="button"
-          size="icon-xs"
-          variant="ghost"
-          onClick={zoomIn}
-          disabled={!canZoomIn}
-          title="Zoom in (+)"
-          aria-label="Zoom in"
-          className="size-7 rounded-full text-foreground/80 hover:bg-muted hover:text-foreground"
-        >
-          <PlusIcon className="size-3.5" />
-        </Button>
-
-        <div className="mx-1 h-3.5 w-px bg-border/80" />
-
-        <Button
-          type="button"
-          size="icon-xs"
-          variant="ghost"
-          onClick={rotateClockwise}
-          title="Rotate 90° (R)"
-          aria-label="Rotate 90 degrees"
-          className="size-7 rounded-full text-foreground/80 hover:bg-muted hover:text-foreground"
-        >
-          <RotateCwIcon className="size-3.5" />
-        </Button>
-
-        <Button
-          type="button"
-          size="icon-xs"
-          variant="ghost"
-          onClick={resetTransform}
-          title="Reset view (0)"
-          aria-label="Reset zoom and rotation"
-          className="size-7 rounded-full text-foreground/80 hover:bg-muted hover:text-foreground"
-        >
-          <RotateCcwIcon className="size-3.5" />
-        </Button>
-      </div>
-    </div>
-  );
-});
+    );
+  }),
+);

--- a/apps/web/src/components/chat/ZoomableImageViewer.tsx
+++ b/apps/web/src/components/chat/ZoomableImageViewer.tsx
@@ -7,6 +7,7 @@ import { useZoomableImage } from "./useZoomableImage";
 export interface ZoomableImageViewerProps {
   readonly src: string;
   readonly alt: string;
+  readonly layout?: "dialog" | "panel";
   readonly className?: string;
   readonly style?: CSSProperties;
   readonly onError?: () => void;
@@ -16,6 +17,7 @@ export interface ZoomableImageViewerProps {
 export const ZoomableImageViewer = memo(function ZoomableImageViewer({
   src,
   alt,
+  layout = "dialog",
   className,
   style,
   onError,
@@ -41,8 +43,15 @@ export const ZoomableImageViewer = memo(function ZoomableImageViewer({
     zoomPercentage,
   } = useZoomableImage(src);
 
+  const isPanel = layout === "panel";
+
   return (
-    <div className="relative flex flex-col items-center justify-center">
+    <div
+      className={cn(
+        "relative flex items-center justify-center",
+        isPanel ? "h-full w-full min-h-0 flex-1 flex-col overflow-hidden" : "flex-col",
+      )}
+    >
       {/* Zoomable Image Viewport */}
       <div
         ref={containerRef}
@@ -53,7 +62,10 @@ export const ZoomableImageViewer = memo(function ZoomableImageViewer({
         onPointerCancel={handlePointerUp}
         onDoubleClick={handleDoubleClick}
         className={cn(
-          "relative flex max-h-[82vh] max-w-[92vw] items-center justify-center overflow-hidden rounded-lg border border-border/70 bg-background/95 shadow-2xl transition-colors touch-none select-none",
+          "relative flex items-center justify-center overflow-hidden transition-colors touch-none select-none",
+          isPanel
+            ? "h-full w-full min-h-0 flex-1 rounded-md border border-border/40 bg-muted/10"
+            : "max-h-[82vh] max-w-[92vw] rounded-lg border border-border/70 bg-background/95 shadow-2xl",
           isDragging ? "cursor-grabbing" : isZoomed ? "cursor-grab" : "cursor-zoom-in",
           className,
         )}
@@ -64,7 +76,10 @@ export const ZoomableImageViewer = memo(function ZoomableImageViewer({
           alt={alt}
           draggable={false}
           onError={onError}
-          className="max-h-[82vh] max-w-[92vw] object-contain select-none will-change-transform"
+          className={cn(
+            "object-contain select-none will-change-transform",
+            isPanel ? "max-h-full max-w-full" : "max-h-[82vh] max-w-[92vw]",
+          )}
           style={{
             transform: `translate3d(${position.x}px, ${position.y}px, 0) scale(${scale}) rotate(${rotation}deg)`,
             transition: isDragging ? "none" : "transform 0.15s ease-out",
@@ -74,7 +89,10 @@ export const ZoomableImageViewer = memo(function ZoomableImageViewer({
 
       {/* Floating Interactive Toolbar */}
       <div
-        className="mt-3 flex items-center gap-1 rounded-full border border-border/80 bg-popover/90 px-2.5 py-1 text-foreground shadow-xl backdrop-blur-md"
+        className={cn(
+          "flex items-center gap-1 rounded-full border border-border/80 bg-popover/90 px-2.5 py-1 text-foreground shadow-xl backdrop-blur-md",
+          isPanel ? "absolute bottom-4 z-10" : "mt-3",
+        )}
         role="toolbar"
         aria-label="Image preview controls"
         onClick={(e) => e.stopPropagation()}

--- a/apps/web/src/components/chat/ZoomableImageViewer.tsx
+++ b/apps/web/src/components/chat/ZoomableImageViewer.tsx
@@ -1,0 +1,146 @@
+import { memo, type CSSProperties, type ReactNode } from "react";
+import { MinusIcon, PlusIcon, RotateCwIcon, RotateCcwIcon } from "lucide-react";
+import { Button } from "../ui/button";
+import { cn } from "../../lib/utils";
+import { useZoomableImage } from "./useZoomableImage";
+
+export interface ZoomableImageViewerProps {
+  readonly src: string;
+  readonly alt: string;
+  readonly className?: string;
+  readonly style?: CSSProperties;
+  readonly onError?: () => void;
+  readonly onOpenOriginal?: ReactNode;
+}
+
+export const ZoomableImageViewer = memo(function ZoomableImageViewer({
+  src,
+  alt,
+  className,
+  style,
+  onError,
+}: ZoomableImageViewerProps) {
+  const {
+    scale,
+    position,
+    rotation,
+    isDragging,
+    containerRef,
+    zoomIn,
+    zoomOut,
+    resetTransform,
+    rotateClockwise,
+    handleWheel,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    handleDoubleClick,
+    canZoomIn,
+    canZoomOut,
+    isZoomed,
+    zoomPercentage,
+  } = useZoomableImage(src);
+
+  return (
+    <div className="relative flex flex-col items-center justify-center">
+      {/* Zoomable Image Viewport */}
+      <div
+        ref={containerRef}
+        onWheel={handleWheel}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onDoubleClick={handleDoubleClick}
+        className={cn(
+          "relative flex max-h-[82vh] max-w-[92vw] items-center justify-center overflow-hidden rounded-lg border border-border/70 bg-background/95 shadow-2xl transition-colors touch-none select-none",
+          isDragging ? "cursor-grabbing" : isZoomed ? "cursor-grab" : "cursor-zoom-in",
+          className,
+        )}
+        style={style}
+      >
+        <img
+          src={src}
+          alt={alt}
+          draggable={false}
+          onError={onError}
+          className="max-h-[82vh] max-w-[92vw] object-contain select-none will-change-transform"
+          style={{
+            transform: `translate3d(${position.x}px, ${position.y}px, 0) scale(${scale}) rotate(${rotation}deg)`,
+            transition: isDragging ? "none" : "transform 0.15s ease-out",
+          }}
+        />
+      </div>
+
+      {/* Floating Interactive Toolbar */}
+      <div
+        className="mt-3 flex items-center gap-1 rounded-full border border-border/80 bg-popover/90 px-2.5 py-1 text-foreground shadow-xl backdrop-blur-md"
+        role="toolbar"
+        aria-label="Image preview controls"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Button
+          type="button"
+          size="icon-xs"
+          variant="ghost"
+          onClick={zoomOut}
+          disabled={!canZoomOut}
+          title="Zoom out (-)"
+          aria-label="Zoom out"
+          className="size-7 rounded-full text-foreground/80 hover:bg-muted hover:text-foreground"
+        >
+          <MinusIcon className="size-3.5" />
+        </Button>
+
+        <button
+          type="button"
+          onClick={resetTransform}
+          title="Reset zoom (0)"
+          aria-label={`Current zoom ${zoomPercentage}%. Click to reset.`}
+          className="min-w-12 px-1 text-center font-mono text-xs font-semibold text-foreground/90 transition-colors hover:text-foreground"
+        >
+          {zoomPercentage}%
+        </button>
+
+        <Button
+          type="button"
+          size="icon-xs"
+          variant="ghost"
+          onClick={zoomIn}
+          disabled={!canZoomIn}
+          title="Zoom in (+)"
+          aria-label="Zoom in"
+          className="size-7 rounded-full text-foreground/80 hover:bg-muted hover:text-foreground"
+        >
+          <PlusIcon className="size-3.5" />
+        </Button>
+
+        <div className="mx-1 h-3.5 w-px bg-border/80" />
+
+        <Button
+          type="button"
+          size="icon-xs"
+          variant="ghost"
+          onClick={rotateClockwise}
+          title="Rotate 90° (R)"
+          aria-label="Rotate 90 degrees"
+          className="size-7 rounded-full text-foreground/80 hover:bg-muted hover:text-foreground"
+        >
+          <RotateCwIcon className="size-3.5" />
+        </Button>
+
+        <Button
+          type="button"
+          size="icon-xs"
+          variant="ghost"
+          onClick={resetTransform}
+          title="Reset view (0)"
+          aria-label="Reset zoom and rotation"
+          className="size-7 rounded-full text-foreground/80 hover:bg-muted hover:text-foreground"
+        >
+          <RotateCcwIcon className="size-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+});

--- a/apps/web/src/components/chat/ZoomableImageViewer.tsx
+++ b/apps/web/src/components/chat/ZoomableImageViewer.tsx
@@ -1,8 +1,17 @@
-import { forwardRef, memo, type HTMLAttributes, type ReactNode } from "react";
+import {
+  forwardRef,
+  memo,
+  useEffect,
+  useState,
+  type CSSProperties,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
 import { MinusIcon, PlusIcon, RotateCwIcon, RotateCcwIcon } from "lucide-react";
 import { Button } from "../ui/button";
 import { cn } from "../../lib/utils";
 import { useZoomableImage } from "./useZoomableImage";
+import { isOrthogonalRotation } from "./zoomableImage.logic";
 
 export interface ZoomableImageViewerProps extends HTMLAttributes<HTMLDivElement> {
   readonly src: string;
@@ -38,7 +47,41 @@ export const ZoomableImageViewer = memo(
       zoomPercentage,
     } = useZoomableImage(src, { layout });
 
+    const [containerSize, setContainerSize] = useState<{ width: number; height: number } | null>(
+      null,
+    );
+
     const isPanel = layout === "panel";
+    const isRotated = isOrthogonalRotation(rotation);
+
+    useEffect(() => {
+      const el = containerRef.current;
+      if (!el || typeof ResizeObserver === "undefined") return;
+
+      const observer = new ResizeObserver((entries) => {
+        const entry = entries[0];
+        if (entry) {
+          const { width, height } = entry.contentRect;
+          if (width > 0 && height > 0) {
+            setContainerSize({ width, height });
+          }
+        }
+      });
+
+      observer.observe(el);
+      return () => observer.disconnect();
+    }, [containerRef]);
+
+    const imgStyle: CSSProperties = {
+      transform: `translate3d(${position.x}px, ${position.y}px, 0) scale(${scale}) rotate(${rotation}deg)`,
+      transition: isDragging ? "none" : "transform 0.15s ease-out",
+      ...(isRotated && containerSize && isPanel
+        ? {
+            maxWidth: `${containerSize.height}px`,
+            maxHeight: `${containerSize.width}px`,
+          }
+        : undefined),
+    };
 
     return (
       <div
@@ -75,12 +118,13 @@ export const ZoomableImageViewer = memo(
             onError={onError}
             className={cn(
               "object-contain select-none will-change-transform",
-              isPanel ? "max-h-full max-w-full" : "max-h-[82vh] max-w-[92vw]",
+              isPanel
+                ? "max-h-full max-w-full"
+                : isRotated
+                  ? "max-h-[92vw] max-w-[82vh]"
+                  : "max-h-[82vh] max-w-[92vw]",
             )}
-            style={{
-              transform: `translate3d(${position.x}px, ${position.y}px, 0) scale(${scale}) rotate(${rotation}deg)`,
-              transition: isDragging ? "none" : "transform 0.15s ease-out",
-            }}
+            style={imgStyle}
           />
         </div>
 

--- a/apps/web/src/components/chat/useZoomableImage.test.tsx
+++ b/apps/web/src/components/chat/useZoomableImage.test.tsx
@@ -1,0 +1,185 @@
+import { act } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { ZoomableImageViewer } from "./ZoomableImageViewer";
+import { useZoomableImage } from "./useZoomableImage";
+
+let listeners: Array<(e: KeyboardEvent) => void> = [];
+
+async function dispatchKeyEvent(eventInit: Partial<KeyboardEvent> & { key: string }) {
+  let defaultPrevented = false;
+  let propagationStopped = false;
+  const event = {
+    bubbles: true,
+    cancelable: true,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    target: null,
+    get defaultPrevented() {
+      return defaultPrevented;
+    },
+    ...eventInit,
+    preventDefault: () => {
+      defaultPrevented = true;
+    },
+    stopPropagation: () => {
+      propagationStopped = true;
+    },
+  } as unknown as KeyboardEvent;
+
+  await act(async () => {
+    for (const listener of [...listeners]) {
+      listener(event);
+    }
+  });
+
+  return { defaultPrevented, propagationStopped };
+}
+
+let activeRenderers: ReactTestRenderer[] = [];
+
+beforeEach(() => {
+  listeners = [];
+  activeRenderers = [];
+  vi.stubGlobal("window", {
+    addEventListener: vi.fn((type: string, listener: (e: KeyboardEvent) => void) => {
+      if (type === "keydown") listeners.push(listener);
+    }),
+    removeEventListener: vi.fn((type: string, listener: (e: KeyboardEvent) => void) => {
+      if (type === "keydown") {
+        listeners = listeners.filter((l) => l !== listener);
+      }
+    }),
+  });
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+});
+
+afterEach(async () => {
+  for (const renderer of activeRenderers) {
+    await act(() => renderer.unmount());
+  }
+  listeners = [];
+  activeRenderers = [];
+  vi.unstubAllGlobals();
+});
+
+function ProbeViewer({
+  src,
+  layout,
+  onState,
+}: {
+  src: string;
+  layout?: "dialog" | "panel" | undefined;
+  onState?: (state: ReturnType<typeof useZoomableImage>) => void;
+}) {
+  const state = useZoomableImage(src, { layout });
+  onState?.(state);
+  return null;
+}
+
+describe("useZoomableImage keyboard shortcuts & scoping", () => {
+  it("ignores zoom shortcuts when Ctrl or Meta keys are pressed", async () => {
+    let viewerState!: ReturnType<typeof useZoomableImage>;
+    let renderer: ReactTestRenderer | undefined;
+
+    await act(() => {
+      renderer = create(
+        <ProbeViewer src="https://example.com/test.png" onState={(s) => (viewerState = s)} />,
+      );
+      activeRenderers.push(renderer);
+    });
+
+    const initialScale = viewerState.scale;
+
+    // Dispatch Ctrl+=
+    const ctrlResult = await dispatchKeyEvent({ key: "+", ctrlKey: true });
+    expect(ctrlResult.defaultPrevented).toBe(false);
+    expect(viewerState.scale).toBe(initialScale);
+
+    // Dispatch Meta+=
+    const metaResult = await dispatchKeyEvent({ key: "+", metaKey: true });
+    expect(metaResult.defaultPrevented).toBe(false);
+    expect(viewerState.scale).toBe(initialScale);
+
+    // Dispatch regular +
+    const regularResult = await dispatchKeyEvent({ key: "+" });
+    expect(regularResult.defaultPrevented).toBe(true);
+    expect(viewerState.scale).toBeGreaterThan(initialScale);
+  });
+
+  it("prioritizes dialog shortcuts over obscured panel when both are mounted", async () => {
+    let panelState!: ReturnType<typeof useZoomableImage>;
+    let dialogState!: ReturnType<typeof useZoomableImage>;
+    let renderer: ReactTestRenderer | undefined;
+
+    function MultiViewer() {
+      return (
+        <>
+          <ProbeViewer
+            src="https://example.com/panel.png"
+            layout="panel"
+            onState={(s) => (panelState = s)}
+          />
+          <ProbeViewer
+            src="https://example.com/dialog.png"
+            layout="dialog"
+            onState={(s) => (dialogState = s)}
+          />
+        </>
+      );
+    }
+
+    await act(() => {
+      renderer = create(<MultiViewer />);
+      activeRenderers.push(renderer);
+    });
+
+    const initialPanelScale = panelState.scale;
+    const initialDialogScale = dialogState.scale;
+
+    // Press '+' to zoom
+    const zoomResult = await dispatchKeyEvent({ key: "+" });
+    expect(zoomResult.defaultPrevented).toBe(true);
+
+    // Dialog should receive zoom, panel should remain untouched
+    expect(dialogState.scale).toBeGreaterThan(initialDialogScale);
+    expect(panelState.scale).toBe(initialPanelScale);
+
+    // Press 'r' to rotate
+    await dispatchKeyEvent({ key: "r" });
+    expect(dialogState.rotation).toBe(90);
+    expect(panelState.rotation).toBe(0);
+  });
+});
+
+describe("ZoomableImageViewer ref and DOM props forwarding", () => {
+  it("forwards ref and spreads DOM props to outer div", async () => {
+    const onContextMenu = vi.fn();
+    let renderer: ReactTestRenderer | undefined;
+
+    await act(() => {
+      renderer = create(
+        <ZoomableImageViewer
+          src="https://example.com/img.png"
+          alt="Test Image"
+          layout="panel"
+          tabIndex={0}
+          data-testid="zoomable-image-viewer"
+          onContextMenu={onContextMenu}
+        />,
+      );
+      activeRenderers.push(renderer);
+    });
+
+    const divs = renderer!.root.findAllByType("div");
+    const outerDiv = divs[0];
+    expect(outerDiv).toBeDefined();
+    if (!outerDiv) return;
+    expect(outerDiv.props.tabIndex).toBe(0);
+    expect(outerDiv.props["data-testid"]).toBe("zoomable-image-viewer");
+    expect(outerDiv.props.onContextMenu).toBe(onContextMenu);
+    expect(outerDiv.props.className).toContain("overflow-hidden");
+  });
+});

--- a/apps/web/src/components/chat/useZoomableImage.test.tsx
+++ b/apps/web/src/components/chat/useZoomableImage.test.tsx
@@ -154,7 +154,7 @@ describe("useZoomableImage keyboard shortcuts & scoping", () => {
   });
 });
 
-describe("ZoomableImageViewer ref and DOM props forwarding", () => {
+describe("ZoomableImageViewer ref, layout & rotation constraints", () => {
   it("forwards ref and spreads DOM props to outer div", async () => {
     const onContextMenu = vi.fn();
     let renderer: ReactTestRenderer | undefined;
@@ -181,5 +181,27 @@ describe("ZoomableImageViewer ref and DOM props forwarding", () => {
     expect(outerDiv.props["data-testid"]).toBe("zoomable-image-viewer");
     expect(outerDiv.props.onContextMenu).toBe(onContextMenu);
     expect(outerDiv.props.className).toContain("overflow-hidden");
+  });
+
+  it("applies rotated max-dimensions in dialog mode when rotated 90 degrees", async () => {
+    let renderer: ReactTestRenderer | undefined;
+
+    await act(() => {
+      renderer = create(
+        <ZoomableImageViewer src="https://example.com/img.png" alt="Test Image" layout="dialog" />,
+      );
+      activeRenderers.push(renderer);
+    });
+
+    const img = renderer!.root.findByType("img");
+    expect(img.props.className).toContain("max-h-[82vh]");
+    expect(img.props.className).toContain("max-w-[92vw]");
+
+    // Rotate 90 degrees
+    await dispatchKeyEvent({ key: "r" });
+
+    const rotatedImg = renderer!.root.findByType("img");
+    expect(rotatedImg.props.className).toContain("max-h-[92vw]");
+    expect(rotatedImg.props.className).toContain("max-w-[82vh]");
   });
 });

--- a/apps/web/src/components/chat/useZoomableImage.ts
+++ b/apps/web/src/components/chat/useZoomableImage.ts
@@ -1,0 +1,232 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type WheelEvent as ReactWheelEvent,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+import {
+  calculateZoomAnchorPosition,
+  clampZoomScale,
+  DEFAULT_ZOOM_SCALE,
+  DOUBLE_CLICK_ZOOM_SCALE,
+  getNextRotation,
+  getNextZoomInScale,
+  getNextZoomOutScale,
+  isEditableElement,
+  MAX_ZOOM_SCALE,
+  MIN_ZOOM_SCALE,
+  type Point,
+} from "./zoomableImage.logic";
+
+export function useZoomableImage(src: string) {
+  const [scale, setScale] = useState(DEFAULT_ZOOM_SCALE);
+  const [position, setPosition] = useState<Point>({ x: 0, y: 0 });
+  const [rotation, setRotation] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const dragStartRef = useRef<{
+    clientX: number;
+    clientY: number;
+    posX: number;
+    posY: number;
+  }>({ clientX: 0, clientY: 0, posX: 0, posY: 0 });
+  const hasMovedRef = useRef(false);
+
+  // Reset transform whenever source image changes
+  useEffect(() => {
+    setScale(DEFAULT_ZOOM_SCALE);
+    setPosition({ x: 0, y: 0 });
+    setRotation(0);
+  }, [src]);
+
+  const zoomIn = useCallback(() => {
+    setScale((prev) => getNextZoomInScale(prev));
+  }, []);
+
+  const zoomOut = useCallback(() => {
+    setScale((prev) => {
+      const next = getNextZoomOutScale(prev);
+      if (next <= DEFAULT_ZOOM_SCALE) {
+        setPosition({ x: 0, y: 0 });
+      }
+      return next;
+    });
+  }, []);
+
+  const resetTransform = useCallback(() => {
+    setScale(DEFAULT_ZOOM_SCALE);
+    setPosition({ x: 0, y: 0 });
+    setRotation(0);
+  }, []);
+
+  const rotateClockwise = useCallback(() => {
+    setRotation((prev) => getNextRotation(prev));
+  }, []);
+
+  const handleWheel = useCallback(
+    (event: ReactWheelEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const container = containerRef.current;
+      if (!container) return;
+
+      const rect = container.getBoundingClientRect();
+      const focalPoint = {
+        x: event.clientX - (rect.left + rect.width / 2),
+        y: event.clientY - (rect.top + rect.height / 2),
+      };
+
+      const factor = event.deltaY < 0 ? 1.15 : 0.87;
+      const nextScale = clampZoomScale(scale * factor);
+
+      if (Math.abs(nextScale - scale) < 0.001) return;
+
+      if (nextScale <= DEFAULT_ZOOM_SCALE && scale > DEFAULT_ZOOM_SCALE) {
+        setScale(DEFAULT_ZOOM_SCALE);
+        setPosition({ x: 0, y: 0 });
+      } else {
+        const newPos = calculateZoomAnchorPosition(scale, nextScale, position, focalPoint);
+        setScale(nextScale);
+        setPosition(newPos);
+      }
+    },
+    [position, scale],
+  );
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0) return; // Only primary mouse button
+      event.stopPropagation();
+
+      setIsDragging(true);
+      hasMovedRef.current = false;
+      dragStartRef.current = {
+        clientX: event.clientX,
+        clientY: event.clientY,
+        posX: position.x,
+        posY: position.y,
+      };
+
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      } catch {
+        // Safe fallback in test environments
+      }
+    },
+    [position],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!isDragging) return;
+      event.stopPropagation();
+
+      const dx = event.clientX - dragStartRef.current.clientX;
+      const dy = event.clientY - dragStartRef.current.clientY;
+
+      if (Math.abs(dx) > 3 || Math.abs(dy) > 3) {
+        hasMovedRef.current = true;
+      }
+
+      setPosition({
+        x: dragStartRef.current.posX + dx,
+        y: dragStartRef.current.posY + dy,
+      });
+    },
+    [isDragging],
+  );
+
+  const handlePointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!isDragging) return;
+      event.stopPropagation();
+      setIsDragging(false);
+
+      try {
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        }
+      } catch {
+        // Safe fallback
+      }
+    },
+    [isDragging],
+  );
+
+  const handleDoubleClick = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      event.stopPropagation();
+      if (scale !== DEFAULT_ZOOM_SCALE || position.x !== 0 || position.y !== 0) {
+        resetTransform();
+      } else {
+        const container = containerRef.current;
+        if (!container) return;
+
+        const rect = container.getBoundingClientRect();
+        const focalPoint = {
+          x: event.clientX - (rect.left + rect.width / 2),
+          y: event.clientY - (rect.top + rect.height / 2),
+        };
+        const targetScale = DOUBLE_CLICK_ZOOM_SCALE;
+        const newPos = calculateZoomAnchorPosition(scale, targetScale, position, focalPoint);
+        setScale(targetScale);
+        setPosition(newPos);
+      }
+    },
+    [position, resetTransform, scale],
+  );
+
+  // Keyboard shortcut listeners (+, -, 0, r)
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || isEditableElement(event.target)) return;
+
+      if (event.key === "+" || event.key === "=") {
+        event.preventDefault();
+        event.stopPropagation();
+        zoomIn();
+      } else if (event.key === "-" || event.key === "_") {
+        event.preventDefault();
+        event.stopPropagation();
+        zoomOut();
+      } else if (event.key === "0") {
+        event.preventDefault();
+        event.stopPropagation();
+        resetTransform();
+      } else if (event.key === "r" || event.key === "R") {
+        event.preventDefault();
+        event.stopPropagation();
+        rotateClockwise();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [resetTransform, rotateClockwise, zoomIn, zoomOut]);
+
+  return {
+    scale,
+    position,
+    rotation,
+    isDragging,
+    containerRef,
+    zoomIn,
+    zoomOut,
+    resetTransform,
+    rotateClockwise,
+    handleWheel,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    handleDoubleClick,
+    canZoomIn: scale < MAX_ZOOM_SCALE,
+    canZoomOut: scale > MIN_ZOOM_SCALE,
+    isZoomed: scale > DEFAULT_ZOOM_SCALE,
+    zoomPercentage: Math.round(scale * 100),
+  };
+}

--- a/apps/web/src/components/chat/useZoomableImage.ts
+++ b/apps/web/src/components/chat/useZoomableImage.ts
@@ -18,10 +18,90 @@ import {
   isEditableElement,
   MAX_ZOOM_SCALE,
   MIN_ZOOM_SCALE,
+  selectActiveViewer,
   type Point,
 } from "./zoomableImage.logic";
 
-export function useZoomableImage(src: string) {
+export interface UseZoomableImageOptions {
+  readonly layout?: "dialog" | "panel" | undefined;
+}
+
+interface ViewerRegistration {
+  readonly id: symbol;
+  readonly layout: "dialog" | "panel";
+  readonly containerRef: React.RefObject<HTMLDivElement | null>;
+  readonly handlersRef: React.RefObject<{
+    zoomIn: () => void;
+    zoomOut: () => void;
+    resetTransform: () => void;
+    rotateClockwise: () => void;
+  }>;
+}
+
+const activeViewers: ViewerRegistration[] = [];
+
+function onGlobalKeyDown(event: KeyboardEvent) {
+  if (
+    event.defaultPrevented ||
+    event.ctrlKey ||
+    event.metaKey ||
+    event.altKey ||
+    isEditableElement(event.target)
+  ) {
+    return;
+  }
+
+  const activeViewer = selectActiveViewer(
+    activeViewers.map((v) => ({
+      viewer: v,
+      layout: v.layout,
+      container: v.containerRef.current,
+    })),
+  )?.viewer;
+
+  if (!activeViewer) return;
+
+  const handlers = activeViewer.handlersRef.current;
+  if (!handlers) return;
+
+  if (event.key === "+" || event.key === "=") {
+    event.preventDefault();
+    event.stopPropagation();
+    handlers.zoomIn();
+  } else if (event.key === "-" || event.key === "_") {
+    event.preventDefault();
+    event.stopPropagation();
+    handlers.zoomOut();
+  } else if (event.key === "0") {
+    event.preventDefault();
+    event.stopPropagation();
+    handlers.resetTransform();
+  } else if (event.key === "r" || event.key === "R") {
+    event.preventDefault();
+    event.stopPropagation();
+    handlers.rotateClockwise();
+  }
+}
+
+function registerViewer(registration: ViewerRegistration) {
+  activeViewers.push(registration);
+  if (activeViewers.length === 1 && typeof window !== "undefined") {
+    window.addEventListener("keydown", onGlobalKeyDown);
+  }
+}
+
+function unregisterViewer(registration: ViewerRegistration) {
+  const index = activeViewers.findIndex((v) => v.id === registration.id);
+  if (index !== -1) {
+    activeViewers.splice(index, 1);
+  }
+  if (activeViewers.length === 0 && typeof window !== "undefined") {
+    window.removeEventListener("keydown", onGlobalKeyDown);
+  }
+}
+
+export function useZoomableImage(src: string, options: UseZoomableImageOptions = {}) {
+  const { layout = "dialog" } = options;
   const [scale, setScale] = useState(DEFAULT_ZOOM_SCALE);
   const [position, setPosition] = useState<Point>({ x: 0, y: 0 });
   const [rotation, setRotation] = useState(0);
@@ -181,33 +261,21 @@ export function useZoomableImage(src: string) {
     [position, resetTransform, scale],
   );
 
-  // Keyboard shortcut listeners (+, -, 0, r)
+  const handlersRef = useRef({ zoomIn, zoomOut, resetTransform, rotateClockwise });
+  handlersRef.current = { zoomIn, zoomOut, resetTransform, rotateClockwise };
+
   useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.defaultPrevented || isEditableElement(event.target)) return;
-
-      if (event.key === "+" || event.key === "=") {
-        event.preventDefault();
-        event.stopPropagation();
-        zoomIn();
-      } else if (event.key === "-" || event.key === "_") {
-        event.preventDefault();
-        event.stopPropagation();
-        zoomOut();
-      } else if (event.key === "0") {
-        event.preventDefault();
-        event.stopPropagation();
-        resetTransform();
-      } else if (event.key === "r" || event.key === "R") {
-        event.preventDefault();
-        event.stopPropagation();
-        rotateClockwise();
-      }
+    const registration: ViewerRegistration = {
+      id: Symbol("ZoomableViewer"),
+      layout,
+      containerRef,
+      handlersRef,
     };
-
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [resetTransform, rotateClockwise, zoomIn, zoomOut]);
+    registerViewer(registration);
+    return () => {
+      unregisterViewer(registration);
+    };
+  }, [layout]);
 
   return {
     scale,

--- a/apps/web/src/components/chat/zoomableImage.logic.test.ts
+++ b/apps/web/src/components/chat/zoomableImage.logic.test.ts
@@ -8,6 +8,7 @@ import {
   getNextZoomInScale,
   getNextZoomOutScale,
   isEditableElement,
+  isOrthogonalRotation,
   MAX_ZOOM_SCALE,
   MIN_ZOOM_SCALE,
   selectActiveViewer,
@@ -86,6 +87,18 @@ describe("zoomableImage.logic", () => {
       expect(getNextRotation(90)).toBe(180);
       expect(getNextRotation(180)).toBe(270);
       expect(getNextRotation(270)).toBe(0);
+    });
+  });
+
+  describe("isOrthogonalRotation", () => {
+    it("identifies 90° and 270° as orthogonal rotations", () => {
+      expect(isOrthogonalRotation(0)).toBe(false);
+      expect(isOrthogonalRotation(90)).toBe(true);
+      expect(isOrthogonalRotation(180)).toBe(false);
+      expect(isOrthogonalRotation(270)).toBe(true);
+      expect(isOrthogonalRotation(360)).toBe(false);
+      expect(isOrthogonalRotation(-90)).toBe(true);
+      expect(isOrthogonalRotation(450)).toBe(true);
     });
   });
 

--- a/apps/web/src/components/chat/zoomableImage.logic.test.ts
+++ b/apps/web/src/components/chat/zoomableImage.logic.test.ts
@@ -7,8 +7,10 @@ import {
   getNextRotation,
   getNextZoomInScale,
   getNextZoomOutScale,
+  isEditableElement,
   MAX_ZOOM_SCALE,
   MIN_ZOOM_SCALE,
+  selectActiveViewer,
   ZOOM_STEP_FACTOR,
 } from "./zoomableImage.logic";
 
@@ -84,6 +86,93 @@ describe("zoomableImage.logic", () => {
       expect(getNextRotation(90)).toBe(180);
       expect(getNextRotation(180)).toBe(270);
       expect(getNextRotation(270)).toBe(0);
+    });
+  });
+
+  describe("isEditableElement", () => {
+    it("handles null/undefined gracefully", () => {
+      expect(isEditableElement(null)).toBe(false);
+    });
+
+    it("identifies elements with isContentEditable as editable", () => {
+      class MockHTMLElement {}
+      (globalThis as unknown as { HTMLElement: typeof MockHTMLElement }).HTMLElement =
+        MockHTMLElement;
+
+      const editableEl = Object.assign(new MockHTMLElement(), { isContentEditable: true });
+      expect(isEditableElement(editableEl as unknown as EventTarget)).toBe(true);
+
+      const nonEditableEl = Object.assign(new MockHTMLElement(), { isContentEditable: false });
+      expect(isEditableElement(nonEditableEl as unknown as EventTarget)).toBe(false);
+    });
+
+    it("identifies input, textarea, and select elements as editable", () => {
+      class MockHTMLInputElement {}
+      class MockHTMLTextAreaElement {}
+      class MockHTMLSelectElement {}
+
+      (
+        globalThis as unknown as { HTMLInputElement: typeof MockHTMLInputElement }
+      ).HTMLInputElement = MockHTMLInputElement;
+      (
+        globalThis as unknown as { HTMLTextAreaElement: typeof MockHTMLTextAreaElement }
+      ).HTMLTextAreaElement = MockHTMLTextAreaElement;
+      (
+        globalThis as unknown as { HTMLSelectElement: typeof MockHTMLSelectElement }
+      ).HTMLSelectElement = MockHTMLSelectElement;
+
+      expect(isEditableElement(new MockHTMLInputElement() as unknown as EventTarget)).toBe(true);
+      expect(isEditableElement(new MockHTMLTextAreaElement() as unknown as EventTarget)).toBe(true);
+      expect(isEditableElement(new MockHTMLSelectElement() as unknown as EventTarget)).toBe(true);
+    });
+  });
+
+  describe("selectActiveViewer", () => {
+    it("returns undefined when no viewers are registered", () => {
+      expect(selectActiveViewer([])).toBeUndefined();
+    });
+
+    it("returns the single mounted viewer", () => {
+      const viewer = { layout: "panel" as const };
+      expect(selectActiveViewer([viewer])).toBe(viewer);
+    });
+
+    it("prioritizes dialog viewers over panel viewers", () => {
+      const panel = { id: 1, layout: "panel" as const };
+      const dialog = { id: 2, layout: "dialog" as const };
+
+      // Even if panel is registered before or after, dialog wins
+      expect(selectActiveViewer([panel, dialog])).toBe(dialog);
+      expect(selectActiveViewer([dialog, panel])).toBe(dialog);
+    });
+
+    it("returns the topmost (most recent) dialog if multiple exist", () => {
+      const dialog1 = { id: 1, layout: "dialog" as const };
+      const dialog2 = { id: 2, layout: "dialog" as const };
+
+      expect(selectActiveViewer([dialog1, dialog2])).toBe(dialog2);
+    });
+
+    it("prioritizes a focused panel viewer when only panels exist", () => {
+      const focusedTarget = { id: "button" } as unknown as Node;
+      const container1 = {
+        contains: (target: Node | null) => target === focusedTarget,
+      };
+      const container2 = {
+        contains: () => false,
+      };
+
+      const panel1 = { id: 1, layout: "panel" as const, container: container1 };
+      const panel2 = { id: 2, layout: "panel" as const, container: container2 };
+
+      expect(selectActiveViewer([panel1, panel2], focusedTarget)).toBe(panel1);
+    });
+
+    it("falls back to the most recently registered viewer", () => {
+      const panel1 = { id: 1, layout: "panel" as const };
+      const panel2 = { id: 2, layout: "panel" as const };
+
+      expect(selectActiveViewer([panel1, panel2], null)).toBe(panel2);
     });
   });
 

--- a/apps/web/src/components/chat/zoomableImage.logic.test.ts
+++ b/apps/web/src/components/chat/zoomableImage.logic.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  calculateZoomAnchorPosition,
+  clampZoomScale,
+  DEFAULT_ZOOM_SCALE,
+  DOUBLE_CLICK_ZOOM_SCALE,
+  getNextRotation,
+  getNextZoomInScale,
+  getNextZoomOutScale,
+  MAX_ZOOM_SCALE,
+  MIN_ZOOM_SCALE,
+  ZOOM_STEP_FACTOR,
+} from "./zoomableImage.logic";
+
+describe("zoomableImage.logic", () => {
+  describe("clampZoomScale", () => {
+    it("preserves zoom levels within bounds", () => {
+      expect(clampZoomScale(1.0)).toBe(1.0);
+      expect(clampZoomScale(2.5)).toBe(2.5);
+      expect(clampZoomScale(0.5)).toBe(0.5);
+    });
+
+    it("clamps values below MIN_ZOOM_SCALE", () => {
+      expect(clampZoomScale(0.1)).toBe(MIN_ZOOM_SCALE);
+      expect(clampZoomScale(-1)).toBe(MIN_ZOOM_SCALE);
+    });
+
+    it("clamps values above MAX_ZOOM_SCALE", () => {
+      expect(clampZoomScale(6.0)).toBe(MAX_ZOOM_SCALE);
+      expect(clampZoomScale(100)).toBe(MAX_ZOOM_SCALE);
+    });
+  });
+
+  describe("calculateZoomAnchorPosition", () => {
+    it("keeps focal point fixed when zooming centered at (0, 0)", () => {
+      const currentScale = 1.0;
+      const newScale = 2.0;
+      const currentPos = { x: 0, y: 0 };
+      const focalPoint = { x: 0, y: 0 };
+
+      const nextPos = calculateZoomAnchorPosition(currentScale, newScale, currentPos, focalPoint);
+
+      expect(nextPos).toEqual({ x: 0, y: 0 });
+    });
+
+    it("shifts offset correctly when zooming into an off-center focal point", () => {
+      const currentScale = 1.0;
+      const newScale = 2.0;
+      const currentPos = { x: 0, y: 0 };
+      const focalPoint = { x: 100, y: 50 };
+
+      const nextPos = calculateZoomAnchorPosition(currentScale, newScale, currentPos, focalPoint);
+
+      // focalPoint.x - (focalPoint.x - currentPos.x) * (newScale / currentScale)
+      // 100 - (100 - 0) * (2 / 1) = 100 - 200 = -100
+      expect(nextPos.x).toBe(-100);
+      // 50 - (50 - 0) * 2 = -50
+      expect(nextPos.y).toBe(-50);
+    });
+
+    it("returns (0, 0) when current scale is non-positive", () => {
+      expect(calculateZoomAnchorPosition(0, 2.0, { x: 10, y: 10 }, { x: 20, y: 20 })).toEqual({
+        x: 0,
+        y: 0,
+      });
+    });
+  });
+
+  describe("getNextZoomInScale & getNextZoomOutScale", () => {
+    it("scales up by ZOOM_STEP_FACTOR up to MAX_ZOOM_SCALE", () => {
+      expect(getNextZoomInScale(1.0)).toBe(1.25);
+      expect(getNextZoomInScale(4.5)).toBe(MAX_ZOOM_SCALE);
+    });
+
+    it("scales down by ZOOM_STEP_FACTOR down to MIN_ZOOM_SCALE", () => {
+      expect(getNextZoomOutScale(1.25)).toBe(1.0);
+      expect(getNextZoomOutScale(0.22)).toBe(MIN_ZOOM_SCALE);
+    });
+  });
+
+  describe("getNextRotation", () => {
+    it("cycles in 90 degree increments modulo 360", () => {
+      expect(getNextRotation(0)).toBe(90);
+      expect(getNextRotation(90)).toBe(180);
+      expect(getNextRotation(180)).toBe(270);
+      expect(getNextRotation(270)).toBe(0);
+    });
+  });
+
+  describe("constants", () => {
+    it("has expected constants configuration", () => {
+      expect(DEFAULT_ZOOM_SCALE).toBe(1.0);
+      expect(MIN_ZOOM_SCALE).toBeLessThan(DEFAULT_ZOOM_SCALE);
+      expect(MAX_ZOOM_SCALE).toBeGreaterThan(DEFAULT_ZOOM_SCALE);
+      expect(ZOOM_STEP_FACTOR).toBeGreaterThan(1.0);
+      expect(DOUBLE_CLICK_ZOOM_SCALE).toBe(2.5);
+    });
+  });
+});

--- a/apps/web/src/components/chat/zoomableImage.logic.ts
+++ b/apps/web/src/components/chat/zoomableImage.logic.ts
@@ -1,0 +1,66 @@
+export const MIN_ZOOM_SCALE = 0.2;
+export const MAX_ZOOM_SCALE = 5.0;
+export const DEFAULT_ZOOM_SCALE = 1.0;
+export const ZOOM_STEP_FACTOR = 1.25;
+export const DOUBLE_CLICK_ZOOM_SCALE = 2.5;
+
+export interface Point {
+  readonly x: number;
+  readonly y: number;
+}
+
+/**
+ * Clamps scale between allowed minimum and maximum boundaries.
+ */
+export function clampZoomScale(scale: number): number {
+  return Math.min(Math.max(scale, MIN_ZOOM_SCALE), MAX_ZOOM_SCALE);
+}
+
+/**
+ * Calculates new position to keep the cursor focal point anchored during zoom.
+ */
+export function calculateZoomAnchorPosition(
+  currentScale: number,
+  newScale: number,
+  currentPosition: Point,
+  focalPoint: Point,
+): Point {
+  if (currentScale <= 0) return { x: 0, y: 0 };
+  const ratio = newScale / currentScale;
+  return {
+    x: focalPoint.x - (focalPoint.x - currentPosition.x) * ratio,
+    y: focalPoint.y - (focalPoint.y - currentPosition.y) * ratio,
+  };
+}
+
+/**
+ * Computes next scale when zooming in.
+ */
+export function getNextZoomInScale(currentScale: number): number {
+  return clampZoomScale(currentScale * ZOOM_STEP_FACTOR);
+}
+
+/**
+ * Computes next scale when zooming out.
+ */
+export function getNextZoomOutScale(currentScale: number): number {
+  return clampZoomScale(currentScale / ZOOM_STEP_FACTOR);
+}
+
+/**
+ * Calculates rotated angle in 90-degree steps within [0, 360).
+ */
+export function getNextRotation(currentRotation: number): number {
+  return (currentRotation + 90) % 360;
+}
+
+/**
+ * Checks if keyboard event targets an editable element.
+ */
+export function isEditableElement(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    (target instanceof HTMLElement && target.isContentEditable)
+  );
+}

--- a/apps/web/src/components/chat/zoomableImage.logic.ts
+++ b/apps/web/src/components/chat/zoomableImage.logic.ts
@@ -58,9 +58,51 @@ export function getNextRotation(currentRotation: number): number {
  * Checks if keyboard event targets an editable element.
  */
 export function isEditableElement(target: EventTarget | null): boolean {
+  if (!target) return false;
   return (
-    target instanceof HTMLInputElement ||
-    target instanceof HTMLTextAreaElement ||
-    (target instanceof HTMLElement && target.isContentEditable)
+    (typeof HTMLInputElement !== "undefined" && target instanceof HTMLInputElement) ||
+    (typeof HTMLTextAreaElement !== "undefined" && target instanceof HTMLTextAreaElement) ||
+    (typeof HTMLSelectElement !== "undefined" && target instanceof HTMLSelectElement) ||
+    (typeof HTMLElement !== "undefined" &&
+      target instanceof HTMLElement &&
+      Boolean(target.isContentEditable))
   );
+}
+
+export interface ZoomableViewerTarget {
+  readonly layout: "dialog" | "panel";
+  readonly container?: { contains?: (other: Node | null) => boolean } | null;
+}
+
+/**
+ * Selects the active viewer that should receive keyboard shortcuts.
+ * Dialog viewers take precedence over panel viewers. When only panel
+ * viewers exist, the focused viewer or most recently registered viewer is chosen.
+ */
+export function selectActiveViewer<T extends ZoomableViewerTarget>(
+  viewers: readonly T[],
+  activeElement: Node | null = typeof document !== "undefined" ? document.activeElement : null,
+): T | undefined {
+  if (viewers.length === 0) return undefined;
+
+  // 1. If any dialog viewer is mounted, the topmost (last mounted) dialog receives shortcuts
+  for (let i = viewers.length - 1; i >= 0; i--) {
+    const viewer = viewers[i];
+    if (viewer && viewer.layout === "dialog") {
+      return viewer;
+    }
+  }
+
+  // 2. If focus is inside a panel viewer container, prioritize that panel viewer
+  if (activeElement) {
+    for (let i = viewers.length - 1; i >= 0; i--) {
+      const viewer = viewers[i];
+      if (viewer?.container?.contains?.(activeElement)) {
+        return viewer;
+      }
+    }
+  }
+
+  // 3. Fallback to the most recently registered viewer
+  return viewers[viewers.length - 1];
 }

--- a/apps/web/src/components/chat/zoomableImage.logic.ts
+++ b/apps/web/src/components/chat/zoomableImage.logic.ts
@@ -55,6 +55,14 @@ export function getNextRotation(currentRotation: number): number {
 }
 
 /**
+ * Returns true if the rotation is 90° or 270° (orthogonal/perpendicular to natural orientation).
+ */
+export function isOrthogonalRotation(rotation: number): boolean {
+  const normalized = ((rotation % 360) + 360) % 360;
+  return normalized === 90 || normalized === 270;
+}
+
+/**
  * Checks if keyboard event targets an editable element.
  */
 export function isEditableElement(target: EventTarget | null): boolean {

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -28,6 +28,7 @@ import { useAssetUrlRefresh, useAssetUrlState } from "~/assets/assetUrls";
 import { OpenInPicker } from "~/components/chat/OpenInPicker";
 import { PierreEntryIcon } from "~/components/chat/PierreEntryIcon";
 import { MediaVideoPlayer } from "~/components/media/MediaVideoPlayer";
+import { ZoomableImageViewer } from "~/components/chat/ZoomableImageViewer";
 import { MediaActions, type MediaActionSource } from "~/components/media/MediaActions";
 import { useRemoteOpenState } from "~/remoteOpen";
 import { useClientSettings } from "~/hooks/useSettings";
@@ -187,12 +188,12 @@ function WorkspaceImagePreview(props: {
   }
 
   return assetUrl._tag === "Success" && imageUrl !== null ? (
-    <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-4">
+    <div className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden p-4">
       <MediaActions source={actionsSource}>
-        <img
-          className="max-h-full max-w-full object-contain"
+        <ZoomableImageViewer
           src={imageUrl}
           alt={props.alt}
+          layout="panel"
           onError={() => setFailedUrl(imageUrl)}
         />
       </MediaActions>


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed
<!-- Describe the change clearly and keep scope tight. -->
- enhance markdown image preview with zoom, pan, rotation, and toolbar controls
- support interactive zoom, pan, and rotate in right-side workspace image preview

## Why
<!-- Explain the problem being solved and why this approach is the right one. -->
Previously, image previews in chat and workspace file viewer only rendered static images without interactive zoom, pan, or rotation controls. This made inspecting large diagrams, UI screenshots, and high-resolution images inconvenient compared to editor experiences like VS Code. 

This change introduces intuitive cursor-anchored wheel zooming, panning, double-click toggling, rotation, and keyboard shortcuts via a modular, non-breaking viewer component.


## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->
<img width="1605" height="942" alt="image" src="https://github.com/user-attachments/assets/dd5fbafc-a13b-417a-9fe0-febb8718621c" />
<img width="550" height="948" alt="image" src="https://github.com/user-attachments/assets/26923585-8868-4c55-95aa-a1e9622bba1f" />


## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add zoomable, pannable image viewer to `ExpandedImageDialog` and `FilePreviewPanel`
> - Adds `ZoomableImageViewer` component and `useZoomableImage` hook supporting bounded zoom (0.2–5.0x), cursor-anchored wheel zoom, pointer dragging, double-click zoom/reset, and 90-degree rotation
> - Extracts transform math, editable-target detection, and active-viewer selection into [zoomableImage.logic.ts](apps/web/src/components/chat/zoomableImage.logic.ts); keyboard shortcuts (`+`, `-`, `0`, `R`) are routed via a module-level viewer registry that prioritizes dialogs over panels
> - Replaces the static `<img>` in [ExpandedImageDialog.tsx](apps/web/src/components/chat/ExpandedImageDialog.tsx) and [FilePreviewPanel.tsx](apps/web/src/components/files/FilePreviewPanel.tsx) with the new viewer; `FilePreviewPanel` container switches from scroll overflow to hidden overflow
> - Adds unit and component tests for scale clamping, focal-point math, rotation cycling, viewer selection precedence, keyboard scoping, and ref forwarding
> - Risk: `ZoomableImageViewer` declares an `onOpenOriginal` prop that is not rendered or used — callers wiring it will see no effect
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80ed5e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->