### PR TITLE
fix(server): avoid color probe hangs in setup terminals

### DIFF
--- a/apps/server/src/project/ProjectSetupScriptRunner.test.ts
+++ b/apps/server/src/project/ProjectSetupScriptRunner.test.ts
@@ -108,7 +108,11 @@ describe("ProjectSetupScriptRunner", () => {
         terminalId: "setup-default-setup",
         cwd: "/repo/worktrees/a",
         worktreePath: "/repo/worktrees/a",
-        env: { T3CODE_PROJECT_ROOT: "/repo/project", T3CODE_WORKTREE_PATH: "/repo/worktrees/a" },
+        env: {
+          T3CODE_PROJECT_ROOT: "/repo/project",
+          T3CODE_WORKTREE_PATH: "/repo/worktrees/a",
+          COLORTERM: "",
+        },
       });
       expect(write).toHaveBeenCalledWith({
         threadId: "thread-1",
@@ -207,6 +211,7 @@ describe("ProjectSetupScriptRunner", () => {
           env: {
             T3CODE_PROJECT_ROOT: "/repo/project",
             T3CODE_WORKTREE_PATH: "/repo/worktrees/a",
+            COLORTERM: "",
           },
         });
         expect(write).toHaveBeenCalledWith({

--- a/apps/server/src/project/ProjectSetupScriptRunner.ts
+++ b/apps/server/src/project/ProjectSetupScriptRunner.ts
@@ -149,10 +149,16 @@ export const make = Effect.gen(function* () {
 
     const terminalId = input.preferredTerminalId ?? `setup-${script.id}`;
     const cwd = input.worktreePath;
-    const env = projectScriptRuntimeEnv({
-      project: { cwd: project.workspaceRoot },
-      worktreePath: input.worktreePath,
-    });
+    const env = {
+      ...projectScriptRuntimeEnv({
+        project: { cwd: project.workspaceRoot },
+        worktreePath: input.worktreePath,
+      }),
+      // Setup runs before a client necessarily attaches. Truecolor probing in
+      // tools such as vp can wait for terminal replies that nobody can send.
+      // Keep TERM's 256-color support without advertising truecolor here.
+      COLORTERM: "",
+    };
 
     yield* terminalManager
       .open({

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1711,7 +1711,8 @@ it.layer(
           [undefined, undefined, "truecolor"],
           ["", undefined, "truecolor"],
           ["24bit", undefined, "24bit"],
-          ["24bit", "", "truecolor"],
+          ["24bit", "", ""],
+          [undefined, "", ""],
           ["24bit", "custom", "custom"],
         ] as const) {
           const env = Object.freeze({ COLORTERM: parentColor });

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1286,8 +1286,9 @@ function createTerminalSpawnEnv(
         key === "CODEX_HOME" || key === "CLAUDE_CONFIG_DIR" ? expandHomePath(value) : value;
     }
   }
-  // Both PTY backends feed truecolor-capable terminal clients.
-  if (spawnEnv.COLORTERM === undefined || spawnEnv.COLORTERM === "") {
+  // An explicit empty override opts out for terminals started without a client.
+  // Otherwise both PTY backends feed truecolor-capable terminal clients.
+  if (!spawnEnv.COLORTERM && runtimeEnv?.COLORTERM === undefined) {
     spawnEnv.COLORTERM = "truecolor";
   }
   return stripAppImageRuntimeEnv(spawnEnv);


### PR DESCRIPTION
Automatic worktree setup can appear stuck with its command visible in the terminal. The command has already started: Vite+ 0.3.0 waits for OSC color-query replies before printing its header, and pressing Enter releases the wait. The default `COLORTERM=truecolor` added in [#7680](https://github.com/pingdotgg/t3code/pull/7680) exposes this on main as well as v2.

Clear `COLORTERM` for automatic setup terminals and honor an explicitly empty terminal environment override. Setup retains `TERM=xterm-256color` and ANSI colors without inviting truecolor probing before a client attaches. Ordinary terminals retain their truecolor default. This is a targeted workaround for automatic setup; it does not change Vite+'s query timeout or terminal replay behavior.

Verification:
- 83 focused tests passed across `ProjectSetupScriptRunner.test.ts` and `terminal/Manager.test.ts`, including explicit empty overrides on Linux, macOS, and Windows host configurations.
- Server typecheck passed. Targeted lint passed with one existing `prefer-array-find` warning outside the change.
- Real macOS PTY, Vite+ 0.3.0, identical disposable package and `vp i --offline --ignore-scripts` command:

| Before, main environment | After, setup environment |
| --- | --- |
| `COLORTERM=truecolor`: emits OSC 10, OSC 4 for colors 4/5, and DA1; no installer output until Enter is sent. | Empty `COLORTERM`: no color queries or input required; install exits 0. |

After output:
```text
VITE+ - The Unified Toolchain for the Web
Already up to date
Done in 181ms using pnpm v11.10.0
```

No UI layout changed; the PTY output above is the before/after evidence. The fix is server-side and applies to automatic setup launched from web, desktop, or mobile, including remote clients.

Model: GPT-6. Harness: Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix setup terminal color probe hangs by emptying `COLORTERM`
> - Setup terminals may run before a client attaches, so `ProjectSetupScriptRunner.runForThread` now sets `COLORTERM` to an empty string to avoid advertising truecolor during that phase.
> - `createTerminalSpawnEnv` in [Manager.ts](https://github.com/pingdotgg/t3code/pull/10331/files#diff-9b98fe5056129db24d311ed1bd8f66a72127cf90fa7529da47e0725f2813532e) now preserves an explicitly empty runtime `COLORTERM` value instead of replacing it with the truecolor fallback. The fallback still applies only when the runtime environment does not define `COLORTERM` at all.
> - Behavioral Change: terminals launched with an explicit empty `COLORTERM` override will no longer get the `truecolor` default; consumers that relied on the fallback overriding an empty value will see `COLORTERM` unset/empty instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1da335.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->