### PR TITLE
fix(server): capture finished work before starting a new turn

### DIFF
--- a/apps/server/integration/orchestrationEngine.integration.test.ts
+++ b/apps/server/integration/orchestrationEngine.integration.test.ts
@@ -378,6 +378,7 @@ it.live.each(["completed", "aborted"] as const)(
       const captureStarted = yield* Deferred.make<void>();
       const finishCapture = yield* Deferred.make<void>();
       const interrupted = yield* Deferred.make<void>();
+      const firstEditFinished = yield* Deferred.make<void>();
       const secondTurnStarted = yield* Deferred.make<void>();
       const firstRef = checkpointRefForThreadTurn(THREAD_ID, 1);
       let firstFilesWereCaptured = false;
@@ -414,6 +415,7 @@ it.live.each(["completed", "aborted"] as const)(
                         NodeFS.writeFileSync(NodePath.join(cwd, "README.md"), "v2\n"),
                       ),
                     ),
+                    Effect.andThen(Deferred.succeed(firstEditFinished, undefined)),
                   ),
             });
             yield* startTurn({
@@ -423,6 +425,7 @@ it.live.each(["completed", "aborted"] as const)(
               text: "Make the first edit",
             });
             yield* Fiber.join(firstTurnRunning);
+            yield* Deferred.await(firstEditFinished);
             if (completion === "aborted") {
               yield* harness.engine.dispatch({
                 type: "thread.turn.interrupt",

--- a/apps/server/integration/providerService.integration.test.ts
+++ b/apps/server/integration/providerService.integration.test.ts
@@ -54,7 +54,11 @@ const makeWorkspaceDirectory = Effect.gen(function* () {
 interface IntegrationFixture {
   readonly cwd: string;
   readonly harness: TestProviderAdapterHarness;
-  readonly layer: Layer.Layer<ProviderService, unknown, never>;
+  readonly layer: Layer.Layer<
+    ProviderService | TurnCheckpointCapture.TurnCheckpointCapture,
+    unknown,
+    never
+  >;
 }
 
 interface RecordedAnalyticsEvent {
@@ -102,7 +106,7 @@ const makeIntegrationFixture = (options?: { readonly analytics?: Layer.Layer<Ana
     ).pipe(Layer.provide(SqlitePersistenceMemory));
 
     const layer = makeProviderServiceLive().pipe(
-      Layer.provide(TurnCheckpointCapture.layer),
+      Layer.provideMerge(TurnCheckpointCapture.layer),
       Layer.provide(NodeServices.layer),
       Layer.provide(shared),
     );
@@ -120,12 +124,18 @@ const collectEventsDuring = <A, E, R>(
   action: Effect.Effect<A, E, R>,
 ) =>
   Effect.gen(function* () {
+    const captures = yield* TurnCheckpointCapture.TurnCheckpointCapture;
     const queue = yield* Queue.unbounded<ProviderRuntimeEvent>();
-    yield* Stream.runForEach(stream, (event) => Queue.offer(queue, event).pipe(Effect.asVoid)).pipe(
-      Effect.forkScoped,
-    );
+    yield* Stream.runForEach(stream, (event) =>
+      Effect.gen(function* () {
+        // This fixture has no checkpoint reactor. Its terminal events finish without a capture.
+        if (event.type === "turn.completed" || event.type === "turn.aborted") {
+          yield* captures.complete(event, "skipped");
+        }
+        yield* Queue.offer(queue, event);
+      }),
+    ).pipe(Effect.forkScoped({ startImmediately: true }));
 
-    yield* Effect.sleep("50 millis");
     yield* action;
 
     return yield* Effect.forEach(

--- a/apps/server/src/checkpointing/TurnCheckpointCapture.test.ts
+++ b/apps/server/src/checkpointing/TurnCheckpointCapture.test.ts
@@ -173,7 +173,7 @@ it.effect.each(["captured", "skipped", "failed"] as const)(
       assert.equal(waiting.pollUnsafe(), undefined);
       yield* submission.nativeCompleted(nativeTerminal.turnId);
       yield* captures.observe(nativeTerminal);
-      assert.equal(yield* captures.shouldCapture(nativeTerminal), true);
+      assert.equal(yield* captures.nativeCaptureReady(nativeTerminal), true);
       assert.equal(waiting.pollUnsafe(), undefined);
       yield* captures.complete(nativeTerminal, outcome);
       yield* Fiber.join(waiting);
@@ -187,7 +187,7 @@ it.effect("does not reuse a synthetic failure capture after native completion", 
     const submission = yield* captures.trackSubmission(threadId, instanceId);
     yield* submission.beforeSubmit(nativeTerminal.turnId);
     yield* captures.observe(nativeTerminal);
-    assert.equal(yield* captures.shouldCapture(nativeTerminal), false);
+    assert.equal(yield* captures.nativeCaptureReady(nativeTerminal), false);
     yield* captures.complete(nativeTerminal, "skipped");
     yield* submission.nativeCompleted(nativeTerminal.turnId);
     const waiting = yield* captures.awaitNativeCapture(threadId).pipe(Effect.forkChild);
@@ -195,7 +195,7 @@ it.effect("does not reuse a synthetic failure capture after native completion", 
     assert.equal(waiting.pollUnsafe(), undefined);
     const confirmed = { ...nativeTerminal, eventId: EventId.make("confirmed") };
     yield* captures.observe(confirmed);
-    assert.equal(yield* captures.shouldCapture(confirmed), true);
+    assert.equal(yield* captures.nativeCaptureReady(confirmed), true);
     yield* captures.complete(confirmed, "captured");
     yield* Fiber.join(waiting);
   }),
@@ -228,12 +228,12 @@ it.effect("keeps each same-turn steering request until its native reply and fina
     yield* steer.beforeSubmit(nativeTerminal.turnId);
     yield* first.nativeCompleted(nativeTerminal.turnId);
     yield* captures.observe(nativeTerminal);
-    assert.equal(yield* captures.shouldCapture(nativeTerminal), false);
+    assert.equal(yield* captures.nativeCaptureReady(nativeTerminal), false);
     yield* captures.complete(nativeTerminal, "skipped");
     yield* steer.nativeCompleted(nativeTerminal.turnId);
     const confirmed = { ...nativeTerminal, eventId: EventId.make("steering-final") };
     yield* captures.observe(confirmed);
-    assert.equal(yield* captures.shouldCapture(confirmed), true);
+    assert.equal(yield* captures.nativeCaptureReady(confirmed), true);
     yield* captures.complete(confirmed, "captured");
     yield* captures.awaitNativeCapture(threadId);
   }),

--- a/apps/server/src/checkpointing/TurnCheckpointCapture.test.ts
+++ b/apps/server/src/checkpointing/TurnCheckpointCapture.test.ts
@@ -1,9 +1,15 @@
-import { EventId, ProviderDriverKind, ThreadId, TurnId } from "@t3tools/contracts";
+import {
+  EventId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 
-import { layer, TurnCheckpointCapture } from "./TurnCheckpointCapture.ts";
+import { layer, make, TurnCheckpointCapture } from "./TurnCheckpointCapture.ts";
 
 const threadId = ThreadId.make("thread-1");
 const started = {
@@ -150,3 +156,174 @@ it.layer(layer)("TurnCheckpointCapture", (it) => {
     }),
   );
 });
+
+const instanceId = ProviderInstanceId.make("codex");
+const nativeTerminal = { ...completed, providerInstanceId: instanceId };
+
+it.effect.each(["captured", "skipped", "failed"] as const)(
+  "waits for native completion and its exact %s capture outcome",
+  (outcome) =>
+    Effect.gen(function* () {
+      const captures = make();
+      const submission = yield* captures.trackSubmission(threadId, instanceId);
+      yield* submission.beforeSubmit(nativeTerminal.turnId);
+      const next = yield* captures.trackSubmission(threadId, instanceId);
+      const waiting = yield* next.beforeSubmit(TurnId.make("next")).pipe(Effect.forkChild);
+      yield* Effect.yieldNow;
+      assert.equal(waiting.pollUnsafe(), undefined);
+      yield* submission.nativeCompleted(nativeTerminal.turnId);
+      yield* captures.observe(nativeTerminal);
+      assert.equal(yield* captures.shouldCapture(nativeTerminal), true);
+      assert.equal(waiting.pollUnsafe(), undefined);
+      yield* captures.complete(nativeTerminal, outcome);
+      yield* Fiber.join(waiting);
+      yield* next.notSubmitted;
+    }),
+);
+
+it.effect("does not reuse a synthetic failure capture after native completion", () =>
+  Effect.gen(function* () {
+    const captures = make();
+    const submission = yield* captures.trackSubmission(threadId, instanceId);
+    yield* submission.beforeSubmit(nativeTerminal.turnId);
+    yield* captures.observe(nativeTerminal);
+    assert.equal(yield* captures.shouldCapture(nativeTerminal), false);
+    yield* captures.complete(nativeTerminal, "skipped");
+    yield* submission.nativeCompleted(nativeTerminal.turnId);
+    const waiting = yield* captures.awaitNativeCapture(threadId).pipe(Effect.forkChild);
+    yield* Effect.yieldNow;
+    assert.equal(waiting.pollUnsafe(), undefined);
+    const confirmed = { ...nativeTerminal, eventId: EventId.make("confirmed") };
+    yield* captures.observe(confirmed);
+    assert.equal(yield* captures.shouldCapture(confirmed), true);
+    yield* captures.complete(confirmed, "captured");
+    yield* Fiber.join(waiting);
+  }),
+);
+
+it.effect("does not release a fresh native capture through an older grouped event", () =>
+  Effect.gen(function* () {
+    const captures = make();
+    const submission = yield* captures.trackSubmission(threadId, instanceId);
+    yield* submission.beforeSubmit(nativeTerminal.turnId);
+    yield* captures.observe(nativeTerminal);
+    yield* submission.nativeCompleted(nativeTerminal.turnId);
+    const confirmed = { ...nativeTerminal, eventId: EventId.make("confirmed-after-synthetic") };
+    yield* captures.observe(confirmed);
+    const waiting = yield* captures.awaitNativeCapture(threadId).pipe(Effect.forkChild);
+    yield* captures.complete(nativeTerminal, "skipped");
+    yield* Effect.yieldNow;
+    assert.equal(waiting.pollUnsafe(), undefined);
+    yield* captures.complete(confirmed, "captured");
+    yield* Fiber.join(waiting);
+  }),
+);
+
+it.effect("keeps each same-turn steering request until its native reply and final capture", () =>
+  Effect.gen(function* () {
+    const captures = make();
+    const first = yield* captures.trackSubmission(threadId, instanceId);
+    const steer = yield* captures.trackSubmission(threadId, instanceId);
+    yield* first.beforeSubmit(nativeTerminal.turnId);
+    yield* steer.beforeSubmit(nativeTerminal.turnId);
+    yield* first.nativeCompleted(nativeTerminal.turnId);
+    yield* captures.observe(nativeTerminal);
+    assert.equal(yield* captures.shouldCapture(nativeTerminal), false);
+    yield* captures.complete(nativeTerminal, "skipped");
+    yield* steer.nativeCompleted(nativeTerminal.turnId);
+    const confirmed = { ...nativeTerminal, eventId: EventId.make("steering-final") };
+    yield* captures.observe(confirmed);
+    assert.equal(yield* captures.shouldCapture(confirmed), true);
+    yield* captures.complete(confirmed, "captured");
+    yield* captures.awaitNativeCapture(threadId);
+  }),
+);
+
+it.effect("binds early Codex receipts only from the exact send response", () =>
+  Effect.gen(function* () {
+    const captures = make();
+    const submission = yield* captures.trackSubmission(threadId, instanceId);
+    yield* submission.beforeSubmit();
+    yield* submission.nativeCompleted(nativeTerminal.turnId);
+    yield* captures.observe(nativeTerminal);
+    yield* captures.complete(nativeTerminal, "captured");
+    const waiting = yield* captures.awaitNativeCapture(threadId).pipe(Effect.forkChild);
+    yield* Effect.yieldNow;
+    assert.equal(waiting.pollUnsafe(), undefined);
+    yield* captures.observe({
+      ...started,
+      providerInstanceId: instanceId,
+      turnId: TurnId.make("unrelated"),
+    });
+    assert.equal((yield* submission.outcome)._tag, "UnknownSubmission");
+    yield* submission.accept(nativeTerminal.turnId);
+    yield* Fiber.join(waiting);
+  }),
+);
+
+it.effect("does not release ownership on generic exit or another provider instance", () =>
+  Effect.gen(function* () {
+    const captures = make();
+    const submission = yield* captures.trackSubmission(threadId, instanceId);
+    yield* submission.beforeSubmit(nativeTerminal.turnId);
+    yield* submission.nativeCompleted(nativeTerminal.turnId);
+    const foreign = { ...nativeTerminal, providerInstanceId: ProviderInstanceId.make("other") };
+    yield* captures.observe(foreign);
+    yield* captures.complete(foreign, "captured");
+    yield* captures.observe({
+      ...started,
+      providerInstanceId: instanceId,
+      type: "session.exited",
+      payload: {},
+    });
+    const waiting = yield* captures.awaitNativeCapture(threadId).pipe(Effect.forkChild);
+    yield* Effect.yieldNow;
+    assert.equal(waiting.pollUnsafe(), undefined);
+    yield* captures.observe(nativeTerminal);
+    yield* captures.complete(nativeTerminal, "captured");
+    yield* Fiber.join(waiting);
+  }),
+);
+
+it.effect("releases only a rejected call and permits that call to retry", () =>
+  Effect.gen(function* () {
+    const captures = make();
+    const first = yield* captures.trackSubmission(threadId, instanceId);
+    const retry = yield* captures.trackSubmission(threadId, instanceId);
+    yield* first.beforeSubmit(nativeTerminal.turnId);
+    yield* retry.beforeSubmit(nativeTerminal.turnId);
+    yield* retry.notSubmitted;
+    assert.equal((yield* retry.outcome)._tag, "NotSubmitted");
+    const waiting = yield* retry.beforeSubmit(TurnId.make("retry")).pipe(Effect.forkChild);
+    yield* Effect.yieldNow;
+    assert.equal(waiting.pollUnsafe(), undefined);
+    yield* first.nativeCompleted(nativeTerminal.turnId);
+    yield* captures.observe(nativeTerminal);
+    yield* captures.complete(nativeTerminal, "captured");
+    yield* Fiber.join(waiting);
+    assert.equal((yield* retry.outcome)._tag, "UnknownSubmission");
+    yield* retry.notSubmitted;
+  }),
+);
+
+it.effect("requires a fresh capture after known-turn native teardown", () =>
+  Effect.gen(function* () {
+    const captures = make();
+    const submission = yield* captures.trackSubmission(threadId, instanceId);
+    yield* submission.beforeSubmit(nativeTerminal.turnId);
+    yield* captures.observe(nativeTerminal);
+    yield* captures.complete(nativeTerminal, "skipped");
+    yield* submission.nativeStopped;
+    const waiting = yield* captures.awaitNativeCapture(threadId).pipe(Effect.forkChild);
+    yield* Effect.yieldNow;
+    assert.equal(waiting.pollUnsafe(), undefined);
+    const stopped = { ...nativeTerminal, eventId: EventId.make("confirmed-stop") };
+    yield* captures.observe(stopped);
+    yield* captures.complete(stopped, "captured");
+    yield* Fiber.join(waiting);
+    const unknown = yield* captures.trackSubmission(threadId, instanceId);
+    yield* unknown.beforeSubmit();
+    yield* unknown.nativeStopped;
+    yield* captures.awaitNativeCapture(threadId);
+  }),
+);

--- a/apps/server/src/checkpointing/TurnCheckpointCapture.ts
+++ b/apps/server/src/checkpointing/TurnCheckpointCapture.ts
@@ -79,7 +79,7 @@ export class TurnCheckpointCapture extends Context.Service<
       instanceId: ProviderInstanceId,
     ) => Effect.Effect<TurnSubmission>;
     readonly awaitNativeCapture: (threadId: ThreadId) => Effect.Effect<void>;
-    readonly shouldCapture: (event: TerminalEvent) => Effect.Effect<boolean>;
+    readonly nativeCaptureReady: (event: TerminalEvent) => Effect.Effect<boolean | undefined>;
   }
 >()("t3/checkpointing/TurnCheckpointCapture") {}
 
@@ -264,7 +264,13 @@ export function make(): TurnCheckpointCapture["Service"] {
       ),
     awaitCapture,
     awaitNativeCapture,
-    shouldCapture: (event) => Effect.sync(() => nativeCaptures.get(event.eventId)?.allowed ?? true),
+    nativeCaptureReady: (event) =>
+      Effect.sync(() => {
+        const capture = nativeCaptures.get(event.eventId);
+        return capture !== undefined && capture.submissions.length > 0
+          ? capture.allowed
+          : undefined;
+      }),
     trackSubmission: (threadId, instanceId) =>
       Effect.sync(() => {
         let submission: NativeSubmission | undefined;

--- a/apps/server/src/checkpointing/TurnCheckpointCapture.ts
+++ b/apps/server/src/checkpointing/TurnCheckpointCapture.ts
@@ -1,4 +1,10 @@
-import { type EventId, type ProviderRuntimeEvent, type ThreadId, TurnId } from "@t3tools/contracts";
+import {
+  type EventId,
+  type ProviderInstanceId,
+  type ProviderRuntimeEvent,
+  type ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
 import * as Context from "effect/Context";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
@@ -10,6 +16,7 @@ export type CaptureOutcome = "captured" | "skipped" | "failed";
 
 interface PendingCapture {
   readonly threadId: ThreadId;
+  readonly instanceId: ProviderInstanceId | undefined;
   readonly turnId: TurnId | undefined;
   readonly events: Set<EventId>;
   readonly reservations: Set<symbol>;
@@ -18,8 +25,46 @@ interface PendingCapture {
 
 interface ThreadCaptureState {
   activeTurnId: TurnId | undefined;
+  activeInstanceId: ProviderInstanceId | undefined;
   readonly pending: Set<PendingCapture>;
+  readonly submissions: Set<NativeSubmission>;
 }
+
+export type TurnSubmissionOutcome =
+  | { readonly _tag: "NotSubmitted" }
+  | { readonly _tag: "Accepted"; readonly turnId: TurnId }
+  | { readonly _tag: "UnknownSubmission"; readonly turnId: TurnId | undefined };
+
+interface NativeSubmission {
+  readonly threadId: ThreadId;
+  readonly instanceId: ProviderInstanceId;
+  turnId: TurnId | undefined;
+  nativeStopped: boolean;
+  readonly nativeTerminals: Set<TurnId>;
+  readonly capturedTurns: Set<TurnId>;
+  readonly released: Deferred.Deferred<void>;
+}
+
+export interface TurnSubmission {
+  readonly beforeSubmit: (turnId?: TurnId) => Effect.Effect<void>;
+  readonly notSubmitted: Effect.Effect<void>;
+  readonly nativeCompleted: (turnId: TurnId) => Effect.Effect<void>;
+  readonly nativeStopped: Effect.Effect<void>;
+  readonly accept: (turnId: TurnId) => Effect.Effect<void>;
+  readonly outcome: Effect.Effect<TurnSubmissionOutcome>;
+}
+
+// An unresolved Codex request can receive native terminals before its response.
+// Keep those receipts with that request, not in an unbounded thread history.
+const MAX_EARLY_TERMINALS = 16;
+
+const remember = (turns: Set<TurnId>, turnId: TurnId) => {
+  turns.add(turnId);
+  if (turns.size > MAX_EARLY_TERMINALS) {
+    const oldest = turns.values().next().value;
+    if (oldest !== undefined) turns.delete(oldest);
+  }
+};
 
 export class TurnCheckpointCapture extends Context.Service<
   TurnCheckpointCapture,
@@ -29,6 +74,12 @@ export class TurnCheckpointCapture extends Context.Service<
     readonly pendingCapture: (threadId: ThreadId) => Effect.Effect<Effect.Effect<void> | undefined>;
     readonly awaitCapture: (threadId: ThreadId) => Effect.Effect<void>;
     readonly complete: (event: TerminalEvent, outcome: CaptureOutcome) => Effect.Effect<void>;
+    readonly trackSubmission: (
+      threadId: ThreadId,
+      instanceId: ProviderInstanceId,
+    ) => Effect.Effect<TurnSubmission>;
+    readonly awaitNativeCapture: (threadId: ThreadId) => Effect.Effect<void>;
+    readonly shouldCapture: (event: TerminalEvent) => Effect.Effect<boolean>;
   }
 >()("t3/checkpointing/TurnCheckpointCapture") {}
 
@@ -37,24 +88,44 @@ export class TurnCheckpointCapture extends Context.Service<
 export function make(): TurnCheckpointCapture["Service"] {
   const threads = new Map<ThreadId, ThreadCaptureState>();
   const events = new Map<EventId, PendingCapture>();
+  const nativeCaptures = new Map<
+    EventId,
+    {
+      readonly allowed: boolean;
+      readonly turnId: TurnId | undefined;
+      readonly submissions: ReadonlyArray<NativeSubmission>;
+    }
+  >();
 
   const stateFor = (threadId: ThreadId) => {
     let state = threads.get(threadId);
     if (!state) {
-      state = { activeTurnId: undefined, pending: new Set() };
+      state = {
+        activeTurnId: undefined,
+        activeInstanceId: undefined,
+        pending: new Set(),
+        submissions: new Set(),
+      };
       threads.set(threadId, state);
     }
     return state;
   };
 
-  const prepare = (threadId: ThreadId, turnId: TurnId | undefined) => {
+  const prepare = (
+    threadId: ThreadId,
+    turnId: TurnId | undefined,
+    instanceId: ProviderInstanceId | undefined,
+  ) => {
     const state = stateFor(threadId);
     const existing = turnId
-      ? [...state.pending].find((capture) => capture.turnId === turnId)
+      ? [...state.pending].find(
+          (capture) => capture.turnId === turnId && capture.instanceId === instanceId,
+        )
       : undefined;
     if (existing) return existing;
     const capture: PendingCapture = {
       threadId,
+      instanceId,
       turnId,
       events: new Set(),
       reservations: new Set(),
@@ -64,12 +135,37 @@ export function make(): TurnCheckpointCapture["Service"] {
     return capture;
   };
 
+  const forgetEmptyThread = (threadId: ThreadId) => {
+    const state = threads.get(threadId);
+    if (
+      state?.activeTurnId === undefined &&
+      state?.pending.size === 0 &&
+      state.submissions.size === 0
+    )
+      threads.delete(threadId);
+  };
+
+  const releaseSubmission = (submission: NativeSubmission) => {
+    threads.get(submission.threadId)?.submissions.delete(submission);
+    Deferred.doneUnsafe(submission.released, Effect.void);
+    forgetEmptyThread(submission.threadId);
+  };
+
+  const finishSubmission = (submission: NativeSubmission) => {
+    const turnId = submission.turnId;
+    if (
+      (turnId === undefined && submission.nativeStopped) ||
+      (turnId !== undefined &&
+        (submission.nativeStopped || submission.nativeTerminals.has(turnId)) &&
+        submission.capturedTurns.has(turnId))
+    )
+      releaseSubmission(submission);
+  };
+
   const complete = (capture: PendingCapture, outcome: CaptureOutcome) => {
     const state = threads.get(capture.threadId);
     state?.pending.delete(capture);
-    if (state?.activeTurnId === undefined && state?.pending.size === 0) {
-      threads.delete(capture.threadId);
-    }
+    forgetEmptyThread(capture.threadId);
     for (const eventId of capture.events) events.delete(eventId);
     Deferred.doneUnsafe(capture.outcome, Effect.succeed(outcome));
   };
@@ -86,35 +182,72 @@ export function make(): TurnCheckpointCapture["Service"] {
     }
   });
 
+  const awaitNativeCapture = Effect.fn("TurnCheckpointCapture.awaitNativeCapture")(function* (
+    threadId: ThreadId,
+  ) {
+    while (true) {
+      yield* awaitCapture(threadId);
+      const submissions = [...(threads.get(threadId)?.submissions ?? [])];
+      if (submissions.length === 0) return;
+      yield* Effect.forEach(submissions, (submission) => Deferred.await(submission.released), {
+        discard: true,
+      });
+    }
+  });
+
   return TurnCheckpointCapture.of({
     observe: (event) =>
       Effect.sync(() => {
         if (event.type === "turn.started" && event.turnId !== undefined) {
           stateFor(event.threadId).activeTurnId = TurnId.make(event.turnId);
+          stateFor(event.threadId).activeInstanceId = event.providerInstanceId;
         } else if (event.type === "turn.completed" || event.type === "turn.aborted") {
           const state = stateFor(event.threadId);
           const turnId =
             event.turnId === undefined ? state.activeTurnId : TurnId.make(event.turnId);
-          const capture = prepare(event.threadId, turnId);
+          const capture = prepare(event.threadId, turnId, event.providerInstanceId);
+          const submissions = [...state.submissions].filter(
+            (submission) =>
+              submission.instanceId === event.providerInstanceId &&
+              (submission.turnId === undefined || submission.turnId === turnId),
+          );
+          // A local failure can arrive while native work still runs. Its capture
+          // cannot be reused when a later native terminal finally confirms completion.
+          nativeCaptures.set(event.eventId, {
+            allowed: submissions.every(
+              (submission) =>
+                submission.nativeStopped ||
+                (turnId !== undefined && submission.nativeTerminals.has(turnId)),
+            ),
+            turnId,
+            submissions,
+          });
           capture.events.add(event.eventId);
           events.set(event.eventId, capture);
-          if (state.activeTurnId === turnId) state.activeTurnId = undefined;
+          if (
+            state.activeTurnId === turnId &&
+            state.activeInstanceId === event.providerInstanceId
+          ) {
+            state.activeTurnId = undefined;
+          }
         } else if (event.type === "session.exited") {
           const state = threads.get(event.threadId);
           if (!state) return;
-          state.activeTurnId = undefined;
+          if (state.activeInstanceId === event.providerInstanceId) state.activeTurnId = undefined;
           for (const capture of state.pending) {
             // Terminal events can still be queued for capture after session exit.
-            if (capture.events.size === 0) complete(capture, "skipped");
+            if (capture.events.size === 0 && capture.instanceId === event.providerInstanceId) {
+              complete(capture, "skipped");
+            }
           }
-          if (state.pending.size === 0) threads.delete(event.threadId);
+          forgetEmptyThread(event.threadId);
         }
       }),
     expectInterrupt: (threadId) =>
       Effect.sync(() => {
         const turnId = threads.get(threadId)?.activeTurnId;
         if (turnId === undefined) return Effect.void;
-        const capture = prepare(threadId, turnId);
+        const capture = prepare(threadId, turnId, threads.get(threadId)?.activeInstanceId);
         const reservation = Symbol();
         capture.reservations.add(reservation);
         return Effect.sync(() => {
@@ -130,10 +263,92 @@ export function make(): TurnCheckpointCapture["Service"] {
         (threads.get(threadId)?.pending.size ?? 0) > 0 ? awaitCapture(threadId) : undefined,
       ),
     awaitCapture,
+    awaitNativeCapture,
+    shouldCapture: (event) => Effect.sync(() => nativeCaptures.get(event.eventId)?.allowed ?? true),
+    trackSubmission: (threadId, instanceId) =>
+      Effect.sync(() => {
+        let submission: NativeSubmission | undefined;
+        let outcome: TurnSubmissionOutcome = { _tag: "NotSubmitted" };
+        return {
+          beforeSubmit: Effect.fn("TurnCheckpointCapture.beforeSubmit")(function* (
+            turnId?: TurnId,
+          ) {
+            if (submission !== undefined) return;
+            while (true) {
+              const state = threads.get(threadId);
+              if (
+                state?.activeTurnId !== undefined &&
+                (state.activeTurnId !== turnId || state.activeInstanceId !== instanceId)
+              ) {
+                prepare(threadId, state.activeTurnId, state.activeInstanceId);
+              }
+              yield* awaitCapture(threadId);
+              const blockers = [...(threads.get(threadId)?.submissions ?? [])].filter(
+                (active) =>
+                  turnId === undefined ||
+                  active.turnId !== turnId ||
+                  active.instanceId !== instanceId,
+              );
+              if (blockers.length > 0) {
+                yield* Effect.forEach(blockers, (active) => Deferred.await(active.released), {
+                  discard: true,
+                });
+                continue;
+              }
+              // No yield between checking ownership and marking possible native submission.
+              submission = {
+                threadId,
+                instanceId,
+                turnId,
+                nativeStopped: false,
+                nativeTerminals: new Set(),
+                capturedTurns: new Set(),
+                released: Deferred.makeUnsafe(),
+              };
+              stateFor(threadId).submissions.add(submission);
+              outcome = { _tag: "UnknownSubmission", turnId };
+              return;
+            }
+          }),
+          notSubmitted: Effect.sync(() => {
+            if (submission !== undefined) releaseSubmission(submission);
+            submission = undefined;
+            outcome = { _tag: "NotSubmitted" };
+          }),
+          nativeCompleted: (turnId) =>
+            Effect.sync(() => {
+              if (submission === undefined) return;
+              remember(submission.nativeTerminals, turnId);
+              finishSubmission(submission);
+            }),
+          nativeStopped: Effect.sync(() => {
+            if (submission === undefined) return;
+            submission.nativeStopped = true;
+            finishSubmission(submission);
+          }),
+          accept: (turnId) =>
+            Effect.sync(() => {
+              if (submission !== undefined) {
+                submission.turnId = turnId;
+                finishSubmission(submission);
+              }
+              outcome = { _tag: "Accepted", turnId };
+            }),
+          outcome: Effect.sync(() => outcome),
+        } satisfies TurnSubmission;
+      }),
     complete: (event, outcome) =>
       Effect.sync(() => {
         const capture = events.get(event.eventId);
         if (capture) complete(capture, outcome);
+        const nativeCapture = nativeCaptures.get(event.eventId);
+        nativeCaptures.delete(event.eventId);
+        if (nativeCapture?.allowed && nativeCapture.turnId !== undefined) {
+          for (const submission of nativeCapture.submissions) {
+            remember(submission.capturedTurns, nativeCapture.turnId);
+            finishSubmission(submission);
+          }
+        }
       }),
   });
 }

--- a/apps/server/src/checkpointing/TurnCheckpointCapture.ts
+++ b/apps/server/src/checkpointing/TurnCheckpointCapture.ts
@@ -275,14 +275,16 @@ export function make(): TurnCheckpointCapture["Service"] {
           ) {
             if (submission !== undefined) return;
             while (true) {
+              yield* awaitCapture(threadId);
               const state = threads.get(threadId);
+              if ((state?.pending.size ?? 0) > 0) continue;
               if (
                 state?.activeTurnId !== undefined &&
                 (state.activeTurnId !== turnId || state.activeInstanceId !== instanceId)
               ) {
                 prepare(threadId, state.activeTurnId, state.activeInstanceId);
+                continue;
               }
-              yield* awaitCapture(threadId);
               const blockers = [...(threads.get(threadId)?.submissions ?? [])].filter(
                 (active) =>
                   turnId === undefined ||

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -670,6 +670,59 @@ describe("CheckpointReactor", () => {
     }),
   );
 
+  effectIt.effect.each([null, TurnId.make("stale-primary-turn")])(
+    "captures a confirmed native stop without a started event and active turn %s",
+    (activeTurnId) =>
+      Effect.gen(function* () {
+        const harness = yield* Effect.promise(() =>
+          createHarness({ seedFilesystemCheckpoints: false }),
+        );
+        const threadId = ThreadId.make("thread-1");
+        const turnId = TurnId.make("accepted-before-started");
+        const providerInstanceId = ProviderInstanceId.make("codex");
+        yield* harness.engine.dispatch({
+          type: "thread.session.set",
+          commandId: CommandId.make("accepted-no-start-session"),
+          threadId,
+          session: {
+            threadId,
+            status: "ready",
+            providerName: "codex",
+            providerInstanceId,
+            runtimeMode: "approval-required",
+            activeTurnId,
+            lastError: null,
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          },
+          createdAt: "2026-01-01T00:00:00.000Z",
+        });
+        const submission = yield* harness.captures.trackSubmission(threadId, providerInstanceId);
+        yield* submission.beforeSubmit(turnId);
+        yield* submission.accept(turnId);
+        NodeFS.writeFileSync(
+          NodePath.join(harness.cwd, "README.md"),
+          "native edits before confirmed stop\n",
+        );
+        yield* submission.nativeStopped;
+        const stopped = {
+          type: "turn.aborted" as const,
+          eventId: EventId.make("accepted-no-start-stopped"),
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId,
+          threadId,
+          turnId,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          payload: { reason: "Native process exited." },
+        };
+        yield* harness.captures.observe(stopped);
+        harness.provider.emit(stopped);
+        yield* harness.captures.awaitNativeCapture(threadId);
+        expect(
+          gitShowFileAtRef(harness.cwd, checkpointRefForThreadTurn(threadId, 1), "README.md"),
+        ).toBe("native edits before confirmed stop\n");
+      }),
+  );
+
   effectIt.effect("captures baseline and large turn summaries before completion receipts", () =>
     Effect.gen(function* () {
       const harness = yield* Effect.promise(() =>

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -307,7 +307,6 @@ describe("CheckpointReactor", () => {
     | CheckpointReactor
     | TurnCheckpointCapture.TurnCheckpointCapture
     | CheckpointStore.CheckpointStore
-    | TurnCheckpointCapture.TurnCheckpointCapture
     | ProjectionSnapshotQuery
     | RuntimeReceiptBus.RuntimeReceiptBus
     | SqlClient.SqlClient,

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -307,6 +307,7 @@ describe("CheckpointReactor", () => {
     | CheckpointReactor
     | TurnCheckpointCapture.TurnCheckpointCapture
     | CheckpointStore.CheckpointStore
+    | TurnCheckpointCapture.TurnCheckpointCapture
     | ProjectionSnapshotQuery
     | RuntimeReceiptBus.RuntimeReceiptBus
     | SqlClient.SqlClient,
@@ -436,6 +437,9 @@ describe("CheckpointReactor", () => {
     const sql = await runtime.runPromise(Effect.service(SqlClient.SqlClient));
     const checkpointReverts = await testRuntime.runPromise(
       CheckpointRevertRecovery.CheckpointRevertRecovery,
+    );
+    const captures = await runtime.runPromise(
+      Effect.service(TurnCheckpointCapture.TurnCheckpointCapture),
     );
     const checkpointStore = await runtime.runPromise(
       Effect.service(CheckpointStore.CheckpointStore),
@@ -597,6 +601,7 @@ describe("CheckpointReactor", () => {
 
     return {
       engine,
+      captures,
       readModel: () => Effect.runPromise(snapshotQuery.getSnapshot()),
       provider,
       cwd,
@@ -609,6 +614,61 @@ describe("CheckpointReactor", () => {
       pullRequestRefreshes,
     };
   }
+
+  effectIt.effect("captures late native edits after an earlier synthetic failure", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() =>
+        createHarness({ seedFilesystemCheckpoints: false }),
+      );
+      const threadId = ThreadId.make("thread-1");
+      const turnId = TurnId.make("late-native-turn");
+      const providerInstanceId = ProviderInstanceId.make("codex");
+      const submission = yield* harness.captures.trackSubmission(threadId, providerInstanceId);
+      yield* submission.beforeSubmit(turnId);
+      const started = {
+        type: "turn.started" as const,
+        eventId: EventId.make("late-native-started"),
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId,
+        threadId,
+        turnId,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        payload: {},
+      };
+      yield* harness.captures.observe(started);
+      harness.provider.emit(started);
+      expect(yield* harness.nextReceipt).toMatchObject({ type: "checkpoint.baseline.captured" });
+      NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "incomplete native work\n");
+      const synthetic = {
+        ...started,
+        type: "turn.completed" as const,
+        eventId: EventId.make("late-native-synthetic-failure"),
+        payload: { state: "failed" as const },
+      };
+      yield* harness.captures.observe(synthetic);
+      harness.provider.emit(synthetic);
+      yield* harness.captures.awaitCapture(threadId);
+      expect(gitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 1))).toBe(false);
+
+      NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "finished native work\n");
+      yield* submission.nativeCompleted(turnId);
+      const confirmed = {
+        ...synthetic,
+        eventId: EventId.make("late-native-confirmed"),
+        payload: { state: "completed" as const },
+      };
+      yield* harness.captures.observe(confirmed);
+      harness.provider.emit(confirmed);
+      expect(yield* harness.nextReceipt).toMatchObject({
+        type: "checkpoint.diff.finalized",
+        turnId,
+      });
+      yield* harness.captures.awaitNativeCapture(threadId);
+      expect(
+        gitShowFileAtRef(harness.cwd, checkpointRefForThreadTurn(threadId, 1), "README.md"),
+      ).toBe("finished native work\n");
+    }),
+  );
 
   effectIt.effect("captures baseline and large turn summaries before completion receipts", () =>
     Effect.gen(function* () {

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -391,7 +391,10 @@ const make = Effect.gen(function* () {
 
   // Capture the files left by a completed or interrupted turn.
   const captureCheckpointFromTurnCompletion = Effect.fn("captureCheckpointFromTurnCompletion")(
-    function* (event: Extract<ProviderRuntimeEvent, { type: "turn.completed" | "turn.aborted" }>) {
+    function* (
+      event: Extract<ProviderRuntimeEvent, { type: "turn.completed" | "turn.aborted" }>,
+      ownsNativeTurn: boolean,
+    ) {
       const turnId = toTurnId(event.turnId);
       if (!turnId) {
         return "skipped" as const;
@@ -403,7 +406,11 @@ const make = Effect.gen(function* () {
       }
 
       // When a primary turn is active, only that turn may produce completion checkpoints.
-      if (thread.session?.activeTurnId && !sameId(thread.session.activeTurnId, turnId)) {
+      if (
+        !ownsNativeTurn &&
+        thread.session?.activeTurnId &&
+        !sameId(thread.session.activeTurnId, turnId)
+      ) {
         return "skipped" as const;
       }
 
@@ -981,7 +988,8 @@ const make = Effect.gen(function* () {
 
   const processTurnCompletion = Effect.fn("processTurnCompletion")(
     function* (event: Extract<ProviderRuntimeEvent, { type: "turn.completed" | "turn.aborted" }>) {
-      if (!(yield* checkpointCapture.shouldCapture(event))) return "skipped" as const;
+      const nativeCaptureReady = yield* checkpointCapture.nativeCaptureReady(event);
+      if (nativeCaptureReady === false) return "skipped" as const;
       const turnId = toTurnId(event.turnId);
       const thread = yield* resolveThreadDetail(event.threadId);
       const startedTurnId = startedTurns.get(event.threadId);
@@ -1002,12 +1010,13 @@ const make = Effect.gen(function* () {
       }
       if (
         event.type === "turn.aborted" &&
+        nativeCaptureReady !== true &&
         !isTrackedTurn &&
         !sameId(thread?.session?.activeTurnId, turnId)
       ) {
         return "skipped" as const;
       }
-      return yield* captureCheckpointFromTurnCompletion(event).pipe(
+      return yield* captureCheckpointFromTurnCompletion(event, nativeCaptureReady === true).pipe(
         Effect.catch((error) =>
           Effect.flatMap(nowIso, (createdAt) =>
             appendCaptureFailureActivity({

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -981,6 +981,7 @@ const make = Effect.gen(function* () {
 
   const processTurnCompletion = Effect.fn("processTurnCompletion")(
     function* (event: Extract<ProviderRuntimeEvent, { type: "turn.completed" | "turn.aborted" }>) {
+      if (!(yield* checkpointCapture.shouldCapture(event))) return "skipped" as const;
       const turnId = toTurnId(event.turnId);
       const thread = yield* resolveThreadDetail(event.threadId);
       const startedTurnId = startedTurns.get(event.threadId);

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -769,6 +769,11 @@ describe("ProviderCommandReactor", () => {
         const thread = (yield* Effect.promise(harness.readModel)).threads.find(
           (entry) => entry.id === threadId,
         );
+        const outcomes = yield* harness.engine.readEvents(0).pipe(
+          Stream.filter((event) => event.type === "thread.activity-appended"),
+          Stream.map((event) => event.payload.operationResult),
+          Stream.runCollect,
+        );
         for (const requestId of ["restart-message", "queued-restart-message"]) {
           expect(thread?.activities).toEqual(
             expect.arrayContaining([
@@ -778,7 +783,11 @@ describe("ProviderCommandReactor", () => {
               }),
             ]),
           );
+          expect(outcomes.filter((outcome) => outcome?.requestId === requestId)).toEqual([
+            { requestId, outcome: "interrupted" },
+          ]);
         }
+        expect(thread?.pendingOperation).toBeNull();
       }
     }),
   );
@@ -867,6 +876,35 @@ describe("ProviderCommandReactor", () => {
           thread?.activities.some((activity) => activity.summary === "Queued message cancelled"),
         ).toBe(false);
       }),
+  );
+
+  effectIt.effect("records an interrupted request when session preparation interrupts itself", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() =>
+        createHarness({ startSessionEffect: () => Effect.interrupt }),
+      );
+      const events = yield* harness.engine.subscribeDomainEvents;
+      const result = yield* events.pipe(
+        Stream.filter(
+          (event) =>
+            event.type === "thread.activity-appended" &&
+            event.payload.operationResult?.requestId === "interrupted-preparation",
+        ),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* dispatchTestTurn(harness.engine, "interrupted-preparation", "hello");
+      const receipts = yield* Fiber.join(result);
+      expect(receipts[0]).toMatchObject({
+        payload: {
+          operationResult: { requestId: "interrupted-preparation", outcome: "interrupted" },
+          activity: { kind: "provider.turn.start.interrupted" },
+        },
+      });
+      expect((yield* Effect.promise(harness.readModel)).threads[0]?.pendingOperation).toBeNull();
+      expect(harness.sendTurn).not.toHaveBeenCalled();
+    }),
   );
 
   effectIt.effect("cancels compaction preparation before stopping its previous session", () =>
@@ -3900,90 +3938,68 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
-  it("restarts the provider session when runtime mode is updated on the thread", async () => {
-    const harness = await createHarness();
-    const now = "2026-01-01T00:00:00.000Z";
+  effectIt.effect(
+    "waits for a runtime-mode restart before sending after the command queue drains",
+    () =>
+      Effect.gen(function* () {
+        const firstSent = yield* Deferred.make<void>();
+        const restartStarted = yield* Deferred.make<void>();
+        const releaseRestart = yield* Deferred.make<void>();
+        const secondSent = yield* Deferred.make<void>();
+        let configuredSession: ProviderSession | undefined;
+        const harness = yield* Effect.promise(() =>
+          createHarness({
+            startSessionEffect: (session) =>
+              Effect.gen(function* () {
+                if (configuredSession !== undefined) {
+                  yield* Deferred.succeed(restartStarted, undefined);
+                  yield* Deferred.await(releaseRestart);
+                }
+                configuredSession = session;
+                return session;
+              }),
+            sendTurnEffect: (input) =>
+              Effect.gen(function* () {
+                expect(configuredSession?.runtimeMode).toBe(
+                  input.input === "first" ? "approval-required" : "full-access",
+                );
+                yield* Deferred.succeed(
+                  input.input === "first" ? firstSent : secondSent,
+                  undefined,
+                );
+                return { threadId: input.threadId, turnId: asTurnId("turn-1") };
+              }),
+          }),
+        );
+        yield* dispatchTestTurn(harness.engine, "runtime-mode-first", "first");
+        yield* Deferred.await(firstSent);
+        yield* harness.engine.dispatch({
+          type: "thread.runtime-mode.set",
+          commandId: CommandId.make("cmd-runtime-mode-set"),
+          threadId: ThreadId.make("thread-1"),
+          runtimeMode: "full-access",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        });
+        yield* Deferred.await(restartStarted);
+        yield* Effect.promise(harness.drain);
+        expect(configuredSession?.runtimeMode).toBe("approval-required");
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.runtime-mode.set",
-        commandId: CommandId.make("cmd-runtime-mode-set-initial-full-access"),
-        threadId: ThreadId.make("thread-1"),
-        runtimeMode: "full-access",
-        createdAt: now,
+        yield* dispatchTestTurn(harness.engine, "runtime-mode-second", "second");
+        yield* Effect.promise(harness.drain);
+        expect(harness.sendTurn).toHaveBeenCalledOnce();
+        yield* Deferred.succeed(releaseRestart, undefined);
+        yield* Deferred.await(secondSent);
+
+        expect(harness.startSession).toHaveBeenCalledTimes(2);
+        expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
+          threadId: ThreadId.make("thread-1"),
+          resumeCursor: { opaque: "resume-1" },
+          runtimeMode: "full-access",
+        });
+        const thread = (yield* Effect.promise(harness.readModel)).threads[0];
+        expect(thread?.session?.runtimeMode).toBe("full-access");
       }),
-    );
-
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.turn.start",
-        commandId: CommandId.make("cmd-turn-start-runtime-mode-1"),
-        threadId: ThreadId.make("thread-1"),
-        message: {
-          messageId: asMessageId("user-message-runtime-mode-1"),
-          role: "user",
-          text: "first",
-          attachments: [],
-        },
-        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-        runtimeMode: "full-access",
-        createdAt: now,
-      }),
-    );
-
-    await waitFor(() => harness.startSession.mock.calls.length === 1);
-    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
-
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.runtime-mode.set",
-        commandId: CommandId.make("cmd-runtime-mode-set-1"),
-        threadId: ThreadId.make("thread-1"),
-        runtimeMode: "approval-required",
-        createdAt: now,
-      }),
-    );
-
-    await waitFor(async () => {
-      const readModel = await harness.readModel();
-      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
-      return thread?.runtimeMode === "approval-required";
-    });
-    await waitFor(() => harness.startSession.mock.calls.length === 2);
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.turn.start",
-        commandId: CommandId.make("cmd-turn-start-runtime-mode-2"),
-        threadId: ThreadId.make("thread-1"),
-        message: {
-          messageId: asMessageId("user-message-runtime-mode-2"),
-          role: "user",
-          text: "second",
-          attachments: [],
-        },
-        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-        runtimeMode: "full-access",
-        createdAt: now,
-      }),
-    );
-
-    await waitFor(() => harness.sendTurn.mock.calls.length === 2);
-
-    expect(harness.stopSession.mock.calls.length).toBe(0);
-    expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
-      threadId: ThreadId.make("thread-1"),
-      resumeCursor: { opaque: "resume-1" },
-      runtimeMode: "approval-required",
-    });
-    expect(harness.sendTurn.mock.calls[1]?.[0]).toMatchObject({
-      threadId: ThreadId.make("thread-1"),
-    });
-
-    const readModel = await harness.readModel();
-    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
-    expect(thread?.session?.threadId).toBe("thread-1");
-    expect(thread?.session?.runtimeMode).toBe("approval-required");
-  });
+  );
 
   it("does not inject derived model options when restarting claude on runtime mode changes", async () => {
     const harness = await createHarness({

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -173,6 +173,7 @@ describe("ProviderCommandReactor", () => {
     readonly baseDir?: string;
     readonly threadModelSelection?: ModelSelection;
     readonly sessionModelSwitch?: "unsupported" | "in-session";
+    readonly beforeCapabilities?: () => Effect.Effect<void>;
     readonly requiresNewThreadForModelChange?: boolean;
     readonly unreadableHistory?: boolean;
     readonly titleRegenerationCompletionDispatchFailures?: number;
@@ -263,7 +264,11 @@ describe("ProviderCommandReactor", () => {
       return (startSessionEffect?.(session) ?? Effect.succeed(session)).pipe(
         Effect.tap((startedSession) =>
           Effect.sync(() => {
-            runtimeSessions.push(startedSession);
+            const index = runtimeSessions.findIndex(
+              (session) => session.threadId === startedSession.threadId,
+            );
+            if (index < 0) runtimeSessions.push(startedSession);
+            else runtimeSessions[index] = startedSession;
           }),
         ),
       );
@@ -369,9 +374,9 @@ describe("ProviderCommandReactor", () => {
       stopSession: stopSession as ProviderServiceShape["stopSession"],
       listSessions: () => Effect.succeed(runtimeSessions),
       getCapabilities: (_provider) =>
-        Effect.succeed({
-          sessionModelSwitch: input?.sessionModelSwitch ?? "in-session",
-        }),
+        (input?.beforeCapabilities?.() ?? Effect.void).pipe(
+          Effect.as({ sessionModelSwitch: input?.sessionModelSwitch ?? "in-session" }),
+        ),
       assertConversationRollbackSupported: () => unsupported(),
       prepareConversationRollback: () => unsupported(),
       forkConversation: () => unsupported(),
@@ -788,6 +793,171 @@ describe("ProviderCommandReactor", () => {
           ]);
         }
         expect(thread?.pendingOperation).toBeNull();
+      }
+    }),
+  );
+
+  effectIt.effect.each([
+    ["runtime mode", "complete"],
+    ["runtime mode", "stop"],
+    ["runtime mode", "revert"],
+    ["message runtime mode", "complete"],
+    ["message runtime mode", "stop"],
+    ["model", "complete"],
+    ["model", "stop"],
+  ] as const)("waits for the earlier send before a %s replacement, then %s", ([change, outcome]) =>
+    Effect.gen(function* () {
+      const sent = yield* Deferred.make<void>();
+      const releaseSend = yield* Deferred.make<void>();
+      const sendJoined = yield* Deferred.make<void>();
+      const checked = yield* Deferred.make<void>();
+      const rechecked = yield* Deferred.make<void>();
+      const restarted = yield* Deferred.make<void>();
+      const stopped = yield* Deferred.make<void>();
+      const secondPreparing = yield* Deferred.make<void>();
+      const releaseSecond = yield* Deferred.make<void>();
+      let changing = false;
+      let checks = 0;
+      let sentSuccessfully = false;
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          sessionModelSwitch: "unsupported",
+          tryHandlePromptCommandEffect: ({ text }) =>
+            text === "second" && change === "message runtime mode"
+              ? Deferred.succeed(secondPreparing, undefined).pipe(
+                  Effect.andThen(Deferred.await(releaseSecond)),
+                  Effect.as(false),
+                )
+              : Effect.succeed(false),
+          beforeCapabilities: () =>
+            changing
+              ? Deferred.succeed(++checks === 1 ? checked : rechecked, undefined).pipe(
+                  Effect.asVoid,
+                )
+              : Effect.void,
+          startSessionEffect: (session) =>
+            Effect.gen(function* () {
+              if (changing) {
+                expect(sentSuccessfully).toBe(true);
+                yield* Deferred.succeed(restarted, undefined);
+              }
+              return session;
+            }),
+          sendTurnEffect: (input) =>
+            input.input === "first"
+              ? Effect.gen(function* () {
+                  yield* Deferred.succeed(sent, undefined);
+                  yield* Deferred.await(releaseSend);
+                  sentSuccessfully = true;
+                  const active = harness.runtimeSessions[0];
+                  if (active)
+                    harness.runtimeSessions[0] = {
+                      ...active,
+                      resumeCursor: { opaque: "after-first-send" },
+                    };
+                  return { threadId: input.threadId, turnId: asTurnId("first-turn") };
+                }).pipe(Effect.ensuring(Deferred.succeed(sendJoined, undefined)))
+              : Effect.succeed({ threadId: input.threadId, turnId: asTurnId("second-turn") }),
+          stopSessionEffect: () =>
+            Effect.gen(function* () {
+              expect(yield* Deferred.isDone(sendJoined)).toBe(true);
+              yield* Deferred.succeed(stopped, undefined);
+            }),
+        }),
+      );
+      yield* dispatchTestTurn(harness.engine, "replacement-first", "first");
+      yield* Deferred.await(sent);
+      changing = true;
+      if (change === "runtime mode") {
+        yield* harness.engine.dispatch({
+          type: "thread.runtime-mode.set",
+          commandId: CommandId.make("replace-runtime-mode"),
+          threadId: ThreadId.make("thread-1"),
+          runtimeMode: "full-access",
+          createdAt: "2026-01-01T00:00:01.000Z",
+        });
+      } else {
+        yield* harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make("replace-model"),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: MessageId.make("replacement-second"),
+            role: "user",
+            text: "second",
+            attachments: [],
+          },
+          ...(change === "model"
+            ? { modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.4" } }
+            : {}),
+          interactionMode: "default",
+          runtimeMode: "approval-required",
+          createdAt: "2026-01-01T00:00:01.000Z",
+        });
+        if (change === "message runtime mode") {
+          yield* Deferred.await(secondPreparing);
+          yield* harness.engine.dispatch({
+            type: "thread.runtime-mode.set",
+            commandId: CommandId.make("message-replace-runtime-mode"),
+            threadId: ThreadId.make("thread-1"),
+            runtimeMode: "full-access",
+            createdAt: "2026-01-01T00:00:01.000Z",
+          });
+          yield* Deferred.succeed(releaseSecond, undefined);
+        }
+      }
+      yield* Deferred.await(checked);
+      yield* Effect.promise(harness.drain);
+      expect(harness.startSession).toHaveBeenCalledOnce();
+      expect(yield* Deferred.isDone(sendJoined)).toBe(false);
+
+      if (outcome === "stop") {
+        yield* harness.engine.dispatch({
+          type: "thread.session.stop",
+          commandId: CommandId.make("stop-replacement"),
+          threadId: ThreadId.make("thread-1"),
+          createdAt: "2026-01-01T00:00:02.000Z",
+        });
+        yield* Deferred.await(stopped);
+        yield* Effect.promise(harness.drain);
+        expect(harness.startSession).toHaveBeenCalledOnce();
+        expect(harness.sendTurn).toHaveBeenCalledOnce();
+      } else if (outcome === "revert") {
+        yield* harness.engine.dispatch({
+          type: "thread.runtime-mode.set",
+          commandId: CommandId.make("revert-runtime-mode"),
+          threadId: ThreadId.make("thread-1"),
+          runtimeMode: "approval-required",
+          createdAt: "2026-01-01T00:00:02.000Z",
+        });
+        yield* Deferred.succeed(releaseSend, undefined);
+        yield* Deferred.await(rechecked);
+        yield* Effect.promise(harness.drain);
+        expect(harness.startSession).toHaveBeenCalledOnce();
+      } else {
+        yield* Deferred.succeed(releaseSend, undefined);
+        yield* Deferred.await(restarted);
+        expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject(
+          change !== "model"
+            ? { runtimeMode: "full-access", resumeCursor: { opaque: "after-first-send" } }
+            : { modelSelection: { model: "gpt-5.4" } },
+        );
+      }
+      const results = yield* harness.engine.readEvents(0).pipe(
+        Stream.filter((event) => event.type === "thread.activity-appended"),
+        Stream.map((event) => event.payload.operationResult),
+        Stream.runCollect,
+      );
+      expect(results.filter((result) => result?.requestId === "replacement-first")).toEqual([
+        {
+          requestId: "replacement-first",
+          outcome: outcome === "stop" ? "interrupted" : "completed",
+        },
+      ]);
+      if (outcome === "stop" && change !== "runtime mode") {
+        expect(results.filter((result) => result?.requestId === "replacement-second")).toEqual([
+          { requestId: "replacement-second", outcome: "interrupted" },
+        ]);
       }
     }),
   );

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -187,6 +187,7 @@ describe("ProviderCommandReactor", () => {
     readonly startSessionEffect?: (
       session: ProviderSession,
     ) => Effect.Effect<ProviderSession, ProviderServiceError>;
+    readonly sendTurnEffect?: ProviderServiceShape["sendTurn"];
     readonly tryHandlePromptCommandEffect?: ProviderAuthService["Service"]["tryHandlePromptCommand"];
   }) {
     const now = "2026-01-01T00:00:00.000Z";
@@ -267,11 +268,13 @@ describe("ProviderCommandReactor", () => {
         ),
       );
     });
-    const sendTurn = vi.fn<ProviderServiceShape["sendTurn"]>((_) =>
-      Effect.succeed({
-        threadId: ThreadId.make("thread-1"),
-        turnId: asTurnId("turn-1"),
-      }),
+    const sendTurn = vi.fn<ProviderServiceShape["sendTurn"]>(
+      input?.sendTurnEffect ??
+        (() =>
+          Effect.succeed({
+            threadId: ThreadId.make("thread-1"),
+            turnId: asTurnId("turn-1"),
+          })),
     );
     const compactThread = vi.fn((_: ThreadId) => input?.compactThreadEffect?.() ?? Effect.void);
     const interruptTurn = vi.fn((_: unknown) => input?.interruptTurnEffect?.() ?? Effect.void);
@@ -639,6 +642,311 @@ describe("ProviderCommandReactor", () => {
   }
 
   effectIt.effect.each([
+    ["message", "thread.turn.interrupt"],
+    ["message", "thread.session.stop"],
+    ["runtime mode", "thread.turn.interrupt"],
+    ["runtime mode", "thread.session.stop"],
+  ] as const)("cancels a %s restart waiting for native capture before %s", ([restart, type]) =>
+    Effect.gen(function* () {
+      const preparing = yield* Deferred.make<void>();
+      const preparationJoined = yield* Deferred.make<void>();
+      const nativeStopped = yield* Deferred.make<void>();
+      let waitForNativeCapture = Effect.void;
+      const stopNative = Effect.gen(function* () {
+        expect(yield* Deferred.isDone(preparationJoined)).toBe(true);
+        yield* Deferred.succeed(nativeStopped, undefined);
+      });
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          startSessionEffect: (session) =>
+            Deferred.succeed(preparing, undefined).pipe(
+              Effect.andThen(Effect.suspend(() => waitForNativeCapture)),
+              Effect.as(session),
+              Effect.ensuring(Deferred.succeed(preparationJoined, undefined)),
+            ),
+          interruptTurnEffect: () => stopNative,
+          stopSessionEffect: () => stopNative,
+        }),
+      );
+      const threadId = ThreadId.make("thread-1");
+      const instanceId = ProviderInstanceId.make("codex");
+      const turnId = asTurnId("active-native-turn");
+      const createdAt = "2026-01-01T00:00:00.000Z";
+      harness.runtimeSessions.push({
+        threadId,
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: instanceId,
+        runtimeMode: "approval-required",
+        status: "running",
+        activeTurnId: turnId,
+        model: "gpt-5-codex",
+        cwd: "/tmp/provider-project",
+        resumeCursor: { opaque: "active-native-session" },
+        createdAt,
+        updatedAt: createdAt,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("restart-active-session"),
+        threadId,
+        session: {
+          threadId,
+          status: "running",
+          providerName: "codex",
+          providerInstanceId: instanceId,
+          runtimeMode: "approval-required",
+          activeTurnId: turnId,
+          lastError: null,
+          updatedAt: createdAt,
+        },
+        createdAt,
+      });
+      const submission = yield* harness.checkpointCapture.trackSubmission(threadId, instanceId);
+      yield* submission.beforeSubmit(turnId);
+      yield* submission.accept(turnId);
+      waitForNativeCapture = harness.checkpointCapture.awaitNativeCapture(threadId);
+
+      if (restart === "message") {
+        for (const messageId of ["restart-message", "queued-restart-message"]) {
+          yield* harness.engine.dispatch({
+            type: "thread.turn.start",
+            commandId: CommandId.make(messageId),
+            threadId,
+            message: {
+              messageId: asMessageId(messageId),
+              role: "user",
+              text: "Continue on my other provider instance",
+              attachments: [],
+            },
+            modelSelection: {
+              instanceId: ProviderInstanceId.make("codex_work"),
+              model: "gpt-5-codex",
+            },
+            interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+            runtimeMode: "approval-required",
+            createdAt,
+          });
+        }
+      } else {
+        yield* harness.engine.dispatch({
+          type: "thread.runtime-mode.set",
+          commandId: CommandId.make("restart-runtime-mode"),
+          threadId,
+          runtimeMode: "full-access",
+          createdAt,
+        });
+      }
+      yield* Deferred.await(preparing);
+      yield* harness.engine.dispatch({
+        type,
+        commandId: CommandId.make("cancel-restart"),
+        threadId,
+        createdAt,
+      });
+      yield* Deferred.await(nativeStopped);
+      yield* Effect.promise(harness.drain);
+
+      // A later native terminal and capture must not revive the cancelled restart.
+      const terminal = {
+        type: "turn.aborted" as const,
+        eventId: EventId.make("restart-native-terminal"),
+        threadId,
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: instanceId,
+        turnId,
+        createdAt,
+        payload: { reason: "interrupted" },
+      };
+      yield* submission.nativeCompleted(turnId);
+      yield* harness.checkpointCapture.observe(terminal);
+      yield* harness.checkpointCapture.complete(terminal, "captured");
+      yield* waitForNativeCapture;
+      yield* Effect.promise(harness.drain);
+      expect(harness.sendTurn).not.toHaveBeenCalled();
+      expect(harness.startSession).toHaveBeenCalledOnce();
+      expect(harness.runtimeSessions).toHaveLength(type === "thread.session.stop" ? 0 : 1);
+      if (restart === "message") {
+        const thread = (yield* Effect.promise(harness.readModel)).threads.find(
+          (entry) => entry.id === threadId,
+        );
+        for (const requestId of ["restart-message", "queued-restart-message"]) {
+          expect(thread?.activities).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                summary: "Queued message cancelled",
+                payload: expect.objectContaining({ requestId }),
+              }),
+            ]),
+          );
+        }
+      }
+    }),
+  );
+
+  effectIt.effect("keeps steering concurrent and joins a pending send before native stop", () =>
+    Effect.gen(function* () {
+      const firstSent = yield* Deferred.make<void>();
+      const secondSent = yield* Deferred.make<void>();
+      const sendJoined = yield* Deferred.make<void>();
+      const stopped = yield* Deferred.make<void>();
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          sendTurnEffect: (input) =>
+            input.input === "first"
+              ? Deferred.succeed(firstSent, undefined).pipe(
+                  Effect.andThen(Effect.never),
+                  Effect.ensuring(Deferred.succeed(sendJoined, undefined)),
+                )
+              : Deferred.succeed(secondSent, undefined).pipe(
+                  Effect.as({ threadId: input.threadId, turnId: asTurnId("turn-1") }),
+                ),
+          stopSessionEffect: () =>
+            Effect.gen(function* () {
+              expect(yield* Deferred.isDone(sendJoined)).toBe(true);
+              yield* Deferred.succeed(stopped, undefined);
+            }),
+        }),
+      );
+      const threadId = ThreadId.make("thread-1");
+      const createdAt = "2026-01-01T00:00:00.000Z";
+      for (const text of ["first", "second"]) {
+        yield* harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make(`concurrent-send-${text}`),
+          threadId,
+          message: {
+            messageId: asMessageId(`concurrent-send-${text}`),
+            role: "user",
+            text,
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt,
+        });
+      }
+      yield* Deferred.await(firstSent);
+      yield* Deferred.await(secondSent);
+      expect(harness.startSession).toHaveBeenCalledOnce();
+      expect(harness.sendTurn.mock.calls.map(([input]) => input.input)).toEqual([
+        "first",
+        "second",
+      ]);
+
+      yield* harness.engine.dispatch({
+        type: "thread.session.stop",
+        commandId: CommandId.make("stop-concurrent-sends"),
+        threadId,
+        createdAt,
+      });
+      yield* Deferred.await(stopped);
+      yield* Effect.promise(harness.drain);
+      const thread = (yield* Effect.promise(harness.readModel)).threads.find(
+        (entry) => entry.id === threadId,
+      );
+      expect(thread?.session?.status).toBe("stopped");
+      expect(
+        thread?.activities.some((activity) => activity.summary === "Queued message cancelled"),
+      ).toBe(false);
+    }),
+  );
+
+  effectIt.effect("cancels compaction preparation before stopping its previous session", () =>
+    Effect.gen(function* () {
+      const firstSent = yield* Deferred.make<void>();
+      const preparing = yield* Deferred.make<void>();
+      const preparationJoined = yield* Deferred.make<void>();
+      const stopped = yield* Deferred.make<void>();
+      let waitForNativeCapture = Effect.void;
+      let restarting = false;
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          startSessionEffect: (session) =>
+            restarting
+              ? Deferred.succeed(preparing, undefined).pipe(
+                  Effect.andThen(Effect.suspend(() => waitForNativeCapture)),
+                  Effect.as(session),
+                  Effect.ensuring(Deferred.succeed(preparationJoined, undefined)),
+                )
+              : Effect.succeed(session),
+          sendTurnEffect: (input) =>
+            Deferred.succeed(firstSent, undefined).pipe(
+              Effect.as({ threadId: input.threadId, turnId: asTurnId("turn-1") }),
+            ),
+          stopSessionEffect: () =>
+            Effect.gen(function* () {
+              expect(yield* Deferred.isDone(preparationJoined)).toBe(true);
+              yield* Deferred.succeed(stopped, undefined);
+            }),
+        }),
+      );
+      const threadId = ThreadId.make("thread-1");
+      const createdAt = "2026-01-01T00:00:00.000Z";
+      const dispatchMessage = (text: string) =>
+        harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make(`compaction-restart-${text}`),
+          threadId,
+          message: {
+            messageId: asMessageId(`compaction-restart-${text}`),
+            role: "user",
+            text,
+            attachments: [],
+          },
+          ...(restarting
+            ? {
+                modelSelection: {
+                  instanceId: ProviderInstanceId.make("codex_work"),
+                  model: "gpt-5-codex",
+                },
+              }
+            : {}),
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt,
+        });
+      yield* dispatchMessage("hello");
+      yield* Deferred.await(firstSent);
+      const submission = yield* harness.checkpointCapture.trackSubmission(
+        threadId,
+        ProviderInstanceId.make("codex"),
+      );
+      yield* submission.beforeSubmit(asTurnId("turn-1"));
+      yield* submission.accept(asTurnId("turn-1"));
+      waitForNativeCapture = harness.checkpointCapture.awaitNativeCapture(threadId);
+      yield* harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("compaction-restart-ready"),
+        threadId,
+        session: {
+          threadId,
+          providerName: "codex",
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          runtimeMode: "approval-required",
+          status: "ready",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: createdAt,
+        },
+        createdAt,
+      });
+      restarting = true;
+      yield* dispatchMessage("/compact");
+      yield* Deferred.await(preparing);
+      yield* harness.engine.dispatch({
+        type: "thread.session.stop",
+        commandId: CommandId.make("stop-compaction-restart"),
+        threadId,
+        createdAt,
+      });
+      yield* Deferred.await(stopped);
+      yield* Effect.promise(harness.drain);
+      expect(harness.compactThread).not.toHaveBeenCalled();
+      expect(harness.runtimeSessions).toEqual([]);
+    }),
+  );
+
+  effectIt.effect.each([
     { type: "thread.turn.interrupt", failCancellationActivity: false },
     { type: "thread.session.stop", failCancellationActivity: false },
     { type: "thread.turn.interrupt", failCancellationActivity: true },
@@ -891,11 +1199,13 @@ describe("ProviderCommandReactor", () => {
     { label: "another provider's command", text: "/logout", attachments: [] },
   ])("sends $label when the provider auth handler leaves it unhandled", ({ text, attachments }) =>
     Effect.gen(function* () {
-      const started = yield* Deferred.make<void>();
+      const sent = yield* Deferred.make<void>();
       const harness = yield* Effect.promise(() =>
         createHarness({
-          startSessionEffect: (session) =>
-            Deferred.succeed(started, undefined).pipe(Effect.as(session)),
+          sendTurnEffect: (input) =>
+            Deferred.succeed(sent, undefined).pipe(
+              Effect.as({ threadId: input.threadId, turnId: asTurnId("turn-1") }),
+            ),
         }),
       );
 
@@ -913,7 +1223,7 @@ describe("ProviderCommandReactor", () => {
         runtimeMode: "approval-required",
         createdAt: "2026-01-01T00:00:00.000Z",
       });
-      yield* Deferred.await(started);
+      yield* Deferred.await(sent);
       yield* Effect.promise(() => harness.drain());
 
       expect(harness.tryHandlePromptCommand).toHaveBeenCalledWith({
@@ -974,11 +1284,16 @@ describe("ProviderCommandReactor", () => {
     Effect.gen(function* () {
       const activation = yield* Deferred.make<void>();
       const started = yield* Deferred.make<ProviderSession>();
+      const sent = yield* Deferred.make<void>();
       const harness = yield* Effect.promise(() =>
         createHarness({
           serverActivation: Deferred.await(activation),
           startSessionEffect: (session) =>
             Deferred.succeed(started, session).pipe(Effect.as(session)),
+          sendTurnEffect: (input) =>
+            Deferred.succeed(sent, undefined).pipe(
+              Effect.as({ threadId: input.threadId, turnId: asTurnId("turn-1") }),
+            ),
         }),
       );
 
@@ -1000,6 +1315,7 @@ describe("ProviderCommandReactor", () => {
 
       yield* Deferred.succeed(activation, undefined);
       const session = yield* Deferred.await(started);
+      yield* Deferred.await(sent);
       yield* Effect.promise(() => harness.drain());
       expect(session.threadId).toBe(ThreadId.make("thread-1"));
       expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({
@@ -1872,7 +2188,6 @@ describe("ProviderCommandReactor", () => {
 
   effectIt.effect("shows the missing workspace message without a provider stack trace", () =>
     Effect.gen(function* () {
-      const attempted = yield* Deferred.make<void>();
       const missingCwd = "/missing/project/worktree";
       const missingWorkspace = new ProviderWorkspaceMissingError({
         threadId: ThreadId.make("thread-1"),
@@ -1880,11 +2195,18 @@ describe("ProviderCommandReactor", () => {
       });
       const harness = yield* Effect.promise(() =>
         createHarness({
-          startSessionEffect: () =>
-            Deferred.succeed(attempted, undefined).pipe(
-              Effect.andThen(Effect.fail(missingWorkspace)),
-            ),
+          startSessionEffect: () => Effect.fail(missingWorkspace),
         }),
+      );
+      const failureRecorded = yield* harness.engine.streamDomainEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.type === "thread.activity-appended" &&
+            event.payload.activity.kind === "provider.turn.start.failed",
+        ),
+        Stream.take(1),
+        Stream.toPull,
+        Scope.provide(scope!),
       );
 
       yield* harness.engine.dispatch({
@@ -1901,7 +2223,7 @@ describe("ProviderCommandReactor", () => {
         runtimeMode: "approval-required",
         createdAt: "2026-01-01T00:00:00.000Z",
       });
-      yield* Deferred.await(attempted);
+      yield* failureRecorded;
       yield* Effect.promise(() => harness.drain());
 
       const thread = (yield* Effect.promise(() => harness.readModel())).threads.find(
@@ -2768,7 +3090,13 @@ describe("ProviderCommandReactor", () => {
   });
 
   it("matches the client-seeded title even when the outgoing prompt is reformatted", async () => {
-    const harness = await createHarness();
+    const sent = Deferred.makeUnsafe<void>();
+    const harness = await createHarness({
+      sendTurnEffect: (input) =>
+        Deferred.succeed(sent, undefined).pipe(
+          Effect.as({ threadId: input.threadId, turnId: asTurnId("turn-1") }),
+        ),
+    });
     const now = "2026-01-01T00:00:00.000Z";
     const seededTitle = "Fix reconnect spinner on resume";
     const prompt = `[effort:high]\\n\\nFix reconnect spinner on resume ${serializeAssistantCitation(assistantCitation)}`;
@@ -2818,6 +3146,7 @@ describe("ProviderCommandReactor", () => {
     );
 
     await harness.runEffect(titleUpdated);
+    await harness.runEffect(Deferred.await(sent));
     await harness.drain();
 
     expect(harness.generateThreadTitle.mock.calls[0]?.[0].message).toBe(

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -783,72 +783,90 @@ describe("ProviderCommandReactor", () => {
     }),
   );
 
-  effectIt.effect("keeps steering concurrent and joins a pending send before native stop", () =>
-    Effect.gen(function* () {
-      const firstSent = yield* Deferred.make<void>();
-      const secondSent = yield* Deferred.make<void>();
-      const sendJoined = yield* Deferred.make<void>();
-      const stopped = yield* Deferred.make<void>();
-      const harness = yield* Effect.promise(() =>
-        createHarness({
-          sendTurnEffect: (input) =>
-            input.input === "first"
-              ? Deferred.succeed(firstSent, undefined).pipe(
-                  Effect.andThen(Effect.never),
-                  Effect.ensuring(Deferred.succeed(sendJoined, undefined)),
-                )
-              : Deferred.succeed(secondSent, undefined).pipe(
-                  Effect.as({ threadId: input.threadId, turnId: asTurnId("turn-1") }),
-                ),
-          stopSessionEffect: () =>
-            Effect.gen(function* () {
-              expect(yield* Deferred.isDone(sendJoined)).toBe(true);
-              yield* Deferred.succeed(stopped, undefined);
+  effectIt.effect.each([false, true])(
+    "joins pending admission before Stop with steering %s",
+    (steer) =>
+      Effect.gen(function* () {
+        const firstSent = yield* Deferred.make<void>();
+        const secondSent = yield* Deferred.make<void>();
+        const sendJoined = yield* Deferred.make<void>();
+        const stopped = yield* Deferred.make<void>();
+        const harness = yield* Effect.promise(() =>
+          createHarness({
+            sendTurnEffect: (input) =>
+              input.input === "first"
+                ? Deferred.succeed(firstSent, undefined).pipe(
+                    Effect.andThen(Effect.never),
+                    Effect.ensuring(Deferred.succeed(sendJoined, undefined)),
+                  )
+                : Deferred.succeed(secondSent, undefined).pipe(
+                    Effect.as({ threadId: input.threadId, turnId: asTurnId("turn-1") }),
+                  ),
+            stopSessionEffect: () =>
+              Effect.gen(function* () {
+                expect(yield* Deferred.isDone(sendJoined)).toBe(true);
+                yield* Deferred.succeed(stopped, undefined);
+              }),
+          }),
+        );
+        const threadId = ThreadId.make("thread-1");
+        const createdAt = "2026-01-01T00:00:00.000Z";
+        const inputs = steer ? ["first", "second"] : ["first"];
+        for (const text of inputs) {
+          yield* harness.engine.dispatch({
+            type: "thread.turn.start",
+            commandId: CommandId.make(`concurrent-send-${text}`),
+            threadId,
+            message: {
+              messageId: asMessageId(`concurrent-send-${text}`),
+              role: "user",
+              text,
+              attachments: [],
+            },
+            interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+            runtimeMode: "approval-required",
+            createdAt,
+          });
+        }
+        yield* Deferred.await(firstSent);
+        if (steer) yield* Deferred.await(secondSent);
+        expect(harness.startSession).toHaveBeenCalledOnce();
+        expect(harness.sendTurn.mock.calls.map(([input]) => input.input)).toEqual(inputs);
+        const events = yield* harness.engine.subscribeDomainEvents;
+        let interrupted = false;
+        yield* events.pipe(
+          Stream.filter(
+            (event) =>
+              event.type === "thread.activity-appended" &&
+              event.payload.operationResult?.requestId === "concurrent-send-first" &&
+              event.payload.operationResult.outcome === "interrupted",
+          ),
+          Stream.runForEach(() =>
+            Effect.sync(() => {
+              interrupted = true;
             }),
-        }),
-      );
-      const threadId = ThreadId.make("thread-1");
-      const createdAt = "2026-01-01T00:00:00.000Z";
-      for (const text of ["first", "second"]) {
+          ),
+          Effect.forkChild({ startImmediately: true }),
+        );
+
         yield* harness.engine.dispatch({
-          type: "thread.turn.start",
-          commandId: CommandId.make(`concurrent-send-${text}`),
+          type: "thread.session.stop",
+          commandId: CommandId.make("stop-concurrent-sends"),
           threadId,
-          message: {
-            messageId: asMessageId(`concurrent-send-${text}`),
-            role: "user",
-            text,
-            attachments: [],
-          },
-          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-          runtimeMode: "approval-required",
           createdAt,
         });
-      }
-      yield* Deferred.await(firstSent);
-      yield* Deferred.await(secondSent);
-      expect(harness.startSession).toHaveBeenCalledOnce();
-      expect(harness.sendTurn.mock.calls.map(([input]) => input.input)).toEqual([
-        "first",
-        "second",
-      ]);
-
-      yield* harness.engine.dispatch({
-        type: "thread.session.stop",
-        commandId: CommandId.make("stop-concurrent-sends"),
-        threadId,
-        createdAt,
-      });
-      yield* Deferred.await(stopped);
-      yield* Effect.promise(harness.drain);
-      const thread = (yield* Effect.promise(harness.readModel)).threads.find(
-        (entry) => entry.id === threadId,
-      );
-      expect(thread?.session?.status).toBe("stopped");
-      expect(
-        thread?.activities.some((activity) => activity.summary === "Queued message cancelled"),
-      ).toBe(false);
-    }),
+        yield* Deferred.await(stopped);
+        yield* Effect.promise(harness.drain);
+        expect(interrupted).toBe(true);
+        const thread = (yield* Effect.promise(harness.readModel)).threads.find(
+          (entry) => entry.id === threadId,
+        );
+        expect(thread?.session?.status).toBe("stopped");
+        expect(thread?.pendingOperation).toBeNull();
+        expect(
+          thread?.activities.some((activity) => activity.summary === "Queued message cancelled"),
+        ).toBe(false);
+      }),
   );
 
   effectIt.effect("cancels compaction preparation before stopping its previous session", () =>
@@ -1328,12 +1346,17 @@ describe("ProviderCommandReactor", () => {
   effectIt.effect("starts a turn and generates its title without loading old message bodies", () =>
     Effect.gen(function* () {
       const started = yield* Deferred.make<void>();
+      const sent = yield* Deferred.make<void>();
       const titleGenerated = yield* Deferred.make<void>();
       const harness = yield* Effect.promise(() =>
         createHarness({
           unreadableHistory: true,
           startSessionEffect: (session) =>
             Deferred.succeed(started, undefined).pipe(Effect.as(session)),
+          sendTurnEffect: (input) =>
+            Deferred.succeed(sent, undefined).pipe(
+              Effect.as({ threadId: input.threadId, turnId: asTurnId("turn-1") }),
+            ),
         }),
       );
       harness.generateThreadTitle.mockReturnValue(
@@ -1356,6 +1379,7 @@ describe("ProviderCommandReactor", () => {
       });
       yield* Deferred.await(started);
       yield* Deferred.await(titleGenerated);
+      yield* Deferred.await(sent);
       yield* Effect.promise(() => harness.drain());
 
       expect(harness.sendTurn).toHaveBeenCalledWith(

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -97,6 +97,7 @@ interface PendingSessionCommand {
     { type: "thread.turn-start-requested" | "thread.runtime-mode-set" }
   >;
   preparing: boolean;
+  cancelledBeforeSend: boolean;
   fiber: Fiber.Fiber<void> | undefined;
 }
 type ProviderCommandInput =
@@ -354,7 +355,12 @@ const make = Effect.gen(function* () {
       pending: new Set<PendingSessionCommand>(),
     };
     sessionCommands.set(threadId, commands);
-    const command: PendingSessionCommand = { event, preparing: true, fiber: undefined };
+    const command: PendingSessionCommand = {
+      event,
+      preparing: true,
+      cancelledBeforeSend: false,
+      fiber: undefined,
+    };
     commands.pending.add(command);
     command.fiber = yield* run(commands.preparation, command).pipe(
       Effect.ensuring(
@@ -1666,8 +1672,13 @@ const make = Effect.gen(function* () {
           Effect.asVoid,
         );
       }).pipe(
-        Effect.catchCause(recoverTurnStartFailure),
-        Effect.onInterrupt(() => recoverTurnStartFailure(Cause.interrupt())),
+        Effect.catchCause((cause) =>
+          Cause.hasInterruptsOnly(cause) ? Effect.interrupt : recoverTurnStartFailure(cause),
+        ),
+        Effect.onInterrupt(() =>
+          // Interrupt and stop own the visible result for requests they cancel before send.
+          command.cancelledBeforeSend ? Effect.void : recoverTurnStartFailure(Cause.interrupt()),
+        ),
       ),
     );
   });
@@ -1973,6 +1984,7 @@ const make = Effect.gen(function* () {
       const pending = [...(sessionCommands.get(event.payload.threadId)?.pending ?? [])];
       for (const command of pending) {
         if (command.preparing && command.event.type === "thread.turn-start-requested") {
+          command.cancelledBeforeSend = true;
           delayed.add(command.event);
         }
       }
@@ -2159,6 +2171,7 @@ const make = Effect.gen(function* () {
   return {
     start,
     drain: Effect.gen(function* () {
+      // Parked session commands and native work have their own completion signals.
       yield* worker.drain;
       yield* threadTitleRegenerationWorker.drain;
     }),

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1665,7 +1665,10 @@ const make = Effect.gen(function* () {
           ),
           Effect.asVoid,
         );
-      }).pipe(Effect.catchCause(recoverTurnStartFailure)),
+      }).pipe(
+        Effect.catchCause(recoverTurnStartFailure),
+        Effect.onInterrupt(() => recoverTurnStartFailure(Cause.interrupt())),
+      ),
     );
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1563,30 +1563,35 @@ const make = Effect.gen(function* () {
             threadModelSelections.set(event.payload.threadId, event.payload.modelSelection);
           }
           command.preparing = false;
-          yield* providerService
-            .compactThread(
-              event.payload.threadId,
-              event.payload.modelSelection,
-              event.payload.messageId,
-            )
-            .pipe(
-              Effect.andThen(
-                restoreCompaction(
+          yield* Effect.uninterruptibleMask((restore) =>
+            Effect.gen(function* () {
+              yield* providerService
+                .compactThread(
                   event.payload.threadId,
-                  { requestId: event.payload.messageId, outcome: "completed" },
-                  true,
-                ),
-              ),
-              Effect.catchCause(recoverCompactionFailure),
-              Effect.ensuring(
-                Effect.sync(() => {
-                  if (!stoppingThreadIds.has(event.payload.threadId))
-                    compactingThreads.delete(event.payload.threadId);
-                }),
-              ),
-              Effect.forkScoped,
-            );
-          compactionStarted = true;
+                  event.payload.modelSelection,
+                  event.payload.messageId,
+                )
+                .pipe(
+                  Effect.andThen(
+                    restoreCompaction(
+                      event.payload.threadId,
+                      { requestId: event.payload.messageId, outcome: "completed" },
+                      true,
+                    ),
+                  ),
+                  Effect.catchCause(recoverCompactionFailure),
+                  Effect.ensuring(
+                    Effect.sync(() => {
+                      if (!stoppingThreadIds.has(event.payload.threadId))
+                        compactingThreads.delete(event.payload.threadId);
+                    }),
+                  ),
+                  restore,
+                  Effect.forkScoped,
+                );
+              compactionStarted = true;
+            }),
+          );
         }).pipe(
           Effect.catchCause(recoverCompactionFailure),
           Effect.ensuring(

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -644,269 +644,287 @@ const make = Effect.gen(function* () {
   const ensureSessionForThread = Effect.fn("ensureSessionForThread")(function* (
     threadId: ThreadId,
     createdAt: string,
+    command: PendingSessionCommand,
     options?: {
       readonly modelSelection?: ModelSelection;
       readonly pendingTurnStart?: boolean;
     },
   ) {
-    const thread = yield* resolveThreadShell(threadId);
-    if (!thread) {
-      return yield* Effect.die(new Error(`Thread '${threadId}' was not found in read model.`));
-    }
-
-    const desiredRuntimeMode = thread.runtimeMode;
-    const requestedModelSelection = options?.modelSelection;
-    const resolveActiveSession = (threadId: ThreadId) =>
-      providerService
-        .listSessions()
-        .pipe(Effect.map((sessions) => sessions.find((session) => session.threadId === threadId)));
-
-    const activeSession = yield* resolveActiveSession(threadId);
-    const activeThreadSession =
-      thread.session !== null && thread.session.status !== "stopped" && activeSession
-        ? thread.session
-        : null;
-    if (
-      activeThreadSession !== null &&
-      activeSession !== undefined &&
-      (activeThreadSession.providerInstanceId === undefined ||
-        activeSession.providerInstanceId === undefined)
-    ) {
-      return yield* new ProviderAdapterRequestError({
-        provider: providerErrorLabel(activeThreadSession.providerName ?? undefined),
-        method: "thread.turn.start",
-        detail: `Thread '${threadId}' has an active provider session without a provider instance id.`,
-      });
-    }
-    const currentInstanceId =
-      activeThreadSession !== null &&
-      activeSession !== undefined &&
-      activeSession.providerInstanceId !== undefined
-        ? activeSession.providerInstanceId
-        : thread.modelSelection.instanceId;
-    const desiredModelSelection = requestedModelSelection ?? thread.modelSelection;
-    const desiredInstanceId = desiredModelSelection.instanceId;
-    const currentInfo = yield* providerService.getInstanceInfo(currentInstanceId).pipe(
-      Effect.mapError(
-        () =>
-          new ProviderAdapterRequestError({
-            provider: providerErrorLabelFromInstanceHint({
-              instanceId: String(currentInstanceId),
-              modelSelectionInstanceId: String(thread.modelSelection.instanceId),
-              sessionProvider: thread.session?.providerName ?? undefined,
-            }),
-            method: "thread.turn.start",
-            detail: `Thread '${threadId}' references unknown provider instance '${currentInstanceId}'. The instance is not configured in this build.`,
-          }),
-      ),
-    );
-    const desiredInfo = yield* providerService.getInstanceInfo(desiredInstanceId).pipe(
-      Effect.mapError(
-        () =>
-          new ProviderAdapterRequestError({
-            provider: providerErrorLabelFromInstanceHint({
-              instanceId: String(desiredModelSelection.instanceId),
-            }),
-            method: "thread.turn.start",
-            detail: `Requested provider instance '${desiredInstanceId}' is not configured in this build.`,
-          }),
-      ),
-    );
-    const desiredDriverKind = desiredInfo.driverKind;
-    if (!isProviderDriverKind(desiredDriverKind)) {
-      return yield* new ProviderAdapterRequestError({
-        provider: providerErrorLabel(String(desiredDriverKind)),
-        method: "thread.turn.start",
-        detail: `Requested provider instance '${desiredInstanceId}' uses unknown provider driver '${desiredDriverKind}'. The driver is not installed in this build.`,
-      });
-    }
-    const preferredProvider: ProviderDriverKind = desiredDriverKind;
-    if (options?.pendingTurnStart === true && thread.session?.status !== "running") {
-      yield* setThreadSession({
-        threadId,
-        session: {
-          threadId,
-          status: "starting",
-          providerName: activeSession?.provider ?? preferredProvider,
-          providerInstanceId: activeSession?.providerInstanceId ?? desiredInstanceId,
-          runtimeMode: desiredRuntimeMode,
-          activeTurnId: null,
-          lastError: null,
-          updatedAt: createdAt,
-        },
-        createdAt,
-      });
-    }
-    if (thread.session !== null) {
-      yield* rejectStartedThreadModelChangeIfRequired({
-        threadId,
-        currentModelSelection:
-          activeSession?.model !== undefined
-            ? {
-                ...thread.modelSelection,
-                instanceId: currentInstanceId,
-                model: activeSession.model,
-              }
-            : thread.modelSelection,
-        requestedModelSelection,
-      });
-    }
-    if (
-      thread.session !== null &&
-      requestedModelSelection !== undefined &&
-      requestedModelSelection.instanceId !== currentInstanceId
-    ) {
-      if (currentInfo.driverKind !== desiredInfo.driverKind) {
-        return yield* new ProviderAdapterRequestError({
-          provider: preferredProvider,
-          method: "thread.turn.start",
-          detail: `Thread '${threadId}' is bound to driver '${currentInfo.driverKind}' and cannot switch to '${desiredInfo.driverKind}'.`,
-        });
+    while (true) {
+      const thread = yield* resolveThreadShell(threadId);
+      if (!thread) {
+        return yield* Effect.die(new Error(`Thread '${threadId}' was not found in read model.`));
       }
+
+      const desiredRuntimeMode = thread.runtimeMode;
+      const requestedModelSelection = options?.modelSelection;
+      const resolveActiveSession = (threadId: ThreadId) =>
+        providerService
+          .listSessions()
+          .pipe(
+            Effect.map((sessions) => sessions.find((session) => session.threadId === threadId)),
+          );
+
+      const activeSession = yield* resolveActiveSession(threadId);
+      const activeThreadSession =
+        thread.session !== null && thread.session.status !== "stopped" && activeSession
+          ? thread.session
+          : null;
       if (
-        currentInfo.continuationIdentity.continuationKey !==
-        desiredInfo.continuationIdentity.continuationKey
+        activeThreadSession !== null &&
+        activeSession !== undefined &&
+        (activeThreadSession.providerInstanceId === undefined ||
+          activeSession.providerInstanceId === undefined)
       ) {
         return yield* new ProviderAdapterRequestError({
-          provider: preferredProvider,
+          provider: providerErrorLabel(activeThreadSession.providerName ?? undefined),
           method: "thread.turn.start",
-          detail: `Thread '${threadId}' cannot switch from instance '${currentInstanceId}' to '${desiredInstanceId}' because their provider resume state is incompatible.`,
+          detail: `Thread '${threadId}' has an active provider session without a provider instance id.`,
         });
       }
-    }
-    const project = yield* resolveProject(thread.projectId);
-    const effectiveCwd = resolveThreadWorkspaceCwd({
-      thread,
-      projects: project ? [project] : [],
-    });
-    const refreshWorkspaceSnapshot = effectiveCwd
-      ? providerRegistry
-          .refreshWorkspaceSnapshot({ instanceId: desiredInstanceId, cwd: effectiveCwd })
-          .pipe(Effect.forkDetach)
-      : Effect.void;
-
-    const startProviderSession = (input?: {
-      readonly resumeCursor?: unknown;
-      readonly provider?: ProviderDriverKind;
-    }) =>
-      providerService
-        .startSession(threadId, {
-          threadId,
-          ...(preferredProvider ? { provider: preferredProvider } : {}),
-          providerInstanceId: desiredInstanceId,
-          ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
-          ...(thread.title ? { title: thread.title } : {}),
-          modelSelection: desiredModelSelection,
-          ...(input?.resumeCursor !== undefined ? { resumeCursor: input.resumeCursor } : {}),
-          runtimeMode: desiredRuntimeMode,
-        })
-        .pipe(Effect.tap(() => refreshWorkspaceSnapshot));
-
-    const bindSessionToThread = (session: ProviderSession) =>
-      Effect.gen(function* () {
-        if (session.providerInstanceId === undefined) {
-          return yield* new ProviderAdapterRequestError({
-            provider: providerErrorLabel(session.provider),
-            method: "thread.turn.start",
-            detail: `Provider session '${session.threadId}' started without a provider instance id.`,
-          });
-        }
+      const currentInstanceId =
+        activeThreadSession !== null &&
+        activeSession !== undefined &&
+        activeSession.providerInstanceId !== undefined
+          ? activeSession.providerInstanceId
+          : thread.modelSelection.instanceId;
+      const desiredModelSelection = requestedModelSelection ?? thread.modelSelection;
+      const desiredInstanceId = desiredModelSelection.instanceId;
+      const currentInfo = yield* providerService.getInstanceInfo(currentInstanceId).pipe(
+        Effect.mapError(
+          () =>
+            new ProviderAdapterRequestError({
+              provider: providerErrorLabelFromInstanceHint({
+                instanceId: String(currentInstanceId),
+                modelSelectionInstanceId: String(thread.modelSelection.instanceId),
+                sessionProvider: thread.session?.providerName ?? undefined,
+              }),
+              method: "thread.turn.start",
+              detail: `Thread '${threadId}' references unknown provider instance '${currentInstanceId}'. The instance is not configured in this build.`,
+            }),
+        ),
+      );
+      const desiredInfo = yield* providerService.getInstanceInfo(desiredInstanceId).pipe(
+        Effect.mapError(
+          () =>
+            new ProviderAdapterRequestError({
+              provider: providerErrorLabelFromInstanceHint({
+                instanceId: String(desiredModelSelection.instanceId),
+              }),
+              method: "thread.turn.start",
+              detail: `Requested provider instance '${desiredInstanceId}' is not configured in this build.`,
+            }),
+        ),
+      );
+      const desiredDriverKind = desiredInfo.driverKind;
+      if (!isProviderDriverKind(desiredDriverKind)) {
+        return yield* new ProviderAdapterRequestError({
+          provider: providerErrorLabel(String(desiredDriverKind)),
+          method: "thread.turn.start",
+          detail: `Requested provider instance '${desiredInstanceId}' uses unknown provider driver '${desiredDriverKind}'. The driver is not installed in this build.`,
+        });
+      }
+      const preferredProvider: ProviderDriverKind = desiredDriverKind;
+      if (options?.pendingTurnStart === true && thread.session?.status !== "running") {
         yield* setThreadSession({
           threadId,
           session: {
             threadId,
-            status:
-              options?.pendingTurnStart === true && session.status === "ready"
-                ? "starting"
-                : mapProviderSessionStatusToOrchestrationStatus(session.status),
-            providerName: session.provider,
-            providerInstanceId: session.providerInstanceId,
+            status: "starting",
+            providerName: activeSession?.provider ?? preferredProvider,
+            providerInstanceId: activeSession?.providerInstanceId ?? desiredInstanceId,
             runtimeMode: desiredRuntimeMode,
-            // Provider turn ids are not orchestration turn ids.
             activeTurnId: null,
-            lastError: session.lastError ?? null,
-            updatedAt: session.updatedAt,
+            lastError: null,
+            updatedAt: createdAt,
           },
           createdAt,
         });
-      });
-
-    const existingSessionThreadId =
-      thread.session && thread.session.status !== "stopped" && activeSession ? thread.id : null;
-    if (existingSessionThreadId) {
-      const runtimeModeChanged = thread.runtimeMode !== thread.session?.runtimeMode;
-      const cwdChanged = effectiveCwd !== activeSession?.cwd;
-      const sessionModelSwitch = (yield* providerService.getCapabilities(desiredInstanceId))
-        .sessionModelSwitch;
-      const modelChanged =
-        requestedModelSelection !== undefined &&
-        requestedModelSelection.model !== activeSession?.model;
-      const instanceChanged =
-        requestedModelSelection !== undefined &&
-        activeSession?.providerInstanceId !== requestedModelSelection.instanceId;
-      const shouldRestartForModelChange = modelChanged && sessionModelSwitch === "unsupported";
-      const previousModelSelection = threadModelSelections.get(threadId);
-      const shouldRestartForModelSelectionChange =
-        preferredProvider === "claudeAgent" &&
-        requestedModelSelection !== undefined &&
-        !Equal.equals(previousModelSelection, requestedModelSelection);
-
+      }
+      if (thread.session !== null) {
+        yield* rejectStartedThreadModelChangeIfRequired({
+          threadId,
+          currentModelSelection:
+            activeSession?.model !== undefined
+              ? {
+                  ...thread.modelSelection,
+                  instanceId: currentInstanceId,
+                  model: activeSession.model,
+                }
+              : thread.modelSelection,
+          requestedModelSelection,
+        });
+      }
       if (
-        !runtimeModeChanged &&
-        !cwdChanged &&
-        !instanceChanged &&
-        !shouldRestartForModelChange &&
-        !shouldRestartForModelSelectionChange
+        thread.session !== null &&
+        requestedModelSelection !== undefined &&
+        requestedModelSelection.instanceId !== currentInstanceId
       ) {
-        yield* refreshWorkspaceSnapshot;
-        return existingSessionThreadId;
+        if (currentInfo.driverKind !== desiredInfo.driverKind) {
+          return yield* new ProviderAdapterRequestError({
+            provider: preferredProvider,
+            method: "thread.turn.start",
+            detail: `Thread '${threadId}' is bound to driver '${currentInfo.driverKind}' and cannot switch to '${desiredInfo.driverKind}'.`,
+          });
+        }
+        if (
+          currentInfo.continuationIdentity.continuationKey !==
+          desiredInfo.continuationIdentity.continuationKey
+        ) {
+          return yield* new ProviderAdapterRequestError({
+            provider: preferredProvider,
+            method: "thread.turn.start",
+            detail: `Thread '${threadId}' cannot switch from instance '${currentInstanceId}' to '${desiredInstanceId}' because their provider resume state is incompatible.`,
+          });
+        }
+      }
+      const project = yield* resolveProject(thread.projectId);
+      const effectiveCwd = resolveThreadWorkspaceCwd({
+        thread,
+        projects: project ? [project] : [],
+      });
+      const refreshWorkspaceSnapshot = effectiveCwd
+        ? providerRegistry
+            .refreshWorkspaceSnapshot({ instanceId: desiredInstanceId, cwd: effectiveCwd })
+            .pipe(Effect.forkDetach)
+        : Effect.void;
+
+      const startProviderSession = (input?: {
+        readonly resumeCursor?: unknown;
+        readonly provider?: ProviderDriverKind;
+      }) =>
+        providerService
+          .startSession(threadId, {
+            threadId,
+            ...(preferredProvider ? { provider: preferredProvider } : {}),
+            providerInstanceId: desiredInstanceId,
+            ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
+            ...(thread.title ? { title: thread.title } : {}),
+            modelSelection: desiredModelSelection,
+            ...(input?.resumeCursor !== undefined ? { resumeCursor: input.resumeCursor } : {}),
+            runtimeMode: desiredRuntimeMode,
+          })
+          .pipe(Effect.tap(() => refreshWorkspaceSnapshot));
+
+      const bindSessionToThread = (session: ProviderSession) =>
+        Effect.gen(function* () {
+          if (session.providerInstanceId === undefined) {
+            return yield* new ProviderAdapterRequestError({
+              provider: providerErrorLabel(session.provider),
+              method: "thread.turn.start",
+              detail: `Provider session '${session.threadId}' started without a provider instance id.`,
+            });
+          }
+          yield* setThreadSession({
+            threadId,
+            session: {
+              threadId,
+              status:
+                options?.pendingTurnStart === true && session.status === "ready"
+                  ? "starting"
+                  : mapProviderSessionStatusToOrchestrationStatus(session.status),
+              providerName: session.provider,
+              providerInstanceId: session.providerInstanceId,
+              runtimeMode: desiredRuntimeMode,
+              // Provider turn ids are not orchestration turn ids.
+              activeTurnId: null,
+              lastError: session.lastError ?? null,
+              updatedAt: session.updatedAt,
+            },
+            createdAt,
+          });
+        });
+
+      const existingSessionThreadId =
+        thread.session && thread.session.status !== "stopped" && activeSession ? thread.id : null;
+      if (existingSessionThreadId) {
+        const runtimeModeChanged = thread.runtimeMode !== activeSession?.runtimeMode;
+        const cwdChanged = effectiveCwd !== activeSession?.cwd;
+        const sessionModelSwitch = (yield* providerService.getCapabilities(desiredInstanceId))
+          .sessionModelSwitch;
+        const modelChanged =
+          requestedModelSelection !== undefined &&
+          requestedModelSelection.model !== activeSession?.model;
+        const instanceChanged =
+          requestedModelSelection !== undefined &&
+          activeSession?.providerInstanceId !== requestedModelSelection.instanceId;
+        const shouldRestartForModelChange = modelChanged && sessionModelSwitch === "unsupported";
+        const previousModelSelection = threadModelSelections.get(threadId);
+        const shouldRestartForModelSelectionChange =
+          preferredProvider === "claudeAgent" &&
+          requestedModelSelection !== undefined &&
+          !Equal.equals(previousModelSelection, requestedModelSelection);
+
+        if (
+          !runtimeModeChanged &&
+          !cwdChanged &&
+          !instanceChanged &&
+          !shouldRestartForModelChange &&
+          !shouldRestartForModelSelectionChange
+        ) {
+          yield* refreshWorkspaceSnapshot;
+          return existingSessionThreadId;
+        }
+
+        const sendingCommands: Array<Fiber.Fiber<void>> = [];
+        for (const pending of sessionCommands.get(threadId)?.pending ?? []) {
+          if (pending !== command && !pending.preparing && pending.fiber !== undefined)
+            sendingCommands.push(pending.fiber);
+        }
+        if (sendingCommands.length > 0) {
+          // Only replacements wait for earlier sends. Unchanged sessions still allow steering.
+          // Preparing commands can be waiting for this permit, so never wait on them here.
+          yield* Fiber.awaitAll(sendingCommands);
+          continue;
+        }
+
+        const resumeCursor = shouldRestartForModelChange
+          ? undefined
+          : (activeSession?.resumeCursor ?? undefined);
+        yield* Effect.logInfo("provider command reactor restarting provider session", {
+          threadId,
+          existingSessionThreadId,
+          currentProvider: activeSession?.provider,
+          currentInstanceId,
+          desiredInstanceId,
+          desiredProvider: desiredModelSelection.instanceId,
+          currentRuntimeMode: thread.session?.runtimeMode,
+          desiredRuntimeMode: thread.runtimeMode,
+          runtimeModeChanged,
+          previousCwd: activeSession?.cwd,
+          desiredCwd: effectiveCwd,
+          cwdChanged,
+          modelChanged,
+          instanceChanged,
+          shouldRestartForModelChange,
+          shouldRestartForModelSelectionChange,
+          hasResumeCursor: resumeCursor !== undefined,
+        });
+        const restartedSession = yield* startProviderSession(
+          resumeCursor !== undefined ? { resumeCursor } : undefined,
+        );
+        yield* Effect.logInfo("provider command reactor restarted provider session", {
+          threadId,
+          previousSessionId: existingSessionThreadId,
+          restartedSessionThreadId: restartedSession.threadId,
+          provider: restartedSession.provider,
+          runtimeMode: restartedSession.runtimeMode,
+          cwd: restartedSession.cwd,
+        });
+        yield* bindSessionToThread(restartedSession);
+        return restartedSession.threadId;
       }
 
-      const resumeCursor = shouldRestartForModelChange
-        ? undefined
-        : (activeSession?.resumeCursor ?? undefined);
-      yield* Effect.logInfo("provider command reactor restarting provider session", {
-        threadId,
-        existingSessionThreadId,
-        currentProvider: activeSession?.provider,
-        currentInstanceId,
-        desiredInstanceId,
-        desiredProvider: desiredModelSelection.instanceId,
-        currentRuntimeMode: thread.session?.runtimeMode,
-        desiredRuntimeMode: thread.runtimeMode,
-        runtimeModeChanged,
-        previousCwd: activeSession?.cwd,
-        desiredCwd: effectiveCwd,
-        cwdChanged,
-        modelChanged,
-        instanceChanged,
-        shouldRestartForModelChange,
-        shouldRestartForModelSelectionChange,
-        hasResumeCursor: resumeCursor !== undefined,
-      });
-      const restartedSession = yield* startProviderSession(
-        resumeCursor !== undefined ? { resumeCursor } : undefined,
-      );
-      yield* Effect.logInfo("provider command reactor restarted provider session", {
-        threadId,
-        previousSessionId: existingSessionThreadId,
-        restartedSessionThreadId: restartedSession.threadId,
-        provider: restartedSession.provider,
-        runtimeMode: restartedSession.runtimeMode,
-        cwd: restartedSession.cwd,
-      });
-      yield* bindSessionToThread(restartedSession);
-      return restartedSession.threadId;
+      const startedSession = yield* startProviderSession(undefined);
+      yield* bindSessionToThread(startedSession);
+      return startedSession.threadId;
     }
-
-    const startedSession = yield* startProviderSession(undefined);
-    yield* bindSessionToThread(startedSession);
-    return startedSession.threadId;
   });
 
   const buildSendTurnRequestForThread = Effect.fnUntraced(function* (input: {
     readonly threadId: ThreadId;
     readonly messageText: string;
+    readonly command: PendingSessionCommand;
     readonly attachments?: ReadonlyArray<ChatAttachment>;
     readonly modelSelection?: ModelSelection;
     readonly interactionMode?: "default" | "plan";
@@ -918,7 +936,7 @@ const make = Effect.gen(function* () {
         new Error(`Thread '${input.threadId}' was not found in read model.`),
       );
     }
-    yield* ensureSessionForThread(input.threadId, input.createdAt, {
+    yield* ensureSessionForThread(input.threadId, input.createdAt, input.command, {
       ...(input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {}),
       pendingTurnStart: true,
     });
@@ -1560,15 +1578,22 @@ const make = Effect.gen(function* () {
           yield* ensureSessionForThread(
             event.payload.threadId,
             event.payload.createdAt,
+            command,
             event.payload.modelSelection !== undefined
               ? { modelSelection: event.payload.modelSelection, pendingTurnStart: true }
               : { pendingTurnStart: true },
-          ).pipe(preparation.withPermit);
-          compactionSessionEnsured = true;
-          if (event.payload.modelSelection !== undefined) {
-            threadModelSelections.set(event.payload.threadId, event.payload.modelSelection);
-          }
-          command.preparing = false;
+          ).pipe(
+            Effect.tap(() =>
+              Effect.sync(() => {
+                compactionSessionEnsured = true;
+                if (event.payload.modelSelection !== undefined) {
+                  threadModelSelections.set(event.payload.threadId, event.payload.modelSelection);
+                }
+                command.preparing = false;
+              }),
+            ),
+            preparation.withPermit,
+          );
           yield* Effect.uninterruptibleMask((restore) =>
             Effect.gen(function* () {
               yield* providerService
@@ -1620,17 +1645,23 @@ const make = Effect.gen(function* () {
         const sendTurnRequest = yield* buildSendTurnRequestForThread({
           threadId: event.payload.threadId,
           messageText: message.text,
+          command,
           ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
           ...(event.payload.modelSelection !== undefined
             ? { modelSelection: event.payload.modelSelection }
             : {}),
           interactionMode: event.payload.interactionMode,
           createdAt: event.payload.createdAt,
-        }).pipe(preparation.withPermit);
+        }).pipe(
+          Effect.tap(() =>
+            Effect.sync(() => {
+              command.preparing = false;
+            }),
+          ),
+          preparation.withPermit,
+        );
 
-        // A cancelled send can already have reached the provider. Only preparation
-        // can be reported as a message that was never submitted.
-        command.preparing = false;
+        // Releasing preparation lets unchanged-session messages steer this send.
         yield* providerService.sendTurn(sendTurnRequest).pipe(
           Effect.flatMap((result) =>
             orchestrationEngine.dispatch({
@@ -2029,12 +2060,13 @@ const make = Effect.gen(function* () {
         if (!thread?.session || thread.session.status === "stopped") {
           return;
         }
-        yield* forkSessionCommand(event, (preparation) =>
+        yield* forkSessionCommand(event, (preparation, command) =>
           Effect.gen(function* () {
             const cachedModelSelection = threadModelSelections.get(event.payload.threadId);
             yield* ensureSessionForThread(
               event.payload.threadId,
               event.occurredAt,
+              command,
               cachedModelSelection !== undefined ? { modelSelection: cachedModelSelection } : {},
             );
           }).pipe(

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -29,11 +29,13 @@ import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Equal from "effect/Equal";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 import { makeDrainableWorker, type DrainableWorker } from "@t3tools/shared/DrainableWorker";
 
@@ -89,6 +91,14 @@ type TurnStartRequestedEvent = Extract<
   ProviderIntentEvent,
   { type: "thread.turn-start-requested" }
 >;
+interface PendingSessionCommand {
+  readonly event: Extract<
+    ProviderIntentEvent,
+    { type: "thread.turn-start-requested" | "thread.runtime-mode-set" }
+  >;
+  preparing: boolean;
+  fiber: Fiber.Fiber<void> | undefined;
+}
 type ProviderCommandInput =
   | ProviderIntentEvent
   | {
@@ -325,6 +335,37 @@ const make = Effect.gen(function* () {
   const compactingThreads = new Map<ThreadId, OrchestrationOperationResult | null>();
   const stoppingThreadIds = new Set<ThreadId>();
   const delayedTurnStarts = new Map<ThreadId, Set<TurnStartRequestedEvent>>();
+  const sessionCommands = new Map<
+    ThreadId,
+    { readonly preparation: Semaphore.Semaphore; readonly pending: Set<PendingSessionCommand> }
+  >();
+
+  // Session preparation stays ordered per thread without blocking interrupt or stop commands.
+  const forkSessionCommand = Effect.fn("forkSessionCommand")(function* <R>(
+    event: PendingSessionCommand["event"],
+    run: (
+      preparation: Semaphore.Semaphore,
+      command: PendingSessionCommand,
+    ) => Effect.Effect<void, never, R>,
+  ) {
+    const threadId = event.payload.threadId;
+    const commands = sessionCommands.get(threadId) ?? {
+      preparation: yield* Semaphore.make(1),
+      pending: new Set<PendingSessionCommand>(),
+    };
+    sessionCommands.set(threadId, commands);
+    const command: PendingSessionCommand = { event, preparing: true, fiber: undefined };
+    commands.pending.add(command);
+    command.fiber = yield* run(commands.preparation, command).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          commands.pending.delete(command);
+          if (commands.pending.size === 0) sessionCommands.delete(threadId);
+        }),
+      ),
+      Effect.forkScoped,
+    );
+  });
 
   const appendProviderFailureActivity = (
     input: {
@@ -1507,42 +1548,53 @@ const make = Effect.gen(function* () {
         return;
       }
       compactingThreads.set(event.payload.threadId, null);
-      yield* Effect.gen(function* () {
-        yield* ensureSessionForThread(
-          event.payload.threadId,
-          event.payload.createdAt,
-          event.payload.modelSelection !== undefined
-            ? { modelSelection: event.payload.modelSelection, pendingTurnStart: true }
-            : { pendingTurnStart: true },
-        );
-        compactionSessionEnsured = true;
-        if (event.payload.modelSelection !== undefined) {
-          threadModelSelections.set(event.payload.threadId, event.payload.modelSelection);
-        }
-        yield* providerService.compactThread(
-          event.payload.threadId,
-          event.payload.modelSelection,
-          event.payload.messageId,
-        );
-      }).pipe(
-        Effect.andThen(
-          restoreCompaction(
+      let compactionStarted = false;
+      yield* forkSessionCommand(event, (preparation, command) =>
+        Effect.gen(function* () {
+          yield* ensureSessionForThread(
             event.payload.threadId,
-            {
-              requestId: event.payload.messageId,
-              outcome: "completed",
-            },
-            true,
+            event.payload.createdAt,
+            event.payload.modelSelection !== undefined
+              ? { modelSelection: event.payload.modelSelection, pendingTurnStart: true }
+              : { pendingTurnStart: true },
+          ).pipe(preparation.withPermit);
+          compactionSessionEnsured = true;
+          if (event.payload.modelSelection !== undefined) {
+            threadModelSelections.set(event.payload.threadId, event.payload.modelSelection);
+          }
+          command.preparing = false;
+          yield* providerService
+            .compactThread(
+              event.payload.threadId,
+              event.payload.modelSelection,
+              event.payload.messageId,
+            )
+            .pipe(
+              Effect.andThen(
+                restoreCompaction(
+                  event.payload.threadId,
+                  { requestId: event.payload.messageId, outcome: "completed" },
+                  true,
+                ),
+              ),
+              Effect.catchCause(recoverCompactionFailure),
+              Effect.ensuring(
+                Effect.sync(() => {
+                  if (!stoppingThreadIds.has(event.payload.threadId))
+                    compactingThreads.delete(event.payload.threadId);
+                }),
+              ),
+              Effect.forkScoped,
+            );
+          compactionStarted = true;
+        }).pipe(
+          Effect.catchCause(recoverCompactionFailure),
+          Effect.ensuring(
+            Effect.sync(() => {
+              if (!compactionStarted) compactingThreads.delete(event.payload.threadId);
+            }),
           ),
         ),
-        Effect.catchCause(recoverCompactionFailure),
-        Effect.ensuring(
-          Effect.sync(() => {
-            if (!stoppingThreadIds.has(event.payload.threadId))
-              compactingThreads.delete(event.payload.threadId);
-          }),
-        ),
-        Effect.forkScoped,
       );
       return;
     }
@@ -1552,63 +1604,63 @@ const make = Effect.gen(function* () {
         "Wait for context compaction to finish before sending another message.",
       );
     }
-    const sendTurnRequest = yield* buildSendTurnRequestForThread({
-      threadId: event.payload.threadId,
-      messageText: message.text,
-      ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
-      ...(event.payload.modelSelection !== undefined
-        ? { modelSelection: event.payload.modelSelection }
-        : {}),
-      interactionMode: event.payload.interactionMode,
-      createdAt: event.payload.createdAt,
-    }).pipe(
-      Effect.map(Option.some),
-      Effect.catchCause((cause) => handleTurnStartFailure(cause).pipe(Effect.as(Option.none()))),
-    );
-
-    if (Option.isNone(sendTurnRequest)) return;
-
-    yield* providerService.sendTurn(sendTurnRequest.value).pipe(
-      Effect.flatMap((result) =>
-        orchestrationEngine.dispatch({
-          type: "thread.activity.append",
-          commandId: CommandId.make(`server:turn-start-accepted:${event.eventId}`),
+    yield* forkSessionCommand(event, (preparation, command) =>
+      Effect.gen(function* () {
+        const sendTurnRequest = yield* buildSendTurnRequestForThread({
           threadId: event.payload.threadId,
-          operationResult: { requestId: event.payload.messageId, outcome: "completed" },
-          activity: {
-            id: EventId.make(`turn-start-accepted:${event.eventId}`),
-            kind: "provider.turn.start.accepted",
-            tone: "info",
-            summary: "Provider accepted the request",
-            payload: {
-              timelineBypass: true,
-              ...({
-                requestId: event.payload.messageId,
-                turnId: result.turnId,
-                requestedAt: event.payload.createdAt,
-                ...(event.payload.sourceProposedPlan
-                  ? { sourceProposedPlan: event.payload.sourceProposedPlan }
-                  : {}),
-              } satisfies OrchestrationTurnStartAcceptance),
-            },
-            turnId: result.turnId,
-            createdAt: event.payload.createdAt,
-          },
+          messageText: message.text,
+          ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
+          ...(event.payload.modelSelection !== undefined
+            ? { modelSelection: event.payload.modelSelection }
+            : {}),
+          interactionMode: event.payload.interactionMode,
           createdAt: event.payload.createdAt,
-        }),
-      ),
-      Effect.andThen(
-        markAcceptedSourcePlan(event).pipe(
-          Effect.catchCause((cause) =>
-            Effect.logWarning("provider command reactor failed to mark source plan", {
-              cause: Cause.pretty(cause),
+        }).pipe(preparation.withPermit);
+
+        // A cancelled send can already have reached the provider. Only preparation
+        // can be reported as a message that was never submitted.
+        command.preparing = false;
+        yield* providerService.sendTurn(sendTurnRequest).pipe(
+          Effect.flatMap((result) =>
+            orchestrationEngine.dispatch({
+              type: "thread.activity.append",
+              commandId: CommandId.make(`server:turn-start-accepted:${event.eventId}`),
+              threadId: event.payload.threadId,
+              operationResult: { requestId: event.payload.messageId, outcome: "completed" },
+              activity: {
+                id: EventId.make(`turn-start-accepted:${event.eventId}`),
+                kind: "provider.turn.start.accepted",
+                tone: "info",
+                summary: "Provider accepted the request",
+                payload: {
+                  timelineBypass: true,
+                  ...({
+                    requestId: event.payload.messageId,
+                    turnId: result.turnId,
+                    requestedAt: event.payload.createdAt,
+                    ...(event.payload.sourceProposedPlan
+                      ? { sourceProposedPlan: event.payload.sourceProposedPlan }
+                      : {}),
+                  } satisfies OrchestrationTurnStartAcceptance),
+                },
+                turnId: result.turnId,
+                createdAt: event.payload.createdAt,
+              },
+              createdAt: event.payload.createdAt,
             }),
           ),
-        ),
-      ),
-      Effect.asVoid,
-      Effect.catchCause(recoverTurnStartFailure),
-      Effect.forkScoped,
+          Effect.andThen(
+            markAcceptedSourcePlan(event).pipe(
+              Effect.catchCause((cause) =>
+                Effect.logWarning("provider command reactor failed to mark source plan", {
+                  cause: Cause.pretty(cause),
+                }),
+              ),
+            ),
+          ),
+          Effect.asVoid,
+        );
+      }).pipe(Effect.catchCause(recoverTurnStartFailure)),
     );
   });
 
@@ -1908,9 +1960,19 @@ const make = Effect.gen(function* () {
       event.type === "thread.turn-interrupt-requested" ||
       event.type === "thread.session-stop-requested"
     ) {
-      const delayed = delayedTurnStarts.get(event.payload.threadId);
+      const delayed = new Set(delayedTurnStarts.get(event.payload.threadId));
       delayedTurnStarts.delete(event.payload.threadId);
-      if (delayed) {
+      const pending = [...(sessionCommands.get(event.payload.threadId)?.pending ?? [])];
+      for (const command of pending) {
+        if (command.preparing && command.event.type === "thread.turn-start-requested") {
+          delayed.add(command.event);
+        }
+      }
+      // Join parked preparation and sends before native stop tries to acquire adapter locks.
+      yield* Fiber.interruptAll(
+        pending.flatMap((command) => (command.fiber === undefined ? [] : [command.fiber])),
+      );
+      if (delayed.size > 0) {
         yield* Effect.forEach(
           delayed,
           (request) =>
@@ -1918,7 +1980,7 @@ const make = Effect.gen(function* () {
               threadId: event.payload.threadId,
               kind: "provider.turn.start.failed",
               summary: "Queued message cancelled",
-              detail: "This message was cancelled before the previous turn's checkpoint finished.",
+              detail: "This message was cancelled before it was sent to the provider.",
               turnId: null,
               requestId: request.payload.messageId,
               operationResult: { requestId: request.payload.messageId, outcome: "interrupted" },
@@ -1947,11 +2009,25 @@ const make = Effect.gen(function* () {
         if (!thread?.session || thread.session.status === "stopped") {
           return;
         }
-        const cachedModelSelection = threadModelSelections.get(event.payload.threadId);
-        yield* ensureSessionForThread(
-          event.payload.threadId,
-          event.occurredAt,
-          cachedModelSelection !== undefined ? { modelSelection: cachedModelSelection } : {},
+        yield* forkSessionCommand(event, (preparation) =>
+          Effect.gen(function* () {
+            const cachedModelSelection = threadModelSelections.get(event.payload.threadId);
+            yield* ensureSessionForThread(
+              event.payload.threadId,
+              event.occurredAt,
+              cachedModelSelection !== undefined ? { modelSelection: cachedModelSelection } : {},
+            );
+          }).pipe(
+            preparation.withPermit,
+            Effect.catchCause((cause) =>
+              Cause.hasInterruptsOnly(cause)
+                ? Effect.interrupt
+                : Effect.logWarning("provider command reactor failed to change runtime mode", {
+                    threadId: event.payload.threadId,
+                    cause: Cause.pretty(cause),
+                  }),
+            ),
+          ),
         );
         return;
       }

--- a/apps/server/src/project/AgentSessionImporter.test.ts
+++ b/apps/server/src/project/AgentSessionImporter.test.ts
@@ -989,6 +989,7 @@ it.layer(integrationLayer)("AgentSessionImporter integration", (it) => {
           );
           expect(sendTurn).toHaveBeenCalledExactlyOnceWith(
             expect.objectContaining({ threadId, input: "Continue this session" }),
+            expect.anything(),
           );
           expect(Option.getOrThrow(yield* directory.getBinding(threadId))).toMatchObject({
             provider,

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -184,6 +184,9 @@ const makeHarness = Effect.fn("makeAntigravityAdapterHarness")(function* (option
       Effect.gen(function* () {
         yield* Deferred.succeed(dispatchStarted, undefined);
         if (options?.holdDispatch) yield* Deferred.await(dispatchRelease);
+        yield* (promptOptions?.beforeSubmit ?? Effect.void).pipe(
+          Effect.onError(() => promptOptions?.notSubmitted ?? Effect.void),
+        );
         const prompt: NativePrompt = {
           index: ++promptIndex,
           content: payload.prompt,
@@ -194,6 +197,7 @@ const makeHarness = Effect.fn("makeAntigravityAdapterHarness")(function* (option
         if (promptOptions?.dispatched) yield* Deferred.succeed(promptOptions.dispatched, undefined);
         yield* Queue.offer(prompts, prompt);
         return yield* Deferred.await(prompt.result).pipe(
+          Effect.tap(() => promptOptions?.nativeCompleted ?? Effect.void),
           Effect.ensuring(
             Effect.sync(() => {
               if (active === prompt) active = undefined;
@@ -343,9 +347,13 @@ it.layer(layer)("AntigravityAdapter", (it) => {
         const modelSelections: string[] = [];
         const observed: ProviderRuntimeEvent[] = [];
         const completed = yield* Deferred.make<void>();
+        const ownedStops: Array<Effect.Effect<void>> = [];
         const adapter = yield* makeAntigravityAdapter(decodeSettings({ enabled: true }), {
           instanceId,
-          withProcess: (_stop, task) => task,
+          withProcess: (stop, task) =>
+            Effect.sync(() => {
+              ownedStops.push(stop);
+            }).pipe(Effect.andThen(task)),
           makeRuntime: (input) =>
             makeAntigravityAcpRuntime({
               ...input,
@@ -396,7 +404,45 @@ it.layer(layer)("AntigravityAdapter", (it) => {
           resumeCursor: original.resumeCursor,
         });
         expect(resumed.model).toBe(nativeAlternative);
-        yield* adapter.sendTurn({ threadId, input: "Reply with one short line." });
+        const admissionEntered = yield* Deferred.make<void>();
+        const admissionRelease = yield* Deferred.make<void>();
+        const notSubmitted = yield* Deferred.make<void>();
+        const parked = yield* adapter
+          .sendTurn(
+            { threadId, input: "This prompt must not reach the provider." },
+            {
+              beforeSubmit: () =>
+                Deferred.succeed(admissionEntered, undefined).pipe(
+                  Effect.andThen(Deferred.await(admissionRelease)),
+                ),
+              nativeCompleted: () => Effect.die("A parked prompt cannot complete natively."),
+              nativeStopped: Effect.die("A parked prompt has no native work to stop."),
+              notSubmitted: Deferred.succeed(notSubmitted, undefined).pipe(Effect.asVoid),
+            },
+          )
+          .pipe(Effect.forkChild);
+        yield* Deferred.await(admissionEntered);
+        yield* Fiber.interrupt(parked);
+        expect(yield* Deferred.isDone(notSubmitted)).toBe(true);
+        yield* adapter.interruptTurn(threadId);
+        yield* Deferred.succeed(admissionRelease, undefined);
+        const proofOrder: string[] = [];
+        const accepted = yield* adapter.sendTurn(
+          { threadId, input: "Reply with one short line." },
+          {
+            beforeSubmit: (turnId) =>
+              Effect.sync(() => {
+                proofOrder.push(`submit:${turnId}`);
+              }),
+            nativeCompleted: (turnId) =>
+              Effect.sync(() => {
+                proofOrder.push(`complete:${turnId}`);
+              }),
+            nativeStopped: Effect.void,
+            notSubmitted: Effect.die("The replacement prompt must be submitted."),
+          },
+        );
+        expect(proofOrder).toEqual([`submit:${accepted.turnId}`, `complete:${accepted.turnId}`]);
         yield* Deferred.await(completed);
         expect(commands).toEqual(["plan", "logout", "plan", "logout"]);
         expect(modelSelections.length).toBeGreaterThan(0);
@@ -414,6 +460,7 @@ it.layer(layer)("AntigravityAdapter", (it) => {
             .filter((request) => request.method === "authenticate")
             .map((request) => request.params),
         ).toEqual([{ methodId: "oauth-personal" }, { methodId: "oauth-personal" }]);
+        expect(requests.filter((request) => request.method === "session/prompt")).toHaveLength(1);
         expect(requests.some((request) => request.method === "session/resume")).toBe(true);
         expect(requests.some((request) => request.method === "session/load")).toBe(false);
         expect(
@@ -421,6 +468,44 @@ it.layer(layer)("AntigravityAdapter", (it) => {
             .filter((request) => request.method === "session/set_config_option")
             .map((request) => request.params),
         ).toContainEqual({ sessionId: "mock-session-1", configId: "mode", value: "auto_edit" });
+
+        for (const cleanup of ["stopAll", "auth-owned"] as const) {
+          yield* adapter.startSession({ threadId, cwd, runtimeMode: "auto-accept-edits" });
+          const entered = yield* Deferred.make<void>();
+          const release = yield* Deferred.make<void>();
+          const rejected = yield* Deferred.make<void>();
+          const pending = yield* adapter
+            .sendTurn(
+              { threadId, input: "Do not dispatch during cleanup." },
+              {
+                beforeSubmit: () =>
+                  Deferred.succeed(entered, undefined).pipe(
+                    Effect.andThen(Deferred.await(release)),
+                  ),
+                nativeCompleted: () => Effect.die("Cleanup must cancel this unsubmitted prompt."),
+                nativeStopped: Effect.die("A parked prompt has no native work to stop."),
+                notSubmitted: Deferred.succeed(rejected, undefined).pipe(Effect.asVoid),
+              },
+            )
+            .pipe(Effect.forkChild);
+          yield* Deferred.await(entered);
+          if (cleanup === "stopAll") {
+            yield* adapter.stopAll();
+          } else {
+            const stop = ownedStops.at(-1);
+            if (!stop) return yield* Effect.die("Missing auth-owned process stop.");
+            yield* stop;
+          }
+          expect(Exit.isFailure(yield* Fiber.await(pending))).toBe(true);
+          expect(yield* Deferred.isDone(rejected)).toBe(true);
+          yield* Deferred.succeed(release, undefined);
+        }
+        const finalRequests = yield* decodeRequestLog(
+          (yield* fileSystem.readFileString(requestLog)).trim().split("\n"),
+        );
+        expect(finalRequests.filter((request) => request.method === "session/prompt")).toHaveLength(
+          1,
+        );
       }),
   );
 

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -189,7 +189,7 @@ const makeHarness = Effect.fn("makeAntigravityAdapterHarness")(function* (option
         );
         const prompt: NativePrompt = {
           index: ++promptIndex,
-          content: payload.prompt,
+          content: (Effect.isEffect(payload) ? yield* payload : payload).prompt,
           result: yield* Deferred.make<AcpSchema.PromptResponse, AcpErrors.AcpError>(),
         };
         active = prompt;

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -1128,11 +1128,9 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
                       context.activeTurnId !== turnId ||
                       context.generation !== turn.generation
                     ) {
-                      return yield* new EffectAcpErrors.AcpTransportError({
-                        method: "session/prompt",
-                        detail: "The Antigravity turn changed before prompt submission.",
-                        cause: undefined,
-                      });
+                      return yield* EffectAcpErrors.AcpRequestError.invalidRequest(
+                        "The Antigravity turn changed before prompt submission.",
+                      );
                     }
                   }),
                   nativeCompleted: startOptions

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -191,6 +191,7 @@ interface TurnIntent {
 }
 
 interface SessionContext {
+  lastTurnCompletion?: Extract<ProviderRuntimeEvent, { type: "turn.completed" }>;
   readonly threadId: ThreadId;
   readonly cwd: string;
   readonly nativeSessionId: string;
@@ -332,7 +333,36 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
     eventId: Effect.map(randomId, EventId.make),
     createdAt: nowIso,
   });
-  const emit = (event: ProviderRuntimeEvent) => PubSub.publish(events, event).pipe(Effect.asVoid);
+  const emit = (event: ProviderRuntimeEvent) =>
+    Effect.gen(function* () {
+      if (event.type === "turn.completed") {
+        const context = sessions.get(event.threadId);
+        if (context) context.lastTurnCompletion = event;
+      }
+      yield* PubSub.publish(events, event);
+    });
+  // A local terminal can precede native completion. Capture again after proof,
+  // using the last result so a late cancelled steer cannot replace the final result.
+  const repeatNativeTerminal = (context: SessionContext, turnId: TurnId, stopped = false) =>
+    Effect.gen(function* () {
+      const previous = context.lastTurnCompletion;
+      if (!stopped && previous?.turnId !== turnId) return;
+      yield* emit({
+        type: "turn.completed",
+        provider: PROVIDER,
+        threadId: context.threadId,
+        turnId,
+        payload:
+          previous?.turnId === turnId
+            ? previous.payload
+            : { state: "cancelled", stopReason: "cancelled" },
+        ...(yield* stamp),
+      });
+    }).pipe(
+      Effect.catch((cause) =>
+        Effect.logError("Failed to record native Antigravity completion.", { cause }),
+      ),
+    );
 
   const withThreadLock = <A, E, R>(threadId: ThreadId, task: Effect.Effect<A, E, R>) =>
     SynchronizedRef.modifyEffect(locks, (current) => {
@@ -428,12 +458,12 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
         Effect.gen(function* () {
           if (context.closed) return;
           context.stopped = true;
-          yield* Effect.gen(function* () {
-            yield* cancelRequests(context);
-            if (context.promptFiber && !context.disconnected) {
-              yield* Effect.ignore(context.runtime.cancel);
-            }
-          }).pipe(Effect.ensuring(Scope.close(context.scope, Exit.void)));
+          // Auth cleanup and adapter disposal bypass ProviderService. Closing the
+          // scope joins parked prompts before process teardown without taking the
+          // native cancel lock that those prompts can hold during admission.
+          yield* cancelRequests(context).pipe(
+            Effect.ensuring(Scope.close(context.scope, Exit.void)),
+          );
           context.closed = true;
           if (sessions.get(context.threadId) === context) sessions.delete(context.threadId);
           yield* finishBackgroundCommands(context);
@@ -969,196 +999,235 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
       }),
     );
 
-  const sendTurn: Adapter["sendTurn"] = Effect.fn("AntigravityAdapter.sendTurn")(function* (input) {
-    const context = yield* requireSession(input.threadId);
-    if (input.modelSelection && input.modelSelection.instanceId !== options.instanceId) {
-      return yield* new ProviderAdapterValidationError({
-        provider: PROVIDER,
-        operation: "sendTurn",
-        issue: "The selected model belongs to another provider instance.",
-      });
-    }
-    const prompt = yield* buildAntigravityPrompt({
-      input: input.input,
-      attachments: input.attachments,
-      attachmentsDir: serverConfig.attachmentsDir,
-    }).pipe(
-      Effect.provideService(FileSystem.FileSystem, fileSystem),
-      Effect.provideService(Path.Path, path),
-      Effect.mapError((cause) => mapAntigravityError(input.threadId, "session/prompt", cause)),
-    );
-    let intent: TurnIntent | undefined;
-    // The caller holds promptLock while it changes or settles the active turn.
-    const finishTurn = (turn: TurnIntent, payload: TurnCompletedPayload) =>
-      Effect.gen(function* () {
-        if (turn.settled || context.stopped || context.generation !== turn.generation) return;
-        turn.settled = true;
-        yield* promoteBackgroundCommands(context);
-        yield* finishSubagents(
-          context,
-          payload.state === "cancelled"
-            ? "cancelled"
-            : payload.state === "failed"
-              ? "failed"
-              : "idle",
-          payload.errorMessage,
-        );
-        context.activeTurnId = undefined;
-        context.promptFiber = undefined;
-        context.session = {
-          ...context.session,
-          status: payload.state === "failed" ? "error" : "ready",
-          activeTurnId: undefined,
-          updatedAt: yield* nowIso,
-          ...(payload.errorMessage
-            ? { lastError: payload.errorMessage }
-            : { lastError: undefined }),
-        };
-        yield* emit({
-          type: "turn.completed",
-          ...(yield* stamp),
+  const sendTurn: Adapter["sendTurn"] = Effect.fn("AntigravityAdapter.sendTurn")(
+    function* (input, startOptions) {
+      const context = yield* requireSession(input.threadId);
+      if (input.modelSelection && input.modelSelection.instanceId !== options.instanceId) {
+        return yield* new ProviderAdapterValidationError({
           provider: PROVIDER,
-          threadId: input.threadId,
-          turnId: turn.turnId,
-          payload,
-        });
-      }).pipe(Effect.uninterruptible);
-
-    return yield* Effect.gen(function* () {
-      const launch = yield* context.promptLock.withPermit(
-        Effect.gen(function* () {
-          yield* requireSession(input.threadId);
-          const requestedModel = input.modelSelection?.model ?? context.session.model;
-          const configOptions = yield* context.runtime.getConfigOptions;
-          const model = resolveAntigravityModel({
-            configOptions,
-            model: requestedModel,
-            defaultModel: yield* options.defaultModel ?? Effect.succeed(undefined),
-          });
-          const availableModels = antigravityModelOptions(configOptions);
-          if (model && !availableModels.some((option) => option.value === model)) {
-            return yield* EffectAcpErrors.AcpRequestError.invalidParams(
-              `Antigravity model '${model}' is unavailable for this Google account. Select an available model.`,
-            );
-          }
-          const turnId = context.activeTurnId ?? TurnId.make(yield* randomId);
-          const steering = context.activeTurnId !== undefined;
-          const turn: TurnIntent = { turnId, generation: ++context.generation, settled: false };
-          intent = turn;
-          context.activeTurnId = turnId;
-          if (!steering) {
-            yield* emit({
-              type: "turn.started",
-              ...(yield* stamp),
-              provider: PROVIDER,
-              threadId: input.threadId,
-              turnId,
-              payload: model ? { model } : {},
-            });
-          }
-          if (context.promptFiber) {
-            yield* cancelRequests(context);
-            yield* context.runtime.cancel;
-            yield* Fiber.await(context.promptFiber);
-            yield* finishSubagents(context, "cancelled");
-          }
-          yield* applyAntigravityAcpModelSelection({
-            runtime: context.runtime,
-            model,
-            mapError: (cause) => cause,
-          });
-          yield* context.runtime.setMode(antigravityPermissionMode(context.session.runtimeMode));
-          context.session = {
-            ...context.session,
-            status: "running",
-            activeTurnId: turnId,
-            ...(model ? { model } : {}),
-            updatedAt: yield* nowIso,
-          };
-          const dispatched = yield* Deferred.make<void>();
-          const fiber = yield* context.runtime
-            .prompt(
-              {
-                prompt: [
-                  ...prompt,
-                  {
-                    type: "text",
-                    text: buildRuntimeInstructions({ harness: "Antigravity", model }),
-                  },
-                ],
-              },
-              { dispatched },
-            )
-            .pipe(Effect.forkIn(context.scope));
-          context.promptFiber = fiber;
-          // Fiber.join can skip a scope-close waiter when the child is interrupted.
-          // Unwrap the Exit after Fiber.await returns.
-          yield* Effect.raceFirst(
-            Deferred.await(dispatched),
-            Fiber.await(fiber).pipe(
-              Effect.flatMap((exit) => exit),
-              Effect.asVoid,
-            ),
-          );
-          return { turn, fiber };
-        }),
-      );
-      const result = yield* Fiber.await(launch.fiber).pipe(Effect.flatMap((exit) => exit));
-      yield* context.runtime.drainEvents;
-      if (context.stopped) {
-        return yield* new ProviderAdapterSessionClosedError({
-          provider: PROVIDER,
-          threadId: input.threadId,
+          operation: "sendTurn",
+          issue: "The selected model belongs to another provider instance.",
         });
       }
-      const record = context.turns.find((turn) => turn.id === launch.turn.turnId);
-      if (record) record.items.push(result);
-      else context.turns.push({ id: launch.turn.turnId, items: [result] });
-      yield* context.promptLock.withPermit(
-        finishTurn(launch.turn, {
-          state: result.stopReason === "cancelled" ? "cancelled" : "completed",
-          stopReason: result.stopReason,
-        }),
+      const prompt = yield* buildAntigravityPrompt({
+        input: input.input,
+        attachments: input.attachments,
+        attachmentsDir: serverConfig.attachmentsDir,
+      }).pipe(
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
+        Effect.mapError((cause) => mapAntigravityError(input.threadId, "session/prompt", cause)),
       );
-      return {
-        threadId: input.threadId,
-        turnId: launch.turn.turnId,
-        resumeCursor: context.session.resumeCursor,
-      };
-    }).pipe(
-      Effect.tapError((cause) =>
-        isAntigravitySignInRequiredError(cause)
-          ? (options.onAuthRequired ?? Effect.void)
-          : Effect.void,
-      ),
-      Effect.mapError((cause) =>
-        isAcpError(cause) ? mapAntigravityError(input.threadId, "session/prompt", cause) : cause,
-      ),
-      Effect.tapError((cause) =>
-        Effect.suspend(() =>
-          intent
-            ? context.promptLock.withPermit(
-                finishTurn(intent, { state: "failed", errorMessage: cause.message }),
+      let intent: TurnIntent | undefined;
+      // The caller holds promptLock while it changes or settles the active turn.
+      const finishTurn = (turn: TurnIntent, payload: TurnCompletedPayload) =>
+        Effect.gen(function* () {
+          if (turn.settled || context.stopped || context.generation !== turn.generation) return;
+          turn.settled = true;
+          yield* promoteBackgroundCommands(context);
+          yield* finishSubagents(
+            context,
+            payload.state === "cancelled"
+              ? "cancelled"
+              : payload.state === "failed"
+                ? "failed"
+                : "idle",
+            payload.errorMessage,
+          );
+          context.activeTurnId = undefined;
+          context.promptFiber = undefined;
+          context.session = {
+            ...context.session,
+            status: payload.state === "failed" ? "error" : "ready",
+            activeTurnId: undefined,
+            updatedAt: yield* nowIso,
+            ...(payload.errorMessage
+              ? { lastError: payload.errorMessage }
+              : { lastError: undefined }),
+          };
+          yield* emit({
+            type: "turn.completed",
+            ...(yield* stamp),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            turnId: turn.turnId,
+            payload,
+          });
+        }).pipe(Effect.uninterruptible);
+
+      return yield* Effect.gen(function* () {
+        const launch = yield* context.promptLock.withPermit(
+          Effect.gen(function* () {
+            yield* requireSession(input.threadId);
+            const requestedModel = input.modelSelection?.model ?? context.session.model;
+            const configOptions = yield* context.runtime.getConfigOptions;
+            const model = resolveAntigravityModel({
+              configOptions,
+              model: requestedModel,
+              defaultModel: yield* options.defaultModel ?? Effect.succeed(undefined),
+            });
+            const availableModels = antigravityModelOptions(configOptions);
+            if (model && !availableModels.some((option) => option.value === model)) {
+              return yield* EffectAcpErrors.AcpRequestError.invalidParams(
+                `Antigravity model '${model}' is unavailable for this Google account. Select an available model.`,
+              );
+            }
+            const turnId = context.activeTurnId ?? TurnId.make(yield* randomId);
+            const steering = context.activeTurnId !== undefined;
+            const turn: TurnIntent = { turnId, generation: ++context.generation, settled: false };
+            intent = turn;
+            context.activeTurnId = turnId;
+            if (!steering) {
+              yield* emit({
+                type: "turn.started",
+                ...(yield* stamp),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                turnId,
+                payload: model ? { model } : {},
+              });
+            }
+            if (context.promptFiber) {
+              yield* cancelRequests(context);
+              yield* context.runtime.cancel;
+              yield* Fiber.await(context.promptFiber);
+              yield* finishSubagents(context, "cancelled");
+            }
+            yield* applyAntigravityAcpModelSelection({
+              runtime: context.runtime,
+              model,
+              mapError: (cause) => cause,
+            });
+            yield* context.runtime.setMode(antigravityPermissionMode(context.session.runtimeMode));
+            context.session = {
+              ...context.session,
+              status: "running",
+              activeTurnId: turnId,
+              ...(model ? { model } : {}),
+              updatedAt: yield* nowIso,
+            };
+            const dispatched = yield* Deferred.make<void>();
+            const fiber = yield* context.runtime
+              .prompt(
+                {
+                  prompt: [
+                    ...prompt,
+                    {
+                      type: "text",
+                      text: buildRuntimeInstructions({ harness: "Antigravity", model }),
+                    },
+                  ],
+                },
+                {
+                  dispatched,
+                  beforeSubmit: Effect.gen(function* () {
+                    yield* startOptions?.beforeSubmit(turnId) ?? Effect.void;
+                    if (
+                      context.stopped ||
+                      sessions.get(input.threadId) !== context ||
+                      context.activeTurnId !== turnId ||
+                      context.generation !== turn.generation
+                    ) {
+                      return yield* new EffectAcpErrors.AcpTransportError({
+                        method: "session/prompt",
+                        detail: "The Antigravity turn changed before prompt submission.",
+                        cause: undefined,
+                      });
+                    }
+                  }),
+                  nativeCompleted: startOptions
+                    ? startOptions
+                        .nativeCompleted(turnId)
+                        .pipe(Effect.andThen(repeatNativeTerminal(context, turnId)))
+                    : Effect.void,
+                  nativeStopped: startOptions
+                    ? startOptions.nativeStopped.pipe(
+                        Effect.andThen(repeatNativeTerminal(context, turnId, true)),
+                      )
+                    : Effect.void,
+                  notSubmitted: startOptions?.notSubmitted ?? Effect.void,
+                },
               )
+              .pipe(Effect.forkIn(context.scope));
+            context.promptFiber = fiber;
+            // Fiber.join can skip a scope-close waiter when the child is interrupted.
+            // Unwrap the Exit after Fiber.await returns.
+            yield* Effect.raceFirst(
+              Deferred.await(dispatched),
+              Fiber.await(fiber).pipe(
+                Effect.flatMap((exit) => exit),
+                Effect.asVoid,
+              ),
+            ).pipe(Effect.onInterrupt(() => Fiber.interrupt(fiber)));
+            return { turn, fiber };
+          }),
+        );
+        const result = yield* Fiber.await(launch.fiber).pipe(Effect.flatMap((exit) => exit));
+        yield* context.runtime.drainEvents;
+        if (context.stopped) {
+          return yield* new ProviderAdapterSessionClosedError({
+            provider: PROVIDER,
+            threadId: input.threadId,
+          });
+        }
+        const record = context.turns.find((turn) => turn.id === launch.turn.turnId);
+        if (record) record.items.push(result);
+        else context.turns.push({ id: launch.turn.turnId, items: [result] });
+        yield* context.promptLock.withPermit(
+          finishTurn(launch.turn, {
+            state: result.stopReason === "cancelled" ? "cancelled" : "completed",
+            stopReason: result.stopReason,
+          }),
+        );
+        return {
+          threadId: input.threadId,
+          turnId: launch.turn.turnId,
+          resumeCursor: context.session.resumeCursor,
+        };
+      }).pipe(
+        Effect.tapError((cause) =>
+          isAntigravitySignInRequiredError(cause)
+            ? (options.onAuthRequired ?? Effect.void)
             : Effect.void,
         ),
-      ),
-      Effect.onInterrupt(() =>
-        context.promptLock.withPermit(
-          Effect.gen(function* () {
-            const turn = intent;
-            if (!turn || turn.settled || context.stopped || context.generation !== turn.generation)
-              return;
-            const promptFiber = context.promptFiber;
-            yield* cancelRequests(context);
-            yield* Effect.ignore(context.runtime.cancel);
-            if (promptFiber) yield* Fiber.interrupt(promptFiber);
-            yield* finishTurn(turn, { state: "cancelled", stopReason: "cancelled" });
-          }),
+        Effect.mapError((cause) =>
+          isAcpError(cause) ? mapAntigravityError(input.threadId, "session/prompt", cause) : cause,
         ),
-      ),
-    );
-  });
+        Effect.tapError((cause) =>
+          Effect.suspend(() =>
+            intent
+              ? context.promptLock.withPermit(
+                  finishTurn(intent, { state: "failed", errorMessage: cause.message }),
+                )
+              : Effect.void,
+          ),
+        ),
+        Effect.onInterrupt(() =>
+          Effect.suspend(() =>
+            intent
+              ? context.promptLock.withPermit(
+                  Effect.gen(function* () {
+                    const turn = intent;
+                    if (
+                      !turn ||
+                      turn.settled ||
+                      context.stopped ||
+                      context.generation !== turn.generation
+                    )
+                      return;
+                    const promptFiber = context.promptFiber;
+                    yield* cancelRequests(context);
+                    yield* Effect.ignore(context.runtime.cancel);
+                    if (promptFiber) yield* Fiber.interrupt(promptFiber);
+                    yield* finishTurn(turn, { state: "cancelled", stopReason: "cancelled" });
+                  }),
+                )
+              : Effect.void,
+          ),
+        ),
+      );
+    },
+  );
 
   const interruptTurn: Adapter["interruptTurn"] = (threadId) =>
     Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -2,6 +2,7 @@
 import * as NodeFS from "node:fs";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
+import * as NodeStream from "node:stream";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import type {
@@ -1602,51 +1603,68 @@ describe("ClaudeAdapterLive", () => {
     }).pipe(Effect.provide(harness.layer));
   });
 
-  it.effect("waits for the captured native process exit before completing Stop", () => {
-    const harness = makeHarness();
-    return Effect.gen(function* () {
-      const adapter = yield* ClaudeAdapter;
-      yield* adapter.startSession({
-        threadId: THREAD_ID,
-        provider: ProviderDriverKind.make("claudeAgent"),
-        runtimeMode: "full-access",
-      });
-      const spawnProcess = harness.getLastCreateQueryInput()?.options.spawnClaudeCodeProcess;
-      assert.isDefined(spawnProcess);
-      // This child is a disposable stdin reader, not a provider session.
-      const child = spawnProcess!({
-        command: process.execPath,
-        args: ["-e", "process.stdin.resume()"],
-        env: {},
-        signal: new AbortController().signal,
-      });
-      try {
-        let nativeStopped = false;
-        yield* adapter.sendTurn(
-          { threadId: THREAD_ID, input: "First" },
-          admissionOptions({
-            nativeStopped: Effect.sync(() => {
-              nativeStopped = true;
-            }),
-          }),
-        );
-        const closeStarted = Promise.withResolvers<void>();
-        vi.spyOn(harness.query, "close").mockImplementation(() => {
-          harness.query.finish();
-          closeStarted.resolve();
+  it.effect.each([false, true])(
+    "waits for native exit before completing Stop with stderr failure %s",
+    (failStderr) => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+        yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
         });
-        const stopFiber = yield* adapter.stopSession(THREAD_ID).pipe(Effect.forkChild);
-        yield* Effect.promise(() => closeStarted.promise);
-        assert.equal(nativeStopped, false);
-        assert.equal(stopFiber.pollUnsafe(), undefined);
-        child.kill("SIGTERM");
-        yield* Fiber.join(stopFiber);
-        assert.equal(nativeStopped, true);
-      } finally {
-        if (child.exitCode === null && child.signalCode == null) child.kill("SIGKILL");
-      }
-    }).pipe(Effect.provide(harness.layer));
-  });
+        const spawnProcess = harness.getLastCreateQueryInput()?.options.spawnClaudeCodeProcess;
+        assert.isDefined(spawnProcess);
+        // This child is a disposable stdin reader, not a provider session.
+        const child = spawnProcess!({
+          command: process.execPath,
+          args: ["-e", "process.stdin.resume()"],
+          env: {},
+          signal: new AbortController().signal,
+        });
+        try {
+          if (!("stderr" in child) || !(child.stderr instanceof NodeStream.Readable)) {
+            return yield* Effect.die("Expected the captured child to expose stderr.");
+          }
+          const stderr = child.stderr;
+          if (failStderr) {
+            yield* Effect.promise(
+              () =>
+                new Promise<void>((resolve) => {
+                  stderr.once("close", resolve);
+                  stderr.destroy(new Error("stderr read failed with private details"));
+                }),
+            );
+          }
+          let nativeStopped = false;
+          yield* adapter.sendTurn(
+            { threadId: THREAD_ID, input: "First" },
+            admissionOptions({
+              nativeStopped: Effect.sync(() => {
+                nativeStopped = true;
+              }),
+            }),
+          );
+          const closeStarted = Promise.withResolvers<void>();
+          vi.spyOn(harness.query, "close").mockImplementation(() => {
+            harness.query.finish();
+            closeStarted.resolve();
+          });
+          const stopFiber = yield* adapter.stopSession(THREAD_ID).pipe(Effect.forkChild);
+          yield* Effect.promise(() => closeStarted.promise);
+          assert.equal(nativeStopped, false);
+          assert.equal(stopFiber.pollUnsafe(), undefined);
+          child.kill("SIGTERM");
+          yield* Fiber.join(stopFiber);
+          assert.equal(nativeStopped, true);
+          assert.equal(stderr.destroyed, true);
+        } finally {
+          if (child.exitCode === null && child.signalCode == null) child.kill("SIGKILL");
+        }
+      }).pipe(Effect.provide(harness.layer));
+    },
+  );
 
   it.effect("steers a running turn instead of opening a new one on mid-turn sendTurn", () => {
     const harness = makeHarness();

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -23,6 +23,7 @@ import {
 } from "@t3tools/contracts";
 import { createModelSelection } from "@t3tools/shared/model";
 import { assert, describe, it } from "@effect/vitest";
+import { vi } from "vite-plus/test";
 import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
 import * as Deferred from "effect/Deferred";
@@ -47,6 +48,7 @@ import {
 } from "../ClaudeModelCatalog.testFixtures.ts";
 import { ProviderAdapterProcessError, ProviderAdapterValidationError } from "../Errors.ts";
 import type { ClaudeAdapterShape } from "../Services/ClaudeAdapter.ts";
+import type { ProviderTurnStartOptions } from "../Services/ProviderAdapter.ts";
 import type { ClaudeScopedLimitNames } from "./claudeUsageLimits.ts";
 import { makeClaudeAdapter, type ClaudeAdapterLiveOptions } from "./ClaudeAdapter.ts";
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
@@ -216,6 +218,18 @@ function makeHarness(config?: {
     ),
     query,
     getLastCreateQueryInput: () => createInput,
+  };
+}
+
+function admissionOptions(
+  overrides: Partial<ProviderTurnStartOptions> = {},
+): ProviderTurnStartOptions {
+  return {
+    beforeSubmit: () => Effect.void,
+    notSubmitted: Effect.void,
+    nativeCompleted: () => Effect.void,
+    nativeStopped: Effect.void,
+    ...overrides,
   };
 }
 
@@ -1396,6 +1410,242 @@ describe("ClaudeAdapterLive", () => {
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
     );
+  });
+
+  it.effect("rechecks the active turn after message preparation and waits before queueing", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      const first = yield* adapter.sendTurn({ threadId: THREAD_ID, input: "First" });
+      const modelStarted = Promise.withResolvers<void>();
+      const modelRelease = Promise.withResolvers<void>();
+      vi.spyOn(harness.query, "setModel").mockImplementation(async () => {
+        modelStarted.resolve();
+        await modelRelease.promise;
+      });
+      const admitted = yield* Deferred.make<void>();
+      const admissionRelease = yield* Deferred.make<void>();
+      const secondFiber = yield* adapter
+        .sendTurn(
+          {
+            threadId: THREAD_ID,
+            input: "Second",
+            modelSelection: createModelSelection(
+              ProviderInstanceId.make("claudeAgent"),
+              SYNTHETIC_CLAUDE_STANDARD_MODEL,
+            ),
+          },
+          admissionOptions({
+            beforeSubmit: () =>
+              Deferred.succeed(admitted, undefined).pipe(
+                Effect.andThen(Deferred.await(admissionRelease)),
+              ),
+          }),
+        )
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => modelStarted.promise);
+      const completed = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        session_id: "sdk-admission",
+        uuid: "result-first",
+      } as unknown as SDKMessage);
+      yield* Fiber.join(completed);
+      modelRelease.resolve();
+      yield* Deferred.await(admitted);
+      const sessions = yield* adapter.listSessions();
+      assert.equal(sessions[0]?.activeTurnId, undefined);
+      const prompt = harness.getLastCreateQueryInput()?.prompt[Symbol.asyncIterator]();
+      assert.isDefined(prompt);
+      const firstMessage = yield* Effect.promise(() => prompt!.next());
+      assert.equal(firstMessage.done, false);
+      let secondQueued = false;
+      const secondMessage = prompt!.next().then((value) => {
+        secondQueued = true;
+        return value;
+      });
+      assert.equal(secondQueued, false);
+      yield* Deferred.succeed(admissionRelease, undefined);
+      const second = yield* Fiber.join(secondFiber);
+      assert.notEqual(second.turnId, first.turnId);
+      assert.equal((yield* Effect.promise(() => secondMessage)).done, false);
+    }).pipe(Effect.provide(harness.layer));
+  });
+
+  it.effect(
+    "keeps concurrent first sends in one turn and does not finish an unconsumed prompt",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+        yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+        const firstAdmitted = yield* Deferred.make<void>();
+        const release = yield* Deferred.make<void>();
+        const firstFinished = yield* Deferred.make<void>();
+        let secondFinished = false;
+        const firstFiber = yield* adapter
+          .sendTurn(
+            { threadId: THREAD_ID, input: "First" },
+            admissionOptions({
+              beforeSubmit: () =>
+                Deferred.succeed(firstAdmitted, undefined).pipe(
+                  Effect.andThen(Deferred.await(release)),
+                ),
+              nativeCompleted: () => Deferred.succeed(firstFinished, undefined).pipe(Effect.asVoid),
+            }),
+          )
+          .pipe(Effect.forkChild);
+        yield* Deferred.await(firstAdmitted);
+        const secondFiber = yield* adapter
+          .sendTurn(
+            { threadId: THREAD_ID, input: "Steer" },
+            admissionOptions({
+              nativeCompleted: () =>
+                Effect.sync(() => {
+                  secondFinished = true;
+                }),
+            }),
+          )
+          .pipe(Effect.forkChild);
+        yield* Deferred.succeed(release, undefined);
+        const first = yield* Fiber.join(firstFiber);
+        const second = yield* Fiber.join(secondFiber);
+        assert.equal(second.turnId, first.turnId);
+        const messages = yield* Effect.promise(() =>
+          readPromptMessages(harness.getLastCreateQueryInput(), 2),
+        );
+        const [firstMessage, secondMessage] = messages;
+        assert.isDefined(firstMessage?.uuid);
+        assert.isDefined(secondMessage?.uuid);
+        harness.query.emit({ ...firstMessage!, session_id: "sdk-admission" });
+        harness.query.emit({ ...secondMessage!, session_id: "sdk-admission" });
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          session_id: "sdk-admission",
+          uuid: "result-first",
+          user_message_uuid: firstMessage!.uuid,
+          queued_turn_count: 1,
+          usage: { input_tokens: 100, output_tokens: 20 },
+        } as unknown as SDKMessage);
+        yield* Deferred.await(firstFinished);
+        assert.equal(secondFinished, false);
+        const completed = yield* adapter.streamEvents.pipe(
+          Stream.filter((event) => event.type === "turn.completed"),
+          Stream.take(1),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        harness.query.emit({ ...secondMessage!, session_id: "sdk-admission" });
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          session_id: "sdk-admission",
+          uuid: "result-second",
+          user_message_uuids: [secondMessage!.uuid],
+          usage: { input_tokens: 50, output_tokens: 10 },
+        } as unknown as SDKMessage);
+        const [event] = yield* Fiber.join(completed);
+        assert.equal(secondFinished, true);
+        assert.equal(event?.type, "turn.completed");
+        if (event?.type === "turn.completed") {
+          assert.equal(event.payload.tokenUsage?.inputTokens, 150);
+          assert.equal(event.payload.tokenUsage?.outputTokens, 30);
+        }
+      }).pipe(Effect.provide(harness.layer));
+    },
+  );
+
+  it.effect("does not treat a local query close as native completion", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      let completed = false;
+      let stopped = false;
+      yield* adapter.sendTurn(
+        { threadId: THREAD_ID, input: "First" },
+        admissionOptions({
+          nativeCompleted: () =>
+            Effect.sync(() => {
+              completed = true;
+            }),
+          nativeStopped: Effect.sync(() => {
+            stopped = true;
+          }),
+        }),
+      );
+      yield* adapter.stopSession(THREAD_ID);
+      assert.equal(completed, false);
+      assert.equal(stopped, false);
+    }).pipe(Effect.provide(harness.layer));
+  });
+
+  it.effect("waits for the captured native process exit before completing Stop", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      const spawnProcess = harness.getLastCreateQueryInput()?.options.spawnClaudeCodeProcess;
+      assert.isDefined(spawnProcess);
+      // This child is a disposable stdin reader, not a provider session.
+      const child = spawnProcess!({
+        command: process.execPath,
+        args: ["-e", "process.stdin.resume()"],
+        env: {},
+        signal: new AbortController().signal,
+      });
+      try {
+        let nativeStopped = false;
+        yield* adapter.sendTurn(
+          { threadId: THREAD_ID, input: "First" },
+          admissionOptions({
+            nativeStopped: Effect.sync(() => {
+              nativeStopped = true;
+            }),
+          }),
+        );
+        const closeStarted = Promise.withResolvers<void>();
+        vi.spyOn(harness.query, "close").mockImplementation(() => {
+          harness.query.finish();
+          closeStarted.resolve();
+        });
+        const stopFiber = yield* adapter.stopSession(THREAD_ID).pipe(Effect.forkChild);
+        yield* Effect.promise(() => closeStarted.promise);
+        assert.equal(nativeStopped, false);
+        assert.equal(stopFiber.pollUnsafe(), undefined);
+        child.kill("SIGTERM");
+        yield* Fiber.join(stopFiber);
+        assert.equal(nativeStopped, true);
+      } finally {
+        if (child.exitCode === null && child.signalCode == null) child.kill("SIGKILL");
+      }
+    }).pipe(Effect.provide(harness.layer));
   });
 
   it.effect("steers a running turn instead of opening a new one on mid-turn sendTurn", () => {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1948,9 +1948,9 @@ describe("ClaudeAdapterLive", () => {
     }).pipe(Effect.provide(harness.layer));
   });
 
-  it.effect(
-    "rejects input before preparation after an unknown result and recovers on exact receipts",
-    () => {
+  it.effect.each([false, true])(
+    "keeps unknown input blocked after another command finishes: %s",
+    (withSecondCommand) => {
       const harness = makeHarness();
       return Effect.gen(function* () {
         const adapter = yield* ClaudeAdapter;
@@ -1966,6 +1966,17 @@ describe("ClaudeAdapterLive", () => {
         const [prompt] = yield* Effect.promise(() =>
           readPromptMessages(harness.getLastCreateQueryInput(), 1),
         );
+        const secondPrompt = withSecondCommand
+          ? yield* Effect.gen(function* () {
+              yield* adapter.sendTurn(
+                { threadId: THREAD_ID, input: "Already queued" },
+                admissionOptions(),
+              );
+              return yield* Effect.promise(() =>
+                readFirstPromptMessage(harness.getLastCreateQueryInput()),
+              );
+            })
+          : undefined;
         const processed = yield* adapter.streamEvents.pipe(
           Stream.takeUntil((event) => event.type === "session.configured"),
           Stream.runCollect,
@@ -1990,21 +2001,72 @@ describe("ClaudeAdapterLive", () => {
           events.some((event) => event.type === "runtime.warning"),
           false,
         );
+        const blockedInput = {
+          threadId: THREAD_ID,
+          input: "Blocked",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("claudeAgent"),
+            SYNTHETIC_CLAUDE_STANDARD_MODEL,
+          ),
+        };
         const rejected = yield* adapter
-          .sendTurn(
-            {
-              threadId: THREAD_ID,
-              input: "Blocked",
-              modelSelection: createModelSelection(
-                ProviderInstanceId.make("claudeAgent"),
-                SYNTHETIC_CLAUDE_STANDARD_MODEL,
-              ),
-            },
-            admissionOptions(),
-          )
+          .sendTurn(blockedInput, admissionOptions())
           .pipe(Effect.flip);
         assert.equal(rejected._tag, "ProviderAdapterRequestError");
         assert.equal(harness.query.setModelCalls.length, 0);
+        if (secondPrompt) {
+          const secondProcessed = yield* adapter.streamEvents.pipe(
+            Stream.takeUntil((event) => event.type === "runtime.warning"),
+            Stream.runCollect,
+            Effect.forkChild,
+          );
+          harness.query.emit({
+            type: "command_lifecycle",
+            command_uuid: secondPrompt.uuid,
+            state: "started",
+            session_id: "sdk-unknown",
+            uuid: "second-started",
+          } as unknown as SDKMessage);
+          harness.query.emit({
+            type: "system",
+            subtype: "init",
+            session_id: "sdk-unknown",
+            uuid: "second-init",
+          } as unknown as SDKMessage);
+          harness.query.emit({
+            type: "result",
+            subtype: "success",
+            is_error: false,
+            session_id: "sdk-unknown",
+            uuid: "second-result",
+          } as unknown as SDKMessage);
+          harness.query.emit({
+            type: "command_lifecycle",
+            command_uuid: secondPrompt.uuid,
+            state: "completed",
+            session_id: "sdk-unknown",
+            uuid: "second-completed",
+          } as unknown as SDKMessage);
+          harness.query.emit({
+            type: "system",
+            subtype: "notification",
+            key: "second-command-processed",
+            text: "Second command processed",
+            priority: "high",
+            session_id: "sdk-unknown",
+            uuid: "second-command-processed",
+          } as unknown as SDKMessage);
+          const secondEvents = yield* Fiber.join(secondProcessed);
+          assert.equal(
+            secondEvents.some((event) => event.type === "turn.completed"),
+            false,
+          );
+          const stillRejected = yield* adapter
+            .sendTurn(blockedInput, admissionOptions())
+            .pipe(Effect.result);
+          assert.equal(stillRejected._tag, "Failure");
+          assert.equal(harness.query.setModelCalls.length, 0);
+        }
         const completed = yield* adapter.streamEvents.pipe(
           Stream.filter((event) => event.type === "turn.completed"),
           Stream.take(1),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1574,6 +1574,527 @@ describe("ClaudeAdapterLive", () => {
     },
   );
 
+  it.effect.each([
+    { resultFirst: true, terminal: "completed", reset: false },
+    { resultFirst: false, terminal: "completed", reset: false },
+    { resultFirst: false, terminal: "cancelled", reset: false },
+    { resultFirst: true, terminal: "completed", reset: true },
+  ])(
+    "keeps accepted steering reserved across local result/terminal order %j",
+    ({ resultFirst, terminal, reset }) => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+        yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+        let completions = 0;
+        let sessionId = "sdk-local-command";
+        const resultSessionId = reset ? "sdk-after-clear" : sessionId;
+        const turn = yield* adapter.sendTurn(
+          { threadId: THREAD_ID, input: reset ? "/clear" : "/agents" },
+          admissionOptions({
+            nativeCompleted: () =>
+              Effect.sync(() => {
+                completions += 1;
+              }),
+          }),
+        );
+        const [prompt] = yield* Effect.promise(() =>
+          readPromptMessages(harness.getLastCreateQueryInput(), 1),
+        );
+        assert.isDefined(prompt?.uuid);
+        const lifecycle = (state: string, commandUuid: string = prompt!.uuid!) =>
+          ({
+            type: "command_lifecycle",
+            command_uuid: commandUuid,
+            state,
+            session_id: sessionId,
+            uuid: `lifecycle-${state}-${commandUuid}`,
+          }) as unknown as SDKMessage;
+        const result = {
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          num_turns: 0,
+          session_id: resultSessionId,
+          uuid: "local-command-result",
+          result: "Local command output",
+          usage: { input_tokens: 0, output_tokens: 0 },
+        } as unknown as SDKMessage;
+        harness.query.emit(lifecycle("queued"));
+        harness.query.emit(lifecycle("started"));
+        if (reset) {
+          harness.query.emit({
+            type: "conversation_reset",
+            session_id: sessionId,
+            new_conversation_id: "independent-conversation-id",
+            uuid: "clear-reset",
+          } as unknown as SDKMessage);
+          sessionId = resultSessionId;
+        }
+        harness.query.emit({
+          type: "system",
+          subtype: "init",
+          session_id: resultSessionId,
+          uuid: "local-command-init",
+        } as unknown as SDKMessage);
+        harness.query.emit(lifecycle("completed", "unrelated-command"));
+        const firstHalf = yield* adapter.streamEvents.pipe(
+          Stream.takeUntil(
+            (event) =>
+              event.type === "runtime.warning" && event.payload.message === "First half processed",
+          ),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        harness.query.emit(resultFirst ? result : lifecycle(terminal));
+        harness.query.emit({
+          type: "system",
+          subtype: "notification",
+          key: "local-command-first-half",
+          text: "First half processed",
+          priority: "high",
+          session_id: resultSessionId,
+          uuid: "local-command-first-half",
+        } as unknown as SDKMessage);
+        const firstEvents = yield* Fiber.join(firstHalf);
+        assert.equal(completions, resultFirst ? 0 : 1);
+        assert.equal(
+          firstEvents.some((event) => event.type === "turn.completed"),
+          false,
+        );
+        const steer = yield* adapter.sendTurn(
+          { threadId: THREAD_ID, input: "/agents" },
+          admissionOptions(),
+        );
+        assert.equal(steer.turnId, turn.turnId);
+        const [steerPrompt] = yield* Effect.promise(() =>
+          readPromptMessages(harness.getLastCreateQueryInput(), 1),
+        );
+        const firstCommand = yield* adapter.streamEvents.pipe(
+          Stream.takeUntil(
+            (event) =>
+              event.type === "runtime.warning" &&
+              event.payload.message === "First command processed",
+          ),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        harness.query.emit(resultFirst ? lifecycle(terminal) : result);
+        harness.query.emit({
+          type: "system",
+          subtype: "notification",
+          key: "first-command-processed",
+          text: "First command processed",
+          priority: "high",
+          session_id: resultSessionId,
+          uuid: "first-command-processed",
+        } as unknown as SDKMessage);
+        const firstCommandEvents = yield* Fiber.join(firstCommand);
+        assert.equal(
+          firstCommandEvents.some((event) => event.type === "turn.completed"),
+          false,
+        );
+        const completed = yield* adapter.streamEvents.pipe(
+          Stream.filter((event) => event.type === "turn.completed"),
+          Stream.take(1),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        harness.query.emit(lifecycle("started", steerPrompt!.uuid));
+        harness.query.emit({
+          type: "system",
+          subtype: "init",
+          session_id: resultSessionId,
+          uuid: "steer-init",
+        } as unknown as SDKMessage);
+        harness.query.emit({ ...result, uuid: "steer-result" } as unknown as SDKMessage);
+        harness.query.emit(lifecycle("completed", steerPrompt!.uuid));
+        const [event] = yield* Fiber.join(completed);
+        assert.equal(event?.turnId, turn.turnId);
+        if (event?.type === "turn.completed") {
+          assert.equal(event.payload.state, terminal === "cancelled" ? "interrupted" : "completed");
+          assert.equal(event.payload.tokenUsage?.inputTokens, 0);
+        }
+        assert.equal(completions, 1);
+        harness.query.emit(lifecycle("completed"));
+        const next = yield* adapter.sendTurn(
+          { threadId: THREAD_ID, input: "/agents" },
+          admissionOptions(),
+        );
+        assert.notEqual(next.turnId, turn.turnId);
+      }).pipe(Effect.provide(harness.layer));
+    },
+  );
+
+  it.effect.each([false, true])(
+    "ignores unrelated anonymous results with an old initial batch: %s",
+    (withOldInitialBatch) => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+        yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+        const oldPrompt = withOldInitialBatch
+          ? yield* Effect.gen(function* () {
+              yield* adapter.sendTurn(
+                { threadId: THREAD_ID, input: "Initial input" },
+                admissionOptions(),
+              );
+              return yield* Effect.promise(() =>
+                readFirstPromptMessage(harness.getLastCreateQueryInput()),
+              );
+            })
+          : undefined;
+        const first = yield* adapter.sendTurn(
+          { threadId: THREAD_ID, input: "Folded input" },
+          admissionOptions(),
+        );
+        const [prompt] = yield* Effect.promise(() =>
+          readPromptMessages(harness.getLastCreateQueryInput(), 1),
+        );
+        const processed = yield* adapter.streamEvents.pipe(
+          Stream.takeUntil(
+            (event) =>
+              event.type === "runtime.warning" &&
+              event.payload.message === "Folded terminal processed",
+          ),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        if (oldPrompt)
+          harness.query.emit({
+            type: "command_lifecycle",
+            command_uuid: oldPrompt.uuid,
+            state: "started",
+            session_id: "sdk-folded",
+            uuid: "initial-started",
+          } as unknown as SDKMessage);
+        harness.query.emit({
+          type: "system",
+          subtype: "init",
+          session_id: "sdk-folded",
+          uuid: "previous-turn-init",
+        } as unknown as SDKMessage);
+        if (oldPrompt) {
+          harness.query.emit({
+            type: "result",
+            subtype: "success",
+            is_error: false,
+            num_turns: 0,
+            session_id: "sdk-folded",
+            uuid: "initial-result",
+            usage: { input_tokens: 7, output_tokens: 1 },
+          } as unknown as SDKMessage);
+          harness.query.emit({
+            type: "command_lifecycle",
+            command_uuid: oldPrompt.uuid,
+            state: "completed",
+            session_id: "sdk-folded",
+            uuid: "initial-completed",
+          } as unknown as SDKMessage);
+        }
+        harness.query.emit({
+          type: "command_lifecycle",
+          command_uuid: prompt!.uuid,
+          state: "started",
+          session_id: "sdk-folded",
+          uuid: "folded-started",
+        } as unknown as SDKMessage);
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          num_turns: 0,
+          session_id: "sdk-folded",
+          uuid: "unrelated-meta-result",
+          usage: { input_tokens: 999, output_tokens: 999 },
+        } as unknown as SDKMessage);
+        harness.query.emit({
+          type: "command_lifecycle",
+          command_uuid: prompt!.uuid,
+          state: "completed",
+          session_id: "sdk-folded",
+          uuid: "folded-completed",
+        } as unknown as SDKMessage);
+        harness.query.emit({
+          type: "system",
+          subtype: "notification",
+          key: "folded-processed",
+          text: "Folded terminal processed",
+          priority: "high",
+          session_id: "sdk-folded",
+          uuid: "folded-processed",
+        } as unknown as SDKMessage);
+        const earlyEvents = yield* Fiber.join(processed);
+        assert.equal(
+          earlyEvents.some((event) => event.type === "turn.completed"),
+          false,
+        );
+        const steer = yield* adapter.sendTurn(
+          { threadId: THREAD_ID, input: "More input" },
+          admissionOptions(),
+        );
+        assert.equal(steer.turnId, first.turnId);
+        const [steerPrompt] = yield* Effect.promise(() =>
+          readPromptMessages(harness.getLastCreateQueryInput(), 1),
+        );
+        const completed = yield* adapter.streamEvents.pipe(
+          Stream.filter((event) => event.type === "turn.completed"),
+          Stream.take(1),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          session_id: "sdk-folded",
+          uuid: "actual-folded-result",
+          user_message_uuids: [prompt!.uuid, steerPrompt!.uuid],
+          usage: { input_tokens: 50, output_tokens: 10 },
+        } as unknown as SDKMessage);
+        const [event] = yield* Fiber.join(completed);
+        if (event?.type === "turn.completed")
+          assert.equal(event.payload.tokenUsage?.inputTokens, withOldInitialBatch ? 57 : 50);
+      }).pipe(Effect.provide(harness.layer));
+    },
+  );
+
+  it.effect("joins a folded command to its initial batch result", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      const first = yield* adapter.sendTurn(
+        { threadId: THREAD_ID, input: "First" },
+        admissionOptions(),
+      );
+      const folded = yield* adapter.sendTurn(
+        { threadId: THREAD_ID, input: "Steer" },
+        admissionOptions(),
+      );
+      assert.equal(folded.turnId, first.turnId);
+      const [firstPrompt, foldedPrompt] = yield* Effect.promise(() =>
+        readPromptMessages(harness.getLastCreateQueryInput(), 2),
+      );
+      const lifecycle = (commandUuid: string, state: "started" | "completed") =>
+        ({
+          type: "command_lifecycle",
+          command_uuid: commandUuid,
+          state,
+          session_id: "sdk-folded-success",
+          uuid: `${commandUuid}-${state}`,
+        }) as unknown as SDKMessage;
+      const processed = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "runtime.warning"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      harness.query.emit(lifecycle(firstPrompt!.uuid!, "started"));
+      harness.query.emit({
+        type: "system",
+        subtype: "init",
+        session_id: "sdk-folded-success",
+        uuid: "own-initial-batch",
+      } as unknown as SDKMessage);
+      harness.query.emit(lifecycle(foldedPrompt!.uuid!, "started"));
+      harness.query.emit(lifecycle(foldedPrompt!.uuid!, "completed"));
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        session_id: "sdk-folded-success",
+        uuid: "shared-result",
+        usage: { input_tokens: 50, output_tokens: 10 },
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "system",
+        subtype: "notification",
+        key: "shared-result-processed",
+        text: "Shared result processed",
+        priority: "high",
+        session_id: "sdk-folded-success",
+        uuid: "shared-result-processed",
+      } as unknown as SDKMessage);
+      const earlyEvents = yield* Fiber.join(processed);
+      assert.equal(
+        earlyEvents.some((event) => event.type === "turn.completed"),
+        false,
+      );
+      const completed = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "turn.completed"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      harness.query.emit(lifecycle(firstPrompt!.uuid!, "completed"));
+      const [event] = yield* Fiber.join(completed);
+      assert.equal(event?.turnId, first.turnId);
+      if (event?.type === "turn.completed") {
+        assert.equal(event.payload.state, "completed");
+        assert.equal(event.payload.tokenUsage?.inputTokens, 50);
+      }
+    }).pipe(Effect.provide(harness.layer));
+  });
+
+  it.effect(
+    "rejects input before preparation after an unknown result and recovers on exact receipts",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+        yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+        const first = yield* adapter.sendTurn(
+          { threadId: THREAD_ID, input: "First" },
+          admissionOptions(),
+        );
+        const [prompt] = yield* Effect.promise(() =>
+          readPromptMessages(harness.getLastCreateQueryInput(), 1),
+        );
+        const processed = yield* adapter.streamEvents.pipe(
+          Stream.takeUntil((event) => event.type === "session.configured"),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          num_turns: 0,
+          session_id: "sdk-unknown",
+          uuid: "unknown-result",
+        } as unknown as SDKMessage);
+        harness.query.emit({
+          type: "system",
+          subtype: "init",
+          session_id: "sdk-unknown",
+          uuid: "unknown-result-processed",
+        } as unknown as SDKMessage);
+        const events = yield* Fiber.join(processed);
+        assert.equal(
+          events.some((event) => event.type === "runtime.warning"),
+          false,
+        );
+        const rejected = yield* adapter
+          .sendTurn(
+            {
+              threadId: THREAD_ID,
+              input: "Blocked",
+              modelSelection: createModelSelection(
+                ProviderInstanceId.make("claudeAgent"),
+                SYNTHETIC_CLAUDE_STANDARD_MODEL,
+              ),
+            },
+            admissionOptions(),
+          )
+          .pipe(Effect.flip);
+        assert.equal(rejected._tag, "ProviderAdapterRequestError");
+        assert.equal(harness.query.setModelCalls.length, 0);
+        const completed = yield* adapter.streamEvents.pipe(
+          Stream.filter((event) => event.type === "turn.completed"),
+          Stream.take(1),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        harness.query.emit({
+          type: "command_lifecycle",
+          command_uuid: prompt!.uuid,
+          state: "started",
+          session_id: "sdk-unknown",
+          uuid: "late-started",
+        } as unknown as SDKMessage);
+        harness.query.emit({
+          type: "system",
+          subtype: "init",
+          session_id: "sdk-unknown",
+          uuid: "late-init",
+        } as unknown as SDKMessage);
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          num_turns: 0,
+          session_id: "sdk-unknown",
+          uuid: "confirmed-command-result",
+        } as unknown as SDKMessage);
+        harness.query.emit({
+          type: "command_lifecycle",
+          command_uuid: prompt!.uuid,
+          state: "completed",
+          session_id: "sdk-unknown",
+          uuid: "late-completed",
+        } as unknown as SDKMessage);
+        yield* Fiber.join(completed);
+        const next = yield* adapter.sendTurn(
+          { threadId: THREAD_ID, input: "Next" },
+          admissionOptions(),
+        );
+        assert.notEqual(next.turnId, first.turnId);
+      }).pipe(Effect.provide(harness.layer));
+    },
+  );
+
+  it.effect.each(["cancelled", "discarded", "refused"] as const)(
+    "finishes an exact %s command without waiting for a result that will not arrive",
+    (state) => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+        yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+        let completions = 0;
+        const turn = yield* adapter.sendTurn(
+          { threadId: THREAD_ID, input: "Queued input" },
+          admissionOptions({
+            nativeCompleted: () =>
+              Effect.sync(() => {
+                completions += 1;
+              }),
+          }),
+        );
+        const [prompt] = yield* Effect.promise(() =>
+          readPromptMessages(harness.getLastCreateQueryInput(), 1),
+        );
+        const completed = yield* adapter.streamEvents.pipe(
+          Stream.filter((event) => event.type === "turn.completed"),
+          Stream.take(1),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        harness.query.emit({
+          type: "command_lifecycle",
+          command_uuid: prompt!.uuid,
+          state,
+          session_id: "sdk-command-rejected",
+          uuid: "command-terminal",
+        } as unknown as SDKMessage);
+        const [event] = yield* Fiber.join(completed);
+        assert.equal(event?.turnId, turn.turnId);
+        assert.equal(completions, 1);
+        if (event?.type === "turn.completed")
+          assert.equal(event.payload.state, state === "refused" ? "failed" : "interrupted");
+      }).pipe(Effect.provide(harness.layer));
+    },
+  );
+
   it.effect("does not treat a local query close as native completion", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1,4 +1,5 @@
 // @effect-diagnostics nodeBuiltinImport:off
+import * as NodeChildProcess from "node:child_process";
 import * as NodeFS from "node:fs";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
@@ -52,6 +53,8 @@ import type { ClaudeAdapterShape } from "../Services/ClaudeAdapter.ts";
 import type { ProviderTurnStartOptions } from "../Services/ProviderAdapter.ts";
 import type { ClaudeScopedLimitNames } from "./claudeUsageLimits.ts";
 import { makeClaudeAdapter, type ClaudeAdapterLiveOptions } from "./ClaudeAdapter.ts";
+vi.mock("node:child_process", { spy: true });
+
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
 const encodeUnknownJsonString = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
 
@@ -1978,14 +1981,19 @@ describe("ClaudeAdapterLive", () => {
             })
           : undefined;
         const processed = yield* adapter.streamEvents.pipe(
-          Stream.takeUntil((event) => event.type === "session.configured"),
+          Stream.takeUntil(
+            (event) =>
+              event.type === "session.configured" &&
+              event.payload.config.uuid === "unknown-result-processed",
+          ),
           Stream.runCollect,
           Effect.forkChild,
         );
         harness.query.emit({
           type: "result",
-          subtype: "success",
-          is_error: false,
+          subtype: "error_during_execution",
+          is_error: true,
+          errors: ["Unowned command failed."],
           num_turns: 0,
           session_id: "sdk-unknown",
           uuid: "unknown-result",
@@ -1998,7 +2006,9 @@ describe("ClaudeAdapterLive", () => {
         } as unknown as SDKMessage);
         const events = yield* Fiber.join(processed);
         assert.equal(
-          events.some((event) => event.type === "runtime.warning"),
+          events.some(
+            (event) => event.type === "runtime.warning" || event.type === "runtime.error",
+          ),
           false,
         );
         const blockedInput = {
@@ -2112,7 +2122,7 @@ describe("ClaudeAdapterLive", () => {
   );
 
   it.effect.each(["cancelled", "discarded", "refused"] as const)(
-    "finishes an exact %s command without waiting for a result that will not arrive",
+    "finishes an exact %s command and ignores its late result on the next turn",
     (state) => {
       const harness = makeHarness();
       return Effect.gen(function* () {
@@ -2153,6 +2163,50 @@ describe("ClaudeAdapterLive", () => {
         assert.equal(completions, 1);
         if (event?.type === "turn.completed")
           assert.equal(event.payload.state, state === "refused" ? "failed" : "interrupted");
+
+        const next = yield* adapter.sendTurn(
+          { threadId: THREAD_ID, input: "Next" },
+          admissionOptions(),
+        );
+        const nextPrompt = yield* Effect.promise(() =>
+          readFirstPromptMessage(harness.getLastCreateQueryInput()),
+        );
+        const nextEvents = yield* adapter.streamEvents.pipe(
+          Stream.takeUntil((nextEvent) => nextEvent.type === "turn.completed"),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        harness.query.emit({
+          type: "result",
+          subtype: "error_during_execution",
+          is_error: true,
+          errors: ["Old command failed."],
+          session_id: "sdk-command-rejected",
+          uuid: "late-old-result",
+          user_message_uuid: prompt!.uuid,
+          usage: { input_tokens: 999, output_tokens: 999 },
+        } as unknown as SDKMessage);
+        harness.query.emit({
+          type: "result",
+          subtype: "error_during_execution",
+          is_error: true,
+          errors: ["Current command failed."],
+          session_id: "sdk-command-rejected",
+          uuid: "current-result",
+          user_message_uuid: nextPrompt!.uuid,
+          usage: { input_tokens: 50, output_tokens: 10 },
+        } as unknown as SDKMessage);
+        const events = yield* Fiber.join(nextEvents);
+        assert.deepEqual(
+          events
+            .filter((nextEvent) => nextEvent.type === "runtime.error")
+            .map((nextEvent) => nextEvent.payload.message),
+          ["Current command failed."],
+        );
+        const nextCompleted = events.find((nextEvent) => nextEvent.type === "turn.completed");
+        assert.equal(nextCompleted?.turnId, next.turnId);
+        assert.equal(nextCompleted?.payload.state, "failed");
+        assert.equal(nextCompleted?.payload.tokenUsage?.inputTokens, 50);
       }).pipe(Effect.provide(harness.layer));
     },
   );
@@ -2183,6 +2237,38 @@ describe("ClaudeAdapterLive", () => {
       yield* adapter.stopSession(THREAD_ID);
       assert.equal(completed, false);
       assert.equal(stopped, false);
+    }).pipe(Effect.provide(harness.layer));
+  });
+
+  it.effect("handles a spawn failure that has no process pipes", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      const spawnProcess = harness.getLastCreateQueryInput()?.options.spawnClaudeCodeProcess;
+      assert.isDefined(spawnProcess);
+      const child = new NodeChildProcess.ChildProcess();
+      const spawn = vi.spyOn(NodeChildProcess, "spawn").mockReturnValueOnce(child);
+      try {
+        assert.throws(
+          () =>
+            spawnProcess!({
+              command: "claude",
+              args: [],
+              env: {},
+              signal: new AbortController().signal,
+            }),
+          /Claude could not create its process streams/u,
+        );
+        // Node emits this after its failed spawn returns without assigning pipes.
+        assert.doesNotThrow(() => child.emit("error", new Error("spawn EMFILE")));
+      } finally {
+        spawn.mockRestore();
+      }
     }).pipe(Effect.provide(harness.layer));
   });
 

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -4797,6 +4797,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         onUserDialog,
         supportedDialogKinds: ["resume_return"],
         env: claudeEnvironment,
+        // Custom spawning disables the SDK's private shared debug-file path.
+        // Keep native debug logs enabled in Claude's own file through the public option.
+        ...(["1", "true", "yes", "on"].includes(
+          claudeEnvironment.DEBUG_CLAUDE_AGENT_SDK?.trim().toLowerCase() ?? "",
+        )
+          ? { debug: true }
+          : {}),
         spawnClaudeCodeProcess: ({ command, args, cwd, env, signal }) => {
           const child = NodeChildProcess.spawn(command, args, {
             cwd,
@@ -4806,8 +4813,15 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
             windowsHide: true,
           });
           nativeProcess.captured = child.pid !== undefined;
+          child.stderr.on("error", () => {
+            runFork(Effect.logWarning("Claude stderr read failed."));
+          });
           child.stderr.resume();
-          child.once("exit", () => Deferred.doneUnsafe(nativeProcess.exited, Exit.void));
+          child.once("exit", () => {
+            Deferred.doneUnsafe(nativeProcess.exited, Exit.void);
+            // The SDK does not consume custom-process stderr. Do not retain inherited pipes.
+            child.stderr.destroy();
+          });
           return child;
         },
         additionalDirectories,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -291,18 +291,44 @@ function rememberPendingTaskModel(
   }
 }
 
+interface ClaudePromptSubmission {
+  readonly turnId: TurnId;
+  readonly options: ProviderTurnStartOptions;
+  started: boolean;
+  nativeInitSessionId?: string;
+  nativeInitSequence?: number;
+  initialBatch: boolean;
+  nativeFinished: boolean;
+  resultObserved: boolean;
+  terminalState?: "cancelled" | "discarded" | "refused";
+}
+
+interface ClaudePendingResult {
+  readonly message: SDKResultMessage;
+  readonly submissions: ReadonlyArray<ClaudePromptSubmission>;
+  readonly exactMatch: boolean;
+}
+
+const decodeClaudeCommandLifecycle = Schema.decodeUnknownExit(
+  Schema.Struct({
+    type: Schema.Literal("command_lifecycle"),
+    command_uuid: Schema.String,
+    session_id: Schema.String,
+    state: Schema.Literals(["queued", "started", "completed", "cancelled", "discarded", "refused"]),
+  }),
+);
+
 interface ClaudeSessionContext {
   session: ProviderSession;
   readonly promptQueue: Queue.Queue<PromptQueueItem>;
   readonly query: ClaudeQueryRuntime;
   readonly submissionSemaphore: Semaphore.Semaphore;
-  readonly submittedPrompts: Map<
-    string,
-    {
-      readonly turnId: TurnId;
-      readonly options: ProviderTurnStartOptions;
-    }
-  >;
+  readonly submittedPrompts: Map<string, ClaudePromptSubmission>;
+  pendingResult: ClaudePendingResult | undefined;
+  recoveryRequired: boolean;
+  nativeInitSequence: number;
+  nativeInitSessionId: string | undefined;
+  lastResultUuid: string | undefined;
   readonly nativeProcess: {
     captured: boolean;
     readonly exited: Deferred.Deferred<void>;
@@ -3315,55 +3341,61 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     yield* updateResumeCursor(context);
   });
 
-  const handleResultMessage = Effect.fn("handleResultMessage")(function* (
-    context: ClaudeSessionContext,
-    message: SDKMessage,
-  ) {
-    if (message.type !== "result") {
-      return;
+  const preservePendingClaudeUsage = (context: ClaudeSessionContext) => {
+    const pending = context.pendingResult;
+    if (
+      context.turnState &&
+      pending &&
+      (pending.exactMatch || pending.submissions.every((submitted) => submitted.nativeFinished))
+    ) {
+      context.turnState.priorTokenUsage = addClaudeTurnTokenUsage(
+        context.turnState.priorTokenUsage,
+        normalizeClaudeTurnTokenUsage(
+          pending.message,
+          context.turnState.hasSubagents,
+          turnStatusFromResult(pending.message),
+        ),
+      );
     }
+    context.pendingResult = undefined;
+  };
 
+  const finishPendingClaudeTurn = Effect.fn("finishPendingClaudeTurn")(function* (
+    context: ClaudeSessionContext,
+  ) {
+    if (context.stopped) return;
+    const pending = context.pendingResult;
+    const submissions = [...context.submittedPrompts.values()];
+    const refused = submissions.some((submitted) => submitted.terminalState === "refused");
+    const interrupted = submissions.some(
+      (submitted) =>
+        submitted.terminalState === "cancelled" || submitted.terminalState === "discarded",
+    );
+    const status = refused
+      ? "failed"
+      : interrupted
+        ? "interrupted"
+        : pending
+          ? turnStatusFromResult(pending.message)
+          : undefined;
+    if (
+      status === undefined ||
+      submissions.some((submitted) => !submitted.nativeFinished || !submitted.resultObserved)
+    )
+      return;
+    const errorMessage = refused
+      ? "Claude refused a command."
+      : interrupted
+        ? "Claude cancelled or discarded a command."
+        : pending
+          ? resultUserFacingError(pending.message)
+          : undefined;
     const completion = Deferred.makeUnsafe<void>();
     context.turnCompletion = completion;
-    yield* Effect.gen(function* () {
-      const status = turnStatusFromResult(message);
-      const errorMessage = resultUserFacingError(message);
-      const completedMessageIds = new Set(message.user_message_uuids ?? []);
-      if (message.user_message_uuid !== undefined)
-        completedMessageIds.add(message.user_message_uuid);
-      let completedOwnPrompt = false;
-      for (const [messageId, submitted] of context.submittedPrompts) {
-        // A result identifies consumed prompts. An echoed or queued prompt can still be pending.
-        if (!completedMessageIds.has(messageId)) continue;
-        completedOwnPrompt = true;
-        context.submittedPrompts.delete(messageId);
-        yield* submitted.options.nativeCompleted(submitted.turnId);
-      }
-      if (status === "failed") {
-        yield* emitRuntimeError(context, errorMessage ?? "Claude turn failed.");
-      }
-      if (context.submittedPrompts.size === 0) {
-        yield* completeTurn(context, status, errorMessage, message);
-      } else if (context.turnState && completedOwnPrompt) {
-        context.turnState.priorTokenUsage = addClaudeTurnTokenUsage(
-          context.turnState.priorTokenUsage,
-          normalizeClaudeTurnTokenUsage(message, context.turnState.hasSubagents, status),
-        );
-      } else if (context.submittedPrompts.size > 0 && completedMessageIds.size === 0) {
-        const stamp = yield* makeEventStamp();
-        yield* offerRuntimeEvent({
-          type: "runtime.warning",
-          eventId: stamp.eventId,
-          provider: PROVIDER,
-          threadId: context.session.threadId,
-          createdAt: stamp.createdAt,
-          payload: {
-            message:
-              "Claude did not identify the completed prompt. Stop the session to confirm that its work has finished.",
-          },
-        });
-      }
-    }).pipe(
+    context.pendingResult = undefined;
+    context.recoveryRequired = false;
+    context.submittedPrompts.clear();
+    yield* completeTurn(context, status, errorMessage, pending?.message).pipe(
       Effect.ensuring(
         Effect.gen(function* () {
           context.turnCompletion = undefined;
@@ -3371,6 +3403,107 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         }),
       ),
     );
+  });
+
+  const handleCommandLifecycle = Effect.fn("handleCommandLifecycle")(function* (
+    context: ClaudeSessionContext,
+    message: unknown,
+  ) {
+    // Real stdout frames are forwarded by the SDK but absent from its message union.
+    const decoded = decodeClaudeCommandLifecycle(message);
+    if (Exit.isFailure(decoded)) return;
+    const receipt = decoded.value;
+    const submitted = context.submittedPrompts.get(receipt.command_uuid);
+    if (!submitted) return;
+    if (receipt.state === "queued") return;
+    context.recoveryRequired = false;
+    if (receipt.state === "started") {
+      submitted.started = true;
+      if (context.nativeInitSessionId !== undefined) {
+        submitted.nativeInitSessionId = context.nativeInitSessionId;
+        submitted.nativeInitSequence = context.nativeInitSequence;
+      }
+      return;
+    }
+    if (receipt.state !== "completed") {
+      submitted.terminalState = receipt.state;
+      // An already-started cancellation can still have a final result in flight.
+      if (receipt.state !== "cancelled" || !submitted.started) submitted.resultObserved = true;
+    }
+    if (!submitted.nativeFinished) {
+      submitted.nativeFinished = true;
+      yield* submitted.options.nativeCompleted(submitted.turnId);
+    }
+    // Folded commands can finish before their result. Keep status and usage pending.
+    yield* finishPendingClaudeTurn(context);
+  });
+
+  const handleResultMessage = Effect.fn("handleResultMessage")(function* (
+    context: ClaudeSessionContext,
+    message: SDKMessage,
+  ) {
+    if (message.type !== "result") return;
+    if (typeof message.uuid === "string" && message.uuid === context.lastResultUuid) return;
+    context.lastResultUuid = message.uuid;
+    const status = turnStatusFromResult(message);
+    const errorMessage = resultUserFacingError(message);
+    const completedMessageIds = new Set(message.user_message_uuids ?? []);
+    if (message.user_message_uuid !== undefined) completedMessageIds.add(message.user_message_uuid);
+    const resultSegments = new Set<number>();
+    for (const [messageId, submitted] of context.submittedPrompts) {
+      if (
+        submitted.nativeInitSequence !== undefined &&
+        submitted.nativeInitSessionId === message.session_id &&
+        (completedMessageIds.has(messageId) ||
+          (completedMessageIds.size === 0 &&
+            submitted.initialBatch &&
+            !submitted.resultObserved &&
+            submitted.nativeInitSequence === context.nativeInitSequence))
+      )
+        resultSegments.add(submitted.nativeInitSequence);
+    }
+    let exactMatch = false;
+    const observedSubmissions: Array<ClaudePromptSubmission> = [];
+    for (const [messageId, submitted] of context.submittedPrompts) {
+      const matches = completedMessageIds.has(messageId);
+      if (matches) {
+        context.recoveryRequired = false;
+        exactMatch = true;
+        if (!submitted.nativeFinished) {
+          submitted.nativeFinished = true;
+          yield* submitted.options.nativeCompleted(submitted.turnId);
+        }
+      }
+      if (
+        matches ||
+        (submitted.nativeInitSessionId === message.session_id &&
+          submitted.nativeInitSequence !== undefined &&
+          resultSegments.has(submitted.nativeInitSequence))
+      ) {
+        submitted.resultObserved = true;
+        observedSubmissions.push(submitted);
+      }
+    }
+    if (status === "failed")
+      yield* emitRuntimeError(context, errorMessage ?? "Claude turn failed.");
+    if (context.stopped) return;
+    if (context.submittedPrompts.size === 0) {
+      context.pendingResult = { message, submissions: [], exactMatch: false };
+      yield* finishPendingClaudeTurn(context);
+      return;
+    }
+    if (observedSubmissions.length > 0) {
+      preservePendingClaudeUsage(context);
+      context.pendingResult = { message, submissions: observedSubmissions, exactMatch };
+      yield* finishPendingClaudeTurn(context);
+    } else if (
+      completedMessageIds.size === 0 &&
+      ![...context.submittedPrompts.values()].some(
+        (submitted) => submitted.started && !submitted.nativeFinished,
+      )
+    ) {
+      context.recoveryRequired = true;
+    }
   });
 
   /**
@@ -3488,6 +3621,19 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     switch (message.subtype) {
       case "init":
+        context.nativeInitSequence += 1;
+        context.nativeInitSessionId = message.session_id;
+        // This owned local query runs one initial batch at a time while stdin is
+        // open. Its started receipts precede init, even when /clear changes the
+        // session ID. Folded commands start after init and finish before the next.
+        for (const submitted of context.submittedPrompts.values()) {
+          if (submitted.started && !submitted.nativeFinished) {
+            submitted.nativeInitSessionId = message.session_id;
+            submitted.nativeInitSequence = context.nativeInitSequence;
+            submitted.initialBatch = true;
+            submitted.resultObserved = false;
+          }
+        }
         yield* offerRuntimeEvent({
           ...base,
           type: "session.configured",
@@ -4004,10 +4150,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     message: SDKMessage,
   ) {
     yield* logNativeSdkMessage(context, message);
+    if (context.stopped) return;
     yield* ensureThreadId(context, message);
+    if (context.stopped) return;
 
-    // Wire-only command bookkeeping has no user-facing T3 lifecycle.
     if (sdkMessageType(message) === "command_lifecycle") {
+      yield* handleCommandLifecycle(context, message);
       return;
     }
 
@@ -4130,6 +4278,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
+    // Closing input permits held-result ordering that has no anonymous-result anchor.
+    if (!context.pendingResult?.exactMatch) context.pendingResult = undefined;
+
     // Schedule process termination before any cleanup that can wait on the
     // provider. The SDK closes stdin, then escalates from SIGTERM to SIGKILL.
     yield* Effect.try({
@@ -4203,10 +4354,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     if (context.nativeProcess.captured) {
       yield* Deferred.await(context.nativeProcess.exited);
       for (const submitted of context.submittedPrompts.values()) {
+        submitted.nativeFinished = true;
         yield* submitted.options.nativeStopped;
       }
       context.submittedPrompts.clear();
     }
+    preservePendingClaudeUsage(context);
     if (context.turnState) {
       yield* completeTurn(
         context,
@@ -4906,6 +5059,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         query: queryRuntime,
         submissionSemaphore: Semaphore.makeUnsafe(1),
         submittedPrompts: new Map(),
+        pendingResult: undefined,
+        recoveryRequired: false,
+        nativeInitSequence: 0,
+        nativeInitSessionId: undefined,
+        lastResultUuid: undefined,
         nativeProcess,
         turnCompletion: undefined,
         streamFiber: undefined,
@@ -5009,9 +5167,20 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     },
   );
 
+  const requireClaudeCompletionEvidence = (context: ClaudeSessionContext) => {
+    if (!context.recoveryRequired) return Effect.void;
+    return new ProviderAdapterRequestError({
+      provider: PROVIDER,
+      method: "turn/start",
+      detail:
+        "Claude has not confirmed the previous input. Stop the session before sending more input, or retry after its exact command receipt arrives.",
+    });
+  };
+
   const sendTurn: ClaudeAdapterShape["sendTurn"] = Effect.fn("sendTurn")(
     function* (input, turnOptions) {
       const context = yield* requireSession(input.threadId);
+      yield* requireClaudeCompletionEvidence(context);
       const modelCatalog = yield* modelCatalogEffect;
       const selectedModel =
         input.modelSelection !== undefined && input.modelSelection.instanceId === boundInstanceId
@@ -5093,6 +5262,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           Effect.gen(function* () {
             while (true) {
               if (context.turnCompletion) yield* Deferred.await(context.turnCompletion);
+              yield* requireClaudeCompletionEvidence(context);
               if (context.stopped || sessions.get(input.threadId) !== context) {
                 return yield* new ProviderAdapterSessionClosedError({
                   provider: PROVIDER,
@@ -5107,6 +5277,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
               const turnId = steeringTurnState?.turnId ?? TurnId.make(yield* randomUUIDv4);
               const stamp = yield* makeEventStamp();
               if (turnOptions) yield* turnOptions.beforeSubmit(turnId);
+              if (context.recoveryRequired) {
+                if (turnOptions) yield* turnOptions.notSubmitted;
+                yield* requireClaudeCompletionEvidence(context);
+              }
               if (context.stopped || sessions.get(input.threadId) !== context) {
                 if (turnOptions) yield* turnOptions.notSubmitted;
                 return yield* new ProviderAdapterSessionClosedError({
@@ -5143,6 +5317,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
                 context.submittedPrompts.set(messageId, {
                   turnId,
                   options: turnOptions,
+                  started: false,
+                  initialBatch: false,
+                  nativeFinished: false,
+                  resultObserved: false,
                 });
               // No async work may separate admission from this queue write.
               const offered = Queue.offerUnsafe(context.promptQueue, { type: "message", message });

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -1,3 +1,4 @@
+// @effect-diagnostics nodeBuiltinImport:off - The SDK spawn hook requires synchronous Node streams and process events.
 /**
  * ClaudeAdapterLive - Scoped live implementation for the Claude Agent provider adapter.
  *
@@ -20,6 +21,7 @@ import {
   type SDKUserMessage,
   type ModelUsage,
 } from "@anthropic-ai/claude-agent-sdk";
+import * as NodeChildProcess from "node:child_process";
 import { parseCliArgs } from "@t3tools/shared/cliArgs";
 import { isWorkspaceImagePreviewPath } from "@t3tools/shared/filePreview";
 import { type ClaudeScopedLimitNames, claudeRateLimitEventToUpdate } from "./claudeUsageLimits.ts";
@@ -77,6 +79,7 @@ import * as Path from "effect/Path";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
@@ -109,6 +112,7 @@ import {
   type ProviderAdapterError,
 } from "../Errors.ts";
 import { type ClaudeAdapterShape } from "../Services/ClaudeAdapter.ts";
+import type { ProviderTurnStartOptions } from "../Services/ProviderAdapter.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
 const decodeUnknownJsonStringExit = Schema.decodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
@@ -160,6 +164,7 @@ interface ClaudeTurnState {
   compactedSinceLatestAssistantUsage: boolean;
   hasSubagents: boolean;
   nextSyntheticAssistantBlockIndex: number;
+  priorTokenUsage?: TurnTokenUsage;
 }
 
 interface AssistantTextBlockState {
@@ -290,6 +295,19 @@ interface ClaudeSessionContext {
   session: ProviderSession;
   readonly promptQueue: Queue.Queue<PromptQueueItem>;
   readonly query: ClaudeQueryRuntime;
+  readonly submissionSemaphore: Semaphore.Semaphore;
+  readonly submittedPrompts: Map<
+    string,
+    {
+      readonly turnId: TurnId;
+      readonly options: ProviderTurnStartOptions;
+    }
+  >;
+  readonly nativeProcess: {
+    captured: boolean;
+    readonly exited: Deferred.Deferred<void>;
+  };
+  turnCompletion: Deferred.Deferred<void> | undefined;
   streamFiber: Fiber.Fiber<void, Error> | undefined;
   readonly startedAt: string;
   readonly basePermissionMode: PermissionMode | undefined;
@@ -775,6 +793,39 @@ function normalizeClaudeTurnTokenUsage(
     usageStatus: "partial",
     ...(inputTokens !== undefined ? { inputTokens } : {}),
     ...(rawOutputTokens !== undefined ? { outputTokens: rawOutputTokens } : {}),
+  };
+}
+
+function addClaudeTurnTokenUsage(
+  previous: TurnTokenUsage | undefined,
+  current: TurnTokenUsage,
+): TurnTokenUsage {
+  if (!previous) return current;
+  const sum = (left: number | undefined, right: number | undefined) =>
+    left === undefined && right === undefined ? undefined : (left ?? 0) + (right ?? 0);
+  const common = {
+    usageScope: "main_agent" as const,
+    hasSubagents: previous.hasSubagents || current.hasSubagents,
+    cachedInputTokens: sum(previous.cachedInputTokens, current.cachedInputTokens),
+    cacheCreationTokens: sum(previous.cacheCreationTokens, current.cacheCreationTokens),
+    reasoningTokens: sum(previous.reasoningTokens, current.reasoningTokens),
+  };
+  if (previous.usageStatus === "complete" && current.usageStatus === "complete") {
+    return {
+      ...common,
+      usageStatus: "complete",
+      inputTokens: previous.inputTokens + current.inputTokens,
+      outputTokens: previous.outputTokens + current.outputTokens,
+    };
+  }
+  return {
+    ...common,
+    usageStatus:
+      previous.usageStatus === "unavailable" && current.usageStatus === "unavailable"
+        ? "unavailable"
+        : "partial",
+    inputTokens: sum(previous.inputTokens, current.inputTokens),
+    outputTokens: sum(previous.outputTokens, current.outputTokens),
   };
 }
 
@@ -2638,7 +2689,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           ? { totalCostUsd: result.total_cost_usd }
           : {}),
         ...(errorMessage ? { errorMessage } : {}),
-        tokenUsage: normalizeClaudeTurnTokenUsage(result, turnState.hasSubagents, status),
+        tokenUsage: addClaudeTurnTokenUsage(
+          turnState.priorTokenUsage,
+          normalizeClaudeTurnTokenUsage(result, turnState.hasSubagents, status),
+        ),
       },
       providerRefs: nativeProviderRefs(context),
     });
@@ -3269,14 +3323,54 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
-    const status = turnStatusFromResult(message);
-    const errorMessage = resultUserFacingError(message);
-
-    if (status === "failed") {
-      yield* emitRuntimeError(context, errorMessage ?? "Claude turn failed.");
-    }
-
-    yield* completeTurn(context, status, errorMessage, message);
+    const completion = Deferred.makeUnsafe<void>();
+    context.turnCompletion = completion;
+    yield* Effect.gen(function* () {
+      const status = turnStatusFromResult(message);
+      const errorMessage = resultUserFacingError(message);
+      const completedMessageIds = new Set(message.user_message_uuids ?? []);
+      if (message.user_message_uuid !== undefined)
+        completedMessageIds.add(message.user_message_uuid);
+      let completedOwnPrompt = false;
+      for (const [messageId, submitted] of context.submittedPrompts) {
+        // A result identifies consumed prompts. An echoed or queued prompt can still be pending.
+        if (!completedMessageIds.has(messageId)) continue;
+        completedOwnPrompt = true;
+        context.submittedPrompts.delete(messageId);
+        yield* submitted.options.nativeCompleted(submitted.turnId);
+      }
+      if (status === "failed") {
+        yield* emitRuntimeError(context, errorMessage ?? "Claude turn failed.");
+      }
+      if (context.submittedPrompts.size === 0) {
+        yield* completeTurn(context, status, errorMessage, message);
+      } else if (context.turnState && completedOwnPrompt) {
+        context.turnState.priorTokenUsage = addClaudeTurnTokenUsage(
+          context.turnState.priorTokenUsage,
+          normalizeClaudeTurnTokenUsage(message, context.turnState.hasSubagents, status),
+        );
+      } else if (context.submittedPrompts.size > 0 && completedMessageIds.size === 0) {
+        const stamp = yield* makeEventStamp();
+        yield* offerRuntimeEvent({
+          type: "runtime.warning",
+          eventId: stamp.eventId,
+          provider: PROVIDER,
+          threadId: context.session.threadId,
+          createdAt: stamp.createdAt,
+          payload: {
+            message:
+              "Claude did not identify the completed prompt. Stop the session to confirm that its work has finished.",
+          },
+        });
+      }
+    }).pipe(
+      Effect.ensuring(
+        Effect.gen(function* () {
+          context.turnCompletion = undefined;
+          yield* Deferred.succeed(completion, undefined);
+        }),
+      ),
+    );
   });
 
   /**
@@ -3997,11 +4091,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
+    let turnStatus: ProviderRuntimeTurnStatus = "interrupted";
+    let turnError = "Claude runtime stream ended.";
     if (Exit.isFailure(exit)) {
       if (isClaudeInterruptedCause(exit.cause)) {
-        if (context.turnState) {
-          yield* completeTurn(context, "interrupted", "Claude runtime interrupted.");
-        }
+        turnError = "Claude runtime interrupted.";
       } else {
         const failures = exit.cause.reasons.flatMap((reason) =>
           Cause.isFailReason(reason) ? [reason.error] : [],
@@ -4011,22 +4105,30 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           failureCount: failures.length,
           failureTags: failures.map((failure) => failure._tag),
         });
-        yield* completeTurn(context, "failed", message);
+        turnStatus = "failed";
+        turnError = message;
       }
-    } else if (context.turnState) {
-      yield* completeTurn(context, "interrupted", "Claude runtime stream ended.");
     }
 
     yield* stopSessionInternal(context, {
       emitExitEvent: true,
+      turnStatus,
+      turnError,
     });
   });
 
   const stopSessionInternal = Effect.fn("stopSessionInternal")(function* (
     context: ClaudeSessionContext,
-    options?: { readonly emitExitEvent?: boolean },
+    options?: {
+      readonly emitExitEvent?: boolean;
+      readonly turnStatus?: ProviderRuntimeTurnStatus;
+      readonly turnError?: string;
+    },
   ) {
-    if (context.stopped) return;
+    if (context.stopped) {
+      if (context.nativeProcess.captured) yield* Deferred.await(context.nativeProcess.exited);
+      return;
+    }
 
     // Schedule process termination before any cleanup that can wait on the
     // provider. The SDK closes stdin, then escalates from SIGTERM to SIGKILL.
@@ -4090,16 +4192,27 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       yield* pending.cancel;
     }
 
-    if (context.turnState) {
-      yield* completeTurn(context, "interrupted", "Session stopped.");
-    }
-
     yield* Queue.shutdown(context.promptQueue);
 
     const streamFiber = context.streamFiber;
     context.streamFiber = undefined;
     if (streamFiber && streamFiber.pollUnsafe() === undefined) {
       yield* Fiber.interrupt(streamFiber);
+    }
+
+    if (context.nativeProcess.captured) {
+      yield* Deferred.await(context.nativeProcess.exited);
+      for (const submitted of context.submittedPrompts.values()) {
+        yield* submitted.options.nativeStopped;
+      }
+      context.submittedPrompts.clear();
+    }
+    if (context.turnState) {
+      yield* completeTurn(
+        context,
+        options?.turnStatus ?? "interrupted",
+        options?.turnError ?? "Session stopped.",
+      );
     }
 
     const updatedAt = yield* nowIso;
@@ -4653,6 +4766,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...(input.cwd ? [input.cwd] : []),
         serverConfig.attachmentsDir,
       ];
+      const nativeProcess = { captured: false, exited: Deferred.makeUnsafe<void>() };
       const queryOptions: ClaudeQueryOptions = {
         ...(input.cwd ? { cwd: input.cwd } : {}),
         ...(apiModelId ? { model: apiModelId } : {}),
@@ -4683,6 +4797,19 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         onUserDialog,
         supportedDialogKinds: ["resume_return"],
         env: claudeEnvironment,
+        spawnClaudeCodeProcess: ({ command, args, cwd, env, signal }) => {
+          const child = NodeChildProcess.spawn(command, args, {
+            cwd,
+            env,
+            signal,
+            stdio: ["pipe", "pipe", "pipe"],
+            windowsHide: true,
+          });
+          nativeProcess.captured = child.pid !== undefined;
+          child.stderr.resume();
+          child.once("exit", () => Deferred.doneUnsafe(nativeProcess.exited, Exit.void));
+          return child;
+        },
         additionalDirectories,
         ...(Object.keys(extraArgs).length > 0 ? { extraArgs } : {}),
         ...(mcpSession
@@ -4763,6 +4890,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         session,
         promptQueue,
         query: queryRuntime,
+        submissionSemaphore: Semaphore.makeUnsafe(1),
+        submittedPrompts: new Map(),
+        nativeProcess,
+        turnCompletion: undefined,
         streamFiber: undefined,
         startedAt,
         basePermissionMode: permissionMode,
@@ -4864,142 +4995,182 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     },
   );
 
-  const sendTurn: ClaudeAdapterShape["sendTurn"] = Effect.fn("sendTurn")(function* (input) {
-    const context = yield* requireSession(input.threadId);
-    const modelCatalog = yield* modelCatalogEffect;
-    const selectedModel =
-      input.modelSelection !== undefined && input.modelSelection.instanceId === boundInstanceId
-        ? input.modelSelection
+  const sendTurn: ClaudeAdapterShape["sendTurn"] = Effect.fn("sendTurn")(
+    function* (input, turnOptions) {
+      const context = yield* requireSession(input.threadId);
+      const modelCatalog = yield* modelCatalogEffect;
+      const selectedModel =
+        input.modelSelection !== undefined && input.modelSelection.instanceId === boundInstanceId
+          ? input.modelSelection
+          : undefined;
+      const modelSelection = selectedModel
+        ? { ...selectedModel, model: resolveClaudeModelSlug(modelCatalog, selectedModel.model) }
         : undefined;
-    const modelSelection = selectedModel
-      ? { ...selectedModel, model: resolveClaudeModelSlug(modelCatalog, selectedModel.model) }
-      : undefined;
 
-    // A sendTurn while a real turn is running is a steer: the message is
-    // queued into the live SDK agent loop and the work continues as the same
-    // turn — no synthetic turn boundary. Stale synthetic turns (from
-    // background agent responses between user prompts) are auto-closed
-    // instead, so they don't block the user's next turn.
-    const steeringTurnState =
-      context.turnState && context.turnState.synthetic !== true ? context.turnState : null;
-    if (context.turnState && steeringTurnState === null) {
-      yield* completeTurn(context, "completed");
-    }
-
-    if (modelSelection?.model) {
-      const apiModelId = resolveClaudeCatalogApiModelId(modelCatalog, modelSelection);
-      if (context.currentApiModelId !== apiModelId) {
-        yield* Effect.tryPromise({
-          try: () => context.query.setModel(apiModelId),
-          catch: (cause) => toRequestError(input.threadId, "turn/setModel", cause),
-        });
-        context.currentApiModelId = apiModelId;
+      if (modelSelection?.model) {
+        const apiModelId = resolveClaudeCatalogApiModelId(modelCatalog, modelSelection);
+        if (context.currentApiModelId !== apiModelId) {
+          yield* Effect.tryPromise({
+            try: () => context.query.setModel(apiModelId),
+            catch: (cause) => toRequestError(input.threadId, "turn/setModel", cause),
+          });
+          context.currentApiModelId = apiModelId;
+        }
+        context.session = {
+          ...context.session,
+          model: modelSelection.model,
+        };
+        const turnEffort = resolveClaudeCatalogEffort(
+          modelCatalog,
+          modelSelection.model,
+          getModelSelectionStringOptionValue(modelSelection, "effort"),
+        );
+        context.currentEffort =
+          getEffectiveClaudeAgentEffort(modelCatalog, turnEffort ?? null, modelSelection.model) ??
+          undefined;
       }
-      context.session = {
-        ...context.session,
-        model: modelSelection.model,
-      };
-      const turnEffort = resolveClaudeCatalogEffort(
-        modelCatalog,
-        modelSelection.model,
-        getModelSelectionStringOptionValue(modelSelection, "effort"),
+
+      // Apply interaction mode by switching the SDK's permission mode.
+      // "plan" maps directly to the SDK's "plan" permission mode;
+      // "default" restores the session's original permission mode.
+      // When interactionMode is absent we leave the current mode unchanged.
+      if (input.interactionMode === "plan") {
+        yield* Effect.tryPromise({
+          try: () => context.query.setPermissionMode("plan"),
+          catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),
+        });
+      } else if (input.interactionMode === "default") {
+        yield* Effect.tryPromise({
+          try: () => context.query.setPermissionMode(context.basePermissionMode ?? "default"),
+          catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),
+        });
+      }
+
+      // Re-scan on every send: skills are added and switched off mid-session,
+      // and the scan is a few directory reads. A skill switched off via
+      // skillOverrides, or reserved for the agent with `user-invocable: false`,
+      // is left as prose: the CLI would answer `/name` with a notice instead of
+      // running it.
+      const skills = yield* discoverClaudeSkills(
+        claudeSettings,
+        context.session.cwd,
+        claudeEnvironment,
+      ).pipe(
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
       );
-      context.currentEffort =
-        getEffectiveClaudeAgentEffort(modelCatalog, turnEffort ?? null, modelSelection.model) ??
-        undefined;
-    }
-
-    // Apply interaction mode by switching the SDK's permission mode.
-    // "plan" maps directly to the SDK's "plan" permission mode;
-    // "default" restores the session's original permission mode.
-    // When interactionMode is absent we leave the current mode unchanged.
-    if (input.interactionMode === "plan") {
-      yield* Effect.tryPromise({
-        try: () => context.query.setPermissionMode("plan"),
-        catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),
+      const message = yield* buildUserMessageEffect(input, {
+        fileSystem,
+        attachmentsDir: serverConfig.attachmentsDir,
+        boundInstanceId,
+        modelCatalog,
+        skillNames: new Set(
+          skills
+            .filter((skill) => skill.enabled && skill.userInvocable !== false)
+            .map((skill) => skill.name),
+        ),
       });
-    } else if (input.interactionMode === "default") {
-      yield* Effect.tryPromise({
-        try: () => context.query.setPermissionMode(context.basePermissionMode ?? "default"),
-        catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),
-      });
-    }
 
-    const turnId = steeringTurnState?.turnId ?? TurnId.make(yield* randomUUIDv4);
-    if (steeringTurnState === null) {
-      const turnState: ClaudeTurnState = {
-        turnId,
-        startedAt: yield* nowIso,
-        items: [],
-        assistantTextBlocks: new Map(),
-        assistantTextBlockOrder: [],
-        capturedProposedPlanKeys: new Set(),
-        latestAssistantUsage: undefined,
-        compactedSinceLatestAssistantUsage: false,
-        hasSubagents: false,
-        nextSyntheticAssistantBlockIndex: -1,
-      };
-
-      const updatedAt = yield* nowIso;
-      context.turnState = turnState;
-      context.session = {
-        ...context.session,
-        status: "running",
-        activeTurnId: turnId,
-        updatedAt,
-      };
-
-      const turnStartedStamp = yield* makeEventStamp();
-      yield* offerRuntimeEvent({
-        type: "turn.started",
-        eventId: turnStartedStamp.eventId,
-        provider: PROVIDER,
-        createdAt: turnStartedStamp.createdAt,
-        threadId: context.session.threadId,
-        turnId,
-        payload: modelSelection?.model ? { model: modelSelection.model } : {},
-        providerRefs: {},
-      });
-    }
-
-    // Re-scan on every send: skills are added and switched off mid-session,
-    // and the scan is a few directory reads. A skill switched off via
-    // skillOverrides, or reserved for the agent with `user-invocable: false`,
-    // is left as prose: the CLI would answer `/name` with a notice instead of
-    // running it.
-    const skills = yield* discoverClaudeSkills(
-      claudeSettings,
-      context.session.cwd,
-      claudeEnvironment,
-    ).pipe(
-      Effect.provideService(FileSystem.FileSystem, fileSystem),
-      Effect.provideService(Path.Path, path),
-    );
-    const message = yield* buildUserMessageEffect(input, {
-      fileSystem,
-      attachmentsDir: serverConfig.attachmentsDir,
-      boundInstanceId,
-      modelCatalog,
-      skillNames: new Set(
-        skills
-          .filter((skill) => skill.enabled && skill.userInvocable !== false)
-          .map((skill) => skill.name),
-      ),
-    });
-
-    yield* Queue.offer(context.promptQueue, {
-      type: "message",
-      message,
-    }).pipe(Effect.mapError((cause) => toRequestError(input.threadId, "turn/start", cause)));
-
-    return {
-      threadId: context.session.threadId,
-      turnId,
-      ...(context.session.resumeCursor !== undefined
-        ? { resumeCursor: context.session.resumeCursor }
-        : {}),
-    };
-  });
+      const messageId = yield* randomUUIDv4;
+      message.uuid = messageId as NonNullable<SDKUserMessage["uuid"]>;
+      let submitted = false;
+      return yield* context.submissionSemaphore
+        .withPermit(
+          Effect.gen(function* () {
+            while (true) {
+              if (context.turnCompletion) yield* Deferred.await(context.turnCompletion);
+              if (context.stopped || sessions.get(input.threadId) !== context) {
+                return yield* new ProviderAdapterSessionClosedError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                });
+              }
+              // Re-read after preparation. The previous turn can finish during file reads.
+              const steeringTurnState =
+                context.turnState?.synthetic !== true ? context.turnState : undefined;
+              if (context.turnState && !steeringTurnState)
+                yield* completeTurn(context, "completed");
+              const turnId = steeringTurnState?.turnId ?? TurnId.make(yield* randomUUIDv4);
+              const stamp = yield* makeEventStamp();
+              if (turnOptions) yield* turnOptions.beforeSubmit(turnId);
+              if (context.stopped || sessions.get(input.threadId) !== context) {
+                if (turnOptions) yield* turnOptions.notSubmitted;
+                return yield* new ProviderAdapterSessionClosedError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                });
+              }
+              if (context.turnCompletion || context.turnState !== steeringTurnState) {
+                if (turnOptions) yield* turnOptions.notSubmitted;
+                continue;
+              }
+              const previousSession = context.session;
+              if (!steeringTurnState) {
+                context.turnState = {
+                  turnId,
+                  startedAt: stamp.createdAt,
+                  items: [],
+                  assistantTextBlocks: new Map(),
+                  assistantTextBlockOrder: [],
+                  capturedProposedPlanKeys: new Set(),
+                  latestAssistantUsage: undefined,
+                  compactedSinceLatestAssistantUsage: false,
+                  hasSubagents: false,
+                  nextSyntheticAssistantBlockIndex: -1,
+                };
+                context.session = {
+                  ...context.session,
+                  status: "running",
+                  activeTurnId: turnId,
+                  updatedAt: stamp.createdAt,
+                };
+              }
+              if (turnOptions)
+                context.submittedPrompts.set(messageId, {
+                  turnId,
+                  options: turnOptions,
+                });
+              // No async work may separate admission from this queue write.
+              const offered = Queue.offerUnsafe(context.promptQueue, { type: "message", message });
+              if (!offered) {
+                context.submittedPrompts.delete(messageId);
+                if (!steeringTurnState) {
+                  context.turnState = undefined;
+                  context.session = previousSession;
+                }
+                if (turnOptions) yield* turnOptions.notSubmitted;
+                return yield* new ProviderAdapterSessionClosedError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                });
+              }
+              submitted = true;
+              if (!steeringTurnState)
+                Queue.offerUnsafe(runtimeEventQueue, {
+                  type: "turn.started",
+                  eventId: stamp.eventId,
+                  provider: PROVIDER,
+                  createdAt: stamp.createdAt,
+                  threadId: context.session.threadId,
+                  turnId,
+                  payload: modelSelection?.model ? { model: modelSelection.model } : {},
+                  providerRefs: {},
+                });
+              return {
+                threadId: context.session.threadId,
+                turnId,
+                ...(context.session.resumeCursor !== undefined
+                  ? { resumeCursor: context.session.resumeCursor }
+                  : {}),
+              };
+            }
+          }),
+        )
+        .pipe(
+          Effect.onExit(() => (!submitted && turnOptions ? turnOptions.notSubmitted : Effect.void)),
+        );
+    },
+  );
 
   const interruptTurn: ClaudeAdapterShape["interruptTurn"] = Effect.fn("interruptTurn")(
     function* (threadId, _turnId) {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -3346,6 +3346,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     if (
       context.turnState &&
       pending &&
+      pending.submissions.length > 0 &&
       (pending.exactMatch || pending.submissions.every((submitted) => submitted.nativeFinished))
     ) {
       context.turnState.priorTokenUsage = addClaudeTurnTokenUsage(
@@ -3483,7 +3484,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         observedSubmissions.push(submitted);
       }
     }
-    if (status === "failed")
+    // Callers without admission callbacks have no submission entries.
+    if (
+      status === "failed" &&
+      (observedSubmissions.length > 0 || context.submittedPrompts.size === 0)
+    )
       yield* emitRuntimeError(context, errorMessage ?? "Claude turn failed.");
     if (context.stopped) return;
     if (context.submittedPrompts.size === 0) {
@@ -4953,6 +4958,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         )
           ? { debug: true }
           : {}),
+        // The public SDK hook needs a concrete Node child process and its exit event.
+        // Effect's process handle cannot satisfy that interface.
         spawnClaudeCodeProcess: ({ command, args, cwd, env, signal }) => {
           const child = NodeChildProcess.spawn(command, args, {
             cwd,
@@ -4962,6 +4969,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
             windowsHide: true,
           });
           nativeProcess.captured = child.pid !== undefined;
+          if (!child.stdin || !child.stdout || !child.stderr) {
+            // EMFILE/ENFILE can return before pipes exist, then emit error on the next tick.
+            child.once("error", () => undefined);
+            throw new Error("Claude could not create its process streams.");
+          }
           child.stderr.on("error", () => {
             runFork(Effect.logWarning("Claude stderr read failed."));
           });

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -300,6 +300,7 @@ interface ClaudePromptSubmission {
   initialBatch: boolean;
   nativeFinished: boolean;
   resultObserved: boolean;
+  completionUnconfirmed: boolean;
   terminalState?: "cancelled" | "discarded" | "refused";
 }
 
@@ -325,7 +326,6 @@ interface ClaudeSessionContext {
   readonly submissionSemaphore: Semaphore.Semaphore;
   readonly submittedPrompts: Map<string, ClaudePromptSubmission>;
   pendingResult: ClaudePendingResult | undefined;
-  recoveryRequired: boolean;
   nativeInitSequence: number;
   nativeInitSessionId: string | undefined;
   lastResultUuid: string | undefined;
@@ -3393,7 +3393,6 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     const completion = Deferred.makeUnsafe<void>();
     context.turnCompletion = completion;
     context.pendingResult = undefined;
-    context.recoveryRequired = false;
     context.submittedPrompts.clear();
     yield* completeTurn(context, status, errorMessage, pending?.message).pipe(
       Effect.ensuring(
@@ -3416,7 +3415,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     const submitted = context.submittedPrompts.get(receipt.command_uuid);
     if (!submitted) return;
     if (receipt.state === "queued") return;
-    context.recoveryRequired = false;
+    submitted.completionUnconfirmed = false;
     if (receipt.state === "started") {
       submitted.started = true;
       if (context.nativeInitSessionId !== undefined) {
@@ -3467,7 +3466,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     for (const [messageId, submitted] of context.submittedPrompts) {
       const matches = completedMessageIds.has(messageId);
       if (matches) {
-        context.recoveryRequired = false;
+        submitted.completionUnconfirmed = false;
         exactMatch = true;
         if (!submitted.nativeFinished) {
           submitted.nativeFinished = true;
@@ -3496,13 +3495,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       preservePendingClaudeUsage(context);
       context.pendingResult = { message, submissions: observedSubmissions, exactMatch };
       yield* finishPendingClaudeTurn(context);
-    } else if (
-      completedMessageIds.size === 0 &&
-      ![...context.submittedPrompts.values()].some(
-        (submitted) => submitted.started && !submitted.nativeFinished,
-      )
-    ) {
-      context.recoveryRequired = true;
+    } else if (completedMessageIds.size === 0) {
+      for (const submitted of context.submittedPrompts.values()) {
+        if (!submitted.nativeFinished) submitted.completionUnconfirmed = true;
+      }
     }
   });
 
@@ -5060,7 +5056,6 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         submissionSemaphore: Semaphore.makeUnsafe(1),
         submittedPrompts: new Map(),
         pendingResult: undefined,
-        recoveryRequired: false,
         nativeInitSequence: 0,
         nativeInitSessionId: undefined,
         lastResultUuid: undefined,
@@ -5167,8 +5162,18 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     },
   );
 
+  const requiresClaudeRecovery = (context: ClaudeSessionContext) => {
+    let unconfirmed = false;
+    for (const submitted of context.submittedPrompts.values()) {
+      // Known active work permits steering but does not confirm other inputs.
+      if (submitted.started && !submitted.nativeFinished) return false;
+      unconfirmed ||= submitted.completionUnconfirmed;
+    }
+    return unconfirmed;
+  };
+
   const requireClaudeCompletionEvidence = (context: ClaudeSessionContext) => {
-    if (!context.recoveryRequired) return Effect.void;
+    if (!requiresClaudeRecovery(context)) return Effect.void;
     return new ProviderAdapterRequestError({
       provider: PROVIDER,
       method: "turn/start",
@@ -5277,7 +5282,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
               const turnId = steeringTurnState?.turnId ?? TurnId.make(yield* randomUUIDv4);
               const stamp = yield* makeEventStamp();
               if (turnOptions) yield* turnOptions.beforeSubmit(turnId);
-              if (context.recoveryRequired) {
+              if (requiresClaudeRecovery(context)) {
                 if (turnOptions) yield* turnOptions.notSubmitted;
                 yield* requireClaudeCompletionEvidence(context);
               }
@@ -5321,6 +5326,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
                   initialBatch: false,
                   nativeFinished: false,
                   resultObserved: false,
+                  completionUnconfirmed: false,
                 });
               // No async work may separate admission from this queue write.
               const offered = Queue.offerUnsafe(context.promptQueue, { type: "message", message });

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -23,6 +23,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it, vi } from "@effect/vitest";
 
 import * as Context from "effect/Context";
+import type * as Cause from "effect/Cause";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -482,7 +483,7 @@ it.effect("rewinds a conversation that has no native goal", () =>
 );
 
 class FakeCodexRuntime implements CodexSessionRuntimeShape {
-  private readonly eventQueue = Effect.runSync(Queue.unbounded<ProviderEvent>());
+  private readonly eventQueue = Effect.runSync(Queue.unbounded<ProviderEvent, Cause.Done>());
   private readonly now = "2026-01-01T00:00:00.000Z";
 
   public readonly startImpl = vi.fn(() =>
@@ -592,7 +593,10 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
     return Stream.fromQueue(this.eventQueue);
   }
 
-  close = Effect.promise(() => this.closeImpl());
+  close = Effect.promise(() => this.closeImpl()).pipe(
+    Effect.andThen(Queue.end(this.eventQueue)),
+    Effect.asVoid,
+  );
 
   emit(event: ProviderEvent) {
     return Queue.offer(this.eventQueue, event).pipe(Effect.asVoid);
@@ -3041,6 +3045,55 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
 });
 
 const scopedLifecycleRuntimeFactory = makeScopedRuntimeFactory();
+
+it.effect("drains terminal events after the native runtime scope closes", () =>
+  Effect.gen(function* () {
+    const threadId = asThreadId("stop-event-drain");
+    const runtimeClosed = yield* Deferred.make<void>();
+    const releaseLogger = yield* Deferred.make<void>();
+    const stopped = yield* Deferred.make<void>();
+    const adapter = yield* makeCodexAdapter(decodeCodexSettings({}), {
+      makeRuntime: Effect.fnUntraced(function* (options: CodexSessionRuntimeOptions) {
+        const scope = yield* Scope.Scope;
+        const runtime = new FakeCodexRuntime(options);
+        const close = runtime.close;
+        runtime.close = Effect.gen(function* () {
+          yield* Scope.close(scope, Exit.void);
+          yield* runtime.emit({
+            id: asEventId("confirmed-stop-terminal"),
+            provider: ProviderDriverKind.make("codex"),
+            threadId,
+            turnId: asTurnId("accepted-turn"),
+            createdAt: "2026-01-01T00:00:00.000Z",
+            kind: "notification",
+            method: "turn/aborted",
+          });
+          yield* close;
+          yield* Deferred.succeed(runtimeClosed, undefined);
+        });
+        return runtime;
+      }),
+      nativeEventLogger: {
+        filePath: "unused",
+        write: () => Deferred.await(releaseLogger),
+        close: () => Effect.void,
+      },
+    }).pipe(Effect.provide(ServerConfig.layerTest(process.cwd(), process.cwd())));
+    yield* adapter.startSession({ threadId, runtimeMode: "full-access" });
+    const stop = yield* adapter.stopSession(threadId).pipe(
+      Effect.tap(() => Deferred.succeed(stopped, undefined)),
+      Effect.forkChild,
+    );
+    yield* Deferred.await(runtimeClosed);
+    NodeAssert.equal(yield* Deferred.isDone(stopped), false);
+    yield* Deferred.succeed(releaseLogger, undefined);
+    yield* Fiber.join(stop);
+    const event = Option.getOrThrow(yield* Stream.runHead(adapter.streamEvents));
+    NodeAssert.equal(event.type, "turn.aborted");
+    NodeAssert.equal(event.turnId, "accepted-turn");
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
 const scopedLifecycleLayer = it.layer(
   Layer.effect(
     CodexAdapter,

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -12,6 +12,7 @@ import {
   ProviderItemId,
   type ProviderApprovalDecision,
   type ProviderEvent,
+  type ProviderRuntimeEvent,
   type ProviderSession,
   type ProviderTurnStartResult,
   type ProviderUserInputAnswers,
@@ -3091,6 +3092,68 @@ it.effect("drains terminal events after the native runtime scope closes", () =>
     const event = Option.getOrThrow(yield* Stream.runHead(adapter.streamEvents));
     NodeAssert.equal(event.type, "turn.aborted");
     NodeAssert.equal(event.turnId, "accepted-turn");
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("retains stop terminals for a busy consumer when the instance scope closes", () =>
+  Effect.gen(function* () {
+    const threadId = asThreadId("instance-stop-drain");
+    const instanceScope = yield* Effect.acquireRelease(Scope.make(), (scope) =>
+      Scope.close(scope, Exit.void),
+    );
+    const consumerBusy = yield* Deferred.make<void>();
+    const releaseConsumer = yield* Deferred.make<void>();
+    const runtime = new FakeCodexRuntime({
+      threadId,
+      binaryPath: "codex",
+      cwd: process.cwd(),
+      runtimeMode: "full-access",
+    });
+    const close = runtime.close;
+    runtime.close = runtime
+      .emit({
+        id: asEventId("instance-stop-terminal"),
+        provider: ProviderDriverKind.make("codex"),
+        threadId,
+        turnId: asTurnId("accepted-turn"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        kind: "notification",
+        method: "turn/aborted",
+      })
+      .pipe(Effect.andThen(close));
+    const adapter = yield* makeCodexAdapter(decodeCodexSettings({}), {
+      makeRuntime: () => Effect.succeed(runtime),
+    }).pipe(
+      Effect.provideService(Scope.Scope, instanceScope),
+      Effect.provide(ServerConfig.layerTest(process.cwd(), process.cwd())),
+    );
+    yield* adapter.startSession({ threadId, runtimeMode: "full-access" });
+    const events: Array<ProviderRuntimeEvent> = [];
+    const consumer = yield* adapter.streamEvents.pipe(
+      Stream.runForEach((event) =>
+        Effect.gen(function* () {
+          events.push(event);
+          if (event.type === "turn.started") {
+            yield* Deferred.succeed(consumerBusy, undefined);
+            yield* Deferred.await(releaseConsumer);
+          }
+        }),
+      ),
+      Effect.forkChild,
+    );
+    yield* runtime.emit({ ...codexTurnEvent("turn/started", "accepted-turn"), threadId });
+    yield* Deferred.await(consumerBusy);
+    yield* Scope.close(instanceScope, Exit.void);
+    yield* Deferred.succeed(releaseConsumer, undefined);
+    const consumerExit = yield* Fiber.await(consumer);
+    NodeAssert.deepStrictEqual(
+      events.map((event) => [event.type, event.turnId]),
+      [
+        ["turn.started", "accepted-turn"],
+        ["turn.aborted", "accepted-turn"],
+      ],
+    );
+    NodeAssert.equal(Exit.isSuccess(consumerExit), true);
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );
 

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -23,6 +23,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it, vi } from "@effect/vitest";
 
 import * as Context from "effect/Context";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
@@ -40,6 +41,7 @@ import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { ProviderAdapterValidationError } from "../Errors.ts";
 import type { CodexAdapterShape } from "../Services/CodexAdapter.ts";
+import type { ProviderTurnStartOptions } from "../Services/ProviderAdapter.ts";
 import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory.ts";
 import {
   CodexSessionRuntimePendingApprovalNotFoundError,
@@ -554,8 +556,10 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
 
   getSession = Effect.promise(() => this.startImpl());
 
-  sendTurn(input: CodexSessionRuntimeSendTurnInput) {
-    return Effect.promise(() => this.sendTurnImpl(input));
+  sendTurn(input: CodexSessionRuntimeSendTurnInput, options?: ProviderTurnStartOptions) {
+    return (options?.beforeSubmit() ?? Effect.void).pipe(
+      Effect.andThen(Effect.promise(() => this.sendTurnImpl(input))),
+    );
   }
 
   interruptTurn(turnId?: TurnId) {
@@ -771,6 +775,46 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
         NodeAssert.equal(error._tag, "ProviderAdapterRequestNotFoundError");
         NodeAssert.equal(error.requestId, requestId);
       }),
+  );
+
+  it.effect("does not submit a parked message to a replaced session", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const threadId = asThreadId("replaced-before-submit");
+      const input = { threadId, runtimeMode: "full-access" as const };
+      yield* adapter.startSession(input);
+      const oldRuntime = sessionRuntimeFactory.lastRuntime;
+      NodeAssert.ok(oldRuntime);
+      const parked = yield* Deferred.make<void>();
+      const released = yield* Deferred.make<void>();
+      let notSubmitted = false;
+      const send = yield* adapter
+        .sendTurn(
+          { threadId, input: "old message" },
+          {
+            beforeSubmit: () =>
+              Deferred.succeed(parked, undefined).pipe(Effect.andThen(Deferred.await(released))),
+            notSubmitted: Effect.sync(() => {
+              notSubmitted = true;
+            }),
+            nativeStopped: Effect.void,
+            nativeCompleted: () => Effect.die("old message was never submitted"),
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(parked);
+      yield* adapter.startSession(input);
+      const newRuntime = sessionRuntimeFactory.lastRuntime;
+      NodeAssert.ok(newRuntime);
+      NodeAssert.notEqual(newRuntime, oldRuntime);
+      yield* Deferred.succeed(released, undefined);
+      NodeAssert.equal(Exit.hasInterrupts(yield* Fiber.await(send)), true);
+      NodeAssert.equal(notSubmitted, true);
+      NodeAssert.equal(oldRuntime.sendTurnImpl.mock.calls.length, 0);
+      NodeAssert.equal(newRuntime.sendTurnImpl.mock.calls.length, 0);
+      yield* adapter.sendTurn({ threadId, input: "new message" });
+      NodeAssert.equal(newRuntime.sendTurnImpl.mock.calls.length, 1);
+    }),
   );
 
   it.effect("maps missing adapter sessions to ProviderAdapterSessionNotFoundError", () =>

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -32,6 +32,7 @@ import {
   ProviderSendTurnInput,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import type * as Cause from "effect/Cause";
 import * as NodeCrypto from "node:crypto";
 import * as Crypto from "effect/Crypto";
 import * as Exit from "effect/Exit";
@@ -2260,7 +2261,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       : undefined);
   const managedNativeEventLogger =
     options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
-  const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
+  const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent, Cause.Done>();
   const sessions = new Map<ThreadId, CodexAdapterSessionContext>();
 
   const startSession: CodexAdapterShape["startSession"] = (input) =>
@@ -2780,7 +2781,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
 
   yield* Effect.acquireRelease(Effect.void, () =>
     stopAll().pipe(
-      Effect.andThen(Queue.shutdown(runtimeEventQueue)),
+      Effect.andThen(Queue.end(runtimeEventQueue)),
       Effect.andThen(managedNativeEventLogger?.close() ?? Effect.void),
       Effect.ignore,
     ),

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -2480,42 +2480,65 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     };
   });
 
-  const sendTurn: CodexAdapterShape["sendTurn"] = Effect.fn("sendTurn")(function* (input) {
-    // Codex ingests images only. Anything else would be base64-encoded as an
-    // image and rejected or misread; generic files reach the agent through the
-    // path line ProviderService puts in the prompt.
-    const codexAttachments = yield* Effect.forEach(
-      (input.attachments ?? []).filter((attachment) => attachment.type === "image"),
-      (attachment) => resolveAttachment(input, attachment),
-      { concurrency: 1 },
-    );
+  const sendTurn: CodexAdapterShape["sendTurn"] = Effect.fn("sendTurn")(
+    function* (input, turnOptions) {
+      // Codex ingests images only. Anything else would be base64-encoded as an
+      // image and rejected or misread; generic files reach the agent through the
+      // path line ProviderService puts in the prompt.
+      const codexAttachments = yield* Effect.forEach(
+        (input.attachments ?? []).filter((attachment) => attachment.type === "image"),
+        (attachment) => resolveAttachment(input, attachment),
+        { concurrency: 1 },
+      );
 
-    const session = yield* requireSession(input.threadId);
-    const reasoningEffort =
-      input.modelSelection?.instanceId === boundInstanceId
-        ? getModelSelectionStringOptionValue(input.modelSelection, "reasoningEffort")
-        : undefined;
-    const serviceTier =
-      input.modelSelection?.instanceId === boundInstanceId
-        ? getCodexServiceTierOptionValue(input.modelSelection)
-        : undefined;
-    return yield* session.runtime
-      .sendTurn({
-        ...(input.input !== undefined ? { input: input.input } : {}),
-        ...(input.modelSelection?.instanceId === boundInstanceId
-          ? { model: input.modelSelection.model }
-          : {}),
-        ...(reasoningEffort
-          ? {
-              effort: reasoningEffort as EffectCodexSchema.V2TurnStartParams__ReasoningEffort,
-            }
-          : {}),
-        ...(serviceTier ? { serviceTier } : {}),
-        ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
-        ...(codexAttachments.length > 0 ? { attachments: codexAttachments } : {}),
-      })
-      .pipe(Effect.mapError((cause) => mapCodexRuntimeError(input.threadId, "turn/start", cause)));
-  });
+      const session = yield* requireSession(input.threadId);
+      const reasoningEffort =
+        input.modelSelection?.instanceId === boundInstanceId
+          ? getModelSelectionStringOptionValue(input.modelSelection, "reasoningEffort")
+          : undefined;
+      const serviceTier =
+        input.modelSelection?.instanceId === boundInstanceId
+          ? getCodexServiceTierOptionValue(input.modelSelection)
+          : undefined;
+      return yield* session.runtime
+        .sendTurn(
+          {
+            ...(input.input !== undefined ? { input: input.input } : {}),
+            ...(input.modelSelection?.instanceId === boundInstanceId
+              ? { model: input.modelSelection.model }
+              : {}),
+            ...(reasoningEffort
+              ? {
+                  effort: reasoningEffort as EffectCodexSchema.V2TurnStartParams__ReasoningEffort,
+                }
+              : {}),
+            ...(serviceTier ? { serviceTier } : {}),
+            ...(input.interactionMode !== undefined
+              ? { interactionMode: input.interactionMode }
+              : {}),
+            ...(codexAttachments.length > 0 ? { attachments: codexAttachments } : {}),
+          },
+          turnOptions
+            ? {
+                ...turnOptions,
+                beforeSubmit: Effect.fnUntraced(function* () {
+                  if (session.stopped || sessions.get(input.threadId) !== session) {
+                    return yield* Effect.interrupt;
+                  }
+                  yield* turnOptions.beforeSubmit();
+                  if (session.stopped || sessions.get(input.threadId) !== session) {
+                    yield* turnOptions.notSubmitted;
+                    return yield* Effect.interrupt;
+                  }
+                }),
+              }
+            : undefined,
+        )
+        .pipe(
+          Effect.mapError((cause) => mapCodexRuntimeError(input.threadId, "turn/start", cause)),
+        );
+    },
+  );
 
   const requireSession = Effect.fn("requireSession")(function* (threadId: ThreadId) {
     const session = sessions.get(threadId);

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -2322,8 +2322,9 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           sessionScopeTransferred ? Effect.void : Scope.close(sessionScope, Exit.void),
         );
         const createRuntime = options?.makeRuntime ?? makeCodexSessionRuntime;
+        const runtimeScope = yield* Scope.fork(sessionScope, "sequential");
         const runtime = yield* createRuntime(runtimeInput).pipe(
-          Effect.provideService(Scope.Scope, sessionScope),
+          Effect.provideService(Scope.Scope, runtimeScope),
           Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
           Effect.provideService(Crypto.Crypto, crypto),
           Effect.mapError(
@@ -2500,7 +2501,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
         input.modelSelection?.instanceId === boundInstanceId
           ? getCodexServiceTierOptionValue(input.modelSelection)
           : undefined;
-      return yield* session.runtime
+      const result = yield* session.runtime
         .sendTurn(
           {
             ...(input.input !== undefined ? { input: input.input } : {}),
@@ -2537,6 +2538,10 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
         .pipe(
           Effect.mapError((cause) => mapCodexRuntimeError(input.threadId, "turn/start", cause)),
         );
+      if (session.stopped || sessions.get(input.threadId) !== session) {
+        return yield* Effect.interrupt;
+      }
+      return result;
     },
   );
 
@@ -2744,8 +2749,8 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     session.stopped = true;
     sessions.delete(session.threadId);
     yield* session.runtime.close.pipe(Effect.ignore);
+    yield* Fiber.join(session.eventFiber).pipe(Effect.ignore);
     yield* Effect.ignore(Scope.close(session.scope, Exit.void));
-    yield* Fiber.interrupt(session.eventFiber).pipe(Effect.ignore);
   });
 
   const stopSession: CodexAdapterShape["stopSession"] = (threadId) =>

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -2523,11 +2523,11 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           turnOptions
             ? {
                 ...turnOptions,
-                beforeSubmit: Effect.fnUntraced(function* () {
+                beforeSubmit: Effect.fnUntraced(function* (turnId) {
                   if (session.stopped || sessions.get(input.threadId) !== session) {
                     return yield* Effect.interrupt;
                   }
-                  yield* turnOptions.beforeSubmit();
+                  yield* turnOptions.beforeSubmit(turnId);
                   if (session.stopped || sessions.get(input.threadId) !== session) {
                     yield* turnOptions.notSubmitted;
                     return yield* Effect.interrupt;

--- a/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
+++ b/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
@@ -605,15 +605,13 @@ describe("CodexSessionRuntime collab integration", () => {
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 
-  it.live("Stop targets the active turn when Codex has accepted a queued follow-up", () =>
+  it.live("Stop targets the active turn after Codex accepts same-turn steering", () =>
     Effect.gen(function* () {
       const activeTurnId = "019fe3e8-f908-7f31-8d51-283f4a47897a";
-      const queuedTurnId = "019fe3eb-8faf-7de3-a85b-ac64c7f9c8c3";
       const script = {
         rootThreadId: ROOT,
         holdTurnOpen: true,
-        onlyFirstTurnStarts: true,
-        turnIds: [activeTurnId, queuedTurnId],
+        turnIds: [activeTurnId],
         expectedActiveTurnId: activeTurnId,
         notifications: [],
       };
@@ -629,7 +627,7 @@ describe("CodexSessionRuntime collab integration", () => {
       );
 
       const runtime = yield* makeCodexSessionRuntime({
-        threadId: ThreadId.make("thread-codex-queued-stop"),
+        threadId: ThreadId.make("thread-codex-steered-stop"),
         binaryPath: peerPath,
         cwd: NodeOS.tmpdir(),
         runtimeMode: "full-access",
@@ -638,7 +636,8 @@ describe("CodexSessionRuntime collab integration", () => {
 
       yield* runtime.start();
       yield* runtime.sendTurn({ input: "keep working" });
-      yield* runtime.sendTurn({ input: "queued follow-up" });
+      const steered = yield* runtime.sendTurn({ input: "follow-up" });
+      assert.equal(steered.turnId, activeTurnId);
       yield* runtime.interruptTurn();
 
       const interrupts = NodeFS.readFileSync(interruptsPath, "utf8")

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -52,6 +52,8 @@ const makeAdmissionRuntime = Effect.fn("makeAdmissionRuntime")(function* (option
   const runtimeScope = yield* Effect.acquireRelease(Scope.make(), (scope) =>
     Scope.close(scope, Exit.void),
   );
+  const nativeRuntimeClosed = yield* Deferred.make<void>();
+  yield* Scope.addFinalizer(runtimeScope, Deferred.succeed(nativeRuntimeClosed, undefined));
   const observed: Array<string> = [];
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
@@ -112,6 +114,7 @@ const makeAdmissionRuntime = Effect.fn("makeAdmissionRuntime")(function* (option
   yield* runtime.start();
   return {
     runtime,
+    nativeRuntimeClosed: Deferred.await(nativeRuntimeClosed),
     nativeExit:
       options?.exitSignal || options?.exitStatusError
         ? Deferred.fail(
@@ -140,6 +143,10 @@ const makeAdmissionRuntime = Effect.fn("makeAdmissionRuntime")(function* (option
         method: "turn/completed",
         params: { threadId, turn: { id: turnId, status: "completed", items: [] } },
       }),
+    marker: write({
+      method: "serverRequest/resolved",
+      params: { threadId: wireFixture.rootThreadId, requestId: "terminal-drained" },
+    }),
   };
 });
 
@@ -295,6 +302,108 @@ describe("Codex native turn admission", () => {
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 
+  for (const completion of [
+    "missing",
+    "before-response",
+    "after-response",
+    "blocked-callback",
+    "late-callback",
+  ] as const) {
+    it.effect(`finishes a stopped accepted turn with native completion ${completion}`, () =>
+      Effect.gen(function* () {
+        const { runtime, respond, nextRequest, complete, nativeExit, marker } =
+          yield* makeAdmissionRuntime({ exitSignal: "SIGTERM" });
+        const nativeTerminal = yield* Deferred.make<void>();
+        const canonicalTerminal = yield* Deferred.make<void>();
+        const releaseCallback = yield* Deferred.make<void>();
+        const abortQueued = yield* Deferred.make<void>();
+        const markerQueued = yield* Deferred.make<void>();
+        const ordering: Array<string> = [];
+        const events = yield* runtime.events.pipe(
+          Stream.tap((event) =>
+            Effect.gen(function* () {
+              if (event.method === "turn/aborted") {
+                ordering.push("aborted");
+                yield* Deferred.succeed(abortQueued, undefined);
+              }
+              if (event.method === "turn/completed")
+                yield* Deferred.succeed(canonicalTerminal, undefined);
+              if (event.method === "session/closed") ordering.push("closed");
+              if (event.method === "serverRequest/resolved")
+                yield* Deferred.succeed(markerQueued, undefined);
+            }),
+          ),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        const send = yield* runtime
+          .sendTurn(
+            { input: "accepted turn" },
+            {
+              beforeSubmit: () => Effect.void,
+              notSubmitted: Effect.die("native work was submitted"),
+              nativeStopped: Effect.sync(() => {
+                ordering.push("proof");
+              }),
+              nativeCompleted: () =>
+                Deferred.succeed(nativeTerminal, undefined).pipe(
+                  Effect.andThen(
+                    completion === "blocked-callback"
+                      ? Effect.never
+                      : completion === "late-callback"
+                        ? Deferred.await(releaseCallback)
+                        : Effect.void,
+                  ),
+                ),
+            },
+          )
+          .pipe(Effect.forkChild);
+        yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+        const request = yield* nextRequest("turn/start");
+        if (completion === "before-response") {
+          yield* complete("accepted-turn");
+          yield* Deferred.await(nativeTerminal);
+        }
+        yield* respond(request, { turn: { id: "accepted-turn", status: "inProgress", items: [] } });
+        yield* Fiber.join(send);
+        if (
+          completion === "after-response" ||
+          completion === "blocked-callback" ||
+          completion === "late-callback"
+        ) {
+          yield* complete("accepted-turn");
+          yield* Deferred.await(nativeTerminal);
+        }
+        if (completion === "before-response" || completion === "after-response")
+          yield* Deferred.await(canonicalTerminal);
+        yield* nativeExit;
+        if (completion === "late-callback") {
+          yield* Deferred.await(abortQueued);
+          yield* Deferred.succeed(releaseCallback, undefined);
+          yield* marker;
+          yield* Deferred.await(markerQueued);
+        }
+        yield* runtime.close;
+        const collectedEvents = yield* Fiber.join(events);
+        const terminalEvents = collectedEvents.filter((event) => event.method === "turn/aborted");
+        const needsAbort =
+          completion === "missing" ||
+          completion === "blocked-callback" ||
+          completion === "late-callback";
+        NodeAssert.equal(terminalEvents.length, needsAbort ? 1 : 0);
+        NodeAssert.equal(
+          collectedEvents.filter((event) => event.method === "turn/completed").length,
+          needsAbort ? 0 : 1,
+        );
+        if (needsAbort) NodeAssert.equal(terminalEvents[0]?.turnId, "accepted-turn");
+        NodeAssert.deepEqual(
+          ordering,
+          needsAbort ? ["proof", "aborted", "closed"] : ["proof", "closed"],
+        );
+      }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+    );
+  }
+
   for (const scenario of [
     { name: "exit code 0", options: {}, stopped: true },
     { name: "SIGTERM", options: { exitSignal: "SIGTERM" as const }, stopped: true },
@@ -307,9 +416,8 @@ describe("Codex native turn admission", () => {
   ]) {
     it.effect(`checks captured process exit after ${scenario.name}`, () =>
       Effect.gen(function* () {
-        const { runtime, respond, nextRequest, nativeExit } = yield* makeAdmissionRuntime(
-          scenario.options,
-        );
+        const { runtime, respond, nextRequest, nativeExit, nativeRuntimeClosed } =
+          yield* makeAdmissionRuntime(scenario.options);
         let stopped = false;
         const send = yield* runtime
           .sendTurn(
@@ -327,13 +435,8 @@ describe("Codex native turn admission", () => {
         yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
         yield* respond(yield* nextRequest("turn/start"), { turn: {} });
         NodeAssert.equal((yield* Fiber.join(send))._tag, "Failure");
-        const closedEvent = yield* runtime.events.pipe(
-          Stream.filter((event) => event.method === "session/closed"),
-          Stream.runHead,
-          Effect.forkChild,
-        );
         const close = yield* runtime.close.pipe(Effect.forkChild);
-        yield* Fiber.join(closedEvent);
+        yield* nativeRuntimeClosed;
         NodeAssert.equal(stopped, false);
         yield* nativeExit;
         yield* Fiber.join(close);

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -1,10 +1,20 @@
 import * as NodeAssert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as Queue from "effect/Queue";
+import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import { ChildProcessSpawner } from "effect/unstable/process";
 import { describe } from "vite-plus/test";
-import { DEFAULT_MODEL, ThreadId } from "@t3tools/contracts";
+import { DEFAULT_MODEL, ThreadId, TurnId } from "@t3tools/contracts";
 import * as CodexErrors from "effect-codex-app-server/errors";
 import * as CodexRpc from "effect-codex-app-server/rpc";
 import * as EffectCodexSchema from "effect-codex-app-server/schema";
@@ -17,10 +27,357 @@ import {
   hasConfiguredMcpServer,
   isRecoverableThreadResumeError,
   makeMemoryConsolidationNotificationFilter,
+  makeCodexSessionRuntime,
   openCodexThread,
   toMcpElicitationResponse,
 } from "./CodexSessionRuntime.ts";
+import wireFixture from "../testFixtures/codexMultiAgentWire.json" with { type: "json" };
 const isCodexAppServerRequestError = Schema.is(CodexErrors.CodexAppServerRequestError);
+
+const NativeRequest = Schema.Struct({
+  id: Schema.optionalKey(Schema.Union([Schema.Number, Schema.String])),
+  method: Schema.String,
+  params: Schema.optionalKey(Schema.Unknown),
+});
+const decodeNativeRequest = Schema.decodeSync(Schema.fromJsonString(NativeRequest));
+const encodeNativeMessage = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
+
+const makeAdmissionRuntime = Effect.fn("makeAdmissionRuntime")(function* (options?: {
+  readonly exitSignal?: "SIGTERM" | "SIGKILL";
+  readonly exitStatusError?: boolean;
+}) {
+  const incoming = yield* Queue.unbounded<Uint8Array>();
+  const requests = yield* Queue.unbounded<typeof NativeRequest.Type>();
+  const exited = yield* Deferred.make<ChildProcessSpawner.ExitCode, PlatformError.PlatformError>();
+  const runtimeScope = yield* Effect.acquireRelease(Scope.make(), (scope) =>
+    Scope.close(scope, Exit.void),
+  );
+  const observed: Array<string> = [];
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const write = (message: unknown) =>
+    Queue.offer(incoming, encoder.encode(`${encodeNativeMessage(message)}\n`)).pipe(Effect.asVoid);
+  const respond = (request: typeof NativeRequest.Type, result: unknown) =>
+    write({ id: request.id, result });
+  let remainder = "";
+  const handle = ChildProcessSpawner.makeHandle({
+    pid: ChildProcessSpawner.ProcessId(1),
+    exitCode: Deferred.await(exited),
+    isRunning: Deferred.isDone(exited).pipe(
+      Effect.map((done) => !done || options?.exitStatusError === true),
+    ),
+    kill: () => Effect.void,
+    unref: Effect.succeed(Effect.void),
+    stdin: Sink.forEach((chunk: Uint8Array) =>
+      Effect.gen(function* () {
+        const lines = (remainder + decoder.decode(chunk, { stream: true })).split("\n");
+        remainder = lines.pop() ?? "";
+        for (const line of lines) {
+          const request = decodeNativeRequest(line);
+          observed.push(request.method);
+          if (request.method === "initialize") {
+            yield* respond(request, {
+              userAgent: "admission-test",
+              codexHome: "/tmp",
+              platformFamily: "unix",
+              platformOs: "linux",
+            });
+          } else if (request.method === "thread/start") {
+            yield* respond(request, wireFixture.responses.threadStart);
+          } else if (request.id !== undefined) {
+            yield* Queue.offer(requests, request);
+          }
+        }
+      }),
+    ),
+    stdout: Stream.fromQueue(incoming),
+    stderr: Stream.empty,
+    all: Stream.empty,
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+  });
+  const runtime = yield* makeCodexSessionRuntime({
+    threadId: ThreadId.make("admission-test"),
+    binaryPath: "codex",
+    cwd: process.cwd(),
+    runtimeMode: "full-access",
+    appServerArgs: ["-c", "mcp_servers.test.url=http://127.0.0.1/mcp"],
+  }).pipe(
+    Effect.provideService(Scope.Scope, runtimeScope),
+    Effect.provideService(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make(() => Effect.succeed(handle)),
+    ),
+  );
+  yield* runtime.start();
+  return {
+    runtime,
+    nativeExit:
+      options?.exitSignal || options?.exitStatusError
+        ? Deferred.fail(
+            exited,
+            PlatformError.systemError({
+              _tag: "Unknown",
+              module: "ChildProcess",
+              method: "exitCode",
+              cause: new Error(
+                options.exitSignal
+                  ? `Process interrupted due to receipt of signal: '${options.exitSignal}'`
+                  : "Could not read exit status",
+              ),
+            }),
+          )
+        : Deferred.succeed(exited, ChildProcessSpawner.ExitCode(0)),
+    observed,
+    respond,
+    nextRequest: Effect.fnUntraced(function* (method: string) {
+      const request = yield* Queue.take(requests);
+      NodeAssert.equal(request.method, method);
+      return request;
+    }),
+    complete: (turnId: string, threadId = wireFixture.rootThreadId) =>
+      write({
+        method: "turn/completed",
+        params: { threadId, turn: { id: turnId, status: "completed", items: [] } },
+      }),
+  };
+});
+
+describe("Codex native turn admission", () => {
+  it.effect("waits after MCP reload when the old turn completes during preparation", () =>
+    Effect.gen(function* () {
+      const { runtime, observed, respond, nextRequest, complete } = yield* makeAdmissionRuntime();
+      const oldTerminal = yield* Deferred.make<void>();
+      const first = yield* runtime
+        .sendTurn(
+          { input: "first" },
+          {
+            beforeSubmit: () => Effect.void,
+            notSubmitted: Effect.die("first turn was submitted"),
+            nativeStopped: Effect.void,
+            nativeCompleted: (turnId) => {
+              NodeAssert.equal(turnId, "old-turn");
+              return Deferred.succeed(oldTerminal, undefined).pipe(Effect.asVoid);
+            },
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+      yield* respond(yield* nextRequest("turn/start"), {
+        turn: { id: "old-turn", status: "inProgress", items: [] },
+      });
+      yield* Fiber.join(first);
+
+      const captureReady = yield* Deferred.make<void>();
+      const admissionReached = yield* Deferred.make<void>();
+      const second = yield* runtime
+        .sendTurn(
+          { input: "follow-up" },
+          {
+            beforeSubmit: (turnId) =>
+              Effect.gen(function* () {
+                NodeAssert.equal(turnId, undefined);
+                yield* Deferred.succeed(admissionReached, undefined);
+                yield* Deferred.await(captureReady);
+              }),
+            notSubmitted: Effect.die("follow-up was submitted"),
+            nativeStopped: Effect.void,
+            nativeCompleted: () => Effect.void,
+          },
+        )
+        .pipe(Effect.forkChild);
+      const reload = yield* nextRequest("config/mcpServer/reload");
+      yield* complete("old-turn");
+      yield* Deferred.await(oldTerminal);
+      NodeAssert.equal(yield* Deferred.isDone(admissionReached), false);
+      yield* respond(reload, {});
+      yield* Deferred.await(admissionReached);
+      NodeAssert.equal(observed.filter((method) => method === "turn/start").length, 1);
+      yield* Deferred.succeed(captureReady, undefined);
+      yield* respond(yield* nextRequest("turn/start"), {
+        turn: { id: "new-turn", status: "inProgress", items: [] },
+      });
+      NodeAssert.equal((yield* Fiber.join(second)).turnId, "new-turn");
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("keeps native callbacks after a bad turn start response", () =>
+    Effect.gen(function* () {
+      const { runtime, respond, nextRequest, complete, nativeExit } = yield* makeAdmissionRuntime();
+      const terminal = yield* Deferred.make<void>();
+      const completed: Array<TurnId> = [];
+      let submitted = false;
+      const send = yield* runtime
+        .sendTurn(
+          { input: "change files" },
+          {
+            beforeSubmit: (turnId) =>
+              Effect.sync(() => {
+                NodeAssert.equal(turnId, undefined);
+                submitted = true;
+              }),
+            notSubmitted: Effect.sync(() => {
+              submitted = false;
+            }),
+            nativeStopped: Effect.void,
+            nativeCompleted: (turnId) =>
+              Effect.gen(function* () {
+                completed.push(turnId);
+                yield* Deferred.succeed(terminal, undefined);
+              }),
+          },
+        )
+        .pipe(Effect.result, Effect.forkChild);
+      yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+      const request = yield* nextRequest("turn/start");
+      NodeAssert.equal(submitted, true);
+      yield* respond(request, { turn: { id: "native-turn" } });
+      const result = yield* Fiber.join(send);
+      NodeAssert.equal(result._tag, "Failure");
+      NodeAssert.equal(result.failure._tag, "CodexAppServerProtocolParseError");
+      NodeAssert.equal(submitted, true);
+      NodeAssert.deepEqual(completed, []);
+      yield* complete("child-turn", "child-thread");
+      yield* complete("native-turn");
+      yield* Deferred.await(terminal);
+      NodeAssert.deepEqual(completed, ["native-turn"]);
+      yield* nativeExit;
+      yield* runtime.close;
+      NodeAssert.deepEqual(completed, ["native-turn"]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("can cancel a parked send even when its caller is uninterruptible", () =>
+    Effect.gen(function* () {
+      const { runtime, observed, respond, nextRequest } = yield* makeAdmissionRuntime();
+      const parked = yield* Deferred.make<void>();
+      const send = yield* runtime
+        .sendTurn(
+          { input: "do not submit" },
+          {
+            beforeSubmit: () =>
+              Deferred.succeed(parked, undefined).pipe(Effect.andThen(Effect.never)),
+            notSubmitted: Effect.void,
+            nativeStopped: Effect.void,
+            nativeCompleted: () => Effect.die("no native work exists"),
+          },
+        )
+        .pipe(Effect.uninterruptible, Effect.forkChild);
+      yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+      yield* Deferred.await(parked);
+      yield* Fiber.interrupt(send);
+      NodeAssert.equal(Exit.hasInterrupts(yield* Fiber.await(send)), true);
+      NodeAssert.equal(observed.includes("turn/start"), false);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("reports a native terminal before the turn start response arrives", () =>
+    Effect.gen(function* () {
+      const { runtime, respond, nextRequest, complete } = yield* makeAdmissionRuntime();
+      const terminal = yield* Deferred.make<TurnId>();
+      const send = yield* runtime
+        .sendTurn(
+          { input: "fast turn" },
+          {
+            beforeSubmit: () => Effect.void,
+            notSubmitted: Effect.die("native work was submitted"),
+            nativeStopped: Effect.void,
+            nativeCompleted: (turnId) => Deferred.succeed(terminal, turnId).pipe(Effect.asVoid),
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+      const request = yield* nextRequest("turn/start");
+      yield* complete("fast-turn");
+      NodeAssert.equal(yield* Deferred.await(terminal), "fast-turn");
+      yield* respond(request, { turn: { id: "fast-turn", status: "completed", items: [] } });
+      NodeAssert.equal((yield* Fiber.join(send)).turnId, "fast-turn");
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  for (const scenario of [
+    { name: "exit code 0", options: {}, stopped: true },
+    { name: "SIGTERM", options: { exitSignal: "SIGTERM" as const }, stopped: true },
+    { name: "SIGKILL", options: { exitSignal: "SIGKILL" as const }, stopped: true },
+    {
+      name: "an exit-status error while still running",
+      options: { exitStatusError: true },
+      stopped: false,
+    },
+  ]) {
+    it.effect(`checks captured process exit after ${scenario.name}`, () =>
+      Effect.gen(function* () {
+        const { runtime, respond, nextRequest, nativeExit } = yield* makeAdmissionRuntime(
+          scenario.options,
+        );
+        let stopped = false;
+        const send = yield* runtime
+          .sendTurn(
+            { input: "uncertain turn" },
+            {
+              beforeSubmit: () => Effect.void,
+              notSubmitted: Effect.die("native work was submitted"),
+              nativeStopped: Effect.sync(() => {
+                stopped = true;
+              }),
+              nativeCompleted: () => Effect.die("no native terminal was received"),
+            },
+          )
+          .pipe(Effect.result, Effect.forkChild);
+        yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+        yield* respond(yield* nextRequest("turn/start"), { turn: {} });
+        NodeAssert.equal((yield* Fiber.join(send))._tag, "Failure");
+        const closedEvent = yield* runtime.events.pipe(
+          Stream.filter((event) => event.method === "session/closed"),
+          Stream.runHead,
+          Effect.forkChild,
+        );
+        const close = yield* runtime.close.pipe(Effect.forkChild);
+        yield* Fiber.join(closedEvent);
+        NodeAssert.equal(stopped, false);
+        yield* nativeExit;
+        yield* Fiber.join(close);
+        NodeAssert.equal(stopped, scenario.stopped);
+      }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+    );
+  }
+
+  it.effect("rejects a parked send after its native process exits", () =>
+    Effect.gen(function* () {
+      const { runtime, observed, respond, nextRequest, nativeExit } = yield* makeAdmissionRuntime();
+      const parked = yield* Deferred.make<void>();
+      const released = yield* Deferred.make<void>();
+      let notSubmitted = false;
+      const send = yield* runtime
+        .sendTurn(
+          { input: "do not send after exit" },
+          {
+            beforeSubmit: () =>
+              Deferred.succeed(parked, undefined).pipe(Effect.andThen(Deferred.await(released))),
+            notSubmitted: Effect.sync(() => {
+              notSubmitted = true;
+            }),
+            nativeStopped: Effect.void,
+            nativeCompleted: () => Effect.die("no native work exists"),
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+      yield* Deferred.await(parked);
+      const exitedEvent = yield* runtime.events.pipe(
+        Stream.filter((event) => event.method === "session/exited"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* nativeExit;
+      yield* Fiber.join(exitedEvent);
+      yield* Deferred.succeed(released, undefined);
+      NodeAssert.equal(Exit.hasInterrupts(yield* Fiber.await(send)), true);
+      NodeAssert.equal(notSubmitted, true);
+      NodeAssert.equal(observed.includes("turn/start"), false);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+});
 
 describe("CodexSessionRuntimeIdentifierGenerationError", () => {
   it("retains identifier purpose and the random source failure", () => {

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -14,13 +14,21 @@ import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { describe } from "vite-plus/test";
-import { DEFAULT_MODEL, ThreadId, TurnId } from "@t3tools/contracts";
+import {
+  DEFAULT_MODEL,
+  EventId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
 import * as CodexErrors from "effect-codex-app-server/errors";
 import * as CodexRpc from "effect-codex-app-server/rpc";
 import * as EffectCodexSchema from "effect-codex-app-server/schema";
 
 import { buildCodexDeveloperInstructions } from "../CodexDeveloperInstructions.ts";
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
+import * as TurnCheckpointCapture from "../../checkpointing/TurnCheckpointCapture.ts";
 import {
   buildTurnStartParams,
   describeMcpElicitation,
@@ -514,73 +522,188 @@ describe("Codex native turn admission", () => {
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 
-  it.effect("keeps native callbacks after a bad turn start response", () =>
-    Effect.gen(function* () {
-      const { runtime, respond, nextRequest, complete, nativeExit } = yield* makeAdmissionRuntime();
-      const terminal = yield* Deferred.make<void>();
-      const completed: Array<TurnId> = [];
-      let submitted = false;
-      const send = yield* runtime
-        .sendTurn(
-          { input: "change files" },
-          {
-            beforeSubmit: (turnId) =>
-              Effect.sync(() => {
-                NodeAssert.equal(turnId, undefined);
-                submitted = true;
-              }),
-            notSubmitted: Effect.sync(() => {
-              submitted = false;
-            }),
-            nativeStopped: Effect.void,
-            nativeCompleted: (turnId) =>
-              Effect.gen(function* () {
-                completed.push(turnId);
-                yield* Deferred.succeed(terminal, undefined);
-              }),
-          },
-        )
-        .pipe(Effect.result, Effect.forkChild);
-      yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
-      const request = yield* nextRequest("turn/start");
-      NodeAssert.equal(submitted, true);
-      yield* respond(request, { turn: { id: "native-turn" } });
-      const result = yield* Fiber.join(send);
-      NodeAssert.equal(result._tag, "Failure");
-      NodeAssert.equal(result.failure._tag, "CodexAppServerProtocolParseError");
-      NodeAssert.equal(submitted, true);
-      NodeAssert.deepEqual(completed, []);
-      yield* complete("child-turn", "child-thread");
-      yield* complete("native-turn");
-      yield* Deferred.await(terminal);
-      NodeAssert.deepEqual(completed, ["native-turn"]);
-      yield* nativeExit;
-      yield* runtime.close;
-      NodeAssert.deepEqual(completed, ["native-turn"]);
-    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
-  );
+  for (const response of [
+    { turn: { id: "native-turn" } },
+    { turn: { id: "native-turn", status: "future-status", items: "future-shape" } },
+  ]) {
+    it.effect(
+      `accepts a correlated turn id without requiring unused response fields: ${Object.keys(response.turn).join(",")}`,
+      () =>
+        Effect.gen(function* () {
+          const { runtime, respond, nextRequest, complete } = yield* makeAdmissionRuntime();
+          const captures = TurnCheckpointCapture.make();
+          const threadId = ThreadId.make("admission-test");
+          const instanceId = ProviderInstanceId.make("codex-test");
+          const submission = yield* captures.trackSubmission(threadId, instanceId);
+          const terminal = yield* Deferred.make<void>();
+          const send = yield* runtime
+            .sendTurn(
+              { input: "change files" },
+              {
+                ...submission,
+                nativeCompleted: (turnId) =>
+                  submission
+                    .nativeCompleted(turnId)
+                    .pipe(Effect.andThen(Deferred.succeed(terminal, undefined))),
+              },
+            )
+            .pipe(
+              Effect.tap((turn) => submission.accept(turn.turnId)),
+              Effect.forkChild,
+            );
+          yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+          yield* respond(yield* nextRequest("turn/start"), response);
+          NodeAssert.equal((yield* Fiber.join(send)).turnId, "native-turn");
+          NodeAssert.deepStrictEqual(yield* submission.outcome, {
+            _tag: "Accepted",
+            turnId: "native-turn",
+          });
+          yield* complete("native-turn");
+          yield* Deferred.await(terminal);
+          const canonicalTerminal = {
+            type: "turn.completed" as const,
+            eventId: EventId.make("native-terminal"),
+            provider: ProviderDriverKind.make("codex"),
+            providerInstanceId: instanceId,
+            threadId,
+            turnId: TurnId.make("native-turn"),
+            createdAt: "2026-01-01T00:00:00.000Z",
+            payload: { state: "completed" as const },
+          };
+          yield* captures.observe(canonicalTerminal);
+          NodeAssert.equal(yield* captures.nativeCaptureReady(canonicalTerminal), true);
+          const nextSubmission = yield* captures.trackSubmission(threadId, instanceId);
+          const next = yield* runtime
+            .sendTurn({ input: "next turn" }, nextSubmission)
+            .pipe(Effect.forkChild);
+          yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+          yield* captures.complete(canonicalTerminal, "captured");
+          yield* respond(yield* nextRequest("turn/start"), { turn: { id: "next-turn" } });
+          NodeAssert.equal((yield* Fiber.join(next)).turnId, "next-turn");
+        }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+    );
+  }
+
+  for (const invalidId of [undefined, "", " ", " native-turn ", 42]) {
+    it.effect(
+      `keeps unknown identity until native stop after invalid acknowledgement id: ${String(invalidId)}`,
+      () =>
+        Effect.gen(function* () {
+          const { runtime, respond, nextRequest, complete, nativeExit } =
+            yield* makeAdmissionRuntime();
+          const captures = TurnCheckpointCapture.make();
+          const threadId = ThreadId.make("admission-test");
+          const instanceId = ProviderInstanceId.make("codex-test");
+          const submission = yield* captures.trackSubmission(threadId, instanceId);
+          const terminal = yield* Deferred.make<void>();
+          const completed: Array<TurnId> = [];
+          const send = yield* runtime
+            .sendTurn(
+              { input: "change files" },
+              {
+                ...submission,
+                nativeCompleted: (turnId) =>
+                  Effect.gen(function* () {
+                    completed.push(turnId);
+                    yield* submission.nativeCompleted(turnId);
+                    yield* Deferred.succeed(terminal, undefined);
+                  }),
+              },
+            )
+            .pipe(Effect.result, Effect.forkChild);
+          yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+          yield* respond(yield* nextRequest("turn/start"), { turn: { id: invalidId } });
+          const result = yield* Fiber.join(send);
+          NodeAssert.equal(result._tag, "Failure");
+          NodeAssert.equal(result.failure._tag, "CodexAppServerProtocolParseError");
+          NodeAssert.deepStrictEqual(yield* submission.outcome, {
+            _tag: "UnknownSubmission",
+            turnId: undefined,
+          });
+          yield* complete("child-turn", "child-thread");
+          yield* complete("native-turn");
+          yield* Deferred.await(terminal);
+          NodeAssert.deepStrictEqual(completed, ["native-turn"]);
+          const canonicalTerminal = {
+            type: "turn.completed" as const,
+            eventId: EventId.make("unknown-native-terminal"),
+            provider: ProviderDriverKind.make("codex"),
+            providerInstanceId: instanceId,
+            threadId,
+            turnId: TurnId.make("native-turn"),
+            createdAt: "2026-01-01T00:00:00.000Z",
+            payload: { state: "completed" as const },
+          };
+          yield* captures.observe(canonicalTerminal);
+          yield* captures.complete(canonicalTerminal, "captured");
+          const released = yield* Deferred.make<void>();
+          const wait = yield* captures
+            .awaitNativeCapture(threadId)
+            .pipe(
+              Effect.andThen(Deferred.succeed(released, undefined)),
+              Effect.forkChild({ startImmediately: true }),
+            );
+          NodeAssert.equal(yield* Deferred.isDone(released), false);
+          yield* nativeExit;
+          yield* runtime.close;
+          yield* Fiber.join(wait);
+          NodeAssert.equal(yield* Deferred.isDone(released), true);
+        }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+    );
+  }
 
   it.effect("can cancel a parked send even when its caller is uninterruptible", () =>
     Effect.gen(function* () {
       const { runtime, observed, respond, nextRequest } = yield* makeAdmissionRuntime();
+      const captures = TurnCheckpointCapture.make();
+      const threadId = ThreadId.make("admission-test");
+      const instanceId = ProviderInstanceId.make("codex-test");
+      const oldTerminal = {
+        type: "turn.completed" as const,
+        eventId: EventId.make("old-terminal"),
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: instanceId,
+        threadId,
+        turnId: TurnId.make("old-turn"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        payload: { state: "completed" as const },
+      };
+      yield* captures.observe(oldTerminal);
+      const submission = yield* captures.trackSubmission(threadId, instanceId);
       const parked = yield* Deferred.make<void>();
       const send = yield* runtime
         .sendTurn(
           { input: "do not submit" },
           {
-            beforeSubmit: () =>
-              Deferred.succeed(parked, undefined).pipe(Effect.andThen(Effect.never)),
-            notSubmitted: Effect.void,
-            nativeStopped: Effect.void,
-            nativeCompleted: () => Effect.die("no native work exists"),
+            ...submission,
+            beforeSubmit: (turnId) =>
+              Deferred.succeed(parked, undefined).pipe(
+                Effect.andThen(submission.beforeSubmit(turnId)),
+              ),
           },
         )
         .pipe(Effect.uninterruptible, Effect.forkChild);
       yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
       yield* Deferred.await(parked);
+      NodeAssert.deepStrictEqual(yield* submission.outcome, { _tag: "NotSubmitted" });
       yield* Fiber.interrupt(send);
       NodeAssert.equal(Exit.hasInterrupts(yield* Fiber.await(send)), true);
       NodeAssert.equal(observed.includes("turn/start"), false);
+      NodeAssert.deepStrictEqual(yield* submission.outcome, { _tag: "NotSubmitted" });
+      yield* captures.complete(oldTerminal, "captured");
+      const nextSubmission = yield* captures.trackSubmission(threadId, instanceId);
+      const next = yield* runtime
+        .sendTurn({ input: "submit after capture" }, nextSubmission)
+        .pipe(Effect.forkChild);
+      yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+      yield* respond(yield* nextRequest("turn/start"), {
+        turn: { id: "new-turn", status: "inProgress", items: [] },
+      });
+      yield* nextSubmission.accept((yield* Fiber.join(next)).turnId);
+      NodeAssert.deepStrictEqual(yield* nextSubmission.outcome, {
+        _tag: "Accepted",
+        turnId: "new-turn",
+      });
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -33,6 +33,7 @@ import {
 } from "./CodexSessionRuntime.ts";
 import wireFixture from "../testFixtures/codexMultiAgentWire.json" with { type: "json" };
 const isCodexAppServerRequestError = Schema.is(CodexErrors.CodexAppServerRequestError);
+const decodeTurnStartParams = Schema.decodeUnknownEffect(EffectCodexSchema.V2TurnStartParams);
 
 const NativeRequest = Schema.Struct({
   id: Schema.optionalKey(Schema.Union([Schema.Number, Schema.String])),
@@ -133,6 +134,8 @@ const makeAdmissionRuntime = Effect.fn("makeAdmissionRuntime")(function* (option
         : Deferred.succeed(exited, ChildProcessSpawner.ExitCode(0)),
     observed,
     respond,
+    reject: (request: typeof NativeRequest.Type, code: number, message: string) =>
+      write({ id: request.id, error: { code, message } }),
     nextRequest: Effect.fnUntraced(function* (method: string) {
       const request = yield* Queue.take(requests);
       NodeAssert.equal(request.method, method);
@@ -151,6 +154,309 @@ const makeAdmissionRuntime = Effect.fn("makeAdmissionRuntime")(function* (option
 });
 
 describe("Codex native turn admission", () => {
+  it.effect("steers the exact active turn and keeps settings for the next admitted turn", () =>
+    Effect.gen(function* () {
+      const { runtime, observed, respond, nextRequest, complete } = yield* makeAdmissionRuntime();
+      const completed: Array<string> = [];
+      const terminal = yield* Deferred.make<void>();
+      const first = yield* runtime
+        .sendTurn(
+          { input: "first", model: "gpt-5.4" },
+          {
+            beforeSubmit: () => Effect.void,
+            notSubmitted: Effect.die("first input was submitted"),
+            nativeStopped: Effect.void,
+            nativeCompleted: (turnId) =>
+              Effect.sync(() => {
+                completed.push(`first:${turnId}`);
+              }),
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+      const firstRequest = yield* nextRequest("turn/start");
+      yield* respond(firstRequest, {
+        turn: { id: "active-turn", status: "inProgress", items: [] },
+      });
+      yield* Fiber.join(first);
+
+      const steer = yield* runtime
+        .sendTurn(
+          {
+            input: "follow-up",
+            model: "gpt-5.3-codex",
+            effort: "high",
+            serviceTier: "fast",
+            interactionMode: "plan",
+          },
+          {
+            beforeSubmit: (turnId) =>
+              Effect.sync(() => {
+                NodeAssert.equal(turnId, "active-turn");
+              }),
+            notSubmitted: Effect.die("steering was submitted"),
+            nativeStopped: Effect.void,
+            nativeCompleted: (turnId) =>
+              Effect.gen(function* () {
+                completed.push(`steer:${turnId}`);
+                yield* Deferred.succeed(terminal, undefined);
+              }),
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+      const steerRequest = yield* nextRequest("turn/steer");
+      NodeAssert.deepStrictEqual(steerRequest.params, {
+        threadId: wireFixture.rootThreadId,
+        expectedTurnId: "active-turn",
+        input: [{ type: "text", text: "follow-up" }],
+      });
+      yield* respond(steerRequest, { turnId: "active-turn" });
+      NodeAssert.equal((yield* Fiber.join(steer)).turnId, "active-turn");
+      yield* complete("active-turn");
+      yield* Deferred.await(terminal);
+      NodeAssert.deepStrictEqual(completed, ["first:active-turn", "steer:active-turn"]);
+
+      const captureReady = yield* Deferred.make<void>();
+      const parked = yield* Deferred.make<void>();
+      const next = yield* runtime
+        .sendTurn(
+          { input: "next turn" },
+          {
+            beforeSubmit: (turnId) =>
+              Effect.gen(function* () {
+                NodeAssert.equal(turnId, undefined);
+                yield* Deferred.succeed(parked, undefined);
+                yield* Deferred.await(captureReady);
+              }),
+            notSubmitted: Effect.void,
+            nativeStopped: Effect.void,
+            nativeCompleted: () => Effect.void,
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+      yield* Deferred.await(parked);
+      NodeAssert.equal(observed.filter((method) => method === "turn/start").length, 1);
+      yield* Deferred.succeed(captureReady, undefined);
+      const nextStart = yield* nextRequest("turn/start");
+      NodeAssert.deepStrictEqual(
+        nextStart.params,
+        yield* buildTurnStartParams({
+          threadId: wireFixture.rootThreadId,
+          runtimeMode: "full-access",
+          prompt: "next turn",
+          model: "gpt-5.3-codex",
+          effort: "high",
+          serviceTier: "fast",
+          interactionMode: "plan",
+        }),
+      );
+      yield* respond(nextStart, { turn: { id: "next-turn", status: "inProgress", items: [] } });
+      NodeAssert.equal((yield* Fiber.join(next)).turnId, "next-turn");
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect(
+    "applies steering defaults before a delayed response and ignores its stale session update",
+    () =>
+      Effect.gen(function* () {
+        const { runtime, respond, nextRequest, complete } = yield* makeAdmissionRuntime();
+        const first = yield* runtime
+          .sendTurn({ input: "first", model: "gpt-5.4" })
+          .pipe(Effect.forkChild);
+        yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+        yield* respond(yield* nextRequest("turn/start"), {
+          turn: { id: "old-turn", status: "inProgress", items: [] },
+        });
+        yield* Fiber.join(first);
+        const terminal = yield* Deferred.make<void>();
+        const steer = yield* runtime
+          .sendTurn(
+            { input: "follow-up", model: "gpt-5.3-codex", effort: "high" },
+            {
+              beforeSubmit: () => Effect.void,
+              notSubmitted: Effect.void,
+              nativeStopped: Effect.void,
+              nativeCompleted: () => Deferred.succeed(terminal, undefined).pipe(Effect.asVoid),
+            },
+          )
+          .pipe(Effect.forkChild);
+        yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+        const delayedResponse = yield* nextRequest("turn/steer");
+        yield* complete("old-turn");
+        yield* Deferred.await(terminal);
+        const next = yield* runtime.sendTurn({ input: "next turn" }).pipe(Effect.forkChild);
+        yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+        const nextStart = yield* nextRequest("turn/start");
+        const nextParams = yield* decodeTurnStartParams(nextStart.params);
+        NodeAssert.equal(nextParams.model, "gpt-5.3-codex");
+        NodeAssert.equal(nextParams.effort, "high");
+        yield* respond(nextStart, { turn: { id: "new-turn", status: "inProgress", items: [] } });
+        yield* Fiber.join(next);
+        const newer = yield* runtime
+          .sendTurn({ input: "newer selection", model: "gpt-5.4", effort: "low" })
+          .pipe(Effect.forkChild);
+        yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+        yield* respond(yield* nextRequest("turn/steer"), { turnId: "new-turn" });
+        yield* Fiber.join(newer);
+        yield* respond(delayedResponse, { turnId: "old-turn" });
+        yield* Fiber.join(steer);
+        const session = yield* runtime.getSession;
+        NodeAssert.equal(session.activeTurnId, "new-turn");
+        NodeAssert.equal(session.model, "gpt-5.4");
+      }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  for (const rejection of [
+    "no active turn to steer",
+    "expected active turn id `old-turn` but found `other-turn`",
+  ]) {
+    it.effect(`requires fresh new-turn admission after steering rejects: ${rejection}`, () =>
+      Effect.gen(function* () {
+        const { runtime, observed, respond, reject, nextRequest, complete } =
+          yield* makeAdmissionRuntime();
+        const first = yield* runtime.sendTurn({ input: "first" }).pipe(Effect.forkChild);
+        yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+        yield* respond(yield* nextRequest("turn/start"), {
+          turn: { id: "old-turn", status: "inProgress", items: [] },
+        });
+        yield* Fiber.join(first);
+        const captureReady = yield* Deferred.make<void>();
+        const parked = yield* Deferred.make<void>();
+        const terminal = yield* Deferred.make<void>();
+        const calls: Array<string | undefined> = [];
+        const send = yield* runtime
+          .sendTurn(
+            { input: "follow-up" },
+            {
+              beforeSubmit: (turnId) =>
+                Effect.gen(function* () {
+                  calls.push(turnId);
+                  if (turnId === undefined) {
+                    yield* Deferred.succeed(parked, undefined);
+                    yield* Deferred.await(captureReady);
+                  }
+                }),
+              notSubmitted: Effect.sync(() => {
+                calls.push("not-submitted");
+              }),
+              nativeStopped: Effect.void,
+              nativeCompleted: () => Deferred.succeed(terminal, undefined).pipe(Effect.asVoid),
+            },
+          )
+          .pipe(Effect.forkChild);
+        yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+        const steer = yield* nextRequest("turn/steer");
+        yield* complete("old-turn");
+        yield* Deferred.await(terminal);
+        yield* reject(steer, -32600, rejection);
+        yield* Deferred.await(parked);
+        NodeAssert.deepStrictEqual(calls, ["old-turn", "not-submitted", undefined]);
+        NodeAssert.equal(observed.filter((method) => method === "turn/start").length, 1);
+        yield* Deferred.succeed(captureReady, undefined);
+        yield* respond(yield* nextRequest("turn/start"), {
+          turn: { id: "new-turn", status: "inProgress", items: [] },
+        });
+        NodeAssert.equal((yield* Fiber.join(send)).turnId, "new-turn");
+      }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+    );
+  }
+
+  it.effect("confirms native stop for the original turn and an uncertain steering claim", () =>
+    Effect.gen(function* () {
+      const { runtime, respond, nextRequest, nativeExit } = yield* makeAdmissionRuntime();
+      const stopped: Array<string> = [];
+      const first = yield* runtime
+        .sendTurn(
+          { input: "first" },
+          {
+            beforeSubmit: () => Effect.void,
+            notSubmitted: Effect.void,
+            nativeStopped: Effect.sync(() => {
+              stopped.push("first");
+            }),
+            nativeCompleted: () => Effect.void,
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+      yield* respond(yield* nextRequest("turn/start"), {
+        turn: { id: "active-turn", status: "inProgress", items: [] },
+      });
+      yield* Fiber.join(first);
+      const steer = yield* runtime
+        .sendTurn(
+          { input: "follow-up" },
+          {
+            beforeSubmit: () => Effect.void,
+            notSubmitted: Effect.die("steering outcome is unknown"),
+            nativeStopped: Effect.sync(() => {
+              stopped.push("steer");
+            }),
+            nativeCompleted: () => Effect.void,
+          },
+        )
+        .pipe(Effect.result, Effect.forkChild);
+      yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+      yield* respond(yield* nextRequest("turn/steer"), {});
+      NodeAssert.equal((yield* Fiber.join(steer))._tag, "Failure");
+      yield* nativeExit;
+      yield* runtime.close;
+      NodeAssert.deepStrictEqual(stopped, ["first", "steer"]);
+      const events = yield* Stream.runCollect(runtime.events);
+      NodeAssert.deepStrictEqual(
+        events.filter((event) => event.method === "turn/aborted").map((event) => event.turnId),
+        ["active-turn"],
+      );
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  for (const outcome of ["bad-response", "request-error"] as const) {
+    it.effect(`does not start a duplicate turn after an uncertain steer ${outcome}`, () =>
+      Effect.gen(function* () {
+        const { runtime, observed, respond, reject, nextRequest, complete } =
+          yield* makeAdmissionRuntime();
+        const first = yield* runtime.sendTurn({ input: "first" }).pipe(Effect.forkChild);
+        yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+        yield* respond(yield* nextRequest("turn/start"), {
+          turn: { id: "active-turn", status: "inProgress", items: [] },
+        });
+        yield* Fiber.join(first);
+        const terminal = yield* Deferred.make<void>();
+        const send = yield* runtime
+          .sendTurn(
+            { input: "follow-up" },
+            {
+              beforeSubmit: (turnId) =>
+                Effect.sync(() => {
+                  NodeAssert.equal(turnId, "active-turn");
+                }),
+              notSubmitted: Effect.die("uncertain steering cannot release admission"),
+              nativeStopped: Effect.void,
+              nativeCompleted: (turnId) =>
+                Effect.gen(function* () {
+                  NodeAssert.equal(turnId, "active-turn");
+                  yield* Deferred.succeed(terminal, undefined);
+                }),
+            },
+          )
+          .pipe(Effect.result, Effect.forkChild);
+        yield* respond(yield* nextRequest("config/mcpServer/reload"), {});
+        const steer = yield* nextRequest("turn/steer");
+        if (outcome === "bad-response") {
+          yield* respond(steer, { turnId: "wrong-turn" });
+        } else {
+          yield* reject(steer, -32603, "could not read native result");
+        }
+        NodeAssert.equal((yield* Fiber.join(send))._tag, "Failure");
+        NodeAssert.equal(observed.filter((method) => method === "turn/start").length, 1);
+        yield* complete("active-turn");
+        yield* Deferred.await(terminal);
+      }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+    );
+  }
+
   it.effect("waits after MCP reload when the old turn completes during preparation", () =>
     Effect.gen(function* () {
       const { runtime, observed, respond, nextRequest, complete } = yield* makeAdmissionRuntime();

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -42,7 +42,15 @@ import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
 import { buildCodexDeveloperInstructions } from "../CodexDeveloperInstructions.ts";
 import type { ProviderTurnStartOptions } from "../Services/ProviderAdapter.ts";
-const decodeV2TurnStartResponse = Schema.decodeUnknownEffect(EffectCodexSchema.V2TurnStartResponse);
+// The correlated acknowledgement supplies identity. Unused snapshot fields
+// must not hide acceptance when a newer Codex version changes their shape.
+const decodeTurnStartAcknowledgement = Schema.decodeUnknownEffect(
+  Schema.Struct({
+    turn: Schema.Struct({
+      id: Schema.String.check(Schema.isNonEmpty(), Schema.isTrimmed()).pipe(Schema.brand("TurnId")),
+    }),
+  }),
+);
 const decodeV2TurnSteerResponse = Schema.decodeUnknownEffect(EffectCodexSchema.V2TurnSteerResponse);
 
 const PROVIDER = ProviderDriverKind.make("codex");
@@ -2519,21 +2527,23 @@ export const makeCodexSessionRuntime = (
               })
               .pipe(
                 Effect.map((response) => ({ response })),
-                Effect.catchTag("CodexAppServerRequestError", (error) => {
-                  const rejected =
-                    error.code === -32600 &&
-                    (error.errorMessage === "no active turn to steer" ||
-                      error.errorMessage.startsWith(
-                        `expected active turn id \`${expectedTurnId}\` but found \``,
-                      ) ||
-                      error.errorMessage === "cannot steer a review turn" ||
-                      error.errorMessage === "cannot steer a compact turn");
-                  if (!rejected) return Effect.fail(error);
-                  return Effect.gen(function* () {
-                    yield* turnOptions?.notSubmitted ?? Effect.void;
-                    if (turnOptions) submission.claims.delete(turnOptions);
-                    return undefined;
-                  });
+                Effect.catchTags({
+                  CodexAppServerRequestError: (error) => {
+                    const rejected =
+                      error.code === -32600 &&
+                      (error.errorMessage === "no active turn to steer" ||
+                        error.errorMessage.startsWith(
+                          `expected active turn id \`${expectedTurnId}\` but found \``,
+                        ) ||
+                        error.errorMessage === "cannot steer a review turn" ||
+                        error.errorMessage === "cannot steer a compact turn");
+                    if (!rejected) return Effect.fail(error);
+                    return Effect.gen(function* () {
+                      yield* turnOptions?.notSubmitted ?? Effect.void;
+                      if (turnOptions) submission.claims.delete(turnOptions);
+                      return undefined;
+                    });
+                  },
                 }),
               );
             if (rawResponse !== undefined) {
@@ -2571,7 +2581,7 @@ export const makeCodexSessionRuntime = (
               return yield* Effect.interrupt;
             }
             const rawResponse = yield* client.raw.request("turn/start", params);
-            const response = yield* decodeV2TurnStartResponse(rawResponse).pipe(
+            const response = yield* decodeTurnStartAcknowledgement(rawResponse).pipe(
               Effect.mapError((error) =>
                 CodexErrors.CodexAppServerProtocolParseError.fromSchemaError(
                   "decode-response-payload",
@@ -2580,7 +2590,7 @@ export const makeCodexSessionRuntime = (
                 ),
               ),
             );
-            turnId = TurnId.make(response.turn.id);
+            turnId = response.turn.id;
             submission.turnId = turnId;
             submission.terminalQueued = submission.earlyTerminals.has(turnId);
             submission.earlyTerminals.clear();

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -20,6 +20,7 @@ import {
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import { normalizeModelSlug } from "@t3tools/shared/model";
 import * as Crypto from "effect/Crypto";
+import type * as Cause from "effect/Cause";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
@@ -189,6 +190,14 @@ export interface CodexThreadTurnSnapshot {
 export interface CodexThreadSnapshot {
   readonly threadId: string;
   readonly turns: ReadonlyArray<CodexThreadTurnSnapshot>;
+}
+
+interface CodexNativeSubmission {
+  readonly options: ProviderTurnStartOptions;
+  turnId: TurnId | undefined;
+  terminalQueued: boolean;
+  stopped: boolean;
+  readonly earlyTerminals: Set<TurnId>;
 }
 
 export interface CodexSessionRuntimeShape {
@@ -1163,7 +1172,7 @@ export const makeCodexSessionRuntime = (
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
     const runtimeScope = yield* Scope.Scope;
     const crypto = yield* Crypto.Crypto;
-    const events = yield* Queue.unbounded<ProviderEvent>();
+    const events = yield* Queue.unbounded<ProviderEvent, Cause.Done>();
     const pendingApprovalsRef = yield* Ref.make(new Map<ApprovalRequestId, PendingApproval>());
     const approvalCorrelationsRef = yield* Ref.make(new Map<string, ApprovalCorrelation>());
     const pendingUserInputsRef = yield* Ref.make(new Map<ApprovalRequestId, PendingUserInput>());
@@ -1174,8 +1183,7 @@ export const makeCodexSessionRuntime = (
     const collabChildLiveTurnsRef = yield* Ref.make(new Map<string, string>());
     const suppressMemoryConsolidationNotification = makeMemoryConsolidationNotificationFilter();
     const closedRef = yield* Ref.make(false);
-    let nativeCompleted: ProviderTurnStartOptions["nativeCompleted"] | undefined;
-    let nativeStopped = Effect.void;
+    let nativeSubmission: CodexNativeSubmission | undefined;
     let nativeExited = false;
 
     // `~` is not shell-expanded when env vars are set via
@@ -1247,7 +1255,33 @@ export const makeCodexSessionRuntime = (
       updatedAt: sessionCreatedAt,
     } satisfies ProviderSession;
     const sessionRef = yield* Ref.make<ProviderSession>(initialSession);
-    const offerEvent = (event: ProviderEvent) => Queue.offer(events, event).pipe(Effect.asVoid);
+    // Queue the terminal and record it together so a native completion racing
+    // process shutdown cannot produce two terminal events.
+    const offerEvent = (event: ProviderEvent) =>
+      Effect.sync(() => {
+        const submission = nativeSubmission;
+        const terminal = event.method === "turn/completed" || event.method === "turn/aborted";
+        if (
+          submission &&
+          terminal &&
+          event.turnId &&
+          ((submission.turnId === event.turnId && submission.terminalQueued) ||
+            (submission.turnId === undefined && submission.earlyTerminals.has(event.turnId)))
+        )
+          return;
+        const offered = Queue.offerUnsafe(events, event);
+        if (offered && submission && terminal && event.turnId) {
+          if (submission.turnId === event.turnId) {
+            submission.terminalQueued = true;
+          } else if (submission.turnId === undefined) {
+            if (submission.earlyTerminals.size === 32) {
+              const oldest = submission.earlyTerminals.values().next().value;
+              if (oldest !== undefined) submission.earlyTerminals.delete(oldest);
+            }
+            submission.earlyTerminals.add(event.turnId);
+          }
+        }
+      });
 
     const emitEvent = (event: Omit<ProviderEvent, "id" | "provider" | "createdAt">) =>
       Effect.gen(function* () {
@@ -1893,7 +1927,8 @@ export const makeCodexSessionRuntime = (
               return;
             }
             if (providerThreadId === payload.threadId && payload.turn.status !== "inProgress") {
-              yield* nativeCompleted?.(TurnId.make(payload.turn.id)) ?? Effect.void;
+              const turnId = TurnId.make(payload.turn.id);
+              yield* nativeSubmission?.options.nativeCompleted(turnId) ?? Effect.void;
             }
             const lastError =
               payload.turn.status === "failed" && "error" in payload.turn && payload.turn.error
@@ -2212,6 +2247,19 @@ export const makeCodexSessionRuntime = (
       Effect.forkIn(runtimeScope),
     );
 
+    const emitStoppedTurn = Effect.fnUntraced(function* (submission: CodexNativeSubmission) {
+      if (!submission.stopped || submission.terminalQueued || submission.turnId === undefined) {
+        return;
+      }
+      yield* emitEvent({
+        kind: "notification",
+        threadId: options.threadId,
+        turnId: submission.turnId,
+        method: "turn/aborted",
+        message: "Codex process stopped before the turn completed.",
+      });
+    });
+
     const confirmNativeStopped = Effect.fnUntraced(function* () {
       // Signal exits fail exitCode. The captured handle tracks the exit signal
       // separately, so an exit-status error alone cannot release native work.
@@ -2219,7 +2267,12 @@ export const makeCodexSessionRuntime = (
         return;
       }
       nativeExited = true;
-      yield* nativeStopped;
+      const submission = nativeSubmission;
+      if (submission && !submission.stopped) {
+        submission.stopped = true;
+        yield* submission.options.nativeStopped;
+        yield* emitStoppedTurn(submission);
+      }
     }, Effect.ignore);
 
     yield* child.exitCode.pipe(
@@ -2302,18 +2355,18 @@ export const makeCodexSessionRuntime = (
         status: "closed",
         activeTurnId: undefined,
       });
-      yield* emitSessionEvent("session/closed", "Session stopped").pipe(
-        Effect.catch((cause) =>
-          Effect.logError("Failed to emit Codex session closed event.", { cause }),
-        ),
-      );
       yield* Scope.close(runtimeScope, Exit.void);
       yield* child.exitCode.pipe(
         Effect.onExit(() => confirmNativeStopped()),
         Effect.ignore,
       );
+      yield* emitSessionEvent("session/closed", "Session stopped").pipe(
+        Effect.catch((cause) =>
+          Effect.logError("Failed to emit Codex session closed event.", { cause }),
+        ),
+      );
       yield* Queue.shutdown(serverNotifications);
-      yield* Queue.shutdown(events);
+      yield* Queue.end(events);
     });
 
     return {
@@ -2362,8 +2415,16 @@ export const makeCodexSessionRuntime = (
           }
           // Admission serializes turn/start calls. Keep this request's callbacks
           // until the next admitted turn, even if its response cannot be read.
-          nativeCompleted = turnOptions?.nativeCompleted;
-          nativeStopped = turnOptions?.nativeStopped ?? Effect.void;
+          const submission: CodexNativeSubmission | undefined = turnOptions
+            ? {
+                options: turnOptions,
+                turnId: undefined,
+                terminalQueued: false,
+                stopped: false,
+                earlyTerminals: new Set(),
+              }
+            : undefined;
+          nativeSubmission = submission;
           const rawResponse = yield* client.raw.request("turn/start", params);
           const response = yield* decodeV2TurnStartResponse(rawResponse).pipe(
             Effect.mapError((error) =>
@@ -2375,6 +2436,12 @@ export const makeCodexSessionRuntime = (
             ),
           );
           const turnId = TurnId.make(response.turn.id);
+          if (submission) {
+            submission.turnId = turnId;
+            submission.terminalQueued = submission.earlyTerminals.has(turnId);
+            submission.earlyTerminals.clear();
+            yield* emitStoppedTurn(submission);
+          }
           yield* updateSession(sessionRef, (session) => ({
             status: "running",
             // Codex accepts follow-ups while the current turn is still

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -43,6 +43,7 @@ import { expandHomePath } from "../../pathExpansion.ts";
 import { buildCodexDeveloperInstructions } from "../CodexDeveloperInstructions.ts";
 import type { ProviderTurnStartOptions } from "../Services/ProviderAdapter.ts";
 const decodeV2TurnStartResponse = Schema.decodeUnknownEffect(EffectCodexSchema.V2TurnStartResponse);
+const decodeV2TurnSteerResponse = Schema.decodeUnknownEffect(EffectCodexSchema.V2TurnSteerResponse);
 
 const PROVIDER = ProviderDriverKind.make("codex");
 
@@ -193,10 +194,11 @@ export interface CodexThreadSnapshot {
 }
 
 interface CodexNativeSubmission {
-  readonly options: ProviderTurnStartOptions;
+  readonly claims: Set<ProviderTurnStartOptions>;
   turnId: TurnId | undefined;
   terminalQueued: boolean;
   stopped: boolean;
+  readonly nativeTerminals: Set<TurnId>;
   readonly earlyTerminals: Set<TurnId>;
 }
 
@@ -1184,6 +1186,11 @@ export const makeCodexSessionRuntime = (
     const suppressMemoryConsolidationNotification = makeMemoryConsolidationNotificationFilter();
     const closedRef = yield* Ref.make(false);
     let nativeSubmission: CodexNativeSubmission | undefined;
+    let pendingTurnSettings: Pick<
+      CodexTurnStartParamsWithCollaborationMode,
+      "model" | "effort" | "serviceTier" | "collaborationMode"
+    > = {};
+    let settingsRevision = 0;
     let nativeExited = false;
 
     // `~` is not shell-expanded when env vars are set via
@@ -1928,7 +1935,17 @@ export const makeCodexSessionRuntime = (
             }
             if (providerThreadId === payload.threadId && payload.turn.status !== "inProgress") {
               const turnId = TurnId.make(payload.turn.id);
-              yield* nativeSubmission?.options.nativeCompleted(turnId) ?? Effect.void;
+              const submission = nativeSubmission;
+              if (submission) {
+                if (submission.nativeTerminals.size === 32) {
+                  const oldest = submission.nativeTerminals.values().next().value;
+                  if (oldest !== undefined) submission.nativeTerminals.delete(oldest);
+                }
+                submission.nativeTerminals.add(turnId);
+                for (const claim of submission.claims) {
+                  yield* claim.nativeCompleted(turnId);
+                }
+              }
             }
             const lastError =
               payload.turn.status === "failed" && "error" in payload.turn && payload.turn.error
@@ -2270,7 +2287,9 @@ export const makeCodexSessionRuntime = (
       const submission = nativeSubmission;
       if (submission && !submission.stopped) {
         submission.stopped = true;
-        yield* submission.options.nativeStopped;
+        for (const claim of submission.claims) {
+          yield* claim.nativeStopped;
+        }
         yield* emitStoppedTurn(submission);
       }
     }, Effect.ignore);
@@ -2388,67 +2407,197 @@ export const makeCodexSessionRuntime = (
               ),
             );
           }
-          const normalizedModel = normalizeCodexModelSlug(
-            input.model ?? (yield* Ref.get(sessionRef)).model,
-          );
-          const params = yield* buildTurnStartParams({
-            threadId: providerThreadId,
-            runtimeMode: options.runtimeMode,
-            ...(input.input ? { prompt: input.input } : {}),
-            ...(input.attachments ? { attachments: input.attachments } : {}),
-            ...(normalizedModel ? { model: normalizedModel } : {}),
-            ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),
-            ...(input.effort ? { effort: input.effort } : {}),
-            ...(input.interactionMode ? { interactionMode: input.interactionMode } : {}),
-            // Derived from the session's own MCP configuration rather than the
-            // setting, so the prompt describes the tools this turn actually
-            // has even if the setting changed after the session started.
-            browserToolsAvailable: hasConfiguredMcpServer(options.appServerArgs),
+          const prepareParams = Effect.gen(function* () {
+            const normalizedModel = normalizeCodexModelSlug(
+              input.model ?? pendingTurnSettings.model ?? (yield* Ref.get(sessionRef)).model,
+            );
+            const requestedParams = yield* buildTurnStartParams({
+              threadId: providerThreadId,
+              runtimeMode: options.runtimeMode,
+              ...(input.input ? { prompt: input.input } : {}),
+              ...(input.attachments ? { attachments: input.attachments } : {}),
+              ...(normalizedModel ? { model: normalizedModel } : {}),
+              ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),
+              ...(input.effort ? { effort: input.effort } : {}),
+              ...(input.interactionMode ? { interactionMode: input.interactionMode } : {}),
+              // Derived from the session's own MCP configuration rather than the
+              // setting, so the prompt describes the tools this turn actually
+              // has even if the setting changed after the session started.
+              browserToolsAvailable: hasConfiguredMcpServer(options.appServerArgs),
+            });
+            const collaborationMode =
+              requestedParams.collaborationMode ??
+              (pendingTurnSettings.collaborationMode
+                ? {
+                    ...pendingTurnSettings.collaborationMode,
+                    settings: {
+                      ...pendingTurnSettings.collaborationMode.settings,
+                      ...(requestedParams.model ? { model: requestedParams.model } : {}),
+                      ...(requestedParams.effort
+                        ? { reasoning_effort: requestedParams.effort }
+                        : {}),
+                    },
+                  }
+                : undefined);
+            return {
+              ...pendingTurnSettings,
+              ...requestedParams,
+              ...(collaborationMode ? { collaborationMode } : {}),
+            };
+          }).pipe(Effect.onError(() => turnOptions?.notSubmitted ?? Effect.void));
+          if ((yield* Ref.get(closedRef)) || nativeExited) {
+            return yield* Effect.interrupt;
+          }
+          const admit = Effect.fnUntraced(function* (turnId?: TurnId) {
+            yield* Effect.interruptible(turnOptions?.beforeSubmit(turnId) ?? Effect.void);
+            if ((yield* Ref.get(closedRef)) || nativeExited) {
+              yield* turnOptions?.notSubmitted ?? Effect.void;
+              return yield* Effect.interrupt;
+            }
           });
-          if ((yield* Ref.get(closedRef)) || nativeExited) {
-            return yield* Effect.interrupt;
-          }
-          yield* Effect.interruptible(turnOptions?.beforeSubmit() ?? Effect.void);
-          if ((yield* Ref.get(closedRef)) || nativeExited) {
-            yield* turnOptions?.notSubmitted ?? Effect.void;
-            return yield* Effect.interrupt;
-          }
-          // Admission serializes turn/start calls. Keep this request's callbacks
-          // until the next admitted turn, even if its response cannot be read.
-          const submission: CodexNativeSubmission | undefined = turnOptions
-            ? {
-                options: turnOptions,
-                turnId: undefined,
-                terminalQueued: false,
-                stopped: false,
-                earlyTerminals: new Set(),
+          const newSubmission = (turnId?: TurnId): CodexNativeSubmission => ({
+            claims: new Set(turnOptions ? [turnOptions] : []),
+            turnId,
+            terminalQueued: false,
+            stopped: false,
+            nativeTerminals: new Set(),
+            earlyTerminals: new Set(),
+          });
+          const activeTurnId = (yield* Ref.get(sessionRef)).activeTurnId;
+          // turn/start can start new work if the observed turn ends. Only
+          // turn/steer guarantees that this input belongs to the expected turn.
+          const expectedTurnId =
+            activeTurnId !== undefined &&
+            (nativeSubmission === undefined || nativeSubmission.turnId === activeTurnId)
+              ? activeTurnId
+              : undefined;
+          let turnId: TurnId | undefined;
+          let submittedSettingsRevision = 0;
+          let submittedModel: string | undefined;
+          let submitted: CodexNativeSubmission | undefined;
+          if (expectedTurnId !== undefined) {
+            yield* admit(expectedTurnId);
+            const submission =
+              nativeSubmission?.turnId === expectedTurnId
+                ? nativeSubmission
+                : newSubmission(expectedTurnId);
+            nativeSubmission = submission;
+            submitted = submission;
+            if (turnOptions) {
+              submission.claims.add(turnOptions);
+              if (submission.nativeTerminals.has(expectedTurnId)) {
+                yield* turnOptions.nativeCompleted(expectedTurnId);
               }
-            : undefined;
-          nativeSubmission = submission;
-          const rawResponse = yield* client.raw.request("turn/start", params);
-          const response = yield* decodeV2TurnStartResponse(rawResponse).pipe(
-            Effect.mapError((error) =>
-              CodexErrors.CodexAppServerProtocolParseError.fromSchemaError(
-                "decode-response-payload",
-                error,
-                { method: "turn/start" },
+            }
+            if ((yield* Ref.get(closedRef)) || nativeExited) {
+              yield* turnOptions?.notSubmitted ?? Effect.void;
+              if (turnOptions) submission.claims.delete(turnOptions);
+              return yield* Effect.interrupt;
+            }
+            const params = yield* prepareParams;
+            // Active inference keeps its original settings. Retain defaults in
+            // dispatch order, since the response can arrive after turn capture.
+            // Direct native clients see them only after the next turn/start.
+            pendingTurnSettings = {
+              ...(params.model ? { model: params.model } : {}),
+              ...(params.effort ? { effort: params.effort } : {}),
+              ...(params.serviceTier ? { serviceTier: params.serviceTier } : {}),
+              ...(params.collaborationMode ? { collaborationMode: params.collaborationMode } : {}),
+            };
+            submittedSettingsRevision = ++settingsRevision;
+            submittedModel = params.model ?? undefined;
+            if ((yield* Ref.get(closedRef)) || nativeExited) {
+              yield* turnOptions?.notSubmitted ?? Effect.void;
+              if (turnOptions) submission.claims.delete(turnOptions);
+              return yield* Effect.interrupt;
+            }
+            const rawResponse = yield* client.raw
+              .request("turn/steer", {
+                threadId: providerThreadId,
+                expectedTurnId,
+                input: params.input,
+              })
+              .pipe(
+                Effect.map((response) => ({ response })),
+                Effect.catchTag("CodexAppServerRequestError", (error) => {
+                  const rejected =
+                    error.code === -32600 &&
+                    (error.errorMessage === "no active turn to steer" ||
+                      error.errorMessage.startsWith(
+                        `expected active turn id \`${expectedTurnId}\` but found \``,
+                      ) ||
+                      error.errorMessage === "cannot steer a review turn" ||
+                      error.errorMessage === "cannot steer a compact turn");
+                  if (!rejected) return Effect.fail(error);
+                  return Effect.gen(function* () {
+                    yield* turnOptions?.notSubmitted ?? Effect.void;
+                    if (turnOptions) submission.claims.delete(turnOptions);
+                    return undefined;
+                  });
+                }),
+              );
+            if (rawResponse !== undefined) {
+              const response = yield* decodeV2TurnSteerResponse(rawResponse.response).pipe(
+                Effect.mapError((error) =>
+                  CodexErrors.CodexAppServerProtocolParseError.fromSchemaError(
+                    "decode-response-payload",
+                    error,
+                    { method: "turn/steer" },
+                  ),
+                ),
+              );
+              if (response.turnId !== expectedTurnId) {
+                return yield* new CodexErrors.CodexAppServerProtocolParseError({
+                  operation: "decode-response-payload",
+                  method: "turn/steer",
+                  cause: new Error("Codex steering returned a different turn id."),
+                });
+              }
+              turnId = expectedTurnId;
+            }
+          }
+          if (turnId === undefined) {
+            yield* admit();
+            const params = yield* prepareParams;
+            // Keep callbacks even when the response cannot be read.
+            const submission = newSubmission();
+            nativeSubmission = submission;
+            submitted = submission;
+            submittedSettingsRevision = ++settingsRevision;
+            submittedModel = params.model ?? undefined;
+            pendingTurnSettings = {};
+            if ((yield* Ref.get(closedRef)) || nativeExited) {
+              yield* turnOptions?.notSubmitted ?? Effect.void;
+              return yield* Effect.interrupt;
+            }
+            const rawResponse = yield* client.raw.request("turn/start", params);
+            const response = yield* decodeV2TurnStartResponse(rawResponse).pipe(
+              Effect.mapError((error) =>
+                CodexErrors.CodexAppServerProtocolParseError.fromSchemaError(
+                  "decode-response-payload",
+                  error,
+                  { method: "turn/start" },
+                ),
               ),
-            ),
-          );
-          const turnId = TurnId.make(response.turn.id);
-          if (submission) {
+            );
+            turnId = TurnId.make(response.turn.id);
             submission.turnId = turnId;
             submission.terminalQueued = submission.earlyTerminals.has(turnId);
             submission.earlyTerminals.clear();
             yield* emitStoppedTurn(submission);
           }
           yield* updateSession(sessionRef, (session) => ({
-            status: "running",
-            // Codex accepts follow-ups while the current turn is still
-            // running. The response contains the queued turn id, but
-            // turn/interrupt only accepts the id that is active now.
-            activeTurnId: session.activeTurnId ?? turnId,
-            ...(normalizedModel ? { model: normalizedModel } : {}),
+            ...(nativeSubmission === submitted
+              ? {
+                  status: submitted?.nativeTerminals.has(turnId) ? session.status : "running",
+                  activeTurnId: submitted?.nativeTerminals.has(turnId)
+                    ? session.activeTurnId
+                    : (session.activeTurnId ?? turnId),
+                }
+              : {}),
+            ...(submittedSettingsRevision === settingsRevision && submittedModel
+              ? { model: submittedModel }
+              : {}),
           }));
           const resumedProviderThreadId = currentProviderThreadId(yield* Ref.get(sessionRef));
           return {

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -40,6 +40,7 @@ import { buildCodexInitializeParams } from "./CodexProvider.ts";
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
 import { buildCodexDeveloperInstructions } from "../CodexDeveloperInstructions.ts";
+import type { ProviderTurnStartOptions } from "../Services/ProviderAdapter.ts";
 const decodeV2TurnStartResponse = Schema.decodeUnknownEffect(EffectCodexSchema.V2TurnStartResponse);
 
 const PROVIDER = ProviderDriverKind.make("codex");
@@ -195,6 +196,7 @@ export interface CodexSessionRuntimeShape {
   readonly getSession: Effect.Effect<ProviderSession>;
   readonly sendTurn: (
     input: CodexSessionRuntimeSendTurnInput,
+    options?: ProviderTurnStartOptions,
   ) => Effect.Effect<ProviderTurnStartResult, CodexSessionRuntimeError>;
   readonly compactThread: Effect.Effect<void, CodexSessionRuntimeError>;
   readonly interruptTurn: (turnId?: TurnId) => Effect.Effect<void, CodexSessionRuntimeError>;
@@ -1172,6 +1174,9 @@ export const makeCodexSessionRuntime = (
     const collabChildLiveTurnsRef = yield* Ref.make(new Map<string, string>());
     const suppressMemoryConsolidationNotification = makeMemoryConsolidationNotificationFilter();
     const closedRef = yield* Ref.make(false);
+    let nativeCompleted: ProviderTurnStartOptions["nativeCompleted"] | undefined;
+    let nativeStopped = Effect.void;
+    let nativeExited = false;
 
     // `~` is not shell-expanded when env vars are set via
     // `child_process.spawn`; `expandHomePath` lets a configured
@@ -1882,20 +1887,25 @@ export const makeCodexSessionRuntime = (
 
     yield* client.handleServerNotification("turn/completed", (payload) =>
       currentSessionProviderThreadId.pipe(
-        Effect.flatMap((providerThreadId) => {
-          if (providerThreadId && payload.threadId !== providerThreadId) {
-            return Effect.void;
-          }
-          const lastError =
-            payload.turn.status === "failed" && "error" in payload.turn && payload.turn.error
-              ? payload.turn.error.message
-              : undefined;
-          return updateSession(sessionRef, {
-            status: payload.turn.status === "failed" ? "error" : "ready",
-            activeTurnId: undefined,
-            ...(lastError ? { lastError } : {}),
-          });
-        }),
+        Effect.flatMap(
+          Effect.fnUntraced(function* (providerThreadId) {
+            if (providerThreadId && payload.threadId !== providerThreadId) {
+              return;
+            }
+            if (providerThreadId === payload.threadId && payload.turn.status !== "inProgress") {
+              yield* nativeCompleted?.(TurnId.make(payload.turn.id)) ?? Effect.void;
+            }
+            const lastError =
+              payload.turn.status === "failed" && "error" in payload.turn && payload.turn.error
+                ? payload.turn.error.message
+                : undefined;
+            yield* updateSession(sessionRef, {
+              status: payload.turn.status === "failed" ? "error" : "ready",
+              activeTurnId: undefined,
+              ...(lastError ? { lastError } : {}),
+            });
+          }),
+        ),
       ),
     );
 
@@ -2202,7 +2212,18 @@ export const makeCodexSessionRuntime = (
       Effect.forkIn(runtimeScope),
     );
 
+    const confirmNativeStopped = Effect.fnUntraced(function* () {
+      // Signal exits fail exitCode. The captured handle tracks the exit signal
+      // separately, so an exit-status error alone cannot release native work.
+      if (yield* child.isRunning) {
+        return;
+      }
+      nativeExited = true;
+      yield* nativeStopped;
+    }, Effect.ignore);
+
     yield* child.exitCode.pipe(
+      Effect.onExit(() => confirmNativeStopped()),
       Effect.flatMap((exitCode) =>
         Ref.get(closedRef).pipe(
           Effect.flatMap((closed) => {
@@ -2287,6 +2308,10 @@ export const makeCodexSessionRuntime = (
         ),
       );
       yield* Scope.close(runtimeScope, Exit.void);
+      yield* child.exitCode.pipe(
+        Effect.onExit(() => confirmNativeStopped()),
+        Effect.ignore,
+      );
       yield* Queue.shutdown(serverNotifications);
       yield* Queue.shutdown(events);
     });
@@ -2298,7 +2323,7 @@ export const makeCodexSessionRuntime = (
         const providerThreadId = yield* readProviderThreadId;
         yield* client.request("thread/compact/start", { threadId: providerThreadId });
       }),
-      sendTurn: (input) =>
+      sendTurn: (input, turnOptions) =>
         Effect.gen(function* () {
           const providerThreadId = yield* readProviderThreadId;
           if (hasConfiguredMcpServer(options.appServerArgs)) {
@@ -2327,6 +2352,18 @@ export const makeCodexSessionRuntime = (
             // has even if the setting changed after the session started.
             browserToolsAvailable: hasConfiguredMcpServer(options.appServerArgs),
           });
+          if ((yield* Ref.get(closedRef)) || nativeExited) {
+            return yield* Effect.interrupt;
+          }
+          yield* Effect.interruptible(turnOptions?.beforeSubmit() ?? Effect.void);
+          if ((yield* Ref.get(closedRef)) || nativeExited) {
+            yield* turnOptions?.notSubmitted ?? Effect.void;
+            return yield* Effect.interrupt;
+          }
+          // Admission serializes turn/start calls. Keep this request's callbacks
+          // until the next admitted turn, even if its response cannot be read.
+          nativeCompleted = turnOptions?.nativeCompleted;
+          nativeStopped = turnOptions?.nativeStopped ?? Effect.void;
           const rawResponse = yield* client.raw.request("turn/start", params);
           const response = yield* decodeV2TurnStartResponse(rawResponse).pipe(
             Effect.mapError((error) =>

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -2560,7 +2560,6 @@ export const makeCodexSessionRuntime = (
                 return yield* new CodexErrors.CodexAppServerProtocolParseError({
                   operation: "decode-response-payload",
                   method: "turn/steer",
-                  cause: new Error("Codex steering returned a different turn id."),
                 });
               }
               turnId = expectedTurnId;

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -336,25 +336,50 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
     );
   }
 
-  it.effect("records a fresh terminal after native completion follows local cancellation", () =>
+  it.effect("retains late native completion after a newer parked turn is cancelled", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("cursor-late-native-proof");
-      const adapter = yield* CursorAdapter;
-      const settings = yield* ServerSettingsService;
       const wrapperPath = yield* Effect.promise(() => makeMockAgentWrapper());
-      yield* settings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
       const nativeReply = yield* Deferred.make<void>();
       const releaseProof = yield* Deferred.make<void>();
+      const proofObserved = yield* Deferred.make<void>();
+      const isPromptSuccess = Schema.is(
+        Schema.Struct({
+          event: Schema.Struct({
+            kind: Schema.Literal("request"),
+            payload: Schema.Struct({
+              method: Schema.Literal("session/prompt"),
+              status: Schema.Literal("succeeded"),
+            }),
+          }),
+        }),
+      );
+      const adapter = yield* makeCursorAdapter(decodeCursorSettings({ binaryPath: wrapperPath }), {
+        nativeEventLogger: {
+          filePath: "memory://cursor-late-native-proof",
+          write: (record) =>
+            isPromptSuccess(record)
+              ? Deferred.succeed(proofObserved, undefined).pipe(Effect.asVoid)
+              : Effect.void,
+          close: () => Effect.void,
+        },
+      });
       yield* Effect.addFinalizer(() => Deferred.succeed(releaseProof, undefined));
       const terminalBeforeProof = yield* Deferred.make<void>();
-      const terminalAfterProof = yield* Deferred.make<void>();
+      const newerTerminal = yield* Deferred.make<void>();
+      const exited = yield* Deferred.make<void>();
       let proved = false;
       const terminalEvents: Array<Extract<ProviderRuntimeEvent, { type: "turn.completed" }>> = [];
       yield* adapter.streamEvents.pipe(
         Stream.runForEach((event) => {
-          if (event.threadId !== threadId || event.type !== "turn.completed") return Effect.void;
+          if (event.threadId !== threadId) return Effect.void;
+          if (event.type === "session.exited") return Deferred.succeed(exited, undefined);
+          if (event.type !== "turn.completed") return Effect.void;
           terminalEvents.push(event);
-          return Deferred.succeed(proved ? terminalAfterProof : terminalBeforeProof, undefined);
+          return Deferred.succeed(
+            terminalEvents.length === 1 ? terminalBeforeProof : newerTerminal,
+            undefined,
+          );
         }),
         Effect.forkChild,
       );
@@ -380,16 +405,40 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
         .pipe(Effect.forkChild);
       yield* Deferred.await(nativeReply);
       yield* adapter.interruptTurn(threadId);
-      yield* Fiber.join(sending);
+      const original = yield* Fiber.join(sending);
       yield* Deferred.await(terminalBeforeProof);
       assert.isFalse(proved);
+
+      const parked = yield* Deferred.make<void>();
+      const notSubmitted = yield* Deferred.make<void>();
+      const newer = yield* adapter
+        .sendTurn(
+          { threadId, input: "must wait for the original native completion" },
+          {
+            beforeSubmit: () =>
+              Deferred.succeed(parked, undefined).pipe(Effect.andThen(Effect.never)),
+            nativeCompleted: () => Effect.die("The newer turn must not be submitted."),
+            nativeStopped: Effect.die("The newer turn has no native work."),
+            notSubmitted: Deferred.succeed(notSubmitted, undefined).pipe(Effect.asVoid),
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(parked);
+      yield* Fiber.interrupt(newer);
+      yield* Deferred.await(newerTerminal);
+      assert.isTrue(yield* Deferred.isDone(notSubmitted));
+      assert.notEqual(terminalEvents[1]?.turnId, original.turnId);
+
       yield* Deferred.succeed(releaseProof, undefined);
-      yield* Deferred.await(terminalAfterProof);
-      assert.lengthOf(terminalEvents, 2);
-      assert.equal(terminalEvents[0]?.turnId, terminalEvents[1]?.turnId);
-      assert.deepEqual(terminalEvents[0]?.payload, terminalEvents[1]?.payload);
-      assert.notEqual(terminalEvents[0]?.eventId, terminalEvents[1]?.eventId);
+      // Request success follows the native proof callback. Session exit drains
+      // the event stream before we assert which terminal events were emitted.
+      yield* Deferred.await(proofObserved);
       yield* adapter.stopSession(threadId);
+      yield* Deferred.await(exited);
+      const originalTerminals = terminalEvents.filter((event) => event.turnId === original.turnId);
+      assert.lengthOf(originalTerminals, 2);
+      assert.deepEqual(originalTerminals[0]?.payload, originalTerminals[1]?.payload);
+      assert.notEqual(originalTerminals[0]?.eventId, originalTerminals[1]?.eventId);
     }),
   );
 

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -162,6 +162,267 @@ const cursorAdapterTestLayer = it.layer(
 );
 
 cursorAdapterTestLayer("CursorAdapterLive", (it) => {
+  for (const failPreparation of [false, true]) {
+    it.effect(
+      `shares a turn with a steer during initial preparation${failPreparation ? " failure" : ""}`,
+      () =>
+        Effect.gen(function* () {
+          const threadId = ThreadId.make("cursor-steer-during-configuration");
+          const configurationStarted = yield* Deferred.make<void>();
+          const releaseConfiguration = yield* Deferred.make<void>();
+          let holdConfiguration = false;
+          let held = false;
+          const isConfigurationStart = Schema.is(
+            Schema.Struct({
+              event: Schema.Struct({
+                kind: Schema.Literal("request"),
+                payload: Schema.Struct({
+                  method: Schema.Literal("session/set_config_option"),
+                  status: Schema.Literal("started"),
+                }),
+              }),
+            }),
+          );
+          const wrapperPath = yield* Effect.promise(() => makeMockAgentWrapper());
+          const adapter = yield* makeCursorAdapter(
+            decodeCursorSettings({ binaryPath: wrapperPath }),
+            {
+              nativeEventLogger: {
+                filePath: "memory://cursor-admission-configuration",
+                write: (record) =>
+                  Effect.gen(function* () {
+                    if (holdConfiguration && !held && isConfigurationStart(record)) {
+                      held = true;
+                      yield* Deferred.succeed(configurationStarted, undefined);
+                      yield* Deferred.await(releaseConfiguration);
+                    }
+                  }),
+                close: () => Effect.void,
+              },
+            },
+          );
+          yield* Effect.addFinalizer(() => Deferred.succeed(releaseConfiguration, undefined));
+          const started: ProviderRuntimeEvent[] = [];
+          const terminal =
+            yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "turn.completed" }>>();
+          yield* adapter.streamEvents.pipe(
+            Stream.runForEach((event) => {
+              if (event.type === "turn.started") started.push(event);
+              return event.type === "turn.completed"
+                ? Deferred.succeed(terminal, event)
+                : Effect.void;
+            }),
+            Effect.forkChild,
+          );
+          yield* adapter.startSession({
+            threadId,
+            cwd: process.cwd(),
+            runtimeMode: "full-access",
+            modelSelection: { instanceId: ProviderInstanceId.make("cursor"), model: "default" },
+          });
+          holdConfiguration = true;
+          const first = yield* adapter
+            .sendTurn({
+              threadId,
+              input: "first",
+              attachments: failPreparation
+                ? [
+                    {
+                      type: "image",
+                      id: "missing-attachment",
+                      name: "missing.png",
+                      mimeType: "image/png",
+                      sizeBytes: 1,
+                    },
+                  ]
+                : [],
+              modelSelection: {
+                instanceId: ProviderInstanceId.make("cursor"),
+                model: "composer-2",
+              },
+            })
+            .pipe(Effect.forkChild);
+          yield* Deferred.await(configurationStarted);
+          const steer = yield* adapter.sendTurn({ threadId, input: "steer" });
+          yield* Deferred.succeed(releaseConfiguration, undefined);
+          if (failPreparation) {
+            const error = yield* Fiber.join(first).pipe(Effect.flip);
+            assert.equal(error._tag, "ProviderAdapterRequestError");
+          } else {
+            const initial = yield* Fiber.join(first);
+            assert.equal(initial.turnId, steer.turnId);
+          }
+          const completed = yield* Deferred.await(terminal);
+          assert.equal(completed.turnId, steer.turnId);
+          assert.equal(completed.payload.state, failPreparation ? "failed" : "completed");
+          assert.lengthOf(started, 1);
+          yield* adapter.stopSession(threadId);
+        }),
+    );
+  }
+
+  it.effect("records a fresh terminal after native completion follows local cancellation", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("cursor-late-native-proof");
+      const adapter = yield* CursorAdapter;
+      const settings = yield* ServerSettingsService;
+      const wrapperPath = yield* Effect.promise(() => makeMockAgentWrapper());
+      yield* settings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
+      const nativeReply = yield* Deferred.make<void>();
+      const releaseProof = yield* Deferred.make<void>();
+      yield* Effect.addFinalizer(() => Deferred.succeed(releaseProof, undefined));
+      const terminalBeforeProof = yield* Deferred.make<void>();
+      const terminalAfterProof = yield* Deferred.make<void>();
+      let proved = false;
+      const terminalEvents: Array<Extract<ProviderRuntimeEvent, { type: "turn.completed" }>> = [];
+      yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) => {
+          if (event.threadId !== threadId || event.type !== "turn.completed") return Effect.void;
+          terminalEvents.push(event);
+          return Deferred.succeed(proved ? terminalAfterProof : terminalBeforeProof, undefined);
+        }),
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({ threadId, cwd: process.cwd(), runtimeMode: "full-access" });
+      const sending = yield* adapter
+        .sendTurn(
+          { threadId, input: "finish this prompt" },
+          {
+            beforeSubmit: () => Effect.void,
+            nativeCompleted: () =>
+              Deferred.succeed(nativeReply, undefined).pipe(
+                Effect.andThen(Deferred.await(releaseProof)),
+                Effect.andThen(
+                  Effect.sync(() => {
+                    proved = true;
+                  }),
+                ),
+              ),
+            nativeStopped: Effect.void,
+            notSubmitted: Effect.die("This prompt has a real native reply."),
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(nativeReply);
+      yield* adapter.interruptTurn(threadId);
+      yield* Fiber.join(sending);
+      yield* Deferred.await(terminalBeforeProof);
+      assert.isFalse(proved);
+      yield* Deferred.succeed(releaseProof, undefined);
+      yield* Deferred.await(terminalAfterProof);
+      assert.lengthOf(terminalEvents, 2);
+      assert.equal(terminalEvents[0]?.turnId, terminalEvents[1]?.turnId);
+      assert.deepEqual(terminalEvents[0]?.payload, terminalEvents[1]?.payload);
+      assert.notEqual(terminalEvents[0]?.eventId, terminalEvents[1]?.eventId);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("records a fresh terminal after stop confirms unresolved native work has exited", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CursorAdapter;
+      const settings = yield* ServerSettingsService;
+      const threadId = ThreadId.make("cursor-native-stop-proof");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockAgentWrapper({ T3_ACP_COMPLETE_FIRST_PROMPT_ON_CANCEL: "1" }),
+      );
+      yield* settings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
+      const nativeStarted = yield* Deferred.make<void>();
+      const stoppedTerminal = yield* Deferred.make<void>();
+      let provedStopped = false;
+      yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) => {
+          if (event.threadId !== threadId) return Effect.void;
+          if (event.type === "item.updated" && event.payload.itemType === "command_execution")
+            return Deferred.succeed(nativeStarted, undefined);
+          if (event.type === "turn.completed" && provedStopped)
+            return Deferred.succeed(stoppedTerminal, undefined);
+          return Effect.void;
+        }),
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({ threadId, cwd: process.cwd(), runtimeMode: "full-access" });
+      const sending = yield* adapter
+        .sendTurn(
+          { threadId, input: "start native work" },
+          {
+            beforeSubmit: () => Effect.void,
+            nativeCompleted: () =>
+              Effect.die("The native prompt must stay unresolved until process exit."),
+            nativeStopped: Effect.sync(() => {
+              provedStopped = true;
+            }),
+            notSubmitted: Effect.die("The native prompt has already started."),
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(nativeStarted);
+      yield* adapter.interruptTurn(threadId);
+      yield* Fiber.join(sending);
+      assert.isFalse(provedStopped);
+      yield* adapter.stopSession(threadId);
+      yield* Deferred.await(stoppedTerminal);
+      assert.isTrue(provedStopped);
+    }),
+  );
+
+  it.effect("cancels a parked native admission and admits a later turn", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("cursor-parked-native-admission");
+      const directory = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "cursor-admission-")),
+      );
+      const requestLog = NodePath.join(directory, "requests.ndjson");
+      const adapter = yield* CursorAdapter;
+      const settings = yield* ServerSettingsService;
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockAgentWrapper({ T3_ACP_REQUEST_LOG_PATH: requestLog }),
+      );
+      yield* settings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
+      const entered = yield* Deferred.make<void>();
+      const release = yield* Deferred.make<void>();
+      const rejected = yield* Deferred.make<void>();
+      yield* adapter.startSession({ threadId, cwd: process.cwd(), runtimeMode: "full-access" });
+      const parked = yield* adapter
+        .sendTurn(
+          { threadId, input: "must not run" },
+          {
+            beforeSubmit: () =>
+              Deferred.succeed(entered, undefined).pipe(Effect.andThen(Deferred.await(release))),
+            nativeCompleted: () => Effect.die("A parked prompt cannot complete natively."),
+            notSubmitted: Deferred.succeed(rejected, undefined).pipe(Effect.asVoid),
+            nativeStopped: Effect.die("A parked prompt has no native work to stop."),
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(entered);
+      yield* Fiber.interrupt(parked);
+      assert.isTrue(yield* Deferred.isDone(rejected));
+      yield* adapter.interruptTurn(threadId);
+      yield* Deferred.succeed(release, undefined);
+      const proofs: string[] = [];
+      const accepted = yield* adapter.sendTurn(
+        { threadId, input: "can run" },
+        {
+          beforeSubmit: (turnId) =>
+            Effect.sync(() => {
+              proofs.push(`submit:${turnId}`);
+            }),
+          nativeCompleted: (turnId) =>
+            Effect.sync(() => {
+              proofs.push(`complete:${turnId}`);
+            }),
+          nativeStopped: Effect.void,
+          notSubmitted: Effect.die("The replacement prompt must be submitted."),
+        },
+      );
+      assert.deepEqual(proofs, [`submit:${accepted.turnId}`, `complete:${accepted.turnId}`]);
+      yield* adapter.stopSession(threadId);
+      const requests = yield* Effect.promise(() => readJsonLines(requestLog));
+      assert.equal(requests.filter((request) => request.method === "session/prompt").length, 1);
+    }),
+  );
+
   it.effect("starts a session and maps mock ACP prompt flow to runtime events", () =>
     Effect.gen(function* () {
       const adapter = yield* CursorAdapter;

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -163,12 +163,19 @@ const cursorAdapterTestLayer = it.layer(
 );
 
 cursorAdapterTestLayer("CursorAdapterLive", (it) => {
-  for (const preparation of ["configuration", "attachment", "failure"] as const) {
+  for (const preparation of [
+    "configuration",
+    "attachment",
+    "configuration failure",
+    "attachment failure",
+  ] as const) {
     it.effect(`keeps prompt order while Cursor ${preparation} preparation is pending`, () =>
       Effect.gen(function* () {
         const threadId = ThreadId.make("cursor-steer-during-configuration");
         const fileSystem = yield* FileSystem.FileSystem;
-        const failPreparation = preparation === "failure";
+        const failConfiguration = preparation === "configuration failure";
+        const failAttachment = preparation === "attachment failure";
+        const failPreparation = failConfiguration || failAttachment;
         let promptStarts = 0;
         const isPromptStart = Schema.is(
           Schema.Struct({
@@ -201,7 +208,10 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
         );
         const requestLog = NodePath.join(directory, "requests.ndjson");
         const wrapperPath = yield* Effect.promise(() =>
-          makeMockAgentWrapper({ T3_ACP_REQUEST_LOG_PATH: requestLog }),
+          makeMockAgentWrapper({
+            T3_ACP_REQUEST_LOG_PATH: requestLog,
+            ...(failConfiguration ? { T3_ACP_FAIL_SET_CONFIG_OPTION: "1" } : {}),
+          }),
         );
         const adapter = yield* makeCursorAdapter(
           decodeCursorSettings({ binaryPath: wrapperPath }),
@@ -253,7 +263,7 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
         yield* adapter.startSession({
           threadId,
           cwd: process.cwd(),
-          runtimeMode: "full-access",
+          runtimeMode: failConfiguration ? "approval-required" : "full-access",
           modelSelection: { instanceId: ProviderInstanceId.make("cursor"), model: "default" },
         });
         holdConfiguration = true;
@@ -261,7 +271,7 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
           .sendTurn({
             threadId,
             input: "first",
-            attachments: failPreparation
+            attachments: failAttachment
               ? [
                   {
                     type: "image",
@@ -313,6 +323,7 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
         assert.equal(completed.turnId, steer.turnId);
         assert.equal(completed.payload.state, "completed");
         assert.lengthOf(started, 1);
+        assert.equal(started[0]?.turnId, steer.turnId);
         yield* adapter.stopSession(threadId);
         const requests = yield* Effect.promise(() => readJsonLines(requestLog));
         const decodePromptRequest = Schema.decodeUnknownEffect(

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -10,6 +10,7 @@ import * as Context from "effect/Context";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
@@ -162,102 +163,176 @@ const cursorAdapterTestLayer = it.layer(
 );
 
 cursorAdapterTestLayer("CursorAdapterLive", (it) => {
-  for (const failPreparation of [false, true]) {
-    it.effect(
-      `shares a turn with a steer during initial preparation${failPreparation ? " failure" : ""}`,
-      () =>
-        Effect.gen(function* () {
-          const threadId = ThreadId.make("cursor-steer-during-configuration");
-          const configurationStarted = yield* Deferred.make<void>();
-          const releaseConfiguration = yield* Deferred.make<void>();
-          let holdConfiguration = false;
-          let held = false;
-          const isConfigurationStart = Schema.is(
-            Schema.Struct({
-              event: Schema.Struct({
-                kind: Schema.Literal("request"),
-                payload: Schema.Struct({
-                  method: Schema.Literal("session/set_config_option"),
-                  status: Schema.Literal("started"),
-                }),
+  for (const preparation of ["configuration", "attachment", "failure"] as const) {
+    it.effect(`keeps prompt order while Cursor ${preparation} preparation is pending`, () =>
+      Effect.gen(function* () {
+        const threadId = ThreadId.make("cursor-steer-during-configuration");
+        const fileSystem = yield* FileSystem.FileSystem;
+        const failPreparation = preparation === "failure";
+        let promptStarts = 0;
+        const isPromptStart = Schema.is(
+          Schema.Struct({
+            event: Schema.Struct({
+              kind: Schema.Literal("request"),
+              payload: Schema.Struct({
+                method: Schema.Literal("session/prompt"),
+                status: Schema.Literal("started"),
               }),
             }),
-          );
-          const wrapperPath = yield* Effect.promise(() => makeMockAgentWrapper());
-          const adapter = yield* makeCursorAdapter(
-            decodeCursorSettings({ binaryPath: wrapperPath }),
-            {
-              nativeEventLogger: {
-                filePath: "memory://cursor-admission-configuration",
-                write: (record) =>
-                  Effect.gen(function* () {
-                    if (holdConfiguration && !held && isConfigurationStart(record)) {
-                      held = true;
-                      yield* Deferred.succeed(configurationStarted, undefined);
-                      yield* Deferred.await(releaseConfiguration);
-                    }
-                  }),
-                close: () => Effect.void,
-              },
-            },
-          );
-          yield* Effect.addFinalizer(() => Deferred.succeed(releaseConfiguration, undefined));
-          const started: ProviderRuntimeEvent[] = [];
-          const terminal =
-            yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "turn.completed" }>>();
-          yield* adapter.streamEvents.pipe(
-            Stream.runForEach((event) => {
-              if (event.type === "turn.started") started.push(event);
-              return event.type === "turn.completed"
-                ? Deferred.succeed(terminal, event)
-                : Effect.void;
+          }),
+        );
+        const configurationStarted = yield* Deferred.make<void>();
+        const releaseConfiguration = yield* Deferred.make<void>();
+        let holdConfiguration = false;
+        let held = false;
+        const isConfigurationStart = Schema.is(
+          Schema.Struct({
+            event: Schema.Struct({
+              kind: Schema.Literal("request"),
+              payload: Schema.Struct({
+                method: Schema.Literal("session/set_config_option"),
+                status: Schema.Literal("started"),
+              }),
             }),
-            Effect.forkChild,
-          );
-          yield* adapter.startSession({
+          }),
+        );
+        const directory = yield* Effect.promise(() =>
+          NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "cursor-preparation-order-")),
+        );
+        const requestLog = NodePath.join(directory, "requests.ndjson");
+        const wrapperPath = yield* Effect.promise(() =>
+          makeMockAgentWrapper({ T3_ACP_REQUEST_LOG_PATH: requestLog }),
+        );
+        const adapter = yield* makeCursorAdapter(
+          decodeCursorSettings({ binaryPath: wrapperPath }),
+          {
+            nativeEventLogger: {
+              filePath: "memory://cursor-admission-configuration",
+              write: (record) =>
+                Effect.gen(function* () {
+                  if (isPromptStart(record)) promptStarts += 1;
+                  if (
+                    preparation !== "attachment" &&
+                    holdConfiguration &&
+                    !held &&
+                    isConfigurationStart(record)
+                  ) {
+                    held = true;
+                    yield* Deferred.succeed(configurationStarted, undefined);
+                    yield* Deferred.await(releaseConfiguration);
+                  }
+                }),
+              close: () => Effect.void,
+            },
+          },
+        ).pipe(
+          Effect.provideService(FileSystem.FileSystem, {
+            ...fileSystem,
+            readFile: (path) =>
+              path.endsWith("blocked-attachment.png")
+                ? Deferred.succeed(configurationStarted, undefined).pipe(
+                    Effect.andThen(Deferred.await(releaseConfiguration)),
+                    Effect.as(new Uint8Array([1, 2, 3])),
+                  )
+                : fileSystem.readFile(path),
+          }),
+        );
+        yield* Effect.addFinalizer(() => Deferred.succeed(releaseConfiguration, undefined));
+        const started: ProviderRuntimeEvent[] = [];
+        const terminal =
+          yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "turn.completed" }>>();
+        yield* adapter.streamEvents.pipe(
+          Stream.runForEach((event) => {
+            if (event.type === "turn.started") started.push(event);
+            return event.type === "turn.completed"
+              ? Deferred.succeed(terminal, event)
+              : Effect.void;
+          }),
+          Effect.forkChild,
+        );
+        yield* adapter.startSession({
+          threadId,
+          cwd: process.cwd(),
+          runtimeMode: "full-access",
+          modelSelection: { instanceId: ProviderInstanceId.make("cursor"), model: "default" },
+        });
+        holdConfiguration = true;
+        const first = yield* adapter
+          .sendTurn({
             threadId,
-            cwd: process.cwd(),
-            runtimeMode: "full-access",
-            modelSelection: { instanceId: ProviderInstanceId.make("cursor"), model: "default" },
-          });
-          holdConfiguration = true;
-          const first = yield* adapter
-            .sendTurn({
-              threadId,
-              input: "first",
-              attachments: failPreparation
+            input: "first",
+            attachments: failPreparation
+              ? [
+                  {
+                    type: "image",
+                    id: "missing-attachment",
+                    name: "missing.png",
+                    mimeType: "image/png",
+                    sizeBytes: 1,
+                  },
+                ]
+              : preparation === "attachment"
                 ? [
                     {
                       type: "image",
-                      id: "missing-attachment",
-                      name: "missing.png",
+                      id: "blocked-attachment",
+                      name: "blocked-attachment.png",
                       mimeType: "image/png",
-                      sizeBytes: 1,
+                      sizeBytes: 3,
                     },
                   ]
                 : [],
-              modelSelection: {
-                instanceId: ProviderInstanceId.make("cursor"),
-                model: "composer-2",
-              },
-            })
-            .pipe(Effect.forkChild);
-          yield* Deferred.await(configurationStarted);
-          const steer = yield* adapter.sendTurn({ threadId, input: "steer" });
-          yield* Deferred.succeed(releaseConfiguration, undefined);
-          if (failPreparation) {
-            const error = yield* Fiber.join(first).pipe(Effect.flip);
-            assert.equal(error._tag, "ProviderAdapterRequestError");
-          } else {
-            const initial = yield* Fiber.join(first);
-            assert.equal(initial.turnId, steer.turnId);
-          }
-          const completed = yield* Deferred.await(terminal);
-          assert.equal(completed.turnId, steer.turnId);
-          assert.equal(completed.payload.state, failPreparation ? "failed" : "completed");
-          assert.lengthOf(started, 1);
-          yield* adapter.stopSession(threadId);
-        }),
+            modelSelection: {
+              instanceId: ProviderInstanceId.make("cursor"),
+              model: "composer-2",
+            },
+          })
+          .pipe(Effect.forkChild);
+        yield* Deferred.await(configurationStarted);
+        const steering = yield* adapter
+          .sendTurn({
+            threadId,
+            input: "steer",
+            modelSelection: {
+              instanceId: ProviderInstanceId.make("cursor"),
+              model: preparation === "attachment" ? "composer-2" : "default",
+            },
+          })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        assert.equal(promptStarts, 0);
+        yield* Deferred.succeed(releaseConfiguration, undefined);
+        const steer = yield* Fiber.join(steering);
+        if (failPreparation) {
+          const error = yield* Fiber.join(first).pipe(Effect.flip);
+          assert.equal(error._tag, "ProviderAdapterRequestError");
+        } else {
+          const initial = yield* Fiber.join(first);
+          assert.equal(initial.turnId, steer.turnId);
+        }
+        const completed = yield* Deferred.await(terminal);
+        assert.equal(completed.turnId, steer.turnId);
+        assert.equal(completed.payload.state, "completed");
+        assert.lengthOf(started, 1);
+        yield* adapter.stopSession(threadId);
+        const requests = yield* Effect.promise(() => readJsonLines(requestLog));
+        const decodePromptRequest = Schema.decodeUnknownEffect(
+          Schema.Struct({
+            params: Schema.Struct({
+              prompt: Schema.Array(
+                Schema.Struct({ type: Schema.String, text: Schema.optional(Schema.String) }),
+              ),
+            }),
+          }),
+        );
+        const promptInputs = yield* Effect.forEach(
+          requests.filter((request) => request.method === "session/prompt"),
+          (request) =>
+            decodePromptRequest(request).pipe(
+              Effect.map((decoded) => decoded.params.prompt[0]?.text),
+            ),
+        );
+        assert.deepEqual(promptInputs, failPreparation ? ["steer"] : ["first", "steer"]);
+      }),
     );
   }
 

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -86,6 +86,7 @@ import {
   rewriteCursorSkillMentions,
 } from "../Drivers/CursorSkills.ts";
 const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
+const isAcpError = Schema.is(EffectAcpErrors.AcpError);
 
 const PROVIDER = ProviderDriverKind.make("cursor");
 const CURSOR_RESUME_VERSION = 1 as const;
@@ -955,243 +956,261 @@ export function makeCursorAdapter(
 
     const sendTurn: CursorAdapterShape["sendTurn"] = (input, startOptions) =>
       Effect.gen(function* () {
-        const { ctx, steeringTurnId, turnId } = yield* withThreadLock(
+        const sending = yield* withThreadLock(
           input.threadId,
-          Effect.gen(function* () {
-            const ctx = yield* requireSession(input.threadId);
-            const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
-            const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
-            // Reserve the local turn before configuration can yield. Concurrent
-            // preparation and native prompts must use the same steering identity.
-            ctx.activeTurnId = turnId;
-            ctx.promptsInFlight += 1;
-            return { ctx, steeringTurnId, turnId };
-          }),
-        );
-
-        return yield* Effect.gen(function* () {
-          const turnModelSelection =
-            input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
-          const model = turnModelSelection?.model ?? ctx.session.model;
-          const resolvedModel = resolveCursorAcpBaseModelId(model);
-          yield* applyRequestedSessionConfiguration({
-            runtime: ctx.acp,
-            runtimeMode: ctx.session.runtimeMode,
-            interactionMode: input.interactionMode,
-            modelSelection:
-              model === undefined
-                ? undefined
-                : {
-                    model,
-                    options: turnModelSelection?.options,
-                  },
-            mapError: ({ cause, method }) =>
-              mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
-          });
-          ctx.activeTurnId = turnId;
-          if (steeringTurnId === undefined) {
-            ctx.lastPlanFingerprint = undefined;
-          }
-          ctx.session = {
-            ...ctx.session,
-            activeTurnId: turnId,
-            updatedAt: yield* nowIso,
-          };
-
-          if (steeringTurnId === undefined) {
-            yield* offerRuntimeEvent({
-              type: "turn.started",
-              ...(yield* makeEventStamp()),
-              provider: PROVIDER,
-              threadId: input.threadId,
-              turnId,
-              payload: { model: resolvedModel },
-            });
-          }
-
-          const promptParts: Array<EffectAcpSchema.ContentBlock> = [];
-          const rawPrompt = input.input?.trim() ?? "";
-          if (rawPrompt) {
-            let cursorSkillNames = ctx.cursorSkillNames;
-            if (hasCursorSkillMention(rawPrompt) && cursorSkillNames === undefined) {
-              const skills = yield* discoverCursorSkills(
-                ctx.session.cwd,
-                options?.environment,
-              ).pipe(
-                Effect.provideService(FileSystem.FileSystem, fileSystem),
-                Effect.provideService(Path.Path, path),
-              );
-              cursorSkillNames = new Set(
-                skills
-                  .filter((skill) => skill.enabled && skill.userInvocable !== false)
-                  .map((skill) => skill.name),
-              );
-              ctx.cursorSkillNames = cursorSkillNames;
-            }
-            const prompt = cursorSkillNames
-              ? rewriteCursorSkillMentions(rawPrompt, cursorSkillNames)
-              : rawPrompt;
-            promptParts.push({ type: "text", text: prompt });
-          }
-          if (input.attachments && input.attachments.length > 0) {
-            for (const attachment of input.attachments) {
-              // Cursor ingests images only. Generic files reach the agent
-              // through the path line ProviderService puts in the prompt.
-              if (attachment.type !== "image") {
-                continue;
-              }
-              const attachmentPath = resolveAttachmentPath({
-                attachmentsDir: serverConfig.attachmentsDir,
-                attachment,
-              });
-              if (!attachmentPath) {
-                return yield* new ProviderAdapterRequestError({
-                  provider: PROVIDER,
-                  method: "session/prompt",
-                  detail: `Invalid attachment id '${attachment.id}'.`,
-                });
-              }
-              const bytes = yield* fileSystem.readFile(attachmentPath).pipe(
-                Effect.mapError(
-                  (cause) =>
-                    new ProviderAdapterRequestError({
-                      provider: PROVIDER,
-                      method: "session/prompt",
-                      detail: cause.message,
-                      cause,
-                    }),
-                ),
-              );
-              promptParts.push({
-                type: "image",
-                data: Buffer.from(bytes).toString("base64"),
-                mimeType: attachment.mimeType,
-              });
-            }
-          }
-
-          if (promptParts.length === 0) {
-            return yield* new ProviderAdapterValidationError({
-              provider: PROVIDER,
-              operation: "sendTurn",
-              issue: "Turn requires non-empty text or attachments.",
-            });
-          }
-
-          // ACP has no system-message field; keep runtime context separate from the user's text.
-          const result = yield* ctx.acp
-            .prompt(
-              {
-                prompt: [
-                  ...promptParts,
-                  {
-                    type: "text",
-                    text: buildRuntimeInstructions({ harness: "Cursor", model: resolvedModel }),
-                  },
-                ],
-              },
-              {
-                beforeSubmit: Effect.gen(function* () {
-                  yield* startOptions?.beforeSubmit(turnId) ?? Effect.void;
-                  if (
-                    ctx.stopped ||
-                    sessions.get(input.threadId) !== ctx ||
-                    ctx.activeTurnId !== turnId
-                  ) {
-                    return yield* new EffectAcpErrors.AcpTransportError({
-                      method: "session/prompt",
-                      detail: "The Cursor session changed before prompt submission.",
-                      cause: undefined,
-                    });
-                  }
-                }),
-                nativeCompleted: startOptions
-                  ? startOptions
-                      .nativeCompleted(turnId)
-                      .pipe(Effect.andThen(repeatNativeTerminal(ctx, turnId)))
-                  : Effect.void,
-                nativeStopped: startOptions
-                  ? startOptions.nativeStopped.pipe(
-                      Effect.andThen(repeatNativeTerminal(ctx, turnId, true)),
-                    )
-                  : Effect.void,
-                notSubmitted: startOptions?.notSubmitted ?? Effect.void,
-              },
-            )
-            .pipe(
-              Effect.mapError((error) =>
-                mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
-              ),
-            );
-
-          const turnRecord = ctx.turns.find((turn) => turn.id === turnId);
-          if (turnRecord) {
-            turnRecord.items.push({ prompt: promptParts, result });
-          } else {
-            ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, result }] });
-          }
-          ctx.session = {
-            ...ctx.session,
-            activeTurnId: turnId,
-            updatedAt: yield* nowIso,
-            model: resolvedModel,
-          };
-
-          // Only the last remaining prompt settles the turn — a steer-
-          // superseded prompt resolving (usually cancelled) while another is
-          // in flight or pending must leave the merged turn running.
-          if (ctx.promptsInFlight === 1) {
-            yield* offerRuntimeEvent({
-              type: "turn.completed",
-              ...(yield* makeEventStamp()),
-              provider: PROVIDER,
-              threadId: input.threadId,
-              turnId,
-              payload: {
-                state: result.stopReason === "cancelled" ? "cancelled" : "completed",
-                stopReason: result.stopReason ?? null,
-              },
-            });
-          }
-
-          return {
-            threadId: input.threadId,
-            turnId,
-            resumeCursor: ctx.session.resumeCursor,
-          };
-        }).pipe(
-          Effect.ensuring(
-            Effect.sync(() => {
-              ctx.promptsInFlight = Math.max(0, ctx.promptsInFlight - 1);
-            }),
-          ),
-          Effect.onError((cause) =>
+          Effect.acquireRelease(
             Effect.gen(function* () {
-              if (
-                ctx.stopped ||
-                ctx.promptsInFlight > 0 ||
-                ctx.activeTurnId !== turnId ||
-                ctx.lastTurnCompletion?.turnId === turnId
-              )
-                return;
-              yield* offerRuntimeEvent({
-                type: "turn.completed",
-                ...(yield* makeEventStamp()),
-                provider: PROVIDER,
-                threadId: input.threadId,
-                turnId,
-                payload: Cause.hasInterruptsOnly(cause)
-                  ? { state: "cancelled", stopReason: "cancelled" }
-                  : { state: "failed", errorMessage: "Cursor prompt request failed." },
-              });
-            }).pipe(
-              Effect.catch((error) =>
-                Effect.logError("Failed to record Cursor prompt failure.", { error }),
-              ),
-            ),
+              const ctx = yield* requireSession(input.threadId);
+              const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
+              const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
+              // Reserve the local turn before configuration can yield. Concurrent
+              // preparation and native prompts must use the same steering identity.
+              ctx.activeTurnId = turnId;
+              ctx.promptsInFlight += 1;
+              return yield* Effect.gen(function* () {
+                const prepare = yield* Effect.cached(
+                  Effect.gen(function* () {
+                    const turnModelSelection =
+                      input.modelSelection?.instanceId === boundInstanceId
+                        ? input.modelSelection
+                        : undefined;
+                    const model = turnModelSelection?.model ?? ctx.session.model;
+                    const resolvedModel = resolveCursorAcpBaseModelId(model);
+                    yield* applyRequestedSessionConfiguration({
+                      runtime: ctx.acp,
+                      runtimeMode: ctx.session.runtimeMode,
+                      interactionMode: input.interactionMode,
+                      modelSelection:
+                        model === undefined
+                          ? undefined
+                          : {
+                              model,
+                              options: turnModelSelection?.options,
+                            },
+                      mapError: ({ cause, method }) =>
+                        mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
+                    });
+                    ctx.activeTurnId = turnId;
+                    if (steeringTurnId === undefined) {
+                      ctx.lastPlanFingerprint = undefined;
+                    }
+                    ctx.session = {
+                      ...ctx.session,
+                      activeTurnId: turnId,
+                      updatedAt: yield* nowIso,
+                    };
+
+                    if (steeringTurnId === undefined) {
+                      yield* offerRuntimeEvent({
+                        type: "turn.started",
+                        ...(yield* makeEventStamp()),
+                        provider: PROVIDER,
+                        threadId: input.threadId,
+                        turnId,
+                        payload: { model: resolvedModel },
+                      });
+                    }
+
+                    const promptParts: Array<EffectAcpSchema.ContentBlock> = [];
+                    const rawPrompt = input.input?.trim() ?? "";
+                    if (rawPrompt) {
+                      let cursorSkillNames = ctx.cursorSkillNames;
+                      if (hasCursorSkillMention(rawPrompt) && cursorSkillNames === undefined) {
+                        const skills = yield* discoverCursorSkills(
+                          ctx.session.cwd,
+                          options?.environment,
+                        ).pipe(
+                          Effect.provideService(FileSystem.FileSystem, fileSystem),
+                          Effect.provideService(Path.Path, path),
+                        );
+                        cursorSkillNames = new Set(
+                          skills
+                            .filter((skill) => skill.enabled && skill.userInvocable !== false)
+                            .map((skill) => skill.name),
+                        );
+                        ctx.cursorSkillNames = cursorSkillNames;
+                      }
+                      const prompt = cursorSkillNames
+                        ? rewriteCursorSkillMentions(rawPrompt, cursorSkillNames)
+                        : rawPrompt;
+                      promptParts.push({ type: "text", text: prompt });
+                    }
+                    if (input.attachments && input.attachments.length > 0) {
+                      for (const attachment of input.attachments) {
+                        // Cursor ingests images only. Generic files reach the agent
+                        // through the path line ProviderService puts in the prompt.
+                        if (attachment.type !== "image") {
+                          continue;
+                        }
+                        const attachmentPath = resolveAttachmentPath({
+                          attachmentsDir: serverConfig.attachmentsDir,
+                          attachment,
+                        });
+                        if (!attachmentPath) {
+                          return yield* new ProviderAdapterRequestError({
+                            provider: PROVIDER,
+                            method: "session/prompt",
+                            detail: `Invalid attachment id '${attachment.id}'.`,
+                          });
+                        }
+                        const bytes = yield* fileSystem.readFile(attachmentPath).pipe(
+                          Effect.mapError(
+                            (cause) =>
+                              new ProviderAdapterRequestError({
+                                provider: PROVIDER,
+                                method: "session/prompt",
+                                detail: cause.message,
+                                cause,
+                              }),
+                          ),
+                        );
+                        promptParts.push({
+                          type: "image",
+                          data: Buffer.from(bytes).toString("base64"),
+                          mimeType: attachment.mimeType,
+                        });
+                      }
+                    }
+
+                    if (promptParts.length === 0) {
+                      return yield* new ProviderAdapterValidationError({
+                        provider: PROVIDER,
+                        operation: "sendTurn",
+                        issue: "Turn requires non-empty text or attachments.",
+                      });
+                    }
+
+                    return { promptParts, resolvedModel };
+                  }),
+                );
+                const result = yield* ctx.acp
+                  .prompt(
+                    prepare.pipe(
+                      Effect.map(({ promptParts, resolvedModel }) => ({
+                        prompt: [
+                          ...promptParts,
+                          {
+                            type: "text",
+                            text: buildRuntimeInstructions({
+                              harness: "Cursor",
+                              model: resolvedModel,
+                            }),
+                          } satisfies EffectAcpSchema.ContentBlock,
+                        ],
+                      })),
+                    ),
+                    {
+                      beforeSubmit: Effect.gen(function* () {
+                        yield* startOptions?.beforeSubmit(turnId) ?? Effect.void;
+                        if (
+                          ctx.stopped ||
+                          sessions.get(input.threadId) !== ctx ||
+                          ctx.activeTurnId !== turnId
+                        ) {
+                          return yield* new EffectAcpErrors.AcpTransportError({
+                            method: "session/prompt",
+                            detail: "The Cursor session changed before prompt submission.",
+                            cause: undefined,
+                          });
+                        }
+                      }),
+                      nativeCompleted: startOptions
+                        ? startOptions
+                            .nativeCompleted(turnId)
+                            .pipe(Effect.andThen(repeatNativeTerminal(ctx, turnId)))
+                        : Effect.void,
+                      nativeStopped: startOptions
+                        ? startOptions.nativeStopped.pipe(
+                            Effect.andThen(repeatNativeTerminal(ctx, turnId, true)),
+                          )
+                        : Effect.void,
+                      notSubmitted: startOptions?.notSubmitted ?? Effect.void,
+                    },
+                  )
+                  .pipe(
+                    Effect.mapError((error) =>
+                      isAcpError(error)
+                        ? mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error)
+                        : error,
+                    ),
+                  );
+
+                const { promptParts, resolvedModel } = yield* prepare;
+                const turnRecord = ctx.turns.find((turn) => turn.id === turnId);
+                if (turnRecord) {
+                  turnRecord.items.push({ prompt: promptParts, result });
+                } else {
+                  ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, result }] });
+                }
+                ctx.session = {
+                  ...ctx.session,
+                  activeTurnId: turnId,
+                  updatedAt: yield* nowIso,
+                  model: resolvedModel,
+                };
+
+                // Only the last remaining prompt settles the turn — a steer-
+                // superseded prompt resolving (usually cancelled) while another is
+                // in flight or pending must leave the merged turn running.
+                if (ctx.promptsInFlight === 1) {
+                  yield* offerRuntimeEvent({
+                    type: "turn.completed",
+                    ...(yield* makeEventStamp()),
+                    provider: PROVIDER,
+                    threadId: input.threadId,
+                    turnId,
+                    payload: {
+                      state: result.stopReason === "cancelled" ? "cancelled" : "completed",
+                      stopReason: result.stopReason ?? null,
+                    },
+                  });
+                }
+
+                return {
+                  threadId: input.threadId,
+                  turnId,
+                  resumeCursor: ctx.session.resumeCursor,
+                };
+              }).pipe(
+                Effect.ensuring(
+                  Effect.sync(() => {
+                    ctx.promptsInFlight = Math.max(0, ctx.promptsInFlight - 1);
+                  }),
+                ),
+                Effect.onError((cause) =>
+                  Effect.gen(function* () {
+                    if (
+                      ctx.stopped ||
+                      ctx.promptsInFlight > 0 ||
+                      ctx.activeTurnId !== turnId ||
+                      ctx.lastTurnCompletion?.turnId === turnId
+                    )
+                      return;
+                    yield* offerRuntimeEvent({
+                      type: "turn.completed",
+                      ...(yield* makeEventStamp()),
+                      provider: PROVIDER,
+                      threadId: input.threadId,
+                      turnId,
+                      payload: Cause.hasInterruptsOnly(cause)
+                        ? { state: "cancelled", stopReason: "cancelled" }
+                        : { state: "failed", errorMessage: "Cursor prompt request failed." },
+                    });
+                  }).pipe(
+                    Effect.catch((error) =>
+                      Effect.logError("Failed to record Cursor prompt failure.", { error }),
+                    ),
+                  ),
+                ),
+                Effect.interruptible,
+                Effect.forkIn(ctx.scope, { startImmediately: true }),
+              );
+            }),
+            Fiber.interrupt,
           ),
         );
-      });
+        return yield* Fiber.join(sending);
+      }).pipe(Effect.scoped);
 
     const interruptTurn: CursorAdapterShape["interruptTurn"] = (threadId) =>
       Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -22,6 +22,7 @@ import {
   TurnId,
 } from "@t3tools/contracts";
 import * as DateTime from "effect/DateTime";
+import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
@@ -130,6 +131,7 @@ interface PendingUserInput {
 }
 
 interface CursorSessionContext {
+  lastTurnCompletion?: Extract<ProviderRuntimeEvent, { type: "turn.completed" }>;
   readonly threadId: ThreadId;
   session: ProviderSession;
   readonly scope: Scope.Closeable;
@@ -370,7 +372,35 @@ export function makeCursorAdapter(
       );
 
     const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
-      PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
+      Effect.gen(function* () {
+        if (event.type === "turn.completed") {
+          const context = sessions.get(event.threadId);
+          if (context) context.lastTurnCompletion = event;
+        }
+        yield* PubSub.publish(runtimeEventPubSub, event);
+      });
+    // A local terminal can precede native completion. Capture again after proof,
+    // using the last result so a late cancelled steer cannot replace the final result.
+    const repeatNativeTerminal = (context: CursorSessionContext, turnId: TurnId, stopped = false) =>
+      Effect.gen(function* () {
+        const previous = context.lastTurnCompletion;
+        if (!stopped && previous?.turnId !== turnId) return;
+        yield* offerRuntimeEvent({
+          type: "turn.completed",
+          provider: PROVIDER,
+          threadId: context.threadId,
+          turnId,
+          payload:
+            previous?.turnId === turnId
+              ? previous.payload
+              : { state: "cancelled", stopReason: "cancelled" },
+          ...(yield* makeEventStamp()),
+        });
+      }).pipe(
+        Effect.catch((cause) =>
+          Effect.logError("Failed to record native Cursor completion.", { cause }),
+        ),
+      );
 
     const getThreadSemaphore = (threadId: string) =>
       SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
@@ -923,18 +953,21 @@ export function makeCursorAdapter(
         }).pipe(Effect.scoped),
       );
 
-    const sendTurn: CursorAdapterShape["sendTurn"] = (input) =>
+    const sendTurn: CursorAdapterShape["sendTurn"] = (input, startOptions) =>
       Effect.gen(function* () {
-        const ctx = yield* requireSession(input.threadId);
-        // A sendTurn while a prompt is in flight is a steer: the agent folds
-        // the new prompt into the ongoing work, so the active turn id is
-        // reused instead of opening a new turn.
-        const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
-        const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
-        // Count this prompt immediately so a superseded in-flight prompt
-        // resolving from here on does not settle the turn; the matching
-        // decrement is the `ensuring` below.
-        ctx.promptsInFlight += 1;
+        const { ctx, steeringTurnId, turnId } = yield* withThreadLock(
+          input.threadId,
+          Effect.gen(function* () {
+            const ctx = yield* requireSession(input.threadId);
+            const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
+            const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
+            // Reserve the local turn before configuration can yield. Concurrent
+            // preparation and native prompts must use the same steering identity.
+            ctx.activeTurnId = turnId;
+            ctx.promptsInFlight += 1;
+            return { ctx, steeringTurnId, turnId };
+          }),
+        );
 
         return yield* Effect.gen(function* () {
           const turnModelSelection =
@@ -1047,15 +1080,44 @@ export function makeCursorAdapter(
 
           // ACP has no system-message field; keep runtime context separate from the user's text.
           const result = yield* ctx.acp
-            .prompt({
-              prompt: [
-                ...promptParts,
-                {
-                  type: "text",
-                  text: buildRuntimeInstructions({ harness: "Cursor", model: resolvedModel }),
-                },
-              ],
-            })
+            .prompt(
+              {
+                prompt: [
+                  ...promptParts,
+                  {
+                    type: "text",
+                    text: buildRuntimeInstructions({ harness: "Cursor", model: resolvedModel }),
+                  },
+                ],
+              },
+              {
+                beforeSubmit: Effect.gen(function* () {
+                  yield* startOptions?.beforeSubmit(turnId) ?? Effect.void;
+                  if (
+                    ctx.stopped ||
+                    sessions.get(input.threadId) !== ctx ||
+                    ctx.activeTurnId !== turnId
+                  ) {
+                    return yield* new EffectAcpErrors.AcpTransportError({
+                      method: "session/prompt",
+                      detail: "The Cursor session changed before prompt submission.",
+                      cause: undefined,
+                    });
+                  }
+                }),
+                nativeCompleted: startOptions
+                  ? startOptions
+                      .nativeCompleted(turnId)
+                      .pipe(Effect.andThen(repeatNativeTerminal(ctx, turnId)))
+                  : Effect.void,
+                nativeStopped: startOptions
+                  ? startOptions.nativeStopped.pipe(
+                      Effect.andThen(repeatNativeTerminal(ctx, turnId, true)),
+                    )
+                  : Effect.void,
+                notSubmitted: startOptions?.notSubmitted ?? Effect.void,
+              },
+            )
             .pipe(
               Effect.mapError((error) =>
                 mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
@@ -1102,6 +1164,31 @@ export function makeCursorAdapter(
             Effect.sync(() => {
               ctx.promptsInFlight = Math.max(0, ctx.promptsInFlight - 1);
             }),
+          ),
+          Effect.onError((cause) =>
+            Effect.gen(function* () {
+              if (
+                ctx.stopped ||
+                ctx.promptsInFlight > 0 ||
+                ctx.activeTurnId !== turnId ||
+                ctx.lastTurnCompletion?.turnId === turnId
+              )
+                return;
+              yield* offerRuntimeEvent({
+                type: "turn.completed",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                turnId,
+                payload: Cause.hasInterruptsOnly(cause)
+                  ? { state: "cancelled", stopReason: "cancelled" }
+                  : { state: "failed", errorMessage: "Cursor prompt request failed." },
+              });
+            }).pipe(
+              Effect.catch((error) =>
+                Effect.logError("Failed to record Cursor prompt failure.", { error }),
+              ),
+            ),
           ),
         );
       });

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -1138,11 +1138,9 @@ export function makeCursorAdapter(
                           sessions.get(input.threadId) !== ctx ||
                           ctx.activeTurnId !== turnId
                         ) {
-                          return yield* new EffectAcpErrors.AcpTransportError({
-                            method: "session/prompt",
-                            detail: "The Cursor session changed before prompt submission.",
-                            cause: undefined,
-                          });
+                          return yield* EffectAcpErrors.AcpRequestError.invalidRequest(
+                            "The Cursor session changed before prompt submission.",
+                          );
                         }
                       }),
                       nativeCompleted: startOptions

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -148,6 +148,7 @@ interface CursorSessionContext {
   readonly pendingUserInputs: Map<ApprovalRequestId, PendingUserInput>;
   readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
   lastPlanFingerprint: string | undefined;
+  lastStartedTurnId: TurnId | undefined;
   activeTurnId: TurnId | undefined;
   cursorSkillNames: ReadonlySet<string> | undefined;
   /** Number of sendTurn prompts currently in flight or being prepared.
@@ -380,6 +381,13 @@ export function makeCursorAdapter(
 
     const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
       Effect.gen(function* () {
+        if (event.type === "turn.started") {
+          const context = sessions.get(event.threadId);
+          if (context) {
+            context.lastStartedTurnId = event.turnId;
+            context.lastPlanFingerprint = undefined;
+          }
+        }
         if (event.type === "turn.completed") {
           const context = sessions.get(event.threadId);
           if (context) {
@@ -829,6 +837,7 @@ export function makeCursorAdapter(
             pendingUserInputs,
             turns: [],
             lastPlanFingerprint: undefined,
+            lastStartedTurnId: undefined,
             activeTurnId: undefined,
             cursorSkillNames: undefined,
             promptsInFlight: 0,
@@ -1008,16 +1017,15 @@ export function makeCursorAdapter(
                         mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
                     });
                     ctx.activeTurnId = turnId;
-                    if (steeringTurnId === undefined) {
-                      ctx.lastPlanFingerprint = undefined;
-                    }
                     ctx.session = {
                       ...ctx.session,
                       activeTurnId: turnId,
                       updatedAt: yield* nowIso,
                     };
 
-                    if (steeringTurnId === undefined) {
+                    // An earlier prompt can fail configuration after reserving
+                    // this turn. The first prepared prompt must still start it.
+                    if (ctx.lastStartedTurnId !== turnId) {
                       yield* offerRuntimeEvent({
                         type: "turn.started",
                         ...(yield* makeEventStamp()),

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -131,8 +131,14 @@ interface PendingUserInput {
   readonly answers: Deferred.Deferred<ProviderUserInputAnswers>;
 }
 
+interface NativeTurnCompletion {
+  readonly turnId: TurnId;
+  completion?: Extract<ProviderRuntimeEvent, { type: "turn.completed" }>;
+}
+
 interface CursorSessionContext {
   lastTurnCompletion?: Extract<ProviderRuntimeEvent, { type: "turn.completed" }>;
+  readonly nativeTurnCompletions: Set<NativeTurnCompletion>;
   readonly threadId: ThreadId;
   session: ProviderSession;
   readonly scope: Scope.Closeable;
@@ -376,25 +382,31 @@ export function makeCursorAdapter(
       Effect.gen(function* () {
         if (event.type === "turn.completed") {
           const context = sessions.get(event.threadId);
-          if (context) context.lastTurnCompletion = event;
+          if (context) {
+            context.lastTurnCompletion = event;
+            for (const nativeTurn of context.nativeTurnCompletions) {
+              if (nativeTurn.turnId === event.turnId) nativeTurn.completion = event;
+            }
+          }
         }
         yield* PubSub.publish(runtimeEventPubSub, event);
       });
-    // A local terminal can precede native completion. Capture again after proof,
-    // using the last result so a late cancelled steer cannot replace the final result.
-    const repeatNativeTerminal = (context: CursorSessionContext, turnId: TurnId, stopped = false) =>
+    // Each native request retains its turn result until proof arrives. A newer
+    // locally cancelled turn must not replace an older request's terminal result.
+    const repeatNativeTerminal = (
+      context: CursorSessionContext,
+      nativeTurn: NativeTurnCompletion,
+      stopped = false,
+    ) =>
       Effect.gen(function* () {
-        const previous = context.lastTurnCompletion;
-        if (!stopped && previous?.turnId !== turnId) return;
+        const previous = nativeTurn.completion;
+        if (!stopped && !previous) return;
         yield* offerRuntimeEvent({
           type: "turn.completed",
           provider: PROVIDER,
           threadId: context.threadId,
-          turnId,
-          payload:
-            previous?.turnId === turnId
-              ? previous.payload
-              : { state: "cancelled", stopReason: "cancelled" },
+          turnId: nativeTurn.turnId,
+          payload: previous?.payload ?? { state: "cancelled", stopReason: "cancelled" },
           ...(yield* makeEventStamp()),
         });
       }).pipe(
@@ -820,6 +832,7 @@ export function makeCursorAdapter(
             activeTurnId: undefined,
             cursorSkillNames: undefined,
             promptsInFlight: 0,
+            nativeTurnCompletions: new Set(),
             stopped: false,
           };
 
@@ -968,6 +981,10 @@ export function makeCursorAdapter(
               ctx.activeTurnId = turnId;
               ctx.promptsInFlight += 1;
               return yield* Effect.gen(function* () {
+                const nativeTurn: NativeTurnCompletion = { turnId };
+                const releaseNativeTurn = Effect.sync(() => {
+                  ctx.nativeTurnCompletions.delete(nativeTurn);
+                });
                 const prepare = yield* Effect.cached(
                   Effect.gen(function* () {
                     const turnModelSelection =
@@ -1101,6 +1118,12 @@ export function makeCursorAdapter(
                     ),
                     {
                       beforeSubmit: Effect.gen(function* () {
+                        if (startOptions) {
+                          if (ctx.lastTurnCompletion?.turnId === turnId) {
+                            nativeTurn.completion = ctx.lastTurnCompletion;
+                          }
+                          ctx.nativeTurnCompletions.add(nativeTurn);
+                        }
                         yield* startOptions?.beforeSubmit(turnId) ?? Effect.void;
                         if (
                           ctx.stopped ||
@@ -1117,14 +1140,20 @@ export function makeCursorAdapter(
                       nativeCompleted: startOptions
                         ? startOptions
                             .nativeCompleted(turnId)
-                            .pipe(Effect.andThen(repeatNativeTerminal(ctx, turnId)))
+                            .pipe(
+                              Effect.andThen(repeatNativeTerminal(ctx, nativeTurn)),
+                              Effect.ensuring(releaseNativeTurn),
+                            )
                         : Effect.void,
                       nativeStopped: startOptions
                         ? startOptions.nativeStopped.pipe(
-                            Effect.andThen(repeatNativeTerminal(ctx, turnId, true)),
+                            Effect.andThen(repeatNativeTerminal(ctx, nativeTurn, true)),
+                            Effect.ensuring(releaseNativeTurn),
                           )
                         : Effect.void,
-                      notSubmitted: startOptions?.notSubmitted ?? Effect.void,
+                      notSubmitted: (startOptions?.notSubmitted ?? Effect.void).pipe(
+                        Effect.ensuring(releaseNativeTurn),
+                      ),
                     },
                   )
                   .pipe(

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -36,6 +36,17 @@ import {
 import { execScriptSource, writeFakeCli } from "../../testUtils/fakeCli.ts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 const decodeGrokSettings = Schema.decodeSync(GrokSettings);
+const isCompletedNativePromptLog = Schema.is(
+  Schema.Struct({
+    event: Schema.Struct({
+      kind: Schema.Literal("request"),
+      payload: Schema.Struct({
+        method: Schema.Literal("session/prompt"),
+        status: Schema.Literal("succeeded"),
+      }),
+    }),
+  }),
+);
 
 const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
 const mockAgentPath = NodePath.join(__dirname, "../../../scripts/acp-mock-agent.ts");
@@ -212,22 +223,38 @@ it("requires a settlement to match the live Grok turn", () => {
 });
 
 it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
-  it.effect("records a fresh terminal after native completion follows local cancellation", () =>
+  it.effect("retains an unresolved turn's terminal when a later parked turn is cancelled", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-late-native-proof");
       const wrapperPath = yield* Effect.promise(() => makeMockGrokWrapper());
-      const adapter = yield* makeTestAdapter(wrapperPath);
+      const nativeRequestDone = yield* Deferred.make<void>();
+      const adapter = yield* makeTestAdapter(wrapperPath, {
+        nativeEventLogger: {
+          filePath: "memory://grok-terminal-ordering",
+          write: (record) =>
+            isCompletedNativePromptLog(record)
+              ? Deferred.succeed(nativeRequestDone, undefined).pipe(Effect.asVoid)
+              : Effect.void,
+          close: () => Effect.void,
+        },
+      });
       const nativeReply = yield* Deferred.make<void>();
       const releaseProof = yield* Deferred.make<void>();
       yield* Effect.addFinalizer(() => Deferred.succeed(releaseProof, undefined));
       const terminalBeforeProof = yield* Deferred.make<void>();
       const terminalAfterProof = yield* Deferred.make<void>();
+      const parkedTerminal = yield* Deferred.make<void>();
+      const exited = yield* Deferred.make<void>();
+      let oldTurnId: TurnId | undefined;
       let proved = false;
       const terminalEvents: Array<Extract<ProviderRuntimeEvent, { type: "turn.completed" }>> = [];
       yield* adapter.streamEvents.pipe(
         Stream.runForEach((event) => {
-          if (event.threadId !== threadId || event.type !== "turn.completed") return Effect.void;
+          if (event.threadId !== threadId) return Effect.void;
+          if (event.type === "session.exited") return Deferred.succeed(exited, undefined);
+          if (event.type !== "turn.completed") return Effect.void;
           terminalEvents.push(event);
+          if (event.turnId !== oldTurnId) return Deferred.succeed(parkedTerminal, undefined);
           return Deferred.succeed(proved ? terminalAfterProof : terminalBeforeProof, undefined);
         }),
         Effect.forkChild,
@@ -237,7 +264,10 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
         .sendTurn(
           { threadId, input: "finish this prompt" },
           {
-            beforeSubmit: () => Effect.void,
+            beforeSubmit: (turnId) =>
+              Effect.sync(() => {
+                oldTurnId = turnId;
+              }),
             nativeCompleted: () =>
               Deferred.succeed(nativeReply, undefined).pipe(
                 Effect.andThen(Deferred.await(releaseProof)),
@@ -257,13 +287,38 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
       yield* Fiber.join(sending);
       yield* Deferred.await(terminalBeforeProof);
       assert.isFalse(proved);
+      const entered = yield* Deferred.make<void>();
+      const rejected = yield* Deferred.make<void>();
+      const parked = yield* adapter
+        .sendTurn(
+          { threadId, input: "do not submit this turn" },
+          {
+            beforeSubmit: (turnId) =>
+              Effect.gen(function* () {
+                assert.notEqual(turnId, oldTurnId);
+                yield* Deferred.succeed(entered, undefined);
+                return yield* Effect.never;
+              }),
+            nativeCompleted: () => Effect.die("The parked turn was never submitted."),
+            nativeStopped: Effect.die("The parked turn has no native work."),
+            notSubmitted: Deferred.succeed(rejected, undefined).pipe(Effect.asVoid),
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(entered);
+      yield* Fiber.interrupt(parked);
+      yield* Deferred.await(rejected);
+      yield* adapter.interruptTurn(threadId);
+      yield* Deferred.await(parkedTerminal);
       yield* Deferred.succeed(releaseProof, undefined);
-      yield* Deferred.await(terminalAfterProof);
-      assert.lengthOf(terminalEvents, 2);
-      assert.equal(terminalEvents[0]?.turnId, terminalEvents[1]?.turnId);
-      assert.deepEqual(terminalEvents[0]?.payload, terminalEvents[1]?.payload);
-      assert.notEqual(terminalEvents[0]?.eventId, terminalEvents[1]?.eventId);
+      yield* Deferred.await(nativeRequestDone);
       yield* adapter.stopSession(threadId);
+      yield* Deferred.await(exited);
+      assert.isTrue(yield* Deferred.isDone(terminalAfterProof));
+      assert.lengthOf(terminalEvents, 3);
+      assert.equal(terminalEvents[0]?.turnId, terminalEvents[2]?.turnId);
+      assert.deepEqual(terminalEvents[0]?.payload, terminalEvents[2]?.payload);
+      assert.notEqual(terminalEvents[0]?.eventId, terminalEvents[2]?.eventId);
     }),
   );
 

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -212,6 +212,116 @@ it("requires a settlement to match the live Grok turn", () => {
 });
 
 it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
+  it.effect("records a fresh terminal after native completion follows local cancellation", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-late-native-proof");
+      const wrapperPath = yield* Effect.promise(() => makeMockGrokWrapper());
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const nativeReply = yield* Deferred.make<void>();
+      const releaseProof = yield* Deferred.make<void>();
+      yield* Effect.addFinalizer(() => Deferred.succeed(releaseProof, undefined));
+      const terminalBeforeProof = yield* Deferred.make<void>();
+      const terminalAfterProof = yield* Deferred.make<void>();
+      let proved = false;
+      const terminalEvents: Array<Extract<ProviderRuntimeEvent, { type: "turn.completed" }>> = [];
+      yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) => {
+          if (event.threadId !== threadId || event.type !== "turn.completed") return Effect.void;
+          terminalEvents.push(event);
+          return Deferred.succeed(proved ? terminalAfterProof : terminalBeforeProof, undefined);
+        }),
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({ threadId, cwd: process.cwd(), runtimeMode: "full-access" });
+      const sending = yield* adapter
+        .sendTurn(
+          { threadId, input: "finish this prompt" },
+          {
+            beforeSubmit: () => Effect.void,
+            nativeCompleted: () =>
+              Deferred.succeed(nativeReply, undefined).pipe(
+                Effect.andThen(Deferred.await(releaseProof)),
+                Effect.andThen(
+                  Effect.sync(() => {
+                    proved = true;
+                  }),
+                ),
+              ),
+            nativeStopped: Effect.void,
+            notSubmitted: Effect.die("This prompt has a real native reply."),
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(nativeReply);
+      yield* adapter.interruptTurn(threadId);
+      yield* Fiber.join(sending);
+      yield* Deferred.await(terminalBeforeProof);
+      assert.isFalse(proved);
+      yield* Deferred.succeed(releaseProof, undefined);
+      yield* Deferred.await(terminalAfterProof);
+      assert.lengthOf(terminalEvents, 2);
+      assert.equal(terminalEvents[0]?.turnId, terminalEvents[1]?.turnId);
+      assert.deepEqual(terminalEvents[0]?.payload, terminalEvents[1]?.payload);
+      assert.notEqual(terminalEvents[0]?.eventId, terminalEvents[1]?.eventId);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("cancels a parked native admission and admits a later turn", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-parked-native-admission");
+      const directory = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-admission-")),
+      );
+      const requestLog = NodePath.join(directory, "requests.ndjson");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({ T3_ACP_REQUEST_LOG_PATH: requestLog }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const entered = yield* Deferred.make<void>();
+      const release = yield* Deferred.make<void>();
+      const rejected = yield* Deferred.make<void>();
+      yield* adapter.startSession({ threadId, cwd: process.cwd(), runtimeMode: "full-access" });
+      const parked = yield* adapter
+        .sendTurn(
+          { threadId, input: "must not run" },
+          {
+            beforeSubmit: () =>
+              Deferred.succeed(entered, undefined).pipe(Effect.andThen(Deferred.await(release))),
+            nativeCompleted: () => Effect.die("A parked prompt cannot complete natively."),
+            notSubmitted: Deferred.succeed(rejected, undefined).pipe(Effect.asVoid),
+            nativeStopped: Effect.die("A parked prompt has no native work to stop."),
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(entered);
+      yield* Fiber.interrupt(parked);
+      assert.isTrue(yield* Deferred.isDone(rejected));
+      yield* adapter.interruptTurn(threadId);
+      yield* Deferred.succeed(release, undefined);
+      const proofs: string[] = [];
+      const accepted = yield* adapter.sendTurn(
+        { threadId, input: "can run" },
+        {
+          beforeSubmit: (turnId) =>
+            Effect.sync(() => {
+              proofs.push(`submit:${turnId}`);
+            }),
+          nativeCompleted: (turnId) =>
+            Effect.sync(() => {
+              proofs.push(`complete:${turnId}`);
+            }),
+          nativeStopped: Effect.void,
+          notSubmitted: Effect.die("The replacement prompt must be submitted."),
+        },
+      );
+      assert.deepEqual(proofs, [`submit:${accepted.turnId}`, `complete:${accepted.turnId}`]);
+      yield* adapter.stopSession(threadId);
+      const requests = yield* Effect.promise(() => readJsonLines(requestLog));
+      assert.equal(requests.filter((request) => request.method === "session/prompt").length, 1);
+    }),
+  );
+
   it.effect("sends runtime context with the current model without changing saved prompts", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-runtime-context");

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -1774,11 +1774,9 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                         liveCtx.interruptedTurnIds.has(prepared.turnId) ||
                         prepared.promptEpoch < liveCtx.discardBeforeEpoch
                       ) {
-                        return yield* new EffectAcpErrors.AcpTransportError({
-                          method: "session/prompt",
-                          detail: "The Grok turn changed before prompt submission.",
-                          cause: undefined,
-                        });
+                        return yield* EffectAcpErrors.AcpRequestError.invalidRequest(
+                          "The Grok turn changed before prompt submission.",
+                        );
                       }
                     }),
                     nativeCompleted: startOptions

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -129,8 +129,13 @@ interface GrokTurnLivenessSignal {
   readonly turnId: TurnId;
 }
 
+interface GrokNativeTurnCompletion {
+  readonly turnId: TurnId;
+  completion: Extract<ProviderRuntimeEvent, { type: "turn.completed" }> | undefined;
+}
+
 interface GrokSessionContext {
-  lastTurnCompletion?: Extract<ProviderRuntimeEvent, { type: "turn.completed" }>;
+  readonly nativeTurnCompletions: Set<GrokNativeTurnCompletion>;
   readonly threadId: ThreadId;
   readonly acpSessionId: string;
   session: ProviderSession;
@@ -410,25 +415,28 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
       Effect.gen(function* () {
         if (event.type === "turn.completed") {
           const context = sessions.get(event.threadId);
-          if (context) context.lastTurnCompletion = event;
+          for (const pending of context?.nativeTurnCompletions ?? []) {
+            if (pending.turnId === event.turnId) pending.completion = event;
+          }
         }
         yield* PubSub.publish(runtimeEventPubSub, event);
       });
     // A local terminal can precede native completion. Capture again after proof,
-    // using the last result so a late cancelled steer cannot replace the final result.
-    const repeatNativeTerminal = (context: GrokSessionContext, turnId: TurnId, stopped = false) =>
+    // using that outstanding request's terminal even if another turn has ended.
+    const repeatNativeTerminal = (
+      context: GrokSessionContext,
+      pending: GrokNativeTurnCompletion,
+      stopped = false,
+    ) =>
       Effect.gen(function* () {
-        const previous = context.lastTurnCompletion;
-        if (!stopped && previous?.turnId !== turnId) return;
+        const previous = pending.completion;
+        if (!stopped && previous === undefined) return;
         yield* offerRuntimeEvent({
           type: "turn.completed",
           provider: PROVIDER,
           threadId: context.threadId,
-          turnId,
-          payload:
-            previous?.turnId === turnId
-              ? previous.payload
-              : { state: "cancelled", stopReason: "cancelled" },
+          turnId: pending.turnId,
+          payload: previous?.payload ?? { state: "cancelled", stopReason: "cancelled" },
           ...(yield* makeEventStamp()),
         });
       }).pipe(
@@ -1301,6 +1309,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
           };
 
           const ctx: GrokSessionContext = {
+            nativeTurnCompletions: new Set(),
             threadId: input.threadId,
             acpSessionId: started.sessionId,
             session,
@@ -1730,6 +1739,13 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 return { _tag: "Skipped" as const, interrupted: true };
               }
               const dispatched = yield* Deferred.make<void>();
+              const nativeCompletion: GrokNativeTurnCompletion = {
+                turnId: prepared.turnId,
+                completion: undefined,
+              };
+              const forgetNativeCompletion = Effect.sync(() =>
+                liveCtx.nativeTurnCompletions.delete(nativeCompletion),
+              );
               const fiber = yield* liveCtx.acp
                 .prompt(
                   {
@@ -1741,6 +1757,15 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                   {
                     dispatched,
                     beforeSubmit: Effect.gen(function* () {
+                      if (startOptions) {
+                        for (const pending of liveCtx.nativeTurnCompletions) {
+                          if (pending.turnId === prepared.turnId) {
+                            nativeCompletion.completion = pending.completion;
+                            break;
+                          }
+                        }
+                        liveCtx.nativeTurnCompletions.add(nativeCompletion);
+                      }
                       yield* startOptions?.beforeSubmit(prepared.turnId) ?? Effect.void;
                       if (
                         liveCtx.stopped ||
@@ -1759,14 +1784,20 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                     nativeCompleted: startOptions
                       ? startOptions
                           .nativeCompleted(prepared.turnId)
-                          .pipe(Effect.andThen(repeatNativeTerminal(liveCtx, prepared.turnId)))
+                          .pipe(
+                            Effect.andThen(repeatNativeTerminal(liveCtx, nativeCompletion)),
+                            Effect.ensuring(forgetNativeCompletion),
+                          )
                       : Effect.void,
                     nativeStopped: startOptions
                       ? startOptions.nativeStopped.pipe(
-                          Effect.andThen(repeatNativeTerminal(liveCtx, prepared.turnId, true)),
+                          Effect.andThen(repeatNativeTerminal(liveCtx, nativeCompletion, true)),
+                          Effect.ensuring(forgetNativeCompletion),
                         )
                       : Effect.void,
-                    notSubmitted: startOptions?.notSubmitted ?? Effect.void,
+                    notSubmitted: (startOptions?.notSubmitted ?? Effect.void).pipe(
+                      Effect.ensuring(forgetNativeCompletion),
+                    ),
                   },
                 )
                 .pipe(Effect.forkChild({ startImmediately: true }));

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -130,6 +130,7 @@ interface GrokTurnLivenessSignal {
 }
 
 interface GrokSessionContext {
+  lastTurnCompletion?: Extract<ProviderRuntimeEvent, { type: "turn.completed" }>;
   readonly threadId: ThreadId;
   readonly acpSessionId: string;
   session: ProviderSession;
@@ -406,7 +407,35 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
       );
 
     const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
-      PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
+      Effect.gen(function* () {
+        if (event.type === "turn.completed") {
+          const context = sessions.get(event.threadId);
+          if (context) context.lastTurnCompletion = event;
+        }
+        yield* PubSub.publish(runtimeEventPubSub, event);
+      });
+    // A local terminal can precede native completion. Capture again after proof,
+    // using the last result so a late cancelled steer cannot replace the final result.
+    const repeatNativeTerminal = (context: GrokSessionContext, turnId: TurnId, stopped = false) =>
+      Effect.gen(function* () {
+        const previous = context.lastTurnCompletion;
+        if (!stopped && previous?.turnId !== turnId) return;
+        yield* offerRuntimeEvent({
+          type: "turn.completed",
+          provider: PROVIDER,
+          threadId: context.threadId,
+          turnId,
+          payload:
+            previous?.turnId === turnId
+              ? previous.payload
+              : { state: "cancelled", stopReason: "cancelled" },
+          ...(yield* makeEventStamp()),
+        });
+      }).pipe(
+        Effect.catch((cause) =>
+          Effect.logError("Failed to record native Grok completion.", { cause }),
+        ),
+      );
 
     const getThreadSemaphore = (threadId: string) =>
       SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
@@ -1472,7 +1501,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
         }).pipe(Effect.scoped),
       );
 
-    const sendTurn: GrokAdapterShape["sendTurn"] = (input) =>
+    const sendTurn: GrokAdapterShape["sendTurn"] = (input, startOptions) =>
       Effect.gen(function* () {
         const prepared = yield* withThreadLock(
           input.threadId,
@@ -1709,7 +1738,36 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                       { type: "text", text: prepared.runtimeInstructions },
                     ],
                   },
-                  { dispatched },
+                  {
+                    dispatched,
+                    beforeSubmit: Effect.gen(function* () {
+                      yield* startOptions?.beforeSubmit(prepared.turnId) ?? Effect.void;
+                      if (
+                        liveCtx.stopped ||
+                        sessions.get(input.threadId) !== liveCtx ||
+                        liveCtx.activeTurnId !== prepared.turnId ||
+                        liveCtx.interruptedTurnIds.has(prepared.turnId) ||
+                        prepared.promptEpoch < liveCtx.discardBeforeEpoch
+                      ) {
+                        return yield* new EffectAcpErrors.AcpTransportError({
+                          method: "session/prompt",
+                          detail: "The Grok turn changed before prompt submission.",
+                          cause: undefined,
+                        });
+                      }
+                    }),
+                    nativeCompleted: startOptions
+                      ? startOptions
+                          .nativeCompleted(prepared.turnId)
+                          .pipe(Effect.andThen(repeatNativeTerminal(liveCtx, prepared.turnId)))
+                      : Effect.void,
+                    nativeStopped: startOptions
+                      ? startOptions.nativeStopped.pipe(
+                          Effect.andThen(repeatNativeTerminal(liveCtx, prepared.turnId, true)),
+                        )
+                      : Effect.void,
+                    notSubmitted: startOptions?.notSubmitted ?? Effect.void,
+                  },
                 )
                 .pipe(Effect.forkChild({ startImmediately: true }));
               // Hold the lifecycle permit until the runtime has registered this
@@ -1718,7 +1776,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               yield* Effect.raceFirst(
                 Deferred.await(dispatched),
                 Fiber.await(fiber).pipe(Effect.asVoid),
-              );
+              ).pipe(Effect.onInterrupt(() => Fiber.interrupt(fiber)));
               return { _tag: "Started" as const, fiber };
             }),
           );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1633,7 +1633,9 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
           stopKind === "external Stop"
             ? yield* OpenCodeAdapter
             : yield* makeOpenCodeAdapter(
-                Schema.decodeSync(OpenCodeSettings)({ binaryPath: "fake-opencode" }),
+                yield* Schema.decodeUnknownEffect(OpenCodeSettings)({
+                  binaryPath: "fake-opencode",
+                }),
               ).pipe(
                 Effect.provideService(OpenCodeRuntime, {
                   ...OpenCodeRuntimeTestDouble,

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -37,6 +37,7 @@ import { ServerSettingsService } from "../../serverSettings.ts";
 import { buildRuntimeInstructions } from "../RuntimeInstructions.ts";
 import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory.ts";
 import type { OpenCodeAdapterShape } from "../Services/OpenCodeAdapter.ts";
+import type { ProviderTurnStartOptions } from "../Services/ProviderAdapter.ts";
 import {
   OpenCodeRuntime,
   OpenCodeRuntimeError,
@@ -567,6 +568,18 @@ beforeEach(() => {
 
 const advanceTestClock = (ms: number) =>
   TestClock.adjust(`${ms} millis`).pipe(Effect.andThen(Effect.yieldNow));
+
+function admissionOptions(
+  overrides: Partial<ProviderTurnStartOptions> = {},
+): ProviderTurnStartOptions {
+  return {
+    beforeSubmit: () => Effect.void,
+    notSubmitted: Effect.void,
+    nativeCompleted: () => Effect.void,
+    nativeStopped: Effect.void,
+    ...overrides,
+  };
+}
 
 function promiseWithResolvers<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -1390,6 +1403,293 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("waits for admission before submitting or marking a new turn running", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-native-admission");
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const entered = yield* Deferred.make<void>();
+      const release = yield* Deferred.make<void>();
+      const send = yield* adapter
+        .sendTurn(
+          {
+            threadId,
+            input: "First",
+            modelSelection: createModelSelection(
+              ProviderInstanceId.make("opencode"),
+              "openai/gpt-5",
+            ),
+          },
+          admissionOptions({
+            beforeSubmit: () =>
+              Deferred.succeed(entered, undefined).pipe(Effect.andThen(Deferred.await(release))),
+          }),
+        )
+        .pipe(Effect.forkChild);
+      const admission = yield* Effect.raceFirst(
+        Deferred.await(entered).pipe(Effect.as("waiting")),
+        Fiber.join(send).pipe(Effect.as("submitted")),
+      );
+      NodeAssert.equal(admission, "waiting");
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 0);
+      NodeAssert.equal((yield* adapter.listSessions())[0]?.activeTurnId, undefined);
+      yield* Deferred.succeed(release, undefined);
+      const first = yield* Fiber.join(send);
+      const second = yield* adapter.sendTurn(
+        {
+          threadId,
+          input: "Steer",
+          modelSelection: createModelSelection(ProviderInstanceId.make("opencode"), "openai/gpt-5"),
+        },
+        admissionOptions(),
+      );
+      NodeAssert.equal(second.turnId, first.turnId);
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 2);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("joins a parked native send before Stop and cancels only that submission", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-cancel-parked-native-send");
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn(
+        {
+          threadId,
+          input: "First",
+          modelSelection: createModelSelection(ProviderInstanceId.make("opencode"), "openai/gpt-5"),
+        },
+        admissionOptions(),
+      );
+      const entered = yield* Deferred.make<void>();
+      const release = yield* Deferred.make<void>();
+      let childJoined = false;
+      let rejected = false;
+      const send = yield* adapter
+        .sendTurn(
+          {
+            threadId,
+            input: "Parked",
+            modelSelection: createModelSelection(
+              ProviderInstanceId.make("opencode"),
+              "openai/gpt-5",
+            ),
+          },
+          admissionOptions({
+            beforeSubmit: () =>
+              Deferred.succeed(entered, undefined).pipe(
+                Effect.andThen(Deferred.await(release)),
+                Effect.ensuring(
+                  Effect.sync(() => {
+                    childJoined = true;
+                  }),
+                ),
+              ),
+            notSubmitted: Effect.sync(() => {
+              rejected = true;
+            }),
+          }),
+        )
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(entered);
+      yield* Fiber.interrupt(send);
+      NodeAssert.equal(childJoined, true);
+      NodeAssert.equal(rejected, true);
+      runtimeMock.state.abortImplementation = async () => {
+        NodeAssert.equal(childJoined, true);
+      };
+      yield* adapter.stopSession(threadId);
+      yield* Deferred.succeed(release, undefined);
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 1);
+    }),
+  );
+
+  it.effect("requires the matching terminal assistant before idle can finish a native prompt", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-native-terminal");
+      const wrongParent = promiseWithResolvers<unknown>();
+      const unfinished = promiseWithResolvers<unknown>();
+      const invalid = promiseWithResolvers<unknown>();
+      const idleBeforeTerminal = promiseWithResolvers<unknown>();
+      const marker = promiseWithResolvers<unknown>();
+      const terminal = promiseWithResolvers<unknown>();
+      const finalIdle = promiseWithResolvers<unknown>();
+      const nativeIdle = {
+        type: "session.status",
+        properties: { sessionID: "http://127.0.0.1:9999/session", status: { type: "idle" } },
+      };
+      runtimeMock.state.subscribedEvents = [
+        wrongParent.promise,
+        nativeIdle,
+        unfinished.promise,
+        nativeIdle,
+        invalid.promise,
+        idleBeforeTerminal.promise,
+        marker.promise,
+        terminal.promise,
+        {
+          type: "session.status",
+          properties: { sessionID: "http://127.0.0.1:9999/session", status: { type: "busy" } },
+        },
+        finalIdle.promise,
+      ];
+      const markerSeen = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "thread.metadata.updated"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const completed = yield* Deferred.make<void>();
+      let completions = 0;
+      const completedTurnIds: Array<string> = [];
+      const turn = yield* adapter.sendTurn(
+        {
+          threadId,
+          input: "First",
+          modelSelection: createModelSelection(ProviderInstanceId.make("opencode"), "openai/gpt-5"),
+        },
+        admissionOptions({
+          nativeCompleted: (turnId) =>
+            Effect.gen(function* () {
+              completedTurnIds.push(turnId);
+              completions += 1;
+              yield* Deferred.succeed(completed, undefined);
+            }),
+        }),
+      );
+      const prompt = runtimeMock.state.promptCalls[0] as { messageID: string };
+      const message = {
+        id: "assistant-native-terminal",
+        role: "assistant",
+        parentID: prompt.messageID,
+        time: { created: 1, completed: 2 },
+        finish: "tool-calls",
+      };
+      wrongParent.resolve({
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: { ...message, parentID: "unrelated-prompt", finish: "stop" },
+        },
+      });
+      unfinished.resolve({
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: { ...message, time: { created: 1 }, finish: "stop" },
+        },
+      });
+      invalid.resolve({
+        type: "message.updated",
+        properties: { sessionID: "http://127.0.0.1:9999/session", info: message },
+      });
+      idleBeforeTerminal.resolve({
+        type: "session.status",
+        properties: { sessionID: "http://127.0.0.1:9999/session", status: { type: "idle" } },
+      });
+      marker.resolve({
+        type: "session.updated",
+        properties: { info: { id: "http://127.0.0.1:9999/session", title: "Events drained" } },
+      });
+      yield* Fiber.join(markerSeen);
+      NodeAssert.equal(completions, 0);
+      terminal.resolve({
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: { ...message, finish: "stop" },
+        },
+      });
+      finalIdle.resolve({
+        type: "session.status",
+        properties: { sessionID: "http://127.0.0.1:9999/session", status: { type: "idle" } },
+      });
+      yield* Deferred.await(completed);
+      NodeAssert.equal(completions, 1);
+      NodeAssert.deepEqual(completedTurnIds, [turn.turnId]);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("keeps observing unknown external work after Stop", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-native-unknown-stop");
+      const terminal = promiseWithResolvers<unknown>();
+      const idle = promiseWithResolvers<unknown>();
+      runtimeMock.state.autoPromptEcho = false;
+      runtimeMock.state.subscribedEvents = [terminal.promise, idle.promise];
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const completed = yield* Deferred.make<void>();
+      let completions = 0;
+      let rejected = false;
+      runtimeMock.state.promptAsyncError = new Error("Response lost after native submission");
+      yield* adapter
+        .sendTurn(
+          {
+            threadId,
+            input: "First",
+            modelSelection: createModelSelection(
+              ProviderInstanceId.make("opencode"),
+              "openai/gpt-5",
+            ),
+          },
+          admissionOptions({
+            notSubmitted: Effect.sync(() => {
+              rejected = true;
+            }),
+            nativeCompleted: () =>
+              Effect.gen(function* () {
+                completions += 1;
+                yield* Deferred.succeed(completed, undefined);
+              }),
+          }),
+        )
+        .pipe(Effect.flip);
+      yield* adapter.stopSession(threadId);
+      NodeAssert.equal(completions, 0);
+      NodeAssert.equal(rejected, false);
+      const prompt = runtimeMock.state.promptCalls[0] as { messageID: string };
+      terminal.resolve({
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: {
+            id: "assistant-after-stop",
+            role: "assistant",
+            parentID: prompt.messageID,
+            time: { created: 1, completed: 2 },
+            finish: "stop",
+          },
+        },
+      });
+      idle.resolve({
+        type: "session.status",
+        properties: { sessionID: "http://127.0.0.1:9999/session", status: { type: "idle" } },
+      });
+      yield* Deferred.await(completed);
+      NodeAssert.equal(completions, 1);
+    }),
+  );
+
   it.effect("rolls back session state when sendTurn fails before OpenCode accepts the prompt", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
@@ -1668,6 +1968,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         })
         .pipe(Effect.forkChild);
       yield* Effect.promise(() => steerStarted.promise);
+      const statusCallsBeforeIdle = runtimeMock.state.sessionStatusCalls;
       const firstMessageId = (runtimeMock.state.promptCalls[0] as { messageID?: string }).messageID;
       const steerMessageId = (runtimeMock.state.promptCalls[1] as { messageID?: string }).messageID;
       NodeAssert.match(firstMessageId ?? "", /^msg_[0-9a-f]{12}[0-9A-Za-z]{14}$/);
@@ -1705,7 +2006,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         },
       });
       yield* Effect.yieldNow;
-      NodeAssert.equal(runtimeMock.state.sessionStatusCalls, 0);
+      NodeAssert.equal(runtimeMock.state.sessionStatusCalls, statusCallsBeforeIdle);
       steerRelease.resolve(undefined);
       yield* Fiber.join(steerFiber);
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1625,70 +1625,104 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
-  it.effect("keeps observing unknown external work after Stop", () =>
-    Effect.gen(function* () {
-      const adapter = yield* OpenCodeAdapter;
-      const threadId = asThreadId("thread-native-unknown-stop");
-      const terminal = promiseWithResolvers<unknown>();
-      const idle = promiseWithResolvers<unknown>();
-      runtimeMock.state.autoPromptEcho = false;
-      runtimeMock.state.subscribedEvents = [terminal.promise, idle.promise];
-      yield* adapter.startSession({
-        provider: ProviderDriverKind.make("opencode"),
-        threadId,
-        runtimeMode: "full-access",
-      });
-      const completed = yield* Deferred.make<void>();
-      let completions = 0;
-      let rejected = false;
-      runtimeMock.state.promptAsyncError = new Error("Response lost after native submission");
-      yield* adapter
-        .sendTurn(
-          {
-            threadId,
-            input: "First",
-            modelSelection: createModelSelection(
-              ProviderInstanceId.make("opencode"),
-              "openai/gpt-5",
-            ),
-          },
-          admissionOptions({
-            notSubmitted: Effect.sync(() => {
-              rejected = true;
-            }),
-            nativeCompleted: () =>
-              Effect.gen(function* () {
-                completions += 1;
-                yield* Deferred.succeed(completed, undefined);
+  for (const stopKind of ["external Stop", "local launcher exit"] as const) {
+    it.effect(`keeps observing unknown native work after ${stopKind}`, () =>
+      Effect.gen(function* () {
+        const launcherExit = yield* Deferred.make<number>();
+        const adapter =
+          stopKind === "external Stop"
+            ? yield* OpenCodeAdapter
+            : yield* makeOpenCodeAdapter(
+                Schema.decodeSync(OpenCodeSettings)({ binaryPath: "fake-opencode" }),
+              ).pipe(
+                Effect.provideService(OpenCodeRuntime, {
+                  ...OpenCodeRuntimeTestDouble,
+                  connectToOpenCodeServer: (input) =>
+                    OpenCodeRuntimeTestDouble.connectToOpenCodeServer(input).pipe(
+                      Effect.map((server) => ({
+                        ...server,
+                        exitCode: Deferred.await(launcherExit),
+                      })),
+                    ),
+                }),
+              );
+        const threadId = asThreadId("thread-native-unknown-stop");
+        const terminal = promiseWithResolvers<unknown>();
+        const idle = promiseWithResolvers<unknown>();
+        runtimeMock.state.autoPromptEcho = false;
+        runtimeMock.state.subscribedEvents = [terminal.promise, idle.promise];
+        yield* adapter.startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "full-access",
+        });
+        const completed = yield* Deferred.make<void>();
+        let completions = 0;
+        let nativeStops = 0;
+        let rejected = false;
+        runtimeMock.state.promptAsyncError = new Error("Response lost after native submission");
+        yield* adapter
+          .sendTurn(
+            {
+              threadId,
+              input: "First",
+              modelSelection: createModelSelection(
+                ProviderInstanceId.make("opencode"),
+                "openai/gpt-5",
+              ),
+            },
+            admissionOptions({
+              nativeStopped: Effect.sync(() => {
+                nativeStops += 1;
               }),
-          }),
-        )
-        .pipe(Effect.flip);
-      yield* adapter.stopSession(threadId);
-      NodeAssert.equal(completions, 0);
-      NodeAssert.equal(rejected, false);
-      const prompt = runtimeMock.state.promptCalls[0] as { messageID: string };
-      terminal.resolve({
-        type: "message.updated",
-        properties: {
-          sessionID: "http://127.0.0.1:9999/session",
-          info: {
-            id: "assistant-after-stop",
-            role: "assistant",
-            parentID: prompt.messageID,
-            time: { created: 1, completed: 2 },
-            finish: "stop",
+              notSubmitted: Effect.sync(() => {
+                rejected = true;
+              }),
+              nativeCompleted: () =>
+                Effect.gen(function* () {
+                  completions += 1;
+                  yield* Deferred.succeed(completed, undefined);
+                }),
+            }),
+          )
+          .pipe(Effect.flip);
+        if (stopKind === "external Stop") {
+          yield* adapter.stopSession(threadId);
+        } else {
+          const exited = yield* adapter.streamEvents.pipe(
+            Stream.filter((event) => event.type === "session.exited"),
+            Stream.runHead,
+            Effect.forkChild,
+          );
+          yield* Deferred.succeed(launcherExit, 0);
+          yield* Fiber.join(exited);
+        }
+        NodeAssert.equal(completions, 0);
+        NodeAssert.equal(nativeStops, 0);
+        NodeAssert.equal(rejected, false);
+        const prompt = runtimeMock.state.promptCalls[0] as { messageID: string; sessionID: string };
+        terminal.resolve({
+          type: "message.updated",
+          properties: {
+            sessionID: prompt.sessionID,
+            info: {
+              id: "assistant-after-stop",
+              role: "assistant",
+              parentID: prompt.messageID,
+              time: { created: 1, completed: 2 },
+              finish: "stop",
+            },
           },
-        },
-      });
-      idle.resolve({
-        type: "session.status",
-        properties: { sessionID: "http://127.0.0.1:9999/session", status: { type: "idle" } },
-      });
-      yield* Deferred.await(completed);
-      NodeAssert.equal(completions, 1);
-    }),
-  );
+        });
+        idle.resolve({
+          type: "session.status",
+          properties: { sessionID: prompt.sessionID, status: { type: "idle" } },
+        });
+        yield* Deferred.await(completed);
+        NodeAssert.equal(completions, 1);
+      }),
+    );
+  }
 
   it.effect("rolls back session state when sendTurn fails before OpenCode accepts the prompt", () =>
     Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -535,6 +535,7 @@ const providerSessionDirectoryTestLayer = Layer.succeed(ProviderSessionDirectory
 // the layer graph reach for it — but the routing values the assertions
 // probe (serverUrl, serverPassword) must be threaded directly through the
 // decoded `OpenCodeSettings`.
+const decodeOpenCodeSettings = Schema.decodeUnknownEffect(OpenCodeSettings);
 const openCodeAdapterTestSettings = Schema.decodeSync(OpenCodeSettings)({
   binaryPath: "fake-opencode",
   serverUrl: "http://127.0.0.1:9999",
@@ -1633,7 +1634,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
           stopKind === "external Stop"
             ? yield* OpenCodeAdapter
             : yield* makeOpenCodeAdapter(
-                yield* Schema.decodeUnknownEffect(OpenCodeSettings)({
+                yield* decodeOpenCodeSettings({
                   binaryPath: "fake-opencode",
                 }),
               ).pipe(

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -45,6 +45,7 @@ import {
 } from "../Errors.ts";
 import { buildRuntimeInstructions } from "../RuntimeInstructions.ts";
 import { type OpenCodeAdapterShape } from "../Services/OpenCodeAdapter.ts";
+import type { ProviderTurnStartOptions } from "../Services/ProviderAdapter.ts";
 import {
   buildOpenCodePermissionRules,
   OpenCodeRuntime,
@@ -226,7 +227,7 @@ interface OpenCodePromptAdmission {
   cancelled: boolean;
   readonly acceptance: Deferred.Deferred<void>;
   readonly submissionSettled: Deferred.Deferred<void>;
-  promptFiber?: Fiber.Fiber<void, ProviderAdapterRequestError>;
+  promptFiber?: Fiber.Fiber<boolean, ProviderAdapterRequestError>;
   recoveryFiber?: Fiber.Fiber<void, never>;
   recoveryRaw: unknown;
 }
@@ -353,6 +354,14 @@ interface OpenCodeSessionContext {
   promptGeneration: number;
   promptAdmission: OpenCodePromptAdmission | undefined;
   readonly promptSemaphore: Semaphore.Semaphore;
+  readonly nativeSubmissions: Map<
+    string,
+    {
+      readonly turnId: TurnId;
+      readonly options: ProviderTurnStartOptions;
+      terminalObserved: boolean;
+    }
+  >;
   readonly firstConnection: Deferred.Deferred<void, ProviderAdapterRequestError>;
   /**
    * One-shot guard flipped by `stopOpenCodeContext` / `emitUnexpectedExit`.
@@ -877,9 +886,11 @@ const closeStartingOpenCodeContext = Effect.fn("closeStartingOpenCodeContext")(f
 
 const stopOpenCodeContext = Effect.fn("stopOpenCodeContext")(function* (
   context: OpenCodeSessionContext,
+  closeObserver = false,
 ) {
   // Race-safe one-shot: first caller flips the flag, everyone else no-ops.
   if (yield* Ref.getAndSet(context.stopped, true)) {
+    if (closeObserver) yield* Scope.close(context.sessionScope, Exit.void);
     return false;
   }
   yield* Deferred.fail(
@@ -903,10 +914,11 @@ const stopOpenCodeContext = Effect.fn("stopOpenCodeContext")(function* (
   // but we still want to tell OpenCode that this session is done.
   yield* abortOpenCodeSessionForTeardown(context);
 
-  // Closing the session scope interrupts every fiber forked into it and
-  // runs each finalizer we registered — the `AbortController.abort()` call,
-  // the child-process termination, etc.
-  yield* Scope.close(context.sessionScope, Exit.void);
+  // Keep native receipts observable after Stop. An abort response can precede
+  // prompt preparation, so only a matching terminal result can release them.
+  if (closeObserver || context.nativeSubmissions.size === 0) {
+    yield* Scope.close(context.sessionScope, Exit.void);
+  }
   return true;
 });
 
@@ -936,6 +948,7 @@ export function makeOpenCodeAdapter(
       options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
     const runtimeEvents = yield* Queue.unbounded<ProviderRuntimeEvent>();
     const sessions = new Map<ThreadId, OpenCodeSessionContext>();
+    const sessionContexts = new Set<OpenCodeSessionContext>();
     const deleteContextIfCurrent = (context: OpenCodeSessionContext) => {
       if (sessions.get(context.session.threadId) === context) {
         sessions.delete(context.session.threadId);
@@ -1028,14 +1041,14 @@ export function makeOpenCodeAdapter(
     // cannot leak OpenCode child processes by forgetting to call `stopAll`.
     yield* Effect.addFinalizer(() =>
       Effect.gen(function* () {
-        const contexts = [...sessions.values()];
+        const contexts = [...sessionContexts];
         sessions.clear();
         // `ignoreCause` swallows both typed failures (none here) and defects
         // from throwing scope finalizers so a sibling's death can't interrupt
         // the remaining cleanups.
         yield* Effect.forEach(
           contexts,
-          (context) => Effect.ignoreCause(stopOpenCodeContext(context)),
+          (context) => Effect.ignoreCause(stopOpenCodeContext(context, true)),
           { concurrency: "unbounded", discard: true },
         );
         // Close the logger AFTER session teardown so any final lifecycle
@@ -1563,7 +1576,9 @@ export function makeOpenCodeAdapter(
       // delegate to it because our `getAndSet` above already flipped the
       // one-shot guard, so the call would no-op.
       yield* abortOpenCodeSessionForTeardown(context);
-      yield* Scope.close(context.sessionScope, Exit.void);
+      if (context.nativeSubmissions.size === 0) {
+        yield* Scope.close(context.sessionScope, Exit.void);
+      }
     });
 
     /** Emit content.delta and item.completed events for an assistant text part. */
@@ -2148,6 +2163,57 @@ export function makeOpenCodeAdapter(
       context: OpenCodeSessionContext,
       event: OpenCodeSubscribedEvent,
     ) {
+      if (openCodeEventSessionId(event) === context.openCodeSessionId) {
+        if (event.type === "message.updated" && event.properties.info.role === "assistant") {
+          const message = event.properties.info;
+          const submitted = context.nativeSubmissions.get(message.parentID);
+          if (submitted) {
+            submitted.terminalObserved =
+              message.time.completed !== undefined &&
+              (message.error !== undefined ||
+                (message.finish !== undefined &&
+                  message.finish !== "tool-calls" &&
+                  message.finish !== "unknown"));
+          }
+        }
+        if (event.type === "session.status" && event.properties.status.type === "idle") {
+          // OpenCode emits busy once more after a terminal result, before its final idle.
+          // Session status cannot invalidate a result for an exact submitted prompt.
+          const completedTurns = new Set<TurnId>();
+          for (const [messageId, submitted] of context.nativeSubmissions) {
+            // Idle alone can precede native prompt preparation. Require the exact reply first.
+            if (!submitted.terminalObserved) continue;
+            context.nativeSubmissions.delete(messageId);
+            completedTurns.add(submitted.turnId);
+            yield* submitted.options.nativeCompleted(submitted.turnId);
+          }
+          const stopped = yield* Ref.get(context.stopped);
+          for (const turnId of completedTurns) {
+            if (stopped || context.activeTurnId !== turnId) {
+              if (
+                [...context.nativeSubmissions.values()].some(
+                  (submitted) => submitted.turnId === turnId,
+                )
+              )
+                continue;
+              yield* emit({
+                ...(yield* buildEventBase({
+                  threadId: context.session.threadId,
+                  turnId,
+                  raw: event,
+                })),
+                type: "turn.completed",
+                payload: { state: stopped ? "interrupted" : "completed" },
+              });
+            }
+          }
+          if (stopped) {
+            if (context.nativeSubmissions.size === 0)
+              yield* Scope.close(context.sessionScope, Exit.void);
+          }
+        }
+      }
+      if (yield* Ref.get(context.stopped)) return;
       if (event.type === "server.connected") {
         if (
           (yield* Ref.get(context.stopped)) ||
@@ -2751,7 +2817,9 @@ export function makeOpenCodeAdapter(
                 ? openCodeRuntimeErrorDetail(Cause.squash(exit.cause))
                 : lastStreamError !== undefined
                   ? `OpenCode event stream disconnected: ${openCodeRuntimeErrorDetail(lastStreamError)}`
-                  : "OpenCode event stream ended unexpectedly. Send another message to reconnect.",
+                  : context.nativeSubmissions.size > 0
+                    ? "OpenCode event stream ended with unconfirmed native work. New turns remain blocked because completion cannot be observed."
+                    : "OpenCode event stream ended unexpectedly. Send another message to reconnect.",
             );
           }),
         ),
@@ -2981,10 +3049,16 @@ export function makeOpenCodeAdapter(
           promptGeneration: 0,
           promptAdmission: undefined,
           promptSemaphore: Semaphore.makeUnsafe(1),
+          nativeSubmissions: new Map(),
           firstConnection: Deferred.makeUnsafe<void, ProviderAdapterRequestError>(),
           stopped: yield* Ref.make(false),
           sessionScope: started.sessionScope,
         };
+        sessionContexts.add(context);
+        yield* Scope.addFinalizer(
+          context.sessionScope,
+          Effect.sync(() => sessionContexts.delete(context)),
+        );
         const raceWinner = sessions.get(input.threadId);
         if (raceWinner) {
           // Another start published first. A newly created remote session
@@ -3042,367 +3116,392 @@ export function makeOpenCodeAdapter(
       },
     );
 
-    const sendTurn: OpenCodeAdapterShape["sendTurn"] = Effect.fn("sendTurn")(function* (input) {
-      const context = yield* ensureSessionContext(sessions, input.threadId);
-      yield* awaitOpenCodeContextReady(context);
-      const modelSelection =
-        input.modelSelection ??
-        (context.session.model
-          ? { instanceId: boundInstanceId, model: context.session.model }
-          : undefined);
-      if (modelSelection !== undefined && modelSelection.instanceId !== boundInstanceId) {
-        return yield* new ProviderAdapterValidationError({
-          provider: PROVIDER,
-          operation: "sendTurn",
-          issue: `OpenCode model selection is bound to instance '${modelSelection?.instanceId}', expected '${boundInstanceId}'.`,
-        });
-      }
-      const parsedModel = parseOpenCodeModelSlug(modelSelection?.model);
-      if (!parsedModel) {
-        return yield* new ProviderAdapterValidationError({
-          provider: PROVIDER,
-          operation: "sendTurn",
-          issue: "OpenCode model selection must use the 'provider/model' format.",
-        });
-      }
+    const sendTurn: OpenCodeAdapterShape["sendTurn"] = Effect.fn("sendTurn")(
+      function* (input, turnOptions) {
+        const context = yield* ensureSessionContext(sessions, input.threadId);
+        yield* awaitOpenCodeContextReady(context);
+        const modelSelection =
+          input.modelSelection ??
+          (context.session.model
+            ? { instanceId: boundInstanceId, model: context.session.model }
+            : undefined);
+        if (modelSelection !== undefined && modelSelection.instanceId !== boundInstanceId) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "sendTurn",
+            issue: `OpenCode model selection is bound to instance '${modelSelection?.instanceId}', expected '${boundInstanceId}'.`,
+          });
+        }
+        const parsedModel = parseOpenCodeModelSlug(modelSelection?.model);
+        if (!parsedModel) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "sendTurn",
+            issue: "OpenCode model selection must use the 'provider/model' format.",
+          });
+        }
 
-      const text = input.input?.trim();
-      // OpenCode ingests images, text, and PDFs natively; formats its model
-      // paths reject ride only as the prompt's file path line.
-      const fileParts = toOpenCodeFileParts({
-        attachments: input.attachments,
-        resolveAttachmentPath: (attachment) =>
-          resolveAttachmentPath({
-            attachmentsDir: serverConfig.attachmentsDir,
-            attachment,
-          }),
-      });
-      if ((!text || text.length === 0) && fileParts.length === 0) {
-        return yield* new ProviderAdapterValidationError({
-          provider: PROVIDER,
-          operation: "sendTurn",
-          issue: "OpenCode turns require text input or at least one attachment.",
-        });
-      }
-
-      return yield* context.promptSemaphore.withPermit(
-        Effect.gen(function* () {
-          const freshTurnId = TurnId.make(`opencode-turn-${yield* randomUUIDv4}`);
-          const messageId = yield* makeOpenCodeMessageId();
-          const pendingCancellation = context.cancellation;
-          if (pendingCancellation) {
-            const cancellationResult = yield* Deferred.await(pendingCancellation.completion).pipe(
-              Effect.result,
-            );
-            if ((yield* Ref.get(context.stopped)) || sessions.get(input.threadId) !== context) {
-              return yield* Effect.interrupt;
-            }
-            if (cancellationResult._tag === "Failure") {
-              return yield* cancellationResult.failure;
-            }
-          }
-          if (sessions.get(input.threadId) !== context || (yield* Ref.get(context.stopped))) {
-            return yield* Effect.interrupt;
-          }
-          // A sendTurn while a turn is active is a steer. OpenCode queues the
-          // prompt into the running session, so the active turn id is reused.
-          const steeringTurnId = context.activeTurnId;
-          const turnId = steeringTurnId ?? freshTurnId;
-          const agent = getModelSelectionStringOptionValue(modelSelection, "agent");
-          const variant = getModelSelectionStringOptionValue(modelSelection, "variant");
-          const pendingIdleReconciliation = context.pendingIdleReconciliation;
-          const priorAwaitingBusy = context.awaitingBusyAfterInterruption;
-          const priorIdleCandidate = pendingIdleReconciliation
-            ? {
-                turnId: pendingIdleReconciliation.turnId,
-                raw: pendingIdleReconciliation.raw,
-              }
-            : undefined;
-          context.pendingIdleReconciliation = undefined;
-          const promptGeneration = context.promptGeneration + 1;
-          const promptAdmission: OpenCodePromptAdmission = {
-            generation: promptGeneration,
-            turnId,
-            messageId,
-            priorAwaitingBusy,
-            priorIdle: priorIdleCandidate,
-            idleDuringAdmission: undefined,
-            idleObservedAfterMessage: false,
-            messageObserved: false,
-            busyObserved: false,
-            idleStatusConfirmations: 0,
-            accepted: false,
-            cancelled: false,
-            acceptance: Deferred.makeUnsafe<void>(),
-            submissionSettled: Deferred.makeUnsafe<void>(),
-            recoveryRaw: undefined,
-          };
-          context.promptGeneration = promptGeneration;
-          context.promptAdmission = promptAdmission;
-
-          context.activeTurnId = turnId;
-          if (steeringTurnId === undefined) {
-            context.turnTokenUsage = makeOpenCodeTurnTokenUsageAccumulator();
-          }
-          context.turnTokenUsage?.promptMessageIds.add(messageId);
-          context.activeAgent = agent ?? (input.interactionMode === "plan" ? "plan" : undefined);
-          context.activeVariant = variant;
-          if (steeringTurnId === undefined) {
-            context.awaitingBusyAfterInterruption = context.interruptedTurnId !== undefined;
-          }
-          if (pendingIdleReconciliation?.fiber) {
-            yield* Fiber.interrupt(pendingIdleReconciliation.fiber);
-          }
-          yield* updateProviderSession(
-            context,
-            {
-              status: "running",
-              activeTurnId: turnId,
-              model: modelSelection?.model ?? context.session.model,
-            },
-            { clearLastError: true },
-          );
-
-          if (steeringTurnId === undefined) {
-            yield* emit({
-              ...(yield* buildEventBase({ threadId: input.threadId, turnId })),
-              type: "turn.started",
-              payload: {
-                model: modelSelection?.model ?? context.session.model,
-              },
-            });
-          }
-
-          if (promptAdmission.cancelled || (yield* Ref.get(context.stopped))) {
-            yield* Deferred.succeed(promptAdmission.submissionSettled, undefined).pipe(
-              Effect.ignore,
-            );
-            const cancellation = context.cancellation;
-            if (cancellation?.turnId === turnId) {
-              yield* Deferred.await(cancellation.completion).pipe(Effect.result);
-            }
-            return yield* Effect.interrupt;
-          }
-
-          let promptTimedOut = false;
-          const promptEffect = runOpenCodeSdk("session.promptAsync", (signal) =>
-            context.client.session.promptAsync(
-              {
-                sessionID: context.openCodeSessionId,
-                messageID: messageId,
-                model: parsedModel,
-                ...(context.activeAgent ? { agent: context.activeAgent } : {}),
-                ...(context.activeVariant ? { variant: context.activeVariant } : {}),
-                // OpenCode appends this after its own agent/provider prompts.
-                system: buildRuntimeInstructions({
-                  harness: "OpenCode",
-                  model: `${parsedModel.providerID}/${parsedModel.modelID}`,
-                }),
-                parts: [...(text ? [{ type: "text" as const, text }] : []), ...fileParts],
-              },
-              { signal },
-            ),
-          ).pipe(
-            Effect.timeout("10 seconds"),
-            Effect.catchTags({
-              OpenCodeRuntimeError: (cause) => Effect.fail(toRequestError(cause)),
-              TimeoutError: (cause) => {
-                promptTimedOut = true;
-                return Effect.fail(
-                  new ProviderAdapterRequestError({
-                    provider: PROVIDER,
-                    method: "session.promptAsync",
-                    detail: "OpenCode prompt submission did not complete within 10 seconds.",
-                    cause,
-                  }),
-                );
-              },
+        const text = input.input?.trim();
+        // OpenCode ingests images, text, and PDFs natively; formats its model
+        // paths reject ride only as the prompt's file path line.
+        const fileParts = toOpenCodeFileParts({
+          attachments: input.attachments,
+          resolveAttachmentPath: (attachment) =>
+            resolveAttachmentPath({
+              attachmentsDir: serverConfig.attachmentsDir,
+              attachment,
             }),
-            Effect.tapError((requestError) =>
-              context.promptAdmission !== promptAdmission || context.activeTurnId !== turnId
-                ? Effect.void
-                : Effect.gen(function* () {
-                    if (!promptTimedOut) {
-                      if (steeringTurnId !== undefined) {
-                        context.promptAdmission = undefined;
-                        context.awaitingBusyAfterInterruption = promptAdmission.priorAwaitingBusy;
-                        const idle =
-                          promptAdmission.idleDuringAdmission ?? promptAdmission.priorIdle;
-                        if (idle) {
-                          yield* scheduleIdleReconciliation(context, idle.turnId, idle.raw);
-                        }
-                        return;
-                      }
-                      const tokenUsage = takeOpenCodeTurnTokenUsage(context, false);
-                      context.promptAdmission = undefined;
-                      context.activeTurnId = undefined;
-                      context.activeAgent = undefined;
-                      context.activeVariant = undefined;
-                      yield* updateProviderSession(
-                        context,
-                        {
-                          status: "ready",
-                          model: modelSelection?.model ?? context.session.model,
-                          lastError: requestError.detail,
-                        },
-                        { clearActiveTurnId: true },
-                      );
-                      yield* emit({
-                        ...(yield* buildEventBase({ threadId: input.threadId, turnId })),
-                        type: "turn.aborted",
-                        payload: {
-                          reason: requestError.detail,
-                          tokenUsage,
-                        },
-                      });
-                      return;
-                    }
-                    const cleanupExit = yield* Effect.exit(
-                      runOpenCodeSdk("session.abort", (signal) =>
-                        context.client.session.abort(
-                          { sessionID: context.openCodeSessionId },
-                          { signal },
-                        ),
-                      ).pipe(Effect.timeout("1 second")),
-                    );
-                    if (Exit.isFailure(cleanupExit)) {
-                      yield* emit({
-                        ...(yield* buildEventBase({ threadId: input.threadId, turnId })),
-                        type: "runtime.warning",
-                        payload: {
-                          message:
-                            "OpenCode prompt submission failed and its cleanup abort did not complete.",
-                          detail: openCodeRuntimeErrorDetail(Cause.squash(cleanupExit.cause)),
-                        },
-                      });
-                      yield* schedulePromptAdmissionRecovery(context, {
-                        requestError,
-                        cleanupError: Cause.squash(cleanupExit.cause),
-                      });
-                      return;
-                    }
-                    const tokenUsage = takeOpenCodeTurnTokenUsage(context, false);
-                    context.promptAdmission = undefined;
-                    context.activeTurnId = undefined;
-                    context.activeAgent = undefined;
-                    context.activeVariant = undefined;
-                    context.awaitingBusyAfterInterruption = false;
-                    context.reconcileIdleStatus = false;
-                    yield* updateProviderSession(
-                      context,
-                      {
-                        status: "ready",
-                        model: modelSelection?.model ?? context.session.model,
-                        lastError: requestError.detail,
-                      },
-                      { clearActiveTurnId: true },
-                    );
-                    yield* emit({
-                      ...(yield* buildEventBase({
-                        threadId: input.threadId,
-                        turnId,
-                      })),
-                      type: "turn.aborted",
-                      payload: {
-                        reason: requestError.detail,
-                        tokenUsage,
-                      },
-                    });
-                  }),
-            ),
-            Effect.onExit((exit) =>
-              Effect.gen(function* () {
-                yield* Deferred.succeed(promptAdmission.submissionSettled, undefined).pipe(
-                  Effect.ignore,
-                );
-                if (Exit.isFailure(exit)) {
-                  yield* Deferred.succeed(promptAdmission.acceptance, undefined).pipe(
-                    Effect.ignore,
-                  );
+        });
+        if ((!text || text.length === 0) && fileParts.length === 0) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "sendTurn",
+            issue: "OpenCode turns require text input or at least one attachment.",
+          });
+        }
+
+        return yield* context.promptSemaphore.withPermit(
+          Effect.gen(function* () {
+            while (true) {
+              const freshTurnId = TurnId.make(`opencode-turn-${yield* randomUUIDv4}`);
+              const messageId = yield* makeOpenCodeMessageId();
+              const pendingCancellation = context.cancellation;
+              if (pendingCancellation) {
+                const cancellationResult = yield* Deferred.await(
+                  pendingCancellation.completion,
+                ).pipe(Effect.result);
+                if ((yield* Ref.get(context.stopped)) || sessions.get(input.threadId) !== context) {
+                  return yield* Effect.interrupt;
                 }
-              }),
-            ),
-            Effect.asVoid,
-          );
-          const promptFiber = yield* promptEffect.pipe(Effect.forkIn(context.sessionScope));
-          promptAdmission.promptFiber = promptFiber;
-          const promptExit = yield* Effect.exit(Fiber.join(promptFiber));
-          delete promptAdmission.promptFiber;
+                if (cancellationResult._tag === "Failure") {
+                  return yield* cancellationResult.failure;
+                }
+              }
+              if (sessions.get(input.threadId) !== context || (yield* Ref.get(context.stopped))) {
+                return yield* Effect.interrupt;
+              }
+              // A sendTurn while a turn is active is a steer. OpenCode queues the
+              // prompt into the running session, so the active turn id is reused.
+              const steeringTurnId = context.activeTurnId;
+              const turnId = steeringTurnId ?? freshTurnId;
+              const agent = getModelSelectionStringOptionValue(modelSelection, "agent");
+              const variant = getModelSelectionStringOptionValue(modelSelection, "variant");
+              const pendingIdleReconciliation = context.pendingIdleReconciliation;
+              const priorAwaitingBusy = context.awaitingBusyAfterInterruption;
+              const priorIdleCandidate = pendingIdleReconciliation
+                ? {
+                    turnId: pendingIdleReconciliation.turnId,
+                    raw: pendingIdleReconciliation.raw,
+                  }
+                : undefined;
+              const promptGeneration = context.promptGeneration + 1;
+              const promptAdmission: OpenCodePromptAdmission = {
+                generation: promptGeneration,
+                turnId,
+                messageId,
+                priorAwaitingBusy,
+                priorIdle: priorIdleCandidate,
+                idleDuringAdmission: undefined,
+                idleObservedAfterMessage: false,
+                messageObserved: false,
+                busyObserved: false,
+                idleStatusConfirmations: 0,
+                accepted: false,
+                cancelled: false,
+                acceptance: Deferred.makeUnsafe<void>(),
+                submissionSettled: Deferred.makeUnsafe<void>(),
+                recoveryRaw: undefined,
+              };
+              let promptTimedOut = false;
+              const startedAt = yield* nowIso;
+              const startedEvent = {
+                ...(yield* buildEventBase({ threadId: input.threadId, turnId })),
+                type: "turn.started" as const,
+                payload: { model: modelSelection?.model ?? context.session.model },
+              };
+              let submitted = false;
+              const promptEffect = Effect.gen(function* () {
+                if (pendingIdleReconciliation?.fiber)
+                  yield* Fiber.interrupt(pendingIdleReconciliation.fiber);
+                if (turnOptions) yield* turnOptions.beforeSubmit(turnId);
+                const didSubmit = yield* runOpenCodeSdk("session.promptAsync", (signal) => {
+                  if (
+                    promptAdmission.cancelled ||
+                    Ref.getUnsafe(context.stopped) ||
+                    sessions.get(input.threadId) !== context ||
+                    context.activeTurnId !== steeringTurnId ||
+                    context.cancellation !== undefined
+                  ) {
+                    return Promise.resolve(false);
+                  }
+                  context.pendingIdleReconciliation = undefined;
+                  context.promptGeneration = promptGeneration;
+                  context.promptAdmission = promptAdmission;
 
-          const intentionallyCancelled =
-            promptAdmission.cancelled ||
-            (yield* Ref.get(context.stopped)) ||
-            sessions.get(input.threadId) !== context;
-          if (Exit.isFailure(promptExit) && !intentionallyCancelled) {
-            return yield* Effect.failCause(promptExit.cause);
-          }
-          const cancelled =
-            intentionallyCancelled ||
-            context.activeTurnId !== turnId ||
-            context.promptGeneration !== promptAdmission.generation;
-          if (cancelled) {
-            const cancellation = context.cancellation;
-            if (cancellation?.turnId === turnId) {
-              yield* Deferred.await(cancellation.completion).pipe(Effect.result);
-            }
-            if (context.promptAdmission === promptAdmission) {
-              context.promptAdmission = undefined;
-            }
-            return yield* Effect.interrupt;
-          }
-          promptAdmission.accepted = true;
-          yield* Deferred.succeed(promptAdmission.acceptance, undefined).pipe(Effect.ignore);
-          if (
-            context.promptAdmission === promptAdmission &&
-            context.activeTurnId === turnId &&
-            context.promptGeneration === promptAdmission.generation &&
-            promptAdmission.messageObserved
-          ) {
-            context.awaitingBusyAfterInterruption = false;
-            const idle = promptAdmission.idleDuringAdmission;
-            if (idle && !promptAdmission.idleObservedAfterMessage) {
-              yield* schedulePromptAdmissionRecovery(context, idle.raw);
-            } else {
-              context.promptAdmission = undefined;
-            }
-            if (idle && promptAdmission.idleObservedAfterMessage) {
-              yield* scheduleIdleReconciliation(context, turnId, idle.raw);
-            }
-          } else {
-            yield* schedulePromptAdmissionRecovery(context, promptAdmission.recoveryRaw);
-          }
+                  context.activeTurnId = turnId;
+                  if (steeringTurnId === undefined) {
+                    context.turnTokenUsage = makeOpenCodeTurnTokenUsageAccumulator();
+                  }
+                  context.turnTokenUsage?.promptMessageIds.add(messageId);
+                  context.activeAgent =
+                    agent ?? (input.interactionMode === "plan" ? "plan" : undefined);
+                  context.activeVariant = variant;
+                  if (steeringTurnId === undefined) {
+                    context.awaitingBusyAfterInterruption = context.interruptedTurnId !== undefined;
+                  }
+                  applyProviderSessionUpdate(
+                    context,
+                    {
+                      status: "running",
+                      activeTurnId: turnId,
+                      model: modelSelection?.model ?? context.session.model,
+                    },
+                    { clearLastError: true },
+                    startedAt,
+                  );
 
-          const stopped = yield* Ref.get(context.stopped);
-          const finalCancellation = context.cancellation;
-          if (
-            stopped ||
-            sessions.get(input.threadId) !== context ||
-            promptAdmission.cancelled ||
-            context.activeTurnId !== turnId ||
-            context.promptGeneration !== promptAdmission.generation ||
-            finalCancellation?.turnId === turnId
-          ) {
-            if (finalCancellation?.turnId === turnId) {
-              yield* Deferred.await(finalCancellation.completion).pipe(Effect.result);
-            }
-            if (context.promptAdmission === promptAdmission) {
-              context.promptAdmission = undefined;
-            }
-            return yield* Effect.interrupt;
-          }
+                  if (steeringTurnId === undefined) emitUnsafe(startedEvent);
+                  if (turnOptions)
+                    context.nativeSubmissions.set(messageId, {
+                      turnId,
+                      options: turnOptions,
+                      terminalObserved: false,
+                    });
+                  // State, receipt, and native dispatch share one synchronous callback.
+                  submitted = true;
+                  return context.client.session
+                    .promptAsync(
+                      {
+                        sessionID: context.openCodeSessionId,
+                        messageID: messageId,
+                        model: parsedModel,
+                        ...(context.activeAgent ? { agent: context.activeAgent } : {}),
+                        ...(context.activeVariant ? { variant: context.activeVariant } : {}),
+                        // OpenCode appends this after its own agent/provider prompts.
+                        system: buildRuntimeInstructions({
+                          harness: "OpenCode",
+                          model: `${parsedModel.providerID}/${parsedModel.modelID}`,
+                        }),
+                        parts: [...(text ? [{ type: "text" as const, text }] : []), ...fileParts],
+                      },
+                      { signal },
+                    )
+                    .then(() => true);
+                }).pipe(
+                  Effect.timeout("10 seconds"),
+                  Effect.catchTags({
+                    OpenCodeRuntimeError: (cause) => Effect.fail(toRequestError(cause)),
+                    TimeoutError: (cause) => {
+                      promptTimedOut = true;
+                      return Effect.fail(
+                        new ProviderAdapterRequestError({
+                          provider: PROVIDER,
+                          method: "session.promptAsync",
+                          detail: "OpenCode prompt submission did not complete within 10 seconds.",
+                          cause,
+                        }),
+                      );
+                    },
+                  }),
+                  Effect.tapError((requestError) =>
+                    context.promptAdmission !== promptAdmission || context.activeTurnId !== turnId
+                      ? Effect.void
+                      : Effect.gen(function* () {
+                          if (!promptTimedOut) {
+                            if (steeringTurnId !== undefined) {
+                              context.promptAdmission = undefined;
+                              context.awaitingBusyAfterInterruption =
+                                promptAdmission.priorAwaitingBusy;
+                              const idle =
+                                promptAdmission.idleDuringAdmission ?? promptAdmission.priorIdle;
+                              if (idle) {
+                                yield* scheduleIdleReconciliation(context, idle.turnId, idle.raw);
+                              }
+                              return;
+                            }
+                            const tokenUsage = takeOpenCodeTurnTokenUsage(context, false);
+                            context.promptAdmission = undefined;
+                            context.activeTurnId = undefined;
+                            context.activeAgent = undefined;
+                            context.activeVariant = undefined;
+                            yield* updateProviderSession(
+                              context,
+                              {
+                                status: "ready",
+                                model: modelSelection?.model ?? context.session.model,
+                                lastError: requestError.detail,
+                              },
+                              { clearActiveTurnId: true },
+                            );
+                            yield* emit({
+                              ...(yield* buildEventBase({ threadId: input.threadId, turnId })),
+                              type: "turn.aborted",
+                              payload: {
+                                reason: requestError.detail,
+                                tokenUsage,
+                              },
+                            });
+                            return;
+                          }
+                          const cleanupExit = yield* Effect.exit(
+                            runOpenCodeSdk("session.abort", (signal) =>
+                              context.client.session.abort(
+                                { sessionID: context.openCodeSessionId },
+                                { signal },
+                              ),
+                            ).pipe(Effect.timeout("1 second")),
+                          );
+                          if (Exit.isFailure(cleanupExit)) {
+                            yield* emit({
+                              ...(yield* buildEventBase({ threadId: input.threadId, turnId })),
+                              type: "runtime.warning",
+                              payload: {
+                                message:
+                                  "OpenCode prompt submission failed and its cleanup abort did not complete.",
+                                detail: openCodeRuntimeErrorDetail(Cause.squash(cleanupExit.cause)),
+                              },
+                            });
+                            yield* schedulePromptAdmissionRecovery(context, {
+                              requestError,
+                              cleanupError: Cause.squash(cleanupExit.cause),
+                            });
+                            return;
+                          }
+                          const tokenUsage = takeOpenCodeTurnTokenUsage(context, false);
+                          context.promptAdmission = undefined;
+                          context.activeTurnId = undefined;
+                          context.activeAgent = undefined;
+                          context.activeVariant = undefined;
+                          context.awaitingBusyAfterInterruption = false;
+                          context.reconcileIdleStatus = false;
+                          yield* updateProviderSession(
+                            context,
+                            {
+                              status: "ready",
+                              model: modelSelection?.model ?? context.session.model,
+                              lastError: requestError.detail,
+                            },
+                            { clearActiveTurnId: true },
+                          );
+                          yield* emit({
+                            ...(yield* buildEventBase({
+                              threadId: input.threadId,
+                              turnId,
+                            })),
+                            type: "turn.aborted",
+                            payload: {
+                              reason: requestError.detail,
+                              tokenUsage,
+                            },
+                          });
+                        }),
+                  ),
+                );
+                if (!didSubmit && turnOptions) yield* turnOptions.notSubmitted;
+                return didSubmit;
+              }).pipe(
+                Effect.onExit((exit) =>
+                  Effect.gen(function* () {
+                    if (!submitted && Exit.isFailure(exit) && turnOptions) {
+                      yield* turnOptions.notSubmitted;
+                    }
+                    yield* Deferred.succeed(promptAdmission.submissionSettled, undefined).pipe(
+                      Effect.ignore,
+                    );
+                    if (Exit.isFailure(exit)) {
+                      yield* Deferred.succeed(promptAdmission.acceptance, undefined).pipe(
+                        Effect.ignore,
+                      );
+                    }
+                  }),
+                ),
+              );
+              const promptFiber = yield* promptEffect.pipe(Effect.forkIn(context.sessionScope));
+              promptAdmission.promptFiber = promptFiber;
+              const promptExit = yield* Effect.exit(
+                Fiber.join(promptFiber).pipe(
+                  Effect.onInterrupt(() => Fiber.interrupt(promptFiber)),
+                ),
+              );
+              delete promptAdmission.promptFiber;
+              if (Exit.isSuccess(promptExit) && !promptExit.value) continue;
 
-          return {
-            threadId: input.threadId,
-            turnId,
-            // Re-surface the durable cursor on every turn so the persisted binding
-            // is refreshed alongside last-seen/runtime state (mirrors Grok/Codex).
-            ...(context.session.resumeCursor !== undefined
-              ? { resumeCursor: context.session.resumeCursor }
-              : {}),
-          };
-        }),
-      );
-    });
+              const intentionallyCancelled =
+                promptAdmission.cancelled ||
+                (yield* Ref.get(context.stopped)) ||
+                sessions.get(input.threadId) !== context;
+              if (Exit.isFailure(promptExit) && !intentionallyCancelled) {
+                return yield* Effect.failCause(promptExit.cause);
+              }
+              const cancelled =
+                intentionallyCancelled ||
+                context.activeTurnId !== turnId ||
+                context.promptGeneration !== promptAdmission.generation;
+              if (cancelled) {
+                const cancellation = context.cancellation;
+                if (cancellation?.turnId === turnId) {
+                  yield* Deferred.await(cancellation.completion).pipe(Effect.result);
+                }
+                if (context.promptAdmission === promptAdmission) {
+                  context.promptAdmission = undefined;
+                }
+                return yield* Effect.interrupt;
+              }
+              promptAdmission.accepted = true;
+              yield* Deferred.succeed(promptAdmission.acceptance, undefined).pipe(Effect.ignore);
+              if (
+                context.promptAdmission === promptAdmission &&
+                context.activeTurnId === turnId &&
+                context.promptGeneration === promptAdmission.generation &&
+                promptAdmission.messageObserved
+              ) {
+                context.awaitingBusyAfterInterruption = false;
+                const idle = promptAdmission.idleDuringAdmission;
+                if (idle && !promptAdmission.idleObservedAfterMessage) {
+                  yield* schedulePromptAdmissionRecovery(context, idle.raw);
+                } else {
+                  context.promptAdmission = undefined;
+                }
+                if (idle && promptAdmission.idleObservedAfterMessage) {
+                  yield* scheduleIdleReconciliation(context, turnId, idle.raw);
+                }
+              } else {
+                yield* schedulePromptAdmissionRecovery(context, promptAdmission.recoveryRaw);
+              }
+
+              const stopped = yield* Ref.get(context.stopped);
+              const finalCancellation = context.cancellation;
+              if (
+                stopped ||
+                sessions.get(input.threadId) !== context ||
+                promptAdmission.cancelled ||
+                context.activeTurnId !== turnId ||
+                context.promptGeneration !== promptAdmission.generation ||
+                finalCancellation?.turnId === turnId
+              ) {
+                if (finalCancellation?.turnId === turnId) {
+                  yield* Deferred.await(finalCancellation.completion).pipe(Effect.result);
+                }
+                if (context.promptAdmission === promptAdmission) {
+                  context.promptAdmission = undefined;
+                }
+                return yield* Effect.interrupt;
+              }
+
+              return {
+                threadId: input.threadId,
+                turnId,
+                // Re-surface the durable cursor on every turn so the persisted binding
+                // is refreshed alongside last-seen/runtime state (mirrors Grok/Codex).
+                ...(context.session.resumeCursor !== undefined
+                  ? { resumeCursor: context.session.resumeCursor }
+                  : {}),
+              };
+            }
+          }),
+        );
+      },
+    );
 
     const compactThread: NonNullable<OpenCodeAdapterShape["compactThread"]> = Effect.fn(
       "compactThread",
@@ -3809,7 +3908,7 @@ export function makeOpenCodeAdapter(
 
     const stopAll: OpenCodeAdapterShape["stopAll"] = () =>
       Effect.gen(function* () {
-        const contexts = [...sessions.values()];
+        const contexts = [...sessionContexts];
         sessions.clear();
         // `stopOpenCodeContext` is typed as never-failing — SDK aborts are
         // already `Effect.ignore`'d inside it. `ignoreCause` here also

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -2827,6 +2827,8 @@ export function makeOpenCodeAdapter(
       );
 
       if (!context.server.external && context.server.exitCode !== null) {
+        // This is the launcher exit, not proof that its native descendants stopped.
+        // Keep unconfirmed prompts reserved until their exact native receipts arrive.
         yield* context.server.exitCode.pipe(
           Effect.flatMap((code) =>
             Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -1005,6 +1005,124 @@ const routing = makeProviderServiceLayer();
 
 const admissionOrdering = makeProviderServiceLayer();
 admissionOrdering.layer("ProviderServiceLive native turn admission", (it) => {
+  it.effect(
+    "keeps the old provider binding and workspace until published native capture finishes",
+    () =>
+      Effect.gen(function* () {
+        const provider = yield* ProviderService.ProviderService;
+        const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+        const captures = yield* TurnCheckpointCapture.TurnCheckpointCapture;
+        const threadId = asThreadId("switch-after-native-capture");
+        const turnId = asTurnId("old-instance-turn");
+        const oldCwd = fixtureCwd("admission-old");
+        const newCwd = fixtureCwd("admission-new");
+        const sent = yield* Deferred.make<ProviderTurnStartOptions>();
+        admissionOrdering.codex.sendTurn.mockImplementationOnce((input, hooks) =>
+          Effect.gen(function* () {
+            if (hooks === undefined)
+              return yield* Effect.die("The real service must supply native admission.");
+            yield* hooks.beforeSubmit(turnId);
+            yield* Deferred.succeed(sent, hooks);
+            return { threadId: input.threadId, turnId };
+          }),
+        );
+        yield* provider.startSession(threadId, {
+          threadId,
+          provider: CODEX_DRIVER,
+          providerInstanceId: codexInstanceId,
+          cwd: oldCwd,
+          runtimeMode: "full-access",
+        });
+        yield* provider.sendTurn({ threadId, input: "old provider work" });
+        const replacement = yield* provider
+          .startSession(threadId, {
+            threadId,
+            provider: CLAUDE_AGENT_DRIVER,
+            providerInstanceId: claudeAgentInstanceId,
+            cwd: newCwd,
+            runtimeMode: "full-access",
+          })
+          .pipe(Effect.forkChild);
+        yield* Effect.yieldNow;
+        assert.equal(replacement.pollUnsafe(), undefined);
+        const oldBinding = Option.getOrThrow(yield* directory.getBinding(threadId));
+        assert.equal(oldBinding.providerInstanceId, codexInstanceId);
+        assert.containSubset(oldBinding.runtimePayload, { cwd: oldCwd });
+        const published =
+          yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "turn.completed" }>>();
+        yield* Stream.runForEach(provider.streamEvents, (event) =>
+          event.threadId === threadId && event.type === "turn.completed"
+            ? Deferred.succeed(published, event)
+            : Effect.void,
+        ).pipe(Effect.forkChild({ startImmediately: true }));
+        yield* (yield* Deferred.await(sent)).nativeCompleted(turnId);
+        admissionOrdering.codex.emit({
+          type: "turn.completed",
+          eventId: asEventId("switch-native-completed"),
+          threadId,
+          turnId,
+          provider: CODEX_DRIVER,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          payload: { state: "completed" },
+        });
+        const terminal = yield* Deferred.await(published);
+        assert.equal(terminal.providerInstanceId, codexInstanceId);
+        assert.equal(yield* captures.shouldCapture(terminal), true);
+        assert.equal(replacement.pollUnsafe(), undefined);
+        yield* captures.complete(terminal, "captured");
+        yield* Fiber.join(replacement);
+        const newBinding = Option.getOrThrow(yield* directory.getBinding(threadId));
+        assert.equal(newBinding.providerInstanceId, claudeAgentInstanceId);
+        assert.containSubset(newBinding.runtimePayload, { cwd: newCwd });
+      }).pipe(Effect.scoped),
+  );
+
+  it.effect("joins a parked native submission before stopping its session", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const captures = yield* TurnCheckpointCapture.TurnCheckpointCapture;
+      const threadId = asThreadId("stop-parked-native-send");
+      const beforeGate = yield* Deferred.make<void>();
+      const order: string[] = [];
+      const old = yield* captures.trackSubmission(threadId, codexInstanceId);
+      yield* provider.startSession(threadId, {
+        threadId,
+        provider: CODEX_DRIVER,
+        providerInstanceId: codexInstanceId,
+        runtimeMode: "full-access",
+      });
+      yield* old.beforeSubmit(asTurnId("old-reserved-turn"));
+      admissionOrdering.codex.sendTurn.mockImplementationOnce((input, hooks) =>
+        Effect.gen(function* () {
+          if (hooks === undefined) return yield* Effect.die("Missing native admission.");
+          yield* Deferred.succeed(beforeGate, undefined);
+          yield* hooks.beforeSubmit(asTurnId("parked-turn"));
+          order.push("native-submit");
+          return { threadId: input.threadId, turnId: asTurnId("parked-turn") };
+        }).pipe(
+          Effect.onInterrupt(() =>
+            Effect.sync(() => {
+              order.push("send-joined");
+            }),
+          ),
+        ),
+      );
+      admissionOrdering.codex.stopSession.mockImplementationOnce(() =>
+        Effect.sync(() => {
+          order.push("native-stop");
+        }),
+      );
+      const send = yield* provider
+        .sendTurn({ threadId, input: "park me" })
+        .pipe(Effect.exit, Effect.forkChild);
+      yield* Deferred.await(beforeGate);
+      yield* provider.stopSession({ threadId });
+      assert.equal(Exit.isFailure(yield* Fiber.join(send)), true);
+      assert.deepEqual(order, ["send-joined", "native-stop"]);
+      yield* old.notSubmitted;
+    }).pipe(Effect.scoped),
+  );
+
   it.effect("waits when the previous terminal arrives during send preparation", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService.ProviderService;

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -60,7 +60,10 @@ import {
   ProviderWorkspaceMissingError,
   type ProviderAdapterError,
 } from "../Errors.ts";
-import type { ProviderAdapterShape, ProviderTurnStartOptions } from "../Services/ProviderAdapter.ts";
+import type {
+  ProviderAdapterShape,
+  ProviderTurnStartOptions,
+} from "../Services/ProviderAdapter.ts";
 import * as ProviderAdapterRegistry from "../Services/ProviderAdapterRegistry.ts";
 import * as ProviderService from "../Services/ProviderService.ts";
 import * as ProviderSessionDirectory from "../Services/ProviderSessionDirectory.ts";
@@ -1027,7 +1030,9 @@ admissionOrdering.layer("ProviderServiceLive native turn admission", (it) => {
         providerInstanceId: codexInstanceId,
         runtimeMode: "full-access",
       });
-      const send = yield* provider.sendTurn({ threadId, input: "next message" }).pipe(Effect.forkChild);
+      const send = yield* provider
+        .sendTurn({ threadId, input: "next message" })
+        .pipe(Effect.forkChild);
       yield* Deferred.await(prepared);
       const terminal = {
         type: "turn.completed",
@@ -2924,10 +2929,11 @@ fanout.layer("ProviderServiceLive fanout", (it) => {
   it.effect("keeps subscriber delivery ordered and isolates failing subscribers", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService.ProviderService;
-      const session = yield* provider.startSession(asThreadId("thread-1"), {
+      const threadId = asThreadId("fanout-subscriber-isolation");
+      const session = yield* provider.startSession(threadId, {
         provider: ProviderDriverKind.make("codex"),
         providerInstanceId: codexInstanceId,
-        threadId: asThreadId("thread-1"),
+        threadId,
         runtimeMode: "full-access",
       });
 

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -60,7 +60,7 @@ import {
   ProviderWorkspaceMissingError,
   type ProviderAdapterError,
 } from "../Errors.ts";
-import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
+import type { ProviderAdapterShape, ProviderTurnStartOptions } from "../Services/ProviderAdapter.ts";
 import * as ProviderAdapterRegistry from "../Services/ProviderAdapterRegistry.ts";
 import * as ProviderService from "../Services/ProviderService.ts";
 import * as ProviderSessionDirectory from "../Services/ProviderSessionDirectory.ts";
@@ -172,6 +172,7 @@ function makeFakeCodexAdapter(
   const sendTurn = vi.fn(
     (
       input: ProviderSendTurnInput,
+      _hooks?: ProviderTurnStartOptions,
     ): Effect.Effect<ProviderTurnStartResult, ProviderAdapterError> => {
       if (!sessions.has(input.threadId)) {
         return Effect.fail(
@@ -998,6 +999,57 @@ it.effect("ProviderServiceLive rejects new sessions for disabled custom instance
 );
 
 const routing = makeProviderServiceLayer();
+
+const admissionOrdering = makeProviderServiceLayer();
+admissionOrdering.layer("ProviderServiceLive native turn admission", (it) => {
+  it.effect("waits when the previous terminal arrives during send preparation", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const captures = yield* TurnCheckpointCapture.TurnCheckpointCapture;
+      const threadId = asThreadId("terminal-during-preparation");
+      const prepared = yield* Deferred.make<void>();
+      const finishPreparation = yield* Deferred.make<void>();
+      const atSubmission = yield* Deferred.make<void>();
+      let nativeSubmitted = false;
+      admissionOrdering.codex.sendTurn.mockImplementationOnce((input, hooks) =>
+        Effect.gen(function* () {
+          yield* Deferred.succeed(prepared, undefined);
+          yield* Deferred.await(finishPreparation);
+          yield* Deferred.succeed(atSubmission, undefined);
+          yield* hooks?.beforeSubmit() ?? Effect.void;
+          nativeSubmitted = true;
+          return { threadId: input.threadId, turnId: asTurnId("next-native-turn") };
+        }),
+      );
+      yield* provider.startSession(threadId, {
+        threadId,
+        provider: CODEX_DRIVER,
+        providerInstanceId: codexInstanceId,
+        runtimeMode: "full-access",
+      });
+      const send = yield* provider.sendTurn({ threadId, input: "next message" }).pipe(Effect.forkChild);
+      yield* Deferred.await(prepared);
+      const terminal = {
+        type: "turn.completed",
+        eventId: asEventId("old-terminal-during-preparation"),
+        threadId,
+        turnId: asTurnId("old-native-turn"),
+        provider: CODEX_DRIVER,
+        providerInstanceId: codexInstanceId,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        payload: { state: "completed" },
+      } satisfies Extract<ProviderRuntimeEvent, { type: "turn.completed" }>;
+      yield* captures.observe(terminal);
+      yield* Deferred.succeed(finishPreparation, undefined);
+      yield* Deferred.await(atSubmission);
+      yield* Effect.yieldNow;
+      assert.equal(nativeSubmitted, false);
+      yield* captures.complete(terminal, "captured");
+      yield* Fiber.join(send);
+      assert.equal(nativeSubmitted, true);
+    }).pipe(Effect.scoped),
+  );
+});
 
 const antigravityDriver = ProviderDriverKind.make("antigravity");
 const replacementAntigravity = makeFakeCodexAdapter(antigravityDriver);

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -574,14 +574,50 @@ for (const [enabled, completed] of [
           });
         }
         const markers: unknown[] = [];
+        const captures = yield* TurnCheckpointCapture.TurnCheckpointCapture.pipe(
+          Effect.provide(services),
+        );
+        const pendingTerminal = {
+          type: "turn.completed" as const,
+          eventId: asEventId("shutdown-pending-terminal"),
+          provider: CODEX_DRIVER,
+          providerInstanceId: codexInstanceId,
+          threadId,
+          turnId,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          payload: { state: "completed" as const },
+        };
+        yield* captures.observe(pendingTerminal);
+        const sendPreparing = yield* Deferred.make<void>();
+        let parkedSendJoined = false;
+        codex.sendTurn.mockImplementationOnce((input, hooks) =>
+          Effect.gen(function* () {
+            if (hooks === undefined) return yield* Effect.die("Missing native admission.");
+            yield* Deferred.succeed(sendPreparing, undefined);
+            yield* hooks.beforeSubmit(asTurnId("shutdown-parked-turn"));
+            return { threadId: input.threadId, turnId: asTurnId("shutdown-parked-turn") };
+          }).pipe(
+            Effect.onInterrupt(() =>
+              Effect.sync(() => {
+                parkedSendJoined = true;
+              }),
+            ),
+          ),
+        );
+        const parkedSend = yield* provider
+          .sendTurn({ threadId, input: "wait for checkpoint" })
+          .pipe(Effect.exit, Effect.forkChild);
+        yield* Deferred.await(sendPreparing);
         codex.stopAll.mockImplementation(() =>
           Effect.gen(function* () {
+            assert.equal(parkedSendJoined, true);
             const binding = yield* directory.getBinding(threadId);
             assert(Option.isSome(binding));
             markers.push(binding.value.runtimePayload);
           }).pipe(Effect.orDie),
         );
         yield* Scope.close(scope, Exit.void);
+        assert.equal(Exit.isFailure(yield* Fiber.join(parkedSend)), true);
         const binding = yield* directory.getBinding(threadId);
         assert(Option.isSome(binding));
         assert.equal(codex.stopAll.mock.calls.length, 1);
@@ -1067,7 +1103,7 @@ admissionOrdering.layer("ProviderServiceLive native turn admission", (it) => {
         });
         const terminal = yield* Deferred.await(published);
         assert.equal(terminal.providerInstanceId, codexInstanceId);
-        assert.equal(yield* captures.shouldCapture(terminal), true);
+        assert.equal(yield* captures.nativeCaptureReady(terminal), true);
         assert.equal(replacement.pollUnsafe(), undefined);
         yield* captures.complete(terminal, "captured");
         yield* Fiber.join(replacement);

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -341,7 +341,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     ProjectionSnapshotQuery.ProjectionSnapshotQuery,
   );
   const checkpointCapture = yield* TurnCheckpointCapture.TurnCheckpointCapture;
-  const pendingSends = new Map<ThreadId, Set<Fiber.Fiber<unknown, unknown>>>();
+  const pendingSends = new Map<ThreadId, Set<Deferred.Deferred<Fiber.Fiber<unknown, unknown>>>>();
   const blockedSends = new Map<ThreadId, Set<symbol>>();
 
   const withPendingSend = <A, E, R>(threadId: ThreadId, effect: Effect.Effect<A, E, R>) =>
@@ -353,18 +353,21 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
             "This thread is stopping. Retry after it stops.",
           );
         }
-        const fiber = yield* effect.pipe(Effect.interruptible, Effect.forkChild);
-        const sends = pendingSends.get(threadId) ?? new Set<Fiber.Fiber<unknown, unknown>>();
+        const sends =
+          pendingSends.get(threadId) ?? new Set<Deferred.Deferred<Fiber.Fiber<unknown, unknown>>>();
+        const ready = Deferred.makeUnsafe<Fiber.Fiber<unknown, unknown>>();
         pendingSends.set(threadId, sends);
-        sends.add(fiber);
-        return { fiber, sends };
+        sends.add(ready);
+        const fiber = yield* effect.pipe(Effect.interruptible, Effect.forkChild);
+        yield* Deferred.succeed(ready, fiber);
+        return { fiber, ready, sends };
       }),
       ({ fiber }) => Fiber.await(fiber).pipe(Effect.flatMap((exit) => exit)),
-      ({ fiber, sends }) =>
+      ({ fiber, ready, sends }) =>
         Fiber.interrupt(fiber).pipe(
           Effect.andThen(
             Effect.sync(() => {
-              sends.delete(fiber);
+              sends.delete(ready);
               if (sends.size === 0) pendingSends.delete(threadId);
             }),
           ),
@@ -385,8 +388,15 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           const current = yield* Effect.fiber;
           // Parked adapter sends can hold setup locks needed by native cancellation.
           // Join their cleanup before attempting interruption or session teardown.
-          yield* Fiber.interruptAll(
-            [...(pendingSends.get(threadId) ?? [])].filter((fiber) => fiber !== current),
+          yield* Effect.forEach(
+            [...(pendingSends.get(threadId) ?? [])],
+            (ready) =>
+              Deferred.await(ready).pipe(
+                Effect.flatMap((fiber) =>
+                  fiber === current ? Effect.void : Fiber.interrupt(fiber),
+                ),
+              ),
+            { discard: true, concurrency: "unbounded" },
           );
           return yield* effect;
         }),
@@ -1537,8 +1547,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
                     provider: routed.adapter.provider,
                     method: "turn/start",
                     detail:
-                      "Native submission could not be confirmed. This thread stays reserved until native completion or confirmed teardown. " +
-                      Cause.pretty(sendExit.cause),
+                      "Native submission could not be confirmed. This thread stays reserved until native completion or confirmed teardown.",
                     cause: sendExit.cause,
                   });
                 }

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -343,11 +343,12 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
   const checkpointCapture = yield* TurnCheckpointCapture.TurnCheckpointCapture;
   const pendingSends = new Map<ThreadId, Set<Deferred.Deferred<Fiber.Fiber<unknown, unknown>>>>();
   const blockedSends = new Map<ThreadId, Set<symbol>>();
+  let stoppingAll = false;
 
   const withPendingSend = <A, E, R>(threadId: ThreadId, effect: Effect.Effect<A, E, R>) =>
     Effect.acquireUseRelease(
       Effect.gen(function* () {
-        if (blockedSends.has(threadId)) {
+        if (stoppingAll || blockedSends.has(threadId)) {
           return yield* toValidationError(
             "ProviderService.sendTurn",
             "This thread is stopping. Retry after it stops.",
@@ -2202,6 +2203,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
   );
 
   const runStopAll = Effect.fn("runStopAll")(function* () {
+    stoppingAll = true;
     const continueAfterRestart = yield* serverSettings.getSettings.pipe(
       Effect.map((settings) => settings.continueThreadsAfterServerUpdate),
       Effect.orElseSucceed(() => false),
@@ -2241,6 +2243,15 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         }),
       ),
     ).pipe(Effect.asVoid);
+    const current = yield* Effect.fiber;
+    yield* Effect.forEach(
+      [...pendingSends.values()].flatMap((sends) => [...sends]),
+      (ready) =>
+        Deferred.await(ready).pipe(
+          Effect.flatMap((fiber) => (fiber === current ? Effect.void : Fiber.interrupt(fiber))),
+        ),
+      { discard: true, concurrency: "unbounded" },
+    );
     yield* Effect.forEach(currentAdapters, ([, adapter]) => adapter.stopAll()).pipe(Effect.asVoid);
     yield* McpSessionRegistry.revokeAllActiveMcpCredentials();
     McpProviderSession.clearAllMcpProviderSessions();

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -35,8 +35,11 @@ import { causeErrorTag } from "@t3tools/shared/observability";
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 import { resolveProjectAgentBrowserAccess } from "@t3tools/shared/serverSettings";
 import * as DateTime from "effect/DateTime";
+import * as Cause from "effect/Cause";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -338,6 +341,61 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     ProjectionSnapshotQuery.ProjectionSnapshotQuery,
   );
   const checkpointCapture = yield* TurnCheckpointCapture.TurnCheckpointCapture;
+  const pendingSends = new Map<ThreadId, Set<Fiber.Fiber<unknown, unknown>>>();
+  const blockedSends = new Map<ThreadId, Set<symbol>>();
+
+  const withPendingSend = <A, E, R>(threadId: ThreadId, effect: Effect.Effect<A, E, R>) =>
+    Effect.acquireUseRelease(
+      Effect.gen(function* () {
+        if (blockedSends.has(threadId)) {
+          return yield* toValidationError(
+            "ProviderService.sendTurn",
+            "This thread is stopping. Retry after it stops.",
+          );
+        }
+        const fiber = yield* effect.pipe(Effect.interruptible, Effect.forkChild);
+        const sends = pendingSends.get(threadId) ?? new Set<Fiber.Fiber<unknown, unknown>>();
+        pendingSends.set(threadId, sends);
+        sends.add(fiber);
+        return { fiber, sends };
+      }),
+      ({ fiber }) => Fiber.await(fiber).pipe(Effect.flatMap((exit) => exit)),
+      ({ fiber, sends }) =>
+        Fiber.interrupt(fiber).pipe(
+          Effect.andThen(
+            Effect.sync(() => {
+              sends.delete(fiber);
+              if (sends.size === 0) pendingSends.delete(threadId);
+            }),
+          ),
+        ),
+    );
+
+  const withSendsBlocked = <A, E, R>(threadId: ThreadId, effect: Effect.Effect<A, E, R>) =>
+    Effect.acquireUseRelease(
+      Effect.sync(() => {
+        const token = Symbol();
+        const blockers = blockedSends.get(threadId) ?? new Set<symbol>();
+        blockedSends.set(threadId, blockers);
+        blockers.add(token);
+        return { token, blockers };
+      }),
+      () =>
+        Effect.gen(function* () {
+          const current = yield* Effect.fiber;
+          // Parked adapter sends can hold setup locks needed by native cancellation.
+          // Join their cleanup before attempting interruption or session teardown.
+          yield* Fiber.interruptAll(
+            [...(pendingSends.get(threadId) ?? [])].filter((fiber) => fiber !== current),
+          );
+          return yield* effect;
+        }),
+      ({ token, blockers }) =>
+        Effect.sync(() => {
+          blockers.delete(token);
+          if (blockers.size === 0) blockedSends.delete(threadId);
+        }),
+    );
   const issueMcpCredential =
     options?.issueMcpCredential ?? McpSessionRegistry.issueActiveMcpCredential;
   const revokeMcpCredential =
@@ -1053,6 +1111,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
       const persistedCwd = readPersistedCwd(input.binding.runtimePayload);
       const persistedModelSelection = readPersistedModelSelection(input.binding.runtimePayload);
 
+      yield* checkpointCapture.awaitNativeCapture(input.binding.threadId);
       yield* prepareMcpSession(input.binding.threadId, bindingInstanceId);
       const resumed = yield* adapter
         .startSession({
@@ -1283,6 +1342,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           }
         }
         const adapter = yield* registry.getByInstance(resolvedInstanceId);
+        yield* checkpointCapture.awaitNativeCapture(threadId);
         yield* clearTurnAnalyticsSession(resolvedInstanceId, threadId);
         yield* prepareMcpSession(threadId, resolvedInstanceId);
         const session = yield* adapter
@@ -1348,177 +1408,204 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         }),
       );
     },
+    (effect, threadId) => withSendsBlocked(threadId, effect),
   );
 
-  const sendTurn: ProviderServiceMethod<"sendTurn"> = Effect.fn("sendTurn")(function* (rawInput) {
-    const parsed = yield* decodeInputOrValidationError({
-      operation: "ProviderService.sendTurn",
-      schema: ProviderSendTurnInput,
-      payload: rawInput,
-    });
-
-    const attachments = parsed.attachments ?? [];
-    if (!parsed.input && attachments.length === 0 && parsed.continuation !== true) {
-      return yield* toValidationError(
-        "ProviderService.sendTurn",
-        "Either input text or at least one attachment is required",
-      );
-    }
-
-    const inputTextWithCitations =
-      parsed.input === undefined ? undefined : expandAssistantCitationsForProvider(parsed.input);
-    if (inputTextWithCitations !== parsed.input) {
-      yield* decodeInputOrValidationError({
+  const sendTurn: ProviderServiceMethod<"sendTurn"> = Effect.fn("sendTurn")(
+    function* (rawInput) {
+      const parsed = yield* decodeInputOrValidationError({
         operation: "ProviderService.sendTurn",
-        schema: ProviderSendTurnInput.fields.input,
-        payload: inputTextWithCitations,
+        schema: ProviderSendTurnInput,
+        payload: rawInput,
       });
-    }
 
-    // Every attachment gets an on-disk path in the prompt so the model's tools
-    // can dereference the actual file. All attachments then go to the adapter,
-    // and each adapter decides what its provider ingests natively: OpenCode
-    // sends generic files as file parts, the others send images only and rely
-    // on the path line for everything else. Unresolvable ids are skipped here
-    // and surface as adapter errors when the file is read.
-    const attachmentPathLines = attachments.flatMap((attachment) => {
-      const attachmentPath = resolveAttachmentPath({
-        attachmentsDir: serverConfig.attachmentsDir,
-        attachment,
-      });
-      return attachmentPath === null
-        ? []
-        : [`[Attached ${attachment.type} "${attachment.name}" is saved at: ${attachmentPath}]`];
-    });
-    const inputTextWithAttachmentPaths =
-      attachmentPathLines.length === 0
-        ? inputTextWithCitations
-        : [inputTextWithCitations, attachmentPathLines.join("\n")]
-            .filter((part): part is string => typeof part === "string" && part.length > 0)
-            .join("\n\n");
-
-    const input = {
-      ...parsed,
-      ...(inputTextWithAttachmentPaths !== undefined
-        ? { input: inputTextWithAttachmentPaths }
-        : {}),
-    };
-    yield* Effect.annotateCurrentSpan({
-      "provider.operation": "send-turn",
-      "provider.thread_id": input.threadId,
-      "provider.interaction_mode": input.interactionMode,
-      "provider.attachment_count": attachments.length,
-    });
-    let metricProvider = "unknown";
-    let metricModel = input.modelSelection?.model;
-    return yield* Effect.gen(function* () {
-      let routed = yield* resolveRoutableSession({
-        threadId: input.threadId,
-        operation: "ProviderService.sendTurn",
-        allowRecovery: false,
-      });
-      if (
-        input.continuation === true &&
-        !input.input &&
-        attachments.length === 0 &&
-        routed.adapter.capabilities.promptlessTurnContinuation !== true
-      ) {
+      const attachments = parsed.attachments ?? [];
+      if (!parsed.input && attachments.length === 0 && parsed.continuation !== true) {
         return yield* toValidationError(
           "ProviderService.sendTurn",
-          `Provider '${routed.adapter.provider}' requires an explicit continuation prompt`,
+          "Either input text or at least one attachment is required",
         );
       }
-      if (!routed.isActive) {
-        routed = yield* resolveRoutableSession({
-          threadId: input.threadId,
+
+      const inputTextWithCitations =
+        parsed.input === undefined ? undefined : expandAssistantCitationsForProvider(parsed.input);
+      if (inputTextWithCitations !== parsed.input) {
+        yield* decodeInputOrValidationError({
           operation: "ProviderService.sendTurn",
-          allowRecovery: true,
+          schema: ProviderSendTurnInput.fields.input,
+          payload: inputTextWithCitations,
         });
       }
-      metricProvider = routed.adapter.provider;
-      metricModel = input.modelSelection?.model;
-      yield* Effect.annotateCurrentSpan({
-        "provider.kind": routed.adapter.provider,
-        ...(input.modelSelection?.model ? { "provider.model": input.modelSelection.model } : {}),
+
+      // Every attachment gets an on-disk path in the prompt so the model's tools
+      // can dereference the actual file. All attachments then go to the adapter,
+      // and each adapter decides what its provider ingests natively: OpenCode
+      // sends generic files as file parts, the others send images only and rely
+      // on the path line for everything else. Unresolvable ids are skipped here
+      // and surface as adapter errors when the file is read.
+      const attachmentPathLines = attachments.flatMap((attachment) => {
+        const attachmentPath = resolveAttachmentPath({
+          attachmentsDir: serverConfig.attachmentsDir,
+          attachment,
+        });
+        return attachmentPath === null
+          ? []
+          : [`[Attached ${attachment.type} "${attachment.name}" is saved at: ${attachmentPath}]`];
       });
-      // A turn is the clearest sign a session is still alive. The MCP
-      // credential is minted once at session start and cannot be rotated into
-      // an already-spawned agent process, so we keep the existing token valid
-      // rather than issuing a new one: sessions that go a long time between
-      // browser tool calls used to lose the toolkit outright.
-      yield* McpSessionRegistry.touchActiveMcpThread(input.threadId);
-      const analyticsModelSelection =
-        input.modelSelection?.instanceId === routed.instanceId ? input.modelSelection : undefined;
-      const turn = yield* Effect.acquireUseRelease(
-        beginTurnAnalytics({
-          providerInstanceId: routed.instanceId,
-          provider: routed.adapter.provider,
+      const inputTextWithAttachmentPaths =
+        attachmentPathLines.length === 0
+          ? inputTextWithCitations
+          : [inputTextWithCitations, attachmentPathLines.join("\n")]
+              .filter((part): part is string => typeof part === "string" && part.length > 0)
+              .join("\n\n");
+
+      const input = {
+        ...parsed,
+        ...(inputTextWithAttachmentPaths !== undefined
+          ? { input: inputTextWithAttachmentPaths }
+          : {}),
+      };
+      yield* Effect.annotateCurrentSpan({
+        "provider.operation": "send-turn",
+        "provider.thread_id": input.threadId,
+        "provider.interaction_mode": input.interactionMode,
+        "provider.attachment_count": attachments.length,
+      });
+      let metricProvider = "unknown";
+      let metricModel = input.modelSelection?.model;
+      return yield* Effect.gen(function* () {
+        let routed = yield* resolveRoutableSession({
           threadId: input.threadId,
-          modelSelection: analyticsModelSelection,
-          interactionMode: input.interactionMode,
-          runtimeMode: routed.runtimeMode,
-        }),
-        (turnMetadata) =>
-          Effect.gen(function* () {
-            const turn = yield* routed.adapter.sendTurn(input);
-            yield* associateTurnAnalytics({
+          operation: "ProviderService.sendTurn",
+          allowRecovery: false,
+        });
+        if (
+          input.continuation === true &&
+          !input.input &&
+          attachments.length === 0 &&
+          routed.adapter.capabilities.promptlessTurnContinuation !== true
+        ) {
+          return yield* toValidationError(
+            "ProviderService.sendTurn",
+            `Provider '${routed.adapter.provider}' requires an explicit continuation prompt`,
+          );
+        }
+        if (!routed.isActive) {
+          routed = yield* resolveRoutableSession({
+            threadId: input.threadId,
+            operation: "ProviderService.sendTurn",
+            allowRecovery: true,
+          });
+        }
+        metricProvider = routed.adapter.provider;
+        metricModel = input.modelSelection?.model;
+        yield* Effect.annotateCurrentSpan({
+          "provider.kind": routed.adapter.provider,
+          ...(input.modelSelection?.model ? { "provider.model": input.modelSelection.model } : {}),
+        });
+        // A turn is the clearest sign a session is still alive. The MCP
+        // credential is minted once at session start and cannot be rotated into
+        // an already-spawned agent process, so we keep the existing token valid
+        // rather than issuing a new one: sessions that go a long time between
+        // browser tool calls used to lose the toolkit outright.
+        yield* McpSessionRegistry.touchActiveMcpThread(input.threadId);
+        const analyticsModelSelection =
+          input.modelSelection?.instanceId === routed.instanceId ? input.modelSelection : undefined;
+        const turn = yield* Effect.acquireUseRelease(
+          beginTurnAnalytics({
+            providerInstanceId: routed.instanceId,
+            provider: routed.adapter.provider,
+            threadId: input.threadId,
+            modelSelection: analyticsModelSelection,
+            interactionMode: input.interactionMode,
+            runtimeMode: routed.runtimeMode,
+          }),
+          (turnMetadata) =>
+            Effect.gen(function* () {
+              const submission = yield* checkpointCapture.trackSubmission(
+                input.threadId,
+                routed.instanceId,
+              );
+              const sendExit = yield* Effect.exit(routed.adapter.sendTurn(input, submission));
+              if (Exit.isFailure(sendExit)) {
+                const outcome = yield* submission.outcome;
+                if (
+                  outcome._tag === "UnknownSubmission" &&
+                  !Cause.hasInterruptsOnly(sendExit.cause)
+                ) {
+                  return yield* new ProviderAdapterRequestError({
+                    provider: routed.adapter.provider,
+                    method: "turn/start",
+                    detail:
+                      "Native submission could not be confirmed. This thread stays reserved until native completion or confirmed teardown. " +
+                      Cause.pretty(sendExit.cause),
+                    cause: sendExit.cause,
+                  });
+                }
+                return yield* Effect.failCause(sendExit.cause);
+              }
+              const turn = sendExit.value;
+              yield* submission.accept(turn.turnId);
+              yield* associateTurnAnalytics({
+                providerInstanceId: routed.instanceId,
+                threadId: input.threadId,
+                turnId: String(turn.turnId),
+                metadata: turnMetadata,
+              });
+              return turn;
+            }),
+          (turnMetadata) =>
+            clearPendingTurnAnalytics({
               providerInstanceId: routed.instanceId,
               threadId: input.threadId,
-              turnId: String(turn.turnId),
-              metadata: turnMetadata,
-            });
-            return turn;
-          }),
-        (turnMetadata) =>
-          clearPendingTurnAnalytics({
-            providerInstanceId: routed.instanceId,
-            threadId: input.threadId,
-            requestId: turnMetadata.requestId,
-          }),
+              requestId: turnMetadata.requestId,
+            }),
+        );
+        yield* directory.upsert({
+          threadId: input.threadId,
+          provider: routed.adapter.provider,
+          providerInstanceId: routed.instanceId,
+          status: "running",
+          ...(turn.resumeCursor !== undefined ? { resumeCursor: turn.resumeCursor } : {}),
+          runtimePayload: {
+            ...(input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {}),
+            activeTurnId: turn.turnId,
+            // Admission and marker consumption must survive the same restart.
+            continueAfterServerUpdate: null,
+            continueAfterServerUpdatePrepared: null,
+            lastRuntimeEvent: "provider.sendTurn",
+            lastRuntimeEventAt: yield* nowIso,
+          },
+        });
+        yield* analytics.record("provider.turn.sent", {
+          provider: routed.adapter.provider,
+          model: input.modelSelection?.model,
+          interactionMode: input.interactionMode,
+          // Session-start events alone skew runtime mode toward users who toggle
+          // often, since every toggle restarts the session. Recording it per turn
+          // gives a usage-weighted view and lets it cross with interactionMode.
+          runtimeMode: routed.runtimeMode,
+          attachmentCount: attachments.length,
+          hasInput: typeof input.input === "string" && input.input.trim().length > 0,
+        });
+        return turn;
+      }).pipe(
+        withMetrics({
+          counter: providerTurnsTotal,
+          timer: providerTurnDuration,
+          attributes: () =>
+            providerTurnMetricAttributes({
+              provider: metricProvider,
+              model: metricModel,
+              extra: {
+                operation: "send",
+              },
+            }),
+        }),
       );
-      yield* directory.upsert({
-        threadId: input.threadId,
-        provider: routed.adapter.provider,
-        providerInstanceId: routed.instanceId,
-        status: "running",
-        ...(turn.resumeCursor !== undefined ? { resumeCursor: turn.resumeCursor } : {}),
-        runtimePayload: {
-          ...(input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {}),
-          activeTurnId: turn.turnId,
-          // Admission and marker consumption must survive the same restart.
-          continueAfterServerUpdate: null,
-          continueAfterServerUpdatePrepared: null,
-          lastRuntimeEvent: "provider.sendTurn",
-          lastRuntimeEventAt: yield* nowIso,
-        },
-      });
-      yield* analytics.record("provider.turn.sent", {
-        provider: routed.adapter.provider,
-        model: input.modelSelection?.model,
-        interactionMode: input.interactionMode,
-        // Session-start events alone skew runtime mode toward users who toggle
-        // often, since every toggle restarts the session. Recording it per turn
-        // gives a usage-weighted view and lets it cross with interactionMode.
-        runtimeMode: routed.runtimeMode,
-        attachmentCount: attachments.length,
-        hasInput: typeof input.input === "string" && input.input.trim().length > 0,
-      });
-      return turn;
-    }).pipe(
-      withMetrics({
-        counter: providerTurnsTotal,
-        timer: providerTurnDuration,
-        attributes: () =>
-          providerTurnMetricAttributes({
-            provider: metricProvider,
-            model: metricModel,
-            extra: {
-              operation: "send",
-            },
-          }),
-      }),
-    );
-  });
+    },
+    (effect, input) => withPendingSend(input.threadId, effect),
+  );
 
   const compactThread: ProviderServiceMethod<"compactThread"> = Effect.fn("compactThread")(
     function* (threadId, modelSelection, requestId) {
@@ -1679,6 +1766,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         }),
       );
     },
+    (effect, input) => withSendsBlocked(input.threadId, effect),
   );
 
   const respondToRequest: ProviderServiceMethod<"respondToRequest"> = Effect.fn("respondToRequest")(
@@ -1809,6 +1897,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         }),
       );
     },
+    (effect, input) => withSendsBlocked(input.threadId, effect),
   );
 
   const listSessions: ProviderServiceMethod<"listSessions"> = Effect.fn("listSessions")(

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -52,6 +52,8 @@ export interface ProviderThreadSnapshot {
 export interface ProviderTurnStartOptions {
   /** Call after preparation, directly before native prompt submission. */
   readonly beforeSubmit: (turnId?: TurnId) => Effect.Effect<void>;
+  /** Release only this send when the adapter proves native submission never occurred. */
+  readonly notSubmitted: Effect.Effect<void>;
   /** Only a native terminal response can confirm that submitted work has finished. */
   readonly nativeCompleted: (turnId: TurnId) => Effect.Effect<void>;
 }

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -50,7 +50,8 @@ export interface ProviderThreadSnapshot {
 }
 
 export interface ProviderTurnStartOptions {
-  /** Call after preparation, directly before native prompt submission. */
+  /** Call after preparation, directly before native prompt submission.
+      Reuse an active turn ID only if native submission cannot start a different turn. */
   readonly beforeSubmit: (turnId?: TurnId) => Effect.Effect<void>;
   /** Release only this send when the adapter proves native submission never occurred. */
   readonly notSubmitted: Effect.Effect<void>;

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -56,6 +56,8 @@ export interface ProviderTurnStartOptions {
   readonly notSubmitted: Effect.Effect<void>;
   /** Only a native terminal response can confirm that submitted work has finished. */
   readonly nativeCompleted: (turnId: TurnId) => Effect.Effect<void>;
+  /** The captured native process has exited. Local stream or scope closure is not enough. */
+  readonly nativeStopped: Effect.Effect<void>;
 }
 
 export interface ProviderAdapterShape<TError> {

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -51,7 +51,8 @@ export interface ProviderThreadSnapshot {
 
 export interface ProviderTurnStartOptions {
   /** Call after preparation, directly before native prompt submission.
-      Reuse an active turn ID only if native submission cannot start a different turn. */
+      Reuse an active T3 turn ID for steering only while that turn remains open.
+      Every accepted input still needs native proof before the turn can finish. */
   readonly beforeSubmit: (turnId?: TurnId) => Effect.Effect<void>;
   /** Release only this send when the adapter proves native submission never occurred. */
   readonly notSubmitted: Effect.Effect<void>;

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -49,6 +49,13 @@ export interface ProviderThreadSnapshot {
   readonly turns: ReadonlyArray<ProviderThreadTurnSnapshot>;
 }
 
+export interface ProviderTurnStartOptions {
+  /** Call after preparation, directly before native prompt submission. */
+  readonly beforeSubmit: (turnId?: TurnId) => Effect.Effect<void>;
+  /** Only a native terminal response can confirm that submitted work has finished. */
+  readonly nativeCompleted: (turnId: TurnId) => Effect.Effect<void>;
+}
+
 export interface ProviderAdapterShape<TError> {
   /**
    * Provider kind implemented by this adapter.
@@ -78,6 +85,7 @@ export interface ProviderAdapterShape<TError> {
    */
   readonly sendTurn: (
     input: ProviderSendTurnInput,
+    options?: ProviderTurnStartOptions,
   ) => Effect.Effect<ProviderTurnStartResult, TError>;
 
   readonly compactThread?: (

--- a/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
+++ b/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
@@ -34,6 +34,58 @@ const mockRuntimeOptions = {
 } satisfies AcpSessionRuntime.AcpSessionRuntimeOptions;
 
 describe("AcpSessionRuntime", () => {
+  it.effect("confirms exit when admission resumes after the native exit watcher drained", () =>
+    Effect.gen(function* () {
+      const entered = yield* Deferred.make<void>();
+      const admission = yield* Deferred.make<void>();
+      const stdoutEnd = yield* Deferred.make<void>();
+      const dispatched = yield* Deferred.make<void>();
+      const nativeStopped = yield* Deferred.make<void>();
+      const exitWatcher = yield* Deferred.make<Fiber.Fiber<unknown, unknown>>();
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const runtime = yield* AcpSessionRuntime.make({
+        ...mockRuntimeOptions,
+        transformStdout: (stdout) =>
+          Stream.concat(stdout, Stream.fromEffect(Deferred.await(stdoutEnd)).pipe(Stream.drain)),
+      }).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, {
+          ...spawner,
+          spawn: (command) =>
+            spawner.spawn(command).pipe(
+              Effect.map((child) => ({
+                ...child,
+                exitCode: Effect.withFiber((fiber) =>
+                  Deferred.succeed(exitWatcher, fiber).pipe(Effect.andThen(child.exitCode)),
+                ),
+              })),
+            ),
+        }),
+      );
+      yield* Effect.addFinalizer(() => Deferred.succeed(stdoutEnd, undefined));
+      yield* runtime.start();
+      const prompt = yield* runtime
+        .prompt(
+          { prompt: [{ type: "text", text: "must retain exit proof" }] },
+          {
+            dispatched,
+            beforeSubmit: Deferred.succeed(entered, undefined).pipe(
+              Effect.andThen(Deferred.await(admission)),
+            ),
+            nativeStopped: Deferred.succeed(nativeStopped, undefined).pipe(Effect.asVoid),
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(entered);
+      yield* runtime.notify("_test/exit", {});
+      yield* Fiber.await(yield* Deferred.await(exitWatcher));
+      yield* Deferred.succeed(admission, undefined);
+      yield* Deferred.await(dispatched);
+      expect(yield* Deferred.isDone(nativeStopped)).toBe(true);
+      yield* Deferred.succeed(stdoutEnd, undefined);
+      expect(Exit.isFailure(yield* Fiber.await(prompt))).toBe(true);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
   for (const cancelBehavior of ["interrupt", "wait-for-prompt"] as const) {
     it.effect(`cancels a parked admission before native ${cancelBehavior} cancellation`, () =>
       Effect.gen(function* () {

--- a/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
+++ b/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
@@ -11,9 +11,11 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as Option from "effect/Option";
+import * as PlatformError from "effect/PlatformError";
 import * as Scope from "effect/Scope";
 import * as TestClock from "effect/testing/TestClock";
 import * as Stream from "effect/Stream";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import { describe, expect } from "vite-plus/test";
 
 import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
@@ -32,6 +34,169 @@ const mockRuntimeOptions = {
 } satisfies AcpSessionRuntime.AcpSessionRuntimeOptions;
 
 describe("AcpSessionRuntime", () => {
+  for (const cancelBehavior of ["interrupt", "wait-for-prompt"] as const) {
+    it.effect(`cancels a parked admission before native ${cancelBehavior} cancellation`, () =>
+      Effect.gen(function* () {
+        const entered = yield* Deferred.make<void>();
+        const release = yield* Deferred.make<void>();
+        const notSubmitted = yield* Deferred.make<void>();
+        const order: string[] = [];
+        let wirePrompts = 0;
+        const runtime = yield* AcpSessionRuntime.make({
+          ...mockRuntimeOptions,
+          cancelBehavior,
+          requestLogger: (event) =>
+            Effect.sync(() => {
+              if (event.method === "session/prompt" && event.status === "started")
+                order.push("logged");
+            }),
+          protocolLogging: {
+            logOutgoing: true,
+            logger: (event) =>
+              Effect.sync(() => {
+                if (
+                  event.direction === "outgoing" &&
+                  event.stage === "raw" &&
+                  typeof event.payload === "string" &&
+                  event.payload.includes('"method":"session/prompt"')
+                )
+                  wirePrompts += 1;
+              }),
+          },
+        });
+        yield* runtime.start();
+        const prompt = yield* runtime
+          .prompt(
+            { prompt: [{ type: "text", text: "must not run" }] },
+            {
+              beforeSubmit: Effect.gen(function* () {
+                order.push("admission");
+                yield* Deferred.succeed(entered, undefined);
+                yield* Deferred.await(release);
+              }),
+              notSubmitted: Deferred.succeed(notSubmitted, undefined).pipe(Effect.asVoid),
+            },
+          )
+          .pipe(Effect.forkChild);
+        yield* Deferred.await(entered);
+        expect(order).toEqual(["logged", "admission"]);
+        expect(wirePrompts).toBe(0);
+        yield* Fiber.interrupt(prompt);
+        expect(yield* Deferred.isDone(notSubmitted)).toBe(true);
+        yield* runtime.cancel;
+        yield* Deferred.succeed(release, undefined);
+        expect(
+          yield* runtime.prompt({ prompt: [{ type: "text", text: "replacement" }] }),
+        ).toMatchObject({ stopReason: "end_turn" });
+        expect(wirePrompts).toBe(1);
+      }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+    );
+  }
+
+  it.effect("observes a true native reply after local cancellation and a replacement prompt", () =>
+    Effect.gen(function* () {
+      const toolStarted = yield* Deferred.make<void>();
+      const nativeCompleted = yield* Deferred.make<void>();
+      const runtime = yield* AcpSessionRuntime.make({
+        ...mockRuntimeOptions,
+        spawn: {
+          ...mockRuntimeOptions.spawn,
+          env: { T3_ACP_COMPLETE_FIRST_PROMPT_ON_CANCEL: "1" },
+        },
+      });
+      yield* runtime.getEvents().pipe(
+        Stream.runForEach((event) => {
+          if (event._tag === "EventStreamBarrier")
+            return Deferred.succeed(event.acknowledge, undefined);
+          if (event._tag === "ToolCallUpdated" && event.toolCall.status === "inProgress")
+            return Deferred.succeed(toolStarted, undefined);
+          return Effect.void;
+        }),
+        Effect.forkChild,
+      );
+      yield* runtime.start();
+      const prompt = yield* runtime
+        .prompt(
+          { prompt: [{ type: "text", text: "first" }] },
+          {
+            nativeCompleted: Deferred.succeed(nativeCompleted, undefined).pipe(Effect.asVoid),
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(toolStarted);
+      yield* runtime.cancel;
+      expect(yield* Fiber.join(prompt)).toEqual({ stopReason: "cancelled" });
+      expect(yield* Deferred.isDone(nativeCompleted)).toBe(false);
+      expect(
+        yield* runtime.prompt({ prompt: [{ type: "text", text: "replacement" }] }),
+      ).toMatchObject({ stopReason: "end_turn" });
+      expect(yield* Deferred.isDone(nativeCompleted)).toBe(false);
+      yield* runtime.request("_test/finish-cancel", {});
+      yield* Deferred.await(nativeCompleted);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("confirms final child cleanup when direct kill cannot prove native exit", () =>
+    Effect.gen(function* () {
+      const toolStarted = yield* Deferred.make<void>();
+      const nativeStopped = yield* Deferred.make<void>();
+      const runtimeScope = yield* Scope.make();
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const runtime = yield* AcpSessionRuntime.make({
+        ...mockRuntimeOptions,
+        spawn: {
+          ...mockRuntimeOptions.spawn,
+          env: { T3_ACP_COMPLETE_FIRST_PROMPT_ON_CANCEL: "1" },
+        },
+      }).pipe(
+        Effect.provideService(Scope.Scope, runtimeScope),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, {
+          ...spawner,
+          spawn: (command) =>
+            spawner.spawn(command).pipe(
+              Effect.map((child) => ({
+                ...child,
+                kill: () =>
+                  Effect.fail(
+                    PlatformError.systemError({
+                      _tag: "Unknown",
+                      module: "ChildProcessSpawner",
+                      method: "kill",
+                      description:
+                        "Direct kill failed. The original scoped process cleanup still owns this child.",
+                    }),
+                  ),
+              })),
+            ),
+        }),
+      );
+      yield* Effect.addFinalizer(() => Scope.close(runtimeScope, Exit.void));
+      yield* runtime.getEvents().pipe(
+        Stream.runForEach((event) => {
+          if (event._tag === "ToolCallUpdated" && event.toolCall.status === "inProgress")
+            return Deferred.succeed(toolStarted, undefined);
+          return Effect.void;
+        }),
+        Effect.forkChild,
+      );
+      yield* runtime.start();
+      const prompt = yield* runtime
+        .prompt(
+          { prompt: [{ type: "text", text: "first" }] },
+          {
+            nativeStopped: Deferred.succeed(nativeStopped, undefined).pipe(Effect.asVoid),
+          },
+        )
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(toolStarted);
+      yield* runtime.cancel;
+      yield* Fiber.join(prompt);
+      expect(yield* Deferred.isDone(nativeStopped)).toBe(false);
+      yield* Scope.close(runtimeScope, Exit.void);
+      expect(yield* Deferred.isDone(nativeStopped)).toBe(true);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
   for (const setupMethod of ["session/new", "session/resume"] as const) {
     it.effect(`buffers root metadata while ${setupMethod} startup is still pending`, () =>
       Effect.gen(function* () {

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -239,7 +239,13 @@ export class AcpSessionRuntime extends Context.Service<
      */
     readonly prompt: (
       payload: Omit<EffectAcpSchema.PromptRequest, "sessionId">,
-      options?: { readonly dispatched?: Deferred.Deferred<void> },
+      options?: {
+        readonly dispatched?: Deferred.Deferred<void>;
+        readonly beforeSubmit?: Effect.Effect<void, EffectAcpErrors.AcpError>;
+        readonly nativeCompleted?: Effect.Effect<void>;
+        readonly nativeStopped?: Effect.Effect<void>;
+        readonly notSubmitted?: Effect.Effect<void>;
+      },
     ) => Effect.Effect<EffectAcpSchema.PromptResponse, EffectAcpErrors.AcpError>;
     /**
      * Sends a real ACP `session/cancel` notification for the active session.
@@ -317,6 +323,7 @@ interface EnsureActiveAssistantSegmentResult {
 interface AcpActivePrompt {
   readonly fiber: Fiber.Fiber<EffectAcpSchema.PromptResponse, EffectAcpErrors.AcpError>;
   readonly completed: Deferred.Deferred<void>;
+  readonly cancelled: Deferred.Deferred<void>;
 }
 
 export const make = (
@@ -358,6 +365,7 @@ export const make = (
     const promptSerializationSemaphore = yield* Semaphore.make(1);
     const promptDispatchSemaphore = yield* Semaphore.make(1);
     const activePromptRef = yield* Ref.make<Option.Option<AcpActivePrompt>>(Option.none());
+    const nativeClaims = new Set<{ readonly stopped: Effect.Effect<void> }>();
     const sessionLoadGateRef = yield* Ref.make<Option.Option<SessionLoadGate>>(Option.none());
 
     const ensureConnected = Effect.gen(function* () {
@@ -394,41 +402,44 @@ export const make = (
     const logRequest = (event: AcpSessionRequestLogEvent) =>
       options.requestLogger ? options.requestLogger(event) : Effect.void;
 
-    const runLoggedRequest = <A>(
+    const observeRequest = <A>(
       method: string,
       payload: unknown,
       effect: Effect.Effect<A, EffectAcpErrors.AcpError>,
     ): Effect.Effect<A, EffectAcpErrors.AcpError> =>
-      logRequest({ method, payload, status: "started" }).pipe(
-        Effect.flatMap(() =>
-          (options.onStderr
-            ? Effect.raceFirst(effect, Deferred.await(stderrFailure))
-            : effect
-          ).pipe(
-            Effect.tap((result) =>
-              logRequest({
-                method,
-                payload,
-                status: "succeeded",
-                result,
-              }),
-            ),
-            Effect.onError((cause) =>
-              logRequest({
-                method,
-                payload,
-                status: "failed",
-                cause,
-              }),
-            ),
-          ),
+      (options.onStderr ? Effect.raceFirst(effect, Deferred.await(stderrFailure)) : effect).pipe(
+        Effect.tap((result) =>
+          logRequest({
+            method,
+            payload,
+            status: "succeeded",
+            result,
+          }),
         ),
+        Effect.onError((cause) =>
+          logRequest({
+            method,
+            payload,
+            status: "failed",
+            cause,
+          }),
+        ),
+      );
+
+    const runLoggedRequest = <A>(
+      method: string,
+      payload: unknown,
+      effect: Effect.Effect<A, EffectAcpErrors.AcpError>,
+    ) =>
+      logRequest({ method, payload, status: "started" }).pipe(
+        Effect.andThen(observeRequest(method, payload, effect)),
       );
 
     const spawnCommand = yield* resolveSpawnCommand(options.spawn.command, options.spawn.args, {
       ...(options.spawn.env ? { env: options.spawn.env } : {}),
       extendEnv: options.spawn.extendEnv ?? true,
     });
+    const processScope = yield* Scope.fork(runtimeScope, "sequential");
     const child = yield* spawner
       .spawn(
         ChildProcess.make(spawnCommand.command, spawnCommand.args, {
@@ -436,10 +447,11 @@ export const make = (
           ...(options.spawn.env ? { env: options.spawn.env } : {}),
           extendEnv: options.spawn.extendEnv ?? true,
           shell: spawnCommand.shell,
+          forceKillAfter: "1 second",
         }),
       )
       .pipe(
-        Effect.provideService(Scope.Scope, runtimeScope),
+        Effect.provideService(Scope.Scope, processScope),
         Effect.mapError(
           (cause) =>
             new EffectAcpErrors.AcpSpawnError({
@@ -448,6 +460,22 @@ export const make = (
             }),
         ),
       );
+
+    const confirmNativeStopped = Effect.gen(function* () {
+      if (yield* child.isRunning.pipe(Effect.orElseSucceed(() => true))) return;
+      const claims = Array.from(nativeClaims);
+      nativeClaims.clear();
+      yield* Effect.forEach(claims, (claim) => claim.stopped, { discard: true });
+    }).pipe(Effect.uninterruptible);
+    yield* child.exitCode.pipe(
+      Effect.exit,
+      Effect.andThen(confirmNativeStopped),
+      Effect.forkIn(runtimeScope),
+    );
+    yield* Scope.addFinalizer(
+      runtimeScope,
+      Scope.close(processScope, Exit.void).pipe(Effect.ensuring(confirmNativeStopped)),
+    );
 
     yield* child.stderr.pipe(
       Stream.decodeText(),
@@ -920,11 +948,11 @@ export const make = (
       const started = yield* getStartedState;
       const activePrompt = yield* Ref.get(activePromptRef);
       if (options.cancelBehavior !== "wait-for-prompt") {
-        if (Option.isSome(activePrompt)) {
-          yield* Fiber.interrupt(activePrompt.value.fiber).pipe(Effect.ignore);
-        }
         // Write cancel before a replacement prompt can reach the agent.
         yield* acp.agent.cancel({ sessionId: started.sessionId }).pipe(Effect.ignore);
+        if (Option.isSome(activePrompt)) {
+          yield* Deferred.succeed(activePrompt.value.cancelled, undefined);
+        }
         return;
       }
 
@@ -989,12 +1017,36 @@ export const make = (
                   ...payload,
                 } satisfies EffectAcpSchema.PromptRequest;
                 const completed = yield* Deferred.make<void>();
-                const fiber = yield* runLoggedRequest(
+                const cancelled = yield* Deferred.make<void>();
+                // Admission can wait for a checkpoint while this permit is held.
+                // Stop must be able to cancel and join that wait before native cancel.
+                yield* Effect.interruptible(
+                  logRequest({
+                    method: "session/prompt",
+                    payload: requestPayload,
+                    status: "started",
+                  }).pipe(
+                    Effect.andThen(promptOptions?.beforeSubmit ?? Effect.void),
+                    Effect.andThen(ensureConnected),
+                  ),
+                ).pipe(Effect.onError(() => promptOptions?.notSubmitted ?? Effect.void));
+                const claim = { stopped: promptOptions?.nativeStopped ?? Effect.void };
+                nativeClaims.add(claim);
+                const fiber = yield* observeRequest(
                   "session/prompt",
                   requestPayload,
-                  acp.agent.prompt(requestPayload),
-                ).pipe(Effect.forkIn(runtimeScope));
-                const active = { fiber, completed } satisfies AcpActivePrompt;
+                  acp.agent
+                    .prompt(requestPayload)
+                    .pipe(
+                      Effect.tap(() =>
+                        (promptOptions?.nativeCompleted ?? Effect.void).pipe(
+                          Effect.andThen(Effect.sync(() => nativeClaims.delete(claim))),
+                          Effect.uninterruptible,
+                        ),
+                      ),
+                    ),
+                ).pipe(Effect.interruptible, Effect.forkIn(runtimeScope));
+                const active = { fiber, completed, cancelled } satisfies AcpActivePrompt;
                 yield* Ref.set(activePromptRef, Option.some(active));
                 if (promptOptions?.dispatched) {
                   yield* Deferred.succeed(promptOptions.dispatched, undefined);
@@ -1003,14 +1055,17 @@ export const make = (
               }),
             ),
             (activePrompt) =>
-              Fiber.join(activePrompt.fiber).pipe(
-                Effect.catchCause((cause) =>
-                  options.cancelBehavior !== "wait-for-prompt" && Cause.hasInterruptsOnly(cause)
-                    ? Effect.succeed({
+              (options.cancelBehavior === "wait-for-prompt"
+                ? Fiber.join(activePrompt.fiber)
+                : Effect.raceFirst(
+                    Fiber.join(activePrompt.fiber),
+                    Deferred.await(activePrompt.cancelled).pipe(
+                      Effect.as({
                         stopReason: "cancelled",
-                      } satisfies EffectAcpSchema.PromptResponse)
-                    : Effect.failCause(cause),
-                ),
+                      } satisfies EffectAcpSchema.PromptResponse),
+                    ),
+                  )
+              ).pipe(
                 Effect.tap(() =>
                   closeActiveAssistantSegment({ queue: eventQueue, assistantSegmentRef }),
                 ),
@@ -1030,7 +1085,11 @@ export const make = (
                     }),
                   );
                 }
-                yield* Fiber.interrupt(activePrompt.fiber).pipe(Effect.ignore);
+                // A local cancellation does not end native work. Keep observing the
+                // RPC response until the agent replies or the runtime scope closes.
+                if (options.cancelBehavior === "wait-for-prompt") {
+                  yield* Fiber.interrupt(activePrompt.fiber).pipe(Effect.ignore);
+                }
                 yield* Ref.set(activePromptRef, Option.none());
                 yield* Deferred.succeed(activePrompt.completed, undefined);
               }),

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -235,10 +235,13 @@ export class AcpSessionRuntime extends Context.Service<
      * Sends a prompt turn to the active session. `options.dispatched` settles once the
      * `session/prompt` RPC is registered as the active prompt, so a caller that forks this
      * effect knows when a later `cancel` will target this prompt.
+     * An Effect payload prepares configuration and content inside the prompt queue.
      * @see https://agentclientprotocol.com/protocol/schema#session/prompt
      */
-    readonly prompt: (
-      payload: Omit<EffectAcpSchema.PromptRequest, "sessionId">,
+    readonly prompt: <E = never>(
+      payload:
+        | Omit<EffectAcpSchema.PromptRequest, "sessionId">
+        | Effect.Effect<Omit<EffectAcpSchema.PromptRequest, "sessionId">, E>,
       options?: {
         readonly dispatched?: Deferred.Deferred<void>;
         readonly beforeSubmit?: Effect.Effect<void, EffectAcpErrors.AcpError>;
@@ -246,7 +249,7 @@ export class AcpSessionRuntime extends Context.Service<
         readonly nativeStopped?: Effect.Effect<void>;
         readonly notSubmitted?: Effect.Effect<void>;
       },
-    ) => Effect.Effect<EffectAcpSchema.PromptResponse, EffectAcpErrors.AcpError>;
+    ) => Effect.Effect<EffectAcpSchema.PromptResponse, EffectAcpErrors.AcpError | E>;
     /**
      * Sends a real ACP `session/cancel` notification for the active session.
      * @see https://agentclientprotocol.com/protocol/schema#session/cancel
@@ -1011,10 +1014,16 @@ export const make = (
             promptDispatchSemaphore.withPermit(
               Effect.gen(function* () {
                 const started = yield* getStartedState;
+                const prepared = yield* (
+                  Effect.isEffect(payload) ? payload : Effect.succeed(payload)
+                ).pipe(
+                  Effect.interruptible,
+                  Effect.onError(() => promptOptions?.notSubmitted ?? Effect.void),
+                );
                 yield* closeActiveAssistantSegment({ queue: eventQueue, assistantSegmentRef });
                 const requestPayload = {
                   sessionId: started.sessionId,
-                  ...payload,
+                  ...prepared,
                 } satisfies EffectAcpSchema.PromptRequest;
                 const completed = yield* Deferred.make<void>();
                 const cancelled = yield* Deferred.make<void>();
@@ -1032,6 +1041,9 @@ export const make = (
                 ).pipe(Effect.onError(() => promptOptions?.notSubmitted ?? Effect.void));
                 const claim = { stopped: promptOptions?.nativeStopped ?? Effect.void };
                 nativeClaims.add(claim);
+                // Child exit can precede protocol EOF while admission is parked.
+                // Recheck after registration so an earlier watcher cannot miss this claim.
+                yield* confirmNativeStopped;
                 const fiber = yield* observeRequest(
                   "session/prompt",
                   requestPayload,

--- a/apps/server/src/provider/acp/XAiAcpExtension.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.ts
@@ -460,14 +460,21 @@ export const makeXAiPromptCompletionRuntime = Effect.fn("makeXAiPromptCompletion
             sessionId,
             promptId,
           );
-          const requestPayload = {
-            ...payload,
-            _meta: {
-              ...payload._meta,
-              promptId: fallback.promptId,
-              requestId: fallback.promptId,
-            },
-          } satisfies Omit<EffectAcpSchema.PromptRequest, "sessionId">;
+          const requestPayload = (
+            Effect.isEffect(payload) ? payload : Effect.succeed(payload)
+          ).pipe(
+            Effect.map(
+              (prepared) =>
+                ({
+                  ...prepared,
+                  _meta: {
+                    ...prepared._meta,
+                    promptId: fallback.promptId,
+                    requestId: fallback.promptId,
+                  },
+                }) satisfies Omit<EffectAcpSchema.PromptRequest, "sessionId">,
+            ),
+          );
 
           return yield* Effect.raceFirst(
             runtime.prompt(requestPayload, promptOptions),

--- a/apps/server/src/provider/testFixtures/codexCollabMockPeer.mjs
+++ b/apps/server/src/provider/testFixtures/codexCollabMockPeer.mjs
@@ -151,6 +151,14 @@ rl.on("line", (line) => {
     }
     return;
   }
+  if (method === "turn/steer") {
+    if (message.params?.expectedTurnId !== activeTurn?.id) {
+      write({ id, error: { code: -32600, message: "no active turn to steer" } });
+    } else {
+      write({ id, result: { turnId: activeTurn.id } });
+    }
+    return;
+  }
   if (method === "turn/interrupt") {
     // Record which thread/turn was interrupted (append-only sidecar file the
     // test reads) so Stop coverage can assert every live child was reached.

--- a/apps/server/src/textGeneration/AntigravityTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/AntigravityTextGeneration.test.ts
@@ -79,7 +79,7 @@ const makeFixture = Effect.fn("makeAntigravityTextGenerationFixture")(function* 
   const state = {
     workspaces: [] as Array<string>,
     closed: [] as Array<string>,
-    prompts: [] as Array<Parameters<TextRuntime["prompt"]>[0]>,
+    prompts: [] as Array<Omit<AcpSchema.PromptRequest, "sessionId">>,
     selectedModels: [] as Array<string>,
     selectedModes: [] as Array<string>,
     nativeFilesAtClose: [] as Array<boolean>,
@@ -172,7 +172,7 @@ const makeFixture = Effect.fn("makeAntigravityTextGenerationFixture")(function* 
           }),
         prompt: (request) =>
           Effect.gen(function* () {
-            state.prompts.push(request);
+            state.prompts.push(Effect.isEffect(request) ? yield* request : request);
             yield* Deferred.succeed(enteredPrompt, undefined);
             const emit: PromptContext["emit"] = (update, sessionId = nativeSessionId) =>
               sessionUpdate({ sessionId, update });


### PR DESCRIPTION
A new T3 turn could reach a provider before the previous turn's checkpoint captured its final files. Cancelled requests could also release local state while native work still ran.

Adapters check capture ownership after send preparation, at submission. Each input stays reserved until exact native completion or confirmed teardown. A known T3 turn must also finish its queued checkpoint capture before that reservation is released. Stop cancels and joins pending sends before it stops the provider. Session preparation no longer blocks the command worker, and active-turn steering still works.

Stacked on [#10299](https://github.com/pingdotgg/t3code/pull/10299).

## Verification

The first review batch passed 804 tests across 18 focused suites, with one existing live-provider test skipped. The final follow-up passed 259 tests across the five changed suites, plus server typecheck and targeted lint. Tests cover late native replies, Stop during preparation and submission, confirmed process exit, exact command receipts, active steering, restart waits, and real Git checkpoint contents. No live app or data was used.

Separate isolated checks with Claude 2.1.263 and SDK 0.3.260 confirmed real `/agents` and `/clear` receipts with no model requests. These checked the native process and SDK, not the full T3 adapter.

## Limits

- The guarantee covers one running environment and the next new T3 turn. It does not persist native ownership across server restart.
- One open T3 turn can cover multiple native tasks. Claude has no expected-native-turn submission option. Every accepted input must finish before that T3 turn closes.
- Missing native proof keeps work unknown. OpenCode stream loss, launcher exit, and observer closure do not prove native shutdown and can leave work blocked. Unsupported Claude receipt streams reject further input until exact proof or confirmed Stop.
- Codex steering keeps requested settings for the next turn. Direct native clients see those defaults after the next native turn starts.
- Claude's public spawn hook preserves native debug logs, but cannot preserve the SDK-private sanitized crash tail or shared debug-file path.

Created with Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Coordinate native turn completion and checkpoint capture before starting new turns across provider adapters
> - Adds per-thread send admission tracking in `ProviderService` via `withPendingSend` and `withSendsBlocked` so sends are rejected during blocking operations or shutdown, and pending sends are interrupted or awaited before teardown
> - Introduces `ProviderTurnStartOptions` as a lifecycle contract across all adapters (Codex, Claude, Cursor, Grok, Antigravity, OpenCode): `beforeSubmit`, `notSubmitted`, `nativeCompleted`, and `nativeStopped` callbacks let the service know whether native submission occurred and when it finishes
> - Reworks `CodexSessionRuntime` turn submission to admit against the exact active turn, support same-turn steering, track native completions and process exits, and emit turn-aborted events when the native process stops mid-turn
> - Reworks `ClaudeAdapter` to serialize submission through a semaphore, correlate results with native command lifecycle frames, accumulate token usage across segments, and complete turns only after all submissions have native completion evidence
> - Tracks session commands per thread in `ProviderCommandReactor` with a preparation semaphore; session replacement now waits for pending sends, stop interrupts tracked command fibers, and pre-send cancellations are recorded as delayed
> - Updates `CheckpointReactor` to process native terminal events even when the stored active turn differs, and to skip capture when native readiness is explicitly unavailable
> - Risk: `ClaudeAdapter.sendTurn` now blocks new input after an unconfirmed prior submission (`handleResultMessage` in `ClaudeAdapter.ts`); `OpenCodeAdapter` session scope stays open while unconfirmed native submissions remain (`stopOpenCodeContext` in `OpenCodeAdapter.ts`); `CodexSessionRuntime.sendTurn` steers only when the active turn matches the expected ID (`sendTurn` in `CodexSessionRuntime.ts`)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7740442.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->