### PR TITLE
fix(web): keep text rendering stable when dropdowns open

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -334,8 +334,8 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     var(--popover) 18%,
     color-mix(in srgb, var(--popover) var(--glass-opacity), transparent)
   );
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturation));
-  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturation));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  backdrop-filter: blur(var(--glass-blur));
   border: 1px solid color-mix(in srgb, var(--contrast-foreground) 10%, transparent);
 
   @supports not ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {


### PR DESCRIPTION
## What Changed

Remove saturation from the shared `dropdown-glass` backdrop filter while retaining the configured blur.

## Why

On Windows Chromium, opening the PR Sort or Usage metric dropdown changes text appearance across the page, including the sidebar. The sampled text's computed color and opacity remain the same. Removing the dropdown's saturation filter eliminates the rendering shift in the tested environment.

The Usage page exposes the metric dropdown in its narrower layout. At wider widths it uses inline Cost, Tokens, and Limits buttons, so that interaction does not open the filtered popup. The shift reproduces while the narrower page has focus.

This restores the blur-only dropdown behavior used by [#4446](https://github.com/pingdotgg/t3code/pull/4446). The change is limited to the standard and WebKit-prefixed backdrop-filter declarations.

## UI Changes

Usage Limits views captured at 1100 × 780 and device-pixel ratio 1 in T3 Code's Windows embedded browser (Chromium 150.0.7871.224), with `document.hasFocus()` true. The test runs from upstream base `00d6109cb` plus the two-line fix. The before capture temporarily restores the original saturation filter in the test page; the after capture uses the proposed CSS without an override.

| Before: menu open changes surrounding text | After: menu open preserves surrounding text |
| --- | --- |
| ![Before: opening Limits changes the percentages, labels, and sidebar text](https://github.com/user-attachments/assets/f00f5c55-bf94-4cde-b7c4-4d9a918ef4f5) | ![After: opening Limits preserves the percentages, labels, and sidebar text](https://github.com/user-attachments/assets/801e6df3-c3d1-4919-a9bc-390488104a0d) |

Before interaction:

https://github.com/user-attachments/assets/21f92872-9bf2-451e-82f8-120c8ea305db

After interaction:

https://github.com/user-attachments/assets/6956a125-c3cc-41d1-8a14-0ffc3114a9ca

Additional PR Sort evidence: [before](https://github.com/user-attachments/assets/da728259-3167-434a-90ba-8f434ec2e913), [after](https://github.com/user-attachments/assets/b374efb0-d793-4b93-a0e1-82908b3bfc1e), [before video](https://github.com/user-attachments/assets/26b3dfe8-2056-4bfb-b838-2cb9078e2aa4), [after video](https://github.com/user-attachments/assets/b697a473-718d-446a-8df7-1e1b217391e3).

## Validation

- `vp fmt --check apps/web/src/index.css` passed.
- `vp run --filter @t3tools/web typecheck` passed.
- `vp run --filter @t3tools/web build` passed. The emitted dropdown CSS retains blur and omits saturation. The build reports its chunk-size warning.
- `git diff --check` passed.
- PR Sort and Usage Limits dropdowns inspected in dark and light themes. Computed blur remains 16px in dark and 12px in light.
- Compared closed/open Usage Limits screenshots in the Search, All projects, Codex Weekly, and Claude Session text regions: all four regions change with the original styling and remain pixel-identical with the fix. The separate PR Sort comparison gives the same result for the sidebar and page-title regions.
- The reporter confirmed the shift is gone after applying the same filter change to their existing Chrome Usage tab, without changing window size or zoom (1013 × 1007 content viewport).
- Independent code review found no blocking issues.

The rendered checks cover Windows Chromium. Safari, Firefox, macOS, Linux, and the full packaged desktop shell were not tested. Native mobile does not use this CSS utility.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: GPT-6; harness: Codex.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `saturate()` from `dropdown-glass` backdrop-filter
> The `dropdown-glass` utility in [index.css](https://github.com/pingdotgg/t3code/pull/10335/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) previously applied both blur and saturation to the backdrop. Saturation caused text behind the dropdown to shift in color, making rendering unstable. The utility now applies blur only, retaining its background, border, and fallback rules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f5629b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->