### PR TITLE
fix(web): allow editing invalid stored preferences

### DIFF
--- a/apps/web/src/hooks/useLocalStorage.test.ts
+++ b/apps/web/src/hooks/useLocalStorage.test.ts
@@ -1,4 +1,6 @@
 import * as Schema from "effect/Schema";
+import { act, createElement, useLayoutEffect } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 function createStorage(overrides: Partial<Storage> = {}): Storage {
@@ -21,14 +23,155 @@ function createStorage(overrides: Partial<Storage> = {}): Storage {
 }
 
 async function loadWithStorage(storage: Storage) {
-  vi.stubGlobal("window", { localStorage: storage });
+  vi.stubGlobal("window", Object.assign(new EventTarget(), { localStorage: storage }));
   vi.stubGlobal("localStorage", storage);
   return import("./useLocalStorage");
 }
 
-afterEach(() => {
+let renderer: ReactTestRenderer | undefined;
+
+async function mountPreference(storage: Storage) {
+  const { useLocalStorage } = await loadWithStorage(storage);
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  let preference: ReturnType<typeof useLocalStorage<boolean, boolean>>;
+
+  function PreferenceProbe() {
+    const state = useLocalStorage("preference-key", false, Schema.Boolean);
+    useLayoutEffect(() => {
+      preference = state;
+    });
+    return null;
+  }
+
+  await act(() => {
+    renderer = create(createElement(PreferenceProbe));
+  });
+
+  return {
+    get value() {
+      return preference[0];
+    },
+    get setValue() {
+      return preference[1];
+    },
+  };
+}
+
+afterEach(async () => {
+  await act(() => renderer?.unmount());
+  renderer = undefined;
+  vi.restoreAllMocks();
   vi.resetModules();
   vi.unstubAllGlobals();
+});
+
+describe("local storage preferences", () => {
+  describe.each([
+    { update: "direct", value: true },
+    { update: "functional", value: (current: boolean) => !current },
+  ])("$update updates", ({ value }) => {
+    it.each(["", "not-json", '"old-format"'])(
+      "replaces invalid value %j on edit",
+      async (stored) => {
+        const storage = createStorage();
+        storage.setItem("preference-key", stored);
+        const preference = await mountPreference(storage);
+
+        expect(preference.value).toBe(false);
+        expect(storage.getItem("preference-key")).toBe(stored);
+
+        await act(() => preference.setValue(value));
+
+        expect(preference.value).toBe(true);
+        expect(storage.getItem("preference-key")).toBe("true");
+
+        await act(() => renderer?.unmount());
+        const reloadedPreference = await mountPreference(storage);
+        expect(reloadedPreference.value).toBe(true);
+      },
+    );
+  });
+
+  it("applies successive functional updates to the latest stored value", async () => {
+    const storage = createStorage();
+    storage.setItem("preference-key", "true");
+    const preference = await mountPreference(storage);
+
+    await act(() => {
+      preference.setValue((current) => !current);
+      preference.setValue((current) => !current);
+    });
+
+    expect(preference.value).toBe(true);
+    expect(storage.getItem("preference-key")).toBe("true");
+  });
+
+  it("does not replace an unreadable preference with the default", async () => {
+    const storage = createStorage();
+    storage.setItem("preference-key", "true");
+    const preference = await mountPreference(storage);
+    const cause = new Error("storage unavailable");
+    const read = vi.spyOn(storage, "getItem").mockImplementation(() => {
+      throw cause;
+    });
+    const consoleError = vi.spyOn(console, "error");
+
+    await act(() => preference.setValue((current) => current));
+
+    read.mockRestore();
+    expect(storage.getItem("preference-key")).toBe("true");
+    expect(preference.value).toBe(true);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[LOCALSTORAGE] Could not update stored value.",
+      expect.objectContaining({ operation: "read", storageKey: "preference-key", cause }),
+    );
+  });
+
+  it("keeps invalid data when a write fails and allows retrying", async () => {
+    const storage = createStorage();
+    storage.setItem("preference-key", "not-json");
+    const preference = await mountPreference(storage);
+    const cause = new Error("storage quota exceeded");
+    const write = vi.spyOn(storage, "setItem").mockImplementation(() => {
+      throw cause;
+    });
+    const consoleError = vi.spyOn(console, "error");
+
+    await act(() => preference.setValue(true));
+
+    expect(storage.getItem("preference-key")).toBe("not-json");
+    expect(preference.value).toBe(false);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[LOCALSTORAGE] Could not update stored value.",
+      expect.objectContaining({ operation: "write", storageKey: "preference-key", cause }),
+    );
+
+    write.mockRestore();
+    await act(() => preference.setValue(true));
+    expect(preference.value).toBe(true);
+    expect(storage.getItem("preference-key")).toBe("true");
+  });
+
+  it("keeps invalid data when the updater fails", async () => {
+    const storage = createStorage();
+    storage.setItem("preference-key", "not-json");
+    const preference = await mountPreference(storage);
+    const cause = new Error("update failed");
+    const consoleError = vi.spyOn(console, "error");
+
+    await act(() =>
+      preference.setValue(() => {
+        throw cause;
+      }),
+    );
+
+    expect(storage.getItem("preference-key")).toBe("not-json");
+    expect(preference.value).toBe(false);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[LOCALSTORAGE] Could not update stored value.",
+      expect.objectContaining({ operation: "update", storageKey: "preference-key", cause }),
+    );
+  });
 });
 
 describe("local storage errors", () => {

--- a/apps/web/src/hooks/useLocalStorage.ts
+++ b/apps/web/src/hooks/useLocalStorage.ts
@@ -15,6 +15,8 @@ export class LocalStorageOperationError extends Schema.TaggedErrorClass<LocalSto
   }
 }
 
+const isLocalStorageOperationError = Schema.is(LocalStorageOperationError);
+
 const fallbackStorage: Storage = (() => {
   const store = new Map<string, string>();
   return {
@@ -150,7 +152,15 @@ export function useLocalStorage<T, E>(
   const setValue = useCallback(
     (value: T | ((val: T) => T)) => {
       try {
-        const currentValue = getLocalStorageItem(key, schema) ?? initialValue;
+        let currentValue = initialValue;
+        try {
+          currentValue = getLocalStorageItem(key, schema) ?? initialValue;
+        } catch (error) {
+          if (!isLocalStorageOperationError(error) || error.operation !== "decode") {
+            throw error;
+          }
+          console.error("[LOCALSTORAGE] Could not decode stored value.", error);
+        }
         let valueToStore: T;
         if (typeof value === "function") {
           try {


### PR DESCRIPTION
## What changed

When a stored preference contains malformed JSON or a value rejected by its schema, `useLocalStorage` displays its default but its setter fails while decoding the same value. This leaves controls such as the Advanced typography switch stuck.

Recover from decode failures inside the setter, using the existing initial value before applying the edit. Invalid data stays untouched until an update is requested. Read failures still stop the update, and the strict storage helpers and error logging remain unchanged.

## Why

Users should be able to change the preference they see without manually clearing browser storage. The shared hook covers web and desktop preferences, including sidebar shelves and file-preview choices. Mobile storage, provider adapters, contracts, product defaults, and diagnostic settings do not change.

```mermaid
flowchart LR
    A[Edit preference] --> B{Read stored value}
    B -->|Valid| C[Use stored value]
    B -->|Missing or decode failure| D[Use existing default]
    B -->|Read failure| E[Report error and stop]
    C --> F[Apply edit and attempt save]
    D --> F
```

## Verification

- `vp test run src/hooks/useLocalStorage.test.ts --project unit --maxWorkers 1`, from `apps/web`: 16 tests pass. The initial regression failed before the fix.
- Tests cover direct and functional updates, invalid JSON, schema mismatch, persistence after remount, successive updates, and read/write/updater failures.
- Targeted lint, formatting, and TypeScript checks for the hook and its tests pass. Fallow's changed-file audit reports no introduced findings, with one analysis thread.
- In the running app, local Chromium confirms that Advanced typography recovers from invalid JSON and schema mismatch, survives reload, and can be switched off again. The Settled shelf's functional updater recovers, survives reload, and collapses again.

## UI changes

Same isolated app and 1200×760 viewport. PNG captures are 2400×1520. The shared T3 preview could not navigate to the dev server, so verification used local Chromium. No native desktop or mobile run is claimed.

Both captures follow a click on Advanced with `t3code:typography-advanced` set to `not-json`. Before uses the hook from `7544d3d2c`; after uses `a61493bdb`.

Before: the switch remains off and the invalid value is unchanged.

![Before: Advanced remains off after clicking](https://github.com/user-attachments/assets/195a5be3-ee39-4f80-a16e-4833b133dd0f)

After: the switch turns on, the advanced fields appear, and the preference saves as `true`.

![After: Advanced turns on and exposes the additional font settings](https://github.com/user-attachments/assets/64cd2893-e4e5-4b5d-b1e6-f5f81b059121)

Before video:

https://github.com/user-attachments/assets/e659c465-2cca-4417-96ee-2d0beb3ede92

After video:

https://github.com/user-attachments/assets/fb28af6a-cdd8-4379-8e81-db71b446dfd3

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes
- [x] I included videos for interaction changes

Model: GPT-5. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test coverage for editing invalid stored preferences in `useLocalStorage`
> - Expands [useLocalStorage.test.ts](https://github.com/pingdotgg/t3code/pull/10339/files#diff-ef2065be3510ddbb1b974a54a7613968800b77da5ff03ec374dd80f176c6b0b3) with a suite covering direct and functional updates over empty, malformed, and legacy stored values
> - Adds tests verifying that editing invalid stored data persists the new value and survives a remount, while read/write/update failures preserve the existing storage and hook state
> - Upgrades test helpers: `loadWithStorage` now uses an `EventTarget`-backed window stub, and `mountPreference` dynamically loads the hook and captures state through a layout effect
> - Risk: no source changes are described; if the fix lives outside this test file, reviewers should confirm the production code already handles invalid stored preferences as the tests expect
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a61493b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preference storage recovery when saved values are invalid, allowing them to be replaced with valid updates.
  - Preserved existing preferences when storage read, write, or update operations fail.
  - Ensured successive preference updates consistently use the latest saved value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->