### PR TITLE
fix(web): restore thread scroll position

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -231,6 +231,7 @@ import {
 } from "~/projectScripts";
 import { newDraftId, newMessageId, newThreadId } from "~/lib/utils";
 import { useBrowserHistoryStore } from "~/browserHistoryStore";
+import { readTimelineScrollPosition } from "~/timelineScrollState";
 import { registerFaviconProjectForThread } from "~/browserFaviconStore";
 import { getProviderModelCapabilities } from "../providerModels";
 import {
@@ -5132,12 +5133,15 @@ export default function ChatView(props: ChatViewProps) {
   }, [activeThread?.id, timelineEntries, getActiveTimelineTurnMetrics]);
 
   useEffect(() => {
+    const restoringSavedPosition = readTimelineScrollPosition(routeThreadKey) !== null;
     setPullRequestDialogState(null);
-    isAtEndRef.current = true;
+    isAtEndRef.current = !restoringSavedPosition;
     timelineScrollIntentRef.current = null;
-    timelineScrollModeRef.current = "following-end";
-    liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
-    setTimelineLiveFollowEnabled(true);
+    timelineScrollModeRef.current = restoringSavedPosition ? "free-scrolling" : "following-end";
+    liveFollowUserScrollGenerationRef.current = restoringSavedPosition
+      ? null
+      : anchorUserScrollGenerationRef.current;
+    setTimelineLiveFollowEnabled(!restoringSavedPosition);
     pendingTimelineAnchorRef.current = null;
     positionedTimelineAnchorRef.current = null;
     settledTimelineAnchorRef.current = null;
@@ -5145,7 +5149,7 @@ export default function ChatView(props: ChatViewProps) {
     showScrollDebouncer.current.cancel();
     setShowScrollToBottom(false);
     // activeThreadRef resets transitively with the active thread.
-  }, [activeThread?.id]);
+  }, [activeThread?.id, routeThreadKey]);
 
   useEffect(() => {
     setIsRevertingCheckpoint(false);
@@ -8226,7 +8230,7 @@ export default function ChatView(props: ChatViewProps) {
                 onCiteAssistantText={citeAssistantText}
                 agentPanelModel={agentPanelModel}
                 onOpenAgents={addAgentsSurface}
-                key={activeThread.id}
+                key={routeThreadKey}
                 isWorking={isWorking}
                 isPreparingWorktree={isPreparingWorktree}
                 isCompacting={isCompacting}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -105,6 +105,11 @@ import {
 } from "lucide-react";
 import { Button } from "../ui/button";
 import { useAssetUrlRefresh, useAssetUrls, useAssetUrlState } from "../../assets/assetUrls";
+import {
+  clearTimelineScrollPosition,
+  readTimelineScrollPosition,
+  rememberTimelineScrollPosition,
+} from "../../timelineScrollState";
 import { MediaVideoPlayer } from "../media/MediaVideoPlayer";
 import { getVirtualizedScrollFadeClassName } from "../ui/scroll-area";
 import {
@@ -403,6 +408,12 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   topFadeEnabled = false,
   loadEarlier = null,
 }: MessagesTimelineProps) {
+  const [initialScrollOffset] = useState(() => readTimelineScrollPosition(routeThreadKey));
+  const [restoringSavedPosition, setRestoringSavedPosition] = useState(
+    initialScrollOffset !== null,
+  );
+  const pendingScrollPositionRef = useRef<number | null>(null);
+  const scrollPositionFrameRef = useRef<number | null>(null);
   const [expandedTurnIds, setExpandedTurnIds] = useState<ReadonlySet<TurnId>>(new Set());
   const citationThreadRef = useMemo(() => parseScopedThreadKey(routeThreadKey), [routeThreadKey]);
   const expandCitedTurn = useCallback((turnId: TurnId) => {
@@ -657,6 +668,30 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   const handleScroll = useCallback(() => {
     const state = listRef.current?.getState?.();
     const isAtEnd = resolveTimelineIsAtEnd(state);
+    if (!citationPositioning) {
+      if (restoringSavedPosition && state) {
+        setRestoringSavedPosition(false);
+      } else if (isAtEnd === true) {
+        pendingScrollPositionRef.current = null;
+        if (scrollPositionFrameRef.current !== null) {
+          cancelAnimationFrame(scrollPositionFrameRef.current);
+          scrollPositionFrameRef.current = null;
+        }
+        clearTimelineScrollPosition(routeThreadKey);
+      } else if (isAtEnd === false && state?.scroll !== undefined) {
+        pendingScrollPositionRef.current = state.scroll;
+        if (scrollPositionFrameRef.current === null) {
+          scrollPositionFrameRef.current = requestAnimationFrame(() => {
+            scrollPositionFrameRef.current = null;
+            const pendingScrollTop = pendingScrollPositionRef.current;
+            pendingScrollPositionRef.current = null;
+            if (pendingScrollTop !== null) {
+              rememberTimelineScrollPosition(routeThreadKey, pendingScrollTop);
+            }
+          });
+        }
+      }
+    }
     if (isAtEnd !== undefined && !citationPositioning) {
       onIsAtEndChange(isAtEnd);
     }
@@ -702,7 +737,28 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     minimapStripMap,
     onIsAtEndChange,
     reportContentOverflow,
+    restoringSavedPosition,
+    routeThreadKey,
   ]);
+
+  useEffect(() => {
+    const mountedList = listRef.current;
+    return () => {
+      pendingScrollPositionRef.current = null;
+      if (scrollPositionFrameRef.current !== null) {
+        cancelAnimationFrame(scrollPositionFrameRef.current);
+        scrollPositionFrameRef.current = null;
+      }
+      if (citationPositioning) return;
+      const state = mountedList?.getState?.();
+      const isAtEnd = resolveTimelineIsAtEnd(state);
+      if (isAtEnd === true) {
+        clearTimelineScrollPosition(routeThreadKey);
+      } else if (isAtEnd === false && state?.scroll !== undefined) {
+        rememberTimelineScrollPosition(routeThreadKey, state.scroll);
+      }
+    };
+  }, [citationPositioning, listRef, routeThreadKey]);
 
   useEffect(() => {
     const frame = requestAnimationFrame(handleScroll);
@@ -842,7 +898,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
             getItemType={getItemType}
             renderItem={renderItem}
             estimatedItemSize={90}
-            initialScrollAtEnd={citationRequest === null}
+            initialScrollAtEnd={citationRequest === null && initialScrollOffset === null}
+            {...(initialScrollOffset !== null ? { initialScrollOffset } : {})}
             // Legend needs a data refresh to mount new pins without a scroll event.
             {...(readyCitationRequest ? { dataVersion: readyCitationRequest.key } : {})}
             {...(citationAlwaysRender ? { alwaysRender: citationAlwaysRender } : {})}
@@ -852,6 +909,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
             maintainScrollAtEnd={
               citationPositioning ||
               anchoredEndSpace ||
+              restoringSavedPosition ||
               !liveFollowEnabled ||
               disclosureToggleSettling
                 ? false

--- a/apps/web/src/lib/lruCache.test.ts
+++ b/apps/web/src/lib/lruCache.test.ts
@@ -7,6 +7,16 @@ describe("LRUCache", () => {
     expect(cache.get("missing")).toBeNull();
   });
 
+  it("deletes an entry and releases its memory budget", () => {
+    const cache = new LRUCache<string>(2, 10);
+    cache.set("a", "A", 10);
+    cache.delete("a");
+    cache.set("b", "B", 10);
+
+    expect(cache.get("a")).toBeNull();
+    expect(cache.get("b")).toBe("B");
+  });
+
   it("evicts oldest by max entries", () => {
     const cache = new LRUCache<string>(2, 1_000);
     cache.set("a", "A", 10);

--- a/apps/web/src/lib/lruCache.ts
+++ b/apps/web/src/lib/lruCache.ts
@@ -38,6 +38,13 @@ export class LRUCache<T> {
     this.totalSize += approximateSize;
   }
 
+  delete(key: string): void {
+    const entry = this.cache.get(key);
+    if (!entry) return;
+    this.cache.delete(key);
+    this.totalSize -= entry.approximateSize;
+  }
+
   clear(): void {
     this.cache.clear();
     this.totalSize = 0;

--- a/apps/web/src/timelineScrollState.test.ts
+++ b/apps/web/src/timelineScrollState.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+
+import {
+  clearTimelineScrollPosition,
+  clearTimelineScrollStateForTests,
+  readTimelineScrollPosition,
+  rememberTimelineScrollPosition,
+} from "./timelineScrollState";
+
+describe("timeline scroll state", () => {
+  beforeEach(clearTimelineScrollStateForTests);
+
+  it("keeps independent positions for each thread", () => {
+    rememberTimelineScrollPosition("environment:thread-a", 420);
+    rememberTimelineScrollPosition("environment:thread-b", 860);
+
+    expect(readTimelineScrollPosition("environment:thread-a")).toBe(420);
+    expect(readTimelineScrollPosition("environment:thread-b")).toBe(860);
+
+    clearTimelineScrollPosition("environment:thread-a");
+    expect(readTimelineScrollPosition("environment:thread-a")).toBeNull();
+    expect(readTimelineScrollPosition("environment:thread-b")).toBe(860);
+  });
+});

--- a/apps/web/src/timelineScrollState.ts
+++ b/apps/web/src/timelineScrollState.ts
@@ -1,0 +1,26 @@
+import { LRUCache } from "./lib/lruCache";
+
+const TIMELINE_SCROLL_CACHE_SIZE = 200;
+const TIMELINE_SCROLL_POSITION_BYTES = 8;
+
+const timelineScrollPositions = new LRUCache<number>(
+  TIMELINE_SCROLL_CACHE_SIZE,
+  TIMELINE_SCROLL_CACHE_SIZE * TIMELINE_SCROLL_POSITION_BYTES,
+);
+
+export function readTimelineScrollPosition(threadKey: string): number | null {
+  return timelineScrollPositions.get(threadKey);
+}
+
+export function rememberTimelineScrollPosition(threadKey: string, scrollTop: number): void {
+  if (!Number.isFinite(scrollTop) || scrollTop < 0) return;
+  timelineScrollPositions.set(threadKey, scrollTop, TIMELINE_SCROLL_POSITION_BYTES);
+}
+
+export function clearTimelineScrollPosition(threadKey: string): void {
+  timelineScrollPositions.delete(threadKey);
+}
+
+export function clearTimelineScrollStateForTests(): void {
+  timelineScrollPositions.clear();
+}

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -91,6 +91,11 @@ offline environments and older servers keep their previous values. If connected
 environments disagree, **Apply to all** copies your current settings to those named
 in the warning. Changing a rule does not reopen already settled threads.
 
+## Returning to a thread
+
+When you switch between threads on web or desktop, each conversation keeps your reading position.
+Positions belong to the current client session and are not shared across devices.
+
 ## Link a pull request
 
 The server finds the PR for each unsettled thread's saved branch, even when your


### PR DESCRIPTION
## What Changed

Switching away from a thread and back now returns the chat timeline to where you were reading, instead of jumping to the latest message. Positions are kept per client session in a small bounded in-memory cache keyed by thread. A thread you left at the bottom keeps following new content as before; only a thread you had scrolled up in is restored.

Scope decisions:
- Web and desktop only, including the web app's narrow layout, which uses the same timeline. The React Native mobile app (`apps/mobile`) has its own timeline and is consciously not covered.
- Nothing is persisted across restarts or synced between devices.
- Citation positioning still takes priority over a saved position.

## Why

Glancing at another thread and losing your place in a long conversation is a constant small annoyance when driving several agents. Provenance: #6195 (transcript half; the open-file half is #9874).

The saved offset is written once per animation frame while scrolling and cleared when the reader reaches the end, so following live output costs nothing extra.

## UI Changes

https://github.com/user-attachments/assets/e352288d-fe58-4794-8bd8-a2c367ecb970

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (motion change, video instead)
- [x] I included a video for animation/interaction changes

Written with Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore per-thread scroll position in `MessagesTimeline`
> - Adds [timelineScrollState.ts](https://github.com/pingdotgg/t3code/pull/10340/files#diff-9c7924c3a9a8982082c408885090c2f8655a455e097fab9cfc7e5e7f10c336a3) module with a bounded LRU cache (200 entries) to store numeric scroll offsets per thread key.
> - [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/10340/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) reads the saved offset on mount, disables end-follow during restoration, and saves or clears the offset on scroll and cleanup.
> - [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/10340/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) starts routed threads in free-scrolling mode when a saved position exists.
> - Adds `delete` method to [lruCache.ts](https://github.com/pingdotgg/t3code/pull/10340/files#diff-8573cd81db1abad92463eb70e3d0f7a754e3d01908f4e1e725138ff1d16cb490) to support removing individual cached entries.
> - Risk: `ChatView` timeline initialization switches from end-following to free-scrolling for threads with a saved non-end position.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73cd51e. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation timelines now preserve and restore your reading position when switching between threads during a session.
  * Returning to the end of a conversation resumes live updates automatically.
  * Reading positions are maintained independently on each client and are not shared across devices.

* **Documentation**
  * Added guidance explaining thread reading-position behavior and session limitations.

* **Tests**
  * Added coverage for independent thread positions and cache cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->