### PR TITLE
feat(web): offer provider updates for remote environments above the composer

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -339,6 +339,7 @@ import {
   ThreadErrorBanner,
 } from "./chat/ThreadErrorBanner";
 import type { ComposerBannerStackItem } from "./chat/ComposerBannerStack";
+import { useComposerProviderUpdateBannerItem } from "./chat/ComposerProviderUpdateNotice";
 import { ComposerSurface } from "./chat/ComposerSurface";
 import {
   hasAvailableCompactionProvider,
@@ -2345,6 +2346,7 @@ export default function ChatView(props: ChatViewProps) {
   const serverUpdateFailureDismissed =
     serverUpdateState === dismissedServerUpdateState ||
     isServerUpdateFailureDismissed(serverUpdateState);
+  const providerUpdateBannerItem = useComposerProviderUpdateBannerItem(serverUpdateEnvironmentId);
   const systemComposerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
     const items: ComposerBannerStackItem[] = [];
     const updateRunning = serverUpdateState.status === "running";
@@ -2495,9 +2497,14 @@ export default function ChatView(props: ChatViewProps) {
             }),
       });
     }
+    // After the server notice, so a version skew keeps priority over a provider one.
+    if (providerUpdateBannerItem) {
+      items.push(providerUpdateBannerItem);
+    }
     return items;
   }, [
     activeEnvironmentUnavailableState,
+    providerUpdateBannerItem,
     reconnectWarningGraceElapsed,
     handleReconnectActiveEnvironment,
     navigate,

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.environments.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.environments.ts
@@ -18,7 +18,7 @@ import {
  * loopback with a bearer token and carries a `local:<backendInstanceId>`
  * connection id. SSH, relay, and other remote targets are excluded.
  */
-function isLocalConnectionTarget(target: ConnectionCatalogEntry["target"]): boolean {
+export function isLocalConnectionTarget(target: ConnectionCatalogEntry["target"]): boolean {
   return target._tag === "PrimaryConnectionTarget" || isDesktopLocalConnectionTarget(target);
 }
 

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
@@ -10,6 +10,7 @@ import { AsyncResult } from "effect/unstable/reactivity";
 
 import {
   buildLocalEnvironmentUpdateGroups,
+  buildRemoteProviderUpdateNotice,
   canOneClickUpdateProviderCandidate,
   collectProviderUpdateCandidates,
   collectProviderUpdateOutcomeSnapshots,
@@ -1036,5 +1037,143 @@ describe("provider update launch notification logic", () => {
         }),
       ).toMatchObject({ kind: "idle", text: "Codex" });
     });
+  });
+});
+
+describe("remote environment provider update notice", () => {
+  const base = {
+    environmentId: "env-remote" as EnvironmentId,
+    environmentLabel: "office-linux",
+    dismissedKeys: new Set<string>(),
+  };
+
+  it("skips providers that are current or disabled", () => {
+    expect(
+      buildRemoteProviderUpdateNotice({
+        ...base,
+        providers: [
+          provider({ driver: driver("codex"), advisoryStatus: "current", latestVersion: null }),
+          provider({ driver: driver("cursor"), enabled: false }),
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("stays quiet without an update command to run", () => {
+    expect(
+      buildRemoteProviderUpdateNotice({
+        ...base,
+        providers: [provider({ driver: driver("codex"), updateCommand: null })],
+      }),
+    ).toBeNull();
+  });
+
+  it("names the provider, version and environment, and targets the driver once", () => {
+    const notice = buildRemoteProviderUpdateNotice({
+      ...base,
+      providers: [
+        provider({
+          driver: driver("codex"),
+          instanceId: instanceId("codex"),
+          latestVersion: "1.1.0",
+        }),
+        provider({
+          driver: driver("codex"),
+          instanceId: instanceId("codex_work"),
+          latestVersion: "1.1.0",
+        }),
+      ],
+    });
+    expect(notice).toMatchObject({
+      title: "Codex v1.1.0 is available on office-linux",
+      status: "idle",
+      failureMessage: null,
+    });
+    expect(notice?.targets).toHaveLength(1);
+  });
+
+  it("lists distinct providers in one notice", () => {
+    expect(
+      buildRemoteProviderUpdateNotice({
+        ...base,
+        providers: [
+          provider({ driver: driver("codex"), latestVersion: "1.1.0" }),
+          provider({ driver: driver("cursor"), latestVersion: "0.3.0" }),
+        ],
+      })?.title,
+    ).toBe("Codex and Cursor updates are available on office-linux");
+  });
+
+  it("stays dismissed until a newer version arrives", () => {
+    const providers = [provider({ driver: driver("codex"), latestVersion: "1.1.0" })];
+    const dismissedKeys = new Set(["env-remote|codex:1.1.0"]);
+    expect(buildRemoteProviderUpdateNotice({ ...base, providers })?.dismissalKey).toBe(
+      "env-remote|codex:1.1.0",
+    );
+    expect(buildRemoteProviderUpdateNotice({ ...base, providers, dismissedKeys })).toBeNull();
+    expect(
+      buildRemoteProviderUpdateNotice({
+        ...base,
+        dismissedKeys,
+        providers: [provider({ driver: driver("codex"), latestVersion: "1.2.0" })],
+      })?.dismissalKey,
+    ).toBe("env-remote|codex:1.2.0");
+  });
+
+  it("reports live update progress and failures from the environment", () => {
+    expect(
+      buildRemoteProviderUpdateNotice({
+        ...base,
+        providers: [
+          provider({
+            driver: driver("codex"),
+            updateState: {
+              status: "running",
+              startedAt: checkedAt,
+              finishedAt: null,
+              message: null,
+              output: null,
+            },
+          }),
+        ],
+      }),
+    ).toMatchObject({ status: "running" });
+    expect(
+      buildRemoteProviderUpdateNotice({
+        ...base,
+        providers: [
+          provider({
+            driver: driver("codex"),
+            updateState: {
+              status: "failed",
+              startedAt: checkedAt,
+              finishedAt: laterCheckedAt,
+              message: "npm exited with 1",
+              output: null,
+            },
+          }),
+        ],
+      }),
+    ).toMatchObject({ status: "failed", failureMessage: "npm exited with 1" });
+  });
+
+  it("treats an unchanged update as a failure so the retry stays visible", () => {
+    expect(
+      buildRemoteProviderUpdateNotice({
+        ...base,
+        providers: [
+          provider({
+            driver: driver("codex"),
+            updateState: {
+              status: "unchanged",
+              startedAt: checkedAt,
+              finishedAt: laterCheckedAt,
+              message: "codex is still on v1.0.0",
+              output: null,
+            },
+          }),
+        ],
+      }),
+    ).toMatchObject({ status: "failed", failureMessage: "codex is still on v1.0.0" });
   });
 });

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
@@ -1132,6 +1132,28 @@ describe("remote environment provider update notice", () => {
     ).toMatchObject({ status: "running" });
   });
 
+  it("reports progress from a sibling instance of the same driver", () => {
+    expect(
+      buildRemoteProviderUpdateNotice({
+        ...base,
+        providers: [
+          provider({ driver: driver("codex") }),
+          provider({
+            driver: driver("codex"),
+            instanceId: instanceId("codex_work"),
+            updateState: {
+              status: "queued",
+              startedAt: checkedAt,
+              finishedAt: null,
+              message: null,
+              output: null,
+            },
+          }),
+        ],
+      }),
+    ).toMatchObject({ status: "running" });
+  });
+
   it("keeps a retry visible after a failed or unchanged update, failure first", () => {
     const settledState = (status: "failed" | "unchanged", message: string) => ({
       status,

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
@@ -1047,23 +1047,15 @@ describe("remote environment provider update notice", () => {
     dismissedKeys: new Set<string>(),
   };
 
-  it("skips providers that are current or disabled", () => {
+  it("stays quiet when there is no one-click update to offer", () => {
     expect(
       buildRemoteProviderUpdateNotice({
         ...base,
         providers: [
           provider({ driver: driver("codex"), advisoryStatus: "current", latestVersion: null }),
           provider({ driver: driver("cursor"), enabled: false }),
+          provider({ driver: driver("claude"), updateCommand: null }),
         ],
-      }),
-    ).toBeNull();
-  });
-
-  it("stays quiet without an update command to run", () => {
-    expect(
-      buildRemoteProviderUpdateNotice({
-        ...base,
-        providers: [provider({ driver: driver("codex"), updateCommand: null })],
       }),
     ).toBeNull();
   });
@@ -1089,7 +1081,7 @@ describe("remote environment provider update notice", () => {
       status: "idle",
       failureMessage: null,
     });
-    expect(notice?.targets).toHaveLength(1);
+    expect(notice?.candidates).toHaveLength(1);
   });
 
   it("lists distinct providers in one notice", () => {
@@ -1120,7 +1112,7 @@ describe("remote environment provider update notice", () => {
     ).toBe("env-remote|codex:1.2.0");
   });
 
-  it("reports live update progress and failures from the environment", () => {
+  it("reports live update progress from the environment", () => {
     expect(
       buildRemoteProviderUpdateNotice({
         ...base,
@@ -1138,42 +1130,41 @@ describe("remote environment provider update notice", () => {
         ],
       }),
     ).toMatchObject({ status: "running" });
-    expect(
-      buildRemoteProviderUpdateNotice({
-        ...base,
-        providers: [
-          provider({
-            driver: driver("codex"),
-            updateState: {
-              status: "failed",
-              startedAt: checkedAt,
-              finishedAt: laterCheckedAt,
-              message: "npm exited with 1",
-              output: null,
-            },
-          }),
-        ],
-      }),
-    ).toMatchObject({ status: "failed", failureMessage: "npm exited with 1" });
   });
 
-  it("treats an unchanged update as a failure so the retry stays visible", () => {
+  it("keeps a retry visible after a failed or unchanged update, failure first", () => {
+    const settledState = (status: "failed" | "unchanged", message: string) => ({
+      status,
+      startedAt: checkedAt,
+      finishedAt: laterCheckedAt,
+      message,
+      output: null,
+    });
     expect(
       buildRemoteProviderUpdateNotice({
         ...base,
         providers: [
           provider({
             driver: driver("codex"),
-            updateState: {
-              status: "unchanged",
-              startedAt: checkedAt,
-              finishedAt: laterCheckedAt,
-              message: "codex is still on v1.0.0",
-              output: null,
-            },
+            updateState: settledState("unchanged", "codex is still on v1.0.0"),
           }),
         ],
       }),
     ).toMatchObject({ status: "failed", failureMessage: "codex is still on v1.0.0" });
+    expect(
+      buildRemoteProviderUpdateNotice({
+        ...base,
+        providers: [
+          provider({
+            driver: driver("codex"),
+            updateState: settledState("unchanged", "codex is still on v1.0.0"),
+          }),
+          provider({
+            driver: driver("cursor"),
+            updateState: settledState("failed", "npm exited with 1"),
+          }),
+        ],
+      }),
+    ).toMatchObject({ status: "failed", failureMessage: "npm exited with 1" });
   });
 });

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
@@ -790,7 +790,8 @@ export interface RemoteProviderUpdateNotice {
   readonly title: string;
   readonly status: "idle" | "running" | "failed";
   readonly failureMessage: string | null;
-  readonly targets: ReadonlyArray<Pick<ServerProvider, "driver" | "instanceId">>;
+  /** One per driver: instances of a driver share an installer, so one dispatch covers them all. */
+  readonly candidates: ProviderUpdateCandidate[];
 }
 
 /**
@@ -805,15 +806,14 @@ export function buildRemoteProviderUpdateNotice(input: {
   readonly providers: ReadonlyArray<ServerProvider>;
   readonly dismissedKeys: ReadonlySet<string>;
 }): RemoteProviderUpdateNotice | null {
-  const candidates = input.providers.filter(
-    (provider): provider is ProviderUpdateCandidate =>
-      isProviderUpdateCandidate(provider) &&
-      hasOneClickUpdateProviderCandidate(provider, input.providers),
+  // Deliberately not canOneClickUpdateProviderCandidate: an update already in
+  // flight must keep its notice so the banner can report progress.
+  const candidates = collectProviderUpdateCandidates(input.providers).filter((candidate) =>
+    hasOneClickUpdateProviderCandidate(candidate, input.providers),
   );
-  const byDriver = dedupeProvidersByDriver(candidates);
-  const [representative] = byDriver;
-  const notificationKey = providerUpdateNotificationKey(byDriver);
-  if (representative === undefined || notificationKey === null) {
+  const [first] = candidates;
+  const notificationKey = providerUpdateNotificationKey(candidates);
+  if (first === undefined || notificationKey === null) {
     return null;
   }
   const dismissalKey = `${input.environmentId}|${notificationKey}`;
@@ -821,24 +821,19 @@ export function buildRemoteProviderUpdateNotice(input: {
     return null;
   }
 
-  const providerName = PROVIDER_DISPLAY_NAMES[representative.driver] ?? representative.driver;
-  const settled = candidates.find(
-    (candidate) =>
-      candidate.updateState?.status === "failed" || candidate.updateState?.status === "unchanged",
-  );
+  // A real failure outranks an update that ran but changed nothing.
+  const settled =
+    candidates.find((candidate) => candidate.updateState?.status === "failed") ??
+    candidates.find((candidate) => candidate.updateState?.status === "unchanged");
+  const providerName = PROVIDER_DISPLAY_NAMES[first.driver] ?? first.driver;
   return {
     dismissalKey,
     title:
-      byDriver.length > 1
-        ? `${formatProviderList(byDriver)} updates are available on ${input.environmentLabel}`
-        : `${providerName} ${formatVersion(representative.versionAdvisory.latestVersion)} is available on ${input.environmentLabel}`,
+      candidates.length > 1
+        ? `${formatProviderList(candidates)} updates are available on ${input.environmentLabel}`
+        : `${providerName} ${formatVersion(first.versionAdvisory.latestVersion)} is available on ${input.environmentLabel}`,
     status: candidates.some(isProviderUpdateActive) ? "running" : settled ? "failed" : "idle",
     failureMessage: settled?.updateState?.message ?? null,
-    // One dispatch per driver: instances of a driver share the installer, so a
-    // per-instance dispatch would just re-run the same install.
-    targets: byDriver.map((candidate) => ({
-      driver: candidate.driver,
-      instanceId: candidate.instanceId,
-    })),
+    candidates,
   };
 }

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
@@ -821,10 +821,15 @@ export function buildRemoteProviderUpdateNotice(input: {
     return null;
   }
 
+  // Progress and outcome come from every instance of a candidate driver: the
+  // deduped representative may be idle while a sibling instance is mid-update.
+  const driverProviders = input.providers.filter((provider) =>
+    candidates.some((candidate) => candidate.driver === provider.driver),
+  );
   // A real failure outranks an update that ran but changed nothing.
   const settled =
-    candidates.find((candidate) => candidate.updateState?.status === "failed") ??
-    candidates.find((candidate) => candidate.updateState?.status === "unchanged");
+    driverProviders.find((provider) => provider.updateState?.status === "failed") ??
+    driverProviders.find((provider) => provider.updateState?.status === "unchanged");
   const providerName = PROVIDER_DISPLAY_NAMES[first.driver] ?? first.driver;
   return {
     dismissalKey,
@@ -832,7 +837,7 @@ export function buildRemoteProviderUpdateNotice(input: {
       candidates.length > 1
         ? `${formatProviderList(candidates)} updates are available on ${input.environmentLabel}`
         : `${providerName} ${formatVersion(first.versionAdvisory.latestVersion)} is available on ${input.environmentLabel}`,
-    status: candidates.some(isProviderUpdateActive) ? "running" : settled ? "failed" : "idle",
+    status: driverProviders.some(isProviderUpdateActive) ? "running" : settled ? "failed" : "idle",
     failureMessage: settled?.updateState?.message ?? null,
     candidates,
   };

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
@@ -780,3 +780,65 @@ export function resolveEnvironmentUpdateRowStatus(input: {
   }
   return { kind: "idle", text: environmentProviderNames(input.group) };
 }
+
+// Local environments get the launch popover above; remote ones (SSH, relay, T3
+// Connect) never do, so the same one-click update becomes a composer notice.
+
+export interface RemoteProviderUpdateNotice {
+  /** Covers environment, driver and latest version, so a newer release re-surfaces. */
+  readonly dismissalKey: string;
+  readonly title: string;
+  readonly status: "idle" | "running" | "failed";
+  readonly failureMessage: string | null;
+  readonly targets: ReadonlyArray<Pick<ServerProvider, "driver" | "instanceId">>;
+}
+
+/**
+ * The composer notice for one remote environment, or null when there is nothing
+ * to offer: nothing outdated, an update this environment cannot run itself
+ * (provider settings still show the manual command), or a candidate set the user
+ * already dismissed.
+ */
+export function buildRemoteProviderUpdateNotice(input: {
+  readonly environmentId: EnvironmentId;
+  readonly environmentLabel: string;
+  readonly providers: ReadonlyArray<ServerProvider>;
+  readonly dismissedKeys: ReadonlySet<string>;
+}): RemoteProviderUpdateNotice | null {
+  const candidates = input.providers.filter(
+    (provider): provider is ProviderUpdateCandidate =>
+      isProviderUpdateCandidate(provider) &&
+      hasOneClickUpdateProviderCandidate(provider, input.providers),
+  );
+  const byDriver = dedupeProvidersByDriver(candidates);
+  const [representative] = byDriver;
+  const notificationKey = providerUpdateNotificationKey(byDriver);
+  if (representative === undefined || notificationKey === null) {
+    return null;
+  }
+  const dismissalKey = `${input.environmentId}|${notificationKey}`;
+  if (input.dismissedKeys.has(dismissalKey)) {
+    return null;
+  }
+
+  const providerName = PROVIDER_DISPLAY_NAMES[representative.driver] ?? representative.driver;
+  const settled = candidates.find(
+    (candidate) =>
+      candidate.updateState?.status === "failed" || candidate.updateState?.status === "unchanged",
+  );
+  return {
+    dismissalKey,
+    title:
+      byDriver.length > 1
+        ? `${formatProviderList(byDriver)} updates are available on ${input.environmentLabel}`
+        : `${providerName} ${formatVersion(representative.versionAdvisory.latestVersion)} is available on ${input.environmentLabel}`,
+    status: candidates.some(isProviderUpdateActive) ? "running" : settled ? "failed" : "idle",
+    failureMessage: settled?.updateState?.message ?? null,
+    // One dispatch per driver: instances of a driver share the installer, so a
+    // per-instance dispatch would just re-run the same install.
+    targets: byDriver.map((candidate) => ({
+      driver: candidate.driver,
+      instanceId: candidate.instanceId,
+    })),
+  };
+}

--- a/apps/web/src/components/chat/ComposerProviderUpdateNotice.tsx
+++ b/apps/web/src/components/chat/ComposerProviderUpdateNotice.tsx
@@ -1,0 +1,111 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { useMemo, useRef, useState } from "react";
+
+import { useEnvironment } from "~/state/environments";
+import { serverEnvironment } from "~/state/server";
+import { useAtomCommand } from "~/state/use-atom-command";
+import { useDismissedProviderUpdateNotificationKeys } from "../../providerUpdateDismissal";
+import { isLocalConnectionTarget } from "../ProviderUpdateLaunchNotification.environments";
+import { buildRemoteProviderUpdateNotice } from "../ProviderUpdateLaunchNotification.logic";
+import { Button } from "../ui/button";
+import type { ComposerBannerStackItem } from "./ComposerBannerStack";
+import { ComposerServerUpdateIcon } from "./ComposerServerUpdateStatus";
+
+/**
+ * The provider update notice for a remote environment (SSH, relay, T3 Connect).
+ * Local environments already get the one-click update from the launch popover,
+ * so they are skipped here and never double-notified.
+ */
+export function useComposerProviderUpdateBannerItem(
+  environmentId: EnvironmentId | null,
+): ComposerBannerStackItem | null {
+  const environment = useEnvironment(environmentId);
+  const { dismissedNotificationKeys, dismissNotificationKey } =
+    useDismissedProviderUpdateNotificationKeys();
+  const updateProvider = useAtomCommand(serverEnvironment.updateProvider);
+  const [pendingKey, setPendingKey] = useState<string | null>(null);
+  // A state update may land after runUpdate returns, so it cannot gate the
+  // dispatch — a ref updates synchronously and blocks a double-click.
+  const inFlightKeyRef = useRef<string | null>(null);
+
+  const environmentLabel = environment?.label;
+  const target = environment?.entry.target;
+  const connectionPhase = environment?.connection.phase;
+  const providers = environment?.serverConfig?.providers;
+
+  const notice = useMemo(
+    () =>
+      environmentId === null ||
+      environmentLabel === undefined ||
+      target === undefined ||
+      isLocalConnectionTarget(target) ||
+      connectionPhase !== "connected"
+        ? null
+        : buildRemoteProviderUpdateNotice({
+            environmentId,
+            environmentLabel,
+            providers: providers ?? [],
+            dismissedKeys: dismissedNotificationKeys,
+          }),
+    [
+      connectionPhase,
+      dismissedNotificationKeys,
+      environmentId,
+      environmentLabel,
+      providers,
+      target,
+    ],
+  );
+
+  return useMemo(() => {
+    if (environmentId === null || notice === null) {
+      return null;
+    }
+    const status = pendingKey === notice.dismissalKey ? "running" : notice.status;
+    const runUpdate = async () => {
+      if (inFlightKeyRef.current === notice.dismissalKey) {
+        return;
+      }
+      inFlightKeyRef.current = notice.dismissalKey;
+      setPendingKey(notice.dismissalKey);
+      try {
+        await Promise.allSettled(
+          notice.targets.map((target) =>
+            updateProvider({
+              environmentId,
+              input: { provider: target.driver, instanceId: target.instanceId },
+            }),
+          ),
+        );
+      } finally {
+        inFlightKeyRef.current = null;
+        setPendingKey(null);
+      }
+    };
+    return {
+      id: `provider-update:${environmentId}`,
+      variant: status === "failed" ? "error" : "default",
+      // Match the server notice: progress outranks passive notices.
+      priority: status === "running" ? "urgent" : "notice",
+      icon: <ComposerServerUpdateIcon status={status} />,
+      title: notice.title,
+      description: notice.failureMessage ?? undefined,
+      actions: (
+        <Button
+          size="xs"
+          variant="ghost"
+          disabled={status === "running"}
+          onClick={() => void runUpdate()}
+        >
+          {status === "running" ? "Updating…" : status === "failed" ? "Retry" : "Update now"}
+        </Button>
+      ),
+      ...(status === "running"
+        ? {}
+        : {
+            dismissLabel: "Dismiss provider update notice",
+            onDismiss: () => dismissNotificationKey(notice.dismissalKey),
+          }),
+    };
+  }, [dismissNotificationKey, environmentId, notice, pendingKey]);
+}

--- a/apps/web/src/components/chat/ComposerProviderUpdateNotice.tsx
+++ b/apps/web/src/components/chat/ComposerProviderUpdateNotice.tsx
@@ -1,5 +1,5 @@
 import type { EnvironmentId } from "@t3tools/contracts";
-import { useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 
 import { useEnvironment } from "~/state/environments";
 import { serverEnvironment } from "~/state/server";
@@ -15,6 +15,11 @@ import { ComposerServerUpdateIcon } from "./ComposerServerUpdateStatus";
  * The provider update notice for a remote environment (SSH, relay, T3 Connect).
  * Local environments already get the one-click update from the launch popover,
  * so they are skipped here and never double-notified.
+ *
+ * Progress comes only from the environment's published `updateState`: the
+ * backend marks a target queued the moment it accepts the dispatch and refuses a
+ * second one for the same instance, so there is nothing for optimistic client
+ * state to cover.
  */
 export function useComposerProviderUpdateBannerItem(
   environmentId: EnvironmentId | null,
@@ -23,65 +28,34 @@ export function useComposerProviderUpdateBannerItem(
   const { dismissedNotificationKeys, dismissNotificationKey } =
     useDismissedProviderUpdateNotificationKeys();
   const updateProvider = useAtomCommand(serverEnvironment.updateProvider);
-  const [pendingKey, setPendingKey] = useState<string | null>(null);
-  // A state update may land after runUpdate returns, so it cannot gate the
-  // dispatch — a ref updates synchronously and blocks a double-click.
-  const inFlightKeyRef = useRef<string | null>(null);
 
   const environmentLabel = environment?.label;
   const target = environment?.entry.target;
-  const connectionPhase = environment?.connection.phase;
+  // Providers survive a disconnect, so offering an update we cannot dispatch
+  // needs the live phase to rule it out.
+  const isConnected = environment?.connection.phase === "connected";
   const providers = environment?.serverConfig?.providers;
 
-  const notice = useMemo(
-    () =>
+  return useMemo(() => {
+    if (
       environmentId === null ||
       environmentLabel === undefined ||
       target === undefined ||
       isLocalConnectionTarget(target) ||
-      connectionPhase !== "connected"
-        ? null
-        : buildRemoteProviderUpdateNotice({
-            environmentId,
-            environmentLabel,
-            providers: providers ?? [],
-            dismissedKeys: dismissedNotificationKeys,
-          }),
-    [
-      connectionPhase,
-      dismissedNotificationKeys,
-      environmentId,
-      environmentLabel,
-      providers,
-      target,
-    ],
-  );
-
-  return useMemo(() => {
-    if (environmentId === null || notice === null) {
+      !isConnected
+    ) {
       return null;
     }
-    const status = pendingKey === notice.dismissalKey ? "running" : notice.status;
-    const runUpdate = async () => {
-      if (inFlightKeyRef.current === notice.dismissalKey) {
-        return;
-      }
-      inFlightKeyRef.current = notice.dismissalKey;
-      setPendingKey(notice.dismissalKey);
-      try {
-        await Promise.allSettled(
-          notice.targets.map((target) =>
-            updateProvider({
-              environmentId,
-              input: { provider: target.driver, instanceId: target.instanceId },
-            }),
-          ),
-        );
-      } finally {
-        inFlightKeyRef.current = null;
-        setPendingKey(null);
-      }
-    };
+    const notice = buildRemoteProviderUpdateNotice({
+      environmentId,
+      environmentLabel,
+      providers: providers ?? [],
+      dismissedKeys: dismissedNotificationKeys,
+    });
+    if (notice === null) {
+      return null;
+    }
+    const { status } = notice;
     return {
       id: `provider-update:${environmentId}`,
       variant: status === "failed" ? "error" : "default",
@@ -95,7 +69,14 @@ export function useComposerProviderUpdateBannerItem(
           size="xs"
           variant="ghost"
           disabled={status === "running"}
-          onClick={() => void runUpdate()}
+          onClick={() => {
+            for (const candidate of notice.candidates) {
+              void updateProvider({
+                environmentId,
+                input: { provider: candidate.driver, instanceId: candidate.instanceId },
+              });
+            }
+          }}
         >
           {status === "running" ? "Updating…" : status === "failed" ? "Retry" : "Update now"}
         </Button>
@@ -107,5 +88,14 @@ export function useComposerProviderUpdateBannerItem(
             onDismiss: () => dismissNotificationKey(notice.dismissalKey),
           }),
     };
-  }, [dismissNotificationKey, environmentId, notice, pendingKey]);
+  }, [
+    dismissNotificationKey,
+    dismissedNotificationKeys,
+    environmentId,
+    environmentLabel,
+    isConnected,
+    providers,
+    target,
+    updateProvider,
+  ]);
 }

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -86,7 +86,9 @@ available version. **Update now** appears only when T3 Code can tell which
 installer owns the CLI (its own update command, Homebrew, or a global npm, pnpm,
 bun, or Vite+ install) and runs that installer. Otherwise update the CLI the same
 way you installed it. Homebrew installs compare against the version Homebrew
-offers, which can trail the npm release by a few hours.
+offers, which can trail the npm release by a few hours. When the thread you have
+open runs on a remote environment, **Update now** is also offered above the
+message box; dismiss it there and it returns for the next release.
 
 Add another provider instance for a separate account or configuration. Each
 instance can have its own environment variables, such as API keys or a custom


### PR DESCRIPTION
## What Changed

Remote environments now get a provider update notice above the composer. When the open thread belongs to an SSH, relay, or T3 Connect environment whose Claude Code or Codex reports `behind_latest` and the server can run the update itself, a notice appears in the composer banner stack after the server-update notice: "Claude v2.1.263 is available on Mac Studio · Update now". **Update now** runs the existing `server.updateProvider` request for that environment, once per outdated provider, shows "Updating…" while the server reports the update as queued or running, and shows the server's failure message with **Retry** when it fails. **Dismiss** persists per environment, provider, and target version, so the notice returns only for a newer release.

- `apps/web/src/components/chat/ComposerProviderUpdateNotice.tsx` (new): one hook returning a `ComposerBannerStackItem`, wired next to the server-update item in `ChatView`.
- `ProviderUpdateLaunchNotification.logic.ts`: a pure `buildRemoteProviderUpdateNotice` helper that reuses the launch popover's candidate filter, provider list formatting, and dismissal store. Unit tests cover candidate selection, dismissal and re-surfacing on a newer version, and the running, failed, and unchanged outcomes.
- `ProviderUpdateLaunchNotification.environments.ts`: exports the existing `isLocalConnectionTarget` so the launch popover and the notice share one definition of "local" and never double-notify. The notice also waits for the environment to be connected.
- One sentence in `docs/user/install.md`.

No contract, server, or polling changes. Installs the server cannot prove ownership of keep the manual command in Settings → Providers as today.

## Why

Local environments already get a one-click provider update from the launch popover. Remote environments never did: the only signal that a remote Claude or Codex is outdated is the small arrow in Settings → Providers, behind the right connection and instance. With several always-on machines this is a daily chore, and machines silently fall behind. #3598 solved the same problem for the T3 server itself with a notice above the composer. This applies that pattern to provider CLIs, keeping the update user-controlled as decided in #2993.

Proposal: #10318.

## UI Changes

Verified against a second `t3 serve` instance registered as a remote environment, with its Claude instance pointed at an outdated npm-managed install.

| Before (only signal: Settings → Providers on the remote environment) | After (thread on the remote environment) |
| --- | --- |
| ![Settings arrow](https://github.com/user-attachments/assets/2e7e0987-ba50-4dce-a069-2d2ee521ba49) | ![Notice](https://github.com/user-attachments/assets/6dd5ba27-f08f-42cd-895b-31fec24992c6) |

| Updating | Failed |
| --- | --- |
| ![Updating](https://github.com/user-attachments/assets/f2b5ce33-c00f-4937-a196-9b0a7c462d73) | ![Failed](https://github.com/user-attachments/assets/ac261a21-f009-4f87-85bf-f2a664e64c56) |

Update now flow:

https://github.com/user-attachments/assets/42227e7a-4828-40a7-b431-87e6ef8d4c0d

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Built with Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add provider update notice for remote environments in `ChatView` composer
> - Added `useComposerProviderUpdateBannerItem` and `buildRemoteProviderUpdateNotice` to show "Update now", "Updating", or "Retry" notices for remote environments with eligible provider updates
> - [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/10343/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) includes this notice in the composer banner stack after server/version-skew notices
> - [ProviderUpdateLaunchNotification.environments.ts](https://github.com/pingdotgg/t3code/pull/10343/files#diff-93b9e69d9484c9b6113731f22188bc01d8426aa14d7d8fb3d9aeebbf3d01c54c) exports `isLocalConnectionTarget` to filter out local or disconnected environments
> - Risk: Existing server update notices retain priority over this new notice; the notice dispatches updates via `serverEnvironment.updateProvider` and disables actions during active runs by deriving status from provider instances in `buildRemoteProviderUpdateNotice`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59c87ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added provider update notices above the message box for remote environments.
  - Shows available provider updates with **Update now**, **Updating…**, and **Retry** actions.
  - Displays live update progress and error states, prioritizing failed updates.
  - Allows notices to be dismissed until a newer provider version becomes available.

- **Documentation**
  - Updated installation guidance to explain remote-environment provider update notices and dismissal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->