### PR TITLE
fix(mobile): slide settled threads out before collapsing

### DIFF
--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -496,12 +496,7 @@ export function HomeScreen(props: HomeScreenProps) {
   // Settled threads stay in the live shell stream (settled ≠ archived), so
   // the partition works directly off live shells — no snapshot merging or
   // optimistic holds.
-  const handleSettleThread = useCallback(
-    (thread: EnvironmentThreadShell) => {
-      void props.onSettleThread(thread);
-    },
-    [props.onSettleThread],
-  );
+  const handleSettleThread = props.onSettleThread;
   const handleSnoozeThread = useCallback(
     (thread: EnvironmentThreadShell, snoozedUntil: string) => {
       void props.onSnoozeThread(thread, snoozedUntil);

--- a/apps/mobile/src/features/home/thread-swipe-actions.tsx
+++ b/apps/mobile/src/features/home/thread-swipe-actions.tsx
@@ -7,6 +7,7 @@ import {
   use,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type ComponentProps,
@@ -19,17 +20,23 @@ import type {
   StyleProp,
   ViewStyle,
 } from "react-native";
-import { Pressable, View } from "react-native";
+import { Alert, Pressable, View } from "react-native";
 import ReanimatedSwipeable, {
   type SwipeableMethods,
 } from "react-native-gesture-handler/ReanimatedSwipeable";
 import Animated, {
+  cancelAnimation,
+  Easing,
   Extrapolation,
+  ReduceMotion,
   interpolate,
   runOnJS,
+  runOnUI,
   type SharedValue,
   useAnimatedReaction,
   useAnimatedStyle,
+  useSharedValue,
+  withTiming,
 } from "react-native-reanimated";
 
 import { AppText as Text } from "../../components/AppText";
@@ -60,6 +67,13 @@ interface ThreadSwipeAction {
   };
   readonly onPress: () => void;
 }
+
+/** Dismiss before committing; false restores the row, success changes its resetKey or removes it. */
+type ThreadSwipePrimaryAction = Omit<ThreadSwipeAction, "onPress"> &
+  (
+    | { readonly dismissOnPress: true; readonly onPress: () => Promise<boolean> }
+    | { readonly dismissOnPress?: false; readonly onPress: () => void }
+  );
 
 interface ThreadSwipeSecondaryAction extends ThreadSwipeAction {
   readonly tone: "primary" | "secondary" | "danger";
@@ -218,7 +232,7 @@ export function useSwipeableScrollGate(options?: {
   };
 }
 
-export function ThreadSwipeable(props: {
+interface ThreadSwipeableProps {
   readonly backgroundColor: ColorValue;
   readonly children: (close: () => void) => ReactNode;
   /** Uses action visuals that fit inside compact 44pt rows. The press target
@@ -238,7 +252,7 @@ export function ThreadSwipeable(props: {
   readonly onDelete: () => void;
   readonly onSwipeableClose?: (methods: SwipeableMethods) => void;
   readonly onSwipeableWillOpen?: (methods: SwipeableMethods) => void;
-  readonly primaryAction: ThreadSwipeAction;
+  readonly primaryAction: ThreadSwipePrimaryAction;
   /**
    * Omitted keeps the v1 destructive Delete action. Explicit null opts out of
    * a secondary action entirely so a gated Snooze can never fall back to an
@@ -255,7 +269,15 @@ export function ThreadSwipeable(props: {
     typeof ReanimatedSwipeable
   >["simultaneousWithExternalGesture"];
   readonly threadTitle: string;
-}) {
+}
+
+export function ThreadSwipeable(props: ThreadSwipeableProps) {
+  // Recycled content gets fresh native and animation state. Late callbacks
+  // from the previous row retain its action, never the replacement's action.
+  return <ThreadSwipeableRow key={props.resetKey} {...props} />;
+}
+
+function ThreadSwipeableRow(props: ThreadSwipeableProps) {
   const swipeableRef = useRef<SwipeableMethods | null>(null);
   const fullSwipeArmedRef = useRef(false);
   const hasSecondaryAction = props.secondaryAction !== null;
@@ -265,14 +287,119 @@ export function ThreadSwipeable(props: {
     props.fullSwipeAction ?? (props.secondaryAction === undefined ? "delete" : "primary");
   const close = useCallback(() => swipeableRef.current?.close(), []);
   const gateEnabled = use(SwipeableScrollGateContext);
-  const resetKey = props.resetKey;
-  useEffect(() => {
-    if (resetKey === undefined) {
-      return;
+  const mountedRef = useRef(true);
+  const pendingDismissRef = useRef<(() => Promise<boolean>) | null>(null);
+  const activeTranslationRef = useRef<SharedValue<number> | null>(null);
+  const [isDismissing, setIsDismissing] = useState(false);
+  const dismissing = useSharedValue(false);
+  const rowHeight = useSharedValue(0);
+  const rowWidth = useSharedValue(props.fullSwipeWidth);
+  const collapse = useSharedValue(0);
+  const actionOpacity = useSharedValue(1);
+  const primaryAction = props.primaryAction;
+  const onSwipeableClose = props.onSwipeableClose;
+
+  const restoreRow = useCallback(() => {
+    swipeableRef.current?.close();
+    collapse.set(0);
+    actionOpacity.set(1);
+    dismissing.set(false);
+    setIsDismissing(false);
+  }, [actionOpacity, collapse, dismissing]);
+
+  const finishDismiss = useCallback(async () => {
+    const action = pendingDismissRef.current;
+    if (!action) return;
+    pendingDismissRef.current = null;
+    try {
+      const succeeded = await action();
+      if (!succeeded && mountedRef.current) restoreRow();
+    } catch (error) {
+      if (mountedRef.current) restoreRow();
+      Alert.alert(
+        "Could not settle thread",
+        error instanceof Error ? error.message : "The thread could not be settled.",
+      );
     }
-    fullSwipeArmedRef.current = false;
-    swipeableRef.current?.reset();
-  }, [resetKey]);
+  }, [restoreRow]);
+
+  useLayoutEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      cancelAnimation(collapse);
+      cancelAnimation(actionOpacity);
+      if (activeTranslationRef.current) cancelAnimation(activeTranslationRef.current);
+      // Scrolling a committed row out of the recycled list must still settle it.
+      void finishDismiss();
+    };
+  }, [actionOpacity, collapse, finishDismiss]);
+
+  const beginDismiss = useCallback(
+    (translation: SharedValue<number>) => {
+      if (!primaryAction.dismissOnPress) return;
+      pendingDismissRef.current = primaryAction.onPress;
+      activeTranslationRef.current = translation;
+      fullSwipeArmedRef.current = false;
+      if (!mountedRef.current) {
+        void finishDismiss();
+        return;
+      }
+      setIsDismissing(true);
+      if (swipeableRef.current) onSwipeableClose?.(swipeableRef.current);
+    },
+    [finishDismiss, primaryAction, onSwipeableClose],
+  );
+
+  const dismiss = useCallback(
+    (translation: SharedValue<number>) => {
+      "worklet";
+      if (dismissing.value) return;
+      dismissing.set(true);
+      runOnJS(beginDismiss)(translation);
+      const timing = {
+        duration: 220,
+        easing: Easing.out(Easing.cubic),
+        reduceMotion: ReduceMotion.System,
+      };
+      actionOpacity.set(withTiming(0, timing));
+      // Never reverse a swipe that already carried the row beyond its width.
+      translation.set(
+        withTiming(Math.min(translation.value, -rowWidth.value), timing, (finished) => {
+          if (!finished) return;
+          collapse.set(
+            withTiming(1, { ...timing, duration: 180 }, (collapsed) => {
+              if (collapsed) runOnJS(finishDismiss)();
+            }),
+          );
+        }),
+      );
+    },
+    [actionOpacity, beginDismiss, collapse, dismissing, finishDismiss, rowWidth],
+  );
+  const dismissStyle = useAnimatedStyle(() => ({
+    height: dismissing.value ? rowHeight.value * (1 - collapse.value) : undefined,
+    pointerEvents: dismissing.value ? "none" : "auto",
+    overflow: "hidden",
+  }));
+  const actionStyle = useAnimatedStyle(() => ({ opacity: actionOpacity.value, height: "100%" }));
+  const dismissOnPress = primaryAction.dismissOnPress === true;
+  const handleRelease = useCallback(
+    (translation: SharedValue<number>) => {
+      "worklet";
+      if (dismissing.value) return true;
+      if (
+        dismissOnPress &&
+        fullSwipeAction === "primary" &&
+        -translation.value >= fullSwipeThreshold
+      ) {
+        dismiss(translation);
+        return true;
+      }
+      return false;
+    },
+    [dismiss, dismissing, dismissOnPress, fullSwipeAction, fullSwipeThreshold],
+  );
   const handleFullSwipeArmedChange = useCallback((armed: boolean) => {
     if (armed && !fullSwipeArmedRef.current) {
       void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
@@ -281,78 +408,94 @@ export function ThreadSwipeable(props: {
   }, []);
 
   return (
-    <ReanimatedSwipeable
-      ref={swipeableRef}
-      animationOptions={THREAD_SWIPE_SPRING}
-      childrenContainerStyle={{ backgroundColor: props.backgroundColor }}
-      containerStyle={[{ backgroundColor: props.backgroundColor }, props.containerStyle]}
-      dragOffsetFromRightEdge={8}
-      enabled={props.enabled !== false && gateEnabled}
-      enableTrackpadTwoFingerGesture={props.enableTrackpadSwipe ?? true}
-      // Fail the swipe once the pan is vertically dominant (patched-in RNGH
-      // prop) — otherwise trackpad scrolls with ~8px of horizontal drift
-      // start opening rows because the swipe pan runs simultaneously with
-      // the list scroll gesture and never gets disqualified by Y movement.
-      failOffsetY={[-10, 10]}
-      friction={1}
-      onSwipeableClose={() => {
-        fullSwipeArmedRef.current = false;
-        if (swipeableRef.current) {
-          props.onSwipeableClose?.(swipeableRef.current);
-        }
-      }}
-      onSwipeableOpenStartDrag={() => {
-        if (swipeableRef.current) {
-          props.onSwipeableWillOpen?.(swipeableRef.current);
-        }
-      }}
-      onSwipeableWillOpen={() => {
-        const methods = swipeableRef.current;
-        if (!methods) {
-          return;
-        }
-
-        props.onSwipeableWillOpen?.(methods);
-        if (fullSwipeArmedRef.current) {
-          fullSwipeArmedRef.current = false;
-          methods.close();
-          if (fullSwipeAction === "primary") {
-            props.primaryAction.onPress();
-          } else {
-            props.onDelete();
-          }
-        }
-      }}
-      overshootFriction={1}
-      overshootRight
-      renderRightActions={(_progress, translation, methods) => (
-        <ThreadSwipeActions
-          backgroundColor={props.backgroundColor}
-          compact={props.compactActions === true}
-          fullSwipeAction={fullSwipeAction}
-          fullSwipeThreshold={fullSwipeThreshold}
-          onFullSwipeArmedChange={handleFullSwipeArmedChange}
-          primaryAction={{
-            ...props.primaryAction,
-            onPress: () => {
-              methods.close();
-              props.primaryAction.onPress();
-            },
+    <Animated.View style={dismissStyle}>
+      <View
+        onLayout={({ nativeEvent: { layout } }) => {
+          rowHeight.set(layout.height);
+          rowWidth.set(layout.width);
+        }}
+      >
+        <ReanimatedSwipeable
+          ref={swipeableRef}
+          animationOptions={THREAD_SWIPE_SPRING}
+          childrenContainerStyle={{ backgroundColor: props.backgroundColor }}
+          containerStyle={[{ backgroundColor: props.backgroundColor }, props.containerStyle]}
+          dragOffsetFromRightEdge={8}
+          enabled={!isDismissing && props.enabled !== false && gateEnabled}
+          enableTrackpadTwoFingerGesture={props.enableTrackpadSwipe ?? true}
+          // Fail the swipe once the pan is vertically dominant (patched-in RNGH
+          // prop) — otherwise trackpad scrolls with ~8px of horizontal drift
+          // start opening rows because the swipe pan runs simultaneously with
+          // the list scroll gesture and never gets disqualified by Y movement.
+          failOffsetY={[-10, 10]}
+          friction={1}
+          onSwipeableClose={() => {
+            fullSwipeArmedRef.current = false;
+            if (swipeableRef.current) {
+              props.onSwipeableClose?.(swipeableRef.current);
+            }
           }}
-          secondaryAction={resolveSecondaryAction({
-            close: () => methods.close(),
-            onDelete: props.onDelete,
-            secondaryAction: props.secondaryAction,
-            threadTitle: props.threadTitle,
-          })}
-          translation={translation}
-        />
-      )}
-      rightThreshold={actionsWidth * 0.42}
-      simultaneousWithExternalGesture={props.simultaneousWithExternalGesture}
-    >
-      {props.children(close)}
-    </ReanimatedSwipeable>
+          onSwipeableRelease={handleRelease}
+          onSwipeableOpenStartDrag={() => {
+            if (swipeableRef.current) {
+              props.onSwipeableWillOpen?.(swipeableRef.current);
+            }
+          }}
+          onSwipeableWillOpen={() => {
+            const methods = swipeableRef.current;
+            if (!methods) {
+              return;
+            }
+
+            props.onSwipeableWillOpen?.(methods);
+            if (fullSwipeArmedRef.current && !(dismissOnPress && fullSwipeAction === "primary")) {
+              fullSwipeArmedRef.current = false;
+              methods.close();
+              if (fullSwipeAction === "primary") {
+                props.primaryAction.onPress();
+              } else {
+                props.onDelete();
+              }
+            }
+          }}
+          overshootFriction={1}
+          overshootRight
+          renderRightActions={(_progress, translation, methods) => (
+            <Animated.View style={actionStyle}>
+              <ThreadSwipeActions
+                backgroundColor={props.backgroundColor}
+                compact={props.compactActions === true}
+                fullSwipeAction={fullSwipeAction}
+                fullSwipeThreshold={fullSwipeThreshold}
+                onFullSwipeArmedChange={handleFullSwipeArmedChange}
+                primaryAction={{
+                  ...primaryAction,
+                  onPress: () => {
+                    if (primaryAction.dismissOnPress) {
+                      runOnUI(dismiss)(translation);
+                    } else {
+                      methods.close();
+                      primaryAction.onPress();
+                    }
+                  },
+                }}
+                secondaryAction={resolveSecondaryAction({
+                  close: () => methods.close(),
+                  onDelete: props.onDelete,
+                  secondaryAction: props.secondaryAction,
+                  threadTitle: props.threadTitle,
+                })}
+                translation={translation}
+              />
+            </Animated.View>
+          )}
+          rightThreshold={actionsWidth * 0.42}
+          simultaneousWithExternalGesture={props.simultaneousWithExternalGesture}
+        >
+          {props.children(close)}
+        </ReanimatedSwipeable>
+      </View>
+    </Animated.View>
   );
 }
 

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -351,7 +351,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
   readonly onSelectThread: (thread: EnvironmentThreadShell) => void;
   readonly onDeleteThread: (thread: EnvironmentThreadShell) => void;
   readonly onRegenerateThreadTitle: (thread: EnvironmentThreadShell) => void;
-  readonly onSettleThread: (thread: EnvironmentThreadShell) => void;
+  readonly onSettleThread: (thread: EnvironmentThreadShell) => Promise<boolean>;
   readonly onSnoozeThread: (thread: EnvironmentThreadShell, snoozedUntil: string) => void;
   readonly onUnsnoozeThread: (thread: EnvironmentThreadShell) => void;
   readonly onUnsettleThread: (thread: EnvironmentThreadShell) => void;
@@ -635,6 +635,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
           accessibilityLabel: `Settle ${thread.title}`,
           icon: "checkmark" as const,
           label: "Settle",
+          dismissOnPress: true as const,
           onPress: handleSettle,
         };
   }, [
@@ -945,7 +946,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
         onSwipeableWillOpen={props.onSwipeableWillOpen}
         primaryAction={primaryAction}
         secondaryAction={secondaryAction}
-        resetKey={`${thread.environmentId}:${thread.id}`}
+        resetKey={`${thread.environmentId}:${thread.id}:${variant}:${snoozedRow}`}
         simultaneousWithExternalGesture={props.simultaneousSwipeGesture}
         threadTitle={thread.title}
       >

--- a/patches/react-native-gesture-handler@2.32.0.patch
+++ b/patches/react-native-gesture-handler@2.32.0.patch
@@ -1,8 +1,8 @@
 diff --git a/lib/commonjs/components/ReanimatedSwipeable/ReanimatedSwipeable.js b/lib/commonjs/components/ReanimatedSwipeable/ReanimatedSwipeable.js
-index 551ab92bf58db0b79d428dcd2f2df898ef686493..f1c355b8e40cd4f583ef3a501b044fb6770f4a24 100644
+index 551ab92bf58db0b79d428dcd2f2df898ef686493..13db26d88bff975bc5d46bb6432cbf9fda3d489a 100644
 --- a/lib/commonjs/components/ReanimatedSwipeable/ReanimatedSwipeable.js
 +++ b/lib/commonjs/components/ReanimatedSwipeable/ReanimatedSwipeable.js
-@@ -34,6 +34,7 @@ const Swipeable = props => {
+@@ -34,11 +34,13 @@ const Swipeable = props => {
      enableTrackpadTwoFingerGesture = DEFAULT_ENABLE_TRACKING_TWO_FINGER_GESTURE,
      dragOffsetFromLeftEdge = DEFAULT_DRAG_OFFSET,
      dragOffsetFromRightEdge = DEFAULT_DRAG_OFFSET,
@@ -10,7 +10,28 @@ index 551ab92bf58db0b79d428dcd2f2df898ef686493..f1c355b8e40cd4f583ef3a501b044fb6
      friction = DEFAULT_FRICTION,
      overshootFriction = DEFAULT_OVERSHOOT_FRICTION,
      onSwipeableOpenStartDrag,
-@@ -285,11 +286,14 @@ const Swipeable = props => {
+     onSwipeableCloseStartDrag,
+     onSwipeableWillOpen,
++    onSwipeableRelease,
+     onSwipeableWillClose,
+     onSwipeableOpen,
+     onSwipeableClose,
+@@ -248,8 +250,13 @@ const Swipeable = props => {
+         toValue = -rightWidth.value;
+       }
+     }
++    // Let a UI-thread full-swipe commit take over before the return spring.
++    if (onSwipeableRelease?.(appliedTranslation)) {
++      return;
++    }
++
+     animateRow(toValue, velocityX / friction);
+-  }, [animateRow, friction, leftThreshold, leftWidth, rightThreshold, rightWidth, rowState, userDrag]);
++  }, [animateRow, friction, leftThreshold, leftWidth, rightThreshold, rightWidth, rowState, userDrag, onSwipeableRelease, appliedTranslation]);
+   const close = (0, _react.useCallback)(() => {
+     'worklet';
+ 
+@@ -285,11 +292,14 @@ const Swipeable = props => {
      }).onFinalize(() => {
        dragStarted.value = false;
      });
@@ -27,10 +48,10 @@ index 551ab92bf58db0b79d428dcd2f2df898ef686493..f1c355b8e40cd4f583ef3a501b044fb6
    const animatedStyle = (0, _reactNativeReanimated.useAnimatedStyle)(() => ({
      transform: [{
 diff --git a/lib/module/components/ReanimatedSwipeable/ReanimatedSwipeable.js b/lib/module/components/ReanimatedSwipeable/ReanimatedSwipeable.js
-index a2835d5416ffd5cf9a04e98774516b9e6569691e..b73c177227bf3a232737b0eb1c0e2bb830493c22 100644
+index a2835d5416ffd5cf9a04e98774516b9e6569691e..055afce410d6eb655532e7a09371dfc22eae5e9c 100644
 --- a/lib/module/components/ReanimatedSwipeable/ReanimatedSwipeable.js
 +++ b/lib/module/components/ReanimatedSwipeable/ReanimatedSwipeable.js
-@@ -29,6 +29,7 @@ const Swipeable = props => {
+@@ -29,11 +29,13 @@ const Swipeable = props => {
      enableTrackpadTwoFingerGesture = DEFAULT_ENABLE_TRACKING_TWO_FINGER_GESTURE,
      dragOffsetFromLeftEdge = DEFAULT_DRAG_OFFSET,
      dragOffsetFromRightEdge = DEFAULT_DRAG_OFFSET,
@@ -38,7 +59,28 @@ index a2835d5416ffd5cf9a04e98774516b9e6569691e..b73c177227bf3a232737b0eb1c0e2bb8
      friction = DEFAULT_FRICTION,
      overshootFriction = DEFAULT_OVERSHOOT_FRICTION,
      onSwipeableOpenStartDrag,
-@@ -280,11 +281,14 @@ const Swipeable = props => {
+     onSwipeableCloseStartDrag,
+     onSwipeableWillOpen,
++    onSwipeableRelease,
+     onSwipeableWillClose,
+     onSwipeableOpen,
+     onSwipeableClose,
+@@ -243,8 +245,13 @@ const Swipeable = props => {
+         toValue = -rightWidth.value;
+       }
+     }
++    // Let a UI-thread full-swipe commit take over before the return spring.
++    if (onSwipeableRelease?.(appliedTranslation)) {
++      return;
++    }
++
+     animateRow(toValue, velocityX / friction);
+-  }, [animateRow, friction, leftThreshold, leftWidth, rightThreshold, rightWidth, rowState, userDrag]);
++  }, [animateRow, friction, leftThreshold, leftWidth, rightThreshold, rightWidth, rowState, userDrag, onSwipeableRelease, appliedTranslation]);
+   const close = useCallback(() => {
+     'worklet';
+ 
+@@ -280,11 +287,14 @@ const Swipeable = props => {
      }).onFinalize(() => {
        dragStarted.value = false;
      });
@@ -55,7 +97,7 @@ index a2835d5416ffd5cf9a04e98774516b9e6569691e..b73c177227bf3a232737b0eb1c0e2bb8
    const animatedStyle = useAnimatedStyle(() => ({
      transform: [{
 diff --git a/lib/typescript/components/ReanimatedSwipeable/ReanimatedSwipeableProps.d.ts b/lib/typescript/components/ReanimatedSwipeable/ReanimatedSwipeableProps.d.ts
-index ac8b76830d468edfbc29052b452a36221323c3de..589e329d2aa706ddfff0d1037df0d85a050edbb0 100644
+index ac8b76830d468edfbc29052b452a36221323c3de..6985d54d9d359e825a5a0e6078bb113204e2807b 100644
 --- a/lib/typescript/components/ReanimatedSwipeable/ReanimatedSwipeableProps.d.ts
 +++ b/lib/typescript/components/ReanimatedSwipeable/ReanimatedSwipeableProps.d.ts
 @@ -64,6 +64,13 @@ export interface SwipeableProps {
@@ -72,11 +114,25 @@ index ac8b76830d468edfbc29052b452a36221323c3de..589e329d2aa706ddfff0d1037df0d85a
      /**
       * Value indicating if the swipeable panel can be pulled further than the left
       * actions panel's width. It is set to true by default as long as the left
+@@ -90,6 +97,13 @@ export interface SwipeableProps {
+      * Called when action panel is closed.
+      */
+     onSwipeableClose?: (direction: SwipeDirection.LEFT | SwipeDirection.RIGHT) => void;
++    /**
++     * UI-thread worklet called on release before the built-in spring starts.
++     * Return true to consume the release and take ownership of translation.
++     * The caller must reset or remove the row after its custom animation.
++     */
++    onSwipeableRelease?: (translation: SharedValue<number>) => boolean;
++
+     /**
+      * Called when action panel starts animating on open (either right or left).
+      */
 diff --git a/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx b/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
-index b6134c908624adc590ebd264e90e558b88e235d5..41535348e937ad7762bd531d5b63ba6e092ea997 100644
+index b6134c908624adc590ebd264e90e558b88e235d5..fa4b1c1749bd0e86cbf5f5546f295d8099e1a481 100644
 --- a/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
 +++ b/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
-@@ -58,6 +58,7 @@ const Swipeable = (props: SwipeableProps) => {
+@@ -58,11 +58,13 @@ const Swipeable = (props: SwipeableProps) => {
      enableTrackpadTwoFingerGesture = DEFAULT_ENABLE_TRACKING_TWO_FINGER_GESTURE,
      dragOffsetFromLeftEdge = DEFAULT_DRAG_OFFSET,
      dragOffsetFromRightEdge = DEFAULT_DRAG_OFFSET,
@@ -84,7 +140,34 @@ index b6134c908624adc590ebd264e90e558b88e235d5..41535348e937ad7762bd531d5b63ba6e
      friction = DEFAULT_FRICTION,
      overshootFriction = DEFAULT_OVERSHOOT_FRICTION,
      onSwipeableOpenStartDrag,
-@@ -537,6 +538,10 @@ const Swipeable = (props: SwipeableProps) => {
+     onSwipeableCloseStartDrag,
+     onSwipeableWillOpen,
++    onSwipeableRelease,
+     onSwipeableWillClose,
+     onSwipeableOpen,
+     onSwipeableClose,
+@@ -457,6 +459,11 @@ const Swipeable = (props: SwipeableProps) => {
+         }
+       }
+ 
++      // Let a UI-thread full-swipe commit take over before the return spring.
++      if (onSwipeableRelease?.(appliedTranslation)) {
++        return;
++      }
++
+       animateRow(toValue, velocityX / friction);
+     },
+     [
+@@ -468,6 +475,8 @@ const Swipeable = (props: SwipeableProps) => {
+       rightWidth,
+       rowState,
+       userDrag,
++      onSwipeableRelease,
++      appliedTranslation,
+     ]
+   );
+ 
+@@ -537,6 +546,10 @@ const Swipeable = (props: SwipeableProps) => {
          dragStarted.value = false;
        });
  
@@ -95,7 +178,7 @@ index b6134c908624adc590ebd264e90e558b88e235d5..41535348e937ad7762bd531d5b63ba6e
      Object.entries(relationProps).forEach(([relationName, relation]) => {
        applyRelationProp(
          pan,
-@@ -552,6 +557,7 @@ const Swipeable = (props: SwipeableProps) => {
+@@ -552,6 +565,7 @@ const Swipeable = (props: SwipeableProps) => {
      enableTrackpadTwoFingerGesture,
      dragOffsetFromRightEdge,
      dragOffsetFromLeftEdge,
@@ -104,7 +187,7 @@ index b6134c908624adc590ebd264e90e558b88e235d5..41535348e937ad7762bd531d5b63ba6e
      relationProps,
      userDrag,
 diff --git a/src/components/ReanimatedSwipeable/ReanimatedSwipeableProps.ts b/src/components/ReanimatedSwipeable/ReanimatedSwipeableProps.ts
-index 0c0e517e0d340faf50ff78c3d48e7a2bbcf808ec..d4b6ff508077728c8be83762923d866dc95b144c 100644
+index 0c0e517e0d340faf50ff78c3d48e7a2bbcf808ec..3ab14d240da346b1927792e480f5b1e902b03bf8 100644
 --- a/src/components/ReanimatedSwipeable/ReanimatedSwipeableProps.ts
 +++ b/src/components/ReanimatedSwipeable/ReanimatedSwipeableProps.ts
 @@ -77,6 +77,14 @@ export interface SwipeableProps {
@@ -122,3 +205,17 @@ index 0c0e517e0d340faf50ff78c3d48e7a2bbcf808ec..d4b6ff508077728c8be83762923d866d
    /**
     * Value indicating if the swipeable panel can be pulled further than the left
     * actions panel's width. It is set to true by default as long as the left
+@@ -112,6 +120,13 @@ export interface SwipeableProps {
+     direction: SwipeDirection.LEFT | SwipeDirection.RIGHT
+   ) => void;
+ 
++  /**
++   * UI-thread worklet called on release before the built-in spring starts.
++   * Return true to consume the release and take ownership of translation.
++   * The caller must reset or remove the row after its custom animation.
++   */
++  onSwipeableRelease?: (translation: SharedValue<number>) => boolean;
++
+   /**
+    * Called when action panel starts animating on open (either right or left).
+    */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,7 +99,7 @@ patchedDependencies:
   effect@4.0.0-beta.103: af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6
   expo-audio@57.0.4: fa9a3e0442ed395d4071bb406e08c3a471c9a84700bdfa0b9ad7ff144c96041a
   expo-sharing@57.0.17: 8d2e3b10eb3f52036a9a086800180ec6cebf3b75bccc5b1775117a7244d4ac45
-  react-native-gesture-handler@2.32.0: 808eb26f9e57cf4945efd3985af4d9c764da6f91f4c9764433cc868602bbf4d3
+  react-native-gesture-handler@2.32.0: 96573c000f7fe56b5abfa13e2e5f0d065907e674cb8e2300155226d7c9874398
   react-native-keyboard-controller@1.21.13: 6e4339347bc5bb3c9ea67d85ff5c814058b211c5750f247aba59d07869a2e787
   react-native-nitro-modules@0.35.9: 825622aae63a8fb5b904f3c77908a0e216261d727ea171709f2c0b6088422675
   react-native-screens@4.26.2: 8156dd0f3407822404793cfdaa95639a36b62102f4507c981b8be83600bb382d
@@ -410,7 +410,7 @@ importers:
         version: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       react-native-gesture-handler:
         specifier: ~2.32.0
-        version: 2.32.0(patch_hash=808eb26f9e57cf4945efd3985af4d9c764da6f91f4c9764433cc868602bbf4d3)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 2.32.0(patch_hash=96573c000f7fe56b5abfa13e2e5f0d065907e674cb8e2300155226d7c9874398)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-image-viewing:
         specifier: ^0.2.2
         version: 0.2.2(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -20045,7 +20045,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-native-gesture-handler@2.32.0(patch_hash=808eb26f9e57cf4945efd3985af4d9c764da6f91f4c9764433cc868602bbf4d3)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  react-native-gesture-handler@2.32.0(patch_hash=96573c000f7fe56b5abfa13e2e5f0d065907e674cb8e2300155226d7c9874398)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       '@types/react-test-renderer': 19.1.0


### PR DESCRIPTION
Settling a thread could spring the row back to the right before it disappeared. Settle now finishes the leftward exit, collapses the gap, and then commits the action. Failed settles restore the row, and recycled rows retain their original pending action.

Intercept the swipe release before Gesture Handler starts its return spring. Full swipes and the Settle button share the dismissal animation and respect Reduce Motion.

Validation: mobile typecheck and 41 thread-list tests pass. Native builds succeeded for the iOS simulator and iPhone; the clip below records two full-swipe settles on an iPhone 15 Pro Max. Simulator interaction testing was stopped at the maintainer's request.

### iPhone recording

https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/ed69ef0c-a417-421e-b445-bc7e1a1c7513/ios-settle-after.mp4

Implemented with GPT-6 in Codex, running through T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Slide settled threads out of view before collapsing in `ThreadSwipeableRow`
> - Settle primary swipe actions now animate the row off-screen and collapse its height before invoking the settlement callback, instead of collapsing immediately
> - The callback returns `Promise<boolean>`; a `false` result restores the row, and a rejected promise restores mounted rows and shows an error alert
> - Patches `ReanimatedSwipeable` in [react-native-gesture-handler@2.32.0.patch](https://github.com/pingdotgg/t3code/pull/10345/files#diff-f12b98ac2bc2f1dee83a421c2216c815b58bd8b54bd81c1d727f6cbae47d5f05) to accept a UI-thread release callback that can consume a full swipe release and take over the animation before the built-in spring runs
> - `ThreadSwipeable` now keys its internal row component on `resetKey`, so changing a row's content identity (variant or snoozed state) remounts the swipeable instead of reusing stale animation state
> - Risk: `Settle` is marked `dismiss-before-commit` in [thread-list-v2-items.tsx](https://github.com/pingdotgg/t3code/pull/10345/files#diff-2cea439fc4533a1bdf479cb7688682b3833ed6dbb1ce83c425862cd1af610fb2); the gesture-handler patch must remain in sync with the upstream `ReanimatedSwipeable` source or the release callback contract breaks
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9e7585.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->