### PR TITLE
feat(server): resume unavailable provider sessions with mobile-safe status

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -234,6 +234,27 @@ function makeThread(
 }
 
 describe("buildThreadFeed", () => {
+  it("hides a cleared waiting notice and shows its replacement after the conversation", () => {
+    const thread = makeThread({
+      id: ThreadId.make("thread-resume"),
+      projectId: ProjectId.make("project-1"),
+      title: "Example thread",
+      messages: [" ", "Example response", "Waiting for provider availability."].map(
+        (text, index) => ({
+          id: MessageId.make(`message-${index}`),
+          role: "assistant",
+          text,
+          turnId: null,
+          streaming: false,
+          createdAt: `2026-04-01T00:00:0${index}.000Z`,
+          updatedAt: "2026-04-01T00:00:03.000Z",
+        }),
+      ),
+    });
+    const feed = buildThreadFeed(thread);
+    expect(feed.map((entry) => entry.id)).toEqual(["message-1", "message-2"]);
+  });
+
   it("keeps setup failures visible without routine setup notices before or after a turn", () => {
     const thread = makeThread({
       id: ThreadId.make("thread-worktree-setup"),

--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -334,6 +334,7 @@ export const makeOrchestrationIntegrationHarness = (
       generateThreadTitle: () => Effect.succeed({ title: "New thread" }),
     } as unknown as TextGenerationShape);
     const providerCommandReactorLayer = ProviderCommandReactorLive.pipe(
+      Layer.provide(OrchestrationEventStoreLive),
       Layer.provideMerge(runtimeServicesLayer),
       Layer.provideMerge(gitWorkflowLayer),
       Layer.provideMerge(textGenerationLayer),

--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -44,6 +44,7 @@ const emitStaleXAiPromptCompleteBeforeSecondHang =
 const emitOverlappingXAiPromptCompleteOutOfOrder =
   process.env.T3_ACP_EMIT_OVERLAPPING_XAI_PROMPT_COMPLETE_OUT_OF_ORDER === "1";
 const failPrompt = process.env.T3_ACP_FAIL_PROMPT === "1";
+const failPromptMessage = process.env.T3_ACP_FAIL_PROMPT_MESSAGE ?? "Mock prompt failure";
 const failSetConfigOption = process.env.T3_ACP_FAIL_SET_CONFIG_OPTION === "1";
 const exitOnSetConfigOption = process.env.T3_ACP_EXIT_ON_SET_CONFIG_OPTION === "1";
 const promptResponseText = process.env.T3_ACP_PROMPT_RESPONSE_TEXT;
@@ -483,7 +484,7 @@ const program = Effect.gen(function* () {
       }
 
       if (failPrompt) {
-        return yield* AcpError.AcpRequestError.internalError("Mock prompt failure");
+        return yield* AcpError.AcpRequestError.internalError(failPromptMessage);
       }
 
       if (emitStaleXAiPromptCompleteBeforeSecondHang && promptCount === 1) {

--- a/apps/server/src/environment/ServerEnvironment.test.ts
+++ b/apps/server/src/environment/ServerEnvironment.test.ts
@@ -166,6 +166,7 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
       expect(second.capabilities.attachmentUploads).toBe(true);
       expect(second.capabilities.fileAttachments).toEqual({ maxUploadBytes: 50 * 1024 * 1024 });
       expect(second.capabilities.pullRequests).toBe(true);
+      expect(second.capabilities.threadUsageLimitResume).toBe(true);
       expect(second.capabilities.threadTitleRegeneration).toBe(true);
       expect(second.capabilities.threadPullRequestLinking).toBe(true);
       expect(second.capabilities.agentActivityPublishing).toBe(false);

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -212,6 +212,7 @@ export const make = Effect.gen(function* () {
       threadAutoSettlement: true,
       threadSnooze: true,
       environmentThemes: true,
+      threadUsageLimitResume: true,
       threadPinning: true,
       threadPinReorder: true,
       threadTitleRegeneration: true,

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -644,6 +644,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             unsettledAt: null,
             snoozedUntil: null,
             snoozedAt: null,
+            usageLimitResume: null,
             pinnedAt: null,
             pinOrderKey: null,
             titleRegenerationRequestId: null,
@@ -755,6 +756,66 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             ...existingRow.value,
             snoozedUntil: null,
             snoozedAt: null,
+            updatedAt: event.payload.updatedAt,
+          });
+          return;
+        }
+
+        case "thread.usage-limit-resume-scheduled": {
+          const existingRow = yield* projectionThreadRepository.getById({
+            threadId: event.payload.threadId,
+          });
+          if (Option.isNone(existingRow)) {
+            return;
+          }
+          yield* projectionThreadRepository.upsert({
+            ...existingRow.value,
+            usageLimitResume: {
+              nextAttemptAt: event.payload.resumeAt,
+              ...(event.payload.pendingMessageId !== undefined
+                ? { pendingMessageId: event.payload.pendingMessageId }
+                : {}),
+              attempt: event.payload.attempt,
+            },
+            updatedAt: event.payload.updatedAt,
+          });
+          return;
+        }
+
+        case "thread.usage-limit-resume-attempted": {
+          if (!event.payload.shouldResume) {
+            return;
+          }
+          const existingRow = yield* projectionThreadRepository.getById({
+            threadId: event.payload.threadId,
+          });
+          if (Option.isNone(existingRow)) {
+            return;
+          }
+          yield* projectionThreadRepository.upsert({
+            ...existingRow.value,
+            usageLimitResume: {
+              nextAttemptAt: null,
+              ...(existingRow.value.usageLimitResume?.pendingMessageId !== undefined
+                ? { pendingMessageId: existingRow.value.usageLimitResume.pendingMessageId }
+                : {}),
+              attempt: event.payload.attempt,
+            },
+            updatedAt: event.payload.updatedAt,
+          });
+          return;
+        }
+
+        case "thread.usage-limit-resume-cancelled": {
+          const existingRow = yield* projectionThreadRepository.getById({
+            threadId: event.payload.threadId,
+          });
+          if (Option.isNone(existingRow)) {
+            return;
+          }
+          yield* projectionThreadRepository.upsert({
+            ...existingRow.value,
+            usageLimitResume: null,
             updatedAt: event.payload.updatedAt,
           });
           return;
@@ -1230,6 +1291,8 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         runtimeMode: event.payload.session.runtimeMode,
         activeTurnId: event.payload.session.activeTurnId,
         lastError: event.payload.session.lastError,
+        lastErrorClass: event.payload.session.lastErrorClass ?? null,
+        retryAt: event.payload.session.retryAt ?? null,
         updatedAt: event.payload.session.updatedAt,
       });
     });

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -49,6 +49,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
       yield* sql`DELETE FROM projection_state`;
       yield* sql`DELETE FROM projection_thread_proposed_plans`;
       yield* sql`DELETE FROM projection_turns`;
+      yield* sql`DELETE FROM orchestration_events`;
 
       yield* sql`
         INSERT INTO projection_projects (
@@ -89,6 +90,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           pending_approval_count,
           pending_user_input_count,
           has_actionable_proposed_plan,
+          usage_limit_resume_json,
           pinned_at,
           pin_order_key,
           created_at,
@@ -110,6 +112,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           1,
           0,
           0,
+          '{"nextAttemptAt":"2026-02-24T01:00:00.000Z","attempt":2}',
           '2026-02-24T00:00:01.000Z',
           'gm',
           '2026-02-24T00:00:02.000Z',
@@ -197,17 +200,21 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           runtime_mode,
           active_turn_id,
           last_error,
+          last_error_class,
+          retry_at,
           updated_at
         )
         VALUES (
           'thread-1',
-          'running',
+          'error',
           'codex',
           'provider-session-1',
           'provider-thread-1',
           'approval-required',
           'turn-1',
-          NULL,
+          'Usage limit reached.',
+          'usage_limit',
+          '2026-02-24T01:00:00.000Z',
           '2026-02-24T00:00:07.000Z'
         )
       `;
@@ -244,6 +251,39 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           'checkpoint-1',
           'ready',
           '[{"path":"README.md","kind":"modified","additions":2,"deletions":1}]'
+        )
+      `;
+
+      yield* sql`
+        INSERT INTO orchestration_events (
+          sequence,
+          event_id,
+          aggregate_kind,
+          stream_id,
+          stream_version,
+          event_type,
+          occurred_at,
+          command_id,
+          causation_event_id,
+          correlation_id,
+          actor_kind,
+          payload_json,
+          metadata_json
+        )
+        VALUES (
+          4,
+          'usage-limit-scheduled-event',
+          'thread',
+          'thread-1',
+          1,
+          'thread.usage-limit-resume-scheduled',
+          '2026-02-24T00:00:08.500Z',
+          NULL,
+          NULL,
+          NULL,
+          'user',
+          '{"threadId":"thread-1","resumeAt":"2026-02-24T01:00:00.000Z","attempt":2,"updatedAt":"2026-02-24T00:00:08.500Z"}',
+          '{}'
         )
       `;
 
@@ -333,6 +373,10 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           unsettledAt: null,
           snoozedUntil: null,
           snoozedAt: null,
+          usageLimitResume: {
+            nextAttemptAt: "2026-02-24T01:00:00.000Z",
+            attempt: 2,
+          },
           pinnedAt: "2026-02-24T00:00:01.000Z",
           pinOrderKey: "gm",
           titleRegeneration: null,
@@ -383,11 +427,13 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           ],
           session: {
             threadId: ThreadId.make("thread-1"),
-            status: "running",
+            status: "error",
             providerName: "codex",
             runtimeMode: "approval-required",
             activeTurnId: asTurnId("turn-1"),
-            lastError: null,
+            lastError: "Usage limit reached.",
+            lastErrorClass: "usage_limit",
+            retryAt: "2026-02-24T01:00:00.000Z",
             updatedAt: "2026-02-24T00:00:07.000Z",
           },
         },
@@ -459,16 +505,22 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           unsettledAt: null,
           snoozedUntil: null,
           snoozedAt: null,
+          usageLimitResume: {
+            nextAttemptAt: "2026-02-24T01:00:00.000Z",
+            attempt: 2,
+          },
           pinnedAt: "2026-02-24T00:00:01.000Z",
           pinOrderKey: "gm",
           titleRegeneration: null,
           session: {
             threadId: ThreadId.make("thread-1"),
-            status: "running",
+            status: "error",
             providerName: "codex",
             runtimeMode: "approval-required",
             activeTurnId: asTurnId("turn-1"),
-            lastError: null,
+            lastError: "Usage limit reached.",
+            lastErrorClass: "usage_limit",
+            retryAt: "2026-02-24T01:00:00.000Z",
             updatedAt: "2026-02-24T00:00:07.000Z",
           },
           latestUserMessageAt: "2026-02-24T00:00:04.000Z",
@@ -555,6 +607,14 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
             createdAt: "2026-02-24T00:00:06.100Z",
           },
         ]);
+      }
+      const windowedThread = yield* snapshotQuery.getThreadDetailSnapshot(
+        ThreadId.make("thread-1"),
+        { turnLimit: 1 },
+      );
+      assert.equal(windowedThread._tag, "Some");
+      if (windowedThread._tag === "Some") {
+        assert.equal(windowedThread.value.page?.threadSequence, 4);
       }
     }),
   );

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -25,6 +25,7 @@ import {
   ModelSelection,
   ProjectId,
   ThreadLinkedPullRequest,
+  ThreadUsageLimitResume,
   ThreadId,
 } from "@t3tools/contracts";
 import * as Arr from "effect/Array";
@@ -96,6 +97,7 @@ const ProjectionThreadDbRowSchema = ProjectionThread.mapFields(
   Struct.assign({
     modelSelection: Schema.fromJsonString(ModelSelection),
     linkedPullRequest: Schema.NullOr(Schema.fromJsonString(ThreadLinkedPullRequest)),
+    usageLimitResume: Schema.NullOr(Schema.fromJsonString(ThreadUsageLimitResume)),
   }),
 );
 const ProjectionThreadActivityDbRowSchema = ProjectionThreadActivity.mapFields(
@@ -323,6 +325,8 @@ function mapSessionRow(
     runtimeMode: row.runtimeMode,
     activeTurnId: row.activeTurnId,
     lastError: row.lastError,
+    ...(row.lastErrorClass !== null ? { lastErrorClass: row.lastErrorClass } : {}),
+    ...(row.retryAt !== null ? { retryAt: row.retryAt } : {}),
     updatedAt: row.updatedAt,
   };
 }
@@ -464,6 +468,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           unsettled_at AS "unsettledAt",
           snoozed_until AS "snoozedUntil",
           snoozed_at AS "snoozedAt",
+          usage_limit_resume_json AS "usageLimitResume",
           pinned_at AS "pinnedAt",
           pin_order_key AS "pinOrderKey",
           title_regeneration_request_id AS "titleRegenerationRequestId",
@@ -502,6 +507,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           unsettled_at AS "unsettledAt",
           snoozed_until AS "snoozedUntil",
           snoozed_at AS "snoozedAt",
+          usage_limit_resume_json AS "usageLimitResume",
           pinned_at AS "pinnedAt",
           pin_order_key AS "pinOrderKey",
           title_regeneration_request_id AS "titleRegenerationRequestId",
@@ -542,6 +548,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           unsettled_at AS "unsettledAt",
           snoozed_until AS "snoozedUntil",
           snoozed_at AS "snoozedAt",
+          usage_limit_resume_json AS "usageLimitResume",
           pinned_at AS "pinnedAt",
           pin_order_key AS "pinOrderKey",
           title_regeneration_request_id AS "titleRegenerationRequestId",
@@ -636,6 +643,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           runtime_mode AS "runtimeMode",
           active_turn_id AS "activeTurnId",
           last_error AS "lastError",
+          last_error_class AS "lastErrorClass",
+          retry_at AS "retryAt",
           updated_at AS "updatedAt"
         FROM projection_thread_sessions
         ORDER BY thread_id ASC
@@ -657,6 +666,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           sessions.runtime_mode AS "runtimeMode",
           sessions.active_turn_id AS "activeTurnId",
           sessions.last_error AS "lastError",
+          sessions.last_error_class AS "lastErrorClass",
+          sessions.retry_at AS "retryAt",
           sessions.updated_at AS "updatedAt"
         FROM projection_thread_sessions sessions
         INNER JOIN projection_threads threads
@@ -682,6 +693,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           sessions.runtime_mode AS "runtimeMode",
           sessions.active_turn_id AS "activeTurnId",
           sessions.last_error AS "lastError",
+          sessions.last_error_class AS "lastErrorClass",
+          sessions.retry_at AS "retryAt",
           sessions.updated_at AS "updatedAt"
         FROM projection_thread_sessions sessions
         INNER JOIN projection_threads threads
@@ -986,6 +999,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           unsettled_at AS "unsettledAt",
           snoozed_until AS "snoozedUntil",
           snoozed_at AS "snoozedAt",
+          usage_limit_resume_json AS "usageLimitResume",
           pinned_at AS "pinnedAt",
           pin_order_key AS "pinOrderKey",
           title_regeneration_request_id AS "titleRegenerationRequestId",
@@ -1178,6 +1192,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           runtime_mode AS "runtimeMode",
           active_turn_id AS "activeTurnId",
           last_error AS "lastError",
+          last_error_class AS "lastErrorClass",
+          retry_at AS "retryAt",
           updated_at AS "updatedAt"
         FROM projection_thread_sessions
         WHERE thread_id = ${threadId}
@@ -1270,7 +1286,10 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             'thread.activity-appended',
             'thread.turn-diff-completed',
             'thread.reverted',
-            'thread.session-set'
+            'thread.session-set',
+            'thread.usage-limit-resume-scheduled',
+            'thread.usage-limit-resume-cancelled',
+            'thread.usage-limit-resume-attempted'
           )
       `,
   });
@@ -1839,6 +1858,8 @@ pending_approval_requests AS (
                   runtimeMode: row.runtimeMode,
                   activeTurnId: row.activeTurnId,
                   lastError: row.lastError,
+                  ...(row.lastErrorClass !== null ? { lastErrorClass: row.lastErrorClass } : {}),
+                  ...(row.retryAt !== null ? { retryAt: row.retryAt } : {}),
                   updatedAt: row.updatedAt,
                 });
               }
@@ -1883,6 +1904,7 @@ pending_approval_requests AS (
                 unsettledAt: row.unsettledAt,
                 snoozedUntil: row.snoozedUntil,
                 snoozedAt: row.snoozedAt,
+                usageLimitResume: row.usageLimitResume,
                 pinnedAt: row.pinnedAt,
                 pinOrderKey: row.pinOrderKey ?? null,
                 titleRegeneration: mapTitleRegeneration(row),
@@ -2094,6 +2116,7 @@ pending_approval_requests AS (
                   unsettledAt: row.unsettledAt,
                   snoozedUntil: row.snoozedUntil,
                   snoozedAt: row.snoozedAt,
+                  usageLimitResume: row.usageLimitResume,
                   pinnedAt: row.pinnedAt,
                   pinOrderKey: row.pinOrderKey ?? null,
                   titleRegeneration: mapTitleRegeneration(row),
@@ -2234,6 +2257,7 @@ pending_approval_requests AS (
                       unsettledAt: row.unsettledAt,
                       snoozedUntil: row.snoozedUntil,
                       snoozedAt: row.snoozedAt,
+                      usageLimitResume: row.usageLimitResume,
                       pinnedAt: row.pinnedAt,
                       pinOrderKey: row.pinOrderKey ?? null,
                       titleRegeneration: mapTitleRegeneration(row),
@@ -2383,6 +2407,7 @@ pending_approval_requests AS (
                   unsettledAt: row.unsettledAt,
                   snoozedUntil: row.snoozedUntil,
                   snoozedAt: row.snoozedAt,
+                  usageLimitResume: row.usageLimitResume,
                   pinnedAt: row.pinnedAt,
                   pinOrderKey: row.pinOrderKey ?? null,
                   titleRegeneration: mapTitleRegeneration(row),
@@ -2666,6 +2691,7 @@ pending_approval_requests AS (
         unsettledAt: threadRow.value.unsettledAt,
         snoozedUntil: threadRow.value.snoozedUntil,
         snoozedAt: threadRow.value.snoozedAt,
+        usageLimitResume: threadRow.value.usageLimitResume,
         pinnedAt: threadRow.value.pinnedAt,
         pinOrderKey: threadRow.value.pinOrderKey ?? null,
         titleRegeneration: mapTitleRegeneration(threadRow.value),
@@ -2904,6 +2930,7 @@ pending_approval_requests AS (
         unsettledAt: threadRow.value.unsettledAt,
         snoozedUntil: threadRow.value.snoozedUntil,
         snoozedAt: threadRow.value.snoozedAt,
+        usageLimitResume: threadRow.value.usageLimitResume,
         pinnedAt: threadRow.value.pinnedAt,
         pinOrderKey: threadRow.value.pinOrderKey ?? null,
         titleRegeneration: mapTitleRegeneration(threadRow.value),

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -23,6 +23,7 @@ import {
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Deferred from "effect/Deferred";
+import * as DateTime from "effect/DateTime";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as ManagedRuntime from "effect/ManagedRuntime";
@@ -35,6 +36,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { deriveServerPaths, ServerConfig } from "../../config.ts";
 import { TextGenerationError } from "@t3tools/contracts";
 import { ProviderAdapterRequestError } from "../../provider/Errors.ts";
+import { OrchestrationListenerCallbackError } from "../Errors.ts";
 import { OrchestrationEventStoreLive } from "../../persistence/Layers/OrchestrationEventStore.ts";
 import { OrchestrationCommandReceiptRepositoryLive } from "../../persistence/Layers/OrchestrationCommandReceipts.ts";
 import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
@@ -93,7 +95,10 @@ async function waitFor(
 
 describe("ProviderCommandReactor", () => {
   let runtime: ManagedRuntime.ManagedRuntime<
-    OrchestrationEngineService | ProviderCommandReactor | ProjectionSnapshotQuery,
+    | OrchestrationEngineService
+    | ProviderCommandReactor
+    | ProjectionSnapshotQuery
+    | ServerSettingsService,
     unknown
   > | null = null;
   let scope: Scope.Closeable | null = null;
@@ -149,9 +154,27 @@ describe("ProviderCommandReactor", () => {
     readonly sessionModelSwitch?: "unsupported" | "in-session";
     readonly requiresNewThreadForModelChange?: boolean;
     readonly titleRegenerationCompletionDispatchFailures?: number;
+    readonly usageLimitResumeAttemptDispatchFailures?: number;
+    readonly usageLimitResumeSessionErrorDispatchFailures?: number;
+    readonly usageLimitResumeActivityDispatchFailures?: number;
+    readonly usageLimitResumeTransitionDispatchFailures?: number;
+    readonly usageLimitResumeTransitionFailureThreadId?: ThreadId;
     readonly titleRegenerationBeforeStart?: "one" | "two";
+    readonly createSecondThread?: boolean;
+    readonly usageLimitResumeScheduledBeforeStart?: string;
+    readonly usageLimitResumeAttemptedBeforeStart?: boolean;
+    readonly usageLimitResumeAttemptedSecondThreadBeforeStart?: boolean;
+    readonly usageLimitedBeforeStart?: boolean;
+    readonly enableAutomaticResume?: boolean;
+    readonly usageLimitResumeCancelledBeforeStart?: boolean;
+    readonly newLimitAfterCancellation?: boolean;
+    readonly usageLimitRetryAtBeforeStart?: string;
     readonly interruptTurnEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
     readonly stopSessionEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
+    readonly sendTurnEffect?: () => Effect.Effect<
+      { readonly threadId: ThreadId; readonly turnId: TurnId },
+      ProviderAdapterRequestError
+    >;
     readonly startSessionEffect?: (
       session: ProviderSession,
     ) => Effect.Effect<ProviderSession, ProviderAdapterRequestError>;
@@ -231,11 +254,13 @@ describe("ProviderCommandReactor", () => {
         ),
       );
     });
-    const sendTurn = vi.fn((_: unknown) =>
-      Effect.succeed({
-        threadId: ThreadId.make("thread-1"),
-        turnId: asTurnId("turn-1"),
-      }),
+    const sendTurn = vi.fn(
+      (_: unknown) =>
+        input?.sendTurnEffect?.() ??
+        Effect.succeed({
+          threadId: ThreadId.make("thread-1"),
+          turnId: asTurnId("turn-1"),
+        }),
     );
     const interruptTurn = vi.fn((_: unknown) => input?.interruptTurnEffect?.() ?? Effect.void);
     const respondToRequest = vi.fn<ProviderServiceShape["respondToRequest"]>(() => Effect.void);
@@ -374,6 +399,17 @@ describe("ProviderCommandReactor", () => {
       Layer.provide(SqlitePersistenceMemory),
     );
     let titleRegenerationCompletionDispatchAttempts = 0;
+    let usageLimitResumeAttemptDispatchAttempts = 0;
+    let usageLimitResumeSessionErrorDispatchAttempts = 0;
+    let usageLimitResumeActivityDispatchAttempts = 0;
+    let usageLimitResumeTransitionDispatchAttempts = 0;
+    const usageLimitResumeTransitionDispatchAttemptsByThread = new Map<ThreadId, number>();
+    const usageLimitResumeAttemptObserved = Effect.runSync(Deferred.make<void>());
+    const usageLimitResumeScheduled = Effect.runSync(Deferred.make<void>());
+    const usageLimitResumeAttemptDispatched = Effect.runSync(Deferred.make<void>());
+    const usageLimitResumeTransitionAttemptObserved = Effect.runSync(Deferred.make<void>());
+    const usageLimitResumeTransitionDispatched = Effect.runSync(Deferred.make<void>());
+    const usageLimitResumeThread2TransitionDispatched = Effect.runSync(Deferred.make<void>());
     const reactorOrchestrationLayer = Layer.effect(
       OrchestrationEngineService,
       Effect.gen(function* () {
@@ -390,7 +426,129 @@ describe("ProviderCommandReactor", () => {
                 return Effect.die(new Error("Injected title regeneration completion failure"));
               }
             }
-            return engine.dispatch(command);
+            if (command.type === "thread.usage-limit-resume.attempt") {
+              return Effect.suspend(() => {
+                usageLimitResumeAttemptDispatchAttempts += 1;
+                const markObserved = Deferred.succeed(usageLimitResumeAttemptObserved, undefined);
+                if (
+                  usageLimitResumeAttemptDispatchAttempts <=
+                  (input?.usageLimitResumeAttemptDispatchFailures ?? 0)
+                ) {
+                  return markObserved.pipe(
+                    Effect.andThen(
+                      Effect.fail(
+                        new OrchestrationListenerCallbackError({
+                          listener: "domain-event",
+                          detail: "Injected usage-limit attempt dispatch failure",
+                        }),
+                      ),
+                    ),
+                  );
+                }
+                return markObserved.pipe(
+                  Effect.andThen(engine.dispatch(command)),
+                  Effect.tap(() => Deferred.succeed(usageLimitResumeAttemptDispatched, undefined)),
+                );
+              });
+            }
+            if (
+              command.type === "thread.session.set" &&
+              command.session.status === "error" &&
+              !String(command.commandId).startsWith("cmd-mark-usage-limited")
+            ) {
+              usageLimitResumeSessionErrorDispatchAttempts += 1;
+              if (
+                usageLimitResumeSessionErrorDispatchAttempts <=
+                (input?.usageLimitResumeSessionErrorDispatchFailures ?? 0)
+              ) {
+                return Effect.fail(
+                  new OrchestrationListenerCallbackError({
+                    listener: "domain-event",
+                    detail: "Injected usage-limit session-error dispatch failure",
+                  }),
+                );
+              }
+            }
+            if (
+              command.type === "thread.activity.append" &&
+              command.activity.kind === "provider.turn.start.failed"
+            ) {
+              usageLimitResumeActivityDispatchAttempts += 1;
+              if (
+                usageLimitResumeActivityDispatchAttempts <=
+                (input?.usageLimitResumeActivityDispatchFailures ?? 0)
+              ) {
+                return Effect.fail(
+                  new OrchestrationListenerCallbackError({
+                    listener: "domain-event",
+                    detail: "Injected usage-limit activity dispatch failure",
+                  }),
+                );
+              }
+            }
+            if (
+              command.type === "thread.usage-limit-resume.retry" ||
+              command.type === "thread.usage-limit-resume.cancel"
+            ) {
+              return Effect.suspend(() => {
+                usageLimitResumeTransitionDispatchAttempts += 1;
+                const markObserved = Deferred.succeed(
+                  usageLimitResumeTransitionAttemptObserved,
+                  undefined,
+                );
+                const threadAttempts =
+                  (usageLimitResumeTransitionDispatchAttemptsByThread.get(command.threadId) ?? 0) +
+                  1;
+                usageLimitResumeTransitionDispatchAttemptsByThread.set(
+                  command.threadId,
+                  threadAttempts,
+                );
+                const failureThreadId = input?.usageLimitResumeTransitionFailureThreadId;
+                if (
+                  (failureThreadId === undefined || failureThreadId === command.threadId) &&
+                  threadAttempts <= (input?.usageLimitResumeTransitionDispatchFailures ?? 0)
+                ) {
+                  return markObserved.pipe(
+                    Effect.andThen(
+                      Effect.fail(
+                        new OrchestrationListenerCallbackError({
+                          listener: "domain-event",
+                          detail: "Injected usage-limit transition dispatch failure",
+                        }),
+                      ),
+                    ),
+                  );
+                }
+                return markObserved.pipe(
+                  Effect.andThen(engine.dispatch(command)),
+                  Effect.tap(() =>
+                    Effect.all(
+                      [
+                        Deferred.succeed(usageLimitResumeTransitionDispatched, undefined),
+                        ...(command.threadId === ThreadId.make("thread-2")
+                          ? [
+                              Deferred.succeed(
+                                usageLimitResumeThread2TransitionDispatched,
+                                undefined,
+                              ),
+                            ]
+                          : []),
+                      ],
+                      { discard: true },
+                    ),
+                  ),
+                );
+              });
+            }
+            return engine
+              .dispatch(command)
+              .pipe(
+                Effect.tap(() =>
+                  command.type === "thread.usage-limit-resume.schedule"
+                    ? Deferred.succeed(usageLimitResumeScheduled, undefined)
+                    : Effect.void,
+                ),
+              );
           },
           get streamDomainEvents() {
             return engine.streamDomainEvents;
@@ -400,6 +558,7 @@ describe("ProviderCommandReactor", () => {
       }),
     ).pipe(Layer.provide(orchestrationLayer));
     const layer = ProviderCommandReactorLive.pipe(
+      Layer.provideMerge(OrchestrationEventStoreLive.pipe(Layer.provide(SqlitePersistenceMemory))),
       Layer.provideMerge(reactorOrchestrationLayer),
       Layer.provideMerge(projectionSnapshotLayer),
       Layer.provideMerge(Layer.succeed(ProviderService, service)),
@@ -426,7 +585,11 @@ describe("ProviderCommandReactor", () => {
           generateThreadTitle,
         }),
       ),
-      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(
+        ServerSettingsService.layerTest({
+          enableAutomaticResume: input?.enableAutomaticResume ?? true,
+        }),
+      ),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
     );
@@ -436,6 +599,29 @@ describe("ProviderCommandReactor", () => {
     const snapshotQuery = await runtime.runPromise(Effect.service(ProjectionSnapshotQuery));
     const reactor = await runtime.runPromise(Effect.service(ProviderCommandReactor));
     const runEffect = <A, E>(effect: Effect.Effect<A, E>) => runtime!.runPromise(effect);
+    let usageLimitSessionIndex = 0;
+    const markUsageLimited = (threadId = ThreadId.make("thread-1")) => {
+      usageLimitSessionIndex += 1;
+      return engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make(`cmd-mark-usage-limited-${usageLimitSessionIndex}`),
+        threadId,
+        session: {
+          threadId,
+          status: "error",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: "Usage limit reached",
+          lastErrorClass: "usage_limit",
+          ...(input?.usageLimitRetryAtBeforeStart !== undefined
+            ? { retryAt: input.usageLimitRetryAtBeforeStart }
+            : {}),
+          updatedAt: now,
+        },
+        createdAt: now,
+      });
+    };
 
     await Effect.runPromise(
       engine.dispatch({
@@ -463,7 +649,11 @@ describe("ProviderCommandReactor", () => {
         createdAt: now,
       }),
     );
-    if (input?.titleRegenerationBeforeStart === "two") {
+    if (
+      input?.titleRegenerationBeforeStart === "two" ||
+      input?.createSecondThread === true ||
+      input?.usageLimitResumeAttemptedSecondThreadBeforeStart === true
+    ) {
       await Effect.runPromise(
         engine.dispatch({
           type: "thread.create",
@@ -498,13 +688,69 @@ describe("ProviderCommandReactor", () => {
         }),
       );
     }
+    const scheduledResumeAt =
+      input?.usageLimitResumeScheduledBeforeStart ??
+      (input?.usageLimitResumeAttemptedBeforeStart === true
+        ? "2099-01-01T00:00:00.000Z"
+        : undefined);
+    const usageLimitResumeThreadIds = [
+      ThreadId.make("thread-1"),
+      ...(input?.usageLimitResumeAttemptedSecondThreadBeforeStart === true
+        ? [ThreadId.make("thread-2")]
+        : []),
+    ];
+    if (input?.usageLimitedBeforeStart === true && scheduledResumeAt === undefined) {
+      await Effect.runPromise(markUsageLimited());
+    }
+    if (scheduledResumeAt !== undefined) {
+      for (const [index, threadId] of usageLimitResumeThreadIds.entries()) {
+        await Effect.runPromise(markUsageLimited(threadId));
+        await Effect.runPromise(
+          engine.dispatch({
+            type: "thread.usage-limit-resume.schedule",
+            commandId: CommandId.make(`cmd-resume-before-reactor-start-${index + 1}`),
+            threadId,
+            resumeAt: scheduledResumeAt,
+          }),
+        );
+      }
+    }
+    if (input?.usageLimitResumeAttemptedBeforeStart === true && scheduledResumeAt !== undefined) {
+      for (const [index, threadId] of usageLimitResumeThreadIds.entries()) {
+        await Effect.runPromise(
+          engine.dispatch({
+            type: "thread.usage-limit-resume.attempt",
+            commandId: CommandId.make(`cmd-resume-attempt-before-reactor-start-${index + 1}`),
+            threadId,
+            expectedAttemptAt: scheduledResumeAt,
+            createdAt: scheduledResumeAt,
+          }),
+        );
+      }
+    }
 
+    if (input?.usageLimitResumeCancelledBeforeStart) {
+      await Effect.runPromise(
+        engine.dispatch({
+          type: "thread.usage-limit-resume.cancel",
+          commandId: CommandId.make("cancel-before-restart"),
+          threadId: ThreadId.make("thread-1"),
+        }),
+      );
+    }
+    if (input?.newLimitAfterCancellation) await Effect.runPromise(markUsageLimited());
     scope = await Effect.runPromise(Scope.make("sequential"));
     await Effect.runPromise(reactor.start().pipe(Scope.provide(scope)));
     const drain = () => Effect.runPromise(reactor.drain);
 
     return {
       engine,
+      updateSettings: (enableAutomaticResume: boolean) =>
+        runtime!.runPromise(
+          Effect.flatMap(ServerSettingsService, (settings) =>
+            settings.updateSettings({ enableAutomaticResume }),
+          ),
+        ),
       readModel: () => Effect.runPromise(snapshotQuery.getSnapshot()),
       startSession,
       sendTurn,
@@ -519,12 +765,37 @@ describe("ProviderCommandReactor", () => {
       generateBranchName,
       generateThreadTitle,
       runtimeSessions,
+      markUsageLimited,
       stateDir,
       drain,
       runEffect,
       get titleRegenerationCompletionDispatchAttempts() {
         return titleRegenerationCompletionDispatchAttempts;
       },
+      get usageLimitResumeAttemptDispatchAttempts() {
+        return usageLimitResumeAttemptDispatchAttempts;
+      },
+      get usageLimitResumeSessionErrorDispatchAttempts() {
+        return usageLimitResumeSessionErrorDispatchAttempts;
+      },
+      get usageLimitResumeActivityDispatchAttempts() {
+        return usageLimitResumeActivityDispatchAttempts;
+      },
+      get usageLimitResumeTransitionDispatchAttempts() {
+        return usageLimitResumeTransitionDispatchAttempts;
+      },
+      usageLimitResumeTransitionDispatchAttemptsForThread: (threadId: ThreadId) =>
+        usageLimitResumeTransitionDispatchAttemptsByThread.get(threadId) ?? 0,
+      usageLimitResumeAttemptObserved: Deferred.await(usageLimitResumeAttemptObserved),
+      usageLimitResumeScheduled: Deferred.await(usageLimitResumeScheduled),
+      usageLimitResumeAttemptDispatched: Deferred.await(usageLimitResumeAttemptDispatched),
+      usageLimitResumeTransitionAttemptObserved: Deferred.await(
+        usageLimitResumeTransitionAttemptObserved,
+      ),
+      usageLimitResumeTransitionDispatched: Deferred.await(usageLimitResumeTransitionDispatched),
+      usageLimitResumeThread2TransitionDispatched: Deferred.await(
+        usageLimitResumeThread2TransitionDispatched,
+      ),
     };
   }
 
@@ -567,6 +838,854 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.status).toBe("starting");
     expect(thread?.session?.runtimeMode).toBe("approval-required");
   });
+
+  it("resumes a provider turn without adding another visible user message", async () => {
+    const harness = await createHarness();
+    const resumeAt = "2099-01-01T00:00:00.000Z";
+
+    await harness.runEffect(harness.markUsageLimited());
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.usage-limit-resume.schedule",
+        commandId: CommandId.make("cmd-auto-resume-schedule"),
+        threadId: ThreadId.make("thread-1"),
+        resumeAt,
+      }),
+    );
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.usage-limit-resume.attempt",
+        commandId: CommandId.make("cmd-auto-resume-attempt"),
+        threadId: ThreadId.make("thread-1"),
+        expectedAttemptAt: resumeAt,
+        createdAt: resumeAt,
+      }),
+    );
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({
+      threadId: ThreadId.make("thread-1"),
+      input: "Continue from where you left off.",
+    });
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.messages.filter((message) => message.role === "user")).toHaveLength(0);
+    expect(thread?.messages).toHaveLength(1);
+    expect(thread?.messages[0]?.text).toContain("Checking provider availability");
+    expect(thread?.usageLimitResume).toEqual({ nextAttemptAt: null, attempt: 0 });
+  });
+
+  effectIt.effect("does not send a resume cancelled during provider preparation", () =>
+    Effect.gen(function* () {
+      const sessionStartEntered = yield* Deferred.make<void>();
+      const releaseSessionStart = yield* Deferred.make<void>();
+      const threadId = ThreadId.make("thread-1");
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          startSessionEffect: (session) =>
+            Deferred.succeed(sessionStartEntered, undefined).pipe(
+              Effect.andThen(Deferred.await(releaseSessionStart)),
+              Effect.as(session),
+            ),
+        }),
+      );
+      const resumeAt = "2099-01-01T00:00:00.000Z";
+
+      yield* harness.markUsageLimited();
+      yield* harness.engine.dispatch({
+        type: "thread.usage-limit-resume.schedule",
+        commandId: CommandId.make("cmd-cancel-preparing-resume-schedule"),
+        threadId,
+        resumeAt,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.usage-limit-resume.attempt",
+        commandId: CommandId.make("cmd-cancel-preparing-resume-attempt"),
+        threadId,
+        expectedAttemptAt: resumeAt,
+        createdAt: resumeAt,
+      });
+      yield* Deferred.await(sessionStartEntered);
+
+      yield* harness.engine.dispatch({
+        type: "thread.usage-limit-resume.cancel",
+        commandId: CommandId.make("cmd-cancel-preparing-resume"),
+        threadId,
+      });
+      yield* Deferred.succeed(releaseSessionStart, undefined);
+      yield* Effect.promise(() => harness.drain());
+
+      expect(harness.sendTurn).not.toHaveBeenCalled();
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      const thread = readModel.threads.find((entry) => entry.id === threadId);
+      expect(thread?.usageLimitResume).toBeNull();
+    }),
+  );
+
+  effectIt.effect("keeps retrying transient automatic-resume attempt dispatch failures", () =>
+    Effect.gen(function* () {
+      const resumeAt = DateTime.formatIso(DateTime.add(DateTime.nowUnsafe(), { seconds: 1 }));
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          usageLimitResumeAttemptDispatchFailures: 2,
+          usageLimitResumeScheduledBeforeStart: resumeAt,
+        }),
+      );
+      yield* harness.usageLimitResumeAttemptObserved;
+      yield* harness.usageLimitResumeAttemptDispatched;
+      yield* Effect.promise(() => harness.drain());
+
+      expect(harness.usageLimitResumeAttemptDispatchAttempts).toBe(3);
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      expect(thread?.usageLimitResume).toEqual({ nextAttemptAt: null, attempt: 0 });
+    }),
+  );
+
+  it("schedules an initial ACP usage-limit rejection without a runtime error event", async () => {
+    const harness = await createHarness({
+      sendTurnEffect: () =>
+        Effect.fail(
+          new ProviderAdapterRequestError({
+            provider: "grok",
+            method: "session/prompt",
+            detail: "Usage limit reached. Try again later.",
+          }),
+        ),
+    });
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("initial-acp-limit"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("initial-message"),
+          role: "user",
+          text: "Continue the task",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: "2099-01-01T00:00:00.000Z",
+      }),
+    );
+    await harness.runEffect(harness.usageLimitResumeScheduled);
+    await harness.drain();
+    const thread = (await harness.readModel()).threads.find(
+      (entry) => entry.id === ThreadId.make("thread-1"),
+    );
+    expect(thread?.session?.lastErrorClass).toBe("usage_limit");
+    expect(thread?.usageLimitResume).toEqual({
+      attempt: 0,
+      nextAttemptAt: "2099-01-01T00:20:00.000Z",
+      pendingMessageId: asMessageId("initial-message"),
+    });
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.usage-limit-resume.attempt",
+        commandId: CommandId.make("replay-rejected-input"),
+        threadId: ThreadId.make("thread-1"),
+        expectedAttemptAt: "2099-01-01T00:20:00.000Z",
+        createdAt: "2099-01-01T00:20:00.000Z",
+      }),
+    );
+    await harness.runEffect(harness.usageLimitResumeTransitionDispatched);
+    expect(harness.sendTurn).toHaveBeenCalledTimes(2);
+    expect(harness.sendTurn.mock.calls[1]?.[0]).toMatchObject({ input: "Continue the task" });
+  });
+
+  it("paces another retry when an ACP provider still reports a usage limit", async () => {
+    const harness = await createHarness({
+      sendTurnEffect: () =>
+        Effect.fail(
+          new ProviderAdapterRequestError({
+            provider: "grok",
+            method: "session/prompt",
+            detail: "Grok usage limit reached. Try again later.",
+          }),
+        ),
+    });
+    const resumeAt = "2099-01-01T00:00:00.000Z";
+
+    await harness.runEffect(harness.markUsageLimited());
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.usage-limit-resume.schedule",
+        commandId: CommandId.make("cmd-acp-resume-schedule"),
+        threadId: ThreadId.make("thread-1"),
+        resumeAt,
+      }),
+    );
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.usage-limit-resume.attempt",
+        commandId: CommandId.make("cmd-acp-resume-attempt"),
+        threadId: ThreadId.make("thread-1"),
+        expectedAttemptAt: resumeAt,
+        createdAt: resumeAt,
+      }),
+    );
+
+    await waitFor(async () => {
+      const readModel = await harness.readModel();
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      return thread?.usageLimitResume?.attempt === 1;
+    });
+    const events = Array.from(
+      await harness.runEffect(Stream.runCollect(harness.engine.readEvents(0, 100))),
+    );
+    const errorSessionEvent = events.findLast(
+      (event) => event.type === "thread.session-set" && event.payload.session.status === "error",
+    );
+    expect(errorSessionEvent?.type).toBe("thread.session-set");
+    if (errorSessionEvent?.type === "thread.session-set") {
+      expect(errorSessionEvent.payload.session.lastErrorClass).toBe("usage_limit");
+    }
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session).toMatchObject({
+      status: "error",
+      lastError: "Grok usage limit reached. Try again later.",
+      lastErrorClass: "usage_limit",
+    });
+    expect(thread?.usageLimitResume?.nextAttemptAt).not.toBeNull();
+  });
+
+  effectIt.effect("ignores an automatic-resume failure superseded by newer work", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("thread-1");
+      const newerTurnId = asTurnId("turn-newer-work");
+      let harness: Awaited<ReturnType<typeof createHarness>>;
+      harness = yield* Effect.promise(() =>
+        createHarness({
+          sendTurnEffect: () =>
+            Effect.gen(function* () {
+              yield* harness.engine
+                .dispatch({
+                  type: "thread.usage-limit-resume.cancel",
+                  commandId: CommandId.make("cmd-cancel-superseded-resume"),
+                  threadId,
+                })
+                .pipe(Effect.orDie);
+              yield* harness.engine
+                .dispatch({
+                  type: "thread.session.set",
+                  commandId: CommandId.make("cmd-session-set-newer-work"),
+                  threadId,
+                  session: {
+                    threadId,
+                    status: "running",
+                    providerName: "codex",
+                    runtimeMode: "approval-required",
+                    activeTurnId: newerTurnId,
+                    lastError: null,
+                    updatedAt: "2026-01-01T00:00:02.000Z",
+                  },
+                  createdAt: "2026-01-01T00:00:02.000Z",
+                })
+                .pipe(Effect.orDie);
+              return yield* new ProviderAdapterRequestError({
+                provider: "codex",
+                method: "thread.turn.start",
+                detail: "stale automatic-resume failure",
+              });
+            }),
+        }),
+      );
+      const resumeAt = "2099-01-01T00:00:00.000Z";
+
+      yield* harness.markUsageLimited();
+      yield* harness.engine.dispatch({
+        type: "thread.usage-limit-resume.schedule",
+        commandId: CommandId.make("cmd-superseded-resume-schedule"),
+        threadId,
+        resumeAt,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.usage-limit-resume.attempt",
+        commandId: CommandId.make("cmd-superseded-resume-attempt"),
+        threadId,
+        expectedAttemptAt: resumeAt,
+        createdAt: resumeAt,
+      });
+      yield* Effect.promise(() =>
+        waitFor(async () => {
+          const thread = (await harness.readModel()).threads.find((entry) => entry.id === threadId);
+          return thread?.usageLimitResume === null && thread.session?.activeTurnId === newerTurnId;
+        }),
+      );
+      yield* Effect.promise(() => harness.drain());
+
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      const thread = readModel.threads.find((entry) => entry.id === threadId);
+      expect(thread?.usageLimitResume).toBeNull();
+      expect(thread?.session).toMatchObject({
+        status: "running",
+        activeTurnId: newerTurnId,
+        lastError: null,
+      });
+      expect(
+        thread?.activities.some((activity) => activity.summary === "Automatic resume failed"),
+      ).toBe(false);
+    }),
+  );
+
+  effectIt.effect("advances the durable retry without appending another failure activity", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          sendTurnEffect: () =>
+            Effect.fail(
+              new ProviderAdapterRequestError({
+                provider: "grok",
+                method: "session/prompt",
+                detail: "Grok usage limit reached. Try again later.",
+              }),
+            ),
+          usageLimitResumeSessionErrorDispatchFailures: 1,
+          usageLimitResumeTransitionDispatchFailures: 1,
+        }),
+      );
+      const resumeAt = "2099-01-01T00:00:00.000Z";
+
+      yield* harness.markUsageLimited();
+      yield* harness.engine.dispatch({
+        type: "thread.usage-limit-resume.schedule",
+        commandId: CommandId.make("cmd-report-failure-resume-schedule"),
+        threadId: ThreadId.make("thread-1"),
+        resumeAt,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.usage-limit-resume.attempt",
+        commandId: CommandId.make("cmd-report-failure-resume-attempt"),
+        threadId: ThreadId.make("thread-1"),
+        expectedAttemptAt: resumeAt,
+        createdAt: resumeAt,
+      });
+      yield* harness.usageLimitResumeTransitionDispatched;
+
+      expect(harness.usageLimitResumeSessionErrorDispatchAttempts).toBe(1);
+      expect(harness.usageLimitResumeActivityDispatchAttempts).toBe(0);
+      expect(harness.usageLimitResumeTransitionDispatchAttempts).toBe(2);
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      expect(thread?.usageLimitResume?.attempt).toBe(1);
+      expect(thread?.usageLimitResume?.nextAttemptAt).not.toBeNull();
+    }),
+  );
+
+  effectIt.effect("keeps the serial worker moving while a resume repair retries", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          startSessionEffect: () =>
+            Effect.fail(
+              new ProviderAdapterRequestError({
+                provider: "grok",
+                method: "session/prompt",
+                detail: "Grok usage limit reached. Try again later.",
+              }),
+            ),
+          usageLimitResumeTransitionDispatchFailures: 1,
+        }),
+      );
+      const resumeAt = "2099-01-01T00:00:00.000Z";
+
+      yield* harness.markUsageLimited();
+      yield* harness.engine.dispatch({
+        type: "thread.usage-limit-resume.schedule",
+        commandId: CommandId.make("cmd-nonblocking-resume-schedule"),
+        threadId: ThreadId.make("thread-1"),
+        resumeAt,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.usage-limit-resume.attempt",
+        commandId: CommandId.make("cmd-nonblocking-resume-attempt"),
+        threadId: ThreadId.make("thread-1"),
+        expectedAttemptAt: resumeAt,
+        createdAt: resumeAt,
+      });
+      yield* harness.usageLimitResumeTransitionAttemptObserved;
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.interrupt",
+        commandId: CommandId.make("cmd-interrupt-during-resume-repair"),
+        threadId: ThreadId.make("thread-1"),
+        createdAt: "2099-01-01T00:00:01.000Z",
+      });
+      yield* Effect.promise(() => harness.drain());
+
+      expect(harness.interruptTurn.mock.calls).toContainEqual([
+        { threadId: ThreadId.make("thread-1") },
+      ]);
+      expect(harness.usageLimitResumeTransitionDispatchAttempts).toBe(1);
+    }),
+  );
+
+  effectIt.effect("retries an in-flight automatic resume repair after a server restart", () =>
+    Effect.gen(function* () {
+      const providerRetryAt = "2099-01-01T02:00:00.000Z";
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          usageLimitResumeAttemptedBeforeStart: true,
+          usageLimitResumeTransitionDispatchFailures: 1,
+          usageLimitRetryAtBeforeStart: providerRetryAt,
+        }),
+      );
+      yield* harness.usageLimitResumeTransitionDispatched;
+
+      expect(harness.usageLimitResumeTransitionDispatchAttempts).toBe(2);
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      expect(thread?.usageLimitResume?.attempt).toBe(1);
+      expect(thread?.usageLimitResume?.nextAttemptAt).toBe("2099-01-01T02:00:02.000Z");
+    }),
+  );
+
+  effectIt.effect("schedules an unsettled usage-limit error after a server restart", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() => createHarness({ usageLimitedBeforeStart: true }));
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+
+      expect(thread?.usageLimitResume?.attempt).toBe(0);
+      expect(thread?.usageLimitResume?.nextAttemptAt).not.toBeNull();
+    }),
+  );
+
+  it.each([
+    { usageLimitedBeforeStart: true, enableAutomaticResume: false },
+    {
+      usageLimitResumeScheduledBeforeStart: "2099-01-01T00:00:00.000Z",
+      enableAutomaticResume: false,
+    },
+    { usageLimitResumeAttemptedBeforeStart: true, enableAutomaticResume: false },
+    { usageLimitedBeforeStart: true, usageLimitResumeCancelledBeforeStart: true },
+  ])("does not revive disabled or cancelled retries after restart: %j", async (input) => {
+    const harness = await createHarness(input);
+    await harness.drain();
+    const thread = (await harness.readModel()).threads.find(
+      (entry) => entry.id === ThreadId.make("thread-1"),
+    );
+    expect(thread?.usageLimitResume).toBeNull();
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+  });
+
+  it("recovers a new limit incident after an older cancellation", async () => {
+    const harness = await createHarness({
+      usageLimitedBeforeStart: true,
+      usageLimitResumeCancelledBeforeStart: true,
+      newLimitAfterCancellation: true,
+    });
+    await harness.drain();
+    const thread = (await harness.readModel()).threads.find(
+      (entry) => entry.id === ThreadId.make("thread-1"),
+    );
+    expect(thread?.usageLimitResume?.attempt).toBe(0);
+    expect(thread?.usageLimitResume?.nextAttemptAt).toBeTruthy();
+  });
+
+  it("cancels pending timers when automatic resume is turned off", async () => {
+    const harness = await createHarness({
+      usageLimitResumeScheduledBeforeStart: "2099-01-01T00:00:00.000Z",
+    });
+    await harness.updateSettings(false);
+    await harness.runEffect(harness.usageLimitResumeTransitionDispatched);
+    await harness.drain();
+    const thread = (await harness.readModel()).threads.find(
+      (entry) => entry.id === ThreadId.make("thread-1"),
+    );
+    expect(thread?.usageLimitResume).toBeNull();
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+  });
+
+  it("updates one mobile-compatible system notice without creating a provider turn", async () => {
+    const harness = await createHarness();
+    const threadId = ThreadId.make("thread-1");
+    await harness.runEffect(harness.markUsageLimited());
+    for (const [index, resumeAt] of [
+      "2099-01-01T00:00:00.000Z",
+      "2099-01-02T00:00:00.000Z",
+    ].entries()) {
+      await harness.runEffect(
+        harness.engine.dispatch({
+          type: "thread.usage-limit-resume.schedule",
+          commandId: CommandId.make(`notice-${index}`),
+          threadId,
+          resumeAt,
+        }),
+      );
+      await harness.drain();
+    }
+    const thread = (await harness.readModel()).threads.find((entry) => entry.id === threadId);
+    expect(thread?.messages).toHaveLength(1);
+    expect(thread?.messages[0]).toMatchObject({
+      role: "assistant",
+      turnId: null,
+      streaming: false,
+    });
+    expect(thread?.messages[0]?.text).toContain("02/01/2099");
+    expect(thread?.messages[0]?.text).not.toContain("01/01/2099");
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+  });
+
+  it("moves a legacy notice below new messages and clears it on cancellation", async () => {
+    const harness = await createHarness();
+    const threadId = ThreadId.make("thread-1");
+    for (const [index, [messageId, text]] of (
+      [
+        ["t3-resume-notice:thread-1", "Old waiting notice"],
+        ["new-response", "Example response"],
+      ] as const
+    ).entries()) {
+      await harness.runEffect(
+        harness.engine.dispatch({
+          type: "thread.message.assistant.complete",
+          commandId: CommandId.make(`seed-${messageId}`),
+          threadId,
+          messageId: MessageId.make(messageId),
+          text,
+          createdAt: `2026-01-01T00:00:0${index}.000Z`,
+        }),
+      );
+    }
+    await harness.runEffect(harness.markUsageLimited());
+    for (const resumeAt of ["2099-01-01T00:00:00.000Z", "2099-01-02T00:00:00.000Z"]) {
+      await harness.runEffect(
+        harness.engine.dispatch({
+          type: "thread.usage-limit-resume.schedule",
+          commandId: CommandId.make(`move-${resumeAt}`),
+          threadId,
+          resumeAt,
+        }),
+      );
+      await harness.drain();
+    }
+    const messages = (await harness.readModel()).threads.find(
+      (thread) => thread.id === threadId,
+    )!.messages;
+    expect(messages).toHaveLength(3);
+    expect(messages[0]?.text.trim()).toBe("");
+    expect(messages.at(-1)?.text).toContain("02/01/2099");
+    expect(messages.at(-1)?.text).not.toMatch(/T3 system notice|server time/);
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.usage-limit-resume.cancel",
+        commandId: CommandId.make("cancel-bottom-notice"),
+        threadId,
+      }),
+    );
+    await harness.drain();
+    const cancelled = (await harness.readModel()).threads.find((thread) => thread.id === threadId)!;
+    expect(cancelled.messages.filter((message) => message.text.trim())).toEqual([messages[1]]);
+  });
+
+  effectIt.effect("keeps startup repairs independent and retries more than once", () =>
+    Effect.gen(function* () {
+      const thread1 = ThreadId.make("thread-1");
+      const thread2 = ThreadId.make("thread-2");
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          usageLimitResumeAttemptedBeforeStart: true,
+          usageLimitResumeAttemptedSecondThreadBeforeStart: true,
+          usageLimitResumeTransitionDispatchFailures: 2,
+          usageLimitResumeTransitionFailureThreadId: thread1,
+        }),
+      );
+      yield* harness.usageLimitResumeThread2TransitionDispatched;
+      yield* Effect.promise(() =>
+        waitFor(async () => {
+          const readModel = await harness.readModel();
+          const thread = readModel.threads.find((entry) => entry.id === thread1);
+          return thread?.usageLimitResume?.attempt === 1;
+        }),
+      );
+
+      expect(harness.usageLimitResumeTransitionDispatchAttemptsForThread(thread1)).toBe(3);
+      expect(harness.usageLimitResumeTransitionDispatchAttemptsForThread(thread2)).toBe(1);
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      const recoveredThread1 = readModel.threads.find((entry) => entry.id === thread1);
+      const recoveredThread = readModel.threads.find((entry) => entry.id === thread2);
+      expect(recoveredThread1?.usageLimitResume?.attempt).toBe(1);
+      expect(recoveredThread1?.usageLimitResume?.nextAttemptAt).not.toBeNull();
+      expect(recoveredThread?.usageLimitResume?.attempt).toBe(1);
+      expect(recoveredThread?.usageLimitResume?.nextAttemptAt).not.toBeNull();
+    }),
+  );
+
+  effectIt.effect("interrupts an in-flight automatic resume when the thread is settled", () =>
+    Effect.gen(function* () {
+      const resumeSendStarted = yield* Deferred.make<void>();
+      const releaseResumeSend = yield* Deferred.make<void>();
+      const threadId = ThreadId.make("thread-1");
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          sendTurnEffect: () =>
+            Deferred.succeed(resumeSendStarted, undefined).pipe(
+              Effect.andThen(Deferred.await(releaseResumeSend)),
+              Effect.as({ threadId, turnId: asTurnId("turn-resume-before-settle") }),
+            ),
+        }),
+      );
+      const resumeAt = "2099-01-01T00:00:00.000Z";
+
+      yield* harness.markUsageLimited();
+      yield* harness.engine.dispatch({
+        type: "thread.usage-limit-resume.schedule",
+        commandId: CommandId.make("cmd-settle-running-resume-schedule"),
+        threadId,
+        resumeAt,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.usage-limit-resume.attempt",
+        commandId: CommandId.make("cmd-settle-running-resume-attempt"),
+        threadId,
+        expectedAttemptAt: resumeAt,
+        createdAt: resumeAt,
+      });
+      yield* Deferred.await(resumeSendStarted);
+      yield* harness.markUsageLimited();
+
+      yield* harness.engine.dispatch({
+        type: "thread.settle",
+        commandId: CommandId.make("cmd-settle-running-resume"),
+        threadId,
+      });
+      yield* Effect.promise(() => harness.drain());
+
+      expect(harness.interruptTurn.mock.calls).toContainEqual([{ threadId }]);
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      const thread = readModel.threads.find((entry) => entry.id === threadId);
+      expect(thread?.settledOverride).toBe("settled");
+      expect(thread?.usageLimitResume).toBeNull();
+      yield* Deferred.succeed(releaseResumeSend, undefined);
+    }),
+  );
+
+  effectIt.effect("does not resume an attempted timer after the thread is settled", () =>
+    Effect.gen(function* () {
+      const blockedSessionStarted = yield* Deferred.make<void>();
+      const releaseBlockedSession = yield* Deferred.make<void>();
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          createSecondThread: true,
+          startSessionEffect: (session) =>
+            session.threadId === ThreadId.make("thread-2")
+              ? Deferred.succeed(blockedSessionStarted, undefined).pipe(
+                  Effect.andThen(Deferred.await(releaseBlockedSession)),
+                  Effect.as(session),
+                )
+              : Effect.succeed(session),
+        }),
+      );
+      const resumeAt = "2099-01-01T00:00:00.000Z";
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-block-reactor-worker"),
+        threadId: ThreadId.make("thread-2"),
+        message: {
+          messageId: asMessageId("message-block-reactor-worker"),
+          role: "user",
+          text: "block the worker",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+      yield* Deferred.await(blockedSessionStarted);
+
+      yield* harness.markUsageLimited();
+      yield* harness.engine.dispatch({
+        type: "thread.usage-limit-resume.schedule",
+        commandId: CommandId.make("cmd-settled-resume-schedule"),
+        threadId: ThreadId.make("thread-1"),
+        resumeAt,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.usage-limit-resume.attempt",
+        commandId: CommandId.make("cmd-settled-resume-attempt"),
+        threadId: ThreadId.make("thread-1"),
+        expectedAttemptAt: resumeAt,
+        createdAt: resumeAt,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.settle",
+        commandId: CommandId.make("cmd-settle-before-resume-processing"),
+        threadId: ThreadId.make("thread-1"),
+      });
+
+      yield* Deferred.succeed(releaseBlockedSession, undefined);
+      yield* Effect.promise(() => harness.drain());
+
+      expect(
+        harness.sendTurn.mock.calls.some(
+          ([input]) =>
+            typeof input === "object" &&
+            input !== null &&
+            "input" in input &&
+            input.input === "Continue from where you left off.",
+        ),
+      ).toBe(false);
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      expect(thread?.settledOverride).toBe("settled");
+      expect(thread?.usageLimitResume).toBeNull();
+    }),
+  );
+
+  effectIt.effect("does not resume an attempted timer after the thread is archived", () =>
+    Effect.gen(function* () {
+      const blockedSessionStarted = yield* Deferred.make<void>();
+      const releaseBlockedSession = yield* Deferred.make<void>();
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          createSecondThread: true,
+          startSessionEffect: (session) =>
+            session.threadId === ThreadId.make("thread-2")
+              ? Deferred.succeed(blockedSessionStarted, undefined).pipe(
+                  Effect.andThen(Deferred.await(releaseBlockedSession)),
+                  Effect.as(session),
+                )
+              : Effect.succeed(session),
+        }),
+      );
+      const resumeAt = "2099-01-01T00:00:00.000Z";
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-block-reactor-worker-for-archive"),
+        threadId: ThreadId.make("thread-2"),
+        message: {
+          messageId: asMessageId("message-block-reactor-worker-for-archive"),
+          role: "user",
+          text: "block the worker",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+      yield* Deferred.await(blockedSessionStarted);
+
+      yield* harness.markUsageLimited();
+      yield* harness.engine.dispatch({
+        type: "thread.usage-limit-resume.schedule",
+        commandId: CommandId.make("cmd-archived-resume-schedule"),
+        threadId: ThreadId.make("thread-1"),
+        resumeAt,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.usage-limit-resume.attempt",
+        commandId: CommandId.make("cmd-archived-resume-attempt"),
+        threadId: ThreadId.make("thread-1"),
+        expectedAttemptAt: resumeAt,
+        createdAt: resumeAt,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.archive",
+        commandId: CommandId.make("cmd-archive-before-resume-processing"),
+        threadId: ThreadId.make("thread-1"),
+      });
+
+      yield* Deferred.succeed(releaseBlockedSession, undefined);
+      yield* Effect.promise(() => harness.drain());
+
+      expect(
+        harness.sendTurn.mock.calls.some(
+          ([input]) =>
+            typeof input === "object" &&
+            input !== null &&
+            "input" in input &&
+            input.input === "Continue from where you left off.",
+        ),
+      ).toBe(false);
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      expect(thread?.archivedAt).not.toBeNull();
+      expect(thread?.usageLimitResume).toBeNull();
+      expect(harness.interruptTurn.mock.calls).toContainEqual([
+        { threadId: ThreadId.make("thread-1") },
+      ]);
+    }),
+  );
+
+  effectIt.effect("does not resume an attempted timer after the thread is deleted", () =>
+    Effect.gen(function* () {
+      const blockedSessionStarted = yield* Deferred.make<void>();
+      const releaseBlockedSession = yield* Deferred.make<void>();
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          createSecondThread: true,
+          startSessionEffect: (session) =>
+            session.threadId === ThreadId.make("thread-2")
+              ? Deferred.succeed(blockedSessionStarted, undefined).pipe(
+                  Effect.andThen(Deferred.await(releaseBlockedSession)),
+                  Effect.as(session),
+                )
+              : Effect.succeed(session),
+        }),
+      );
+      const resumeAt = "2099-01-01T00:00:00.000Z";
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-block-reactor-worker-for-delete"),
+        threadId: ThreadId.make("thread-2"),
+        message: {
+          messageId: asMessageId("message-block-reactor-worker-for-delete"),
+          role: "user",
+          text: "block the worker",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+      yield* Deferred.await(blockedSessionStarted);
+
+      yield* harness.markUsageLimited();
+      yield* harness.engine.dispatch({
+        type: "thread.usage-limit-resume.schedule",
+        commandId: CommandId.make("cmd-deleted-resume-schedule"),
+        threadId: ThreadId.make("thread-1"),
+        resumeAt,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.usage-limit-resume.attempt",
+        commandId: CommandId.make("cmd-deleted-resume-attempt"),
+        threadId: ThreadId.make("thread-1"),
+        expectedAttemptAt: resumeAt,
+        createdAt: resumeAt,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.delete",
+        commandId: CommandId.make("cmd-delete-before-resume-processing"),
+        threadId: ThreadId.make("thread-1"),
+      });
+
+      yield* Deferred.succeed(releaseBlockedSession, undefined);
+      yield* Effect.promise(() => harness.drain());
+
+      expect(
+        harness.sendTurn.mock.calls.some(
+          ([input]) =>
+            typeof input === "object" &&
+            input !== null &&
+            "input" in input &&
+            input.input === "Continue from where you left off.",
+        ),
+      ).toBe(false);
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      expect(thread?.deletedAt).not.toBeNull();
+      expect(thread?.usageLimitResume).toBeNull();
+      expect(harness.interruptTurn.mock.calls).toContainEqual([
+        { threadId: ThreadId.make("thread-1") },
+      ]);
+    }),
+  );
 
   effectIt.effect("projects starting before a slow provider session finishes", () =>
     Effect.gen(function* () {
@@ -2997,7 +4116,7 @@ describe("ProviderCommandReactor", () => {
       ),
     );
 
-    await Effect.runPromise(
+    await harness.runEffect(
       harness.engine.dispatch({
         type: "thread.session.set",
         commandId: CommandId.make("cmd-session-set-for-approval-error"),
@@ -3015,7 +4134,7 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await Effect.runPromise(
+    await harness.runEffect(
       harness.engine.dispatch({
         type: "thread.activity.append",
         commandId: CommandId.make("cmd-approval-requested"),
@@ -3036,7 +4155,7 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await Effect.runPromise(
+    await harness.runEffect(
       harness.engine.dispatch({
         type: "thread.approval.respond",
         commandId: CommandId.make("cmd-approval-respond-stale"),
@@ -3092,7 +4211,7 @@ describe("ProviderCommandReactor", () => {
       ),
     );
 
-    await Effect.runPromise(
+    await harness.runEffect(
       harness.engine.dispatch({
         type: "thread.session.set",
         commandId: CommandId.make("cmd-session-set-for-user-input-error"),
@@ -3110,7 +4229,7 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await Effect.runPromise(
+    await harness.runEffect(
       harness.engine.dispatch({
         type: "thread.activity.append",
         commandId: CommandId.make("cmd-user-input-requested"),
@@ -3143,7 +4262,7 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await Effect.runPromise(
+    await harness.runEffect(
       harness.engine.dispatch({
         type: "thread.user-input.respond",
         commandId: CommandId.make("cmd-user-input-respond-stale"),

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -2,6 +2,7 @@ import {
   type ChatAttachment,
   CommandId,
   EventId,
+  MessageId,
   type ModelSelection,
   type OrchestrationEvent,
   ProviderDriverKind,
@@ -16,10 +17,12 @@ import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shar
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Equal from "effect/Equal";
 import * as FileSystem from "effect/FileSystem";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
@@ -34,7 +37,9 @@ import type { ProviderServiceError } from "../../provider/Errors.ts";
 import { TextGeneration } from "../../textGeneration/TextGeneration.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProviderRegistry } from "../../provider/Services/ProviderRegistry.ts";
+import type { OrchestrationDispatchError } from "../Errors.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
+import { OrchestrationEventStore } from "../../persistence/Services/OrchestrationEventStore.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
 import {
   ProviderCommandReactor,
@@ -48,6 +53,7 @@ import {
 } from "../../serverSettings.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import { GitWorkflowService } from "../../git/GitWorkflowService.ts";
+import { nextUsageLimitRetryAt, providerUsageLimitFromError } from "../../provider/usageLimits.ts";
 const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
 const isProviderDriverKind = Schema.is(ProviderDriverKind);
 
@@ -62,7 +68,12 @@ type ProviderIntentEvent = Extract<
       | "thread.approval-response-requested"
       | "thread.user-input-response-requested"
       | "thread.session-stop-requested"
-      | "thread.settled";
+      | "thread.settled"
+      | "thread.deleted"
+      | "thread.archived"
+      | "thread.usage-limit-resume-scheduled"
+      | "thread.usage-limit-resume-cancelled"
+      | "thread.usage-limit-resume-attempted";
   }
 >;
 
@@ -314,6 +325,7 @@ const make = Effect.gen(function* () {
   const vcsStatusBroadcaster = yield* VcsStatusBroadcaster;
   const textGeneration = yield* TextGeneration;
   const serverSettingsService = yield* ServerSettingsService;
+  const eventStore = yield* OrchestrationEventStore;
   const serverCommandId = (tag: string) =>
     crypto.randomUUIDv4.pipe(Effect.map((uuid) => CommandId.make(`server:${tag}:${uuid}`)));
   const serverEventId = () => crypto.randomUUIDv4.pipe(Effect.map(EventId.make));
@@ -331,6 +343,7 @@ const make = Effect.gen(function* () {
     );
 
   const threadModelSelections = new Map<string, ModelSelection>();
+  const usageLimitResumeFibers = new Map<ThreadId, Fiber.Fiber<void, never>>();
 
   const appendProviderFailureActivity = (input: {
     readonly threadId: ThreadId;
@@ -401,6 +414,7 @@ const make = Effect.gen(function* () {
     );
 
   const setThreadSessionErrorOnTurnStartFailure = Effect.fnUntraced(function* (input: {
+    readonly pendingMessageId?: MessageId;
     readonly threadId: ThreadId;
     readonly detail: string;
     readonly createdAt: string;
@@ -410,22 +424,48 @@ const make = Effect.gen(function* () {
       return;
     }
     const session = thread.session;
-    yield* setThreadSession({
-      threadId: input.threadId,
-      session: {
-        ...(session ?? {
+    const usageLimit = providerUsageLimitFromError({ message: input.detail });
+    const baseSession = session
+      ? (({ lastErrorClass: _lastErrorClass, retryAt: _retryAt, ...rest }) => rest)(session)
+      : {
           threadId: input.threadId,
           providerName: null,
           providerInstanceId: thread.modelSelection.instanceId,
           runtimeMode: thread.runtimeMode,
-        }),
+        };
+    yield* setThreadSession({
+      threadId: input.threadId,
+      session: {
+        ...baseSession,
         status: session?.status === "stopped" ? "stopped" : "error",
         activeTurnId: null,
         lastError: input.detail,
+        lastErrorClass: usageLimit === null ? "provider_error" : "usage_limit",
+        ...(usageLimit?.retryAt !== undefined ? { retryAt: usageLimit.retryAt } : {}),
         updatedAt: input.createdAt,
       },
       createdAt: input.createdAt,
     });
+    if (
+      usageLimit !== null &&
+      thread.usageLimitResume == null &&
+      session?.status !== "stopped" &&
+      (yield* serverSettingsService.getSettings).enableAutomaticResume
+    ) {
+      yield* orchestrationEngine.dispatch({
+        type: "thread.usage-limit-resume.schedule",
+        commandId: yield* serverCommandId("usage-limit-turn-start-failure"),
+        ...(input.pendingMessageId !== undefined
+          ? { pendingMessageId: input.pendingMessageId }
+          : {}),
+        threadId: input.threadId,
+        resumeAt: nextUsageLimitRetryAt({
+          now: input.createdAt,
+          attempt: 0,
+          ...(usageLimit.retryAt !== undefined ? { providerRetryAt: usageLimit.retryAt } : {}),
+        }),
+      });
+    }
   });
 
   const resolveProject = Effect.fnUntraced(function* (projectId: ProjectId) {
@@ -470,7 +510,7 @@ const make = Effect.gen(function* () {
       Effect.andThen(gitWorkflow.createWorktree({ cwd, refName: branch, path: worktreePath })),
       Effect.catchCause((cause) =>
         Cause.hasInterruptsOnly(cause)
-          ? Effect.failCause(cause)
+          ? Effect.interrupt
           : Effect.logWarning("provider command reactor failed to recreate worktree", {
               threadId: thread.id,
               worktreePath,
@@ -1181,6 +1221,7 @@ const make = Effect.gen(function* () {
       }
       const detail = formatFailureDetail(cause);
       return setThreadSessionErrorOnTurnStartFailure({
+        pendingMessageId: message.id,
         threadId: event.payload.threadId,
         detail,
         createdAt: event.payload.createdAt,
@@ -1234,11 +1275,367 @@ const make = Effect.gen(function* () {
       .pipe(Effect.catchCause(recoverTurnStartFailure), Effect.forkScoped);
   });
 
+  const isRetryableUsageLimitResumeDispatchError = (error: OrchestrationDispatchError) =>
+    error._tag === "OrchestrationListenerCallbackError" || error._tag === "PersistenceSqlError";
+
+  const usageLimitResumeDispatchRetrySchedule = () =>
+    Schedule.exponential("1 second").pipe(
+      Schedule.modifyDelay(({ duration }) =>
+        Effect.succeed(Duration.min(duration, Duration.seconds(30))),
+      ),
+    );
+
+  const retryUsageLimitResumeDispatch = <A, R>(
+    effect: Effect.Effect<A, OrchestrationDispatchError, R>,
+    input: {
+      readonly threadId: ThreadId;
+      readonly operation: "attempt" | "retry" | "cancel";
+    },
+  ): Effect.Effect<A, OrchestrationDispatchError, R> =>
+    effect.pipe(
+      Effect.tapError((error) =>
+        Effect.logWarning("provider command reactor usage-limit dispatch failed", {
+          threadId: input.threadId,
+          operation: input.operation,
+          error,
+        }),
+      ),
+      Effect.retry({
+        while: isRetryableUsageLimitResumeDispatchError,
+        schedule: usageLimitResumeDispatchRetrySchedule(),
+      }),
+    );
+
+  const retryUsageLimitResumeRecoveryDispatch = <A, R>(
+    effect: Effect.Effect<A, OrchestrationDispatchError, R>,
+    threadId: ThreadId,
+  ): Effect.Effect<A, OrchestrationDispatchError, R> =>
+    effect.pipe(
+      Effect.tapError((error) =>
+        Effect.logWarning("provider command reactor usage-limit recovery dispatch failed", {
+          threadId,
+          error,
+        }),
+      ),
+      Effect.retry({
+        while: isRetryableUsageLimitResumeDispatchError,
+        schedule: usageLimitResumeDispatchRetrySchedule(),
+      }),
+    );
+
+  const scheduleUsageLimitResumeAttempt = Effect.fn("scheduleUsageLimitResumeAttempt")(function* (
+    threadId: ThreadId,
+    resumeAt: string,
+  ) {
+    // Timer wakeups can precede their wall-clock deadline. Recheck before
+    // dispatch: the decider rejects early attempts without scheduling another.
+    let remaining = Date.parse(resumeAt) - DateTime.toEpochMillis(yield* DateTime.now);
+    while (remaining > 0) {
+      yield* Effect.sleep(Duration.millis(remaining));
+      remaining = Date.parse(resumeAt) - DateTime.toEpochMillis(yield* DateTime.now);
+    }
+    const createdAt = DateTime.formatIso(yield* DateTime.now);
+    const commandId = yield* serverCommandId("usage-limit-resume-attempt");
+    yield* retryUsageLimitResumeDispatch(
+      orchestrationEngine.dispatch({
+        type: "thread.usage-limit-resume.attempt",
+        commandId,
+        threadId,
+        expectedAttemptAt: resumeAt,
+        createdAt,
+      }),
+      { threadId, operation: "attempt" },
+    );
+  });
+
+  const replaceUsageLimitResumeSchedule = Effect.fn("replaceUsageLimitResumeSchedule")(function* (
+    threadId: ThreadId,
+    resumeAt: string,
+  ) {
+    if (!(yield* serverSettingsService.getSettings).enableAutomaticResume) {
+      yield* orchestrationEngine.dispatch({
+        type: "thread.usage-limit-resume.cancel",
+        commandId: yield* serverCommandId("usage-limit-disabled"),
+        threadId,
+      });
+      return;
+    }
+    const previous = usageLimitResumeFibers.get(threadId);
+    if (previous !== undefined) {
+      yield* Fiber.interrupt(previous).pipe(Effect.ignore);
+    }
+    const fiber = yield* scheduleUsageLimitResumeAttempt(threadId, resumeAt).pipe(
+      Effect.catchCause((cause) =>
+        Cause.hasInterruptsOnly(cause)
+          ? Effect.void
+          : Effect.logWarning("provider command reactor usage-limit timer failed", {
+              threadId,
+              resumeAt,
+              cause: Cause.pretty(cause),
+            }),
+      ),
+      Effect.forkScoped,
+    );
+    usageLimitResumeFibers.set(threadId, fiber);
+  });
+
+  const cancelUsageLimitResumeSchedule = Effect.fn("cancelUsageLimitResumeSchedule")(function* (
+    threadId: ThreadId,
+  ) {
+    const fiber = usageLimitResumeFibers.get(threadId);
+    usageLimitResumeFibers.delete(threadId);
+    if (fiber !== undefined) {
+      yield* Fiber.interrupt(fiber).pipe(Effect.ignore);
+    }
+  });
+
+  const publishResumeNotice = Effect.fn("publishResumeNotice")(
+    function* (threadId: ThreadId) {
+      const thread = yield* resolveThread(threadId);
+      if (thread === undefined || thread.deletedAt !== null) return;
+      const noticePrefix = `t3-resume-notice:${threadId}`;
+      const isNotice = (message: (typeof thread.messages)[number]) =>
+        message.id === noticePrefix || message.id.startsWith(`${noticePrefix}:`);
+      const visibleNotices = thread.messages.filter(
+        (message) => isNotice(message) && message.text.trim().length > 0,
+      );
+      const resume = (yield* serverSettingsService.getSettings).enableAutomaticResume
+        ? thread.usageLimitResume
+        : null;
+      const finalMessage = thread.messages.at(-1);
+      const targetMessageId =
+        finalMessage !== undefined && isNotice(finalMessage)
+          ? finalMessage.id
+          : MessageId.make(`${noticePrefix}:${finalMessage?.id ?? "initial"}`);
+      const text =
+        resume?.nextAttemptAt != null
+          ? `Waiting for provider availability. Work is not finished. Next automatic attempt: ${new Intl.DateTimeFormat("en-GB", { year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", timeZoneName: "short" }).format(Date.parse(resume.nextAttemptAt))}.`
+          : "Checking provider availability and attempting to continue.";
+      const targetNotice = thread.messages.find((message) => message.id === targetMessageId);
+      for (const message of visibleNotices) {
+        if (message.id === targetMessageId && resume != null) continue;
+        // Legacy completion preserves empty text; trimmed blanks are hidden by clients.
+        yield* orchestrationEngine.dispatch({
+          type: "thread.message.assistant.complete",
+          commandId: yield* serverCommandId("resume-notice-clear"),
+          threadId,
+          messageId: message.id,
+          text: " ",
+          createdAt: DateTime.formatIso(yield* DateTime.now),
+        });
+      }
+      if (resume == null) return;
+      if (targetNotice?.text === text && finalMessage?.id === targetMessageId) return;
+      yield* orchestrationEngine.dispatch({
+        type: "thread.message.assistant.complete",
+        commandId: yield* serverCommandId("resume-notice"),
+        threadId,
+        messageId: targetMessageId,
+        text,
+        createdAt: DateTime.formatIso(yield* DateTime.now),
+      });
+    },
+    Effect.catchCause((cause) =>
+      Cause.hasInterruptsOnly(cause)
+        ? Effect.interrupt
+        : Effect.logWarning("Failed to update automatic resume notice", {
+            cause: Cause.pretty(cause),
+          }),
+    ),
+  );
+
+  const processUsageLimitResumeAttempted = Effect.fn("processUsageLimitResumeAttempted")(function* (
+    event: Extract<ProviderIntentEvent, { type: "thread.usage-limit-resume-attempted" }>,
+  ) {
+    if (!event.payload.shouldResume) {
+      return;
+    }
+    if (!(yield* serverSettingsService.getSettings).enableAutomaticResume) {
+      yield* orchestrationEngine.dispatch({
+        type: "thread.usage-limit-resume.cancel",
+        commandId: yield* serverCommandId("usage-limit-disabled"),
+        threadId: event.payload.threadId,
+      });
+      return;
+    }
+    const resolveEligibleThread = Effect.fnUntraced(function* () {
+      const candidate = yield* resolveThread(event.payload.threadId);
+      const candidateResume = candidate?.usageLimitResume ?? null;
+      return candidate !== undefined &&
+        candidateResume !== null &&
+        candidateResume.nextAttemptAt === null &&
+        candidateResume.attempt === event.payload.attempt &&
+        candidate.deletedAt === null &&
+        candidate.archivedAt === null &&
+        candidate.settledOverride !== "settled"
+        ? Option.some(candidate)
+        : Option.none();
+    });
+    const initialThread = yield* resolveEligibleThread();
+    if (Option.isNone(initialThread)) return;
+
+    const thread = initialThread.value;
+    yield* ensureThreadWorktree(thread);
+    const preparedThread = yield* resolveEligibleThread();
+    if (Option.isNone(preparedThread)) return;
+
+    const retryOrCancel = (cause: Cause.Cause<unknown>) =>
+      Effect.gen(function* () {
+        if (Cause.hasInterruptsOnly(cause)) {
+          return;
+        }
+        const latestThread = yield* resolveThread(event.payload.threadId);
+        const latestUsageLimitResume = latestThread?.usageLimitResume ?? null;
+        if (
+          latestThread === undefined ||
+          latestUsageLimitResume === null ||
+          latestUsageLimitResume.nextAttemptAt !== null ||
+          latestUsageLimitResume.attempt !== event.payload.attempt ||
+          latestThread.deletedAt !== null ||
+          latestThread.archivedAt !== null ||
+          latestThread.settledOverride === "settled"
+        ) {
+          return;
+        }
+        const detail = formatFailureDetail(cause);
+        const usageLimit = providerUsageLimitFromError({ message: detail });
+        const createdAt = DateTime.formatIso(yield* DateTime.now);
+        yield* setThreadSessionErrorOnTurnStartFailure({
+          threadId: event.payload.threadId,
+          detail,
+          createdAt,
+        }).pipe(
+          Effect.catchCause((reportingCause) =>
+            Cause.hasInterruptsOnly(reportingCause)
+              ? Effect.failCause(reportingCause)
+              : Effect.logWarning(
+                  "provider command reactor failed to report automatic-resume session error",
+                  {
+                    threadId: event.payload.threadId,
+                    cause: Cause.pretty(reportingCause),
+                  },
+                ),
+          ),
+        );
+        if (
+          usageLimit !== null &&
+          (yield* serverSettingsService.getSettings).enableAutomaticResume
+        ) {
+          yield* retryUsageLimitResumeDispatch(
+            orchestrationEngine.dispatch({
+              type: "thread.usage-limit-resume.retry",
+              commandId: yield* serverCommandId("usage-limit-resume-retry"),
+              ...(latestUsageLimitResume.pendingMessageId !== undefined
+                ? { pendingMessageId: latestUsageLimitResume.pendingMessageId }
+                : {}),
+              threadId: event.payload.threadId,
+              resumeAt: nextUsageLimitRetryAt({
+                now: createdAt,
+                attempt: event.payload.attempt + 1,
+                ...(usageLimit.retryAt !== undefined
+                  ? { providerRetryAt: usageLimit.retryAt }
+                  : {}),
+              }),
+              attempt: event.payload.attempt,
+              createdAt,
+            }),
+            { threadId: event.payload.threadId, operation: "retry" },
+          );
+        } else {
+          yield* appendProviderFailureActivity({
+            threadId: event.payload.threadId,
+            kind: "provider.turn.start.failed",
+            summary: "Automatic resume failed",
+            detail,
+            turnId: null,
+            createdAt,
+          }).pipe(
+            Effect.catchCause((reportingCause) =>
+              Cause.hasInterruptsOnly(reportingCause)
+                ? Effect.failCause(reportingCause)
+                : Effect.logWarning(
+                    "provider command reactor failed to report automatic-resume activity",
+                    {
+                      threadId: event.payload.threadId,
+                      cause: Cause.pretty(reportingCause),
+                    },
+                  ),
+            ),
+          );
+          yield* retryUsageLimitResumeDispatch(
+            orchestrationEngine.dispatch({
+              type: "thread.usage-limit-resume.cancel",
+              commandId: yield* serverCommandId("usage-limit-resume-cancel"),
+              threadId: event.payload.threadId,
+            }),
+            { threadId: event.payload.threadId, operation: "cancel" },
+          );
+        }
+      });
+
+    const pendingMessageId = preparedThread.value.usageLimitResume?.pendingMessageId;
+    const pendingMessage =
+      pendingMessageId === undefined
+        ? undefined
+        : preparedThread.value.messages.find(
+            (message) => message.id === pendingMessageId && message.role === "user",
+          );
+    if (pendingMessageId !== undefined && pendingMessage === undefined) {
+      yield* orchestrationEngine.dispatch({
+        type: "thread.usage-limit-resume.cancel",
+        commandId: yield* serverCommandId("missing-pending-input"),
+        threadId: event.payload.threadId,
+      });
+      return;
+    }
+    const sendTurnRequest = yield* buildSendTurnRequestForThread({
+      threadId: event.payload.threadId,
+      messageText: pendingMessage?.text ?? "Continue from where you left off.",
+      ...(pendingMessage?.attachments !== undefined
+        ? { attachments: pendingMessage.attachments }
+        : {}),
+      interactionMode: preparedThread.value.interactionMode,
+      createdAt: event.occurredAt,
+    }).pipe(
+      Effect.map(Option.some),
+      Effect.catchCause((cause) =>
+        retryOrCancel(cause).pipe(Effect.forkScoped, Effect.as(Option.none())),
+      ),
+    );
+    if (Option.isNone(sendTurnRequest)) {
+      return;
+    }
+    yield* Effect.gen(function* () {
+      if (Option.isNone(yield* resolveEligibleThread())) return;
+      yield* providerService.sendTurn(sendTurnRequest.value);
+    }).pipe(Effect.catchCause(retryOrCancel), Effect.forkScoped);
+  });
+
   const processTurnInterruptRequested = Effect.fn("processTurnInterruptRequested")(function* (
     event: Extract<ProviderIntentEvent, { type: "thread.turn-interrupt-requested" }>,
   ) {
     const thread = yield* resolveThread(event.payload.threadId);
     if (!thread) {
+      yield* providerService.interruptTurn({ threadId: event.payload.threadId }).pipe(
+        Effect.catchCause((cause) =>
+          Cause.hasInterruptsOnly(cause)
+            ? Effect.interrupt
+            : providerService.stopSession({ threadId: event.payload.threadId }).pipe(
+                Effect.catchCause((stopCause) =>
+                  Cause.hasInterruptsOnly(stopCause)
+                    ? Effect.interrupt
+                    : Effect.logWarning(
+                        "provider command reactor failed to stop an inactive thread after interrupt failure",
+                        {
+                          threadId: event.payload.threadId,
+                          cause: Cause.pretty(stopCause),
+                          originalCause: Cause.pretty(cause),
+                        },
+                      ),
+                ),
+              ),
+        ),
+      );
       return;
     }
     const session = thread.session;
@@ -1509,6 +1906,22 @@ const make = Effect.gen(function* () {
         });
         return;
       }
+      case "thread.deleted":
+      case "thread.archived":
+        yield* cancelUsageLimitResumeSchedule(event.payload.threadId);
+        return;
+      case "thread.usage-limit-resume-scheduled":
+        yield* replaceUsageLimitResumeSchedule(event.payload.threadId, event.payload.resumeAt);
+        yield* publishResumeNotice(event.payload.threadId);
+        return;
+      case "thread.usage-limit-resume-attempted":
+        if (event.payload.shouldResume) yield* publishResumeNotice(event.payload.threadId);
+        yield* processUsageLimitResumeAttempted(event);
+        return;
+      case "thread.usage-limit-resume-cancelled":
+        yield* cancelUsageLimitResumeSchedule(event.payload.threadId);
+        yield* publishResumeNotice(event.payload.threadId);
+        return;
     }
   });
 
@@ -1528,6 +1941,32 @@ const make = Effect.gen(function* () {
   const worker = yield* makeDrainableWorker(processDomainEventSafely);
 
   const start: ProviderCommandReactorShape["start"] = Effect.fn("start")(function* () {
+    const settingsChanges = yield* serverSettingsService.subscribeChanges;
+    const resumeEnabled = (yield* serverSettingsService.getSettings.pipe(Effect.orDie))
+      .enableAutomaticResume;
+    yield* forkParked(
+      Stream.runForEach(settingsChanges, (settings) =>
+        settings.enableAutomaticResume
+          ? Effect.void
+          : Effect.gen(function* () {
+              const model = yield* projectionSnapshotQuery.getCommandReadModel();
+              for (const thread of model.threads) {
+                if (thread.usageLimitResume == null) continue;
+                yield* orchestrationEngine.dispatch({
+                  type: "thread.usage-limit-resume.cancel",
+                  commandId: yield* serverCommandId("usage-limit-opt-out"),
+                  threadId: thread.id,
+                });
+              }
+            }).pipe(
+              Effect.catchCause((cause) =>
+                Effect.logWarning("Failed to cancel automatic resumes", {
+                  cause: Cause.pretty(cause),
+                }),
+              ),
+            ),
+      ),
+    );
     const interruptedTitleRegenerations = yield* findInterruptedThreadTitleRegenerations().pipe(
       Effect.catchCause((cause) => {
         if (Cause.hasInterruptsOnly(cause)) {
@@ -1548,13 +1987,168 @@ const make = Effect.gen(function* () {
         event.type === "thread.approval-response-requested" ||
         event.type === "thread.user-input-response-requested" ||
         event.type === "thread.session-stop-requested" ||
-        event.type === "thread.settled"
+        event.type === "thread.deleted" ||
+        event.type === "thread.archived" ||
+        event.type === "thread.settled" ||
+        event.type === "thread.usage-limit-resume-scheduled" ||
+        event.type === "thread.usage-limit-resume-cancelled" ||
+        event.type === "thread.usage-limit-resume-attempted"
       ) {
         return yield* worker.enqueue(event);
       }
     });
 
-    yield* forkParked(Stream.runForEach(orchestrationEngine.streamDomainEvents, processEvent));
+    // Acquire the hot-stream subscription before reading recovery state. Any
+    // event committed during that query is buffered by the subscription and
+    // cannot leave a newer durable resume without a matching timer.
+    const domainEventsPull = yield* Stream.toPull(orchestrationEngine.streamDomainEvents);
+    const usageLimitResumeRecovery = yield* projectionSnapshotQuery.getCommandReadModel().pipe(
+      Effect.map((readModel) => ({
+        pending: readModel.threads.flatMap((thread) =>
+          thread.deletedAt !== null ||
+          thread.archivedAt !== null ||
+          thread.settledOverride === "settled" ||
+          thread.usageLimitResume == null
+            ? []
+            : [
+                {
+                  threadId: thread.id,
+                  resumeAt: thread.usageLimitResume.nextAttemptAt,
+                  attempt: thread.usageLimitResume.attempt,
+                  pendingMessageId: thread.usageLimitResume.pendingMessageId,
+                  providerRetryAt: thread.session?.retryAt,
+                },
+              ],
+        ),
+        missing: readModel.threads.flatMap((thread) =>
+          !resumeEnabled ||
+          thread.deletedAt !== null ||
+          thread.archivedAt !== null ||
+          thread.settledOverride === "settled" ||
+          thread.usageLimitResume !== null ||
+          thread.session?.status !== "error" ||
+          thread.session.lastErrorClass !== "usage_limit"
+            ? []
+            : [{ threadId: thread.id, providerRetryAt: thread.session.retryAt }],
+        ),
+      })),
+      Effect.catchCause((cause) =>
+        Cause.hasInterruptsOnly(cause)
+          ? Effect.interrupt
+          : Effect.logWarning("provider command reactor failed to restore usage-limit resumes", {
+              cause: Cause.pretty(cause),
+            }).pipe(Effect.as({ pending: [], missing: [] })),
+      ),
+    );
+    yield* Effect.forEach(
+      usageLimitResumeRecovery.pending,
+      ({ threadId, resumeAt }) =>
+        Effect.gen(function* () {
+          if (!resumeEnabled) {
+            yield* orchestrationEngine.dispatch({
+              type: "thread.usage-limit-resume.cancel",
+              commandId: yield* serverCommandId("usage-limit-disabled"),
+              threadId,
+            });
+          } else if (resumeAt !== null) {
+            yield* replaceUsageLimitResumeSchedule(threadId, resumeAt);
+            yield* publishResumeNotice(threadId);
+          }
+        }).pipe(
+          Effect.catchCause((cause) =>
+            Cause.hasInterruptsOnly(cause)
+              ? Effect.interrupt
+              : Effect.logWarning("Failed to restore automatic resume", {
+                  threadId,
+                  cause: Cause.pretty(cause),
+                }),
+          ),
+        ),
+      { concurrency: "unbounded", discard: true },
+    );
+    // Replay the buffered event stream only after snapshot timers are in
+    // place, so a newer event always wins over its stale snapshot entry.
+    yield* forkParked(
+      Stream.runForEach(Stream.fromPull(Effect.succeed(domainEventsPull)), processEvent),
+    );
+    yield* Effect.forEach(
+      usageLimitResumeRecovery.missing,
+      ({ threadId, providerRetryAt }) =>
+        Effect.gen(function* () {
+          // Backfill legacy errors, never resurrect a deliberately cleared schedule.
+          if (
+            yield* eventStore.hasEventAfter({
+              aggregateKind: "thread",
+              aggregateId: threadId,
+              type: "thread.usage-limit-resume-cancelled",
+              sequenceExclusive: 0,
+              afterLatestEvent: "thread.session-set",
+            })
+          )
+            return;
+          const createdAt = DateTime.formatIso(yield* DateTime.now);
+          yield* retryUsageLimitResumeRecoveryDispatch(
+            orchestrationEngine.dispatch({
+              type: "thread.usage-limit-resume.schedule",
+              commandId: yield* serverCommandId("usage-limit-resume-recover-missing"),
+              threadId,
+              resumeAt: nextUsageLimitRetryAt({
+                now: createdAt,
+                attempt: 0,
+                ...(providerRetryAt !== undefined ? { providerRetryAt } : {}),
+              }),
+            }),
+            threadId,
+          );
+        }).pipe(
+          Effect.catchCause((cause) =>
+            Cause.hasInterruptsOnly(cause)
+              ? Effect.interrupt
+              : Effect.logWarning(
+                  "provider command reactor failed to recover a missing usage-limit resume",
+                  { threadId, cause: Cause.pretty(cause) },
+                ),
+          ),
+        ),
+      { concurrency: "unbounded", discard: true },
+    );
+    yield* Effect.forEach(
+      usageLimitResumeRecovery.pending,
+      ({ threadId, resumeAt, attempt, providerRetryAt, pendingMessageId }) =>
+        !resumeEnabled || resumeAt !== null
+          ? Effect.void
+          : forkParked(
+              Effect.gen(function* () {
+                const createdAt = DateTime.formatIso(yield* DateTime.now);
+                yield* retryUsageLimitResumeRecoveryDispatch(
+                  orchestrationEngine.dispatch({
+                    type: "thread.usage-limit-resume.retry",
+                    commandId: yield* serverCommandId("usage-limit-resume-recover"),
+                    ...(pendingMessageId !== undefined ? { pendingMessageId } : {}),
+                    threadId,
+                    resumeAt: nextUsageLimitRetryAt({
+                      now: createdAt,
+                      attempt: attempt + 1,
+                      ...(providerRetryAt !== undefined ? { providerRetryAt } : {}),
+                    }),
+                    attempt,
+                    createdAt,
+                  }),
+                  threadId,
+                );
+              }).pipe(
+                Effect.catchCause((cause) =>
+                  Cause.hasInterruptsOnly(cause)
+                    ? Effect.interrupt
+                    : Effect.logWarning(
+                        "provider command reactor failed to recover an in-flight usage-limit resume",
+                        { threadId, cause: Cause.pretty(cause) },
+                      ),
+                ),
+              ),
+            ),
+      { concurrency: "unbounded", discard: true },
+    );
 
     // The domain event stream is hot, so work pending before this reactor
     // starts cannot be resumed. Correlated completions only clear the request

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
@@ -16,6 +16,21 @@ const base = {
 };
 
 describe("runtimeEventToActivities task progress", () => {
+  it("uses an existing activity kind without claiming a retry is enabled", () => {
+    const [activity] = runtimeEventToActivities({
+      ...base,
+      type: "runtime.error",
+      eventId: EventId.make("evt-usage-limit"),
+      payload: {
+        message: "Usage limit reached",
+        class: "usage_limit",
+      },
+    });
+
+    expect(activity?.kind).toBe("runtime.error");
+    expect(activity?.summary).toBe("Provider usage limit or temporary unavailability");
+  });
+
   it("persists usage independently from replaceable activity", () => {
     const taskId = RuntimeTaskId.make("agent-1");
     const usageOnly = {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -316,6 +316,23 @@ describe("ProviderRuntimeIngestion", () => {
       createdAt,
       updatedAt: createdAt,
     });
+    const markUsageLimited = () =>
+      dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-session-usage-limited"),
+        threadId: ThreadId.make("thread-1"),
+        session: {
+          threadId: ThreadId.make("thread-1"),
+          status: "error",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: "Usage limit reached",
+          lastErrorClass: "usage_limit",
+          updatedAt: createdAt,
+        },
+        createdAt,
+      });
 
     return {
       engine,
@@ -323,6 +340,7 @@ describe("ProviderRuntimeIngestion", () => {
       readModel: () => Effect.runPromise(snapshotQuery.getSnapshot()),
       emit: provider.emit,
       setProviderSession: provider.setSession,
+      markUsageLimited,
       drain,
     };
   }
@@ -455,6 +473,49 @@ describe("ProviderRuntimeIngestion", () => {
     );
     expect(thread.session?.status).toBe("ready");
     expect(thread.session?.lastError).toBeNull();
+  });
+
+  it("does not reuse usage-limit metadata for an unrelated session error", async () => {
+    const harness = await createHarness();
+    const threadId = ThreadId.make("thread-1");
+    const now = "2026-01-01T00:00:00.000Z";
+
+    await harness.dispatch({
+      type: "thread.session.set",
+      commandId: CommandId.make("cmd-session-with-usage-limit-metadata"),
+      threadId,
+      session: {
+        threadId,
+        status: "error",
+        providerName: "codex",
+        runtimeMode: "approval-required",
+        activeTurnId: null,
+        lastError: "Usage limit reached",
+        lastErrorClass: "usage_limit",
+        retryAt: "2099-01-01T00:00:00.000Z",
+        updatedAt: now,
+      },
+      createdAt: now,
+    });
+
+    harness.emit({
+      type: "session.state.changed",
+      eventId: asEventId("evt-unrelated-session-error"),
+      provider: ProviderDriverKind.make("codex"),
+      threadId: asThreadId("thread-1"),
+      createdAt: "2026-01-01T00:00:01.000Z",
+      payload: {
+        state: "error",
+        reason: "Windows sandbox failed to start",
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.session?.lastError === "Windows sandbox failed to start",
+    );
+    expect(thread.session?.lastErrorClass).toBeUndefined();
+    expect(thread.session?.retryAt).toBeUndefined();
   });
 
   it("clears active turn when provider session becomes ready", async () => {
@@ -2736,6 +2797,482 @@ describe("ProviderRuntimeIngestion", () => {
     );
     expect(thread.session?.status).toBe("error");
     expect(thread.session?.lastError).toBe("runtime exploded");
+  });
+
+  it("reschedules an active automatic resume from a typed usage-limit error", async () => {
+    const harness = await createHarness();
+    const attemptedAt = "2099-01-01T00:00:00.000Z";
+    const providerRetryAt = "2099-01-01T01:00:00.000Z";
+
+    await harness.markUsageLimited();
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.schedule",
+      commandId: CommandId.make("cmd-runtime-resume-schedule"),
+      threadId: ThreadId.make("thread-1"),
+      resumeAt: attemptedAt,
+      pendingMessageId: asMessageId("pending-usage-message"),
+    });
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.attempt",
+      commandId: CommandId.make("cmd-runtime-resume-attempt"),
+      threadId: ThreadId.make("thread-1"),
+      expectedAttemptAt: attemptedAt,
+      createdAt: attemptedAt,
+    });
+    harness.emit({
+      type: "runtime.error",
+      eventId: asEventId("evt-runtime-usage-limit"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: attemptedAt,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-usage-limit"),
+      payload: {
+        message: "Usage limit reached",
+        class: "usage_limit",
+        retryAt: providerRetryAt,
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.session?.lastErrorClass === "usage_limit" && entry.usageLimitResume?.attempt === 1,
+    );
+    expect(thread.session?.retryAt).toBe(providerRetryAt);
+    expect(thread.usageLimitResume).toEqual({
+      nextAttemptAt: "2099-01-01T01:00:02.000Z",
+      attempt: 1,
+      pendingMessageId: "pending-usage-message",
+    });
+
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-runtime-usage-limit-failed"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: attemptedAt,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-usage-limit"),
+      payload: { state: "failed" },
+    });
+    await harness.drain();
+
+    const afterCompletion = (await harness.readModel()).threads.find(
+      (entry) => entry.id === ThreadId.make("thread-1"),
+    );
+    expect(afterCompletion?.usageLimitResume).toEqual({
+      nextAttemptAt: "2099-01-01T01:00:02.000Z",
+      attempt: 1,
+      pendingMessageId: "pending-usage-message",
+    });
+    expect(
+      afterCompletion?.activities.filter((activity) => activity.kind === "runtime.error"),
+    ).toHaveLength(0);
+  });
+
+  it("schedules automatic resume without UI opt-in", async () => {
+    const harness = await createHarness();
+    const now = "2099-01-01T00:00:00.000Z";
+
+    harness.emit({
+      type: "runtime.error",
+      eventId: asEventId("evt-runtime-spend-cap"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-spend-cap"),
+      payload: {
+        message: "You hit your spend cap set by the owner of your workspace.",
+        class: "usage_limit",
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.usageLimitResume?.nextAttemptAt === "2099-01-01T00:20:00.000Z",
+    );
+    expect(thread.usageLimitResume).toEqual({
+      nextAttemptAt: "2099-01-01T00:20:00.000Z",
+      attempt: 0,
+    });
+  });
+
+  it("counts the initial wait in the three short waits and five hourly waits", async () => {
+    const harness = await createHarness();
+    const threadId = ThreadId.make("thread-1");
+    let resumeAt = "2099-01-01T00:20:00.000Z";
+    await harness.markUsageLimited();
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.schedule",
+      commandId: CommandId.make("cadence-start"),
+      threadId,
+      resumeAt,
+    });
+    for (let attempt = 0; attempt < 9; attempt++) {
+      await harness.dispatch({
+        type: "thread.usage-limit-resume.attempt",
+        commandId: CommandId.make(`cadence-attempt-${attempt}`),
+        threadId,
+        expectedAttemptAt: resumeAt,
+        createdAt: resumeAt,
+      });
+      harness.emit({
+        type: "runtime.error",
+        eventId: asEventId(`cadence-error-${attempt}`),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: resumeAt,
+        threadId,
+        payload: { message: "Usage limit reached", class: "usage_limit" },
+      });
+      const thread = await waitForThread(
+        harness.readModel,
+        (entry) => entry.usageLimitResume?.attempt === attempt + 1,
+      );
+      const next = thread.usageLimitResume!.nextAttemptAt!;
+      const minutes = attempt < 2 ? 20 : attempt < 7 ? 60 : 360;
+      expect(Date.parse(next) - Date.parse(resumeAt)).toBe(minutes * 60_000);
+      resumeAt = next;
+    }
+  });
+
+  it("clears automatic resume after a successful provider turn", async () => {
+    const harness = await createHarness();
+    const attemptedAt = "2099-01-01T00:00:00.000Z";
+
+    await harness.markUsageLimited();
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.schedule",
+      commandId: CommandId.make("cmd-successful-resume-schedule"),
+      threadId: ThreadId.make("thread-1"),
+      resumeAt: attemptedAt,
+    });
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.attempt",
+      commandId: CommandId.make("cmd-successful-resume-attempt"),
+      threadId: ThreadId.make("thread-1"),
+      expectedAttemptAt: attemptedAt,
+      createdAt: attemptedAt,
+    });
+
+    const attempted = await waitForThread(
+      harness.readModel,
+      (entry) => entry.usageLimitResume?.nextAttemptAt === null,
+    );
+    expect(attempted.usageLimitResume).toEqual({ nextAttemptAt: null, attempt: 0 });
+
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-successful-auto-resume"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: attemptedAt,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-successful-auto-resume"),
+      payload: { state: "completed" },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.usageLimitResume === null,
+    );
+    expect(thread.usageLimitResume).toBeNull();
+  });
+
+  it("keeps a scheduled resume when a delayed provider turn completes", async () => {
+    const harness = await createHarness();
+    const resumeAt = "2099-01-01T01:00:00.000Z";
+
+    await harness.markUsageLimited();
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.schedule",
+      commandId: CommandId.make("cmd-delayed-completion-resume-schedule"),
+      threadId: ThreadId.make("thread-1"),
+      resumeAt,
+    });
+
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-delayed-provider-completion"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2099-01-01T00:00:00.000Z",
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-before-scheduled-resume"),
+      payload: { state: "completed" },
+    });
+    await harness.drain();
+
+    const thread = (await harness.readModel()).threads.find(
+      (entry) => entry.id === ThreadId.make("thread-1"),
+    );
+    expect(thread?.usageLimitResume).toEqual({ nextAttemptAt: resumeAt, attempt: 0 });
+  });
+
+  it("clears automatic resume after an interrupted provider turn", async () => {
+    const harness = await createHarness();
+    const attemptedAt = "2099-01-01T00:00:00.000Z";
+
+    await harness.markUsageLimited();
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.schedule",
+      commandId: CommandId.make("cmd-interrupted-resume-schedule"),
+      threadId: ThreadId.make("thread-1"),
+      resumeAt: attemptedAt,
+    });
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.attempt",
+      commandId: CommandId.make("cmd-interrupted-resume-attempt"),
+      threadId: ThreadId.make("thread-1"),
+      expectedAttemptAt: attemptedAt,
+      createdAt: attemptedAt,
+    });
+
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-interrupted-auto-resume"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: attemptedAt,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-interrupted-auto-resume"),
+      payload: { state: "cancelled" },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.usageLimitResume === null,
+    );
+    expect(thread.usageLimitResume).toBeNull();
+  });
+
+  it("clears an in-flight automatic resume after a failed turn without a runtime error", async () => {
+    const harness = await createHarness();
+    const attemptedAt = "2099-01-01T00:00:00.000Z";
+
+    await harness.markUsageLimited();
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.schedule",
+      commandId: CommandId.make("cmd-failed-resume-schedule"),
+      threadId: ThreadId.make("thread-1"),
+      resumeAt: attemptedAt,
+    });
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.attempt",
+      commandId: CommandId.make("cmd-failed-resume-attempt"),
+      threadId: ThreadId.make("thread-1"),
+      expectedAttemptAt: attemptedAt,
+      createdAt: attemptedAt,
+    });
+
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-failed-auto-resume"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: attemptedAt,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-failed-auto-resume"),
+      payload: { state: "failed" },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.usageLimitResume === null,
+    );
+    expect(thread.usageLimitResume).toBeNull();
+    expect(thread.session?.status).toBe("error");
+  });
+
+  it("waits for OpenCode's runtime error after its failed completion", async () => {
+    const harness = await createHarness();
+    const attemptedAt = "2099-01-01T00:00:00.000Z";
+    const providerRetryAt = "2099-01-01T01:00:00.000Z";
+
+    await harness.markUsageLimited();
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.schedule",
+      commandId: CommandId.make("cmd-opencode-resume-schedule"),
+      threadId: ThreadId.make("thread-1"),
+      resumeAt: attemptedAt,
+    });
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.attempt",
+      commandId: CommandId.make("cmd-opencode-resume-attempt"),
+      threadId: ThreadId.make("thread-1"),
+      expectedAttemptAt: attemptedAt,
+      createdAt: attemptedAt,
+    });
+
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-opencode-resume-failed"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: attemptedAt,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-opencode-resume"),
+      payload: { state: "failed" },
+    });
+    await harness.drain();
+
+    const afterCompletion = (await harness.readModel()).threads.find(
+      (entry) => entry.id === ThreadId.make("thread-1"),
+    );
+    expect(afterCompletion?.usageLimitResume).toEqual({ nextAttemptAt: null, attempt: 0 });
+
+    harness.emit({
+      type: "runtime.error",
+      eventId: asEventId("evt-opencode-resume-usage-limit"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: attemptedAt,
+      threadId: asThreadId("thread-1"),
+      payload: {
+        message: "OpenCode provider request failed.",
+        class: "usage_limit",
+        retryAt: providerRetryAt,
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.usageLimitResume?.nextAttemptAt !== null,
+    );
+    expect(thread.usageLimitResume).toEqual({
+      nextAttemptAt: "2099-01-01T01:00:02.000Z",
+      attempt: 1,
+    });
+  });
+
+  it("keeps automatic resume active after Grok's failed completion", async () => {
+    const harness = await createHarness();
+    const attemptedAt = "2099-01-01T00:00:00.000Z";
+
+    await harness.markUsageLimited();
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.schedule",
+      commandId: CommandId.make("cmd-grok-resume-schedule"),
+      threadId: ThreadId.make("thread-1"),
+      resumeAt: attemptedAt,
+    });
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.attempt",
+      commandId: CommandId.make("cmd-grok-resume-attempt"),
+      threadId: ThreadId.make("thread-1"),
+      expectedAttemptAt: attemptedAt,
+      createdAt: attemptedAt,
+    });
+
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-grok-resume-failed"),
+      provider: ProviderDriverKind.make("grok"),
+      createdAt: attemptedAt,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-grok-resume"),
+      payload: { state: "failed" },
+    });
+    await harness.drain();
+
+    const afterCompletion = (await harness.readModel()).threads.find(
+      (entry) => entry.id === ThreadId.make("thread-1"),
+    );
+    expect(afterCompletion?.usageLimitResume).toEqual({ nextAttemptAt: null, attempt: 0 });
+  });
+
+  it("keeps automatic resume active when a superseded turn completes", async () => {
+    const harness = await createHarness();
+    const attemptedAt = "2099-01-01T00:00:00.000Z";
+
+    await harness.markUsageLimited();
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.schedule",
+      commandId: CommandId.make("cmd-stale-completion-resume-schedule"),
+      threadId: ThreadId.make("thread-1"),
+      resumeAt: attemptedAt,
+    });
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.attempt",
+      commandId: CommandId.make("cmd-stale-completion-resume-attempt"),
+      threadId: ThreadId.make("thread-1"),
+      expectedAttemptAt: attemptedAt,
+      createdAt: attemptedAt,
+    });
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-current-auto-resume-started"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: attemptedAt,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-current-auto-resume"),
+    });
+    await waitForThread(
+      harness.readModel,
+      (entry) => entry.session?.activeTurnId === "turn-current-auto-resume",
+    );
+
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-superseded-auto-resume-completed"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: attemptedAt,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-superseded-auto-resume"),
+      payload: { state: "completed" },
+    });
+    await harness.drain();
+
+    const thread = (await harness.readModel()).threads.find(
+      (entry) => entry.id === ThreadId.make("thread-1"),
+    );
+    expect(thread?.session?.activeTurnId).toBe("turn-current-auto-resume");
+    expect(thread?.usageLimitResume).toEqual({ nextAttemptAt: null, attempt: 0 });
+  });
+
+  it("ignores a superseded runtime error while an automatic resume is active", async () => {
+    const harness = await createHarness();
+    const attemptedAt = "2099-01-01T00:00:00.000Z";
+
+    await harness.markUsageLimited();
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.schedule",
+      commandId: CommandId.make("cmd-stale-error-resume-schedule"),
+      threadId: ThreadId.make("thread-1"),
+      resumeAt: attemptedAt,
+    });
+    await harness.dispatch({
+      type: "thread.usage-limit-resume.attempt",
+      commandId: CommandId.make("cmd-stale-error-resume-attempt"),
+      threadId: ThreadId.make("thread-1"),
+      expectedAttemptAt: attemptedAt,
+      createdAt: attemptedAt,
+    });
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-current-auto-resume-before-stale-error"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: attemptedAt,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-current-before-stale-error"),
+    });
+    await waitForThread(
+      harness.readModel,
+      (entry) => entry.session?.activeTurnId === "turn-current-before-stale-error",
+    );
+
+    harness.emit({
+      type: "runtime.error",
+      eventId: asEventId("evt-superseded-runtime-error"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: attemptedAt,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-superseded-runtime-error"),
+      payload: {
+        message: "Old turn failed",
+        class: "usage_limit",
+        retryAt: "2099-01-01T01:00:00.000Z",
+      },
+    });
+    await harness.drain();
+
+    const thread = (await harness.readModel()).threads.find(
+      (entry) => entry.id === ThreadId.make("thread-1"),
+    );
+    expect(thread?.session?.activeTurnId).toBe("turn-current-before-stale-error");
+    expect(thread?.usageLimitResume).toEqual({ nextAttemptAt: null, attempt: 0 });
   });
 
   it("records runtime.error activities from the typed payload message", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -17,6 +17,7 @@ import {
   type OrchestrationProposedPlan,
   type OrchestrationThread,
   type OrchestrationThreadActivity,
+  ProviderDriverKind,
   type ProviderRuntimeEvent,
 } from "@t3tools/contracts";
 import * as Cache from "effect/Cache";
@@ -45,6 +46,7 @@ import { projectActivityPayload } from "../ActivityPayloadProjection.ts";
 import { forkParked } from "../../serverActivation.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { canReplaceThreadTitle } from "../threadTitles.ts";
+import { nextUsageLimitRetryAt } from "../../provider/usageLimits.ts";
 
 const providerTurnKey = (threadId: ThreadId, turnId: TurnId) => `${threadId}:${turnId}`;
 const providerTaskKey = (threadId: ThreadId, taskId: string) => `${threadId}:${taskId}`;
@@ -439,9 +441,14 @@ export function runtimeEventToActivities(
           createdAt: event.createdAt,
           tone: "error",
           kind: "runtime.error",
-          summary: "Runtime error",
+          summary:
+            event.payload.class === "usage_limit"
+              ? "Provider usage limit or temporary unavailability"
+              : "Runtime error",
           payload: {
             message: truncateDetail(event.payload.message),
+            ...(event.payload.class !== undefined ? { class: event.payload.class } : {}),
+            ...(event.payload.retryAt !== undefined ? { retryAt: event.payload.retryAt } : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,
@@ -1635,6 +1642,9 @@ const make = Effect.gen(function* () {
               : status === "ready"
                 ? null
                 : (thread.session?.lastError ?? null);
+        const preservesErrorMetadata =
+          event.type === "turn.completed" &&
+          normalizeRuntimeTurnState(event.payload.state) === "failed";
 
         if (shouldApplyThreadLifecycle) {
           if (event.type === "turn.started" && acceptedTurnStartedSourcePlan !== null) {
@@ -1671,6 +1681,12 @@ const make = Effect.gen(function* () {
               runtimeMode: thread.session?.runtimeMode ?? "full-access",
               activeTurnId: nextActiveTurnId,
               lastError,
+              ...(preservesErrorMetadata && thread.session?.lastErrorClass !== undefined
+                ? { lastErrorClass: thread.session.lastErrorClass }
+                : {}),
+              ...(preservesErrorMetadata && thread.session?.retryAt !== undefined
+                ? { retryAt: thread.session.retryAt }
+                : {}),
               updatedAt: now,
             },
             createdAt: now,
@@ -1921,9 +1937,73 @@ const make = Effect.gen(function* () {
               runtimeMode: thread.session?.runtimeMode ?? "full-access",
               activeTurnId: eventTurnId ?? null,
               lastError: runtimeErrorMessage,
+              ...(event.payload.class !== undefined ? { lastErrorClass: event.payload.class } : {}),
+              ...(event.payload.retryAt !== undefined ? { retryAt: event.payload.retryAt } : {}),
               updatedAt: now,
             },
             createdAt: now,
+          });
+        }
+
+        if (
+          shouldApplyRuntimeError &&
+          event.payload.class === "usage_limit" &&
+          (yield* serverSettingsService.getSettings).enableAutomaticResume
+        ) {
+          const usageLimitResume = thread.usageLimitResume;
+          const resumeAt = nextUsageLimitRetryAt({
+            now,
+            attempt: usageLimitResume == null ? 0 : usageLimitResume.attempt + 1,
+            ...(event.payload.retryAt !== undefined
+              ? { providerRetryAt: event.payload.retryAt }
+              : {}),
+          });
+          if (usageLimitResume == null) {
+            yield* orchestrationEngine.dispatch({
+              type: "thread.usage-limit-resume.schedule",
+              commandId: yield* providerCommandId(event, "usage-limit-resume-schedule"),
+              threadId: thread.id,
+              resumeAt,
+            });
+          } else if (usageLimitResume.nextAttemptAt === null) {
+            yield* orchestrationEngine.dispatch({
+              type: "thread.usage-limit-resume.retry",
+              commandId: yield* providerCommandId(event, "usage-limit-resume-retry"),
+              ...(usageLimitResume.pendingMessageId !== undefined
+                ? { pendingMessageId: usageLimitResume.pendingMessageId }
+                : {}),
+              threadId: thread.id,
+              resumeAt,
+              attempt: usageLimitResume.attempt,
+              createdAt: now,
+            });
+          }
+        } else if (shouldApplyRuntimeError && thread.usageLimitResume?.nextAttemptAt === null) {
+          yield* orchestrationEngine.dispatch({
+            type: "thread.usage-limit-resume.cancel",
+            commandId: yield* providerCommandId(event, "usage-limit-resume-cancel"),
+            threadId: thread.id,
+          });
+        }
+      }
+
+      if (
+        shouldApplyThreadLifecycle &&
+        event.type === "turn.completed" &&
+        thread.usageLimitResume != null
+      ) {
+        const completedState = normalizeRuntimeTurnState(event.payload.state);
+        const resumeIsInFlight = thread.usageLimitResume.nextAttemptAt === null;
+        // OpenCode reports a trailing runtime error; Grok rejects sendTurn for reactor handling.
+        const awaitsFailureHandling =
+          completedState === "failed" &&
+          (event.provider === ProviderDriverKind.make("opencode") ||
+            event.provider === ProviderDriverKind.make("grok"));
+        if (resumeIsInFlight && !awaitsFailureHandling) {
+          yield* orchestrationEngine.dispatch({
+            type: "thread.usage-limit-resume.cancel",
+            commandId: yield* providerCommandId(event, "usage-limit-resume-completed"),
+            threadId: thread.id,
           });
         }
       }
@@ -2043,7 +2123,12 @@ const make = Effect.gen(function* () {
         }
       }
 
-      const activities = runtimeEventToActivities(event, taskTitle);
+      const activities =
+        event.type === "runtime.error" &&
+        event.payload.class === "usage_limit" &&
+        thread.usageLimitResume != null
+          ? []
+          : runtimeEventToActivities(event, taskTitle);
       yield* Effect.forEach(activities, (activity) =>
         providerCommandId(event, "thread-activity-append").pipe(
           Effect.flatMap((commandId) =>

--- a/apps/server/src/orchestration/Schemas.ts
+++ b/apps/server/src/orchestration/Schemas.ts
@@ -13,6 +13,9 @@ import {
   ThreadUnsettledPayload as ContractsThreadUnsettledPayloadSchema,
   ThreadSnoozedPayload as ContractsThreadSnoozedPayloadSchema,
   ThreadUnsnoozedPayload as ContractsThreadUnsnoozedPayloadSchema,
+  ThreadUsageLimitResumeScheduledPayload as ContractsThreadUsageLimitResumeScheduledPayloadSchema,
+  ThreadUsageLimitResumeCancelledPayload as ContractsThreadUsageLimitResumeCancelledPayloadSchema,
+  ThreadUsageLimitResumeAttemptedPayload as ContractsThreadUsageLimitResumeAttemptedPayloadSchema,
   ThreadPinnedPayload as ContractsThreadPinnedPayloadSchema,
   ThreadUnpinnedPayload as ContractsThreadUnpinnedPayloadSchema,
   ThreadPinReorderedPayload as ContractsThreadPinReorderedPayloadSchema,
@@ -45,6 +48,12 @@ export const ThreadUnarchivedPayload = ContractsThreadUnarchivedPayloadSchema;
 export const ThreadUnsettledPayload = ContractsThreadUnsettledPayloadSchema;
 export const ThreadSnoozedPayload = ContractsThreadSnoozedPayloadSchema;
 export const ThreadUnsnoozedPayload = ContractsThreadUnsnoozedPayloadSchema;
+export const ThreadUsageLimitResumeScheduledPayload =
+  ContractsThreadUsageLimitResumeScheduledPayloadSchema;
+export const ThreadUsageLimitResumeCancelledPayload =
+  ContractsThreadUsageLimitResumeCancelledPayloadSchema;
+export const ThreadUsageLimitResumeAttemptedPayload =
+  ContractsThreadUsageLimitResumeAttemptedPayloadSchema;
 export const ThreadPinnedPayload = ContractsThreadPinnedPayloadSchema;
 export const ThreadUnpinnedPayload = ContractsThreadUnpinnedPayloadSchema;
 export const ThreadPinReorderedPayload = ContractsThreadPinReorderedPayloadSchema;

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -30,6 +30,13 @@ import { threadHasQueuedTurnStart } from "./ThreadSettlementPolicy.ts";
 
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
 
+function isStoppedByUsageLimit(thread: Pick<OrchestrationThread, "session">): boolean {
+  return thread.session?.status === "error" && thread.session.lastErrorClass === "usage_limit";
+}
+
+function hasActiveSession(thread: Pick<OrchestrationThread, "session">): boolean {
+  return thread.session?.status === "starting" || thread.session?.status === "running";
+}
 /**
  * Blocked-on-you work derived from the thread's retained activities: an
  * approval or user-input request with no later resolution for the same
@@ -354,70 +361,157 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
     }
 
     case "thread.delete": {
-      yield* requireThread({
+      const thread = yield* requireThread({
         readModel,
         command,
         threadId: command.threadId,
       });
       const occurredAt = yield* nowIso;
-      return {
+      const deletedEvent = {
         ...(yield* withEventBase({
           aggregateKind: "thread",
           aggregateId: command.threadId,
           occurredAt,
           commandId: command.commandId,
         })),
-        type: "thread.deleted",
+        type: "thread.deleted" as const,
         payload: {
           threadId: command.threadId,
           deletedAt: occurredAt,
         },
       };
+      if (thread.usageLimitResume == null) {
+        return deletedEvent;
+      }
+      const companionEvents: Array<Omit<OrchestrationEvent, "sequence">> = [
+        {
+          ...(yield* withEventBase({
+            aggregateKind: "thread",
+            aggregateId: command.threadId,
+            occurredAt,
+            commandId: command.commandId,
+          })),
+          type: "thread.usage-limit-resume-cancelled",
+          payload: {
+            threadId: command.threadId,
+            updatedAt: occurredAt,
+          },
+        },
+      ];
+      if (thread.usageLimitResume.nextAttemptAt === null) {
+        companionEvents.push({
+          ...(yield* withEventBase({
+            aggregateKind: "thread",
+            aggregateId: command.threadId,
+            occurredAt,
+            commandId: command.commandId,
+          })),
+          type: "thread.turn-interrupt-requested",
+          payload: {
+            threadId: command.threadId,
+            createdAt: occurredAt,
+          },
+        });
+      }
+      return [...companionEvents, deletedEvent];
     }
 
     case "thread.archive": {
-      yield* requireThreadNotArchived({
+      const thread = yield* requireThreadNotArchived({
         readModel,
         command,
         threadId: command.threadId,
       });
       const occurredAt = yield* nowIso;
-      return {
+      const archivedEvent = {
         ...(yield* withEventBase({
           aggregateKind: "thread",
           aggregateId: command.threadId,
           occurredAt,
           commandId: command.commandId,
         })),
-        type: "thread.archived",
+        type: "thread.archived" as const,
         payload: {
           threadId: command.threadId,
           archivedAt: occurredAt,
           updatedAt: occurredAt,
         },
       };
+      if (thread.usageLimitResume == null) {
+        return archivedEvent;
+      }
+      const companionEvents: Array<Omit<OrchestrationEvent, "sequence">> = [
+        {
+          ...(yield* withEventBase({
+            aggregateKind: "thread",
+            aggregateId: command.threadId,
+            occurredAt,
+            commandId: command.commandId,
+          })),
+          type: "thread.usage-limit-resume-cancelled" as const,
+          payload: {
+            threadId: command.threadId,
+            updatedAt: occurredAt,
+          },
+        },
+      ];
+      if (thread.usageLimitResume.nextAttemptAt === null) {
+        companionEvents.push({
+          ...(yield* withEventBase({
+            aggregateKind: "thread",
+            aggregateId: command.threadId,
+            occurredAt,
+            commandId: command.commandId,
+          })),
+          type: "thread.turn-interrupt-requested",
+          payload: {
+            threadId: command.threadId,
+            createdAt: occurredAt,
+          },
+        });
+      }
+      return [...companionEvents, archivedEvent];
     }
 
     case "thread.unarchive": {
-      yield* requireThreadArchived({
+      const thread = yield* requireThreadArchived({
         readModel,
         command,
         threadId: command.threadId,
       });
       const occurredAt = yield* nowIso;
-      return {
+      const unarchivedEvent = {
         ...(yield* withEventBase({
           aggregateKind: "thread",
           aggregateId: command.threadId,
           occurredAt,
           commandId: command.commandId,
         })),
-        type: "thread.unarchived",
+        type: "thread.unarchived" as const,
         payload: {
           threadId: command.threadId,
           updatedAt: occurredAt,
         },
       };
+      if (thread.usageLimitResume == null) {
+        return unarchivedEvent;
+      }
+      return [
+        {
+          ...(yield* withEventBase({
+            aggregateKind: "thread",
+            aggregateId: command.threadId,
+            occurredAt,
+            commandId: command.commandId,
+          })),
+          type: "thread.usage-limit-resume-cancelled" as const,
+          payload: {
+            threadId: command.threadId,
+            updatedAt: occurredAt,
+          },
+        },
+        unarchivedEvent,
+      ];
     }
 
     case "thread.settle":
@@ -505,6 +599,36 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
             updatedAt: occurredAt,
           },
         });
+      }
+      if (thread.usageLimitResume != null) {
+        companionEvents.push({
+          ...(yield* withEventBase({
+            aggregateKind: "thread",
+            aggregateId: command.threadId,
+            occurredAt,
+            commandId: command.commandId,
+          })),
+          type: "thread.usage-limit-resume-cancelled",
+          payload: {
+            threadId: command.threadId,
+            updatedAt: occurredAt,
+          },
+        });
+        if (thread.usageLimitResume.nextAttemptAt === null) {
+          companionEvents.push({
+            ...(yield* withEventBase({
+              aggregateKind: "thread",
+              aggregateId: command.threadId,
+              occurredAt,
+              commandId: command.commandId,
+            })),
+            type: "thread.turn-interrupt-requested",
+            payload: {
+              threadId: command.threadId,
+              createdAt: occurredAt,
+            },
+          });
+        }
       }
       return companionEvents.length > 0 ? [settledEvent, ...companionEvents] : settledEvent;
     }
@@ -629,6 +753,208 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           threadId: command.threadId,
           reason: command.reason,
           updatedAt: alreadyAwake ? thread.updatedAt : occurredAt,
+        },
+      };
+    }
+
+    case "thread.usage-limit-resume.schedule": {
+      const thread = yield* requireThreadNotArchived({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+      if (thread.deletedAt !== null) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `thread ${command.threadId} is deleted and cannot schedule an automatic resume`,
+        });
+      }
+      if (thread.settledOverride === "settled") {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `thread ${command.threadId} is settled and cannot schedule an automatic resume`,
+        });
+      }
+      if (!isStoppedByUsageLimit(thread)) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `thread ${command.threadId} is not stopped by a usage limit`,
+        });
+      }
+      const occurredAt = yield* nowIso;
+      if (!(Date.parse(command.resumeAt) > Date.parse(occurredAt))) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `thread ${command.threadId} usage-limit resume time ${command.resumeAt} is not in the future`,
+        });
+      }
+      return {
+        ...(yield* withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt,
+          commandId: command.commandId,
+        })),
+        type: "thread.usage-limit-resume-scheduled",
+        payload: {
+          threadId: command.threadId,
+          resumeAt: command.resumeAt,
+          attempt: 0,
+          ...(command.pendingMessageId !== undefined
+            ? { pendingMessageId: command.pendingMessageId }
+            : {}),
+          updatedAt: occurredAt,
+        },
+      };
+    }
+
+    case "thread.usage-limit-resume.retry": {
+      const thread = yield* requireThread({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+      if (
+        thread.deletedAt !== null ||
+        thread.archivedAt !== null ||
+        thread.settledOverride === "settled"
+      ) {
+        return {
+          ...(yield* withEventBase({
+            aggregateKind: "thread",
+            aggregateId: command.threadId,
+            occurredAt: command.createdAt,
+            commandId: command.commandId,
+          })),
+          type: "thread.usage-limit-resume-cancelled",
+          payload: {
+            threadId: command.threadId,
+            updatedAt: command.createdAt,
+          },
+        };
+      }
+      const current = thread.usageLimitResume ?? null;
+      const isCurrentAttempt =
+        current !== null && current.nextAttemptAt === null && current.attempt === command.attempt;
+      const validResumeAt = Date.parse(command.resumeAt) > Date.parse(command.createdAt);
+      if (!isCurrentAttempt || !validResumeAt) {
+        if (current?.nextAttemptAt != null) {
+          return {
+            ...(yield* withEventBase({
+              aggregateKind: "thread",
+              aggregateId: command.threadId,
+              occurredAt: command.createdAt,
+              commandId: command.commandId,
+            })),
+            type: "thread.usage-limit-resume-scheduled",
+            payload: {
+              threadId: command.threadId,
+              resumeAt: current.nextAttemptAt,
+              attempt: current.attempt,
+              updatedAt: thread.updatedAt,
+            },
+          };
+        }
+        return {
+          ...(yield* withEventBase({
+            aggregateKind: "thread",
+            aggregateId: command.threadId,
+            occurredAt: command.createdAt,
+            commandId: command.commandId,
+          })),
+          type: "thread.usage-limit-resume-cancelled",
+          payload: {
+            threadId: command.threadId,
+            updatedAt: thread.updatedAt,
+          },
+        };
+      }
+      return {
+        ...(yield* withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        })),
+        type: "thread.usage-limit-resume-scheduled",
+        payload: {
+          threadId: command.threadId,
+          resumeAt: command.resumeAt,
+          attempt: command.attempt + 1,
+          ...(command.pendingMessageId !== undefined
+            ? { pendingMessageId: command.pendingMessageId }
+            : {}),
+          updatedAt: command.createdAt,
+        },
+      };
+    }
+
+    case "thread.usage-limit-resume.cancel": {
+      const thread = yield* requireThread({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+      const occurredAt = yield* nowIso;
+      return {
+        ...(yield* withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt,
+          commandId: command.commandId,
+        })),
+        type: "thread.usage-limit-resume-cancelled",
+        payload: {
+          threadId: command.threadId,
+          updatedAt: thread.usageLimitResume == null ? thread.updatedAt : occurredAt,
+        },
+      };
+    }
+
+    case "thread.usage-limit-resume.attempt": {
+      const thread = yield* requireThreadNotArchived({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+      const current = thread.usageLimitResume ?? null;
+      if (
+        (thread.deletedAt !== null ||
+          thread.settledOverride === "settled" ||
+          hasActiveSession(thread)) &&
+        current !== null
+      ) {
+        return {
+          ...(yield* withEventBase({
+            aggregateKind: "thread",
+            aggregateId: command.threadId,
+            occurredAt: command.createdAt,
+            commandId: command.commandId,
+          })),
+          type: "thread.usage-limit-resume-cancelled",
+          payload: {
+            threadId: command.threadId,
+            updatedAt: command.createdAt,
+          },
+        };
+      }
+      const shouldResume =
+        current?.nextAttemptAt === command.expectedAttemptAt &&
+        Date.parse(command.expectedAttemptAt) <= Date.parse(command.createdAt);
+      return {
+        ...(yield* withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        })),
+        type: "thread.usage-limit-resume-attempted",
+        payload: {
+          threadId: command.threadId,
+          expectedAttemptAt: command.expectedAttemptAt,
+          attempt: current?.attempt ?? 0,
+          shouldResume,
+          updatedAt: shouldResume ? command.createdAt : thread.updatedAt,
         },
       };
     }
@@ -999,29 +1325,63 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           },
         });
       }
+      if (targetThread.usageLimitResume != null) {
+        lifecycleResetEvents.push({
+          ...(yield* withEventBase({
+            aggregateKind: "thread",
+            aggregateId: command.threadId,
+            occurredAt: command.createdAt,
+            commandId: command.commandId,
+          })),
+          type: "thread.usage-limit-resume-cancelled",
+          payload: {
+            threadId: command.threadId,
+            updatedAt: command.createdAt,
+          },
+        });
+      }
       return [...lifecycleResetEvents, userMessageEvent, turnStartRequestedEvent];
     }
 
     case "thread.turn.interrupt": {
-      yield* requireThread({
+      const thread = yield* requireThread({
         readModel,
         command,
         threadId: command.threadId,
       });
-      return {
+      const interruptEvent = {
         ...(yield* withEventBase({
           aggregateKind: "thread",
           aggregateId: command.threadId,
           occurredAt: command.createdAt,
           commandId: command.commandId,
         })),
-        type: "thread.turn-interrupt-requested",
+        type: "thread.turn-interrupt-requested" as const,
         payload: {
           threadId: command.threadId,
           ...(command.turnId !== undefined ? { turnId: command.turnId } : {}),
           createdAt: command.createdAt,
         },
       };
+      if (thread.usageLimitResume == null) {
+        return interruptEvent;
+      }
+      return [
+        {
+          ...(yield* withEventBase({
+            aggregateKind: "thread",
+            aggregateId: command.threadId,
+            occurredAt: command.createdAt,
+            commandId: command.commandId,
+          })),
+          type: "thread.usage-limit-resume-cancelled" as const,
+          payload: {
+            threadId: command.threadId,
+            updatedAt: command.createdAt,
+          },
+        },
+        interruptEvent,
+      ];
     }
 
     case "thread.approval.respond": {
@@ -1236,7 +1596,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           threadId: command.threadId,
           messageId: command.messageId,
           role: "assistant",
-          text: "",
+          text: command.text ?? "",
           turnId: command.turnId ?? null,
           streaming: false,
           createdAt: command.createdAt,

--- a/apps/server/src/orchestration/decider.usageLimitResume.test.ts
+++ b/apps/server/src/orchestration/decider.usageLimitResume.test.ts
@@ -1,0 +1,465 @@
+import {
+  CommandId,
+  MessageId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  type OrchestrationReadModel,
+  type OrchestrationThread,
+} from "@t3tools/contracts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+import { decideOrchestrationCommand } from "./decider.ts";
+
+const NOW = "2026-01-01T00:00:00.000Z";
+const FIRST_ATTEMPT = "1970-01-01T00:05:00.000Z";
+const SECOND_ATTEMPT = "1970-01-01T00:20:00.000Z";
+const USAGE_LIMIT_SESSION = {
+  threadId: ThreadId.make("thread-1"),
+  status: "error" as const,
+  providerName: "codex",
+  runtimeMode: "full-access" as const,
+  activeTurnId: null,
+  lastError: "Usage limit reached",
+  lastErrorClass: "usage_limit" as const,
+  updatedAt: NOW,
+};
+
+function makeReadModel(
+  usageLimitResume: OrchestrationThread["usageLimitResume"] = null,
+  settledOverride: OrchestrationThread["settledOverride"] = null,
+  archivedAt: string | null = null,
+  deletedAt: string | null = null,
+  session: OrchestrationThread["session"] = USAGE_LIMIT_SESSION,
+): OrchestrationReadModel {
+  return {
+    snapshotSequence: 0,
+    projects: [],
+    threads: [
+      {
+        id: ThreadId.make("thread-1"),
+        projectId: ProjectId.make("project-1"),
+        title: "Thread",
+        modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.4" },
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        branch: null,
+        worktreePath: null,
+        latestTurn: null,
+        createdAt: NOW,
+        updatedAt: NOW,
+        archivedAt,
+        settledOverride,
+        settledAt: settledOverride === "settled" ? NOW : null,
+        usageLimitResume,
+        deletedAt,
+        messages: [],
+        proposedPlans: [],
+        activities: [],
+        checkpoints: [],
+        session,
+      },
+    ],
+    updatedAt: NOW,
+  };
+}
+
+it.layer(NodeServices.layer)("usage-limit resume decider", (it) => {
+  it.effect("schedules, attempts, and paces a retry", () =>
+    Effect.gen(function* () {
+      const scheduled = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.usage-limit-resume.schedule",
+          commandId: CommandId.make("cmd-schedule"),
+          threadId: ThreadId.make("thread-1"),
+          resumeAt: FIRST_ATTEMPT,
+        },
+        readModel: makeReadModel(),
+      });
+      const scheduledEvents = Array.isArray(scheduled) ? scheduled : [scheduled];
+      const scheduledEvent = scheduledEvents[0];
+      expect(scheduledEvents).toHaveLength(1);
+      if (scheduledEvent?.type !== "thread.usage-limit-resume-scheduled") {
+        return;
+      }
+      expect(scheduledEvent.payload).toMatchObject({ resumeAt: FIRST_ATTEMPT, attempt: 0 });
+
+      const attempted = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.usage-limit-resume.attempt",
+          commandId: CommandId.make("cmd-attempt"),
+          threadId: ThreadId.make("thread-1"),
+          expectedAttemptAt: FIRST_ATTEMPT,
+          createdAt: FIRST_ATTEMPT,
+        },
+        readModel: makeReadModel({ nextAttemptAt: FIRST_ATTEMPT, attempt: 0 }),
+      });
+      const attemptedEvents = Array.isArray(attempted) ? attempted : [attempted];
+      const attemptedEvent = attemptedEvents[0];
+      expect(attemptedEvents).toHaveLength(1);
+      if (attemptedEvent?.type !== "thread.usage-limit-resume-attempted") {
+        return;
+      }
+      expect(attemptedEvent.payload.shouldResume).toBe(true);
+
+      const retried = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.usage-limit-resume.retry",
+          commandId: CommandId.make("cmd-retry"),
+          threadId: ThreadId.make("thread-1"),
+          resumeAt: SECOND_ATTEMPT,
+          attempt: 0,
+          createdAt: FIRST_ATTEMPT,
+        },
+        readModel: makeReadModel({ nextAttemptAt: null, attempt: 0 }),
+      });
+      const retriedEvents = Array.isArray(retried) ? retried : [retried];
+      const retriedEvent = retriedEvents[0];
+      expect(retriedEvents).toHaveLength(1);
+      if (retriedEvent?.type !== "thread.usage-limit-resume-scheduled") {
+        return;
+      }
+      expect(retriedEvent.payload).toMatchObject({ resumeAt: SECOND_ATTEMPT, attempt: 1 });
+    }),
+  );
+
+  it.effect("ignores a stale timer and clears automatic resume on a manual turn", () =>
+    Effect.gen(function* () {
+      const staleAttempt = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.usage-limit-resume.attempt",
+          commandId: CommandId.make("cmd-stale"),
+          threadId: ThreadId.make("thread-1"),
+          expectedAttemptAt: FIRST_ATTEMPT,
+          createdAt: SECOND_ATTEMPT,
+        },
+        readModel: makeReadModel({ nextAttemptAt: SECOND_ATTEMPT, attempt: 1 }),
+      });
+      const staleEvents = Array.isArray(staleAttempt) ? staleAttempt : [staleAttempt];
+      const staleEvent = staleEvents[0];
+      expect(staleEvents).toHaveLength(1);
+      if (staleEvent?.type !== "thread.usage-limit-resume-attempted") {
+        return;
+      }
+      expect(staleEvent.payload.shouldResume).toBe(false);
+
+      const manualTurn = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.turn.start",
+          commandId: CommandId.make("cmd-manual-turn"),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: MessageId.make("message-1"),
+            role: "user",
+            text: "Try now",
+            attachments: [],
+          },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          createdAt: NOW,
+        },
+        readModel: makeReadModel({ nextAttemptAt: SECOND_ATTEMPT, attempt: 1 }),
+      });
+      const events = Array.isArray(manualTurn) ? manualTurn : [manualTurn];
+      expect(events.some((event) => event.type === "thread.usage-limit-resume-cancelled")).toBe(
+        true,
+      );
+      expect(events.some((event) => event.type === "thread.turn-start-requested")).toBe(true);
+    }),
+  );
+
+  it.effect("requires a usage limit to schedule and only cancels attempts for active work", () =>
+    Effect.gen(function* () {
+      const runningSession: OrchestrationThread["session"] = {
+        threadId: ThreadId.make("thread-1"),
+        status: "running",
+        providerName: "codex",
+        runtimeMode: "full-access",
+        activeTurnId: null,
+        lastError: null,
+        updatedAt: NOW,
+      };
+      const scheduleError = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.usage-limit-resume.schedule",
+          commandId: CommandId.make("cmd-running-schedule"),
+          threadId: ThreadId.make("thread-1"),
+          resumeAt: FIRST_ATTEMPT,
+        },
+        readModel: makeReadModel(null, null, null, null, runningSession),
+      }).pipe(Effect.flip);
+      expect(scheduleError._tag).toBe("OrchestrationCommandInvariantError");
+
+      const attempted = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.usage-limit-resume.attempt",
+          commandId: CommandId.make("cmd-running-attempt"),
+          threadId: ThreadId.make("thread-1"),
+          expectedAttemptAt: FIRST_ATTEMPT,
+          createdAt: FIRST_ATTEMPT,
+        },
+        readModel: makeReadModel(
+          { nextAttemptAt: FIRST_ATTEMPT, attempt: 0 },
+          null,
+          null,
+          null,
+          runningSession,
+        ),
+      });
+      const attemptedEvents = Array.isArray(attempted) ? attempted : [attempted];
+      expect(attemptedEvents.map((event) => event.type)).toEqual([
+        "thread.usage-limit-resume-cancelled",
+      ]);
+
+      const readySession: OrchestrationThread["session"] = {
+        ...runningSession,
+        status: "ready",
+      };
+      const metadataClearedAttempt = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.usage-limit-resume.attempt",
+          commandId: CommandId.make("cmd-metadata-cleared-attempt"),
+          threadId: ThreadId.make("thread-1"),
+          expectedAttemptAt: FIRST_ATTEMPT,
+          createdAt: FIRST_ATTEMPT,
+        },
+        readModel: makeReadModel(
+          { nextAttemptAt: FIRST_ATTEMPT, attempt: 0 },
+          null,
+          null,
+          null,
+          readySession,
+        ),
+      });
+      const metadataClearedEvents = Array.isArray(metadataClearedAttempt)
+        ? metadataClearedAttempt
+        : [metadataClearedAttempt];
+      expect(metadataClearedEvents[0]).toMatchObject({
+        type: "thread.usage-limit-resume-attempted",
+        payload: { shouldResume: true },
+      });
+    }),
+  );
+
+  it.effect("clears automatic resume on settlement and rejects a settled timer", () =>
+    Effect.gen(function* () {
+      const scheduleError = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.usage-limit-resume.schedule",
+          commandId: CommandId.make("cmd-settled-schedule"),
+          threadId: ThreadId.make("thread-1"),
+          resumeAt: FIRST_ATTEMPT,
+        },
+        readModel: makeReadModel(null, "settled"),
+      }).pipe(Effect.flip);
+      expect(scheduleError._tag).toBe("OrchestrationCommandInvariantError");
+
+      const settled = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.settle",
+          commandId: CommandId.make("cmd-settle"),
+          threadId: ThreadId.make("thread-1"),
+        },
+        readModel: makeReadModel({ nextAttemptAt: FIRST_ATTEMPT, attempt: 0 }),
+      });
+      const settledEvents = Array.isArray(settled) ? settled : [settled];
+      expect(settledEvents.map((event) => event.type)).toEqual([
+        "thread.settled",
+        "thread.usage-limit-resume-cancelled",
+      ]);
+
+      const settledInFlight = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.settle",
+          commandId: CommandId.make("cmd-settle-in-flight"),
+          threadId: ThreadId.make("thread-1"),
+        },
+        readModel: makeReadModel({ nextAttemptAt: null, attempt: 0 }),
+      });
+      const settledInFlightEvents = Array.isArray(settledInFlight)
+        ? settledInFlight
+        : [settledInFlight];
+      expect(settledInFlightEvents.map((event) => event.type)).toEqual([
+        "thread.settled",
+        "thread.usage-limit-resume-cancelled",
+        "thread.turn-interrupt-requested",
+      ]);
+
+      const attempted = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.usage-limit-resume.attempt",
+          commandId: CommandId.make("cmd-settled-attempt"),
+          threadId: ThreadId.make("thread-1"),
+          expectedAttemptAt: FIRST_ATTEMPT,
+          createdAt: FIRST_ATTEMPT,
+        },
+        readModel: makeReadModel({ nextAttemptAt: FIRST_ATTEMPT, attempt: 0 }, "settled"),
+      });
+      const attemptedEvents = Array.isArray(attempted) ? attempted : [attempted];
+      expect(attemptedEvents).toHaveLength(1);
+      expect(attemptedEvents[0]?.type).toBe("thread.usage-limit-resume-cancelled");
+
+      const retried = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.usage-limit-resume.retry",
+          commandId: CommandId.make("cmd-settled-retry"),
+          threadId: ThreadId.make("thread-1"),
+          resumeAt: SECOND_ATTEMPT,
+          attempt: 0,
+          createdAt: FIRST_ATTEMPT,
+        },
+        readModel: makeReadModel({ nextAttemptAt: null, attempt: 0 }, "settled"),
+      });
+      const retriedEvents = Array.isArray(retried) ? retried : [retried];
+      expect(retriedEvents).toHaveLength(1);
+      expect(retriedEvents[0]?.type).toBe("thread.usage-limit-resume-cancelled");
+    }),
+  );
+
+  it.effect("rejects scheduling and timers after a thread is deleted", () =>
+    Effect.gen(function* () {
+      const scheduleError = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.usage-limit-resume.schedule",
+          commandId: CommandId.make("cmd-deleted-schedule"),
+          threadId: ThreadId.make("thread-1"),
+          resumeAt: FIRST_ATTEMPT,
+        },
+        readModel: makeReadModel(null, null, null, NOW),
+      }).pipe(Effect.flip);
+      expect(scheduleError._tag).toBe("OrchestrationCommandInvariantError");
+
+      const deleted = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.delete",
+          commandId: CommandId.make("cmd-delete-in-flight-resume"),
+          threadId: ThreadId.make("thread-1"),
+        },
+        readModel: makeReadModel({ nextAttemptAt: null, attempt: 0 }),
+      });
+      const deletedEvents = Array.isArray(deleted) ? deleted : [deleted];
+      expect(deletedEvents.map((event) => event.type)).toEqual([
+        "thread.usage-limit-resume-cancelled",
+        "thread.turn-interrupt-requested",
+        "thread.deleted",
+      ]);
+
+      const attempted = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.usage-limit-resume.attempt",
+          commandId: CommandId.make("cmd-deleted-attempt"),
+          threadId: ThreadId.make("thread-1"),
+          expectedAttemptAt: FIRST_ATTEMPT,
+          createdAt: FIRST_ATTEMPT,
+        },
+        readModel: makeReadModel({ nextAttemptAt: FIRST_ATTEMPT, attempt: 0 }, null, null, NOW),
+      });
+      const attemptedEvents = Array.isArray(attempted) ? attempted : [attempted];
+      expect(attemptedEvents).toHaveLength(1);
+      expect(attemptedEvents[0]?.type).toBe("thread.usage-limit-resume-cancelled");
+    }),
+  );
+
+  it.effect("cancels automatic resume when a thread is archived or interrupted", () =>
+    Effect.gen(function* () {
+      const archived = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.archive",
+          commandId: CommandId.make("cmd-archive-resume"),
+          threadId: ThreadId.make("thread-1"),
+        },
+        readModel: makeReadModel({ nextAttemptAt: FIRST_ATTEMPT, attempt: 2 }),
+      });
+      const archivedEvents = Array.isArray(archived) ? archived : [archived];
+      expect(archivedEvents.map((event) => event.type)).toEqual([
+        "thread.usage-limit-resume-cancelled",
+        "thread.archived",
+      ]);
+
+      const archivedInFlight = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.archive",
+          commandId: CommandId.make("cmd-archive-in-flight-resume"),
+          threadId: ThreadId.make("thread-1"),
+        },
+        readModel: makeReadModel({ nextAttemptAt: null, attempt: 2 }),
+      });
+      const archivedInFlightEvents = Array.isArray(archivedInFlight)
+        ? archivedInFlight
+        : [archivedInFlight];
+      expect(archivedInFlightEvents.map((event) => event.type)).toEqual([
+        "thread.usage-limit-resume-cancelled",
+        "thread.turn-interrupt-requested",
+        "thread.archived",
+      ]);
+
+      const interrupted = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.turn.interrupt",
+          commandId: CommandId.make("cmd-interrupt-resume"),
+          threadId: ThreadId.make("thread-1"),
+          createdAt: NOW,
+        },
+        readModel: makeReadModel({ nextAttemptAt: null, attempt: 2 }),
+      });
+      const interruptedEvents = Array.isArray(interrupted) ? interrupted : [interrupted];
+      expect(interruptedEvents.map((event) => event.type)).toEqual([
+        "thread.usage-limit-resume-cancelled",
+        "thread.turn-interrupt-requested",
+      ]);
+    }),
+  );
+
+  it.effect("rejects archived timers and clears legacy resume state on unarchive", () =>
+    Effect.gen(function* () {
+      const archivedReadModel = makeReadModel(
+        { nextAttemptAt: FIRST_ATTEMPT, attempt: 2 },
+        null,
+        NOW,
+      );
+      const attemptError = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.usage-limit-resume.attempt",
+          commandId: CommandId.make("cmd-archived-attempt"),
+          threadId: ThreadId.make("thread-1"),
+          expectedAttemptAt: FIRST_ATTEMPT,
+          createdAt: FIRST_ATTEMPT,
+        },
+        readModel: archivedReadModel,
+      }).pipe(Effect.flip);
+      expect(attemptError._tag).toBe("OrchestrationCommandInvariantError");
+
+      const unarchived = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.unarchive",
+          commandId: CommandId.make("cmd-unarchive-resume"),
+          threadId: ThreadId.make("thread-1"),
+        },
+        readModel: archivedReadModel,
+      });
+      const unarchivedEvents = Array.isArray(unarchived) ? unarchived : [unarchived];
+      expect(unarchivedEvents.map((event) => event.type)).toEqual([
+        "thread.usage-limit-resume-cancelled",
+        "thread.unarchived",
+      ]);
+
+      const retried = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.usage-limit-resume.retry",
+          commandId: CommandId.make("cmd-archived-retry"),
+          threadId: ThreadId.make("thread-1"),
+          resumeAt: SECOND_ATTEMPT,
+          attempt: 2,
+          createdAt: FIRST_ATTEMPT,
+        },
+        readModel: makeReadModel({ nextAttemptAt: null, attempt: 2 }, null, NOW),
+      });
+      const retriedEvents = Array.isArray(retried) ? retried : [retried];
+      expect(retriedEvents.map((event) => event.type)).toEqual([
+        "thread.usage-limit-resume-cancelled",
+      ]);
+    }),
+  );
+});

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -94,6 +94,7 @@ describe("orchestration projector", () => {
         unsettledAt: null,
         snoozedUntil: null,
         snoozedAt: null,
+        usageLimitResume: null,
         deletedAt: null,
         messages: [],
         proposedPlans: [],

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -30,6 +30,9 @@ import {
   ThreadUnarchivedPayload,
   ThreadUnsettledPayload,
   ThreadUnsnoozedPayload,
+  ThreadUsageLimitResumeScheduledPayload,
+  ThreadUsageLimitResumeCancelledPayload,
+  ThreadUsageLimitResumeAttemptedPayload,
   ThreadRevertedPayload,
   ThreadSessionSetPayload,
   ThreadTurnDiffCompletedPayload,
@@ -306,6 +309,7 @@ export function projectEvent(
             unsettledAt: null,
             snoozedUntil: null,
             snoozedAt: null,
+            usageLimitResume: null,
             deletedAt: null,
             messages: [],
             activities: [],
@@ -412,6 +416,67 @@ export function projectEvent(
           threads: updateThread(nextBase.threads, payload.threadId, {
             snoozedUntil: null,
             snoozedAt: null,
+            updatedAt: payload.updatedAt,
+          }),
+        })),
+      );
+
+    case "thread.usage-limit-resume-scheduled":
+      return decodeForEvent(
+        ThreadUsageLimitResumeScheduledPayload,
+        event.payload,
+        event.type,
+        "payload",
+      ).pipe(
+        Effect.map((payload) => ({
+          ...nextBase,
+          threads: updateThread(nextBase.threads, payload.threadId, {
+            usageLimitResume: {
+              nextAttemptAt: payload.resumeAt,
+              ...(payload.pendingMessageId !== undefined
+                ? { pendingMessageId: payload.pendingMessageId }
+                : {}),
+              attempt: payload.attempt,
+            },
+            updatedAt: payload.updatedAt,
+          }),
+        })),
+      );
+
+    case "thread.usage-limit-resume-attempted":
+      return decodeForEvent(
+        ThreadUsageLimitResumeAttemptedPayload,
+        event.payload,
+        event.type,
+        "payload",
+      ).pipe(
+        Effect.map((payload) => ({
+          ...nextBase,
+          threads: payload.shouldResume
+            ? updateThread(nextBase.threads, payload.threadId, {
+                usageLimitResume: {
+                  ...nextBase.threads.find((thread) => thread.id === payload.threadId)
+                    ?.usageLimitResume,
+                  nextAttemptAt: null,
+                  attempt: payload.attempt,
+                },
+                updatedAt: payload.updatedAt,
+              })
+            : nextBase.threads,
+        })),
+      );
+
+    case "thread.usage-limit-resume-cancelled":
+      return decodeForEvent(
+        ThreadUsageLimitResumeCancelledPayload,
+        event.payload,
+        event.type,
+        "payload",
+      ).pipe(
+        Effect.map((payload) => ({
+          ...nextBase,
+          threads: updateThread(nextBase.threads, payload.threadId, {
+            usageLimitResume: null,
             updatedAt: payload.updatedAt,
           }),
         })),

--- a/apps/server/src/orchestration/projector.usageLimitResume.test.ts
+++ b/apps/server/src/orchestration/projector.usageLimitResume.test.ts
@@ -1,0 +1,87 @@
+import {
+  CommandId,
+  EventId,
+  ProjectId,
+  ThreadId,
+  type OrchestrationEvent,
+} from "@t3tools/contracts";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+import { createEmptyReadModel, projectEvent } from "./projector.ts";
+
+function event(
+  sequence: number,
+  type: OrchestrationEvent["type"],
+  payload: unknown,
+): OrchestrationEvent {
+  return {
+    sequence,
+    eventId: EventId.make(`event-${sequence}`),
+    type,
+    aggregateKind: "thread",
+    aggregateId: ThreadId.make("thread-1"),
+    occurredAt: "2026-01-01T00:00:00.000Z",
+    commandId: CommandId.make(`command-${sequence}`),
+    causationEventId: null,
+    correlationId: null,
+    metadata: {},
+    payload: payload as never,
+  } as OrchestrationEvent;
+}
+
+it.effect("projects the complete usage-limit resume lifecycle", () =>
+  Effect.gen(function* () {
+    const now = "2026-01-01T00:00:00.000Z";
+    const created = yield* projectEvent(
+      createEmptyReadModel(now),
+      event(1, "thread.created", {
+        threadId: ThreadId.make("thread-1"),
+        projectId: ProjectId.make("project-1"),
+        title: "Thread",
+        modelSelection: { provider: "codex", model: "gpt-5.4" },
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        branch: null,
+        worktreePath: null,
+        createdAt: now,
+        updatedAt: now,
+      }),
+    );
+    const resumeAt = "2026-01-01T01:00:00.000Z";
+    const scheduled = yield* projectEvent(
+      created,
+      event(2, "thread.usage-limit-resume-scheduled", {
+        threadId: ThreadId.make("thread-1"),
+        resumeAt,
+        attempt: 0,
+        updatedAt: now,
+      }),
+    );
+    expect(scheduled.threads[0]?.usageLimitResume).toEqual({
+      nextAttemptAt: resumeAt,
+      attempt: 0,
+    });
+
+    const attempted = yield* projectEvent(
+      scheduled,
+      event(3, "thread.usage-limit-resume-attempted", {
+        threadId: ThreadId.make("thread-1"),
+        expectedAttemptAt: resumeAt,
+        attempt: 0,
+        shouldResume: true,
+        updatedAt: resumeAt,
+      }),
+    );
+    expect(attempted.threads[0]?.usageLimitResume).toEqual({ nextAttemptAt: null, attempt: 0 });
+
+    const cancelled = yield* projectEvent(
+      attempted,
+      event(4, "thread.usage-limit-resume-cancelled", {
+        threadId: ThreadId.make("thread-1"),
+        updatedAt: resumeAt,
+      }),
+    );
+    expect(cancelled.threads[0]?.usageLimitResume).toBeNull();
+  }),
+);

--- a/apps/server/src/persistence/Layers/OrchestrationEventStore.ts
+++ b/apps/server/src/persistence/Layers/OrchestrationEventStore.ts
@@ -65,6 +65,7 @@ const HasEventAfterRequestSchema = Schema.Struct({
   aggregateKind: Schema.String,
   aggregateId: Schema.String,
   type: Schema.optional(Schema.String),
+  afterLatestEvent: Schema.optional(Schema.String),
   sequenceExclusive: NonNegativeInt,
 });
 
@@ -279,6 +280,16 @@ const makeEventStore = Effect.gen(function* () {
             AND ${sql.and([
               sql`sequence > ${request.sequenceExclusive}`,
               ...(request.type === undefined ? [] : [sql`event_type = ${request.type}`]),
+              ...(request.afterLatestEvent === undefined
+                ? []
+                : [
+                    sql`sequence > COALESCE((
+                SELECT MAX(sequence) FROM orchestration_events
+                WHERE aggregate_kind = ${request.aggregateKind}
+                  AND stream_id = ${request.aggregateId}
+                  AND event_type = ${request.afterLatestEvent}
+              ), 0)`,
+                  ]),
             ])}
           LIMIT 1
         `,

--- a/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
@@ -97,6 +97,7 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
         unsettledAt: null,
         snoozedUntil: null,
         snoozedAt: null,
+        usageLimitResume: null,
         pinnedAt: null,
         latestUserMessageAt: null,
         pendingApprovalCount: 0,
@@ -161,6 +162,7 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
         unsettledAt: null,
         snoozedUntil: "2026-03-26T09:00:00.000Z",
         snoozedAt: "2026-03-25T00:00:00.000Z",
+        usageLimitResume: null,
         pinnedAt: "2026-03-25T00:00:00.000Z",
         latestUserMessageAt: null,
         pendingApprovalCount: 0,
@@ -191,6 +193,7 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
         unsettledAt: "2026-03-26T00:00:00.000Z",
         snoozedUntil: null,
         snoozedAt: null,
+        usageLimitResume: null,
         pinnedAt: null,
       });
       const repersisted = yield* threads.getById({
@@ -238,6 +241,7 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
         unsettledAt: null,
         snoozedUntil: null,
         snoozedAt: null,
+        usageLimitResume: null,
         pinnedAt: null,
         latestUserMessageAt: null,
         pendingApprovalCount: 0,

--- a/apps/server/src/persistence/Layers/ProjectionThreadSessions.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadSessions.ts
@@ -28,6 +28,8 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           runtime_mode,
           active_turn_id,
           last_error,
+          last_error_class,
+          retry_at,
           updated_at
         )
         VALUES (
@@ -38,6 +40,8 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           ${row.runtimeMode},
           ${row.activeTurnId},
           ${row.lastError},
+          ${row.lastErrorClass},
+          ${row.retryAt},
           ${row.updatedAt}
         )
         ON CONFLICT (thread_id)
@@ -48,6 +52,8 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           runtime_mode = excluded.runtime_mode,
           active_turn_id = excluded.active_turn_id,
           last_error = excluded.last_error,
+          last_error_class = excluded.last_error_class,
+          retry_at = excluded.retry_at,
           updated_at = excluded.updated_at
       `,
   });
@@ -65,6 +71,8 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           runtime_mode AS "runtimeMode",
           active_turn_id AS "activeTurnId",
           last_error AS "lastError",
+          last_error_class AS "lastErrorClass",
+          retry_at AS "retryAt",
           updated_at AS "updatedAt"
         FROM projection_thread_sessions
         WHERE thread_id = ${threadId}

--- a/apps/server/src/persistence/Layers/ProjectionThreads.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreads.ts
@@ -14,12 +14,17 @@ import {
   ProjectionThreadRepository,
   type ProjectionThreadRepositoryShape,
 } from "../Services/ProjectionThreads.ts";
-import { ModelSelection, ThreadLinkedPullRequest } from "@t3tools/contracts";
+import {
+  ModelSelection,
+  ThreadLinkedPullRequest,
+  ThreadUsageLimitResume,
+} from "@t3tools/contracts";
 
 const ProjectionThreadDbRow = ProjectionThread.mapFields(
   Struct.assign({
     modelSelection: Schema.fromJsonString(ModelSelection),
     linkedPullRequest: Schema.NullOr(Schema.fromJsonString(ThreadLinkedPullRequest)),
+    usageLimitResume: Schema.NullOr(Schema.fromJsonString(ThreadUsageLimitResume)),
   }),
 );
 type ProjectionThreadDbRow = typeof ProjectionThreadDbRow.Type;
@@ -50,6 +55,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           unsettled_at,
           snoozed_until,
           snoozed_at,
+          usage_limit_resume_json,
           pinned_at,
           pin_order_key,
           title_regeneration_request_id,
@@ -79,6 +85,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           ${row.unsettledAt},
           ${row.snoozedUntil},
           ${row.snoozedAt},
+          ${row.usageLimitResume === null ? null : JSON.stringify(row.usageLimitResume)},
           ${row.pinnedAt},
           ${row.pinOrderKey ?? null},
           ${row.titleRegenerationRequestId ?? null},
@@ -108,6 +115,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           unsettled_at = excluded.unsettled_at,
           snoozed_until = excluded.snoozed_until,
           snoozed_at = excluded.snoozed_at,
+          usage_limit_resume_json = excluded.usage_limit_resume_json,
           pinned_at = excluded.pinned_at,
           pin_order_key = excluded.pin_order_key,
           title_regeneration_request_id = excluded.title_regeneration_request_id,
@@ -144,6 +152,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           unsettled_at AS "unsettledAt",
           snoozed_until AS "snoozedUntil",
           snoozed_at AS "snoozedAt",
+          usage_limit_resume_json AS "usageLimitResume",
           pinned_at AS "pinnedAt",
           pin_order_key AS "pinOrderKey",
           title_regeneration_request_id AS "titleRegenerationRequestId",
@@ -182,6 +191,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           unsettled_at AS "unsettledAt",
           snoozed_until AS "snoozedUntil",
           snoozed_at AS "snoozedAt",
+          usage_limit_resume_json AS "usageLimitResume",
           pinned_at AS "pinnedAt",
           pin_order_key AS "pinOrderKey",
           title_regeneration_request_id AS "titleRegenerationRequestId",

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -56,6 +56,7 @@ import Migration0040 from "./Migrations/040_ProjectionProjectFaviconPath.ts";
 import Migration0041 from "./Migrations/041_AuthSessionClientConnection.ts";
 import Migration0042 from "./Migrations/042_ProjectionThreadLinkedPullRequest.ts";
 import Migration0043 from "./Migrations/043_ProjectionThreadsUnsettledAt.ts";
+import Migration0044 from "./Migrations/044_UsageLimitResume.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -111,6 +112,7 @@ export const migrationEntries = [
   [41, "AuthSessionClientConnection", Migration0041],
   [42, "ProjectionThreadLinkedPullRequest", Migration0042],
   [43, "ProjectionThreadsUnsettledAt", Migration0043],
+  [44, "UsageLimitResume", Migration0044],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);

--- a/apps/server/src/persistence/Migrations/044_UsageLimitResume.ts
+++ b/apps/server/src/persistence/Migrations/044_UsageLimitResume.ts
@@ -1,0 +1,31 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const threadColumns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(projection_threads)
+  `;
+  const sessionColumns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(projection_thread_sessions)
+  `;
+
+  if (!threadColumns.some((column) => column.name === "usage_limit_resume_json")) {
+    yield* sql`
+      ALTER TABLE projection_threads
+      ADD COLUMN usage_limit_resume_json TEXT
+    `;
+  }
+  if (!sessionColumns.some((column) => column.name === "last_error_class")) {
+    yield* sql`
+      ALTER TABLE projection_thread_sessions
+      ADD COLUMN last_error_class TEXT
+    `;
+  }
+  if (!sessionColumns.some((column) => column.name === "retry_at")) {
+    yield* sql`
+      ALTER TABLE projection_thread_sessions
+      ADD COLUMN retry_at TEXT
+    `;
+  }
+});

--- a/apps/server/src/persistence/Services/OrchestrationEventStore.ts
+++ b/apps/server/src/persistence/Services/OrchestrationEventStore.ts
@@ -65,6 +65,7 @@ export interface OrchestrationEventStoreShape {
     readonly aggregateId: string;
     readonly type?: OrchestrationEvent["type"];
     readonly sequenceExclusive: number;
+    readonly afterLatestEvent?: OrchestrationEvent["type"];
   }) => Effect.Effect<boolean, OrchestrationEventStoreError>;
 }
 

--- a/apps/server/src/persistence/Services/ProjectionThreadSessions.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadSessions.ts
@@ -10,6 +10,7 @@ import {
   RuntimeMode,
   IsoDateTime,
   OrchestrationSessionStatus,
+  OrchestrationRuntimeErrorClass,
   ProviderInstanceId,
   ThreadId,
   TurnId,
@@ -29,6 +30,8 @@ export const ProjectionThreadSession = Schema.Struct({
   runtimeMode: RuntimeMode,
   activeTurnId: Schema.NullOr(TurnId),
   lastError: Schema.NullOr(Schema.String),
+  lastErrorClass: Schema.NullOr(OrchestrationRuntimeErrorClass),
+  retryAt: Schema.NullOr(IsoDateTime),
   updatedAt: IsoDateTime,
 });
 export type ProjectionThreadSession = typeof ProjectionThreadSession.Type;

--- a/apps/server/src/persistence/Services/ProjectionThreads.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreads.ts
@@ -15,6 +15,7 @@ import {
   ProviderInteractionMode,
   RuntimeMode,
   ThreadLinkedPullRequest,
+  ThreadUsageLimitResume,
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
@@ -44,6 +45,7 @@ export const ProjectionThread = Schema.Struct({
   unsettledAt: Schema.NullOr(IsoDateTime),
   snoozedUntil: Schema.NullOr(IsoDateTime),
   snoozedAt: Schema.NullOr(IsoDateTime),
+  usageLimitResume: Schema.NullOr(ThreadUsageLimitResume),
   pinnedAt: Schema.NullOr(IsoDateTime),
   pinOrderKey: Schema.optional(Schema.NullOr(Schema.String)),
   titleRegenerationRequestId: Schema.optional(Schema.NullOr(CommandId)),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -24,6 +24,7 @@ import {
 import { createModelSelection } from "@t3tools/shared/model";
 import { assert, describe, it } from "@effect/vitest";
 import * as Context from "effect/Context";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
@@ -2315,6 +2316,138 @@ describe("ClaudeAdapterLive", () => {
         assert.equal(completed.payload.state, "failed");
         assert.equal(completed.payload.errorMessage, "Claude runtime stream failed.");
       }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("maps rejected subscription limits with their reset timestamp", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      const runtimeErrorFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "runtime.error"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+
+      harness.query.emit({
+        type: "rate_limit_event",
+        session_id: "sdk-session-rate-limit",
+        uuid: "rate-limit-1",
+        rate_limit_info: {
+          status: "rejected",
+          resetsAt: 1_787_944_200,
+        },
+      } as unknown as SDKMessage);
+
+      const runtimeError = yield* Fiber.join(runtimeErrorFiber);
+      assert.equal(runtimeError._tag, "Some");
+      if (runtimeError._tag !== "Some" || runtimeError.value.type !== "runtime.error") {
+        return;
+      }
+      assert.equal(runtimeError.value.payload.class, "usage_limit");
+      assert.equal(runtimeError.value.payload.retryAt, "2026-08-28T19:10:00.000Z");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("classifies Claude CLI API 429 results as usage limits", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const apiErrorMessage =
+        "API Error: Request rejected (429) · Usage limit reached. Try again later.";
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const sawRuntimeError = yield* Deferred.make<ProviderRuntimeEvent>();
+      const sawTurnCompleted = yield* Deferred.make<ProviderRuntimeEvent>();
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }).pipe(
+          Effect.andThen(
+            event.type === "runtime.error" && event.payload.message === apiErrorMessage
+              ? Deferred.succeed(sawRuntimeError, event).pipe(Effect.asVoid)
+              : event.type === "turn.completed"
+                ? Deferred.succeed(sawTurnCompleted, event).pipe(Effect.asVoid)
+                : Effect.void,
+          ),
+        ),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "continue the task",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "rate_limit_event",
+        session_id: "sdk-session-api-429",
+        uuid: "rate-limit-api-429",
+        rate_limit_info: {
+          status: "rejected",
+          resetsAt: 1_787_944_200,
+        },
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-api-429",
+        uuid: "assistant-api-429",
+        parent_tool_use_id: null,
+        error: "rate_limit",
+        is_api_error_message: true,
+        message: {
+          id: "assistant-message-api-429",
+          model: "<synthetic>",
+          role: "assistant",
+          content: [{ type: "text", text: apiErrorMessage }],
+        },
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: true,
+        terminal_reason: "api_error",
+        api_error_status: 429,
+        result: apiErrorMessage,
+        session_id: "sdk-session-api-429",
+        uuid: "result-api-429",
+      } as unknown as SDKMessage);
+
+      const runtimeError = yield* Deferred.await(sawRuntimeError);
+      assert.equal(runtimeError.type, "runtime.error");
+      if (runtimeError.type === "runtime.error") {
+        assert.equal(runtimeError.payload.class, "usage_limit");
+        assert.equal(runtimeError.payload.message, apiErrorMessage);
+        assert.equal(runtimeError.payload.retryAt, "2026-08-28T19:10:00.000Z");
+      }
+
+      const completed = yield* Deferred.await(sawTurnCompleted);
+      assert.equal(completed.type, "turn.completed");
+      if (completed.type === "turn.completed") {
+        assert.equal(completed.payload.state, "failed");
+        assert.equal(completed.payload.errorMessage, apiErrorMessage);
+      }
+      assert.notInclude(
+        runtimeEvents.map((event) => event.type),
+        "content.delta",
+      );
+
+      yield* Fiber.interrupt(runtimeEventsFiber);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -101,6 +101,11 @@ import {
 } from "../Errors.ts";
 import { type ClaudeAdapterShape } from "../Services/ClaudeAdapter.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+import {
+  providerUsageLimitFromError,
+  retryAtFromEpochSeconds,
+  type ProviderUsageLimit,
+} from "../usageLimits.ts";
 const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
 const decodeUnknownJsonStringExit = Schema.decodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
 
@@ -318,6 +323,8 @@ interface ClaudeSessionContext {
   lastKnownTotalProcessedTokens: number | undefined;
   lastAssistantUuid: string | undefined;
   lastThreadStartedId: string | undefined;
+  usageLimitError: ProviderUsageLimit | undefined;
+  apiErrorMessage: string | undefined;
   stopped: boolean;
 }
 
@@ -430,6 +437,74 @@ function resultUserFacingError(result: SDKResultMessage): string | undefined {
     return undefined;
   }
   return result.errors.find((error) => !error.startsWith("[ede_diagnostic]"));
+}
+
+function assistantApiErrorMessage(message: SDKMessage): string | undefined {
+  if (message.type !== "assistant") {
+    return undefined;
+  }
+  const apiError = message as unknown as {
+    readonly is_api_error_message?: unknown;
+    readonly error?: unknown;
+  };
+  if (apiError.is_api_error_message !== true) {
+    return undefined;
+  }
+  const content = message.message?.content;
+  if (Array.isArray(content)) {
+    const text = content
+      .flatMap((block) =>
+        block &&
+        typeof block === "object" &&
+        "type" in block &&
+        block.type === "text" &&
+        "text" in block &&
+        typeof block.text === "string"
+          ? [block.text]
+          : [],
+      )
+      .join("\n")
+      .trim();
+    if (text.length > 0) {
+      return text;
+    }
+  }
+  return typeof apiError.error === "string" && apiError.error.trim().length > 0
+    ? apiError.error.trim()
+    : "Claude API request failed.";
+}
+
+function resultApiError(
+  result: SDKResultMessage,
+  pendingMessage: string | undefined,
+): { readonly message: string; readonly usageLimit: ProviderUsageLimit | undefined } | undefined {
+  const apiResult = result as unknown as {
+    readonly api_error_status?: unknown;
+    readonly result?: unknown;
+    readonly terminal_reason?: unknown;
+  };
+  if (
+    result.is_error !== true ||
+    (apiResult.terminal_reason !== "api_error" && typeof apiResult.api_error_status !== "number")
+  ) {
+    return undefined;
+  }
+  const resultMessage =
+    typeof apiResult.result === "string" && apiResult.result.trim().length > 0
+      ? apiResult.result.trim()
+      : undefined;
+  const message = pendingMessage ?? resultMessage ?? "Claude API request failed.";
+  return {
+    message,
+    usageLimit: providerUsageLimitFromError({ message, detail: result }) ?? undefined,
+  };
+}
+
+function usageLimitWithKnownRetryAt(
+  next: ProviderUsageLimit | undefined,
+  previous: ProviderUsageLimit | undefined,
+): ProviderUsageLimit | undefined {
+  return next?.retryAt !== undefined ? next : (previous ?? next);
 }
 
 function isInterruptedResult(result: SDKResultMessage): boolean {
@@ -2031,6 +2106,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     context: ClaudeSessionContext,
     message: string,
     cause?: unknown,
+    usageLimit = providerUsageLimitFromError({ message, detail: cause }) ?? undefined,
   ) {
     if (cause !== undefined) {
       void cause;
@@ -2046,7 +2122,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       ...(turnState ? { turnId: asCanonicalTurnId(turnState.turnId) } : {}),
       payload: {
         message,
-        class: "provider_error",
+        class: usageLimit === undefined ? "provider_error" : "usage_limit",
+        ...(usageLimit?.retryAt !== undefined ? { retryAt: usageLimit.retryAt } : {}),
         ...(cause !== undefined ? { detail: cause } : {}),
       },
       providerRefs: nativeProviderRefs(context),
@@ -2901,6 +2978,18 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
+    const apiErrorMessage = assistantApiErrorMessage(message);
+    if (apiErrorMessage !== undefined) {
+      context.apiErrorMessage = apiErrorMessage;
+      context.usageLimitError = usageLimitWithKnownRetryAt(
+        providerUsageLimitFromError({ message: apiErrorMessage, detail: message }) ?? undefined,
+        context.usageLimitError,
+      );
+      context.lastAssistantUuid = message.uuid;
+      yield* updateResumeCursor(context);
+      return;
+    }
+
     // Auto-start a synthetic turn for assistant messages that arrive without
     // an active turn (e.g., background agent/subagent responses between user prompts).
     if (!context.turnState) {
@@ -3001,11 +3090,18 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
-    const status = turnStatusFromResult(message);
-    const errorMessage = resultUserFacingError(message);
+    const apiError = resultApiError(message, context.apiErrorMessage);
+    context.apiErrorMessage = undefined;
+    const status = apiError === undefined ? turnStatusFromResult(message) : "failed";
+    const errorMessage = apiError?.message ?? resultUserFacingError(message);
 
     if (status === "failed") {
-      yield* emitRuntimeError(context, errorMessage ?? "Claude turn failed.");
+      yield* emitRuntimeError(
+        context,
+        errorMessage ?? "Claude turn failed.",
+        apiError === undefined ? undefined : message,
+        usageLimitWithKnownRetryAt(apiError?.usageLimit, context.usageLimitError),
+      );
     }
 
     yield* completeTurn(context, status, errorMessage, message);
@@ -3551,6 +3647,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           rateLimits: message,
         },
       });
+      if (message.rate_limit_info.status === "rejected") {
+        const retryAt = retryAtFromEpochSeconds(message.rate_limit_info.resetsAt);
+        const usageLimit: ProviderUsageLimit = retryAt === undefined ? {} : { retryAt };
+        context.usageLimitError = usageLimit;
+        yield* emitRuntimeError(context, "Claude usage limit reached.", message, usageLimit);
+      }
       return;
     }
   });
@@ -4426,6 +4528,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         lastKnownTotalProcessedTokens: undefined,
         lastAssistantUuid: resumeState?.resumeSessionAt,
         lastThreadStartedId: undefined,
+        usageLimitError: undefined,
+        apiErrorMessage: undefined,
         stopped: false,
       };
       yield* Ref.set(contextRef, context);
@@ -4507,6 +4611,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
   const sendTurn: ClaudeAdapterShape["sendTurn"] = Effect.fn("sendTurn")(function* (input) {
     const context = yield* requireSession(input.threadId);
+    context.usageLimitError = undefined;
+    context.apiErrorMessage = undefined;
     const modelCatalog = yield* modelCatalogEffect;
     const selectedModel =
       input.modelSelection !== undefined && input.modelSelection.instanceId === boundInstanceId

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -1114,6 +1114,149 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
     }),
   );
 
+  it.effect("maps usage-limit errors with the latest account reset timestamp", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const runtimeErrorFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "runtime.error"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+
+      yield* runtime.emit({
+        id: asEventId("evt-rate-limits"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-1"),
+        createdAt: "2026-08-28T18:00:00.000Z",
+        method: "account/rateLimits/updated",
+        payload: {
+          rateLimits: {
+            primary: { usedPercent: 100, resetsAt: 1_787_944_200 },
+            secondary: { usedPercent: 20, resetsAt: 1_788_548_200 },
+            rateLimitReachedType: "rate_limit_reached",
+          },
+        },
+      } satisfies ProviderEvent);
+      yield* runtime.emit({
+        id: asEventId("evt-usage-limit"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
+        createdAt: "2026-08-28T18:00:01.000Z",
+        method: "error",
+        message: "You have no weighted tokens left",
+        payload: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          willRetry: false,
+          error: {
+            message: "You have no weighted tokens left",
+            codexErrorInfo: "usageLimitExceeded",
+          },
+        },
+      } satisfies ProviderEvent);
+
+      const runtimeError = yield* Fiber.join(runtimeErrorFiber);
+      NodeAssert.equal(runtimeError._tag, "Some");
+      if (runtimeError._tag !== "Some" || runtimeError.value.type !== "runtime.error") {
+        return;
+      }
+      NodeAssert.equal(runtimeError.value.payload.class, "usage_limit");
+      NodeAssert.equal(runtimeError.value.payload.retryAt, "2026-08-28T19:10:00.000Z");
+    }),
+  );
+
+  it.effect("does not apply account reset times to a capacity outage", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const errorFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "runtime.error"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* runtime.emit({
+        id: asEventId("cached-account-limit"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-1"),
+        createdAt: "2026-08-28T18:00:00.000Z",
+        method: "account/rateLimits/updated",
+        payload: {
+          rateLimits: { primary: { usedPercent: 100, resetsAt: 1_788_548_200 }, secondary: null },
+        },
+      } satisfies ProviderEvent);
+      yield* runtime.emit({
+        id: asEventId("capacity-error"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-1"),
+        createdAt: "2026-08-28T18:00:01.000Z",
+        method: "error",
+        payload: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          willRetry: false,
+          error: { message: "Model is at capacity", codexErrorInfo: "other" },
+        },
+      } satisfies ProviderEvent);
+      const error = yield* Fiber.join(errorFiber);
+      NodeAssert.equal(error._tag, "Some");
+      if (error._tag === "Some" && error.value.type === "runtime.error") {
+        NodeAssert.equal(error.value.payload.class, "usage_limit");
+        NodeAssert.equal(error.value.payload.retryAt, undefined);
+      }
+    }),
+  );
+
+  it.effect("preserves the message reset time after an account update without a reset", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const errorFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "runtime.error"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* runtime.emit({
+        id: asEventId("empty-limit-state"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-1"),
+        createdAt: "2026-08-28T18:00:00.000Z",
+        method: "account/rateLimits/updated",
+        payload: { rateLimits: { primary: null, secondary: null } },
+      } satisfies ProviderEvent);
+      yield* runtime.emit({
+        id: asEventId("timed-limit-error"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-1"),
+        createdAt: "2026-08-28T18:00:01.000Z",
+        method: "error",
+        payload: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          willRetry: false,
+          error: {
+            message: "Usage limit reached. Try again at 7:41 PM.",
+            codexErrorInfo: "usageLimitExceeded",
+          },
+        },
+      } satisfies ProviderEvent);
+      const result = yield* Fiber.join(errorFiber);
+      NodeAssert.equal(result._tag, "Some");
+      if (result._tag !== "Some" || result.value.type !== "runtime.error") return;
+      NodeAssert.ok(result.value.payload.retryAt);
+      const reset = new Intl.DateTimeFormat("en-GB", {
+        hour: "2-digit",
+        minute: "2-digit",
+        hourCycle: "h23",
+      }).format(Date.parse(result.value.payload.retryAt));
+      NodeAssert.equal(reset, "19:42");
+    }),
+  );
+
   it.effect("preserves request type when mapping serverRequest/resolved", () =>
     Effect.gen(function* () {
       const { adapter, runtime } = yield* startLifecycleRuntime();

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -65,6 +65,11 @@ import {
 } from "./CodexSessionRuntime.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 import { resolveCodexLaunchArgs } from "./codexLaunchArgs.ts";
+import {
+  providerUsageLimitFromError,
+  retryAtFromEpochSeconds,
+  type ProviderUsageLimit,
+} from "../usageLimits.ts";
 const isCodexAppServerProcessExitedError = Schema.is(CodexErrors.CodexAppServerProcessExitedError);
 const isCodexAppServerTransportError = Schema.is(CodexErrors.CodexAppServerTransportError);
 const isCodexSessionRuntimeThreadIdMissingError = Schema.is(
@@ -94,6 +99,34 @@ interface CodexAdapterSessionContext {
   readonly runtime: CodexSessionRuntimeShape;
   readonly eventFiber: Fiber.Fiber<void, never>;
   stopped: boolean;
+}
+
+interface CodexUsageLimitState {
+  latest: ProviderUsageLimit | undefined;
+}
+
+function codexRateLimitResetAt(
+  snapshot: EffectCodexSchema.V2AccountRateLimitsUpdatedNotification__RateLimitSnapshot,
+) {
+  const exhaustedResetCandidates = [
+    (snapshot.primary?.usedPercent ?? 0) >= 100 ? snapshot.primary?.resetsAt : undefined,
+    (snapshot.secondary?.usedPercent ?? 0) >= 100 ? snapshot.secondary?.resetsAt : undefined,
+    snapshot.spendControlReached === true ||
+    (snapshot.individualLimit?.remainingPercent ?? 100) <= 0
+      ? snapshot.individualLimit?.resetsAt
+      : undefined,
+  ].filter((value): value is number => typeof value === "number");
+  const resetCandidates =
+    exhaustedResetCandidates.length > 0
+      ? exhaustedResetCandidates
+      : [
+          snapshot.primary?.resetsAt,
+          snapshot.secondary?.resetsAt,
+          snapshot.individualLimit?.resetsAt,
+        ].filter((value): value is number => typeof value === "number");
+  return resetCandidates.length === 0
+    ? undefined
+    : retryAtFromEpochSeconds(Math.max(...resetCandidates));
 }
 
 function mapCodexRuntimeError(
@@ -770,6 +803,7 @@ function mapCollabAgentEvent(
 function mapToRuntimeEvents(
   event: ProviderEvent,
   canonicalThreadId: ThreadId,
+  usageLimitState: CodexUsageLimitState,
 ): ReadonlyArray<ProviderRuntimeEvent> {
   if (event.kind === "notification" && event.method.startsWith("collabAgent/")) {
     return mapCollabAgentEvent(event, canonicalThreadId);
@@ -778,13 +812,18 @@ function mapToRuntimeEvents(
     if (!event.message) {
       return [];
     }
+    const usageLimit = providerUsageLimitFromError({
+      message: event.message,
+      detail: event.payload,
+    });
     return [
       {
         ...runtimeEventBase(event, canonicalThreadId),
         type: "runtime.error",
         payload: {
           message: event.message,
-          class: "provider_error",
+          class: usageLimit === null ? "provider_error" : "usage_limit",
+          ...(usageLimit?.retryAt !== undefined ? { retryAt: usageLimit.retryAt } : {}),
           ...(event.payload !== undefined ? { detail: event.payload } : {}),
         },
       },
@@ -1414,9 +1453,15 @@ function mapToRuntimeEvents(
   }
 
   if (event.method === "account/rateLimits/updated") {
-    if (!readPayload(EffectCodexSchema.V2AccountRateLimitsUpdatedNotification, event.payload)) {
+    const payload = readPayload(
+      EffectCodexSchema.V2AccountRateLimitsUpdatedNotification,
+      event.payload,
+    );
+    if (!payload) {
       return [];
     }
+    const retryAt = codexRateLimitResetAt(payload.rateLimits);
+    usageLimitState.latest = retryAt === undefined ? {} : { retryAt };
     return [
       {
         type: "account.rate-limits.updated",
@@ -1540,13 +1585,32 @@ function mapToRuntimeEvents(
     const payload = readPayload(EffectCodexSchema.V2ErrorNotification, event.payload);
     const message = payload?.error.message ?? event.message ?? "Provider runtime error";
     const willRetry = payload?.willRetry === true;
+    const parsedUsageLimit = providerUsageLimitFromError({
+      message,
+      detail: event.payload,
+      ...(payload?.error.codexErrorInfo === "usageLimitExceeded" &&
+      usageLimitState.latest?.retryAt !== undefined
+        ? { retryAt: usageLimitState.latest.retryAt }
+        : {}),
+    });
+    const usageLimit =
+      payload?.error.codexErrorInfo === "usageLimitExceeded"
+        ? (parsedUsageLimit ?? usageLimitState.latest ?? {})
+        : parsedUsageLimit;
     return [
       {
         type: willRetry ? "runtime.warning" : "runtime.error",
         ...runtimeEventBase(event, canonicalThreadId),
         payload: {
           message,
-          ...(!willRetry ? { class: "provider_error" as const } : {}),
+          ...(!willRetry
+            ? {
+                class: usageLimit === null ? ("provider_error" as const) : ("usage_limit" as const),
+              }
+            : {}),
+          ...(!willRetry && usageLimit?.retryAt !== undefined
+            ? { retryAt: usageLimit.retryAt }
+            : {}),
           ...(event.payload !== undefined ? { detail: event.payload } : {}),
         },
       },
@@ -1740,10 +1804,11 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
         // this a child of `startSession`, and Effect interrupts a fiber's
         // children when it completes, so the consumer died on return and every
         // runtime event the session emitted afterwards was dropped.
+        const usageLimitState: CodexUsageLimitState = { latest: undefined };
         const eventFiber = yield* Stream.runForEach(runtime.events, (event) =>
           Effect.gen(function* () {
             yield* writeNativeEvent(event);
-            const runtimeEvents = mapToRuntimeEvents(event, event.threadId);
+            const runtimeEvents = mapToRuntimeEvents(event, event.threadId, usageLimitState);
             if (runtimeEvents.length === 0) {
               yield* Effect.logDebug("ignoring unhandled Codex provider event", {
                 method: event.method,

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -250,6 +250,111 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
     }),
   );
 
+  it.effect("preserves Cursor usage-limit prompt errors for orchestration", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CursorAdapter;
+      const settings = yield* ServerSettingsService;
+      const threadId = ThreadId.make("cursor-usage-limit-error");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockAgentWrapper({
+          T3_ACP_FAIL_PROMPT: "1",
+          T3_ACP_FAIL_PROMPT_MESSAGE: "You've hit your Cursor usage limit.",
+        }),
+      );
+      yield* settings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("cursor"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("cursor"), model: "default" },
+      });
+
+      const error = yield* Effect.flip(
+        adapter.sendTurn({
+          threadId,
+          input: "continue the task",
+          attachments: [],
+        }),
+      );
+
+      assert.equal(error._tag, "ProviderAdapterRequestError");
+      assert.include(error.message, "You've hit your Cursor usage limit.");
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("classifies Cursor's native ACP resource-exhausted message", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CursorAdapter;
+      const settings = yield* ServerSettingsService;
+      const threadId = ThreadId.make("cursor-native-usage-limit-error");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockAgentWrapper({
+          T3_ACP_PROMPT_RESPONSE_TEXT:
+            "Error: RetriableError: [resource_exhausted] You have reached your Cursor usage limit. Try again later.",
+        }),
+      );
+      yield* settings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
+
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const sawRuntimeError = yield* Deferred.make<ProviderRuntimeEvent>();
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          if (event.threadId !== threadId) {
+            return;
+          }
+          runtimeEvents.push(event);
+        }).pipe(
+          Effect.andThen(
+            event.threadId === threadId && event.type === "runtime.error"
+              ? Deferred.succeed(sawRuntimeError, event).pipe(Effect.asVoid)
+              : Effect.void,
+          ),
+        ),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("cursor"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("cursor"), model: "default" },
+      });
+
+      yield* adapter.sendTurn({
+        threadId,
+        input: "continue the task",
+        attachments: [],
+      });
+
+      const runtimeError = yield* Deferred.await(sawRuntimeError);
+      assert.equal(runtimeError.type, "runtime.error");
+      if (runtimeError.type === "runtime.error") {
+        assert.equal(runtimeError.payload.class, "usage_limit");
+        assert.equal(
+          runtimeError.payload.message,
+          "You have reached your Cursor usage limit. Try again later.",
+        );
+      }
+
+      const completed = runtimeEvents.find((event) => event.type === "turn.completed");
+      assert.isDefined(completed);
+      if (completed?.type === "turn.completed") {
+        assert.equal(completed.payload.state, "failed");
+      }
+      assert.notInclude(
+        runtimeEvents.map((event) => event.type),
+        "content.delta",
+      );
+
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("steers a running turn instead of opening a new one on mid-turn sendTurn", () =>
     Effect.gen(function* () {
       const adapter = yield* CursorAdapter;

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -77,6 +77,7 @@ import {
 import { type CursorAdapterShape } from "../Services/CursorAdapter.ts";
 import { resolveCursorAcpBaseModelId } from "./CursorProvider.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+import { providerUsageLimitFromError } from "../usageLimits.ts";
 const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
 
 const PROVIDER = ProviderDriverKind.make("cursor");
@@ -84,6 +85,26 @@ const CURSOR_RESUME_VERSION = 1 as const;
 const ACP_PLAN_MODE_ALIASES = ["plan", "architect"];
 const ACP_IMPLEMENT_MODE_ALIASES = ["code", "agent", "default", "chat", "implement"];
 const ACP_APPROVAL_MODE_ALIASES = ["ask"];
+const CURSOR_ACP_USAGE_LIMIT_ERROR =
+  /^\s*Error:\s*(?:RetriableError:\s*)?\[resource_exhausted\]\s*(?<message>.+?)\s*$/is;
+
+interface CursorAcpUsageLimitError {
+  readonly message: string;
+  readonly rawPayload: unknown;
+  readonly turnId: TurnId | undefined;
+}
+
+function cursorAcpUsageLimitMessage(text: string): string | undefined {
+  const match = CURSOR_ACP_USAGE_LIMIT_ERROR.exec(text);
+  if (!match) {
+    return undefined;
+  }
+  const message = match.groups?.message?.trim();
+  if (!message) {
+    return undefined;
+  }
+  return providerUsageLimitFromError({ message: text }) === null ? undefined : message;
+}
 
 function encodeJsonStringForDiagnostics(input: unknown): string | undefined {
   const result = encodeUnknownJsonStringExit(input);
@@ -133,6 +154,7 @@ interface CursorSessionContext {
   readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
   lastPlanFingerprint: string | undefined;
   activeTurnId: TurnId | undefined;
+  pendingUsageLimitError: CursorAcpUsageLimitError | undefined;
   /** Number of sendTurn prompts currently in flight or being prepared.
    * >0 means a turn is actively running, so a new sendTurn is a steer that
    * continues it, and only the last remaining prompt settles the turn. */
@@ -778,6 +800,7 @@ export function makeCursorAdapter(
             turns: [],
             lastPlanFingerprint: undefined,
             activeTurnId: undefined,
+            pendingUsageLimitError: undefined,
             promptsInFlight: 0,
             stopped: false,
           };
@@ -855,6 +878,15 @@ export function makeCursorAdapter(
                       event.rawPayload,
                       "acp.jsonrpc",
                     );
+                    const usageLimitMessage = cursorAcpUsageLimitMessage(event.text);
+                    if (usageLimitMessage !== undefined) {
+                      ctx.pendingUsageLimitError = {
+                        message: usageLimitMessage,
+                        rawPayload: event.rawPayload,
+                        turnId: ctx.activeTurnId,
+                      };
+                      return;
+                    }
                     yield* offerRuntimeEvent(
                       makeAcpContentDeltaEvent({
                         stamp: yield* makeEventStamp(),
@@ -948,6 +980,7 @@ export function makeCursorAdapter(
           ctx.activeTurnId = turnId;
           if (steeringTurnId === undefined) {
             ctx.lastPlanFingerprint = undefined;
+            ctx.pendingUsageLimitError = undefined;
           }
           ctx.session = {
             ...ctx.session,
@@ -1024,6 +1057,9 @@ export function makeCursorAdapter(
                 mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
               ),
             );
+          if (!ctx.stopped) {
+            yield* ctx.acp.drainEvents;
+          }
 
           const turnRecord = ctx.turns.find((turn) => turn.id === turnId);
           if (turnRecord) {
@@ -1042,6 +1078,27 @@ export function makeCursorAdapter(
           // superseded prompt resolving (usually cancelled) while another is
           // in flight or pending must leave the merged turn running.
           if (ctx.promptsInFlight === 1) {
+            const usageLimitError = ctx.pendingUsageLimitError;
+            ctx.pendingUsageLimitError = undefined;
+            if (usageLimitError !== undefined) {
+              yield* offerRuntimeEvent({
+                type: "runtime.error",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                turnId,
+                payload: {
+                  message: usageLimitError.message,
+                  class: "usage_limit",
+                  detail: usageLimitError.rawPayload,
+                },
+                raw: {
+                  source: "acp.jsonrpc",
+                  method: "session/update",
+                  payload: usageLimitError.rawPayload,
+                },
+              });
+            }
             yield* offerRuntimeEvent({
               type: "turn.completed",
               ...(yield* makeEventStamp()),
@@ -1049,8 +1106,14 @@ export function makeCursorAdapter(
               threadId: input.threadId,
               turnId,
               payload: {
-                state: result.stopReason === "cancelled" ? "cancelled" : "completed",
+                state:
+                  usageLimitError !== undefined
+                    ? "failed"
+                    : result.stopReason === "cancelled"
+                      ? "cancelled"
+                      : "completed",
                 stopReason: result.stopReason ?? null,
+                ...(usageLimitError !== undefined ? { errorMessage: usageLimitError.message } : {}),
               },
             });
           }

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1255,6 +1255,49 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("classifies native OpenCode quota errors as usage limits", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-usage-limit");
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "session.error",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            error: {
+              name: "APIError",
+              data: {
+                message: "OpenCode provider request failed.",
+                statusCode: 429,
+              },
+            },
+          },
+        },
+      ];
+      const runtimeErrorFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "runtime.error"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const runtimeError = yield* Fiber.join(runtimeErrorFiber).pipe(Effect.timeout("1 second"));
+      NodeAssert.equal(runtimeError._tag, "Some");
+      if (runtimeError._tag !== "Some" || runtimeError.value.type !== "runtime.error") {
+        throw new Error("Expected an OpenCode runtime error");
+      }
+      NodeAssert.equal(runtimeError.value.payload.class, "usage_limit");
+      NodeAssert.equal(runtimeError.value.payload.message, "OpenCode provider request failed.");
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("rolls back session state when sendTurn fails before OpenCode accepts the prompt", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -42,6 +42,7 @@ import {
   ProviderAdapterValidationError,
 } from "../Errors.ts";
 import { type OpenCodeAdapterShape } from "../Services/OpenCodeAdapter.ts";
+import { providerUsageLimitFromError } from "../usageLimits.ts";
 import {
   buildOpenCodePermissionRules,
   OpenCodeRuntime,
@@ -2233,6 +2234,10 @@ export function makeOpenCodeAdapter(
 
         case "session.error": {
           const message = sessionErrorMessage(event.properties.error);
+          const usageLimit = providerUsageLimitFromError({
+            message,
+            detail: event.properties.error,
+          });
           const activeTurnId = context.activeTurnId;
           const cancellation = context.cancellation;
           if (isOpenCodeAbortError(event.properties.error)) {
@@ -2293,7 +2298,8 @@ export function makeOpenCodeAdapter(
             type: "runtime.error",
             payload: {
               message,
-              class: "provider_error",
+              class: usageLimit === null ? "provider_error" : "usage_limit",
+              ...(usageLimit?.retryAt !== undefined ? { retryAt: usageLimit.retryAt } : {}),
               detail: event.properties.error,
             },
           });

--- a/apps/server/src/provider/usageLimits.test.ts
+++ b/apps/server/src/provider/usageLimits.test.ts
@@ -1,0 +1,122 @@
+import * as DateTime from "effect/DateTime";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  nextUsageLimitRetryAt,
+  providerUsageLimitFromError,
+  retryAtFromEpochSeconds,
+  retryAtFromUsageLimitMessage,
+} from "./usageLimits.ts";
+
+describe("provider usage limits", () => {
+  it("parses a dated production-style reset instead of falling back to the cadence", () => {
+    expect(
+      retryAtFromUsageLimitMessage(
+        "Usage limit reached. Try again at Sep 6th, 2026 1:13 AM.",
+        DateTime.makeUnsafe("2026-09-05T20:54:05.027Z"),
+        "Europe/Berlin",
+      ),
+    ).toBe("2026-09-05T23:14:00.000Z");
+  });
+  it("classifies common subscription and API limit errors", () => {
+    for (const message of [
+      "Usage limit reached",
+      "rate limit exceeded",
+      "HTTP 429 Too Many Requests",
+      "HTTP 404: Service is temporarily unavailable.",
+      "RESOURCE_EXHAUSTED",
+      "insufficient_quota",
+      "You've hit your Cursor usage limit.",
+      "Grok usage limit reached. Try again later.",
+      "OpenCode request failed with HTTP 429.",
+      "You hit your spend cap set by the owner of your workspace.",
+      "The selected model is currently at capacity.",
+    ]) {
+      expect(providerUsageLimitFromError({ message })).not.toBeNull();
+    }
+    expect(providerUsageLimitFromError({ message: "Context window exceeded" })).toBeNull();
+  });
+
+  it("does not retry a bare 404 or missing provider resources", () => {
+    for (const message of [
+      "Provider request failed with HTTP 404.",
+      "HTTP 404: Model not found.",
+      "HTTP 404: Invalid endpoint.",
+      "HTTP 404: Session expired.",
+    ]) {
+      expect(providerUsageLimitFromError({ message })).toBeNull();
+      expect(
+        providerUsageLimitFromError({
+          message: "Request failed",
+          detail: { message, status: 404 },
+        }),
+      ).toBeNull();
+    }
+  });
+
+  it("parses provider clock times one minute after the advertised reset", () => {
+    expect(
+      retryAtFromUsageLimitMessage(
+        "Try again at 7:41 PM.",
+        DateTime.makeUnsafe("2026-09-02T16:43:00.000Z"),
+        "Europe/Berlin",
+      ),
+    ).toBe("2026-09-02T17:42:00.000Z");
+  });
+
+  it("extracts nested absolute reset timestamps", () => {
+    const timed = providerUsageLimitFromError({
+      message: "Usage limit reached. Try again at 7:41 PM.",
+      retryAt: "2020-01-01T00:00:00.000Z",
+    });
+    expect(timed?.retryAt).toBeDefined();
+    expect(timed?.retryAt).not.toBe("2020-01-01T00:00:00.000Z");
+    expect(
+      providerUsageLimitFromError({
+        message: "rate limit exceeded",
+        detail: { error: { rate_limit: { resetsAt: 1_787_944_200 } } },
+      }),
+    ).toEqual({ retryAt: "2026-08-28T19:10:00.000Z" });
+    expect(retryAtFromEpochSeconds(1_787_944_200)).toBe("2026-08-28T19:10:00.000Z");
+  });
+
+  it("classifies structured quota details when the outer message is generic", () => {
+    expect(
+      providerUsageLimitFromError({
+        message: "Provider request failed.",
+        detail: { error: { statusCode: 429 } },
+      }),
+    ).toEqual({});
+    expect(
+      providerUsageLimitFromError({
+        message: "Provider request failed.",
+        detail: { error: { code: "insufficient_quota" } },
+      }),
+    ).toEqual({});
+  });
+
+  it("uses the provider reset when available and paced fallback retries otherwise", () => {
+    expect(
+      nextUsageLimitRetryAt({
+        now: "2026-08-28T18:00:00.000Z",
+        attempt: 0,
+        providerRetryAt: "2026-08-28T18:30:00.000Z",
+      }),
+    ).toBe("2026-08-28T18:30:02.000Z");
+    expect(nextUsageLimitRetryAt({ now: "2026-08-28T18:00:00.000Z", attempt: 0 })).toBe(
+      "2026-08-28T18:20:00.000Z",
+    );
+    expect(nextUsageLimitRetryAt({ now: "2026-08-28T18:00:00.000Z", attempt: 2 })).toBe(
+      "2026-08-28T18:20:00.000Z",
+    );
+    expect(nextUsageLimitRetryAt({ now: "2026-08-28T18:00:00.000Z", attempt: 3 })).toBe(
+      "2026-08-28T19:00:00.000Z",
+    );
+    expect(nextUsageLimitRetryAt({ now: "2026-08-28T18:00:00.000Z", attempt: 7 })).toBe(
+      "2026-08-28T19:00:00.000Z",
+    );
+    expect(nextUsageLimitRetryAt({ now: "2026-08-28T18:00:00.000Z", attempt: 8 })).toBe(
+      "2026-08-29T00:00:00.000Z",
+    );
+  });
+});

--- a/apps/server/src/provider/usageLimits.ts
+++ b/apps/server/src/provider/usageLimits.ts
@@ -1,0 +1,151 @@
+import type { IsoDateTime } from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Option from "effect/Option";
+import * as Predicate from "effect/Predicate";
+
+const USAGE_LIMIT_MESSAGE =
+  /(?:usage|rate) limit|spend cap|model (?:is )?(?:currently )?at capacity|(?:provider|service|server) (?:is )?temporarily unavailable|quota (?:has been )?(?:exceeded|reached|exhausted)|too many requests|\b429\b|resource[_ ]exhausted|insufficient[_ ]quota/i;
+const RETRY_AT_CLOCK_TIME =
+  /\btry again at\s+(?:(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+(\d{1,2})(?:st|nd|rd|th)?,?\s+(\d{4})\s+)?(\d{1,2}):([0-5]\d)\s*([ap])\.?m\.?\b/i;
+const ABSOLUTE_RETRY_KEYS = new Set([
+  "resetat",
+  "resetsat",
+  "reset_at",
+  "resets_at",
+  "retryat",
+  "retry_at",
+]);
+const HTTP_STATUS_KEYS = new Set(["code", "status", "statuscode", "status_code"]);
+
+export interface ProviderUsageLimit {
+  readonly retryAt?: IsoDateTime;
+}
+
+export function retryAtFromUsageLimitMessage(
+  message: string,
+  now = DateTime.nowUnsafe(),
+  timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone,
+): IsoDateTime | undefined {
+  const match = RETRY_AT_CLOCK_TIME.exec(message);
+  if (match === null) return undefined;
+  const hour = Number(match[4]);
+  if (hour < 1 || hour > 12) return undefined;
+  const zonedNow = DateTime.makeZonedUnsafe(now, { timeZone });
+  let retryAt = DateTime.setParts(zonedNow, {
+    ...(match[1]
+      ? {
+          year: Number(match[3]),
+          month:
+            "jan feb mar apr may jun jul aug sep oct nov dec"
+              .split(" ")
+              .indexOf(match[1].toLowerCase()) + 1,
+          day: Number(match[2]),
+        }
+      : {}),
+    hour: (hour % 12) + (match[6]?.toLowerCase() === "p" ? 12 : 0),
+    minute: Number(match[5]),
+    second: 0,
+    millisecond: 0,
+  }).pipe(DateTime.add({ minutes: 1 }));
+  if (!match[1] && DateTime.toEpochMillis(retryAt) <= DateTime.toEpochMillis(now)) {
+    retryAt = DateTime.add(retryAt, { days: 1 });
+  }
+  return DateTime.formatIso(retryAt) as IsoDateTime;
+}
+
+function isoFromAbsoluteTime(value: unknown): IsoDateTime | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const epochMillis = value < 10_000_000_000 ? value * 1_000 : value;
+    return DateTime.formatIso(DateTime.makeUnsafe(epochMillis)) as IsoDateTime;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  return Option.match(DateTime.make(value), {
+    onNone: () => undefined,
+    onSome: (dateTime) => DateTime.formatIso(dateTime) as IsoDateTime,
+  });
+}
+
+function retryAtFromDetail(value: unknown, depth = 0): IsoDateTime | undefined {
+  if (depth > 6 || !Predicate.isObject(value)) {
+    return undefined;
+  }
+  for (const [key, entry] of Object.entries(value)) {
+    if (ABSOLUTE_RETRY_KEYS.has(key.toLowerCase())) {
+      const retryAt = isoFromAbsoluteTime(entry);
+      if (retryAt !== undefined) {
+        return retryAt;
+      }
+    }
+  }
+  for (const entry of Object.values(value)) {
+    const retryAt = retryAtFromDetail(entry, depth + 1);
+    if (retryAt !== undefined) {
+      return retryAt;
+    }
+  }
+  return undefined;
+}
+
+function detailContainsUsageLimit(value: unknown, depth = 0): boolean {
+  if (depth > 6) {
+    return false;
+  }
+  if (typeof value === "string") {
+    return USAGE_LIMIT_MESSAGE.test(value);
+  }
+  if (!Predicate.isObject(value)) {
+    return false;
+  }
+  for (const [key, entry] of Object.entries(value)) {
+    if (
+      HTTP_STATUS_KEYS.has(key.toLowerCase()) &&
+      (entry === 429 || (typeof entry === "string" && entry.trim() === "429"))
+    ) {
+      return true;
+    }
+    if (detailContainsUsageLimit(entry, depth + 1)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function providerUsageLimitFromError(input: {
+  readonly message: string;
+  readonly detail?: unknown;
+  readonly retryAt?: IsoDateTime;
+}): ProviderUsageLimit | null {
+  if (!USAGE_LIMIT_MESSAGE.test(input.message) && !detailContainsUsageLimit(input.detail)) {
+    return null;
+  }
+  const retryAt =
+    retryAtFromUsageLimitMessage(input.message) ?? retryAtFromDetail(input.detail) ?? input.retryAt;
+  return retryAt === undefined ? {} : { retryAt };
+}
+
+export function retryAtFromEpochSeconds(value: number | undefined): IsoDateTime | undefined {
+  return value === undefined ? undefined : isoFromAbsoluteTime(value);
+}
+
+export function nextUsageLimitRetryAt(input: {
+  readonly now: IsoDateTime;
+  readonly attempt: number;
+  readonly providerRetryAt?: IsoDateTime;
+}): IsoDateTime {
+  const now = DateTime.makeUnsafe(input.now);
+  const providerRetryAt =
+    input.providerRetryAt === undefined
+      ? undefined
+      : Option.getOrUndefined(DateTime.make(input.providerRetryAt));
+  if (
+    providerRetryAt !== undefined &&
+    DateTime.toEpochMillis(providerRetryAt) > DateTime.toEpochMillis(now)
+  ) {
+    return DateTime.formatIso(DateTime.add(providerRetryAt, { seconds: 2 })) as IsoDateTime;
+  }
+  const delay =
+    input.attempt < 3 ? { minutes: 20 } : input.attempt < 8 ? { hours: 1 } : { hours: 6 };
+  return DateTime.formatIso(DateTime.add(now, delay)) as IsoDateTime;
+}

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -108,6 +108,7 @@ import * as ServerConfig from "./config.ts";
 import { HTTP_ROUTER_CONFIG, makeRoutesLayer } from "./server.ts";
 import {
   isThreadDetailEvent,
+  shouldStreamThreadDetailEvent,
   resolveAvailableEditorsForConfig,
   resolveFileManagerRevealKindForConfig,
 } from "./ws.ts";
@@ -1500,6 +1501,20 @@ const NodeHttpServerTestWithWsDeflate = HttpServer.layerTestClient.pipe(
 );
 
 it.layer(NodeServices.layer)("server router seam", (it) => {
+  it("streams usage-limit resume state changes to active thread clients", () => {
+    for (const type of [
+      "thread.usage-limit-resume-scheduled",
+      "thread.usage-limit-resume-cancelled",
+      "thread.usage-limit-resume-attempted",
+    ] as const) {
+      assertTrue(isThreadDetailEvent({ type } as OrchestrationEvent));
+      assertTrue(shouldStreamThreadDetailEvent({ type } as OrchestrationEvent, "web"));
+      assertTrue(!shouldStreamThreadDetailEvent({ type } as OrchestrationEvent, "mobile"));
+      assertTrue(!shouldStreamThreadDetailEvent({ type } as OrchestrationEvent, undefined));
+      assertTrue(shouldStreamThreadDetailEvent({ type } as OrchestrationEvent, "desktop"));
+    }
+  });
+
   it.effect("parks HTTP ingress until command readiness", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -209,6 +209,7 @@ const makeTest = (overrides: DeepPartial<ServerSettings> = {}) =>
         : {}),
     });
     const currentSettingsRef = yield* Ref.make<ServerSettings>(initialSettings);
+    const changes = yield* PubSub.unbounded<ServerSettings>();
 
     return {
       start: Effect.void,
@@ -219,10 +220,11 @@ const makeTest = (overrides: DeepPartial<ServerSettings> = {}) =>
           Effect.map((currentSettings) => applyServerSettingsPatch(currentSettings, patch)),
           Effect.flatMap(normalizeServerSettings),
           Effect.tap((nextSettings) => Ref.set(currentSettingsRef, nextSettings)),
+          Effect.tap((nextSettings) => PubSub.publish(changes, nextSettings)),
           Effect.map(resolveTextGenerationProvider),
         ),
-      streamChanges: Stream.empty,
-      subscribeChanges: Effect.succeed(Stream.empty),
+      streamChanges: Stream.fromPubSub(changes),
+      subscribeChanges: PubSub.subscribe(changes).pipe(Effect.map(Stream.fromSubscription)),
     } satisfies ServerSettingsService["Service"];
   });
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -307,7 +307,10 @@ export function isThreadDetailEvent(event: OrchestrationEvent): event is Extract
       | "thread.activity-appended"
       | "thread.turn-diff-completed"
       | "thread.reverted"
-      | "thread.session-set";
+      | "thread.session-set"
+      | "thread.usage-limit-resume-scheduled"
+      | "thread.usage-limit-resume-cancelled"
+      | "thread.usage-limit-resume-attempted";
   }
 > {
   return (
@@ -316,7 +319,22 @@ export function isThreadDetailEvent(event: OrchestrationEvent): event is Extract
     event.type === "thread.activity-appended" ||
     event.type === "thread.turn-diff-completed" ||
     event.type === "thread.reverted" ||
-    event.type === "thread.session-set"
+    event.type === "thread.session-set" ||
+    event.type === "thread.usage-limit-resume-scheduled" ||
+    event.type === "thread.usage-limit-resume-cancelled" ||
+    event.type === "thread.usage-limit-resume-attempted"
+  );
+}
+
+export function shouldStreamThreadDetailEvent(
+  event: OrchestrationEvent,
+  surface: OrchestrationClientOrigin["surface"],
+): boolean {
+  return (
+    isThreadDetailEvent(event) &&
+    (surface === "web" ||
+      surface === "desktop" ||
+      !event.type.startsWith("thread.usage-limit-resume-"))
   );
 }
 
@@ -1479,7 +1497,7 @@ const makeWsRpcLayer = (
               const isThisThreadDetailEvent = (event: OrchestrationEvent) =>
                 event.aggregateKind === "thread" &&
                 event.aggregateId === input.threadId &&
-                isThreadDetailEvent(event);
+                shouldStreamThreadDetailEvent(event, clientOrigin.surface);
 
               const liveStream = orchestrationEngine.streamDomainEvents.pipe(
                 Stream.filter(isThisThreadDetailEvent),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -108,6 +108,7 @@ import {
   getAnchoredTurnMetrics,
   type TimelineScrollMode,
 } from "./chat/timelineScrollAnchoring";
+import { snoozeWakeDescription } from "./Sidebar.snooze";
 import {
   buildPendingUserInputAnswers,
   derivePendingUserInputProgress,
@@ -1667,6 +1668,18 @@ function ChatViewContent(props: ChatViewProps) {
   // session.lastError. Bump a tick so the banner hides immediately. Mirrors
   // the branch mismatch banner.
   const [, setThreadErrorBannerDismissTick] = useState(0);
+  const usageLimitResume = activeServerThread?.usageLimitResume ?? null;
+  const displayedThreadError = visibleThreadError;
+  const usageLimitActionDescription =
+    usageLimitResume?.nextAttemptAt === null
+      ? "Trying again now."
+      : usageLimitResume?.nextAttemptAt
+        ? `Automatic resume scheduled for ${snoozeWakeDescription(
+            usageLimitResume.nextAttemptAt,
+            new Date(),
+            timestampFormat,
+          )}.`
+        : undefined;
   const runtimeMode = composerRuntimeMode ?? activeThread?.runtimeMode ?? DEFAULT_RUNTIME_MODE;
   // Plan mode is legacy (Settings → Beta). With the flag off the effective
   // mode is forced to "default" — even for threads with a stored plan mode —
@@ -2990,7 +3003,7 @@ function ChatViewContent(props: ChatViewProps) {
   )
     ? activeProviderStatus
     : null;
-  const hasTimelineTopBanner = Boolean(visibleThreadError) || visibleProviderStatus !== null;
+  const hasTimelineTopBanner = Boolean(displayedThreadError) || visibleProviderStatus !== null;
   const activeProjectCwd = activeProject?.workspaceRoot ?? null;
   const activeThreadWorktreePath = activeThread?.worktreePath ?? null;
   const activeWorkspaceRoot = activeThreadWorktreePath ?? activeProjectCwd ?? undefined;
@@ -7239,7 +7252,8 @@ function ChatViewContent(props: ChatViewProps) {
         </WorkspacePageHeader>
 
         <ThreadErrorBanner
-          error={visibleThreadError}
+          error={displayedThreadError}
+          actionDescription={usageLimitActionDescription}
           onDismiss={() => {
             setThreadError(activeThread.id, null);
             dismissThreadErrorBannerForSession(threadErrorBannerKey);

--- a/apps/web/src/components/Sidebar.snooze.test.ts
+++ b/apps/web/src/components/Sidebar.snooze.test.ts
@@ -80,6 +80,9 @@ describe("snoozeWakeDescription", () => {
     expect(snoozeWakeDescription(localDate(2026, 4, 9, 9).toISOString(), now, "locale")).toContain(
       "tomorrow",
     );
+    expect(
+      snoozeWakeDescription(localDate(2026, 4, 9, 0, 30).toISOString(), now, "locale"),
+    ).toContain("tomorrow");
     expect(snoozeWakeDescription(localDate(2026, 4, 13, 9).toISOString(), now, "locale")).toMatch(
       /Mon/,
     );
@@ -91,6 +94,15 @@ describe("snoozeWakeDescription", () => {
     );
     expect(snoozeWakeDescription(localDate(2026, 4, 8, 18).toISOString(), now, "24-hour")).toBe(
       "18:00",
+    );
+  });
+
+  it("uses calendar days across a spring daylight-saving transition", () => {
+    const transitionDay = localDate(2026, 3, 8, 10);
+    const nextCalendarDay = localDate(2026, 3, 9, 0, 30);
+
+    expect(snoozeWakeDescription(nextCalendarDay.toISOString(), transitionDay, "locale")).toContain(
+      "tomorrow",
     );
   });
 });

--- a/apps/web/src/components/Sidebar.snooze.ts
+++ b/apps/web/src/components/Sidebar.snooze.ts
@@ -45,9 +45,11 @@ export function snoozeWakeDescription(
   const wake = parseTimestampDate(snoozedUntil);
   if (wake === null) return "";
   const time = timeOfDayLabel(wake, timestampFormat);
-  const startOfToday = new Date(now);
-  startOfToday.setHours(0, 0, 0, 0);
-  const dayDelta = Math.floor((wake.getTime() - startOfToday.getTime()) / DAY_MS);
+  // Compare local calendar ordinals rather than elapsed time so a DST-shifted
+  // 23- or 25-hour day still counts as exactly one day.
+  const todayOrdinal = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+  const wakeOrdinal = Date.UTC(wake.getFullYear(), wake.getMonth(), wake.getDate());
+  const dayDelta = (wakeOrdinal - todayOrdinal) / DAY_MS;
   if (dayDelta === 0) return time;
   if (dayDelta === 1) return `tomorrow ${time}`;
   const weekday = wake.toLocaleDateString(undefined, { weekday: "short" });

--- a/apps/web/src/components/chat/ThreadErrorBanner.test.tsx
+++ b/apps/web/src/components/chat/ThreadErrorBanner.test.tsx
@@ -85,4 +85,17 @@ describe("ThreadErrorBanner", () => {
     expect(markup).toContain("h-lh w-4");
     expect(markup).toContain("h-lh self-start");
   });
+
+  it("renders automatic resume status with a dismiss action", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadErrorBanner
+        error="Usage limit reached"
+        actionDescription="Automatic resume scheduled for Aug 28, 1:10 PM."
+        onDismiss={() => {}}
+      />,
+    );
+
+    expect(markup).toContain("Automatic resume scheduled");
+    expect(markup).toContain('aria-label="Dismiss error"');
+  });
 });

--- a/apps/web/src/components/chat/ThreadErrorBanner.tsx
+++ b/apps/web/src/components/chat/ThreadErrorBanner.tsx
@@ -36,9 +36,11 @@ export function isThreadErrorBannerDismissedForSession(bannerKey: string | null)
 export const ThreadErrorBanner = memo(function ThreadErrorBanner({
   error,
   onDismiss,
+  actionDescription,
 }: {
   error: string | null;
-  onDismiss?: () => void;
+  onDismiss?: (() => void) | undefined;
+  actionDescription?: string | undefined;
 }) {
   if (!error) return null;
   return (
@@ -52,6 +54,7 @@ export const ThreadErrorBanner = memo(function ThreadErrorBanner({
               {error}
             </TooltipPopup>
           </Tooltip>
+          {actionDescription ? <div className="text-xs">{actionDescription}</div> : null}
         </AlertDescription>
         {onDismiss && (
           <AlertAction>

--- a/apps/web/src/components/settings/IntegrationsSettings.tsx
+++ b/apps/web/src/components/settings/IntegrationsSettings.tsx
@@ -25,6 +25,7 @@ import {
 import { PREVIEW_VIEWPORT_PRESETS } from "@t3tools/shared/previewViewport";
 import { InfoIcon } from "lucide-react";
 import type { ReactNode } from "react";
+import { useAtomValue } from "@effect/atom-react";
 
 import { ScreenRotationIcon } from "~/browser/ScreenRotationIcon";
 import { isElectron } from "../../env";
@@ -47,6 +48,7 @@ import {
   usePrimarySettings,
   useUpdatePrimarySettings,
 } from "~/hooks/useSettings";
+import { primaryServerConfigAtom } from "~/state/server";
 
 import {
   SettingResetButton,
@@ -501,6 +503,10 @@ function DesktopOnlyBrowserDefaults({ children }: { readonly children: ReactNode
 }
 
 export function IntegrationsSettingsPanel() {
+  const settings = usePrimarySettings();
+  const updateSettings = useUpdatePrimarySettings();
+  const supportsUsageLimitResume =
+    useAtomValue(primaryServerConfigAtom)?.environment.capabilities.threadUsageLimitResume === true;
   // Client-local preview defaults are editable only where the preview exists.
   const previewDefaultsDisabled = !isElectron;
   const previewDefaults = (
@@ -515,6 +521,23 @@ export function IntegrationsSettingsPanel() {
 
   return (
     <SettingsPageContainer>
+      {supportsUsageLimitResume ? (
+        <SettingsSection id="automatic-resume" title="Automatic resume">
+          <SettingsRow
+            {...searchableSetting("automatic-resume")}
+            description="Automatically continue after provider limits or temporary outages. Turning this off cancels pending retries in this environment. Each retry sends a continuation prompt."
+            control={
+              <Switch
+                checked={settings.enableAutomaticResume}
+                onCheckedChange={(checked) =>
+                  updateSettings({ enableAutomaticResume: Boolean(checked) })
+                }
+                aria-label="Enable automatic resume"
+              />
+            }
+          />
+        </SettingsSection>
+      ) : null}
       <SettingsSection id="browser" title="Browser">
         {/* Server-authoritative, so it stays editable on every client and sits
             outside the block covering the desktop-only defaults. */}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -552,6 +552,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.confirmQuit !== DEFAULT_UNIFIED_SETTINGS.confirmQuit ? ["Quit shortcut"] : []),
       ...(isTextGenerationModelDirty ? ["Text generation model"] : []),
       ...getChangedBrowserSettingLabels(settings),
+      ...(settings.enableAutomaticResume !== DEFAULT_UNIFIED_SETTINGS.enableAutomaticResume
+        ? ["Resume when available"]
+        : []),
       ...(settings.enableAgentBrowserAccess !== DEFAULT_UNIFIED_SETTINGS.enableAgentBrowserAccess
         ? ["Agent browser access"]
         : []),
@@ -566,6 +569,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.browserAutoShowFloatingPreview,
       settings.appearanceContrast,
       settings.enableAgentBrowserAccess,
+      settings.enableAutomaticResume,
       settings.confirmQuit,
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
@@ -704,6 +708,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       // name, so a user restoring defaults is told the agent regains access
       // rather than discovering it later.
       enableAgentBrowserAccess: DEFAULT_UNIFIED_SETTINGS.enableAgentBrowserAccess,
+      enableAutomaticResume: DEFAULT_UNIFIED_SETTINGS.enableAutomaticResume,
     });
     onRestored?.();
   }, [

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -135,6 +135,7 @@ describe("searchSettings", () => {
       canManageLocalBackend: false,
       isWslSettingsRowVisible: false,
       hasThreadAutoSettlement: false,
+      hasThreadUsageLimitResume: false,
     });
 
     const gatedIds = new Set<string>([
@@ -151,6 +152,7 @@ describe("searchSettings", () => {
       "auto-settle-inactive-threads",
       "auto-settle-merged-threads",
       "days-before-auto-settle",
+      "automatic-resume",
     ]);
     expect(available.map((item) => item.id).filter((id) => gatedIds.has(id))).toEqual([]);
   });
@@ -163,6 +165,7 @@ describe("searchSettings", () => {
       canManageLocalBackend: false,
       isWslSettingsRowVisible: false,
       hasThreadAutoSettlement: true,
+      hasThreadUsageLimitResume: false,
     });
 
     expect(searchSettings("auto-settle", available).map((item) => item.id)).toEqual([
@@ -170,6 +173,28 @@ describe("searchSettings", () => {
       "auto-settle-merged-threads",
       "days-before-auto-settle",
     ]);
+  });
+
+  it("shows automatic resume only when the server supports it", () => {
+    const base = {
+      hasCloudPublicConfig: false,
+      hasPrimaryEnvironment: false,
+      hasProviderSettingsEnvironment: false,
+      canManageLocalBackend: false,
+      isWslSettingsRowVisible: false,
+      hasThreadAutoSettlement: false,
+    };
+
+    expect(
+      filterAvailableSettingsSearchItems({ ...base, hasThreadUsageLimitResume: false }).some(
+        (item) => item.id === "automatic-resume",
+      ),
+    ).toBe(false);
+    expect(
+      filterAvailableSettingsSearchItems({ ...base, hasThreadUsageLimitResume: true }).some(
+        (item) => item.id === "automatic-resume",
+      ),
+    ).toBe(true);
   });
 
   it("keeps catalog result ids unique", () => {

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -31,6 +31,7 @@ export interface SettingsSearchItem {
   readonly localBackendManagementOnly?: boolean;
   readonly wslAvailableOnly?: boolean;
   readonly requiresThreadAutoSettlement?: boolean;
+  readonly requiresThreadUsageLimitResume?: boolean;
 }
 
 export interface SettingsSearchAvailability {
@@ -40,6 +41,7 @@ export interface SettingsSearchAvailability {
   readonly canManageLocalBackend: boolean;
   readonly isWslSettingsRowVisible: boolean;
   readonly hasThreadAutoSettlement: boolean;
+  readonly hasThreadUsageLimitResume: boolean;
 }
 
 /**
@@ -295,6 +297,13 @@ export const SETTINGS_SEARCH_ITEMS = [
     providerSettingsOnly: true,
   },
   {
+    id: "automatic-resume",
+    title: "Resume when available",
+    to: "/settings/integrations",
+    searchTerms: ["automatic retry usage limit capacity outage waiting opt out"],
+    requiresThreadUsageLimitResume: true,
+  },
+  {
     id: "agent-browser-access",
     title: "Agent browser access",
     to: "/settings/integrations",
@@ -467,7 +476,8 @@ export function filterAvailableSettingsSearchItems(
       (!item.providerSettingsOnly || availability.hasProviderSettingsEnvironment) &&
       (!item.localBackendManagementOnly || availability.canManageLocalBackend) &&
       (!item.wslAvailableOnly || availability.isWslSettingsRowVisible) &&
-      (!item.requiresThreadAutoSettlement || availability.hasThreadAutoSettlement),
+      (!item.requiresThreadAutoSettlement || availability.hasThreadAutoSettlement) &&
+      (!item.requiresThreadUsageLimitResume || availability.hasThreadUsageLimitResume),
   );
 }
 

--- a/apps/web/src/components/settings/useAvailableSettingsSearchItems.ts
+++ b/apps/web/src/components/settings/useAvailableSettingsSearchItems.ts
@@ -43,6 +43,8 @@ export function useAvailableSettingsSearchItems() {
         }),
         hasThreadAutoSettlement:
           primaryServerConfig?.environment.capabilities.threadAutoSettlement === true,
+        hasThreadUsageLimitResume:
+          primaryServerConfig?.environment.capabilities.threadUsageLimitResume === true,
       }),
     [
       canManageLocalBackend,

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -11,3 +11,23 @@ completed-turn record will not appear.
 Use **Past 24h** for an hourly chart covering the exact rolling 24-hour period. The **7 days**,
 **30 days**, and **90 days** ranges use daily resolution. Cost and token toggles update both the
 headline and chart, and refreshing rescans every connected environment.
+
+## Resume after a subscription limit
+
+Automatic resume is on by default. After a provider usage limit, spend cap, capacity error, or
+recognized temporary outage, T3 Code schedules a continuation in the same thread. A reported reset
+time takes priority, including messages such as "try again at 7:41 PM". T3 Code waits one minute
+past a parsed reset time, plus a small scheduling cushion. Without a reset time, it waits 20 minutes
+three times, one hour five times, then six hours between later attempts. Each attempt sends a real
+continuation prompt, not a status-only probe.
+
+The automatic resume is stored on the T3 Code server, so it continues across page reloads and is
+available in the desktop client. The computer hosting that server must be awake and T3 Code must be
+running for the resume to happen on time. If the server was offline, it restores the schedule when
+it starts again. Turn off **Resume when available** in **Settings → Integrations → Automatic
+resume** to cancel pending retries and disable automatic scheduling for that environment. Sending
+a new message manually also cancels the pending automatic resume.
+
+A waiting notice shows the next attempt at the bottom of the conversation, including on existing
+mobile clients. It updates as the schedule changes and disappears when waiting ends. It is not a
+response from the model, and waiting does not mean the task is complete.

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -95,6 +95,7 @@ export function applyThreadDetailEvent(
           unsettledAt: null,
           snoozedUntil: null,
           snoozedAt: null,
+          usageLimitResume: null,
           deletedAt: null,
           messages: [],
           proposedPlans: [],
@@ -171,6 +172,50 @@ export function applyThreadDetailEvent(
           ...thread,
           snoozedUntil: null,
           snoozedAt: null,
+          updatedAt: event.payload.updatedAt,
+        },
+      };
+
+    case "thread.usage-limit-resume-scheduled":
+      return {
+        kind: "updated",
+        thread: {
+          ...thread,
+          usageLimitResume: {
+            nextAttemptAt: event.payload.resumeAt,
+            ...(event.payload.pendingMessageId !== undefined
+              ? { pendingMessageId: event.payload.pendingMessageId }
+              : {}),
+            attempt: event.payload.attempt,
+          },
+          updatedAt: event.payload.updatedAt,
+        },
+      };
+
+    case "thread.usage-limit-resume-attempted":
+      return event.payload.shouldResume
+        ? {
+            kind: "updated",
+            thread: {
+              ...thread,
+              usageLimitResume: {
+                nextAttemptAt: null,
+                ...(thread.usageLimitResume?.pendingMessageId !== undefined
+                  ? { pendingMessageId: thread.usageLimitResume.pendingMessageId }
+                  : {}),
+                attempt: event.payload.attempt,
+              },
+              updatedAt: event.payload.updatedAt,
+            },
+          }
+        : { kind: "unchanged" };
+
+    case "thread.usage-limit-resume-cancelled":
+      return {
+        kind: "updated",
+        thread: {
+          ...thread,
+          usageLimitResume: null,
           updatedAt: event.payload.updatedAt,
         },
       };

--- a/packages/contracts/src/environment.test.ts
+++ b/packages/contracts/src/environment.test.ts
@@ -27,6 +27,16 @@ describe("ExecutionEnvironmentDescriptor", () => {
     ).toBe(true);
   });
 
+  it("gates usage-limit resume commands under version skew", () => {
+    expect(decodeDescriptor(descriptor).capabilities.threadUsageLimitResume).toBeUndefined();
+    expect(
+      decodeDescriptor({
+        ...descriptor,
+        capabilities: { ...descriptor.capabilities, threadUsageLimitResume: true },
+      }).capabilities.threadUsageLimitResume,
+    ).toBe(true);
+  });
+
   it("treats a missing attachment upload capability as unsupported", () => {
     expect(decodeDescriptor(descriptor).capabilities.attachmentUploads).toBeUndefined();
   });

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -73,6 +73,9 @@ export const ExecutionEnvironmentCapabilities = Schema.Struct({
       client reconnecting to one must drop published themes rather than keep
       showing a set nothing will ever update. */
   environmentThemes: Schema.optionalKey(Schema.Boolean),
+  /** Server understands durable usage-limit resume schedule/cancel commands.
+      Same version-skew contract as threadSettlement. */
+  threadUsageLimitResume: Schema.optionalKey(Schema.Boolean),
   /** Server understands thread.pin / thread.unpin commands. Same
       version-skew contract as threadSettlement. */
   threadPinning: Schema.optionalKey(Schema.Boolean),

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -347,6 +347,16 @@ export const OrchestrationSessionStatus = Schema.Literals([
 ]);
 export type OrchestrationSessionStatus = typeof OrchestrationSessionStatus.Type;
 
+export const OrchestrationRuntimeErrorClass = Schema.Literals([
+  "provider_error",
+  "usage_limit",
+  "transport_error",
+  "permission_error",
+  "validation_error",
+  "unknown",
+]);
+export type OrchestrationRuntimeErrorClass = typeof OrchestrationRuntimeErrorClass.Type;
+
 export const OrchestrationSession = Schema.Struct({
   threadId: ThreadId,
   status: OrchestrationSessionStatus,
@@ -355,6 +365,8 @@ export const OrchestrationSession = Schema.Struct({
   runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_RUNTIME_MODE))),
   activeTurnId: Schema.NullOr(TurnId),
   lastError: Schema.NullOr(TrimmedNonEmptyString),
+  lastErrorClass: Schema.optional(OrchestrationRuntimeErrorClass),
+  retryAt: Schema.optional(IsoDateTime),
   updatedAt: IsoDateTime,
 });
 export type OrchestrationSession = typeof OrchestrationSession.Type;
@@ -434,6 +446,13 @@ export const ThreadLinkedPullRequest = Schema.Struct({
 });
 export type ThreadLinkedPullRequest = typeof ThreadLinkedPullRequest.Type;
 
+export const ThreadUsageLimitResume = Schema.Struct({
+  pendingMessageId: Schema.optional(MessageId),
+  nextAttemptAt: Schema.NullOr(IsoDateTime),
+  attempt: NonNegativeInt,
+});
+export type ThreadUsageLimitResume = typeof ThreadUsageLimitResume.Type;
+
 export const OrchestrationThread = Schema.Struct({
   id: ThreadId,
   projectId: ProjectId,
@@ -465,6 +484,9 @@ export const OrchestrationThread = Schema.Struct({
   // Optional so payloads from pre-snooze servers still decode.
   snoozedUntil: Schema.optional(Schema.NullOr(IsoDateTime)),
   snoozedAt: Schema.optional(Schema.NullOr(IsoDateTime)),
+  // A server-owned deferred continuation. Optional keeps older servers and
+  // clients wire-compatible while the server persists and recovers timers.
+  usageLimitResume: Schema.optional(Schema.NullOr(ThreadUsageLimitResume)),
   // Active pinned threads render in the pinned block. Settled and snoozed
   // threads remain in their respective shelves even when pinned.
   // Optional so payloads from pre-pinning servers still decode.
@@ -534,6 +556,7 @@ export const OrchestrationThreadShell = Schema.Struct({
   unsettledAt: Schema.optional(Schema.NullOr(IsoDateTime)),
   snoozedUntil: Schema.optional(Schema.NullOr(IsoDateTime)),
   snoozedAt: Schema.optional(Schema.NullOr(IsoDateTime)),
+  usageLimitResume: Schema.optional(Schema.NullOr(ThreadUsageLimitResume)),
   pinnedAt: Schema.optional(Schema.NullOr(IsoDateTime)),
   pinOrderKey: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
   titleRegeneration: Schema.optional(Schema.NullOr(ThreadTitleRegeneration)),
@@ -810,6 +833,20 @@ const ThreadUnsnoozeCommand = Schema.Struct({
   reason: Schema.Literal("user"),
 });
 
+const ThreadUsageLimitResumeScheduleCommand = Schema.Struct({
+  pendingMessageId: Schema.optional(MessageId),
+  type: Schema.Literal("thread.usage-limit-resume.schedule"),
+  commandId: CommandId,
+  threadId: ThreadId,
+  resumeAt: IsoDateTime,
+});
+
+const ThreadUsageLimitResumeCancelCommand = Schema.Struct({
+  type: Schema.Literal("thread.usage-limit-resume.cancel"),
+  commandId: CommandId,
+  threadId: ThreadId,
+});
+
 const ThreadPinCommand = Schema.Struct({
   type: Schema.Literal("thread.pin"),
   commandId: CommandId,
@@ -997,6 +1034,8 @@ const DispatchableClientOrchestrationCommand = Schema.Union([
   ThreadUnsettleCommand,
   ThreadSnoozeCommand,
   ThreadUnsnoozeCommand,
+  ThreadUsageLimitResumeScheduleCommand,
+  ThreadUsageLimitResumeCancelCommand,
   ThreadPinCommand,
   ThreadUnpinCommand,
   ThreadPinReorderCommand,
@@ -1025,6 +1064,8 @@ export const ClientOrchestrationCommand = Schema.Union([
   ThreadUnsettleCommand,
   ThreadSnoozeCommand,
   ThreadUnsnoozeCommand,
+  ThreadUsageLimitResumeScheduleCommand,
+  ThreadUsageLimitResumeCancelCommand,
   ThreadPinCommand,
   ThreadUnpinCommand,
   ThreadPinReorderCommand,
@@ -1048,6 +1089,24 @@ const ThreadSessionSetCommand = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+const ThreadUsageLimitResumeAttemptCommand = Schema.Struct({
+  type: Schema.Literal("thread.usage-limit-resume.attempt"),
+  commandId: CommandId,
+  threadId: ThreadId,
+  expectedAttemptAt: IsoDateTime,
+  createdAt: IsoDateTime,
+});
+
+const ThreadUsageLimitResumeRetryCommand = Schema.Struct({
+  pendingMessageId: Schema.optional(MessageId),
+  type: Schema.Literal("thread.usage-limit-resume.retry"),
+  commandId: CommandId,
+  threadId: ThreadId,
+  resumeAt: IsoDateTime,
+  attempt: NonNegativeInt,
+  createdAt: IsoDateTime,
+});
+
 const ThreadMessageAssistantDeltaCommand = Schema.Struct({
   type: Schema.Literal("thread.message.assistant.delta"),
   commandId: CommandId,
@@ -1060,6 +1119,7 @@ const ThreadMessageAssistantDeltaCommand = Schema.Struct({
 
 const ThreadMessageAssistantCompleteCommand = Schema.Struct({
   type: Schema.Literal("thread.message.assistant.complete"),
+  text: Schema.optional(Schema.String),
   commandId: CommandId,
   threadId: ThreadId,
   messageId: MessageId,
@@ -1115,6 +1175,8 @@ const ThreadTitleRegenerationCompleteCommand = Schema.Struct({
 
 const InternalOrchestrationCommand = Schema.Union([
   ThreadAutoSettleCommand,
+  ThreadUsageLimitResumeAttemptCommand,
+  ThreadUsageLimitResumeRetryCommand,
   ThreadSessionSetCommand,
   ThreadMessageAssistantDeltaCommand,
   ThreadMessageAssistantCompleteCommand,
@@ -1144,6 +1206,9 @@ export const OrchestrationEventType = Schema.Literals([
   "thread.unsettled",
   "thread.snoozed",
   "thread.unsnoozed",
+  "thread.usage-limit-resume-scheduled",
+  "thread.usage-limit-resume-cancelled",
+  "thread.usage-limit-resume-attempted",
   "thread.pinned",
   "thread.unpinned",
   "thread.pin-reordered",
@@ -1256,6 +1321,27 @@ export const ThreadUnsnoozedPayload = Schema.Struct({
   // thread.unsettled's activity resets. Timer wakes emit no event: clients
   // derive them from snoozedUntil passing.
   reason: Schema.Literals(["user", "activity"]),
+  updatedAt: IsoDateTime,
+});
+
+export const ThreadUsageLimitResumeScheduledPayload = Schema.Struct({
+  pendingMessageId: Schema.optional(MessageId),
+  threadId: ThreadId,
+  resumeAt: IsoDateTime,
+  attempt: NonNegativeInt,
+  updatedAt: IsoDateTime,
+});
+
+export const ThreadUsageLimitResumeCancelledPayload = Schema.Struct({
+  threadId: ThreadId,
+  updatedAt: IsoDateTime,
+});
+
+export const ThreadUsageLimitResumeAttemptedPayload = Schema.Struct({
+  threadId: ThreadId,
+  expectedAttemptAt: IsoDateTime,
+  attempt: NonNegativeInt,
+  shouldResume: Schema.Boolean,
   updatedAt: IsoDateTime,
 });
 
@@ -1486,6 +1572,21 @@ export const OrchestrationEvent = Schema.Union([
     ...EventBaseFields,
     type: Schema.Literal("thread.unsnoozed"),
     payload: ThreadUnsnoozedPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.usage-limit-resume-scheduled"),
+    payload: ThreadUsageLimitResumeScheduledPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.usage-limit-resume-cancelled"),
+    payload: ThreadUsageLimitResumeCancelledPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.usage-limit-resume-attempted"),
+    payload: ThreadUsageLimitResumeAttemptedPayload,
   }),
   Schema.Struct({
     ...EventBaseFields,

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -93,8 +93,9 @@ export type RuntimeContentStreamKind = typeof RuntimeContentStreamKind.Type;
 const RuntimeSessionExitKind = Schema.Literals(["graceful", "error"]);
 export type RuntimeSessionExitKind = typeof RuntimeSessionExitKind.Type;
 
-const RuntimeErrorClass = Schema.Literals([
+export const RuntimeErrorClass = Schema.Literals([
   "provider_error",
+  "usage_limit",
   "transport_error",
   "permission_error",
   "validation_error",
@@ -777,6 +778,7 @@ export type RuntimeWarningPayload = typeof RuntimeWarningPayload.Type;
 const RuntimeErrorPayload = Schema.Struct({
   message: TrimmedNonEmptyStringSchema,
   class: Schema.optional(RuntimeErrorClass),
+  retryAt: Schema.optional(IsoDateTime),
   detail: Schema.optional(Schema.Unknown),
 });
 export type RuntimeErrorPayload = typeof RuntimeErrorPayload.Type;

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -21,6 +21,14 @@ const decodeServerSettingsPatch = Schema.decodeUnknownSync(ServerSettingsPatch);
 const encodeServerSettings = Schema.encodeSync(ServerSettings);
 const decodeClaudeSettings = Schema.decodeUnknownSync(ClaudeSettings);
 
+it("defaults automatic resume on and preserves a persisted opt-out", () => {
+  expect(decodeServerSettings({}).enableAutomaticResume).toBe(true);
+  expect(decodeServerSettings({ enableAutomaticResume: false }).enableAutomaticResume).toBe(false);
+  expect(decodeServerSettingsPatch({ enableAutomaticResume: false })).toEqual({
+    enableAutomaticResume: false,
+  });
+});
+
 describe("ClaudeSettings auto-compaction", () => {
   it("uses Claude's default threshold when no override is configured", () => {
     expect(decodeClaudeSettings({}).autoCompactWindow).toBe("");

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -653,6 +653,7 @@ export const BackgroundActivitySettings = Schema.Struct({
 export type BackgroundActivitySettings = typeof BackgroundActivitySettings.Type;
 
 export const ServerSettings = Schema.Struct({
+  enableAutomaticResume: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   // Legacy token-by-token assistant output. Deliberately a fresh key (was
   // `enableAssistantStreaming`): decoding drops the old key, so everyone,
   // including prior opt-ins, resets to the buffered default.
@@ -897,6 +898,7 @@ const OpenCodeSettingsPatch = Schema.Struct({
 });
 
 export const ServerSettingsPatch = Schema.Struct({
+  enableAutomaticResume: Schema.optionalKey(Schema.Boolean),
   // Server settings
   enableLegacyTokenStreaming: Schema.optionalKey(Schema.Boolean),
   enableProviderUpdateChecks: Schema.optionalKey(Schema.Boolean),

--- a/packages/shared/src/agentAwareness.test.ts
+++ b/packages/shared/src/agentAwareness.test.ts
@@ -177,4 +177,35 @@ describe("projectThreadAwareness", () => {
       detail: "Provider process exited.",
     });
   });
+
+  it("projects scheduled usage-limit retries as active instead of repeated failures", () => {
+    const resumeAt = "2099-01-01T14:11:00.000Z";
+    const state = projectThreadAwareness({
+      environmentId: "env-1" as EnvironmentId,
+      project,
+      thread: thread({
+        session: {
+          threadId: "thread-1" as ThreadId,
+          status: "error",
+          providerName: "Codex",
+          runtimeMode: "full-access",
+          activeTurnId: null,
+          lastError: "Usage limit reached",
+          lastErrorClass: "usage_limit",
+          updatedAt: NOW,
+        },
+        usageLimitResume: { nextAttemptAt: resumeAt, attempt: 1 },
+      }),
+    });
+
+    expect(state).toMatchObject({
+      phase: "running",
+      headline: `Automatic resume ${new Intl.DateTimeFormat(undefined, {
+        weekday: "short",
+        hour: "numeric",
+        minute: "2-digit",
+      }).format(Date.parse(resumeAt))}`,
+      detail: "Waiting for provider capacity.",
+    });
+  });
 });

--- a/packages/shared/src/agentAwareness.ts
+++ b/packages/shared/src/agentAwareness.ts
@@ -37,6 +37,7 @@ export interface ProjectThreadAwarenessInput {
     | "modelSelection"
     | "session"
     | "latestTurn"
+    | "usageLimitResume"
     | "updatedAt"
     | "hasPendingApprovals"
     | "hasPendingUserInput"
@@ -66,7 +67,7 @@ export function projectThreadAwareness(
     projectTitle: project.title,
     threadTitle: thread.title,
     phase,
-    headline: headlineForPhase(phase),
+    headline: usageLimitResumeHeadline(thread) ?? headlineForPhase(phase),
     ...(detail === undefined ? {} : { detail }),
     modelTitle: thread.modelSelection.model,
     updatedAt: thread.updatedAt,
@@ -82,6 +83,13 @@ function resolveThreadAwarenessPhase(
   }
   if (thread.hasPendingUserInput) {
     return "waiting_for_input";
+  }
+  if (
+    thread.session?.status === "error" &&
+    thread.session.lastErrorClass === "usage_limit" &&
+    thread.usageLimitResume != null
+  ) {
+    return "running";
   }
   if (thread.session?.status === "error" || thread.latestTurn?.state === "error") {
     return "failed";
@@ -116,6 +124,23 @@ function resolveThreadAwarenessPhase(
   return null;
 }
 
+const resumeTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  weekday: "short",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+function usageLimitResumeHeadline(
+  thread: ProjectThreadAwarenessInput["thread"],
+): string | undefined {
+  if (thread.session?.lastErrorClass !== "usage_limit" || thread.usageLimitResume == null)
+    return undefined;
+  const resumeAt = thread.usageLimitResume?.nextAttemptAt;
+  return resumeAt === null || resumeAt === undefined
+    ? "Resuming automatically"
+    : `Automatic resume ${resumeTimeFormatter.format(Date.parse(resumeAt))}`;
+}
+
 function headlineForPhase(phase: AgentAwarenessPhase): string {
   switch (phase) {
     case "starting":
@@ -139,6 +164,9 @@ function detailForPhase(
   phase: AgentAwarenessPhase,
   thread: ProjectThreadAwarenessInput["thread"],
 ): string | undefined {
+  if (thread.session?.lastErrorClass === "usage_limit" && thread.usageLimitResume != null) {
+    return "Waiting for provider capacity.";
+  }
   if (phase === "failed") {
     return thread.session?.lastError ?? undefined;
   }


### PR DESCRIPTION
## What Changed

Updated code is on the fork branch at `2a004458d`. GitHub currently refuses to reopen this closed PR (HTTP 422), so its cached diff still shows the previous head. Maintainer help is requested in the comments.

Builds on #8577 with default-on, server-side resume for unfinished provider work. Users can turn it off in Settings. Explicit reset times take priority; AM/PM messages get a one-minute cushion. Without a reset time, retries wait 20 minutes three times, one hour five times, then six hours.

Schedules survive restarts and cannot be silently cancelled by inactivity-based settlement. Each attempt sends a real prompt. If the provider rejected the original input, the retry retains that message and its attachments.

Released mobile clients receive ordinary message events, not new resume-only event tags. A waiting notice shows the next attempt at the end of the conversation and clears when waiting ends. Repeated retry failures do not add more error activities. Web and desktop expose the setting only when the connected server supports it.

## Why

Provider limits leave unattended tasks unfinished for hours. Server-side scheduling lets work resume without keeping a client connected or repeatedly checking it manually. The increasing intervals limit traffic during long waits.

We have used iterations of this patch for roughly a week on multiple production clients by monkeypatching the official 0.0.37 and 0.0.38 releases. That use exposed mobile compatibility and scheduling bugs that informed these corrections. It is useful production experience, not a claim that every revision was regression-free.

The scope remains one feature and adds no dependencies. It reuses existing messages, settings, and event storage. The cross-surface diff is not small; I have left that checklist item unchecked rather than claiming otherwise. This revision rebases the work onto current main and addresses the Grok retry, 404 classification, and automatic-settlement review findings.

## UI Changes

Before: not applicable. The automatic waiting notice and setting did not exist in the official release.

After: the supplied mobile and desktop screenshots show the notice running in production, with its earlier wording. Upload through the requested Safari session is still pending; those images are not yet attached here. No interaction video is available yet.

The desktop error banner is dismissible. Released mobile binaries do not gain new native controls or status enums from this server patch; their waiting notice uses the existing message format.

## Validation

- 241 focused tests passed after rebasing onto main at `4664c572a`, including the full Codex adapter file, reactor, ingestion, settlement, and reset parser. Server and web typechecks passed.
- Mobile stream filtering and snapshot coverage passed. Earlier checks against unmodified 0.0.38 schemas accepted the message/event and settings extension; this does not establish compatibility with every mobile version.
- The exact 0.0.40 release port passed 235 focused tests and server typecheck. Web/server builds passed. A copy of the installed database migrated and passed SQLite's integrity check; the packaged server served the app successfully.
- The 0.0.40 local bundle is signed, notarized, installed, and running after desktop launch verification. Its installed ASAR header hash matches the verified build. These latest corrections have not accumulated a week of production use.

## Checklist

- [ ] This PR is small and focused (one feature, but a large cross-surface diff)
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (before is not applicable; after upload pending)
- [ ] I included a video for animation/interaction changes

Implemented with Codex in T3 Code, using GPT-5.6 Luna implementation subagents and primary-agent review.
