### PR TITLE
feat(mobile): start a new thread on an existing branch

### DIFF
--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -214,6 +214,17 @@ export function HomeRouteScreen() {
           onSelectThread={handleSelectThread}
           onSelectPendingTask={openPendingTask}
           onDeletePendingTask={confirmDeletePendingTask}
+          onNewThreadOnBranch={(thread) => {
+            navigation.navigate("NewTaskSheet", {
+              screen: "NewTaskDraft",
+              params: {
+                environmentId: String(thread.environmentId),
+                projectId: String(thread.projectId),
+                branch: thread.branch,
+                worktreePath: thread.worktreePath,
+              },
+            });
+          }}
           onNewThreadInProject={(project) => {
             navigation.navigate("NewTaskSheet", {
               screen: "NewTaskDraft",

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -124,6 +124,7 @@ interface HomeScreenProps {
   readonly onRegenerateThreadTitle: (thread: EnvironmentThreadShell) => Promise<boolean>;
   readonly onSelectPendingTask: (pendingTask: PendingNewTask) => void;
   readonly onDeletePendingTask: (pendingTask: PendingNewTask) => void;
+  readonly onNewThreadOnBranch: (thread: EnvironmentThreadShell) => void;
   readonly onNewThreadInProject: (project: EnvironmentProject) => void;
 }
 
@@ -824,6 +825,7 @@ export function HomeScreen(props: HomeScreenProps) {
       const movedId = `${thread.environmentId}:${thread.id}`;
       return (
         <ThreadListV2Row
+          onNewThreadOnBranch={props.onNewThreadOnBranch}
           thread={thread}
           variant={item.item.variant}
           hasQueuedMessages={queuedThreadKeys.has(movedId)}
@@ -911,6 +913,7 @@ export function HomeScreen(props: HomeScreenProps) {
       props.onDeletePendingTask,
       props.onSelectPendingTask,
       props.onSelectThread,
+      props.onNewThreadOnBranch,
       props.savedConnectionsById,
       serverConfigs,
       shelfPreferencesLoaded,
@@ -1001,6 +1004,7 @@ export function HomeScreen(props: HomeScreenProps) {
           const thread = item.thread;
           return (
             <ThreadListRow
+              onNewThreadOnBranch={props.onNewThreadOnBranch}
               variant="compact"
               thread={thread}
               hasQueuedMessages={queuedThreadKeys.has(`${thread.environmentId}:${thread.id}`)}
@@ -1050,6 +1054,7 @@ export function HomeScreen(props: HomeScreenProps) {
       props.onNewThreadInProject,
       props.onSelectPendingTask,
       props.onSelectThread,
+      props.onNewThreadOnBranch,
       props.searchQuery,
       props.savedConnectionsById,
       threadSearchMatchByKey,

--- a/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
+++ b/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
@@ -449,6 +449,21 @@ function AdaptiveWorkspaceLayoutContent(
     });
   }, [navigation]);
 
+  const handleNewThreadOnBranch = useCallback(
+    (thread: EnvironmentThreadShell) => {
+      navigation.navigate("NewTaskSheet", {
+        screen: "NewTaskDraft",
+        params: {
+          environmentId: String(thread.environmentId),
+          projectId: String(thread.projectId),
+          branch: thread.branch,
+          worktreePath: thread.worktreePath,
+        },
+      });
+    },
+    [navigation],
+  );
+
   const handleNewThreadInProject = useCallback(
     (project: EnvironmentProject) => {
       navigation.navigate("NewTaskSheet", {
@@ -543,6 +558,7 @@ function AdaptiveWorkspaceLayoutContent(
                     onOpenSettings={handleOpenSettings}
                     onOpenEnvironmentSettings={handleOpenEnvironmentSettings}
                     onNewThreadInProject={handleNewThreadInProject}
+                    onNewThreadOnBranch={handleNewThreadOnBranch}
                     onSelectThread={handleSelectThread}
                     onSearchQueryChange={setPrimarySidebarSearchQuery}
                     searchQuery={primarySidebarSearchQuery}

--- a/apps/mobile/src/features/threads/NewTaskContextPickerScreens.tsx
+++ b/apps/mobile/src/features/threads/NewTaskContextPickerScreens.tsx
@@ -35,7 +35,7 @@ import {
   NATIVE_MAIL_SEARCH_TOOLBAR_SUPPORTED,
 } from "../layout/native-mail-search-toolbar";
 import { branchBadgeLabel, useNewTaskFlow } from "./new-task-flow-provider";
-import { shouldCheckoutNewTaskBranch } from "./new-task-context-presentation";
+import { checkoutNewTaskBranch } from "./checkout-new-task-branch";
 
 function SelectionRow(props: {
   readonly icon?: "arrow.triangle.branch" | ReactNode;
@@ -257,43 +257,29 @@ export function NewTaskBranchPickerRouteScreen() {
       void Haptics.selectionAsync();
 
       try {
-        let selectedBranch = branch;
-        const needsCheckout = shouldCheckoutNewTaskBranch({
-          branchIsCurrent: branch.current,
-          branchWorktreePath: branch.worktreePath,
+        if (!flow.selectedProject) return;
+        setSwitchingBranchName(branch.name);
+        const result = await checkoutNewTaskBranch({
+          branch,
+          project: flow.selectedProject,
           workspaceMode: flow.workspaceMode,
+          switchRef,
         });
-        if (needsCheckout && flow.selectedProject) {
-          setSwitchingBranchName(branch.name);
-          const result = await switchRef({
-            environmentId: flow.selectedProject.environmentId,
-            input: {
-              cwd: flow.selectedProject.workspaceRoot,
-              refName: branch.name,
-            },
-          });
-          if (result._tag === "Failure") {
-            if (mountedRef.current && navigation.isFocused() && !isAtomCommandInterrupted(result)) {
-              const error = squashAtomCommandFailure(result);
-              Alert.alert(
-                "Could not switch branch",
-                error instanceof Error ? error.message : "The branch could not be checked out.",
-              );
-            }
-            return;
+        if (result._tag === "Failure") {
+          if (mountedRef.current && navigation.isFocused() && !isAtomCommandInterrupted(result)) {
+            const error = squashAtomCommandFailure(result);
+            Alert.alert(
+              "Could not switch branch",
+              error instanceof Error ? error.message : "The branch could not be checked out.",
+            );
           }
-          selectedBranch = {
-            ...branch,
-            current: true,
-            isRemote: false,
-            name: result.value.refName ?? branch.name,
-          };
+          return;
         }
 
         // The checkout has already changed the repository. Persist the matching
         // draft selection even if the native sheet was dismissed while the
         // command was in flight; only visible-screen work is focus-gated below.
-        flow.selectBranch(selectedBranch);
+        flow.selectBranch(result.value);
         if (!mountedRef.current || !navigation.isFocused()) {
           return;
         }

--- a/apps/mobile/src/features/threads/NewTaskDraftRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftRouteScreen.tsx
@@ -7,6 +7,8 @@ import { NewTaskDraftScreen } from "./NewTaskDraftScreen";
 type NewTaskDraftRouteParams = {
   readonly environmentId?: string | string[];
   readonly projectId?: string | string[];
+  readonly branch?: string | null;
+  readonly worktreePath?: string | null;
   readonly title?: string | string[];
   readonly pendingTaskId?: string | string[];
   readonly draftId?: string | string[];
@@ -25,6 +27,8 @@ export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraf
         ? params.environmentId[0]
         : params.environmentId,
       projectId: Array.isArray(params.projectId) ? params.projectId[0] : params.projectId,
+      branch: params.branch,
+      worktreePath: params.worktreePath,
     }),
     [route.params],
   );

--- a/apps/mobile/src/features/threads/NewTaskDraftRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftRouteScreen.tsx
@@ -1,5 +1,5 @@
 import { useNavigation, usePreventRemove, type StaticScreenProps } from "@react-navigation/native";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Alert, View } from "react-native";
 import {
   isAtomCommandInterrupted,
@@ -8,6 +8,7 @@ import {
 import { AppText as Text } from "../../components/AppText";
 import { useProjects } from "../../state/entities";
 import { useAtomCommand } from "../../state/use-atom-command";
+import { useWorkspaceState } from "../../state/workspace";
 import { vcsEnvironment } from "../../state/vcs";
 import { checkoutNewTaskBranch } from "./checkout-new-task-branch";
 import { NativeStackScreenOptions } from "../../native/StackHeader";
@@ -32,6 +33,7 @@ export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraf
     : params.pendingTaskId;
   const draftId = Array.isArray(params.draftId) ? params.draftId[0] : params.draftId;
   const projects = useProjects();
+  const { state: catalogState } = useWorkspaceState();
   const navigation = useNavigation();
   const switchRef = useAtomCommand(vcsEnvironment.switchRef, { reportFailure: false });
 
@@ -65,31 +67,52 @@ export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraf
   const needsPreparation = Boolean(initialProjectRef.branch && !pendingTaskId && !draftId);
 
   const [pendingCheckouts, setPendingCheckouts] = useState(0);
+  const checkoutTail = useRef(Promise.resolve());
+  const waitingForProject =
+    !project &&
+    (catalogState.isLoadingConnections ||
+      (!catalogState.hasLoadedShellSnapshot &&
+        catalogState.hasConnectingEnvironment &&
+        catalogState.connectionError === null));
 
   useEffect(() => {
-    if (!needsPreparation || !initialProjectRef.branch) return;
+    if (!needsPreparation || !initialProjectRef.branch || waitingForProject) return;
+    const branchName = initialProjectRef.branch;
     let active = true;
     setPendingCheckouts((count) => count + 1);
-    void checkoutNewTaskBranch({
-      // A thread's branch is historical; only switchRef can establish that
-      // the shared project checkout now matches it.
-      branch: {
-        name: initialProjectRef.branch,
-        current: false,
-        isDefault: false,
-        worktreePath: initialProjectRef.worktreePath ?? null,
-      },
-      project: environmentId && workspaceRoot ? { environmentId, workspaceRoot } : null,
-      workspaceMode: "local",
-      switchRef,
-    }).then((result) => {
+    // Serialize replacements: ignoring a stale result cannot undo its Git mutation.
+    checkoutTail.current = checkoutTail.current.then(async () => {
+      if (!active) {
+        setPendingCheckouts((count) => count - 1);
+        return;
+      }
+      const result = await checkoutNewTaskBranch({
+        // A thread's branch is historical; only switchRef can establish that
+        // the shared project checkout now matches it.
+        branch: {
+          name: branchName,
+          current: false,
+          isDefault: false,
+          worktreePath: initialProjectRef.worktreePath ?? null,
+        },
+        project: environmentId && workspaceRoot ? { environmentId, workspaceRoot } : null,
+        workspaceMode: "local",
+        switchRef,
+      });
       setPendingCheckouts((count) => count - 1);
       if (active) setPreparation({ request: initialProjectRef, result, workspaceRoot });
     });
     return () => {
       active = false;
     };
-  }, [environmentId, workspaceRoot, initialProjectRef, needsPreparation, switchRef]);
+  }, [
+    environmentId,
+    workspaceRoot,
+    initialProjectRef,
+    needsPreparation,
+    switchRef,
+    waitingForProject,
+  ]);
 
   const result =
     preparation?.request === initialProjectRef && preparation.workspaceRoot === workspaceRoot

--- a/apps/mobile/src/features/threads/NewTaskDraftRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftRouteScreen.tsx
@@ -1,5 +1,15 @@
-import type { StaticScreenProps } from "@react-navigation/native";
-import { useMemo } from "react";
+import { useNavigation, type StaticScreenProps } from "@react-navigation/native";
+import { useEffect, useMemo, useState } from "react";
+import { Alert, View } from "react-native";
+import {
+  isAtomCommandInterrupted,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
+import { AppText as Text } from "../../components/AppText";
+import { useProjects } from "../../state/entities";
+import { useAtomCommand } from "../../state/use-atom-command";
+import { vcsEnvironment } from "../../state/vcs";
+import { checkoutNewTaskBranch } from "./checkout-new-task-branch";
 import { NativeStackScreenOptions } from "../../native/StackHeader";
 
 import { NewTaskDraftScreen } from "./NewTaskDraftScreen";
@@ -16,7 +26,10 @@ type NewTaskDraftRouteParams = {
 };
 
 export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraftRouteParams>) {
-  const params = route.params ?? {};
+  const params = useMemo(() => route.params ?? {}, [route.params]);
+  const projects = useProjects();
+  const navigation = useNavigation();
+  const switchRef = useAtomCommand(vcsEnvironment.switchRef, { reportFailure: false });
 
   // Keyed on the params object so a fresh navigation to this (already
   // mounted) screen produces a new reference, letting the draft screen
@@ -30,8 +43,70 @@ export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraf
       branch: params.branch,
       worktreePath: params.worktreePath,
     }),
-    [route.params],
+    [params],
   );
+
+  const [preparedProject, setPreparedProject] = useState<{
+    request: typeof initialProjectRef;
+    projectRef: typeof initialProjectRef;
+    workspaceRoot: string;
+  } | null>(null);
+  const project = projects.find(
+    (candidate) =>
+      candidate.environmentId === initialProjectRef.environmentId &&
+      candidate.id === initialProjectRef.projectId,
+  );
+  const environmentId = project?.environmentId;
+  const workspaceRoot = project?.workspaceRoot;
+  const needsPreparation = Boolean(
+    initialProjectRef.branch && !params.pendingTaskId && !params.draftId,
+  );
+
+  useEffect(() => {
+    if (!needsPreparation || !initialProjectRef.branch || !environmentId || !workspaceRoot) return;
+    let active = true;
+    void checkoutNewTaskBranch({
+      // A thread's branch is historical; only switchRef can establish that
+      // the shared project checkout now matches it.
+      branch: {
+        name: initialProjectRef.branch,
+        current: false,
+        isDefault: false,
+        worktreePath: initialProjectRef.worktreePath ?? null,
+      },
+      project: { environmentId, workspaceRoot },
+      workspaceMode: "local",
+      switchRef,
+    }).then((result) => {
+      if (!active) return;
+      if (result._tag === "Failure") {
+        if (!isAtomCommandInterrupted(result)) {
+          const error = squashAtomCommandFailure(result);
+          Alert.alert(
+            "Could not switch branch",
+            error instanceof Error ? error.message : "The branch could not be checked out.",
+          );
+        }
+        navigation.goBack();
+        return;
+      }
+      setPreparedProject({
+        request: initialProjectRef,
+        projectRef: { ...initialProjectRef, branch: result.value.name },
+        workspaceRoot,
+      });
+    });
+    return () => {
+      active = false;
+    };
+  }, [environmentId, workspaceRoot, initialProjectRef, needsPreparation, navigation, switchRef]);
+
+  // Do not mount the composer, restore its draft, or expose send/queue actions
+  // until this exact navigation's checkout has succeeded.
+  const prepared =
+    preparedProject?.request === initialProjectRef &&
+    preparedProject.workspaceRoot === workspaceRoot;
+  const preparingBranch = needsPreparation && !prepared;
 
   return (
     <>
@@ -40,16 +115,24 @@ export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraf
           title: Array.isArray(params.title) ? params.title[0] : (params.title ?? "New task"),
         }}
       />
-      <NewTaskDraftScreen
-        initialProjectRef={initialProjectRef}
-        incomingShareId={
-          Array.isArray(params.incomingShareId) ? params.incomingShareId[0] : params.incomingShareId
-        }
-        pendingTaskId={
-          Array.isArray(params.pendingTaskId) ? params.pendingTaskId[0] : params.pendingTaskId
-        }
-        draftId={Array.isArray(params.draftId) ? params.draftId[0] : params.draftId}
-      />
+      {preparingBranch ? (
+        <View className="flex-1 items-center justify-center bg-screen">
+          <Text className="text-foreground">Switching branch...</Text>
+        </View>
+      ) : (
+        <NewTaskDraftScreen
+          initialProjectRef={prepared ? preparedProject.projectRef : initialProjectRef}
+          incomingShareId={
+            Array.isArray(params.incomingShareId)
+              ? params.incomingShareId[0]
+              : params.incomingShareId
+          }
+          pendingTaskId={
+            Array.isArray(params.pendingTaskId) ? params.pendingTaskId[0] : params.pendingTaskId
+          }
+          draftId={Array.isArray(params.draftId) ? params.draftId[0] : params.draftId}
+        />
+      )}
     </>
   );
 }

--- a/apps/mobile/src/features/threads/NewTaskDraftRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftRouteScreen.tsx
@@ -27,6 +27,10 @@ type NewTaskDraftRouteParams = {
 
 export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraftRouteParams>) {
   const params = useMemo(() => route.params ?? {}, [route.params]);
+  const pendingTaskId = Array.isArray(params.pendingTaskId)
+    ? params.pendingTaskId[0]
+    : params.pendingTaskId;
+  const draftId = Array.isArray(params.draftId) ? params.draftId[0] : params.draftId;
   const projects = useProjects();
   const navigation = useNavigation();
   const switchRef = useAtomCommand(vcsEnvironment.switchRef, { reportFailure: false });
@@ -49,7 +53,7 @@ export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraf
   const [preparedProject, setPreparedProject] = useState<{
     request: typeof initialProjectRef;
     projectRef: typeof initialProjectRef;
-    workspaceRoot: string;
+    workspaceRoot: string | undefined;
   } | null>(null);
   const project = projects.find(
     (candidate) =>
@@ -58,12 +62,10 @@ export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraf
   );
   const environmentId = project?.environmentId;
   const workspaceRoot = project?.workspaceRoot;
-  const needsPreparation = Boolean(
-    initialProjectRef.branch && !params.pendingTaskId && !params.draftId,
-  );
+  const needsPreparation = Boolean(initialProjectRef.branch && !pendingTaskId && !draftId);
 
   useEffect(() => {
-    if (!needsPreparation || !initialProjectRef.branch || !environmentId || !workspaceRoot) return;
+    if (!needsPreparation || !initialProjectRef.branch) return;
     let active = true;
     void checkoutNewTaskBranch({
       // A thread's branch is historical; only switchRef can establish that
@@ -74,7 +76,7 @@ export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraf
         isDefault: false,
         worktreePath: initialProjectRef.worktreePath ?? null,
       },
-      project: { environmentId, workspaceRoot },
+      project: environmentId && workspaceRoot ? { environmentId, workspaceRoot } : null,
       workspaceMode: "local",
       switchRef,
     }).then((result) => {
@@ -127,10 +129,8 @@ export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraf
               ? params.incomingShareId[0]
               : params.incomingShareId
           }
-          pendingTaskId={
-            Array.isArray(params.pendingTaskId) ? params.pendingTaskId[0] : params.pendingTaskId
-          }
-          draftId={Array.isArray(params.draftId) ? params.draftId[0] : params.draftId}
+          pendingTaskId={pendingTaskId}
+          draftId={draftId}
         />
       )}
     </>

--- a/apps/mobile/src/features/threads/NewTaskDraftRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftRouteScreen.tsx
@@ -1,4 +1,4 @@
-import { useNavigation, type StaticScreenProps } from "@react-navigation/native";
+import { useNavigation, usePreventRemove, type StaticScreenProps } from "@react-navigation/native";
 import { useEffect, useMemo, useState } from "react";
 import { Alert, View } from "react-native";
 import {
@@ -50,9 +50,9 @@ export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraf
     [params],
   );
 
-  const [preparedProject, setPreparedProject] = useState<{
+  const [preparation, setPreparation] = useState<{
     request: typeof initialProjectRef;
-    projectRef: typeof initialProjectRef;
+    result: Awaited<ReturnType<typeof checkoutNewTaskBranch>>;
     workspaceRoot: string | undefined;
   } | null>(null);
   const project = projects.find(
@@ -64,9 +64,12 @@ export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraf
   const workspaceRoot = project?.workspaceRoot;
   const needsPreparation = Boolean(initialProjectRef.branch && !pendingTaskId && !draftId);
 
+  const [pendingCheckouts, setPendingCheckouts] = useState(0);
+
   useEffect(() => {
     if (!needsPreparation || !initialProjectRef.branch) return;
     let active = true;
+    setPendingCheckouts((count) => count + 1);
     void checkoutNewTaskBranch({
       // A thread's branch is historical; only switchRef can establish that
       // the shared project checkout now matches it.
@@ -80,35 +83,43 @@ export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraf
       workspaceMode: "local",
       switchRef,
     }).then((result) => {
-      if (!active) return;
-      if (result._tag === "Failure") {
-        if (!isAtomCommandInterrupted(result)) {
-          const error = squashAtomCommandFailure(result);
-          Alert.alert(
-            "Could not switch branch",
-            error instanceof Error ? error.message : "The branch could not be checked out.",
-          );
-        }
-        navigation.goBack();
-        return;
-      }
-      setPreparedProject({
-        request: initialProjectRef,
-        projectRef: { ...initialProjectRef, branch: result.value.name },
-        workspaceRoot,
-      });
+      setPendingCheckouts((count) => count - 1);
+      if (active) setPreparation({ request: initialProjectRef, result, workspaceRoot });
     });
     return () => {
       active = false;
     };
-  }, [environmentId, workspaceRoot, initialProjectRef, needsPreparation, navigation, switchRef]);
+  }, [environmentId, workspaceRoot, initialProjectRef, needsPreparation, switchRef]);
 
-  // Do not mount the composer, restore its draft, or expose send/queue actions
-  // until this exact navigation's checkout has succeeded.
-  const prepared =
-    preparedProject?.request === initialProjectRef &&
-    preparedProject.workspaceRoot === workspaceRoot;
-  const preparingBranch = needsPreparation && !prepared;
+  const result =
+    preparation?.request === initialProjectRef && preparation.workspaceRoot === workspaceRoot
+      ? preparation.result
+      : null;
+  // The native-stack guard covers iOS swipe dismissal as well as back actions.
+  // A replaced request must settle too before the shared checkout is left behind.
+  const checkoutPending = pendingCheckouts > 0 || (needsPreparation && result === null);
+  usePreventRemove(checkoutPending, () => undefined);
+  useEffect(() => {
+    if (checkoutPending || result?._tag !== "Failure") return;
+    if (!isAtomCommandInterrupted(result)) {
+      const error = squashAtomCommandFailure(result);
+      Alert.alert(
+        "Could not switch branch",
+        error instanceof Error ? error.message : "The branch could not be checked out.",
+      );
+    }
+    navigation.goBack();
+  }, [checkoutPending, result, navigation]);
+
+  const preparedProjectRef = useMemo(
+    () =>
+      result?._tag === "Success"
+        ? { ...initialProjectRef, branch: result.value.name }
+        : initialProjectRef,
+    [initialProjectRef, result],
+  );
+  // Send/queue remain unavailable on failure while the unlocked route closes.
+  const preparingBranch = checkoutPending || (needsPreparation && result?._tag !== "Success");
 
   return (
     <>
@@ -123,7 +134,7 @@ export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraf
         </View>
       ) : (
         <NewTaskDraftScreen
-          initialProjectRef={prepared ? preparedProject.projectRef : initialProjectRef}
+          initialProjectRef={preparedProjectRef}
           incomingShareId={
             Array.isArray(params.incomingShareId)
               ? params.incomingShareId[0]

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -82,6 +82,7 @@ import {
   getComposerDraftSnapshot,
   mergeComposerDraftContent,
   restoreComposerDraftSnapshot,
+  updateComposerDraftSettings,
   scheduleUnusedComposerAttachmentCleanup,
   type ComposerDraft,
   waitForComposerDraftsLoaded,
@@ -149,6 +150,8 @@ export function NewTaskDraftScreen(props: {
   readonly initialProjectRef?: {
     readonly environmentId?: string;
     readonly projectId?: string;
+    readonly branch?: string | null;
+    readonly worktreePath?: string | null;
   };
   /** Queued outbox message id when editing an existing pending task. */
   readonly pendingTaskId?: string;
@@ -537,6 +540,18 @@ export function NewTaskDraftScreen(props: {
           return;
         }
         appliedInitialProjectKeyRef.current = directProjectKey;
+        if (props.initialProjectRef?.branch) {
+          // Mobile's local mode also reuses an existing worktree. Worktree mode
+          // creates a new one, which would lose the source thread's workspace.
+          updateComposerDraftSettings(`new-task:${directProjectKey}`, {
+            workspaceSelection: {
+              mode: "local",
+              branch: props.initialProjectRef.branch,
+              worktreePath: props.initialProjectRef.worktreePath ?? null,
+              startFromOrigin: false,
+            },
+          });
+        }
         if (
           selectedProject?.environmentId === directProject.environmentId &&
           selectedProject.id === directProject.id

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -539,11 +539,18 @@ export function NewTaskDraftScreen(props: {
         if (appliedInitialProjectKeyRef.current === directProjectKey) {
           return;
         }
-        appliedInitialProjectKeyRef.current = directProjectKey;
         if (props.initialProjectRef?.branch) {
-          // Mobile's local mode also reuses an existing worktree. Worktree mode
-          // creates a new one, which would lose the source thread's workspace.
-          updateComposerDraftSettings(`new-task:${directProjectKey}`, {
+          if (
+            selectedProject?.environmentId !== directProject.environmentId ||
+            selectedProject.id !== directProject.id
+          ) {
+            setProject(directProject);
+            return;
+          }
+          if (!flow.draftKey) return;
+          // The route completes checkout before mounting this composer. Local
+          // mode reuses an existing worktree; worktree mode would create another.
+          updateComposerDraftSettings(flow.draftKey, {
             workspaceSelection: {
               mode: "local",
               branch: props.initialProjectRef.branch,
@@ -552,6 +559,7 @@ export function NewTaskDraftScreen(props: {
             },
           });
         }
+        appliedInitialProjectKeyRef.current = directProjectKey;
         if (
           selectedProject?.environmentId === directProject.environmentId &&
           selectedProject.id === directProject.id
@@ -584,6 +592,7 @@ export function NewTaskDraftScreen(props: {
   }, [
     projectScopes,
     projects,
+    flow.draftKey,
     props.initialProjectRef,
     props.incomingShareId,
     props.pendingTaskId,

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -103,6 +103,7 @@ interface ThreadNavigationSidebarProps {
   readonly selectedThreadKey: string | null;
   readonly onOpenSettings: () => void;
   readonly onOpenEnvironmentSettings: () => void;
+  readonly onNewThreadOnBranch: (thread: EnvironmentThreadShell) => void;
   readonly onNewThreadInProject: (project: EnvironmentProject) => void;
   readonly onSearchQueryChange: (query: string) => void;
   readonly onSelectThread: (thread: EnvironmentThreadShell) => void;
@@ -890,6 +891,7 @@ function ThreadNavigationSidebarPane(
           const scopeKey = scopedProjectKey(thread.environmentId, thread.projectId);
           return (
             <ThreadListV2Row
+              onNewThreadOnBranch={props.onNewThreadOnBranch}
               thread={thread}
               variant={item.item.variant}
               hasQueuedMessages={queuedThreadKeys.has(`${thread.environmentId}:${thread.id}`)}
@@ -1024,6 +1026,7 @@ function ThreadNavigationSidebarPane(
           const thread = item.thread;
           return (
             <ThreadListRow
+              onNewThreadOnBranch={props.onNewThreadOnBranch}
               variant="sidebar"
               thread={thread}
               hasQueuedMessages={queuedThreadKeys.has(`${thread.environmentId}:${thread.id}`)}
@@ -1087,6 +1090,7 @@ function ThreadNavigationSidebarPane(
       projectTitleByProjectKey,
       regenerateThreadTitle,
       props.onNewThreadInProject,
+      props.onNewThreadOnBranch,
       props.searchQuery,
       props.selectedThreadKey,
       props.width,

--- a/apps/mobile/src/features/threads/checkout-new-task-branch.test.ts
+++ b/apps/mobile/src/features/threads/checkout-new-task-branch.test.ts
@@ -1,0 +1,117 @@
+import * as NodeChildProcess from "node:child_process";
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeUtil from "node:util";
+import { EnvironmentId } from "@t3tools/contracts";
+import { settlePromise, squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+
+import { checkoutNewTaskBranch } from "./checkout-new-task-branch";
+
+const exec = NodeUtil.promisify(NodeChildProcess.execFile);
+let directory: string;
+let cwd: string;
+const git = (...args: string[]) => exec("git", ["-C", cwd, ...args]);
+const branch = { name: "feature/a", current: false, isDefault: false, worktreePath: null };
+const environmentId = EnvironmentId.make("branch-test-environment");
+
+beforeEach(async () => {
+  directory = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3-branch-selection-"));
+  cwd = NodePath.join(directory, "project");
+  await exec("git", ["init", "-b", "main", cwd]);
+  await git("config", "user.name", "Branch test");
+  await git("config", "user.email", "branch-test@example.com");
+  await NodeFSP.writeFile(NodePath.join(cwd, "file.txt"), "main\n");
+  await git("add", ".");
+  await git("commit", "-m", "main");
+  await git("checkout", "-b", branch.name);
+  await NodeFSP.writeFile(NodePath.join(cwd, "file.txt"), "feature\n");
+  await git("commit", "-am", "feature");
+  await git("checkout", "main");
+});
+
+afterEach(async () => {
+  await NodeFSP.rm(directory, { recursive: true, force: true });
+});
+
+function selectBranch(switchRef: Parameters<typeof checkoutNewTaskBranch>[0]["switchRef"]) {
+  return checkoutNewTaskBranch({
+    branch,
+    project: { environmentId, workspaceRoot: cwd },
+    workspaceMode: "local",
+    switchRef,
+  });
+}
+
+const switchRef: Parameters<typeof checkoutNewTaskBranch>[0]["switchRef"] = (request) =>
+  settlePromise(async () => {
+    expect(request.environmentId).toBe(environmentId);
+    await exec("git", ["-C", request.input.cwd, "checkout", request.input.refName]);
+    const { stdout } = await exec("git", ["-C", request.input.cwd, "branch", "--show-current"]);
+    return { refName: stdout.trim() };
+  });
+
+describe("new-task branch checkout", () => {
+  it("switches main to the older thread's feature branch before returning a selection", async () => {
+    const result = await selectBranch(switchRef);
+    expect(result._tag).toBe("Success");
+    if (result._tag !== "Success") throw new Error("Checkout failed");
+    expect(result.value.name).toBe("feature/a");
+    expect(result.value.current).toBe(true);
+    expect((await git("branch", "--show-current")).stdout.trim()).toBe("feature/a");
+    expect(await NodeFSP.readFile(NodePath.join(cwd, "file.txt"), "utf8")).toBe("feature\n");
+  });
+
+  it("does not release the selection while checkout is still pending", async () => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    let completed = false;
+    const selection = selectBranch(async (request) => {
+      entered.resolve();
+      await release.promise;
+      return switchRef(request);
+    }).then((result) => {
+      completed = true;
+      return result;
+    });
+    await entered.promise;
+    expect(completed).toBe(false);
+    expect((await git("branch", "--show-current")).stdout.trim()).toBe("main");
+    release.resolve();
+    expect((await selection)._tag).toBe("Success");
+    expect((await git("branch", "--show-current")).stdout.trim()).toBe("feature/a");
+  });
+
+  it("returns checkout failure without selecting the branch or losing dirty files", async () => {
+    await NodeFSP.writeFile(NodePath.join(cwd, "file.txt"), "unsaved local changes\n");
+    const result = await selectBranch(switchRef);
+    expect(result._tag).toBe("Failure");
+    if (result._tag !== "Failure") throw new Error("Expected checkout to fail");
+    expect(String(squashAtomCommandFailure(result))).toContain("would be overwritten");
+    expect((await git("branch", "--show-current")).stdout.trim()).toBe("main");
+    expect(await NodeFSP.readFile(NodePath.join(cwd, "file.txt"), "utf8")).toBe(
+      "unsaved local changes\n",
+    );
+  });
+
+  it("reuses an existing worktree without switching the project checkout", async () => {
+    const worktreePath = NodePath.join(directory, "worktree");
+    await git("worktree", "add", worktreePath, "feature/a");
+    const result = await checkoutNewTaskBranch({
+      branch: { ...branch, worktreePath },
+      project: { environmentId, workspaceRoot: cwd },
+      workspaceMode: "local",
+      switchRef: () => {
+        throw new Error("Existing worktrees must not switch the project checkout");
+      },
+    });
+    expect(result._tag).toBe("Success");
+    if (result._tag !== "Success") throw new Error("Worktree selection failed");
+    expect(result.value.worktreePath).toBe(worktreePath);
+    expect((await git("branch", "--show-current")).stdout.trim()).toBe("main");
+    expect(await NodeFSP.readFile(NodePath.join(worktreePath, "file.txt"), "utf8")).toBe(
+      "feature\n",
+    );
+  });
+});

--- a/apps/mobile/src/features/threads/checkout-new-task-branch.test.ts
+++ b/apps/mobile/src/features/threads/checkout-new-task-branch.test.ts
@@ -95,6 +95,21 @@ describe("new-task branch checkout", () => {
     );
   });
 
+  it("fails when the source project is unavailable instead of releasing a composer selection", async () => {
+    const result = await checkoutNewTaskBranch({
+      branch,
+      project: null,
+      workspaceMode: "local",
+      switchRef: () => {
+        throw new Error("An unavailable project must not run checkout");
+      },
+    });
+    expect(result._tag).toBe("Failure");
+    if (result._tag !== "Failure") throw new Error("Expected an unavailable-project failure");
+    expect(String(squashAtomCommandFailure(result))).toContain("selected project is unavailable");
+    expect((await git("branch", "--show-current")).stdout.trim()).toBe("main");
+  });
+
   it("reuses an existing worktree without switching the project checkout", async () => {
     const worktreePath = NodePath.join(directory, "worktree");
     await git("worktree", "add", worktreePath, "feature/a");

--- a/apps/mobile/src/features/threads/checkout-new-task-branch.ts
+++ b/apps/mobile/src/features/threads/checkout-new-task-branch.ts
@@ -5,6 +5,7 @@ import {
   mapAtomCommandResult,
 } from "@t3tools/client-runtime/state/runtime";
 import type { VcsSwitchRefInput, VcsSwitchRefResult } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
 
 import { shouldCheckoutNewTaskBranch } from "./new-task-context-presentation";
@@ -13,13 +14,18 @@ import { shouldCheckoutNewTaskBranch } from "./new-task-context-presentation";
  * and new-worktree base selections already identify a separate workspace. */
 export async function checkoutNewTaskBranch<E>(input: {
   readonly branch: VcsRef;
-  readonly project: Pick<EnvironmentProject, "environmentId" | "workspaceRoot">;
+  readonly project: Pick<EnvironmentProject, "environmentId" | "workspaceRoot"> | null;
   readonly workspaceMode: "local" | "worktree";
   readonly switchRef: (request: {
     readonly environmentId: EnvironmentProject["environmentId"];
     readonly input: VcsSwitchRefInput;
   }) => Promise<AtomCommandResult<VcsSwitchRefResult, E>>;
-}): Promise<AtomCommandResult<VcsRef, E>> {
+}): Promise<AtomCommandResult<VcsRef, E | Error>> {
+  if (!input.project) {
+    return AsyncResult.failure(
+      Cause.fail(new Error("The selected project is unavailable. Reconnect and try again.")),
+    );
+  }
   if (
     !shouldCheckoutNewTaskBranch({
       branchIsCurrent: input.branch.current,

--- a/apps/mobile/src/features/threads/checkout-new-task-branch.ts
+++ b/apps/mobile/src/features/threads/checkout-new-task-branch.ts
@@ -1,0 +1,43 @@
+import type { EnvironmentProject } from "@t3tools/client-runtime/state/shell";
+import type { VcsRef } from "@t3tools/client-runtime/state/vcs";
+import {
+  type AtomCommandResult,
+  mapAtomCommandResult,
+} from "@t3tools/client-runtime/state/runtime";
+import type { VcsSwitchRefInput, VcsSwitchRefResult } from "@t3tools/contracts";
+import { AsyncResult } from "effect/unstable/reactivity";
+
+import { shouldCheckoutNewTaskBranch } from "./new-task-context-presentation";
+
+/** Resolve a composer branch only after its checkout succeeds. Existing worktrees
+ * and new-worktree base selections already identify a separate workspace. */
+export async function checkoutNewTaskBranch<E>(input: {
+  readonly branch: VcsRef;
+  readonly project: Pick<EnvironmentProject, "environmentId" | "workspaceRoot">;
+  readonly workspaceMode: "local" | "worktree";
+  readonly switchRef: (request: {
+    readonly environmentId: EnvironmentProject["environmentId"];
+    readonly input: VcsSwitchRefInput;
+  }) => Promise<AtomCommandResult<VcsSwitchRefResult, E>>;
+}): Promise<AtomCommandResult<VcsRef, E>> {
+  if (
+    !shouldCheckoutNewTaskBranch({
+      branchIsCurrent: input.branch.current,
+      branchWorktreePath: input.branch.worktreePath,
+      workspaceMode: input.workspaceMode,
+    })
+  ) {
+    return AsyncResult.success(input.branch);
+  }
+
+  const result = await input.switchRef({
+    environmentId: input.project.environmentId,
+    input: { cwd: input.project.workspaceRoot, refName: input.branch.name },
+  });
+  return mapAtomCommandResult(result, (value) => ({
+    ...input.branch,
+    current: true,
+    isRemote: false,
+    name: value.refName ?? input.branch.name,
+  }));
+}

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -8,7 +8,7 @@ import type { EnvironmentMachineKind } from "@t3tools/contracts";
 import type { MenuAction } from "@react-native-menu/menu";
 import { SymbolView } from "../../components/AppSymbol";
 import { memo, useCallback, useMemo, type ComponentProps } from "react";
-import { Pressable, useWindowDimensions, View } from "react-native";
+import { Platform, Pressable, useWindowDimensions, View } from "react-native";
 import type { SwipeableMethods } from "react-native-gesture-handler/ReanimatedSwipeable";
 import { useAppearancePreferences } from "../settings/appearance/AppearancePreferencesProvider";
 import Svg, { Circle, Path } from "react-native-svg";
@@ -453,6 +453,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   readonly onSelectThread: (thread: EnvironmentThreadShell) => void;
   readonly onArchiveThread: (thread: EnvironmentThreadShell) => void;
   readonly onDeleteThread: (thread: EnvironmentThreadShell) => void;
+  readonly onNewThreadOnBranch: (thread: EnvironmentThreadShell) => void;
   readonly onRegenerateThreadTitle: (thread: EnvironmentThreadShell) => void;
   readonly titleRegenerationSupported: boolean;
   readonly onSwipeableWillOpen: (methods: SwipeableMethods) => void;
@@ -476,8 +477,14 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   const selectedBackgroundColor = theme["--color-user-bubble"];
   const selectedForegroundColor = theme["--color-user-bubble-foreground"];
 
-  const { thread, onSelectThread, onArchiveThread, onDeleteThread, onRegenerateThreadTitle } =
-    props;
+  const {
+    thread,
+    onSelectThread,
+    onArchiveThread,
+    onDeleteThread,
+    onRegenerateThreadTitle,
+    onNewThreadOnBranch,
+  } = props;
   const status = resolveThreadStatus(thread);
   const pr = useThreadPr(thread);
   const timestamp = relativeTime(
@@ -515,6 +522,16 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   );
   const menuActions = useMemo<MenuAction[]>(
     () => [
+      ...(thread.branch
+        ? [
+            {
+              id: "new-thread-on-branch",
+              title:
+                Platform.OS === "ios" ? "New thread on branch" : `New thread on ${thread.branch}`,
+              image: "square.and.pencil",
+            },
+          ]
+        : []),
       THREAD_ROW_MENU_ACTIONS[0]!,
       ...buildThreadTitleRegenerationMenuItems({
         supported: props.titleRegenerationSupported,
@@ -522,7 +539,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
       }),
       THREAD_ROW_MENU_ACTIONS[1]!,
     ],
-    [props.titleRegenerationSupported, thread.titleRegeneration],
+    [props.titleRegenerationSupported, thread.branch, thread.titleRegeneration],
   );
   const primaryAction = useMemo(
     () => ({
@@ -535,11 +552,12 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   );
   const handleMenuAction = useCallback(
     ({ nativeEvent }: { readonly nativeEvent: { readonly event: string } }) => {
+      if (nativeEvent.event === "new-thread-on-branch") onNewThreadOnBranch(thread);
       if (nativeEvent.event === "archive") handleArchive();
       if (nativeEvent.event === "regenerate-title") handleRegenerateTitle();
       if (nativeEvent.event === "delete") handleDelete();
     },
-    [handleArchive, handleDelete, handleRegenerateTitle],
+    [handleArchive, handleDelete, handleRegenerateTitle, onNewThreadOnBranch, thread],
   );
 
   const statusPill = effectiveStatus ? (

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -373,6 +373,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
   readonly fullSwipeWidth?: number;
   readonly onSelectThread: (thread: EnvironmentThreadShell) => void;
   readonly onDeleteThread: (thread: EnvironmentThreadShell) => void;
+  readonly onNewThreadOnBranch: (thread: EnvironmentThreadShell) => void;
   readonly onRegenerateThreadTitle: (thread: EnvironmentThreadShell) => void;
   readonly onSettleThread: (thread: EnvironmentThreadShell) => Promise<boolean>;
   readonly onSnoozeThread: (thread: EnvironmentThreadShell, snoozedUntil: string) => void;
@@ -412,6 +413,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
     onSelectThread,
     onDeleteThread,
     onRegenerateThreadTitle,
+    onNewThreadOnBranch,
     onSettleThread,
     onSnoozeThread,
     onUnsnoozeThread,
@@ -589,6 +591,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
   );
   const handleMenuAction = useCallback(
     ({ nativeEvent }: { readonly nativeEvent: { readonly event: string } }) => {
+      if (nativeEvent.event === "new-thread-on-branch") onNewThreadOnBranch(thread);
       if (nativeEvent.event === "settle") handleSettle();
       if (nativeEvent.event === "unsettle") handleUnsettle();
       if (nativeEvent.event === "unsnooze") handleUnsnooze();
@@ -611,6 +614,8 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
       }
     },
     [
+      onNewThreadOnBranch,
+      thread,
       handleArchive,
       handleDelete,
       handleRegenerateTitle,
@@ -979,8 +984,20 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
       >
         {(close) => (
           <ControlPillMenu
-            actions={
-              snoozedRow
+            actions={[
+              ...(thread.branch
+                ? [
+                    {
+                      id: "new-thread-on-branch",
+                      title:
+                        Platform.OS === "ios"
+                          ? "New thread on branch"
+                          : `New thread on ${thread.branch}`,
+                      image: "square.and.pencil",
+                    },
+                  ]
+                : []),
+              ...(snoozedRow
                 ? snoozedMenuActions
                 : !props.settlementSupported
                   ? legacyMenuActions
@@ -988,8 +1005,8 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
                     ? slimMenuActions
                     : swipeActions.secondary === "snooze"
                       ? snoozableCardMenuActions
-                      : cardMenuActions
-            }
+                      : cardMenuActions),
+            ]}
             onPressAction={handleMenuAction}
             shouldOpenOnLongPress
           >

--- a/apps/mobile/src/lib/projectThreadStartTurn.test.ts
+++ b/apps/mobile/src/lib/projectThreadStartTurn.test.ts
@@ -66,3 +66,38 @@ describe("project thread title", () => {
     expect(input.message.text).toBe(text);
   });
 });
+
+describe("new thread on an existing branch", () => {
+  it.each([null, "/worktrees/existing"])(
+    "reuses the selected workspace %s without preparing a new worktree",
+    (worktreePath) => {
+      const input = buildProjectThreadStartTurnInput({
+        projectId: ProjectId.make("project"),
+        projectCwd: "/workspace",
+        threadId: "new-thread",
+        commandId: "command",
+        messageId: "message",
+        createdAt: "2026-09-06T00:00:00Z",
+        text: "Start fresh",
+        uploadedAttachments: [],
+        modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.6-sol" },
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        workspaceMode: "local",
+        branch: "feature/existing",
+        worktreePath,
+        startFromOrigin: false,
+        worktreeBranchName: "unused",
+      });
+
+      expect(input.bootstrap.createThread).toMatchObject({
+        projectId: "project",
+        branch: "feature/existing",
+        worktreePath,
+      });
+      expect(input.bootstrap).not.toHaveProperty("prepareWorktree");
+      expect(input.bootstrap).not.toHaveProperty("runSetupScript");
+      expect(input.threadId).toBe("new-thread");
+    },
+  );
+});


### PR DESCRIPTION
Mobile users cannot start a new conversation on an existing thread's branch from its long-press menu.

Add the action to both mobile list layouts and carry the environment, project, branch, and existing worktree into the composer. iOS uses “New thread on branch”; the action appears only for threads with a branch.

For a local checkout, reuse the branch picker's `switchRef` path before mounting the composer. Send and queue remain unavailable until checkout succeeds. A checkout failure shows the Git error and returns to the list. Existing worktrees are reused without switching the project checkout.

Validated with 20 focused tests and mobile TypeScript checks. Real Git tests cover main-to-feature checkout, pending checkout, dirty-file checkout failure, missing projects, and existing-worktree reuse. The original feature was built and recorded on an iPhone 15 Pro Max; the checkout correction has not been rebuilt on iOS.

https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/e0264c93-ff2e-468c-9d50-89c3334eacc0/new-thread-on-branch-ios.mp4

Built with GPT-6 in Codex, running through T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add "New thread on branch" action to mobile thread list and draft flow
> - Adds a "New thread on branch" context-menu action to both V2 and legacy thread rows, wired through `HomeScreen`, `ThreadNavigationSidebar`, and `AdaptiveWorkspaceLayout` to open the new-task draft with branch and worktree context
> - Introduces `checkoutNewTaskBranch` helper in [checkout-new-task-branch.ts](https://github.com/pingdotgg/t3code/pull/10359/files#diff-687ce6d9808858eb6913b216137617d04fa0c2f1e96dc5c2ce10bfca869594d6) that rejects unavailable projects, skips switching for existing worktrees, and returns a checked-out branch selection only after the VCS switch command succeeds
> - `NewTaskDraftRouteScreen` now checks out the selected branch before mounting the composer, serializes checkout requests, shows a switching state, and alerts + closes on checkout failure; pending-task and existing-draft routes bypass this preparation
> - `NewTaskBranchPickerRouteScreen` delegates checkout to the shared helper and persists the returned VCS selection before navigating back
> - Risk: `NewTaskDraftRouteScreen` blocks native-stack route removal while checkout is pending; a stuck checkout could prevent the user from dismissing the draft screen
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ba0048.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Start a new thread directly from an existing branch through thread menus.
  - Carry branch, project, and worktree details into the new thread setup.
  - Reuse existing worktrees when creating a thread on a branch.

- **Bug Fixes**
  - Improved branch switching and checkout handling during new thread creation.
  - Added loading and error handling when a branch cannot be prepared.
  - Preserved pending selections and local changes during checkout operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->