### PR TITLE
fix(codex): accept misalignment policy errors on thread resume

### DIFF
--- a/packages/effect-codex-app-server/scripts/generate.ts
+++ b/packages/effect-codex-app-server/scripts/generate.ts
@@ -194,17 +194,28 @@ const Codex0150DefinitionSchemas: Record<string, Schema.Json> = {
   },
 };
 
+// Pinned protocol JSON omits later CodexErrorInfo variants. Keep historical
+// thread payloads decodable; do not fold unknown values into "other".
+const CodexErrorInfoCompatibilityValues = [
+  "rateLimitExceeded",
+  "misalignmentPolicyViolation",
+] as const;
+
+const CodexErrorInfoCompatibilityExports = new Set([
+  "V2ThreadReadResponse",
+  "V2ThreadResumeResponse",
+  "V2ThreadRollbackResponse",
+  "V2ThreadForkResponse",
+  "V2TurnCompletedNotification",
+]);
+
 function applyCodex0151DefinitionCompatibility(
   exportName: string,
   definitionName: string,
   definitionSchema: Schema.Json,
 ): Schema.Json {
-  const isThreadResponse =
-    exportName === "V2ThreadReadResponse" ||
-    exportName === "V2ThreadResumeResponse" ||
-    exportName === "V2ThreadRollbackResponse";
   if (
-    !isThreadResponse ||
+    !CodexErrorInfoCompatibilityExports.has(exportName) ||
     definitionName !== "CodexErrorInfo" ||
     typeof definitionSchema !== "object"
   ) {
@@ -215,16 +226,28 @@ function applyCodex0151DefinitionCompatibility(
     readonly oneOf?: ReadonlyArray<{ readonly enum?: ReadonlyArray<string> }>;
   };
   const [firstVariant, ...remainingVariants] = schema.oneOf ?? [];
-  if (!firstVariant?.enum || firstVariant.enum.includes("rateLimitExceeded")) {
+  const currentEnum = firstVariant?.enum;
+  if (!currentEnum) {
     return definitionSchema;
   }
 
+  const missingValues = CodexErrorInfoCompatibilityValues.filter(
+    (value) => !currentEnum.includes(value),
+  );
+  if (missingValues.length === 0) {
+    return definitionSchema;
+  }
+
+  const enumValues = [...currentEnum];
+  const otherIndex = enumValues.indexOf("other");
+  const nextEnum =
+    otherIndex === -1
+      ? [...enumValues, ...missingValues]
+      : [...enumValues.slice(0, otherIndex), ...missingValues, ...enumValues.slice(otherIndex)];
+
   return {
     ...definitionSchema,
-    oneOf: [
-      { ...firstVariant, enum: [...firstVariant.enum, "rateLimitExceeded"] },
-      ...remainingVariants,
-    ],
+    oneOf: [{ ...firstVariant, enum: nextEnum }, ...remainingVariants],
   };
 }
 

--- a/packages/effect-codex-app-server/src/_generated/schema.gen.ts
+++ b/packages/effect-codex-app-server/src/_generated/schema.gen.ts
@@ -15947,6 +15947,8 @@ export type V2ThreadForkResponse__CodexErrorInfo =
   | "badRequest"
   | "threadRollbackFailed"
   | "sandboxError"
+  | "rateLimitExceeded"
+  | "misalignmentPolicyViolation"
   | "other"
   | { readonly httpConnectionFailed: { readonly httpStatusCode?: number | null } }
   | { readonly responseStreamConnectionFailed: { readonly httpStatusCode?: number | null } }
@@ -15970,6 +15972,8 @@ export const V2ThreadForkResponse__CodexErrorInfo = Schema.Union(
       "badRequest",
       "threadRollbackFailed",
       "sandboxError",
+      "rateLimitExceeded",
+      "misalignmentPolicyViolation",
       "other",
     ]),
     Schema.Struct({
@@ -16855,6 +16859,7 @@ export type V2ThreadReadResponse__CodexErrorInfo =
   | "threadRollbackFailed"
   | "sandboxError"
   | "rateLimitExceeded"
+  | "misalignmentPolicyViolation"
   | "other"
   | { readonly httpConnectionFailed: { readonly httpStatusCode?: number | null } }
   | { readonly responseStreamConnectionFailed: { readonly httpStatusCode?: number | null } }
@@ -16879,6 +16884,7 @@ export const V2ThreadReadResponse__CodexErrorInfo = Schema.Union(
       "threadRollbackFailed",
       "sandboxError",
       "rateLimitExceeded",
+      "misalignmentPolicyViolation",
       "other",
     ]),
     Schema.Struct({
@@ -17210,6 +17216,7 @@ export type V2ThreadResumeResponse__CodexErrorInfo =
   | "threadRollbackFailed"
   | "sandboxError"
   | "rateLimitExceeded"
+  | "misalignmentPolicyViolation"
   | "other"
   | { readonly httpConnectionFailed: { readonly httpStatusCode?: number | null } }
   | { readonly responseStreamConnectionFailed: { readonly httpStatusCode?: number | null } }
@@ -17234,6 +17241,7 @@ export const V2ThreadResumeResponse__CodexErrorInfo = Schema.Union(
       "threadRollbackFailed",
       "sandboxError",
       "rateLimitExceeded",
+      "misalignmentPolicyViolation",
       "other",
     ]),
     Schema.Struct({
@@ -17490,6 +17498,7 @@ export type V2ThreadRollbackResponse__CodexErrorInfo =
   | "threadRollbackFailed"
   | "sandboxError"
   | "rateLimitExceeded"
+  | "misalignmentPolicyViolation"
   | "other"
   | { readonly httpConnectionFailed: { readonly httpStatusCode?: number | null } }
   | { readonly responseStreamConnectionFailed: { readonly httpStatusCode?: number | null } }
@@ -17514,6 +17523,7 @@ export const V2ThreadRollbackResponse__CodexErrorInfo = Schema.Union(
       "threadRollbackFailed",
       "sandboxError",
       "rateLimitExceeded",
+      "misalignmentPolicyViolation",
       "other",
     ]),
     Schema.Struct({
@@ -18713,6 +18723,8 @@ export type V2TurnCompletedNotification__CodexErrorInfo =
   | "badRequest"
   | "threadRollbackFailed"
   | "sandboxError"
+  | "rateLimitExceeded"
+  | "misalignmentPolicyViolation"
   | "other"
   | { readonly httpConnectionFailed: { readonly httpStatusCode?: number | null } }
   | { readonly responseStreamConnectionFailed: { readonly httpStatusCode?: number | null } }
@@ -18736,6 +18748,8 @@ export const V2TurnCompletedNotification__CodexErrorInfo = Schema.Union(
       "badRequest",
       "threadRollbackFailed",
       "sandboxError",
+      "rateLimitExceeded",
+      "misalignmentPolicyViolation",
       "other",
     ]),
     Schema.Struct({

--- a/packages/effect-codex-app-server/src/schema.test.ts
+++ b/packages/effect-codex-app-server/src/schema.test.ts
@@ -7,6 +7,9 @@ const isGetAccountResponse = Schema.is(CodexSchema.V2GetAccountResponse);
 const isThreadReadResponse = Schema.is(CodexSchema.V2ThreadReadResponse);
 const isThreadResumeResponse = Schema.is(CodexSchema.V2ThreadResumeResponse);
 const isThreadRollbackResponse = Schema.is(CodexSchema.V2ThreadRollbackResponse);
+const isThreadForkResponse = Schema.is(CodexSchema.V2ThreadForkResponse);
+const isTurnCompletedNotification = Schema.is(CodexSchema.V2TurnCompletedNotification);
+const decodeThreadResumeResponse = Schema.decodeUnknownSync(CodexSchema.V2ThreadResumeResponse);
 
 it("keeps async questions in live notifications and thread history", () => {
   const item = {
@@ -139,6 +142,63 @@ it("accepts Codex rate limit errors for thread responses", () => {
     true,
   );
   assert.equal(isThreadRollbackResponse({ thread: failedThread }), true);
+});
+
+it("accepts Codex misalignment policy errors for thread responses", () => {
+  const failedThread = {
+    cliVersion: "0.150.0",
+    createdAt: 0,
+    cwd: "/tmp/project",
+    ephemeral: false,
+    id: "thread-1",
+    modelProvider: "openai",
+    preview: "",
+    sessionId: "session-1",
+    source: "cli",
+    status: { type: "idle" },
+    turns: [
+      {
+        error: {
+          codexErrorInfo: "misalignmentPolicyViolation",
+          message: "Misalignment policy violation",
+        },
+        id: "turn-1",
+        items: [],
+        status: "failed",
+      },
+    ],
+    updatedAt: 0,
+  };
+  const resumeLikeResponse = {
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    cwd: "/tmp/project",
+    model: "gpt-5.6-sol",
+    modelProvider: "openai",
+    sandbox: { type: "dangerFullAccess" },
+    thread: failedThread,
+  };
+  assert.equal(isThreadReadResponse({ thread: failedThread }), true);
+  assert.equal(isThreadResumeResponse(resumeLikeResponse), true);
+  assert.equal(isThreadRollbackResponse({ thread: failedThread }), true);
+  assert.equal(isThreadForkResponse(resumeLikeResponse), true);
+  const decodedResume = decodeThreadResumeResponse(resumeLikeResponse);
+  assert.equal(decodedResume.thread.turns[0]?.error?.codexErrorInfo, "misalignmentPolicyViolation");
+  assert.equal(
+    isTurnCompletedNotification({
+      threadId: "thread-1",
+      turn: {
+        error: {
+          codexErrorInfo: "misalignmentPolicyViolation",
+          message: "Misalignment policy violation",
+        },
+        id: "turn-1",
+        items: [],
+        status: "failed",
+      },
+    }),
+    true,
+  );
 });
 
 it("accepts Codex 0.150 account plan values", () => {


### PR DESCRIPTION
## What Changed

`thread/resume` (and the matching read, rollback, fork, and `turn/completed` schemas) now accept Codex `codexErrorInfo: "misalignmentPolicyViolation"`.

The generator compatibility override keeps that value on the next protocol refresh, next to the existing `rateLimitExceeded` exception. Decode preserves the variant; it is not folded into `other`.

## Why

[#10362](https://github.com/pingdotgg/t3code/issues/10362): a persisted failed turn with `misalignmentPolicyViolation` was rejected while decoding `thread/resume`. That decode failure is not treated as recoverable, so the conversation could not be opened.

Same pattern as [#8897](https://github.com/pingdotgg/t3code/pull/8897) for `rateLimitExceeded`. The pinned Codex protocol ref does not include this value yet; current `openai/codex` does. T3 should still accept the historical value so the thread can be opened and the blocked status kept.

Fixes #10362

## UI Changes

None. Schema decode only.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (not applicable)

Grok 4.6 (Grok Build)