### PR TITLE
fix(web): keep screenshots when attaching preview annotations

### DIFF
--- a/apps/web/src/components/preview/PreviewView.test.tsx
+++ b/apps/web/src/components/preview/PreviewView.test.tsx
@@ -342,7 +342,7 @@ describe("PreviewView navigation", () => {
     mocks.closePictureInPicture.mockClear();
     mocks.pickElement.mockReset();
     mocks.capturePreviewAnnotationScreenshot.mockReset();
-    mocks.capturePreviewAnnotationScreenshot.mockResolvedValue({ status: "none" });
+    mocks.capturePreviewAnnotationScreenshot.mockReturnValue({ status: "none" });
     mocks.addPreviewAnnotation.mockClear();
     vi.mocked(toastManager.add).mockClear();
     mocks.addImage.mockClear();
@@ -601,7 +601,7 @@ describe("PreviewView navigation", () => {
     };
     const onSendAnnotation = vi.fn();
     mocks.pickElement.mockResolvedValue({ annotation, submission: "send" });
-    mocks.capturePreviewAnnotationScreenshot.mockResolvedValue({ status: "failed" });
+    mocks.capturePreviewAnnotationScreenshot.mockReturnValue({ status: "failed" });
 
     renderToStaticMarkup(
       <PreviewView

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -599,7 +599,7 @@ export function PreviewView({
         // instead of holding the composer for an attachment that never lands.
         // The stored copy drops the screenshot on failure, otherwise the prompt
         // would tell the agent a crop is attached when none was sent.
-        const capture = await capturePreviewAnnotationScreenshot(picked);
+        const capture = capturePreviewAnnotationScreenshot(picked);
         // Main reports a crop that failed or timed out on its side; the local
         // conversion can fail too. Either way the user should hear about it.
         const cropDropped = screenshotFailed || capture.status === "failed";

--- a/apps/web/src/lib/imageCompression.ts
+++ b/apps/web/src/lib/imageCompression.ts
@@ -170,7 +170,7 @@ function dataUrlByteLength(dataUrl: string): number {
 }
 
 /** Base64 payload of a data URL decoded back into a `File`. */
-function dataUrlToFile(dataUrl: string, name: string, mimeType: string): File {
+export function dataUrlToFile(dataUrl: string, name: string, mimeType: string): File {
   const payload = dataUrl.slice(dataUrl.indexOf(",") + 1);
   const binary = atob(payload);
   const bytes = new Uint8Array(binary.length);

--- a/apps/web/src/lib/previewAnnotation.test.ts
+++ b/apps/web/src/lib/previewAnnotation.test.ts
@@ -89,33 +89,38 @@ describe("preview annotations", () => {
 
 describe("preview annotation capture", () => {
   afterEach(() => {
-    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
-  it("returns the crop when the fetch resolves", async () => {
-    vi.stubGlobal("fetch", async () => new Response(new Blob(["png"], { type: "image/png" })));
-    const capture = await capturePreviewAnnotationScreenshot(annotation);
-    expect(capture.status).toBe("captured");
-  });
-
-  it("reports none when the annotation carries no crop", async () => {
-    const capture = await capturePreviewAnnotationScreenshot({ ...annotation, screenshot: null });
-    expect(capture).toEqual({ status: "none" });
-  });
-
-  it("fails instead of hanging when the crop never arrives", async () => {
-    vi.useFakeTimers();
-    vi.stubGlobal("fetch", () => new Promise<Response>(() => {}));
-    const capturePromise = capturePreviewAnnotationScreenshot(annotation, 1_000);
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(await capturePromise).toEqual({ status: "failed" });
-  });
-
-  it("fails when the crop fetch throws", async () => {
-    vi.stubGlobal("fetch", async () => {
-      throw new Error("data url unreadable");
+  it("decodes the screenshot when desktop CSP blocks data URL fetches", async () => {
+    vi.stubGlobal("fetch", () => {
+      throw new TypeError("Refused to connect because it violates Content Security Policy");
     });
-    expect(await capturePreviewAnnotationScreenshot(annotation)).toEqual({ status: "failed" });
+    const capture = capturePreviewAnnotationScreenshot(annotation);
+    expect(capture.status).toBe("captured");
+    if (capture.status !== "captured") throw new Error("Screenshot was dropped");
+    expect(capture.file.name).toBe("preview-annotation-annotation_1.png");
+    expect(capture.file.type).toBe("image/png");
+    expect(new Uint8Array(await capture.file.arrayBuffer())).toEqual(new Uint8Array([0]));
+  });
+
+  it("reports none when the annotation carries no crop", () => {
+    expect(capturePreviewAnnotationScreenshot({ ...annotation, screenshot: null })).toEqual({
+      status: "none",
+    });
+  });
+
+  it.each([
+    "data:image/png;base64,not!base64",
+    "data:image/png;base64,",
+    "data:image/png,not-base64",
+    "https://example.com/screenshot.png",
+  ])("reports a failed conversion for an invalid screenshot: %s", (dataUrl) => {
+    expect(
+      capturePreviewAnnotationScreenshot({
+        ...annotation,
+        screenshot: { ...annotation.screenshot!, dataUrl },
+      }),
+    ).toEqual({ status: "failed" });
   });
 });

--- a/apps/web/src/lib/previewAnnotation.ts
+++ b/apps/web/src/lib/previewAnnotation.ts
@@ -1,4 +1,5 @@
 import type { PreviewAnnotationPayload } from "@t3tools/contracts";
+import { dataUrlToFile } from "./imageCompression";
 import { buildElementContextBlock, normalizeElementContextSelection } from "./elementContext";
 
 const TRAILING_PREVIEW_ANNOTATION_BLOCK_PATTERN =
@@ -99,50 +100,28 @@ export function extractTrailingPreviewAnnotation(prompt: string): ExtractedPrevi
   };
 }
 
-async function previewAnnotationScreenshotFile(
-  annotation: PreviewAnnotationPayload,
-): Promise<File | null> {
-  if (!annotation.screenshot) return null;
-  const response = await fetch(annotation.screenshot.dataUrl);
-  const blob = await response.blob();
-  return new File([blob], `preview-annotation-${annotation.id}.png`, {
-    type: blob.type || "image/png",
-  });
-}
-
-/** Upper bound on turning a picked element's crop into a composer attachment. */
-const PREVIEW_ANNOTATION_CAPTURE_TIMEOUT_MS = 5_000;
-
 export type PreviewAnnotationCapture =
   /** The crop is ready to attach. */
   | { readonly status: "captured"; readonly file: File }
   /** The pick carried no crop, which is normal for comment-only annotations. */
   | { readonly status: "none" }
-  /** The crop stalled or threw. Send the annotation without it. */
+  /** The crop could not be decoded. Send the annotation without it. */
   | { readonly status: "failed" };
 
-/**
- * Bounded wrapper around `previewAnnotationScreenshotFile`. The picker holds the
- * composer while this runs, so it must always settle: a stalled crop resolves as
- * `failed` instead of leaving the caller waiting.
- */
-export async function capturePreviewAnnotationScreenshot(
+/** Decode locally because the desktop CSP does not allow fetching data URLs. */
+export function capturePreviewAnnotationScreenshot(
   annotation: PreviewAnnotationPayload,
-  timeoutMs: number = PREVIEW_ANNOTATION_CAPTURE_TIMEOUT_MS,
-): Promise<PreviewAnnotationCapture> {
+): PreviewAnnotationCapture {
   if (!annotation.screenshot) return { status: "none" };
-  let timer: ReturnType<typeof setTimeout> | undefined;
+  const { dataUrl } = annotation.screenshot;
+  const match = /^data:(image\/[^;,]+);base64,.+$/s.exec(dataUrl);
+  if (!match?.[1]) return { status: "failed" };
   try {
-    const file = await Promise.race([
-      previewAnnotationScreenshotFile(annotation),
-      new Promise<null>((resolve) => {
-        timer = setTimeout(() => resolve(null), timeoutMs);
-      }),
-    ]);
-    return file ? { status: "captured", file } : { status: "failed" };
+    return {
+      status: "captured",
+      file: dataUrlToFile(dataUrl, `preview-annotation-${annotation.id}.png`, match[1]),
+    };
   } catch {
     return { status: "failed" };
-  } finally {
-    clearTimeout(timer);
   }
 }


### PR DESCRIPTION
Preview annotations captured their screenshot, then dropped it because desktop CSP blocks `fetch(data:...)`. Decode the image with the existing `dataUrlToFile` helper and remove the redundant conversion timeout. Failed conversions still keep the annotation without promising an attached image.

Overlaps with #6242. Found while investigating #10366; the separate five-second Electron capture timeout is unchanged and was not reproduced locally.

Verified in desktop on macOS: the crop now attaches and opens correctly; normal screenshots still work. All 43 focused tests and web typecheck passed. Targeted lint reported only existing warnings; formatting passed.

### Before / after

| Before: crop dropped | After: crop attached |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/af42facd-ff99-4e19-a6d5-2f8b8fe63a62) | ![After](https://github.com/user-attachments/assets/26084978-2c7b-452b-b871-dbe94f848321) |


Created with GPT-6 in Codex in T3 Code
