### PR TITLE
fix(server): treat a missing git binary as no repository

### DIFF
--- a/apps/server/src/vcs/GitVcsDriver.test.ts
+++ b/apps/server/src/vcs/GitVcsDriver.test.ts
@@ -7,7 +7,7 @@ import * as PlatformError from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { assert, it } from "@effect/vitest";
 
-import { GitCommandError } from "@t3tools/contracts";
+import { GitCommandError, VcsProcessSpawnError } from "@t3tools/contracts";
 import * as ServerConfig from "../config.ts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
 import * as VcsProcess from "./VcsProcess.ts";
@@ -107,6 +107,71 @@ it.effect("GitVcsDriver forwards execute env to the VCS process", () => {
                 stderrTruncated: false,
               };
             }),
+        }),
+      ),
+    ),
+  );
+});
+
+const missingGitSpawnError = (cwd: string, operation: string) =>
+  new VcsProcessSpawnError({
+    operation,
+    command: "git",
+    cwd,
+    argumentCount: 4,
+    cause: PlatformError.systemError({
+      _tag: "NotFound",
+      module: "ChildProcess",
+      method: "spawn",
+      pathOrDescriptor: "git",
+    }),
+  });
+
+it.effect("treats a missing git executable as outside a work tree", () => {
+  const cwd = "/repo";
+  return Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.makeVcsDriverShape();
+
+    assert.equal(yield* driver.isInsideWorkTree(cwd), false);
+    assert.equal(yield* driver.detectRepository(cwd), null);
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        NodeServices.layer,
+        Layer.mock(VcsProcess.VcsProcess)({
+          run: (input) => Effect.fail(missingGitSpawnError(input.cwd, input.operation)),
+        }),
+      ),
+    ),
+  );
+});
+
+it.effect("does not treat a missing working directory as a missing git executable", () => {
+  const cwd = "/missing/repo";
+  const cause = new VcsProcessSpawnError({
+    operation: "GitVcsDriver.isInsideWorkTree",
+    command: "git",
+    cwd,
+    argumentCount: 4,
+    cause: PlatformError.systemError({
+      _tag: "NotFound",
+      module: "FileSystem",
+      method: "access",
+      pathOrDescriptor: cwd,
+    }),
+  });
+
+  return Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.makeVcsDriverShape();
+    const error = yield* driver.isInsideWorkTree(cwd).pipe(Effect.flip);
+
+    assert.strictEqual(error, cause);
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        NodeServices.layer,
+        Layer.mock(VcsProcess.VcsProcess)({
+          run: () => Effect.fail(cause),
         }),
       ),
     ),

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -7,11 +7,14 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
   GitCommandError,
+  type VcsError,
   VcsProcessExitError,
+  VcsProcessSpawnError,
   type VcsSwitchRefInput,
   type VcsSwitchRefResult,
   type VcsCreateRefInput,
@@ -420,6 +423,18 @@ function parseGitRemoteVerboseOutput(
   return remotes;
 }
 
+// Missing `git` is "not a repository," same as exit 128. Keep missing cwd as a spawn error.
+function isMissingGitExecutableError(error: VcsError): error is VcsProcessSpawnError {
+  return (
+    error._tag === "VcsProcessSpawnError" &&
+    error.cause instanceof PlatformError.PlatformError &&
+    error.cause.reason._tag === "NotFound" &&
+    error.cause.reason.module === "ChildProcess" &&
+    error.cause.reason.method === "spawn" &&
+    error.cause.reason.syscall !== "chdir"
+  );
+}
+
 const gitCommand = (
   process: VcsProcess.VcsProcess["Service"],
   operation: string,
@@ -478,7 +493,10 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
         timeoutMs: 5_000,
         maxOutputBytes: 4_096,
       },
-    ).pipe(Effect.map((result) => result.exitCode === 0 && result.stdout.trim() === "true"));
+    ).pipe(
+      Effect.map((result) => result.exitCode === 0 && result.stdout.trim() === "true"),
+      Effect.catchIf(isMissingGitExecutableError, () => Effect.succeed(false)),
+    );
 
   const execute: VcsDriver.VcsDriver["Service"]["execute"] = (input) =>
     gitCommand(vcsProcess, input.operation, input.cwd, input.args, {

--- a/apps/server/src/vcs/VcsDriverRegistry.test.ts
+++ b/apps/server/src/vcs/VcsDriverRegistry.test.ts
@@ -2,7 +2,9 @@ import { assert, it, describe } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as PlatformError from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process";
+import { VcsProcessSpawnError } from "@t3tools/contracts";
 
 import * as VcsProcess from "./VcsProcess.ts";
 import * as VcsProjectConfig from "./VcsProjectConfig.ts";
@@ -135,6 +137,43 @@ describe("VcsDriverRegistry", () => {
       assert.equal(yield* registry.detect({ cwd: "/repo" }), null);
       assert.equal((yield* registry.detect({ cwd: "/repo" }))?.repository.rootPath, "/repo");
       assert.equal(insideWorkTreeChecks, 2);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("treats a missing git executable as no repository", () => {
+    const cwd = "/repo";
+    const layer = Layer.effect(VcsDriverRegistry.VcsDriverRegistry, VcsDriverRegistry.make).pipe(
+      Layer.provide(NodeServices.layer),
+      Layer.provide(
+        Layer.mock(VcsProjectConfig.VcsProjectConfig)({
+          resolveKind: (input) => Effect.succeed(input.requestedKind ?? "auto"),
+        }),
+      ),
+      Layer.provide(
+        Layer.mock(VcsProcess.VcsProcess)({
+          run: (input) =>
+            Effect.fail(
+              new VcsProcessSpawnError({
+                operation: input.operation,
+                command: "git",
+                cwd,
+                argumentCount: input.args.length,
+                cause: PlatformError.systemError({
+                  _tag: "NotFound",
+                  module: "ChildProcess",
+                  method: "spawn",
+                  pathOrDescriptor: "git",
+                }),
+              }),
+            ),
+        }),
+      ),
+    );
+
+    return Effect.gen(function* () {
+      const registry = yield* VcsDriverRegistry.VcsDriverRegistry;
+
+      assert.equal(yield* registry.detect({ cwd }), null);
     }).pipe(Effect.provide(layer));
   });
 });


### PR DESCRIPTION
## What Changed

`GitVcsDriver.isInsideWorkTree` now treats a missing `git` executable as “not a repository” instead of failing.

A `VcsProcessSpawnError` whose cause is `PlatformError` `NotFound` on `ChildProcess.spawn` (and not `chdir`) maps to `false`. `detectRepository` already returns `null` when that probe is false, so folder-open VCS detect no longer toasts. A missing working directory still fails.

## Why

[#10351](https://github.com/pingdotgg/t3code/issues/10351): opening a folder without Git on PATH showed `VCS process failed to spawn… git`. Exit 128 (“not a repo”) was already silent. A missing binary was not.

Settings → Version Control already reports Git as unavailable via `git --version`. That switch is an availability indicator, not an off switch, and detect did not use it. Same missing-binary handling as `gh` / `az`.

Fixes #10351

## UI Changes

None. The spawn toast on folder open goes away when Git is not installed. No copy or layout change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (not applicable)

Grok 4.6 (Grok Build)