### PR TITLE
fix(web): stop drawing background tasks as agents in the timeline

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -3060,7 +3060,9 @@ function workEntryIconName(workEntry: TimelineWorkEntry): WorkEntryIconName {
   }
 
   // Subagent lifecycle rows (grouped by taskId) get agent identity chrome.
-  if (workEntry.taskId) {
+  // Background tasks carry a taskId too but are not agents: the Agents panel
+  // leaves them out, so the timeline must not dress them up as one.
+  if (workEntry.taskId && !workEntry.isBackgroundTask) {
     return "bot";
   }
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -89,6 +89,11 @@ export interface WorkLogEntry {
     workflowId: string | null;
     agentTaskIds: ReadonlyArray<string>;
   };
+  /**
+   * Shell/monitor/plan tasks: ordinary work-log rows that carry a taskId but
+   * are not agents, so they get neither spawn CTAs nor agent chrome.
+   */
+  isBackgroundTask?: boolean;
 }
 
 const workLogCollapseKey = Symbol();
@@ -98,8 +103,6 @@ interface DerivedWorkLogEntry extends WorkLogEntry {
   [workLogCollapseKey]?: string;
   toolCallId?: string;
   isWorkflowCoordinator?: boolean;
-  /** Shell/monitor/plan tasks: ordinary work-log rows, never spawn CTAs. */
-  isBackgroundTask?: boolean;
 }
 
 const derivedWorkLogEntryByActivity = new WeakMap<

--- a/packages/client-runtime/src/work-log/presentation.test.ts
+++ b/packages/client-runtime/src/work-log/presentation.test.ts
@@ -409,6 +409,31 @@ describe("browser group summaries", () => {
   });
 });
 
+describe("task group summaries", () => {
+  const agentTask: WorkLogPresentationEntry = {
+    label: "Started agent",
+    taskId: "task-1",
+    tone: "tool",
+  };
+  // A foreground Bash call Claude promoted to a local_bash task: same row
+  // shape as a subagent, stamped background by the server.
+  const backgroundTask: WorkLogPresentationEntry = {
+    label: "Run the test suite",
+    taskId: "task-2",
+    isBackgroundTask: true,
+    tone: "tool",
+  };
+
+  it("keeps agent chrome for subagent lifecycle rows", () => {
+    expect(toolGroupSummaryKind([agentTask])).toBe("agent-tool");
+  });
+
+  it("does not present a background task as an agent", () => {
+    expect(toolGroupSummaryKind([backgroundTask])).toBe("tone-tool");
+    expect(toolGroupSummaryKind([backgroundTask, backgroundTask])).toBe("tone-tool");
+  });
+});
+
 describe("command work-log details", () => {
   it("extracts Claude result blocks and projected output", () => {
     expect(

--- a/packages/client-runtime/src/work-log/presentation.ts
+++ b/packages/client-runtime/src/work-log/presentation.ts
@@ -32,6 +32,8 @@ export interface WorkLogPresentationEntry {
   readonly toolLifecycleStatus?: string;
   readonly sourceActivityKind?: string;
   readonly taskId?: string;
+  /** Set on task rows the server classified as background work rather than an agent. */
+  readonly isBackgroundTask?: boolean;
   readonly toolSource?: ToolActivitySource;
 }
 
@@ -611,7 +613,15 @@ export function toolGroupSummaryKind(
     entries.map((entry): ToolGroupSummaryKind => {
       if (entry.itemType === "mcp_tool_call") return "other";
       if (entry.itemType === "dynamic_tool_call") return "dynamic-tool";
-      if (entry.itemType === "collab_agent_tool_call" || entry.taskId) return "agent-tool";
+      // A background task (a foreground Bash call Claude promoted to
+      // local_bash, a monitor loop) shares the row shape of a subagent but
+      // is not one; the Agents panel already leaves it out.
+      if (
+        entry.itemType === "collab_agent_tool_call" ||
+        (entry.taskId && !entry.isBackgroundTask)
+      ) {
+        return "agent-tool";
+      }
       if (entry.tone === "thinking") return "agent-tool";
       if (entry.tone === "tool") return "tone-tool";
       return "other";


### PR DESCRIPTION
Fixes #10375

## Problem

When a foreground Bash call in a Claude thread runs longer than a couple of seconds, Claude Code registers it as a `local_bash` task and T3 records `task.started` / `task.completed` rows for it. The server stamps those rows `agentKind: "background"` and the Agents panel correctly leaves them out, but the timeline gave the row the Bot icon because the icon rule only asked "does this entry have a `taskId`?". The two surfaces disagreed: the transcript showed a robot, the Agents panel showed no agent. A failed command made it worse, since the robot got the failed-tool tint.

## Fix

- `toolGroupSummaryKind` (shared by web and mobile) and the web `workEntryIconName` treat a `taskId` as agent chrome only when the entry is not a background task. Background task rows fall back to their tone icon, so a completed promoted Bash shows the ordinary work icon and a failed one the error icon, next to the terminal row of the Bash call itself.
- `isBackgroundTask` moves from the web's private derived entry onto `WorkLogEntry`, which the timeline rows are typed as; the shared presentation entry gains the same optional flag. The server stamp and the Agents panel filter are unchanged.

## Verification

- `presentation.test.ts`: a subagent row keeps `agent-tool`; a background task row (alone or repeated) does not.
- Web `session-logic` and `MessagesTimeline.logic` tests, client-runtime, web and mobile typecheck, lint.
- Real client: a Claude Haiku thread on main and on this branch, each asked to run `sleep 5 && exit 2` through the Bash tool. Both produce the same activity pair (`task.started` / `task.completed`, `taskType: local_bash`, `agentKind: background`) next to the Bash `tool.*` rows. On main the task row renders with `lucide-bot`; on this branch it renders with the error tone icon, and the Bash row keeps its terminal icon in both.

## Before

main at `223ff4490`, Claude Haiku, failed `sleep 5 && exit 2` promoted to a `local_bash` task: the task row wears the Bot icon (`lucide-bot`) although the Agents panel lists no agent.

![Before: task row with the Bot icon](https://raw.githubusercontent.com/Mnigos/t3code/pr-assets/task-row-icon/10377-before-rows.png)

## After

This branch, same reproduction: the task row uses the error tone icon (`lucide-circle-alert`); the Bash row keeps its terminal icon in both.

![After: task row with the error icon](https://raw.githubusercontent.com/Mnigos/t3code/pr-assets/task-row-icon/10377-after-rows.png)

Both captures are Playwright screenshots at 2x of the dev web client with the fold expanded (full-window versions: [before](https://raw.githubusercontent.com/Mnigos/t3code/pr-assets/task-row-icon/10377-before-full.png), [after](https://raw.githubusercontent.com/Mnigos/t3code/pr-assets/task-row-icon/10377-after-full.png)).

Implemented with Claude Code (Claude Fable 5).

