### PR TITLE
feat(web): name the drop action while dragging sidebar threads

### DIFF
--- a/apps/web/src/components/Sidebar.drag.test.ts
+++ b/apps/web/src/components/Sidebar.drag.test.ts
@@ -245,7 +245,9 @@ describe("sidebar drag projection", () => {
       settledExpanded: true,
     });
     const args = layout(pinned, active, over);
+    // dnd-kit moves the lifted row by the pointer delta, so only peers matter.
     for (let index = 0; index < pinned.length; index += 1) {
+      if (index === args.activeIndex) continue;
       expect(strategy({ ...args, index })).toEqual(verticalListSortingStrategy({ ...args, index }));
     }
   });
@@ -282,6 +284,7 @@ describe("sidebar drag projection", () => {
     });
     const args = layout(items, active, over);
     for (let index = 0; index < items.length; index += 1) {
+      if (index === args.activeIndex) continue;
       expect(strategy({ ...args, index })).toEqual(verticalListSortingStrategy({ ...args, index }));
     }
   });
@@ -304,11 +307,11 @@ describe("sidebar drag projection", () => {
   });
 
   it.each([
-    [sidebarMarkerId("pinned-divider"), 16, 16],
-    ["a1", -67, 16],
-    ["a2", -67, -67],
+    [sidebarMarkerId("pinned-divider"), 0, 0],
+    ["a1", -83, 0],
+    ["a2", -83, -83],
   ] as const)(
-    "opens the active pointer slot over %s and keeps a label of height for the emptied pins",
+    "opens the active pointer slot over %s without adding an empty pinned row",
     (over, a1Offset, a2Offset) => {
       const items = [
         pinnedHeader,
@@ -321,33 +324,14 @@ describe("sidebar drag projection", () => {
       ];
       const result = preview({ items, settledOrder: [], settledExpanded: true }, "p", over);
       expect(result.get(sidebarMarkerId("pinned-header"))).toEqual(stationary);
-      expect(result.get(sidebarMarkerId("pinned-divider"))?.y).toBe(-67);
+      expect(result.get(sidebarMarkerId("pinned-divider"))?.y).toBe(-83);
       expect(result.get("a1")?.y).toBe(a1Offset);
       expect(result.get("a2")?.y).toBe(a2Offset);
-      expect(result.get(sidebarMarkerId("settled-header"))?.y).toBe(16);
+      expect(result.get(sidebarMarkerId("settled-header"))?.y).toBe(0);
     },
   );
 
-  it("projects an active reorder with no pins so the empty pinned header keeps its label height", () => {
-    const items = [
-      pinnedHeader,
-      divider,
-      thread("a1", "active"),
-      thread("a2", "active"),
-      thread("a3", "active"),
-      settledHeader,
-      thread("s", "settled"),
-    ];
-    const result = preview({ items, settledOrder: [], settledExpanded: true }, "a3", "a1");
-    expect(result.get(sidebarMarkerId("pinned-header"))).toEqual(stationary);
-    expect(result.get(sidebarMarkerId("pinned-divider"))?.y).toBe(16);
-    expect(result.get("a3")).toEqual(stationary);
-    expect(result.get("a1")?.y).toBe(99);
-    expect(result.get("a2")?.y).toBe(99);
-    expect(result.get(sidebarMarkerId("settled-header"))?.y).toBe(16);
-  });
-
-  it("leaves an active reorder to the default strategy while pins exist", () => {
+  it("opens label space below each pinned boundary while dragging", () => {
     const items = [
       pinnedHeader,
       thread("p", "pinned"),
@@ -357,9 +341,51 @@ describe("sidebar drag projection", () => {
       settledHeader,
       thread("s", "settled"),
     ];
-    const result = preview({ items, settledOrder: [], settledExpanded: true }, "a2", "a1");
-    expect(result.get(sidebarMarkerId("pinned-divider"))?.y).toBe(0);
-    expect(result.get(sidebarMarkerId("settled-header"))?.y).toBe(0);
+    // Reorder inside active: the header gap shifts every row, the divider
+    // gap shifts the active rows and the shelf below by a second label.
+    const result = preview(
+      { items, settledOrder: [], settledExpanded: true, boundaryLabelHeight: 16 },
+      "a2",
+      "a1",
+    );
+    expect(result.get(sidebarMarkerId("pinned-header"))).toEqual(stationary);
+    expect(result.get("p")?.y).toBe(16);
+    expect(result.get(sidebarMarkerId("pinned-divider"))?.y).toBe(16);
+    expect(result.get("a2")).toEqual(stationary);
+    expect(result.get("a1")?.y).toBe(32 + 83);
+    expect(result.get(sidebarMarkerId("settled-header"))?.y).toBe(32);
+    expect(result.get("s")?.y).toBe(32);
+  });
+
+  it("stacks the labels with their gaps when the pinned section is empty", () => {
+    const items = [
+      pinnedHeader,
+      divider,
+      thread("a1", "active"),
+      thread("a2", "active"),
+      settledHeader,
+      thread("s", "settled"),
+    ];
+    const result = preview(
+      { items, settledOrder: [], settledExpanded: true, boundaryLabelHeight: 16 },
+      "a2",
+      "a1",
+    );
+    expect(result.get(sidebarMarkerId("pinned-header"))).toEqual(stationary);
+    expect(result.get(sidebarMarkerId("pinned-divider"))?.y).toBe(16);
+    expect(result.get("a1")?.y).toBe(32 + 83);
+    expect(result.get(sidebarMarkerId("settled-header"))?.y).toBe(32);
+  });
+
+  it("scales the label space with the measured root scale", () => {
+    const items = [pinnedHeader, thread("p", "pinned"), divider, thread("a1", "active")];
+    const result = preview(
+      { items, settledOrder: [], settledExpanded: true, boundaryLabelHeight: 16 },
+      "a1",
+      "p",
+      2,
+    );
+    expect(result.get(sidebarMarkerId("pinned-divider"))?.y).toBe(32 + 165);
   });
 
   it("keeps the pinned header above the first arriving pin", () => {
@@ -383,7 +409,7 @@ describe("sidebar drag projection", () => {
   });
 
   it.each([
-    ["p", -67, -21],
+    ["p", -83, -37],
     ["s", 0, 46],
   ] as const)(
     "replaces the empty Active target when %s enters",

--- a/apps/web/src/components/Sidebar.drag.test.ts
+++ b/apps/web/src/components/Sidebar.drag.test.ts
@@ -328,6 +328,40 @@ describe("sidebar drag projection", () => {
     },
   );
 
+  it("projects an active reorder with no pins so the empty pinned header keeps its label height", () => {
+    const items = [
+      pinnedHeader,
+      divider,
+      thread("a1", "active"),
+      thread("a2", "active"),
+      thread("a3", "active"),
+      settledHeader,
+      thread("s", "settled"),
+    ];
+    const result = preview({ items, settledOrder: [], settledExpanded: true }, "a3", "a1");
+    expect(result.get(sidebarMarkerId("pinned-header"))).toEqual(stationary);
+    expect(result.get(sidebarMarkerId("pinned-divider"))?.y).toBe(16);
+    expect(result.get("a3")).toEqual(stationary);
+    expect(result.get("a1")?.y).toBe(99);
+    expect(result.get("a2")?.y).toBe(99);
+    expect(result.get(sidebarMarkerId("settled-header"))?.y).toBe(16);
+  });
+
+  it("leaves an active reorder to the default strategy while pins exist", () => {
+    const items = [
+      pinnedHeader,
+      thread("p", "pinned"),
+      divider,
+      thread("a1", "active"),
+      thread("a2", "active"),
+      settledHeader,
+      thread("s", "settled"),
+    ];
+    const result = preview({ items, settledOrder: [], settledExpanded: true }, "a2", "a1");
+    expect(result.get(sidebarMarkerId("pinned-divider"))?.y).toBe(0);
+    expect(result.get(sidebarMarkerId("settled-header"))?.y).toBe(0);
+  });
+
   it("keeps the pinned header above the first arriving pin", () => {
     const items = [
       pinnedHeader,

--- a/apps/web/src/components/Sidebar.drag.test.ts
+++ b/apps/web/src/components/Sidebar.drag.test.ts
@@ -304,11 +304,11 @@ describe("sidebar drag projection", () => {
   });
 
   it.each([
-    [sidebarMarkerId("pinned-divider"), 0, 0],
-    ["a1", -83, 0],
-    ["a2", -83, -83],
+    [sidebarMarkerId("pinned-divider"), 16, 16],
+    ["a1", -67, 16],
+    ["a2", -67, -67],
   ] as const)(
-    "opens the active pointer slot over %s without adding an empty pinned row",
+    "opens the active pointer slot over %s and keeps a label of height for the emptied pins",
     (over, a1Offset, a2Offset) => {
       const items = [
         pinnedHeader,
@@ -321,10 +321,10 @@ describe("sidebar drag projection", () => {
       ];
       const result = preview({ items, settledOrder: [], settledExpanded: true }, "p", over);
       expect(result.get(sidebarMarkerId("pinned-header"))).toEqual(stationary);
-      expect(result.get(sidebarMarkerId("pinned-divider"))?.y).toBe(-83);
+      expect(result.get(sidebarMarkerId("pinned-divider"))?.y).toBe(-67);
       expect(result.get("a1")?.y).toBe(a1Offset);
       expect(result.get("a2")?.y).toBe(a2Offset);
-      expect(result.get(sidebarMarkerId("settled-header"))?.y).toBe(0);
+      expect(result.get(sidebarMarkerId("settled-header"))?.y).toBe(16);
     },
   );
 
@@ -349,7 +349,7 @@ describe("sidebar drag projection", () => {
   });
 
   it.each([
-    ["p", -83, -37],
+    ["p", -67, -21],
     ["s", 0, 46],
   ] as const)(
     "replaces the empty Active target when %s enters",

--- a/apps/web/src/components/Sidebar.drag.ts
+++ b/apps/web/src/components/Sidebar.drag.ts
@@ -10,11 +10,6 @@ import {
 } from "./Sidebar.logic";
 
 const stationary = { x: 0, y: 0, scaleX: 1, scaleY: 1 };
-
-/** Height kept for the pinned header while the previewed pinned section is
- * empty, so the Pinned and Active labels have room to stack. It exists only
- * during a drag; nothing is reserved at rest. */
-const EMPTY_PINNED_HEADER_HEIGHT = 16;
 const hidden = { ...stationary, scaleY: 0 };
 type ThreadItem = Extract<SidebarListItem, { kind: "thread" }>;
 type Layout = Parameters<SortingStrategy>[0];
@@ -67,6 +62,9 @@ export function createSidebarSortingStrategy(input: {
   snoozedThreadCount?: number;
   cardHeight?: number;
   slimHeight?: number;
+  /** Space each pinned boundary opens for its label while dragging. The
+   * markers stay zero height at rest, so nothing is reserved until pickup. */
+  boundaryLabelHeight?: number;
 }): SortingStrategy {
   const { items } = input;
   const indices = new Map(items.map((item, index) => [sidebarListItemId(item), index]));
@@ -79,15 +77,10 @@ export function createSidebarSortingStrategy(input: {
     if (active?.kind !== "thread" || !over || !rects[0]) return [];
     const target = resolveSidebarDropTarget(items, active.key, sidebarListItemId(over));
     if (!target) return [];
-    if (target.section === active.section && over.kind === "thread") {
-      if (target.section === "settled") return [];
-      // Reordering the active list with no pins still projects, so the
-      // empty pinned header keeps its label height for the drag.
-      const otherPins = items.some(
-        (item) => item.kind === "thread" && item.section === "pinned" && item.key !== active.key,
-      );
-      if (target.section === "pinned" || otherPins) return null;
-    }
+    // Settled keeps time order, so a reorder inside it previews nothing.
+    // Every other drag projects so the boundary labels get their space.
+    if (target.section === active.section && over.kind === "thread" && target.section === "settled")
+      return [];
     const groups: Record<SidebarSection, ThreadItem[]> = {
       pinned: [],
       active: [],
@@ -110,6 +103,7 @@ export function createSidebarSortingStrategy(input: {
     const scale = slimHeight !== undefined ? slimHeight / 36 : (cardHeight ?? 82) / 82;
     cardHeight ??= 82 * scale;
     slimHeight ??= 36 * scale;
+    const labelHeight = (input.boundaryLabelHeight ?? 0) * scale;
     const group = groups[target.section];
     const order =
       target.section === "pinned"
@@ -166,10 +160,9 @@ export function createSidebarSortingStrategy(input: {
           : slimHeight;
       const moved = item.kind === "thread" && item.key === active.key;
       const height =
-        item.kind === "marker" && item.marker === "pinned-header"
-          ? groups.pinned.length === 0
-            ? EMPTY_PINNED_HEADER_HEIGHT * scale
-            : 0
+        item.kind === "marker" &&
+        (item.marker === "pinned-header" || item.marker === "pinned-divider")
+          ? labelHeight
           : moved
             ? fallback
             : (rect?.height ?? fallback);

--- a/apps/web/src/components/Sidebar.drag.ts
+++ b/apps/web/src/components/Sidebar.drag.ts
@@ -12,8 +12,8 @@ import {
 const stationary = { x: 0, y: 0, scaleX: 1, scaleY: 1 };
 
 /** Height kept for the pinned header while the previewed pinned section is
- * empty, so the Pinned and Active labels have room to stack. The header
- * reserves the same height at rest when there are no pins. */
+ * empty, so the Pinned and Active labels have room to stack. It exists only
+ * during a drag; nothing is reserved at rest. */
 const EMPTY_PINNED_HEADER_HEIGHT = 16;
 const hidden = { ...stationary, scaleY: 0 };
 type ThreadItem = Extract<SidebarListItem, { kind: "thread" }>;
@@ -79,8 +79,15 @@ export function createSidebarSortingStrategy(input: {
     if (active?.kind !== "thread" || !over || !rects[0]) return [];
     const target = resolveSidebarDropTarget(items, active.key, sidebarListItemId(over));
     if (!target) return [];
-    if (target.section === active.section && over.kind === "thread")
-      return target.section === "settled" ? [] : null;
+    if (target.section === active.section && over.kind === "thread") {
+      if (target.section === "settled") return [];
+      // Reordering the active list with no pins still projects, so the
+      // empty pinned header keeps its label height for the drag.
+      const otherPins = items.some(
+        (item) => item.kind === "thread" && item.section === "pinned" && item.key !== active.key,
+      );
+      if (target.section === "pinned" || otherPins) return null;
+    }
     const groups: Record<SidebarSection, ThreadItem[]> = {
       pinned: [],
       active: [],

--- a/apps/web/src/components/Sidebar.drag.ts
+++ b/apps/web/src/components/Sidebar.drag.ts
@@ -14,7 +14,7 @@ const stationary = { x: 0, y: 0, scaleX: 1, scaleY: 1 };
 /** Height kept for the pinned header while the previewed pinned section is
  * empty, so the Pinned and Active labels have room to stack. The header
  * reserves the same height at rest when there are no pins. */
-export const EMPTY_PINNED_HEADER_HEIGHT = 16;
+const EMPTY_PINNED_HEADER_HEIGHT = 16;
 const hidden = { ...stationary, scaleY: 0 };
 type ThreadItem = Extract<SidebarListItem, { kind: "thread" }>;
 type Layout = Parameters<SortingStrategy>[0];

--- a/apps/web/src/components/Sidebar.drag.ts
+++ b/apps/web/src/components/Sidebar.drag.ts
@@ -10,6 +10,11 @@ import {
 } from "./Sidebar.logic";
 
 const stationary = { x: 0, y: 0, scaleX: 1, scaleY: 1 };
+
+/** Height kept for the pinned header while the previewed pinned section is
+ * empty, so the Pinned and Active labels have room to stack. The header
+ * reserves the same height at rest when there are no pins. */
+export const EMPTY_PINNED_HEADER_HEIGHT = 16;
 const hidden = { ...stationary, scaleY: 0 };
 type ThreadItem = Extract<SidebarListItem, { kind: "thread" }>;
 type Layout = Parameters<SortingStrategy>[0];
@@ -153,7 +158,15 @@ export function createSidebarSortingStrategy(input: {
           ? cardHeight
           : slimHeight;
       const moved = item.kind === "thread" && item.key === active.key;
-      top += (moved ? fallback : (rect?.height ?? fallback)) + 1;
+      const height =
+        item.kind === "marker" && item.marker === "pinned-header"
+          ? groups.pinned.length === 0
+            ? EMPTY_PINNED_HEADER_HEIGHT * scale
+            : 0
+          : moved
+            ? fallback
+            : (rect?.height ?? fallback);
+      top += height + 1;
     }
     result[activeIndex] = stationary;
     return result;

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -48,6 +48,7 @@ import {
   type SidebarListItem,
   type SidebarListMarker,
   type SidebarSection,
+  resolveSidebarDropVerb,
 } from "./Sidebar.logic";
 import {
   EnvironmentId,
@@ -2467,5 +2468,26 @@ describe("sortLogicalProjectsForSidebar", () => {
         (project) => project.projectKey,
       ),
     ).toEqual(["logical-newer", "logical-older"]);
+  });
+});
+
+describe("resolveSidebarDropVerb", () => {
+  it("names the state change a cross-section drop performs", () => {
+    expect(resolveSidebarDropVerb("active", "pinned")).toBe("pin");
+    expect(resolveSidebarDropVerb("settled", "pinned")).toBe("pin");
+    expect(resolveSidebarDropVerb("snoozed", "pinned")).toBe("pin");
+    expect(resolveSidebarDropVerb("pinned", "active")).toBe("unpin");
+    expect(resolveSidebarDropVerb("settled", "active")).toBe("unsettle");
+    expect(resolveSidebarDropVerb("snoozed", "active")).toBe("wake");
+    expect(resolveSidebarDropVerb("active", "settled")).toBe("settle");
+    expect(resolveSidebarDropVerb("pinned", "settled")).toBe("settle");
+    expect(resolveSidebarDropVerb("snoozed", "settled")).toBe("settle");
+  });
+
+  it("stays silent for same-section reorders, no target, and the snoozed shelf", () => {
+    expect(resolveSidebarDropVerb("active", "active")).toBeNull();
+    expect(resolveSidebarDropVerb("pinned", "pinned")).toBeNull();
+    expect(resolveSidebarDropVerb("active", null)).toBeNull();
+    expect(resolveSidebarDropVerb("active", "snoozed")).toBeNull();
   });
 });

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -197,6 +197,23 @@ export type SidebarThreadDropPlan =
     }
   | { readonly kind: "settle" };
 
+/** What dropping in `to` does to a thread lifted from `from`, for the badge
+    on the lifted row. Null while reordering inside one section and for the
+    snoozed shelf, which cannot be a drop target. */
+export type SidebarDropVerb = "pin" | "unpin" | "settle" | "unsettle" | "wake";
+
+export function resolveSidebarDropVerb(
+  from: SidebarSection,
+  to: SidebarSection | null,
+): SidebarDropVerb | null {
+  if (to === null || to === from || to === "snoozed") return null;
+  if (to === "pinned") return "pin";
+  if (to === "settled") return "settle";
+  if (from === "pinned") return "unpin";
+  if (from === "settled") return "unsettle";
+  return "wake";
+}
+
 export function planSidebarThreadDrop(input: {
   readonly activeKey: string;
   readonly activeSection: SidebarSection;

--- a/apps/web/src/components/Sidebar.motion.test.ts
+++ b/apps/web/src/components/Sidebar.motion.test.ts
@@ -71,8 +71,6 @@ function fixture(rows: TestRow[]) {
     children: rows,
     ownerDocument: { defaultView: { matchMedia: () => media } },
     getBoundingClientRect: () => ({ top: 0 }),
-    querySelector: (selector: string) =>
-      parent.children.find((row) => selector === `[data-thread-key="${row.name}"]`) ?? null,
     append(node: TestRow) {
       parent.children.push(node);
       node.remove.mockImplementation(() => {
@@ -152,37 +150,39 @@ describe("sidebar list motion", () => {
     expectMove(a, -83);
   });
 
-  it("glides the released row from its lifted position into its committed slot", () => {
+  it("glides every row from its released position into its committed slot", () => {
     const [a, b, c] = [new TestRow("a"), new TestRow("b"), new TestRow("c")];
     const { motion, layout } = fixture([a, b, c]);
     motion.update(true);
     motion.suspend();
-    // a is lifted 130px below its slot; b previews upward into a's place.
+    // a is lifted 130px below its slot; b previews upward into a's place
+    // and c holds a 16px label gap open below the divider.
     a.dragTranslate = 130;
     b.dragTranslate = -83;
+    c.dragTranslate = 16;
     motion.update(false);
-    motion.release("a", a.getBoundingClientRect().top);
+    motion.release();
     layout([b, a, c]);
-    a.dragTranslate = b.dragTranslate = 0;
+    a.dragTranslate = b.dragTranslate = c.dragTranslate = 0;
     motion.update(true);
     // Lifted top 138, committed slot top 91: glide the remaining 47px.
     expectMove(a, 47);
+    // b already sits where it lands; c closes its 16px gap.
     expect(b.animations).toHaveLength(0);
-    expect(c.animations).toHaveLength(0);
+    expectMove(c, 16);
   });
 
-  it("does not glide when release has no position or motion is reduced", () => {
+  it("does not glide on release when motion is reduced", () => {
     const [a, b] = [new TestRow("a"), new TestRow("b")];
     const { motion, layout, media } = fixture([a, b]);
     motion.update(true);
-    motion.release("a", null);
+    media.matches = true;
+    a.dragTranslate = 100;
+    motion.release();
     layout([b, a]);
+    a.dragTranslate = 0;
     motion.update(true);
     expect(a.animations).toHaveLength(0);
-    media.matches = true;
-    motion.release("b", 300);
-    layout([a, b]);
-    motion.update(true);
     expect(b.animations).toHaveLength(0);
   });
 

--- a/apps/web/src/components/Sidebar.motion.test.ts
+++ b/apps/web/src/components/Sidebar.motion.test.ts
@@ -70,6 +70,9 @@ function fixture(rows: TestRow[]) {
   const parent = {
     children: rows,
     ownerDocument: { defaultView: { matchMedia: () => media } },
+    getBoundingClientRect: () => ({ top: 0 }),
+    querySelector: (selector: string) =>
+      parent.children.find((row) => selector === `[data-thread-key="${row.name}"]`) ?? null,
     append(node: TestRow) {
       parent.children.push(node);
       node.remove.mockImplementation(() => {
@@ -147,6 +150,40 @@ describe("sidebar list motion", () => {
     expectMove(c, 166);
     expectMove(b, -83);
     expectMove(a, -83);
+  });
+
+  it("glides the released row from its lifted position into its committed slot", () => {
+    const [a, b, c] = [new TestRow("a"), new TestRow("b"), new TestRow("c")];
+    const { motion, layout } = fixture([a, b, c]);
+    motion.update(true);
+    motion.suspend();
+    // a is lifted 130px below its slot; b previews upward into a's place.
+    a.dragTranslate = 130;
+    b.dragTranslate = -83;
+    motion.update(false);
+    motion.release("a", a.getBoundingClientRect().top);
+    layout([b, a, c]);
+    a.dragTranslate = b.dragTranslate = 0;
+    motion.update(true);
+    // Lifted top 138, committed slot top 91: glide the remaining 47px.
+    expectMove(a, 47);
+    expect(b.animations).toHaveLength(0);
+    expect(c.animations).toHaveLength(0);
+  });
+
+  it("does not glide when release has no position or motion is reduced", () => {
+    const [a, b] = [new TestRow("a"), new TestRow("b")];
+    const { motion, layout, media } = fixture([a, b]);
+    motion.update(true);
+    motion.release("a", null);
+    layout([b, a]);
+    motion.update(true);
+    expect(a.animations).toHaveLength(0);
+    media.matches = true;
+    motion.release("b", 300);
+    layout([a, b]);
+    motion.update(true);
+    expect(b.animations).toHaveLength(0);
   });
 
   it("does not carry a canceled drag's transformed position into the next move", () => {

--- a/apps/web/src/components/Sidebar.motion.ts
+++ b/apps/web/src/components/Sidebar.motion.ts
@@ -19,9 +19,9 @@ export function createSidebarListMotion(parent: HTMLUListElement) {
   const running = new Map<HTMLElement, { animation: Animation; offset: number }>();
   const entering = new Map<HTMLElement, Animation>();
   const exiting = new Map<HTMLElement, Animation>();
-  // The lifted row's visual top at release, relative to the list, so the
-  // release commit can glide it into its committed slot.
-  let released: { key: string; top: number } | null = null;
+  // Visual tops at drag release, relative to the list, so the release
+  // commit can glide every row from where dnd-kit left it into its slot.
+  let released: Map<HTMLElement, number> | null = null;
 
   const remainingOffset = (node: HTMLElement) => {
     const current = running.get(node);
@@ -164,24 +164,28 @@ export function createSidebarListMotion(parent: HTMLUListElement) {
         }
       }
       if (released !== null) {
-        const node = parent.querySelector<HTMLElement>(
-          `[data-thread-key="${released.key.replace(/["\\]/g, "\\$&")}"]`,
-        );
-        const position = node === null ? undefined : next.get(node);
-        if (node && position && !reducedMotion?.matches) move(node, released.top - position.top);
+        if (!reducedMotion?.matches) {
+          for (const [node, position] of next) {
+            const top = released.get(node);
+            if (top !== undefined) move(node, top - position.top);
+          }
+        }
         released = null;
       }
       positions = next;
     },
     /** Called on drag release, before the commit that clears dnd-kit's
-     * transform. `visualTop` is the lifted row's client top; the next update
-     * animates that row from there into wherever it lands, and the other
-     * rows only refresh their baseline since they already sit at their
-     * previewed positions. */
-    release(key: string, visualTop: number | null | undefined) {
+     * transforms. Takes every row's visual top, including the lifted row
+     * under the pointer and the peers holding the label gaps open, so the
+     * next update glides each of them into its committed slot. */
+    release() {
       suspend();
-      if (visualTop == null) return;
-      released = { key, top: visualTop - parent.getBoundingClientRect().top };
+      const origin = parent.getBoundingClientRect().top;
+      released = new Map(
+        Array.from(parent.children)
+          .filter((node): node is HTMLElement => node instanceof HTMLElement && !exiting.has(node))
+          .map((node) => [node, node.getBoundingClientRect().top - origin]),
+      );
     },
     suspend,
     dispose() {

--- a/apps/web/src/components/Sidebar.motion.ts
+++ b/apps/web/src/components/Sidebar.motion.ts
@@ -19,6 +19,9 @@ export function createSidebarListMotion(parent: HTMLUListElement) {
   const running = new Map<HTMLElement, { animation: Animation; offset: number }>();
   const entering = new Map<HTMLElement, Animation>();
   const exiting = new Map<HTMLElement, Animation>();
+  // The lifted row's visual top at release, relative to the list, so the
+  // release commit can glide it into its committed slot.
+  let released: { key: string; top: number } | null = null;
 
   const remainingOffset = (node: HTMLElement) => {
     const current = running.get(node);
@@ -86,6 +89,23 @@ export function createSidebarListMotion(parent: HTMLUListElement) {
     for (const node of running.keys()) cancel(node);
     clearFades();
     positions = null;
+    released = null;
+  };
+  const move = (node: HTMLElement, offset: number) => {
+    cancel(node);
+    if (offset === 0) return;
+    const animation = node.animate(
+      [{ transform: `translateY(${offset}px)` }, { transform: "translateY(0px)" }],
+      motionTiming,
+    );
+    running.set(node, { animation, offset });
+    animation.addEventListener(
+      "finish",
+      () => {
+        if (running.get(node)?.animation === animation) running.delete(node);
+      },
+      { once: true },
+    );
   };
 
   return {
@@ -140,24 +160,28 @@ export function createSidebarListMotion(parent: HTMLUListElement) {
           if (previousTop === position.top) continue;
           // Computed progress includes the effect's easing. Only our own
           // translate is carried forward; dnd-kit's transforms are never read.
-          const offset = previousTop + remainingOffset(node) - position.top;
-          cancel(node);
-          if (offset === 0) continue;
-          const animation = node.animate(
-            [{ transform: `translateY(${offset}px)` }, { transform: "translateY(0px)" }],
-            motionTiming,
-          );
-          running.set(node, { animation, offset });
-          animation.addEventListener(
-            "finish",
-            () => {
-              if (running.get(node)?.animation === animation) running.delete(node);
-            },
-            { once: true },
-          );
+          move(node, previousTop + remainingOffset(node) - position.top);
         }
       }
+      if (released !== null) {
+        const node = parent.querySelector<HTMLElement>(
+          `[data-thread-key="${released.key.replace(/["\\]/g, "\\$&")}"]`,
+        );
+        const position = node === null ? undefined : next.get(node);
+        if (node && position && !reducedMotion?.matches) move(node, released.top - position.top);
+        released = null;
+      }
       positions = next;
+    },
+    /** Called on drag release, before the commit that clears dnd-kit's
+     * transform. `visualTop` is the lifted row's client top; the next update
+     * animates that row from there into wherever it lands, and the other
+     * rows only refresh their baseline since they already sit at their
+     * previewed positions. */
+    release(key: string, visualTop: number | null | undefined) {
+      suspend();
+      if (visualTop == null) return;
+      released = { key, top: visualTop - parent.getBoundingClientRect().top };
     },
     suspend,
     dispose() {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -5,7 +5,6 @@ import {
   PointerSensor,
   useSensor,
   useSensors,
-  type DragCancelEvent,
   type DragEndEvent,
   type DragOverEvent,
   type DragStartEvent,
@@ -491,7 +490,7 @@ function SnoozePopoverButton(props: {
 type SortableThreadRowBag = Pick<
   ReturnType<typeof useSortable>,
   "listeners" | "setNodeRef" | "transform" | "transition" | "isDragging"
-> & { id: string };
+>;
 
 function SortableThreadRow(props: {
   id: string;
@@ -503,7 +502,7 @@ function SortableThreadRow(props: {
     disabled: { draggable: props.disabled },
     animateLayoutChanges: animateSidebarLayoutChanges,
   });
-  return props.children({ id: props.id, listeners, setNodeRef, transform, transition, isDragging });
+  return props.children({ listeners, setNodeRef, transform, transition, isDragging });
 }
 
 // Unsent work shares one look: the new-thread draft rows and thread rows
@@ -567,12 +566,16 @@ function SidebarSectionPlaceholder(props: {
   );
 }
 
-// Boundary labels overlay the cards' padding during a drag. They read at
-// full strength so the sections are easy to find, and the section under the
-// lifted row takes the accent. The measured marker stays empty, so showing a
-// label never pushes a row out of the way, and the label paints above the
-// lifted row so it stays visible when the row lands on the boundary, such as
-// the first drop into an empty pinned section.
+// Boundary labels appear during a drag in space the sorting strategy opens
+// below each marker (SIDEBAR_DRAG_LABEL_HEIGHT), so they never sit on a row.
+// The marker itself stays zero height, so nothing is reserved at rest and
+// pickup measurements are unchanged. They read at full strength so the
+// sections are easy to find, and the section under the lifted row takes the
+// accent. They paint above the lifted row so a card dragged across a
+// boundary never hides its label.
+// Matches the label's h-4 below.
+const SIDEBAR_DRAG_LABEL_HEIGHT = 16;
+
 function SidebarDragBoundary(props: {
   marker: "pinned-header" | "pinned-divider";
   label: string;
@@ -586,7 +589,7 @@ function SidebarDragBoundary(props: {
       className="pointer-events-none relative z-30 mx-0.5 h-0"
     >
       {props.visible ? (
-        <div className="absolute inset-x-2 top-0 flex h-4 -translate-y-1/2 items-center gap-1.5">
+        <div className="absolute inset-x-2 top-0 flex h-4 items-center gap-1.5">
           <span
             className={cn(
               "inline-flex h-4 shrink-0 items-center rounded-sm border bg-sidebar px-1.5 text-[10px] leading-none font-medium",
@@ -1372,8 +1375,6 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   const sortableRootProps = sortable
     ? {
         ref: sortable.setNodeRef,
-        // Lets the list motion find this row for the release glide.
-        "data-thread-key": sortable.id,
         style: {
           transform: CSS.Translate.toString(sortable.transform),
           transition: sortable.transition,
@@ -3189,11 +3190,8 @@ export default function Sidebar() {
     },
     [sectionByThreadKey],
   );
-  const handleThreadDragCancel = useCallback((event: DragCancelEvent) => {
-    listMotionRef.current?.release(
-      String(event.active.id),
-      event.active.rect.current.translated?.top,
-    );
+  const handleThreadDragCancel = useCallback(() => {
+    listMotionRef.current?.release();
     setDragState(null);
     setDragTargetSection(null);
   }, []);
@@ -3248,8 +3246,8 @@ export default function Sidebar() {
   const listMotionPaused = dragState !== null;
   useLayoutEffect(() => {
     // Drag release clears the baseline, so its commit cannot replay the
-    // sortable preview; only the released row glides into its slot. Later
-    // thread actions can animate while writes settle.
+    // sortable preview; rows glide from their released positions instead.
+    // Later thread actions can animate while writes settle.
     // Draft navigation can reveal a frozen row without changing the draft count.
     listMotionRef.current?.update(
       !listMotionPaused && sidebarListItems.length + visibleDraftSessionCount > 0,
@@ -3279,6 +3277,7 @@ export default function Sidebar() {
     () =>
       createSidebarSortingStrategy({
         items: sidebarListItems,
+        boundaryLabelHeight: SIDEBAR_DRAG_LABEL_HEIGHT,
         settledOrder: draggedSettledOrder,
         settledExpanded: settledShelfExpanded,
         settledVisibleCount,
@@ -3356,10 +3355,7 @@ export default function Sidebar() {
   ]);
   const handleThreadDragEnd = useCallback(
     (event: DragEndEvent) => {
-      listMotionRef.current?.release(
-        String(event.active.id),
-        event.active.rect.current.translated?.top,
-      );
+      listMotionRef.current?.release();
       setDragState(null);
       setDragTargetSection(null);
       const activeKey = String(event.active.id);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -564,15 +564,14 @@ function SidebarSectionPlaceholder(props: {
   );
 }
 
-// Boundary labels overlay the cards' padding during a drag. The measured
-// marker stays empty, so showing a label never pushes a row out of the way.
+// Boundary labels overlay the cards' padding during a drag, in the accent
+// color for the whole drag so they never flicker with the pointer. The
+// measured marker stays empty, so showing a label never pushes a row out of
+// the way.
 function SidebarDragBoundary(props: {
   marker: "pinned-header" | "pinned-divider";
   label: string;
   visible: boolean;
-  // The pinned boundary wears the accent for the whole drag, marking the
-  // section that changes state, so it never flickers with the pointer.
-  accent?: boolean;
 }) {
   return (
     <SortableSidebarMarker
@@ -584,16 +583,12 @@ function SidebarDragBoundary(props: {
         <div className="absolute inset-x-2 top-0 flex h-4 -translate-y-1/2 items-center gap-1.5">
           <span
             className={cn(
-              "inline-flex h-4 shrink-0 items-center rounded-sm border border-sidebar-border bg-sidebar px-1.5 text-[10px] leading-none font-medium text-sidebar-muted-foreground",
-              props.accent && "border-primary/40 text-primary",
+              "inline-flex h-4 shrink-0 items-center rounded-sm border border-primary/40 bg-sidebar px-1.5 text-[10px] leading-none font-medium text-primary",
             )}
           >
             {props.label}
           </span>
-          <span
-            aria-hidden
-            className={cn("h-px flex-1 bg-sidebar-border", props.accent && "bg-primary/50")}
-          />
+          <span aria-hidden className="h-px flex-1 bg-primary/50" />
         </div>
       ) : null}
     </SortableSidebarMarker>
@@ -4710,7 +4705,6 @@ export default function Sidebar() {
                                 marker="pinned-header"
                                 label="Pinned"
                                 visible={from !== null}
-                                accent
                               />,
                             );
                             break;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1346,9 +1346,11 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       !isSelected &&
       "opacity-70 transition-opacity hover:opacity-100",
     // The lifted row is an opaque card so boundary labels beneath it vanish
-    // instead of showing through.
+    // instead of showing through. The row tint is translucent in dark themes
+    // and the pointer keeps the hover color applied, so both the tint and the
+    // solid sidebar color are stacked as background images.
     props.sortable?.isDragging &&
-      "bg-sidebar-row-active text-sidebar-foreground opacity-100 shadow-lg",
+      "bg-[linear-gradient(var(--sidebar-row-active),var(--sidebar-row-active)),linear-gradient(var(--sidebar),var(--sidebar))] text-sidebar-foreground opacity-100 shadow-lg",
   );
   // dnd-kit props for the row root. Same bag on both variants: every row in
   // the list translates around the gap as the drag passes it.

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -46,6 +46,7 @@ import {
   FolderPlusIcon,
   GitBranchIcon,
   PinIcon,
+  PinOffIcon,
   PlusIcon,
   SearchIcon,
   SettingsIcon,
@@ -150,6 +151,8 @@ import {
   reduceSidebarProjectScopeMenuState,
   resolveAdjacentThreadId,
   resolveSidebarDropTarget,
+  resolveSidebarDropVerb,
+  type SidebarDropVerb,
   resolveSidebarThreadStatus,
   searchSidebarThreadsByTitle,
   shouldCreateNewThreadInCurrentProject,
@@ -546,7 +549,6 @@ function SidebarSectionPlaceholder(props: {
   marker: "active-placeholder" | "settled-placeholder";
   label: string;
   showHint: boolean;
-  isDropTarget: boolean;
 }) {
   return (
     <SortableSidebarMarker
@@ -555,7 +557,6 @@ function SidebarSectionPlaceholder(props: {
       className={cn(
         "mx-0.5 flex h-9 items-center justify-center rounded-md border border-dashed border-transparent text-xs text-sidebar-muted-foreground/60",
         props.showHint && "border-sidebar-border",
-        props.isDropTarget && "border-primary/40 bg-primary/5 text-primary",
       )}
     >
       {props.showHint ? props.label : null}
@@ -569,7 +570,9 @@ function SidebarDragBoundary(props: {
   marker: "pinned-header" | "pinned-divider";
   label: string;
   visible: boolean;
-  isDropTarget: boolean;
+  // The pinned boundary wears the accent for the whole drag, marking the
+  // section that changes state, so it never flickers with the pointer.
+  accent?: boolean;
 }) {
   return (
     <SortableSidebarMarker
@@ -581,15 +584,15 @@ function SidebarDragBoundary(props: {
         <div className="absolute inset-x-2 top-0 flex h-4 -translate-y-1/2 items-center gap-1.5">
           <span
             className={cn(
-              "inline-flex h-4 shrink-0 items-center gap-2 rounded-sm border border-sidebar-border bg-sidebar px-1.5 text-[10px] leading-none font-medium text-sidebar-muted-foreground",
-              props.isDropTarget && "border-primary/40 text-primary",
+              "inline-flex h-4 shrink-0 items-center rounded-sm border border-sidebar-border bg-sidebar px-1.5 text-[10px] leading-none font-medium text-sidebar-muted-foreground",
+              props.accent && "border-primary/40 text-primary",
             )}
           >
             {props.label}
           </span>
           <span
             aria-hidden
-            className={cn("h-px flex-1 bg-sidebar-border", props.isDropTarget && "bg-primary/50")}
+            className={cn("h-px flex-1 bg-sidebar-border", props.accent && "bg-primary/50")}
           />
         </div>
       ) : null}
@@ -601,14 +604,15 @@ function SidebarDragBoundary(props: {
 function SidebarSectionHeader(props: {
   marker: "snoozed-header" | "settled-header";
   label: string;
-  isDropTarget?: boolean;
+  // Settled wears the accent for the whole drag, like the pinned boundary.
+  accent?: boolean;
   toggle: { expanded: boolean; onToggle: () => void };
 }) {
   const snoozed = props.marker === "snoozed-header";
   const className = cn(
     "flex h-full w-full items-center gap-2 rounded-md border border-dashed border-transparent px-2 text-left text-xs font-medium",
     snoozed ? "text-blue-600 dark:text-blue-400" : "text-sidebar-muted-foreground/60",
-    props.isDropTarget && "border-primary/40 bg-primary/5 text-primary",
+    props.accent && "text-primary",
   );
   const content = (
     <>
@@ -618,7 +622,7 @@ function SidebarSectionHeader(props: {
         className={cn(
           "h-px min-w-2 flex-1",
           snoozed ? "bg-blue-500/20 dark:bg-blue-400/15" : "bg-sidebar-border/60",
-          props.isDropTarget && "bg-primary/30",
+          props.accent && "bg-primary/50",
         )}
       />
       <ChevronDownIcon
@@ -887,6 +891,42 @@ const SidebarDraftBlock = memo(function SidebarDraftBlock(props: {
   );
 });
 
+// Verb and icon on the lifted row while it hovers over another section. Uses
+// the same icons as the row actions and context menu so the drop reads as the
+// action it performs.
+const dropVerbBadge: Record<SidebarDropVerb, ReactNode> = {
+  pin: (
+    <>
+      <PinIcon aria-hidden className="size-3" />
+      Pin
+    </>
+  ),
+  unpin: (
+    <>
+      <PinOffIcon aria-hidden className="size-3" />
+      Unpin
+    </>
+  ),
+  settle: (
+    <>
+      <CircleCheckIcon aria-hidden className="size-3" />
+      Settle
+    </>
+  ),
+  unsettle: (
+    <>
+      <Undo2Icon aria-hidden className="size-3" />
+      Un-settle
+    </>
+  ),
+  wake: (
+    <>
+      <AlarmClockOffIcon aria-hidden className="size-3" />
+      Wake
+    </>
+  ),
+};
+
 const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   thread: SidebarThreadSummary;
   variant: "card" | "slim";
@@ -906,7 +946,11 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // sortable bag applied to the row root so the whole row drags (the
   // pointer sensor's distance constraint keeps plain clicks working).
   sortable?: SortableThreadRowBag | undefined;
-  dropSection: Exclude<SidebarSection, "snoozed"> | null;
+  dropVerb: SidebarDropVerb | null;
+  // While dragging, the pin marker stays only for a pinned thread still over
+  // the pinned section. Any other position shows the verb badge instead, and
+  // the badge carries its own icon.
+  dragOverPinned: boolean;
   // Compact wake countdown ("2h") for rows in the snoozed shelf.
   snoozeWakeLabelText: string | null;
   // When a snooze ended (timer or early wake); drives the Woke pill until
@@ -1301,6 +1345,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       !props.isActive &&
       !isSelected &&
       "opacity-70 transition-opacity hover:opacity-100",
+    // The lifted row is an opaque card so boundary labels beneath it vanish
+    // instead of showing through.
+    props.sortable?.isDragging &&
+      "bg-sidebar-row-active text-sidebar-foreground opacity-100 shadow-lg",
   );
   // dnd-kit props for the row root. Same bag on both variants: every row in
   // the list translates around the gap as the drag passes it.
@@ -1322,18 +1370,12 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       }
     : {};
   const dragDestination =
-    sortable?.isDragging && props.dropSection !== null ? (
+    sortable?.isDragging && props.dropVerb !== null ? (
       <span
         role="status"
-        className="pointer-events-none ml-auto inline-flex h-5 shrink-0 items-center gap-1 rounded-sm border border-primary/30 bg-sidebar px-1.5 text-[11px] font-medium text-primary"
+        className="pointer-events-none ml-auto inline-flex h-5 shrink-0 items-center gap-1 rounded-sm border border-primary/40 bg-primary/10 px-1.5 text-[11px] font-medium text-primary"
       >
-        <span className="sr-only">Move to </span>
-        <span aria-hidden>→</span>
-        {props.dropSection === "pinned"
-          ? "Pinned"
-          : props.dropSection === "active"
-            ? "Active"
-            : "Settled"}
+        {dropVerbBadge[props.dropVerb]}
       </span>
     ) : null;
 
@@ -1437,32 +1479,33 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       <TooltipPopup side="top">Unsent draft</TooltipPopup>
     </Tooltip>
   ) : null;
-  const pinIndicator =
-    props.isPinned && !sortable?.isDragging ? (
-      props.pinningSupported ? (
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <button
-                type="button"
-                aria-label="Unpin thread"
-                onClick={handleUnpinClick}
-                className="inline-flex cursor-pointer items-center rounded-sm text-muted-foreground/65 outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
-              />
-            }
-          >
-            <PinIcon aria-hidden className="size-3 shrink-0" />
-          </TooltipTrigger>
-          <TooltipPopup>Unpin thread</TooltipPopup>
-        </Tooltip>
-      ) : (
-        <PinIcon
-          aria-label="Pinned"
-          role="img"
-          className="size-3 shrink-0 text-muted-foreground/65"
-        />
-      )
-    ) : null;
+  const showPin =
+    props.isPinned && (!sortable?.isDragging || (props.dragOverPinned && props.dropVerb === null));
+  const pinIndicator = showPin ? (
+    props.pinningSupported && !sortable?.isDragging ? (
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              aria-label="Unpin thread"
+              onClick={handleUnpinClick}
+              className="inline-flex cursor-pointer items-center rounded-sm text-muted-foreground/65 outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+            />
+          }
+        >
+          <PinIcon aria-hidden className="size-3 shrink-0" />
+        </TooltipTrigger>
+        <TooltipPopup>Unpin thread</TooltipPopup>
+      </Tooltip>
+    ) : (
+      <PinIcon
+        aria-label="Pinned"
+        role="img"
+        className="size-3 shrink-0 text-muted-foreground/65"
+      />
+    )
+  ) : null;
 
   if (variant === "slim") {
     return (
@@ -1471,7 +1514,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
         {...sortableRootProps}
         className={cn(
           "list-none [content-visibility:auto] [contain-intrinsic-size:auto_34px]",
-          sortable?.isDragging && "z-20 opacity-80",
+          sortable?.isDragging && "relative z-20",
         )}
       >
         <Tooltip disabled={sortable?.isDragging}>
@@ -1629,7 +1672,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       {...sortableRootProps}
       className={cn(
         "list-none py-0.5 [content-visibility:auto] [contain-intrinsic-size:auto_96px]",
-        sortable?.isDragging && "z-20 opacity-80",
+        sortable?.isDragging && "relative z-20",
       )}
     >
       <Tooltip disabled={snoozeMenuOpen || sortable?.isDragging}>
@@ -4533,12 +4576,13 @@ export default function Sidebar() {
                             }
                             isPinned={thread.pinnedAt != null}
                             sortable={sortable}
-                            dropSection={
-                              dragState?.activeKey === threadKey &&
-                              dragTargetSection !== dragState.activeSection &&
-                              dragTargetSection !== "snoozed"
-                                ? dragTargetSection
+                            dropVerb={
+                              dragState?.activeKey === threadKey
+                                ? resolveSidebarDropVerb(dragState.activeSection, dragTargetSection)
                                 : null
+                            }
+                            dragOverPinned={
+                              dragState?.activeKey === threadKey && dragTargetSection === "pinned"
                             }
                             snoozeWakeLabelText={
                               section === "snoozed" && thread.snoozedUntil != null
@@ -4663,8 +4707,8 @@ export default function Sidebar() {
                                 key="pinned-header"
                                 marker="pinned-header"
                                 label="Pinned"
-                                isDropTarget={dragTargetSection === "pinned"}
                                 visible={from !== null}
+                                accent
                               />,
                             );
                             break;
@@ -4674,7 +4718,6 @@ export default function Sidebar() {
                                 key="pinned-divider"
                                 marker="pinned-divider"
                                 label="Active"
-                                isDropTarget={dragTargetSection === "active"}
                                 visible={from !== null && previewPinnedCount > 0}
                               />,
                             );
@@ -4686,7 +4729,6 @@ export default function Sidebar() {
                                 marker="active-placeholder"
                                 label="Active"
                                 showHint={from !== null}
-                                isDropTarget={dragTargetSection === "active"}
                               />,
                             );
                             break;
@@ -4717,7 +4759,7 @@ export default function Sidebar() {
                                     ? "Settled"
                                     : `Settled (${settledThreads.length})`
                                 }
-                                isDropTarget={dragTargetSection === "settled"}
+                                accent={from !== null}
                                 toggle={{
                                   expanded: settledShelfExpanded,
                                   onToggle: toggleSettledShelf,
@@ -4732,7 +4774,6 @@ export default function Sidebar() {
                                 marker="settled-placeholder"
                                 label="Settled"
                                 showHint={from !== null && from !== "settled"}
-                                isDropTarget={dragTargetSection === "settled"}
                               />,
                             );
                             break;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -567,9 +567,9 @@ function SidebarSectionPlaceholder(props: {
 }
 
 // Boundary labels overlay the cards' padding during a drag. They read at
-// full strength so the sections are easy to find, and take the accent only
-// for the section a drop would move the thread into. The measured marker
-// stays empty, so showing a label never pushes a row out of the way.
+// full strength so the sections are easy to find, and the section under the
+// lifted row takes the accent. The measured marker stays empty, so showing a
+// label never pushes a row out of the way.
 function SidebarDragBoundary(props: {
   marker: "pinned-header" | "pinned-divider";
   label: string;
@@ -611,8 +611,8 @@ function SidebarDragBoundary(props: {
 function SidebarSectionHeader(props: {
   marker: "snoozed-header" | "settled-header";
   label: string;
-  // While dragging, the settled header reads at full strength; it takes the
-  // accent only when a drop on it would settle the thread.
+  // While dragging, the settled header reads at full strength and takes the
+  // accent while the lifted row is over it.
   dragging?: boolean;
   isDropTarget?: boolean;
   toggle: { expanded: boolean; onToggle: () => void };
@@ -4687,11 +4687,6 @@ export default function Sidebar() {
                         );
                       };
                       const from = dragState?.activeSection ?? null;
-                      // The section a drop would move the thread into, if any.
-                      const changingTo =
-                        from !== null && resolveSidebarDropVerb(from, dragTargetSection) !== null
-                          ? dragTargetSection
-                          : null;
                       const previewPinnedCount =
                         pinnedThreads.length +
                         (from !== "pinned" && dragTargetSection === "pinned" ? 1 : 0) -
@@ -4726,7 +4721,7 @@ export default function Sidebar() {
                                 marker="pinned-header"
                                 label="Pinned"
                                 visible={from !== null}
-                                isDropTarget={changingTo === "pinned"}
+                                isDropTarget={dragTargetSection === "pinned"}
                               />,
                             );
                             break;
@@ -4737,7 +4732,7 @@ export default function Sidebar() {
                                 marker="pinned-divider"
                                 label="Active"
                                 visible={from !== null && previewPinnedCount > 0}
-                                isDropTarget={changingTo === "active"}
+                                isDropTarget={dragTargetSection === "active"}
                               />,
                             );
                             break;
@@ -4748,7 +4743,7 @@ export default function Sidebar() {
                                 marker="active-placeholder"
                                 label="Active"
                                 showHint={from !== null}
-                                isDropTarget={changingTo === "active"}
+                                isDropTarget={dragTargetSection === "active"}
                               />,
                             );
                             break;
@@ -4780,7 +4775,7 @@ export default function Sidebar() {
                                     : `Settled (${settledThreads.length})`
                                 }
                                 dragging={from !== null}
-                                isDropTarget={changingTo === "settled"}
+                                isDropTarget={dragTargetSection === "settled"}
                                 toggle={{
                                   expanded: settledShelfExpanded,
                                   onToggle: toggleSettledShelf,
@@ -4795,7 +4790,7 @@ export default function Sidebar() {
                                 marker="settled-placeholder"
                                 label="Settled"
                                 showHint={from !== null && from !== "settled"}
-                                isDropTarget={changingTo === "settled"}
+                                isDropTarget={dragTargetSection === "settled"}
                               />,
                             );
                             break;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -549,6 +549,7 @@ function SidebarSectionPlaceholder(props: {
   marker: "active-placeholder" | "settled-placeholder";
   label: string;
   showHint: boolean;
+  isDropTarget: boolean;
 }) {
   return (
     <SortableSidebarMarker
@@ -556,7 +557,8 @@ function SidebarSectionPlaceholder(props: {
       data-testid={`sidebar-${props.marker}`}
       className={cn(
         "mx-0.5 flex h-9 items-center justify-center rounded-md border border-dashed border-transparent text-xs text-sidebar-muted-foreground/60",
-        props.showHint && "border-sidebar-border",
+        props.showHint && "border-sidebar-foreground/25 text-sidebar-foreground/80",
+        props.isDropTarget && "border-primary/40 bg-primary/5 text-primary",
       )}
     >
       {props.showHint ? props.label : null}
@@ -564,14 +566,15 @@ function SidebarSectionPlaceholder(props: {
   );
 }
 
-// Boundary labels overlay the cards' padding during a drag, in the accent
-// color for the whole drag so they never flicker with the pointer. The
-// measured marker stays empty, so showing a label never pushes a row out of
-// the way.
+// Boundary labels overlay the cards' padding during a drag. They read at
+// full strength so the sections are easy to find, and take the accent only
+// for the section a drop would move the thread into. The measured marker
+// stays empty, so showing a label never pushes a row out of the way.
 function SidebarDragBoundary(props: {
   marker: "pinned-header" | "pinned-divider";
   label: string;
   visible: boolean;
+  isDropTarget: boolean;
 }) {
   return (
     <SortableSidebarMarker
@@ -583,12 +586,21 @@ function SidebarDragBoundary(props: {
         <div className="absolute inset-x-2 top-0 flex h-4 -translate-y-1/2 items-center gap-1.5">
           <span
             className={cn(
-              "inline-flex h-4 shrink-0 items-center rounded-sm border border-primary/40 bg-sidebar px-1.5 text-[10px] leading-none font-medium text-primary",
+              "inline-flex h-4 shrink-0 items-center rounded-sm border bg-sidebar px-1.5 text-[10px] leading-none font-medium",
+              props.isDropTarget
+                ? "border-primary/40 text-primary"
+                : "border-sidebar-foreground/25 text-sidebar-foreground/80",
             )}
           >
             {props.label}
           </span>
-          <span aria-hidden className="h-px flex-1 bg-primary/50" />
+          <span
+            aria-hidden
+            className={cn(
+              "h-px flex-1",
+              props.isDropTarget ? "bg-primary/50" : "bg-sidebar-foreground/25",
+            )}
+          />
         </div>
       ) : null}
     </SortableSidebarMarker>
@@ -599,15 +611,18 @@ function SidebarDragBoundary(props: {
 function SidebarSectionHeader(props: {
   marker: "snoozed-header" | "settled-header";
   label: string;
-  // Settled wears the accent for the whole drag, like the pinned boundary.
-  accent?: boolean;
+  // While dragging, the settled header reads at full strength; it takes the
+  // accent only when a drop on it would settle the thread.
+  dragging?: boolean;
+  isDropTarget?: boolean;
   toggle: { expanded: boolean; onToggle: () => void };
 }) {
   const snoozed = props.marker === "snoozed-header";
   const className = cn(
     "flex h-full w-full items-center gap-2 rounded-md border border-dashed border-transparent px-2 text-left text-xs font-medium",
     snoozed ? "text-blue-600 dark:text-blue-400" : "text-sidebar-muted-foreground/60",
-    props.accent && "text-primary",
+    props.dragging && "text-sidebar-foreground/80",
+    props.isDropTarget && "border-primary/40 bg-primary/5 text-primary",
   );
   const content = (
     <>
@@ -617,7 +632,8 @@ function SidebarSectionHeader(props: {
         className={cn(
           "h-px min-w-2 flex-1",
           snoozed ? "bg-blue-500/20 dark:bg-blue-400/15" : "bg-sidebar-border/60",
-          props.accent && "bg-primary/50",
+          props.dragging && "bg-sidebar-foreground/25",
+          props.isDropTarget && "bg-primary/50",
         )}
       />
       <ChevronDownIcon
@@ -4671,6 +4687,11 @@ export default function Sidebar() {
                         );
                       };
                       const from = dragState?.activeSection ?? null;
+                      // The section a drop would move the thread into, if any.
+                      const changingTo =
+                        from !== null && resolveSidebarDropVerb(from, dragTargetSection) !== null
+                          ? dragTargetSection
+                          : null;
                       const previewPinnedCount =
                         pinnedThreads.length +
                         (from !== "pinned" && dragTargetSection === "pinned" ? 1 : 0) -
@@ -4705,6 +4726,7 @@ export default function Sidebar() {
                                 marker="pinned-header"
                                 label="Pinned"
                                 visible={from !== null}
+                                isDropTarget={changingTo === "pinned"}
                               />,
                             );
                             break;
@@ -4715,6 +4737,7 @@ export default function Sidebar() {
                                 marker="pinned-divider"
                                 label="Active"
                                 visible={from !== null && previewPinnedCount > 0}
+                                isDropTarget={changingTo === "active"}
                               />,
                             );
                             break;
@@ -4725,6 +4748,7 @@ export default function Sidebar() {
                                 marker="active-placeholder"
                                 label="Active"
                                 showHint={from !== null}
+                                isDropTarget={changingTo === "active"}
                               />,
                             );
                             break;
@@ -4755,7 +4779,8 @@ export default function Sidebar() {
                                     ? "Settled"
                                     : `Settled (${settledThreads.length})`
                                 }
-                                accent={from !== null}
+                                dragging={from !== null}
+                                isDropTarget={changingTo === "settled"}
                                 toggle={{
                                   expanded: settledShelfExpanded,
                                   onToggle: toggleSettledShelf,
@@ -4770,6 +4795,7 @@ export default function Sidebar() {
                                 marker="settled-placeholder"
                                 label="Settled"
                                 showHint={from !== null && from !== "settled"}
+                                isDropTarget={changingTo === "settled"}
                               />,
                             );
                             break;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -578,18 +578,12 @@ function SidebarDragBoundary(props: {
   label: string;
   visible: boolean;
   isDropTarget: boolean;
-  // The pinned header keeps one label of height while there are no pins so
-  // the Pinned and Active labels can stack instead of sharing a line.
-  reserveHeight?: boolean;
 }) {
   return (
     <SortableSidebarMarker
       marker={props.marker}
       data-testid={`sidebar-${props.marker}`}
-      className={cn(
-        "pointer-events-none relative z-30 mx-0.5",
-        props.reserveHeight ? "h-4" : "h-0",
-      )}
+      className="pointer-events-none relative z-30 mx-0.5 h-0"
     >
       {props.visible ? (
         <div className="absolute inset-x-2 top-0 flex h-4 -translate-y-1/2 items-center gap-1.5">
@@ -4732,7 +4726,6 @@ export default function Sidebar() {
                                 label="Pinned"
                                 visible={from !== null}
                                 isDropTarget={dragTargetSection === "pinned"}
-                                reserveHeight={pinnedThreads.length === 0}
                               />,
                             );
                             break;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   PointerSensor,
   useSensor,
   useSensors,
+  type DragCancelEvent,
   type DragEndEvent,
   type DragOverEvent,
   type DragStartEvent,
@@ -490,7 +491,7 @@ function SnoozePopoverButton(props: {
 type SortableThreadRowBag = Pick<
   ReturnType<typeof useSortable>,
   "listeners" | "setNodeRef" | "transform" | "transition" | "isDragging"
->;
+> & { id: string };
 
 function SortableThreadRow(props: {
   id: string;
@@ -502,7 +503,7 @@ function SortableThreadRow(props: {
     disabled: { draggable: props.disabled },
     animateLayoutChanges: animateSidebarLayoutChanges,
   });
-  return props.children({ listeners, setNodeRef, transform, transition, isDragging });
+  return props.children({ id: props.id, listeners, setNodeRef, transform, transition, isDragging });
 }
 
 // Unsent work shares one look: the new-thread draft rows and thread rows
@@ -1377,6 +1378,8 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   const sortableRootProps = sortable
     ? {
         ref: sortable.setNodeRef,
+        // Lets the list motion find this row for the release glide.
+        "data-thread-key": sortable.id,
         style: {
           transform: CSS.Translate.toString(sortable.transform),
           transition: sortable.transition,
@@ -3192,8 +3195,11 @@ export default function Sidebar() {
     },
     [sectionByThreadKey],
   );
-  const handleThreadDragCancel = useCallback(() => {
-    listMotionRef.current?.suspend();
+  const handleThreadDragCancel = useCallback((event: DragCancelEvent) => {
+    listMotionRef.current?.release(
+      String(event.active.id),
+      event.active.rect.current.translated?.top,
+    );
     setDragState(null);
     setDragTargetSection(null);
   }, []);
@@ -3248,7 +3254,8 @@ export default function Sidebar() {
   const listMotionPaused = dragState !== null;
   useLayoutEffect(() => {
     // Drag release clears the baseline, so its commit cannot replay the
-    // sortable preview. Later thread actions can animate while writes settle.
+    // sortable preview; only the released row glides into its slot. Later
+    // thread actions can animate while writes settle.
     // Draft navigation can reveal a frozen row without changing the draft count.
     listMotionRef.current?.update(
       !listMotionPaused && sidebarListItems.length + visibleDraftSessionCount > 0,
@@ -3355,7 +3362,10 @@ export default function Sidebar() {
   ]);
   const handleThreadDragEnd = useCallback(
     (event: DragEndEvent) => {
-      listMotionRef.current?.suspend();
+      listMotionRef.current?.release(
+        String(event.active.id),
+        event.active.rect.current.translated?.top,
+      );
       setDragState(null);
       setDragTargetSection(null);
       const activeKey = String(event.active.id);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -577,12 +577,18 @@ function SidebarDragBoundary(props: {
   label: string;
   visible: boolean;
   isDropTarget: boolean;
+  // The pinned header keeps one label of height while there are no pins so
+  // the Pinned and Active labels can stack instead of sharing a line.
+  reserveHeight?: boolean;
 }) {
   return (
     <SortableSidebarMarker
       marker={props.marker}
       data-testid={`sidebar-${props.marker}`}
-      className="pointer-events-none relative z-30 mx-0.5 h-0"
+      className={cn(
+        "pointer-events-none relative z-30 mx-0.5",
+        props.reserveHeight ? "h-4" : "h-0",
+      )}
     >
       {props.visible ? (
         <div className="absolute inset-x-2 top-0 flex h-4 -translate-y-1/2 items-center gap-1.5">
@@ -4689,14 +4695,6 @@ export default function Sidebar() {
                         );
                       };
                       const from = dragState?.activeSection ?? null;
-                      const previewPinnedCount =
-                        pinnedThreads.length +
-                        (from !== "pinned" && dragTargetSection === "pinned" ? 1 : 0) -
-                        (from === "pinned" &&
-                        dragTargetSection !== null &&
-                        dragTargetSection !== "pinned"
-                          ? 1
-                          : 0);
                       const items: ReactNode[] = [
                         <SidebarDraftBlock
                           key="draft-sessions"
@@ -4724,6 +4722,7 @@ export default function Sidebar() {
                                 label="Pinned"
                                 visible={from !== null}
                                 isDropTarget={dragTargetSection === "pinned"}
+                                reserveHeight={pinnedThreads.length === 0}
                               />,
                             );
                             break;
@@ -4733,7 +4732,7 @@ export default function Sidebar() {
                                 key="pinned-divider"
                                 marker="pinned-divider"
                                 label="Active"
-                                visible={from !== null && previewPinnedCount > 0}
+                                visible={from !== null}
                                 isDropTarget={dragTargetSection === "active"}
                               />,
                             );

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -569,7 +569,9 @@ function SidebarSectionPlaceholder(props: {
 // Boundary labels overlay the cards' padding during a drag. They read at
 // full strength so the sections are easy to find, and the section under the
 // lifted row takes the accent. The measured marker stays empty, so showing a
-// label never pushes a row out of the way.
+// label never pushes a row out of the way, and the label paints above the
+// lifted row so it stays visible when the row lands on the boundary, such as
+// the first drop into an empty pinned section.
 function SidebarDragBoundary(props: {
   marker: "pinned-header" | "pinned-divider";
   label: string;
@@ -580,7 +582,7 @@ function SidebarDragBoundary(props: {
     <SortableSidebarMarker
       marker={props.marker}
       data-testid={`sidebar-${props.marker}`}
-      className="pointer-events-none relative z-10 mx-0.5 h-0"
+      className="pointer-events-none relative z-30 mx-0.5 h-0"
     >
       {props.visible ? (
         <div className="absolute inset-x-2 top-0 flex h-4 -translate-y-1/2 items-center gap-1.5">
@@ -1356,10 +1358,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       !props.isActive &&
       !isSelected &&
       "opacity-70 transition-opacity hover:opacity-100",
-    // The lifted row is an opaque card so boundary labels beneath it vanish
-    // instead of showing through. The row tint is translucent in dark themes
-    // and the pointer keeps the hover color applied, so both the tint and the
-    // solid sidebar color are stacked as background images.
+    // The lifted row is an opaque card so the rows beneath it never show
+    // through. The row tint is translucent in dark themes and the pointer
+    // keeps the hover color applied, so both the tint and the solid sidebar
+    // color are stacked as background images.
     props.sortable?.isDragging &&
       "bg-[linear-gradient(var(--sidebar-row-active),var(--sidebar-row-active)),linear-gradient(var(--sidebar),var(--sidebar))] text-sidebar-foreground opacity-100 shadow-lg",
   );

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -38,9 +38,8 @@ the dragged thread shows the action the drop performs, with its icon: **Pin**, *
 **Settle**, **Un-settle**, or **Wake**. Its status and hover actions hide during the drag. A pinned
 thread keeps its pin only while it stays in the pinned section; once it leaves, the badge takes
 over. Reordering within the same section shows no badge. When there are no pins, drag to the top
-edge to pin a thread. Section labels stay readable for the whole drag, and the section a drop
-would move the thread into takes the accent color. Reordering within a section highlights
-nothing. Section labels also
+edge to pin a thread. Section labels stay readable for the whole drag, and the section the
+thread is over takes the accent color. Section labels also
 identify empty sections and a collapsed settled shelf.
 
 Drag within the pinned or active section to change its order. Other rows slide aside to show the

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -38,9 +38,9 @@ the dragged thread shows the action the drop performs, with its icon: **Pin**, *
 **Settle**, **Un-settle**, or **Wake**. Its status and hover actions hide during the drag. A pinned
 thread keeps its pin only while it stays in the pinned section; once it leaves, the badge takes
 over. Reordering within the same section shows no badge. When there are no pins, drag to the top
-edge to pin a thread. For the whole drag, the section labels wear the accent color and do not
-react to the pointer. The badge on the dragged thread is the signal that the drop changes its
-state. Section labels also
+edge to pin a thread. Section labels stay readable for the whole drag, and the section a drop
+would move the thread into takes the accent color. Reordering within a section highlights
+nothing. Section labels also
 identify empty sections and a collapsed settled shelf.
 
 Drag within the pinned or active section to change its order. Other rows slide aside to show the

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -33,11 +33,15 @@ thread into the active list un-settles it. A snoozed thread can be dragged out o
 shelf, which wakes it, but threads cannot be dragged into the shelf because snoozing needs a wake
 time. Dragging a pinned thread out of the pinned section does not ask for unpin confirmation.
 Pinned and active boundary labels appear only while dragging, without moving the rows. The
-destination boundary highlights. When you cross into another section, the dragged thread shows
-its destination, such as **→ Active**. Its usual pin, status, and hover actions hide during the
-drag. Reordering within the same section does not show a destination badge. When there are no
-pins, drag to the top edge to pin a thread. Section labels also identify empty sections and a
-collapsed settled shelf.
+other rows slide aside to show where the thread will land. When you cross into another section,
+the dragged thread shows the action the drop performs, with its icon: **Pin**, **Unpin**,
+**Settle**, **Un-settle**, or **Wake**. Its status and hover actions hide during the drag. A pinned
+thread keeps its pin only while it stays in the pinned section; once it leaves, the badge takes
+over. Reordering within the same section shows no badge. When there are no pins, drag to the top
+edge to pin a thread. For the whole drag, the **Pinned** and **Settled** labels wear the accent
+color to mark the sections that change a thread's state; they do not react to the pointer. The
+badge on the dragged thread is the signal that the drop changes its state. Section labels also
+identify empty sections and a collapsed settled shelf.
 
 Drag within the pinned or active section to change its order. Other rows slide aside to show the
 spot where the thread will land. Drops into either section keep the position you choose. On

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -38,9 +38,9 @@ the dragged thread shows the action the drop performs, with its icon: **Pin**, *
 **Settle**, **Un-settle**, or **Wake**. Its status and hover actions hide during the drag. A pinned
 thread keeps its pin only while it stays in the pinned section; once it leaves, the badge takes
 over. Reordering within the same section shows no badge. When there are no pins, drag to the top
-edge to pin a thread. For the whole drag, the **Pinned** and **Settled** labels wear the accent
-color to mark the sections that change a thread's state; they do not react to the pointer. The
-badge on the dragged thread is the signal that the drop changes its state. Section labels also
+edge to pin a thread. For the whole drag, the section labels wear the accent color and do not
+react to the pointer. The badge on the dragged thread is the signal that the drop changes its
+state. Section labels also
 identify empty sections and a collapsed settled shelf.
 
 Drag within the pinned or active section to change its order. Other rows slide aside to show the


### PR DESCRIPTION
Follow-up to the merged sidebar drag work, now based on main.

**Problem.** While dragging a thread across sections, the destination divider lit up in the accent color, which reads as an insertion line rather than a state change, and the lifted row only said "→ Section". On first use it was not clear what a drop would do. The lifted row also let the rows beneath it show through: its z-index sat on an unpositioned list item, so neighbouring rows' content painted over it.

**Fix.**
- The lifted row shows a verb badge with the matching icon: **Pin**, **Unpin**, **Settle**, **Un-settle**, or **Wake**, derived from source and destination by a small pure helper, `resolveSidebarDropVerb`. Same-section reorders show no badge. The verbs match the row actions and context menu, so nothing new to learn.
- Section labels render at a readable neutral for the whole drag, and the section under the lifted row takes the accent. The verb badge is the only signal that the drop changes state.
- The lifted row is opaque, shadowed, and positioned so its z-index applies, so the rows beneath it never show through. The opaque base is stacked as a background image because the hover color stays applied while dragging and is translucent in dark themes. Boundary labels paint above the lifted row, so the Pinned label stays readable when the first thread is dropped into an empty pinned section.
- A pinned thread keeps its pin marker only while it stays inside Pinned. Everywhere else the badge carries the icon, so the pin is never shown twice.
- A dropped thread glides from under the pointer into its committed slot instead of snapping, and a cancelled or rejected drop glides back to where it came from. The list motion takes every row's visual position at release and glides each into its committed slot, so the label gaps close with the same motion as the drop.
- Section labels get their own space. The sorting strategy opens one label of height below each pinned boundary for the whole drag and the labels render inside that gap, so they never sit on a row. Every drag projects through the strategy so the space exists for same-section reorders too. The markers stay zero height at rest, so nothing is reserved and pickup measurements are unchanged.

Tests: two cases for the verb mapping in `Sidebar.logic.test.ts`. Doc paragraph in `docs/user/thread-sidebar.md` updated.

**Before**

| Active thread over Pinned | Row beneath bleeding through |
| --- | --- |
| <img src="https://codex-file-host.shawnadedeji.workers.dev/files/pr-10378/06be41c2bacf-before-pin.png" width="300"> | <img src="https://codex-file-host.shawnadedeji.workers.dev/files/pr-10378/0c12a539da98-before-bleed.png" width="300"> |

**After**

| Pin | Unpin |
| --- | --- |
| <img src="https://codex-file-host.shawnadedeji.workers.dev/files/pr-10378/after-v8-1-pin.png" width="300"> | <img src="https://codex-file-host.shawnadedeji.workers.dev/files/pr-10378/after-v8-2-unpin.png" width="300"> |

| Reorder inside Pinned (no badge, pin marker stays, label above the card) | Settle |
| --- | --- |
| <img src="https://codex-file-host.shawnadedeji.workers.dev/files/pr-10378/after-v8-3-reorder-pinned.png" width="300"> | <img src="https://codex-file-host.shawnadedeji.workers.dev/files/pr-10378/after-v8-4-settle.png" width="300"> |

| Last pinned thread leaves Pinned | No pins: drag to the top edge |
| --- | --- |
| <img src="https://codex-file-host.shawnadedeji.workers.dev/files/pr-10378/after-v8-5-last-unpin.png" width="300"> | <img src="https://codex-file-host.shawnadedeji.workers.dev/files/pr-10378/after-v8-7-no-pins-pin.png" width="300"> |

| No pins: reorder inside Active (labels stack only during the drag) | |
| --- | --- |
| <img src="https://codex-file-host.shawnadedeji.workers.dev/files/pr-10378/after-v8-8-no-pins-reorder.png" width="300"> | |

**Drop motion** (unpin by drop, pin by drop, then a cancelled drag)

Screen recording of the full drag flow: https://cap.so/s/b3r1wwtkwxw0x1s

<img src="https://codex-file-host.shawnadedeji.workers.dev/files/pr-10378/drop-glide.gif" width="260">



### Drag recording

[Pin and Settle badges during a drag](https://codex-file-host.shawnadedeji.workers.dev/files/pr-10378/99afd298451a-t3-pr-10378-drag.mp4), verified in an isolated web client using renamed UI fixtures. The drag is cancelled at the end.


Rebased onto main. Web typecheck and all 216 focused sidebar tests pass.


### Final verification

Fixed the unused export reported by CI; no behavior changed in this fix. Web typecheck, all 216 sidebar tests, scoped Knip, and targeted lint pass. React Doctor reports only the two existing sidebar complexity warnings. Manual source review found no additional blockers.

Verified unpin, pin, and cancel in isolated web clients using the same fixture, viewport, and theme. Base `9a47c7bd405`; head `5dc842ea269`. This applies to web and desktop’s shared sidebar; mobile, contracts, and server behavior are unchanged.

| Before | After |
| --- | --- |
| ![Before: destination badge](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/7de19b1ceae0e585/base-unpin.png) | ![After: Unpin action badge](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/0b262c4857a0f05b/head-unpin.png) |

[Before recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/0985c89f2c0b2a47/base-drag.mp4) · [After recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/123f70ba908c255e/head-drag.mp4)

All executed CI jobs pass. Macroscope approvability is neutral because its correctness review is unavailable under the workspace spending limit; Bugbot also reports a spending limit. There are no unresolved review threads.


