### PR TITLE
feat(web): show provider usage limits and reset credits in settings

### DIFF
--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -18,6 +18,7 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 import {
   isProviderDriverKind,
   resolveProviderInstanceEnabled,
+  type EnvironmentId,
   type ProviderInstanceConfig,
   type ProviderInstanceEnvironmentVariable,
   type ProviderInstanceId,
@@ -31,6 +32,7 @@ import {
   readCustomModelEntries,
   toCustomModelSetting,
 } from "@t3tools/shared/model";
+import { limitsNotice } from "@t3tools/shared/usageLimits";
 import { cn } from "../../lib/utils";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { normalizeProviderAccentColor } from "../../providerInstances";
@@ -48,6 +50,7 @@ import { ProviderInstanceIcon, providerInstanceInitials } from "../chat/Provider
 import { ProviderAccentColorPicker } from "./ProviderAccentColorPicker";
 import { RedactedSensitiveText } from "./RedactedSensitiveText";
 import { SettingsRow, SettingsSection } from "./settingsLayout";
+import { LimitWindows, ResetCredits } from "../usage/UsageLimits";
 import {
   getProviderVersionAdvisoryPresentation,
   PROVIDER_STATUS_STYLES,
@@ -167,6 +170,60 @@ function ProviderAuthEmail(props: { readonly email: string | undefined }) {
       hideTooltip="Click to hide email"
       className="max-w-full truncate"
     />
+  );
+}
+
+function ProviderUsageLimits({
+  environmentId,
+  provider,
+}: {
+  readonly environmentId?: EnvironmentId;
+  readonly provider: ServerProvider | undefined;
+}) {
+  const [now] = useState(() => Date.now());
+  const usageLimits = provider?.usageLimits;
+  const notice = usageLimits ? limitsNotice(usageLimits) : null;
+  const providerName = provider?.displayName?.trim() || provider?.driver || "provider";
+
+  return (
+    <SettingsSection title="Usage limits">
+      {!provider ? (
+        <SettingsRow title="Usage data is not available yet." />
+      ) : !usageLimits ? (
+        <SettingsRow
+          title="No usage data reported"
+          description={`Refresh provider status after signing in to ${providerName} to check your limits.`}
+        />
+      ) : notice ? (
+        <SettingsRow title="Usage limits unavailable" description={notice} />
+      ) : (
+        <div className="overflow-hidden p-3 sm:p-4">
+          <div className="relative overflow-hidden">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-foreground">Current subscription</p>
+                <p className="mt-1 truncate text-xs text-muted-foreground">
+                  {provider.auth.label ?? provider.auth.type ?? "Not reported"}
+                </p>
+              </div>
+            </div>
+            <div className="mt-4 border-t border-border/60 pt-3">
+              <LimitWindows driver={provider.driver} windows={usageLimits.windows} now={now} />
+            </div>
+            {usageLimits.resetCredits && environmentId ? (
+              <div className="mt-3 border-t border-border/60 pt-3">
+                <ResetCredits
+                  environmentId={environmentId}
+                  instanceId={provider.instanceId}
+                  credits={usageLimits.resetCredits}
+                  now={now}
+                />
+              </div>
+            ) : null}
+          </div>
+        </div>
+      )}
+    </SettingsSection>
   );
 }
 
@@ -344,6 +401,7 @@ function ProviderEnvironmentSection(props: {
 
 interface ProviderInstanceCardProps {
   readonly instanceId: ProviderInstanceId;
+  readonly environmentId?: EnvironmentId;
   readonly instance: ProviderInstanceConfig;
   readonly driverOption: DriverOption | undefined;
   readonly liveProvider: ServerProvider | undefined;
@@ -399,6 +457,7 @@ interface ProviderInstanceCardProps {
  */
 export function ProviderInstanceCard({
   instanceId,
+  environmentId,
   instance,
   driverOption,
   liveProvider,
@@ -913,6 +972,13 @@ export function ProviderInstanceCard({
             />
           </div>
         </SettingsSection>
+      ) : null}
+
+      {mode === "editor" ? (
+        <ProviderUsageLimits
+          {...(environmentId ? { environmentId } : {})}
+          provider={liveProvider}
+        />
       ) : null}
     </>
   );

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -162,7 +162,7 @@ function ProviderLastChecked({ lastCheckedAt }: { lastCheckedAt: string | null }
   );
 }
 
-function CodexUsageLimits({
+function ProviderUsageLimits({
   environmentId,
   provider,
 }: {
@@ -1115,7 +1115,7 @@ export function EnvironmentProviderSettings({
                 <div className="space-y-6 p-4">
                   {renderProviderInstance(selectedRow, "editor")}
                   {selectedRow.driver === "codex" ? (
-                    <CodexUsageLimits
+                    <ProviderUsageLimits
                       environmentId={environmentId}
                       provider={selectedLiveProvider}
                     />

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -13,6 +13,7 @@ import {
   ProviderDriverKind,
   type ProviderInstanceConfig,
   type ProviderInstanceId,
+  type ServerProvider,
   resolveEnvironmentMachineKind,
   resolveProviderInstanceEnabled,
 } from "@t3tools/contracts";
@@ -21,6 +22,7 @@ import {
   getBackgroundActivityPresetSettings,
   resolveServerBackgroundActivitySettings,
 } from "@t3tools/shared/backgroundActivitySettings";
+import { limitsNotice } from "@t3tools/shared/usageLimits";
 import * as Arr from "effect/Array";
 import * as Duration from "effect/Duration";
 import * as Equal from "effect/Equal";
@@ -77,10 +79,11 @@ import { stackedThreadToast, toastManager } from "../ui/toast";
 import { AddProviderInstanceDialog } from "./AddProviderInstanceDialog";
 import { ExpandableText } from "./ExpandableText";
 import { ProviderInstanceCard } from "./ProviderInstanceCard";
-import { UsageProviderSettings } from "./UsageProviderSettings";
+import { LimitWindows, ResetCredits } from "../usage/UsageLimits";
 import { ProviderSetupSection, readAntigravityAuthMethod } from "./ProviderSetupSection";
 import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
 import { searchableSetting } from "./settingsSearch";
+import { UsageProviderSettings } from "./UsageProviderSettings";
 import {
   backgroundActivityOverrideSettings,
   buildProviderInstanceUpdatePatch,
@@ -156,6 +159,49 @@ function ProviderLastChecked({ lastCheckedAt }: { lastCheckedAt: string | null }
         <>Checked {lastCheckedRelative.value}</>
       )}
     </span>
+  );
+}
+
+function CodexUsageLimits({
+  environmentId,
+  provider,
+}: {
+  readonly environmentId: EnvironmentId;
+  readonly provider: ServerProvider | undefined;
+}) {
+  const [now] = useState(() => Date.now());
+  const usageLimits = provider?.usageLimits;
+  const notice = usageLimits ? limitsNotice(usageLimits) : null;
+
+  return (
+    <SettingsSection title="Usage limits">
+      {!provider ? (
+        <SettingsRow title="Usage data is not available yet." />
+      ) : !usageLimits ? (
+        <SettingsRow
+          title="No usage data reported"
+          description="Refresh provider status after signing in to Codex to check your limits."
+        />
+      ) : notice ? (
+        <SettingsRow title="Usage limits unavailable" description={notice} />
+      ) : (
+        <div className="space-y-3 p-3 sm:p-4">
+          <SettingsRow
+            title="Current subscription"
+            description={provider.auth.label ?? provider.auth.type ?? "Not reported"}
+          />
+          <LimitWindows driver={provider.driver} windows={usageLimits.windows} now={now} />
+          {usageLimits.resetCredits ? (
+            <ResetCredits
+              environmentId={environmentId}
+              instanceId={provider.instanceId}
+              credits={usageLimits.resetCredits}
+              now={now}
+            />
+          ) : null}
+        </div>
+      )}
+    </SettingsSection>
   );
 }
 
@@ -777,6 +823,9 @@ export function EnvironmentProviderSettings({
   const selectedRow =
     rows.find((row) => row.instanceId === selectedInstanceId) ??
     (targetInstanceMissing ? null : (rows[0] ?? null));
+  const selectedLiveProvider = selectedRow
+    ? serverProviders.find((provider) => provider.instanceId === selectedRow.instanceId)
+    : undefined;
 
   const updateProviderInstance = (
     row: InstanceRow,
@@ -1053,7 +1102,15 @@ export function EnvironmentProviderSettings({
           <div className="min-w-0 lg:min-h-0">
             {selectedRow ? (
               <ScrollArea scrollFade chainVerticalScroll className="lg:h-full">
-                <div className="space-y-6 p-4">{renderProviderInstance(selectedRow, "editor")}</div>
+                <div className="space-y-6 p-4">
+                  {renderProviderInstance(selectedRow, "editor")}
+                  {selectedRow.driver === "codex" ? (
+                    <CodexUsageLimits
+                      environmentId={environmentId}
+                      provider={selectedLiveProvider}
+                    />
+                  ) : null}
+                </div>
               </ScrollArea>
             ) : (
               <div className="p-6 text-sm text-muted-foreground">

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -13,7 +13,6 @@ import {
   ProviderDriverKind,
   type ProviderInstanceConfig,
   type ProviderInstanceId,
-  type ServerProvider,
   resolveEnvironmentMachineKind,
   resolveProviderInstanceEnabled,
 } from "@t3tools/contracts";
@@ -22,7 +21,6 @@ import {
   getBackgroundActivityPresetSettings,
   resolveServerBackgroundActivitySettings,
 } from "@t3tools/shared/backgroundActivitySettings";
-import { limitsNotice } from "@t3tools/shared/usageLimits";
 import * as Arr from "effect/Array";
 import * as Duration from "effect/Duration";
 import * as Equal from "effect/Equal";
@@ -79,7 +77,6 @@ import { stackedThreadToast, toastManager } from "../ui/toast";
 import { AddProviderInstanceDialog } from "./AddProviderInstanceDialog";
 import { ExpandableText } from "./ExpandableText";
 import { ProviderInstanceCard } from "./ProviderInstanceCard";
-import { LimitWindows, ResetCredits } from "../usage/UsageLimits";
 import { ProviderSetupSection, readAntigravityAuthMethod } from "./ProviderSetupSection";
 import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
 import { searchableSetting } from "./settingsSearch";
@@ -159,59 +156,6 @@ function ProviderLastChecked({ lastCheckedAt }: { lastCheckedAt: string | null }
         <>Checked {lastCheckedRelative.value}</>
       )}
     </span>
-  );
-}
-
-function ProviderUsageLimits({
-  environmentId,
-  provider,
-}: {
-  readonly environmentId: EnvironmentId;
-  readonly provider: ServerProvider | undefined;
-}) {
-  const [now] = useState(() => Date.now());
-  const usageLimits = provider?.usageLimits;
-  const notice = usageLimits ? limitsNotice(usageLimits) : null;
-
-  return (
-    <SettingsSection title="Usage limits">
-      {!provider ? (
-        <SettingsRow title="Usage data is not available yet." />
-      ) : !usageLimits ? (
-        <SettingsRow
-          title="No usage data reported"
-          description="Refresh provider status after signing in to Codex to check your limits."
-        />
-      ) : notice ? (
-        <SettingsRow title="Usage limits unavailable" description={notice} />
-      ) : (
-        <div className="overflow-hidden p-3 sm:p-4">
-          <div className="relative overflow-hidden">
-            <div className="flex items-start justify-between gap-4">
-              <div className="min-w-0">
-                <p className="text-sm font-medium text-foreground">Current subscription</p>
-                <p className="mt-1 truncate text-xs text-muted-foreground">
-                  {provider.auth.label ?? provider.auth.type ?? "Not reported"}
-                </p>
-              </div>
-            </div>
-            <div className="mt-4 border-t border-border/60 pt-3">
-              <LimitWindows driver={provider.driver} windows={usageLimits.windows} now={now} />
-            </div>
-            {usageLimits.resetCredits ? (
-              <div className="mt-3 border-t border-border/60 pt-3">
-                <ResetCredits
-                  environmentId={environmentId}
-                  instanceId={provider.instanceId}
-                  credits={usageLimits.resetCredits}
-                  now={now}
-                />
-              </div>
-            ) : null}
-          </div>
-        </div>
-      )}
-    </SettingsSection>
   );
 }
 
@@ -833,10 +777,6 @@ export function EnvironmentProviderSettings({
   const selectedRow =
     rows.find((row) => row.instanceId === selectedInstanceId) ??
     (targetInstanceMissing ? null : (rows[0] ?? null));
-  const selectedLiveProvider = selectedRow
-    ? serverProviders.find((provider) => provider.instanceId === selectedRow.instanceId)
-    : undefined;
-
   const updateProviderInstance = (
     row: InstanceRow,
     next: ProviderInstanceConfig,
@@ -951,6 +891,7 @@ export function EnvironmentProviderSettings({
       <ProviderInstanceCard
         key={row.instanceId}
         instanceId={row.instanceId}
+        environmentId={environmentId}
         instance={row.instance}
         driverOption={driverOption}
         liveProvider={liveProvider}
@@ -1112,15 +1053,7 @@ export function EnvironmentProviderSettings({
           <div className="min-w-0 lg:min-h-0">
             {selectedRow ? (
               <ScrollArea scrollFade chainVerticalScroll className="lg:h-full">
-                <div className="space-y-6 p-4">
-                  {renderProviderInstance(selectedRow, "editor")}
-                  {selectedRow.driver === "codex" ? (
-                    <ProviderUsageLimits
-                      environmentId={environmentId}
-                      provider={selectedLiveProvider}
-                    />
-                  ) : null}
-                </div>
+                <div className="space-y-6 p-4">{renderProviderInstance(selectedRow, "editor")}</div>
               </ScrollArea>
             ) : (
               <div className="p-6 text-sm text-muted-foreground">

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -185,20 +185,30 @@ function CodexUsageLimits({
       ) : notice ? (
         <SettingsRow title="Usage limits unavailable" description={notice} />
       ) : (
-        <div className="space-y-3 p-3 sm:p-4">
-          <SettingsRow
-            title="Current subscription"
-            description={provider.auth.label ?? provider.auth.type ?? "Not reported"}
-          />
-          <LimitWindows driver={provider.driver} windows={usageLimits.windows} now={now} />
-          {usageLimits.resetCredits ? (
-            <ResetCredits
-              environmentId={environmentId}
-              instanceId={provider.instanceId}
-              credits={usageLimits.resetCredits}
-              now={now}
-            />
-          ) : null}
+        <div className="overflow-hidden p-3 sm:p-4">
+          <div className="relative overflow-hidden">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-foreground">Current subscription</p>
+                <p className="mt-1 truncate text-xs text-muted-foreground">
+                  {provider.auth.label ?? provider.auth.type ?? "Not reported"}
+                </p>
+              </div>
+            </div>
+            <div className="mt-4 border-t border-border/60 pt-3">
+              <LimitWindows driver={provider.driver} windows={usageLimits.windows} now={now} />
+            </div>
+            {usageLimits.resetCredits ? (
+              <div className="mt-3 border-t border-border/60 pt-3">
+                <ResetCredits
+                  environmentId={environmentId}
+                  instanceId={provider.instanceId}
+                  credits={usageLimits.resetCredits}
+                  now={now}
+                />
+              </div>
+            ) : null}
+          </div>
         </div>
       )}
     </SettingsSection>

--- a/apps/web/src/components/usage/UsageLimits.tsx
+++ b/apps/web/src/components/usage/UsageLimits.tsx
@@ -176,14 +176,14 @@ export function LimitWindows({
         const resetsIn = formatResetsIn(window, now);
         return (
           <Fragment key={window.id}>
-            <span className="flex min-w-0 items-center gap-2 text-xs">
+            <span className="flex min-w-0 items-center gap-1 text-xs">
               <span className="truncate text-muted-foreground">{window.label}</span>
               <span className="ms-auto shrink-0 font-medium text-foreground tabular-nums">
                 {remainingPercent(window)}% left
               </span>
             </span>
             <WindowBar color={color} window={window} now={now} />
-            <span className="flex items-center gap-2 text-xs whitespace-nowrap text-muted-foreground tabular-nums">
+            <span className="flex items-center gap-2 text-xs whitespace-nowrap text-muted-foreground tabular-nums w-full">
               {pace ? <PaceIcon pace={pace} /> : null}
               <span className="ms-auto shrink-0">{resetsIn ?? ""}</span>
             </span>


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Added a Usage limits section to each provider instance in Settings.
- Displayed subscription details, usage windows, remaining percentages, reset countdowns, and pacing indicators.
- Added reset-credit summaries and a confirmation flow for redeeming available credits.
- Passed the environment ID through provider settings to support reset-credit actions.
- Adjusted usage-limit row spacing for the provider settings layout.

## Why

Provider usage limits and reset credits were available in the broader usage view but were not visible while managing an individual provider. Showing them directly in the provider settings gives users context at the point where they configure and troubleshoot provider access, while reusing the existing usage-limit and reset-credit components to keep behavior consistent.

## UI Changes

- Before: Provider settings did not show usage limits or reset-credit information.
- After: Provider settings show current subscription details, usage windows, reset timing, and an optional “Use reset” action with confirmation.

<img width="769" height="236" alt="image" src="https://github.com/user-attachments/assets/0493ca2b-f9f0-4b9c-9ca1-0d1b70021a67" />

## Checklist

- [x] I included before/after screenshots for any UI changes
- [x] I explained what changed and why
- [x] This PR is small and focused
- [x] I included a video for animation/interaction changes