### PR TITLE
fix(web): hide browser when the right panel starts closing

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -7632,7 +7632,7 @@ export default function ChatView(props: ChatViewProps) {
           threadRef={activeThreadRef}
           tabId={renderedRightPanelSurface.resourceId}
           configuredUrls={configuredPreviewUrls}
-          visible
+          visible={rightPanelOpen}
           onSendAnnotation={(annotation, image) => {
             void onSend(undefined, "foreground", { annotation, image });
           }}


### PR DESCRIPTION
## What Changed

Pass `visible={rightPanelOpen}` to `PreviewPanel` so the docked browser hides as soon as the right panel starts closing, matching the terminal panel.

## Why

With panel motion enabled, the panel stays mounted during its closing animation. The desktop webview previously stayed visible throughout that animation and lingered over the expanding chat. This uses the existing surface visibility handling, including parking inactive macOS guests offscreen.

Fixes #10383. Implements the immediate-hide fix suggested in [Julius's triage](https://github.com/pingdotgg/t3code/issues/10383#issuecomment-5560527940).

## Validation

- 15 focused browser surface, hosted webview, and visibility style tests passed.
- Web typecheck, targeted formatting, and desktop build passed. Targeted lint reported existing warnings.
- Tested in an isolated macOS desktop instance with panel motion set to 400 ms: close, reopen, and interaction with the reopened page. Reporter also tested and supplied the after recording.

## UI Changes

| Before: browser lingers over chat | After: browser hides during collapse |
| --- | --- |
| ![Browser still visible after the panel begins closing](https://github.com/user-attachments/assets/29131687-de69-45e1-9dd0-58aac30dbe53) | ![Browser hidden while the panel finishes closing](https://github.com/user-attachments/assets/a6eaa0a6-d41e-465d-bc3b-0d8e35b97d2c) |

Before:

https://github.com/user-attachments/assets/02076bb9-4a5a-4100-b200-d68167731556

After:

https://github.com/user-attachments/assets/edb63890-dc83-4912-9ab9-031bf1d0ce5d

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: GPT-6-Astra. Harness: Codex.
