### PR TITLE
fix(web): go back with Escape from Usage and Pull Requests

### DIFF
--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -6,8 +6,9 @@ import {
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { memo, useCallback } from "react";
-import { Link, useCanGoBack, useLocation, useNavigate } from "@tanstack/react-router";
+import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 
+import { useNavigateBack } from "../../hooks/useNavigateBack";
 import { useEnvironmentIdentificationMode } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
 import { useEnvironments } from "../../state/environments";
@@ -133,7 +134,7 @@ function SidebarUtilityItem({
 
 export const SidebarUtilityMenu = memo(function SidebarUtilityMenu() {
   const navigate = useNavigate();
-  const canGoBack = useCanGoBack();
+  const navigateBack = useNavigateBack();
   const { isMobile, setOpenMobile } = useSidebar();
   const currentFooterPage = useLocation({
     select: (location) =>
@@ -179,12 +180,8 @@ export const SidebarUtilityMenu = memo(function SidebarUtilityMenu() {
 
   const handleBackClick = useCallback(() => {
     closeMobileSidebar();
-    if (canGoBack) {
-      window.history.back();
-      return;
-    }
-    void navigate({ to: "/" });
-  }, [canGoBack, closeMobileSidebar, navigate]);
+    navigateBack();
+  }, [closeMobileSidebar, navigateBack]);
 
   return (
     <SidebarMenu className="flex-row items-center">

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -9,6 +9,8 @@ const testState = vi.hoisted(() => ({
   breakdown: "time" as "model" | "time",
 }));
 
+vi.mock("../../hooks/useNavigateBack", () => ({ useEscapeToGoBack: () => {} }));
+
 vi.mock("react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react")>();
   return {

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -20,6 +20,7 @@ import {
 } from "@t3tools/shared/usageMerge";
 
 import { isElectron } from "../../env";
+import { useEscapeToGoBack } from "../../hooks/useNavigateBack";
 import { cn } from "../../lib/utils";
 import { environmentPresentations } from "../../state/presentation";
 import { serverEnvironment } from "../../state/server";
@@ -91,6 +92,7 @@ function isUsageWindowDays(value: number): value is UsagePagePreferences["window
 }
 
 export function UsagePage() {
+  useEscapeToGoBack();
   const [preferences, setPreferences] = useState(readUsagePagePreferences);
   const [windowSelection, setWindowSelection] = useState(() => ({
     days: preferences.windowDays,

--- a/apps/web/src/hooks/useNavigateBack.test.tsx
+++ b/apps/web/src/hooks/useNavigateBack.test.tsx
@@ -1,0 +1,105 @@
+import { createMemoryHistory } from "@tanstack/react-router";
+import { act } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { useEscapeToGoBack } from "./useNavigateBack";
+
+let history: ReturnType<typeof createMemoryHistory>;
+const navigate = ({ to }: { to: string }) => history.push(to);
+
+vi.mock("@tanstack/react-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-router")>()),
+  useCanGoBack: () => history.canGoBack(),
+  useNavigate: () => navigate,
+}));
+
+let renderer: ReactTestRenderer | undefined;
+let events: EventTarget;
+const blur = vi.fn();
+
+function Page() {
+  useEscapeToGoBack();
+  return null;
+}
+
+async function openPage(entries: string[]) {
+  history = createMemoryHistory({ initialEntries: entries });
+  events = new EventTarget();
+  vi.stubGlobal("window", Object.assign(events, { history }));
+  await act(() => {
+    renderer = create(<Page />);
+  });
+}
+
+function pressKey(init: KeyboardEventInit = {}) {
+  const event = Object.assign(new Event("keydown", { cancelable: true }), {
+    key: "Escape",
+    repeat: false,
+    isComposing: false,
+    ...init,
+  });
+  events.dispatchEvent(event);
+  return event;
+}
+
+beforeEach(() => {
+  class FocusedElement {
+    blur = blur;
+  }
+  blur.mockClear();
+  vi.stubGlobal("HTMLElement", FocusedElement);
+  vi.stubGlobal("document", { activeElement: new FocusedElement() });
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+});
+
+afterEach(async () => {
+  await act(() => renderer?.unmount());
+  renderer = undefined;
+  vi.unstubAllGlobals();
+});
+
+describe("Escape page navigation", () => {
+  it("returns to the previous app page and releases input focus", async () => {
+    await openPage(["/env/thread", "/pull-requests"]);
+    expect(pressKey().defaultPrevented).toBe(true);
+    expect(history.location.pathname).toBe("/env/thread");
+    expect(blur).toHaveBeenCalledOnce();
+  });
+
+  it("returns home when the page was opened without app history", async () => {
+    await openPage(["/usage"]);
+    pressKey();
+    expect(history.location.pathname).toBe("/");
+  });
+
+  it("lets an editor or popup consume Escape before navigating", async () => {
+    await openPage(["/env/thread", "/pull-requests"]);
+    const event = Object.assign(new Event("keydown", { cancelable: true }), { key: "Escape" });
+    event.preventDefault();
+    events.dispatchEvent(event);
+    expect(history.location.pathname).toBe("/pull-requests");
+    expect(blur).not.toHaveBeenCalled();
+
+    pressKey();
+    expect(history.location.pathname).toBe("/env/thread");
+  });
+
+  it.each([{ repeat: true }, { isComposing: true }, { key: "Enter" }])(
+    "does not navigate for %j",
+    async (init) => {
+      await openPage(["/env/thread", "/usage"]);
+      expect(pressKey(init).defaultPrevented).toBe(false);
+      expect(history.location.pathname).toBe("/usage");
+      expect(blur).not.toHaveBeenCalled();
+    },
+  );
+
+  it("stops handling Escape after leaving the page", async () => {
+    await openPage(["/env/thread", "/usage"]);
+    await act(() => renderer?.unmount());
+    renderer = undefined;
+    expect(pressKey().defaultPrevented).toBe(false);
+    expect(history.location.pathname).toBe("/usage");
+  });
+});

--- a/apps/web/src/hooks/useNavigateBack.ts
+++ b/apps/web/src/hooks/useNavigateBack.ts
@@ -1,0 +1,39 @@
+import { useCanGoBack, useNavigate } from "@tanstack/react-router";
+import { useCallback, useEffect } from "react";
+
+/** Returns to the previous app page, or home when opened without app history. */
+export function useNavigateBack() {
+  const navigate = useNavigate();
+  const canGoBack = useCanGoBack();
+
+  return useCallback(() => {
+    if (canGoBack) {
+      window.history.back();
+      return;
+    }
+    void navigate({ to: "/" });
+  }, [canGoBack, navigate]);
+}
+
+/** Enables page-level Escape navigation, letting controls consume Escape first. */
+export function useEscapeToGoBack() {
+  const navigateBack = useNavigateBack();
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.repeat || event.isComposing || event.key !== "Escape")
+        return;
+      event.preventDefault();
+
+      const activeElement = document.activeElement;
+      if (activeElement instanceof HTMLElement) {
+        activeElement.blur();
+      }
+
+      navigateBack();
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [navigateBack]);
+}

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -112,6 +112,7 @@ import { WorkspacePageContainer } from "../components/WorkspacePageContainer";
 import { WorkspacePageHeader } from "../components/WorkspacePageHeader";
 import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { isElectron } from "../env";
+import { useEscapeToGoBack } from "../hooks/useNavigateBack";
 import { resolveShortcutCommand } from "../keybindings";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { PanelLayoutControls } from "../components/chat/PanelLayoutControls";
@@ -1871,6 +1872,8 @@ function PullRequestsRouteView() {
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [keybindings]);
+
+  useEscapeToGoBack();
 
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -1,13 +1,6 @@
 import { RotateCcwIcon } from "lucide-react";
-import {
-  Outlet,
-  createFileRoute,
-  redirect,
-  useCanGoBack,
-  useLocation,
-  useNavigate,
-} from "@tanstack/react-router";
-import { useCallback, useEffect, useState } from "react";
+import { Outlet, createFileRoute, redirect, useLocation } from "@tanstack/react-router";
+import { useState } from "react";
 
 import { useSettingsRestore } from "../components/settings/SettingsPanels";
 import { SettingsBreadcrumb } from "../components/settings/SettingsBreadcrumb";
@@ -15,6 +8,7 @@ import { Button } from "../components/ui/button";
 import { SidebarInset } from "../components/ui/sidebar";
 import { WorkspacePageHeader } from "../components/WorkspacePageHeader";
 import { isElectron } from "../env";
+import { useEscapeToGoBack } from "../hooks/useNavigateBack";
 
 function RestoreDefaultsButton({ onRestored }: { onRestored: () => void }) {
   const { changedSettingLabels, restoreDefaults } = useSettingsRestore(onRestored);
@@ -34,39 +28,10 @@ function RestoreDefaultsButton({ onRestored }: { onRestored: () => void }) {
 
 function SettingsContentLayout() {
   const location = useLocation();
-  const navigate = useNavigate();
-  const canGoBack = useCanGoBack();
+  useEscapeToGoBack();
   const [restoreSignal, setRestoreSignal] = useState(0);
   const showRestoreDefaults = location.pathname === "/settings/general";
   const handleRestored = () => setRestoreSignal((value) => value + 1);
-  const navigateBackWithinApp = useCallback(() => {
-    if (canGoBack) {
-      window.history.back();
-      return;
-    }
-    void navigate({ to: "/" });
-  }, [canGoBack, navigate]);
-
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.defaultPrevented) return;
-      if (event.key === "Escape") {
-        event.preventDefault();
-
-        const activeElement = document.activeElement;
-        if (activeElement instanceof HTMLElement) {
-          activeElement.blur();
-        }
-
-        navigateBackWithinApp();
-      }
-    };
-
-    window.addEventListener("keydown", onKeyDown);
-    return () => {
-      window.removeEventListener("keydown", onKeyDown);
-    };
-  }, [navigateBackWithinApp]);
 
   return (
     <SidebarInset


### PR DESCRIPTION
Escape returned from Settings but did nothing on Usage and Pull Requests. Reuse the shared back-navigation hooks from #10158 across all three pages and the sidebar Back button. Editors and popovers that consume Escape still dismiss first.

Fixes #10388. Overlaps with #10158 for Usage and the shared hooks; this also covers Pull Requests, without adding Usage shortcuts.

Validated with 17 focused tests, web typecheck, formatting, and a desktop build. Targeted lint reported existing warnings only. Reporter tested both pages in the local macOS desktop app.

### Desktop verification

https://github.com/user-attachments/assets/b2968fd4-1bb2-49a9-a669-ea013edfc0a3

Created with GPT-6 in Codex in T3 Code
