### PR TITLE
fix(web, mobile): replace Apple desktop machine labels

### DIFF
--- a/apps/mobile/src/components/EnvironmentMachineSymbol.tsx
+++ b/apps/mobile/src/components/EnvironmentMachineSymbol.tsx
@@ -19,8 +19,8 @@ export const ENVIRONMENT_MACHINE_KIND_LABELS: Record<EnvironmentMachineKind, str
   linux: "Linux/WSL",
   desktop: "Desktop",
   laptop: "Laptop",
-  "mac-mini": "Mac mini",
-  "mac-studio": "Mac Studio",
+  "mac-mini": "Mini PC",
+  "mac-studio": "Workstation",
 };
 
 /** The glyph an environment wears in lists; SF Symbols on iOS, Tabler on Android. */

--- a/apps/web/src/components/EnvironmentMachineIcon.tsx
+++ b/apps/web/src/components/EnvironmentMachineIcon.tsx
@@ -59,8 +59,8 @@ export const ENVIRONMENT_MACHINE_KIND_LABELS: Record<EnvironmentMachineKind, str
   linux: "Linux/WSL",
   desktop: "Desktop",
   laptop: "Laptop",
-  "mac-mini": "Mac mini",
-  "mac-studio": "Mac Studio",
+  "mac-mini": "Mini PC",
+  "mac-studio": "Workstation",
 };
 
 export function environmentMachineIcon(


### PR DESCRIPTION
## What Changed

Replaces the Apple-specific environment labels `Mac mini` and `Mac Studio` with `Mini PC` and `Workstation` in web and mobile.

## Why

These labels describe machine types, not Apple products. The neutral names fit the existing `Server`, `Cloud VM`, `Desktop`, and `Laptop` options.

## UI Changes

- `Mac mini` → `Mini PC`
- `Mac Studio` → `Workstation`

Prepared by Codex on behalf of extoci. Model: GPT-6 Astra. Harness: T3 Code.