### PR TITLE
fix(clients): show feedback results in composer banners

### DIFF
--- a/apps/mobile/src/features/threads/ComposerFeedback.tsx
+++ b/apps/mobile/src/features/threads/ComposerFeedback.tsx
@@ -1,0 +1,63 @@
+import {
+  codexFeedbackNotice,
+  type CodexFeedbackSubmission,
+} from "@t3tools/client-runtime/state/threads";
+import { Pressable, View } from "react-native";
+
+import { AppText as Text } from "../../components/AppText";
+import { SymbolView } from "../../components/AppSymbol";
+import { copyTextWithHaptic } from "../../lib/copyTextWithHaptic";
+
+export function ComposerFeedback({
+  submission,
+  onDismiss,
+}: {
+  readonly submission: CodexFeedbackSubmission;
+  readonly onDismiss: () => void;
+}) {
+  const notice = codexFeedbackNotice(submission);
+  if (!notice) return null;
+  return (
+    <View className="px-4 pb-3">
+      <View className="gap-2 rounded-[20px] border-continuous bg-card p-4">
+        <View className="flex-row items-center gap-3">
+          <Text accessibilityLiveRegion="polite" className="min-w-0 flex-1 text-sm text-foreground">
+            {notice.title}
+          </Text>
+          {submission.status !== "uploading" ? (
+            <Pressable
+              accessibilityLabel="Dismiss feedback notice"
+              accessibilityRole="button"
+              hitSlop={12}
+              onPress={onDismiss}
+              className="p-1 active:opacity-60"
+            >
+              <SymbolView
+                name="xmark"
+                size={14}
+                tintColorClassName="accent-icon-muted"
+                type="monochrome"
+              />
+            </Pressable>
+          ) : null}
+        </View>
+        {notice.description ? (
+          <Text selectable className="text-xs text-foreground-muted">
+            {notice.description}
+          </Text>
+        ) : null}
+        {submission.status === "sent" ? (
+          <Pressable
+            accessibilityRole="button"
+            onPress={() =>
+              copyTextWithHaptic(submission.feedbackId, { target: "Codex feedback thread ID" })
+            }
+            className="self-start py-1 active:opacity-60"
+          >
+            <Text className="text-sm text-foreground">Copy ID</Text>
+          </Pressable>
+        ) : null}
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -3,7 +3,10 @@ import {
   appendCodexArtifactTemplateUsePrompt,
   type CodexArtifactTemplate,
 } from "@t3tools/client-runtime/codex-artifact-templates";
-import type { EnvironmentThreadStatus } from "@t3tools/client-runtime/state/threads";
+import type {
+  CodexFeedbackSubmission,
+  EnvironmentThreadStatus,
+} from "@t3tools/client-runtime/state/threads";
 import { useKeyboardChatComposerInset, useKeyboardScrollToEnd } from "@legendapp/list/keyboard";
 import { resolveProviderSkillsForCwd } from "@t3tools/client-runtime/providerSkills";
 import type { LegendListRef } from "@legendapp/list/react-native";
@@ -72,6 +75,7 @@ import type {
   ThreadFeedEntry,
 } from "../../lib/threadActivity";
 import { PendingApprovalCard } from "./PendingApprovalCard";
+import { ComposerFeedback } from "./ComposerFeedback";
 import { ComposerUsageLimits } from "./ComposerUsageLimits";
 import { PendingUserInputCard } from "./PendingUserInputCard";
 import {
@@ -101,6 +105,8 @@ export interface ThreadDetailScreenProps {
   readonly screenTone: StatusTone;
   readonly connectionError: string | null;
   readonly environmentLabel: string | null;
+  readonly feedbackSubmissions: ReadonlyArray<CodexFeedbackSubmission>;
+  readonly onDismissFeedback: (id: MessageId) => void;
   readonly selectedThreadFeed: ReadonlyArray<ThreadFeedEntry>;
   readonly activeWorkStartedAt: string | null;
   readonly isCompacting: boolean;
@@ -847,6 +853,13 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
                 onScrollToEnd={handleScrollToEnd}
               />
               <View className="w-full self-center" style={{ maxWidth: contentMaxWidth }}>
+                {props.feedbackSubmissions.map((submission) => (
+                  <ComposerFeedback
+                    key={submission.id}
+                    submission={submission}
+                    onDismiss={() => props.onDismissFeedback(submission.id)}
+                  />
+                ))}
                 {usageLimitsReport && activeUserInputRequestId === null ? (
                   <Animated.View
                     className="shrink-0 px-4 pb-3"

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -787,6 +787,8 @@ function ThreadRouteContent(
           screenTone={connectionTone(routeConnectionState)}
           connectionError={routeConnectionError}
           environmentLabel={selectedEnvironmentConnection?.environmentLabel ?? null}
+          feedbackSubmissions={composer.feedbackSubmissions}
+          onDismissFeedback={composer.dismissFeedback}
           selectedThreadFeed={composer.selectedThreadFeed}
           activeWorkStartedAt={composer.activeWorkStartedAt}
           isCompacting={composer.isCompacting}

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -1,6 +1,5 @@
 import { derivePendingRequests } from "@t3tools/client-runtime/pending-requests";
 import { describe, expect, it } from "vite-plus/test";
-import { codexFeedbackMessage } from "@t3tools/client-runtime/state/threads";
 
 import {
   EventId,
@@ -26,34 +25,6 @@ import {
   type ThreadFeedEntry,
   type WorkLogEntry,
 } from "./threadActivity";
-
-describe("Codex feedback pseudo-messages", () => {
-  it("keeps pending and completed feedback messages in the mobile thread body", () => {
-    const pending = {
-      id: MessageId.make("feedback-command"),
-      command: "/feedback The agent stopped early.",
-      createdAt: "2026-08-23T00:00:00.000Z",
-      status: "uploading" as const,
-    };
-    const entries = [codexFeedbackMessage(pending), codexFeedbackMessage(pending, "assistant")].map(
-      (message) => ({
-        type: "message" as const,
-        id: message.id,
-        createdAt: message.createdAt,
-        message,
-      }),
-    );
-
-    expect(deriveThreadFeedPresentation(entries, null, new Set())).toEqual(entries);
-    expect(entries[1]?.message.text).toBe("Sending feedback to OpenAI...");
-
-    const completed = codexFeedbackMessage(
-      { ...pending, status: "sent", feedbackId: "codex-thread-1" },
-      "assistant",
-    );
-    expect(completed.text).toContain("codex-thread-1");
-  });
-});
 
 const singleSelectQuestion = {
   id: "runtime",
@@ -878,44 +849,6 @@ describe("buildThreadFeed", () => {
       ]);
     },
   );
-
-  it("keeps older local feedback before newer messages returned by the server", () => {
-    const submission = {
-      id: MessageId.make("feedback-command-ordering"),
-      command: "/feedback The agent stopped early.",
-      createdAt: "2026-08-23T00:00:01.000Z",
-      status: "sent" as const,
-      feedbackId: "codex-thread-1",
-    };
-    const laterMessage = {
-      id: MessageId.make("later-server-message"),
-      role: "assistant" as const,
-      text: "Newer server response",
-      turnId: null,
-      createdAt: "2026-08-23T00:00:02.000Z",
-      updatedAt: "2026-08-23T00:00:02.000Z",
-      streaming: false,
-    };
-    const thread = makeThread({
-      id: ThreadId.make("thread-feedback-ordering"),
-      projectId: ProjectId.make("project-1"),
-      title: "Feedback ordering",
-      messages: [laterMessage],
-    });
-
-    const feed = buildThreadFeed(thread, {
-      localMessages: [
-        codexFeedbackMessage(submission),
-        codexFeedbackMessage(submission, "assistant"),
-      ],
-    });
-
-    expect(feed.map((entry) => entry.id)).toEqual([
-      "feedback-command-ordering",
-      "feedback-command-ordering:feedback",
-      "later-server-message",
-    ]);
-  });
 
   it("keeps historic work entries attributed to their turns", () => {
     const thread = makeThread({

--- a/apps/mobile/src/state/use-thread-composer-state.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.ts
@@ -1,7 +1,6 @@
 import { useAtomValue } from "@effect/atom-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Alert } from "react-native";
-import * as Cause from "effect/Cause";
 
 import {
   CommandId,
@@ -16,12 +15,10 @@ import {
 } from "@t3tools/contracts";
 import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
 import {
-  codexFeedbackMessage,
   parseCodexFeedbackCommand,
   submitCodexFeedback,
   type CodexFeedbackSubmission,
 } from "@t3tools/client-runtime/state/threads";
-import { isAtomCommandInterrupted } from "@t3tools/client-runtime/state/runtime";
 import { deriveActiveWorkStartedAt } from "@t3tools/shared/orchestrationTiming";
 
 import { makeQueuedMessageMetadata } from "../lib/commandMetadata";
@@ -35,7 +32,6 @@ import {
 } from "../lib/composerImages";
 import type { DraftComposerImageAttachment } from "../lib/composerImages";
 import { scopedThreadKey } from "../lib/scopedEntities";
-import { copyTextWithHaptic } from "../lib/copyTextWithHaptic";
 import { buildThreadFeed } from "../lib/threadActivity";
 import { appAtomRegistry } from "../state/atom-registry";
 import {
@@ -126,27 +122,31 @@ export function useThreadComposerState() {
     () => (selectedThreadKey ? (queuedMessagesByThreadKey[selectedThreadKey] ?? []) : []),
     [queuedMessagesByThreadKey, selectedThreadKey],
   );
-  const localFeedbackMessages = useMemo(() => {
-    const submissions = selectedThreadKey
-      ? (feedbackSubmissionsByThreadKey[selectedThreadKey] ?? [])
-      : [];
-    return submissions.flatMap((submission) =>
-      submission.status === "interrupted"
-        ? []
-        : [codexFeedbackMessage(submission), codexFeedbackMessage(submission, "assistant")],
-    );
-  }, [feedbackSubmissionsByThreadKey, selectedThreadKey]);
+  const feedbackSubmissions = useMemo(
+    () => (selectedThreadKey ? (feedbackSubmissionsByThreadKey[selectedThreadKey] ?? []) : []),
+    [feedbackSubmissionsByThreadKey, selectedThreadKey],
+  );
+  const dismissFeedback = useCallback(
+    (id: MessageId) => {
+      if (!selectedThreadKey) return;
+      setFeedbackSubmissionsByThreadKey((current) => ({
+        ...current,
+        [selectedThreadKey]: (current[selectedThreadKey] ?? []).filter((entry) => entry.id !== id),
+      }));
+    },
+    [selectedThreadKey],
+  );
   const selectedThreadMessages = selectedThreadDetail?.messages;
   const selectedThreadActivities = selectedThreadDetail?.activities;
   const selectedThreadFeed = useMemo(
     () =>
       selectedThreadMessages && selectedThreadActivities
-        ? buildThreadFeed(
-            { messages: selectedThreadMessages, activities: selectedThreadActivities },
-            { localMessages: localFeedbackMessages },
-          )
+        ? buildThreadFeed({
+            messages: selectedThreadMessages,
+            activities: selectedThreadActivities,
+          })
         : [],
-    [localFeedbackMessages, selectedThreadActivities, selectedThreadMessages],
+    [selectedThreadActivities, selectedThreadMessages],
   );
 
   const selectedDraft = selectedThreadKey ? composerDrafts[selectedThreadKey] : null;
@@ -294,7 +294,7 @@ export function useThreadComposerState() {
         return null;
       }
       const metadata = makeQueuedMessageMetadata();
-      const result = await submitCodexFeedback({
+      await submitCodexFeedback({
         submission: {
           id: MessageId.make(metadata.messageId),
           command: text,
@@ -322,25 +322,6 @@ export function useThreadComposerState() {
             },
           }),
       });
-      if (result._tag === "Failure") {
-        if (isAtomCommandInterrupted(result)) {
-          return null;
-        }
-        const error = Cause.squash(result.cause);
-        Alert.alert(
-          "Could not send feedback to OpenAI",
-          error instanceof Error ? error.message : "An error occurred.",
-        );
-        return null;
-      }
-      const feedbackId = result.value.feedbackId;
-      Alert.alert("Feedback sent to OpenAI", `Thread ID: ${feedbackId}`, [
-        { text: "OK", style: "cancel" },
-        {
-          text: "Copy ID",
-          onPress: () => copyTextWithHaptic(feedbackId, { target: "Codex feedback thread ID" }),
-        },
-      ]);
       return null;
     }
 
@@ -573,6 +554,8 @@ export function useThreadComposerState() {
   );
 
   return {
+    feedbackSubmissions,
+    dismissFeedback,
     selectedThreadFeed,
     selectedThreadQueueCount,
     activeWorkStartedAt,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5,6 +5,7 @@ import {
   hasProviderUsageLimits,
   isUsageLimitsCommand,
 } from "@t3tools/shared/usageLimits";
+import { feedbackBannerItem } from "./chat/ComposerFeedback";
 import { usageLimitsBannerItem } from "./chat/ComposerUsageLimits";
 import { derivePendingRequests } from "@t3tools/client-runtime/pending-requests";
 import {
@@ -40,7 +41,6 @@ import { wasBootstrapThreadDeleted } from "@t3tools/client-runtime/errors";
 import { type CodexArtifactTemplate } from "@t3tools/client-runtime/codex-artifact-templates";
 import { effectiveSnoozed, threadWokeAt } from "@t3tools/client-runtime/state/thread-settled";
 import {
-  codexFeedbackMessage,
   parseCodexFeedbackCommand,
   submitCodexFeedback,
   type CodexFeedbackSubmission,
@@ -3027,14 +3027,7 @@ export default function ChatView(props: ChatViewProps) {
             });
           });
 
-    const localMessages = [
-      ...optimisticUserMessages,
-      ...feedbackSubmissions.flatMap((submission) =>
-        submission.status === "interrupted"
-          ? []
-          : [codexFeedbackMessage(submission), codexFeedbackMessage(submission, "assistant")],
-      ),
-    ];
+    const localMessages = optimisticUserMessages;
     if (localMessages.length === 0) {
       return serverMessagesWithPreviewHandoff;
     }
@@ -3047,7 +3040,6 @@ export default function ChatView(props: ChatViewProps) {
   }, [
     attachmentPreviewHandoffByMessageId,
     displayServerMessages,
-    feedbackSubmissions,
     optimisticUserMessages,
     projectHandoffMessagePreviews,
   ]);
@@ -5624,6 +5616,21 @@ export default function ChatView(props: ChatViewProps) {
     }
     void handleSwitchCheckoutToThread();
   }, [gitStatusQuery.data?.hasWorkingTreeChanges, handleSwitchCheckoutToThread]);
+  const feedbackBannerItems = useMemo(
+    () =>
+      feedbackSubmissions.flatMap((submission) => {
+        const item = feedbackBannerItem(submission, () => {
+          setFeedbackSubmissionsByThreadKey((current) => ({
+            ...current,
+            [routeThreadKey]: (current[routeThreadKey] ?? []).filter(
+              (entry) => entry.id !== submission.id,
+            ),
+          }));
+        });
+        return item ? [item] : [];
+      }),
+    [feedbackSubmissions, routeThreadKey],
+  );
   const composerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
     const backgroundLivenessItems =
       backgroundLivenessBannerItem === null ? [] : [backgroundLivenessBannerItem];
@@ -5635,6 +5642,7 @@ export default function ChatView(props: ChatViewProps) {
     const usageLimitsItems = usageLimitsBanner === null ? [] : [usageLimitsBanner];
     if (!localCheckoutBranchMismatch || !showBranchMismatchBanner || !activeBranchMismatchKey) {
       return [
+        ...feedbackBannerItems,
         ...usageLimitsItems,
         ...systemComposerBannerItems,
         ...backgroundLivenessItems,
@@ -5644,6 +5652,7 @@ export default function ChatView(props: ChatViewProps) {
       ];
     }
     return [
+      ...feedbackBannerItems,
       ...usageLimitsItems,
       ...systemComposerBannerItems,
       ...backgroundLivenessItems,
@@ -5692,6 +5701,7 @@ export default function ChatView(props: ChatViewProps) {
   }, [
     activeBranchMismatchKey,
     backgroundLivenessBannerItem,
+    feedbackBannerItems,
     handleRestoreThreadBranch,
     isRestoringThreadBranch,
     localCheckoutBranchMismatch,
@@ -6276,7 +6286,7 @@ export default function ChatView(props: ChatViewProps) {
         return;
       }
       feedbackUploadsInFlightRef.current.add(routeThreadKey);
-      const result = await submitCodexFeedback({
+      await submitCodexFeedback({
         submission: {
           id: newMessageId(),
           command: trimmed,
@@ -6286,7 +6296,6 @@ export default function ChatView(props: ChatViewProps) {
           promptRef.current = "";
           clearComposerDraftContent(composerDraftTarget);
           composerRef.current?.resetCursorState();
-          scrollToEnd();
         },
         onUpdate: (submission) => {
           setFeedbackSubmissionsByThreadKey((current) => {
@@ -6311,43 +6320,7 @@ export default function ChatView(props: ChatViewProps) {
       }).finally(() => {
         feedbackUploadsInFlightRef.current.delete(routeThreadKey);
       });
-      if (result._tag === "Failure") {
-        if (!isAtomCommandInterrupted(result)) {
-          toastManager.add(
-            stackedThreadToast({
-              type: "error",
-              title: "Could not send feedback to OpenAI",
-              description: chatActionErrorMessage(squashAtomCommandFailure(result)),
-            }),
-          );
-        }
-        return;
-      }
-      const feedbackId = result.value.feedbackId;
-      toastManager.add(
-        stackedThreadToast({
-          type: "success",
-          title: "Feedback sent to OpenAI",
-          description: `Thread ID: ${feedbackId}`,
-          timeout: 0,
-          actionProps: {
-            children: "Copy ID",
-            onClick: () => {
-              void writeTextToClipboard(feedbackId, "Codex feedback thread ID").catch(
-                (error: unknown) => {
-                  toastManager.add(
-                    stackedThreadToast({
-                      type: "error",
-                      title: "Could not copy thread ID",
-                      description: chatActionErrorMessage(error),
-                    }),
-                  );
-                },
-              );
-            },
-          },
-        }),
-      );
+
       return;
     }
     if (

--- a/apps/web/src/components/chat/ComposerFeedback.tsx
+++ b/apps/web/src/components/chat/ComposerFeedback.tsx
@@ -1,0 +1,49 @@
+import {
+  codexFeedbackNotice,
+  type CodexFeedbackSubmission,
+} from "@t3tools/client-runtime/state/threads";
+import { MessageSquareIcon } from "lucide-react";
+
+import { writeTextToClipboard } from "../../hooks/useCopyToClipboard";
+import { Button } from "../ui/button";
+import { toastManager } from "../ui/toast";
+import type { ComposerBannerStackItem } from "./ComposerBannerStack";
+
+export function feedbackBannerItem(
+  submission: CodexFeedbackSubmission,
+  onDismiss: () => void,
+): ComposerBannerStackItem | null {
+  const notice = codexFeedbackNotice(submission);
+  if (!notice) return null;
+  return {
+    id: `feedback:${submission.id}`,
+    variant:
+      submission.status === "failed" ? "error" : submission.status === "sent" ? "success" : "info",
+    priority: submission.status === "uploading" ? "activity" : "notice",
+    icon: <MessageSquareIcon />,
+    ...notice,
+    actions:
+      submission.status === "sent" ? (
+        <Button
+          size="xs"
+          variant="ghost"
+          onClick={() => {
+            void writeTextToClipboard(submission.feedbackId, "Codex feedback thread ID").catch(
+              (error: unknown) => {
+                toastManager.add({
+                  type: "error",
+                  title: "Could not copy thread ID",
+                  description: error instanceof Error ? error.message : "An error occurred.",
+                });
+              },
+            );
+          }}
+        >
+          Copy ID
+        </Button>
+      ) : undefined,
+    ...(submission.status !== "uploading"
+      ? { dismissLabel: "Dismiss feedback notice", onDismiss }
+      : {}),
+  };
+}

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1,5 +1,4 @@
 import { CheckpointRef, EnvironmentId, MessageId, TurnId } from "@t3tools/contracts";
-import { codexFeedbackMessage } from "@t3tools/client-runtime/state/threads";
 import { act, createRef, useLayoutEffect, type ReactNode, type Ref } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { create, type ReactTestRenderer } from "react-test-renderer";
@@ -327,61 +326,6 @@ describe("MessagesTimeline", () => {
       }
     },
   );
-
-  it("renders a feedback command and its pending response as normal thread messages", () => {
-    const submission = {
-      id: MessageId.make("feedback-command"),
-      command: "/feedback The agent stopped early.",
-      createdAt: MESSAGE_CREATED_AT,
-      status: "uploading" as const,
-    };
-    const messages = [
-      codexFeedbackMessage(submission),
-      codexFeedbackMessage(submission, "assistant"),
-    ];
-    const markup = renderToStaticMarkup(
-      <MessagesTimeline
-        {...buildProps()}
-        timelineEntries={messages.map((message) => ({
-          id: message.id,
-          kind: "message" as const,
-          createdAt: message.createdAt,
-          message,
-        }))}
-      />,
-    );
-
-    expect(markup).toContain("/feedback The agent stopped early.");
-    expect(markup).toContain("Sending feedback to OpenAI...");
-  });
-
-  it("renders the returned Codex thread ID in the feedback response", () => {
-    const submission = {
-      id: MessageId.make("feedback-command"),
-      command: "/feedback The agent stopped early.",
-      createdAt: MESSAGE_CREATED_AT,
-      status: "sent" as const,
-      feedbackId: "codex-thread-1",
-    };
-    const messages = [
-      codexFeedbackMessage(submission),
-      codexFeedbackMessage(submission, "assistant"),
-    ];
-    const markup = renderToStaticMarkup(
-      <MessagesTimeline
-        {...buildProps()}
-        timelineEntries={messages.map((message) => ({
-          id: message.id,
-          kind: "message" as const,
-          createdAt: message.createdAt,
-          message,
-        }))}
-      />,
-    );
-
-    expect(markup).toContain("Feedback sent to OpenAI.");
-    expect(markup).toContain("codex-thread-1");
-  });
 
   it("renders elapsed time for a completed turn", () => {
     const turnId = TurnId.make("turn-with-fold");

--- a/packages/client-runtime/src/state/threadFeedback.test.ts
+++ b/packages/client-runtime/src/state/threadFeedback.test.ts
@@ -4,7 +4,7 @@ import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
 
 import {
-  codexFeedbackMessage,
+  codexFeedbackNotice,
   parseCodexFeedbackCommand,
   submitCodexFeedback,
   type CodexFeedbackSubmission,
@@ -40,7 +40,7 @@ describe("submitCodexFeedback", () => {
     createdAt: "2026-08-23T00:00:00.000Z",
   } as const;
 
-  it("shows the command and clears the draft before the upload finishes", async () => {
+  it("reports upload progress and clears the draft before the upload finishes", async () => {
     let draft: string = submission.command;
     let finishUpload:
       | ((result: ReturnType<typeof AsyncResult.success<{ feedbackId: string }>>) => void)
@@ -66,14 +66,10 @@ describe("submitCodexFeedback", () => {
 
     expect(draft).toBe("");
     expect(states).toEqual([{ ...submission, status: "uploading" }]);
-    expect(codexFeedbackMessage(states[0]!)).toMatchObject({
-      id: submission.id,
-      role: "user",
-      text: submission.command,
+    expect(codexFeedbackNotice(states[0]!)).toEqual({
+      title: "Sending feedback to OpenAI...",
+      description: undefined,
     });
-    expect(codexFeedbackMessage(states[0]!, "assistant").text).toBe(
-      "Sending feedback to OpenAI...",
-    );
 
     draft = "Keep this newer message.";
     finishUpload?.(AsyncResult.success({ feedbackId: "codex-thread-1" }));
@@ -85,7 +81,7 @@ describe("submitCodexFeedback", () => {
       status: "sent",
       feedbackId: "codex-thread-1",
     });
-    expect(codexFeedbackMessage(states.at(-1)!, "assistant").text).toContain("codex-thread-1");
+    expect(codexFeedbackNotice(states.at(-1)!)?.description).toContain("codex-thread-1");
   });
 
   it("records a failed upload without losing its user-facing error", async () => {
@@ -105,6 +101,7 @@ describe("submitCodexFeedback", () => {
       status: "failed",
       errorMessage: "Upload rejected.",
     });
+    expect(codexFeedbackNotice(states.at(-1)!)?.description).toBe("Upload rejected.");
   });
 
   it("marks interruptions without reporting them as upload failures", async () => {
@@ -119,6 +116,7 @@ describe("submitCodexFeedback", () => {
     });
 
     expect(states.at(-1)).toEqual({ ...submission, status: "interrupted" });
+    expect(codexFeedbackNotice(states.at(-1)!)).toBeNull();
   });
 
   it("lets another feedback submission finish while the first remains in flight", async () => {

--- a/packages/client-runtime/src/state/threadFeedback.ts
+++ b/packages/client-runtime/src/state/threadFeedback.ts
@@ -1,8 +1,4 @@
-import {
-  MessageId,
-  type OrchestrationMessage,
-  type ProviderUploadFeedbackResult,
-} from "@t3tools/contracts";
+import type { MessageId, ProviderUploadFeedbackResult } from "@t3tools/contracts";
 
 import {
   isAtomCommandInterrupted,
@@ -32,28 +28,20 @@ export function parseCodexFeedbackCommand(text: string): { readonly reason?: str
   return reason ? { reason } : {};
 }
 
-export function codexFeedbackMessage(
-  submission: CodexFeedbackSubmission,
-  role: "user" | "assistant" = "user",
-): OrchestrationMessage {
-  const text =
-    role === "user"
-      ? submission.command
-      : submission.status === "sent"
-        ? `Feedback sent to OpenAI.\n\nThread ID: \`${submission.feedbackId}\``
-        : submission.status === "failed"
-          ? `Could not send feedback to OpenAI.\n\n${submission.errorMessage}`
-          : "Sending feedback to OpenAI...";
-
-  return {
-    id: role === "user" ? submission.id : MessageId.make(`${submission.id}:feedback`),
-    role,
-    text,
-    turnId: null,
-    streaming: false,
-    createdAt: submission.createdAt,
-    updatedAt: submission.createdAt,
-  };
+export function codexFeedbackNotice(submission: CodexFeedbackSubmission) {
+  switch (submission.status) {
+    case "interrupted":
+      return null;
+    case "uploading":
+      return { title: "Sending feedback to OpenAI...", description: undefined };
+    case "sent":
+      return {
+        title: "Feedback sent to OpenAI",
+        description: `Thread ID: ${submission.feedbackId}`,
+      };
+    case "failed":
+      return { title: "Could not send feedback to OpenAI", description: submission.errorMessage };
+  }
 }
 
 export async function submitCodexFeedback<E>(input: {


### PR DESCRIPTION
`/feedback` inserted synthetic user and assistant messages into the conversation. It now shows upload progress and the result beside the composer, with Copy ID and dismissal controls. This applies to web, desktop, and mobile; submitting feedback no longer scrolls the web conversation.

Verification: 140 focused tests passed, plus web, mobile, and client-runtime typechecks. Targeted lint passed with existing warnings in the large chat screens. Browser verification covered upload progress, success, draft preservation, and dismissal. Native mobile was typechecked, not simulator-tested.

The captures use the actual base (`98469159dd9`) and head (`7bfbaf327ff`), identical disposable fixture data, and a 1440 × 1000 viewport. The feedback RPC was intercepted with a test response; no conversation was uploaded to OpenAI.

Before:

![Before: feedback creates two synthetic chat messages](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d1f0034d2aa838e0/before-sent.png)

After:

![After: feedback result attaches to the composer and preserves the draft](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/2b7ff79e7eaebb34/after-sent.png)

Upload, draft preservation, and dismissal:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/9d357eeb3b9da60c/feedback-flow.mp4

CI passed on `7bfbaf327ff`. No unresolved review findings. Macroscope approvability finished **neutral**: its eligibility verdict was “Would Approve,” but correctness review was unavailable because the workspace reached its monthly spending limit. Automated review completion remains unavailable.

Model: GPT-6. Harness: Codex.
