### PR TITLE
fix(web): improve preview recording frame delivery

### DIFF
--- a/apps/web/src/browser/browserRecording.test.ts
+++ b/apps/web/src/browser/browserRecording.test.ts
@@ -146,6 +146,7 @@ describe("browser recording", () => {
     vi.stubGlobal("cancelAnimationFrame", vi.fn());
     vi.stubGlobal("MediaRecorder", FakeMediaRecorder as unknown as typeof MediaRecorder);
     getDisplayMedia.mockResolvedValue({
+      getVideoTracks: () => [],
       getTracks: () => [{ stop: vi.fn() }],
     });
     requestDisplayMediaCapture.mockImplementation((tabId: string) => {
@@ -187,7 +188,7 @@ describe("browser recording", () => {
     getDisplayMedia.mockImplementationOnce(async () => {
       expect(animationFrameCount).toBe(2);
       expect(useBrowserSurfaceStore.getState().activityByTabId["background-tab"]).toBe(1);
-      return { getTracks: () => [{ stop: vi.fn() }] };
+      return { getVideoTracks: () => [], getTracks: () => [{ stop: vi.fn() }] };
     });
 
     await startBrowserRecording("background-tab");
@@ -214,18 +215,26 @@ describe("browser recording", () => {
     await stopBrowserRecording("hidden-window-tab");
   });
 
-  it("records the native tab stream armed by the main process", async () => {
+  it.each([
+    { width: 1280, height: 720, frameRate: 60, bitrate: 11_059_200 },
+    { width: 320, height: 240, frameRate: 30, bitrate: 2_500_000 },
+    { width: 3840, height: 2160, frameRate: 60, bitrate: 50_000_000 },
+  ])("records the native $width x $height stream at $frameRate fps", async (settings) => {
     const stopTrack = vi.fn();
-    const stream = { getTracks: () => [{ stop: stopTrack }] } as unknown as MediaStream;
+    const stream = {
+      getVideoTracks: () => [{ getSettings: () => settings }],
+      getTracks: () => [{ stop: stopTrack }],
+    } as unknown as MediaStream;
     getDisplayMedia.mockResolvedValueOnce(stream);
 
     await startBrowserRecording("recording-tab");
 
     expect(getDisplayMedia).toHaveBeenCalledWith({
       audio: false,
-      video: { frameRate: { max: 30 } },
+      video: { frameRate: { ideal: 30, max: 30 } },
     });
     expect(FakeMediaRecorder.instances[0]?.stream).toBe(stream);
+    expect(FakeMediaRecorder.instances[0]?.options?.videoBitsPerSecond).toBe(settings.bitrate);
 
     await stopBrowserRecording("recording-tab");
     expect(stopTrack).toHaveBeenCalledOnce();
@@ -238,7 +247,7 @@ describe("browser recording", () => {
 
     expect(getDisplayMedia).toHaveBeenCalledWith({
       audio: false,
-      video: { frameRate: { max: 60 } },
+      video: { frameRate: { ideal: 60, max: 60 } },
     });
     await stopBrowserRecording("recording-tab");
   });
@@ -263,7 +272,7 @@ describe("browser recording", () => {
 
     expect(getDisplayMedia).toHaveBeenCalledWith({
       audio: false,
-      video: { frameRate: { max: 60 } },
+      video: { frameRate: { ideal: 60, max: 60 } },
     });
     await stopBrowserRecording(tabId);
 
@@ -275,6 +284,7 @@ describe("browser recording", () => {
   it("stops the native stream when MediaRecorder cleanup fails", async () => {
     const stopTrack = vi.fn();
     getDisplayMedia.mockResolvedValueOnce({
+      getVideoTracks: () => [],
       getTracks: () => [{ stop: stopTrack }],
     });
 
@@ -290,6 +300,7 @@ describe("browser recording", () => {
 
   it("uses the best supported encoder and saves the recorder's actual format", async () => {
     FakeMediaRecorder.supportedTypes = new Set([
+      "video/mp4;codecs=avc1",
       "video/mp4;codecs=avc1.42e01e",
       "video/webm;codecs=vp9",
       "video/webm;codecs=av1",
@@ -300,7 +311,8 @@ describe("browser recording", () => {
     await stopBrowserRecording("recording-tab");
 
     expect(FakeMediaRecorder.instances[0]?.options).toEqual({
-      mimeType: "video/webm;codecs=av1",
+      mimeType: "video/mp4;codecs=avc1",
+      videoBitsPerSecond: 12_441_600,
     });
     expect(save).toHaveBeenCalledWith(
       "recording-tab",
@@ -316,7 +328,7 @@ describe("browser recording", () => {
     await startBrowserRecording("recording-tab");
     await stopBrowserRecording("recording-tab");
 
-    expect(FakeMediaRecorder.instances[0]?.options).toBeUndefined();
+    expect(FakeMediaRecorder.instances[0]?.options).toEqual({ videoBitsPerSecond: 12_441_600 });
     expect(save).toHaveBeenCalledWith(
       "recording-tab",
       "video/platform-default",
@@ -375,7 +387,10 @@ describe("browser recording", () => {
     expect(readActiveBrowserRecordingTabIds()).toEqual(new Set());
     expect(useBrowserSurfaceStore.getState().activityByTabId["recording-tab"]).toBeUndefined();
 
-    finishCapture({ getTracks: () => [{ stop: stopTrack }] } as unknown as MediaStream);
+    finishCapture({
+      getVideoTracks: () => [],
+      getTracks: () => [{ stop: stopTrack }],
+    } as unknown as MediaStream);
     await vi.advanceTimersByTimeAsync(0);
     expect(stopTrack).toHaveBeenCalledOnce();
   });
@@ -411,7 +426,10 @@ describe("browser recording", () => {
 
   it("serializes display media grants for concurrent recording starts", async () => {
     let finishFirstCapture!: (stream: MediaStream) => void;
-    const stream = { getTracks: () => [{ stop: vi.fn() }] } as unknown as MediaStream;
+    const stream = {
+      getVideoTracks: () => [],
+      getTracks: () => [{ stop: vi.fn() }],
+    } as unknown as MediaStream;
     getDisplayMedia
       .mockImplementationOnce(
         () =>
@@ -440,7 +458,10 @@ describe("browser recording", () => {
 
   it("cancels a queued recording when stopped before its media grant", async () => {
     let finishFirstCapture!: (stream: MediaStream) => void;
-    const stream = { getTracks: () => [{ stop: vi.fn() }] } as unknown as MediaStream;
+    const stream = {
+      getVideoTracks: () => [],
+      getTracks: () => [{ stop: vi.fn() }],
+    } as unknown as MediaStream;
     getDisplayMedia.mockImplementationOnce(
       () =>
         new Promise<MediaStream>((resolve) => {
@@ -477,7 +498,10 @@ describe("browser recording", () => {
       }),
     );
     let finishBlockingCapture!: (stream: MediaStream) => void;
-    const stream = { getTracks: () => [{ stop: vi.fn() }] } as unknown as MediaStream;
+    const stream = {
+      getVideoTracks: () => [],
+      getTracks: () => [{ stop: vi.fn() }],
+    } as unknown as MediaStream;
     getDisplayMedia.mockImplementationOnce(
       () =>
         new Promise<MediaStream>((resolve) => {

--- a/apps/web/src/browser/browserRecording.test.ts
+++ b/apps/web/src/browser/browserRecording.test.ts
@@ -216,9 +216,10 @@ describe("browser recording", () => {
   });
 
   it.each([
-    { width: 1280, height: 720, frameRate: 60, bitrate: 11_059_200 },
+    { width: 1280, height: 720, frameRate: 60, bitrate: 2_764_800 },
     { width: 320, height: 240, frameRate: 30, bitrate: 2_500_000 },
-    { width: 3840, height: 2160, frameRate: 60, bitrate: 50_000_000 },
+    { width: 3840, height: 2160, frameRate: 60, bitrate: 24_883_200 },
+    { width: 7680, height: 4320, frameRate: 60, bitrate: 50_000_000 },
   ])("records the native $width x $height stream at $frameRate fps", async (settings) => {
     const stopTrack = vi.fn();
     const stream = {
@@ -238,6 +239,7 @@ describe("browser recording", () => {
 
     await stopBrowserRecording("recording-tab");
     expect(stopTrack).toHaveBeenCalledOnce();
+    expect(stopTrack.mock.invocationCallOrder[0]).toBeLessThan(save.mock.invocationCallOrder[0]!);
   });
 
   it("uses the configured recording frame rate", async () => {
@@ -312,7 +314,7 @@ describe("browser recording", () => {
 
     expect(FakeMediaRecorder.instances[0]?.options).toEqual({
       mimeType: "video/mp4;codecs=avc1",
-      videoBitsPerSecond: 12_441_600,
+      videoBitsPerSecond: 3_110_400,
     });
     expect(save).toHaveBeenCalledWith(
       "recording-tab",
@@ -328,7 +330,7 @@ describe("browser recording", () => {
     await startBrowserRecording("recording-tab");
     await stopBrowserRecording("recording-tab");
 
-    expect(FakeMediaRecorder.instances[0]?.options).toEqual({ videoBitsPerSecond: 12_441_600 });
+    expect(FakeMediaRecorder.instances[0]?.options).toEqual({ videoBitsPerSecond: 3_110_400 });
     expect(save).toHaveBeenCalledWith(
       "recording-tab",
       "video/platform-default",

--- a/apps/web/src/browser/browserRecording.ts
+++ b/apps/web/src/browser/browserRecording.ts
@@ -256,7 +256,7 @@ const createMediaRecorder = (stream: MediaStream): MediaRecorder => {
       50_000_000,
       Math.max(
         2_500_000,
-        (settings?.width ?? 1920) * (settings?.height ?? 1080) * (settings?.frameRate ?? 30) * 0.2,
+        (settings?.width ?? 1920) * (settings?.height ?? 1080) * (settings?.frameRate ?? 30) * 0.05,
       ),
     ),
   );
@@ -692,6 +692,9 @@ const finalizeBrowserRecording = async (
           cause,
         });
       }
+      // Encoding has flushed; release native capture before materializing and saving the file.
+      stopMediaStream(recording.stream);
+      recording.stream = null;
       const mimeType =
         recording.recorder.mimeType ||
         recording.chunks.find((chunk) => chunk.type.length > 0)?.type;

--- a/apps/web/src/browser/browserRecording.ts
+++ b/apps/web/src/browser/browserRecording.ts
@@ -238,17 +238,29 @@ export function findActiveBrowserRecordingRuntimeTabId(
 }
 
 const preferredMimeTypes = [
-  "video/webm;codecs=av1",
-  "video/webm;codecs=vp9",
+  "video/mp4;codecs=avc1",
   "video/mp4;codecs=avc1.640028",
   "video/mp4;codecs=avc1.42e01e",
+  "video/webm;codecs=vp9",
   "video/webm;codecs=vp8",
   "video/webm",
 ] as const;
 
 const createMediaRecorder = (stream: MediaStream): MediaRecorder => {
   const mimeType = preferredMimeTypes.find((candidate) => MediaRecorder.isTypeSupported(candidate));
-  return mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
+  const settings = stream.getVideoTracks()[0]?.getSettings();
+  // Browser defaults under-budget native-resolution text and motion. Scale with captured pixels
+  // and frames, while bounding storage and encoder load for very large displays.
+  const videoBitsPerSecond = Math.round(
+    Math.min(
+      50_000_000,
+      Math.max(
+        2_500_000,
+        (settings?.width ?? 1920) * (settings?.height ?? 1080) * (settings?.frameRate ?? 30) * 0.2,
+      ),
+    ),
+  );
+  return new MediaRecorder(stream, { ...(mimeType ? { mimeType } : {}), videoBitsPerSecond });
 };
 
 const captureTabMediaStream = (frameRate: number): Promise<MediaStream> =>
@@ -256,7 +268,7 @@ const captureTabMediaStream = (frameRate: number): Promise<MediaStream> =>
   // stream already arrives at that tab's native size and needs no source or dimension constraints.
   navigator.mediaDevices.getDisplayMedia({
     audio: false,
-    video: { frameRate: { max: frameRate } },
+    video: { frameRate: { ideal: frameRate, max: frameRate } },
   });
 
 const stopMediaRecorder = async (recorder: MediaRecorder | null): Promise<void> => {


### PR DESCRIPTION
preview recordings can lose motion frames when the browser selects av1 at its default bitrate. prefer h.264 with compatible fallbacks, request the selected fps explicitly, and scale the requested bitrate with captured pixels and frames (0.05 bits/pixel/frame, bounded to 2.5–50 mbps). stop media tracks once the encoder has flushed, before allocating the output buffer and saving the file, so native capture does not continue during that work.

verified 34 focused recording/scope tests, scoped lint, and the web typecheck. a repeated 1920×1080 encoder stress benchmark compared the final 6.22 mbps request against a 24.88 mbps reference using the same dense moving pattern for four seconds, reversing run order on the repeat:

| four-second recording | 24.88 mbps reference | final 6.22 mbps request |
| --- | --- | --- |
| encoded frames, two runs | 229 / 235 | 236 / 234 |
| delivered frames per second | 57.25–58.75 | 58.5–59.0 |
| file size | 19.52 / 20.31 mb | 6.29 / 6.27 mb |
| moving-pattern psnr, first run | 28.03 db | 27.37 db |

this reduces encoded data to buffer, copy, save, and upload by 68–69% against the high-bitrate reference, with similar frame delivery and a small measured detail loss. total process cpu and peak rss were not measured; bitrate requests are advisory. the earlier upstream av1 baseline delivered 47.8–55.0 fps in two six-second runs of the dense pattern, so final frame delivery remains improved over that baseline, though file size remains larger than av1.

the benchmark uses canvas capture and real browser encoders in the attached mac preview, with native recording active in both cases to keep the background tab unthrottled. the current source's encoder factory was evaluated in that browser and selected h.264 at 6,220,800 bps. the installed desktop client has not been rebuilt, so the changed native recording interaction remains unverified. the uploaded original output decoded locally and played through from its uploaded url at 1920×1080 with 236 frames.

the image below is a reduced 320px / 10 fps motion preview. measurements use the original 1080p recording.

![final: reduced motion preview of the lighter h.264 recording](https://uploads-production-47e4.up.railway.app/files/eb53c92d-17b1-4480-ae9c-150c52bac2bf/replay.gif)

model: gpt-5.6-sol. harness: codex.
