### PR TITLE
feat(mobile): queue a message while its attachment is still uploading

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -42,6 +42,7 @@ import { ComposerAttachmentStrip } from "../../components/ComposerAttachmentStri
 import { EnvironmentMachineSymbol } from "../../components/EnvironmentMachineSymbol";
 import {
   composerAttachmentUploadBlockReason,
+  composerAttachmentsStillUploading,
   composerAttachmentUploadsAtom,
 } from "../../state/composer-attachment-uploads";
 import { FilePreviewModal, type FilePreviewSource } from "../../components/FilePreviewModal";
@@ -192,6 +193,18 @@ export function NewTaskDraftScreen(props: {
         states: uploadStates,
       })
     : null;
+  // A connected composer with uploads still in flight queues the task rather
+  // than making the user wait: the outbox drain finishes the upload and sends.
+  const attachmentsUploading =
+    environmentConnected &&
+    selectedProject !== null &&
+    composerAttachmentsStillUploading({
+      environmentId: selectedProject.environmentId,
+      attachments: flow.attachments,
+      serverConfig: selectedEnvironmentServerConfig,
+      states: uploadStates,
+    });
+  const queuesInsteadOfStarting = !environmentConnected || attachmentsUploading;
   const promptInputRef = useRef<ComposerEditorHandle>(null);
   const loadedBranchesProjectKeyRef = useRef<string | null>(null);
   const [isComposerFocused, setIsComposerFocused] = useState(false);
@@ -987,10 +1000,11 @@ export function NewTaskDraftScreen(props: {
 
     const editingPendingTask = flow.editingPendingTask;
 
-    if (!environmentConnected) {
-      // Offline: park the task in the outbox; the drain sends it when the
-      // environment reconnects. Editing an existing pending task re-queues it
-      // under its original identifiers.
+    if (queuesInsteadOfStarting) {
+      // Offline, or an attachment is still uploading: park the task in the
+      // outbox and let the drain send it once the environment is reachable
+      // and the bytes are on the server. Editing an existing pending task
+      // re-queues it under its original identifiers.
       const metadata = editingPendingTask
         ? {
             threadId: editingPendingTask.threadId,
@@ -1255,7 +1269,7 @@ export function NewTaskDraftScreen(props: {
 
   const workspaceControls = (
     <View className="flex-row items-center gap-1 px-2">
-      {flow.submitting && environmentConnected && flow.workspaceMode === "worktree" ? (
+      {flow.submitting && !queuesInsteadOfStarting && flow.workspaceMode === "worktree" ? (
         <View
           accessible
           accessibilityLabel="Setting up worktree…"
@@ -1444,12 +1458,14 @@ export function NewTaskDraftScreen(props: {
                     attachmentBlockReason ??
                     (flow.submitting
                       ? "Starting task"
-                      : environmentConnected
-                        ? "Start task"
-                        : "Queue task")
+                      : attachmentsUploading
+                        ? "Queue task, sends when uploads finish"
+                        : environmentConnected
+                          ? "Start task"
+                          : "Queue task")
                   }
                   disabled={!canStart}
-                  icon={environmentConnected ? "arrow.up" : "tray.and.arrow.up"}
+                  icon={queuesInsteadOfStarting ? "tray.and.arrow.up" : "arrow.up"}
                   onPress={() => void handleStart()}
                   variant="primary"
                 />

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -30,6 +30,7 @@ import { ActivityIndicator, Alert, Platform, Pressable, View, type ViewStyle } f
 import { FilePreviewModal, type FilePreviewSource } from "../../components/FilePreviewModal";
 import {
   composerAttachmentUploadBlockReason,
+  composerAttachmentsStillUploading,
   composerAttachmentUploadsAtom,
 } from "../../state/composer-attachment-uploads";
 import Animated, {
@@ -323,8 +324,21 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     (props.selectedThread.session?.status === "running" ||
       props.selectedThread.session?.status === "starting");
 
+  const uploadStates = useAtomValue(composerAttachmentUploadsAtom);
+  const attachmentsUploading =
+    props.connectionState === "connected" &&
+    composerAttachmentsStillUploading({
+      environmentId: props.environmentId,
+      attachments: props.draftAttachments,
+      serverConfig: props.serverConfig,
+      states: uploadStates,
+    });
+  // Every send goes through the outbox; the label says whether it leaves now
+  // or waits (for the connection, an earlier queued message, or an upload).
   const sendLabel =
-    props.connectionState !== "connected" || props.queueCount > 0 ? "Queue" : "Send";
+    props.connectionState !== "connected" || props.queueCount > 0 || attachmentsUploading
+      ? "Queue"
+      : "Send";
   const currentModelSelection = props.selectedThread.modelSelection;
   const currentRuntimeMode = props.selectedThread.runtimeMode;
   const modelUnavailable =
@@ -403,7 +417,6 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   const isExpanded = isFocused || settingsSheetPresentation.isActive;
   const showsCompactDictation = isVoiceInputPresented && !isExpanded;
   const isToolbarVisible = isExpanded || isVoiceInputPresented;
-  const uploadStates = useAtomValue(composerAttachmentUploadsAtom);
   const attachmentBlockReason = composerAttachmentUploadBlockReason({
     environmentId: props.environmentId,
     attachments: props.draftAttachments,

--- a/apps/mobile/src/lib/composerAttachmentUploadQueue.test.ts
+++ b/apps/mobile/src/lib/composerAttachmentUploadQueue.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
   composerAttachmentUploadBlockReason,
+  composerAttachmentsStillUploading,
   composerAttachmentUploadKey,
   composerDraftEnvironmentId,
   createComposerAttachmentUploadQueue,
@@ -248,7 +249,7 @@ describe("draft upload scope and offline submission", () => {
     );
   });
 
-  it("allows offline queuing while a connected composer waits for upload or retry", () => {
+  it("only a failed upload blocks sending; an in-flight one queues instead", () => {
     const key = composerAttachmentUploadKey(environmentId, "file");
     const input = {
       environmentId,
@@ -261,7 +262,16 @@ describe("draft upload scope and offline submission", () => {
       },
       states: {},
     };
-    expect(composerAttachmentUploadBlockReason(input)).toBe("Attachment still uploading");
+    // Not started yet and mid-transfer both let the send through as a queued
+    // message; the outbox drain finishes (or redoes) the upload.
+    expect(composerAttachmentUploadBlockReason(input)).toBeNull();
+    expect(composerAttachmentsStillUploading(input)).toBe(true);
+    expect(
+      composerAttachmentsStillUploading({
+        ...input,
+        states: { [key]: { status: "uploading", progress: 0.6 } },
+      }),
+    ).toBe(true);
     expect(composerAttachmentUploadBlockReason({ ...input, connected: false })).toBeNull();
     expect(
       composerAttachmentUploadBlockReason({
@@ -270,7 +280,18 @@ describe("draft upload scope and offline submission", () => {
       }),
     ).toBe("Retry or remove the failed attachment");
     expect(
+      composerAttachmentsStillUploading({
+        ...input,
+        states: { [key]: { status: "failed", reason: "Offline" } },
+      }),
+    ).toBe(false);
+    expect(
       composerAttachmentUploadBlockReason({ ...input, states: { [key]: { status: "ready" } } }),
     ).toBeNull();
+    expect(
+      composerAttachmentsStillUploading({ ...input, states: { [key]: { status: "ready" } } }),
+    ).toBe(false);
+    // Attachments the environment cannot accept never count as uploading.
+    expect(composerAttachmentsStillUploading({ ...input, serverConfig: null })).toBe(false);
   });
 });

--- a/apps/mobile/src/lib/composerAttachmentUploadQueue.ts
+++ b/apps/mobile/src/lib/composerAttachmentUploadQueue.ts
@@ -75,6 +75,12 @@ export function canUploadComposerAttachment(
   );
 }
 
+/**
+ * Only a failed upload blocks sending: the outbox drain would hit the same
+ * failure, so the user has to retry or remove the file first. An upload still
+ * in flight does not block; the message queues and the drain reuses the
+ * finished upload (or re-sends the local bytes) when it delivers.
+ */
 export function composerAttachmentUploadBlockReason(input: {
   readonly environmentId: EnvironmentId;
   readonly attachments: ReadonlyArray<DraftComposerAttachment>;
@@ -87,9 +93,22 @@ export function composerAttachmentUploadBlockReason(input: {
     if (!canUploadComposerAttachment(attachment, input.serverConfig)) continue;
     const state = input.states[composerAttachmentUploadKey(input.environmentId, attachment.id)];
     if (state?.status === "failed") return "Retry or remove the failed attachment";
-    if (state?.status !== "ready") return "Attachment still uploading";
   }
   return null;
+}
+
+/** Whether any attachment the environment accepts is still being uploaded. */
+export function composerAttachmentsStillUploading(input: {
+  readonly environmentId: EnvironmentId;
+  readonly attachments: ReadonlyArray<DraftComposerAttachment>;
+  readonly serverConfig: UploadServerConfig | null;
+  readonly states: Readonly<Record<string, ComposerAttachmentUploadState>>;
+}): boolean {
+  return input.attachments.some((attachment) => {
+    if (!canUploadComposerAttachment(attachment, input.serverConfig)) return false;
+    const state = input.states[composerAttachmentUploadKey(input.environmentId, attachment.id)];
+    return state?.status !== "ready" && state?.status !== "failed";
+  });
 }
 
 /** Bounds transfers across environments; disconnected or discarded drafts keep their local bytes. */

--- a/apps/mobile/src/state/composer-attachment-uploads.ts
+++ b/apps/mobile/src/state/composer-attachment-uploads.ts
@@ -25,7 +25,10 @@ import {
 } from "./use-composer-drafts";
 import { useRemoteConnectionStatus } from "./use-remote-environment-registry";
 
-export { composerAttachmentUploadBlockReason } from "../lib/composerAttachmentUploadQueue";
+export {
+  composerAttachmentUploadBlockReason,
+  composerAttachmentsStillUploading,
+} from "../lib/composerAttachmentUploadQueue";
 
 export const composerAttachmentUploadsAtom = Atom.make<
   Readonly<Record<string, ComposerAttachmentUploadState>>


### PR DESCRIPTION
## Problem

A connected composer disabled Send until every attachment had finished uploading. On a slow link that meant sitting and watching a progress ring, even though the *offline* path already knew how to queue the message and let the outbox drain finish the upload later. Reported from the field: a video at 60% with a greyed-out button.

## Fix

`composerAttachmentUploadBlockReason` now only blocks on a **failed** upload, since the outbox drain would hit the same failure and the user has to retry or remove the file first. An upload still in flight no longer blocks: the message queues, and the drain's `prepareQueuedMessageAttachments` reuses the finished upload (or re-sends the local bytes if the pending upload expired).

- **New-task screen:** when connected but an attachment is still uploading, `handleStart` takes the outbox branch instead of calling `createProjectThread`. The button switches to the tray icon and its accessibility label reads "Queue task, sends when uploads finish". The worktree-setup shimmer no longer shows for a queued task.
- **Thread composer:** every send already goes through the outbox, so removing the gate is enough; the button label now reads "Queue" while an upload is in flight, matching the offline and already-queued cases.
- New helper `composerAttachmentsStillUploading` for the label logic, alongside the (now narrower) block reason.

## Verification

`apps/mobile`: `vp test run src/lib/composerAttachmentUploadQueue.test.ts` (9 passed; the block-reason test now pins that in-flight does not block and failed does). `vpr typecheck` passes. Lint on touched files shows only pre-existing warnings (15, same as base).

### Before / after — new-task composer with a 45 MB video mid-upload

![Before: the send button is greyed out with accessibility label "Attachment still uploading" while the video is at 25%. After: the button is enabled with the tray icon while the video is at 30%](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/a1847ef815dea2c7/queue-upload-before-after.png)

### After tapping Queue mid-upload

The task lands in the Unsent section as "Sends on reconnect". About 75 seconds later the drain delivered it; the server's projection shows the created thread, the user message with the 47 MB file attachment claimed, and the agent's reply.

![The Unsent section shows the queued task with Sends on reconnect while the upload continues](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/507407c7affee966/queue-upload-queued.png)

Captured on an iPhone 17 Pro simulator against a disposable backend behind a 150 KB/s throttling proxy so the upload was slow enough to observe; the "before" is `main` with the same seeded draft.

## Surfaces

- Entry points: new-task composer (Home compose, project row, Draft rows) and the thread composer.
- Clients: mobile only. Web has no offline outbox; server untouched.
- Reverse state: a failed upload still blocks with the existing "Retry or remove" affordance.

Model: Claude Fable 5 · Harness: Claude Code in T3 Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
