### PR TITLE
fix(web): only show auto balance errors after failed checks

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3331,7 +3331,9 @@ export default function ChatView(props: ChatViewProps) {
       ? "Auto balance"
       : loadBalancing.pending
         ? "Checking machines…"
-        : "Auto balance unavailable"
+        : loadBalancing.failed
+          ? "Auto balance unavailable"
+          : "Auto balance"
     : undefined;
 
   // Handle environment change for draft threads.  When the user picks a

--- a/apps/web/src/hooks/useLoadBalancedEnvironment.ts
+++ b/apps/web/src/hooks/useLoadBalancedEnvironment.ts
@@ -30,21 +30,25 @@ export function useLoadBalancedEnvironment(
             resources: result._tag === "Success" ? result.value : null,
             receivedAt: result._tag === "Success" ? result.timestamp : 0,
             pending: result._tag === "Initial" || result.waiting,
+            failed: result._tag === "Failure",
           };
         }),
       ),
     [environmentIds],
   );
   const resources = useAtomValue(resourcesAtom);
+  const pending = resources.some((resource) => resource.pending);
+  const environmentId = chooseLoadBalancedEnvironment(
+    resources.map((resource) => ({
+      ...resource,
+      weight: weights[resource.environmentId] ?? 50,
+    })),
+    Date.now(),
+  ) as EnvironmentId | null;
   return {
     refresh,
-    pending: resources.some((resource) => resource.pending),
-    environmentId: chooseLoadBalancedEnvironment(
-      resources.map((resource) => ({
-        ...resource,
-        weight: weights[resource.environmentId] ?? 50,
-      })),
-      Date.now(),
-    ) as EnvironmentId | null,
+    pending,
+    environmentId,
+    failed: !pending && environmentId === null && resources.some((resource) => resource.failed),
   };
 }

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -1021,6 +1021,7 @@ export function createServerEnvironmentAtoms<R, E>(
     }),
     hostResources: createEnvironmentQueryAtomFamily(runtime, {
       label: "environment-data:server:host-resources",
+      idleTtlMs: 0,
       staleTimeMs: 5_000,
       execute: (input: EnvironmentRpcInput<typeof WS_METHODS.serverGetHostResources>) =>
         request(WS_METHODS.serverGetHostResources, input).pipe(Effect.timeout("5 seconds")),


### PR DESCRIPTION
Auto balance could show "unavailable" without a failed resource request, including while a successful machine selection was being saved. The label now requires a completed request failure with no selectable machine, and idle host samples are discarded so reopening a draft checks fresh resources.

Verified the false label with two connected environments and no eligible providers, then confirmed the corrected label with identical data and exercised manual selection and return to automatic selection. Inspected dark 1280×800 and light 900×700 layouts; web and client-runtime typechecks, 109 existing routing/toolbar/query-runtime tests, targeted lint (existing warnings), and GitHub CI passed. Two independent code reviewers approved head `21da94405`; successful live provider routing remains unverified because these isolated environments have no installed providers. The interaction recording was saved on the remote preview machine and could not be retrieved by the available tools.

Before:

![Before: auto balance incorrectly unavailable without a request failure](https://uploads-production-47e4.up.railway.app/files/210fa3a8-17d8-4360-b187-3a7766f03e49/auto-balance-before.png)

After:

![After: auto balance stays neutral without a request failure](https://uploads-production-47e4.up.railway.app/files/fedfc417-1da1-4e4d-85dc-784c6908896b/auto-balance-after.png)

Implemented with gpt-5.6-sol in Codex.
