### PR TITLE
feat(usage): read cursor, opencode, and antigravity history

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -81,6 +81,21 @@ export function UsageRouteScreen() {
     selectedEnvironmentIds,
   );
   const limits = useRefreshLimits(selectedEnvironmentIds);
+  const sourceMessages = [
+    ...new Set(
+      selectedEnvironments.flatMap(
+        (environment) =>
+          environment.summary?.sources.flatMap((source) =>
+            source.message &&
+            (source.status === "partial" ||
+              source.status === "failed" ||
+              source.fingerprint.provider === "cursor")
+              ? [source.message]
+              : [],
+          ) ?? [],
+      ),
+    ),
+  ];
 
   const days = useMemo(
     () => enumerateDays(window.sinceDay, window.untilDay),
@@ -295,6 +310,11 @@ export function UsageRouteScreen() {
                 </Text>
               ) : (
                 <>
+                  {sourceMessages.map((message) => (
+                    <Text key={message} className="text-sm text-foreground-muted">
+                      {message}
+                    </Text>
+                  ))}
                   <ChartCard
                     merged={merged}
                     days={chartDays}

--- a/apps/mobile/src/features/usage/usageProviders.ts
+++ b/apps/mobile/src/features/usage/usageProviders.ts
@@ -5,12 +5,22 @@ import { useAppearancePreferences } from "../settings/appearance/AppearancePrefe
  * Series and table order. The chart stacks providers from the bottom in this
  * order, so it also fixes which band sits on top of the bars.
  */
-export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude", "grok"];
+export const PROVIDER_ORDER: readonly UsageProviderKind[] = [
+  "codex",
+  "claude",
+  "grok",
+  "cursor",
+  "opencode",
+  "antigravity",
+];
 
 export const PROVIDER_LABEL: Record<UsageProviderKind, string> = {
   claude: "Claude Code",
   codex: "Codex",
   grok: "Grok Build",
+  cursor: "Cursor",
+  opencode: "OpenCode",
+  antigravity: "Antigravity",
 };
 
 /**
@@ -23,5 +33,8 @@ export function useProviderColors(): Record<UsageProviderKind, string> {
     claude: "#d97757",
     codex: scheme === "dark" ? "#e6e6e6" : "#3c3c43",
     grok: scheme === "dark" ? "#a1a1aa" : "#52525b",
+    cursor: "#8b8b8b",
+    opencode: "#5b9bbd",
+    antigravity: "#8c7bd1",
   };
 }

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -6,7 +6,7 @@ import * as NodePath from "node:path";
 
 import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
+import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { UsageDay, type UsageSummaryInput } from "@t3tools/contracts";
 import * as Duration from "effect/Duration";
 import * as Deferred from "effect/Deferred";
@@ -16,6 +16,7 @@ import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Scheduler from "effect/Scheduler";
+import * as Schema from "effect/Schema";
 import * as TestClock from "effect/testing/TestClock";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
@@ -74,6 +75,7 @@ const serviceLayers = (input: {
 }) =>
   ServerConfig.layerTest(process.cwd(), { prefix: input.prefix }).pipe(
     Layer.provideMerge(NodeServices.layer),
+    Layer.provideMerge(Layer.succeed(HostProcessPlatform, "linux")),
     Layer.provideMerge(ServerSettings.layerTest(input.settings)),
     Layer.provideMerge(
       Layer.succeed(
@@ -89,7 +91,13 @@ const serviceLayers = (input: {
       ),
     ),
     Layer.provideMerge(
-      Layer.succeed(HostProcessEnvironment, { GROK_HOME: NodePath.join(input.home, "grok") }),
+      Layer.succeed(HostProcessEnvironment, {
+        GROK_HOME: NodePath.join(input.home, "grok"),
+        OPENCODE_DATA_DIR: NodePath.join(input.home, "opencode"),
+        ANTIGRAVITY_DATA_DIR: NodePath.join(input.home, "antigravity"),
+        XDG_CONFIG_HOME: NodePath.join(input.home, "config"),
+        APPDATA: NodePath.join(input.home, "config"),
+      }),
     ),
   );
 
@@ -98,6 +106,42 @@ function totalOutputTokens(summary: { buckets: readonly { totals: { outputTokens
 }
 
 describe("UsageService", () => {
+  it.live("includes OpenCode history with its source and reports Cursor's missing coverage", () =>
+    Effect.gen(function* () {
+      const { settings, home } = yield* setup;
+      const root = NodePath.join(home, "opencode");
+      const message = yield* Schema.encodeEffect(Schema.fromJsonString(Schema.Unknown))({
+        id: "msg_1",
+        sessionID: "session-1",
+        role: "assistant",
+        modelID: "example-model",
+        time: { created: Date.parse("2026-08-01T10:00:00Z") },
+        tokens: { input: 10, output: 5, reasoning: 2, cache: { read: 20, write: 3 } },
+      });
+      yield* Effect.promise(async () => {
+        const directory = NodePath.join(root, "storage", "message", "session-1");
+        await NodeFSP.mkdir(directory, { recursive: true });
+        await NodeFSP.writeFile(NodePath.join(directory, "msg_1.json"), message);
+      });
+      const service = yield* UsageService.make.pipe(
+        Effect.provide(serviceLayers({ prefix: "usage-service-opencode", home, settings })),
+      );
+      const summary = yield* service.readSummary(WINDOW);
+      assert.strictEqual(summary.buckets[0]?.provider, "opencode");
+      assert.strictEqual(summary.buckets[0]?.sourcePath, root);
+      assert.strictEqual(summary.buckets[0]?.totals.outputTokens, 7);
+      assert.strictEqual(
+        summary.sources.find((source) => source.fingerprint.provider === "opencode")
+          ?.distinctSessions,
+        1,
+      );
+      assert.include(
+        summary.sources.find((source) => source.fingerprint.provider === "cursor")?.message ?? "",
+        "Cursor CLI does not save token totals",
+      );
+    }).pipe(Effect.scoped),
+  );
+
   it.live("reprices unchanged transcripts when custom prices are added, edited, or removed", () =>
     Effect.gen(function* () {
       const { transcript, settings, home } = yield* setup;

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -137,7 +137,7 @@ describe("UsageService", () => {
       );
       assert.include(
         summary.sources.find((source) => source.fingerprint.provider === "cursor")?.message ?? "",
-        "Cursor CLI does not save token totals",
+        "Cursor account history needs a Cursor CLI login",
       );
     }).pipe(Effect.scoped),
   );

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -3,6 +3,7 @@
 import * as NodeFSP from "node:fs/promises";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
+import * as NodeSqlite from "node:sqlite";
 
 import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -23,6 +24,8 @@ import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 import * as ServerConfig from "../config.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import * as UsageService from "./UsageService.ts";
+
+const encodeUnknownJson = Schema.encodeEffect(Schema.fromJsonString(Schema.Unknown));
 
 function claudeLine(id: number, outputTokens: number, model = "claude-fable-5"): string {
   return `${JSON.stringify({
@@ -106,40 +109,65 @@ function totalOutputTokens(summary: { buckets: readonly { totals: { outputTokens
 }
 
 describe("UsageService", () => {
-  it.live("includes OpenCode history with its source and reports Cursor's missing coverage", () =>
-    Effect.gen(function* () {
-      const { settings, home } = yield* setup;
-      const root = NodePath.join(home, "opencode");
-      const message = yield* Schema.encodeEffect(Schema.fromJsonString(Schema.Unknown))({
-        id: "msg_1",
-        sessionID: "session-1",
-        role: "assistant",
-        modelID: "example-model",
-        time: { created: Date.parse("2026-08-01T10:00:00Z") },
-        tokens: { input: 10, output: 5, reasoning: 2, cache: { read: 20, write: 3 } },
-      });
-      yield* Effect.promise(async () => {
-        const directory = NodePath.join(root, "storage", "message", "session-1");
-        await NodeFSP.mkdir(directory, { recursive: true });
-        await NodeFSP.writeFile(NodePath.join(directory, "msg_1.json"), message);
-      });
-      const service = yield* UsageService.make.pipe(
-        Effect.provide(serviceLayers({ prefix: "usage-service-opencode", home, settings })),
-      );
-      const summary = yield* service.readSummary(WINDOW);
-      assert.strictEqual(summary.buckets[0]?.provider, "opencode");
-      assert.strictEqual(summary.buckets[0]?.sourcePath, root);
-      assert.strictEqual(summary.buckets[0]?.totals.outputTokens, 7);
-      assert.strictEqual(
-        summary.sources.find((source) => source.fingerprint.provider === "opencode")
-          ?.distinctSessions,
-        1,
-      );
-      assert.include(
-        summary.sources.find((source) => source.fingerprint.provider === "cursor")?.message ?? "",
-        "Cursor account history needs a Cursor CLI login",
-      );
-    }).pipe(Effect.scoped),
+  it.live(
+    "includes OpenCode history but does not substitute desktop usage for an unavailable Cursor account",
+    () =>
+      Effect.gen(function* () {
+        const { settings, home } = yield* setup;
+        const root = NodePath.join(home, "opencode");
+        const message = yield* encodeUnknownJson({
+          id: "msg_1",
+          sessionID: "session-1",
+          role: "assistant",
+          modelID: "example-model",
+          time: { created: Date.parse("2026-08-01T10:00:00Z") },
+          tokens: { input: 10, output: 5, reasoning: 2, cache: { read: 20, write: 3 } },
+        });
+        const bubble = yield* encodeUnknownJson({
+          type: 2,
+          createdAt: "2026-08-01T10:00:00Z",
+          modelInfo: { modelName: "example-model" },
+          tokenCount: { inputTokens: 100, outputTokens: 20 },
+        });
+        yield* Effect.promise(async () => {
+          const directory = NodePath.join(root, "storage", "message", "session-1");
+          await NodeFSP.mkdir(directory, { recursive: true });
+          await NodeFSP.writeFile(NodePath.join(directory, "msg_1.json"), message);
+          const desktop = NodePath.join(home, "config", "Cursor", "User", "globalStorage");
+          await NodeFSP.mkdir(desktop, { recursive: true });
+          const db = new NodeSqlite.DatabaseSync(NodePath.join(desktop, "state.vscdb"));
+          try {
+            db.exec("CREATE TABLE cursorDiskKV (key TEXT, value TEXT)");
+            db.prepare("INSERT INTO cursorDiskKV VALUES (?, ?)").run(
+              "bubbleId:session:assistant",
+              bubble,
+            );
+          } finally {
+            db.close();
+          }
+        });
+        const service = yield* UsageService.make.pipe(
+          Effect.provide(serviceLayers({ prefix: "usage-service-opencode", home, settings })),
+        );
+        const summary = yield* service.readSummary(WINDOW);
+        assert.strictEqual(summary.buckets[0]?.provider, "opencode");
+        assert.isFalse(summary.buckets.some((bucket) => bucket.provider === "cursor"));
+        assert.strictEqual(
+          summary.sources.find((source) => source.fingerprint.provider === "cursor")?.status,
+          "missing",
+        );
+        assert.strictEqual(summary.buckets[0]?.sourcePath, root);
+        assert.strictEqual(summary.buckets[0]?.totals.outputTokens, 7);
+        assert.strictEqual(
+          summary.sources.find((source) => source.fingerprint.provider === "opencode")
+            ?.distinctSessions,
+          1,
+        );
+        assert.include(
+          summary.sources.find((source) => source.fingerprint.provider === "cursor")?.message ?? "",
+          "Cursor account history needs a Cursor CLI login",
+        );
+      }).pipe(Effect.scoped),
   );
 
   it.live("reprices unchanged transcripts when custom prices are added, edited, or removed", () =>

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -48,7 +48,7 @@ import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
 import { resolveAntigravityProfileDirectory } from "../provider/antigravityAuthSupport.ts";
 import { readOpenCodeUsage } from "./opencodeUsageReader.ts";
 import { readAntigravityUsage } from "./antigravityUsageReader.ts";
-import { readCursorAccountUsage, readCursorUsage } from "./cursorUsageReader.ts";
+import { readCursorAccountUsage } from "./cursorUsageReader.ts";
 import { UsageAggregator } from "./usageAggregation.ts";
 import { createOverrideRateTable, parseRateTable, type RateTable } from "./usagePricing.ts";
 import {
@@ -503,7 +503,6 @@ export const make = Effect.gen(function* () {
           : configHome && path.isAbsolute(configHome)
             ? configHome
             : path.join(home, ".config");
-    const cursorPath = path.join(cursorHome, "Cursor", "User", "globalStorage", "state.vscdb");
     const cursorAuthPath =
       platform === "darwin"
         ? path.join(home, ".cursor", "auth.json")
@@ -526,16 +525,14 @@ export const make = Effect.gen(function* () {
       });
       return scanned;
     }
-    const cursor = yield* Effect.promise(() => readCursorUsage(cursorPath, windowStartMs));
     scanned.push({
       provider: "cursor",
-      dir: cursorPath,
-      volumeId: yield* Effect.promise(() => readDirectoryVolumeId(cursorPath)),
-      files: cursor.missing && !cursor.error ? null : cursor.files,
-      status: "partial",
+      dir: cursorAuthPath,
+      volumeId: yield* Effect.promise(() => readDirectoryVolumeId(cursorAuthPath)),
+      // Never combine a local fallback with another server's account-wide history.
+      files: null,
       message:
-        account.error ??
-        "Cursor account history needs a Cursor CLI login saved on this server. Only available desktop token counts are shown.",
+        account.error ?? "Cursor account history needs a Cursor CLI login saved on this server.",
     });
     return scanned;
   });

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -1,14 +1,14 @@
 /**
  * UsageService - scans provider transcripts and returns priced usage buckets.
  *
- * The scan reads the provider CLIs' own session files (Claude Code, Codex, and
- * Grok Build) rather than T3 Code's orchestration projections, so usage covers
- * turns driven outside T3 Code too. This is the approach `ccusage` takes.
+ * The scan reads native session files and databases, including work driven
+ * outside T3 Code. Cursor's local records provide only partial coverage.
  *
- * Transcripts are append-only, so parsed records are memoised per file by
+ * JSONL transcripts are append-only, so parsed records are memoised per file by
  * `(size, mtime)`. A cold 30-day scan of ~1.4 GB lands around 2-3 seconds; warm
  * scans only reparse files that changed, and a file that merely grew resumes
  * from its cached parse position so only the appended bytes are read.
+ * SQLite readers query live databases each scan so WAL writes remain visible.
  *
  * @module UsageService
  */
@@ -16,6 +16,7 @@ import * as NodeOS from "node:os";
 
 import {
   USAGE_CONTRACT_VERSION,
+  ProviderInstanceId,
   type ServerSettings as ServerSettingsValue,
   type UsageProviderKind,
   type UsageSource,
@@ -24,7 +25,7 @@ import {
   type UsageSummaryInput,
   UsageReadError,
 } from "@t3tools/contracts";
-import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
+import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Cause from "effect/Cause";
 import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
@@ -44,6 +45,10 @@ import { expandHomePath } from "../pathExpansion.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
+import { resolveAntigravityProfileDirectory } from "../provider/antigravityAuthSupport.ts";
+import { readOpenCodeUsage } from "./opencodeUsageReader.ts";
+import { readAntigravityUsage } from "./antigravityUsageReader.ts";
+import { readCursorUsage } from "./cursorUsageReader.ts";
 import { UsageAggregator } from "./usageAggregation.ts";
 import { createOverrideRateTable, parseRateTable, type RateTable } from "./usagePricing.ts";
 import {
@@ -139,6 +144,7 @@ export const make = Effect.gen(function* () {
   const settingsService = yield* ServerSettings.ServerSettingsService;
   const httpClient = yield* HttpClient.HttpClient;
   const hostEnvironment = yield* HostProcessEnvironment;
+  const platform = yield* HostProcessPlatform;
 
   const fileCache: ScanCache = new Map();
   let cacheDirty = false;
@@ -372,6 +378,8 @@ export const make = Effect.gen(function* () {
     readonly provider: UsageProviderKind;
     readonly dir: string;
     readonly volumeId: string;
+    readonly status?: UsageSource["status"];
+    readonly message?: string;
     /** Parsed records per file, or `null` when the directory does not exist. */
     readonly files:
       | readonly { readonly path: string; readonly records: readonly UsageRecord[] }[]
@@ -407,6 +415,97 @@ export const make = Effect.gen(function* () {
       }
       scanned.push({ provider, dir, volumeId, files: parsedFiles });
     }
+
+    const home = NodeOS.homedir();
+    const envRoots = (key: string, defaults: readonly string[]) => {
+      const roots = hostEnvironment[key]
+        ?.split(",")
+        .map((value) => value.trim())
+        .filter(Boolean);
+      return [
+        ...new Set(
+          (roots?.length ? roots : defaults).map((root) => path.resolve(expandHomePath(root))),
+        ),
+      ];
+    };
+    const dataHome = hostEnvironment["XDG_DATA_HOME"]?.trim();
+    for (const dir of envRoots("OPENCODE_DATA_DIR", [
+      path.join(
+        dataHome && path.isAbsolute(dataHome) ? dataHome : path.join(home, ".local", "share"),
+        "opencode",
+      ),
+    ])) {
+      const result = yield* Effect.promise(() => readOpenCodeUsage(dir, windowStartMs));
+      scanned.push({
+        provider: "opencode",
+        dir,
+        volumeId: yield* Effect.promise(() => readDirectoryVolumeId(dir)),
+        files: result.missing && !result.error ? null : result.files,
+        status: result.error ? "partial" : "ok",
+        ...(result.error ? { message: "Some OpenCode history could not be read." } : {}),
+      });
+    }
+    const antigravityRoots = envRoots("ANTIGRAVITY_DATA_DIR", [
+      ...["antigravity", "antigravity-cli", "antigravity-ide", "antigravity-backup"].map((name) =>
+        path.join(home, ".gemini", name),
+      ),
+      path.join(home, ".config", "antigravity"),
+    ]);
+    for (const [instanceId, instance] of Object.entries(settings.providerInstances)) {
+      if (instance.driver === "antigravity") {
+        antigravityRoots.push(
+          path.join(
+            resolveAntigravityProfileDirectory(
+              config.stateDir,
+              ProviderInstanceId.make(instanceId),
+            ),
+            "antigravity-acp",
+          ),
+        );
+      }
+    }
+    for (const root of new Set(antigravityRoots)) {
+      const nested = path.join(root, "conversations");
+      const dir = (yield* fileSystem
+        .exists(nested)
+        .pipe(Effect.catchCause(() => Effect.succeed(false))))
+        ? nested
+        : root;
+      const exists = yield* fileSystem
+        .exists(dir)
+        .pipe(Effect.catchCause(() => Effect.succeed(false)));
+      const result = yield* Effect.promise(() => readAntigravityUsage(dir, windowStartMs));
+      scanned.push({
+        provider: "antigravity",
+        dir,
+        volumeId: yield* Effect.promise(() => readDirectoryVolumeId(dir)),
+        files: !exists && result.errors.length === 0 ? null : result.files,
+        status: result.errors.length > 0 ? "partial" : "ok",
+        ...(result.errors.length > 0
+          ? { message: "Some Antigravity history could not be read." }
+          : {}),
+      });
+    }
+    const configHome = hostEnvironment["XDG_CONFIG_HOME"]?.trim();
+    const cursorHome =
+      platform === "darwin"
+        ? path.join(home, "Library", "Application Support")
+        : platform === "win32"
+          ? hostEnvironment["APPDATA"] || path.join(home, "AppData", "Roaming")
+          : configHome && path.isAbsolute(configHome)
+            ? configHome
+            : path.join(home, ".config");
+    const cursorPath = path.join(cursorHome, "Cursor", "User", "globalStorage", "state.vscdb");
+    const cursor = yield* Effect.promise(() => readCursorUsage(cursorPath, windowStartMs));
+    scanned.push({
+      provider: "cursor",
+      dir: cursorPath,
+      volumeId: yield* Effect.promise(() => readDirectoryVolumeId(cursorPath)),
+      files: cursor.missing && !cursor.error ? null : cursor.files,
+      status: "partial",
+      message:
+        "Cursor local history is incomplete. Cursor CLI does not save token totals; check the Cursor Usage Dashboard for complete usage.",
+    });
     return scanned;
   });
 
@@ -481,7 +580,7 @@ export const make = Effect.gen(function* () {
     const livePaths = new Set<string>();
     const walkedRoots: string[] = [];
 
-    for (const { provider, dir, volumeId, files } of scannedDirs) {
+    for (const { provider, dir, volumeId, files, status, message } of scannedDirs) {
       if (files === null) {
         sources.push({
           fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
@@ -490,7 +589,7 @@ export const make = Effect.gen(function* () {
           skippedFiles: 0,
           malformedRecords: 0,
           distinctSessions: 0,
-          message: "No transcript directory on this environment.",
+          message: message ?? "No transcript directory on this environment.",
         });
         continue;
       }
@@ -512,7 +611,7 @@ export const make = Effect.gen(function* () {
         for (const record of file.records) {
           // Only sessions that contributed in-window count: the mtime slack
           // admits boundary files whose records fall outside the range.
-          if (aggregator.add(record) && record.sessionId.length > 0) {
+          if (aggregator.add(record, dir) && record.sessionId.length > 0) {
             sessionIds.add(record.sessionId);
           }
         }
@@ -520,12 +619,12 @@ export const make = Effect.gen(function* () {
 
       sources.push({
         fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
-        status: "ok",
+        status: status ?? "ok",
         scannedFiles,
         skippedFiles,
         malformedRecords: 0,
         distinctSessions: sessionIds.size,
-        message: null,
+        message: message ?? null,
       });
     }
 

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -464,6 +464,7 @@ export const make = Effect.gen(function* () {
         );
       }
     }
+    const antigravityDirs = new Set<string>();
     for (const root of new Set(antigravityRoots)) {
       const nested = path.join(root, "conversations");
       const dir = (yield* fileSystem
@@ -471,19 +472,25 @@ export const make = Effect.gen(function* () {
         .pipe(Effect.catchCause(() => Effect.succeed(false))))
         ? nested
         : root;
+      antigravityDirs.add(dir);
+    }
+    const antigravity = yield* Effect.promise(() =>
+      readAntigravityUsage([...antigravityDirs], windowStartMs),
+    );
+    for (const dir of antigravityDirs) {
       const exists = yield* fileSystem
         .exists(dir)
         .pipe(Effect.catchCause(() => Effect.succeed(false)));
-      const result = yield* Effect.promise(() => readAntigravityUsage(dir, windowStartMs));
+      const failed = antigravity.errors.some(
+        (error) => error === dir || error.startsWith(`${dir}${path.sep}`),
+      );
       scanned.push({
         provider: "antigravity",
         dir,
         volumeId: yield* Effect.promise(() => readDirectoryVolumeId(dir)),
-        files: !exists && result.errors.length === 0 ? null : result.files,
-        status: result.errors.length > 0 ? "partial" : "ok",
-        ...(result.errors.length > 0
-          ? { message: "Some Antigravity history could not be read." }
-          : {}),
+        files: !exists && !failed ? null : antigravity.files.filter((file) => file.root === dir),
+        status: failed ? "partial" : "ok",
+        ...(failed ? { message: "Some Antigravity history could not be read." } : {}),
       });
     }
     const configHome = hostEnvironment["XDG_CONFIG_HOME"]?.trim();

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -48,7 +48,7 @@ import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
 import { resolveAntigravityProfileDirectory } from "../provider/antigravityAuthSupport.ts";
 import { readOpenCodeUsage } from "./opencodeUsageReader.ts";
 import { readAntigravityUsage } from "./antigravityUsageReader.ts";
-import { readCursorUsage } from "./cursorUsageReader.ts";
+import { readCursorAccountUsage, readCursorUsage } from "./cursorUsageReader.ts";
 import { UsageAggregator } from "./usageAggregation.ts";
 import { createOverrideRateTable, parseRateTable, type RateTable } from "./usagePricing.ts";
 import {
@@ -378,6 +378,7 @@ export const make = Effect.gen(function* () {
     readonly provider: UsageProviderKind;
     readonly dir: string;
     readonly volumeId: string;
+    readonly hostId?: string;
     readonly status?: UsageSource["status"];
     readonly message?: string;
     /** Parsed records per file, or `null` when the directory does not exist. */
@@ -503,6 +504,28 @@ export const make = Effect.gen(function* () {
             ? configHome
             : path.join(home, ".config");
     const cursorPath = path.join(cursorHome, "Cursor", "User", "globalStorage", "state.vscdb");
+    const cursorAuthPath =
+      platform === "darwin"
+        ? path.join(home, ".cursor", "auth.json")
+        : path.join(cursorHome, platform === "win32" ? "Cursor" : "cursor", "auth.json");
+    const cursorUntilMs = yield* Clock.currentTimeMillis;
+    const account = yield* Effect.promise(() =>
+      readCursorAccountUsage(cursorAuthPath, windowStartMs, cursorUntilMs),
+    );
+    if (account.accountKey !== null && account.error === null && !account.missing) {
+      // The same account includes CLI and desktop history from every machine.
+      // A stable remote fingerprint prevents connected environments counting it twice.
+      const source = `cursor-account:${account.accountKey}`;
+      scanned.push({
+        provider: "cursor",
+        dir: source,
+        hostId: "cursor.com",
+        volumeId: account.accountKey,
+        files: [{ path: source, records: account.records }],
+        status: "ok",
+      });
+      return scanned;
+    }
     const cursor = yield* Effect.promise(() => readCursorUsage(cursorPath, windowStartMs));
     scanned.push({
       provider: "cursor",
@@ -511,7 +534,8 @@ export const make = Effect.gen(function* () {
       files: cursor.missing && !cursor.error ? null : cursor.files,
       status: "partial",
       message:
-        "Cursor local history is incomplete. Cursor CLI does not save token totals; check the Cursor Usage Dashboard for complete usage.",
+        account.error ??
+        "Cursor account history needs a Cursor CLI login saved on this server. Only available desktop token counts are shown.",
     });
     return scanned;
   });
@@ -587,10 +611,23 @@ export const make = Effect.gen(function* () {
     const livePaths = new Set<string>();
     const walkedRoots: string[] = [];
 
-    for (const { provider, dir, volumeId, files, status, message } of scannedDirs) {
+    for (const {
+      provider,
+      dir,
+      volumeId,
+      files,
+      status,
+      message,
+      hostId: sourceHostId,
+    } of scannedDirs) {
       if (files === null) {
         sources.push({
-          fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
+          fingerprint: {
+            hostId: sourceHostId ?? hostId,
+            provider,
+            resolvedHomePath: dir,
+            volumeId,
+          },
           status: "missing",
           scannedFiles: 0,
           skippedFiles: 0,
@@ -625,7 +662,7 @@ export const make = Effect.gen(function* () {
       }
 
       sources.push({
-        fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
+        fingerprint: { hostId: sourceHostId ?? hostId, provider, resolvedHomePath: dir, volumeId },
         status: status ?? "ok",
         scannedFiles,
         skippedFiles,

--- a/apps/server/src/usage/antigravityUsageReader.ts
+++ b/apps/server/src/usage/antigravityUsageReader.ts
@@ -1,0 +1,310 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFSP from "node:fs/promises";
+import * as NodePath from "node:path";
+import * as NodeSqlite from "node:sqlite";
+import * as NodeTimersPromises from "node:timers/promises";
+
+import type { UsageRecord } from "./usageTranscripts.ts";
+
+type Fields = Map<number, Array<number | Uint8Array>>;
+
+/** Antigravity stores usage metadata as protobuf, independently of conversation text. */
+function fields(bytes: Uint8Array): Fields {
+  let offset = 0;
+  const result: Fields = new Map();
+  const varint = () => {
+    let value = 0n;
+    for (let shift = 0n; shift < 70n; shift += 7n) {
+      const byte = bytes[offset++];
+      if (byte === undefined || (shift === 63n && byte > 1)) {
+        throw new Error("Invalid Antigravity protobuf varint");
+      }
+      value |= BigInt(byte & 127) << shift;
+      if (byte < 128) {
+        if (value > BigInt(Number.MAX_SAFE_INTEGER)) throw new Error("Unsafe protobuf number");
+        return Number(value);
+      }
+    }
+    throw new Error("Invalid Antigravity protobuf varint");
+  };
+  while (offset < bytes.length) {
+    const tag = varint();
+    const number = Math.floor(tag / 8);
+    const wire = tag % 8;
+    if (number === 0) throw new Error("Invalid protobuf field");
+    let value: number | Uint8Array;
+    if (wire === 0) {
+      value = varint();
+    } else if (wire === 1 || wire === 5 || wire === 2) {
+      const length = wire === 2 ? varint() : wire === 1 ? 8 : 4;
+      if (length > bytes.length - offset) throw new Error("Truncated protobuf field");
+      value = bytes.subarray(offset, offset + length);
+      offset += length;
+      if (wire !== 2) continue;
+    } else {
+      throw new Error("Unsupported protobuf wire type");
+    }
+    const entries = result.get(number) ?? [];
+    entries.push(value);
+    result.set(number, entries);
+  }
+  return result;
+}
+
+const numberAt = (value: Fields, key: number) => {
+  const entry = value.get(key)?.[0];
+  return typeof entry === "number" ? entry : 0;
+};
+const bytesAt = (value: Fields, key: number) => {
+  const entry = value.get(key)?.[0];
+  return entry instanceof Uint8Array ? entry : undefined;
+};
+const nested = (value: Fields, key: number) => {
+  const bytes = bytesAt(value, key);
+  return bytes === undefined ? new Map<number, Array<number | Uint8Array>>() : fields(bytes);
+};
+const textAt = (value: Fields, key: number) => {
+  const bytes = bytesAt(value, key);
+  return bytes === undefined ? "" : new TextDecoder("utf-8", { fatal: true }).decode(bytes).trim();
+};
+const timestamp = (value: Fields) => {
+  const seconds = numberAt(value, 1);
+  return seconds > 0 ? seconds * 1000 + Math.floor(numberAt(value, 2) / 1_000_000) : null;
+};
+
+const MODEL_IDS: Record<number, string> = {
+  246: "gemini-2.5-pro",
+  312: "gemini-2.5-flash",
+  313: "gemini-2.5-flash-thinking",
+  329: "gemini-2.5-flash-thinking",
+  330: "gemini-2.5-flash-lite",
+  281: "claude-sonnet-4",
+  282: "claude-sonnet-4",
+  290: "claude-opus-4",
+  291: "claude-opus-4",
+  333: "claude-sonnet-4-5",
+  334: "claude-sonnet-4-5",
+  340: "claude-haiku-4-5",
+  341: "claude-haiku-4-5",
+  1026: "claude-opus-4-6",
+  1035: "claude-sonnet-4-6",
+  1016: "gemini-3.1-pro",
+  1036: "gemini-3.1-pro",
+  1037: "gemini-3.1-pro",
+  1018: "gemini-3-flash-preview",
+  1084: "gemini-3-flash-preview",
+  1047: "gemini-3-flash-preview",
+};
+
+function modelName(name: string, id: number): string {
+  if (name) {
+    const normalized = name
+      .toLowerCase()
+      .replace(/\s*\([^)]*\)\s*$/, "")
+      .replaceAll(" ", "-");
+    if (normalized.startsWith("claude-")) {
+      return normalized
+        .replace(/^claude-(4(?:\.\d+)?)-(sonnet|opus|haiku)/, "claude-$2-$1")
+        .replaceAll(".", "-");
+    }
+    return normalized;
+  }
+  return MODEL_IDS[id] ?? (id > 0 ? `antigravity-model-${id}` : "");
+}
+
+interface Metadata {
+  model: string;
+  timestampMs: number | null;
+  usages: Fields[];
+}
+
+function metadata(bytes: Uint8Array, step: boolean): Metadata {
+  const root = fields(bytes);
+  if (!step && bytesAt(root, 1) === undefined) {
+    throw new Error("Missing Antigravity generation metadata");
+  }
+  const data = step ? root : nested(root, 1);
+  const model = step ? nested(data, 24) : data;
+  const usage = bytesAt(data, step ? 9 : 4);
+  const usages = usage === undefined ? [] : [fields(usage)];
+  for (const retry of data.get(step ? 28 : 17) ?? []) {
+    if (!(retry instanceof Uint8Array)) throw new Error("Invalid retry metadata");
+    const retryUsage = bytesAt(fields(retry), 2);
+    if (retryUsage !== undefined) usages.push(fields(retryUsage));
+  }
+  return {
+    model: modelName(
+      textAt(model, step ? 12 : 19) || textAt(model, step ? 8 : 21),
+      numberAt(model, step ? 1 : 3),
+    ),
+    timestampMs: step
+      ? (timestamp(nested(data, 8)) ?? timestamp(nested(data, 1)))
+      : timestamp(nested(nested(data, 9), 4)),
+    usages,
+  };
+}
+
+function blob(value: unknown): Uint8Array {
+  if (!(value instanceof Uint8Array)) throw new Error("Invalid Antigravity metadata blob");
+  return value;
+}
+
+async function readDatabase(path: string, fallbackTimestamp: number): Promise<UsageRecord[]> {
+  const db = new NodeSqlite.DatabaseSync(path, { readOnly: true });
+  try {
+    db.exec("PRAGMA busy_timeout = 100; BEGIN");
+    const tables = new Set(
+      db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+        .all()
+        .map((row) => row.name),
+    );
+    if (!tables.has("gen_metadata") && !tables.has("steps")) {
+      throw new Error("Missing Antigravity usage tables");
+    }
+    const readMetadata = async (query: string, column: string, step: boolean) => {
+      const entries: Metadata[] = [];
+      for (const row of db.prepare(query).iterate()) {
+        entries.push(metadata(blob(row[column]), step));
+        if (entries.length % 256 === 0) await NodeTimersPromises.setImmediate();
+      }
+      return entries;
+    };
+    const generations = tables.has("gen_metadata")
+      ? await readMetadata("SELECT data FROM gen_metadata ORDER BY idx", "data", false)
+      : [];
+    let trajectoryTimestamp: number | null = null;
+    if (tables.has("trajectory_metadata_blob")) {
+      for (const row of db.prepare("SELECT data FROM trajectory_metadata_blob").iterate()) {
+        trajectoryTimestamp ??= timestamp(nested(fields(blob(row.data)), 2));
+      }
+    }
+    const steps = tables.has("steps")
+      ? await readMetadata(
+          "SELECT metadata FROM steps WHERE metadata IS NOT NULL ORDER BY idx",
+          "metadata",
+          true,
+        )
+      : [];
+    const sessionId = NodePath.basename(path, ".db");
+    const records: UsageRecord[] = [];
+    const identities = new Map<string, number>();
+    let currentModel = "";
+    const generationModel = generations.findLast((entry) => entry.model)?.model ?? "";
+    for (const [source, entries] of [
+      ["step", steps],
+      ["generation", generations],
+    ] as const) {
+      for (const [index, entry] of entries.entries()) {
+        if (entry.model) currentModel = entry.model;
+        for (const [usageIndex, usage] of entry.usages.entries()) {
+          const outputTokens = Math.max(
+            numberAt(usage, 3),
+            numberAt(usage, 9) + numberAt(usage, 10),
+          );
+          const totals = {
+            uncachedInputTokens: numberAt(usage, 2),
+            cachedInputTokens: numberAt(usage, 5),
+            cacheCreationTokens: numberAt(usage, 4),
+            outputTokens,
+            reasoningTokens: Math.min(outputTokens, numberAt(usage, 9)),
+          };
+          if (
+            totals.uncachedInputTokens +
+              totals.cachedInputTokens +
+              totals.cacheCreationTokens +
+              outputTokens ===
+            0
+          )
+            continue;
+          const keys = ([11, 12, 7] as const).flatMap((key) => {
+            const id = textAt(usage, key);
+            return id ? [`antigravity:${key}:${id}`] : [];
+          });
+          const existingIndex = keys
+            .map((key) => identities.get(key))
+            .find((value) => value !== undefined);
+          const record: UsageRecord = {
+            provider: "antigravity",
+            sessionId,
+            timestampMs: entry.timestampMs ?? trajectoryTimestamp ?? fallbackTimestamp,
+            model:
+              MODEL_IDS[numberAt(usage, 1)] ||
+              entry.model ||
+              (source === "step" ? generationModel : currentModel) ||
+              modelName("", numberAt(usage, 1)) ||
+              "antigravity-unknown",
+            totals,
+            reportedCostUsd: null,
+            dedupeKey: keys[0] ?? `antigravity:${sessionId}:${source}:${index}:${usageIndex}`,
+          };
+          if (existingIndex === undefined) {
+            for (const key of keys) identities.set(key, records.length);
+            records.push(record);
+          } else {
+            const existing = records[existingIndex]!;
+            records[existingIndex] = {
+              ...existing,
+              totals: {
+                uncachedInputTokens: Math.max(
+                  existing.totals.uncachedInputTokens,
+                  totals.uncachedInputTokens,
+                ),
+                cachedInputTokens: Math.max(
+                  existing.totals.cachedInputTokens,
+                  totals.cachedInputTokens,
+                ),
+                cacheCreationTokens: Math.max(
+                  existing.totals.cacheCreationTokens,
+                  totals.cacheCreationTokens,
+                ),
+                outputTokens: Math.max(existing.totals.outputTokens, totals.outputTokens),
+                reasoningTokens: Math.max(existing.totals.reasoningTokens, totals.reasoningTokens),
+              },
+            };
+            for (const key of keys) identities.set(key, existingIndex);
+          }
+        }
+      }
+      currentModel = "";
+    }
+    return records;
+  } finally {
+    db.close();
+  }
+}
+
+/** Reads the SQLite usage metadata described by ccusage's Antigravity adapter. */
+export async function readAntigravityUsage(conversationsDirectory: string, sinceMs: number) {
+  const files: Array<{ path: string; records: readonly UsageRecord[] }> = [];
+  const errors: string[] = [];
+  const walk = async (directory: string): Promise<void> => {
+    let entries;
+    try {
+      entries = await NodeFSP.readdir(directory, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") errors.push(directory);
+      return;
+    }
+    for (const entry of entries) {
+      const path = NodePath.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await walk(path);
+      } else if (entry.isFile() && entry.name.endsWith(".db")) {
+        try {
+          const stat = await NodeFSP.stat(path);
+          files.push({
+            path,
+            records: (await readDatabase(path, stat.mtimeMs)).filter(
+              (record) => record.timestampMs >= sinceMs,
+            ),
+          });
+        } catch {
+          errors.push(path);
+        }
+      }
+    }
+  };
+  await walk(conversationsDirectory);
+  return { files, errors };
+}

--- a/apps/server/src/usage/antigravityUsageReader.ts
+++ b/apps/server/src/usage/antigravityUsageReader.ts
@@ -149,7 +149,13 @@ function blob(value: unknown): Uint8Array {
   return value;
 }
 
-async function readDatabase(path: string, fallbackTimestamp: number): Promise<UsageRecord[]> {
+interface UsageCandidate {
+  record: UsageRecord;
+  keys: readonly string[];
+  timestampQuality: number;
+}
+
+async function readDatabase(path: string, fallbackTimestamp: number): Promise<UsageCandidate[]> {
   const db = new NodeSqlite.DatabaseSync(path, { readOnly: true });
   try {
     db.exec("PRAGMA busy_timeout = 100; BEGIN");
@@ -187,8 +193,7 @@ async function readDatabase(path: string, fallbackTimestamp: number): Promise<Us
         )
       : [];
     const sessionId = NodePath.basename(path, ".db");
-    const records: UsageRecord[] = [];
-    const identities = new Map<string, number>();
+    const records: UsageCandidate[] = [];
     let currentModel = "";
     const generationModel = generations.findLast((entry) => entry.model)?.model ?? "";
     for (const [source, entries] of [
@@ -221,9 +226,6 @@ async function readDatabase(path: string, fallbackTimestamp: number): Promise<Us
             const id = textAt(usage, key);
             return id ? [`antigravity:${key}:${id}`] : [];
           });
-          const existingIndex = keys
-            .map((key) => identities.get(key))
-            .find((value) => value !== undefined);
           const record: UsageRecord = {
             provider: "antigravity",
             sessionId,
@@ -238,32 +240,11 @@ async function readDatabase(path: string, fallbackTimestamp: number): Promise<Us
             reportedCostUsd: null,
             dedupeKey: keys[0] ?? `antigravity:${sessionId}:${source}:${index}:${usageIndex}`,
           };
-          if (existingIndex === undefined) {
-            for (const key of keys) identities.set(key, records.length);
-            records.push(record);
-          } else {
-            const existing = records[existingIndex]!;
-            records[existingIndex] = {
-              ...existing,
-              totals: {
-                uncachedInputTokens: Math.max(
-                  existing.totals.uncachedInputTokens,
-                  totals.uncachedInputTokens,
-                ),
-                cachedInputTokens: Math.max(
-                  existing.totals.cachedInputTokens,
-                  totals.cachedInputTokens,
-                ),
-                cacheCreationTokens: Math.max(
-                  existing.totals.cacheCreationTokens,
-                  totals.cacheCreationTokens,
-                ),
-                outputTokens: Math.max(existing.totals.outputTokens, totals.outputTokens),
-                reasoningTokens: Math.max(existing.totals.reasoningTokens, totals.reasoningTokens),
-              },
-            };
-            for (const key of keys) identities.set(key, existingIndex);
-          }
+          records.push({
+            record,
+            keys,
+            timestampQuality: entry.timestampMs !== null ? 2 : trajectoryTimestamp !== null ? 1 : 0,
+          });
         }
       }
       currentModel = "";
@@ -274,11 +255,82 @@ async function readDatabase(path: string, fallbackTimestamp: number): Promise<Us
   }
 }
 
-/** Reads the SQLite usage metadata described by ccusage's Antigravity adapter. */
-export async function readAntigravityUsage(conversationsDirectory: string, sinceMs: number) {
-  const files: Array<{ path: string; records: readonly UsageRecord[] }> = [];
+/** Reads and merges aliases across every configured Antigravity store before date filtering. */
+export async function readAntigravityUsage(
+  conversationsDirectories: string | readonly string[],
+  sinceMs: number,
+) {
+  const roots =
+    typeof conversationsDirectories === "string"
+      ? [conversationsDirectories]
+      : conversationsDirectories;
+  const files: Array<{ root: string; path: string; records: UsageRecord[] }> = [];
   const errors: string[] = [];
-  const walk = async (directory: string): Promise<void> => {
+  const identities = new Map<string, number>();
+  const groups: Array<
+    UsageCandidate & { parent: number; size: number; owner: number; fileIndex: number }
+  > = [];
+  const find = (index: number): number => {
+    let root = index;
+    while (groups[root]!.parent !== root) root = groups[root]!.parent;
+    while (index !== root) {
+      const parent = groups[index]!.parent;
+      groups[index]!.parent = root;
+      index = parent;
+    }
+    return root;
+  };
+  const merge = (left: number, right: number): number => {
+    let a = find(left);
+    let b = find(right);
+    if (a === b) return a;
+    if (groups[a]!.size < groups[b]!.size) [a, b] = [b, a];
+    const target = groups[a]!;
+    const source = groups[b]!;
+    const first = target.owner < source.owner ? target : source;
+    const bestTime =
+      source.timestampQuality > target.timestampQuality ||
+      (source.timestampQuality === target.timestampQuality &&
+        source.record.timestampMs < target.record.timestampMs)
+        ? source
+        : target;
+    const x = target.record.totals;
+    const y = source.record.totals;
+    target.record = {
+      ...first.record,
+      model:
+        first.record.model === "antigravity-unknown"
+          ? first === target
+            ? source.record.model
+            : target.record.model
+          : first.record.model,
+      timestampMs: bestTime.record.timestampMs,
+      totals: {
+        uncachedInputTokens: Math.max(x.uncachedInputTokens, y.uncachedInputTokens),
+        cachedInputTokens: Math.max(x.cachedInputTokens, y.cachedInputTokens),
+        cacheCreationTokens: Math.max(x.cacheCreationTokens, y.cacheCreationTokens),
+        outputTokens: Math.max(x.outputTokens, y.outputTokens),
+        reasoningTokens: Math.max(x.reasoningTokens, y.reasoningTokens),
+      },
+    };
+    target.timestampQuality = bestTime.timestampQuality;
+    target.owner = first.owner;
+    target.fileIndex = first.fileIndex;
+    target.size += source.size;
+    source.parent = a;
+    return a;
+  };
+  const append = (candidate: UsageCandidate, fileIndex: number) => {
+    const index = groups.length;
+    groups.push({ ...candidate, parent: index, size: 1, owner: index, fileIndex });
+    for (const key of candidate.keys) {
+      const existing = identities.get(key);
+      if (existing !== undefined) merge(index, existing);
+      identities.set(key, index);
+    }
+  };
+  const visited = new Set<string>();
+  const walk = async (directory: string, root: string): Promise<void> => {
     let entries;
     try {
       entries = await NodeFSP.readdir(directory, { withFileTypes: true });
@@ -286,25 +338,35 @@ export async function readAntigravityUsage(conversationsDirectory: string, since
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") errors.push(directory);
       return;
     }
+    entries.sort((a, b) => a.name.localeCompare(b.name));
     for (const entry of entries) {
       const path = NodePath.join(directory, entry.name);
       if (entry.isDirectory()) {
-        await walk(path);
+        await walk(path, root);
       } else if (entry.isFile() && entry.name.endsWith(".db")) {
         try {
+          const canonical = await NodeFSP.realpath(path);
+          if (visited.has(canonical)) continue;
+          visited.add(canonical);
           const stat = await NodeFSP.stat(path);
-          files.push({
-            path,
-            records: (await readDatabase(path, stat.mtimeMs)).filter(
-              (record) => record.timestampMs >= sinceMs,
-            ),
-          });
+          const candidates = await readDatabase(path, stat.mtimeMs);
+          const fileIndex = files.length;
+          files.push({ root, path, records: [] });
+          for (const [index, candidate] of candidates.entries()) {
+            append(candidate, fileIndex);
+            if (index % 256 === 255) await NodeTimersPromises.setImmediate();
+          }
         } catch {
           errors.push(path);
         }
       }
     }
   };
-  await walk(conversationsDirectory);
+  for (const root of roots) await walk(root, root);
+  for (const [index, group] of groups.entries()) {
+    if (group.parent === index && group.record.timestampMs >= sinceMs) {
+      files[group.fileIndex]!.records.push(group.record);
+    }
+  }
   return { files, errors };
 }

--- a/apps/server/src/usage/cursorUsageReader.ts
+++ b/apps/server/src/usage/cursorUsageReader.ts
@@ -1,7 +1,6 @@
 // @effect-diagnostics nodeBuiltinImport:off
 import * as NodeFSP from "node:fs/promises";
 import * as NodeCrypto from "node:crypto";
-import * as NodeSqlite from "node:sqlite";
 import * as NodeTimersPromises from "node:timers/promises";
 
 import type { UsageRecord } from "./usageTranscripts.ts";
@@ -16,58 +15,6 @@ function tokens(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
 }
 
-/** Only recorded token counts count as usage; text length and context meters do not. */
-export function parseCursorBubble(key: string, source: string): UsageRecord | null {
-  const match = /^bubbleId:([^:]+):(.+)$/.exec(key);
-  if (match === null) return null;
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(source);
-  } catch {
-    return null;
-  }
-  const bubble = object(parsed);
-  if (bubble.type !== 2) return null;
-  const usage = object(bubble.tokenCount);
-  const inputTokens = tokens(usage.inputTokens);
-  const outputTokens = tokens(usage.outputTokens);
-  if (inputTokens + outputTokens === 0) return null;
-  const timestampMs =
-    typeof bubble.createdAt === "number"
-      ? bubble.createdAt
-      : typeof bubble.createdAt === "string"
-        ? Date.parse(bubble.createdAt)
-        : NaN;
-  if (!Number.isFinite(timestampMs)) return null;
-  const modelName = object(bubble.modelInfo).modelName;
-  const model =
-    typeof modelName === "string" && modelName && modelName !== "default"
-      ? modelName
-      : "cursor-auto";
-  return {
-    provider: "cursor",
-    timestampMs,
-    model,
-    sessionId: match[1] ?? "",
-    totals: {
-      uncachedInputTokens: inputTokens,
-      cachedInputTokens: 0,
-      cacheCreationTokens: 0,
-      outputTokens,
-      reasoningTokens: 0,
-    },
-    reportedCostUsd: null,
-    // One request can produce several distinct token-bearing assistant bubbles.
-    dedupeKey: `cursor:${key}`,
-  };
-}
-
-export interface CursorUsageReadResult {
-  readonly files: readonly { readonly path: string; readonly records: readonly UsageRecord[] }[];
-  readonly missing: boolean;
-  readonly error: boolean;
-}
-
 export interface CursorAccountUsageReadResult {
   readonly accountKey: string | null;
   readonly records: readonly UsageRecord[];
@@ -76,6 +23,30 @@ export interface CursorAccountUsageReadResult {
 }
 
 const accountHash = (value: string) => NodeCrypto.createHash("sha256").update(value).digest("hex");
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    return `{${Object.entries(value)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+/** Find the longest exact suffix/prefix overlap in linear time. */
+function boundaryOverlap(previous: readonly string[], current: readonly string[]): number {
+  const sequence = [...current, "", ...previous];
+  const lengths = Array.from({ length: sequence.length }, () => 0);
+  for (let index = 1; index < sequence.length; index++) {
+    let length = lengths[index - 1]!;
+    while (length > 0 && sequence[index] !== sequence[length]) length = lengths[length - 1]!;
+    if (sequence[index] === sequence[length]) length++;
+    lengths[index] = length;
+  }
+  return lengths.at(-1) ?? 0;
+}
 
 /** Dashboard usage includes headless agents and reports fresh input separately from cache reads. */
 export async function readCursorAccountUsage(
@@ -109,15 +80,15 @@ export async function readCursorAccountUsage(
     const userId = subject.split("|").at(-1);
     if (!userId) throw new Error("Invalid authentication");
     accountKey = accountHash(subject);
-    if (!Number.isFinite(sinceMs) || sinceMs < 0 || sinceMs > endDate)
+    if (!Number.isFinite(sinceMs) || !Number.isFinite(endDate) || sinceMs < 0 || sinceMs > endDate)
       throw new Error("Invalid date window");
     const signal = AbortSignal.timeout(10_000);
     const records: UsageRecord[] = [];
     const occurrences = new Map<string, number>();
-    const pages = new Set<string>();
+    const pages: unknown[][] = [];
+    let completed = false;
     const pageSize = 1000;
     let total: number | undefined;
-    let received = 0;
     for (let page = 1; page <= 100; page++) {
       const response = await request("https://cursor.com/api/dashboard/get-filtered-usage-events", {
         method: "POST",
@@ -144,25 +115,51 @@ export async function readCursorAccountUsage(
         };
       }
       if (!response.ok) throw new Error("Account usage request failed");
-      const body = object(await response.json());
-      const count = body.totalUsageEventsCount;
-      const events = body.usageEventsDisplay;
+      const parsed: unknown = await response.json();
+      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("Invalid account usage page");
+      }
+      const body = object(parsed);
+      const keys = Object.keys(body);
+      if ("error" in body || "message" in body || "code" in body)
+        throw new Error("Account usage error response");
+      const count = keys.length === 0 ? 0 : body.totalUsageEventsCount;
+      const events =
+        keys.length === 0 || (keys.length === 1 && keys[0] === "totalUsageEventsCount")
+          ? []
+          : body.usageEventsDisplay;
       if (
-        typeof count !== "number" ||
-        !Number.isSafeInteger(count) ||
-        count < 0 ||
-        count > pageSize * 100 ||
-        (total !== undefined && count !== total) ||
+        (count !== undefined &&
+          (typeof count !== "number" ||
+            !Number.isSafeInteger(count) ||
+            count < 0 ||
+            count > pageSize * 100 ||
+            (total !== undefined && count !== total))) ||
         !Array.isArray(events) ||
-        events.length !== Math.min(pageSize, count - received)
+        events.length > pageSize ||
+        (count === undefined && !Array.isArray(body.usageEventsDisplay))
       ) {
         throw new Error("Inconsistent account usage page");
       }
-      total = count;
-      const signature = accountHash(JSON.stringify(events));
-      if (pages.has(signature)) throw new Error("Repeated account usage page");
-      pages.add(signature);
-      for (const raw of events) {
+      if (typeof count === "number") total = count;
+      pages.push(events);
+      if (events.length < pageSize) {
+        completed = true;
+        break;
+      }
+    }
+    if (!completed) throw new Error("Account usage page limit exceeded");
+    const rawCount = pages.reduce((sum, page) => sum + page.length, 0);
+    if (total !== undefined && rawCount < total) throw new Error("Incomplete account usage pages");
+    let removalsRemaining = total === undefined ? 0 : rawCount - total;
+    let previousKeys: string[] = [];
+    for (const events of pages) {
+      const eventKeys =
+        removalsRemaining > 0 ? events.map((event) => accountHash(canonicalJson(event))) : [];
+      const removalCount = Math.min(removalsRemaining, boundaryOverlap(previousKeys, eventKeys));
+      removalsRemaining -= removalCount;
+      previousKeys = eventKeys;
+      for (const raw of events.slice(removalCount)) {
         const event = object(raw);
         const usage = object(event.tokenUsage);
         if (event.tokenUsage === undefined || event.tokenUsage === null) continue;
@@ -219,10 +216,10 @@ export async function readCursorAccountUsage(
           dedupeKey: `cursor-account:${accountKey}:${key}:${occurrence}`,
         });
       }
-      received += events.length;
-      if (received === total) return { accountKey, records, missing: false, error: null };
+      await NodeTimersPromises.setImmediate();
     }
-    throw new Error("Account usage page limit exceeded");
+    if (removalsRemaining !== 0) throw new Error("Inconsistent account usage boundaries");
+    return { accountKey, records, missing: false, error: null };
   } catch {
     return {
       accountKey,
@@ -230,51 +227,5 @@ export async function readCursorAccountUsage(
       missing: false,
       error: "Cursor account usage could not be read.",
     };
-  }
-}
-
-/** Cursor's desktop store only exposes counts for some versions and requests. */
-export async function readCursorUsage(
-  dbPath: string,
-  sinceMs: number,
-): Promise<CursorUsageReadResult> {
-  try {
-    await NodeFSP.stat(dbPath);
-  } catch (cause) {
-    const missing = object(cause).code === "ENOENT";
-    return { files: [], missing, error: !missing };
-  }
-  const records: UsageRecord[] = [];
-  const files = [{ path: dbPath, records }];
-  const seen = new Set<string>();
-  let database: NodeSqlite.DatabaseSync | undefined;
-  try {
-    database = new NodeSqlite.DatabaseSync(dbPath, { readOnly: true });
-    database.exec("PRAGMA busy_timeout = 100");
-    const statement = database.prepare(
-      "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'bubbleId:%'",
-    );
-    let count = 0;
-    for (const row of statement.iterate()) {
-      const source =
-        typeof row.value === "string"
-          ? row.value
-          : row.value instanceof Uint8Array
-            ? Buffer.from(row.value).toString("utf8")
-            : "";
-      const record = parseCursorBubble(typeof row.key === "string" ? row.key : "", source);
-      if (record !== null && record.timestampMs >= sinceMs) {
-        if (record.dedupeKey === null || !seen.has(record.dedupeKey)) {
-          if (record.dedupeKey !== null) seen.add(record.dedupeKey);
-          records.push(record);
-        }
-      }
-      if (++count % 256 === 0) await NodeTimersPromises.setImmediate();
-    }
-    return { files, missing: false, error: false };
-  } catch {
-    return { files, missing: false, error: true };
-  } finally {
-    database?.close();
   }
 }

--- a/apps/server/src/usage/cursorUsageReader.ts
+++ b/apps/server/src/usage/cursorUsageReader.ts
@@ -43,7 +43,6 @@ export function parseCursorBubble(key: string, source: string): UsageRecord | nu
     typeof modelName === "string" && modelName && modelName !== "default"
       ? modelName
       : "cursor-auto";
-  const requestId = typeof bubble.requestId === "string" ? bubble.requestId : "";
   return {
     provider: "cursor",
     timestampMs,
@@ -57,7 +56,8 @@ export function parseCursorBubble(key: string, source: string): UsageRecord | nu
       reasoningTokens: 0,
     },
     reportedCostUsd: null,
-    dedupeKey: requestId ? `cursor:request:${requestId}` : `cursor:${key}`,
+    // One request can produce several distinct token-bearing assistant bubbles.
+    dedupeKey: `cursor:${key}`,
   };
 }
 

--- a/apps/server/src/usage/cursorUsageReader.ts
+++ b/apps/server/src/usage/cursorUsageReader.ts
@@ -1,5 +1,6 @@
 // @effect-diagnostics nodeBuiltinImport:off
 import * as NodeFSP from "node:fs/promises";
+import * as NodeCrypto from "node:crypto";
 import * as NodeSqlite from "node:sqlite";
 import * as NodeTimersPromises from "node:timers/promises";
 
@@ -65,6 +66,171 @@ export interface CursorUsageReadResult {
   readonly files: readonly { readonly path: string; readonly records: readonly UsageRecord[] }[];
   readonly missing: boolean;
   readonly error: boolean;
+}
+
+export interface CursorAccountUsageReadResult {
+  readonly accountKey: string | null;
+  readonly records: readonly UsageRecord[];
+  readonly missing: boolean;
+  readonly error: string | null;
+}
+
+const accountHash = (value: string) => NodeCrypto.createHash("sha256").update(value).digest("hex");
+
+/** Dashboard usage includes headless agents and reports fresh input separately from cache reads. */
+export async function readCursorAccountUsage(
+  authPath: string,
+  sinceMs: number,
+  endDate: number,
+  request: (url: string, init: RequestInit) => Promise<Response> = globalThis.fetch,
+): Promise<CursorAccountUsageReadResult> {
+  let auth: Record<string, unknown>;
+  try {
+    auth = object(JSON.parse(await NodeFSP.readFile(authPath, "utf8")));
+  } catch (cause) {
+    const missing = object(cause).code === "ENOENT";
+    return {
+      accountKey: null,
+      records: [],
+      missing,
+      error: missing ? null : "Cursor credentials could not be read.",
+    };
+  }
+  if (typeof auth.accessToken !== "string" || !auth.accessToken) {
+    return { accountKey: null, records: [], missing: true, error: null };
+  }
+  let accountKey: string | null = null;
+  try {
+    const payload = auth.accessToken.split(".")[1];
+    const subject = object(
+      JSON.parse(Buffer.from(payload ?? "", "base64url").toString("utf8")),
+    ).sub;
+    if (typeof subject !== "string" || !subject) throw new Error("Invalid authentication");
+    const userId = subject.split("|").at(-1);
+    if (!userId) throw new Error("Invalid authentication");
+    accountKey = accountHash(subject);
+    if (!Number.isFinite(sinceMs) || sinceMs < 0 || sinceMs > endDate)
+      throw new Error("Invalid date window");
+    const signal = AbortSignal.timeout(10_000);
+    const records: UsageRecord[] = [];
+    const occurrences = new Map<string, number>();
+    const pages = new Set<string>();
+    const pageSize = 1000;
+    let total: number | undefined;
+    let received = 0;
+    for (let page = 1; page <= 100; page++) {
+      const response = await request("https://cursor.com/api/dashboard/get-filtered-usage-events", {
+        method: "POST",
+        redirect: "error",
+        signal,
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "https://cursor.com",
+          Cookie: `WorkosCursorSessionToken=${encodeURIComponent(`${userId}::${auth.accessToken}`)}`,
+        },
+        body: JSON.stringify({
+          page,
+          pageSize,
+          startDate: String(sinceMs),
+          endDate: String(endDate),
+        }),
+      });
+      if (response.status === 401 || response.status === 403) {
+        return {
+          accountKey,
+          records: [],
+          missing: false,
+          error: "Sign in to Cursor again to read account usage.",
+        };
+      }
+      if (!response.ok) throw new Error("Account usage request failed");
+      const body = object(await response.json());
+      const count = body.totalUsageEventsCount;
+      const events = body.usageEventsDisplay;
+      if (
+        typeof count !== "number" ||
+        !Number.isSafeInteger(count) ||
+        count < 0 ||
+        count > pageSize * 100 ||
+        (total !== undefined && count !== total) ||
+        !Array.isArray(events) ||
+        events.length !== Math.min(pageSize, count - received)
+      ) {
+        throw new Error("Inconsistent account usage page");
+      }
+      total = count;
+      const signature = accountHash(JSON.stringify(events));
+      if (pages.has(signature)) throw new Error("Repeated account usage page");
+      pages.add(signature);
+      for (const raw of events) {
+        const event = object(raw);
+        const usage = object(event.tokenUsage);
+        if (event.tokenUsage === undefined || event.tokenUsage === null) continue;
+        for (const key of [
+          "inputTokens",
+          "outputTokens",
+          "cacheReadTokens",
+          "cacheWriteTokens",
+          "totalCents",
+        ]) {
+          const value = usage[key];
+          if (
+            value !== undefined &&
+            (typeof value !== "number" || !Number.isFinite(value) || value < 0)
+          ) {
+            throw new Error("Invalid account usage totals");
+          }
+        }
+        const timestampMs =
+          typeof event.timestamp === "string" && event.timestamp.trim() !== ""
+            ? Number(event.timestamp)
+            : event.timestamp;
+        if (
+          typeof timestampMs !== "number" ||
+          !Number.isFinite(timestampMs) ||
+          typeof event.model !== "string" ||
+          !event.model
+        )
+          throw new Error("Invalid account usage event");
+        if (timestampMs < sinceMs || timestampMs > endDate) continue;
+        const totals = {
+          uncachedInputTokens: tokens(usage.inputTokens),
+          cachedInputTokens: tokens(usage.cacheReadTokens),
+          cacheCreationTokens: tokens(usage.cacheWriteTokens),
+          outputTokens: tokens(usage.outputTokens),
+          reasoningTokens: 0,
+        };
+        const reportedCostUsd =
+          typeof usage.totalCents === "number" ? usage.totalCents / 100 : null;
+        const sessionId = typeof event.conversationId === "string" ? event.conversationId : "";
+        // No event ID is provided. Preserve identical billed rows with an occurrence index.
+        const key = accountHash(
+          JSON.stringify([timestampMs, event.model, sessionId, totals, reportedCostUsd]),
+        );
+        const occurrence = occurrences.get(key) ?? 0;
+        occurrences.set(key, occurrence + 1);
+        records.push({
+          provider: "cursor",
+          timestampMs,
+          model: event.model,
+          sessionId,
+          totals,
+          reportedCostUsd,
+          dedupeKey: `cursor-account:${accountKey}:${key}:${occurrence}`,
+        });
+      }
+      received += events.length;
+      if (received === total) return { accountKey, records, missing: false, error: null };
+    }
+    throw new Error("Account usage page limit exceeded");
+  } catch {
+    return {
+      accountKey,
+      records: [],
+      missing: false,
+      error: "Cursor account usage could not be read.",
+    };
+  }
 }
 
 /** Cursor's desktop store only exposes counts for some versions and requests. */

--- a/apps/server/src/usage/cursorUsageReader.ts
+++ b/apps/server/src/usage/cursorUsageReader.ts
@@ -1,0 +1,114 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFSP from "node:fs/promises";
+import * as NodeSqlite from "node:sqlite";
+import * as NodeTimersPromises from "node:timers/promises";
+
+import type { UsageRecord } from "./usageTranscripts.ts";
+
+function object(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function tokens(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
+}
+
+/** Only recorded token counts count as usage; text length and context meters do not. */
+export function parseCursorBubble(key: string, source: string): UsageRecord | null {
+  const match = /^bubbleId:([^:]+):(.+)$/.exec(key);
+  if (match === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    return null;
+  }
+  const bubble = object(parsed);
+  if (bubble.type !== 2) return null;
+  const usage = object(bubble.tokenCount);
+  const inputTokens = tokens(usage.inputTokens);
+  const outputTokens = tokens(usage.outputTokens);
+  if (inputTokens + outputTokens === 0) return null;
+  const timestampMs =
+    typeof bubble.createdAt === "number"
+      ? bubble.createdAt
+      : typeof bubble.createdAt === "string"
+        ? Date.parse(bubble.createdAt)
+        : NaN;
+  if (!Number.isFinite(timestampMs)) return null;
+  const modelName = object(bubble.modelInfo).modelName;
+  const model =
+    typeof modelName === "string" && modelName && modelName !== "default"
+      ? modelName
+      : "cursor-auto";
+  const requestId = typeof bubble.requestId === "string" ? bubble.requestId : "";
+  return {
+    provider: "cursor",
+    timestampMs,
+    model,
+    sessionId: match[1] ?? "",
+    totals: {
+      uncachedInputTokens: inputTokens,
+      cachedInputTokens: 0,
+      cacheCreationTokens: 0,
+      outputTokens,
+      reasoningTokens: 0,
+    },
+    reportedCostUsd: null,
+    dedupeKey: requestId ? `cursor:request:${requestId}` : `cursor:${key}`,
+  };
+}
+
+export interface CursorUsageReadResult {
+  readonly files: readonly { readonly path: string; readonly records: readonly UsageRecord[] }[];
+  readonly missing: boolean;
+  readonly error: boolean;
+}
+
+/** Cursor's desktop store only exposes counts for some versions and requests. */
+export async function readCursorUsage(
+  dbPath: string,
+  sinceMs: number,
+): Promise<CursorUsageReadResult> {
+  try {
+    await NodeFSP.stat(dbPath);
+  } catch (cause) {
+    const missing = object(cause).code === "ENOENT";
+    return { files: [], missing, error: !missing };
+  }
+  const records: UsageRecord[] = [];
+  const files = [{ path: dbPath, records }];
+  const seen = new Set<string>();
+  let database: NodeSqlite.DatabaseSync | undefined;
+  try {
+    database = new NodeSqlite.DatabaseSync(dbPath, { readOnly: true });
+    database.exec("PRAGMA busy_timeout = 100");
+    const statement = database.prepare(
+      "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'bubbleId:%'",
+    );
+    let count = 0;
+    for (const row of statement.iterate()) {
+      const source =
+        typeof row.value === "string"
+          ? row.value
+          : row.value instanceof Uint8Array
+            ? Buffer.from(row.value).toString("utf8")
+            : "";
+      const record = parseCursorBubble(typeof row.key === "string" ? row.key : "", source);
+      if (record !== null && record.timestampMs >= sinceMs) {
+        if (record.dedupeKey === null || !seen.has(record.dedupeKey)) {
+          if (record.dedupeKey !== null) seen.add(record.dedupeKey);
+          records.push(record);
+        }
+      }
+      if (++count % 256 === 0) await NodeTimersPromises.setImmediate();
+    }
+    return { files, missing: false, error: false };
+  } catch {
+    return { files, missing: false, error: true };
+  } finally {
+    database?.close();
+  }
+}

--- a/apps/server/src/usage/opencodeUsageReader.ts
+++ b/apps/server/src/usage/opencodeUsageReader.ts
@@ -1,0 +1,186 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFSP from "node:fs/promises";
+import * as NodePath from "node:path";
+import * as NodeSqlite from "node:sqlite";
+import * as NodeTimersPromises from "node:timers/promises";
+
+import { totalTokens, type UsageRecord } from "./usageTranscripts.ts";
+
+function object(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function tokens(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/** OpenCode stores uncached input and reasoning separately from input/output. */
+export function parseOpenCodeMessage(
+  source: string,
+  fallback: {
+    readonly id?: string;
+    readonly sessionId?: string;
+    readonly timestampMs?: number;
+  } = {},
+): UsageRecord | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    return null;
+  }
+  const message = object(parsed);
+  if (message.role !== undefined && message.role !== "assistant") return null;
+  const usage = object(message.tokens);
+  const cache = object(usage.cache);
+  const modelReference = object(message.model);
+  const model = text(modelReference.id) || text(modelReference.modelID) || text(message.modelID);
+  const timestampMs = object(message.time).created ?? fallback.timestampMs;
+  if (!model || typeof timestampMs !== "number" || !Number.isFinite(timestampMs)) return null;
+  const reasoningTokens = tokens(usage.reasoning);
+  const totals = {
+    uncachedInputTokens: tokens(usage.input),
+    cachedInputTokens: tokens(cache.read),
+    cacheCreationTokens: tokens(cache.write),
+    outputTokens: tokens(usage.output) + reasoningTokens,
+    reasoningTokens,
+  };
+  if (totalTokens(totals) === 0) return null;
+  const id = fallback.id || text(message.id);
+  const cost = message.cost;
+  return {
+    provider: "opencode",
+    timestampMs,
+    model,
+    sessionId: fallback.sessionId || text(message.sessionID),
+    totals,
+    // OpenCode writes zero for models without a known rate, including paid
+    // subscription models. Let the shared price table estimate those records.
+    reportedCostUsd: typeof cost === "number" && Number.isFinite(cost) && cost > 0 ? cost : null,
+    dedupeKey: id ? `opencode:${id}` : null,
+  };
+}
+
+export interface OpenCodeUsageReadResult {
+  readonly files: readonly { readonly path: string; readonly records: readonly UsageRecord[] }[];
+  readonly missing: boolean;
+  readonly error: boolean;
+}
+
+/** Reads current SQLite and pre-migration JSON stores without modifying either. */
+export async function readOpenCodeUsage(
+  root: string,
+  sinceMs: number,
+): Promise<OpenCodeUsageReadResult> {
+  const files: { path: string; records: UsageRecord[] }[] = [];
+  const seen = new Set<string>();
+  let found = false;
+  let error = false;
+  const append = (records: UsageRecord[], record: UsageRecord | null) => {
+    if (record === null || record.timestampMs < sinceMs) return;
+    if (record.dedupeKey !== null) {
+      if (seen.has(record.dedupeKey)) return;
+      seen.add(record.dedupeKey);
+    }
+    records.push(record);
+  };
+
+  let databases: string[] = [];
+  try {
+    databases = (await NodeFSP.readdir(root, { withFileTypes: true }))
+      .filter((entry) => entry.isFile() && /^opencode(?:-[a-zA-Z0-9_-]+)?\.db$/.test(entry.name))
+      .map((entry) => entry.name)
+      .sort((a, b) => (a === "opencode.db" ? -1 : b === "opencode.db" ? 1 : a.localeCompare(b)));
+  } catch (cause) {
+    if (object(cause).code !== "ENOENT") error = true;
+  }
+  for (const name of databases) {
+    found = true;
+    const file = { path: NodePath.join(root, name), records: [] as UsageRecord[] };
+    files.push(file);
+    let database: NodeSqlite.DatabaseSync | undefined;
+    try {
+      database = new NodeSqlite.DatabaseSync(NodePath.join(root, name), { readOnly: true });
+      // A busy live provider should fail this source promptly rather than
+      // stalling the server while SQLite waits for its writer.
+      database.exec("PRAGMA busy_timeout = 100");
+      const tables = new Set(
+        database
+          .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+          .all()
+          .map((row) => row.name),
+      );
+      if (!tables.has("message") && !tables.has("session_message")) error = true;
+      for (const table of ["message", "session_message"] as const) {
+        if (!tables.has(table)) continue;
+        const columns = new Set(
+          database
+            .prepare(`PRAGMA table_info(${table})`)
+            .all()
+            .map((row) => row.name),
+        );
+        const timestamp = columns.has("time_created") ? "time_created" : "NULL";
+        const predicates = table === "session_message" ? ["type = 'assistant'"] : [];
+        if (timestamp !== "NULL") predicates.push("time_created >= ?");
+        const where = predicates.length > 0 ? ` WHERE ${predicates.join(" AND ")}` : "";
+        const statement = database.prepare(
+          `SELECT id, session_id, data, ${timestamp} AS created FROM ${table}${where}`,
+        );
+        let count = 0;
+        for (const row of statement.iterate(...(timestamp === "NULL" ? [] : [sinceMs]))) {
+          append(
+            file.records,
+            parseOpenCodeMessage(text(row.data), {
+              id: text(row.id),
+              sessionId: text(row.session_id),
+              ...(typeof row.created === "number" ? { timestampMs: row.created } : {}),
+            }),
+          );
+          if (++count % 256 === 0) await NodeTimersPromises.setImmediate();
+        }
+      }
+    } catch {
+      error = true;
+    } finally {
+      database?.close();
+    }
+  }
+
+  // Do not follow symlinks, including cycles. Database records win over their
+  // old JSON copies when OpenCode has migrated a store in place.
+  const directories = [NodePath.join(root, "storage", "message")];
+  while (directories.length > 0) {
+    const directory = directories.pop()!;
+    try {
+      for (const entry of await NodeFSP.readdir(directory, { withFileTypes: true })) {
+        const path = NodePath.join(directory, entry.name);
+        if (entry.isDirectory()) {
+          directories.push(path);
+        } else if (entry.isFile() && entry.name.endsWith(".json")) {
+          found = true;
+          const id = entry.name.slice(0, -5);
+          if (seen.has(`opencode:${id}`)) continue;
+          const file = { path, records: [] as UsageRecord[] };
+          files.push(file);
+          try {
+            append(
+              file.records,
+              parseOpenCodeMessage(await NodeFSP.readFile(path, "utf8"), { id }),
+            );
+          } catch (cause) {
+            if (object(cause).code !== "ENOENT") error = true;
+          }
+        }
+      }
+    } catch (cause) {
+      if (object(cause).code !== "ENOENT") error = true;
+    }
+  }
+  return { files, missing: !found && !error, error };
+}

--- a/apps/server/src/usage/usageAggregation.ts
+++ b/apps/server/src/usage/usageAggregation.ts
@@ -112,7 +112,7 @@ export class UsageAggregator {
    * can derive per-window facts (distinct sessions, for one) from the records
    * that landed rather than everything the mtime prefilter happened to admit.
    */
-  add(record: UsageRecord): boolean {
+  add(record: UsageRecord, sourcePath?: string): boolean {
     if (record.dedupeKey !== null) {
       if (this.#seen.has(record.dedupeKey)) {
         this.#duplicatesDropped += 1;
@@ -146,7 +146,7 @@ export class UsageAggregator {
             this.#hourlyWindow.sinceTimeMs +
               Math.floor((record.timestampMs - this.#hourlyWindow.sinceTimeMs) / HOUR_MS) * HOUR_MS,
           ).toISOString();
-    const key = `${day}\u0000${hourStart}\u0000${record.provider}\u0000${record.model}`;
+    const key = `${day}\u0000${hourStart}\u0000${record.provider}\u0000${record.model}\u0000${sourcePath ?? ""}`;
     let bucket = this.#buckets.get(key);
     if (bucket === undefined) {
       bucket = {
@@ -187,12 +187,14 @@ export class UsageAggregator {
   finish(): AggregateResult {
     const buckets: UsageBucket[] = [];
     for (const [key, bucket] of this.#buckets) {
-      const [day = "", hourStart = "", provider = "", model = ""] = key.split("\u0000");
+      const [day = "", hourStart = "", provider = "", model = "", sourcePath = ""] =
+        key.split("\u0000");
       buckets.push({
         day: day as UsageDay,
         ...(hourStart === "" ? {} : { hourStart }),
         provider: provider as UsageBucket["provider"],
         model,
+        ...(sourcePath === "" ? {} : { sourcePath }),
         totals: bucket.totals,
         costUsd: bucket.costUsd,
         cacheSavingsUsd: bucket.cacheSavingsUsd,

--- a/apps/server/src/usage/usageTranscriptReader.test.ts
+++ b/apps/server/src/usage/usageTranscriptReader.test.ts
@@ -10,7 +10,7 @@ import { afterEach, assert, beforeEach, describe, it } from "@effect/vitest";
 
 import { readTranscriptRecords } from "./usageTranscriptReader.ts";
 import { readOpenCodeUsage } from "./opencodeUsageReader.ts";
-import { readCursorUsage } from "./cursorUsageReader.ts";
+import { readCursorAccountUsage, readCursorUsage } from "./cursorUsageReader.ts";
 import { readAntigravityUsage } from "./antigravityUsageReader.ts";
 
 let dir: string;
@@ -237,6 +237,85 @@ describe("readTranscriptRecords resume", () => {
 });
 
 describe("SQLite usage readers", () => {
+  it("reads paginated Cursor account history including headless calls with separate cache tokens", async () => {
+    const authPath = NodePath.join(dir, "auth.json");
+    const accessToken = `header.${Buffer.from(JSON.stringify({ sub: "auth|demo", exp: 4102444800 })).toString("base64url")}.signature`;
+    await NodeFSP.writeFile(authPath, JSON.stringify({ accessToken }));
+    const pages: number[] = [];
+    const request = async (url: string, init: RequestInit) => {
+      assert.strictEqual(String(url), "https://cursor.com/api/dashboard/get-filtered-usage-events");
+      assert.strictEqual(init?.redirect, "error");
+      const headers = new Headers(init?.headers);
+      assert.strictEqual(headers.get("origin"), "https://cursor.com");
+      assert.include(headers.get("cookie") ?? "", "WorkosCursorSessionToken=demo%3A%3A");
+      const body = JSON.parse(String(init?.body));
+      pages.push(body.page);
+      return Response.json({
+        totalUsageEventsCount: 1001,
+        usageEventsDisplay: Array.from({ length: body.page === 1 ? 1000 : 1 }, (_, index) => ({
+          timestamp: String(1780000000000 + ((body.page - 1) * 1000 + index) * 1000),
+          model: "claude-sonnet-4-5",
+          conversationId: `conversation-${body.page}`,
+          isHeadless: body.page === 2,
+          chargedCents: 0,
+          tokenUsage: {
+            inputTokens: 10,
+            outputTokens: 5,
+            cacheReadTokens: 30,
+            cacheWriteTokens: 2,
+            totalCents: 25,
+          },
+        })),
+      });
+    };
+    const result = await readCursorAccountUsage(authPath, 0, 1781000000000, request);
+    assert.isNull(result.error);
+    assert.deepStrictEqual(pages, [1, 2]);
+    assert.strictEqual(result.records.length, 1001);
+    assert.strictEqual(result.records.at(-1)?.sessionId, "conversation-2");
+    assert.deepStrictEqual(result.records[0]?.totals, {
+      uncachedInputTokens: 10,
+      cachedInputTokens: 30,
+      cacheCreationTokens: 2,
+      outputTokens: 5,
+      reasoningTokens: 0,
+    });
+    assert.strictEqual(result.records[0]?.reportedCostUsd, 0.25);
+    assert.isFalse(result.accountKey?.includes("demo") ?? true);
+  });
+
+  it("does not present truncated Cursor account pages or authentication failures as complete history", async () => {
+    const authPath = NodePath.join(dir, "auth.json");
+    const accessToken = `header.${Buffer.from(JSON.stringify({ sub: "auth|demo", exp: 4102444800 })).toString("base64url")}.signature`;
+    await NodeFSP.writeFile(authPath, JSON.stringify({ accessToken }));
+    const truncated = await readCursorAccountUsage(authPath, 0, 1781000000000, async () =>
+      Response.json({ totalUsageEventsCount: 101, usageEventsDisplay: [] }),
+    );
+    assert.isNotNull(truncated.error);
+    assert.deepStrictEqual(truncated.records, []);
+    const denied = await readCursorAccountUsage(
+      authPath,
+      0,
+      1781000000000,
+      async () => new Response(accessToken, { status: 401 }),
+    );
+    assert.isNotNull(denied.error);
+    assert.isFalse(denied.error?.includes(accessToken) ?? true);
+    assert.deepStrictEqual(denied.records, []);
+    let requested = false;
+    const missing = await readCursorAccountUsage(
+      NodePath.join(dir, "missing.json"),
+      0,
+      1781000000000,
+      async () => {
+        requested = true;
+        return Response.json({});
+      },
+    );
+    assert.isTrue(missing.missing);
+    assert.isFalse(requested);
+  });
+
   it("counts migrated OpenCode messages once and sees subsequent WAL writes", async () => {
     const db = new NodeSqlite.DatabaseSync(NodePath.join(dir, "opencode.db"));
     try {

--- a/apps/server/src/usage/usageTranscriptReader.test.ts
+++ b/apps/server/src/usage/usageTranscriptReader.test.ts
@@ -4,12 +4,39 @@
 import * as NodeFSP from "node:fs/promises";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
+import * as NodeSqlite from "node:sqlite";
 
 import { afterEach, assert, beforeEach, describe, it } from "@effect/vitest";
 
 import { readTranscriptRecords } from "./usageTranscriptReader.ts";
+import { readOpenCodeUsage } from "./opencodeUsageReader.ts";
+import { readCursorUsage } from "./cursorUsageReader.ts";
+import { readAntigravityUsage } from "./antigravityUsageReader.ts";
 
 let dir: string;
+
+function protoNumber(field: number, value: number): number[] {
+  const varint = (number: number) => {
+    const bytes: number[] = [];
+    do {
+      const byte = number % 128;
+      number = Math.floor(number / 128);
+      bytes.push(byte + (number > 0 ? 128 : 0));
+    } while (number > 0);
+    return bytes;
+  };
+  return [...varint(field * 8), ...varint(value)];
+}
+
+function protoBytes(field: number, bytes: readonly number[]): number[] {
+  const encoded = protoNumber(field, bytes.length);
+  encoded[0] = encoded[0]! + 2;
+  return [...encoded, ...bytes];
+}
+
+function protoText(field: number, value: string): number[] {
+  return protoBytes(field, [...Buffer.from(value)]);
+}
 
 beforeEach(async () => {
   dir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "usage-reader-test-"));
@@ -206,5 +233,178 @@ describe("readTranscriptRecords resume", () => {
 
   it("returns null for an unreadable file", async () => {
     assert.isNull(await readTranscriptRecords(NodePath.join(dir, "missing.jsonl"), "claude"));
+  });
+});
+
+describe("SQLite usage readers", () => {
+  it("counts migrated OpenCode messages once and sees subsequent WAL writes", async () => {
+    const db = new NodeSqlite.DatabaseSync(NodePath.join(dir, "opencode.db"));
+    try {
+      db.exec(
+        "PRAGMA journal_mode = WAL; PRAGMA wal_autocheckpoint = 0; CREATE TABLE message (id TEXT, session_id TEXT, data TEXT)",
+      );
+      const message = {
+        id: "msg-1",
+        sessionID: "session-1",
+        role: "assistant",
+        modelID: "claude-sonnet-4-5",
+        time: { created: 1780000000000 },
+        cost: 0.25,
+        tokens: { input: 100, output: 20, reasoning: 5, cache: { read: 30, write: 10 } },
+      };
+      const insert = db.prepare("INSERT INTO message VALUES (?, ?, ?)");
+      insert.run(message.id, message.sessionID, JSON.stringify(message));
+      const legacy = NodePath.join(dir, "storage", "message", message.sessionID);
+      await NodeFSP.mkdir(legacy, { recursive: true });
+      await NodeFSP.writeFile(NodePath.join(legacy, "msg-1.json"), JSON.stringify(message));
+      const first = await readOpenCodeUsage(dir, 0);
+      assert.isFalse(first.error);
+      const records = first.files.flatMap((file) => file.records);
+      assert.strictEqual(records.length, 1);
+      assert.deepStrictEqual(records[0]?.totals, {
+        uncachedInputTokens: 100,
+        cachedInputTokens: 30,
+        cacheCreationTokens: 10,
+        outputTokens: 25,
+        reasoningTokens: 5,
+      });
+      assert.strictEqual(records[0]?.reportedCostUsd, 0.25);
+      insert.run(
+        "msg-2",
+        message.sessionID,
+        JSON.stringify({ ...message, id: "msg-2", time: { created: 1780000001000 } }),
+      );
+      const next = await readOpenCodeUsage(dir, 1780000001000);
+      assert.isFalse(next.error);
+      assert.deepStrictEqual(
+        next.files.flatMap((file) => file.records).map((record) => record.dedupeKey),
+        ["opencode:msg-2"],
+      );
+      assert.isAbove((await NodeFSP.stat(NodePath.join(dir, "opencode.db-wal"))).size, 0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("counts Cursor assistant usage without estimating zero-count or user bubbles", async () => {
+    const path = NodePath.join(dir, "state.vscdb");
+    const db = new NodeSqlite.DatabaseSync(path);
+    try {
+      db.exec("CREATE TABLE cursorDiskKV (key TEXT, value TEXT)");
+      const insert = db.prepare("INSERT INTO cursorDiskKV VALUES (?, ?)");
+      const bubble = {
+        type: 2,
+        createdAt: "2026-08-01T10:00:00Z",
+        requestId: "request-1",
+        modelInfo: { modelName: "claude-sonnet-4-5" },
+        tokenCount: { inputTokens: 120, outputTokens: 30 },
+      };
+      insert.run("bubbleId:session-1:assistant", JSON.stringify(bubble));
+      insert.run("bubbleId:session-1:copy", JSON.stringify(bubble));
+      insert.run(
+        "bubbleId:session-1:user",
+        JSON.stringify({ ...bubble, type: 1, requestId: "user-request" }),
+      );
+      insert.run(
+        "bubbleId:session-1:zero",
+        JSON.stringify({
+          ...bubble,
+          requestId: "zero",
+          tokenCount: { inputTokens: 0, outputTokens: 0 },
+          text: "real text without recorded usage",
+        }),
+      );
+    } finally {
+      db.close();
+    }
+    const result = await readCursorUsage(path, 0);
+    assert.isFalse(result.error);
+    const records = result.files.flatMap((file) => file.records);
+    assert.strictEqual(records.length, 1);
+    assert.strictEqual(records[0]?.model, "claude-sonnet-4-5");
+    assert.strictEqual(records[0]?.sessionId, "session-1");
+    assert.strictEqual(records[0]?.totals.uncachedInputTokens, 120);
+    assert.strictEqual(records[0]?.totals.outputTokens, 30);
+    assert.strictEqual(records[0]?.timestampMs, Date.parse("2026-08-01T10:00:00Z"));
+  });
+
+  it("deduplicates Antigravity generation and step usage while preserving retry model and token buckets", async () => {
+    const db = new NodeSqlite.DatabaseSync(NodePath.join(dir, "session-1.db"));
+    const stamp = protoNumber(1, 1780000000);
+    const usage = [
+      ...protoNumber(2, 100),
+      ...protoNumber(3, 40),
+      ...protoNumber(4, 5),
+      ...protoNumber(5, 20),
+      ...protoNumber(9, 10),
+      ...protoText(11, "response-1"),
+    ];
+    const retry = [
+      ...protoNumber(1, 1026),
+      ...protoNumber(2, 12),
+      ...protoNumber(3, 3),
+      ...protoText(11, "retry-1"),
+    ];
+    const generation = protoBytes(1, [
+      ...protoBytes(4, usage),
+      ...protoText(19, "Gemini 3 Pro"),
+      ...protoBytes(9, protoBytes(4, stamp)),
+    ]);
+    const step = [
+      ...protoBytes(9, usage),
+      ...protoBytes(8, stamp),
+      ...protoBytes(28, protoBytes(2, retry)),
+    ];
+    try {
+      db.exec(
+        "CREATE TABLE gen_metadata (idx INTEGER, data BLOB); CREATE TABLE steps (idx INTEGER, metadata BLOB)",
+      );
+      db.prepare("INSERT INTO gen_metadata VALUES (?, ?)").run(0, new Uint8Array(generation));
+      db.prepare("INSERT INTO steps VALUES (?, ?)").run(0, new Uint8Array(step));
+    } finally {
+      db.close();
+    }
+    const result = await readAntigravityUsage(dir, 0);
+    assert.deepStrictEqual(result.errors, []);
+    const records = result.files.flatMap((file) => file.records);
+    assert.strictEqual(records.length, 2);
+    const main = records.find((record) => record.model === "gemini-3-pro");
+    assert.isDefined(main);
+    assert.strictEqual(main?.timestampMs, 1780000000000);
+    assert.strictEqual(main?.sessionId, "session-1");
+    assert.deepStrictEqual(main?.totals, {
+      uncachedInputTokens: 100,
+      cachedInputTokens: 20,
+      cacheCreationTokens: 5,
+      outputTokens: 40,
+      reasoningTokens: 10,
+    });
+    assert.strictEqual(
+      records.find((record) => record.model === "claude-opus-4-6")?.totals.uncachedInputTokens,
+      12,
+    );
+    assert.deepStrictEqual(
+      (await readAntigravityUsage(dir, 1780000000001)).files.flatMap((file) => file.records),
+      [],
+    );
+  });
+
+  it("reads Antigravity step-only stores and reports malformed databases", async () => {
+    const db = new NodeSqlite.DatabaseSync(NodePath.join(dir, "steps.db"));
+    try {
+      db.exec("CREATE TABLE steps (idx INTEGER, metadata BLOB)");
+      const usage = [...protoNumber(1, 246), ...protoNumber(2, 10), ...protoNumber(3, 5)];
+      db.prepare("INSERT INTO steps VALUES (?, ?)").run(
+        0,
+        new Uint8Array([...protoBytes(9, usage), ...protoBytes(8, protoNumber(1, 1780000000))]),
+      );
+    } finally {
+      db.close();
+    }
+    await NodeFSP.writeFile(NodePath.join(dir, "broken.db"), "not a sqlite database");
+    const result = await readAntigravityUsage(dir, 0);
+    assert.strictEqual(result.errors.length, 1);
+    assert.strictEqual(result.files.flatMap((file) => file.records)[0]?.model, "gemini-2.5-pro");
+    assert.strictEqual(result.files.flatMap((file) => file.records)[0]?.totals.outputTokens, 5);
   });
 });

--- a/apps/server/src/usage/usageTranscriptReader.test.ts
+++ b/apps/server/src/usage/usageTranscriptReader.test.ts
@@ -300,6 +300,7 @@ describe("SQLite usage readers", () => {
         tokenCount: { inputTokens: 120, outputTokens: 30 },
       };
       insert.run("bubbleId:session-1:assistant", JSON.stringify(bubble));
+      insert.run("bubbleId:session-1:assistant", JSON.stringify(bubble));
       insert.run("bubbleId:session-1:copy", JSON.stringify(bubble));
       insert.run(
         "bubbleId:session-1:user",
@@ -320,7 +321,11 @@ describe("SQLite usage readers", () => {
     const result = await readCursorUsage(path, 0);
     assert.isFalse(result.error);
     const records = result.files.flatMap((file) => file.records);
-    assert.strictEqual(records.length, 1);
+    assert.strictEqual(records.length, 2);
+    assert.strictEqual(
+      records.reduce((sum, record) => sum + record.totals.outputTokens, 0),
+      60,
+    );
     assert.strictEqual(records[0]?.model, "claude-sonnet-4-5");
     assert.strictEqual(records[0]?.sessionId, "session-1");
     assert.strictEqual(records[0]?.totals.uncachedInputTokens, 120);
@@ -386,6 +391,132 @@ describe("SQLite usage readers", () => {
     assert.deepStrictEqual(
       (await readAntigravityUsage(dir, 1780000000001)).files.flatMap((file) => file.records),
       [],
+    );
+  });
+
+  it("merges Antigravity aliases that bridge previously separate step records", async () => {
+    const db = new NodeSqlite.DatabaseSync(NodePath.join(dir, "bridge.db"));
+    try {
+      db.exec(
+        "CREATE TABLE gen_metadata (idx INTEGER, data BLOB); CREATE TABLE steps (idx INTEGER, metadata BLOB)",
+      );
+      const step = db.prepare("INSERT INTO steps VALUES (?, ?)");
+      step.run(
+        0,
+        new Uint8Array(protoBytes(9, [...protoNumber(2, 100), ...protoText(11, "response")])),
+      );
+      step.run(
+        1,
+        new Uint8Array(protoBytes(9, [...protoNumber(3, 40), ...protoText(12, "provider")])),
+      );
+      db.prepare("INSERT INTO gen_metadata VALUES (?, ?)").run(
+        0,
+        new Uint8Array(
+          protoBytes(1, [
+            ...protoText(19, "Gemini 3 Pro"),
+            ...protoBytes(4, [
+              ...protoNumber(2, 50),
+              ...protoNumber(5, 20),
+              ...protoText(11, "response"),
+              ...protoText(12, "provider"),
+            ]),
+          ]),
+        ),
+      );
+    } finally {
+      db.close();
+    }
+    const result = await readAntigravityUsage(dir, 0);
+    assert.deepStrictEqual(result.errors, []);
+    const records = result.files.flatMap((file) => file.records);
+    assert.strictEqual(records.length, 1);
+    assert.deepStrictEqual(records[0]?.totals, {
+      uncachedInputTokens: 100,
+      cachedInputTokens: 20,
+      cacheCreationTokens: 0,
+      outputTokens: 40,
+      reasoningTokens: 0,
+    });
+  });
+
+  it("merges Antigravity provider and message aliases across configured roots while keeping original ownership", async () => {
+    const roots = [NodePath.join(dir, "first"), NodePath.join(dir, "second")];
+    for (const [index, root] of roots.entries()) {
+      await NodeFSP.mkdir(root);
+      const db = new NodeSqlite.DatabaseSync(NodePath.join(root, `session-${index}.db`));
+      try {
+        db.exec("CREATE TABLE steps (idx INTEGER, metadata BLOB)");
+        for (const identity of [7, 12]) {
+          const usage = [
+            ...protoNumber(1, 246),
+            ...protoNumber(2, index === 0 ? 100 : 150),
+            ...protoText(11, `response-${index}-${identity}`),
+            ...protoText(identity, `shared-${identity}`),
+          ];
+          db.prepare("INSERT INTO steps VALUES (?, ?)").run(
+            identity,
+            new Uint8Array(protoBytes(9, usage)),
+          );
+        }
+      } finally {
+        db.close();
+      }
+    }
+    const result = await readAntigravityUsage(roots, 0);
+    assert.deepStrictEqual(result.errors, []);
+    assert.strictEqual(result.files.length, 2);
+    assert.strictEqual(result.files[0]?.root, roots[0]);
+    assert.strictEqual(result.files[0]?.records.length, 2);
+    assert.strictEqual(result.files[1]?.records.length, 0);
+    assert.deepStrictEqual(
+      result.files[0]?.records.map((record) => record.totals.uncachedInputTokens),
+      [150, 150],
+    );
+    assert.isTrue(result.files[0]?.records.every((record) => record.sessionId === "session-0"));
+  });
+
+  it("upgrades Antigravity fallback timestamps before applying the date window", async () => {
+    for (const fallback of ["mtime", "trajectory"]) {
+      const path = NodePath.join(dir, `${fallback}.db`);
+      const db = new NodeSqlite.DatabaseSync(path);
+      try {
+        db.exec(
+          "CREATE TABLE gen_metadata (idx INTEGER, data BLOB); CREATE TABLE steps (idx INTEGER, metadata BLOB)",
+        );
+        if (fallback === "trajectory") {
+          db.exec("CREATE TABLE trajectory_metadata_blob (data BLOB)");
+          db.prepare("INSERT INTO trajectory_metadata_blob VALUES (?)").run(
+            new Uint8Array(protoBytes(2, protoNumber(1, 1780000200))),
+          );
+        }
+        for (const [index, seconds] of [1780000000, 1780000200].entries()) {
+          const usage = [...protoNumber(2, 10), ...protoText(11, `${fallback}-${index}`)];
+          db.prepare("INSERT INTO steps VALUES (?, ?)").run(
+            index,
+            new Uint8Array(protoBytes(9, usage)),
+          );
+          db.prepare("INSERT INTO gen_metadata VALUES (?, ?)").run(
+            index,
+            new Uint8Array(
+              protoBytes(1, [
+                ...protoBytes(4, usage),
+                ...protoBytes(9, protoBytes(4, protoNumber(1, seconds))),
+              ]),
+            ),
+          );
+        }
+      } finally {
+        db.close();
+      }
+      await NodeFSP.utimes(path, 1780000000, 1780000000);
+    }
+    const result = await readAntigravityUsage(dir, 1780000100000);
+    assert.deepStrictEqual(result.errors, []);
+    const records = result.files.flatMap((file) => file.records);
+    assert.strictEqual(records.length, 2);
+    assert.deepStrictEqual(
+      records.map((record) => record.timestampMs),
+      [1780000200000, 1780000200000],
     );
   });
 

--- a/apps/server/src/usage/usageTranscriptReader.test.ts
+++ b/apps/server/src/usage/usageTranscriptReader.test.ts
@@ -10,7 +10,7 @@ import { afterEach, assert, beforeEach, describe, it } from "@effect/vitest";
 
 import { readTranscriptRecords } from "./usageTranscriptReader.ts";
 import { readOpenCodeUsage } from "./opencodeUsageReader.ts";
-import { readCursorAccountUsage, readCursorUsage } from "./cursorUsageReader.ts";
+import { readCursorAccountUsage } from "./cursorUsageReader.ts";
 import { readAntigravityUsage } from "./antigravityUsageReader.ts";
 
 let dir: string;
@@ -284,6 +284,112 @@ describe("SQLite usage readers", () => {
     assert.isFalse(result.accountKey?.includes("demo") ?? true);
   });
 
+  it("accepts confirmed empty Cursor usage but rejects error envelopes", async () => {
+    const authPath = NodePath.join(dir, "auth.json");
+    const accessToken = `header.${Buffer.from(JSON.stringify({ sub: "auth|demo" })).toString("base64url")}.signature`;
+    await NodeFSP.writeFile(authPath, JSON.stringify({ accessToken }));
+    for (const body of [
+      {},
+      { totalUsageEventsCount: 0 },
+      { totalUsageEventsCount: 0, usageEventsDisplay: [] },
+    ]) {
+      const result = await readCursorAccountUsage(authPath, 0, 1781000000000, async () =>
+        Response.json(body),
+      );
+      assert.isNull(result.error);
+      assert.deepStrictEqual(result.records, []);
+      assert.isFalse(result.missing);
+    }
+    for (const body of [
+      { error: "upstream error" },
+      { detail: "unknown error envelope" },
+      { totalUsageEventsCount: 0, error: "upstream error" },
+      null,
+      [],
+      "invalid",
+      0,
+    ]) {
+      const result = await readCursorAccountUsage(authPath, 0, 1781000000000, async () =>
+        Response.json(body),
+      );
+      assert.isNotNull(result.error);
+      assert.deepStrictEqual(result.records, []);
+    }
+  });
+
+  it("requires a terminal Cursor page after a full page reaches the reported count", async () => {
+    const authPath = NodePath.join(dir, "auth.json");
+    const accessToken = `header.${Buffer.from(JSON.stringify({ sub: "auth|demo" })).toString("base64url")}.signature`;
+    await NodeFSP.writeFile(authPath, JSON.stringify({ accessToken }));
+    let requests = 0;
+    const result = await readCursorAccountUsage(authPath, 0, 1781000000000, async () => {
+      requests++;
+      return Response.json(
+        requests === 1
+          ? {
+              totalUsageEventsCount: 1000,
+              usageEventsDisplay: Array.from({ length: 1000 }, (_, index) => ({
+                timestamp: String(1780000000000 + index),
+                model: "gpt-5",
+                tokenUsage: { inputTokens: 10, outputTokens: 5 },
+              })),
+            }
+          : { totalUsageEventsCount: 1000 },
+      );
+    });
+    assert.isNull(result.error);
+    assert.strictEqual(result.records.length, 1000);
+    assert.strictEqual(requests, 2);
+  });
+
+  it("removes only count-proven Cursor boundary copies and preserves identical billed events", async () => {
+    const authPath = NodePath.join(dir, "auth.json");
+    const accessToken = `header.${Buffer.from(JSON.stringify({ sub: "auth|demo" })).toString("base64url")}.signature`;
+    await NodeFSP.writeFile(authPath, JSON.stringify({ accessToken }));
+    const event = (index: number) => ({
+      timestamp: String(1780000000000 + index),
+      model: "gpt-5",
+      tokenUsage: { inputTokens: 10, outputTokens: 5, totalCents: 1 },
+    });
+    for (const total of [2000, 2001]) {
+      let requests = 0;
+      const result = await readCursorAccountUsage(authPath, 0, 1781000000000, async () => {
+        requests++;
+        return Response.json({
+          totalUsageEventsCount: total,
+          usageEventsDisplay:
+            requests === 1
+              ? Array.from({ length: 1000 }, (_, index) => event(index))
+              : requests === 2
+                ? Array.from({ length: 1000 }, (_, index) => event(999 + index))
+                : [event(1999)],
+        });
+      });
+      assert.isNull(result.error);
+      assert.strictEqual(result.records.length, total);
+      assert.strictEqual(requests, 3);
+      assert.strictEqual(result.records.at(-1)?.timestampMs, 1780000001999);
+      assert.strictEqual(
+        result.records.filter((record) => record.timestampMs === 1780000000999).length,
+        total === 2000 ? 1 : 2,
+      );
+      assert.strictEqual(new Set(result.records.map((record) => record.dedupeKey)).size, total);
+    }
+    let requests = 0;
+    const inconsistent = await readCursorAccountUsage(authPath, 0, 1781000000000, async () => {
+      requests++;
+      return Response.json({
+        totalUsageEventsCount: 1001,
+        usageEventsDisplay:
+          requests === 1
+            ? Array.from({ length: 1000 }, (_, index) => event(index))
+            : [event(500), event(1000)],
+      });
+    });
+    assert.isNotNull(inconsistent.error);
+    assert.deepStrictEqual(inconsistent.records, []);
+  });
+
   it("does not present truncated Cursor account pages or authentication failures as complete history", async () => {
     const authPath = NodePath.join(dir, "auth.json");
     const accessToken = `header.${Buffer.from(JSON.stringify({ sub: "auth|demo", exp: 4102444800 })).toString("base64url")}.signature`;
@@ -363,53 +469,6 @@ describe("SQLite usage readers", () => {
     } finally {
       db.close();
     }
-  });
-
-  it("counts Cursor assistant usage without estimating zero-count or user bubbles", async () => {
-    const path = NodePath.join(dir, "state.vscdb");
-    const db = new NodeSqlite.DatabaseSync(path);
-    try {
-      db.exec("CREATE TABLE cursorDiskKV (key TEXT, value TEXT)");
-      const insert = db.prepare("INSERT INTO cursorDiskKV VALUES (?, ?)");
-      const bubble = {
-        type: 2,
-        createdAt: "2026-08-01T10:00:00Z",
-        requestId: "request-1",
-        modelInfo: { modelName: "claude-sonnet-4-5" },
-        tokenCount: { inputTokens: 120, outputTokens: 30 },
-      };
-      insert.run("bubbleId:session-1:assistant", JSON.stringify(bubble));
-      insert.run("bubbleId:session-1:assistant", JSON.stringify(bubble));
-      insert.run("bubbleId:session-1:copy", JSON.stringify(bubble));
-      insert.run(
-        "bubbleId:session-1:user",
-        JSON.stringify({ ...bubble, type: 1, requestId: "user-request" }),
-      );
-      insert.run(
-        "bubbleId:session-1:zero",
-        JSON.stringify({
-          ...bubble,
-          requestId: "zero",
-          tokenCount: { inputTokens: 0, outputTokens: 0 },
-          text: "real text without recorded usage",
-        }),
-      );
-    } finally {
-      db.close();
-    }
-    const result = await readCursorUsage(path, 0);
-    assert.isFalse(result.error);
-    const records = result.files.flatMap((file) => file.records);
-    assert.strictEqual(records.length, 2);
-    assert.strictEqual(
-      records.reduce((sum, record) => sum + record.totals.outputTokens, 0),
-      60,
-    );
-    assert.strictEqual(records[0]?.model, "claude-sonnet-4-5");
-    assert.strictEqual(records[0]?.sessionId, "session-1");
-    assert.strictEqual(records[0]?.totals.uncachedInputTokens, 120);
-    assert.strictEqual(records[0]?.totals.outputTokens, 30);
-    assert.strictEqual(records[0]?.timestampMs, Date.parse("2026-08-01T10:00:00Z"));
   });
 
   it("deduplicates Antigravity generation and step usage while preserving retry model and token buckets", async () => {

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -114,6 +114,21 @@ export function UsagePage() {
     selectedEnvironmentIds,
   );
   const presentations = useAtomValue(environmentPresentations.presentationsAtom);
+  const sourceMessages = [
+    ...new Set(
+      selectedEnvironments.flatMap(
+        (environment) =>
+          environment.summary?.sources.flatMap((source) =>
+            source.message &&
+            (source.status === "partial" ||
+              source.status === "failed" ||
+              source.fingerprint.provider === "cursor")
+              ? [source.message]
+              : [],
+          ) ?? [],
+      ),
+    ),
+  ];
   const refreshProviders = useAtomCommand(serverEnvironment.refreshProviders, {
     reportFailure: false,
   });
@@ -354,6 +369,11 @@ export function UsagePage() {
               <UsageSkeleton />
             ) : (
               <>
+                {sourceMessages.map((message) => (
+                  <p key={message} className="mb-4 text-sm text-muted-foreground">
+                    {message}
+                  </p>
+                ))}
                 <section className="grid gap-6 lg:grid-cols-[minmax(0,18rem)_minmax(0,1fr)]">
                   <div className="flex min-w-0 flex-col gap-5">
                     <div className="flex flex-col gap-1">

--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -89,6 +89,9 @@ describe("buildPeriodColumns", () => {
       { provider: "codex", value: 10 },
       { provider: "claude", value: 20 },
       { provider: "grok", value: 0 },
+      { provider: "cursor", value: 0 },
+      { provider: "opencode", value: 0 },
+      { provider: "antigravity", value: 0 },
     ]);
   });
 

--- a/apps/web/src/components/usage/usageProviders.ts
+++ b/apps/web/src/components/usage/usageProviders.ts
@@ -1,6 +1,14 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
 
-import { ClaudeAI, GrokIcon, type Icon, OpenAI } from "../Icons";
+import {
+  AntigravityIcon,
+  ClaudeAI,
+  CursorIcon,
+  GrokIcon,
+  type Icon,
+  OpenAI,
+  OpenCodeIcon,
+} from "../Icons";
 
 type UsageProviderPresentation = {
   readonly label: string;
@@ -30,6 +38,9 @@ export const PROVIDER_PRESENTATION = {
     color: "color-mix(in oklab, var(--contrast-foreground) 72%, var(--background))",
     mark: GrokIcon,
   },
+  cursor: { label: "Cursor", color: "#8b8b8b", mark: CursorIcon },
+  opencode: { label: "OpenCode", color: "#5b9bbd", mark: OpenCodeIcon },
+  antigravity: { label: "Antigravity", color: "#8c7bd1", mark: AntigravityIcon },
 } satisfies Record<UsageProviderKind, UsageProviderPresentation>;
 
 /** Stable provider reading order across charts, summaries, tables, and hover rows. */

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -2,12 +2,20 @@
 
 ## Understand your usage
 
-**Usage** combines Codex, Claude Code, and Grok Build session history from your connected
+**Usage** combines Codex, Claude Code, Grok Build, OpenCode, Antigravity, and available Cursor desktop history from your connected
 environments. It shows token use, cache savings, model breakdowns, and estimated API-equivalent
 cost. These estimates are not your subscription bill.
 
 Totals depend on the history available on each server. Grok turns without a saved completed-turn
 record are missing from the totals.
+
+OpenCode reads its SQLite database and older JSON history. Antigravity reads local conversation
+databases, including T3-managed profiles. Set `OPENCODE_DATA_DIR` or `ANTIGRAVITY_DATA_DIR` on the
+server to read a different data directory; comma-separated paths read multiple directories.
+
+Cursor coverage is partial: only saved desktop token counts are included. Cursor CLI transcripts
+do not contain token totals, and recent desktop versions often omit them too. Use Cursor's Usage
+Dashboard for complete usage. T3 does not estimate missing tokens from conversation text.
 
 On web and desktop, use the environment dropdown to filter costs, tokens, and limits. All
 environments are selected by default. The dropdown shows which environments are still scanning;

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -2,7 +2,7 @@
 
 ## Understand your usage
 
-**Usage** combines Codex, Claude Code, Grok Build, OpenCode, Antigravity, and available Cursor desktop history from your connected
+**Usage** combines Codex, Claude Code, Grok Build, OpenCode, Antigravity, and Cursor history from your connected
 environments. It shows token use, cache savings, model breakdowns, and estimated API-equivalent
 cost. These estimates are not your subscription bill.
 
@@ -13,9 +13,10 @@ OpenCode reads its SQLite database and older JSON history. Antigravity reads loc
 databases, including T3-managed profiles. Set `OPENCODE_DATA_DIR` or `ANTIGRAVITY_DATA_DIR` on the
 server to read a different data directory; comma-separated paths read multiple directories.
 
-Cursor coverage is partial: only saved desktop token counts are included. Cursor CLI transcripts
-do not contain token totals, and recent desktop versions often omit them too. Use Cursor's Usage
-Dashboard for complete usage. T3 does not estimate missing tokens from conversation text.
+Cursor reads account usage from Cursor's dashboard API using the CLI login saved on the server.
+This includes headless T3 sessions and desktop usage across machines; the same account counts
+once across connected environments. Without an accessible file-based CLI login, T3 falls back
+to partial desktop history and shows a notice. T3 does not estimate missing tokens from conversation text.
 
 On web and desktop, use the environment dropdown to filter costs, tokens, and limits. All
 environments are selected by default. The dropdown shows which environments are still scanning;

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -15,8 +15,8 @@ server to read a different data directory; comma-separated paths read multiple d
 
 Cursor reads account usage from Cursor's dashboard API using the CLI login saved on the server.
 This includes headless T3 sessions and desktop usage across machines; the same account counts
-once across connected environments. Without an accessible file-based CLI login, T3 falls back
-to partial desktop history and shows a notice. T3 does not estimate missing tokens from conversation text.
+once across connected environments. Without an accessible file-based CLI login, T3 shows a
+notice instead of incomplete local totals. T3 does not estimate missing tokens from conversation text.
 
 On web and desktop, use the environment dropdown to filter costs, tokens, and limits. All
 environments are selected by default. The dropdown shows which environments are still scanning;

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -1,13 +1,10 @@
 /**
  * Usage reporting contract.
  *
- * Each environment scans the provider CLIs' own on-disk session transcripts
- * (`~/.claude/projects/**\/*.jsonl`, `~/.codex/sessions/**\/*.jsonl`,
- * `~/.grok/sessions/**\/updates.jsonl`) rather than relying on T3 Code's own
- * orchestration projections, so usage stays complete even for turns that were
- * never driven through T3 Code. This mirrors the approach `ccusage` takes.
+ * Each environment scans native session files and databases, including work
+ * driven outside T3 Code. Source status describes gaps in local coverage.
  *
- * Environments return pre-aggregated `(day, hourStart?, provider, model)`
+ * Environments return pre-aggregated `(day, hourStart?, provider, model, sourcePath?)`
  * buckets. Raw transcript records never cross the wire.
  *
  * @module usage
@@ -21,18 +18,24 @@ import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 5 as const;
+export const USAGE_CONTRACT_VERSION = 6 as const;
 
 /**
  * Oldest {@link UsageSummary} version a current client will still merge.
  *
- * v5 only adds `grok` to {@link UsageProviderKind}; v4 Claude/Codex buckets
- * remain valid, so mixed-version environments keep those totals instead of
- * treating every older server as stale.
+ * v5/v6 add providers and optional source attribution; v4 Claude/Codex
+ * buckets remain valid in mixed-version environments.
  */
 export const USAGE_MERGE_COMPATIBLE_SINCE = 4 as const;
 
-export const UsageProviderKind = Schema.Literals(["claude", "codex", "grok"]);
+export const UsageProviderKind = Schema.Literals([
+  "claude",
+  "codex",
+  "grok",
+  "cursor",
+  "opencode",
+  "antigravity",
+]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;
 
 /**
@@ -93,6 +96,8 @@ export const UsageBucket = Schema.Struct({
   hourStart: Schema.optional(TrimmedNonEmptyString),
   provider: UsageProviderKind,
   model: TrimmedNonEmptyString,
+  /** Source directory, so overlapping multi-home environments merge once per source. */
+  sourcePath: Schema.optional(TrimmedNonEmptyString),
   totals: UsageTokenTotals,
   costUsd: Schema.Number,
   /**

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -75,6 +75,41 @@ function environment(id: string, usageSummary: UsageSummary): EnvironmentUsage {
 }
 
 describe("mergeUsage", () => {
+  it("counts a Cursor account once across servers while retaining each server's other providers", () => {
+    const account = {
+      provider: "cursor" as const,
+      hostId: "cursor.com",
+      homePath: "cursor-account:account-hash",
+      volumeId: "account-hash",
+    };
+    const merged = mergeUsage(
+      [
+        environment(
+          "mac",
+          summary([bucket({ provider: "cursor", sourcePath: account.homePath })], [account]),
+        ),
+        environment(
+          "linux",
+          summary(
+            [
+              bucket({ provider: "cursor", sourcePath: account.homePath }),
+              bucket({ provider: "opencode", sourcePath: "/opencode" }),
+            ],
+            [account, { provider: "opencode", hostId: "linux", homePath: "/opencode" }],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+    expect(
+      merged.providers.map((provider) => [provider.provider, provider.costUsd]).sort(),
+    ).toEqual([
+      ["cursor", 10],
+      ["opencode", 10],
+    ]);
+    expect(merged.duplicateSources).toHaveLength(1);
+  });
+
   it("sums environments that read different transcript directories", () => {
     const merged = mergeUsage(
       [

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -1,5 +1,6 @@
 import {
   USAGE_CONTRACT_VERSION,
+  USAGE_MERGE_COMPATIBLE_SINCE,
   type EnvironmentId,
   type UsageBucket,
   type UsageDay,
@@ -146,6 +147,31 @@ describe("mergeUsage", () => {
     ).toEqual({ claude: 1, codex: 1 });
   });
 
+  it("counts overlapping provider roots once while keeping each environment's unique root", () => {
+    const source = (homePath: string) => ({
+      provider: "opencode" as const,
+      hostId: "host",
+      homePath,
+    });
+    const usage = (sourcePath: string, costUsd: number) =>
+      bucket({ provider: "opencode", sourcePath, costUsd });
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary([usage("/shared", 10), usage("/a", 2)], [source("/shared"), source("/a")]),
+        ),
+        environment(
+          "env-b",
+          summary([usage("/shared", 10), usage("/b", 3)], [source("/shared"), source("/b")]),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+    expect(merged.costUsd).toBe(15);
+    expect(merged.sessions).toBe(3);
+  });
+
   it("excludes an environment reporting an older contract version", () => {
     const merged = mergeUsage(
       [
@@ -158,7 +184,7 @@ describe("mergeUsage", () => {
           summary(
             [bucket()],
             [{ provider: "claude", hostId: "linux", homePath: "/b" }],
-            USAGE_CONTRACT_VERSION - 2,
+            USAGE_MERGE_COMPATIBLE_SINCE - 1,
           ),
         ),
       ],

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -142,6 +142,7 @@ function ownedContribution(
   readonly sessionsByProvider: ReadonlyMap<UsageProviderKind, number>;
 } {
   const ownedProviders = new Set<UsageProviderKind>();
+  const ownedSources = new Set<string>();
   const sessionsByProvider = new Map<UsageProviderKind, number>();
   for (const source of environment.summary.sources) {
     if (source.status === "missing") continue;
@@ -149,6 +150,7 @@ function ownedContribution(
     if (ownerByFingerprint.get(key) === environment.environmentId) {
       const provider = source.fingerprint.provider;
       ownedProviders.add(provider);
+      ownedSources.add(`${provider}\u0000${source.fingerprint.resolvedHomePath}`);
       // Distinct within a directory. Summing per-bucket session counts instead
       // would count a session once per day and model it spans.
       sessionsByProvider.set(
@@ -158,7 +160,11 @@ function ownedContribution(
     }
   }
   return {
-    buckets: environment.summary.buckets.filter((bucket) => ownedProviders.has(bucket.provider)),
+    buckets: environment.summary.buckets.filter((bucket) =>
+      bucket.sourcePath === undefined
+        ? ownedProviders.has(bucket.provider)
+        : ownedSources.has(`${bucket.provider}\u0000${bucket.sourcePath}`),
+    ),
     sessionsByProvider,
   };
 }


### PR DESCRIPTION
cursor, opencode, and antigravity were absent from usage because the scanner and clients only supported claude, codex, and grok. this adds read-only opencode sqlite/legacy-json readers, antigravity protobuf/sqlite readers, and cursor account history using the existing file-based CLI login, covering headless T3 sessions and desktop usage; empty windows and overlapping page boundaries are handled, and cursor uses account history exclusively to avoid counting local records twice. subscription quota support is unchanged.

source-attributed buckets avoid double counting overlapping data directories and shared cursor accounts across environments, while web, desktop, and mobile can display all six providers. verified with focused reader/service/aggregation/merge/chart tests, scoped lint and typechecks, real opencode history, 118 real cursor usage records with all three headless events verified and a real empty-history query, and browser checks for cost, tokens, refresh, light/dark themes, and narrow layout; native mobile rendering is unverified because this machine has no android sdk/emulator.

current real history: cursor account usage over 90 days, including three headless events whose token counts were checked against the endpoint response. the reader returned 118 token-bearing records across 38 conversations. opencode remains visible from its real local history. cost/tokens switching and refresh preserve these totals.

![real cursor account history including headless usage](https://uploads-production-47e4.up.railway.app/files/8ce4f988-c6df-4e10-886a-707ad19c4042/usage-real-cursor-api-final-light.png)

![real cursor account history at narrow width](https://uploads-production-47e4.up.railway.app/files/f9da7772-4bb7-4493-bfa9-0e092b8ec1a1/usage-real-cursor-cli-account-narrow.png)

earlier layout captures below use synthetic demo histories for all three added providers, read through local readers: seven sessions each, 3.51m tokens total. cost/tokens switching and refresh were exercised with stable totals. the cursor notice in these earlier demo captures predates account-history support.

![demo data: cursor, opencode, and antigravity populated in light mode](https://uploads-production-47e4.up.railway.app/files/3c374daf-181b-491c-84e0-cc692d0b7baa/usage-demo-all-harnesses-light.png)

![demo data: all three added harnesses in dark mode](https://uploads-production-47e4.up.railway.app/files/793516a8-e568-4e04-a51e-f46ecd9a4b99/usage-demo-all-harnesses-dark.png)

![demo data: all three added harnesses at a narrow viewport](https://uploads-production-47e4.up.railway.app/files/fdff6d79-b1c5-4a73-9eb7-c591a054afb4/usage-demo-all-harnesses-narrow.png)

matching before/after below uses fixed copies of real history; opencode's 428k tokens appear after the reader is enabled.

![before: real codex history only](https://uploads-production-47e4.up.railway.app/files/666ee8ea-a989-4c40-87f0-9d5301d32682/usage-before-light.png)

![after: same real history with opencode included](https://uploads-production-47e4.up.railway.app/files/3ed09e24-2dee-4657-bc94-d82d49e1e0a1/usage-after-light.png)

model: `gpt-6-astra`; harness: codex.


