### PR TITLE
feat(ci): ship stable releases from the latest nightly commit

### DIFF
--- a/.github/scripts/check-nightly-release.cjs
+++ b/.github/scripts/check-nightly-release.cjs
@@ -1,19 +1,21 @@
 const MINIMUM_RELEASE_GAP_MS = 6 * 60 * 60 * 1000;
 
-// Runs after the workflow acquires the nightly concurrency lock.
-async function shouldReleaseNightly({ github, context, core, now = Date.now() }) {
+const isNightlyTag = (tag) => /^v.*-nightly\./.test(tag) || tag.startsWith("nightly-v");
+
+// Newest published nightly by publication time, or undefined when none exists.
+async function findLatestNightly({ github, context }) {
   const releases = await github.paginate(github.rest.repos.listReleases, {
     ...context.repo,
     per_page: 100,
   });
-  const lastNightly = releases
-    .filter(
-      (release) =>
-        !release.draft &&
-        release.published_at &&
-        (/^v.*-nightly\./.test(release.tag_name) || release.tag_name.startsWith("nightly-v")),
-    )
+  return releases
+    .filter((release) => !release.draft && release.published_at && isNightlyTag(release.tag_name))
     .sort((a, b) => Date.parse(b.published_at) - Date.parse(a.published_at))[0];
+}
+
+// Runs after the workflow acquires the nightly concurrency lock.
+async function shouldReleaseNightly({ github, context, core, now = Date.now() }) {
+  const lastNightly = await findLatestNightly({ github, context });
 
   if (!lastNightly) {
     core.info("No published nightly found. Proceeding with release.");
@@ -41,4 +43,25 @@ async function shouldReleaseNightly({ github, context, core, now = Date.now() })
   return true;
 }
 
-module.exports = { shouldReleaseNightly };
+// Stable releases build the commit the latest nightly shipped, so the stable
+// build is one nightly users already ran. Returns the nightly tag, its commit,
+// and the stable version that nightly was a preview of.
+async function resolveLatestNightlyCommit({ github, context, core }) {
+  const lastNightly = await findLatestNightly({ github, context });
+  if (!lastNightly) {
+    throw new Error("No published nightly found. Stable releases build the latest nightly commit.");
+  }
+
+  const tag = lastNightly.tag_name;
+  // repos.getCommit dereferences annotated tags, so this is the commit either way.
+  const { data: commit } = await github.rest.repos.getCommit({ ...context.repo, ref: tag });
+  const version = /^(?:nightly-)?v(\d+\.\d+\.\d+)-nightly\./.exec(tag)?.[1];
+  if (!version) {
+    throw new Error(`Cannot derive a stable version from nightly tag ${tag}.`);
+  }
+
+  core.info(`Latest nightly ${tag} shipped ${commit.sha} as a preview of ${version}.`);
+  return { tag, sha: commit.sha, version };
+}
+
+module.exports = { shouldReleaseNightly, resolveLatestNightlyCommit };

--- a/.github/scripts/check-nightly-release.test.cjs
+++ b/.github/scripts/check-nightly-release.test.cjs
@@ -99,3 +99,45 @@ for (const status of ["behind", "diverged"]) {
     assert.equal(await shouldReleaseNightly(options), false);
   });
 }
+
+const { resolveLatestNightlyCommit } = require("./check-nightly-release.cjs");
+
+function nightlyCommitFixture({ releases, commitSha = "abc123" }) {
+  const refs = [];
+  const { options } = fixture({ releases });
+  options.github.rest.repos.getCommit = async ({ ref }) => {
+    refs.push(ref);
+    return { data: { sha: commitSha } };
+  };
+  return { options, refs };
+}
+
+test("stable releases resolve the commit of the newest published nightly", async () => {
+  const { options, refs } = nightlyCommitFixture({
+    releases: [
+      nightly(10, { tag_name: "v1.0.1-nightly.20260905.100" }),
+      nightly(1, { tag_name: "v1.0.1-nightly.20260905.123" }),
+      nightly(0, { tag_name: "v1.0.0" }),
+      nightly(0, { draft: true, tag_name: "v1.0.1-nightly.20260905.999" }),
+    ],
+    commitSha: "deadbeef",
+  });
+  assert.deepEqual(await resolveLatestNightlyCommit(options), {
+    tag: "v1.0.1-nightly.20260905.123",
+    sha: "deadbeef",
+    version: "1.0.1",
+  });
+  assert.deepEqual(refs, ["v1.0.1-nightly.20260905.123"]);
+});
+
+test("stable releases derive the version from legacy nightly tags", async () => {
+  const { options } = nightlyCommitFixture({
+    releases: [nightly(1, { tag_name: "nightly-v0.9.0-nightly.20260905.5" })],
+  });
+  assert.equal((await resolveLatestNightlyCommit(options)).version, "0.9.0");
+});
+
+test("stable releases fail without a published nightly", async () => {
+  const { options } = nightlyCommitFixture({ releases: [nightly(0, { tag_name: "v1.0.0" })] });
+  await assert.rejects(resolveLatestNightlyCommit(options), /No published nightly/);
+});

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
           - stable
           - nightly
       version:
-        description: "Release version (for example 1.2.3 or v1.2.3)"
+        description: "Stable version override (for example 1.2.3). Defaults to the version the latest nightly previewed."
         required: false
         type: string
 
@@ -39,33 +39,54 @@ permissions:
   id-token: none
 
 jobs:
-  check_changes:
-    name: Check automatic nightly release
-    if: github.event_name == 'schedule'
+  # Picks the commit every later job builds. Nightlies and tag pushes build the
+  # triggering commit. Manual stable releases build the commit of the latest
+  # published nightly, so stable only ever ships a build that nightly users
+  # have already run. Scheduled runs also decide here whether a nightly is due.
+  resolve_commit:
+    name: Resolve release commit
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 5
     outputs:
-      has_changes: ${{ steps.check.outputs.result }}
+      ref: ${{ steps.resolve.outputs.ref }}
+      nightly_version: ${{ steps.resolve.outputs.nightly_version }}
+      has_changes: ${{ steps.resolve.outputs.has_changes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           sparse-checkout: .github/scripts
 
-      - id: check
-        name: Check release gap and new commits
+      - id: resolve
+        name: Resolve release commit
         uses: actions/github-script@v8
+        env:
+          DISPATCH_CHANNEL: ${{ inputs.channel }}
         with:
           script: |
-            const { shouldReleaseNightly } = require('./.github/scripts/check-nightly-release.cjs');
-            return await shouldReleaseNightly({ github, context, core });
+            const {
+              shouldReleaseNightly,
+              resolveLatestNightlyCommit,
+            } = require('./.github/scripts/check-nightly-release.cjs');
+
+            if (context.eventName === 'schedule') {
+              core.setOutput('has_changes', await shouldReleaseNightly({ github, context, core }));
+              core.setOutput('ref', context.sha);
+            } else if (context.eventName === 'workflow_dispatch' && process.env.DISPATCH_CHANNEL !== 'nightly') {
+              const { tag, sha, version } = await resolveLatestNightlyCommit({ github, context, core });
+              core.notice(`Stable release builds ${sha}, the commit shipped by ${tag}.`);
+              core.setOutput('ref', sha);
+              core.setOutput('nightly_version', version);
+            } else {
+              core.setOutput('ref', context.sha);
+            }
 
   preflight:
     name: Preflight
-    needs: [check_changes]
+    needs: [resolve_commit]
     if: |
-      !failure() && !cancelled() &&
-      (github.event_name != 'schedule' || needs.check_changes.outputs.has_changes == 'true')
+      needs.resolve_commit.result == 'success' &&
+      (github.event_name != 'schedule' || needs.resolve_commit.outputs.has_changes == 'true')
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     outputs:
@@ -78,11 +99,12 @@ jobs:
       cli_dist_tag: ${{ steps.release_meta.outputs.cli_dist_tag }}
       is_prerelease: ${{ steps.release_meta.outputs.is_prerelease }}
       make_latest: ${{ steps.release_meta.outputs.make_latest }}
-      ref: ${{ github.sha }}
+      ref: ${{ needs.resolve_commit.outputs.ref }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ needs.resolve_commit.outputs.ref }}
           fetch-depth: 0
           sparse-checkout: |
             /*
@@ -104,8 +126,9 @@ jobs:
         env:
           DISPATCH_CHANNEL: ${{ github.event.inputs.channel }}
           DISPATCH_VERSION: ${{ github.event.inputs.version }}
+          NIGHTLY_VERSION: ${{ needs.resolve_commit.outputs.nightly_version }}
           NIGHTLY_DATE: ${{ github.run_started_at }}
-          NIGHTLY_SHA: ${{ github.sha }}
+          NIGHTLY_SHA: ${{ needs.resolve_commit.outputs.ref }}
           NIGHTLY_RUN_NUMBER: ${{ github.run_number }}
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "schedule" || ( "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${DISPATCH_CHANNEL:-stable}" == "nightly" ) ]]; then
@@ -123,9 +146,9 @@ jobs:
             echo "make_latest=false" >> "$GITHUB_OUTPUT"
           else
             if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-              raw="${DISPATCH_VERSION}"
+              raw="${DISPATCH_VERSION:-$NIGHTLY_VERSION}"
               if [[ -z "$raw" ]]; then
-                echo "workflow_dispatch stable releases require the version input." >&2
+                echo "workflow_dispatch stable releases need a version input or a published nightly." >&2
                 exit 1
               fi
             else
@@ -210,14 +233,12 @@ jobs:
 
   relay_public_config:
     name: Resolve T3 Connect public config
-    # Consumes only the commit SHA, not preflight's resolved version, so it runs
-    # alongside preflight instead of after it. The condition mirrors preflight's:
-    # check_changes is skipped on manual and tag releases (skipped is neither failure
-    # nor success, so success() would be wrong here).
-    needs: [check_changes]
+    # Consumes only the release commit, not preflight's resolved version, so it
+    # runs alongside preflight instead of after it. The condition mirrors preflight's.
+    needs: [resolve_commit]
     if: |
-      !failure() && !cancelled() &&
-      (github.event_name != 'schedule' || needs.check_changes.outputs.has_changes == 'true')
+      needs.resolve_commit.result == 'success' &&
+      (github.event_name != 'schedule' || needs.resolve_commit.outputs.has_changes == 'true')
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 5
     environment:
@@ -239,7 +260,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ needs.resolve_commit.outputs.ref }}
           sparse-checkout: |
             /*
             !/.repos/
@@ -312,19 +333,19 @@ jobs:
   # machine. node-pty is N-API, so one binary works across all WSL Node versions.
   build_wsl_node_pty:
     name: Build WSL node-pty (linux-x64)
-    # Same gating as relay_public_config: only the commit SHA is needed, so this
-    # runs alongside preflight. See the condition comment there.
-    needs: [check_changes]
+    # Same gating as relay_public_config: only the release commit is needed, so
+    # this runs alongside preflight. See the condition comment there.
+    needs: [resolve_commit]
     if: |
-      !failure() && !cancelled() &&
-      (github.event_name != 'schedule' || needs.check_changes.outputs.has_changes == 'true')
+      needs.resolve_commit.result == 'success' &&
+      (github.event_name != 'schedule' || needs.resolve_commit.outputs.has_changes == 'true')
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ needs.resolve_commit.outputs.ref }}
           sparse-checkout: |
             /*
             !/.repos/

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -8,9 +8,18 @@ This document covers the unified release workflow for stable and nightly desktop
 
 - Workflow: `.github/workflows/release.yml`
 - Triggers:
-  - push tag matching `v*.*.*` for stable releases
+  - manual `workflow_dispatch` with `channel=stable`, the normal way to ship stable
+  - push tag matching `v*.*.*` for a stable release of an explicit commit
   - scheduled nightly check every 30 minutes
-  - manual `workflow_dispatch` for either channel
+  - manual `workflow_dispatch` with `channel=nightly`
+- A manual stable release builds the commit of the latest published nightly, not `main` HEAD.
+  Nightly is the release candidate: verify the nightly, then promote it. Merges to `main` keep
+  landing while you verify and never leak into the stable build.
+  - The version defaults to the one the nightly previewed (`0.0.39-nightly.*` ships as `0.0.39`).
+    Pass the `version` input to override it, for example for a minor bump.
+  - The stable tag is created on the nightly's commit when the GitHub Release is published.
+  - Pushing a `vX.Y.Z` tag by hand still works and builds exactly the tagged commit. Use it when
+    the commit to ship is not the latest nightly, such as a cherry-picked fix on a release branch.
 - Runs lint, typecheck, and tests alongside artifact builds. Publishing waits for every check.
 - Reads the shared production T3 Connect relay URL and Clerk client configuration before packaging clients.
 - Builds four artifacts in parallel for both channels:
@@ -291,8 +300,8 @@ risk, manually dispatch `channel=nightly`; this still publishes a real nightly n
 prerelease, desktop updater release, and hosted nightly alias, but it does not update stable aliases or
 commit a version bump to `main`. Only run it when a real nightly release is acceptable.
 
-Manual `channel=stable` with a version input is also a real stable-channel release. Omitting signing
-secrets only makes platform artifacts unsigned; it does not prevent publication.
+Manual `channel=stable` is also a real stable-channel release. Omitting signing secrets only makes
+platform artifacts unsigned; it does not prevent publication.
 
 ## 2) Apple signing + notarization setup (macOS)
 
@@ -370,17 +379,19 @@ Checklist:
 
 ## 4) Ongoing release checklist
 
-1. Ensure `main` is green in CI.
-2. Bump app version as needed.
-3. Create release tag: `vX.Y.Z`.
-4. Push tag.
-5. Verify workflow steps:
+1. Pick the latest nightly and verify it: run the smoke test above against its artifacts and
+   check the nightly channel for regressions.
+2. Dispatch the Release workflow with `channel=stable`. Leave `version` empty unless the version
+   should differ from the one the nightly previewed.
+3. Confirm the `Resolve release commit` notice names the nightly tag and commit you verified. If a
+   newer nightly published in between, the run builds that one instead.
+4. Verify workflow steps:
    - preflight passes
    - release quality checks pass
    - all matrix builds pass
    - `publish_cli` publishes the exact release version before the release job
    - release job uploads expected files
-6. Smoke test downloaded artifacts.
+5. Smoke test downloaded artifacts.
 
 ## 5) Troubleshooting
 


### PR DESCRIPTION
We merge hundreds of PRs a day. By the time a nightly is verified, main has moved on, so cutting a stable from main HEAD ships code nobody has run. Pausing merges is not an option at this rate.

Now a manual stable release builds the commit of the latest published nightly instead of main HEAD. Nightly is the release candidate. Verify it, dispatch the Release workflow with `channel=stable`, and the stable build is byte-for-byte the code nightly users already ran. Merges keep landing the whole time.

Details:

- A `resolve_commit` job runs first on every trigger and picks the commit every later job checks out. Schedule and tag push still build the triggering commit.
- Stable dispatch looks up the newest published nightly release, dereferences its tag to a commit, and builds that. The run posts a notice naming the nightly tag and commit so you can confirm it matches what you verified.
- The version defaults to the one the nightly previewed, so `v0.0.39-nightly.*` ships as `0.0.39`. The `version` input still overrides it.
- Pushing a `vX.Y.Z` tag by hand is unchanged and still builds exactly that commit, for cherry-picked fixes on a release branch.
- The nightly lookup is shared with the existing nightly gap check, so both agree on which nightly is latest. Tests cover the new resolver.

Created with Claude Fable 5.1 in Claude Code.