### PR TITLE
feat(cli): add 't3 drive' interface for simulating every state in the app

### DIFF
--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -22,6 +22,7 @@ import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as DateTime from "effect/DateTime";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServer from "effect/unstable/http/HttpServer";
@@ -1022,8 +1023,23 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
         assert.include(completed?.messages[1]?.text ?? "", "Verification");
         const streaming = snapshot.threads.find((thread) => thread.id === "drive-streaming");
         assert.equal(streaming?.session?.status, "running");
-        assert.equal(streaming?.messages[0]?.streaming, true);
-        assert.isNotEmpty(streaming?.messages[0]?.text);
+        assert.equal(streaming?.messages[1]?.streaming, true);
+        assert.isNotEmpty(streaming?.messages[1]?.text);
+        const config = yield* makeCliTestServerConfig(scenarioHome);
+        const windowed = yield* Effect.gen(function* () {
+          const query = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
+          return yield* query.getThreadDetailSnapshot(ThreadId.make("drive-streaming"), {
+            turnLimit: 1,
+          });
+        }).pipe(Effect.provide(makeProjectPersistenceLayer(config)));
+        assert.isTrue(Option.isSome(windowed));
+        if (Option.isSome(windowed)) {
+          assert.deepEqual(
+            windowed.value.thread.messages.map((message) => message.role),
+            ["user", "assistant"],
+          );
+          assert.equal(windowed.value.thread.messages[1]?.streaming, true);
+        }
         assert.equal(
           snapshot.threads.find((thread) => thread.id === "drive-error")?.session?.status,
           "error",

--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -9,7 +9,10 @@ import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import {
   CommandId,
+  DispatchResult,
   EnvironmentOrchestrationHttpApi,
+  OrchestrationReadModel,
+  OrchestrationThreadDetailSnapshot,
   ProviderInstanceId,
   ThreadId,
 } from "@t3tools/contracts";
@@ -19,6 +22,7 @@ import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as DateTime from "effect/DateTime";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServer from "effect/unstable/http/HttpServer";
 import * as HttpApi from "effect/unstable/httpapi/HttpApi";
@@ -51,6 +55,18 @@ import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
 import { environmentAuthenticatedAuthLayer } from "./auth/http.ts";
 
 import packageJson from "../package.json" with { type: "json" };
+
+const encodeDriveJson = Schema.encodeEffect(Schema.fromJsonString(Schema.Unknown));
+const decodeDriveReceipt = Schema.decodeUnknownEffect(Schema.fromJsonString(DispatchResult));
+const decodeDriveSnapshot = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(OrchestrationReadModel),
+);
+const decodeDriveThread = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(OrchestrationThreadDetailSnapshot),
+);
+const decodeDriveSchemaDocument = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(Schema.Struct({ $schema: Schema.String })),
+);
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 const DisconnectedLauncherChildLayer = Layer.mergeAll(
@@ -823,6 +839,199 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
         }),
       );
     }),
+  );
+
+  it.effect("drives live project and thread commands and sends with the current thread modes", () =>
+    Effect.gen(function* () {
+      const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-cli-drive-live-"));
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => NodeFS.rmSync(baseDir, { recursive: true, force: true })),
+      );
+      const commandFile = NodePath.join(baseDir, "command.json");
+      const createdAt = DateTime.formatIso(yield* DateTime.now);
+      yield* withLiveProjectCliServer(baseDir, () =>
+        Effect.gen(function* () {
+          NodeFS.writeFileSync(
+            commandFile,
+            yield* encodeDriveJson({
+              type: "project.create",
+              commandId: "drive-test-project",
+              projectId: "drive-test-project",
+              title: "Drive live project",
+              workspaceRoot: baseDir,
+              createdAt,
+            }),
+          );
+          const projectOutput = yield* captureStdout(
+            runCli(["drive", "dispatch", commandFile, "--home-dir", baseDir]),
+          );
+          const projectReceipt = yield* decodeDriveReceipt(projectOutput.output);
+          assert.isAbove(projectReceipt.sequence, 0);
+          NodeFS.writeFileSync(
+            commandFile,
+            yield* encodeDriveJson({
+              type: "thread.create",
+              commandId: "drive-test-thread",
+              threadId: "drive-test-thread",
+              projectId: "drive-test-project",
+              title: "Drive live thread",
+              modelSelection: { instanceId: "codex", model: "gpt-5-codex" },
+              runtimeMode: "full-access",
+              interactionMode: "plan",
+              branch: null,
+              worktreePath: null,
+              createdAt,
+            }),
+          );
+          yield* runCliWithRuntime(["drive", "dispatch", commandFile, "--home-dir", baseDir]);
+          const snapshotOutput = yield* captureStdout(
+            runCli(["drive", "snapshot", "--home-dir", baseDir]),
+          );
+          const snapshot = yield* decodeDriveSnapshot(snapshotOutput.output);
+          assert.equal(snapshot.projects[0]?.title, "Drive live project");
+          assert.equal(snapshot.threads[0]?.title, "Drive live thread");
+
+          const sentOutput = yield* captureStdout(
+            runCli([
+              "drive",
+              "send",
+              "drive-test-thread",
+              "Verify this state",
+              "--home-dir",
+              baseDir,
+            ]),
+          );
+          const sent = yield* Schema.decodeUnknownEffect(
+            Schema.fromJsonString(
+              Schema.Struct({
+                commandId: Schema.String,
+                messageId: Schema.String,
+                sequence: Schema.Number,
+              }),
+            ),
+          )(sentOutput.output);
+          assert.isAbove(sent.sequence, projectReceipt.sequence);
+          assert.isNotEmpty(sent.commandId);
+          const threadOutput = yield* captureStdout(
+            runCli(["drive", "snapshot", "--thread", "drive-test-thread", "--home-dir", baseDir]),
+          );
+          const { thread } = yield* decodeDriveThread(threadOutput.output);
+          assert.equal(thread.runtimeMode, "full-access");
+          assert.equal(thread.interactionMode, "plan");
+          assert.deepEqual(thread.modelSelection, {
+            instanceId: ProviderInstanceId.make("codex"),
+            model: "gpt-5-codex",
+          });
+          assert.equal(thread.messages[0]?.id, sent.messageId);
+          assert.equal(thread.messages[0]?.role, "user");
+          assert.equal(thread.messages[0]?.text, "Verify this state");
+        }),
+      );
+      const persisted = yield* readPersistedSnapshot(baseDir);
+      assert.equal(persisted.threads[0]?.messages[0]?.text, "Verify this state");
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect(
+    "prints schemas and rejects synthetic commands before connecting to a live environment",
+    () =>
+      Effect.gen(function* () {
+        const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-cli-drive-schema-"));
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => NodeFS.rmSync(baseDir, { recursive: true, force: true })),
+        );
+        const liveSchema = yield* captureStdout(runCli(["drive", "schema"]));
+        const scenarioSchema = yield* captureStdout(runCli(["drive", "schema", "--scenario"]));
+        const document = yield* decodeDriveSchemaDocument(liveSchema.output);
+        assert.equal(document.$schema, "https://json-schema.org/draft/2020-12/schema");
+        assert.include(liveSchema.output, "thread.turn.start");
+        assert.notInclude(liveSchema.output, "thread.message.assistant.delta");
+        assert.include(scenarioSchema.output, "thread.message.assistant.delta");
+        const commandFile = NodePath.join(baseDir, "command.json");
+        NodeFS.writeFileSync(
+          commandFile,
+          yield* encodeDriveJson({
+            type: "thread.message.assistant.delta",
+            commandId: "synthetic-delta",
+            threadId: "synthetic-thread",
+            messageId: "synthetic-message",
+            delta: "Synthetic content",
+            createdAt: DateTime.formatIso(yield* DateTime.now),
+          }),
+        );
+        const error = yield* runCliWithRuntime([
+          "drive",
+          "dispatch",
+          commandFile,
+          "--home-dir",
+          NodePath.join(baseDir, "missing"),
+        ]).pipe(Effect.flip);
+        assert.isTrue(Schema.isSchemaError(error));
+        assert.isFalse(NodeFS.existsSync(NodePath.join(baseDir, "missing")));
+      }).pipe(Effect.scoped),
+  );
+
+  it.effect(
+    "validates drive scenarios, preserves synthetic states, and refuses an existing home",
+    () =>
+      Effect.gen(function* () {
+        const baseDir = NodeFS.mkdtempSync(
+          NodePath.join(NodeOS.tmpdir(), "t3-cli-drive-scenario-"),
+        );
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => NodeFS.rmSync(baseDir, { recursive: true, force: true })),
+        );
+        const scenarioFile = NodePath.join(baseDir, "scenario.json");
+        const homeDir = NodePath.join(baseDir, "new-home");
+        NodeFS.writeFileSync(
+          scenarioFile,
+          yield* encodeDriveJson({
+            version: 1,
+            commands: [{ type: "invalid" }],
+          }),
+        );
+        yield* runCliWithRuntime(["drive", "scenario", scenarioFile, "--home-dir", homeDir]).pipe(
+          Effect.flip,
+        );
+        assert.isFalse(NodeFS.existsSync(homeDir));
+        const example = yield* captureStdout(runCli(["drive", "example", "--workspace", baseDir]));
+        NodeFS.writeFileSync(scenarioFile, example.output);
+        NodeFS.mkdirSync(homeDir);
+        const marker = NodePath.join(homeDir, "keep.txt");
+        NodeFS.writeFileSync(marker, "existing state");
+        const error = yield* runCliWithRuntime([
+          "drive",
+          "scenario",
+          scenarioFile,
+          "--home-dir",
+          homeDir,
+        ]).pipe(Effect.flip);
+        assert.include(String(error), "Scenario homes must not already exist");
+        assert.equal(NodeFS.readFileSync(marker, "utf8"), "existing state");
+        assert.deepEqual(NodeFS.readdirSync(homeDir), ["keep.txt"]);
+
+        const scenarioHome = NodePath.join(baseDir, "scenario-home");
+        yield* runCliWithRuntime(["drive", "scenario", scenarioFile, "--home-dir", scenarioHome]);
+        const snapshot = yield* readPersistedSnapshot(scenarioHome);
+        assert.lengthOf(snapshot.threads, 5);
+        const completed = snapshot.threads.find((thread) => thread.id === "drive-completed");
+        assert.deepEqual(
+          completed?.messages.map((message) => message.role),
+          ["user", "assistant"],
+        );
+        assert.include(completed?.messages[1]?.text ?? "", "Verification");
+        const streaming = snapshot.threads.find((thread) => thread.id === "drive-streaming");
+        assert.equal(streaming?.session?.status, "running");
+        assert.equal(streaming?.messages[0]?.streaming, true);
+        assert.isNotEmpty(streaming?.messages[0]?.text);
+        assert.equal(
+          snapshot.threads.find((thread) => thread.id === "drive-error")?.session?.status,
+          "error",
+        );
+        assert.isNotNull(
+          snapshot.threads.find((thread) => thread.id === "drive-archived")?.archivedAt,
+        );
+      }).pipe(Effect.scoped),
   );
 
   it.effect("rejects dev-url on project commands", () =>

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -9,6 +9,7 @@ import * as NetService from "@t3tools/shared/Net";
 import packageJson from "../package.json" with { type: "json" };
 import { authCommand } from "./cli/auth.ts";
 import { appCommand } from "./cli/app.ts";
+import { driveCommand } from "./cli/drive.ts";
 import { connectCommand } from "./cli/connect.ts";
 import { pairCommand } from "./cli/pair.ts";
 import { hasCloudPublicConfig } from "./cloud/publicConfig.ts";
@@ -55,6 +56,7 @@ export const makeCli = ({ cloudEnabled = hasCloudPublicConfig } = {}) =>
       startCommand,
       serveCommand,
       appCommand,
+      driveCommand,
       pairCommand,
       authCommand,
       projectCommand,

--- a/apps/server/src/cli/drive.ts
+++ b/apps/server/src/cli/drive.ts
@@ -1,0 +1,243 @@
+import {
+  AuthOrchestrationOperateScope,
+  AuthOrchestrationReadScope,
+  ClientOrchestrationCommand,
+  CommandId,
+  EnvironmentHttpApi,
+  MessageId,
+  ThreadId,
+} from "@t3tools/contracts";
+import * as Config from "effect/Config";
+import * as Console from "effect/Console";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
+import * as Option from "effect/Option";
+import * as Redacted from "effect/Redacted";
+import * as Schema from "effect/Schema";
+import { Argument, Command, Flag, GlobalFlag } from "effect/unstable/cli";
+import { FetchHttpClient } from "effect/unstable/http";
+import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
+
+import * as EnvironmentAuth from "../auth/EnvironmentAuth.ts";
+import * as ServerConfig from "../config.ts";
+import { readPersistedServerRuntimeState } from "../serverRuntimeState.ts";
+import { resolveCliAuthConfig } from "./config.ts";
+import {
+  DriveScenario,
+  driveExampleCommand,
+  driveScenarioCommand,
+  driveServeCommand,
+} from "./driveScenario.ts";
+
+const connectionFlags = {
+  baseDir: Flag.string("home-dir").pipe(Flag.withAlias("base-dir"), Flag.optional),
+  url: Flag.string("url").pipe(
+    Flag.withDescription("Running environment origin; authenticate with T3_DRIVE_TOKEN."),
+    Flag.optional,
+  ),
+};
+
+type ConnectionFlags = {
+  readonly baseDir: Option.Option<string>;
+  readonly url: Option.Option<string>;
+};
+
+class DriveConnectionError extends Schema.TaggedErrorClass<DriveConnectionError>()(
+  "DriveConnectionError",
+  { message: Schema.String },
+) {}
+
+const decodeUrl = Schema.decodeUnknownEffect(Schema.URLFromString);
+const decodeThreadId = Schema.decodeUnknownEffect(ThreadId);
+const decodeCommand = Schema.decodeUnknownEffect(Schema.fromJsonString(ClientOrchestrationCommand));
+const encodeJson = Schema.encodeEffect(Schema.fromJsonString(Schema.Unknown));
+
+const makeClient = (origin: string) => HttpApiClient.make(EnvironmentHttpApi, { baseUrl: origin });
+type DriveClient = Effect.Success<ReturnType<typeof makeClient>>;
+
+// Local commands borrow a short-lived session, just like `t3 project`.
+// A failed live connection never falls back to opening the database offline.
+const withConnection = Effect.fn("drive.withConnection")(function* <A, E, R>(
+  flags: ConnectionFlags,
+  operate: boolean,
+  run: (client: DriveClient, headers: { authorization: string }) => Effect.Effect<A, E, R>,
+) {
+  const call = (origin: string, token: string) =>
+    Effect.gen(function* () {
+      const client = yield* makeClient(origin);
+      return yield* run(client, { authorization: `Bearer ${token}` });
+    }).pipe(Effect.timeout("30 seconds"), Effect.provide(FetchHttpClient.layer));
+
+  if (Option.isSome(flags.url)) {
+    const origin = flags.url.value;
+    const parsed = yield* decodeUrl(origin);
+    if (
+      !["http:", "https:"].includes(parsed.protocol) ||
+      parsed.username ||
+      parsed.password ||
+      parsed.search ||
+      parsed.hash ||
+      parsed.pathname !== "/"
+    ) {
+      return yield* new DriveConnectionError({
+        message: "--url must be an HTTP(S) origin without credentials, path, query, or fragment.",
+      });
+    }
+    const token = yield* Config.redacted("T3_DRIVE_TOKEN");
+    return yield* call(origin, Redacted.value(token));
+  }
+
+  const config = yield* resolveCliAuthConfig(flags, yield* GlobalFlag.LogLevel);
+  const runtime = yield* readPersistedServerRuntimeState(config.serverRuntimeStatePath);
+  if (Option.isNone(runtime)) {
+    return yield* new DriveConnectionError({
+      message:
+        "No running server found. Start t3 serve for this --home-dir, or pass --url and T3_DRIVE_TOKEN.",
+    });
+  }
+  const origin = runtime.value.origin;
+  return yield* Effect.gen(function* () {
+    const auth = yield* EnvironmentAuth.EnvironmentAuth;
+    return yield* Effect.acquireUseRelease(
+      auth.issueSession({
+        scopes: operate
+          ? [AuthOrchestrationReadScope, AuthOrchestrationOperateScope]
+          : [AuthOrchestrationReadScope],
+        label: "t3 drive cli",
+      }),
+      (issued) => call(origin, issued.token),
+      (issued) => auth.revokeSession(issued.sessionId).pipe(Effect.ignore({ log: true })),
+    );
+  }).pipe(
+    Effect.provide(EnvironmentAuth.runtimeLayer.pipe(Layer.provide(ServerConfig.layer(config)))),
+  );
+});
+
+const printJson = (value: unknown) => encodeJson(value).pipe(Effect.flatMap(Console.log));
+
+const snapshotCommand = Command.make("snapshot", {
+  ...connectionFlags,
+  thread: Flag.string("thread").pipe(
+    Flag.optional,
+    Flag.withDescription("Thread id for full messages, activities, and state."),
+  ),
+}).pipe(
+  Command.withDescription("Read the environment summary or one full thread as JSON."),
+  Command.withHandler((flags) =>
+    withConnection(flags, false, (client, headers) =>
+      Effect.gen(function* () {
+        const snapshot = Option.isSome(flags.thread)
+          ? yield* client.orchestration.threadSnapshot({
+              headers,
+              params: { threadId: ThreadId.make(flags.thread.value) },
+              payload: {},
+            })
+          : yield* client.orchestration.snapshot({ headers });
+        yield* printJson(snapshot);
+      }),
+    ),
+  ),
+);
+
+const dispatchCommand = Command.make("dispatch", {
+  ...connectionFlags,
+  file: Argument.string("file").pipe(
+    Argument.withDescription("JSON client command. See t3 drive schema."),
+  ),
+}).pipe(
+  Command.withDescription(
+    "Dispatch one validated live command; print its durable sequence receipt.",
+  ),
+  Command.withHandler((flags) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const command = yield* decodeCommand(yield* fs.readFileString(flags.file));
+      yield* withConnection(flags, true, (client, headers) =>
+        client.orchestration
+          .dispatch({ headers, payload: command } as Parameters<
+            typeof client.orchestration.dispatch
+          >[0])
+          .pipe(Effect.flatMap(printJson)),
+      );
+    }),
+  ),
+);
+
+const sendCommand = Command.make("send", {
+  ...connectionFlags,
+  thread: Argument.string("thread"),
+  text: Argument.string("text"),
+}).pipe(
+  Command.withDescription(
+    "Send a real user message using the thread's current model and permission modes.",
+  ),
+  Command.withHandler((flags) =>
+    withConnection(flags, true, (client, headers) =>
+      Effect.gen(function* () {
+        const threadId = yield* decodeThreadId(flags.thread);
+        const { thread } = yield* client.orchestration.threadSnapshot({
+          headers,
+          params: { threadId },
+          payload: {},
+        });
+        const crypto = yield* Crypto.Crypto;
+        const commandId = CommandId.make(yield* crypto.randomUUIDv4);
+        const messageId = MessageId.make(yield* crypto.randomUUIDv4);
+        const receipt = yield* client.orchestration.dispatch({
+          headers,
+          payload: {
+            type: "thread.turn.start",
+            commandId,
+            threadId,
+            message: { messageId, role: "user", text: flags.text, attachments: [] },
+            modelSelection: thread.modelSelection,
+            runtimeMode: thread.runtimeMode,
+            interactionMode: thread.interactionMode,
+            createdAt: DateTime.formatIso(yield* DateTime.now),
+          },
+        });
+        yield* printJson({ commandId, messageId, ...receipt });
+      }),
+    ),
+  ),
+);
+
+const schemaCommand = Command.make("schema", {
+  scenario: Flag.boolean("scenario").pipe(Flag.withDefault(false)),
+}).pipe(
+  Command.withDescription(
+    "Print JSON Schema for live commands, or --scenario for isolated scenarios.",
+  ),
+  Command.withHandler(({ scenario }) =>
+    Effect.suspend(() => {
+      const document = Schema.toJsonSchemaDocument(
+        scenario ? DriveScenario : ClientOrchestrationCommand,
+      );
+      return printJson({
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+        ...document.schema,
+        $defs: document.definitions,
+      });
+    }),
+  ),
+);
+
+export const driveCommand = Command.make("drive").pipe(
+  Command.withDescription(
+    "Control running threads and build isolated, repeatable verification states. JSON output; no SQL.",
+  ),
+  Command.withSubcommands([
+    snapshotCommand,
+    dispatchCommand,
+    sendCommand,
+    schemaCommand,
+    driveExampleCommand,
+    driveScenarioCommand,
+    driveServeCommand,
+  ]),
+  Command.provide(Layer.succeed(Logger.LogToStderr, true)),
+);

--- a/apps/server/src/cli/driveScenario.ts
+++ b/apps/server/src/cli/driveScenario.ts
@@ -235,6 +235,20 @@ export const driveExampleCommand = Command.make("example", {
         }
         if (state === "streaming" || state === "error") {
           commands.push({
+            type: "thread.turn.start",
+            commandId: `${threadId}-start`,
+            threadId,
+            message: {
+              messageId: `${threadId}-user`,
+              role: "user",
+              text: "Show the verification results.",
+              attachments: [],
+            },
+            runtimeMode: "approval-required",
+            interactionMode: "default",
+            createdAt,
+          });
+          commands.push({
             type: "thread.session.set",
             commandId: `${threadId}-session`,
             threadId,
@@ -259,7 +273,7 @@ export const driveExampleCommand = Command.make("example", {
             messageId: `${threadId}-assistant`,
             turnId: `${threadId}-turn`,
             delta: "Synthetic partial response, preserved for inspecting the streaming state…",
-            createdAt,
+            createdAt: completedAt,
           });
         }
         if (state === "archived") {

--- a/apps/server/src/cli/driveScenario.ts
+++ b/apps/server/src/cli/driveScenario.ts
@@ -1,0 +1,273 @@
+import { OrchestrationCommand, OrchestrationShellSnapshot } from "@t3tools/contracts";
+import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
+import { fromJsonStringPretty } from "@t3tools/shared/schemaJson";
+import * as Console from "effect/Console";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { Argument, Command, Flag, GlobalFlag } from "effect/unstable/cli";
+
+import * as ServerConfig from "../config.ts";
+import { expandHomePath } from "../os-jank.ts";
+import { OrchestrationLayerLive } from "../orchestration/runtimeLayer.ts";
+import { OrchestrationEngineService } from "../orchestration/Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { layerConfig as SqlitePersistenceLayerLive } from "../persistence/Layers/Sqlite.ts";
+import * as RepositoryIdentityResolver from "../project/RepositoryIdentityResolver.ts";
+import { SERVICE_LAUNCHER_CONTEXT_ENV } from "../cloud/serviceProtocol.ts";
+import { DriveMode } from "../driveMode.ts";
+import { runServer } from "../server.ts";
+import { resolveServerConfig, sharedServerCommandFlags, resolveCliAuthConfig } from "./config.ts";
+
+export const DriveScenario = Schema.Struct({
+  version: Schema.Literal(1),
+  commands: Schema.Array(OrchestrationCommand).check(Schema.isNonEmpty()),
+});
+
+const decodeScenarioFile = Schema.decodeUnknownEffect(Schema.fromJsonString(DriveScenario));
+const decodeScenario = Schema.decodeUnknownEffect(DriveScenario);
+
+const encodeScenario = Schema.encodeEffect(fromJsonStringPretty(DriveScenario));
+const encodeScenarioSummary = Schema.encodeEffect(
+  Schema.fromJsonString(
+    Schema.Struct({
+      homeDir: Schema.String,
+      commandCount: Schema.Int,
+      snapshot: OrchestrationShellSnapshot,
+    }),
+  ),
+);
+
+class DriveScenarioError extends Schema.TaggedErrorClass<DriveScenarioError>()(
+  "DriveScenarioError",
+  { message: Schema.String, cause: Schema.optional(Schema.Defect()) },
+) {}
+
+const scenarioRuntimeLayer = OrchestrationLayerLive.pipe(
+  Layer.provideMerge(RepositoryIdentityResolver.layer),
+  Layer.provideMerge(SqlitePersistenceLayerLive),
+);
+
+const prepareScenario = Effect.fn("drive.prepareScenario")(function* (
+  file: string,
+  destination: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const scenario = yield* decodeScenarioFile(yield* fs.readFileString(file));
+  const ids = new Set<string>();
+  for (const command of scenario.commands) {
+    if (ids.has(command.commandId)) {
+      return yield* new DriveScenarioError({
+        message: `Duplicate commandId '${command.commandId}' would silently skip a command.`,
+      });
+    }
+    ids.add(command.commandId);
+  }
+  const homeDir = path.resolve(yield* expandHomePath(destination));
+  yield* fs.makeDirectory(path.dirname(homeDir), { recursive: true });
+  // Nonrecursive mkdir is the claim: even an empty existing directory or symlink is refused.
+  yield* fs.makeDirectory(homeDir).pipe(
+    Effect.mapError(
+      (cause) =>
+        new DriveScenarioError({
+          message: `Cannot create '${homeDir}'. Scenario homes must not already exist.`,
+          cause,
+        }),
+    ),
+  );
+
+  return { scenario, homeDir };
+});
+
+export const driveScenarioCommand = Command.make("scenario", {
+  file: Argument.string("file").pipe(Argument.withDescription("Version 1 scenario JSON file.")),
+  homeDir: Flag.string("home-dir").pipe(
+    Flag.withDescription("New, nonexistent T3 home to populate. Existing paths are refused."),
+  ),
+}).pipe(
+  Command.withDescription(
+    "Create isolated synthetic state through the event engine, without providers.",
+  ),
+  Command.withHandler(
+    Effect.fn("driveScenario")(function* (flags) {
+      const { scenario, homeDir } = yield* prepareScenario(flags.file, flags.homeDir);
+      const logLevel = yield* GlobalFlag.LogLevel;
+      const config = yield* resolveCliAuthConfig({ baseDir: Option.some(homeDir) }, logLevel);
+      const snapshot = yield* Effect.gen(function* () {
+        const engine = yield* OrchestrationEngineService;
+        const query = yield* ProjectionSnapshotQuery;
+        for (const [index, command] of scenario.commands.entries()) {
+          yield* engine.dispatch(command).pipe(
+            Effect.mapError(
+              (cause) =>
+                new DriveScenarioError({
+                  message: `Scenario command ${index + 1} (${command.type}) failed. Partial state remains at '${homeDir}'.`,
+                  cause,
+                }),
+            ),
+          );
+        }
+        return yield* query.getShellSnapshot();
+      }).pipe(Effect.provide(scenarioRuntimeLayer.pipe(Layer.provide(ServerConfig.layer(config)))));
+      yield* Console.log(
+        yield* encodeScenarioSummary({ homeDir, commandCount: scenario.commands.length, snapshot }),
+      );
+    }),
+  ),
+);
+
+export const driveServeCommand = Command.make("serve", {
+  file: Argument.string("file"),
+  homeDir: Flag.string("home-dir").pipe(
+    Flag.withDescription("New, nonexistent home for the demo server."),
+  ),
+  port: sharedServerCommandFlags.port,
+  host: sharedServerCommandFlags.host,
+  devUrl: sharedServerCommandFlags.devUrl,
+}).pipe(
+  Command.withDescription(
+    "Serve a scenario in the real client with provider reactors disabled. Uses a new home.",
+  ),
+  Command.withHandler(
+    Effect.fn("drive.serve")(function* (flags) {
+      const { scenario, homeDir } = yield* prepareScenario(flags.file, flags.homeDir);
+      const config = yield* resolveServerConfig(
+        {
+          baseDir: Option.some(homeDir),
+          port: flags.port,
+          host: flags.host,
+          devUrl: flags.devUrl,
+          mode: Option.some("web"),
+          cwd: Option.none(),
+          noBrowser: Option.some(true),
+          bootstrapFd: Option.none(),
+          autoBootstrapProjectFromCwd: Option.some(false),
+          logWebSocketEvents: Option.some(false),
+          tailscaleServeEnabled: Option.some(false),
+          tailscaleServePort: Option.none(),
+        },
+        yield* GlobalFlag.LogLevel,
+        { startupPresentation: "headless", forceAutoBootstrapProjectFromCwd: false },
+      );
+      yield* Console.error(
+        "Drive demo: provider reactors are disabled. Use a normal server to verify real provider interactions.",
+      );
+      const environment = yield* HostProcessEnvironment;
+      return yield* runServer.pipe(
+        Effect.provideService(HostProcessEnvironment, {
+          ...environment,
+          [SERVICE_LAUNCHER_CONTEXT_ENV]: undefined,
+          T3_BOOT_SERVICE_UNIT: undefined,
+        }),
+        Effect.provideService(ServerConfig.ServerConfig, config),
+        Effect.provideService(DriveMode, scenario.commands),
+      );
+    }),
+  ),
+);
+
+export const driveExampleCommand = Command.make("example", {
+  workspace: Flag.string("workspace").pipe(
+    Flag.withDescription("Existing project workspace path to reference in the example."),
+  ),
+}).pipe(
+  Command.withDescription(
+    "Print an editable scenario covering empty, completed, streaming, error, and archived threads.",
+  ),
+  Command.withHandler(
+    Effect.fn("driveExample")(function* (flags) {
+      const path = yield* Path.Path;
+      const now = yield* DateTime.now;
+      const createdAt = DateTime.formatIso(now);
+      const completedAt = DateTime.formatIso(DateTime.add(now, { milliseconds: 1 }));
+      const projectId = "drive-project";
+      const commands: unknown[] = [
+        {
+          type: "project.create",
+          commandId: "drive-project-create",
+          projectId,
+          title: "Drive scenarios",
+          workspaceRoot: path.resolve(yield* expandHomePath(flags.workspace)),
+          createdAt,
+        },
+      ];
+      for (const state of ["empty", "completed", "streaming", "error", "archived"] as const) {
+        const threadId = `drive-${state}`;
+        commands.push({
+          type: "thread.create",
+          commandId: `${threadId}-create`,
+          threadId,
+          projectId,
+          title: `Drive: ${state}`,
+          modelSelection: { instanceId: "codex", model: "gpt-5" },
+          runtimeMode: "approval-required",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt,
+          historyImport: true,
+        });
+        if (state === "completed" || state === "archived") {
+          commands.push({
+            type: "thread.history.import",
+            commandId: `${threadId}-history`,
+            threadId,
+            messages: [
+              {
+                messageId: `${threadId}-user`,
+                role: "user",
+                text: "Show the verification results.",
+                createdAt,
+              },
+              {
+                messageId: `${threadId}-assistant`,
+                role: "assistant",
+                text: "## Verification\n\nThis is synthetic scenario content.\n\n- [x] Completed state\n- [x] Markdown rendering\n\n```ts\nconst result = { status: 'ready' };\n```",
+                createdAt: completedAt,
+              },
+            ],
+          });
+        }
+        if (state === "streaming" || state === "error") {
+          commands.push({
+            type: "thread.session.set",
+            commandId: `${threadId}-session`,
+            threadId,
+            session: {
+              threadId,
+              status: state === "streaming" ? "running" : "error",
+              providerName: "codex",
+              providerInstanceId: "codex",
+              runtimeMode: "approval-required",
+              activeTurnId: state === "streaming" ? `${threadId}-turn` : null,
+              lastError: state === "error" ? "Synthetic provider failure for verification." : null,
+              updatedAt: createdAt,
+            },
+            createdAt,
+          });
+        }
+        if (state === "streaming") {
+          commands.push({
+            type: "thread.message.assistant.delta",
+            commandId: `${threadId}-delta`,
+            threadId,
+            messageId: `${threadId}-assistant`,
+            turnId: `${threadId}-turn`,
+            delta: "Synthetic partial response, preserved for inspecting the streaming state…",
+            createdAt,
+          });
+        }
+        if (state === "archived") {
+          commands.push({ type: "thread.archive", commandId: `${threadId}-archive`, threadId });
+        }
+      }
+      const scenario = yield* decodeScenario({ version: 1, commands });
+      yield* Console.log(yield* encodeScenario(scenario));
+    }),
+  ),
+);

--- a/apps/server/src/driveMode.ts
+++ b/apps/server/src/driveMode.ts
@@ -1,0 +1,8 @@
+import type { OrchestrationCommand } from "@t3tools/contracts";
+import * as Context from "effect/Context";
+
+/** Supplied only by drive serve for a newly claimed, isolated scenario home. */
+export class DriveMode extends Context.Reference<ReadonlyArray<OrchestrationCommand> | undefined>(
+  "t3/driveMode",
+  { defaultValue: () => undefined },
+) {}

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -28,6 +28,7 @@ import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 
 import * as ServerConfig from "./config.ts";
+import { DriveMode } from "./driveMode.ts";
 import * as Keybindings from "./keybindings.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
 import * as OrchestrationEngine from "./orchestration/Services/OrchestrationEngine.ts";
@@ -806,6 +807,9 @@ export const autoPullProjects = Effect.fn("autoPullProjects")(function* (
 export const make = (options?: StartupOptions) =>
   Effect.gen(function* () {
     const serverConfig = yield* ServerConfig.ServerConfig;
+    const driveCommands = yield* DriveMode;
+    const autoBootstrapProjectFromCwd =
+      driveCommands === undefined && serverConfig.autoBootstrapProjectFromCwd;
     const keybindings = yield* Keybindings.Keybindings;
     const orchestrationReactor = yield* OrchestrationReactor.OrchestrationReactor;
     const providerSessionReaper = yield* ProviderSessionReaper.ProviderSessionReaper;
@@ -865,25 +869,36 @@ export const make = (options?: StartupOptions) =>
         ),
       );
 
-      yield* Effect.logDebug("startup phase: parking orchestration roots at activation");
-      yield* runStartupPhase(
-        "reactors.start",
-        Effect.gen(function* () {
-          yield* orchestrationReactor.start().pipe(Scope.provide(reactorScope));
-          yield* providerSessionReaper.start().pipe(Scope.provide(reactorScope));
-        }),
-      );
+      if (driveCommands !== undefined) {
+        const engine = yield* OrchestrationEngine.OrchestrationEngineService;
+        yield* runStartupPhase(
+          "drive.scenario",
+          Effect.forEach(driveCommands, (command) => engine.dispatch(command), {
+            concurrency: 1,
+            discard: true,
+          }),
+        );
+      } else {
+        yield* Effect.logDebug("startup phase: parking orchestration roots at activation");
+        yield* runStartupPhase(
+          "reactors.start",
+          Effect.gen(function* () {
+            yield* orchestrationReactor.start().pipe(Scope.provide(reactorScope));
+            yield* providerSessionReaper.start().pipe(Scope.provide(reactorScope));
+          }),
+        );
 
-      yield* runStartupPhase("provider-sessions.reconcile", reconcileProviderSessions);
+        yield* runStartupPhase("provider-sessions.reconcile", reconcileProviderSessions);
 
-      yield* Effect.logDebug("startup phase: syncing clean projects");
-      yield* runStartupPhase("projects.auto-pull", syncAutoPullProjects);
+        yield* Effect.logDebug("startup phase: syncing clean projects");
+        yield* runStartupPhase("projects.auto-pull", syncAutoPullProjects);
+      }
 
       const welcomeBase = yield* resolveWelcomeBase;
       const environment = yield* serverEnvironment.getDescriptor;
       yield* Effect.logDebug("startup phase: preparing welcome payload");
 
-      if (serverConfig.autoBootstrapProjectFromCwd) {
+      if (autoBootstrapProjectFromCwd) {
         yield* forkParked(
           runStartupPhase(
             "welcome.autobootstrap",
@@ -961,7 +976,7 @@ export const make = (options?: StartupOptions) =>
           payload: {
             environment,
             ...welcomeBase,
-            bootstrapStatus: serverConfig.autoBootstrapProjectFromCwd ? "pending" : "complete",
+            bootstrapStatus: autoBootstrapProjectFromCwd ? "pending" : "complete",
           },
         }),
       );

--- a/docs/user/drive.md
+++ b/docs/user/drive.md
@@ -1,0 +1,48 @@
+# Drive T3 Code from an agent
+
+`t3 drive` gives scripts and agents JSON access to running environments and repeatable synthetic conversation states. Use `t3 drive --help` for commands and each subcommand's `--help` for flags.
+
+## Control a running environment
+
+Start an environment normally, then use the same T3 home:
+
+```sh
+t3 drive snapshot --home-dir /tmp/t3-demo
+t3 drive snapshot --home-dir /tmp/t3-demo --thread THREAD_ID
+t3 drive send --home-dir /tmp/t3-demo THREAD_ID "Verify the changes and report the results."
+```
+
+The environment snapshot includes projects and thread metadata, including archived threads. Request a thread snapshot to inspect its messages, activities, plans, and checkpoints. `send` starts a real provider turn using that thread's current model and permission modes. Its JSON response includes the command ID, message ID, and persisted sequence. Acceptance means the command was saved, not that the provider has completed the work.
+
+For project and thread creation, archive/unarchive, settle/unsettle, interruption, approval responses, and other actions, write a client command to a JSON file:
+
+```sh
+t3 drive schema > command.schema.json
+t3 drive dispatch command.json --home-dir /tmp/t3-demo
+```
+
+Commands use the same validation, authorization, and event handling as the app. Supply a unique `commandId` for each new action; reusing an ID makes a retry idempotent. Internal synthetic commands are rejected by live dispatch. A missing or unreachable server is an error; live commands never switch to offline database access.
+
+To connect to a remote environment, replace `--home-dir` with `--url https://your-environment.example` and supply an existing environment bearer session in `T3_DRIVE_TOKEN`. Read operations require `orchestration:read`; mutations also require `orchestration:operate`. Keep tokens out of command files and source control. Local commands create and revoke their own temporary session.
+
+## Build a repeatable scenario
+
+Generate an editable example with empty, completed, streaming, error, and archived threads:
+
+```sh
+t3 drive example --workspace /path/to/project > scenario.json
+t3 drive schema --scenario > scenario.schema.json
+t3 drive serve scenario.json --home-dir /tmp/t3-drive-example
+```
+
+`serve` starts the real application server, loads the scenario before it becomes ready, and leaves orchestration reactors and session recovery disabled. Synthetic streaming and error states remain available to inspect. Pair the web, desktop, or mobile client with the printed URL. This is a demo environment: provider turns, checkpoint work, and other reactor-driven actions do not run. Direct terminal, filesystem, and git controls still operate normally.
+
+To generate a home without starting a server, use `t3 drive scenario scenario.json --home-dir /tmp/t3-drive-offline`. Starting that home later with `t3 serve --base-dir /tmp/t3-drive-offline` enables normal recovery, which changes orphaned running sessions into errors. Use `drive serve` for stable synthetic states.
+
+The destination must not already exist, even as an empty directory. Use a new path for each run. Scenarios never overwrite an existing home. The workspace path points at an existing project; generating or loading the example does not create workspace files.
+
+A scenario is `{ "version": 1, "commands": [...] }`. Edit the example or use the schema to describe assistant deltas and completions, imported history, sessions, activities, plans, diffs, and other durable domain state. The entire file is schema-validated before creating the home, and duplicate command IDs are rejected. Commands then run in order through the event engine and its projections, without provider processes or side-effect reactors. The output identifies the new home and its shell snapshot. If a command violates a domain invariant, the error identifies the command and retains the partial home for inspection; retry with a corrected scenario and a new home.
+
+Scenarios reproduce persisted application state, not external filesystem contents, provider callbacks, terminal processes, network failures, or every transient client state. Starting a normal server restores normal provider and recovery behavior. Synthetic approval requests do not create real provider callbacks. Use real turns and the client to verify those interactions.
+
+Compare thread snapshots with expected values in your agent or shell assertions, and inspect the corresponding client behavior. Scenario data makes a verification case repeatable; it does not itself establish that there are no regressions.


### PR DESCRIPTION
Adds `t3 drive` so agents can inspect and control running threads through authenticated commands, and build repeatable synthetic states without editing SQLite. `drive serve` loads a validated scenario into a newly claimed home and serves the real client with orchestration reactors disabled, preserving streaming, error, completed, and archived demo states; normal server startup is unchanged.

Verified with 40 focused CLI/startup tests, the server typecheck, scoped lint, all GitHub CI checks, real-server snapshots, archive/unarchive and settle/unsettle commands, and desktop-dark/narrow-light browser checks. The sampled walkthrough below shows CLI-driven unsettle/settle at 4× playback; synthetic state does not replace real provider, terminal, or network integration tests.

![CLI-driven unsettle and settle, sampled walkthrough at 4x playback](https://uploads-production-47e4.up.railway.app/files/b8809e88-12b8-445d-b914-17de34f0e7ad/t3-drive-live-control.gif)

![Completed scenario with ordered messages and settled state, desktop dark](https://uploads-production-47e4.up.railway.app/files/ab2e2e89-e392-4b6c-859e-8b1eb7e1336a/t3-drive-completed-dark.png)

![Streaming scenario retains its user and partial assistant messages after history synchronization](https://uploads-production-47e4.up.railway.app/files/a9da3cdc-67c2-43ac-a3cd-c0318705305c/t3-drive-streaming-reviewed.png)

Model: `gpt-5.6-sol`; harness: Codex.
