### PR TITLE
fix(web): keep settings section headings description-free

### DIFF
--- a/.macroscope/check-run-agents/ui-consistency.md
+++ b/.macroscope/check-run-agents/ui-consistency.md
@@ -22,7 +22,7 @@ maxBudgetPerRun: 10
 
 # UI consistency review
 
-This is a styling guard for `apps/web`, not a general review. Review only the changed lines in the diff against the four rules below. Do not build the project, inspect emitted CSS, trace selector consumers across the codebase, or ask for screenshots. If the diff does not make a violation obvious, there is no finding.
+This is a styling guard for `apps/web`, not a general review. Review only the changed lines in the diff and answer three questions. Do not build the project, inspect emitted CSS, trace selector consumers across the codebase, or ask for screenshots. If the diff does not make a violation obvious, there is no finding.
 
 ## 1. Shared primitives over custom controls
 
@@ -53,11 +53,6 @@ Hold new and changed UI to that shape:
 - Flag a new component that copies a chunk of an existing primitive's markup and classes instead of composing or extending it.
 - Flag a large one-off class string on a shared component when it is clearly the same treatment another call site already uses. The fix is a variant or a new slot on the shared component.
 - Flag a new composer banner or notice that bypasses `ComposerBanner` slots and hand-builds its row, icon column, or actions.
-
-## 4. Concise settings copy
-
-- Muted settings section titles must never have descriptions. Flag descriptions added to `SettingsSection` headings or equivalent muted section headings.
-- Keep individual setting descriptions short enough for one line where possible. Flag unnecessarily verbose copy; allow wrapping when needed for clarity or narrow screens. Do not require truncation or no-wrap styling.
 
 ## Reporting
 

--- a/.macroscope/check-run-agents/ui-consistency.md
+++ b/.macroscope/check-run-agents/ui-consistency.md
@@ -22,7 +22,7 @@ maxBudgetPerRun: 10
 
 # UI consistency review
 
-This is a styling guard for `apps/web`, not a general review. Review only the changed lines in the diff and answer three questions. Do not build the project, inspect emitted CSS, trace selector consumers across the codebase, or ask for screenshots. If the diff does not make a violation obvious, there is no finding.
+This is a styling guard for `apps/web`, not a general review. Review only the changed lines in the diff against the four rules below. Do not build the project, inspect emitted CSS, trace selector consumers across the codebase, or ask for screenshots. If the diff does not make a violation obvious, there is no finding.
 
 ## 1. Shared primitives over custom controls
 
@@ -53,6 +53,11 @@ Hold new and changed UI to that shape:
 - Flag a new component that copies a chunk of an existing primitive's markup and classes instead of composing or extending it.
 - Flag a large one-off class string on a shared component when it is clearly the same treatment another call site already uses. The fix is a variant or a new slot on the shared component.
 - Flag a new composer banner or notice that bypasses `ComposerBanner` slots and hand-builds its row, icon column, or actions.
+
+## 4. Concise settings copy
+
+- Muted settings section titles must never have descriptions. Flag descriptions added to `SettingsSection` headings or equivalent muted section headings.
+- Keep individual setting descriptions short enough for one line where possible. Flag unnecessarily verbose copy; allow wrapping when needed for clarity or narrow screens. Do not require truncation or no-wrap styling.
 
 ## Reporting
 

--- a/apps/web/src/components/settings/LoadBalancingSettings.tsx
+++ b/apps/web/src/components/settings/LoadBalancingSettings.tsx
@@ -28,13 +28,10 @@ export function LoadBalancingSettings({
   const updateSettings = useUpdateClientSettings();
 
   return (
-    <SettingsSection
-      {...searchableSetting("load-balancing")}
-      description="Choose how often each machine is used. Prefer gives a machine more work when it has capacity; Less often gives it less. Manual only excludes it from automatic selection. Preferences are saved for this client."
-    >
+    <SettingsSection {...searchableSetting("load-balancing")}>
       <SettingsRow
         title="Automatically balance load"
-        description="Automatically choose a connected machine for new threads in shared projects. You can choose a machine in the composer."
+        description="Choose a machine automatically for new threads in shared projects."
         control={
           <Switch
             aria-label="Automatically balance load"

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -801,14 +801,12 @@ export function ProviderInstanceCard({
 
   return (
     <>
-      <SettingsSection
-        title={displayName}
-        description={editorStatusNode}
-        icon={titleIconNode}
-        headerAction={editorHeaderAction}
-      >
+      <SettingsSection title={displayName} icon={titleIconNode} headerAction={editorHeaderAction}>
         <SettingsRow
           title="Display name"
+          status={
+            <div className="flex min-w-0 flex-wrap items-center gap-x-1.5">{editorStatusNode}</div>
+          }
           control={
             <div
               inert={readOnly}

--- a/apps/web/src/components/settings/UsageProviderSettings.tsx
+++ b/apps/web/src/components/settings/UsageProviderSettings.tsx
@@ -37,7 +37,6 @@ export function UsageProviderSettings({
     <>
       <SettingsSection
         {...searchableSetting("usage-providers")}
-        description="Connect a CLIProxyAPI hub to show its accounts on Usage → Limits."
         headerAction={
           !readOnly ? (
             <Button size="xs" variant="outline" onClick={() => setAdding(true)}>

--- a/apps/web/src/components/settings/settingsLayout.tsx
+++ b/apps/web/src/components/settings/settingsLayout.tsx
@@ -167,7 +167,6 @@ export function SettingsSection({
   ...sectionProps
 }: ComponentPropsWithoutRef<"section"> & {
   title: string;
-  description?: never;
   hideTitle?: boolean;
   icon?: ReactNode;
   headerAction?: ReactNode;

--- a/apps/web/src/components/settings/settingsLayout.tsx
+++ b/apps/web/src/components/settings/settingsLayout.tsx
@@ -155,6 +155,7 @@ export function useRelativeTimeTick(intervalMs = 1_000) {
   return nowMs;
 }
 
+/** Muted section headings have no descriptions; explanatory copy belongs to individual settings. */
 export function SettingsSection({
   title,
   hideTitle = false,
@@ -218,6 +219,9 @@ export function SettingsSection({
  * environment's settings.json; where there is no primary (the hosted app)
  * the control goes inert with a tooltip instead of showing an editable
  * default that would never save.
+ *
+ * Keep descriptions short enough for one line where possible. Allow wrapping
+ * for clarity or narrow screens instead of truncating or forcing no-wrap.
  *
  * Control sizing across settings follows three tiers so rows share a baseline:
  * - `control` slot: `size="sm"` (Button, Select, Input, NumberField) or `icon-sm`.

--- a/apps/web/src/components/settings/settingsLayout.tsx
+++ b/apps/web/src/components/settings/settingsLayout.tsx
@@ -157,7 +157,6 @@ export function useRelativeTimeTick(intervalMs = 1_000) {
 
 export function SettingsSection({
   title,
-  description,
   hideTitle = false,
   icon,
   headerAction,
@@ -167,7 +166,7 @@ export function SettingsSection({
   ...sectionProps
 }: ComponentPropsWithoutRef<"section"> & {
   title: string;
-  description?: ReactNode;
+  description?: never;
   hideTitle?: boolean;
   icon?: ReactNode;
   headerAction?: ReactNode;
@@ -195,11 +194,6 @@ export function SettingsSection({
               {icon}
               {title}
             </h2>
-            {description ? (
-              <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 text-[13px] leading-[1.45] text-muted-foreground/80">
-                {description}
-              </div>
-            ) : null}
           </div>
           <div className="flex min-h-7 min-w-7 items-center justify-end">{headerAction}</div>
         </div>


### PR DESCRIPTION
Removes descriptions beneath muted settings headings and shortens the load balancing setting text. `SettingsSection` no longer exposes or renders a description prop; provider status stays visible in the display-name row, and source comments beside the shared settings components guide implementers toward concise copy.

Verified web typecheck, scoped lint and formatting. Checked Connections and Providers at desktop and phone widths in dark and light themes, including the load switch and machine preference selector. Web and desktop share this component; mobile already omits section descriptions.

![load balancing before](https://uploads-production-47e4.up.railway.app/files/bd8ccb65-5696-4238-9180-0505b58dde48/settings-before.png)

![load balancing after](https://uploads-production-47e4.up.railway.app/files/1bc624fc-bf76-4792-bde8-1dd19d24bdd0/settings-after.png)

![provider settings before](https://uploads-production-47e4.up.railway.app/files/505f9ea0-0ef1-4e71-bf66-2e36ce7e1d1b/settings-providers-before.png)

![provider settings after](https://uploads-production-47e4.up.railway.app/files/6f3d6f3f-1559-4d99-b490-e5cb77b3103f/settings-providers-after.png)

Model: gpt-5.6-sol. Harness: Codex in T3 Code.


