### PR TITLE
fix(clients): show the submitted answers on user input rows

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -3384,3 +3384,53 @@ it("makes attachment-only question answers expandable in the mobile feed", () =>
   });
   expect(group.activities[0]?.getFullDetail()).toBeNull();
 });
+
+describe("user input answers", () => {
+  it("shows the submitted answers on the resolved row, labelled by their questions", () => {
+    const turnId = TurnId.make("turn-answers");
+    const thread = makeThread({
+      id: ThreadId.make("thread-answers"),
+      projectId: ProjectId.make("project-1"),
+      title: "Answers",
+      activities: [
+        makeActivity({
+          id: EventId.make("asked"),
+          kind: "user-input.requested",
+          summary: "User input requested",
+          createdAt: "2026-04-01T00:00:01.000Z",
+          turnId,
+          payload: {
+            requestId: "req-1",
+            questions: [
+              {
+                id: "approach",
+                header: "Approach",
+                question: "How should we proceed?",
+                options: [],
+              },
+            ],
+          },
+        }),
+        makeActivity({
+          id: EventId.make("answered"),
+          kind: "user-input.resolved",
+          summary: "User input submitted",
+          createdAt: "2026-04-01T00:00:02.000Z",
+          turnId,
+          payload: { requestId: "req-1", answers: { approach: "Ship the minimal fix" } },
+        }),
+      ],
+    });
+    const activities = buildThreadFeed(thread).flatMap((item) =>
+      item.type === "activity-group"
+        ? item.activities
+        : item.type === "activity"
+          ? [item.activity]
+          : [],
+    );
+    expect(activities.map((activity) => [activity.id, activity.workEntry.detail])).toEqual([
+      ["asked", undefined],
+      ["answered", "Approach: Ship the minimal fix"],
+    ]);
+  });
+});

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -3422,11 +3422,7 @@ describe("user input answers", () => {
       ],
     });
     const activities = buildThreadFeed(thread).flatMap((item) =>
-      item.type === "activity-group"
-        ? item.activities
-        : item.type === "activity"
-          ? [item.activity]
-          : [],
+      item.type === "activity-group" ? item.activities : [],
     );
     expect(activities.map((activity) => [activity.id, activity.workEntry.detail])).toEqual([
       ["asked", undefined],

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -34,6 +34,10 @@ import {
 } from "@t3tools/client-runtime/work-log/presentation";
 import { extractToolActivityPresentation } from "@t3tools/client-runtime/work-log/tool-presentation";
 import { commandProgramName } from "@t3tools/client-runtime/work-log/command-label";
+import {
+  formatUserInputAnswers,
+  readUserInputQuestions,
+} from "@t3tools/client-runtime/user-input-answers";
 
 import * as Arr from "effect/Array";
 import * as Order from "effect/Order";
@@ -405,6 +409,7 @@ function deriveWorkLogEntries(
 ): DerivedWorkLogEntry[] {
   const ordered = Arr.sort(activities, activityOrder);
   const entries: DerivedWorkLogEntry[] = [];
+  const questionsByRequestId = new Map<string, ReturnType<typeof readUserInputQuestions>>();
   for (const activity of ordered) {
     if (activity.tone !== "error" && isWorktreeSetupActivity(activity.kind)) continue;
     if (activity.kind === "tool.started") continue;
@@ -420,9 +425,33 @@ function deriveWorkLogEntries(
     if (isNoContentRuntimeWarning(activity)) continue;
     if (isPlanBoundaryToolActivity(activity)) continue;
     if (isAgentInternalActivity(activity)) continue;
-    entries.push(toDerivedWorkLogEntry(activity));
+    const entry = toDerivedWorkLogEntry(activity);
+    attachUserInputAnswers(activity, entry, questionsByRequestId);
+    entries.push(entry);
   }
   return collapseDerivedWorkLogEntries(entries);
+}
+
+/**
+ * A resolved user-input row only carries answers keyed by question id; the
+ * question text lives on the request row that preceded it. Pair the two here
+ * so the row can show what was actually answered.
+ */
+function attachUserInputAnswers(
+  activity: OrchestrationThreadActivity,
+  entry: DerivedWorkLogEntry,
+  questionsByRequestId: Map<string, ReturnType<typeof readUserInputQuestions>>,
+): void {
+  const payload = asRecord(activity.payload);
+  const requestId = asTrimmedString(payload?.requestId);
+  if (activity.kind === "user-input.requested") {
+    if (requestId) questionsByRequestId.set(requestId, readUserInputQuestions(payload));
+    return;
+  }
+  if (activity.kind !== "user-input.resolved" || entry.detail) return;
+  const questions = (requestId && questionsByRequestId.get(requestId)) || [];
+  const detail = formatUserInputAnswers(questions, payload?.answers);
+  if (detail) entry.detail = detail;
 }
 
 /** Adapters forward unknown wire-only SDK messages (background_tasks_changed,

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -450,6 +450,42 @@ describe("workEntryIndicatesToolNeutralStatus", () => {
 });
 
 describe("deriveWorkLogEntries", () => {
+  it("shows the submitted answers on the user-input row, labelled by their questions", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        id: "asked",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        sequence: 0,
+        payload: {
+          requestId: "req-1",
+          questions: [
+            { id: "approach", header: "Approach", question: "How should we proceed?", options: [] },
+          ],
+        },
+      }),
+      makeActivity({
+        id: "answered",
+        kind: "user-input.resolved",
+        summary: "User input submitted",
+        sequence: 1,
+        payload: { requestId: "req-1", answers: { approach: "Ship the minimal fix" } },
+      }),
+      makeActivity({
+        id: "answered-alone",
+        kind: "user-input.resolved",
+        summary: "User input submitted",
+        sequence: 2,
+        payload: { requestId: "req-unknown", answers: { note: "typed by hand" } },
+      }),
+    ]);
+    expect(entries.map((entry) => [entry.id, entry.detail])).toEqual([
+      ["asked", undefined],
+      ["answered", "Approach: Ship the minimal fix"],
+      ["answered-alone", "note: typed by hand"],
+    ]);
+  });
+
   it("keeps the latest task progress without emitting plan-update log entries", () => {
     const activities = [
       makeActivity({ id: "before", kind: "tool.completed", summary: "Read files", sequence: 0 }),

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -9,6 +9,10 @@ import * as Arr from "effect/Array";
 import { shallow } from "zustand/vanilla/shallow";
 import { isBackgroundTaskActivity } from "@t3tools/client-runtime/state/subagentRuntime";
 import {
+  formatUserInputAnswers,
+  readUserInputQuestions,
+} from "@t3tools/client-runtime/user-input-answers";
+import {
   commandDetailRepeatsCommand,
   extractCommandOutputText,
   extractWorkLogToolLifecycleStatus,
@@ -451,6 +455,7 @@ export function deriveWorkLogEntries(
 ): WorkLogEntry[] {
   const ordered = [...activities].toSorted(compareActivitiesByOrder);
   const entries: DerivedWorkLogEntry[] = [];
+  const questionsByRequestId = new Map<string, ReturnType<typeof readUserInputQuestions>>();
   for (const activity of ordered) {
     if (activity.tone !== "error" && isWorktreeSetupActivity(activity.kind)) continue;
     if (activity.kind === "tool.started") continue;
@@ -467,9 +472,33 @@ export function deriveWorkLogEntries(
     if (isNoContentRuntimeWarning(activity)) continue;
     if (isPlanBoundaryToolActivity(activity)) continue;
     if (isAgentInternalActivity(activity)) continue;
-    entries.push(toDerivedWorkLogEntry(activity));
+    const entry = toDerivedWorkLogEntry(activity);
+    attachUserInputAnswers(activity, entry, questionsByRequestId);
+    entries.push(entry);
   }
   return collapseDerivedWorkLogEntries(entries);
+}
+
+/**
+ * A resolved user-input row only carries answers keyed by question id; the
+ * question text lives on the request row that preceded it. Pair the two here
+ * so the row can show what was actually answered.
+ */
+function attachUserInputAnswers(
+  activity: OrchestrationThreadActivity,
+  entry: DerivedWorkLogEntry,
+  questionsByRequestId: Map<string, ReturnType<typeof readUserInputQuestions>>,
+): void {
+  const payload = asRecord(activity.payload);
+  const requestId = asTrimmedString(payload?.requestId);
+  if (activity.kind === "user-input.requested") {
+    if (requestId) questionsByRequestId.set(requestId, readUserInputQuestions(payload));
+    return;
+  }
+  if (activity.kind !== "user-input.resolved" || entry.detail) return;
+  const questions = (requestId && questionsByRequestId.get(requestId)) || [];
+  const detail = formatUserInputAnswers(questions, payload?.answers);
+  if (detail) entry.detail = detail;
 }
 
 /** Adapters forward unknown wire-only SDK messages (background_tasks_changed,

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -15,6 +15,10 @@
       "types": "./src/pendingRequests.ts",
       "default": "./src/pendingRequests.ts"
     },
+    "./user-input-answers": {
+      "types": "./src/userInputAnswers.ts",
+      "default": "./src/userInputAnswers.ts"
+    },
     "./connection": {
       "types": "./src/connection/index.ts",
       "default": "./src/connection/index.ts"

--- a/packages/client-runtime/src/userInputAnswers.test.ts
+++ b/packages/client-runtime/src/userInputAnswers.test.ts
@@ -31,4 +31,18 @@ describe("formatUserInputAnswers", () => {
     expect(formatUserInputAnswers(questions, {})).toBeUndefined();
     expect(readUserInputQuestions({ questions: "nope" })).toEqual([]);
   });
+
+  it("keeps the questions it can read when a request row carries a malformed one", () => {
+    const asked = readUserInputQuestions({
+      questions: [
+        { id: "approach", header: "Approach", question: "How should we proceed?" },
+        { header: "No id" },
+        { id: "scope", header: "Scope", question: "Which areas?", options: [], multiSelect: true },
+      ],
+    });
+    expect(asked.map((question) => question.id)).toEqual(["approach", "scope"]);
+    expect(formatUserInputAnswers(asked, { approach: "Minimal", scope: ["Web"] })).toBe(
+      "Approach: Minimal\nScope: Web",
+    );
+  });
 });

--- a/packages/client-runtime/src/userInputAnswers.test.ts
+++ b/packages/client-runtime/src/userInputAnswers.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { formatUserInputAnswers, readUserInputQuestions } from "./userInputAnswers.ts";
+
+const questions = readUserInputQuestions({
+  questions: [
+    { id: "approach", header: "Approach", question: "How should we proceed?", options: [] },
+    { id: "scope", header: "Scope", question: "Which areas?", options: [], multiSelect: true },
+  ],
+});
+
+describe("formatUserInputAnswers", () => {
+  it("lists one line per question in the order asked, joining multi-select answers", () => {
+    expect(
+      formatUserInputAnswers(questions, {
+        scope: ["Server", "Web"],
+        approach: "Ship the minimal fix",
+      }),
+    ).toBe("Approach: Ship the minimal fix\nScope: Server, Web");
+  });
+
+  it("keeps answers whose question is unknown and skips blank ones", () => {
+    expect(formatUserInputAnswers(questions, { approach: "  ", extra: "Free text" })).toBe(
+      "extra: Free text",
+    );
+    expect(formatUserInputAnswers([], { note: "typed by hand" })).toBe("note: typed by hand");
+  });
+
+  it("returns nothing for answers it cannot show", () => {
+    expect(formatUserInputAnswers(questions, undefined)).toBeUndefined();
+    expect(formatUserInputAnswers(questions, {})).toBeUndefined();
+    expect(readUserInputQuestions({ questions: "nope" })).toEqual([]);
+  });
+});

--- a/packages/client-runtime/src/userInputAnswers.ts
+++ b/packages/client-runtime/src/userInputAnswers.ts
@@ -1,0 +1,72 @@
+import type { UserInputQuestion } from "@t3tools/contracts";
+
+type UserInputQuestionLike = Pick<UserInputQuestion, "id" | "header" | "question">;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmpty(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+/**
+ * The questions a `user-input.requested` payload carried, read structurally
+ * so a row from an older server (or one with the questions stripped) still
+ * yields an empty list rather than throwing.
+ */
+export function readUserInputQuestions(payload: unknown): ReadonlyArray<UserInputQuestionLike> {
+  const questions = isRecord(payload) ? payload.questions : undefined;
+  if (!Array.isArray(questions)) return [];
+  const result: UserInputQuestionLike[] = [];
+  for (const question of questions) {
+    if (!isRecord(question)) continue;
+    const id = nonEmpty(question.id);
+    if (!id) continue;
+    result.push({
+      id,
+      header: nonEmpty(question.header) ?? "",
+      question: nonEmpty(question.question) ?? "",
+    });
+  }
+  return result;
+}
+
+function formatAnswer(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    const parts = value.map(formatAnswer).filter((part): part is string => part !== undefined);
+    return parts.length > 0 ? parts.join(", ") : undefined;
+  }
+  if (typeof value === "string") return nonEmpty(value);
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (isRecord(value)) return JSON.stringify(value);
+  return undefined;
+}
+
+/**
+ * The submitted answers as one `Question: answer` line per question, in the
+ * order they were asked; multi-select answers join with commas. Answers whose
+ * question is unknown (older history, keys the provider chose) still list
+ * under their key so nothing the user typed goes missing.
+ */
+export function formatUserInputAnswers(
+  questions: ReadonlyArray<UserInputQuestionLike>,
+  answers: unknown,
+): string | undefined {
+  if (!isRecord(answers)) return undefined;
+  const lines: string[] = [];
+  const seen = new Set<string>();
+  for (const question of questions) {
+    seen.add(question.id);
+    const answer = formatAnswer(answers[question.id]);
+    if (answer === undefined) continue;
+    const label = question.header || question.question || question.id;
+    lines.push(`${label}: ${answer}`);
+  }
+  for (const [key, value] of Object.entries(answers)) {
+    if (seen.has(key)) continue;
+    const answer = formatAnswer(value);
+    if (answer !== undefined) lines.push(`${key}: ${answer}`);
+  }
+  return lines.length > 0 ? lines.join("\n") : undefined;
+}

--- a/packages/client-runtime/src/userInputAnswers.ts
+++ b/packages/client-runtime/src/userInputAnswers.ts
@@ -1,45 +1,43 @@
-import type { UserInputQuestion } from "@t3tools/contracts";
+import * as Option from "effect/Option";
+import * as Predicate from "effect/Predicate";
+import * as Schema from "effect/Schema";
 
-type UserInputQuestionLike = Pick<UserInputQuestion, "id" | "header" | "question">;
+import { UserInputQuestion } from "@t3tools/contracts";
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
+// Older request rows can carry less than the current contract, and question
+// ids are the answer keys, so they are read as plain strings and never trimmed.
+const decodeAskedQuestions = Schema.decodeUnknownOption(
+  Schema.Struct({
+    questions: Schema.Array(
+      Schema.Struct({
+        ...UserInputQuestion.fields,
+        id: Schema.String,
+        header: Schema.String,
+        question: Schema.String,
+        options: Schema.Array(Schema.Unknown),
+      }),
+    ),
+  }),
+);
 
-function nonEmpty(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
-}
+type AskedQuestion = Pick<UserInputQuestion, "id" | "header" | "question">;
 
-/**
- * The questions a `user-input.requested` payload carried, read structurally
- * so a row from an older server (or one with the questions stripped) still
- * yields an empty list rather than throwing.
- */
-export function readUserInputQuestions(payload: unknown): ReadonlyArray<UserInputQuestionLike> {
-  const questions = isRecord(payload) ? payload.questions : undefined;
-  if (!Array.isArray(questions)) return [];
-  const result: UserInputQuestionLike[] = [];
-  for (const question of questions) {
-    if (!isRecord(question)) continue;
-    const id = nonEmpty(question.id);
-    if (!id) continue;
-    result.push({
-      id,
-      header: nonEmpty(question.header) ?? "",
-      question: nonEmpty(question.question) ?? "",
-    });
-  }
-  return result;
+/** The questions a `user-input.requested` payload asked, in order. */
+export function readUserInputQuestions(payload: unknown): ReadonlyArray<AskedQuestion> {
+  return Option.match(decodeAskedQuestions(payload), {
+    onNone: () => [],
+    onSome: ({ questions }) => questions,
+  });
 }
 
 function formatAnswer(value: unknown): string | undefined {
   if (Array.isArray(value)) {
-    const parts = value.map(formatAnswer).filter((part): part is string => part !== undefined);
+    const parts = value.map(formatAnswer).filter(Predicate.isString);
     return parts.length > 0 ? parts.join(", ") : undefined;
   }
-  if (typeof value === "string") return nonEmpty(value);
-  if (typeof value === "number" || typeof value === "boolean") return String(value);
-  if (isRecord(value)) return JSON.stringify(value);
+  if (Predicate.isString(value)) return value.trim() || undefined;
+  if (Predicate.isNumber(value) || Predicate.isBoolean(value)) return String(value);
+  if (Predicate.isObject(value)) return JSON.stringify(value);
   return undefined;
 }
 
@@ -50,10 +48,10 @@ function formatAnswer(value: unknown): string | undefined {
  * under their key so nothing the user typed goes missing.
  */
 export function formatUserInputAnswers(
-  questions: ReadonlyArray<UserInputQuestionLike>,
+  questions: ReadonlyArray<AskedQuestion>,
   answers: unknown,
 ): string | undefined {
-  if (!isRecord(answers)) return undefined;
+  if (!Predicate.isObject(answers)) return undefined;
   const lines: string[] = [];
   const seen = new Set<string>();
   for (const question of questions) {

--- a/packages/client-runtime/src/userInputAnswers.ts
+++ b/packages/client-runtime/src/userInputAnswers.ts
@@ -2,22 +2,16 @@ import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
 import * as Schema from "effect/Schema";
 
-import { UserInputQuestion } from "@t3tools/contracts";
+import type { UserInputQuestion } from "@t3tools/contracts";
 
-// Older request rows can carry less than the current contract, and question
-// ids are the answer keys, so they are read as plain strings and never trimmed.
+// Older request rows can carry less than the current contract, so each
+// question decodes on its own and a malformed one does not hide the rest.
+// Question ids are the answer keys, so they are read as-is and never trimmed.
+const decodeAskedQuestion = Schema.decodeUnknownOption(
+  Schema.Struct({ id: Schema.String, header: Schema.String, question: Schema.String }),
+);
 const decodeAskedQuestions = Schema.decodeUnknownOption(
-  Schema.Struct({
-    questions: Schema.Array(
-      Schema.Struct({
-        ...UserInputQuestion.fields,
-        id: Schema.String,
-        header: Schema.String,
-        question: Schema.String,
-        options: Schema.Array(Schema.Unknown),
-      }),
-    ),
-  }),
+  Schema.Struct({ questions: Schema.Array(Schema.Unknown) }),
 );
 
 type AskedQuestion = Pick<UserInputQuestion, "id" | "header" | "question">;
@@ -26,7 +20,8 @@ type AskedQuestion = Pick<UserInputQuestion, "id" | "header" | "question">;
 export function readUserInputQuestions(payload: unknown): ReadonlyArray<AskedQuestion> {
   return Option.match(decodeAskedQuestions(payload), {
     onNone: () => [],
-    onSome: ({ questions }) => questions,
+    onSome: ({ questions }) =>
+      questions.flatMap((question) => Option.toArray(decodeAskedQuestion(question))),
   });
 }
 


### PR DESCRIPTION
## Problem

When an agent asks a question through the user-input request (AskUserQuestion and the Codex equivalent) and the user answers, the timeline only shows a bare "User input submitted" row. What was actually chosen or typed is not visible anywhere afterwards, even though the resolved activity already carries the answers.

## Fix

- New shared helper `formatUserInputAnswers` in `@t3tools/client-runtime/user-input-answers`: one `Question: answer` line per question in the order asked, multi-select answers joined with commas, and answers whose question is unknown (older history) listed under their key. `readUserInputQuestions` reads the questions structurally from the request payload.
- Web and mobile pair each `user-input.resolved` row with its `user-input.requested` row by `requestId` while deriving work-log entries and set the formatted answers as the row's detail. The row keeps its icon and label; it just becomes expandable and shows the exchange. Rows already carrying a detail are left alone.

No server or contract change: the answers were always in the payload.

## Verification

- `userInputAnswers.test.ts`: ordering, multi-select joining, unknown keys, blank answers, malformed questions.
- Web `session-logic.test.ts` and mobile `threadActivity.test.ts`: the resolved row gets the answers labelled by their questions, and a resolved row without a matching request still lists what was typed.
- Typecheck for client-runtime, web and mobile.

## Before

main, Claude Haiku asked through AskUserQuestion ("Approach": Minimal fix / Full rewrite), answered from the card: the submitted row is a bare label with nothing to expand.

![Before: bare User input submitted row](https://raw.githubusercontent.com/Mnigos/t3code/pr-assets/user-input-answers/10417-before-rows.png)

## After

Same exchange on this branch. On web the timeline already prefers a row's detail as its label for rows like this, so the answer is readable without expanding and the expanded body repeats it; on mobile the row keeps its "User input submitted" heading with the answer as the preview line.

![After: row shows Approach: Minimal fix](https://raw.githubusercontent.com/Mnigos/t3code/pr-assets/user-input-answers/10417-after-rows.png)

Playwright screenshots at 2x of the dev web client (full window: [before](https://raw.githubusercontent.com/Mnigos/t3code/pr-assets/user-input-answers/10417-before-full.png), [after](https://raw.githubusercontent.com/Mnigos/t3code/pr-assets/user-input-answers/10417-after-full.png)).

Implemented with Claude Code (Claude Fable 5).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Resolved user-input activities now display submitted answers directly in the work log across mobile and web.
  - Answers are labeled with their corresponding question text for easier review.
  - Multi-select responses are shown in a readable format, while other response types are formatted clearly.
  - Answers without a matching question are still displayed using their original keys.
  - Blank responses are omitted from displayed answer details.

- **Bug Fixes**
  - Malformed question entries no longer prevent valid questions from being displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->