### PR TITLE
fix(web): keep composer expanded when clicking model row padding

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -4787,11 +4787,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         if (isInteractive) return;
 
         setIsComposerScrollCollapsed(false);
-        if (isComposerResting && !target.closest('[data-testid="composer-editor"]')) {
-          // Clicking resting-surface padding would otherwise blur the still
-          // focused editor after pointerdown: expansion starts, the blur check
-          // runs, and it immediately collapses again. Treat that padding like
-          // the editor without stealing native caret placement from text.
+        if (
+          (isComposerResting ||
+            (!isMobileViewport && target.closest('[data-chat-composer-footer="true"]'))) &&
+          !target.closest('[data-testid="composer-editor"]')
+        ) {
+          // Resting-surface and desktop footer padding must keep editor focus
+          // so the blur check does not collapse the composer after the click.
+          // Leave editor clicks alone for native caret placement and selection.
           event.preventDefault();
           setIsComposerFocused(true);
           scheduleComposerFocus();


### PR DESCRIPTION
Clicking the empty space beside the model selector blurred the editor and collapsed the expanded composer. Preserve editor focus for desktop footer padding while retaining native button actions, editor selection, and mobile behavior.

Verified in the real web client at 1280px/dark and 1024px/light: the original row click collapsed the composer from 142px to 48px; repeated clicks after the fix retain 142px. Model selection, editor caret placement, and outside-click collapse still work. The 58 focused tests, web typecheck, targeted lint (existing warnings), and formatting checks pass. Both independent final reviews found no code issues on `21558fe83`.

![composer remains expanded after clicking model row padding](https://uploads-production-47e4.up.railway.app/files/a757815f-a496-4d8a-b7fd-52ae7318ccd7/after.png)

Recording evidence is blocked: the preview saved before/after videos on the desktop host and returned local paths, while this agent runs on Linux. The videos cannot yet be downloaded, watched, or uploaded through the available connection. This screenshot supplements the runtime checks; recording evidence remains outstanding.

Implemented with `gpt-5.6-sol` in Codex.
