### PR TITLE
perf(web): speed up diff file sorting

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -409,12 +409,14 @@ export default function DiffPanel({
     if (!renderablePatch || renderablePatch.kind !== "files") {
       return [];
     }
-    return renderablePatch.files.toSorted((left, right) =>
-      resolveFileDiffPath(left).localeCompare(resolveFileDiffPath(right), undefined, {
+    let collator: Intl.Collator | undefined;
+    return renderablePatch.files.toSorted((left, right) => {
+      collator ??= new Intl.Collator(undefined, {
         numeric: true,
         sensitivity: "base",
-      }),
-    );
+      });
+      return collator.compare(resolveFileDiffPath(left), resolveFileDiffPath(right));
+    });
   }, [renderablePatch]);
   const renderableFileEntries = useMemo(
     () =>


### PR DESCRIPTION
## What Changed

`DiffPanel` repeats locale setup while comparing file paths in a patch. Create an `Intl.Collator` on the first comparison and reuse it for the rest of the sort, with the existing default locale, numeric ordering, and base sensitivity. This applies the folder-menu optimization from #10190 to the diff panel.

## Why

Sorting 500 tracked repository paths in Git order took 5.48 ms before and 0.11 ms after in a warmed Node 24.14.0 benchmark on Windows (median of 25 batches). This compares the actual memo bodies using synthetic patches; it measures sorting, excluding parsing and rendering.

## Verification

- Output matched the baseline for numeric names, case/leading-zero ties, Unicode paths, and renamed/deleted files; the input array stayed unchanged.
- `diffRendering.test.ts` and `diffFileTree.logic.test.ts`: 14 tests passed.
- Web typecheck, targeted formatting, and `git diff --check` passed. Targeted lint reports only two warnings reproduced on the original file.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

No appearance or interaction changes.

Implemented with GPT-6 through Codex desktop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved file path sorting efficiency in the diff panel while preserving the existing sort order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->