### PR TITLE
fix(server): run OpenCode CLI commands sequentially

### DIFF
--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -945,10 +945,11 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
           ...commandContext,
         }).pipe(Effect.exit);
 
-      // First attempt — run all inventory commands in parallel.
+      // Every OpenCode CLI command opens the same shared SQLite database. Running them
+      // concurrently causes "database is locked" failures, so run them one at a time.
       const [initialModelsResult, initialAgentsResult, initialSkillsResult] = yield* Effect.all(
         [runModelsCli(), runAgentsCli(), runSkillsCli()],
-        { concurrency: "unbounded" },
+        { concurrency: 1 },
       );
       let modelsResult = initialModelsResult;
       let agentsResult = initialAgentsResult;
@@ -966,7 +967,7 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
             needsAgentsRetry ? runAgentsCli() : Effect.succeed(agentsResult),
             needsSkillsRetry ? runSkillsCli() : Effect.succeed(skillsResult),
           ],
-          { concurrency: "unbounded" },
+          { concurrency: 1 },
         );
         modelsResult = m2;
         agentsResult = a2;


### PR DESCRIPTION
OpenCode startup runs `models --verbose`, `agent list`, and `debug skill` at the same time. Every OpenCode CLI command opens the same shared SQLite database, so the concurrent runs fail with "database is locked" and the provider exits with `OpenCode server exited before startup completed (code: 1)`. The one second retry does not reliably cover this, and a second session in the desktop app can hard fail until restart.

The fix runs the three inventory commands one at a time in both the initial pass and the retry pass. The retry stays as it was. A comment above the call explains the SQLite constraint.

Closes #9208

Created by Claude Fable 5.1 in Claude Code.