### PR TITLE
fix(web): retry failed thread loads

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -69,7 +69,7 @@ import {
   resolveTerminalSessionLabel,
 } from "@t3tools/shared/terminalLabels";
 import { Debouncer } from "@tanstack/react-pacer";
-import { useAtomValue } from "@effect/atom-react";
+import { useAtomRefresh, useAtomValue } from "@effect/atom-react";
 import {
   lazy,
   memo,
@@ -289,7 +289,7 @@ import {
   serverEnvironment,
 } from "../state/server";
 import { terminalEnvironment } from "../state/terminal";
-import { threadEnvironment, useEnvironmentThread } from "../state/threads";
+import { environmentThreads, threadEnvironment, useEnvironmentThread } from "../state/threads";
 import {
   requestOlderThreadTurns,
   threadHasOlderTurns,
@@ -405,7 +405,7 @@ import {
   toolGroupConsumesUpwardNavigation,
   waitForStartedServerThread,
 } from "./ChatView.logic";
-import type { ThreadSyncPhase } from "../threadSync";
+import { resolveThreadSyncPhase } from "../threadSync";
 import { useLocalStorage } from "~/hooks/useLocalStorage";
 import { useComposerHandleContext } from "../composerHandleContext";
 import {
@@ -652,7 +652,6 @@ type ChatViewProps =
       onDiffPanelOpen?: () => void;
       reserveTitleBarControlInset?: boolean;
       forceExpandedMobileComposer?: boolean;
-      threadSyncPhase?: ThreadSyncPhase | null;
       routeKind: "server";
       draftId?: never;
     }
@@ -662,7 +661,6 @@ type ChatViewProps =
       onDiffPanelOpen?: () => void;
       reserveTitleBarControlInset?: boolean;
       forceExpandedMobileComposer?: boolean;
-      threadSyncPhase?: never;
       routeKind: "draft";
       draftId: DraftId;
     };
@@ -1376,8 +1374,6 @@ export default function ChatView(props: ChatViewProps) {
     forceExpandedMobileComposer = false,
   } = props;
   const draftId = routeKind === "draft" ? props.draftId : null;
-  const threadSyncPhase = routeKind === "server" ? (props.threadSyncPhase ?? null) : null;
-  const threadDetailLoading = threadSyncPhase === "loading";
   const handleNewThread = useNewThreadHandler();
   const { settleThread, pinThread, confirmAndUnpinThread } = useThreadActions();
   const routeThreadRef = useMemo(
@@ -1446,6 +1442,23 @@ export default function ChatView(props: ChatViewProps) {
   );
   const routeServerThreadShell = useThreadShell(routeKind === "server" ? routeThreadRef : null);
   const serverThread = useThread(routeThreadRef, { waitForShell: draftThread !== null });
+  const routeThreadState = useEnvironmentThread(
+    routeKind === "server" ? routeThreadRef.environmentId : null,
+    routeKind === "server" ? routeThreadRef.threadId : null,
+  );
+  const retryThreadSync = useAtomRefresh(environmentThreads.stateAtom(environmentId, threadId));
+  const threadSyncError =
+    routeThreadState.error._tag === "Some" ? routeThreadState.error.value : null;
+  const threadDetailLoading =
+    routeServerThreadShell !== null &&
+    serverThread === null &&
+    routeThreadState.status !== "deleted";
+  const threadSyncPhase = resolveThreadSyncPhase({
+    detailExists: serverThread !== null,
+    shellExists: routeServerThreadShell !== null,
+    status: routeThreadState.status,
+    error: threadSyncError,
+  });
   const loadingServerThread = useMemo(
     () =>
       threadDetailLoading && routeServerThreadShell
@@ -1456,10 +1469,6 @@ export default function ChatView(props: ChatViewProps) {
   const activeServerThread = serverThread ?? loadingServerThread;
   // Pagination window state for the routed server thread: drives the
   // "load earlier turns" header when the loaded window has older history.
-  const routeThreadState = useEnvironmentThread(
-    routeKind === "server" ? routeThreadRef.environmentId : null,
-    routeKind === "server" ? routeThreadRef.threadId : null,
-  );
   const loadEarlierTurns = useMemo(() => {
     if (routeKind !== "server" || !threadHasOlderTurns(routeThreadState)) {
       return null;
@@ -7831,12 +7840,17 @@ export default function ChatView(props: ChatViewProps) {
                 onOpenProviderSetup={openProviderSetup}
               />
               <ThreadErrorBanner
-                error={visibleThreadError}
-                onDismiss={() => {
-                  setThreadError(activeThread.id, null);
-                  dismissThreadErrorBannerForSession(threadErrorBannerKey);
-                  setThreadErrorBannerDismissTick((tick) => tick + 1);
-                }}
+                error={threadSyncError ?? visibleThreadError}
+                onRetry={threadSyncError === null ? undefined : retryThreadSync}
+                onDismiss={
+                  threadSyncError === null
+                    ? () => {
+                        setThreadError(activeThread.id, null);
+                        dismissThreadErrorBannerForSession(threadErrorBannerKey);
+                        setThreadErrorBannerDismissTick((tick) => tick + 1);
+                      }
+                    : undefined
+                }
               />
             </div>
             {/* Messages Wrapper */}

--- a/apps/web/src/components/chat/ThreadErrorBanner.tsx
+++ b/apps/web/src/components/chat/ThreadErrorBanner.tsx
@@ -36,9 +36,11 @@ export function isThreadErrorBannerDismissedForSession(bannerKey: string | null)
 export const ThreadErrorBanner = memo(function ThreadErrorBanner({
   error,
   onDismiss,
+  onRetry,
 }: {
   error: string | null;
-  onDismiss?: () => void;
+  onDismiss?: (() => void) | undefined;
+  onRetry?: (() => void) | undefined;
 }) {
   if (!error) return null;
   return (
@@ -58,11 +60,18 @@ export const ThreadErrorBanner = memo(function ThreadErrorBanner({
             </TooltipPopup>
           </Tooltip>
         </AlertDescription>
-        {onDismiss && (
+        {(onRetry || onDismiss) && (
           <AlertAction>
-            <Button variant="ghost" size="icon-xs" aria-label="Dismiss error" onClick={onDismiss}>
-              <XIcon className="text-destructive" />
-            </Button>
+            {onRetry && (
+              <Button variant="ghost" size="xs" onClick={onRetry}>
+                Retry
+              </Button>
+            )}
+            {onDismiss && (
+              <Button variant="ghost" size="icon-xs" aria-label="Dismiss error" onClick={onDismiss}>
+                <XIcon className="text-destructive" />
+              </Button>
+            )}
           </AlertAction>
         )}
       </Alert>

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -5,7 +5,6 @@ import ChatView from "../components/ChatView";
 import { threadHasStarted } from "../components/ChatView.logic";
 import { finalizePromotedDraftThreadByRef, useComposerDraftStore } from "../composerDraftStore";
 import { resolveThreadRouteRef, resolveThreadRouteRenderState } from "../threadRoutes";
-import { resolveThreadSyncPhase } from "../threadSync";
 import { SidebarInset } from "~/components/ui/sidebar";
 import {
   useEnvironmentThreadRefs,
@@ -49,11 +48,6 @@ function ChatThreadRouteView() {
     serverThreadDetailDeleted: serverThreadStatus === "deleted",
     draftThreadExists,
   });
-  const threadSyncPhase = resolveThreadSyncPhase({
-    detailExists: serverThreadDetail !== null,
-    shellExists: serverThreadShell !== null,
-    status: serverThreadStatus,
-  });
   const serverThreadStarted = threadHasStarted(serverThreadDetail);
   const environmentHasAnyThreads = environmentHasServerThreads || environmentHasDraftThreads;
 
@@ -85,7 +79,6 @@ function ChatThreadRouteView() {
           environmentId={threadRef.environmentId}
           threadId={threadRef.threadId}
           routeKind="server"
-          threadSyncPhase={threadSyncPhase}
         />
       ) : null}
     </SidebarInset>

--- a/apps/web/src/state/threads.ts
+++ b/apps/web/src/state/threads.ts
@@ -16,7 +16,7 @@ import { connectionAtomRuntime } from "../connection/runtime";
 import { environmentSnapshotAtom } from "./shell";
 
 export const threadEnvironment = createThreadEnvironmentAtoms(connectionAtomRuntime);
-const environmentThreads = createEnvironmentThreadStateAtoms(connectionAtomRuntime);
+export const environmentThreads = createEnvironmentThreadStateAtoms(connectionAtomRuntime);
 export const environmentThreadDetails = createEnvironmentThreadDetailAtoms(
   environmentThreads.stateAtom,
 );

--- a/apps/web/src/threadSync.test.ts
+++ b/apps/web/src/threadSync.test.ts
@@ -3,6 +3,22 @@ import { describe, expect, it } from "vite-plus/test";
 import { resolveThreadSyncPhase } from "./threadSync";
 
 describe("resolveThreadSyncPhase", () => {
+  it.each([false, true])(
+    "does not report progress after a failed load (detail: %s)",
+    (detailExists) => {
+      const failed = {
+        detailExists,
+        shellExists: true,
+        status: "synchronizing" as const,
+        error: "Could not synchronize the thread.",
+      };
+      expect(resolveThreadSyncPhase(failed)).toBeNull();
+      expect(resolveThreadSyncPhase({ ...failed, error: null })).toBe(
+        detailExists ? "syncing" : "loading",
+      );
+    },
+  );
+
   it("loads when only shell data is available", () => {
     expect(
       resolveThreadSyncPhase({

--- a/apps/web/src/threadSync.ts
+++ b/apps/web/src/threadSync.ts
@@ -6,8 +6,9 @@ export function resolveThreadSyncPhase(input: {
   readonly detailExists: boolean;
   readonly shellExists: boolean;
   readonly status: EnvironmentThreadStatus;
+  readonly error?: string | null;
 }): ThreadSyncPhase | null {
-  if (!input.shellExists) {
+  if (!input.shellExists || input.error != null) {
     return null;
   }
 

--- a/packages/client-runtime/src/state/threads-atoms.test.ts
+++ b/packages/client-runtime/src/state/threads-atoms.test.ts
@@ -394,6 +394,35 @@ describe("createEnvironmentThreadStateAtoms", () => {
       }),
   );
 
+  it.effect.each([true, false])(
+    "refreshes a failed load while still mounted (empty: %s)",
+    (httpNone) =>
+      Effect.gen(function* () {
+        const h = yield* makeHarness({ connected: true, httpNone });
+        const unmount = h.registry.mount(h.stateAtom);
+        const first = yield* Queue.take(h.subscriptions);
+        yield* Queue.failCause(first.events, Cause.die(new Error("snapshot failed")));
+        yield* Deferred.await(first.closed);
+        yield* observeState(h.registry, h.stateAtom, (state) => Option.isSome(state.error));
+
+        h.registry.refresh(h.rawAtoms.stateAtom(h.ref.environmentId, h.ref.threadId));
+        const next = yield* Queue.take(h.subscriptions);
+        expect(h.registry.get(h.stateAtom).error).toEqual(Option.none());
+        yield* Queue.offer(next.events, { kind: "snapshot", snapshot: SNAPSHOT });
+        yield* Queue.offer(next.events, { kind: "synchronized" });
+        const recovered = yield* observeState(
+          h.registry,
+          h.stateAtom,
+          (state) => state.status === "live",
+        );
+        expect(recovered.data).toEqual(Option.some(THREAD));
+        expect(recovered.error).toEqual(Option.none());
+        expect(h.counts().active).toBe(1);
+        unmount();
+        yield* Deferred.await(next.closed);
+      }),
+  );
+
   it.effect("retries a protocol failure on foreground without replacing the session", () =>
     Effect.gen(function* () {
       const h = yield* makeHarness({ connected: true, httpNone: true });


### PR DESCRIPTION
Failed thread subscriptions left web/desktop showing “Loading messages…” even after the runtime recorded an error. Show that error in the existing banner and let Retry refresh the thread atom on the current connection. Keep the thread shell visible and sending blocked while history is missing; cached history and ordinary dismissible session errors keep their existing behavior.

Fixes #10418. Reproduced with an injected subscription failure in an isolated local web client, then verified a failed retry and successful recovery after removing the fault, without restarting the app. This confirms the stuck-loading path, not disk exhaustion as the original trigger. The temporary fault and synthetic data are not included in the diff.

Verification: 67 focused tests pass, including failed-load presentation and mounted-atom recovery with empty/cached history. Web and client-runtime typechecks pass. Scoped lint and React Doctor report existing warnings only. Web and desktop share this view; mobile, provider adapters, contracts, and connection transports are unchanged. Browser verification used the local web client, not a packaged desktop build.

| Before | After |
| --- | --- |
| ![Failed subscription still shows Loading messages](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-10418/t3-10418-before.png) | ![Failed subscription shows its error and Retry](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-10418/t3-10418-after.png) |

[Retry recording: failure persists, then history recovers without restart](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-10418/t3-10418-retry.mp4)

Model: GPT-6. Harness: Codex in T3 Code.
