### PR TITLE
fix(web): render stored HEIC attachments

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -118,6 +118,7 @@ import {
   type ComposerBannerStackItem,
 } from "./ComposerBannerStack";
 import { compressImageForStash, prepareImageForAttachment } from "../../lib/imageCompression";
+import { AttachmentImage } from "../media/AttachmentImage";
 import {
   fileAttachmentTooLargeMessage,
   formatAttachmentSize,
@@ -3932,7 +3933,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
             }}
           >
             {image.previewUrl ? (
-              <img src={image.previewUrl} alt="" className="size-full object-cover" />
+              <AttachmentImage
+                name={image.name}
+                mimeType={image.mimeType}
+                src={image.previewUrl}
+                alt=""
+                className="size-full object-cover"
+              />
             ) : (
               <PierreEntryIcon
                 pathValue={image.name}
@@ -5400,7 +5407,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                                   onExpandImage(preview);
                                 }}
                               >
-                                <img
+                                <AttachmentImage
+                                  name={image.name}
+                                  mimeType={image.mimeType}
                                   src={image.previewUrl}
                                   alt={image.name}
                                   className="h-full w-full object-cover"

--- a/apps/web/src/components/chat/ExpandedImageDialog.tsx
+++ b/apps/web/src/components/chat/ExpandedImageDialog.tsx
@@ -218,6 +218,7 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
               key={`${index}:${item.src}`}
               src={item.src}
               name={item.name}
+              mimeType={item.mimeType}
               onError={() => setFailedImageSrc(item.src)}
             />
           )}

--- a/apps/web/src/components/chat/ExpandedImagePreview.test.ts
+++ b/apps/web/src/components/chat/ExpandedImagePreview.test.ts
@@ -42,6 +42,27 @@ describe("resolveMarkdownMediaPreview", () => {
 });
 
 describe("buildExpandedImagePreview", () => {
+  it("keeps MIME type for stored images without a filename extension", () => {
+    const preview = buildExpandedImagePreview(
+      [
+        {
+          type: "image",
+          id: "heic-1",
+          name: "photo",
+          mimeType: "image/heic",
+          sizeBytes: 3,
+          previewUrl: "blob:heic",
+        },
+      ],
+      "heic-1",
+    );
+    expect(preview?.images[0]).toMatchObject({
+      name: "photo",
+      mimeType: "image/heic",
+      src: "blob:heic",
+    });
+  });
+
   it("keeps window capture details with the expanded image", () => {
     const source = {
       kind: "snap-shot" as const,

--- a/apps/web/src/components/chat/ExpandedImagePreview.tsx
+++ b/apps/web/src/components/chat/ExpandedImagePreview.tsx
@@ -24,6 +24,7 @@ export interface ExpandedImageItem {
   /** A loadable URL, or null when the dialog must mint one from `asset` first. */
   src: string | null;
   name: string;
+  mimeType?: string;
   type?: "video";
   source?: SnapShotSource;
   autoPlay?: boolean;
@@ -144,7 +145,15 @@ export function buildExpandedImagePreview(
   }
   const previewableImages = images.flatMap((image) =>
     image.type === "image" && image.previewUrl
-      ? [{ id: image.id, src: image.previewUrl, name: image.name, source: image.source }]
+      ? [
+          {
+            id: image.id,
+            src: image.previewUrl,
+            name: image.name,
+            mimeType: image.mimeType,
+            source: image.source,
+          },
+        ]
       : [],
   );
   if (previewableImages.length === 0) {
@@ -158,6 +167,7 @@ export function buildExpandedImagePreview(
     images: previewableImages.map((image) => ({
       src: image.src,
       name: image.name,
+      mimeType: image.mimeType,
       ...(image.source?.kind === "snap-shot" ? { source: image.source } : {}),
     })),
     index: selectedIndex,

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -112,6 +112,7 @@ import {
 } from "lucide-react";
 import { Button } from "../ui/button";
 import { useAssetUrlRefresh, useAssetUrls, useAssetUrlState } from "../../assets/assetUrls";
+import { AttachmentImage } from "../media/AttachmentImage";
 import { MediaVideoPlayer } from "../media/MediaVideoPlayer";
 import { getVirtualizedScrollFadeClassName } from "../ui/scroll-area";
 import {
@@ -1457,7 +1458,9 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
                       ctx.onImageExpand(preview);
                     }}
                   >
-                    <img
+                    <AttachmentImage
+                      name={image.name}
+                      mimeType={image.mimeType}
                       src={image.previewUrl}
                       alt={image.name}
                       className="block size-full object-cover"

--- a/apps/web/src/components/chat/ZoomableImage.tsx
+++ b/apps/web/src/components/chat/ZoomableImage.tsx
@@ -8,6 +8,8 @@ import {
   type Ref,
 } from "react";
 
+import { AttachmentImage } from "../media/AttachmentImage";
+
 const MAX_ZOOM = 8;
 
 export interface ZoomableImageHandle {
@@ -18,11 +20,13 @@ export interface ZoomableImageHandle {
 export function ZoomableImage({
   src,
   name,
+  mimeType,
   onError,
   ref,
 }: {
   src: string;
   name: string;
+  mimeType?: string | undefined;
   onError: () => void;
   ref?: Ref<ZoomableImageHandle>;
 }) {
@@ -216,7 +220,9 @@ export function ZoomableImage({
           setDragging(false);
         }}
       >
-        <img
+        <AttachmentImage
+          name={name}
+          mimeType={mimeType}
           src={src}
           alt={name}
           draggable={false}

--- a/apps/web/src/components/media/AttachmentImage.test.tsx
+++ b/apps/web/src/components/media/AttachmentImage.test.tsx
@@ -1,0 +1,98 @@
+import { act, type SyntheticEvent } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, expect, it, vi } from "vite-plus/test";
+import { AttachmentImage } from "./AttachmentImage";
+import { prepareImageForAttachment } from "../../lib/imageCompression";
+
+vi.mock("../../lib/imageCompression", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../lib/imageCompression")>()),
+  prepareImageForAttachment: vi.fn(),
+}));
+
+let renderer: ReactTestRenderer;
+const fetchImage = vi.fn();
+const revokeUrl = vi.fn();
+const decodeError = {} as SyntheticEvent<HTMLImageElement>;
+const jpeg = new File(["jpeg"], "photo.jpg", { type: "image/jpeg" });
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("fetch", fetchImage);
+  vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:jpeg");
+  vi.spyOn(URL, "revokeObjectURL").mockImplementation(revokeUrl);
+  fetchImage.mockResolvedValue(new Response(new Blob(["heic"])));
+  vi.mocked(prepareImageForAttachment).mockResolvedValue({
+    ok: true,
+    file: jpeg,
+    recompressed: true,
+  });
+});
+
+afterEach(async () => {
+  await act(() => renderer?.unmount());
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+it.each([
+  { name: "photo.HEIC", mimeType: undefined },
+  { name: "photo", mimeType: "image/heif" },
+])(
+  "converts $name after native decoding fails and releases its preview",
+  async ({ name, mimeType }) => {
+    await act(() => {
+      renderer = create(
+        <AttachmentImage src="https://environment.test/photo" name={name} mimeType={mimeType} />,
+      );
+    });
+    expect(fetchImage).not.toHaveBeenCalled();
+    await act(() => renderer.root.findByType("img").props.onError(decodeError));
+    expect(renderer.root.findByType("img").props.src).toBe("blob:jpeg");
+    expect(prepareImageForAttachment).toHaveBeenCalledWith(
+      expect.objectContaining({ name, type: "image/heic" }),
+      50 * 1024 * 1024,
+    );
+    await act(() => renderer.unmount());
+    expect(revokeUrl).toHaveBeenCalledWith("blob:jpeg");
+  },
+);
+
+it("leaves PNG errors to the caller without fetching or converting", async () => {
+  const onError = vi.fn();
+  await act(() => {
+    renderer = create(<AttachmentImage src="blob:png" name="photo.png" onError={onError} />);
+  });
+  await act(() => renderer.root.findByType("img").props.onError(decodeError));
+  expect(onError).toHaveBeenCalledWith(decodeError);
+  expect(fetchImage).not.toHaveBeenCalled();
+});
+
+it("reports failed HEIC conversion through the existing error handler", async () => {
+  const onError = vi.fn();
+  vi.mocked(prepareImageForAttachment).mockResolvedValue({ ok: false, reason: "unreadable" });
+  await act(() => {
+    renderer = create(<AttachmentImage src="blob:heic" name="photo.heif" onError={onError} />);
+  });
+  await act(() => renderer.root.findByType("img").props.onError(decodeError));
+  expect(onError).toHaveBeenCalledWith(decodeError);
+  expect(URL.createObjectURL).not.toHaveBeenCalled();
+});
+
+it("discards an old decode when navigating to a different source", async () => {
+  let finishDecode!: (result: Awaited<ReturnType<typeof prepareImageForAttachment>>) => void;
+  vi.mocked(prepareImageForAttachment).mockReturnValue(
+    new Promise((resolve) => {
+      finishDecode = resolve;
+    }),
+  );
+  await act(() => {
+    renderer = create(<AttachmentImage src="blob:first" name="photo.heic" />);
+  });
+  await act(() => renderer.root.findByType("img").props.onError(decodeError));
+  await act(() => renderer.update(<AttachmentImage src="blob:second" name="photo.heic" />));
+  await act(() => finishDecode({ ok: true, file: jpeg, recompressed: true }));
+  expect(renderer.root.findByType("img").props.src).toBe("blob:second");
+  expect(URL.createObjectURL).not.toHaveBeenCalled();
+  expect(fetchImage.mock.calls[0]?.[1].signal.aborted).toBe(true);
+});

--- a/apps/web/src/components/media/AttachmentImage.tsx
+++ b/apps/web/src/components/media/AttachmentImage.tsx
@@ -1,0 +1,62 @@
+import {
+  useEffect,
+  useEffectEvent,
+  useState,
+  type ComponentProps,
+  type SyntheticEvent,
+} from "react";
+import {
+  isHeicImageFile,
+  MAX_COMPRESSIBLE_SOURCE_BYTES,
+  prepareImageForAttachment,
+} from "../../lib/imageCompression";
+
+type AttachmentImageProps = ComponentProps<"img"> & { name: string; mimeType?: string | undefined };
+
+export function AttachmentImage({ name, mimeType, ...props }: AttachmentImageProps) {
+  return isHeicImageFile({ name, type: mimeType ?? "" }) ? (
+    <HeicImage key={props.src} {...props} name={name} />
+  ) : (
+    <img {...props} />
+  );
+}
+
+function HeicImage({ name, src, onError, ...props }: Omit<AttachmentImageProps, "mimeType">) {
+  const [decodeError, setDecodeError] = useState<SyntheticEvent<HTMLImageElement> | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string>();
+
+  const reportError = useEffectEvent((event: SyntheticEvent<HTMLImageElement>) => onError?.(event));
+
+  useEffect(() => {
+    if (!decodeError || !src) return;
+    const controller = new AbortController();
+    let objectUrl: string | undefined;
+    const decode = async () => {
+      try {
+        const response = await fetch(src, { signal: controller.signal });
+        if (!response.ok) return reportError(decodeError);
+        const blob = await response.blob();
+        if (controller.signal.aborted) return;
+        const result = await prepareImageForAttachment(
+          new File([blob], name, { type: "image/heic" }),
+          MAX_COMPRESSIBLE_SOURCE_BYTES,
+        );
+        if (controller.signal.aborted) return;
+        if (!result.ok) return reportError(decodeError);
+        objectUrl = URL.createObjectURL(result.file);
+        setPreviewUrl(objectUrl);
+      } catch {
+        if (!controller.signal.aborted) reportError(decodeError);
+      }
+    };
+    void decode();
+    return () => {
+      controller.abort();
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [decodeError, name, src]);
+
+  return (
+    <img {...props} src={previewUrl ?? src} onError={decodeError ? onError : setDecodeError} />
+  );
+}


### PR DESCRIPTION
Stored HEIC photos uploaded from another client render as broken images on Desktop. Upload-time conversion only helps newly attached files.

Reuse the existing HEIC decoder when native image decoding fails, through one shared component used by the timeline, composer thumbnails, and lightbox. The lightbox keeps `ZoomableImage` and its sizing/interaction handlers, using the fallback only for its inner image. MIME type and snapshot source metadata stay attached to the preview. Ordinary images stay on the native path. Converted preview URLs are released on unmount, and navigation discards unfinished conversions. Stored attachments remain unchanged.

Fixes #10356.

Verified 40 focused tests, web typecheck, scoped lint, and formatting. In Chromium against an isolated server, all eight stored HEIC images went from `naturalWidth: 0` to `1280`; lightbox navigation and a restored HEIC composer draft also rendered correctly. Web and Desktop share these components; the packaged Electron app was not rebuilt. Mobile and workspace-file previews are unchanged. React Doctor reports no compiler errors; its async-state/error-forwarding warnings remain on the cancellation-guarded fallback, whose stale-decode behavior is tested.

| Timeline before | Timeline after |
| --- | --- |
| ![Stored HEIC attachments fail to decode](https://github.com/user-attachments/assets/1c6f4c35-f9a0-49de-9eb9-6d9a8d852947) | ![All eight stored HEIC attachments render](https://github.com/user-attachments/assets/1a3d8e55-23ce-4e07-a44f-41f0a4c0edf5) |

![HEIC lightbox after navigating to the next image](https://github.com/user-attachments/assets/8cd1ecbf-7f8a-4f13-a122-d3ae84a4525b)

Current lightbox verification in Chromium with a real HEIC component fixture: an extensionless image decodes to 1280×854, click zoom reaches 200%, arrow keys pan while zoomed and navigate at fit, and snapshot accessibility text remains available.

https://github.com/user-attachments/assets/2702132f-8ac6-4992-8aa8-f123b019802b

Model: GPT-6. Harness: Codex in T3 Code.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved image attachment previews, including support for HEIC and HEIF images that cannot be displayed natively.
  * Added automatic conversion and preview handling for compatible image attachments.
  * Preserved image metadata and previews for files without filename extensions.
  * Extended zoomable and expanded image views to retain MIME type information.

* **Bug Fixes**
  * Improved cleanup and cancellation of image processing when previews change or are closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->