### PR TITLE
fix(web): show load balancing note for a single machine

### DIFF
--- a/apps/web/src/components/settings/LoadBalancingSettings.tsx
+++ b/apps/web/src/components/settings/LoadBalancingSettings.tsx
@@ -27,6 +27,16 @@ export function LoadBalancingSettings({
   const settingsHydrated = useClientSettingsHydrated();
   const updateSettings = useUpdateClientSettings();
 
+  if (environments.length < 2) {
+    return (
+      <SettingsSection {...searchableSetting("load-balancing")} variant="plain">
+        <p className="px-3 text-sm text-muted-foreground sm:px-4">
+          Connect another machine to automatically balance load across environments.
+        </p>
+      </SettingsSection>
+    );
+  }
+
   return (
     <SettingsSection {...searchableSetting("load-balancing")}>
       <SettingsRow


### PR DESCRIPTION
Load balancing showed actionable controls with only one machine. Clients with fewer than two saved environments now see a muted note explaining that another machine is needed; the existing controls and saved preferences remain available with multiple environments.

Verified in the real web client at desktop and narrow widths in dark/light themes, including the settings search destination and pairing a second environment. Web typecheck, targeted lint, and 22 existing settings-search tests pass.

![before: single-machine load balancing controls](https://uploads-production-47e4.up.railway.app/files/6a37d7d4-aedb-4db2-b3ce-53dd9273d754/load-balancing-before.png)

![after: single-machine load balancing note](https://uploads-production-47e4.up.railway.app/files/fb2a6713-e1b0-416f-857b-8ad068106dd6/load-balancing-after.png)

Model: gpt-5.6-sol. Harness: Codex.
