### PR TITLE
fix(mobile): show background monitoring status

### DIFF
--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -96,6 +96,7 @@ import {
   ThreadComposer,
 } from "./ThreadComposer";
 import { ThreadFeed } from "./ThreadFeed";
+import { resolveThreadStatus } from "./threadPresentation";
 import type { ThreadContentPresentation } from "./threadContentPresentation";
 import { resolveThreadFeedSubmissionAnchor } from "./thread-feed-live-follow";
 
@@ -344,6 +345,12 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
     }
     if (props.activeWorkStartedAt !== null && contentPresentationKind === "ready") {
       return { kind: "working", startedAt: props.activeWorkStartedAt };
+    }
+    if (contentPresentationKind === "ready") {
+      const status = resolveThreadStatus(props.selectedThread);
+      if (status?.kind === "monitoring" || status?.kind === "working") {
+        return { kind: "background", label: status.label };
+      }
     }
     return null;
   })();

--- a/apps/mobile/src/features/threads/floating-working-control.tsx
+++ b/apps/mobile/src/features/threads/floating-working-control.tsx
@@ -54,7 +54,8 @@ export const FLOATING_WORKING_CONTROL_COVERAGE = CONTROL_OVERLAY_OFFSET + CONTRO
 export type FloatingWorkingStatus =
   | { readonly kind: "working"; readonly startedAt: string }
   | { readonly kind: "syncing"; readonly label: string }
-  | { readonly kind: "compacting" };
+  | { readonly kind: "compacting" }
+  | { readonly kind: "background"; readonly label: string };
 
 export function FloatingWorkingControl(props: {
   readonly colorScheme: "light" | "dark";
@@ -188,14 +189,16 @@ function CompactingLabel() {
 }
 
 function FloatingStatusLabel(props: { readonly status: FloatingWorkingStatus }) {
-  if (props.status.kind === "syncing") {
+  if (props.status.kind === "syncing" || props.status.kind === "background") {
     return (
       <View
         accessible
         accessibilityLabel={props.status.label}
         className="h-11 flex-row items-center gap-2 px-4"
       >
-        <ActivityIndicator size="small" colorClassName="accent-icon-muted" />
+        {props.status.kind === "syncing" ? (
+          <ActivityIndicator size="small" colorClassName="accent-icon-muted" />
+        ) : null}
         <Text className="font-t3-medium text-xs text-foreground">{props.status.label}</Text>
       </View>
     );

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -485,6 +485,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   );
   const threadAccessibilityLabel = [
     thread.title,
+    status?.label,
     pr?.accessibilityLabel,
     props.hasQueuedMessages ? "messages queued to send" : null,
   ]

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -56,6 +56,7 @@ const STATUS_LABEL_BY_STATUS: Partial<
   approval: { label: "Approval", className: "text-warning-foreground" },
   input: { label: "Input", className: "text-foreground-secondary" },
   working: { label: "Working", className: "text-foreground-secondary" },
+  monitoring: { label: "Monitoring", className: "text-foreground-secondary" },
   failed: { label: "Failed", className: "text-danger-foreground" },
 };
 
@@ -436,6 +437,13 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
 
   const status = resolveThreadListV2Status(thread);
   const statusLabel = STATUS_LABEL_BY_STATUS[status];
+  const accessibilityLabel = [
+    thread.title,
+    statusLabel?.label,
+    props.hasQueuedMessages ? "messages queued to send" : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
   // Settled rows label by the same stamp they sort by, so order and label
   // can't disagree. updatedAt is always present, so the resolver never
   // returns null here.
@@ -834,9 +842,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
     variant === "card" ? (
       <Pressable
         accessibilityHint={swipeAccessibilityHint}
-        accessibilityLabel={
-          props.hasQueuedMessages ? `${thread.title}, messages queued to send` : thread.title
-        }
+        accessibilityLabel={accessibilityLabel}
         accessibilityRole="button"
         accessibilityState={{ selected }}
         onPress={() => {
@@ -876,9 +882,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
     ) : (
       <Pressable
         accessibilityHint={swipeAccessibilityHint}
-        accessibilityLabel={
-          props.hasQueuedMessages ? `${thread.title}, messages queued to send` : thread.title
-        }
+        accessibilityLabel={accessibilityLabel}
         accessibilityRole="button"
         accessibilityState={{ selected }}
         className={sidebarPane ? undefined : "bg-screen"}

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -32,6 +32,8 @@ import {
   sortThreadsForListV2,
 } from "./threadListV2";
 
+import { resolveThreadStatus } from "./threadPresentation";
+
 const environmentId = EnvironmentId.make("environment-1");
 
 function makeThread(
@@ -140,6 +142,67 @@ describe("resolveThreadListV2Enabled", () => {
 });
 
 describe("resolveThreadListV2Status", () => {
+  it("distinguishes background monitoring, work, and cleared liveness in both lists", () => {
+    const thread = makeThread({
+      id: ThreadId.make("t"),
+      title: "t",
+      latestTurn: {
+        turnId: TurnId.make("turn"),
+        state: "completed",
+        requestedAt: NOW,
+        startedAt: NOW,
+        completedAt: NOW,
+        assistantMessageId: null,
+      },
+    });
+    for (const backgroundLiveness of ["monitoring", "working", null] as const) {
+      const current = { ...thread, backgroundLiveness };
+      expect.soft(resolveThreadListV2Status(current)).toBe(backgroundLiveness ?? "ready");
+      const status = resolveThreadStatus(current);
+      expect.soft(status?.kind ?? null).toBe(backgroundLiveness);
+      if (backgroundLiveness !== null) {
+        expect
+          .soft(status?.label)
+          .toBe(backgroundLiveness === "monitoring" ? "Monitoring" : "Working");
+        expect.soft(status?.pulse).toBe(backgroundLiveness === "working");
+      }
+    }
+  });
+
+  it.each(["monitoring", "working"] as const)(
+    "preserves status priority over %s",
+    (backgroundLiveness) => {
+      const thread = makeThread({ id: ThreadId.make("t"), title: "t", backgroundLiveness });
+      expect(resolveThreadListV2Status({ ...thread, hasPendingApprovals: true })).toBe("approval");
+      expect(resolveThreadStatus({ ...thread, hasPendingApprovals: true })?.kind).toBe(
+        "pending-approval",
+      );
+      expect(resolveThreadListV2Status({ ...thread, hasPendingUserInput: true })).toBe("input");
+      expect(resolveThreadStatus({ ...thread, hasPendingUserInput: true })?.kind).toBe(
+        "awaiting-input",
+      );
+      for (const status of ["running", "starting", "error"] as const) {
+        const current = {
+          ...thread,
+          session: {
+            threadId: thread.id,
+            status,
+            providerName: "Codex",
+            providerInstanceId: ProviderInstanceId.make("codex"),
+            runtimeMode: "full-access" as const,
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: NOW,
+          },
+        };
+        expect(resolveThreadListV2Status(current)).toBe(status === "error" ? "failed" : "working");
+        expect(resolveThreadStatus(current)?.kind).toBe(
+          status === "running" ? "working" : status === "starting" ? "connecting" : "error",
+        );
+      }
+    },
+  );
+
   it("prioritizes approval over a running session", () => {
     const thread = makeThread({
       id: ThreadId.make("t"),

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -29,11 +29,17 @@ export { snoozeWakeLabel };
  * Thread List v2 model, ported from the web sidebar v2
  * (apps/web/src/components/Sidebar.logic.ts + SidebarV2.tsx).
  *
- * Four visual states, three colors: color is reserved for "act now"
+ * Color is reserved for "act now"
  * (approval), "in motion" (working), and "broken" (failed). Ready is the
  * unlabeled resting state.
  */
-export type ThreadListV2Status = "approval" | "input" | "working" | "failed" | "ready";
+export type ThreadListV2Status =
+  | "approval"
+  | "input"
+  | "working"
+  | "monitoring"
+  | "failed"
+  | "ready";
 export type ThreadListV2SwipeAction = "archive" | "settle" | "unsettle" | "snooze" | "unsnooze";
 
 export function resolveThreadListV2SnoozeMenuSelection(input: {
@@ -132,7 +138,10 @@ export function resolveThreadListV2Enabled(input: {
 }
 
 export function resolveThreadListV2Status(
-  thread: Pick<EnvironmentThreadShell, "hasPendingApprovals" | "hasPendingUserInput" | "session">,
+  thread: Pick<
+    EnvironmentThreadShell,
+    "hasPendingApprovals" | "hasPendingUserInput" | "session" | "backgroundLiveness"
+  >,
 ): ThreadListV2Status {
   if (thread.hasPendingApprovals) {
     return "approval";
@@ -145,6 +154,9 @@ export function resolveThreadListV2Status(
   }
   if (thread.session?.status === "error") {
     return "failed";
+  }
+  if (thread.backgroundLiveness) {
+    return thread.backgroundLiveness;
   }
   return "ready";
 }

--- a/apps/mobile/src/features/threads/threadPresentation.ts
+++ b/apps/mobile/src/features/threads/threadPresentation.ts
@@ -1,10 +1,14 @@
 import type { StatusTone } from "../../components/StatusPill";
-import type { OrchestrationLatestTurn, OrchestrationSession } from "@t3tools/contracts";
-import { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import type {
+  OrchestrationLatestTurn,
+  OrchestrationSession,
+  OrchestrationThreadShell,
+} from "@t3tools/contracts";
 
 export type ThreadStatusKind =
   | "pending-approval"
   | "awaiting-input"
+  | "monitoring"
   | "working"
   | "connecting"
   | "error"
@@ -36,7 +40,7 @@ function isLatestTurnSettled(
  * Mirrors `resolveThreadStatusPill` in apps/web/src/components/Sidebar.logic.ts.
  */
 export function resolveThreadStatus(
-  thread: EnvironmentThreadShell,
+  thread: OrchestrationThreadShell,
 ): ThreadStatusPresentation | null {
   if (thread.hasPendingApprovals) {
     return {
@@ -111,6 +115,18 @@ export function resolveThreadStatus(
       iconColor: "#bf5af2",
       iconBackground: "rgba(191,90,242,0.22)",
       pulse: false,
+    };
+  }
+
+  if (thread.backgroundLiveness) {
+    return {
+      kind: thread.backgroundLiveness,
+      label: thread.backgroundLiveness === "monitoring" ? "Monitoring" : "Working",
+      pillClassName: "bg-primary/10",
+      textClassName: "text-foreground-secondary",
+      iconColor: "#0a84ff",
+      iconBackground: "rgba(10,132,255,0.22)",
+      pulse: thread.backgroundLiveness === "working",
     };
   }
 


### PR DESCRIPTION
Mobile looked idle after a turn completed even when the server still reported background monitoring or work. Both thread lists now show Monitoring or Working, and the open thread reuses the same status resolver for its floating label. Monitoring stays static and disappears when liveness clears. Existing approval, input, error, and plan priorities are preserved.

Fixes #10372.

Verified the regression fails on the original code and passes with the fix: 62 focused tests, mobile typecheck, and scoped lint with the same 23 existing warnings. React Doctor's before/after diagnostics are unchanged. On an iPhone 17 Pro simulator, checked Monitoring, Working, and cleared liveness in the default list and open thread. The legacy list is covered by resolver tests; Android and iPad share the changed components but were not run separately.

Screenshots use a disposable environment with a completed parent turn and controlled server liveness. They verify native presentation, not a live provider watch loop. No server or contract changes ship.

| Default list: before | Default list: after |
| --- | --- |
| ![Before: monitoring thread shows only a timestamp](https://github.com/user-attachments/assets/2b1e0c2f-1166-4e81-bcc2-8dc7a6599d52) | ![After: thread shows Monitoring](https://github.com/user-attachments/assets/dedc773b-eb5a-497f-a28d-9fe4657d740e) |

| Open thread: before | Open thread: after |
| --- | --- |
| ![Before: no monitoring indicator above the composer](https://github.com/user-attachments/assets/f006d0b0-b4e9-4fc0-a248-742901e6772c) | ![After: static Monitoring label above the composer](https://github.com/user-attachments/assets/304d72c7-24f7-4d1d-b0c6-0afb49cbfecd) |

Model: GPT-6. Harness: Codex in T3 Code.
