### PR TITLE
fix(mobile): show connection status in the floating pill instead of a second one

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -26,7 +26,7 @@ import {
   useState,
   type RefObject,
 } from "react";
-import { ActivityIndicator, Alert, Platform, Pressable, View, type ViewStyle } from "react-native";
+import { Alert, Platform, Pressable, View, type ViewStyle } from "react-native";
 import { FilePreviewModal, type FilePreviewSource } from "../../components/FilePreviewModal";
 import {
   composerAttachmentUploadBlockReason,
@@ -113,7 +113,6 @@ export interface ThreadComposerProps {
   readonly contentMaxWidth?: number;
   readonly bottomInset?: number;
   readonly connectionState: RemoteClientConnectionState;
-  readonly connectionError: string | null;
   readonly environmentLabel: string | null;
   readonly selectedThread: OrchestrationThreadShell;
   readonly hasCompactableConversation: boolean;
@@ -134,7 +133,6 @@ export interface ThreadComposerProps {
   readonly onUpdateModelSelection: (modelSelection: ModelSelection) => void;
   readonly onUpdateRuntimeMode: (runtimeMode: RuntimeMode) => void;
   readonly onUpdateInteractionMode: (interactionMode: ProviderInteractionMode) => void;
-  readonly onReconnectEnvironment: () => void;
   readonly onExpandedChange?: (expanded: boolean) => void;
   /** Fires on editor focus/blur; hosts use it to vet stale keyboard state. */
   readonly onEditorFocusChange?: (focused: boolean) => void;
@@ -226,72 +224,6 @@ export function ComposerSurface(props: {
   );
 }
 
-type ComposerStatusPillState = {
-  readonly kind: "unavailable" | "reconnecting";
-  readonly label: string;
-};
-
-function composerConnectionStatus(input: {
-  readonly connectionError: string | null;
-  readonly connectionState: RemoteClientConnectionState;
-  readonly environmentLabel: string | null;
-}): ComposerStatusPillState | null {
-  const environmentLabel = input.environmentLabel ?? "Environment";
-
-  switch (input.connectionState) {
-    case "connecting":
-    case "reconnecting":
-      return {
-        kind: "reconnecting",
-        label:
-          input.connectionError === null
-            ? `Reconnecting to ${environmentLabel}...`
-            : `Failed to connect. Retrying ${environmentLabel}...`,
-      };
-    case "offline":
-      return { kind: "unavailable", label: "You are offline" };
-    case "error":
-      return {
-        kind: "unavailable",
-        label: input.connectionError
-          ? `Failed to connect to ${environmentLabel}: ${input.connectionError}`
-          : `Failed to connect to ${environmentLabel}`,
-      };
-    case "available":
-      return { kind: "unavailable", label: `${environmentLabel} is not connected` };
-    case "connected":
-      return null;
-  }
-}
-
-const ComposerConnectionStatusPill = memo(function ComposerConnectionStatusPill(props: {
-  readonly onPress: () => void;
-  readonly status: ComposerStatusPillState;
-}) {
-  const isReconnecting = props.status.kind === "reconnecting";
-  return (
-    <View className="absolute inset-x-0 bottom-full items-center pb-2" pointerEvents="box-none">
-      <Pressable
-        accessibilityRole="button"
-        onPress={props.onPress}
-        className="max-w-full flex-row items-center gap-2 rounded-full bg-card px-3 py-2 shadow-sm active:opacity-70"
-      >
-        {isReconnecting ? (
-          <ActivityIndicator size="small" colorClassName={"accent-icon-muted"} />
-        ) : (
-          <View className="h-2 w-2 rounded-full bg-red-500" />
-        )}
-        <Text
-          className="max-w-[260px] text-sm font-t3-bold leading-snug text-foreground"
-          numberOfLines={1}
-        >
-          {props.status.label}
-        </Text>
-      </Pressable>
-    </View>
-  );
-});
-
 export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposerProps) {
   const navigation = useNavigation();
   const foregroundColor = useUniwindTheme()["--color-foreground"];
@@ -337,11 +269,6 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   const modelUnavailable =
     props.connectionState === "connected" &&
     isModelSelectionUnavailable(props.serverConfig, currentModelSelection);
-  const connectionStatus = composerConnectionStatus({
-    connectionError: props.connectionError,
-    connectionState: props.connectionState,
-    environmentLabel: props.environmentLabel,
-  });
   const selectedProviderStatus = useMemo(() => {
     if (!props.serverConfig) return null;
     return (
@@ -638,13 +565,6 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
               onSelect={composerMenu.onSelect}
             />
           </View>
-        ) : null}
-
-        {connectionStatus ? (
-          <ComposerConnectionStatusPill
-            status={connectionStatus}
-            onPress={props.onReconnectEnvironment}
-          />
         ) : null}
 
         {modelUnavailable ? (

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -82,11 +82,10 @@ import { ComposerFeedback } from "./ComposerFeedback";
 import { ComposerUsageLimits } from "./ComposerUsageLimits";
 import { PendingUserInputCard } from "./PendingUserInputCard";
 import {
-  connectionFloatingStatus,
   FLOATING_WORKING_CONTROL_COVERAGE,
   FloatingWorkingControl,
-  type FloatingWorkingStatus,
 } from "./floating-working-control";
+import { connectionFloatingStatus, type FloatingWorkingStatus } from "./floating-working-status";
 import {
   derivePendingUserInputMaxHeight,
   ESTIMATED_KEYBOARD_HEIGHT,

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -82,6 +82,7 @@ import { ComposerFeedback } from "./ComposerFeedback";
 import { ComposerUsageLimits } from "./ComposerUsageLimits";
 import { PendingUserInputCard } from "./PendingUserInputCard";
 import {
+  connectionFloatingStatus,
   FLOATING_WORKING_CONTROL_COVERAGE,
   FloatingWorkingControl,
   type FloatingWorkingStatus,
@@ -331,14 +332,20 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
         return null;
     }
   })();
-  // One floating pill above the composer: it reads the sync state while
-  // messages load, then the working timer once the feed is settled.
+  // One floating pill above the composer: it reads the connection phase while
+  // disconnected, the sync state while messages load, then the working timer
+  // once the feed is settled.
   const floatingStatus = ((): FloatingWorkingStatus | null => {
-    if (
-      props.connectionStateLabel !== "connected" ||
-      props.activePendingApproval !== null ||
-      props.activePendingUserInput !== null
-    ) {
+    const connectionStatus = connectionFloatingStatus({
+      connectionError: props.connectionError,
+      connectionState: props.connectionStateLabel,
+      environmentLabel: props.environmentLabel,
+      onReconnect: props.onReconnectEnvironment,
+    });
+    if (connectionStatus !== null) {
+      return connectionStatus;
+    }
+    if (props.activePendingApproval !== null || props.activePendingUserInput !== null) {
       return null;
     }
     if (threadSyncLabel !== null) {
@@ -964,7 +971,6 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
                   placeholder="Ask the repo agent, or run a command…"
                   contentMaxWidth={contentMaxWidth}
                   connectionState={props.connectionStateLabel}
-                  connectionError={props.connectionError}
                   environmentLabel={props.environmentLabel}
                   selectedThread={props.selectedThread}
                   hasCompactableConversation={hasCompactableConversation && !props.isCompacting}
@@ -981,7 +987,6 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
                   onStopThread={props.onStopThread}
                   onSendMessage={handleSendMessage}
                   onShowUsageLimits={showUsageLimits}
-                  onReconnectEnvironment={props.onReconnectEnvironment}
                   onUpdateModelSelection={props.onUpdateThreadModelSelection}
                   onUpdateRuntimeMode={props.onUpdateThreadRuntimeMode}
                   onUpdateInteractionMode={props.onUpdateThreadInteractionMode}

--- a/apps/mobile/src/features/threads/floating-working-control.tsx
+++ b/apps/mobile/src/features/threads/floating-working-control.tsx
@@ -40,8 +40,10 @@ const CONTROL_TIMING = {
   reduceMotion: ReduceMotion.System,
 } as const;
 const CONTROL_SEPARATION = (16 + CONTROL_HEIGHT) / 2;
-const LABEL_ENTERING = FadeIn.duration(180).reduceMotion(ReduceMotion.System);
-const LABEL_EXITING = FadeOut.duration(120).reduceMotion(ReduceMotion.System);
+// Both rows share the same centered anchor, so the outgoing one clears fast and
+// the incoming one waits for it to be mostly gone before it starts to show.
+const LABEL_ENTERING = FadeIn.duration(160).delay(80).reduceMotion(ReduceMotion.System);
+const LABEL_EXITING = FadeOut.duration(100).reduceMotion(ReduceMotion.System);
 
 // Expo reapplies glass after native layout and window reattachment, when UIKit
 // can otherwise leave the label visible but lose the material behind it.
@@ -173,12 +175,16 @@ export function FloatingWorkingControl(props: {
   // Only the connection label is a button (tap to reconnect); the others
   // pass touches through to the feed like before.
   const statusInteractive = props.status?.kind === "connection";
-  // A zero-width anchor at the capsule's midpoint. Labels are centered on it
-  // and never clipped, so an incoming wider label sits at its final position
-  // while the capsule catches up underneath.
+  // A zero-width anchor at the capsule's midpoint. Yoga centers an absolute
+  // child with no insets on the parent's justify-content, so every label row
+  // lands centered on the anchor without measuring itself, and the capsule
+  // clips whatever the label overhangs while it catches up.
   const statusLabel =
     props.status !== null ? (
-      <View pointerEvents="box-none" className="absolute inset-y-0 left-1/2 w-0 overflow-visible">
+      <View
+        pointerEvents="box-none"
+        className="absolute inset-y-0 left-1/2 w-0 flex-row items-center justify-center"
+      >
         <FloatingStatusLabel status={props.status} onLayout={handleLabelLayout} />
       </View>
     ) : null;
@@ -201,7 +207,7 @@ export function FloatingWorkingControl(props: {
               view only fills it, since it does not follow animated layout props. */}
           <Animated.View
             pointerEvents={statusInteractive ? "box-none" : "none"}
-            className="h-11"
+            className="h-11 overflow-hidden rounded-full"
             style={capsuleStyle}
           >
             <UniwindGlassView
@@ -233,7 +239,7 @@ export function FloatingWorkingControl(props: {
         <View pointerEvents="box-none" className="flex-row items-center gap-4">
           <Animated.View
             pointerEvents={statusInteractive ? "box-none" : "none"}
-            className="h-11 rounded-full border border-border bg-card shadow-md shadow-black/10"
+            className="h-11 overflow-hidden rounded-full border border-border bg-card shadow-md shadow-black/10"
             style={capsuleStyle}
           >
             {statusLabel}
@@ -350,18 +356,12 @@ function StatusLabelRow(props: {
   readonly onPress?: () => void;
 }) {
   const rowClassName = `h-11 flex-row items-center px-4 ${props.className ?? ""}`;
-  const [width, setWidth] = useState<number | null>(null);
-  const handleLayout = (event: LayoutChangeEvent) => {
-    setWidth(event.nativeEvent.layout.width);
-    props.onLayout(event);
-  };
   return (
     <Animated.View
-      className="absolute top-0"
-      style={{ left: width === null ? undefined : -width / 2, opacity: width === null ? 0 : 1 }}
+      className="absolute"
       entering={LABEL_ENTERING}
       exiting={LABEL_EXITING}
-      onLayout={handleLayout}
+      onLayout={props.onLayout}
     >
       {props.onPress ? (
         <Pressable

--- a/apps/mobile/src/features/threads/floating-working-control.tsx
+++ b/apps/mobile/src/features/threads/floating-working-control.tsx
@@ -1,11 +1,13 @@
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
 import { formatDuration } from "@t3tools/shared/orchestrationTiming";
 import { GlassContainer, GlassView } from "expo-glass-effect";
-import { useEffect, useState } from "react";
-import { ActivityIndicator, Text as SystemText, View } from "react-native";
+import { type ReactNode, useEffect, useState } from "react";
+import { ActivityIndicator, Pressable, Text as SystemText, View } from "react-native";
 import Animated, {
   Easing,
   FadeIn,
   FadeOut,
+  LinearTransition,
   ReduceMotion,
   useAnimatedStyle,
   useSharedValue,
@@ -33,6 +35,14 @@ const CONTROL_TIMING = {
   reduceMotion: ReduceMotion.System,
 } as const;
 const CONTROL_SEPARATION = (16 + CONTROL_HEIGHT) / 2;
+// The label swaps between syncing, compacting, and working while the capsule
+// stays mounted, so the capsule animates to the new label's width and the
+// labels cross-fade instead of the pill snapping between sizes.
+const CAPSULE_LAYOUT = LinearTransition.duration(CONTROL_TIMING.duration)
+  .easing(CONTROL_TIMING.easing)
+  .reduceMotion(ReduceMotion.System);
+const LABEL_ENTERING = FadeIn.duration(180).reduceMotion(ReduceMotion.System);
+const LABEL_EXITING = FadeOut.duration(120).reduceMotion(ReduceMotion.System);
 
 // Expo reapplies glass after native layout and window reattachment, when UIKit
 // can otherwise leave the label visible but lose the material behind it.
@@ -48,13 +58,61 @@ const CONTROL_OVERLAY_OFFSET = CONTROL_HEIGHT + CONTROL_GAP - COMPOSER_CAPSULE_I
 export const FLOATING_WORKING_CONTROL_COVERAGE = CONTROL_OVERLAY_OFFSET + CONTROL_GAP;
 
 /**
- * What the floating pill says. Syncing and working share one element so the
- * label swaps in place instead of one pill fading out for another.
+ * What the floating pill says. Connection, syncing, and working share one
+ * element so the label swaps in place instead of one pill fading out for
+ * another. The connection variant is tappable and triggers a reconnect.
  */
 export type FloatingWorkingStatus =
   | { readonly kind: "working"; readonly startedAt: string }
   | { readonly kind: "syncing"; readonly label: string }
-  | { readonly kind: "compacting" };
+  | { readonly kind: "compacting" }
+  | {
+      readonly kind: "connection";
+      readonly tone: "reconnecting" | "unavailable";
+      readonly label: string;
+      readonly onPress: () => void;
+    };
+
+export function connectionFloatingStatus(input: {
+  readonly connectionError: string | null;
+  readonly connectionState: EnvironmentConnectionPhase;
+  readonly environmentLabel: string | null;
+  readonly onReconnect: () => void;
+}): FloatingWorkingStatus | null {
+  const environmentLabel = input.environmentLabel ?? "Environment";
+  const unavailable = (label: string): FloatingWorkingStatus => ({
+    kind: "connection",
+    tone: "unavailable",
+    label,
+    onPress: input.onReconnect,
+  });
+
+  switch (input.connectionState) {
+    case "connecting":
+    case "reconnecting":
+      return {
+        kind: "connection",
+        tone: "reconnecting",
+        label:
+          input.connectionError === null
+            ? `Reconnecting to ${environmentLabel}...`
+            : `Failed to connect. Retrying ${environmentLabel}...`,
+        onPress: input.onReconnect,
+      };
+    case "offline":
+      return unavailable("You are offline");
+    case "error":
+      return unavailable(
+        input.connectionError
+          ? `Failed to connect to ${environmentLabel}: ${input.connectionError}`
+          : `Failed to connect to ${environmentLabel}`,
+      );
+    case "available":
+      return unavailable(`${environmentLabel} is not connected`);
+    case "connected":
+      return null;
+  }
+}
 
 export function FloatingWorkingControl(props: {
   readonly colorScheme: "light" | "dark";
@@ -82,6 +140,10 @@ export function FloatingWorkingControl(props: {
     return null;
   }
 
+  // Only the connection label is a button (tap to reconnect); the others
+  // pass touches through to the feed like before.
+  const statusInteractive = props.status?.kind === "connection";
+
   return (
     <Animated.View
       pointerEvents="box-none"
@@ -99,9 +161,11 @@ export function FloatingWorkingControl(props: {
           <AnimatedGlassView
             colorScheme={props.colorScheme}
             glassEffectStyle="regular"
-            pointerEvents="none"
+            isInteractive={statusInteractive}
+            pointerEvents={statusInteractive ? "auto" : "none"}
             className="h-11 justify-center overflow-hidden rounded-full"
             style={timerStyle}
+            layout={CAPSULE_LAYOUT}
           >
             <FloatingStatusLabel status={props.status} />
           </AnimatedGlassView>
@@ -124,9 +188,10 @@ export function FloatingWorkingControl(props: {
       ) : props.status !== null ? (
         <View pointerEvents="box-none" className="flex-row items-center gap-4">
           <Animated.View
-            pointerEvents="none"
+            pointerEvents={statusInteractive ? "auto" : "none"}
             className="h-11 justify-center rounded-full border border-border bg-card shadow-md shadow-black/10"
             style={timerStyle}
+            layout={CAPSULE_LAYOUT}
           >
             <FloatingStatusLabel status={props.status} />
           </Animated.View>
@@ -171,11 +236,7 @@ export function FloatingWorkingControl(props: {
 
 function CompactingLabel() {
   return (
-    <View
-      accessible
-      accessibilityLabel="Compacting"
-      className="h-11 flex-row items-center gap-1.5 px-4"
-    >
+    <StatusLabelRow accessibilityLabel="Compacting" className="gap-1.5">
       <SymbolView
         name="arrow.down.right.and.arrow.up.left"
         size={13}
@@ -183,27 +244,73 @@ function CompactingLabel() {
         type="monochrome"
       />
       <Text className="font-t3-medium text-xs text-foreground">Compacting…</Text>
-    </View>
+    </StatusLabelRow>
   );
 }
 
 function FloatingStatusLabel(props: { readonly status: FloatingWorkingStatus }) {
+  // Keyed by kind so a swap mounts a fresh row and the two cross-fade while
+  // the capsule's layout transition carries the width change.
   if (props.status.kind === "syncing") {
     return (
-      <View
-        accessible
-        accessibilityLabel={props.status.label}
-        className="h-11 flex-row items-center gap-2 px-4"
-      >
+      <StatusLabelRow key="syncing" accessibilityLabel={props.status.label} className="gap-2">
         <ActivityIndicator size="small" colorClassName="accent-icon-muted" />
         <Text className="font-t3-medium text-xs text-foreground">{props.status.label}</Text>
-      </View>
+      </StatusLabelRow>
     );
   }
   if (props.status.kind === "compacting") {
-    return <CompactingLabel />;
+    return <CompactingLabel key="compacting" />;
   }
-  return <WorkingDuration startedAt={props.status.startedAt} />;
+  if (props.status.kind === "connection") {
+    return (
+      <StatusLabelRow
+        key="connection"
+        accessibilityLabel={props.status.label}
+        accessibilityRole="button"
+        className="gap-2"
+        onPress={props.status.onPress}
+      >
+        {props.status.tone === "reconnecting" ? (
+          <ActivityIndicator size="small" colorClassName="accent-icon-muted" />
+        ) : (
+          <View className="h-2 w-2 rounded-full bg-red-500" />
+        )}
+        <Text className="max-w-[260px] font-t3-medium text-xs text-foreground" numberOfLines={1}>
+          {props.status.label}
+        </Text>
+      </StatusLabelRow>
+    );
+  }
+  return <WorkingDuration key="working" startedAt={props.status.startedAt} />;
+}
+
+function StatusLabelRow(props: {
+  readonly accessibilityLabel: string;
+  readonly accessibilityRole?: "button";
+  readonly className?: string;
+  readonly children: ReactNode;
+  readonly onPress?: () => void;
+}) {
+  const rowClassName = `h-11 flex-row items-center px-4 ${props.className ?? ""}`;
+  return (
+    <Animated.View entering={LABEL_ENTERING} exiting={LABEL_EXITING}>
+      {props.onPress ? (
+        <Pressable
+          accessibilityLabel={props.accessibilityLabel}
+          accessibilityRole={props.accessibilityRole}
+          className={`${rowClassName} active:opacity-70`}
+          onPress={props.onPress}
+        >
+          {props.children}
+        </Pressable>
+      ) : (
+        <View accessible accessibilityLabel={props.accessibilityLabel} className={rowClassName}>
+          {props.children}
+        </View>
+      )}
+    </Animated.View>
+  );
 }
 
 function WorkingDuration(props: { readonly startedAt: string }) {
@@ -219,7 +326,7 @@ function WorkingDuration(props: { readonly startedAt: string }) {
   const label = `Working for ${duration}`;
 
   return (
-    <View accessible accessibilityLabel={label} className="h-11 flex-row items-center px-4">
+    <StatusLabelRow accessibilityLabel={label}>
       <Text className="font-t3-medium text-xs text-foreground">Working for </Text>
       <SystemText
         className="text-xs text-foreground"
@@ -227,7 +334,7 @@ function WorkingDuration(props: { readonly startedAt: string }) {
       >
         {duration}
       </SystemText>
-    </View>
+    </StatusLabelRow>
   );
 }
 

--- a/apps/mobile/src/features/threads/floating-working-control.tsx
+++ b/apps/mobile/src/features/threads/floating-working-control.tsx
@@ -1,4 +1,3 @@
-import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
 import { formatDuration } from "@t3tools/shared/orchestrationTiming";
 import { GlassContainer, GlassView } from "expo-glass-effect";
 import { type ReactNode, useEffect, useRef, useState } from "react";
@@ -24,6 +23,7 @@ import { AppText as Text } from "../../components/AppText";
 import { SymbolView } from "../../components/AppSymbol";
 import { ControlPill } from "../../components/ControlPill";
 import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../../native/native-glass";
+import type { FloatingWorkingStatus } from "./floating-working-status";
 
 const CONTROL_HEIGHT = 38.5; // h-11 with the mobile 14px rem
 // The collapsed composer capsule starts 6 below its overlay's top edge, so
@@ -57,63 +57,6 @@ const AnimatedGlassView = Animated.createAnimatedComponent(UniwindGlassView);
 
 const CONTROL_OVERLAY_OFFSET = CONTROL_HEIGHT + CONTROL_GAP - COMPOSER_CAPSULE_INSET;
 export const FLOATING_WORKING_CONTROL_COVERAGE = CONTROL_OVERLAY_OFFSET + CONTROL_GAP;
-
-/**
- * What the floating pill says. Connection, syncing, and working share one
- * element so the label swaps in place instead of one pill fading out for
- * another. The connection variant is tappable and triggers a reconnect.
- */
-export type FloatingWorkingStatus =
-  | { readonly kind: "working"; readonly startedAt: string }
-  | { readonly kind: "syncing"; readonly label: string }
-  | { readonly kind: "compacting" }
-  | {
-      readonly kind: "connection";
-      readonly tone: "reconnecting" | "unavailable";
-      readonly label: string;
-      readonly onPress: () => void;
-    };
-
-export function connectionFloatingStatus(input: {
-  readonly connectionError: string | null;
-  readonly connectionState: EnvironmentConnectionPhase;
-  readonly environmentLabel: string | null;
-  readonly onReconnect: () => void;
-}): FloatingWorkingStatus | null {
-  const environmentLabel = input.environmentLabel ?? "Environment";
-  const unavailable = (label: string): FloatingWorkingStatus => ({
-    kind: "connection",
-    tone: "unavailable",
-    label,
-    onPress: input.onReconnect,
-  });
-
-  switch (input.connectionState) {
-    case "connecting":
-    case "reconnecting":
-      return {
-        kind: "connection",
-        tone: "reconnecting",
-        label:
-          input.connectionError === null
-            ? `Reconnecting to ${environmentLabel}...`
-            : `Failed to connect. Retrying ${environmentLabel}...`,
-        onPress: input.onReconnect,
-      };
-    case "offline":
-      return unavailable("You are offline");
-    case "error":
-      return unavailable(
-        input.connectionError
-          ? `Failed to connect to ${environmentLabel}: ${input.connectionError}`
-          : `Failed to connect to ${environmentLabel}`,
-      );
-    case "available":
-      return unavailable(`${environmentLabel} is not connected`);
-    case "connected":
-      return null;
-  }
-}
 
 export function FloatingWorkingControl(props: {
   readonly colorScheme: "light" | "dark";

--- a/apps/mobile/src/features/threads/floating-working-control.tsx
+++ b/apps/mobile/src/features/threads/floating-working-control.tsx
@@ -136,10 +136,15 @@ export function FloatingWorkingControl(props: {
 
   // The label swaps between connection, syncing, compacting, and working while
   // the capsule stays mounted. A layout transition on the capsule would move
-  // its left edge, and children laid out from that edge slide with it, so the
-  // pill reads as shifting sideways. Instead the labels hang off a fixed
-  // midpoint anchor and the capsule animates its width to the measured label,
-  // shrinking and growing symmetrically under text that stays put.
+  // its left edge, and labels laid out from that edge slide with it, so the pill
+  // reads as shifting sideways. Instead an in-flow sizer animates to the
+  // measured label width and the capsule takes its size from that, while the
+  // labels sit centered on top. The row re-centers as the capsule grows, so its
+  // midpoint never moves and the text underneath stays put.
+  //
+  // The sizer has to carry the width rather than the capsule itself: the native
+  // glass view only picks up a size from a real layout pass, so an animated
+  // width set straight on it leaves the glass stuck at its mounted size.
   const capsuleWidth = useSharedValue<number | null>(null);
   const measuredWidthRef = useRef<number | null>(null);
   const handleLabelLayout = (event: LayoutChangeEvent) => {
@@ -160,13 +165,12 @@ export function FloatingWorkingControl(props: {
       capsuleWidth.value = null;
     }
   }, [capsuleWidth, hasStatus]);
-  // Hidden until the first measurement lands so the capsule never paints at
-  // zero width around a clipped label.
   const capsuleStyle = useAnimatedStyle(() => ({
-    width: capsuleWidth.value ?? CONTROL_HEIGHT,
-    opacity: capsuleWidth.value === null ? 0 : 1,
     transform: [{ translateX: CONTROL_SEPARATION * (1 - separationProgress.value) }],
   }));
+  // Zero until the first measurement lands, so the capsule never paints around
+  // a label it has not sized to yet.
+  const capsuleSizerStyle = useAnimatedStyle(() => ({ width: capsuleWidth.value ?? 0 }));
 
   if (props.status === null && !props.showScrollToEnd) {
     return null;
@@ -175,18 +179,16 @@ export function FloatingWorkingControl(props: {
   // Only the connection label is a button (tap to reconnect); the others
   // pass touches through to the feed like before.
   const statusInteractive = props.status?.kind === "connection";
-  // A zero-width anchor at the capsule's midpoint. Yoga centers an absolute
-  // child with no insets on the parent's justify-content, so every label row
-  // lands centered on the anchor without measuring itself, and the capsule
-  // clips whatever the label overhangs while it catches up.
-  const statusLabel =
+  // Yoga centers an absolute child that has no insets on its parent's align and
+  // justify, so each label row lands centered on the capsule without measuring
+  // itself, and the capsule clips whatever a wider label overhangs while it
+  // catches up.
+  const statusContent =
     props.status !== null ? (
-      <View
-        pointerEvents="box-none"
-        className="absolute inset-y-0 left-1/2 w-0 flex-row items-center justify-center"
-      >
+      <>
+        <Animated.View className="h-11" style={capsuleSizerStyle} />
         <FloatingStatusLabel status={props.status} onLayout={handleLabelLayout} />
-      </View>
+      </>
     ) : null;
 
   return (
@@ -203,22 +205,16 @@ export function FloatingWorkingControl(props: {
           pointerEvents="box-none"
           className="flex-row items-center gap-4"
         >
-          {/* A plain animated wrapper owns the animated width; the native glass
-              view only fills it, since it does not follow animated layout props. */}
-          <Animated.View
+          <AnimatedGlassView
+            colorScheme={props.colorScheme}
+            glassEffectStyle="regular"
+            isInteractive={statusInteractive}
             pointerEvents={statusInteractive ? "box-none" : "none"}
-            className="h-11 overflow-hidden rounded-full"
+            className="h-11 items-center justify-center overflow-hidden rounded-full"
             style={capsuleStyle}
           >
-            <UniwindGlassView
-              colorScheme={props.colorScheme}
-              glassEffectStyle="regular"
-              isInteractive={statusInteractive}
-              pointerEvents="none"
-              className="absolute inset-0 rounded-full"
-            />
-            {statusLabel}
-          </Animated.View>
+            {statusContent}
+          </AnimatedGlassView>
 
           <AnimatedGlassView
             colorScheme={props.colorScheme}
@@ -239,10 +235,10 @@ export function FloatingWorkingControl(props: {
         <View pointerEvents="box-none" className="flex-row items-center gap-4">
           <Animated.View
             pointerEvents={statusInteractive ? "box-none" : "none"}
-            className="h-11 overflow-hidden rounded-full border border-border bg-card shadow-md shadow-black/10"
+            className="h-11 items-center justify-center overflow-hidden rounded-full border border-border bg-card shadow-md shadow-black/10"
             style={capsuleStyle}
           >
-            {statusLabel}
+            {statusContent}
           </Animated.View>
 
           <Animated.View
@@ -345,7 +341,7 @@ function FloatingStatusLabel(props: {
   );
 }
 
-// Each row is absolutely centered on the capsule's midpoint anchor, so an
+// Rows are absolute with no insets, so the capsule centers them on itself and an
 // exiting row fading out never shifts the incoming one.
 function StatusLabelRow(props: {
   readonly accessibilityLabel: string;

--- a/apps/mobile/src/features/threads/floating-working-control.tsx
+++ b/apps/mobile/src/features/threads/floating-working-control.tsx
@@ -161,7 +161,7 @@ export function FloatingWorkingControl(props: {
   // Hidden until the first measurement lands so the capsule never paints at
   // zero width around a clipped label.
   const capsuleStyle = useAnimatedStyle(() => ({
-    width: capsuleWidth.value ?? undefined,
+    width: capsuleWidth.value ?? CONTROL_HEIGHT,
     opacity: capsuleWidth.value === null ? 0 : 1,
     transform: [{ translateX: CONTROL_SEPARATION * (1 - separationProgress.value) }],
   }));
@@ -197,16 +197,22 @@ export function FloatingWorkingControl(props: {
           pointerEvents="box-none"
           className="flex-row items-center gap-4"
         >
-          <AnimatedGlassView
-            colorScheme={props.colorScheme}
-            glassEffectStyle="regular"
-            isInteractive={statusInteractive}
+          {/* A plain animated wrapper owns the animated width; the native glass
+              view only fills it, since it does not follow animated layout props. */}
+          <Animated.View
             pointerEvents={statusInteractive ? "box-none" : "none"}
-            className="h-11 rounded-full"
+            className="h-11"
             style={capsuleStyle}
           >
+            <UniwindGlassView
+              colorScheme={props.colorScheme}
+              glassEffectStyle="regular"
+              isInteractive={statusInteractive}
+              pointerEvents="none"
+              className="absolute inset-0 rounded-full"
+            />
             {statusLabel}
-          </AnimatedGlassView>
+          </Animated.View>
 
           <AnimatedGlassView
             colorScheme={props.colorScheme}

--- a/apps/mobile/src/features/threads/floating-working-control.tsx
+++ b/apps/mobile/src/features/threads/floating-working-control.tsx
@@ -1,13 +1,18 @@
 import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
 import { formatDuration } from "@t3tools/shared/orchestrationTiming";
 import { GlassContainer, GlassView } from "expo-glass-effect";
-import { type ReactNode, useEffect, useState } from "react";
-import { ActivityIndicator, Pressable, Text as SystemText, View } from "react-native";
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  type LayoutChangeEvent,
+  Pressable,
+  Text as SystemText,
+  View,
+} from "react-native";
 import Animated, {
   Easing,
   FadeIn,
   FadeOut,
-  LinearTransition,
   ReduceMotion,
   useAnimatedStyle,
   useSharedValue,
@@ -35,12 +40,6 @@ const CONTROL_TIMING = {
   reduceMotion: ReduceMotion.System,
 } as const;
 const CONTROL_SEPARATION = (16 + CONTROL_HEIGHT) / 2;
-// The label swaps between syncing, compacting, and working while the capsule
-// stays mounted, so the capsule animates to the new label's width and the
-// labels cross-fade instead of the pill snapping between sizes.
-const CAPSULE_LAYOUT = LinearTransition.duration(CONTROL_TIMING.duration)
-  .easing(CONTROL_TIMING.easing)
-  .reduceMotion(ReduceMotion.System);
 const LABEL_ENTERING = FadeIn.duration(180).reduceMotion(ReduceMotion.System);
 const LABEL_EXITING = FadeOut.duration(120).reduceMotion(ReduceMotion.System);
 
@@ -126,14 +125,45 @@ export function FloatingWorkingControl(props: {
     separationProgress.value = withTiming(props.showScrollToEnd ? 1 : 0, CONTROL_TIMING);
   }, [props.showScrollToEnd, separationProgress]);
 
-  const timerStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: CONTROL_SEPARATION * (1 - separationProgress.value) }],
-  }));
   const arrowTransformStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: -CONTROL_SEPARATION * (1 - separationProgress.value) }],
   }));
   const arrowContentStyle = useAnimatedStyle(() => ({
     opacity: separationProgress.value,
+  }));
+
+  // The label swaps between connection, syncing, compacting, and working while
+  // the capsule stays mounted. A layout transition on the capsule would move
+  // its left edge, and children laid out from that edge slide with it, so the
+  // pill reads as shifting sideways. Instead the labels hang off a fixed
+  // midpoint anchor and the capsule animates its width to the measured label,
+  // shrinking and growing symmetrically under text that stays put.
+  const capsuleWidth = useSharedValue<number | null>(null);
+  const measuredWidthRef = useRef<number | null>(null);
+  const handleLabelLayout = (event: LayoutChangeEvent) => {
+    const width = event.nativeEvent.layout.width;
+    if (width === measuredWidthRef.current) {
+      return;
+    }
+    const first = measuredWidthRef.current === null;
+    measuredWidthRef.current = width;
+    capsuleWidth.value = first ? width : withTiming(width, CONTROL_TIMING);
+  };
+  // Forget the width while no label is shown so the next one appears at its
+  // own size instead of animating from the previous label's.
+  const hasStatus = props.status !== null;
+  useEffect(() => {
+    if (!hasStatus) {
+      measuredWidthRef.current = null;
+      capsuleWidth.value = null;
+    }
+  }, [capsuleWidth, hasStatus]);
+  // Hidden until the first measurement lands so the capsule never paints at
+  // zero width around a clipped label.
+  const capsuleStyle = useAnimatedStyle(() => ({
+    width: capsuleWidth.value ?? undefined,
+    opacity: capsuleWidth.value === null ? 0 : 1,
+    transform: [{ translateX: CONTROL_SEPARATION * (1 - separationProgress.value) }],
   }));
 
   if (props.status === null && !props.showScrollToEnd) {
@@ -143,6 +173,15 @@ export function FloatingWorkingControl(props: {
   // Only the connection label is a button (tap to reconnect); the others
   // pass touches through to the feed like before.
   const statusInteractive = props.status?.kind === "connection";
+  // A zero-width anchor at the capsule's midpoint. Labels are centered on it
+  // and never clipped, so an incoming wider label sits at its final position
+  // while the capsule catches up underneath.
+  const statusLabel =
+    props.status !== null ? (
+      <View pointerEvents="box-none" className="absolute inset-y-0 left-1/2 w-0 overflow-visible">
+        <FloatingStatusLabel status={props.status} onLayout={handleLabelLayout} />
+      </View>
+    ) : null;
 
   return (
     <Animated.View
@@ -162,12 +201,11 @@ export function FloatingWorkingControl(props: {
             colorScheme={props.colorScheme}
             glassEffectStyle="regular"
             isInteractive={statusInteractive}
-            pointerEvents={statusInteractive ? "auto" : "none"}
-            className="h-11 justify-center overflow-hidden rounded-full"
-            style={timerStyle}
-            layout={CAPSULE_LAYOUT}
+            pointerEvents={statusInteractive ? "box-none" : "none"}
+            className="h-11 rounded-full"
+            style={capsuleStyle}
           >
-            <FloatingStatusLabel status={props.status} />
+            {statusLabel}
           </AnimatedGlassView>
 
           <AnimatedGlassView
@@ -188,12 +226,11 @@ export function FloatingWorkingControl(props: {
       ) : props.status !== null ? (
         <View pointerEvents="box-none" className="flex-row items-center gap-4">
           <Animated.View
-            pointerEvents={statusInteractive ? "auto" : "none"}
-            className="h-11 justify-center rounded-full border border-border bg-card shadow-md shadow-black/10"
-            style={timerStyle}
-            layout={CAPSULE_LAYOUT}
+            pointerEvents={statusInteractive ? "box-none" : "none"}
+            className="h-11 rounded-full border border-border bg-card shadow-md shadow-black/10"
+            style={capsuleStyle}
           >
-            <FloatingStatusLabel status={props.status} />
+            {statusLabel}
           </Animated.View>
 
           <Animated.View
@@ -234,9 +271,9 @@ export function FloatingWorkingControl(props: {
   );
 }
 
-function CompactingLabel() {
+function CompactingLabel(props: { readonly onLayout: (event: LayoutChangeEvent) => void }) {
   return (
-    <StatusLabelRow accessibilityLabel="Compacting" className="gap-1.5">
+    <StatusLabelRow accessibilityLabel="Compacting" className="gap-1.5" onLayout={props.onLayout}>
       <SymbolView
         name="arrow.down.right.and.arrow.up.left"
         size={13}
@@ -248,19 +285,27 @@ function CompactingLabel() {
   );
 }
 
-function FloatingStatusLabel(props: { readonly status: FloatingWorkingStatus }) {
+function FloatingStatusLabel(props: {
+  readonly status: FloatingWorkingStatus;
+  readonly onLayout: (event: LayoutChangeEvent) => void;
+}) {
   // Keyed by kind so a swap mounts a fresh row and the two cross-fade while
-  // the capsule's layout transition carries the width change.
+  // the capsule animates to the new row's measured width.
   if (props.status.kind === "syncing") {
     return (
-      <StatusLabelRow key="syncing" accessibilityLabel={props.status.label} className="gap-2">
+      <StatusLabelRow
+        key="syncing"
+        accessibilityLabel={props.status.label}
+        className="gap-2"
+        onLayout={props.onLayout}
+      >
         <ActivityIndicator size="small" colorClassName="accent-icon-muted" />
         <Text className="font-t3-medium text-xs text-foreground">{props.status.label}</Text>
       </StatusLabelRow>
     );
   }
   if (props.status.kind === "compacting") {
-    return <CompactingLabel key="compacting" />;
+    return <CompactingLabel key="compacting" onLayout={props.onLayout} />;
   }
   if (props.status.kind === "connection") {
     return (
@@ -269,6 +314,7 @@ function FloatingStatusLabel(props: { readonly status: FloatingWorkingStatus }) 
         accessibilityLabel={props.status.label}
         accessibilityRole="button"
         className="gap-2"
+        onLayout={props.onLayout}
         onPress={props.status.onPress}
       >
         {props.status.tone === "reconnecting" ? (
@@ -282,19 +328,35 @@ function FloatingStatusLabel(props: { readonly status: FloatingWorkingStatus }) 
       </StatusLabelRow>
     );
   }
-  return <WorkingDuration key="working" startedAt={props.status.startedAt} />;
+  return (
+    <WorkingDuration key="working" startedAt={props.status.startedAt} onLayout={props.onLayout} />
+  );
 }
 
+// Each row is absolutely centered on the capsule's midpoint anchor, so an
+// exiting row fading out never shifts the incoming one.
 function StatusLabelRow(props: {
   readonly accessibilityLabel: string;
   readonly accessibilityRole?: "button";
   readonly className?: string;
   readonly children: ReactNode;
+  readonly onLayout: (event: LayoutChangeEvent) => void;
   readonly onPress?: () => void;
 }) {
   const rowClassName = `h-11 flex-row items-center px-4 ${props.className ?? ""}`;
+  const [width, setWidth] = useState<number | null>(null);
+  const handleLayout = (event: LayoutChangeEvent) => {
+    setWidth(event.nativeEvent.layout.width);
+    props.onLayout(event);
+  };
   return (
-    <Animated.View entering={LABEL_ENTERING} exiting={LABEL_EXITING}>
+    <Animated.View
+      className="absolute top-0"
+      style={{ left: width === null ? undefined : -width / 2, opacity: width === null ? 0 : 1 }}
+      entering={LABEL_ENTERING}
+      exiting={LABEL_EXITING}
+      onLayout={handleLayout}
+    >
       {props.onPress ? (
         <Pressable
           accessibilityLabel={props.accessibilityLabel}
@@ -313,7 +375,10 @@ function StatusLabelRow(props: {
   );
 }
 
-function WorkingDuration(props: { readonly startedAt: string }) {
+function WorkingDuration(props: {
+  readonly startedAt: string;
+  readonly onLayout: (event: LayoutChangeEvent) => void;
+}) {
   const [nowMs, setNowMs] = useState(() => Date.now());
 
   useEffect(() => {
@@ -326,7 +391,7 @@ function WorkingDuration(props: { readonly startedAt: string }) {
   const label = `Working for ${duration}`;
 
   return (
-    <StatusLabelRow accessibilityLabel={label}>
+    <StatusLabelRow accessibilityLabel={label} onLayout={props.onLayout}>
       <Text className="font-t3-medium text-xs text-foreground">Working for </Text>
       <SystemText
         className="text-xs text-foreground"

--- a/apps/mobile/src/features/threads/floating-working-status.test.ts
+++ b/apps/mobile/src/features/threads/floating-working-status.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { connectionFloatingStatus } from "./floating-working-status";
+
+const status = (
+  connectionState: Parameters<typeof connectionFloatingStatus>[0]["connectionState"],
+  overrides: { connectionError?: string | null; environmentLabel?: string | null } = {},
+) =>
+  connectionFloatingStatus({
+    connectionError: overrides.connectionError ?? null,
+    connectionState,
+    environmentLabel:
+      overrides.environmentLabel === undefined ? "Mac mini" : overrides.environmentLabel,
+    onReconnect: () => {},
+  });
+
+describe("connectionFloatingStatus", () => {
+  it("yields the pill to sync and working state once connected", () => {
+    expect(status("connected")).toBeNull();
+  });
+
+  it("names the environment it is retrying, and says so only after a failure", () => {
+    expect(status("connecting")).toMatchObject({
+      tone: "reconnecting",
+      label: "Reconnecting to Mac mini...",
+    });
+    expect(status("reconnecting", { connectionError: "ECONNREFUSED" })).toMatchObject({
+      tone: "reconnecting",
+      label: "Failed to connect. Retrying Mac mini...",
+    });
+  });
+
+  it("reports why the environment is unreachable", () => {
+    expect(status("offline")).toMatchObject({
+      tone: "unavailable",
+      label: "You are offline",
+    });
+    expect(status("available")).toMatchObject({
+      tone: "unavailable",
+      label: "Mac mini is not connected",
+    });
+    expect(status("error", { connectionError: "handshake timed out" })).toMatchObject({
+      label: "Failed to connect to Mac mini: handshake timed out",
+    });
+    expect(status("error")).toMatchObject({ label: "Failed to connect to Mac mini" });
+  });
+
+  it("falls back to a generic name when the environment has no label", () => {
+    expect(status("error", { environmentLabel: null })).toMatchObject({
+      label: "Failed to connect to Environment",
+    });
+  });
+
+  it("carries the reconnect handler so the pill can trigger it", () => {
+    const onReconnect = vi.fn();
+    const pill = connectionFloatingStatus({
+      connectionError: null,
+      connectionState: "offline",
+      environmentLabel: "Mac mini",
+      onReconnect,
+    });
+    if (pill?.kind !== "connection") throw new Error("expected a connection pill");
+    pill.onPress();
+    expect(onReconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/mobile/src/features/threads/floating-working-status.ts
+++ b/apps/mobile/src/features/threads/floating-working-status.ts
@@ -1,0 +1,62 @@
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
+
+/**
+ * What the floating pill says. Connection, syncing, and working share one
+ * element so the label swaps in place instead of one pill fading out for
+ * another. The connection variant is tappable and triggers a reconnect.
+ */
+export type FloatingWorkingStatus =
+  | { readonly kind: "working"; readonly startedAt: string }
+  | { readonly kind: "syncing"; readonly label: string }
+  | { readonly kind: "compacting" }
+  | {
+      readonly kind: "connection";
+      readonly tone: "reconnecting" | "unavailable";
+      readonly label: string;
+      readonly onPress: () => void;
+    };
+
+/**
+ * The pill's connection variant, or null once the environment is connected and
+ * the pill is free to report sync and working state instead.
+ */
+export function connectionFloatingStatus(input: {
+  readonly connectionError: string | null;
+  readonly connectionState: EnvironmentConnectionPhase;
+  readonly environmentLabel: string | null;
+  readonly onReconnect: () => void;
+}): FloatingWorkingStatus | null {
+  const environmentLabel = input.environmentLabel ?? "Environment";
+  const unavailable = (label: string): FloatingWorkingStatus => ({
+    kind: "connection",
+    tone: "unavailable",
+    label,
+    onPress: input.onReconnect,
+  });
+
+  switch (input.connectionState) {
+    case "connecting":
+    case "reconnecting":
+      return {
+        kind: "connection",
+        tone: "reconnecting",
+        label:
+          input.connectionError === null
+            ? `Reconnecting to ${environmentLabel}...`
+            : `Failed to connect. Retrying ${environmentLabel}...`,
+        onPress: input.onReconnect,
+      };
+    case "offline":
+      return unavailable("You are offline");
+    case "error":
+      return unavailable(
+        input.connectionError
+          ? `Failed to connect to ${environmentLabel}: ${input.connectionError}`
+          : `Failed to connect to ${environmentLabel}`,
+      );
+    case "available":
+      return unavailable(`${environmentLabel} is not connected`);
+    case "connected":
+      return null;
+  }
+}


### PR DESCRIPTION
## Problem

While an environment is disconnected, mobile shows the connection state in its own
pill anchored above the composer, and the floating working pill hides itself
entirely (`connectionStateLabel !== "connected"` returned `null`). So a dropped
connection mid-turn swapped a centered glass pill for a differently-styled,
left-aligned one in a different place, dropped the working timer, and covered the
last feed row. The feed also shifted, because the floating control stops reserving
its space.

## What changed

One pill. `connectionFloatingStatus` maps the connection phase into the floating
pill's status, so connection, syncing, compacting, and working all swap labels in
place inside the same capsule. The composer's `ComposerConnectionStatusPill` and
its `connectionError` / `onReconnectEnvironment` props are gone.

Making one capsule change width needed three fixes:

- The capsule's Reanimated layout transition moved its left edge, and labels laid
  out from that edge slid with it. Labels are now absolute children centered by
  the capsule, and an in-flow sizer animates to the measured label width.
- The native `GlassView` only takes a size from a real layout pass, so an animated
  width set on it left the material stuck at its mounted size — the pill rendered
  as a bare label with a stray circle behind it until the first label swap forced
  a re-layout. The sizer drives the width so the glass gets a genuine layout.
- Labels cross-fade staggered (exit 100 ms, enter 160 ms after 80 ms) since both
  rows now occupy the same centered spot.

## Before / after

Same thread, same environment, same scroll and viewport, connection cut at the
same point by killing a TCP proxy in front of the server. iOS 26 simulator, dark.

![before and after, connected and disconnected](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4e30f3558f4942f4/pr-compare.png)

**Before (main)** — working pill disappears, a left-aligned pill takes over lower
down and covers "Thinking", and the feed shifts:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d63e91c34a63230b/pr-clip-before.mp4

**After** — one capsule resizes in place through
working → failed to connect → syncing → working:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/72200c880a081030/pr-clip-after.mp4

The glass regression caught during review of my own recordings, before (stuck
capsule showing through as a circle) and after:

![glass rendering before and after](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/55aed10bab43525c/glass-fix.png)

## Verification

- `vp test run apps/mobile/src/features/threads/floating-working-status.test.ts` —
  5 passing, covering every connection phase, the missing-label fallback, and the
  reconnect handler. The mapping moved to a pure module so it is testable without
  the native view stack.
- Measured the capsule's pixel extent frame by frame through a swap: growing from
  404 px to 907 px, its center held at 662.5–663 px on every frame.
- Checked at mount, through both swap directions, after the pill goes away and
  returns, and with the scroll-to-end button both merged and separated.
- Typecheck and lint clean on the touched files. (`tsgo` reports 63 pre-existing
  navigation-typing errors on `main` too; the repo's `typecheck` script uses `tsc`.)

## Limits

Verified on the iOS 26 simulator, where the native liquid-glass path runs. The
non-glass fallback branch got the same layout treatment but was not exercised on
a device.

Opus 5 via Claude Code.


## Notes for review

**Precedence with pending approvals.** The floating pill used to be suppressed
whenever an approval or user-input card was up, and it now returns the connection
status first, so it renders in that state too. That is not new information on
screen: the composer pill it replaces had no such suppression, so a disconnected
environment with a pending approval already showed a pill. It is the same single
pill, just in the floating control's position now.

**Why the UI paths are not unit-tested.** Every existing test under
`apps/mobile/src` covers pure modules, and the repo guidance is explicit about not
rendering components to assert props or attributes. The animation and glass work
here is only meaningful against real UIKit — the stuck-glass bug in particular was
invisible to anything but a device, since it came from the native view taking its
size from a layout pass. So the mapping is unit-tested and the rendering is
covered by the simulator captures above, including a frame-by-frame measurement of
the capsule's center through a resize.
