### PR TITLE
fix(server): handle JSON-wrapped titles and verbose Claude output

### DIFF
--- a/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
@@ -394,6 +394,75 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
     }),
   );
 
+  for (const previousTitle of [undefined, "Old thread title"]) {
+    it.effect(
+      `reads the result from verbose Claude output when ${previousTitle ? "regenerating" : "generating"} a title`,
+      () =>
+        withFakeClaudeEnv(
+          {
+            output: JSON.stringify([
+              { type: "system", subtype: "init" },
+              { type: "assistant", message: { content: [] } },
+              { type: "user", message: { content: [] } },
+              { type: "rate_limit_event" },
+              {
+                type: "result",
+                subtype: "success",
+                result: '{"title":"Refresh ev-stg APP ASG Instances"}',
+                structured_output: { title: "Refresh ev-stg APP ASG Instances" },
+              },
+            ]),
+          },
+          (textGeneration) =>
+            Effect.gen(function* () {
+              const generated = yield* textGeneration.generateThreadTitle({
+                cwd: process.cwd(),
+                message: "Refresh ev-stg APP ASG instances",
+                previousTitle,
+                modelSelection: {
+                  instanceId: ProviderInstanceId.make("claudeAgent"),
+                  model: SYNTHETIC_CLAUDE_STANDARD_MODEL,
+                },
+              });
+
+              expect(generated.title).toBe("Refresh ev-stg APP ASG Instances");
+            }),
+        ),
+    );
+  }
+
+  for (const [name, output] of [
+    ["empty message array", []],
+    ["missing result", [{ type: "assistant", structured_output: { title: "Not a result" } }]],
+    ["invalid title", [{ type: "result", structured_output: { title: 42 } }]],
+    [
+      "final result without structured output",
+      [
+        { type: "result", structured_output: { title: "Earlier result" } },
+        { type: "result", subtype: "error_max_structured_output_retries" },
+      ],
+    ],
+  ] as const) {
+    it.effect(`rejects verbose Claude output with ${name}`, () =>
+      withFakeClaudeEnv({ output: JSON.stringify(output) }, (textGeneration) =>
+        Effect.gen(function* () {
+          const error = yield* Effect.flip(
+            textGeneration.generateThreadTitle({
+              cwd: process.cwd(),
+              message: "Name this thread",
+              modelSelection: {
+                instanceId: ProviderInstanceId.make("claudeAgent"),
+                model: SYNTHETIC_CLAUDE_STANDARD_MODEL,
+              },
+            }),
+          );
+
+          expect(error._tag).toBe("TextGenerationError");
+        }),
+      ),
+    );
+  }
+
   it.effect("falls back when Claude thread title normalization becomes whitespace-only", () =>
     withFakeClaudeEnv(
       {

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
@@ -394,6 +394,31 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
     }),
   );
 
+  for (const verbose of [false, true]) {
+    it.effect(`unwraps a JSON title in ${verbose ? "verbose" : "normal"} Claude output`, () => {
+      const result = {
+        type: "result",
+        structured_output: { title: '{"title": "Refresh ev-stg APP ASG instances"}' },
+      };
+      return withFakeClaudeEnv(
+        { output: JSON.stringify(verbose ? [result] : result) },
+        (textGeneration) =>
+          Effect.gen(function* () {
+            const generated = yield* textGeneration.generateThreadTitle({
+              cwd: process.cwd(),
+              message: "Refresh ev-stg APP ASG instances",
+              modelSelection: {
+                instanceId: ProviderInstanceId.make("claudeAgent"),
+                model: SYNTHETIC_CLAUDE_STANDARD_MODEL,
+              },
+            });
+
+            expect(generated.title).toBe("Refresh ev-stg APP ASG instances");
+          }),
+      );
+    });
+  }
+
   for (const previousTitle of [undefined, "Old thread title"]) {
     it.effect(
       `reads the result from verbose Claude output when ${previousTitle ? "regenerating" : "generating"} a title`,

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.ts
@@ -53,14 +53,21 @@ const CLAUDE_TIMEOUT_MS = 180_000;
 
 /**
  * Schema for the wrapper JSON returned by `claude -p --output-format json`.
- * We only care about `structured_output`.
+ * Verbose mode wraps the result in an array of conversation messages.
  */
 const ClaudeOutputEnvelope = Schema.Struct({
   structured_output: Schema.Unknown,
 });
+const ClaudeOutputMessage = Schema.Struct({
+  type: Schema.String,
+  structured_output: Schema.optionalKey(Schema.Unknown),
+});
+const isClaudeOutputEnvelope = Schema.is(ClaudeOutputEnvelope);
 
 const encodeJsonString = Schema.encodeEffect(Schema.fromJsonString(Schema.Unknown));
-const decodeClaudeOutputEnvelope = Schema.decodeEffect(Schema.fromJsonString(ClaudeOutputEnvelope));
+const decodeClaudeOutput = Schema.decodeEffect(
+  Schema.fromJsonString(Schema.Union([ClaudeOutputEnvelope, Schema.Array(ClaudeOutputMessage)])),
+);
 
 export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(function* (
   claudeSettings: ClaudeSettings,
@@ -254,7 +261,7 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
       ),
     );
 
-    const envelope = yield* decodeClaudeOutputEnvelope(rawStdout).pipe(
+    const output = yield* decodeClaudeOutput(rawStdout).pipe(
       Effect.catchTags({
         SchemaError: (cause) =>
           Effect.fail(
@@ -266,9 +273,12 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
           ),
       }),
     );
+    const envelope = isClaudeOutputEnvelope(output)
+      ? output
+      : output.findLast((message) => message.type === "result");
 
     const decodeOutput = Schema.decodeEffect(outputSchemaJson);
-    return yield* decodeOutput(envelope.structured_output).pipe(
+    return yield* decodeOutput(envelope?.structured_output).pipe(
       Effect.catchTags({
         SchemaError: (cause) =>
           Effect.fail(

--- a/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
@@ -216,6 +216,35 @@ describe("buildThreadTitlePrompt", () => {
 });
 
 describe("sanitizeThreadTitle", () => {
+  it.each([
+    '{"title": "Refresh ev-stg APP ASG instances"}',
+    '{\n  "title": "Refresh ev-stg APP ASG instances"\n}',
+  ])("unwraps a JSON title before normalizing: %s", (raw) => {
+    expect(sanitizeThreadTitle(raw)).toBe("Refresh ev-stg APP ASG instances");
+  });
+
+  it.each([
+    "Rolling ES Refresh ev-stg",
+    "Fix {title} interpolation",
+    '{"title": 42}',
+    '{"subject": "Fix parsing"}',
+    '{"title": "unfinished}',
+  ])("preserves text that is not a JSON title: %s", (raw) => {
+    expect(sanitizeThreadTitle(raw)).toBe(raw);
+  });
+
+  it("normalizes the extracted title", () => {
+    expect(sanitizeThreadTitle('{"title": "  Fix   reconnect failures  "}')).toBe(
+      "Fix reconnect failures",
+    );
+    expect(sanitizeThreadTitle('{"title": "  "}')).toBe("New thread");
+    expect(
+      sanitizeThreadTitle(
+        '{"title": "Reconnect failures after restart because the session state does not recover"}',
+      ),
+    ).toBe("Reconnect failures after restart because the se...");
+  });
+
   it("truncates long titles with the shared sidebar-safe limit", () => {
     expect(
       sanitizeThreadTitle(

--- a/apps/server/src/textGeneration/TextGenerationUtils.ts
+++ b/apps/server/src/textGeneration/TextGenerationUtils.ts
@@ -1,7 +1,11 @@
 import { TextGenerationError } from "@t3tools/contracts";
+import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 
 const isTextGenerationError = Schema.is(TextGenerationError);
+const decodeJsonThreadTitle = Schema.decodeOption(
+  Schema.fromJsonString(Schema.Struct({ title: Schema.String })),
+);
 
 /** Convert an Effect Schema to a flat JSON Schema object, inlining `$defs` when present. */
 export function toJsonSchemaObject(schema: Schema.Top): unknown {
@@ -44,7 +48,10 @@ export function sanitizePrTitle(raw: string): string {
 
 /** Normalise a raw thread title to a compact single-line sidebar-safe label. */
 export function sanitizeThreadTitle(raw: string): string {
-  const normalized = raw
+  // Unwrap a JSON-formatted title before truncation can cut off the closing brace.
+  const decoded = decodeJsonThreadTitle(raw);
+  const title = Option.isSome(decoded) ? decoded.value.title : raw;
+  const normalized = title
     .trim()
     .split(/\r?\n/g)[0]
     ?.trim()

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -37,6 +37,10 @@ state. Claude does not have Codex's shared-home and shadow-home arrangement.
 For presets that differ only in API keys or endpoints, use the instance's
 **Environment variables**. Variable assignments do not belong in **Launch arguments**.
 
+Claude Code's verbose mode can stay enabled when you use Claude for text generation, including
+thread titles, branch names, commit messages, and pull request descriptions. On a remote connection,
+T3 Code uses the Claude configuration on the connected server.
+
 ## Compact long conversations
 
 Set **Auto-compact after** in the Claude provider settings to an integer between


### PR DESCRIPTION
Generated thread titles containing JSON such as `{"title":"Refresh ASG instances"}` were accepted as plain strings and saved with the JSON wrapper intact. Separately, Claude Code's verbose mode returns an array of conversation messages where T3 expected a single result object, causing text generation to fail.

Unwrap valid JSON objects with a string `title` before applying the existing whitespace cleanup, fallback, and length limit. This shared normalization covers all six providers for initial title generation and regeneration. Ordinary titles, malformed JSON, and objects without a string title retain the existing handling. Existing saved titles are not migrated.

For Claude, accept either CLI output shape and read `structured_output` from the last `result` message in verbose output. Keep operation-specific schema validation, rejecting missing or malformed results instead of using assistant messages, earlier results, or the JSON-formatted `result` text. This covers all Claude text-generation operations through the shared adapter.

## Testing

- 41 focused Claude text-generation and shared prompt/normalization tests pass. JSON-title cases cover normal and verbose output, multiline JSON, whitespace, fallback, truncation, and invalid/non-title inputs. The new positive cases failed before their fixes.
- Reproduced the verbose-array failure with real Claude CLI 2.1.263; the patched adapter successfully generated a clean title with `--verbose` and Sonnet 5.
- Targeted lint, formatting, and diff checks pass.
- Server typecheck was attempted but remains blocked by unrelated checkout dependency mismatches, including missing `yauzl`, `stream-json`/`stream-chain`, and stale Claude SDK types. No diagnostics in the changed files.

The JSON-title normalization is covered by controlled response fixtures matching the reported symptom. Six live calls across Sonnet 5, Haiku 4.5, and Opus 5 did not reproduce Claude generating a nested JSON title, so its upstream cause remains unconfirmed.

Model: GPT-6. Harness: Codex.
