### PR TITLE
fix(server): pause Codex goals before stopping turns

### DIFF
--- a/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
+++ b/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
@@ -615,16 +615,21 @@ describe("CodexSessionRuntime collab integration", () => {
         onlyFirstTurnStarts: true,
         turnIds: [activeTurnId, queuedTurnId],
         expectedActiveTurnId: activeTurnId,
+        goalStatus: "active",
+        recordControlRequests: true,
         notifications: [],
       };
       // @effect-diagnostics-next-line preferSchemaOverJson:off
       NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
       const interruptsPath = `${scriptPath}.interrupts`;
+      const controlPath = `${scriptPath}.control`;
       NodeFS.rmSync(interruptsPath, { force: true });
+      NodeFS.rmSync(controlPath, { force: true });
       yield* Effect.addFinalizer(() =>
         Effect.sync(() => {
           NodeFS.rmSync(scriptPath, { force: true });
           NodeFS.rmSync(interruptsPath, { force: true });
+          NodeFS.rmSync(controlPath, { force: true });
         }),
       );
 
@@ -649,6 +654,26 @@ describe("CodexSessionRuntime collab integration", () => {
         threadId: ROOT,
         turnId: activeTurnId,
       });
+      const controlRequests = NodeFS.readFileSync(controlPath, "utf8")
+        .trim()
+        .split("\n")
+        .map(
+          (line) =>
+            JSON.parse(line) as {
+              method?: string;
+              params?: { threadId?: string; turnId?: string; status?: string };
+            },
+        );
+      assert.deepEqual(controlRequests, [
+        {
+          method: "thread/goal/set",
+          params: { threadId: ROOT, status: "paused" },
+        },
+        {
+          method: "turn/interrupt",
+          params: { threadId: ROOT, turnId: activeTurnId },
+        },
+      ]);
 
       yield* runtime.close;
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -2386,6 +2386,22 @@ export const makeCodexSessionRuntime = (
         Effect.gen(function* () {
           const providerThreadId = yield* readProviderThreadId;
           const session = yield* Ref.get(sessionRef);
+          // An interrupted goal turn must not leave its persisted goal active,
+          // or Codex can schedule another continuation immediately after Stop.
+          // Keep this best-effort and bounded so goal-control failures cannot
+          // prevent the turn and its child fleet from being interrupted.
+          yield* Effect.gen(function* () {
+            const { goal } = yield* client.request("thread/goal/get", {
+              threadId: providerThreadId,
+            });
+            if (goal?.status !== "active") {
+              return;
+            }
+            yield* client.request("thread/goal/set", {
+              threadId: providerThreadId,
+              status: "paused",
+            });
+          }).pipe(Effect.timeoutOption("1 second"), Effect.ignore);
           // Stop-everything: children are full threads with their own turns;
           // interrupting only the parent leaves the fleet running. Interrupt
           // each live child turn first, best-effort per child, BOUNDED: the

--- a/apps/server/src/provider/testFixtures/codexCollabMockPeer.mjs
+++ b/apps/server/src/provider/testFixtures/codexCollabMockPeer.mjs
@@ -151,6 +151,51 @@ rl.on("line", (line) => {
     }
     return;
   }
+  if (method === "thread/goal/get") {
+    const status = script.goalStatus;
+    write({
+      id,
+      result: {
+        goal: status
+          ? {
+              createdAt: 1,
+              objective: "Keep working",
+              status,
+              threadId: script.rootThreadId,
+              timeUsedSeconds: 0,
+              tokenBudget: null,
+              tokensUsed: 0,
+              updatedAt: 1,
+            }
+          : null,
+      },
+    });
+    return;
+  }
+  if (method === "thread/goal/set") {
+    if (script.recordControlRequests) {
+      NodeFS.appendFileSync(
+        `${process.env.T3_CODEX_COLLAB_SCRIPT}.control`,
+        `${JSON.stringify({ method, params: message.params })}\n`,
+      );
+    }
+    write({
+      id,
+      result: {
+        goal: {
+          createdAt: 1,
+          objective: "Keep working",
+          status: message.params?.status ?? script.goalStatus ?? "active",
+          threadId: script.rootThreadId,
+          timeUsedSeconds: 0,
+          tokenBudget: null,
+          tokensUsed: 0,
+          updatedAt: 2,
+        },
+      },
+    });
+    return;
+  }
   if (method === "turn/interrupt") {
     // Record which thread/turn was interrupted (append-only sidecar file the
     // test reads) so Stop coverage can assert every live child was reached.
@@ -160,6 +205,12 @@ rl.on("line", (line) => {
       `${process.env.T3_CODEX_COLLAB_SCRIPT}.interrupts`,
       `${JSON.stringify({ threadId: target, turnId: message.params?.turnId })}\n`,
     );
+    if (script.recordControlRequests) {
+      NodeFS.appendFileSync(
+        `${process.env.T3_CODEX_COLLAB_SCRIPT}.control`,
+        `${JSON.stringify({ method, params: message.params })}\n`,
+      );
+    }
     if (
       script.expectedActiveTurnId &&
       message.params?.threadId === script.rootThreadId &&


### PR DESCRIPTION
Stopping a Codex turn can leave its persisted native goal active, allowing the scheduler to inject continuation turns immediately after Stop.

Read the thread goal and pause it only when active, before interrupting the child fleet and root turn. Bound the combined goal lookup/update to one second and ignore goal-control errors so Stop still reaches turn interruption. Extend the collab mock and queued-follow-up regression to assert goal pause precedes the active root turn interrupt.

Validation: original commit `54b359252440a17c59bee6dc77bbf9eaaeac407c` was recovered intact from the contributor fork. Sequential source self-review completed; current-upstream synchronization and current-revision CI verification are in progress. Historical reports of 11 focused integration tests plus lint/format/server typecheck are not being presented as fresh results. No merge or deployment is requested by this publication.

Model and harness: GPT-6 Astra Pro, ChatGPT GitHub + Scratch (Level 2), one agent with sequential self-review.