### PR TITLE
fix(web): keep sidebar drag dividers clear and gestures smooth

### DIFF
--- a/apps/web/src/components/Sidebar.drag.test.ts
+++ b/apps/web/src/components/Sidebar.drag.test.ts
@@ -7,6 +7,7 @@ import {
   restrictBelowSidebarLabel,
 } from "./Sidebar.drag";
 import {
+  resolveSidebarDropTarget,
   sidebarListItemId,
   sidebarMarkerId,
   type SidebarListItem,
@@ -123,92 +124,92 @@ describe("sidebar collision detection", () => {
     expect(detector(collisionArgs())[0]?.id).toBe("blocked");
   });
 
-  function clampedArgs() {
-    const args = collisionArgs();
-    const pinned = args.droppableRects.get(sidebarMarkerId("pinned-header"))!;
-    const source = args.droppableRects.get("source")!;
-    const collisionRect = {
-      ...source,
-      top: pinned.top - 8,
-      bottom: pinned.top - 8 + source.height,
-    };
-    return {
-      ...args,
-      active: {
-        ...args.active,
-        rect: { current: { initial: source, translated: collisionRect } },
-      },
-      collisionRect,
-      pointerCoordinates: { x: pinned.left + pinned.width / 2, y: pinned.top + 8 },
-    };
-  }
-
-  it("reaches empty Pins with an upward pointer while the card is clamped at the top", () => {
-    const args = clampedArgs();
-    const detector = createSidebarCollisionDetection(() => true, {
-      emptyPins: true,
-      activationY: args.pointerCoordinates.y + 6,
-    });
-    expect(args.droppableRects.get(sidebarMarkerId("pinned-header"))?.height).toBe(0);
-    expect(closestCenter(args)[0]?.id).toBe("source");
-    expect(detector(args)[0]?.id).toBe(sidebarMarkerId("pinned-header"));
-  });
-
-  it.each([114, 400])(
-    "keeps empty Pins selected across its opened slot from pickup y=%s",
-    (activationY) => {
-      const args = clampedArgs();
+  it.each([
+    { sourceSection: "active", pins: 0 },
+    { sourceSection: "active", pins: 1 },
+    { sourceSection: "pinned", pins: 1 },
+    { sourceSection: "settled", pins: 1 },
+  ] as const)(
+    "switches on crossing the divider row from $sourceSection with $pins pins",
+    ({ sourceSection, pins }) => {
+      const items = [
+        pinnedHeader,
+        ...(pins ? [thread("p", "pinned")] : []),
+        ...(sourceSection === "pinned" ? [thread("source", "pinned")] : []),
+        divider,
+        thread("a", "active"),
+        ...(sourceSection === "active" ? [thread("source", "active")] : []),
+        settledHeader,
+        ...(sourceSection === "settled" ? [thread("source", "settled")] : []),
+      ];
+      const { rects, activeIndex } = layout(items, "source", "a");
+      const sourceRect = rects[activeIndex]!;
+      let boundaryTop = 300;
+      const boundaryNode = {
+        querySelector: () => ({
+          getBoundingClientRect: () => ({
+            top: boundaryTop,
+            bottom: boundaryTop + 16,
+            left: 0,
+            right: 260,
+          }),
+        }),
+      } as unknown as HTMLElement;
       const detector = createSidebarCollisionDetection(() => true, {
-        emptyPins: true,
-        activationY,
-        emptyPinCardId: "source",
-        boundaryLabelHeight: 24,
+        items,
+        activationY: sourceSection === "pinned" ? 200 : 600,
       });
-      const at = (y: number) => detector({ ...args, pointerCoordinates: { x: 130, y } })[0]?.id;
-      expect(at(108)).toBe(sidebarMarkerId("pinned-header"));
-      // The pointer crosses the old 8px cue, then moves through the visible slot.
-      expect(at(109)).toBe(sidebarMarkerId("pinned-header"));
-      expect(at(160)).toBe(sidebarMarkerId("pinned-header"));
-      expect(at(207)).toBe(sidebarMarkerId("pinned-header"));
-      expect(at(208)).toBe("source");
-      // Returning to the ordinary list does not immediately re-open Pins.
-      expect(at(160)).toBe("source");
-      expect(at(108)).toBe(sidebarMarkerId("pinned-header"));
+      const at = (center: number) => {
+        const collisionRect = {
+          ...sourceRect,
+          top: center - sourceRect.height / 2,
+          bottom: center + sourceRect.height / 2,
+        };
+        const args = {
+          ...collisionArgs(),
+          active: {
+            id: "source",
+            data: { current: {} },
+            rect: { current: { initial: sourceRect, translated: collisionRect } },
+          },
+          collisionRect,
+          pointerCoordinates: { x: 130, y: center },
+          droppableRects: new Map(
+            items.map((item, index) => [sidebarListItemId(item), rects[index]!]),
+          ),
+          droppableContainers: items.map((item, index) => ({
+            id: sidebarListItemId(item),
+            key: sidebarListItemId(item),
+            disabled: false,
+            data: { current: {} },
+            node: {
+              current:
+                item === divider
+                  ? boundaryNode
+                  : item === settledHeader
+                    ? ({ getBoundingClientRect: () => ({ top: 600 }) } as unknown as HTMLElement)
+                    : null,
+            },
+            rect: { current: rects[index]! },
+          })),
+        };
+        const over = detector(args)[0];
+        return over ? resolveSidebarDropTarget(items, "source", String(over.id))?.section : null;
+      };
+      expect(at(330)).toBe("active");
+      expect(at(317)).toBe("active");
+      expect(at(316)).toBe("pinned");
+      // The preview moves the divider; a stationary pointer must not undo the drop target.
+      boundaryTop = 400;
+      expect(at(316)).toBe("pinned");
+      expect(at(399)).toBe("pinned");
+      expect(at(400)).toBe("active");
+      boundaryTop = 300;
+      expect(at(400)).toBe("active");
+      expect(at(317)).toBe("active");
+      expect(at(316)).toBe("pinned");
     },
   );
-
-  it.each([
-    { reason: "below the boundary cue", x: 130, y: 109, activationY: 140, emptyPins: true },
-    { reason: "left of the list", x: -1, y: 108, activationY: 140, emptyPins: true },
-    { reason: "right of the list", x: 261, y: 108, activationY: 140, emptyPins: true },
-    { reason: "less than 6px upward", x: 130, y: 108, activationY: 113, emptyPins: true },
-    { reason: "without an activation point", x: 130, y: 108, activationY: null, emptyPins: true },
-    { reason: "with populated Pins", x: 130, y: 108, activationY: 140, emptyPins: false },
-  ])("keeps ordinary collision behavior $reason", ({ x, y, activationY, emptyPins }) => {
-    const detector = createSidebarCollisionDetection(() => true, { emptyPins, activationY });
-    const args = { ...clampedArgs(), pointerCoordinates: { x, y } };
-    expect(detector(args)[0]?.id).toBe("source");
-  });
-
-  it("keeps ordinary collision behavior without pointer coordinates", () => {
-    const detector = createSidebarCollisionDetection(() => true, {
-      emptyPins: true,
-      activationY: 140,
-    });
-    expect(detector({ ...clampedArgs(), pointerCoordinates: null })[0]?.id).toBe("source");
-  });
-
-  it("validates the empty Pins override and caches an unsupported result", () => {
-    const isValid = vi.fn(() => false);
-    const detector = createSidebarCollisionDetection(isValid, {
-      emptyPins: true,
-      activationY: 140,
-    });
-    const args = clampedArgs();
-    expect(detector(args).map((collision) => collision.id)).toEqual(["source"]);
-    expect(detector(args).map((collision) => collision.id)).toEqual(["source"]);
-    expect(isValid.mock.calls).toEqual([[sidebarMarkerId("pinned-header")]]);
-  });
 
   it("returns no collision if an unsupported target has no source fallback", () => {
     const args = collisionArgs();

--- a/apps/web/src/components/Sidebar.drag.test.ts
+++ b/apps/web/src/components/Sidebar.drag.test.ts
@@ -40,7 +40,7 @@ function layout(
         ? (item.section === "pinned" || item.section === "active" ? cardHeight : 36) * scale
         : item.marker === "pinned-header" || item.marker === "pinned-divider"
           ? 0
-          : (item.marker.endsWith("placeholder") ? 36 : 32) * scale;
+          : (item.marker.endsWith("placeholder") ? 0 : 32) * scale;
     const rect = { top, height, bottom: top + height, left: 0, right: 260, width: 260 };
     top += height + 1;
     return rect;
@@ -317,7 +317,7 @@ describe("sidebar drag projection", () => {
     }
   });
 
-  it("leaves canonically sorted settled peers in place", () => {
+  it("preserves settled order while opening the zero-height Active target", () => {
     const items = [
       pinnedHeader,
       divider,
@@ -331,7 +331,10 @@ describe("sidebar drag projection", () => {
       "second",
       "first",
     );
-    expect([...result.values()]).toEqual(items.map(() => stationary));
+    expect(result.get(sidebarMarkerId("active-placeholder"))).toEqual(stationary);
+    expect(result.get(sidebarMarkerId("settled-header"))).toEqual({ ...stationary, y: 36 });
+    expect(result.get("first")).toEqual({ ...stationary, y: 36 });
+    expect(result.get("second")).toEqual(stationary);
   });
 
   it.each([
@@ -467,8 +470,8 @@ describe("sidebar drag projection", () => {
   });
 
   it.each([
-    ["p", -83, -37],
-    ["s", 0, 46],
+    ["p", -83, -1],
+    ["s", 0, 82],
   ] as const)(
     "replaces the empty Active target when %s enters",
     (active, dividerOffset, settledOffset) => {
@@ -619,7 +622,7 @@ describe("sidebar drag projection", () => {
     expect(strategy({ ...smaller, index: 2 })?.y).toBe(-62.5);
   });
 
-  it("uses measured placeholder sizing when card height differs from its default", () => {
+  it("uses shelf height for empty target sizing when card height differs from its default", () => {
     const items = [
       pinnedHeader,
       thread("p", "pinned"),

--- a/apps/web/src/components/Sidebar.drag.test.ts
+++ b/apps/web/src/components/Sidebar.drag.test.ts
@@ -357,6 +357,36 @@ describe("sidebar drag projection", () => {
     expect(result.get("s")?.y).toBe(32);
   });
 
+  it.each(["s1", "missing-target"])(
+    "keeps label clearance when a settled drag is over %s",
+    (over) => {
+      const items = [
+        pinnedHeader,
+        thread("p", "pinned"),
+        divider,
+        thread("a", "active"),
+        settledHeader,
+        thread("s1", "settled"),
+        thread("s2", "settled"),
+      ];
+      const result = preview(
+        {
+          items,
+          settledOrder: ["s1", "s2"],
+          settledExpanded: true,
+          boundaryLabelHeight: 24,
+        },
+        "s2",
+        over,
+      );
+      expect(result.get("p")?.y).toBe(24);
+      expect(result.get(sidebarMarkerId("pinned-divider"))?.y).toBe(24);
+      expect(result.get("a")?.y).toBe(48);
+      expect(result.get("s1")?.y).toBe(48);
+      expect(result.get("s2")).toEqual(stationary);
+    },
+  );
+
   it("stacks the labels with their gaps when the pinned section is empty", () => {
     const items = [
       pinnedHeader,

--- a/apps/web/src/components/Sidebar.drag.test.ts
+++ b/apps/web/src/components/Sidebar.drag.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import { closestCenter, type CollisionDetection } from "@dnd-kit/core";
 import { verticalListSortingStrategy, type SortingStrategy } from "@dnd-kit/sortable";
-import { createSidebarCollisionDetection, createSidebarSortingStrategy } from "./Sidebar.drag";
+import {
+  createSidebarCollisionDetection,
+  createSidebarSortingStrategy,
+  restrictBelowSidebarLabel,
+} from "./Sidebar.drag";
 import {
   sidebarListItemId,
   sidebarMarkerId,
@@ -725,5 +729,49 @@ describe("sidebar drag projection", () => {
     );
     expect(result.get(sidebarMarkerId("snoozed-header"))).toEqual({ ...stationary, y: 83 });
     expect(result.get(sidebarMarkerId("settled-header"))?.y).toBe(46);
+  });
+});
+
+describe("lifted card clearance", () => {
+  const rect = (top: number, height: number) => ({
+    top,
+    bottom: top + height,
+    height,
+    left: 0,
+    right: 260,
+    width: 260,
+  });
+  const apply = (cardTop: number, cardHeight: number, y: number, listTop = 136, offset = 32) =>
+    restrictBelowSidebarLabel(
+      {
+        transform: { ...stationary, y },
+        containerNodeRect: rect(listTop, 500),
+        draggingNodeRect: rect(cardTop, cardHeight),
+        activatorEvent: null,
+        active: null,
+        activeNodeRect: null,
+        over: null,
+        overlayNodeRect: null,
+        scrollableAncestors: [],
+        scrollableAncestorRects: [],
+        windowRect: null,
+      },
+      offset,
+    );
+
+  it.each([36, 82])("keeps a %ipx row below empty Pins even past the top edge", (height) => {
+    for (const pointerY of [150, 136, 100, 0]) {
+      const transform = apply(511, height, pointerY - 529);
+      expect(511 + transform.y).toBe(168);
+    }
+  });
+
+  it("preserves pointer movement below the label", () => {
+    expect(apply(511, 36, -200).y).toBe(-200);
+  });
+
+  it("follows the list when it scrolls and includes content preceding Pins", () => {
+    expect(511 + apply(511, 36, -500, 96).y).toBe(128);
+    expect(511 + apply(511, 36, -500, 136, 114).y).toBe(250);
   });
 });

--- a/apps/web/src/components/Sidebar.drag.test.ts
+++ b/apps/web/src/components/Sidebar.drag.test.ts
@@ -150,6 +150,29 @@ describe("sidebar collision detection", () => {
     expect(detector(args)[0]?.id).toBe(sidebarMarkerId("pinned-header"));
   });
 
+  it.each([114, 400])(
+    "keeps empty Pins selected across its opened slot from pickup y=%s",
+    (activationY) => {
+      const args = clampedArgs();
+      const detector = createSidebarCollisionDetection(() => true, {
+        emptyPins: true,
+        activationY,
+        emptyPinCardId: "source",
+        boundaryLabelHeight: 24,
+      });
+      const at = (y: number) => detector({ ...args, pointerCoordinates: { x: 130, y } })[0]?.id;
+      expect(at(108)).toBe(sidebarMarkerId("pinned-header"));
+      // The pointer crosses the old 8px cue, then moves through the visible slot.
+      expect(at(109)).toBe(sidebarMarkerId("pinned-header"));
+      expect(at(160)).toBe(sidebarMarkerId("pinned-header"));
+      expect(at(207)).toBe(sidebarMarkerId("pinned-header"));
+      expect(at(208)).toBe("source");
+      // Returning to the ordinary list does not immediately re-open Pins.
+      expect(at(160)).toBe("source");
+      expect(at(108)).toBe(sidebarMarkerId("pinned-header"));
+    },
+  );
+
   it.each([
     { reason: "below the boundary cue", x: 130, y: 109, activationY: 140, emptyPins: true },
     { reason: "left of the list", x: -1, y: 108, activationY: 140, emptyPins: true },

--- a/apps/web/src/components/Sidebar.drag.ts
+++ b/apps/web/src/components/Sidebar.drag.ts
@@ -73,14 +73,10 @@ export function createSidebarSortingStrategy(input: {
 
   function project({ rects, activeIndex, overIndex }: Layout) {
     const active = items[activeIndex];
-    const over = items[overIndex];
+    const over = items[overIndex] ?? active;
     if (active?.kind !== "thread" || !over || !rects[0]) return [];
     const target = resolveSidebarDropTarget(items, active.key, sidebarListItemId(over));
     if (!target) return [];
-    // Settled keeps time order, so a reorder inside it previews nothing.
-    // Every other drag projects so the boundary labels get their space.
-    if (target.section === active.section && over.kind === "thread" && target.section === "settled")
-      return [];
     const groups: Record<SidebarSection, ThreadItem[]> = {
       pinned: [],
       active: [],

--- a/apps/web/src/components/Sidebar.drag.ts
+++ b/apps/web/src/components/Sidebar.drag.ts
@@ -126,9 +126,13 @@ export function createSidebarSortingStrategy(input: {
     };
     let cardHeight = input.cardHeight;
     let slimHeight = input.slimHeight;
+    let headerScale: number | undefined;
     for (const [index, item] of items.entries()) {
       if (item.kind === "marker") {
-        if (item.marker.endsWith("placeholder")) slimHeight ??= rects[index]?.height;
+        if (item.marker === "settled-header" || item.marker === "snoozed-header") {
+          const height = rects[index]?.height;
+          if (height) headerScale ??= height / 32;
+        }
         continue;
       }
       if (item.section === "pinned" || item.section === "active")
@@ -137,7 +141,8 @@ export function createSidebarSortingStrategy(input: {
       if (item.key !== active.key) groups[item.section].push(item);
     }
     // Cards are 4.875rem + 0.25rem padding; slim rows/placeholders are h-9.
-    const scale = slimHeight !== undefined ? slimHeight / 36 : (cardHeight ?? 82) / 82;
+    const scale =
+      slimHeight !== undefined ? slimHeight / 36 : (headerScale ?? (cardHeight ?? 82) / 82);
     cardHeight ??= 82 * scale;
     slimHeight ??= 36 * scale;
     const labelHeight = (input.boundaryLabelHeight ?? 0) * scale;
@@ -200,9 +205,11 @@ export function createSidebarSortingStrategy(input: {
         item.kind === "marker" &&
         (item.marker === "pinned-header" || item.marker === "pinned-divider")
           ? labelHeight
-          : moved
-            ? fallback
-            : (rect?.height ?? fallback);
+          : item.kind === "marker" && item.marker.endsWith("placeholder")
+            ? slimHeight
+            : moved
+              ? fallback
+              : (rect?.height ?? fallback);
       top += height + 1;
     }
     result[activeIndex] = stationary;

--- a/apps/web/src/components/Sidebar.drag.ts
+++ b/apps/web/src/components/Sidebar.drag.ts
@@ -1,4 +1,4 @@
-import { closestCenter, type CollisionDetection } from "@dnd-kit/core";
+import { closestCenter, type CollisionDetection, type Modifier } from "@dnd-kit/core";
 import { verticalListSortingStrategy, type SortingStrategy } from "@dnd-kit/sortable";
 import {
   resolveSidebarDropTarget,
@@ -13,6 +13,17 @@ const stationary = { x: 0, y: 0, scaleX: 1, scaleY: 1 };
 const hidden = { ...stationary, scaleY: 0 };
 type ThreadItem = Extract<SidebarListItem, { kind: "thread" }>;
 type Layout = Parameters<SortingStrategy>[0];
+
+/** Keep the lifted card below the Pins label, including when Pins is empty.
+ * The container rect follows scrolling; the offset is measured once at pickup. */
+export function restrictBelowSidebarLabel(
+  { transform, containerNodeRect, draggingNodeRect }: Parameters<Modifier>[0],
+  offset: number,
+) {
+  if (!containerNodeRect || !draggingNodeRect) return transform;
+  const minimumY = containerNodeRect.top + offset - draggingNodeRect.top;
+  return transform.y < minimumY ? { ...transform, y: minimumY } : transform;
+}
 
 /** Reject the nearest unsupported target without selecting another section.
  * Recreate this detector when drop eligibility changes. */

--- a/apps/web/src/components/Sidebar.drag.ts
+++ b/apps/web/src/components/Sidebar.drag.ts
@@ -18,22 +18,36 @@ type Layout = Parameters<SortingStrategy>[0];
  * Recreate this detector when drop eligibility changes. */
 export function createSidebarCollisionDetection(
   isValidTarget: (id: string) => boolean,
-  options: { emptyPins?: boolean; activationY?: number | null } = {},
+  options: {
+    emptyPins?: boolean;
+    activationY?: number | null;
+    emptyPinCardId?: string | null;
+    boundaryLabelHeight?: number;
+  } = {},
 ): CollisionDetection {
   const validity = new Map<string, boolean>();
   const pinnedHeaderId = sidebarMarkerId("pinned-header");
+  let overEmptyPins = false;
   return (args) => {
     let collisions = closestCenter(args);
     const pinnedRect = options.emptyPins ? args.droppableRects.get(pinnedHeaderId) : undefined;
     const pointer = args.pointerCoordinates;
+    const cardHeight = options.emptyPinCardId
+      ? args.droppableRects.get(options.emptyPinCardId)?.height
+      : undefined;
+    // Once Pins opens a slot, keep it selected until the pointer leaves that
+    // slot. Reusing the original 8px cue makes tiny movements collapse it.
+    const pinTargetHeight = overEmptyPins
+      ? (cardHeight ?? 82) + (options.boundaryLabelHeight ?? 0) * ((cardHeight ?? 82) / 82) + 1
+      : 8;
     // The card itself is clamped by the scroll container. An upward pointer
     // gesture can still reach the empty pinned boundary without reserving a row.
     if (
       pinnedRect &&
       pointer &&
       options.activationY != null &&
-      pointer.y <= options.activationY - 6 &&
-      pointer.y <= pinnedRect.top + 8 &&
+      (overEmptyPins || pointer.y <= options.activationY - 6) &&
+      pointer.y <= pinnedRect.top + pinTargetHeight &&
       pointer.x >= pinnedRect.left &&
       pointer.x <= pinnedRect.right
     ) {
@@ -43,10 +57,14 @@ export function createSidebarCollisionDetection(
       }
     }
     const nearest = collisions[0];
-    if (!nearest || nearest.id === args.active.id) return collisions;
+    if (!nearest || nearest.id === args.active.id) {
+      overEmptyPins = false;
+      return collisions;
+    }
     const id = String(nearest.id);
     const valid = validity.get(id) ?? isValidTarget(id);
     validity.set(id, valid);
+    overEmptyPins = valid && id === pinnedHeaderId;
     return valid ? collisions : collisions.filter((collision) => collision.id === args.active.id);
   };
 }

--- a/apps/web/src/components/Sidebar.drag.ts
+++ b/apps/web/src/components/Sidebar.drag.ts
@@ -30,52 +30,64 @@ export function restrictBelowSidebarLabel(
 export function createSidebarCollisionDetection(
   isValidTarget: (id: string) => boolean,
   options: {
-    emptyPins?: boolean;
+    items?: readonly SidebarListItem[];
     activationY?: number | null;
-    emptyPinCardId?: string | null;
-    boundaryLabelHeight?: number;
   } = {},
 ): CollisionDetection {
   const validity = new Map<string, boolean>();
-  const pinnedHeaderId = sidebarMarkerId("pinned-header");
-  let overEmptyPins = false;
+  const sections = new Map<string, SidebarSection | null>();
+  let previousPointerY = options.activationY;
+  let boundarySection: "pinned" | "active" | undefined;
   return (args) => {
     let collisions = closestCenter(args);
-    const pinnedRect = options.emptyPins ? args.droppableRects.get(pinnedHeaderId) : undefined;
     const pointer = args.pointerCoordinates;
-    const cardHeight = options.emptyPinCardId
-      ? args.droppableRects.get(options.emptyPinCardId)?.height
-      : undefined;
-    // Once Pins opens a slot, keep it selected until the pointer leaves that
-    // slot. Reusing the original 8px cue makes tiny movements collapse it.
-    const pinTargetHeight = overEmptyPins
-      ? (cardHeight ?? 82) + (options.boundaryLabelHeight ?? 0) * ((cardHeight ?? 82) / 82) + 1
-      : 8;
-    // The card itself is clamped by the scroll container. An upward pointer
-    // gesture can still reach the empty pinned boundary without reserving a row.
-    if (
-      pinnedRect &&
-      pointer &&
-      options.activationY != null &&
-      (overEmptyPins || pointer.y <= options.activationY - 6) &&
-      pointer.y <= pinnedRect.top + pinTargetHeight &&
-      pointer.x >= pinnedRect.left &&
-      pointer.x <= pinnedRect.right
-    ) {
-      const pinned = collisions.find((collision) => collision.id === pinnedHeaderId);
-      if (pinned) {
-        collisions = [pinned, ...collisions.filter((collision) => collision !== pinned)];
+    const items = options.items;
+    const source = items?.find((item) => item.kind === "thread" && item.key === args.active.id);
+    const boundary = args.droppableContainers
+      .find((container) => container.id === sidebarMarkerId("pinned-divider"))
+      ?.node.current?.querySelector(".sidebar-drag-boundary-label")
+      ?.getBoundingClientRect();
+    if (items && boundary && source?.kind === "thread" && pointer) {
+      boundarySection ??= source.section === "pinned" ? "pinned" : "active";
+      // Use the visible divider row, including its sortable translation.
+      // Only pointer movement can change sections: opening the destination
+      // moves this row, but must not toggle a stationary gesture back.
+      const previousY = previousPointerY ?? pointer.y;
+      previousPointerY = pointer.y;
+      if (pointer.x >= boundary.left && pointer.x <= boundary.right) {
+        if (pointer.y < previousY && pointer.y <= boundary.bottom) boundarySection = "pinned";
+        else if (pointer.y > previousY && pointer.y >= boundary.top) boundarySection = "active";
+        const nextHeader =
+          args.droppableContainers.find(
+            (container) => container.id === sidebarMarkerId("snoozed-header"),
+          ) ??
+          args.droppableContainers.find(
+            (container) => container.id === sidebarMarkerId("settled-header"),
+          );
+        const activeBottom = nextHeader?.node.current?.getBoundingClientRect().top;
+        if (boundarySection === "pinned" || (activeBottom != null && pointer.y < activeBottom)) {
+          const target = collisions.find((collision) => {
+            const id = String(collision.id);
+            if (!sections.has(id)) {
+              sections.set(
+                id,
+                resolveSidebarDropTarget(items, String(args.active.id), id)?.section ?? null,
+              );
+            }
+            return sections.get(id) === boundarySection;
+          });
+          if (target)
+            collisions = [target, ...collisions.filter((collision) => collision !== target)];
+        }
       }
     }
     const nearest = collisions[0];
     if (!nearest || nearest.id === args.active.id) {
-      overEmptyPins = false;
       return collisions;
     }
     const id = String(nearest.id);
     const valid = validity.get(id) ?? isValidTarget(id);
     validity.set(id, valid);
-    overEmptyPins = valid && id === pinnedHeaderId;
     return valid ? collisions : collisions.filter((collision) => collision.id === args.active.id);
   };
 }

--- a/apps/web/src/components/Sidebar.pointer.test.ts
+++ b/apps/web/src/components/Sidebar.pointer.test.ts
@@ -1,0 +1,173 @@
+import type { SensorProps } from "@dnd-kit/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { act, createElement, StrictMode } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { SidebarDragLifecycle, SidebarPointerSensor } from "./Sidebar.pointer";
+
+class TestDocument extends EventTarget {
+  hidden = false;
+  getSelection = () => ({ removeAllRanges() {} });
+}
+
+let document: TestDocument;
+let window: EventTarget;
+const sensors: SidebarPointerSensor[] = [];
+
+function pointer(type: string, values: Partial<PointerEvent> = {}) {
+  return Object.assign(new Event(type, { cancelable: true }), {
+    pointerId: 1,
+    clientX: 10,
+    clientY: 10,
+    buttons: 1,
+    ...values,
+  });
+}
+
+function gesture() {
+  const callbacks = {
+    onStart: vi.fn(),
+    onMove: vi.fn(),
+    onEnd: vi.fn(),
+    onCancel: vi.fn(),
+    onAbort: vi.fn(),
+    onPending: vi.fn(),
+  };
+  const onFinish = vi.fn();
+  // The sensor never reads dnd-kit's layout context or active node.
+  const props = {
+    active: "thread",
+    event: pointer("pointerdown"),
+    options: { distance: 6, onAttach: vi.fn(), onFinish },
+    ...callbacks,
+  } as unknown as SensorProps<ConstructorParameters<typeof SidebarPointerSensor>[0]["options"]>;
+  const sensor = new SidebarPointerSensor(props);
+  sensors.push(sensor);
+  return { sensor, onFinish, ...callbacks };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  document = new TestDocument();
+  window = Object.assign(new EventTarget(), { setTimeout });
+  vi.stubGlobal("document", document);
+  vi.stubGlobal("window", window);
+});
+afterEach(() => {
+  for (const sensor of sensors.splice(0)) sensor.cancel();
+  vi.runAllTimers();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("sidebar pointer lifecycle", () => {
+  it("keeps a click idle and starts only after the drag threshold", () => {
+    const click = gesture();
+    document.dispatchEvent(pointer("pointermove", { clientY: 16 }));
+    expect(click.onStart).not.toHaveBeenCalled();
+    document.dispatchEvent(pointer("pointerup", { buttons: 0 }));
+    expect(click.onAbort).toHaveBeenCalledOnce();
+    expect(click.onFinish).toHaveBeenCalledOnce();
+
+    const drag = gesture();
+    document.dispatchEvent(pointer("pointermove", { clientY: 17 }));
+    expect(drag.onStart).toHaveBeenCalledExactlyOnceWith({ x: 10, y: 10 });
+    document.dispatchEvent(pointer("pointerup", { buttons: 0 }));
+    expect(drag.onEnd).toHaveBeenCalledOnce();
+    expect(drag.onAbort).not.toHaveBeenCalled();
+    expect(drag.onFinish).toHaveBeenCalledOnce();
+  });
+
+  const interruptions = {
+    blur: () => window.dispatchEvent(new Event("blur")),
+    hidden: () => {
+      document.hidden = true;
+      document.dispatchEvent(new Event("visibilitychange"));
+    },
+    pagehide: () => window.dispatchEvent(new Event("pagehide")),
+    resize: () => window.dispatchEvent(new Event("resize")),
+    escape: () => document.dispatchEvent(Object.assign(new Event("keydown"), { code: "Escape" })),
+    pointercancel: () => document.dispatchEvent(pointer("pointercancel")),
+    "missed release": () =>
+      document.dispatchEvent(pointer("pointermove", { buttons: 0, clientY: 100 })),
+  };
+  for (const [name, interrupt] of Object.entries(interruptions)) {
+    it.each([false, true])(`cancels on ${name}, started=%s, and ignores late events`, (started) => {
+      const drag = gesture();
+      if (started) document.dispatchEvent(pointer("pointermove", { clientY: 20 }));
+      interrupt();
+      document.dispatchEvent(pointer("pointermove", { clientY: 100 }));
+      document.dispatchEvent(pointer("pointerup", { buttons: 0 }));
+      drag.sensor.cancel();
+      expect(drag.onCancel).toHaveBeenCalledOnce();
+      expect(drag.onEnd).not.toHaveBeenCalled();
+      expect(drag.onFinish).toHaveBeenCalledOnce();
+      expect(drag.onStart).toHaveBeenCalledTimes(started ? 1 : 0);
+      expect(drag.onAbort).toHaveBeenCalledTimes(started ? 0 : 1);
+
+      document.hidden = false;
+      const next = gesture();
+      document.dispatchEvent(pointer("pointermove", { clientY: 20 }));
+      document.dispatchEvent(pointer("pointerup", { buttons: 0 }));
+      expect(next.onStart).toHaveBeenCalledOnce();
+      expect(next.onEnd).toHaveBeenCalledOnce();
+    });
+  }
+
+  it("does not move after cancellation during activation", () => {
+    const drag = gesture();
+    drag.onStart.mockImplementation(() => drag.sensor.cancel());
+    document.dispatchEvent(pointer("pointermove", { clientY: 20 }));
+    expect(drag.onCancel).toHaveBeenCalledOnce();
+    expect(drag.onMove).not.toHaveBeenCalled();
+    expect(drag.onFinish).toHaveBeenCalledOnce();
+  });
+
+  it("ignores events from other pointers", () => {
+    const drag = gesture();
+    document.dispatchEvent(pointer("pointermove", { pointerId: 2, buttons: 0, clientY: 100 }));
+    document.dispatchEvent(pointer("pointercancel", { pointerId: 2 }));
+    document.dispatchEvent(pointer("pointerup", { pointerId: 2 }));
+    expect(drag.onStart).not.toHaveBeenCalled();
+    expect(drag.onFinish).not.toHaveBeenCalled();
+    document.dispatchEvent(pointer("pointermove", { clientY: 20 }));
+    expect(drag.onStart).toHaveBeenCalledOnce();
+  });
+
+  it.each([false, true])("cancels when search unmounts the list, started=%s", (started) => {
+    let renderer: ReactTestRenderer;
+    let drag: ReturnType<typeof gesture> | undefined;
+    act(() => {
+      renderer = create(
+        createElement(
+          StrictMode,
+          null,
+          createElement(SidebarDragLifecycle, {
+            onUnmount: () => drag?.sensor.cancel(),
+          }),
+        ),
+      );
+    });
+    drag = gesture();
+    if (started) document.dispatchEvent(pointer("pointermove", { clientY: 20 }));
+    act(() => renderer.unmount());
+    document.dispatchEvent(pointer("pointermove", { clientY: 100 }));
+    document.dispatchEvent(pointer("pointerup", { buttons: 0 }));
+    expect(drag.onStart).toHaveBeenCalledTimes(started ? 1 : 0);
+    expect(drag.onCancel).toHaveBeenCalledOnce();
+    expect(drag.onEnd).not.toHaveBeenCalled();
+    expect(drag.onFinish).toHaveBeenCalledOnce();
+  });
+
+  it("detaches a cancelled sensor before a replacement gesture starts", () => {
+    const previous = gesture();
+    document.dispatchEvent(pointer("pointermove", { clientY: 20 }));
+    previous.sensor.cancel();
+    const next = gesture();
+    document.dispatchEvent(pointer("pointermove", { clientY: 20 }));
+    document.dispatchEvent(pointer("pointerup", { buttons: 0 }));
+    expect(previous.onCancel).toHaveBeenCalledOnce();
+    expect(previous.onEnd).not.toHaveBeenCalled();
+    expect(next.onEnd).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/Sidebar.pointer.test.ts
+++ b/apps/web/src/components/Sidebar.pointer.test.ts
@@ -114,6 +114,33 @@ describe("sidebar pointer lifecycle", () => {
     });
   }
 
+  it("suppresses a delayed release click after cancellation, then accepts the next click", () => {
+    const drag = gesture();
+    document.dispatchEvent(pointer("pointermove", { clientY: 20 }));
+    drag.sensor.cancel();
+    vi.advanceTimersByTime(1000);
+    const releaseClick = new Event("click");
+    const releasePropagation = vi.spyOn(releaseClick, "stopPropagation");
+    document.dispatchEvent(releaseClick);
+    expect(releasePropagation).toHaveBeenCalledOnce();
+    document.dispatchEvent(pointer("pointerdown"));
+    const nextClick = new Event("click");
+    const nextPropagation = vi.spyOn(nextClick, "stopPropagation");
+    document.dispatchEvent(nextClick);
+    expect(nextPropagation).not.toHaveBeenCalled();
+  });
+
+  it("allows the next click when the cancelled release happened outside the document", () => {
+    const drag = gesture();
+    document.dispatchEvent(pointer("pointermove", { clientY: 20 }));
+    drag.sensor.cancel();
+    document.dispatchEvent(pointer("pointerdown"));
+    const click = new Event("click");
+    const propagation = vi.spyOn(click, "stopPropagation");
+    document.dispatchEvent(click);
+    expect(propagation).not.toHaveBeenCalled();
+  });
+
   it("does not move after cancellation during activation", () => {
     const drag = gesture();
     drag.onStart.mockImplementation(() => drag.sensor.cancel());

--- a/apps/web/src/components/Sidebar.pointer.ts
+++ b/apps/web/src/components/Sidebar.pointer.ts
@@ -35,9 +35,9 @@ export class SidebarPointerSensor {
     this.document = getOwnerDocument(this.pointer.target);
     this.window = getWindow(this.pointer.target);
     this.document.addEventListener("pointermove", this.move, { passive: false, capture: true });
-    this.document.addEventListener("pointerup", this.end, true);
-    this.document.addEventListener("pointercancel", this.pointerCancel, true);
-    this.document.addEventListener("keydown", this.keydown, true);
+    this.document.addEventListener("pointerup", this.end, { capture: true });
+    this.document.addEventListener("pointercancel", this.pointerCancel, { capture: true });
+    this.document.addEventListener("keydown", this.keydown, { capture: true });
     this.document.addEventListener("visibilitychange", this.visibilityChange);
     this.window.addEventListener("blur", this.cancel);
     this.window.addEventListener("pagehide", this.cancel);
@@ -50,7 +50,14 @@ export class SidebarPointerSensor {
 
   private coordinates = () => ({ x: this.pointer.clientX, y: this.pointer.clientY });
   private preventDefault = (event: Event) => event.preventDefault();
-  private suppressClick = (event: Event) => event.stopPropagation();
+  private clearClickSuppression = () => {
+    this.document.removeEventListener("click", this.suppressClick, { capture: true });
+    this.document.removeEventListener("pointerdown", this.clearClickSuppression, { capture: true });
+  };
+  private suppressClick = (event: Event) => {
+    event.stopPropagation();
+    this.clearClickSuppression();
+  };
   private clearSelection = () => this.document.getSelection()?.removeAllRanges();
 
   private move = (event: PointerEvent) => {
@@ -74,7 +81,7 @@ export class SidebarPointerSensor {
         return;
       }
       this.phase = "dragging";
-      this.document.addEventListener("click", this.suppressClick, true);
+      this.document.addEventListener("click", this.suppressClick, { capture: true });
       this.document.addEventListener("selectionchange", this.clearSelection);
       this.clearSelection();
       this.props.onStart(this.coordinates());
@@ -103,10 +110,10 @@ export class SidebarPointerSensor {
     if (this.phase === "finished") return;
     const aborted = this.phase === "pending";
     this.phase = "finished";
-    this.document.removeEventListener("pointermove", this.move, true);
-    this.document.removeEventListener("pointerup", this.end, true);
-    this.document.removeEventListener("pointercancel", this.pointerCancel, true);
-    this.document.removeEventListener("keydown", this.keydown, true);
+    this.document.removeEventListener("pointermove", this.move, { capture: true });
+    this.document.removeEventListener("pointerup", this.end, { capture: true });
+    this.document.removeEventListener("pointercancel", this.pointerCancel, { capture: true });
+    this.document.removeEventListener("keydown", this.keydown, { capture: true });
     this.document.removeEventListener("visibilitychange", this.visibilityChange);
     this.window.removeEventListener("blur", this.cancel);
     this.window.removeEventListener("pagehide", this.cancel);
@@ -114,10 +121,12 @@ export class SidebarPointerSensor {
     this.document.removeEventListener("dragstart", this.preventDefault);
     this.document.removeEventListener("contextmenu", this.preventDefault);
     this.document.removeEventListener("selectionchange", this.clearSelection);
-    // Keep the release click from opening the thread after a drag.
-    this.window.setTimeout(() => {
-      this.document.removeEventListener("click", this.suppressClick, true);
-    }, 0);
+    // Cancellation can precede release by an arbitrary amount of time. Consume
+    // that release click, or let a fresh pointerdown end suppression if release
+    // happened outside the document. Ordinary clicks never install this guard.
+    if (!aborted) {
+      this.document.addEventListener("pointerdown", this.clearClickSuppression, { capture: true });
+    }
     try {
       // Release the sidebar preview before dnd-kit clears its transforms.
       // Its public end/cancel event can be omitted before its first layout.

--- a/apps/web/src/components/Sidebar.pointer.ts
+++ b/apps/web/src/components/Sidebar.pointer.ts
@@ -85,6 +85,7 @@ export class SidebarPointerSensor {
       this.document.addEventListener("selectionchange", this.clearSelection);
       this.clearSelection();
       this.props.onStart(this.coordinates());
+      return;
     }
     if (this.phase === "dragging") {
       if (event.cancelable) event.preventDefault();

--- a/apps/web/src/components/Sidebar.pointer.ts
+++ b/apps/web/src/components/Sidebar.pointer.ts
@@ -1,0 +1,131 @@
+import { useLayoutEffect, type PointerEvent as ReactPointerEvent } from "react";
+import { type SensorProps } from "@dnd-kit/core";
+import { getOwnerDocument, getWindow } from "@dnd-kit/utilities";
+
+// Search unmounts the drag context while its owning Sidebar remains mounted.
+export function SidebarDragLifecycle({ onUnmount }: { onUnmount: () => void }) {
+  useLayoutEffect(() => onUnmount, [onUnmount]);
+  return null;
+}
+
+type Options = {
+  distance: number;
+  onAttach: (sensor: SidebarPointerSensor) => void;
+  onFinish: (started: boolean) => void;
+};
+
+/** A sidebar gesture ends on release, cancellation, or loss of its window.
+ * Own the listeners so unmounting the list can cancel the sensor too. */
+export class SidebarPointerSensor {
+  static activators = [
+    {
+      eventName: "onPointerDown" as const,
+      handler: ({ nativeEvent }: ReactPointerEvent) =>
+        nativeEvent.isPrimary && nativeEvent.button === 0,
+    },
+  ];
+  autoScrollEnabled = true;
+  private phase: "pending" | "dragging" | "finished" = "pending";
+  private readonly pointer: PointerEvent;
+  private readonly document: Document;
+  private readonly window: Window;
+
+  constructor(private readonly props: SensorProps<Options>) {
+    this.pointer = props.event as PointerEvent;
+    this.document = getOwnerDocument(this.pointer.target);
+    this.window = getWindow(this.pointer.target);
+    this.document.addEventListener("pointermove", this.move, { passive: false, capture: true });
+    this.document.addEventListener("pointerup", this.end, true);
+    this.document.addEventListener("pointercancel", this.pointerCancel, true);
+    this.document.addEventListener("keydown", this.keydown, true);
+    this.document.addEventListener("visibilitychange", this.visibilityChange);
+    this.window.addEventListener("blur", this.cancel);
+    this.window.addEventListener("pagehide", this.cancel);
+    this.window.addEventListener("resize", this.cancel);
+    this.document.addEventListener("dragstart", this.preventDefault);
+    this.document.addEventListener("contextmenu", this.preventDefault);
+    props.options.onAttach(this);
+    props.onPending(props.active, { distance: props.options.distance }, this.coordinates());
+  }
+
+  private coordinates = () => ({ x: this.pointer.clientX, y: this.pointer.clientY });
+  private preventDefault = (event: Event) => event.preventDefault();
+  private suppressClick = (event: Event) => event.stopPropagation();
+  private clearSelection = () => this.document.getSelection()?.removeAllRanges();
+
+  private move = (event: PointerEvent) => {
+    if (this.phase === "finished" || event.pointerId !== this.pointer.pointerId) return;
+    // A release outside the window can be missed. Never activate or continue
+    // a drag when the initiating button is no longer held.
+    if ((event.buttons & 1) === 0) return this.cancel();
+    const coordinates = { x: event.clientX, y: event.clientY };
+    if (this.phase === "pending") {
+      const offset = {
+        x: event.clientX - this.pointer.clientX,
+        y: event.clientY - this.pointer.clientY,
+      };
+      if (Math.hypot(offset.x, offset.y) <= this.props.options.distance) {
+        this.props.onPending(
+          this.props.active,
+          { distance: this.props.options.distance },
+          this.coordinates(),
+          offset,
+        );
+        return;
+      }
+      this.phase = "dragging";
+      this.document.addEventListener("click", this.suppressClick, true);
+      this.document.addEventListener("selectionchange", this.clearSelection);
+      this.clearSelection();
+      this.props.onStart(this.coordinates());
+    }
+    if (this.phase === "dragging") {
+      if (event.cancelable) event.preventDefault();
+      this.props.onMove(coordinates);
+    }
+  };
+
+  private end = (event: PointerEvent) => {
+    if (event.pointerId === this.pointer.pointerId) this.finish(false);
+  };
+  private pointerCancel = (event: PointerEvent) => {
+    if (event.pointerId === this.pointer.pointerId) this.cancel();
+  };
+  private keydown = (event: KeyboardEvent) => {
+    if (event.code === "Escape") this.cancel();
+  };
+  private visibilityChange = () => {
+    if (this.document.hidden) this.cancel();
+  };
+  cancel = () => this.finish(true);
+
+  private finish(cancelled: boolean) {
+    if (this.phase === "finished") return;
+    const aborted = this.phase === "pending";
+    this.phase = "finished";
+    this.document.removeEventListener("pointermove", this.move, true);
+    this.document.removeEventListener("pointerup", this.end, true);
+    this.document.removeEventListener("pointercancel", this.pointerCancel, true);
+    this.document.removeEventListener("keydown", this.keydown, true);
+    this.document.removeEventListener("visibilitychange", this.visibilityChange);
+    this.window.removeEventListener("blur", this.cancel);
+    this.window.removeEventListener("pagehide", this.cancel);
+    this.window.removeEventListener("resize", this.cancel);
+    this.document.removeEventListener("dragstart", this.preventDefault);
+    this.document.removeEventListener("contextmenu", this.preventDefault);
+    this.document.removeEventListener("selectionchange", this.clearSelection);
+    // Keep the release click from opening the thread after a drag.
+    this.window.setTimeout(() => {
+      this.document.removeEventListener("click", this.suppressClick, true);
+    }, 0);
+    try {
+      // Release the sidebar preview before dnd-kit clears its transforms.
+      // Its public end/cancel event can be omitted before its first layout.
+      this.props.options.onFinish(!aborted);
+    } finally {
+      if (aborted) this.props.onAbort(this.props.active);
+      if (cancelled) this.props.onCancel();
+      else this.props.onEnd();
+    }
+  }
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -554,8 +554,8 @@ function SortableSidebarMarker(props: {
   );
 }
 
-// Empty targets stay mounted before pickup so starting a drag never changes
-// the list's measured positions.
+// Empty targets stay measurable without reserving space at rest. The sorting
+// strategy opens their hint space during a drag.
 function SidebarSectionPlaceholder(props: {
   marker: "active-placeholder" | "settled-placeholder";
   label: string;
@@ -566,13 +566,18 @@ function SidebarSectionPlaceholder(props: {
     <SortableSidebarMarker
       marker={props.marker}
       data-testid={`sidebar-${props.marker}`}
-      className={cn(
-        "mx-0.5 flex h-9 items-center justify-center rounded-md border border-dashed border-transparent text-xs text-sidebar-muted-foreground/60",
-        props.showHint && "border-sidebar-foreground/25 text-sidebar-foreground/80",
-        props.isDropTarget && "border-primary/40 bg-primary/5 text-primary",
-      )}
+      className="relative mx-0.5 h-0"
     >
-      {props.showHint ? props.label : null}
+      {props.showHint ? (
+        <div
+          className={cn(
+            "absolute inset-x-0 top-0 flex h-9 items-center justify-center rounded-md border border-dashed border-sidebar-foreground/25 text-xs text-sidebar-foreground/80",
+            props.isDropTarget && "border-primary/40 bg-primary/5 text-primary",
+          )}
+        >
+          {props.label}
+        </div>
+      ) : null}
     </SortableSidebarMarker>
   );
 }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3392,10 +3392,8 @@ export default function Sidebar() {
         );
       },
       {
-        emptyPins: pinnedKeys.length === 0,
+        items: sidebarListItems,
         activationY: dragActivationY ?? null,
-        emptyPinCardId: activeKeys[0] ?? null,
-        boundaryLabelHeight: SIDEBAR_DRAG_LABEL_HEIGHT,
       },
     );
   }, [

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -501,8 +501,6 @@ function SortableThreadRow(props: {
     id: props.id,
     disabled: { draggable: props.disabled },
     animateLayoutChanges: animateSidebarLayoutChanges,
-    // Apply label clearance and row positions together, without tweening through content.
-    transition: null,
   });
   // dnd-kit memoizes each field but not the bag, so the memoized row would
   // rerender on every shell update without this.
@@ -533,7 +531,6 @@ function SortableSidebarMarker(props: {
     id: sidebarMarkerId(props.marker),
     disabled: { draggable: true },
     animateLayoutChanges: animateSidebarLayoutChanges,
-    transition: null,
   });
   return (
     <li
@@ -592,7 +589,7 @@ function SidebarDragBoundary(props: {
       className="pointer-events-none relative mx-0.5 h-0"
     >
       {props.visible ? (
-        <div className="absolute inset-x-2 top-1 flex h-4 items-center gap-1.5">
+        <div className="sidebar-drag-boundary-label absolute inset-x-2 top-1 flex h-4 items-center gap-1.5">
           <span
             className={cn(
               "inline-flex h-4 shrink-0 items-center rounded-sm border bg-sidebar px-1.5 text-[10px] leading-none font-medium",
@@ -3341,18 +3338,22 @@ export default function Sidebar() {
     }),
     [threads],
   );
+  const draggedThreadKey = dragState?.activeKey;
+  const draggedFromSection = dragState?.activeSection;
+  const dragActivationY = dragState?.activationY;
   const dndCollisionDetection = useMemo(() => {
-    if (dragState === null) return createSidebarCollisionDetection(() => true);
-    const source = threadByKey.get(dragState.activeKey);
+    if (draggedThreadKey === undefined || draggedFromSection === undefined)
+      return createSidebarCollisionDetection(() => true);
+    const source = threadByKey.get(draggedThreadKey);
     if (source === undefined) return createSidebarCollisionDetection(() => false);
     return createSidebarCollisionDetection(
       (id) => {
-        const target = resolveSidebarDropTarget(sidebarListItems, dragState.activeKey, id);
+        const target = resolveSidebarDropTarget(sidebarListItems, draggedThreadKey, id);
         if (target === null) return false;
         return (
           planSidebarThreadDrop({
-            activeKey: dragState.activeKey,
-            activeSection: dragState.activeSection,
+            activeKey: draggedThreadKey,
+            activeSection: draggedFromSection,
             activePinned: source.pinnedAt != null,
             activeSettled: source.settledOverride === "settled",
             supportsSettlement:
@@ -3368,7 +3369,12 @@ export default function Sidebar() {
           }).kind !== "none"
         );
       },
-      { emptyPins: pinnedKeys.length === 0, activationY: dragState.activationY },
+      {
+        emptyPins: pinnedKeys.length === 0,
+        activationY: dragActivationY ?? null,
+        emptyPinCardId: activeKeys[0] ?? null,
+        boundaryLabelHeight: SIDEBAR_DRAG_LABEL_HEIGHT,
+      },
     );
   }, [
     activeKeysById,
@@ -3376,7 +3382,9 @@ export default function Sidebar() {
     serverConfigs,
     activeKeys,
     activeReorderableThreadKeys,
-    dragState,
+    draggedThreadKey,
+    draggedFromSection,
+    dragActivationY,
     draggableThreadKeys,
     pinnedKeys,
     sidebarListItems,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2,7 +2,6 @@ import { useAtomValue } from "@effect/atom-react";
 import * as Schema from "effect/Schema";
 import {
   DndContext,
-  PointerSensor,
   useSensor,
   useSensors,
   type DragEndEvent,
@@ -173,6 +172,7 @@ import {
 } from "./Sidebar.logic";
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
 import { createSidebarCollisionDetection, createSidebarSortingStrategy } from "./Sidebar.drag";
+import { SidebarDragLifecycle, SidebarPointerSensor } from "./Sidebar.pointer";
 import { createSidebarListMotion } from "./Sidebar.motion";
 import {
   ThreadWorktreeIndicator,
@@ -501,6 +501,8 @@ function SortableThreadRow(props: {
     id: props.id,
     disabled: { draggable: props.disabled },
     animateLayoutChanges: animateSidebarLayoutChanges,
+    // Apply label clearance and row positions together, without tweening through content.
+    transition: null,
   });
   // dnd-kit memoizes each field but not the bag, so the memoized row would
   // rerender on every shell update without this.
@@ -531,6 +533,7 @@ function SortableSidebarMarker(props: {
     id: sidebarMarkerId(props.marker),
     disabled: { draggable: true },
     animateLayoutChanges: animateSidebarLayoutChanges,
+    transition: null,
   });
   return (
     <li
@@ -572,15 +575,9 @@ function SidebarSectionPlaceholder(props: {
   );
 }
 
-// Boundary labels appear during a drag in space the sorting strategy opens
-// below each marker (SIDEBAR_DRAG_LABEL_HEIGHT), so they never sit on a row.
-// The marker itself stays zero height, so nothing is reserved at rest and
-// pickup measurements are unchanged. They read at full strength so the
-// sections are easy to find, and the section under the lifted row takes the
-// accent. They paint above the lifted row so a card dragged across a
-// boundary never hides its label.
-// Matches the label's h-4 below.
-const SIDEBAR_DRAG_LABEL_HEIGHT = 16;
+// Zero-height markers reserve no label space at rest. During a drag the
+// sorting strategy opens 24px for a 16px label with 4px clearance on each side.
+const SIDEBAR_DRAG_LABEL_HEIGHT = 24;
 
 function SidebarDragBoundary(props: {
   marker: "pinned-header" | "pinned-divider";
@@ -592,10 +589,10 @@ function SidebarDragBoundary(props: {
     <SortableSidebarMarker
       marker={props.marker}
       data-testid={`sidebar-${props.marker}`}
-      className="pointer-events-none relative z-30 mx-0.5 h-0"
+      className="pointer-events-none relative mx-0.5 h-0"
     >
       {props.visible ? (
-        <div className="absolute inset-x-2 top-0 flex h-4 items-center gap-1.5">
+        <div className="absolute inset-x-2 top-1 flex h-4 items-center gap-1.5">
           <span
             className={cn(
               "inline-flex h-4 shrink-0 items-center rounded-sm border bg-sidebar px-1.5 text-[10px] leading-none font-medium",
@@ -3031,16 +3028,35 @@ export default function Sidebar() {
   // Hold the chosen section and order until every key write arrives. This
   // also covers first-time ordering, which assigns keys to keyless neighbors.
   // A failed write, concurrent reorder, or membership change releases the hold.
-  const dndSensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
-  );
   const [dragState, setDragState] = useState<{
     readonly activeKey: string;
     readonly activeSection: SidebarSection;
     readonly occurredAt: string;
     readonly activationY: number | null;
+    readonly targetSection: SidebarSection | null;
   } | null>(null);
-  const [dragTargetSection, setDragTargetSection] = useState<SidebarSection | null>(null);
+  const dragTargetSection = dragState?.targetSection ?? null;
+  const dragSensorRef = useRef<SidebarPointerSensor | null>(null);
+  const finishThreadDrag = useCallback((started: boolean) => {
+    dragSensorRef.current = null;
+    if (started) {
+      listMotionRef.current?.release();
+      setDragState(null);
+    }
+  }, []);
+  const attachDragSensor = useCallback((sensor: SidebarPointerSensor) => {
+    dragSensorRef.current = sensor;
+  }, []);
+  const cancelThreadDrag = useCallback(() => {
+    dragSensorRef.current?.cancel();
+  }, []);
+  const dndSensors = useSensors(
+    useSensor(SidebarPointerSensor, {
+      distance: 6,
+      onAttach: attachDragSensor,
+      onFinish: finishThreadDrag,
+    }),
+  );
   const sectionByThreadKey = useMemo(() => {
     const map = new Map<string, SidebarSection>();
     const add = (list: readonly EnvironmentThreadShell[], section: SidebarSection) => {
@@ -3188,19 +3204,14 @@ export default function Sidebar() {
       setDragState({
         activeKey,
         activeSection,
+        targetSection: activeSection,
         occurredAt: new Date().toISOString(),
         activationY:
           event.activatorEvent instanceof PointerEvent ? event.activatorEvent.clientY : null,
       });
-      setDragTargetSection(activeSection);
     },
     [sectionByThreadKey],
   );
-  const handleThreadDragCancel = useCallback(() => {
-    listMotionRef.current?.release();
-    setDragState(null);
-    setDragTargetSection(null);
-  }, []);
   // Include every visible row in the measured order. Older servers disable
   // pickup on their rows without changing where those rows render.
   const sidebarListItems = useMemo((): readonly SidebarListItem[] => {
@@ -3249,6 +3260,14 @@ export default function Sidebar() {
     snoozedThreads.length,
     visibleSnoozedThreads,
   ]);
+  useEffect(() => {
+    if (
+      dragState !== null &&
+      !sidebarListItems.some((item) => item.kind === "thread" && item.key === dragState.activeKey)
+    ) {
+      cancelThreadDrag();
+    }
+  }, [cancelThreadDrag, dragState, sidebarListItems]);
   const listMotionPaused = dragState !== null;
   useLayoutEffect(() => {
     // Drag release clears the baseline, so its commit cannot replay the
@@ -3264,7 +3283,11 @@ export default function Sidebar() {
       const target = event.over
         ? resolveSidebarDropTarget(sidebarListItems, String(event.active.id), String(event.over.id))
         : null;
-      setDragTargetSection(target?.section ?? null);
+      setDragState((current) =>
+        current === null || current.activeKey !== String(event.active.id)
+          ? current
+          : { ...current, targetSection: target?.section ?? null },
+      );
     },
     [sidebarListItems],
   );
@@ -3361,9 +3384,6 @@ export default function Sidebar() {
   ]);
   const handleThreadDragEnd = useCallback(
     (event: DragEndEvent) => {
-      listMotionRef.current?.release();
-      setDragState(null);
-      setDragTargetSection(null);
       const activeKey = String(event.active.id);
       const activeSection = sectionByThreadKey.get(activeKey);
       const target =
@@ -4550,9 +4570,9 @@ export default function Sidebar() {
                 modifiers={[restrictToVerticalAxis, restrictToFirstScrollableAncestor]}
                 onDragStart={handleThreadDragStart}
                 onDragOver={handleThreadDragOver}
-                onDragCancel={handleThreadDragCancel}
                 onDragEnd={handleThreadDragEnd}
               >
+                <SidebarDragLifecycle onUnmount={cancelThreadDrag} />
                 <SortableContext items={sortableIds} strategy={sidebarSortingStrategy}>
                   <ul
                     ref={attachListMotionRef}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   type DragEndEvent,
   type DragOverEvent,
   type DragStartEvent,
+  type Modifier,
 } from "@dnd-kit/core";
 import { SortableContext, useSortable } from "@dnd-kit/sortable";
 import { restrictToFirstScrollableAncestor, restrictToVerticalAxis } from "@dnd-kit/modifiers";
@@ -171,7 +172,11 @@ import {
   type SidebarSection,
 } from "./Sidebar.logic";
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
-import { createSidebarCollisionDetection, createSidebarSortingStrategy } from "./Sidebar.drag";
+import {
+  createSidebarCollisionDetection,
+  createSidebarSortingStrategy,
+  restrictBelowSidebarLabel,
+} from "./Sidebar.drag";
 import { SidebarDragLifecycle, SidebarPointerSensor } from "./Sidebar.pointer";
 import { createSidebarListMotion } from "./Sidebar.motion";
 import {
@@ -3015,8 +3020,15 @@ export default function Sidebar() {
     },
     [unsnoozeThread],
   );
+  const threadListRef = useRef<HTMLUListElement | null>(null);
+  const dragLabelOffsetRef = useRef(0);
+  const restrictBelowPins = useCallback<Modifier>(
+    (args) => restrictBelowSidebarLabel(args, dragLabelOffsetRef.current),
+    [],
+  );
   const listMotionRef = useRef<ReturnType<typeof createSidebarListMotion> | null>(null);
   const attachListMotionRef = useCallback((node: HTMLUListElement | null) => {
+    threadListRef.current = node;
     listMotionRef.current?.dispose();
     listMotionRef.current = node === null ? null : createSidebarListMotion(node);
     listMotionRef.current?.update(false);
@@ -3198,6 +3210,16 @@ export default function Sidebar() {
       if (activeSection === undefined) return;
       // Stop normal section motion before dnd-kit measures the picked-up row.
       listMotionRef.current?.suspend();
+      const list = threadListRef.current;
+      const header = list?.querySelector<HTMLElement>('[data-testid="sidebar-pinned-header"]');
+      if (list && header) {
+        const listRect = list.getBoundingClientRect();
+        const scale = list.offsetWidth > 0 ? listRect.width / list.offsetWidth : 1;
+        dragLabelOffsetRef.current =
+          header.getBoundingClientRect().top - listRect.top + SIDEBAR_DRAG_LABEL_HEIGHT * scale;
+      } else {
+        dragLabelOffsetRef.current = 0;
+      }
       setDragState({
         activeKey,
         activeSection,
@@ -4575,7 +4597,11 @@ export default function Sidebar() {
               <DndContext
                 sensors={dndSensors}
                 collisionDetection={dndCollisionDetection}
-                modifiers={[restrictToVerticalAxis, restrictToFirstScrollableAncestor]}
+                modifiers={[
+                  restrictToVerticalAxis,
+                  restrictBelowPins,
+                  restrictToFirstScrollableAncestor,
+                ]}
                 onDragStart={handleThreadDragStart}
                 onDragOver={handleThreadDragOver}
                 onDragEnd={handleThreadDragEnd}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2056,3 +2056,18 @@ code {
     transform: scaleX(0.9);
   }
 }
+
+/* Let the sortable rows open label clearance before painting the dividers.
+   This runs once per pickup; rows retain dnd-kit's normal 200ms transitions. */
+.sidebar-drag-boundary-label {
+  animation: sidebar-drag-label-reveal 200ms step-end;
+}
+
+@keyframes sidebar-drag-label-reveal {
+  from {
+    visibility: hidden;
+  }
+  to {
+    visibility: visible;
+  }
+}


### PR DESCRIPTION
Sidebar drag dividers overlapped thread content, could remain visible after interrupted gestures, and disappeared behind cards dragged into empty Pins.

Dividers and empty-section targets now reserve clearance only during a drag. Empty Active previously left a hidden 36px target behind when the last active thread was pinned; the target now stays zero-height at rest. Rows retain smooth sorting transitions. Crossing the visible divider row immediately switches between Pins and Active. The target follows pointer movement, so opening a slot cannot toggle a stationary gesture back. The lifted card stops below the Pins label at the top edge. A single gesture cleanup path handles release, Escape, window blur, hidden tabs, missed releases, and list unmount, without turning a cancelled drag into a thread click.

Verified with 237 focused sidebar tests, web typecheck, and browser checks for empty Pins, full and compact rows, successful drops, cancellation, and subsequent drags. Targeted lint and React Doctor report existing sidebar warnings. The change applies to the sidebar shared by web and desktop; mobile and wire contracts are unchanged.

Matching 1280 × 720 dark-mode captures use identical disposable synthetic threads. The static spacing comparison is main at `52b2bf77a94` versus `d0ec56e58a7`. The divider-crossing recording is from `0422f94ed06`. The empty-target spacing comparison below covers the follow-up at `4aa3a090707`.

| Before: dragging within Settled | After: dragging within Settled |
| --- | --- |
| ![Before: divider labels collide with the following thread](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/5b932d06570c941f/before-drag.png) | ![After: dividers have clearance above thread content](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/bb413c7f544ea7e9/after-drag.png) |

| Before: after window blur | After: after window blur |
| --- | --- |
| ![Before: drag dividers remain after blur](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d8b2b31c74b36a77/before-blur.png) | ![After: blur clears the dividers and restores idle spacing](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/c5e5536961239c0d/after-blur.png) |

Divider-crossing recording: cross the visible divider into Pins, cross it back into Active, and return to Pins to drop. A one-pixel movement onto the divider changes the target; no thread-center threshold is involved. Empty Pins and compact settled rows were checked separately, including top-edge clamping and release cleanup.

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/ee332894b7e464c2/cross-divider.mp4

![Crossing the divider selects Pins immediately](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d3fc9566c4b35319/cross-pin.png)

Empty Active regression: with identical pinned threads, the old target retained 36px even after all labels and transforms cleared. Three repeated drag/drop cycles reproduced it; the same three cycles with this fix ended at zero target height. No separate stuck-transform case was reproduced.

| Before: hidden target retains space | After: empty target collapses |
| --- | --- |
| ![Before: empty Active reserves 36px](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/680ab0540ce7b557/before.png) | ![After: no reserved empty Active space](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/07e8a4f6ee50cacb/after.png) |

Macroscope skipped correctness review because the workspace monthly spending limit was reached; its approvability summary reports that limitation. The full diff was reviewed locally.

Authored with GPT-6 in Codex.
