### PR TITLE
fix(web): clear stuck sidebar drag labels

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2,7 +2,6 @@ import { useAtomValue } from "@effect/atom-react";
 import * as Schema from "effect/Schema";
 import {
   DndContext,
-  PointerSensor,
   useSensor,
   useSensors,
   type DragEndEvent,
@@ -174,6 +173,7 @@ import {
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
 import { createSidebarCollisionDetection, createSidebarSortingStrategy } from "./Sidebar.drag";
 import { createSidebarListMotion } from "./Sidebar.motion";
+import { SidebarPointerSensor } from "./SidebarPointerSensor";
 import {
   ThreadWorktreeIndicator,
   prStatusIndicator,
@@ -3032,7 +3032,7 @@ export default function Sidebar() {
   // also covers first-time ordering, which assigns keys to keyless neighbors.
   // A failed write, concurrent reorder, or membership change releases the hold.
   const dndSensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(SidebarPointerSensor, { activationConstraint: { distance: 6 } }),
   );
   const [dragState, setDragState] = useState<{
     readonly activeKey: string;

--- a/apps/web/src/components/SidebarPointerSensor.test.ts
+++ b/apps/web/src/components/SidebarPointerSensor.test.ts
@@ -1,0 +1,101 @@
+import type { PointerSensorProps } from "@dnd-kit/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { SidebarPointerSensor } from "./SidebarPointerSensor";
+
+let document: EventTarget;
+let window: EventTarget;
+
+function pointer(type: string, buttons = 1, clientY = 0, pointerId = 1) {
+  return Object.assign(new Event(type), { buttons, clientX: 0, clientY, pointerId });
+}
+
+function pickup() {
+  const event = pointer("pointerdown");
+  document.dispatchEvent(event);
+  const callbacks = {
+    onStart: vi.fn(),
+    onMove: vi.fn(),
+    onEnd: vi.fn(),
+    onCancel: vi.fn(),
+    onAbort: vi.fn(),
+    onPending: vi.fn(),
+  };
+  const sensor = new SidebarPointerSensor({
+    active: "thread",
+    activeNode: {} as PointerSensorProps["activeNode"],
+    context: {} as PointerSensorProps["context"],
+    event,
+    options: { activationConstraint: { distance: 6 } },
+    ...callbacks,
+  });
+  return { ...callbacks, sensor };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  document = Object.assign(new EventTarget(), { getSelection: () => null });
+  window = new EventTarget();
+  vi.stubGlobal("document", document);
+  vi.stubGlobal("window", window);
+});
+
+afterEach(() => {
+  document.dispatchEvent(new Event("pointercancel"));
+  vi.runAllTimers();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("sidebar pointer drag cleanup", () => {
+  it("does not start a drag after a missed release", () => {
+    const callbacks = pickup();
+    document.dispatchEvent(pointer("pointermove", 0, 20));
+    expect(callbacks.onStart).not.toHaveBeenCalled();
+    expect(callbacks.onCancel).toHaveBeenCalledOnce();
+    expect(callbacks.onAbort).toHaveBeenCalledWith("thread");
+  });
+
+  it("cancels an active drag when the button is no longer held", () => {
+    const callbacks = pickup();
+    document.dispatchEvent(pointer("pointermove", 1, 20));
+    expect(callbacks.onStart).toHaveBeenCalledOnce();
+    document.dispatchEvent(pointer("pointermove", 0, 40));
+    expect(callbacks.onCancel).toHaveBeenCalledOnce();
+    expect(callbacks.onMove).not.toHaveBeenCalled();
+    expect(callbacks.onEnd).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])("cancels on window blur with an active drag of %s", (active) => {
+    const callbacks = pickup();
+    if (active) document.dispatchEvent(pointer("pointermove", 1, 20));
+    window.dispatchEvent(new Event("blur"));
+    document.dispatchEvent(pointer("pointermove", 1, 40));
+    expect(callbacks.onCancel).toHaveBeenCalledOnce();
+    expect(callbacks.onStart).toHaveBeenCalledTimes(active ? 1 : 0);
+    expect(callbacks.onMove).not.toHaveBeenCalled();
+    expect(callbacks.onEnd).not.toHaveBeenCalled();
+  });
+
+  it("preserves normal drops and removes the extra listeners", () => {
+    const callbacks = pickup();
+    document.dispatchEvent(pointer("pointermove", 1, 20));
+    document.dispatchEvent(pointer("pointermove", 1, 40));
+    document.dispatchEvent(pointer("pointerup", 0, 40));
+    const cancel = vi.fn();
+    document.addEventListener("pointercancel", cancel);
+    window.dispatchEvent(new Event("blur"));
+    document.dispatchEvent(pointer("pointermove", 0, 60));
+    expect(callbacks.onMove).toHaveBeenCalledWith({ x: 0, y: 40 });
+    expect(callbacks.onEnd).toHaveBeenCalledOnce();
+    expect(callbacks.onCancel).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  it("ignores button releases from another pointer", () => {
+    const callbacks = pickup();
+    document.dispatchEvent(pointer("pointermove", 1, 20));
+    document.dispatchEvent(pointer("pointermove", 0, 20, 2));
+    expect(callbacks.onCancel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/SidebarPointerSensor.ts
+++ b/apps/web/src/components/SidebarPointerSensor.ts
@@ -1,0 +1,34 @@
+import { PointerSensor, type PointerSensorProps } from "@dnd-kit/core";
+import { getOwnerDocument, getWindow } from "@dnd-kit/utilities";
+
+// A release outside the app can go missing. Cancel the sensor itself so its
+// listeners, sortable state, and sidebar drag labels all reset together.
+export class SidebarPointerSensor extends PointerSensor {
+  constructor(props: PointerSensorProps) {
+    const document = getOwnerDocument(props.event.target);
+    const window = getWindow(props.event.target);
+    const cancel = () => document.dispatchEvent(new Event("pointercancel"));
+    const handleMove = (event: PointerEvent) => {
+      if (event.pointerId !== (props.event as PointerEvent).pointerId) return;
+      if ((event.buttons & 1) === 0) cancel();
+    };
+    const cleanup = () => {
+      window.removeEventListener("blur", cancel);
+      document.removeEventListener("pointermove", handleMove, { capture: true });
+    };
+    window.addEventListener("blur", cancel);
+    // Run before dnd-kit's move listener, including before drag activation.
+    document.addEventListener("pointermove", handleMove, { capture: true });
+    super({
+      ...props,
+      onEnd() {
+        cleanup();
+        props.onEnd();
+      },
+      onCancel() {
+        cleanup();
+        props.onCancel();
+      },
+    });
+  }
+}


### PR DESCRIPTION
A missed mouse release can leave the sidebar in drag mode, with the Pinned and Active labels visible until another drag clears them. The pointer sensor did not cancel on window blur or check whether the mouse button was still held.

Cancel through the drag library when the window loses focus or the initiating pointer moves without its primary button held. This resets both the drag state and the sidebar labels in web and desktop.

Validation: 48 focused tests pass, including missed releases before and after drag activation, window blur, normal drops, and listener cleanup. Web typecheck passes.

Created with GPT-6 Astra in Codex.
