### PR TITLE
fix(codex): keep Spark limits from replacing the main allowance

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -49,6 +49,10 @@ const RATE_LIMITS_PROBE_TIMEOUT_MS = 3_000;
 type CodexRateLimitsProbe =
   | {
       readonly snapshot: CodexRateLimitSnapshot;
+      readonly rateLimitsByLimitId?:
+        | Readonly<Record<string, CodexRateLimitSnapshot>>
+        | null
+        | undefined;
       readonly resetCredits: CodexResetCreditsSummary | null | undefined;
     }
   | { readonly failure: string };
@@ -434,6 +438,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
       client.request("account/rateLimits/read", undefined).pipe(
         Effect.map((response): CodexRateLimitsProbe => ({
           snapshot: response.rateLimits,
+          rateLimitsByLimitId: response.rateLimitsByLimitId,
           resetCredits: response.rateLimitResetCredits,
         })),
         Effect.timeoutOption(Duration.millis(RATE_LIMITS_PROBE_TIMEOUT_MS)),
@@ -652,6 +657,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
           })
         : codexRateLimitsToLimits({
             snapshot: snapshot.rateLimits.snapshot,
+            rateLimitsByLimitId: snapshot.rateLimits.rateLimitsByLimitId,
             resetCredits: snapshot.rateLimits.resetCredits,
             checkedAt,
           });

--- a/apps/server/src/provider/Layers/codexUsageLimits.test.ts
+++ b/apps/server/src/provider/Layers/codexUsageLimits.test.ts
@@ -60,6 +60,54 @@ describe("codexRateLimitsToLimits", () => {
       },
     ]);
   });
+
+  it("selects the main Codex allowance and leaves Spark out", () => {
+    const spark = {
+      limitId: "codex_bengalfox",
+      primary: { usedPercent: 0, windowDurationMins: 300 },
+      secondary: { usedPercent: 90, windowDurationMins: 10080 },
+    };
+    expect(
+      codexRateLimitsToLimits({
+        checkedAt,
+        snapshot: spark,
+        rateLimitsByLimitId: {
+          codex_bengalfox: spark,
+          codex: { secondary: { usedPercent: 42, windowDurationMins: 10080 } },
+        },
+      }).windows,
+    ).toEqual([
+      {
+        id: "secondary",
+        kind: "weekly",
+        label: "Weekly",
+        usedPercent: 42,
+        windowDurationMins: 10080,
+      },
+    ]);
+  });
+
+  it.each([undefined, null, {}])(
+    "supports legacy reads with no bucket map: %j",
+    (rateLimitsByLimitId) => {
+      const snapshot = { primary: { usedPercent: 12, windowDurationMins: 300 } };
+      expect(codexRateLimitsToLimits({ checkedAt, snapshot, rateLimitsByLimitId })).toEqual(
+        codexRateLimitsToLimits({ checkedAt, snapshot }),
+      );
+    },
+  );
+
+  it("does not show a model-specific legacy snapshot as the main allowance", () => {
+    expect(
+      codexRateLimitsToLimits({
+        checkedAt,
+        snapshot: {
+          limitId: "codex_bengalfox",
+          secondary: { usedPercent: 90 },
+        },
+      }).windows,
+    ).toEqual([]);
+  });
 });
 
 describe("codexRateLimitsToUpdate", () => {
@@ -80,6 +128,30 @@ describe("codexRateLimitsToUpdate", () => {
       ],
     });
     expect(codexRateLimitsToUpdate({ planType: "plus" })).toBeUndefined();
+  });
+
+  it("ignores Spark notifications so they cannot overwrite the main allowance", () => {
+    expect(
+      codexRateLimitsToUpdate({
+        limitId: "codex_bengalfox",
+        primary: { usedPercent: 0, windowDurationMins: 300 },
+        secondary: { usedPercent: 90, windowDurationMins: 10080 },
+      }),
+    ).toBeUndefined();
+    expect(
+      codexRateLimitsToUpdate({
+        limitId: "codex",
+        secondary: { usedPercent: 42, windowDurationMins: 10080 },
+      })?.windows,
+    ).toEqual([
+      {
+        id: "secondary",
+        kind: "weekly",
+        label: "Weekly",
+        usedPercent: 42,
+        windowDurationMins: 10080,
+      },
+    ]);
   });
 });
 

--- a/apps/server/src/provider/Layers/codexUsageLimits.ts
+++ b/apps/server/src/provider/Layers/codexUsageLimits.ts
@@ -26,6 +26,7 @@ interface CodexRateLimitWindow {
 
 /** Structural view of the generated `RateLimitSnapshot`; both messages satisfy it. */
 export interface CodexRateLimitSnapshot {
+  readonly limitId?: string | null;
   readonly planType?: string | null;
   readonly primary?: CodexRateLimitWindow | null;
   readonly secondary?: CodexRateLimitWindow | null;
@@ -68,6 +69,9 @@ function labelForKind(kind: ServerProviderUsageWindow["kind"]): string {
 export function codexRateLimitsToWindows(
   snapshot: CodexRateLimitSnapshot,
 ): ReadonlyArray<ServerProviderUsageWindow> {
+  // Show the main allowance only. Model-specific notifications (such as Spark)
+  // must not replace its primary/secondary rows. Older CLIs omit the limit id.
+  if (snapshot.limitId && snapshot.limitId !== "codex") return [];
   const isMonthlyPlan = snapshot.planType === "free" || snapshot.planType === "go";
   const positions = [
     ["primary", snapshot.primary, isMonthlyPlan ? MONTH_MINS : SESSION_MINS],
@@ -110,14 +114,20 @@ export function codexResetCreditsToContract(
 
 export function codexRateLimitsToLimits(input: {
   readonly snapshot: CodexRateLimitSnapshot;
+  readonly rateLimitsByLimitId?:
+    | Readonly<Record<string, CodexRateLimitSnapshot>>
+    | null
+    | undefined;
   readonly resetCredits?: CodexResetCreditsSummary | null | undefined;
   readonly checkedAt: string;
 }): ServerProviderUsageLimits {
   const resetCredits = codexResetCreditsToContract(input.resetCredits);
+  // Select the main bucket explicitly; the legacy snapshot can name another limit.
+  const windows = codexRateLimitsToWindows(input.rateLimitsByLimitId?.codex ?? input.snapshot);
   return {
     ...makeUsageLimits({
       checkedAt: input.checkedAt,
-      windows: codexRateLimitsToWindows(input.snapshot),
+      windows,
     }),
     ...(resetCredits ? { resetCredits } : {}),
   };


### PR DESCRIPTION
## What Changed

- Preserve the main Codex allowance when Spark/model-specific rate-limit notifications are received.
- Prefer the explicit `codex` rate-limit bucket when available, while retaining compatibility with legacy responses.
- Ignore Spark notifications as standalone usage-limit updates.
- Replace the marketing-page endorsement marquee with a responsive, horizontally scrollable carousel that pauses for user interaction, hidden content, and reduced-motion preferences.
- Disable automatic CodeRabbit reviews for this change.

## Why

Spark rate-limit notifications could overwrite the main Codex allowance and show users incorrect usage information. Selecting the main bucket explicitly prevents model-specific limits from replacing the primary account limits while preserving legacy CLI behavior.

The endorsement carousel now uses native scrolling so users retain control and the layout works consistently across viewport sizes and input methods.

## UI Changes

The marketing homepage endorsement section now displays a responsive scrollable carousel instead of continuously animated marquee rows. Before/after screenshots are not included.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes