### PR TITLE
fix(review): preserve trailing whitespace in diffs

### DIFF
--- a/apps/mobile/src/features/review/reviewModel.test.ts
+++ b/apps/mobile/src/features/review/reviewModel.test.ts
@@ -135,6 +135,41 @@ describe("buildReviewSectionItems", () => {
 });
 
 describe("buildReviewParsedDiff", () => {
+  it.each(["after  \n", "after\t\n", "\n"])("preserves the final added line %j", (line) => {
+    const patch = [
+      "diff --git a/example.txt b/example.txt",
+      "--- a/example.txt",
+      "+++ b/example.txt",
+      "@@ -1 +1 @@",
+      "-before",
+      `+${line}`,
+    ].join("\n");
+    const parsed = buildReviewParsedDiff(patch, "whitespace");
+    expect(parsed.kind).toBe("files");
+    if (parsed.kind !== "files") return;
+
+    expect(parsed.files[0]?.additionLines).toEqual([line]);
+  });
+
+  it.each(["", "\n\n[truncated]"])("preserves blank context before suffix %j", (suffix) => {
+    const patch = [
+      "diff --git a/example.txt b/example.txt",
+      "--- a/example.txt",
+      "+++ b/example.txt",
+      "@@ -1,2 +1,2 @@",
+      "-before",
+      "+after",
+      " \n",
+    ].join("\n");
+    const parsed = buildReviewParsedDiff(`${patch}${suffix}`, "blank-context");
+    expect(parsed.kind).toBe("files");
+    if (parsed.kind !== "files") return;
+
+    expect(parsed.files[0]?.additionLines).toEqual(["after\n", "\n"]);
+    expect(parsed.files[0]?.deletionLines).toEqual(["before\n", "\n"]);
+    expect(parsed.notice !== null).toBe(suffix.length > 0);
+  });
+
   it("builds renderable rows from a unified patch", () => {
     const parsed = buildReviewParsedDiff(
       [

--- a/apps/mobile/src/features/review/reviewModel.ts
+++ b/apps/mobile/src/features/review/reviewModel.ts
@@ -144,15 +144,10 @@ function splitTruncationMarker(diff: string): {
   readonly text: string;
   readonly truncated: boolean;
 } {
-  const trimmed = diff.trimEnd();
-  if (!trimmed.endsWith("[truncated]")) {
-    return { text: trimmed, truncated: false };
-  }
-
-  return {
-    text: trimmed.replace(/\n*\[truncated\]\s*$/, "").trimEnd(),
-    truncated: true,
-  };
+  const marker = /\n\n\[truncated\]\s*$/.exec(diff);
+  return marker
+    ? { text: diff.slice(0, marker.index), truncated: true }
+    : { text: diff, truncated: false };
 }
 
 function runDiffParserSilently<T>(callback: () => T): T {
@@ -224,14 +219,9 @@ function fnv1a32(input: string, seed: number, multiplier: number): number {
 }
 
 function buildPatchCacheKey(patch: string, scope: string): string {
-  const normalizedPatch = patch.trim();
-  const primary = fnv1a32(normalizedPatch, FNV_OFFSET_BASIS_32, FNV_PRIME_32).toString(36);
-  const secondary = fnv1a32(
-    normalizedPatch,
-    SECONDARY_HASH_SEED,
-    SECONDARY_HASH_MULTIPLIER,
-  ).toString(36);
-  return `${scope}:${normalizedPatch.length}:${primary}:${secondary}`;
+  const primary = fnv1a32(patch, FNV_OFFSET_BASIS_32, FNV_PRIME_32).toString(36);
+  const secondary = fnv1a32(patch, SECONDARY_HASH_SEED, SECONDARY_HASH_MULTIPLIER).toString(36);
+  return `${scope}:${patch.length}:${primary}:${secondary}`;
 }
 
 function getFileExtension(path: string): string | null {
@@ -473,12 +463,11 @@ export function buildReviewParsedDiff(
   diff: string | null | undefined,
   cacheScope: string,
 ): ReviewParsedDiff {
-  const normalized = diff?.trim();
-  if (!normalized) {
+  if (!diff?.trim()) {
     return { kind: "empty" };
   }
 
-  const { text, truncated } = splitTruncationMarker(normalized);
+  const { text, truncated } = splitTruncationMarker(diff);
   if (text.length === 0) {
     return { kind: "empty" };
   }

--- a/apps/mobile/src/features/review/reviewState.test.ts
+++ b/apps/mobile/src/features/review/reviewState.test.ts
@@ -49,15 +49,26 @@ it("stores review async loading and error state in atoms", () => {
 it("reuses unchanged parsed diffs and replaces changed sections", () => {
   const parsed = getCachedReviewParsedDiff(reviewInput);
 
-  assert.strictEqual(
-    getCachedReviewParsedDiff({ ...reviewInput, diff: `\n${reviewInput.diff}\n` }),
-    parsed,
-  );
+  assert.strictEqual(getCachedReviewParsedDiff(reviewInput), parsed);
 
   const changed = { ...reviewInput, diff: reviewInput.diff.replace("value = 1", "value = 2") };
   const updated = getCachedReviewParsedDiff(changed);
   assert.notStrictEqual(updated, parsed);
   assert.strictEqual(getCachedReviewParsedDiff(changed), updated);
+});
+
+it.each([" ", "\t", "\n"])("refreshes the cached diff for a trailing %j", (suffix) => {
+  const parsed = getCachedReviewParsedDiff(reviewInput);
+  const changed = { ...reviewInput, diff: `${reviewInput.diff}${suffix}` };
+  const updated = getCachedReviewParsedDiff(changed);
+
+  assert.notStrictEqual(updated, parsed);
+  assert.strictEqual(getCachedReviewParsedDiff(changed), updated);
+  assert.strictEqual(parsed.kind, "files");
+  assert.strictEqual(updated.kind, "files");
+  if (parsed.kind !== "files" || updated.kind !== "files") return;
+  assert.notStrictEqual(updated.files[0]?.cacheKey, parsed.files[0]?.cacheKey);
+  assert.deepStrictEqual(updated.files[0]?.additionLines, [`export const value = 1;${suffix}`]);
 });
 
 it("evicts the least recently used section across threads without changing live results or IDs", () => {

--- a/apps/mobile/src/features/review/reviewState.ts
+++ b/apps/mobile/src/features/review/reviewState.ts
@@ -274,7 +274,7 @@ export function getReviewParsedDiffSourceCharacterCount(input: {
   const sourceCharacterCount = input.diff?.length ?? 0;
   const cache = appAtomRegistry.get(reviewParsedDiffCacheAtom);
   const cached = cache.entries.get(buildSectionCacheKey(input.threadKey, input.sectionId));
-  return cached && cached.diff === (input.diff?.trim() ?? null)
+  return cached && cached.diff === (input.diff ?? null)
     ? Math.max(sourceCharacterCount, cached.sourceCharacterCount)
     : sourceCharacterCount;
 }
@@ -289,10 +289,10 @@ export function getCachedReviewParsedDiff(input: {
   }
 
   const cacheKey = buildSectionCacheKey(input.threadKey, input.sectionId);
-  const normalizedDiff = input.diff?.trim() ?? null;
+  const diff = input.diff ?? null;
   const cache = appAtomRegistry.get(reviewParsedDiffCacheAtom);
   const cached = cache.entries.get(cacheKey);
-  if (cached && cached.diff === normalizedDiff) {
+  if (cached && cached.diff === diff) {
     cache.entries.delete(cacheKey);
     cache.entries.set(cacheKey, cached);
     return cached.parsed;
@@ -319,7 +319,7 @@ export function getCachedReviewParsedDiff(input: {
     cache.sourceCharacterCount -= oldest.sourceCharacterCount;
   }
   cache.entries.set(cacheKey, {
-    diff: normalizedDiff,
+    diff,
     parsed,
     sourceCharacterCount,
   });

--- a/apps/mobile/src/features/review/useReviewDiffPrewarming.test.ts
+++ b/apps/mobile/src/features/review/useReviewDiffPrewarming.test.ts
@@ -88,7 +88,7 @@ it("reserves the selected source budget and skips unloaded or oversized sections
   prepareSelection(sections, "turn:3");
 });
 
-it("reserves a larger retained source when the selected input loses whitespace", () => {
+it("replaces the retained source when the selected input loses whitespace", () => {
   const parsed = getCachedReviewParsedDiff({
     threadKey,
     sectionId: "turn:0",
@@ -98,11 +98,11 @@ it("reserves a larger retained source when the selected input loses whitespace",
 
   const selected = prepareSelection([makeSection(0), makeSection(1)], "turn:0");
 
-  assert.strictEqual(selected.parsed, parsed);
-  assert.strictEqual(selected.native, native);
+  assert.notStrictEqual(selected.parsed, parsed);
+  assert.notStrictEqual(selected.native, native);
 });
 
-it("reserves a larger retained source when a neighboring input loses whitespace", () => {
+it("replaces the retained source when a neighboring input loses whitespace", () => {
   const parsed = getCachedReviewParsedDiff({
     threadKey,
     sectionId: "turn:1",
@@ -112,14 +112,9 @@ it("reserves a larger retained source when a neighboring input loses whitespace"
 
   prepareSelection([makeSection(0), makeSection(1), makeSection(2)], "turn:0");
 
-  assert.strictEqual(
-    getCachedReviewParsedDiff({
-      threadKey,
-      sectionId: "turn:1",
-      diff: reviewDiff,
-    }),
-    parsed,
-  );
+  const updated = getCachedReviewParsedDiff({ threadKey, sectionId: "turn:1", diff: reviewDiff });
+  assert.notStrictEqual(updated, parsed);
+  assert.notStrictEqual(getCachedNativeReviewDiffData({ parsedDiff: updated }), native);
   assert.strictEqual(getCachedNativeReviewDiffData({ parsedDiff: parsed }), native);
 });
 

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -813,6 +813,28 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
   });
 
   describe("review diff previews", () => {
+    it.effect("preserves trailing whitespace in tracked and untracked patches", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        yield* writeTextFile(cwd, "README.md", "# changed  \n");
+
+        const tracked = yield* driver.getReviewDiffPreview({ cwd, ignoreWhitespace: false });
+        assert.isTrue(
+          tracked.sources
+            .find((source) => source.kind === "working-tree")
+            ?.diff.endsWith("+# changed  \n"),
+        );
+
+        yield* writeTextFile(cwd, "untracked.txt", "untracked\t\n");
+        const combined = yield* driver.getReviewDiffPreview({ cwd, ignoreWhitespace: false });
+        const diff = combined.sources.find((source) => source.kind === "working-tree")?.diff;
+        assert.include(diff, "+# changed  \n\ndiff --git a/untracked.txt b/untracked.txt");
+        assert.isTrue(diff?.endsWith("+untracked\t\n"));
+      }),
+    );
+
     it.effect("drops an unterminated path from truncated NUL-separated git output", () =>
       Effect.sync(() => {
         const paths = splitNullSeparatedGitStdoutPaths({

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -2320,7 +2320,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     const dirtyUntracked = yield* readUntrackedReviewDiffs(input.cwd).pipe(
       Effect.orElseSucceed(() => ({ diff: "", truncated: false })),
     );
-    const dirtyDiff = [dirtyTrackedResult.stdout.trimEnd(), dirtyUntracked.diff.trimEnd()]
+    const dirtyDiff = [dirtyTrackedResult.stdout, dirtyUntracked.diff]
       .filter((diff) => diff.length > 0)
       .join("\n");
 

--- a/apps/web/src/lib/diffRendering.test.ts
+++ b/apps/web/src/lib/diffRendering.test.ts
@@ -9,10 +9,10 @@ import {
 } from "./diffRendering";
 
 describe("buildPatchCacheKey", () => {
-  it("normalizes outer whitespace before hashing", () => {
+  it.each([" ", "\t", "\n"])("distinguishes a trailing %j in the patch", (suffix) => {
     const patch = "diff --git a/a.ts b/a.ts\n+console.log('hello')";
 
-    expect(buildPatchCacheKey(`\n${patch}\n`)).toBe(buildPatchCacheKey(patch));
+    expect(buildPatchCacheKey(`${patch}${suffix}`)).not.toBe(buildPatchCacheKey(patch));
   });
 
   it("changes when diff content changes", () => {
@@ -32,6 +32,40 @@ describe("buildPatchCacheKey", () => {
 });
 
 describe("getRenderablePatch", () => {
+  it.each(["after  \n", "after\t\n", "\n"])("preserves the final added line %j", (line) => {
+    const patch = [
+      "diff --git a/example.txt b/example.txt",
+      "--- a/example.txt",
+      "+++ b/example.txt",
+      "@@ -1 +1 @@",
+      "-before",
+      `+${line}`,
+    ].join("\n");
+    const parsed = getRenderablePatch(patch);
+    expect(parsed?.kind).toBe("files");
+    if (parsed?.kind !== "files") return;
+
+    expect(parsed.files[0]?.additionLines).toEqual([line]);
+  });
+
+  it("preserves a final blank context line", () => {
+    const patch = [
+      "diff --git a/example.txt b/example.txt",
+      "--- a/example.txt",
+      "+++ b/example.txt",
+      "@@ -1,2 +1,2 @@",
+      "-before",
+      "+after",
+      " \n",
+    ].join("\n");
+    const parsed = getRenderablePatch(patch);
+    expect(parsed?.kind).toBe("files");
+    if (parsed?.kind !== "files") return;
+
+    expect(parsed.files[0]?.additionLines).toEqual(["after\n", "\n"]);
+    expect(parsed.files[0]?.deletionLines).toEqual(["before\n", "\n"]);
+  });
+
   it("compacts partial hunk render offsets for virtualized review diffs", () => {
     const patch = [
       "diff --git a/example.ts b/example.ts",

--- a/apps/web/src/lib/diffRendering.ts
+++ b/apps/web/src/lib/diffRendering.ts
@@ -31,14 +31,9 @@ export function fnv1a32(
 }
 
 export function buildPatchCacheKey(patch: string, scope = "diff-panel"): string {
-  const normalizedPatch = patch.trim();
-  const primary = fnv1a32(normalizedPatch, FNV_OFFSET_BASIS_32, FNV_PRIME_32).toString(36);
-  const secondary = fnv1a32(
-    normalizedPatch,
-    SECONDARY_HASH_SEED,
-    SECONDARY_HASH_MULTIPLIER,
-  ).toString(36);
-  return `${scope}:${normalizedPatch.length}:${primary}:${secondary}`;
+  const primary = fnv1a32(patch, FNV_OFFSET_BASIS_32, FNV_PRIME_32).toString(36);
+  const secondary = fnv1a32(patch, SECONDARY_HASH_SEED, SECONDARY_HASH_MULTIPLIER).toString(36);
+  return `${scope}:${patch.length}:${primary}:${secondary}`;
 }
 
 export type RenderablePatch =
@@ -111,15 +106,10 @@ export function getRenderablePatch(
   cacheScope = "diff-panel",
   options: RenderablePatchOptions = {},
 ): RenderablePatch | null {
-  if (!patch) return null;
-  const normalizedPatch = patch.trim();
-  if (normalizedPatch.length === 0) return null;
+  if (!patch?.trim()) return null;
 
   try {
-    const parsedPatches = parsePatchFiles(
-      normalizedPatch,
-      buildPatchCacheKey(normalizedPatch, cacheScope),
-    );
+    const parsedPatches = parsePatchFiles(patch, buildPatchCacheKey(patch, cacheScope));
     const files = parsedPatches.flatMap((parsedPatch) =>
       options.compactPartialHunkOffsets
         ? parsedPatch.files.map(compactPartialHunkOffsets)
@@ -131,13 +121,13 @@ export function getRenderablePatch(
 
     return {
       kind: "raw",
-      text: normalizedPatch,
+      text: patch,
       reason: "Unsupported diff format. Showing raw patch.",
     };
   } catch {
     return {
       kind: "raw",
-      text: normalizedPatch,
+      text: patch,
       reason: "Failed to parse patch. Showing raw patch.",
     };
   }


### PR DESCRIPTION
Trimming an entire Git patch removes meaningful trailing spaces, tabs and blank context lines. It can hide the last line in a review diff and make whitespace-only updates reuse stale parsed results.

Keep patch contents intact when the server combines working-tree patches and when web and mobile parse or hash them. Mobile strips only the server's explicit truncation marker. Cache entry and source-character limits stay unchanged.

```mermaid
flowchart LR
    git["Git patch"] --> server["Server preserves patch whitespace"]
    server --> cache["Cache compares exact content"]
    server --> parser["Parser retains final lines"]
    parser --> clients["Web, desktop and mobile diffs"]
```

## Before and after

The same working-tree diff in the real web client, captured in Chromium at 2× density with isolated test data. The blank context line numbered 8 disappears before the fix and remains visible after it.

| Before | After |
| --- | --- |
| ![Before: final blank context line 8 is missing](https://github.com/user-attachments/assets/32cbefdb-b38f-4ff9-a4e9-5098a3840227) | ![After: final blank context line 8 is preserved](https://github.com/user-attachments/assets/b083e0f7-1b1c-4bff-8e88-05e3d2d3b6e5) |

## Verification

- 54 focused web and mobile tests pass, covering parsing, file contents, cache invalidation, prewarming and native diff data.
- 9 server review-preview integration tests pass. The new regression checks tracked and untracked patches against real Git output.
- The new regressions failed before their fixes: 13 client cases and the server case.
- Targeted lint, formatting, typechecks and `git diff --check` pass. No repository-wide checks ran.
- Fallow review ran separately for web, mobile and server with one thread. Its caller-compatibility pointers were checked against source and focused tests.

The shared web helper covers the diff panel, chat turn diffs and pull-request code view; desktop uses the same helper. Mobile has matching parser and cache fixes, verified in tests rather than on a device. No wire schemas or provider behavior change.

Model: GPT-5. Harness: Codex in T3 Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved trailing spaces, tabs, and blank lines in code review diffs and previews.
  * Ensured whitespace changes produce distinct parsed results instead of reusing stale cached content.
  * Preserved raw diff text when rendering unsupported or unparseable patches.
  * Improved handling of truncated diff markers while retaining surrounding whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->