### PR TITLE
fix(marketing): send 95 nightly downloads to the downloads page

### DIFF
--- a/apps/marketing/src/pages/95.astro
+++ b/apps/marketing/src/pages/95.astro
@@ -104,7 +104,7 @@ const userDigits = MARKETING_STATS.users.replaceAll(",", "").padStart(7, "0").sp
                 <RetroBox image="t3-code-lime" alt="T3 Code in a lime and teal software box." sizes="(max-width: 620px) 38vw, 170px" eager />
                 <span class="retro-button edition-download">Get Stable <span aria-hidden="true">↗</span></span>
               </a>
-              <a class="hero-package nightly-package" id="nightly" href={`${GITHUB_REPOSITORY_URL}/releases?q=nightly&expanded=true`} aria-label="Download T3 Code Nightly preview builds">
+              <a class="hero-package nightly-package" id="nightly" href="/download?channel=nightly" aria-label="Download T3 Code Nightly preview builds">
                 <RetroBox image="t3-code-nightly-clouds" alt="T3 Code Nightly in a navy box with violet clouds." sizes="(max-width: 620px) 38vw, 170px" eager />
                 <span class="retro-button edition-download">Get Nightly <span aria-hidden="true">↗</span></span>
               </a>


### PR DESCRIPTION
The Get Nightly button on `/95` sent users to GitHub releases. It now opens `/download?channel=nightly`, which selects nightly downloads.

Verified the downloads page reads `channel=nightly`. `git diff --check` passed. This only changes the link destination, with no visual changes.

Created with GPT-6 Astra in Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Nightly download link to direct users to the download page with the Nightly channel selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->