### PR TITLE
fix(shared): redeem reset credits through the hub when it holds the account

### DIFF
--- a/packages/shared/src/usageLimits.test.ts
+++ b/packages/shared/src/usageLimits.test.ts
@@ -839,6 +839,46 @@ describe("/usage-limits", () => {
     });
   });
 
+  it("redeems a native duplicate through the hub even when the native snapshot is fresher", () => {
+    const fresher = provider({
+      usageLimits: {
+        checkedAt: "2026-09-03T11:30:00.000Z",
+        windows: [window],
+        resetCredits: { availableCount: 3, nextCreditId: "native-credit" },
+      },
+      auth: { status: "authenticated", email: "same@example.com" },
+    });
+    const stale = [
+      {
+        id: UsageLimitSourceId.make("hub"),
+        kind: "cliproxy" as const,
+        label: "Accounts",
+        checkedAt: limits.checkedAt,
+        accounts: [
+          {
+            id: "duplicate",
+            driver: fresher.driver,
+            email: "SAME@example.com",
+            usageLimits: {
+              ...limits,
+              resetCredits: { availableCount: 2, nextCreditId: "hub-credit" },
+            },
+          },
+        ],
+      },
+    ];
+    const report = collectProviderUsageLimits(fresher.instanceId, [fresher], stale, now);
+    // Only redeeming through the hub clears the routing cooldown it holds for
+    // this account, so the hub wins the path even with a staler balance.
+    expect(report?.accounts[0]?.resetCreditInput).toEqual({
+      sourceId: "hub",
+      accountId: "duplicate",
+      creditId: "hub-credit",
+    });
+    // The fresher native balance is still the one shown.
+    expect(report?.accounts[0]?.limits.resetCredits?.availableCount).toBe(3);
+  });
+
   it("keeps accounts and custom instances separate, filtering by driver", () => {
     const report = collectProviderUsageLimits(
       selected.instanceId,

--- a/packages/shared/src/usageLimits.test.ts
+++ b/packages/shared/src/usageLimits.test.ts
@@ -433,6 +433,55 @@ describe("pools", () => {
     expect(account?.environments).toEqual([{ environmentId: "env-a", label: "Laptop" }]);
   });
 
+  it("redeems through the hub when it holds a credit, even with a fresher native read", () => {
+    const native = provider({
+      driver: claude,
+      instanceId: ProviderInstanceId.make("claude"),
+      auth: { status: "authenticated", email: "same@example.com" },
+      usageLimits: {
+        checkedAt: "2026-09-03T11:30:00.000Z",
+        windows: [{ ...window, usedPercent: 40 }],
+        resetCredits: { availableCount: 3, nextCreditId: "native-credit" },
+      },
+    });
+    const input = new Map([
+      [
+        EnvironmentId.make("env-a"),
+        {
+          ...laptop,
+          serverConfig: {
+            providers: [native],
+            usageLimitSources: [
+              {
+                ...source,
+                accounts: [
+                  {
+                    id: "claude-same@example.com.json",
+                    driver: claude,
+                    email: "same@example.com",
+                    usageLimits: {
+                      checkedAt,
+                      windows: [{ ...window, usedPercent: 55 }],
+                      resetCredits: { availableCount: 2, nextCreditId: "hub-credit" },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    ]);
+    const [account] = collectLimitAccounts(input);
+    // Only the hub path clears the routing cooldown it holds for this account.
+    expect(account?.redeem).toEqual({
+      environmentId: "env-a",
+      input: { sourceId: "hub", accountId: "claude-same@example.com.json", creditId: "hub-credit" },
+    });
+    // The fresher native balance is still the one shown.
+    expect(account?.limits.resetCredits?.availableCount).toBe(3);
+  });
+
   it("redeems on the environment whose snapshot supplied the credits on show", () => {
     const stale = provider({
       auth: { status: "authenticated", email: "same@example.com" },

--- a/packages/shared/src/usageLimits.ts
+++ b/packages/shared/src/usageLimits.ts
@@ -645,14 +645,20 @@ export function collectProviderUsageLimits(
         (a, b) =>
           Date.parse(b.account.usageLimits.checkedAt) - Date.parse(a.account.usageLimits.checkedAt),
       )[0];
-    const useHubCredits =
+    // Two independent decisions. Which balance to *display* follows whichever
+    // snapshot is fresher. Which path to *redeem through* always prefers the
+    // hub, because only the hub path clears the routing cooldown it holds for
+    // that account; redeeming natively against the same account resets the
+    // subscription upstream but leaves the hub refusing to route to it until
+    // its own cooldown expires. A hub credit id that a fresher native redeem
+    // already spent comes back as `alreadyRedeemed`, which still clears the
+    // cooldown, so preferring it is safe even when the hub snapshot is stale.
+    const hubCreditId = hubCredits?.account.usageLimits.resetCredits?.nextCreditId;
+    const showHubCredits =
       hubCredits &&
       (!provider.usageLimits.resetCredits ||
         Date.parse(hubCredits.account.usageLimits.checkedAt) >
           Date.parse(provider.usageLimits.checkedAt));
-    const hubCreditId = useHubCredits
-      ? hubCredits.account.usageLimits.resetCredits?.nextCreditId
-      : undefined;
     accounts.push({
       id: provider.instanceId,
       driver: provider.driver,
@@ -670,7 +676,7 @@ export function collectProviderUsageLimits(
       ...(provider.displayName ? { displayName: provider.displayName } : {}),
       ...(provider.accentColor ? { accentColor: provider.accentColor } : {}),
       ...(provider.auth.email ? { email: provider.auth.email } : {}),
-      limits: useHubCredits
+      limits: showHubCredits
         ? { ...provider.usageLimits, resetCredits: hubCredits.account.usageLimits.resetCredits }
         : provider.usageLimits,
     });

--- a/packages/shared/src/usageLimits.ts
+++ b/packages/shared/src/usageLimits.ts
@@ -189,7 +189,21 @@ export function collectLimitAccounts(
 ): readonly LimitAccount[] {
   const accounts = new Map<string, LimitAccount>();
   const creditSources = new Map<string, LimitAccount>();
+  const hubRedeems = new Map<string, LimitAccount>();
   const merge = (key: string, next: LimitAccount) => {
+    // Redeeming through a hub also clears the routing cooldown that hub holds
+    // for the account. Redeeming natively against the same subscription resets
+    // it upstream but leaves the hub refusing to route to the account until
+    // its own cooldown expires, so a hub target wins the redemption outright
+    // while the displayed balance still follows the freshest read.
+    const previousHub = hubRedeems.get(key);
+    if (
+      next.redeem &&
+      "sourceId" in next.redeem.input &&
+      (!previousHub || Date.parse(next.limits.checkedAt) > Date.parse(previousHub.limits.checkedAt))
+    ) {
+      hubRedeems.set(key, next);
+    }
     const previousCredit = creditSources.get(key);
     if (
       next.limits.resetCredits &&
@@ -224,9 +238,9 @@ export function collectLimitAccounts(
       environments,
       // A hub only names the account when no environment has it natively.
       sourceLabel: environments.length > 0 ? null : (previous.sourceLabel ?? next.sourceLabel),
-      redeem: creditSource
-        ? creditSource.redeem
-        : (winner.redeem ?? previous.redeem ?? next.redeem),
+      redeem:
+        hubRedeems.get(key)?.redeem ??
+        (creditSource ? creditSource.redeem : (winner.redeem ?? previous.redeem ?? next.redeem)),
       limits: {
         ...winner.limits,
         ...(creditSource?.limits.resetCredits


### PR DESCRIPTION
## Problem

When a Codex account is signed in natively *and* also pooled behind a CLIProxyAPI hub, the "Use reset" button could redeem down either path. Which one it took came down to whichever usage snapshot happened to be fresher, because a single flag decided both **which credit balance to display** and **which path to redeem through**.

Those are different questions. Redeeming natively goes through the local Codex app-server against the instance's own `CODEX_HOME`, which resets the subscription upstream but never calls the hub's `/v0/management/reset-quota`. The hub therefore kept its routing cooldown for that account and went on refusing every request to it — in the case that prompted this, for another ~119h — even though the account had just been reset. Redeeming through the hub does both, because `cliproxyApi.consume` clears the cooldown after a successful redemption.

The user has no way to choose: a hub account that duplicates a native provider is folded into the native entry, so there is exactly one button and a `checkedAt` race decides where it goes.

This is client-side logic in `packages/shared`, and it had the same defect in **two** independent builders, so both are fixed here:

- `collectProviderUsageLimits` — the chat view and composer banners (`ChatView.tsx`, `ComposerUsageLimits.tsx`).
- `collectLimitAccounts` — the pooled usage panel (`UsageLimitsPooled.tsx`).

Both are imported by web and mobile, and desktop wraps web, so all three surfaces are covered.

## Fix

Split the fused decision in each builder. Display still follows the fresher snapshot. The redemption path now prefers the hub whenever it has a credit for that account, and falls back to the native instance only when the hub genuinely has nothing to redeem — a hub contributor only carries a redemption target when it has a credit id, so that fallback keeps working.

One case worth naming: if the hub snapshot is stale and its `nextCreditId` was already spent by an earlier native redeem, we now send that spent id. The hub returns `already_redeemed`, which is already treated as a success that still clears the cooldown, and the clients already have copy for it. That is strictly better than the old behavior, which left the hub cooling down a healthy account.

## Verification

- A focused test per builder, each covering the regressed case: native contributor with its own credits and a fresher `checkedAt`, hub duplicate on the same email with a staler one. Both fail on `main` — the first with the exact production symptom, `expected { instanceId: 'codex' } to deeply equal { sourceId: 'hub', … }` — and pass here.
- `packages/shared/src/usageLimits.test.ts`: 41 passed. The existing tests that assert a native redemption target still pass, because in those the hub has no credit to redeem.
- `tsgo --noEmit` on `@t3tools/shared` clean; lint and `fmt --check` clean.
- No further client changes needed: the composers' `?? { instanceId }` fallback only fires when the field is absent, which never happens for native providers, and the contract union already carried both shapes.

No UI change — nothing about the rendered output moves, only which backend path the existing button takes.

---

Written by Claude Opus 5 (1M context) in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
