### PR TITLE
fix(web): clarify sidebar drag dividers and empty targets

### DIFF
--- a/apps/web/src/components/Sidebar.drag.test.ts
+++ b/apps/web/src/components/Sidebar.drag.test.ts
@@ -622,6 +622,31 @@ describe("sidebar drag projection", () => {
     expect(strategy({ ...smaller, index: 2 })?.y).toBe(-62.5);
   });
 
+  it.each(["active", "settled"] as const)(
+    "reveals the mounted empty %s target when its last row leaves and hides it on return",
+    (section) => {
+      const items = [
+        pinnedHeader,
+        thread("p", "pinned"),
+        divider,
+        marker("active-placeholder"),
+        thread("a", "active"),
+        settledHeader,
+        marker("settled-placeholder"),
+        thread("s", "settled"),
+      ];
+      const active = section === "active" ? "a" : "s";
+      const input = { items, settledOrder: ["s"], settledExpanded: true };
+      const placeholderId = sidebarMarkerId(`${section}-placeholder`);
+      const resting = preview(input, active, active);
+      expect(resting.get(placeholderId)?.scaleY).toBe(0);
+      const leaving = preview(input, active, sidebarMarkerId("pinned-header"));
+      expect(leaving.get(placeholderId)?.scaleY).toBe(1);
+      const returning = preview(input, active, active);
+      expect(returning.get(placeholderId)?.scaleY).toBe(0);
+    },
+  );
+
   it("uses shelf height for empty target sizing when card height differs from its default", () => {
     const items = [
       pinnedHeader,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -633,10 +633,10 @@ function SidebarSectionHeader(props: {
 }) {
   const snoozed = props.marker === "snoozed-header";
   const className = cn(
-    "flex h-full w-full items-center gap-2 rounded-md border border-dashed border-transparent px-2 text-left text-xs font-medium",
+    "flex h-full w-full items-center gap-2 px-2 text-left text-xs font-medium",
     snoozed ? "text-blue-600 dark:text-blue-400" : "text-sidebar-muted-foreground/60",
     props.dragging && "text-sidebar-foreground/80",
-    props.isDropTarget && "border-primary/40 bg-primary/5 text-primary",
+    props.isDropTarget && "text-primary",
   );
   const content = (
     <>
@@ -3259,9 +3259,7 @@ export default function Sidebar() {
     items.push(...pinnedRows);
     items.push({ kind: "marker", marker: "pinned-divider" });
     const activeRows = rowsOf(activeThreads, "active");
-    if (activeRows.length === 0) {
-      items.push({ kind: "marker", marker: "active-placeholder" });
-    }
+    items.push({ kind: "marker", marker: "active-placeholder" });
     items.push(...activeRows);
     if (snoozedThreads.length > 0) {
       items.push({ kind: "marker", marker: "snoozed-header" });
@@ -3269,9 +3267,7 @@ export default function Sidebar() {
     }
     items.push({ kind: "marker", marker: "settled-header" });
     const settledRows = rowsOf(renderedSettledThreads, "settled");
-    if (settledRows.length === 0) {
-      items.push({ kind: "marker", marker: "settled-placeholder" });
-    }
+    items.push({ kind: "marker", marker: "settled-placeholder" });
     items.push(...settledRows);
     return items;
   }, [
@@ -4803,7 +4799,14 @@ export default function Sidebar() {
                                 key="active-placeholder"
                                 marker="active-placeholder"
                                 label="Active"
-                                showHint={from !== null}
+                                showHint={
+                                  from !== null &&
+                                  (activeThreads.length === 0 ||
+                                    (from === "active" &&
+                                      activeThreads.length === 1 &&
+                                      dragTargetSection !== null &&
+                                      dragTargetSection !== "active"))
+                                }
                                 isDropTarget={dragTargetSection === "active"}
                               />,
                             );
@@ -4850,7 +4853,14 @@ export default function Sidebar() {
                                 key="settled-placeholder"
                                 marker="settled-placeholder"
                                 label="Settled"
-                                showHint={from !== null && from !== "settled"}
+                                showHint={
+                                  from !== null &&
+                                  (renderedSettledThreads.length === 0 ||
+                                    (from === "settled" &&
+                                      renderedSettledThreads.length === 1 &&
+                                      dragTargetSection !== null &&
+                                      dragTargetSection !== "settled"))
+                                }
                                 isDropTarget={dragTargetSection === "settled"}
                               />,
                             );

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -554,38 +554,17 @@ function SortableSidebarMarker(props: {
   );
 }
 
-// Empty targets stay measurable without reserving space at rest. The sorting
-// strategy opens their hint space during a drag.
+// Empty targets stay measurable without reserving space at rest. During a
+// drag their section header supplies the label; the target only opens a slot.
 function SidebarSectionPlaceholder(props: {
   marker: "active-placeholder" | "settled-placeholder";
-  label: string;
-  showHint: boolean;
-  isDropTarget: boolean;
 }) {
   return (
     <SortableSidebarMarker
       marker={props.marker}
       data-testid={`sidebar-${props.marker}`}
       className="relative mx-0.5 h-0"
-    >
-      {props.showHint ? (
-        <div
-          className={cn(
-            "absolute inset-x-0 top-0 flex h-9 items-center gap-2 px-2 text-xs font-medium text-sidebar-foreground/80",
-            props.isDropTarget && "text-primary",
-          )}
-        >
-          <span className="shrink-0">{props.label}</span>
-          <span
-            aria-hidden
-            className={cn(
-              "h-px min-w-2 flex-1",
-              props.isDropTarget ? "bg-primary/50" : "bg-sidebar-foreground/25",
-            )}
-          />
-        </div>
-      ) : null}
-    </SortableSidebarMarker>
+    />
   );
 }
 
@@ -4809,9 +4788,6 @@ export default function Sidebar() {
                               <SidebarSectionPlaceholder
                                 key="active-placeholder"
                                 marker="active-placeholder"
-                                label="Active"
-                                showHint={from !== null}
-                                isDropTarget={dragTargetSection === "active"}
                               />,
                             );
                             break;
@@ -4856,9 +4832,6 @@ export default function Sidebar() {
                               <SidebarSectionPlaceholder
                                 key="settled-placeholder"
                                 marker="settled-placeholder"
-                                label="Settled"
-                                showHint={from !== null && from !== "settled"}
-                                isDropTarget={dragTargetSection === "settled"}
                               />,
                             );
                             break;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -554,17 +554,31 @@ function SortableSidebarMarker(props: {
   );
 }
 
-// Empty targets stay measurable without reserving space at rest. During a
-// drag their section header supplies the label; the target only opens a slot.
+// Empty targets stay measurable without reserving space at rest. The sorting
+// strategy opens their hint space during a drag.
 function SidebarSectionPlaceholder(props: {
   marker: "active-placeholder" | "settled-placeholder";
+  label: string;
+  showHint: boolean;
+  isDropTarget: boolean;
 }) {
   return (
     <SortableSidebarMarker
       marker={props.marker}
       data-testid={`sidebar-${props.marker}`}
       className="relative mx-0.5 h-0"
-    />
+    >
+      {props.showHint ? (
+        <div
+          className={cn(
+            "absolute inset-x-0 top-0 flex h-9 items-center justify-center rounded-md border border-dashed border-sidebar-foreground/25 text-xs text-sidebar-foreground/80",
+            props.isDropTarget && "border-primary/40 bg-primary/5 text-primary",
+          )}
+        >
+          {props.label}
+        </div>
+      ) : null}
+    </SortableSidebarMarker>
   );
 }
 
@@ -4788,6 +4802,9 @@ export default function Sidebar() {
                               <SidebarSectionPlaceholder
                                 key="active-placeholder"
                                 marker="active-placeholder"
+                                label="Active"
+                                showHint={from !== null}
+                                isDropTarget={dragTargetSection === "active"}
                               />,
                             );
                             break;
@@ -4832,6 +4849,9 @@ export default function Sidebar() {
                               <SidebarSectionPlaceholder
                                 key="settled-placeholder"
                                 marker="settled-placeholder"
+                                label="Settled"
+                                showHint={from !== null && from !== "settled"}
+                                isDropTarget={dragTargetSection === "settled"}
                               />,
                             );
                             break;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -545,7 +545,8 @@ function SortableSidebarMarker(props: {
       className={cn("list-none", props.className)}
       style={{
         transform: CSS.Translate.toString(transform),
-        transition,
+        // A newly revealed target must not slide from its hidden position.
+        transition: props.marker.endsWith("-placeholder") ? "none" : transition,
         visibility: transform?.scaleY === 0 ? "hidden" : undefined,
       }}
     >

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -571,11 +571,18 @@ function SidebarSectionPlaceholder(props: {
       {props.showHint ? (
         <div
           className={cn(
-            "absolute inset-x-0 top-0 flex h-9 items-center justify-center rounded-md border border-dashed border-sidebar-foreground/25 text-xs text-sidebar-foreground/80",
-            props.isDropTarget && "border-primary/40 bg-primary/5 text-primary",
+            "absolute inset-x-0 top-0 flex h-9 items-center gap-2 px-2 text-xs font-medium text-sidebar-foreground/80",
+            props.isDropTarget && "text-primary",
           )}
         >
-          {props.label}
+          <span className="shrink-0">{props.label}</span>
+          <span
+            aria-hidden
+            className={cn(
+              "h-px min-w-2 flex-1",
+              props.isDropTarget ? "bg-primary/50" : "bg-sidebar-foreground/25",
+            )}
+          />
         </div>
       ) : null}
     </SortableSidebarMarker>
@@ -599,13 +606,11 @@ function SidebarDragBoundary(props: {
       className="pointer-events-none relative mx-0.5 h-0"
     >
       {props.visible ? (
-        <div className="sidebar-drag-boundary-label absolute inset-x-2 top-1 flex h-4 items-center gap-1.5">
+        <div className="sidebar-drag-boundary-label absolute inset-x-2 top-1 flex h-4 items-center gap-2">
           <span
             className={cn(
-              "inline-flex h-4 shrink-0 items-center rounded-sm border bg-sidebar px-1.5 text-[10px] leading-none font-medium",
-              props.isDropTarget
-                ? "border-primary/40 text-primary"
-                : "border-sidebar-foreground/25 text-sidebar-foreground/80",
+              "shrink-0 text-xs font-medium",
+              props.isDropTarget ? "text-primary" : "text-sidebar-foreground/80",
             )}
           >
             {props.label}


### PR DESCRIPTION
Dragging the last thread out of Active or Settled left no visible empty drop target. Divider labels also used boxed styling that did not match the existing section headers.

Keep empty targets mounted at zero height and reveal their dashed boxes when the dragged thread leaves the section. Reveal them directly in place, without the sortable slide transition. Divider labels now use plain text and a line; Settled highlights its text and line rather than drawing another dashed box.

Verified with 239 focused sidebar tests, web typecheck, and browser checks for leaving/returning to the last-thread section and cancelling back to idle. Targeted lint and React Doctor report existing Sidebar warnings. This affects the sidebar shared by web and desktop; no wire, provider, or mobile changes.

Matching 1280 × 720 captures from main `f5fb056d248` and head `1c0d4e8a968`, using the same thread snapshot and gesture.

| Before | After |
| --- | --- |
| ![Before: boxed dividers and no Active drop target after its last thread leaves](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4796809249a3a5dc/before.png) | ![After: plain dividers and a dashed target in the emptied Active section](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/dcf0f67401cc4825/after.png) |

The recording moves the last Active thread toward Settled, returns it, leaves again, and cancels. Empty targets appear in place and the idle layout recovers.

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/ee5214b732055bfb/motion.mp4

Authored with GPT-6 in Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Empty sidebar sections now display placeholders correctly when their final item is moved or returned.
  - Dragging items between sections provides more consistent placeholder visibility.

- **Style**
  - Sidebar placeholders appear without unintended movement animations.
  - Section labels use simpler text styling.
  - Shelf headers no longer show dashed borders or drop-area backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->