### PR TITLE
fix(web): show the Done badge on a thread's first completion

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1959,16 +1959,20 @@ export default function ChatView(props: ChatViewProps) {
   // stamped at the turn's completion time — not now/updatedAt — so it clears
   // exactly the completion the user is looking at: a wake or completion that
   // lands later still gets its signal (markThreadVisited never moves the
-  // timestamp backwards).
+  // timestamp backwards). A thread with no completed turn yet is stamped at
+  // its creation time: an unstamped thread reads as "read", which would hide
+  // the first completion when it lands in the background. createdAt predates
+  // every completion and wake, so it never clears one.
   useEffect(() => {
-    const completedAt = serverThread?.latestTurn?.completedAt;
-    if (!serverThread?.id || !completedAt) return;
+    if (!serverThread?.id) return;
+    const visitedAt = serverThread.latestTurn?.completedAt ?? serverThread.createdAt;
     markThreadVisited(
       scopedThreadKey(scopeThreadRef(serverThread.environmentId, serverThread.id)),
-      completedAt,
+      visitedAt,
     );
   }, [
     markThreadVisited,
+    serverThread?.createdAt,
     serverThread?.environmentId,
     serverThread?.id,
     serverThread?.latestTurn?.completedAt,

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -337,6 +337,20 @@ describe("hasUnseenCompletion", () => {
     ).toBe(true);
   });
 
+  it("flags a first completion when the visit was stamped at thread creation", () => {
+    expect(
+      hasUnseenCompletion({
+        hasActionableProposedPlan: false,
+        hasPendingApprovals: false,
+        hasPendingUserInput: false,
+        interactionMode: "default",
+        latestTurn: makeLatestTurn(),
+        lastVisitedAt: "2026-03-09T09:00:00.000Z",
+        session: null,
+      }),
+    ).toBe(true);
+  });
+
   it("treats a missing client visit marker as read", () => {
     expect(
       hasUnseenCompletion({


### PR DESCRIPTION
## What Changed

`ChatView` stamps a thread's visit time with `latestTurn.completedAt` when a completed turn exists, and now falls back to the thread's `createdAt` when there is none. One new `hasUnseenCompletion` case covers the fallback.

Two files, +22/-4.

## Why

A thread that has never completed a turn is never stamped with a visit time, and `hasUnseenCompletion` treats a missing `lastVisitedAt` as "read":

https://github.com/pingdotgg/t3code/blob/main/apps/web/src/components/Sidebar.logic.ts#L617

So the very first completion of a brand-new thread produces no Done badge. Open a thread, send the first message, navigate away, and the finish is silent. Every later completion behaves correctly, because the first one leaves a stamp behind.

The effect that does the stamping returns early when there is no completed turn, and nothing else stamps a first visit:

https://github.com/pingdotgg/t3code/blob/main/apps/web/src/components/ChatView.tsx#L1963-L1975

**Why `createdAt` is the safe fallback.** It predates every completion and wake for that thread, so it only converts "unstamped" into "read nothing yet". It can never clear a signal. `markThreadVisited` also refuses to move a timestamp backwards, so the fallback cannot undo a real visit:

https://github.com/pingdotgg/t3code/blob/main/apps/web/src/uiStateStore.ts#L241-L247

## Scope

`markThreadVisited` and `hasUnseenCompletion` are referenced only under `apps/web/`. Mobile has no equivalent, desktop wraps web and inherits the fix. Nothing crosses `packages/contracts`.

## UI Changes

No new UI. This makes an existing sidebar affordance appear in a case where it was being suppressed.

Repro for before/after: open a brand-new thread, send the first message, navigate to another thread, wait for the turn to finish, then look at the sidebar row.

- **Before:** the row shows no Done badge, the completion is silent.
- **After:** the row shows the same Done badge every subsequent completion already produces. Opening the thread clears it, unchanged.

Screenshots to follow.

## Verification

- `vp test run apps/web/src/components/Sidebar.logic.test.ts` — 159 passed
- `tsgo --noEmit` in `apps/web` — clean
- `vp lint` on both files — 17 warnings on this branch, 17 on `origin/main`, none introduced
- `vp fmt --check` on both files — clean

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ChatView` to show Done badge on a thread's first completion
> The thread-visit effect in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/10471/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) previously only ran when a completed turn existed, so the first completion of a new thread was never marked as visited. Now it runs for any identified server thread, falling back to the thread creation timestamp when no turn completion exists, so the first completion compares as newer and triggers the unseen-completion signal.
> - Adds regression coverage in [Sidebar.logic.test.ts](https://github.com/pingdotgg/t3code/pull/10471/files#diff-32549f6f09ae3a1d9d846a62727c17b9f9ec246030982995fd972b497a87335a) for a completed latest turn whose visit marker is the thread creation time.
> - Behavioral Change: the visit effect now fires on threads with no completed turn, using `thread.createdAt` as the visit timestamp instead of skipping the effect entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f590ce1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Threads are now marked as visited even when they have no completed turns.
  - Unseen completion indicators now correctly appear when a completion occurs after the thread was initially visited.
- **Tests**
  - Added coverage for detecting completions that happen after a thread’s creation-time visit timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->