### PR TITLE
fix: use Pierre icons consistently for attachments

### DIFF
--- a/apps/mobile/src/components/ComposerAttachmentStrip.tsx
+++ b/apps/mobile/src/components/ComposerAttachmentStrip.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Image, Pressable, ScrollView, View } from "react-native";
 
 import { AppText as Text } from "./AppText";
+import { PierreEntryIcon } from "./PierreEntryIcon";
 import {
   isFileBackedComposerAttachment,
   type DraftComposerAttachment,
@@ -192,12 +193,7 @@ function ComposerAttachmentContent(props: ComposerAttachmentThumbnailProps) {
         }
         style={style}
       >
-        <SymbolView
-          name="doc.text"
-          size={props.compact ? 15 : 22}
-          tintColorClassName="accent-icon-subtle"
-          type="monochrome"
-        />
+        <PierreEntryIcon path={attachment.name} kind="file" size={props.compact ? 15 : 22} />
         {!props.compact ? (
           <Text className="w-full text-center text-2xs text-foreground" numberOfLines={1}>
             {attachment.name}

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -129,6 +129,7 @@ import {
 import { useAppearancePreferences } from "../settings/appearance/AppearancePreferencesProvider";
 import { useAppearanceCodeSurface } from "../settings/appearance/useAppearanceCodeSurface";
 import { markdownFileIconSource } from "@t3tools/mobile-markdown-text/file-icons";
+import { PierreEntryIcon } from "../../components/PierreEntryIcon";
 import { markdownLinkIconSource } from "@t3tools/mobile-markdown-text/link-icons";
 import {
   normalizeNativeMarkdownUrl,
@@ -474,12 +475,7 @@ function MessageAttachmentFile(props: {
           {opening ? (
             <ActivityIndicator size="small" />
           ) : (
-            <SymbolView
-              name="doc.text"
-              size={26}
-              tintColorClassName={isPdf ? "accent-red-500" : "accent-foreground-muted"}
-              type="monochrome"
-            />
+            <PierreEntryIcon path={attachment.name} kind="file" size={26} />
           )}
         </View>
         <View className="min-w-0 flex-1 gap-1">
@@ -508,7 +504,7 @@ function MessageAttachmentFile(props: {
 function MessageAttachmentUnknown(props: { readonly name: string }) {
   return (
     <View className="flex-row items-center gap-2 py-1">
-      <SymbolView name="doc.text" size={16} tintColor="#a3a3a3" type="monochrome" />
+      <PierreEntryIcon path={props.name} kind="file" size={16} />
       <Text className="min-w-0 flex-1 text-sm text-foreground" numberOfLines={1}>
         {props.name}
       </Text>

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -208,6 +208,7 @@ import {
   submitComposerDraft,
 } from "./composerSubmission";
 import { ComposerPromptLengthValidation } from "./ComposerPromptLengthValidation";
+import { PierreEntryIcon } from "./PierreEntryIcon";
 import {
   createComposerScrollGestureState,
   recordComposerScrollGestureEvent,
@@ -783,7 +784,6 @@ import { toastManager } from "../ui/toast";
 import {
   BotIcon,
   CircleAlertIcon,
-  FileIcon,
   PaperclipIcon,
   PencilRulerIcon,
   PlayIcon,
@@ -3767,7 +3767,12 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
             {image.previewUrl ? (
               <img src={image.previewUrl} alt="" className="size-full object-cover" />
             ) : (
-              <FileIcon className="m-auto size-3.5 text-secondary-label" />
+              <PierreEntryIcon
+                pathValue={image.name}
+                kind="file"
+                theme={resolvedTheme}
+                className="m-auto size-3.5"
+              />
             )}
           </button>
         ))}
@@ -5320,7 +5325,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                           key={file.id}
                           className="flex min-w-0 items-center gap-2 py-1 text-sm text-foreground"
                         >
-                          <FileIcon className="size-4 shrink-0 text-secondary-label" />
+                          <PierreEntryIcon
+                            pathValue={file.name}
+                            kind="file"
+                            theme={resolvedTheme}
+                          />
                           <span className="min-w-0 flex-1 truncate">{file.name}</span>
                           <span className="shrink-0 text-xs text-secondary-label">
                             {needsReattach


### PR DESCRIPTION
Attachment icons changed between the composer and sent messages. Use the existing Pierre file-icon components for composer attachments on web and desktop, and for composer and message attachments on mobile.

Verified web behavior with a CSV attachment, using the same draft and viewport on base and head. Web and mobile typechecks pass; targeted lint reports existing warnings; all six Pierre icon-resolution tests pass. Native runtime verification was unavailable because this Linux host has no Android SDK or emulator.

### Before

![Before: generic CSV attachment icon](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/e0627a3aaddf41f0/pierre-icons-before.png)

### After

![After: Pierre CSV attachment icon](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/bc36b5c0585a2aeb/pierre-icons-after.png)

Model: GPT-6. Harness: Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `PierreEntryIcon` consistently for attachments across mobile and web
> - Replaces generic `SymbolView` document icons with `PierreEntryIcon` for non-image/non-video attachments in [ComposerAttachmentStrip.tsx](https://github.com/pingdotgg/t3code/pull/10475/files#diff-ad34ba5314fc0b4664c898b0f23c61f385536f23504e434cc795a8a46932fa4d) and [ThreadFeed.tsx](https://github.com/pingdotgg/t3code/pull/10475/files#diff-97b9e47f1a8b00c4bb1a972e454769238aaceb538a03329f461e5c5d34cf7245)
> - Replaces `Lucide FileIcon` with `PierreEntryIcon` in the image-preview fallback and staged-file list in [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/10475/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a); removes the now-unused `FileIcon` import
> - Icon selection uses the attachment filename as its path; sizes, labels, and press/preview behavior are unchanged
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4dfc52.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated attachment previews across mobile and web to use file-aware icons.
  - File attachments now display icons based on their names and types instead of generic document symbols.
  - Improved consistency for image, known-file, and unknown-attachment previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->