### PR TITLE
fix(web): make the unchecked switch thumb visible in dark mode

### DIFF
--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -24,7 +24,7 @@ function Switch({
     >
       <SwitchPrimitive.Thumb
         className={cn(
-          "pointer-events-none block size-[calc(var(--thumb-size)-2px)] shrink-0 origin-left in-[[role=switch]:active,[data-slot=label]:active,[data-slot=field-label]:active]:not-data-disabled:scale-x-110 in-[[role=switch]:active,[data-slot=label]:active,[data-slot=field-label]:active]:rounded-[var(--thumb-size)/calc(var(--thumb-size)*1.1)] rounded-(--thumb-size) bg-background shadow-sm/5 will-change-transform [transition:translate_.15s,border-radius_.15s,scale_.1s_.1s,transform-origin_.15s] data-checked:origin-right data-checked:translate-x-[calc(var(--thumb-size)-4px)]",
+          "pointer-events-none block size-[calc(var(--thumb-size)-2px)] shrink-0 origin-left in-[[role=switch]:active,[data-slot=label]:active,[data-slot=field-label]:active]:not-data-disabled:scale-x-110 in-[[role=switch]:active,[data-slot=label]:active,[data-slot=field-label]:active]:rounded-[var(--thumb-size)/calc(var(--thumb-size)*1.1)] rounded-(--thumb-size) bg-background shadow-sm/5 dark:data-unchecked:bg-foreground will-change-transform [transition:translate_.15s,border-radius_.15s,scale_.1s_.1s,transform-origin_.15s] data-checked:origin-right data-checked:translate-x-[calc(var(--thumb-size)-4px)]",
         )}
         data-slot="switch-thumb"
       />


### PR DESCRIPTION
## What Changed

The switch thumb gets the foreground colour when the switch is unchecked in dark mode (`dark:data-unchecked:bg-foreground` on the thumb in `apps/web/src/components/ui/switch.tsx`). One class, nothing else touched: light mode, the checked state and the disabled opacity are unchanged, and custom dark themes pick it up through the existing `.dark` variant.

Surfaces: web and desktop (desktop renders the web UI). Mobile is unaffected, it uses its own native switch.

## Why

In the default dark theme the thumb is `bg-background`, which is the page colour, and the unchecked track is an 8% white fill. So an unchecked switch is a faint pill with no visible knob. A disabled one adds 64% opacity on top and vanishes. On Settings → Connections the Network access, Tailscale HTTPS and Publish agent activity toggles were unreadable on a dark monitor.

Making the thumb readable is the smallest change that fixes it. The track is left as the theme intends (the dark theme deliberately relies on edges rather than milky fills), and the checked state already has a dark thumb on the primary colour.

## UI Changes

Settings → Connections, default dark theme, disabled unchecked switch (web dev server, Chrome).

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deathemperor/t3code/d03cf42d7ced272e42cb00b2cd7dabc392142c22/switch-dark-before-zoom.png) | ![after](https://raw.githubusercontent.com/deathemperor/t3code/d03cf42d7ced272e42cb00b2cd7dabc392142c22/switch-dark-after-zoom.png) |

Full row:

Before
![before row](https://raw.githubusercontent.com/deathemperor/t3code/d03cf42d7ced272e42cb00b2cd7dabc392142c22/switch-dark-before.png)

After
![after row](https://raw.githubusercontent.com/deathemperor/t3code/d03cf42d7ced272e42cb00b2cd7dabc392142c22/switch-dark-after.png)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (no motion change)

Verified with `vp lint apps/web/src/components/ui/switch.tsx` and `vp run --filter @t3tools/web typecheck`.

Claude Fable 5.1 via Claude Code
