### PR TITLE
fix(mobile): wait for native thread scroll before reveal

### DIFF
--- a/patches/@legendapp__list@3.3.5.patch
+++ b/patches/@legendapp__list@3.3.5.patch
@@ -241,7 +241,7 @@ index ce1fe00001c9e5aee6c6ea8bb2d4757d4586d002..3ccf6f16067152dfcb0c143371e2ec6a
       * Number of columns to render items in.
       * @default 1
 diff --git a/react-native.js b/react-native.js
-index b3c5a306b293f797a8b338adfca3060c0f6db22b..4e8f9a7d4c650cf8ea8314ef353433900a86bbde 100644
+index b3c5a306b293f797a8b338adfca3060c0f6db22b..c239dae7390aead3968863fc0d5a4de165521bc6 100644
 --- a/react-native.js
 +++ b/react-native.js
 @@ -717,6 +717,15 @@ function hasActiveInitialScroll(state) {
@@ -277,7 +277,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..4e8f9a7d4c650cf8ea8314ef35343390
 +  // Native contentOffset can seed an end target without dispatchInitialScroll.
 +  // Both overflow completion paths must wait for the native end landing.
 +  // Underflow needs no scroll: preserve UIKit's untouched resting position.
-+  if (state.didContainersLayout && state.didFinishInitialScroll && state.props.initialScrollAtEnd && state.props.data.length > 0) {
++  if (state.didContainersLayout && state.didFinishInitialScroll && state.initialScroll && state.initialScroll.viewPosition === 1 && state.props.data.length > 0) {
 +    const insetStartAdjustment = getContentInsetStartAdjustment(ctx);
 +    if (insetStartAdjustment > 0 && getContentSize(ctx) > state.scrollLength - insetStartAdjustment + 1) {
 +      startInsetEndSettleWatchdog(ctx);
@@ -809,7 +809,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..4e8f9a7d4c650cf8ea8314ef35343390
        recycleItems,
        refreshControl: refreshControlElement ? stylePaddingTopState > 0 ? React2__namespace.cloneElement(refreshControlElement, {
 diff --git a/react-native.mjs b/react-native.mjs
-index 40e87cda8c9bc79a889e5542f29af429a24b24d4..792fed9a2b9597cc22a3ea89617088a85aabd1ef 100644
+index 40e87cda8c9bc79a889e5542f29af429a24b24d4..c5c131969e03afab6859c04022b8620cc43e7e5e 100644
 --- a/react-native.mjs
 +++ b/react-native.mjs
 @@ -696,6 +696,15 @@ function hasActiveInitialScroll(state) {
@@ -845,7 +845,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..792fed9a2b9597cc22a3ea89617088a8
 +  // Native contentOffset can seed an end target without dispatchInitialScroll.
 +  // Both overflow completion paths must wait for the native end landing.
 +  // Underflow needs no scroll: preserve UIKit's untouched resting position.
-+  if (state.didContainersLayout && state.didFinishInitialScroll && state.props.initialScrollAtEnd && state.props.data.length > 0) {
++  if (state.didContainersLayout && state.didFinishInitialScroll && state.initialScroll && state.initialScroll.viewPosition === 1 && state.props.data.length > 0) {
 +    const insetStartAdjustment = getContentInsetStartAdjustment(ctx);
 +    if (insetStartAdjustment > 0 && getContentSize(ctx) > state.scrollLength - insetStartAdjustment + 1) {
 +      startInsetEndSettleWatchdog(ctx);

--- a/patches/@legendapp__list@3.3.5.patch
+++ b/patches/@legendapp__list@3.3.5.patch
@@ -241,7 +241,7 @@ index ce1fe00001c9e5aee6c6ea8bb2d4757d4586d002..3ccf6f16067152dfcb0c143371e2ec6a
       * Number of columns to render items in.
       * @default 1
 diff --git a/react-native.js b/react-native.js
-index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac0047a8ead3 100644
+index b3c5a306b293f797a8b338adfca3060c0f6db22b..4e8f9a7d4c650cf8ea8314ef353433900a86bbde 100644
 --- a/react-native.js
 +++ b/react-native.js
 @@ -717,6 +717,15 @@ function hasActiveInitialScroll(state) {
@@ -269,16 +269,25 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
      set$(ctx, "isNearEnd", isContentLess || distanceFromEnd <= onEndReachedThreshold * scrollLength);
      set$(
        ctx,
-@@ -954,7 +963,7 @@ function setInitialRenderState(ctx, {
+@@ -954,7 +963,16 @@ function setInitialRenderState(ctx, {
    if (didInitialScroll) {
      state.didFinishInitialScroll = true;
    }
 -  const isReadyToRender = Boolean(state.didContainersLayout && state.didFinishInitialScroll);
++  // Native contentOffset can seed an end target without dispatchInitialScroll.
++  // Both overflow completion paths must wait for the native end landing.
++  // Underflow needs no scroll: preserve UIKit's untouched resting position.
++  if (state.didContainersLayout && state.didFinishInitialScroll && state.props.initialScrollAtEnd && state.props.data.length > 0) {
++    const insetStartAdjustment = getContentInsetStartAdjustment(ctx);
++    if (insetStartAdjustment > 0 && getContentSize(ctx) > state.scrollLength - insetStartAdjustment + 1) {
++      startInsetEndSettleWatchdog(ctx);
++    }
++  }
 +  const isReadyToRender = Boolean(state.didContainersLayout && state.didFinishInitialScroll && !state.insetEndRevealHold);
    if (isReadyToRender && !peek$(ctx, "readyToRender")) {
      set$(ctx, "readyToRender", true);
      setAdaptiveRender(ctx, "normal", "ready");
-@@ -1090,7 +1099,7 @@ function getRawContentLength(ctx) {
+@@ -1090,7 +1108,7 @@ function getRawContentLength(ctx) {
  function getAlignItemsAtEndPadding(ctx) {
    const { state } = ctx;
    const shouldPad = !!state.props.alignItemsAtEndPaddingEnabled && !state.props.horizontal && state.props.data.length > 0 && state.scrollLength > 0;
@@ -287,7 +296,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
  }
  function updateContentMetricsState(ctx) {
    const previousPadding = peek$(ctx, "alignItemsAtEndPadding") || 0;
-@@ -1115,6 +1124,10 @@ function addTotalSize(ctx, key, add, notifyTotalSize = true) {
+@@ -1115,6 +1133,10 @@ function addTotalSize(ctx, key, add, notifyTotalSize = true) {
      totalSize += add;
    }
    if (prevTotalSize !== totalSize) {
@@ -298,7 +307,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
      if (!IsNewArchitecture && state.initialScroll && totalSize < prevTotalSize) {
        state.pendingTotalSize = totalSize;
      } else {
-@@ -1304,18 +1317,23 @@ function calculateOffsetWithOffsetPosition(ctx, offsetParam, params) {
+@@ -1304,18 +1326,23 @@ function calculateOffsetWithOffsetPosition(ctx, offsetParam, params) {
  }
  
  // src/core/clampScrollOffset.ts
@@ -324,7 +333,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
    return clampedOffset;
  }
  
-@@ -1451,10 +1469,10 @@ function checkFinishedScrollFrame(ctx) {
+@@ -1451,10 +1478,10 @@ function checkFinishedScrollFrame(ctx) {
      finishScrollTo(ctx);
    }
  }
@@ -337,7 +346,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
      x: ctx.state.props.horizontal ? offset : 0,
      y: ctx.state.props.horizontal ? 0 : offset
    });
-@@ -1503,7 +1521,10 @@ function checkFinishedScrollFallback(ctx) {
+@@ -1503,7 +1530,10 @@ function checkFinishedScrollFallback(ctx) {
          );
          scheduleFallbackCheck(SILENT_INITIAL_SCROLL_RETRY_DELAY_MS);
        } else if (shouldRetryUnalignedEndScroll) {
@@ -349,7 +358,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
          scheduleFallbackCheck(100);
        } else if (shouldFinishZeroTarget || shouldFinishAfterObservedScroll || canFinishInitialScrollWithoutNativeProgress || canFinishAfterSilentNativeDispatch || numChecks > maxChecks) {
          finishScrollTo(ctx);
-@@ -1560,15 +1581,28 @@ function doMaintainScrollAtEnd(ctx) {
+@@ -1560,15 +1590,28 @@ function doMaintainScrollAtEnd(ctx) {
    } = state;
    const isWithinMaintainScrollAtEndThreshold = peek$(ctx, "isWithinMaintainScrollAtEndThreshold");
    const shouldMaintainScrollAtEnd = !!(isWithinMaintainScrollAtEndThreshold && maintainScrollAtEnd && didContainersLayout);
@@ -379,7 +388,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
      }
      if (!state.maintainingScrollAtEnd) {
        const pendingState = maintainScrollAtEnd.animated ? "pending-animated" : "pending-instant";
-@@ -1591,9 +1625,18 @@ function doMaintainScrollAtEnd(ctx) {
+@@ -1591,9 +1634,18 @@ function doMaintainScrollAtEnd(ctx) {
                y: 0
              });
            } else {
@@ -401,7 +410,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
            }
            setTimeout(
              () => {
-@@ -1624,6 +1667,10 @@ function doMaintainScrollAtEnd(ctx) {
+@@ -1624,6 +1676,10 @@ function doMaintainScrollAtEnd(ctx) {
  function requestAdjust(ctx, positionDiff, dataChanged) {
    const state = ctx.state;
    if (Math.abs(positionDiff) > 0.1) {
@@ -412,7 +421,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
      const needsScrollWorkaround = Platform.OS === "android" && !IsNewArchitecture && dataChanged && state.scroll <= positionDiff;
      const doit = () => {
        if (needsScrollWorkaround) {
-@@ -1728,7 +1775,9 @@ function getPredictedNativeClamp(state, unresolvedAmount, totalSize) {
+@@ -1728,7 +1784,9 @@ function getPredictedNativeClamp(state, unresolvedAmount, totalSize) {
    if (Math.abs(unresolvedAmount) <= MVCP_POSITION_EPSILON) {
      return 0;
    }
@@ -423,7 +432,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
    const clampDelta = maxScroll - state.scroll;
    if (unresolvedAmount < 0) {
      return Math.max(unresolvedAmount, Math.min(0, clampDelta));
-@@ -1790,7 +1839,7 @@ function resolvePendingNativeMVCPAdjust(ctx, newScroll) {
+@@ -1790,7 +1848,7 @@ function resolvePendingNativeMVCPAdjust(ctx, newScroll) {
      settlePendingNativeMVCPAdjust(ctx, remainingAfterManual, nativeDelta);
      return true;
    }
@@ -432,7 +441,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
    const distanceToClamp = Math.abs(newScroll - expectedNativeClampScroll);
    const isAtExpectedNativeClamp = distanceToClamp <= NATIVE_END_CLAMP_EPSILON;
    if (isAtExpectedNativeClamp) {
-@@ -1923,7 +1972,7 @@ function prepareMVCP(ctx, dataChanged) {
+@@ -1923,7 +1981,7 @@ function prepareMVCP(ctx, dataChanged) {
              if (diff > 0) {
                diff = Math.max(0, totalSize - state.scroll - state.scrollLength);
              } else {
@@ -441,7 +450,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
                state.scroll = maxScroll;
                state.scrollPending = maxScroll;
                diff = 0;
-@@ -2320,8 +2369,121 @@ function scrollToIndex(ctx, {
+@@ -2320,8 +2378,121 @@ function scrollToIndex(ctx, {
  }
  
  // src/core/initialScroll.ts
@@ -451,11 +460,11 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
 +var INSET_END_REVEAL_MAX_HOLD_FRAMES = 40;
 +function startInsetEndSettleWatchdog(ctx) {
 +  const state = ctx.state;
-+  if (state.insetEndSettleWatchdogActive) {
++  if (state.insetEndSettleWatchdogStarted || state.didLoad) {
 +    return;
 +  }
++  state.insetEndSettleWatchdogStarted = true;
 +  state.insetEndSettleWatchdogActive = true;
-+  state.didUserDrag = false;
 +  // Hold the readyToRender opacity gate until the end landing is stable, so
 +  // the estimated-to-measured settle chase happens before first VISIBLE
 +  // paint instead of in front of the user. Capped so slow measurement can
@@ -464,6 +473,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
 +  let frames = 0;
 +  let settledFrames = 0;
 +  let revealStableFrames = 0;
++  let previousEndOffset;
 +  const releaseRevealHold = () => {
 +    if (state.insetEndRevealHold) {
 +      state.insetEndRevealHold = false;
@@ -503,33 +513,32 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
 +    const insetStartAdjustment = getContentInsetStartAdjustment(ctx);
 +    const contentSize = getContentSize(ctx);
 +    const scrollLength = state.scrollLength;
-+    if (insetStartAdjustment > 0 && scrollLength > 0 && Number.isFinite(contentSize) && contentSize > scrollLength && !state.scrollingTo && !state.maintainingScrollAtEnd) {
-+      const endOffset = Math.max(-insetStartAdjustment, contentSize - scrollLength);
-+      const distance = endOffset - state.scroll;
-+      // Estimated row sizes converging to measured ones can strand the initial
-+      // end landing when the library's own end-anchor bookkeeping gives up.
-+      // While still near the end (never fighting a user who scrolled away),
-+      // re-pin to the current true end until sizes stop changing.
-+      if (Math.abs(distance) > 2 && Math.abs(distance) <= scrollLength * 0.5) {
-+        settledFrames = 0;
-+        revealStableFrames = 0;
++    const endOffset = Math.max(-insetStartAdjustment, contentSize - scrollLength);
++    // state.scroll is optimistic: non-animated scrollTo writes it before UIKit
++    // moves. Only a native scroll event proves that the requested offset landed.
++    const nativeOffset = state.lastNativeScroll;
++    const hasNativeOffset = typeof nativeOffset === "number" && Number.isFinite(nativeOffset);
++    const distance = hasNativeOffset ? endOffset - nativeOffset : Infinity;
++    const isIdle = !state.scrollingTo && !state.maintainingScrollAtEnd;
++    const hasViewport = insetStartAdjustment > 0 && scrollLength > 0 && Number.isFinite(contentSize);
++    const isStable = hasViewport && isIdle && Math.abs(distance) <= 2 && previousEndOffset !== void 0 && Math.abs(endOffset - previousEndOffset) <= 1;
++    previousEndOffset = endOffset;
++    if (isStable) {
++      settledFrames++;
++      revealStableFrames++;
++      if (revealStableFrames >= INSET_END_REVEAL_STABLE_FRAMES) {
++        onRevealStability();
++      }
++    } else {
++      settledFrames = 0;
++      revealStableFrames = 0;
++      // Keep the existing near-end correction limit. In-flight scrolls and
++      // unknown native offsets wait; neither counts as a settled frame.
++      if (hasViewport && isIdle && Math.abs(distance) > 2 && Math.abs(distance) <= scrollLength * 0.5) {
 +        const scroller = state.refScroller.current;
 +        if (scroller) {
 +          scroller.scrollTo({ animated: false, x: 0, y: endOffset });
 +        }
-+      } else {
-+        settledFrames++;
-+        revealStableFrames++;
-+        if (revealStableFrames >= INSET_END_REVEAL_STABLE_FRAMES) {
-+          onRevealStability();
-+        }
-+      }
-+    } else {
-+      // Conditions that make re-pinning unnecessary (underflow, in-flight
-+      // programmatic scroll) count toward stability for the reveal.
-+      revealStableFrames++;
-+      if (revealStableFrames >= INSET_END_REVEAL_STABLE_FRAMES) {
-+        onRevealStability();
 +      }
 +    }
 +    requestAnimationFrame(tick);
@@ -563,7 +572,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
    const requestedIndex = target.index;
    const index = requestedIndex !== void 0 ? clampScrollIndex(requestedIndex, ctx.state.props.data.length) : void 0;
    const itemSize = getItemSizeAtIndex(ctx, index);
-@@ -2747,7 +2909,9 @@ function clearFinishedBootstrapInitialScrollTargetIfMovedAway(ctx) {
+@@ -2747,7 +2918,9 @@ function clearFinishedBootstrapInitialScrollTargetIfMovedAway(ctx) {
      return;
    }
    if (didFinishedInitialScrollMoveAwayFromTarget(ctx, initialScroll)) {
@@ -574,7 +583,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
      if (!shouldKeepEndTargetAlive) {
        if (shouldPreserveInitialScrollForFooterLayout(initialScroll)) {
          clearPendingInitialScrollFooterLayout(ctx, {
-@@ -4672,7 +4836,8 @@ function maybeUpdateAnchoredEndSpace(ctx) {
+@@ -4672,7 +4845,8 @@ function maybeUpdateAnchoredEndSpace(ctx) {
        contentBelowAnchor = Math.max(0, contentBelowAnchor - ctx.scrollAxisGap);
        contentBelowAnchor += (ctx.values.get("footerSize") || 0) + getStylePaddingEnd(state.props);
        isReady = !hasUnknownTailSize;
@@ -584,7 +593,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
      } else if (anchorIndex >= 0) {
        isReady = false;
      }
-@@ -4692,6 +4857,12 @@ function maybeUpdateAnchoredEndSpace(ctx) {
+@@ -4692,6 +4866,12 @@ function maybeUpdateAnchoredEndSpace(ctx) {
        updateScroll(ctx, state.scroll, true, { markHasScrolled: false });
      }
      (_b = anchoredEndSpace == null ? void 0 : anchoredEndSpace.onReady) == null ? void 0 : _b.call(anchoredEndSpace, { anchorIndex: nextAnchorIndex, anchorKey: nextAnchorKey, size: nextSize });
@@ -597,7 +606,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
    }
    return nextSize;
  }
-@@ -5715,6 +5886,7 @@ var ContainersLayer = typedMemo(function ContainersLayer2({
+@@ -5715,6 +5895,7 @@ var ContainersLayer = typedMemo(function ContainersLayer2({
    horizontal
  }) {
    const ctx = useStateContext();
@@ -605,7 +614,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
    const columnWrapperStyle = ctx.columnWrapperStyle;
    const animSize = useValue$("totalSize");
    const [readyToRender, numColumns, otherAxisSize = 0] = useArr$(["readyToRender", "numColumns", "otherAxisSize"]);
-@@ -5725,6 +5897,13 @@ var ContainersLayer = typedMemo(function ContainersLayer2({
+@@ -5725,6 +5906,13 @@ var ContainersLayer = typedMemo(function ContainersLayer2({
      opacity: isVisible ? 1 : 0,
      width: animSize
    } : { height: animSize, minWidth: otherAxisSize, opacity: isVisible ? 1 : 0 };
@@ -619,7 +628,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
    if (columnWrapperStyle) {
      const { columnGap, rowGap, gap } = columnWrapperStyle;
      const gapX = columnGap || gap || 0;
-@@ -5745,7 +5924,8 @@ var ContainersLayer = typedMemo(function ContainersLayer2({
+@@ -5745,7 +5933,8 @@ var ContainersLayer = typedMemo(function ContainersLayer2({
        }
      }
    }
@@ -629,7 +638,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
  });
  var Containers = typedMemo(function Containers2({
    freshDataTransitionEpoch,
-@@ -5896,7 +6076,12 @@ var StyleSheet = ReactNative.StyleSheet;
+@@ -5896,7 +6085,12 @@ var StyleSheet = ReactNative.StyleSheet;
  
  // src/components/ListComponent.tsx
  var AlignItemsAtEndSpacer = typedMemo(function AlignItemsAtEndSpacer2({ horizontal }) {
@@ -642,7 +651,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
    if (alignItemsAtEndPadding <= 0) {
      return null;
    }
-@@ -5929,8 +6114,12 @@ var ListComponent = typedMemo(function ListComponent2({
+@@ -5929,8 +6123,12 @@ var ListComponent = typedMemo(function ListComponent2({
    refScrollView,
    renderScrollComponent,
    onLayoutFooter,
@@ -655,7 +664,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
    scrollAdjustHandler,
    snapToIndices,
    stickyHeaderConfig,
-@@ -6001,7 +6190,17 @@ var ListComponent = typedMemo(function ListComponent2({
+@@ -6001,7 +6199,17 @@ var ListComponent = typedMemo(function ListComponent2({
      SnapOrScroll,
      {
        ...rest,
@@ -674,7 +683,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
        contentContainerStyle: [
          horizontal ? { height: "100%" } : {},
          contentContainerStyle,
-@@ -6010,7 +6209,10 @@ var ListComponent = typedMemo(function ListComponent2({
+@@ -6010,7 +6218,10 @@ var ListComponent = typedMemo(function ListComponent2({
        ],
        contentOffset: initialContentOffset !== void 0 ? horizontal ? { x: initialContentOffset, y: 0 } : { x: 0, y: initialContentOffset } : void 0,
        horizontal,
@@ -686,7 +695,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
        onLayout,
        onScroll: onScroll2,
        ref: refScrollView,
-@@ -6751,7 +6953,7 @@ function createImperativeHandle(ctx, scheduleImperativeScrollCommit) {
+@@ -6751,7 +6962,7 @@ function createImperativeHandle(ctx, scheduleImperativeScrollCommit) {
        endBuffered: state.endBuffered,
        getAverageItemSizes: () => getAverageItemSizes(state),
        indexByKey: (key) => state.indexByKey.get(key),
@@ -695,7 +704,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
        isAtStart: peek$(ctx, "isAtStart"),
        isEndReached: state.isEndReached,
        isNearEnd: peek$(ctx, "isNearEnd"),
-@@ -7075,6 +7277,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7075,6 +7286,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
      dataVersion,
      drawDistance = 250,
      contentInsetEndAdjustment,
@@ -703,7 +712,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
      estimatedItemSize = 100,
      estimatedListSize,
      extraData,
-@@ -7132,10 +7335,12 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7132,10 +7344,12 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
    const animatedPropsInternal = props.animatedPropsInternal;
    const anchoredEndSpaceOwner = (_a3 = props.anchoredEndSpaceOwnerInternal) != null ? _a3 : "list";
    const positionComponentInternal = props.positionComponentInternal;
@@ -716,7 +725,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
      stickyPositionComponentInternal: _stickyPositionComponentInternal,
      ...restProps
    } = rest;
-@@ -7200,7 +7405,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7200,7 +7414,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
    const combinedRef = useCombinedRef(refScroller, refScrollView);
    const keyExtractor = keyExtractorProp != null ? keyExtractorProp : ((_item, index) => index.toString());
    const stickyHeaderIndices = stickyHeaderIndicesProp;
@@ -725,7 +734,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
    const previousContentInsetEndAdjustmentRef = React2.useRef(contentInsetEndAdjustmentResolved);
    const alwaysRenderIndices = React2.useMemo(() => {
      const indices = getAlwaysRenderIndices(alwaysRender, dataProp, keyExtractor, anchoredEndSpace == null ? void 0 : anchoredEndSpace.anchorIndex);
-@@ -7341,6 +7546,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7341,6 +7555,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
      contentContainerAlignItems: contentContainerStyle.alignItems,
      contentInset,
      contentInsetEndAdjustment: contentInsetEndAdjustmentResolved,
@@ -733,7 +742,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
      data: dataProp,
      dataKey,
      dataVersion,
-@@ -7372,6 +7578,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7372,6 +7587,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
      renderItem,
      rtl,
      snapToIndices,
@@ -741,7 +750,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
      stickyHeaderIndicesArr: stickyHeaderIndices != null ? stickyHeaderIndices : [],
      stickyHeaderIndicesSet: React2.useMemo(() => new Set(stickyHeaderIndices != null ? stickyHeaderIndices : []), [stickyHeaderIndices == null ? void 0 : stickyHeaderIndices.join(",")]),
      stickyPositionComponentInternal,
-@@ -7423,6 +7630,13 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7423,6 +7639,13 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
        return void 0;
      }
      const resolvedOffset = (_a4 = initialScroll.contentOffset) != null ? _a4 : resolveInitialScrollOffset(ctx, initialScroll);
@@ -755,7 +764,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
      return usesBootstrapInitialScroll && ((_b2 = state.initialScrollSession) == null ? void 0 : _b2.kind) === "bootstrap" && Platform.OS === "web" ? void 0 : resolvedOffset;
    }, [usesBootstrapInitialScroll]);
    React2.useLayoutEffect(() => {
-@@ -7547,6 +7761,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7547,6 +7770,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
      [
        dataKey,
        dataVersion,
@@ -763,7 +772,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
        memoizedLastItemKeys.join(","),
        numColumnsProp,
        nextScrollAxisGap,
-@@ -7643,6 +7858,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7643,6 +7867,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
      () => ({
        getRenderedItem: (key) => getRenderedItem(ctx, key),
        onMomentumScrollEnd: (event) => {
@@ -771,7 +780,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
          checkFinishedScrollFallback(ctx);
          if (state.props.onMomentumScrollEnd) {
            state.props.onMomentumScrollEnd(event);
-@@ -7651,6 +7867,8 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7651,6 +7876,8 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
        onScroll: (event) => onScroll(ctx, event),
        onScrollBeginDrag: (event) => {
          var _a4, _b2;
@@ -780,7 +789,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
          prepareReachedEdgeForNextUserScroll(ctx);
          (_b2 = (_a4 = state.props).onScrollBeginDrag) == null ? void 0 : _b2.call(_a4, event);
        },
-@@ -7676,11 +7894,18 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7676,11 +7903,18 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
        ListFooterComponent,
        ListFooterComponentStyle,
        ListHeaderComponent,
@@ -800,7 +809,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..ddca4bcd8a5dc5863cb65e03b6cfac00
        recycleItems,
        refreshControl: refreshControlElement ? stylePaddingTopState > 0 ? React2__namespace.cloneElement(refreshControlElement, {
 diff --git a/react-native.mjs b/react-native.mjs
-index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97440bc623 100644
+index 40e87cda8c9bc79a889e5542f29af429a24b24d4..792fed9a2b9597cc22a3ea89617088a85aabd1ef 100644
 --- a/react-native.mjs
 +++ b/react-native.mjs
 @@ -696,6 +696,15 @@ function hasActiveInitialScroll(state) {
@@ -828,16 +837,25 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
      set$(ctx, "isNearEnd", isContentLess || distanceFromEnd <= onEndReachedThreshold * scrollLength);
      set$(
        ctx,
-@@ -933,7 +942,7 @@ function setInitialRenderState(ctx, {
+@@ -933,7 +942,16 @@ function setInitialRenderState(ctx, {
    if (didInitialScroll) {
      state.didFinishInitialScroll = true;
    }
 -  const isReadyToRender = Boolean(state.didContainersLayout && state.didFinishInitialScroll);
++  // Native contentOffset can seed an end target without dispatchInitialScroll.
++  // Both overflow completion paths must wait for the native end landing.
++  // Underflow needs no scroll: preserve UIKit's untouched resting position.
++  if (state.didContainersLayout && state.didFinishInitialScroll && state.props.initialScrollAtEnd && state.props.data.length > 0) {
++    const insetStartAdjustment = getContentInsetStartAdjustment(ctx);
++    if (insetStartAdjustment > 0 && getContentSize(ctx) > state.scrollLength - insetStartAdjustment + 1) {
++      startInsetEndSettleWatchdog(ctx);
++    }
++  }
 +  const isReadyToRender = Boolean(state.didContainersLayout && state.didFinishInitialScroll && !state.insetEndRevealHold);
    if (isReadyToRender && !peek$(ctx, "readyToRender")) {
      set$(ctx, "readyToRender", true);
      setAdaptiveRender(ctx, "normal", "ready");
-@@ -1069,7 +1078,7 @@ function getRawContentLength(ctx) {
+@@ -1069,7 +1087,7 @@ function getRawContentLength(ctx) {
  function getAlignItemsAtEndPadding(ctx) {
    const { state } = ctx;
    const shouldPad = !!state.props.alignItemsAtEndPaddingEnabled && !state.props.horizontal && state.props.data.length > 0 && state.scrollLength > 0;
@@ -846,7 +864,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
  }
  function updateContentMetricsState(ctx) {
    const previousPadding = peek$(ctx, "alignItemsAtEndPadding") || 0;
-@@ -1094,6 +1103,10 @@ function addTotalSize(ctx, key, add, notifyTotalSize = true) {
+@@ -1094,6 +1112,10 @@ function addTotalSize(ctx, key, add, notifyTotalSize = true) {
      totalSize += add;
    }
    if (prevTotalSize !== totalSize) {
@@ -857,7 +875,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
      if (!IsNewArchitecture && state.initialScroll && totalSize < prevTotalSize) {
        state.pendingTotalSize = totalSize;
      } else {
-@@ -1283,18 +1296,23 @@ function calculateOffsetWithOffsetPosition(ctx, offsetParam, params) {
+@@ -1283,18 +1305,23 @@ function calculateOffsetWithOffsetPosition(ctx, offsetParam, params) {
  }
  
  // src/core/clampScrollOffset.ts
@@ -883,7 +901,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
    return clampedOffset;
  }
  
-@@ -1430,10 +1448,10 @@ function checkFinishedScrollFrame(ctx) {
+@@ -1430,10 +1457,10 @@ function checkFinishedScrollFrame(ctx) {
      finishScrollTo(ctx);
    }
  }
@@ -896,7 +914,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
      x: ctx.state.props.horizontal ? offset : 0,
      y: ctx.state.props.horizontal ? 0 : offset
    });
-@@ -1482,7 +1500,10 @@ function checkFinishedScrollFallback(ctx) {
+@@ -1482,7 +1509,10 @@ function checkFinishedScrollFallback(ctx) {
          );
          scheduleFallbackCheck(SILENT_INITIAL_SCROLL_RETRY_DELAY_MS);
        } else if (shouldRetryUnalignedEndScroll) {
@@ -908,7 +926,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
          scheduleFallbackCheck(100);
        } else if (shouldFinishZeroTarget || shouldFinishAfterObservedScroll || canFinishInitialScrollWithoutNativeProgress || canFinishAfterSilentNativeDispatch || numChecks > maxChecks) {
          finishScrollTo(ctx);
-@@ -1539,15 +1560,28 @@ function doMaintainScrollAtEnd(ctx) {
+@@ -1539,15 +1569,28 @@ function doMaintainScrollAtEnd(ctx) {
    } = state;
    const isWithinMaintainScrollAtEndThreshold = peek$(ctx, "isWithinMaintainScrollAtEndThreshold");
    const shouldMaintainScrollAtEnd = !!(isWithinMaintainScrollAtEndThreshold && maintainScrollAtEnd && didContainersLayout);
@@ -938,7 +956,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
      }
      if (!state.maintainingScrollAtEnd) {
        const pendingState = maintainScrollAtEnd.animated ? "pending-animated" : "pending-instant";
-@@ -1570,9 +1604,18 @@ function doMaintainScrollAtEnd(ctx) {
+@@ -1570,9 +1613,18 @@ function doMaintainScrollAtEnd(ctx) {
                y: 0
              });
            } else {
@@ -960,7 +978,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
            }
            setTimeout(
              () => {
-@@ -1603,6 +1646,10 @@ function doMaintainScrollAtEnd(ctx) {
+@@ -1603,6 +1655,10 @@ function doMaintainScrollAtEnd(ctx) {
  function requestAdjust(ctx, positionDiff, dataChanged) {
    const state = ctx.state;
    if (Math.abs(positionDiff) > 0.1) {
@@ -971,7 +989,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
      const needsScrollWorkaround = Platform.OS === "android" && !IsNewArchitecture && dataChanged && state.scroll <= positionDiff;
      const doit = () => {
        if (needsScrollWorkaround) {
-@@ -1707,7 +1754,9 @@ function getPredictedNativeClamp(state, unresolvedAmount, totalSize) {
+@@ -1707,7 +1763,9 @@ function getPredictedNativeClamp(state, unresolvedAmount, totalSize) {
    if (Math.abs(unresolvedAmount) <= MVCP_POSITION_EPSILON) {
      return 0;
    }
@@ -982,7 +1000,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
    const clampDelta = maxScroll - state.scroll;
    if (unresolvedAmount < 0) {
      return Math.max(unresolvedAmount, Math.min(0, clampDelta));
-@@ -1769,7 +1818,7 @@ function resolvePendingNativeMVCPAdjust(ctx, newScroll) {
+@@ -1769,7 +1827,7 @@ function resolvePendingNativeMVCPAdjust(ctx, newScroll) {
      settlePendingNativeMVCPAdjust(ctx, remainingAfterManual, nativeDelta);
      return true;
    }
@@ -991,7 +1009,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
    const distanceToClamp = Math.abs(newScroll - expectedNativeClampScroll);
    const isAtExpectedNativeClamp = distanceToClamp <= NATIVE_END_CLAMP_EPSILON;
    if (isAtExpectedNativeClamp) {
-@@ -1902,7 +1951,7 @@ function prepareMVCP(ctx, dataChanged) {
+@@ -1902,7 +1960,7 @@ function prepareMVCP(ctx, dataChanged) {
              if (diff > 0) {
                diff = Math.max(0, totalSize - state.scroll - state.scrollLength);
              } else {
@@ -1000,7 +1018,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
                state.scroll = maxScroll;
                state.scrollPending = maxScroll;
                diff = 0;
-@@ -2299,8 +2348,121 @@ function scrollToIndex(ctx, {
+@@ -2299,8 +2357,121 @@ function scrollToIndex(ctx, {
  }
  
  // src/core/initialScroll.ts
@@ -1010,11 +1028,11 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
 +var INSET_END_REVEAL_MAX_HOLD_FRAMES = 40;
 +function startInsetEndSettleWatchdog(ctx) {
 +  const state = ctx.state;
-+  if (state.insetEndSettleWatchdogActive) {
++  if (state.insetEndSettleWatchdogStarted || state.didLoad) {
 +    return;
 +  }
++  state.insetEndSettleWatchdogStarted = true;
 +  state.insetEndSettleWatchdogActive = true;
-+  state.didUserDrag = false;
 +  // Hold the readyToRender opacity gate until the end landing is stable, so
 +  // the estimated-to-measured settle chase happens before first VISIBLE
 +  // paint instead of in front of the user. Capped so slow measurement can
@@ -1023,6 +1041,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
 +  let frames = 0;
 +  let settledFrames = 0;
 +  let revealStableFrames = 0;
++  let previousEndOffset;
 +  const releaseRevealHold = () => {
 +    if (state.insetEndRevealHold) {
 +      state.insetEndRevealHold = false;
@@ -1062,33 +1081,32 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
 +    const insetStartAdjustment = getContentInsetStartAdjustment(ctx);
 +    const contentSize = getContentSize(ctx);
 +    const scrollLength = state.scrollLength;
-+    if (insetStartAdjustment > 0 && scrollLength > 0 && Number.isFinite(contentSize) && contentSize > scrollLength && !state.scrollingTo && !state.maintainingScrollAtEnd) {
-+      const endOffset = Math.max(-insetStartAdjustment, contentSize - scrollLength);
-+      const distance = endOffset - state.scroll;
-+      // Estimated row sizes converging to measured ones can strand the initial
-+      // end landing when the library's own end-anchor bookkeeping gives up.
-+      // While still near the end (never fighting a user who scrolled away),
-+      // re-pin to the current true end until sizes stop changing.
-+      if (Math.abs(distance) > 2 && Math.abs(distance) <= scrollLength * 0.5) {
-+        settledFrames = 0;
-+        revealStableFrames = 0;
++    const endOffset = Math.max(-insetStartAdjustment, contentSize - scrollLength);
++    // state.scroll is optimistic: non-animated scrollTo writes it before UIKit
++    // moves. Only a native scroll event proves that the requested offset landed.
++    const nativeOffset = state.lastNativeScroll;
++    const hasNativeOffset = typeof nativeOffset === "number" && Number.isFinite(nativeOffset);
++    const distance = hasNativeOffset ? endOffset - nativeOffset : Infinity;
++    const isIdle = !state.scrollingTo && !state.maintainingScrollAtEnd;
++    const hasViewport = insetStartAdjustment > 0 && scrollLength > 0 && Number.isFinite(contentSize);
++    const isStable = hasViewport && isIdle && Math.abs(distance) <= 2 && previousEndOffset !== void 0 && Math.abs(endOffset - previousEndOffset) <= 1;
++    previousEndOffset = endOffset;
++    if (isStable) {
++      settledFrames++;
++      revealStableFrames++;
++      if (revealStableFrames >= INSET_END_REVEAL_STABLE_FRAMES) {
++        onRevealStability();
++      }
++    } else {
++      settledFrames = 0;
++      revealStableFrames = 0;
++      // Keep the existing near-end correction limit. In-flight scrolls and
++      // unknown native offsets wait; neither counts as a settled frame.
++      if (hasViewport && isIdle && Math.abs(distance) > 2 && Math.abs(distance) <= scrollLength * 0.5) {
 +        const scroller = state.refScroller.current;
 +        if (scroller) {
 +          scroller.scrollTo({ animated: false, x: 0, y: endOffset });
 +        }
-+      } else {
-+        settledFrames++;
-+        revealStableFrames++;
-+        if (revealStableFrames >= INSET_END_REVEAL_STABLE_FRAMES) {
-+          onRevealStability();
-+        }
-+      }
-+    } else {
-+      // Conditions that make re-pinning unnecessary (underflow, in-flight
-+      // programmatic scroll) count toward stability for the reveal.
-+      revealStableFrames++;
-+      if (revealStableFrames >= INSET_END_REVEAL_STABLE_FRAMES) {
-+        onRevealStability();
 +      }
 +    }
 +    requestAnimationFrame(tick);
@@ -1122,7 +1140,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
    const requestedIndex = target.index;
    const index = requestedIndex !== void 0 ? clampScrollIndex(requestedIndex, ctx.state.props.data.length) : void 0;
    const itemSize = getItemSizeAtIndex(ctx, index);
-@@ -2726,7 +2888,9 @@ function clearFinishedBootstrapInitialScrollTargetIfMovedAway(ctx) {
+@@ -2726,7 +2897,9 @@ function clearFinishedBootstrapInitialScrollTargetIfMovedAway(ctx) {
      return;
    }
    if (didFinishedInitialScrollMoveAwayFromTarget(ctx, initialScroll)) {
@@ -1133,7 +1151,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
      if (!shouldKeepEndTargetAlive) {
        if (shouldPreserveInitialScrollForFooterLayout(initialScroll)) {
          clearPendingInitialScrollFooterLayout(ctx, {
-@@ -4651,7 +4815,8 @@ function maybeUpdateAnchoredEndSpace(ctx) {
+@@ -4651,7 +4824,8 @@ function maybeUpdateAnchoredEndSpace(ctx) {
        contentBelowAnchor = Math.max(0, contentBelowAnchor - ctx.scrollAxisGap);
        contentBelowAnchor += (ctx.values.get("footerSize") || 0) + getStylePaddingEnd(state.props);
        isReady = !hasUnknownTailSize;
@@ -1143,7 +1161,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
      } else if (anchorIndex >= 0) {
        isReady = false;
      }
-@@ -4671,6 +4836,12 @@ function maybeUpdateAnchoredEndSpace(ctx) {
+@@ -4671,6 +4845,12 @@ function maybeUpdateAnchoredEndSpace(ctx) {
        updateScroll(ctx, state.scroll, true, { markHasScrolled: false });
      }
      (_b = anchoredEndSpace == null ? void 0 : anchoredEndSpace.onReady) == null ? void 0 : _b.call(anchoredEndSpace, { anchorIndex: nextAnchorIndex, anchorKey: nextAnchorKey, size: nextSize });
@@ -1156,7 +1174,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
    }
    return nextSize;
  }
-@@ -5694,6 +5865,7 @@ var ContainersLayer = typedMemo(function ContainersLayer2({
+@@ -5694,6 +5874,7 @@ var ContainersLayer = typedMemo(function ContainersLayer2({
    horizontal
  }) {
    const ctx = useStateContext();
@@ -1164,7 +1182,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
    const columnWrapperStyle = ctx.columnWrapperStyle;
    const animSize = useValue$("totalSize");
    const [readyToRender, numColumns, otherAxisSize = 0] = useArr$(["readyToRender", "numColumns", "otherAxisSize"]);
-@@ -5704,6 +5876,13 @@ var ContainersLayer = typedMemo(function ContainersLayer2({
+@@ -5704,6 +5885,13 @@ var ContainersLayer = typedMemo(function ContainersLayer2({
      opacity: isVisible ? 1 : 0,
      width: animSize
    } : { height: animSize, minWidth: otherAxisSize, opacity: isVisible ? 1 : 0 };
@@ -1178,7 +1196,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
    if (columnWrapperStyle) {
      const { columnGap, rowGap, gap } = columnWrapperStyle;
      const gapX = columnGap || gap || 0;
-@@ -5724,7 +5903,8 @@ var ContainersLayer = typedMemo(function ContainersLayer2({
+@@ -5724,7 +5912,8 @@ var ContainersLayer = typedMemo(function ContainersLayer2({
        }
      }
    }
@@ -1188,7 +1206,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
  });
  var Containers = typedMemo(function Containers2({
    freshDataTransitionEpoch,
-@@ -5875,7 +6055,12 @@ var StyleSheet = StyleSheet$1;
+@@ -5875,7 +6064,12 @@ var StyleSheet = StyleSheet$1;
  
  // src/components/ListComponent.tsx
  var AlignItemsAtEndSpacer = typedMemo(function AlignItemsAtEndSpacer2({ horizontal }) {
@@ -1201,7 +1219,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
    if (alignItemsAtEndPadding <= 0) {
      return null;
    }
-@@ -5908,8 +6093,12 @@ var ListComponent = typedMemo(function ListComponent2({
+@@ -5908,8 +6102,12 @@ var ListComponent = typedMemo(function ListComponent2({
    refScrollView,
    renderScrollComponent,
    onLayoutFooter,
@@ -1214,7 +1232,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
    scrollAdjustHandler,
    snapToIndices,
    stickyHeaderConfig,
-@@ -5980,7 +6169,17 @@ var ListComponent = typedMemo(function ListComponent2({
+@@ -5980,7 +6178,17 @@ var ListComponent = typedMemo(function ListComponent2({
      SnapOrScroll,
      {
        ...rest,
@@ -1233,7 +1251,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
        contentContainerStyle: [
          horizontal ? { height: "100%" } : {},
          contentContainerStyle,
-@@ -5989,7 +6188,10 @@ var ListComponent = typedMemo(function ListComponent2({
+@@ -5989,7 +6197,10 @@ var ListComponent = typedMemo(function ListComponent2({
        ],
        contentOffset: initialContentOffset !== void 0 ? horizontal ? { x: initialContentOffset, y: 0 } : { x: 0, y: initialContentOffset } : void 0,
        horizontal,
@@ -1245,7 +1263,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
        onLayout,
        onScroll: onScroll2,
        ref: refScrollView,
-@@ -6730,7 +6932,7 @@ function createImperativeHandle(ctx, scheduleImperativeScrollCommit) {
+@@ -6730,7 +6941,7 @@ function createImperativeHandle(ctx, scheduleImperativeScrollCommit) {
        endBuffered: state.endBuffered,
        getAverageItemSizes: () => getAverageItemSizes(state),
        indexByKey: (key) => state.indexByKey.get(key),
@@ -1254,7 +1272,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
        isAtStart: peek$(ctx, "isAtStart"),
        isEndReached: state.isEndReached,
        isNearEnd: peek$(ctx, "isNearEnd"),
-@@ -7054,6 +7256,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7054,6 +7265,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
      dataVersion,
      drawDistance = 250,
      contentInsetEndAdjustment,
@@ -1262,7 +1280,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
      estimatedItemSize = 100,
      estimatedListSize,
      extraData,
-@@ -7111,10 +7314,12 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7111,10 +7323,12 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
    const animatedPropsInternal = props.animatedPropsInternal;
    const anchoredEndSpaceOwner = (_a3 = props.anchoredEndSpaceOwnerInternal) != null ? _a3 : "list";
    const positionComponentInternal = props.positionComponentInternal;
@@ -1275,7 +1293,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
      stickyPositionComponentInternal: _stickyPositionComponentInternal,
      ...restProps
    } = rest;
-@@ -7179,7 +7384,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7179,7 +7393,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
    const combinedRef = useCombinedRef(refScroller, refScrollView);
    const keyExtractor = keyExtractorProp != null ? keyExtractorProp : ((_item, index) => index.toString());
    const stickyHeaderIndices = stickyHeaderIndicesProp;
@@ -1284,7 +1302,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
    const previousContentInsetEndAdjustmentRef = useRef(contentInsetEndAdjustmentResolved);
    const alwaysRenderIndices = useMemo(() => {
      const indices = getAlwaysRenderIndices(alwaysRender, dataProp, keyExtractor, anchoredEndSpace == null ? void 0 : anchoredEndSpace.anchorIndex);
-@@ -7320,6 +7525,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7320,6 +7534,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
      contentContainerAlignItems: contentContainerStyle.alignItems,
      contentInset,
      contentInsetEndAdjustment: contentInsetEndAdjustmentResolved,
@@ -1292,7 +1310,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
      data: dataProp,
      dataKey,
      dataVersion,
-@@ -7351,6 +7557,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7351,6 +7566,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
      renderItem,
      rtl,
      snapToIndices,
@@ -1300,7 +1318,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
      stickyHeaderIndicesArr: stickyHeaderIndices != null ? stickyHeaderIndices : [],
      stickyHeaderIndicesSet: useMemo(() => new Set(stickyHeaderIndices != null ? stickyHeaderIndices : []), [stickyHeaderIndices == null ? void 0 : stickyHeaderIndices.join(",")]),
      stickyPositionComponentInternal,
-@@ -7402,6 +7609,13 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7402,6 +7618,13 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
        return void 0;
      }
      const resolvedOffset = (_a4 = initialScroll.contentOffset) != null ? _a4 : resolveInitialScrollOffset(ctx, initialScroll);
@@ -1314,7 +1332,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
      return usesBootstrapInitialScroll && ((_b2 = state.initialScrollSession) == null ? void 0 : _b2.kind) === "bootstrap" && Platform.OS === "web" ? void 0 : resolvedOffset;
    }, [usesBootstrapInitialScroll]);
    useLayoutEffect(() => {
-@@ -7526,6 +7740,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7526,6 +7749,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
      [
        dataKey,
        dataVersion,
@@ -1322,7 +1340,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
        memoizedLastItemKeys.join(","),
        numColumnsProp,
        nextScrollAxisGap,
-@@ -7622,6 +7837,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7622,6 +7846,7 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
      () => ({
        getRenderedItem: (key) => getRenderedItem(ctx, key),
        onMomentumScrollEnd: (event) => {
@@ -1330,7 +1348,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
          checkFinishedScrollFallback(ctx);
          if (state.props.onMomentumScrollEnd) {
            state.props.onMomentumScrollEnd(event);
-@@ -7630,6 +7846,8 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7630,6 +7855,8 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
        onScroll: (event) => onScroll(ctx, event),
        onScrollBeginDrag: (event) => {
          var _a4, _b2;
@@ -1339,7 +1357,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..b8c6faf0be51cbda3e8af01f290dbe97
          prepareReachedEdgeForNextUserScroll(ctx);
          (_b2 = (_a4 = state.props).onScrollBeginDrag) == null ? void 0 : _b2.call(_a4, event);
        },
-@@ -7655,11 +7873,18 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
+@@ -7655,11 +7882,18 @@ var LegendListInner = typedForwardRef(function LegendListInner2(props, forwarded
        ListFooterComponent,
        ListFooterComponentStyle,
        ListHeaderComponent,

--- a/patches/@legendapp__list@3.3.5.patch
+++ b/patches/@legendapp__list@3.3.5.patch
@@ -241,7 +241,7 @@ index ce1fe00001c9e5aee6c6ea8bb2d4757d4586d002..3ccf6f16067152dfcb0c143371e2ec6a
       * Number of columns to render items in.
       * @default 1
 diff --git a/react-native.js b/react-native.js
-index b3c5a306b293f797a8b338adfca3060c0f6db22b..c239dae7390aead3968863fc0d5a4de165521bc6 100644
+index b3c5a306b293f797a8b338adfca3060c0f6db22b..5ac6bbe8fe40bf252fefa6b885c2196d0677d75f 100644
 --- a/react-native.js
 +++ b/react-native.js
 @@ -717,6 +717,15 @@ function hasActiveInitialScroll(state) {
@@ -277,7 +277,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..c239dae7390aead3968863fc0d5a4de1
 +  // Native contentOffset can seed an end target without dispatchInitialScroll.
 +  // Both overflow completion paths must wait for the native end landing.
 +  // Underflow needs no scroll: preserve UIKit's untouched resting position.
-+  if (state.didContainersLayout && state.didFinishInitialScroll && state.initialScroll && state.initialScroll.viewPosition === 1 && state.props.data.length > 0) {
++  if (state.didContainersLayout && state.didFinishInitialScroll && state.initialScroll && state.initialScroll.viewPosition === 1 && state.initialScroll.index === state.props.data.length - 1 && state.props.data.length > 0) {
 +    const insetStartAdjustment = getContentInsetStartAdjustment(ctx);
 +    if (insetStartAdjustment > 0 && getContentSize(ctx) > state.scrollLength - insetStartAdjustment + 1) {
 +      startInsetEndSettleWatchdog(ctx);
@@ -809,7 +809,7 @@ index b3c5a306b293f797a8b338adfca3060c0f6db22b..c239dae7390aead3968863fc0d5a4de1
        recycleItems,
        refreshControl: refreshControlElement ? stylePaddingTopState > 0 ? React2__namespace.cloneElement(refreshControlElement, {
 diff --git a/react-native.mjs b/react-native.mjs
-index 40e87cda8c9bc79a889e5542f29af429a24b24d4..c5c131969e03afab6859c04022b8620cc43e7e5e 100644
+index 40e87cda8c9bc79a889e5542f29af429a24b24d4..93aac741d2cf77ce35996362439108176f19da7a 100644
 --- a/react-native.mjs
 +++ b/react-native.mjs
 @@ -696,6 +696,15 @@ function hasActiveInitialScroll(state) {
@@ -845,7 +845,7 @@ index 40e87cda8c9bc79a889e5542f29af429a24b24d4..c5c131969e03afab6859c04022b8620c
 +  // Native contentOffset can seed an end target without dispatchInitialScroll.
 +  // Both overflow completion paths must wait for the native end landing.
 +  // Underflow needs no scroll: preserve UIKit's untouched resting position.
-+  if (state.didContainersLayout && state.didFinishInitialScroll && state.initialScroll && state.initialScroll.viewPosition === 1 && state.props.data.length > 0) {
++  if (state.didContainersLayout && state.didFinishInitialScroll && state.initialScroll && state.initialScroll.viewPosition === 1 && state.initialScroll.index === state.props.data.length - 1 && state.props.data.length > 0) {
 +    const insetStartAdjustment = getContentInsetStartAdjustment(ctx);
 +    if (insetStartAdjustment > 0 && getContentSize(ctx) > state.scrollLength - insetStartAdjustment + 1) {
 +      startInsetEndSettleWatchdog(ctx);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ patchedDependencies:
   '@effect/vitest@4.0.0-beta.103': a16b1e870d8c29e4a98b17cc4c638a4ff471753d8ca3487f78a22b759caf951b
   '@expo/metro-config@57.0.12': 96f1a75347e6ea02dc4b7034ace815d8ee39e18b8166ebfb573d9e58328f0dc2
   '@ff-labs/fff-node@0.9.4': ab9ff544009e1891cfe3930105862d3699007f38922a79f3c98d90018deca368
-  '@legendapp/list@3.3.5': 2c042ab630ac8b857024c178ee8c145d99c2f7297d9f94f5676238f08f0806ee
+  '@legendapp/list@3.3.5': 8651501f9691a01bb59a814be010381b3eaf768a77929d4355e1d7bb2a290b2c
   '@pierre/diffs@1.3.0-beta.10': 0ccee155b93b63d810e2c1a40c1fd676fb6fbcfa72cf6430dcedf1a3ae475ab4
   '@react-native-ai/apple@0.12.0': 2d09870c2848d185cb05b53ed823a46e12dba519324d8dd8e584e28731990f9d
   '@react-native-menu/menu@2.0.0': f63d256bf6a97a873b5e628eb595bd6ef0075ddd5bdd890fc920f7a6024290dd
@@ -236,7 +236,7 @@ importers:
         version: 57.0.14(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@legendapp/list':
         specifier: 'catalog:'
-        version: 3.3.5(patch_hash=2c042ab630ac8b857024c178ee8c145d99c2f7297d9f94f5676238f08f0806ee)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 3.3.5(patch_hash=8651501f9691a01bb59a814be010381b3eaf768a77929d4355e1d7bb2a290b2c)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@noble/curves':
         specifier: 'catalog:'
         version: 1.9.1
@@ -580,7 +580,7 @@ importers:
         version: 0.9.0
       '@legendapp/list':
         specifier: 'catalog:'
-        version: 3.3.5(patch_hash=2c042ab630ac8b857024c178ee8c145d99c2f7297d9f94f5676238f08f0806ee)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.3.5(patch_hash=8651501f9691a01bb59a814be010381b3eaf768a77929d4355e1d7bb2a290b2c)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@lexical/react':
         specifier: ^0.41.0
         version: 0.41.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(yjs@13.6.31)
@@ -13269,7 +13269,7 @@ snapshots:
     dependencies:
       jsbi: 4.3.2
 
-  '@legendapp/list@3.3.5(patch_hash=2c042ab630ac8b857024c178ee8c145d99c2f7297d9f94f5676238f08f0806ee)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
+  '@legendapp/list@3.3.5(patch_hash=8651501f9691a01bb59a814be010381b3eaf768a77929d4355e1d7bb2a290b2c)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
       react: 19.2.3
       use-sync-external-store: 1.6.0(react@19.2.3)
@@ -13277,7 +13277,7 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-  '@legendapp/list@3.3.5(patch_hash=2c042ab630ac8b857024c178ee8c145d99c2f7297d9f94f5676238f08f0806ee)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@legendapp/list@3.3.5(patch_hash=8651501f9691a01bb59a814be010381b3eaf768a77929d4355e1d7bb2a290b2c)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       react: 19.2.6
       use-sync-external-store: 1.6.0(react@19.2.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ patchedDependencies:
   '@effect/vitest@4.0.0-beta.103': a16b1e870d8c29e4a98b17cc4c638a4ff471753d8ca3487f78a22b759caf951b
   '@expo/metro-config@57.0.12': 96f1a75347e6ea02dc4b7034ace815d8ee39e18b8166ebfb573d9e58328f0dc2
   '@ff-labs/fff-node@0.9.4': ab9ff544009e1891cfe3930105862d3699007f38922a79f3c98d90018deca368
-  '@legendapp/list@3.3.5': 8651501f9691a01bb59a814be010381b3eaf768a77929d4355e1d7bb2a290b2c
+  '@legendapp/list@3.3.5': 0e5996cffd0ddba2c28d10cb939ad8a25f11a2856aa614bd14bf4970bc138817
   '@pierre/diffs@1.3.0-beta.10': 0ccee155b93b63d810e2c1a40c1fd676fb6fbcfa72cf6430dcedf1a3ae475ab4
   '@react-native-ai/apple@0.12.0': 2d09870c2848d185cb05b53ed823a46e12dba519324d8dd8e584e28731990f9d
   '@react-native-menu/menu@2.0.0': f63d256bf6a97a873b5e628eb595bd6ef0075ddd5bdd890fc920f7a6024290dd
@@ -236,7 +236,7 @@ importers:
         version: 57.0.14(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@legendapp/list':
         specifier: 'catalog:'
-        version: 3.3.5(patch_hash=8651501f9691a01bb59a814be010381b3eaf768a77929d4355e1d7bb2a290b2c)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 3.3.5(patch_hash=0e5996cffd0ddba2c28d10cb939ad8a25f11a2856aa614bd14bf4970bc138817)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@noble/curves':
         specifier: 'catalog:'
         version: 1.9.1
@@ -580,7 +580,7 @@ importers:
         version: 0.9.0
       '@legendapp/list':
         specifier: 'catalog:'
-        version: 3.3.5(patch_hash=8651501f9691a01bb59a814be010381b3eaf768a77929d4355e1d7bb2a290b2c)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.3.5(patch_hash=0e5996cffd0ddba2c28d10cb939ad8a25f11a2856aa614bd14bf4970bc138817)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@lexical/react':
         specifier: ^0.41.0
         version: 0.41.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(yjs@13.6.31)
@@ -13269,7 +13269,7 @@ snapshots:
     dependencies:
       jsbi: 4.3.2
 
-  '@legendapp/list@3.3.5(patch_hash=8651501f9691a01bb59a814be010381b3eaf768a77929d4355e1d7bb2a290b2c)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
+  '@legendapp/list@3.3.5(patch_hash=0e5996cffd0ddba2c28d10cb939ad8a25f11a2856aa614bd14bf4970bc138817)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
       react: 19.2.3
       use-sync-external-store: 1.6.0(react@19.2.3)
@@ -13277,7 +13277,7 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-  '@legendapp/list@3.3.5(patch_hash=8651501f9691a01bb59a814be010381b3eaf768a77929d4355e1d7bb2a290b2c)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@legendapp/list@3.3.5(patch_hash=0e5996cffd0ddba2c28d10cb939ad8a25f11a2856aa614bd14bf4970bc138817)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       react: 19.2.6
       use-sync-external-store: 1.6.0(react@19.2.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ patchedDependencies:
   '@effect/vitest@4.0.0-beta.103': a16b1e870d8c29e4a98b17cc4c638a4ff471753d8ca3487f78a22b759caf951b
   '@expo/metro-config@57.0.12': 96f1a75347e6ea02dc4b7034ace815d8ee39e18b8166ebfb573d9e58328f0dc2
   '@ff-labs/fff-node@0.9.4': ab9ff544009e1891cfe3930105862d3699007f38922a79f3c98d90018deca368
-  '@legendapp/list@3.3.5': 0e5996cffd0ddba2c28d10cb939ad8a25f11a2856aa614bd14bf4970bc138817
+  '@legendapp/list@3.3.5': a05e968651a1352d2f374324016d1034b763b9fb2c5bf5f95111540d6899a52b
   '@pierre/diffs@1.3.0-beta.10': 0ccee155b93b63d810e2c1a40c1fd676fb6fbcfa72cf6430dcedf1a3ae475ab4
   '@react-native-ai/apple@0.12.0': 2d09870c2848d185cb05b53ed823a46e12dba519324d8dd8e584e28731990f9d
   '@react-native-menu/menu@2.0.0': f63d256bf6a97a873b5e628eb595bd6ef0075ddd5bdd890fc920f7a6024290dd
@@ -236,7 +236,7 @@ importers:
         version: 57.0.14(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@legendapp/list':
         specifier: 'catalog:'
-        version: 3.3.5(patch_hash=0e5996cffd0ddba2c28d10cb939ad8a25f11a2856aa614bd14bf4970bc138817)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 3.3.5(patch_hash=a05e968651a1352d2f374324016d1034b763b9fb2c5bf5f95111540d6899a52b)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@noble/curves':
         specifier: 'catalog:'
         version: 1.9.1
@@ -580,7 +580,7 @@ importers:
         version: 0.9.0
       '@legendapp/list':
         specifier: 'catalog:'
-        version: 3.3.5(patch_hash=0e5996cffd0ddba2c28d10cb939ad8a25f11a2856aa614bd14bf4970bc138817)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.3.5(patch_hash=a05e968651a1352d2f374324016d1034b763b9fb2c5bf5f95111540d6899a52b)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@lexical/react':
         specifier: ^0.41.0
         version: 0.41.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(yjs@13.6.31)
@@ -13269,7 +13269,7 @@ snapshots:
     dependencies:
       jsbi: 4.3.2
 
-  '@legendapp/list@3.3.5(patch_hash=0e5996cffd0ddba2c28d10cb939ad8a25f11a2856aa614bd14bf4970bc138817)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
+  '@legendapp/list@3.3.5(patch_hash=a05e968651a1352d2f374324016d1034b763b9fb2c5bf5f95111540d6899a52b)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
       react: 19.2.3
       use-sync-external-store: 1.6.0(react@19.2.3)
@@ -13277,7 +13277,7 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-  '@legendapp/list@3.3.5(patch_hash=0e5996cffd0ddba2c28d10cb939ad8a25f11a2856aa614bd14bf4970bc138817)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@legendapp/list@3.3.5(patch_hash=a05e968651a1352d2f374324016d1034b763b9fb2c5bf5f95111540d6899a52b)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       react: 19.2.6
       use-sync-external-store: 1.6.0(react@19.2.6)

--- a/scripts/legend-list-initial-reveal.test.ts
+++ b/scripts/legend-list-initial-reveal.test.ts
@@ -1,3 +1,4 @@
+// @effect-diagnostics nodeBuiltinImport:off - reads the installed native JS bundle for synchronous VM tests.
 import * as NodeFS from "node:fs";
 import * as NodeVM from "node:vm";
 import { describe, expect, it, vi } from "vite-plus/test";

--- a/scripts/legend-list-initial-reveal.test.ts
+++ b/scripts/legend-list-initial-reveal.test.ts
@@ -101,6 +101,16 @@ for (const bundle of ["react-native.js", "react-native.mjs"]) {
       expect(list.ready()).toBe(true);
     });
 
+    it("preserves an initial index before the last item", () => {
+      const list = createList(bundle);
+      list.state.props.data = ["requested message", "later message"];
+      list.state.scroll = 200;
+      list.complete();
+      list.advance(8);
+      expect(list.ready()).toBe(true);
+      expect(list.scrollTo).not.toHaveBeenCalled();
+    });
+
     it("does not count an in-flight scroll as stability", () => {
       const list = createList(bundle);
       list.state.lastNativeScroll = 400;

--- a/scripts/legend-list-initial-reveal.test.ts
+++ b/scripts/legend-list-initial-reveal.test.ts
@@ -23,7 +23,8 @@ function createList(bundle: string) {
   const scrollTo = vi.fn();
   const onLoad = vi.fn();
   const state = {
-    props: { initialScrollAtEnd: true, data: ["message"], onLoad, drawDistance: 500 },
+    props: { data: ["message"], onLoad, drawDistance: 500 },
+    initialScroll: { index: 0, viewPosition: 1 },
     loadStartTime: 0,
     didContainersLayout: true,
     didFinishInitialScroll: true,

--- a/scripts/legend-list-initial-reveal.test.ts
+++ b/scripts/legend-list-initial-reveal.test.ts
@@ -1,0 +1,202 @@
+import * as NodeFS from "node:fs";
+import * as NodeVM from "node:vm";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+// Exercise the shipped patch without loading React Native in the Node runner.
+// Native scroll delivery and animation frames advance independently here.
+function createList(bundle: string) {
+  const source = NodeFS.readFileSync(
+    new URL(`../apps/mobile/node_modules/@legendapp/list/${bundle}`, import.meta.url),
+    "utf8",
+  );
+  const renderState = source.slice(
+    source.indexOf("function setInitialRenderState("),
+    source.indexOf("// src/core/finishInitialScroll.ts"),
+  );
+  const watchdog = source.slice(
+    source.indexOf("var INSET_END_SETTLE_WATCHDOG_FRAMES"),
+    source.indexOf("function dispatchInitialScroll("),
+  );
+  const frames: Array<() => void> = [];
+  const values = new Map<string, unknown>();
+  const scrollTo = vi.fn();
+  const onLoad = vi.fn();
+  const state = {
+    props: { initialScrollAtEnd: true, data: ["message"], onLoad, drawDistance: 500 },
+    loadStartTime: 0,
+    didContainersLayout: true,
+    didFinishInitialScroll: true,
+    didLoad: false,
+    didUserDrag: false,
+    scrollLength: 800,
+    scroll: 400,
+    lastNativeScroll: 200 as number | undefined,
+    scrollingTo: undefined as { offset: number } | undefined,
+    maintainingScrollAtEnd: false,
+    refScroller: { current: { scrollTo } },
+  };
+  const ctx = { state };
+  let contentSize = 1200;
+  let inset = 100;
+  const api = NodeVM.runInNewContext(
+    `${renderState}\n${watchdog}\n({ start: startInsetEndSettleWatchdog, complete: setInitialRenderState })`,
+    {
+      requestAnimationFrame: (callback: () => void) => frames.push(callback),
+      getContentSize: () => contentSize,
+      getContentInsetStartAdjustment: () => inset,
+      peek$: (_ctx: unknown, key: string) => values.get(key),
+      set$: (_ctx: unknown, key: string, value: unknown) => values.set(key, value),
+      setAdaptiveRender: vi.fn(),
+      scheduleFullDrawDistancePrewarm: vi.fn(),
+      INITIAL_DRAW_DISTANCE: 250,
+    },
+  ) as {
+    start: (context: typeof ctx) => void;
+    complete: (context: typeof ctx, flags: Record<string, boolean>) => void;
+  };
+  return {
+    state,
+    scrollTo,
+    onLoad,
+    start: () => api.start(ctx),
+    complete: () => api.complete(ctx, {}),
+    ready: () => values.get("readyToRender") === true,
+    resize: (size: number) => {
+      contentSize = size;
+    },
+    setInset: (value: number) => {
+      inset = value;
+    },
+    advance(count: number) {
+      for (let index = 0; index < count; index++) {
+        const batch = frames.splice(0);
+        for (const frame of batch) frame();
+      }
+    },
+  };
+}
+
+for (const bundle of ["react-native.js", "react-native.mjs"]) {
+  describe(`initial inset end reveal (${bundle})`, () => {
+    it("waits for the native offset instead of the optimistic scroll target", () => {
+      const list = createList(bundle);
+      list.start();
+      list.advance(8);
+      expect(list.ready()).toBe(false);
+      expect(list.scrollTo).toHaveBeenCalledWith({ animated: false, x: 0, y: 400 });
+      list.state.lastNativeScroll = 400;
+      list.advance(7);
+      expect(list.ready()).toBe(true);
+      expect(list.onLoad).toHaveBeenCalledTimes(1);
+    });
+
+    it("gates the seeded contentOffset completion path too", () => {
+      const list = createList(bundle);
+      list.complete();
+      expect(list.ready()).toBe(false);
+      list.state.lastNativeScroll = 400;
+      list.advance(7);
+      expect(list.ready()).toBe(true);
+    });
+
+    it("does not count an in-flight scroll as stability", () => {
+      const list = createList(bundle);
+      list.state.lastNativeScroll = 400;
+      list.state.scrollingTo = { offset: 400 };
+      list.start();
+      list.advance(8);
+      expect(list.ready()).toBe(false);
+      list.state.scrollingTo = undefined;
+      list.state.maintainingScrollAtEnd = true;
+      list.advance(8);
+      expect(list.ready()).toBe(false);
+      list.state.maintainingScrollAtEnd = false;
+      list.advance(7);
+      expect(list.ready()).toBe(true);
+    });
+
+    it("waits for a stable end target even when native scrolling follows each measurement", () => {
+      const list = createList(bundle);
+      list.start();
+      for (let index = 0; index < 10; index++) {
+        list.resize(1200 + index * 10);
+        list.state.lastNativeScroll = 400 + index * 10;
+        list.advance(1);
+      }
+      expect(list.ready()).toBe(false);
+      list.advance(7);
+      expect(list.ready()).toBe(true);
+    });
+
+    it("accounts for header insets when content is shorter than the full viewport", () => {
+      const list = createList(bundle);
+      list.resize(780);
+      list.state.scroll = -20;
+      list.state.lastNativeScroll = -100;
+      list.start();
+      list.advance(8);
+      expect(list.ready()).toBe(false);
+      expect(list.scrollTo).toHaveBeenCalledWith({ animated: false, x: 0, y: -20 });
+      list.state.lastNativeScroll = -20;
+      list.advance(7);
+      expect(list.ready()).toBe(true);
+    });
+
+    it("keeps the reveal bounded when native events never arrive", () => {
+      const list = createList(bundle);
+      list.state.lastNativeScroll = undefined;
+      list.start();
+      list.advance(8);
+      expect(list.ready()).toBe(false);
+      expect(list.scrollTo).not.toHaveBeenCalled();
+      list.advance(32);
+      expect(list.ready()).toBe(true);
+    });
+
+    it("releases control on drag and never starts another initial hold", () => {
+      const list = createList(bundle);
+      list.start();
+      list.state.didUserDrag = true;
+      list.advance(1);
+      expect(list.ready()).toBe(true);
+      expect(list.scrollTo).not.toHaveBeenCalled();
+      list.complete();
+      list.start();
+      list.advance(20);
+      expect(list.state.didUserDrag).toBe(true);
+      expect(list.scrollTo).not.toHaveBeenCalled();
+      expect(list.onLoad).toHaveBeenCalledTimes(1);
+    });
+
+    it("preserves a drag that started before initial layout completed", () => {
+      const list = createList(bundle);
+      list.state.didUserDrag = true;
+      list.complete();
+      list.advance(1);
+      expect(list.ready()).toBe(true);
+      expect(list.state.didUserDrag).toBe(true);
+      expect(list.scrollTo).not.toHaveBeenCalled();
+    });
+
+    it("reveals short content at UIKit's resting offset without awaiting a scroll event", () => {
+      const list = createList(bundle);
+      list.resize(700);
+      list.state.lastNativeScroll = undefined;
+      list.complete();
+      expect(list.ready()).toBe(true);
+      list.advance(10);
+      expect(list.scrollTo).not.toHaveBeenCalled();
+    });
+
+    it("does not gate empty lists or lists without an automatic header inset", () => {
+      const list = createList(bundle);
+      list.setInset(0);
+      list.complete();
+      expect(list.ready()).toBe(true);
+      const empty = createList(bundle);
+      empty.state.props.data = [];
+      empty.complete();
+      expect(empty.ready()).toBe(true);
+    });
+  });
+}


### PR DESCRIPTION
Opening an existing iOS thread can expose a user bubble halfway down the screen, then jump it upward on the next frame. In the reported thread, a late row measurement moves the rows by about 276 points after the list is visible; native scrolling catches up afterward.

Keep the existing initial reveal gate closed until the measured end target is stable and the observed native scroll position has reached it. In-flight scrolls and moving targets no longer count as settled frames. Apply the gate to the seeded `contentOffset` completion path using the preserved initial end target. Short threads still render immediately, the existing timeout stays bounded, and dragging releases control to the user.

### Evidence

Matched base and head recordings use the actual “Triage Open Bug Reports” thread, 13-point text, the same iPhone 17 Pro simulator, and production JavaScript. No forced scroll delays or diagnostic instrumentation are present in these captures. Before: both openings exhibit the jump, including one on the very first visible frame. After: both openings retain the final vertical position from their first visible frame.

The first two panels are consecutive frames from the before recording. The third is the first visible frame after the fix.

![Before first frame, before next frame, and after first frame](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/108d76603b91c0dd/first-visible-comparison.png)

Full opening comparison at quarter speed. The fixed version waits for layout and native scrolling to settle before revealing the feed.

![Before and after thread opening, quarter speed](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/f7a2c67289cdf781/actual-comparison-v2.gif)

[Before recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/6d9d132141152aee/actual-before-v2.mp4) · [After recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/0f9e83f7545ac27e/actual-after-v2.mp4)

### Validation

- 22 focused regression tests pass against both shipped native bundles, covering native delivery, changing measurements, seeded offsets, explicit earlier-message targets, underflow, drag cancellation, and the timeout.
- Scoped TypeScript, lint, formatting, bundle syntax, and frozen-lockfile installation pass.
- The supplied recording used TestFlight 1.0.4 build 49, built from [7129797](https://github.com/pingdotgg/t3code/commit/71297974c666b0db50a3e3b1a861742f2cdd4d7d). Reproduction uses production JavaScript from this PR’s base/head in a development native shell on iOS 26.5, not the device-only TestFlight binary.
- The change is confined to the native list implementation. Web/desktop use the separate web implementation; no provider, contract, connection-mode, or documentation changes are needed.

Implemented with GPT-6 in Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wait for native scroll stability before initial inset-end reveal in `@legendapp/list`
> - Updates the patched `setInitialRenderState` and `startInsetEndSettleWatchdog` functions in both `react-native.js` and `react-native.mjs` bundles so that lists targeting their final item with a positive inset now start the inset-end settle watchdog before readiness is established.
> - The watchdog releases the reveal hold only after a known native scroll offset, an idle list, and a stable end offset across frames are confirmed. Corrective scrolling is restricted to idle states with a known native offset; unknown or in-flight states reset stability rather than counting toward it.
> - Adds a VM-based test fixture in [legend-list-initial-reveal.test.ts](https://github.com/pingdotgg/t3code/pull/10486/files#diff-d0ed23e3a88c5254810b1fdf31e17aa42651d1c634203bdc570fdfe6c1d6648d) covering native-offset confirmation, in-flight scrolls, changing measured end targets, user drags, underflow, and missing native events.
> - Risk: lists that previously revealed immediately on initial render at an inset-adjusted end target now delay until the watchdog confirms native scroll stability or times out; review `setInitialRenderState` in `patches/@legendapp__list@3.3.5.patch` to confirm the gating condition matches expected list configurations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a0ab3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added leading-inset support for native and animated lists.
  * Added inset-aware scrolling, end positioning, and initial-scroll handling.
  * Added keyboard and safe-area compensation for chat-style lists.
  * Added animated composer-height adjustments and anchored spacing.
  * Added configurable inset and static end-adjustment options.

* **Bug Fixes**
  * Improved scroll-end detection and recovery during active scrolling.
  * Corrected web scroll-padding calculations and iOS position maintenance.
  * Improved behavior for short, empty, and repeatedly measured lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->