### PR TITLE
fix(server): include Claude advisor calls in usage totals

### DIFF
--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -125,7 +125,7 @@ describe("scan cache round trip", () => {
 
   it("rejects a document from the previous cache version", () => {
     const encoded = encodeScanCache(cacheWith([["/a.jsonl", 100, [record()]]]));
-    const previous = { ...encoded, version: 2 };
+    const previous = { ...encoded, version: 3 };
 
     expect(decodeScanCache(JSON.parse(JSON.stringify(previous))).size).toBe(0);
   });

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -26,7 +26,8 @@ import type { CodexScanState, UsageRecord } from "./usageTranscripts.ts";
 // entries would keep serving double-counted records forever.
 // v3: entries carry the parse position and reducer state so a grown file
 // re-parses only its appended bytes instead of starting over.
-export const USAGE_SCAN_CACHE_VERSION = 3 as const;
+// v4: re-parse existing Claude transcripts to include nested advisor usage.
+export const USAGE_SCAN_CACHE_VERSION = 4 as const;
 
 export interface CachedFile {
   readonly size: number;

--- a/apps/server/src/usage/usageTranscriptReader.test.ts
+++ b/apps/server/src/usage/usageTranscriptReader.test.ts
@@ -8,6 +8,9 @@ import * as NodePath from "node:path";
 import { afterEach, assert, beforeEach, describe, it } from "@effect/vitest";
 
 import { readTranscriptRecords } from "./usageTranscriptReader.ts";
+import { UsageAggregator } from "./usageAggregation.ts";
+import { dedupeWithinFile } from "./usageScanCache.ts";
+import { parseRateTable } from "./usagePricing.ts";
 
 let dir: string;
 
@@ -61,6 +64,65 @@ function codexUsageLine(outputTokens: number, secondsOffset: number): string {
 }
 
 describe("readTranscriptRecords resume", () => {
+  it("counts and prices an advisor arriving after the executor, once across replays", async () => {
+    const path = NodePath.join(dir, "advisor.jsonl");
+    const executor = JSON.parse(claudeLine(1, 5));
+    executor.message.usage.iterations = [
+      { type: "message", input_tokens: 10, output_tokens: 5 },
+      { type: "advisor_message", model: "claude-opus-5" },
+    ];
+    await NodeFSP.writeFile(path, JSON.stringify(executor) + "\n");
+    const first = await readTranscriptRecords(path, "claude");
+    assert.isNotNull(first);
+    assert.strictEqual(first.records.length, 1);
+
+    executor.message.usage.iterations = [
+      { type: "message", input_tokens: 10, output_tokens: 5 },
+      { type: "advisor_message", model: "claude-opus-5", input_tokens: 100, output_tokens: 20 },
+    ];
+    const advisorLine = JSON.stringify(executor) + "\n";
+    executor.message.usage.iterations.push({
+      type: "advisor_message",
+      model: "claude-opus-5",
+      input_tokens: 200,
+      output_tokens: 40,
+    });
+    const secondAdvisorLine = JSON.stringify(executor) + "\n";
+    await NodeFSP.appendFile(path, advisorLine + secondAdvisorLine + secondAdvisorLine);
+    const appended = await readTranscriptRecords(path, "claude", first.position);
+    assert.isNotNull(appended);
+    assert.isTrue(appended.resumed);
+    const records = dedupeWithinFile([...first.records, ...appended.records]);
+    assert.strictEqual(records.length, 3);
+
+    const replayPath = NodePath.join(dir, "replayed.jsonl");
+    await NodeFSP.writeFile(replayPath, secondAdvisorLine);
+    const replay = await readTranscriptRecords(replayPath, "claude");
+    assert.isNotNull(replay);
+    const aggregator = new UsageAggregator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-01",
+      rates: parseRateTable({
+        "claude-fable-5": { input_cost_per_token: 1e-5, output_cost_per_token: 5e-5 },
+        "claude-opus-5": { input_cost_per_token: 5e-6, output_cost_per_token: 2.5e-5 },
+      }),
+    });
+    for (const record of [...records, ...replay.records]) aggregator.add(record);
+    const buckets = aggregator.finish().buckets;
+    assert.strictEqual(buckets.length, 2);
+    const advisor = buckets.find((bucket) => bucket.model === "claude-opus-5");
+    assert.isDefined(advisor);
+    assert.strictEqual(advisor.records, 2);
+    assert.strictEqual(advisor.totals.uncachedInputTokens, 300);
+    assert.strictEqual(advisor.totals.outputTokens, 60);
+    assert.approximately(advisor.costUsd, 0.003, 1e-10);
+    assert.strictEqual(
+      buckets.find((bucket) => bucket.model === "claude-fable-5")?.totals.outputTokens,
+      5,
+    );
+  });
+
   it("parses only appended lines when resuming a grown file", async () => {
     const path = NodePath.join(dir, "claude.jsonl");
     await NodeFSP.writeFile(path, claudeLine(1, 5) + claudeLine(2, 7));

--- a/apps/server/src/usage/usageTranscriptReader.ts
+++ b/apps/server/src/usage/usageTranscriptReader.ts
@@ -217,6 +217,10 @@ export async function readTranscriptRecords(
       resumed = true;
     }
 
+    /**
+     * Appends all usage records from one provider transcript line, including
+     * Claude advisor calls, and updates Codex state even on context-only lines.
+     */
     const parseLine = (line: string, state: CodexScanState, out: UsageRecord[]): void => {
       if (provider === "codex") {
         if (

--- a/apps/server/src/usage/usageTranscriptReader.ts
+++ b/apps/server/src/usage/usageTranscriptReader.ts
@@ -235,8 +235,7 @@ export async function readTranscriptRecords(
         for (const grokRecord of parseGrokLine(line)) out.push(grokRecord);
         return;
       }
-      const record = parseClaudeLine(line);
-      if (record !== null) out.push(record);
+      for (const record of parseClaudeLine(line)) out.push(record);
     };
 
     const toLineString = (lineBuffer: Buffer): string => {

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -38,9 +38,9 @@ function claudeLine(overrides: {
 
 describe("parseClaudeLine", () => {
   it("extracts token totals and a dedupe key", () => {
-    const record = parseClaudeLine(claudeLine({ messageId: "msg_1", contentType: "text" }));
+    const [record] = parseClaudeLine(claudeLine({ messageId: "msg_1", contentType: "text" }));
 
-    expect(record).not.toBeNull();
+    expect(record).toBeDefined();
     expect(record?.provider).toBe("claude");
     expect(record?.model).toBe("claude-fable-5");
     expect(record?.totals).toEqual({
@@ -56,16 +56,110 @@ describe("parseClaudeLine", () => {
   it("gives every content block of one message the same dedupe key", () => {
     // T3 Code writes one record per content block, each repeating the parent
     // message's full usage. Summing them would overcount ~2.4x on real data.
-    const text = parseClaudeLine(claudeLine({ messageId: "msg_2", contentType: "text" }));
-    const toolUse = parseClaudeLine(claudeLine({ messageId: "msg_2", contentType: "tool_use" }));
+    const [text] = parseClaudeLine(claudeLine({ messageId: "msg_2", contentType: "text" }));
+    const [toolUse] = parseClaudeLine(claudeLine({ messageId: "msg_2", contentType: "tool_use" }));
 
     expect(text?.dedupeKey).toBe(toolUse?.dedupeKey);
     expect(text?.totals).toEqual(toolUse?.totals);
   });
 
   it("ignores records that are not assistant messages", () => {
-    expect(parseClaudeLine(JSON.stringify({ type: "user", message: {} }))).toBeNull();
-    expect(parseClaudeLine("not json")).toBeNull();
+    expect(parseClaudeLine(JSON.stringify({ type: "user", message: {} }))).toEqual([]);
+    expect(parseClaudeLine("not json")).toEqual([]);
+  });
+
+  it("separates advisor calls without counting executor iterations twice", () => {
+    const records = parseClaudeLine(
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-08-07T04:05:13.944Z",
+        sessionId: "session",
+        requestId: "request",
+        costUSD: 0.5,
+        message: {
+          id: "message",
+          model: "claude-sonnet-5",
+          usage: {
+            input_tokens: 30,
+            output_tokens: 10,
+            iterations: [
+              { type: "message", input_tokens: 10, output_tokens: 4 },
+              {
+                type: "advisor_message",
+                model: "claude-opus-5",
+                input_tokens: 100,
+                cache_read_input_tokens: 50,
+                cache_creation_input_tokens: 20,
+                output_tokens: 40,
+              },
+              { type: "message", input_tokens: 20, output_tokens: 6 },
+              {
+                type: "advisor_message",
+                model: "claude-opus-5",
+                input_tokens: 200,
+                output_tokens: 60,
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(records.map((record) => record.model)).toEqual([
+      "claude-sonnet-5",
+      "claude-opus-5",
+      "claude-opus-5",
+    ]);
+    expect(records.map((record) => totalTokens(record.totals))).toEqual([40, 210, 260]);
+    expect(new Set(records.map((record) => record.dedupeKey)).size).toBe(3);
+    expect(records.map((record) => record.reportedCostUsd)).toEqual([0.5, null, null]);
+    expect(records[1]?.totals).toEqual({
+      uncachedInputTokens: 100,
+      cachedInputTokens: 50,
+      cacheCreationTokens: 20,
+      outputTokens: 40,
+      reasoningTokens: 0,
+    });
+  });
+
+  it("ignores malformed advisor entries and preserves calls without message IDs", () => {
+    const line = {
+      type: "assistant",
+      timestamp: "2026-08-07T04:05:13.944Z",
+      message: {
+        model: "claude-sonnet-5",
+        usage: {
+          input_tokens: 1,
+          iterations: [
+            null,
+            5,
+            { type: "advisor_message" },
+            { type: "advisor_message", model: " " },
+            {
+              type: "advisor_message",
+              model: "claude-opus-5",
+              input_tokens: 100,
+              output_tokens: 20,
+            },
+          ],
+        },
+      },
+    };
+    const records = parseClaudeLine(JSON.stringify(line));
+    expect(records).toHaveLength(2);
+    expect(records.map((record) => record.dedupeKey)).toEqual([null, null]);
+    expect(records[1]?.totals.outputTokens).toBe(20);
+    expect(
+      parseClaudeLine(
+        JSON.stringify({
+          ...line,
+          message: {
+            ...line.message,
+            usage: { input_tokens: 1, iterations: {} },
+          },
+        }),
+      ),
+    ).toHaveLength(1);
   });
 });
 

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -89,38 +89,38 @@ export function grokCostTicksToUsd(ticks: unknown): number | null {
 /* -------------------------------------------------------------------------- */
 
 /**
- * Parses one line of a Claude Code transcript.
+ * Parses the executor and any advisor usage from a Claude Code transcript line.
  *
  * T3 Code writes one record per assistant *content block*, and every one of
  * those records repeats the same complete `usage` object for the parent
  * message. Summing them overcounts by roughly 2.4x on a real workload, so the
  * caller must drop repeats by `dedupeKey` and keep the first.
  */
-export function parseClaudeLine(line: string): UsageRecord | null {
+export function parseClaudeLine(line: string): readonly UsageRecord[] {
   let parsed: unknown;
   try {
     parsed = JSON.parse(line);
   } catch {
-    return null;
+    return [];
   }
-  if (typeof parsed !== "object" || parsed === null) return null;
+  if (typeof parsed !== "object" || parsed === null) return [];
 
   const record = parsed as Record<string, unknown>;
-  if (record["type"] !== "assistant") return null;
+  if (record["type"] !== "assistant") return [];
 
   const message = record["message"];
-  if (typeof message !== "object" || message === null) return null;
+  if (typeof message !== "object" || message === null) return [];
   const messageRecord = message as Record<string, unknown>;
 
   const usage = messageRecord["usage"];
-  if (typeof usage !== "object" || usage === null) return null;
+  if (typeof usage !== "object" || usage === null) return [];
   const usageRecord = usage as Record<string, unknown>;
 
   const timestampMs = parseTimestampMs(record["timestamp"]);
-  if (timestampMs === null) return null;
+  if (timestampMs === null) return [];
 
   const model = typeof messageRecord["model"] === "string" ? messageRecord["model"] : "";
-  if (model.length === 0) return null;
+  if (model.length === 0) return [];
 
   const messageId = typeof messageRecord["id"] === "string" ? messageRecord["id"] : null;
   const requestId = typeof record["requestId"] === "string" ? record["requestId"] : null;
@@ -131,7 +131,7 @@ export function parseClaudeLine(line: string): UsageRecord | null {
 
   const cost = record["costUSD"];
 
-  return {
+  const executor: UsageRecord = {
     provider: "claude",
     timestampMs,
     model,
@@ -147,6 +147,36 @@ export function parseClaudeLine(line: string): UsageRecord | null {
     reportedCostUsd: typeof cost === "number" && Number.isFinite(cost) ? cost : null,
     dedupeKey,
   };
+
+  const records = [executor];
+  const iterations = usageRecord["iterations"];
+  if (!Array.isArray(iterations)) return records;
+
+  // Top-level usage includes executor iterations only. Advisor sub-inferences
+  // have their own model and rates; ordinary "message" iterations are already counted.
+  for (const [index, raw] of iterations.entries()) {
+    if (typeof raw !== "object" || raw === null) continue;
+    const iteration = raw as Record<string, unknown>;
+    if (iteration["type"] !== "advisor_message") continue;
+    const advisorModel = iteration["model"];
+    if (typeof advisorModel !== "string" || advisorModel.trim().length === 0) continue;
+    const advisor: UsageRecord = {
+      ...executor,
+      model: advisorModel,
+      totals: {
+        uncachedInputTokens: int(iteration["input_tokens"]),
+        cachedInputTokens: int(iteration["cache_read_input_tokens"]),
+        cacheCreationTokens: int(iteration["cache_creation_input_tokens"]),
+        outputTokens: int(iteration["output_tokens"]),
+        reasoningTokens: 0,
+      },
+      // Legacy costUSD remains executor cost; do not copy it to advisor calls.
+      reportedCostUsd: null,
+      dedupeKey: dedupeKey === null ? null : `${dedupeKey}:advisor:${index}`,
+    };
+    if (totalTokens(advisor.totals) > 0) records.push(advisor);
+  }
+  return records;
 }
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## The problem

The usage dashboard provides clarity on token usage through the harnesses across interfaces. Even though T3 Code does not yet support Claude's advisor mode (see #9640), cost incurred through that in Claude Code should show up in the usage tracker here so that the numbers are accurate. 

## What Changed

The Usage dashboard now includes Claude advisor calls as separate usage records, priced at the advisor model's rates. Executor usage remains counted once, and advisor records use distinct keys so repeated content blocks and copied transcripts do not multiply their usage. The scan cache version is bumped to reprocess existing transcripts.

## Why

Claude reports advisor sub-inferences in `usage.iterations` with `type: "advisor_message"`. Those tokens are excluded from top-level executor usage ([Anthropic documentation](https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool#usage-and-billing)). The parser previously ignored them, so advisor tokens and estimated costs were absent from the Usage dashboard.

Related: #9640 explicitly leaves advisor token/cost attribution outside its scope. This change is limited to transcript-based Usage reporting.

## Validation

- 76 tests pass across the usage parser, transcript reader, scan cache, aggregation, pricing, and Usage service suites.
- Regression coverage includes multiple advisor calls, cached tokens, malformed and empty entries, per-model pricing, resumed scans, duplicate content blocks, copied transcripts, and invalidation of the previous cache version.
- Targeted lint and formatting checks pass; server typecheck passes.
- Independent Fable review approved the final diff with no blocking findings.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Written by GPT-6 in Codex. Reviewed by Claude Fable through Claude Code (`claude -p --model fable`).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include Claude advisor calls in usage totals via `parseClaudeLine`
> - Refactors `parseClaudeLine` in [usageTranscripts.ts](https://github.com/pingdotgg/t3code/pull/10488/files#diff-639e969b22f50fb1c28800a8caacb40faa709fb5b829f6c1e0a06a1be5fd5871) to return a read-only list of usage records instead of a single nullable record, emitting separate nonzero-token advisor records from nested iterations with distinct deduplication keys
> - Reported cost stays on the executor record; advisor records inherit transcript metadata and their own token totals from their iteration
> - Updates [usageTranscriptReader.ts](https://github.com/pingdotgg/t3code/pull/10488/files#diff-abfb6e6193baf30b1461a91349257b617fc266915d75b17a73ca21ccd1041d08) to append every record returned for a Claude line instead of at most one
> - Bumps usage scan cache schema version from 3 to 4 in [usageScanCache.ts](https://github.com/pingdotgg/t3code/pull/10488/files#diff-ca3f710ebaf0cd708cedab20134ea19de9a81237223250d0402fa68c37498806) to force re-parsing of existing transcripts
> - Behavioral Change: version-3 cache entries are treated as stale; old caches are rebuilt on next scan
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8cb5ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Claude usage tracking now includes advisor iterations with separate token totals and model attribution.
  - Usage totals and pricing remain accurate when transcripts contain resumed or repeated messages.
  - Invalid or incomplete transcript entries are handled more reliably without disrupting usage processing.

- **Improvements**
  - Existing Claude usage data is reprocessed to apply the updated accounting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->