### PR TITLE
fix(web): avoid trailing newline when copying code blocks

### DIFF
--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -199,7 +199,7 @@ describe("ChatMarkdown streaming", () => {
       });
       const details = mounted.root.findByProps({ "data-markdown-details": "" });
       expect(details.props["data-markdown-details-open"]).toBe("true");
-      expect(writeText).toHaveBeenCalledWith("First code block\n");
+      expect(writeText).toHaveBeenCalledWith("First code block");
       expect(highlight).toHaveBeenCalledTimes(1);
 
       for (let index = 0; index < 10; index += 1) {
@@ -226,7 +226,7 @@ describe("ChatMarkdown streaming", () => {
       await act(async () => {
         copyUpdated.onClick?.({} as Parameters<NonNullable<typeof copyUpdated.onClick>>[0]);
       });
-      expect(writeText).toHaveBeenLastCalledWith("Updated code block\n");
+      expect(writeText).toHaveBeenLastCalledWith("Updated code block");
       expect(highlight).toHaveBeenCalledTimes(2);
     } finally {
       await act(async () => renderer?.unmount());

--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -343,6 +343,39 @@ describe("hasMarkdownFilePrimaryAction", () => {
   });
 });
 
+describe("ChatMarkdown code block copying", () => {
+  async function copyCodeBlock(text: string): Promise<string | undefined> {
+    const writeText = vi.fn(async (_text: string) => {});
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    let renderer: ReactTestRenderer | undefined;
+    try {
+      await act(async () => {
+        renderer = create(<ChatMarkdown cwd="/tmp/project" text={text} />);
+      });
+      const copy = codeButton(renderer!, "Copy code");
+      await act(async () => {
+        copy.onClick?.({} as Parameters<NonNullable<typeof copy.onClick>>[0]);
+      });
+      return writeText.mock.calls[0]?.[0];
+    } finally {
+      await act(async () => renderer?.unmount());
+      vi.unstubAllGlobals();
+    }
+  }
+
+  // Pasting should leave the cursor on the command, so the last newline is
+  // dropped whether it came from fence serialization or raw HTML.
+  it("copies a command without a trailing newline to paste", async () => {
+    expect(await copyCodeBlock("```sh\nnpm install\n```")).toBe("npm install");
+    expect(await copyCodeBlock("<pre><code>npm install\n</code></pre>")).toBe("npm install");
+  });
+
+  it("keeps trailing blank lines the author wrote", async () => {
+    expect(await copyCodeBlock("```sh\nnpm install\n\n```")).toBe("npm install\n");
+  });
+});
+
 describe("ChatMarkdown skill chips", () => {
   it("updates digit-leading skill labels when discovered skills change", async () => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -650,7 +650,9 @@ function extractCodeBlock(
 
   return {
     className: onlyChild.props.className,
-    code: nodeToPlainText(onlyChild.props.children),
+    // Fenced code always serializes with a closing newline; drop it so copying
+    // a command does not paste a stray line break into a terminal.
+    code: nodeToPlainText(onlyChild.props.children).replace(/\n$/, ""),
   };
 }
 

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -650,8 +650,8 @@ function extractCodeBlock(
 
   return {
     className: onlyChild.props.className,
-    // Fenced code always serializes with a closing newline; drop it so copying
-    // a command does not paste a stray line break into a terminal.
+    // Drop the closing newline so pasting leaves the cursor on the command
+    // instead of below it. Only the last one, so authored blank lines survive.
     code: nodeToPlainText(onlyChild.props.children).replace(/\n$/, ""),
   };
 }


### PR DESCRIPTION
Copying a code block put a trailing newline on the clipboard, so pasting a command into a terminal left the cursor on an empty line below it.

`extractCodeBlock` reads the rendered `<pre><code>` text, and markdown-to-HAST appends a closing newline to every fence. Stripping it there covers both readers of that text: the copy button and the Shiki highlighter.

Clipboard for a fenced `npm install` block: `"npm install\n"` → `"npm install"`.

- Seen on the macOS desktop nightly. The code is the shared web client that desktop renders, so web has it too; mobile already strips it in `ThreadFeed.tsx`.
- Only the last newline goes, so authored trailing blank lines survive.
- Selection copy (`markdown-clipboard.ts`) is untouched — it rebuilds whole fences, which need the newline.
- No visual change. Tests cover fenced, raw HTML, and blank-line cases (45 passing).

Written by Claude Opus 5 in T3 Code (Claude Code harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
