### PR TITLE
fix(mobile): restore assistant message bottom padding

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -2260,11 +2260,18 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
   );
   const markdownStyles = useMarkdownStyles(onMarkdownLinkPress, renderMarkdownImage);
   const reviewCommentColors = useReviewCommentColors();
+  const unsettledTurnId =
+    props.latestTurn &&
+    (props.latestTurn.completedAt === null || props.latestTurn.state === "running")
+      ? props.latestTurn.turnId
+      : null;
   // LegendList does not invalidate visible rows when only the renderItem closure changes.
-  // Keep row-local interaction props in extraData so disclosures and copy feedback repaint.
+  // Include turn completion so unchanged message rows reveal their footer and spacing
+  // even when the final message update arrives before the turn settles.
   const listAppearanceData = useMemo(
     () => ({
       dispatchingMessageId: props.dispatchingMessageId,
+      unsettledTurnId,
       copiedRowId,
       expandedWorkRows,
       workRowSizing,
@@ -2277,6 +2284,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
     }),
     [
       props.dispatchingMessageId,
+      unsettledTurnId,
       copiedRowId,
       expandedWorkRows,
       workRowSizing,
@@ -2472,12 +2480,6 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
     }
     return new Set(terminalIdsByTurn.values());
   }, [props.feed]);
-  const unsettledTurnId =
-    props.latestTurn &&
-    (props.latestTurn.completedAt === null || props.latestTurn.state === "running")
-      ? props.latestTurn.turnId
-      : null;
-
   useEffect(() => {
     const previous = previousLatestTurnRef.current;
     previousLatestTurnRef.current = props.latestTurn;


### PR DESCRIPTION
## What Changed

- Restored assistant message footer and bottom spacing updates when the latest turn settles.
- Simplified thread swipe dismissal so actions commit from the row and restore correctly on failure.
- Removed the shared thread-dismissal coordination layer and updated swipe reset behavior.

## Why

Assistant messages could render without their expected bottom padding when the final message update arrived before the turn completed. The swipe dismissal coordination also added complexity and could leave rows in inconsistent states across recycled or duplicated thread lists. The updated row-local flow keeps dismissal and recovery tied to the action that initiated them.

## UI Changes

Mobile thread feed spacing and thread swipe interactions changed. No before/after screenshots or video were included.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix assistant message bottom padding in `ThreadFeed` by adding `unsettledTurnId` to list extra data
> Moves the unsettled-turn calculation before `listAppearanceData` is created and adds `unsettledTurnId` to the extra-data object and its memo dependencies. This makes the list invalidate unchanged message rows when the latest turn transitions between unsettled and settled states, so footers and spacing reflect turn completion. Risk: [ThreadFeed.tsx](https://github.com/pingdotgg/t3code/pull/10491/files#diff-97b9e47f1a8b00c4bb1a972e454769238aaceb538a03329f461e5c5d34cf7245) now repaints affected rows on every turn-state change; verify no unintended scroll or performance regressions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c778682.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Thread feed rows now refresh correctly when the latest turn completes or changes state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->