### PR TITLE
fix(mobile): preserve chat rows when toggling commands

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -210,6 +210,7 @@ function formatMessageTime(input: string): string {
 // text fits at the current font settings. Larger accessibility text is measured.
 const TURN_FOLD_HEIGHT = 42; // min-h-11 (38.5) + mb-1 (3.5), with the mobile 14px rem
 const THREAD_FEED_LAYOUT_TRANSITION = LinearTransition.duration(THREAD_DISCLOSURE_TRANSITION_MS);
+const THREAD_FEED_IMMEDIATE_TRANSITION = LinearTransition.duration(0);
 // Tailwind spacing on the mobile 14px rem: px-3.5 on the user bubble, px-1 on
 // assistant rows. Images size their frame from these before their own layout.
 const USER_BUBBLE_HORIZONTAL_PADDING = 3.5 * 3.5;
@@ -2863,8 +2864,13 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
               entry.type === "message" ? `message:${entry.message.role}` : entry.type
             }
             getFixedItemSize={getFixedItemSize}
+            // LegendList swaps its position and size component types when this
+            // becomes undefined, remounting the feed and replaying row entrances.
+            // Keep those containers mounted while ordinary updates stay immediate.
             itemLayoutAnimation={
-              disclosureToggleSettling ? THREAD_FEED_LAYOUT_TRANSITION : undefined
+              disclosureToggleSettling
+                ? THREAD_FEED_LAYOUT_TRANSITION
+                : THREAD_FEED_IMMEDIATE_TRANSITION
             }
             onItemSizeChanged={handleItemSizeChanged}
             // Measure rows well before they scroll into view so estimate→actual


### PR DESCRIPTION
Expanding a command can briefly blank the entire mobile conversation and remount unrelated messages. This regressed in [#10449](https://github.com/pingdotgg/t3code/pull/10449), merged September 6 at 10:24 p.m. Pacific, when `itemLayoutAnimation` started switching between a transition and `undefined`. LegendList uses that presence to select its position and size component types, so a disclosure can replace the containers around the feed and replay row entrance animations.

Keep a zero-duration transition installed outside disclosure changes. The component types stay stable, ordinary updates remain immediate, and disclosures retain their existing transition.

Verified on an iOS 26.5 simulator with disposable showcase data. Expanding the same command remounted all five rendered rows on the base, including the unchanged user message and assistant answer; with this fix it remounted none. Temporary mount instrumentation was removed before the evidence captures. Repeated group and individual command expansion/collapse passed. Android shares this component but was not exercised separately.

Mobile typecheck, targeted lint and formatting passed. Lint reports existing warnings. All 29 tests in `thread-feed-live-follow.test.ts` and `pending-thread-feed.test.ts` passed.

| Before: feed disappears during command expansion | After: conversation stays visible |
| --- | --- |
| ![Before: blank mobile conversation](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/e506b3361edac5ec/before.png) | ![After: command expands without clearing the feed](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/bc9c3857dab4bede/after.png) |

Recording, before on the left and after on the right:

[Before/after command expansion recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/3c9049d7b5997876/comparison.mp4)

Model: GPT-6. Harness: Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve `ThreadFeed` row layout animation when toggling commands
> - Adds `THREAD_FEED_IMMEDIATE_TRANSITION`, a zero-duration `LinearTransition`, to keep the LegendList item layout animation container mounted during ordinary feed updates.
> - `itemLayoutAnimation` now uses the timed disclosure transition while disclosure is settling, and the zero-duration transition otherwise. Previously the prop became `undefined` outside disclosure settling, causing LegendList to swap component types, remount the feed, and replay row entrances.
> - Risk: callers relying on the animation prop being `undefined` outside disclosure settling will see a zero-duration transition object instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a34b15c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread feed updates by ensuring ordinary list changes appear immediately, while disclosure-related changes retain their existing animation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->