### PR TITLE
feat(web): group onboarding project import by repository

### DIFF
--- a/apps/server/src/project/AgentSessionScanner.test.ts
+++ b/apps/server/src/project/AgentSessionScanner.test.ts
@@ -213,6 +213,7 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
             threadCount: 1,
             lastActiveAt: "2026-03-01T00:00:00.000Z",
             alreadyImported: false,
+            git: null,
           },
           {
             path: olderWorkspace,
@@ -221,6 +222,7 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
             threadCount: 2,
             lastActiveAt: "2026-01-02T00:00:00.000Z",
             alreadyImported: false,
+            git: null,
           },
         ]);
       }),
@@ -263,6 +265,7 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
             threadCount: 1,
             lastActiveAt: "2026-02-09T11:00:00.000Z",
             alreadyImported: false,
+            git: null,
           },
           {
             path: workspace,
@@ -271,6 +274,7 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
             threadCount: 2,
             lastActiveAt: "2026-02-09T10:00:00.000Z",
             alreadyImported: false,
+            git: null,
           },
         ]);
       }),
@@ -389,6 +393,7 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
             threadCount: 2,
             lastActiveAt: "2026-04-01T09:00:00.000Z",
             alreadyImported: true,
+            git: null,
           },
         ]);
       }),
@@ -421,6 +426,7 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
           path: workspace,
           projectId: ProjectId.make("project-1"),
           alreadyImported: true,
+          git: null,
         });
       }),
     );
@@ -452,6 +458,7 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
           path: workspaceAlias,
           projectId: ProjectId.make("project-1"),
           alreadyImported: true,
+          git: null,
         });
       }),
     );
@@ -498,6 +505,7 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
             threadCount: 2,
             lastActiveAt: "2026-01-02T00:00:00.000Z",
             alreadyImported: true,
+            git: null,
           },
         ]);
       }),
@@ -852,6 +860,92 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
         const result = yield* runScan({ claudeHomePath, codexHomePath });
 
         expect(result.candidates).toEqual([]);
+      }),
+    );
+
+    it.effect("excludes Codex scratch directories and Downloads", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const claudeHomePath = yield* makeTempDir("t3code-claude-home-");
+        const codexHomePath = yield* makeTempDir("t3code-codex-home-");
+        const home = NodeOS.homedir();
+        const scratch = path.join(home, "Documents", "Codex", "2026-09-01", "t3code-scanner-test");
+        const downloads = path.join(home, "Downloads", "t3code-scanner-test");
+        const keep = yield* makeTempDir("t3code-workspace-keep-");
+        yield* fileSystem.makeDirectory(scratch, { recursive: true });
+        yield* fileSystem.makeDirectory(downloads, { recursive: true });
+        yield* Effect.addFinalizer(() =>
+          Effect.all([
+            fileSystem.remove(scratch, { recursive: true }).pipe(Effect.ignore),
+            fileSystem.remove(downloads, { recursive: true }).pipe(Effect.ignore),
+          ]),
+        );
+
+        for (const [index, cwd] of [scratch, downloads, keep].entries()) {
+          yield* writeTranscript({
+            filePath: path.join(
+              codexHomePath,
+              "sessions",
+              "2026",
+              "09",
+              "01",
+              `rollout-${index}.jsonl`,
+            ),
+            contents: codexRolloutLine(cwd),
+            mtimeMs: Date.parse("2026-09-01T00:00:00.000Z"),
+          });
+        }
+
+        const result = yield* runScan({ claudeHomePath, codexHomePath });
+
+        expect(result.candidates.map((candidate) => candidate.path)).toEqual([keep]);
+      }),
+    );
+
+    it.effect("skips linked git worktrees and reports the origin of real checkouts", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const claudeHomePath = yield* makeTempDir("t3code-claude-home-");
+        const codexHomePath = yield* makeTempDir("t3code-codex-home-");
+        const repo = yield* makeTempDir("t3code-workspace-repo-");
+        const worktree = yield* makeTempDir("t3code-workspace-worktree-");
+        const plain = yield* makeTempDir("t3code-workspace-plain-");
+        const noRemote = yield* makeTempDir("t3code-workspace-noremote-");
+
+        yield* fileSystem.makeDirectory(path.join(repo, ".git"));
+        yield* fileSystem.writeFileString(
+          path.join(repo, ".git", "config"),
+          '[core]\n\tbare = false\n[remote "origin"]\n\turl = git@github.com:pingdotgg/t3code.git\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n',
+        );
+        yield* fileSystem.writeFileString(
+          path.join(worktree, ".git"),
+          `gitdir: ${path.join(repo, ".git", "worktrees", "wt")}\n`,
+        );
+        yield* fileSystem.makeDirectory(path.join(noRemote, ".git"));
+        yield* fileSystem.writeFileString(path.join(noRemote, ".git", "config"), "[core]\n");
+
+        for (const [index, cwd] of [repo, worktree, plain, noRemote].entries()) {
+          yield* writeTranscript({
+            filePath: path.join(claudeHomePath, "projects", `-slug-${index}`, "a.jsonl"),
+            contents: claudeSessionLine(cwd),
+            mtimeMs: Date.parse(`2026-01-0${index + 1}T00:00:00.000Z`),
+          });
+        }
+
+        const result = yield* runScan({ claudeHomePath, codexHomePath });
+
+        expect(
+          result.candidates.map((candidate) => ({ path: candidate.path, git: candidate.git })),
+        ).toEqual([
+          { path: noRemote, git: { remoteKey: null, repository: null } },
+          { path: plain, git: null },
+          {
+            path: repo,
+            git: { remoteKey: "github.com/pingdotgg/t3code", repository: "pingdotgg/t3code" },
+          },
+        ]);
       }),
     );
 
@@ -1231,6 +1325,7 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
             threadCount: 1,
             lastActiveAt: "2026-05-03T00:00:00.000Z",
             alreadyImported: false,
+            git: null,
           },
         ]);
       }),

--- a/apps/server/src/project/AgentSessionScanner.test.ts
+++ b/apps/server/src/project/AgentSessionScanner.test.ts
@@ -869,15 +869,20 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
         const fileSystem = yield* FileSystem.FileSystem;
         const claudeHomePath = yield* makeTempDir("t3code-claude-home-");
         const codexHomePath = yield* makeTempDir("t3code-codex-home-");
+        // The exclusions key off the real home directory, so these fixtures
+        // must live there. Each run owns a uniquely named subtree and removes
+        // only that subtree, never the shared Codex or Downloads parents.
         const home = NodeOS.homedir();
-        const scratch = path.join(home, "Documents", "Codex", "2026-09-01", "t3code-scanner-test");
-        const downloads = path.join(home, "Downloads", "t3code-scanner-test");
+        const runId = `t3code-scanner-test-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const scratchRoot = path.join(home, "Documents", "Codex", runId);
+        const scratch = path.join(scratchRoot, "2026-09-01", "some-conversation");
+        const downloads = path.join(home, "Downloads", runId);
         const keep = yield* makeTempDir("t3code-workspace-keep-");
         yield* fileSystem.makeDirectory(scratch, { recursive: true });
         yield* fileSystem.makeDirectory(downloads, { recursive: true });
         yield* Effect.addFinalizer(() =>
           Effect.all([
-            fileSystem.remove(scratch, { recursive: true }).pipe(Effect.ignore),
+            fileSystem.remove(scratchRoot, { recursive: true }).pipe(Effect.ignore),
             fileSystem.remove(downloads, { recursive: true }).pipe(Effect.ignore),
           ]),
         );
@@ -913,6 +918,7 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
         const worktree = yield* makeTempDir("t3code-workspace-worktree-");
         const plain = yield* makeTempDir("t3code-workspace-plain-");
         const noRemote = yield* makeTempDir("t3code-workspace-noremote-");
+        const submodule = yield* makeTempDir("t3code-workspace-submodule-");
 
         yield* fileSystem.makeDirectory(path.join(repo, ".git"));
         yield* fileSystem.writeFileString(
@@ -925,8 +931,19 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
         );
         yield* fileSystem.makeDirectory(path.join(noRemote, ".git"));
         yield* fileSystem.writeFileString(path.join(noRemote, ".git", "config"), "[core]\n");
+        // Submodules also use a gitdir pointer, but into `modules/`, not `worktrees/`.
+        const submoduleGitDir = path.join(repo, ".git", "modules", "vendor");
+        yield* fileSystem.makeDirectory(submoduleGitDir, { recursive: true });
+        yield* fileSystem.writeFileString(
+          path.join(submoduleGitDir, "config"),
+          '[remote "origin"]\n\turl = ssh://github.com/pingdotgg/vendor.git\n',
+        );
+        yield* fileSystem.writeFileString(
+          path.join(submodule, ".git"),
+          `gitdir: ${submoduleGitDir}\n`,
+        );
 
-        for (const [index, cwd] of [repo, worktree, plain, noRemote].entries()) {
+        for (const [index, cwd] of [repo, worktree, plain, noRemote, submodule].entries()) {
           yield* writeTranscript({
             filePath: path.join(claudeHomePath, "projects", `-slug-${index}`, "a.jsonl"),
             contents: claudeSessionLine(cwd),
@@ -939,6 +956,10 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
         expect(
           result.candidates.map((candidate) => ({ path: candidate.path, git: candidate.git })),
         ).toEqual([
+          {
+            path: submodule,
+            git: { remoteKey: "github.com/pingdotgg/vendor", repository: "pingdotgg/vendor" },
+          },
           { path: noRemote, git: { remoteKey: null, repository: null } },
           { path: plain, git: null },
           {

--- a/apps/server/src/project/AgentSessionScanner.test.ts
+++ b/apps/server/src/project/AgentSessionScanner.test.ts
@@ -873,7 +873,9 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
         // must live there. Each run owns a uniquely named subtree and removes
         // only that subtree, never the shared Codex or Downloads parents.
         const home = NodeOS.homedir();
-        const runId = `t3code-scanner-test-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        // Borrow a unique suffix from a scoped temp dir instead of reaching for
+        // Date.now or Math.random, which the Effect lint rejects.
+        const runId = path.basename(yield* makeTempDir("t3code-scanner-test-"));
         const scratchRoot = path.join(home, "Documents", "Codex", runId);
         const scratch = path.join(scratchRoot, "2026-09-01", "some-conversation");
         const downloads = path.join(home, "Downloads", runId);

--- a/apps/server/src/project/AgentSessionScanner.ts
+++ b/apps/server/src/project/AgentSessionScanner.ts
@@ -686,8 +686,11 @@ export const make = Effect.gen(function* () {
   /**
    * Git identity of a directory, or the reason it has none. Reads `.git`
    * directly instead of spawning git so a scan over hundreds of candidates
-   * stays cheap. A `.git` file means a linked worktree, which onboarding
-   * skips: its history belongs to the main checkout.
+   * stays cheap. A `.git` file is a `gitdir:` pointer. When it points into a
+   * `worktrees/` directory the checkout is a linked worktree, which
+   * onboarding skips because its history belongs to the main checkout.
+   * Submodules use the same pointer shape but live under `modules/`, and
+   * are offered like any other repository.
    */
   const readGitIdentity = Effect.fn("AgentSessionScanner.readGitIdentity")(function* (
     directory: string,
@@ -699,9 +702,18 @@ export const make = Effect.gen(function* () {
     const gitPath = path.join(directory, ".git");
     const gitStats = yield* statOption(gitPath);
     if (Option.isNone(gitStats)) return { _tag: "NotGit" } as const;
-    if (gitStats.value.type !== "Directory") return { _tag: "Worktree" } as const;
+    let gitDir = gitPath;
+    if (gitStats.value.type !== "Directory") {
+      const pointer = yield* fileSystem
+        .readFileString(gitPath)
+        .pipe(Effect.orElseSucceed(() => ""));
+      const target = /^gitdir:\s*(.+)$/m.exec(pointer)?.[1]?.trim();
+      if (target === undefined || target.length === 0) return { _tag: "NotGit" } as const;
+      gitDir = path.resolve(directory, target);
+      if (/[\\/]worktrees[\\/][^\\/]+[\\/]?$/.test(gitDir)) return { _tag: "Worktree" } as const;
+    }
     const configText = yield* fileSystem
-      .readFileString(path.join(gitPath, "config"))
+      .readFileString(path.join(gitDir, "config"))
       .pipe(Effect.orElseSucceed(() => ""));
     const originUrl = parseOriginUrlFromGitConfig(configText);
     return {

--- a/apps/server/src/project/AgentSessionScanner.ts
+++ b/apps/server/src/project/AgentSessionScanner.ts
@@ -38,6 +38,11 @@ import * as Schema from "effect/Schema";
 import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 
+import {
+  normalizeGitRemoteUrl,
+  parseGitHubRepositoryNameWithOwnerFromRemoteUrl,
+  parseOriginUrlFromGitConfig,
+} from "@t3tools/shared/git";
 import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { normalizeProjectPathForComparison } from "@t3tools/shared/path";
 
@@ -624,14 +629,28 @@ export const make = Effect.gen(function* () {
   // must case fold.
   const foldWorktreeCase = (yield* HostProcessPlatform) === "win32";
   const hostEnvironment = yield* HostProcessEnvironment;
+  const homeDir = NodeOS.homedir();
+  // `/private/tmp` is what macOS reports for sessions started in `/tmp`.
   const excludedProjectRoots = new Set(
-    [NodeOS.homedir(), NodeOS.tmpdir()].map((directory) =>
+    [homeDir, NodeOS.tmpdir(), "/tmp", "/private/tmp"].map((directory) =>
       normalizeProjectPathForComparison(path.resolve(directory)),
     ),
   );
+  // Codex creates one scratch directory per conversation under
+  // ~/Documents/Codex/<date>/<slug>. Neither those nor anything a user
+  // unpacked into Downloads is a project.
+  const excludedProjectAncestors = [
+    path.join(homeDir, "Downloads"),
+    path.join(homeDir, "Documents", "Codex"),
+  ];
 
   const isExcludedProjectPath = (candidatePath: string) =>
     excludedProjectRoots.has(normalizeProjectPathForComparison(candidatePath)) ||
+    excludedProjectAncestors.some((ancestor) =>
+      normalizeForWorktreeMatch(candidatePath, foldWorktreeCase).startsWith(
+        normalizeForWorktreeMatch(ancestor, foldWorktreeCase),
+      ),
+    ) ||
     normalizeForWorktreeMatch(candidatePath, foldWorktreeCase).startsWith(
       normalizeForWorktreeMatch(baseDir, foldWorktreeCase),
     ) ||
@@ -662,6 +681,36 @@ export const make = Effect.gen(function* () {
       .realPath(resolved)
       .pipe(Effect.orElseSucceed(() => resolved));
     return `path:${normalizeProjectPathForComparison(realPath)}`;
+  });
+
+  /**
+   * Git identity of a directory, or the reason it has none. Reads `.git`
+   * directly instead of spawning git so a scan over hundreds of candidates
+   * stays cheap. A `.git` file means a linked worktree, which onboarding
+   * skips: its history belongs to the main checkout.
+   */
+  const readGitIdentity = Effect.fn("AgentSessionScanner.readGitIdentity")(function* (
+    directory: string,
+  ): Effect.fn.Return<
+    | { readonly _tag: "Repository"; readonly git: AgentSessionProjectCandidate["git"] }
+    | { readonly _tag: "Worktree" }
+    | { readonly _tag: "NotGit" }
+  > {
+    const gitPath = path.join(directory, ".git");
+    const gitStats = yield* statOption(gitPath);
+    if (Option.isNone(gitStats)) return { _tag: "NotGit" } as const;
+    if (gitStats.value.type !== "Directory") return { _tag: "Worktree" } as const;
+    const configText = yield* fileSystem
+      .readFileString(path.join(gitPath, "config"))
+      .pipe(Effect.orElseSucceed(() => ""));
+    const originUrl = parseOriginUrlFromGitConfig(configText);
+    return {
+      _tag: "Repository",
+      git: {
+        remoteKey: originUrl === null ? null : normalizeGitRemoteUrl(originUrl),
+        repository: parseGitHubRepositoryNameWithOwnerFromRemoteUrl(originUrl),
+      },
+    } as const;
   });
 
   // A large history snapshot can precede session metadata. Read bounded
@@ -1148,9 +1197,11 @@ export const make = Effect.gen(function* () {
         sources: Array<AgentSessionSource>;
         threadCount: number;
         lastActiveAtMs: number | null;
+        git: AgentSessionProjectCandidate["git"];
       }
     >();
     const directoryKeys = new Map<string, string>();
+    const gitIdentities = new Map<string, AgentSessionProjectCandidate["git"]>();
 
     for (const candidate of raw) {
       const expanded = expandHomePath(candidate.cwd.trim());
@@ -1173,7 +1224,13 @@ export const make = Effect.gen(function* () {
         if (isExcludedProjectPath(realPath)) {
           key = "";
         } else {
-          key = yield* directoryIdentity(resolved, stats.value);
+          const gitIdentity = yield* readGitIdentity(resolved);
+          if (gitIdentity._tag === "Worktree") {
+            key = "";
+          } else {
+            key = yield* directoryIdentity(resolved, stats.value);
+            gitIdentities.set(key, gitIdentity._tag === "Repository" ? gitIdentity.git : null);
+          }
         }
         directoryKeys.set(resolved, key);
       }
@@ -1186,6 +1243,7 @@ export const make = Effect.gen(function* () {
           sources: [candidate.source],
           threadCount: candidate.threadCount,
           lastActiveAtMs: candidate.lastActiveAtMs,
+          git: gitIdentities.get(key) ?? null,
         });
         continue;
       }
@@ -1234,6 +1292,7 @@ export const make = Effect.gen(function* () {
             ? null
             : DateTime.formatIso(DateTime.makeUnsafe(entry.lastActiveAtMs)),
         alreadyImported: importedProject !== undefined,
+        git: entry.git,
       });
     }
 

--- a/apps/web/src/components/onboarding/WelcomeWizard.tsx
+++ b/apps/web/src/components/onboarding/WelcomeWizard.tsx
@@ -1342,7 +1342,7 @@ function ImportCandidateList({
             <CollapsibleTrigger className="group flex min-w-0 flex-1 items-center gap-1.5 text-left">
               <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-panel-open:rotate-90" />
               <span className="truncate text-sm text-muted-foreground">Other folders</span>
-              <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+              <span className="ml-auto shrink-0 text-xs text-muted-foreground tabular-nums">
                 {other.length} {other.length === 1 ? "folder" : "folders"}
               </span>
             </CollapsibleTrigger>
@@ -1400,11 +1400,11 @@ function ImportRepositoryGroup({
         <CollapsibleTrigger className="group flex min-w-0 flex-1 items-center gap-1.5 text-left">
           <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-panel-open:rotate-90" />
           <span className="truncate text-sm font-medium">{group.label}</span>
-          <span className="ml-auto flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
-            <SourceIcons sources={[...new Set(group.candidates.flatMap((c) => c.sources))]} />
-            <span className="tabular-nums">{group.threadCount}</span>
-            <ActiveAgo lastActiveAt={group.lastActiveAt} />
-          </span>
+          <ImportRowMeta
+            sources={[...new Set(group.candidates.flatMap((c) => c.sources))]}
+            threadCount={group.threadCount}
+            lastActiveAt={group.lastActiveAt}
+          />
         </CollapsibleTrigger>
       </div>
       <CollapsiblePanel>
@@ -1461,31 +1461,46 @@ function ImportCandidateRow({
         </TooltipTrigger>
         <TooltipPopup className="max-w-96 break-all font-mono">{candidate.path}</TooltipPopup>
       </Tooltip>
-      <span className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
-        {nested ? <span className="w-8" /> : <SourceIcons sources={candidate.sources} />}
-        <span className="w-8 text-right tabular-nums">{candidate.threadCount}</span>
-        <ActiveAgo lastActiveAt={candidate.lastActiveAt} />
-      </span>
+      <ImportRowMeta
+        sources={nested ? null : candidate.sources}
+        threadCount={candidate.threadCount}
+        lastActiveAt={candidate.lastActiveAt}
+      />
     </label>
   );
 }
 
-function SourceIcons({ sources }: { readonly sources: ReadonlyArray<"claudeAgent" | "codex"> }) {
-  return (
-    <span className="flex w-8 items-center justify-end gap-1">
-      {sources.includes("claudeAgent") ? (
-        <ClaudeAI className="size-3" aria-label="Claude Code" />
-      ) : null}
-      {sources.includes("codex") ? <OpenAI className="size-3" aria-label="Codex" /> : null}
-    </span>
-  );
-}
-
-function ActiveAgo({ lastActiveAt }: { readonly lastActiveAt: string | null }) {
+/**
+ * Trailing columns shared by every import row: source icons, thread count,
+ * last activity. Each column has a fixed width and each icon has its own slot
+ * so nothing shifts between rows that differ in sources or digit count.
+ */
+function ImportRowMeta({
+  sources,
+  threadCount,
+  lastActiveAt,
+}: {
+  readonly sources: ReadonlyArray<"claudeAgent" | "codex"> | null;
+  readonly threadCount: number;
+  readonly lastActiveAt: string | null;
+}) {
   const relative = lastActiveAt === null ? null : formatRelativeTime(lastActiveAt);
   // "just now" does not fit the fixed column, so collapse it.
-  const value = relative === null ? "" : relative.suffix === null ? "now" : relative.value;
-  return <span className="w-8 shrink-0 text-right tabular-nums whitespace-nowrap">{value}</span>;
+  const age = relative === null ? "" : relative.suffix === null ? "now" : relative.value;
+  return (
+    <span className="ml-auto grid shrink-0 grid-cols-[1rem_1rem_2.5rem_2.25rem] items-center gap-x-1 text-xs text-muted-foreground tabular-nums">
+      <span className="flex size-4 items-center justify-center">
+        {sources?.includes("claudeAgent") ? (
+          <ClaudeAI className="size-3" aria-label="Claude Code" />
+        ) : null}
+      </span>
+      <span className="flex size-4 items-center justify-center">
+        {sources?.includes("codex") ? <OpenAI className="size-3" aria-label="Codex" /> : null}
+      </span>
+      <span className="text-right">{threadCount}</span>
+      <span className="text-right whitespace-nowrap">{age}</span>
+    </span>
+  );
 }
 
 // ── Shared bits ──────────────────────────────────────────────

--- a/apps/web/src/components/onboarding/WelcomeWizard.tsx
+++ b/apps/web/src/components/onboarding/WelcomeWizard.tsx
@@ -1294,6 +1294,7 @@ type ImportCandidate = AgentSessionProjectCandidate & {
  * Repositories first, newest activity on top. Clones of one repository share
  * a group with a tri-state checkbox. Folders that are not git repositories
  * sit collapsed at the bottom so they stay reachable without adding noise.
+ * Source icons appear only on repository rows so the columns stay still.
  */
 function ImportCandidateList({
   candidates,
@@ -1352,6 +1353,7 @@ function ImportCandidateList({
                 key={candidate.key}
                 candidate={candidate}
                 label={candidate.path}
+                nested
                 checked={selectedKeys.has(candidate.key)}
                 onCheckedChange={(checked) => setKeys([candidate.key], checked)}
               />
@@ -1460,7 +1462,7 @@ function ImportCandidateRow({
         <TooltipPopup className="max-w-96 break-all font-mono">{candidate.path}</TooltipPopup>
       </Tooltip>
       <span className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
-        <SourceIcons sources={candidate.sources} />
+        {nested ? <span className="w-8" /> : <SourceIcons sources={candidate.sources} />}
         <span className="w-8 text-right tabular-nums">{candidate.threadCount}</span>
         <ActiveAgo lastActiveAt={candidate.lastActiveAt} />
       </span>
@@ -1481,7 +1483,9 @@ function SourceIcons({ sources }: { readonly sources: ReadonlyArray<"claudeAgent
 
 function ActiveAgo({ lastActiveAt }: { readonly lastActiveAt: string | null }) {
   const relative = lastActiveAt === null ? null : formatRelativeTime(lastActiveAt);
-  return <span className="w-8 text-right tabular-nums">{relative?.value ?? ""}</span>;
+  // "just now" does not fit the fixed column, so collapse it.
+  const value = relative === null ? "" : relative.suffix === null ? "now" : relative.value;
+  return <span className="w-8 shrink-0 text-right tabular-nums whitespace-nowrap">{value}</span>;
 }
 
 // ── Shared bits ──────────────────────────────────────────────

--- a/apps/web/src/components/onboarding/WelcomeWizard.tsx
+++ b/apps/web/src/components/onboarding/WelcomeWizard.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from "@clerk/react";
 import { useAtomValue } from "@effect/atom-react";
 import type {
+  AgentSessionProjectCandidate,
   EnvironmentId,
   ProjectId,
   ScopedProjectRef,
@@ -32,10 +33,12 @@ import { hasCloudPublicConfig } from "../../cloud/publicConfig";
 import { useT3ConnectAuthPrompt } from "../clerk/useT3ConnectAuthPrompt";
 import { useCompleteOnboarding } from "../../onboarding/firstRun";
 import {
+  groupOnboardingProjects,
   partitionOnboardingProjects,
   onboardingProjectKey,
   resolveOnboardingLandingProject,
   resolveOnboardingProjectId,
+  type OnboardingProjectGroup,
 } from "../../onboarding/projectImport.logic";
 import {
   getOnboardingProviderState,
@@ -59,6 +62,7 @@ import { getProviderSummary } from "../settings/providerStatus";
 import { getDriverOption } from "../settings/providerDriverMeta";
 import { TerminalViewport } from "../ThreadTerminalDrawer";
 import { CloudEnvironmentConnectRows } from "../cloud/CloudEnvironmentConnectList";
+import { ClaudeAI, OpenAI } from "../Icons";
 import { T3Wordmark } from "../T3Wordmark";
 import { Button } from "../ui/button";
 import { Checkbox } from "../ui/checkbox";
@@ -71,6 +75,7 @@ import { WizardPanel, WizardSteps } from "../ui/wizard";
 import { Dialog, DialogHeader, DialogPopup, DialogTitle } from "../ui/dialog";
 import { toastManager } from "../ui/toast";
 import { cn } from "../../lib/utils";
+import { formatRelativeTime } from "../../timestampFormat";
 
 /**
  * First-run welcome wizard. Rendered over the workspace at `/welcome` on a
@@ -1008,11 +1013,11 @@ function ImportStep({
       ),
     [scans],
   );
-  const selected = candidates.filter((candidate) =>
-    selectedPaths
-      ? selectedPaths.has(candidate.key)
-      : recent.some((item) => item.key === candidate.key),
+  const selectedKeys = useMemo(
+    () => selectedPaths ?? new Set(recent.map((candidate) => candidate.key)),
+    [selectedPaths, recent],
   );
+  const selected = candidates.filter((candidate) => selectedKeys.has(candidate.key));
 
   const finishAfterImport = () => {
     const projectRef = resolveOnboardingLandingProject(
@@ -1176,13 +1181,38 @@ function ImportStep({
       title="Choose your projects"
       description="Import projects and conversations from your selected computers."
     >
+      {candidates.length > 0 ? (
+        <div className="mt-5 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+          <span role="status">
+            {selected.length} of {candidates.length} selected
+          </span>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="xs"
+              disabled={isImporting || selected.length === candidates.length}
+              onClick={() => setSelectedPaths(new Set(candidates.map((item) => item.key)))}
+            >
+              Select all
+            </Button>
+            <Button
+              variant="ghost"
+              size="xs"
+              disabled={isImporting || selected.length === 0}
+              onClick={() => setSelectedPaths(new Set())}
+            >
+              Select none
+            </Button>
+          </div>
+        </div>
+      ) : null}
       <ScrollArea
         scrollFade
-        className="mt-5 h-auto max-h-80 [&_[data-slot=scroll-area-scrollbar]]:opacity-100"
+        className="mt-2 h-auto max-h-80 [&_[data-slot=scroll-area-scrollbar]]:opacity-100"
       >
         <div className="space-y-5 pr-3">
           {scans.map((scan) => {
-            const groupCandidates = candidates.filter(
+            const scanCandidates = candidates.filter(
               (candidate) => candidate.environmentId === scan.environmentId,
             );
             const label =
@@ -1191,10 +1221,12 @@ function ImportStep({
             return (
               <fieldset
                 key={scan.environmentId}
-                className="min-w-0 space-y-1.5"
+                className="min-w-0 space-y-0.5"
                 disabled={isImporting}
               >
-                <legend className="mb-2 text-sm font-medium">{label}</legend>
+                {scans.length > 1 ? (
+                  <legend className="mb-2 text-sm font-medium">{label}</legend>
+                ) : null}
                 {scan.isPending && scan.data === null ? (
                   <div className="flex items-center gap-2 py-3 text-sm text-muted-foreground">
                     <Spinner className="size-4" />
@@ -1210,7 +1242,7 @@ function ImportStep({
                       Retry
                     </Button>
                   </div>
-                ) : groupCandidates.length === 0 ? (
+                ) : scanCandidates.length === 0 ? (
                   <p className="py-2 text-sm text-muted-foreground">
                     No existing Claude Code or Codex projects found.
                   </p>
@@ -1220,38 +1252,11 @@ function ImportStep({
                     {SCAN_LIMIT_MESSAGE}
                   </p>
                 ) : null}
-                {groupCandidates.map((candidate) => (
-                  <label
-                    key={candidate.key}
-                    className="flex cursor-pointer items-center gap-2.5 rounded-lg border border-border bg-background px-2.5 py-2 has-disabled:cursor-default"
-                  >
-                    <Checkbox
-                      checked={selected.some((item) => item.key === candidate.key)}
-                      onCheckedChange={(checked) => {
-                        const next = new Set(selected.map((item) => item.key));
-                        if (checked) next.add(candidate.key);
-                        else next.delete(candidate.key);
-                        setSelectedPaths(next);
-                      }}
-                    />
-                    <Tooltip>
-                      <TooltipTrigger
-                        render={<span className="min-w-0 flex-1 truncate font-mono text-xs" />}
-                      >
-                        {candidate.path}
-                      </TooltipTrigger>
-                      <TooltipPopup className="max-w-96 break-all font-mono">
-                        {candidate.path}
-                      </TooltipPopup>
-                    </Tooltip>
-                    <span className="shrink-0 whitespace-nowrap text-[11px] text-muted-foreground">
-                      {candidate.sources
-                        .map((source) => (source === "claudeAgent" ? "Claude" : "Codex"))
-                        .join(", ")}{" "}
-                      · {candidate.threadCount} {candidate.threadCount === 1 ? "thread" : "threads"}
-                    </span>
-                  </label>
-                ))}
+                <ImportCandidateList
+                  candidates={scanCandidates}
+                  selectedKeys={selectedKeys}
+                  onSelectionChange={setSelectedPaths}
+                />
               </fieldset>
             );
           })}
@@ -1278,6 +1283,205 @@ function ImportStep({
       </div>
     </StepShell>
   );
+}
+
+type ImportCandidate = AgentSessionProjectCandidate & {
+  readonly environmentId: EnvironmentId;
+  readonly key: string;
+};
+
+/**
+ * Repositories first, newest activity on top. Clones of one repository share
+ * a group with a tri-state checkbox. Folders that are not git repositories
+ * sit collapsed at the bottom so they stay reachable without adding noise.
+ */
+function ImportCandidateList({
+  candidates,
+  selectedKeys,
+  onSelectionChange,
+}: {
+  readonly candidates: ReadonlyArray<ImportCandidate>;
+  readonly selectedKeys: ReadonlySet<string>;
+  readonly onSelectionChange: (next: ReadonlySet<string>) => void;
+}) {
+  const { repositories, other } = useMemo(() => groupOnboardingProjects(candidates), [candidates]);
+  const setKeys = (keys: ReadonlyArray<string>, checked: boolean) => {
+    const next = new Set(selectedKeys);
+    for (const key of keys) {
+      if (checked) next.add(key);
+      else next.delete(key);
+    }
+    onSelectionChange(next);
+  };
+  const otherSelected = other.filter((candidate) => selectedKeys.has(candidate.key)).length;
+
+  return (
+    <>
+      {repositories.map((group) => (
+        <ImportRepositoryGroup
+          key={group.key}
+          group={group}
+          selectedKeys={selectedKeys}
+          onToggle={setKeys}
+        />
+      ))}
+      {other.length > 0 ? (
+        <Collapsible>
+          <div className="flex items-center gap-2.5 rounded-md px-2 py-1.5 hover:bg-muted/40">
+            <Checkbox
+              checked={otherSelected === other.length}
+              indeterminate={otherSelected > 0 && otherSelected < other.length}
+              onCheckedChange={(checked) =>
+                setKeys(
+                  other.map((candidate) => candidate.key),
+                  checked === true,
+                )
+              }
+            />
+            <CollapsibleTrigger className="group flex min-w-0 flex-1 items-center gap-1.5 text-left">
+              <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-panel-open:rotate-90" />
+              <span className="truncate text-sm text-muted-foreground">Other folders</span>
+              <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                {other.length} {other.length === 1 ? "folder" : "folders"}
+              </span>
+            </CollapsibleTrigger>
+          </div>
+          <CollapsiblePanel>
+            {other.map((candidate) => (
+              <ImportCandidateRow
+                key={candidate.key}
+                candidate={candidate}
+                label={candidate.path}
+                checked={selectedKeys.has(candidate.key)}
+                onCheckedChange={(checked) => setKeys([candidate.key], checked)}
+              />
+            ))}
+          </CollapsiblePanel>
+        </Collapsible>
+      ) : null}
+    </>
+  );
+}
+
+function ImportRepositoryGroup({
+  group,
+  selectedKeys,
+  onToggle,
+}: {
+  readonly group: OnboardingProjectGroup<ImportCandidate>;
+  readonly selectedKeys: ReadonlySet<string>;
+  readonly onToggle: (keys: ReadonlyArray<string>, checked: boolean) => void;
+}) {
+  const keys = group.candidates.map((candidate) => candidate.key);
+  const selectedCount = keys.filter((key) => selectedKeys.has(key)).length;
+  const single = group.candidates.length === 1;
+  const only = group.candidates[0];
+  if (single && only !== undefined) {
+    return (
+      <ImportCandidateRow
+        candidate={only}
+        label={group.label}
+        {...(group.repository === null ? {} : { secondary: only.path })}
+        checked={selectedKeys.has(only.key)}
+        onCheckedChange={(checked) => onToggle([only.key], checked)}
+      />
+    );
+  }
+  return (
+    <Collapsible defaultOpen>
+      <div className="flex items-center gap-2.5 rounded-md px-2 py-1.5 hover:bg-muted/40">
+        <Checkbox
+          checked={selectedCount === keys.length}
+          indeterminate={selectedCount > 0 && selectedCount < keys.length}
+          onCheckedChange={(checked) => onToggle(keys, checked === true)}
+        />
+        <CollapsibleTrigger className="group flex min-w-0 flex-1 items-center gap-1.5 text-left">
+          <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-panel-open:rotate-90" />
+          <span className="truncate text-sm font-medium">{group.label}</span>
+          <span className="ml-auto flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
+            <SourceIcons sources={[...new Set(group.candidates.flatMap((c) => c.sources))]} />
+            <span className="tabular-nums">{group.threadCount}</span>
+            <ActiveAgo lastActiveAt={group.lastActiveAt} />
+          </span>
+        </CollapsibleTrigger>
+      </div>
+      <CollapsiblePanel>
+        {group.candidates.map((candidate) => (
+          <ImportCandidateRow
+            key={candidate.key}
+            candidate={candidate}
+            label={candidate.path}
+            nested
+            checked={selectedKeys.has(candidate.key)}
+            onCheckedChange={(checked) => onToggle([candidate.key], checked)}
+          />
+        ))}
+      </CollapsiblePanel>
+    </Collapsible>
+  );
+}
+
+function ImportCandidateRow({
+  candidate,
+  label,
+  secondary,
+  nested = false,
+  checked,
+  onCheckedChange,
+}: {
+  readonly candidate: ImportCandidate;
+  readonly label: string;
+  readonly secondary?: string;
+  readonly nested?: boolean;
+  readonly checked: boolean;
+  readonly onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <label
+      className={cn(
+        "flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 hover:bg-muted/40 has-disabled:cursor-default",
+        nested && "pl-8",
+      )}
+    >
+      <Checkbox checked={checked} onCheckedChange={(value) => onCheckedChange(value === true)} />
+      <Tooltip>
+        <TooltipTrigger
+          render={<span className="flex min-w-0 flex-1 items-baseline gap-2 truncate" />}
+        >
+          <span className={cn("truncate", nested ? "font-mono text-xs" : "text-sm font-medium")}>
+            {label}
+          </span>
+          {secondary !== undefined ? (
+            <span className="truncate font-mono text-[11px] text-muted-foreground">
+              {secondary}
+            </span>
+          ) : null}
+        </TooltipTrigger>
+        <TooltipPopup className="max-w-96 break-all font-mono">{candidate.path}</TooltipPopup>
+      </Tooltip>
+      <span className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
+        <SourceIcons sources={candidate.sources} />
+        <span className="w-8 text-right tabular-nums">{candidate.threadCount}</span>
+        <ActiveAgo lastActiveAt={candidate.lastActiveAt} />
+      </span>
+    </label>
+  );
+}
+
+function SourceIcons({ sources }: { readonly sources: ReadonlyArray<"claudeAgent" | "codex"> }) {
+  return (
+    <span className="flex w-8 items-center justify-end gap-1">
+      {sources.includes("claudeAgent") ? (
+        <ClaudeAI className="size-3" aria-label="Claude Code" />
+      ) : null}
+      {sources.includes("codex") ? <OpenAI className="size-3" aria-label="Codex" /> : null}
+    </span>
+  );
+}
+
+function ActiveAgo({ lastActiveAt }: { readonly lastActiveAt: string | null }) {
+  const relative = lastActiveAt === null ? null : formatRelativeTime(lastActiveAt);
+  return <span className="w-8 text-right tabular-nums">{relative?.value ?? ""}</span>;
 }
 
 // ── Shared bits ──────────────────────────────────────────────

--- a/apps/web/src/onboarding/projectImport.logic.test.ts
+++ b/apps/web/src/onboarding/projectImport.logic.test.ts
@@ -2,6 +2,7 @@ import { EnvironmentId, ProjectId, type AgentSessionProjectCandidate } from "@t3
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  groupOnboardingProjects,
   partitionOnboardingProjects,
   onboardingProjectKey,
   resolveOnboardingLandingProject,
@@ -18,12 +19,18 @@ function candidate(
     title: path.split("/").at(-1) ?? path,
     path,
     sources: ["codex"],
-    threadCount: 1,
+    threadCount: 3,
     lastActiveAt: "2026-08-20T12:00:00.000Z",
     alreadyImported: false,
+    git: { remoteKey: null, repository: null },
     ...overrides,
   };
 }
+
+const github = (repository: string) => ({
+  remoteKey: `github.com/${repository.toLowerCase()}`,
+  repository,
+});
 
 describe("partitionOnboardingProjects", () => {
   it("keeps existing projects available for thread history import", () => {
@@ -58,6 +65,67 @@ describe("partitionOnboardingProjects", () => {
       available: [recent, future],
       recent: [recent],
     });
+  });
+
+  it("keeps non-git folders and thin histories out of the default selection", () => {
+    const repo = candidate("/projects/repo");
+    const folder = candidate("/projects/folder", { git: null });
+    const thin = candidate("/projects/thin", { threadCount: 2 });
+
+    expect(partitionOnboardingProjects([repo, folder, thin], now).recent).toEqual([repo]);
+  });
+});
+
+describe("groupOnboardingProjects", () => {
+  it("groups clones by origin, keeps local repos separate, and folds non-git folders away", () => {
+    const main = candidate("/code/t3code", {
+      git: github("pingdotgg/t3code"),
+      threadCount: 79,
+      lastActiveAt: "2026-08-21T12:00:00.000Z",
+    });
+    const clone = candidate("/code/clones/t3code-2", {
+      git: github("pingdotgg/t3code"),
+      threadCount: 13,
+      lastActiveAt: "2026-08-10T12:00:00.000Z",
+    });
+    const older = candidate("/code/fleet", {
+      git: github("t3dotgg/fleet"),
+      threadCount: 295,
+      lastActiveAt: "2026-08-22T00:00:00.000Z",
+    });
+    const local = candidate("/code/scratch-repo", { title: "scratch-repo" });
+    const folder = candidate("/tmp/notes", { git: null });
+
+    const grouped = groupOnboardingProjects([main, clone, older, local, folder]);
+
+    expect(grouped.other).toEqual([folder]);
+    expect(
+      grouped.repositories.map((group) => ({
+        label: group.label,
+        paths: group.candidates.map((item) => item.path),
+        threadCount: group.threadCount,
+        lastActiveAt: group.lastActiveAt,
+      })),
+    ).toEqual([
+      {
+        label: "t3dotgg/fleet",
+        paths: ["/code/fleet"],
+        threadCount: 295,
+        lastActiveAt: "2026-08-22T00:00:00.000Z",
+      },
+      {
+        label: "pingdotgg/t3code",
+        paths: ["/code/t3code", "/code/clones/t3code-2"],
+        threadCount: 92,
+        lastActiveAt: "2026-08-21T12:00:00.000Z",
+      },
+      {
+        label: "scratch-repo",
+        paths: ["/code/scratch-repo"],
+        threadCount: 3,
+        lastActiveAt: "2026-08-20T12:00:00.000Z",
+      },
+    ]);
   });
 });
 

--- a/apps/web/src/onboarding/projectImport.logic.ts
+++ b/apps/web/src/onboarding/projectImport.logic.ts
@@ -2,8 +2,14 @@ import { findProjectByPath } from "@t3tools/client-runtime/state/projects";
 import type { AgentSessionProjectCandidate, EnvironmentId, ProjectId } from "@t3tools/contracts";
 
 const RECENT_PROJECT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+/** One or two threads in a directory is usually a one-off question, not a project. */
+const DEFAULT_SELECTION_MIN_THREADS = 3;
 
-/** Existing projects still need their agent history imported, so every scan candidate is offered. */
+/**
+ * Existing projects still need their agent history imported, so every scan
+ * candidate is offered. The default selection is narrower: git repositories
+ * active in the last 30 days with enough threads to look like real work.
+ */
 export function partitionOnboardingProjects<T extends AgentSessionProjectCandidate>(
   candidates: ReadonlyArray<T>,
   now = Date.now(),
@@ -13,11 +19,85 @@ export function partitionOnboardingProjects<T extends AgentSessionProjectCandida
   return {
     available: candidates,
     recent: candidates.filter((candidate) => {
+      if (candidate.git === null) return false;
+      if (candidate.threadCount < DEFAULT_SELECTION_MIN_THREADS) return false;
       if (candidate.lastActiveAt === null) return false;
       const lastActiveAt = Date.parse(candidate.lastActiveAt);
       return lastActiveAt >= cutoff && lastActiveAt <= now;
     }),
   };
+}
+
+export interface OnboardingProjectGroup<T> {
+  /** Stable identity for collapse state and React keys. */
+  readonly key: string;
+  /** GitHub `owner/name`, or the checkout's folder name when the origin is elsewhere. */
+  readonly label: string;
+  readonly repository: string | null;
+  readonly candidates: ReadonlyArray<T>;
+  readonly threadCount: number;
+  readonly lastActiveAt: string | null;
+}
+
+function latestActivity(left: string | null, right: string | null): string | null {
+  if (left === null) return right;
+  if (right === null) return left;
+  return left > right ? left : right;
+}
+
+/**
+ * Group scan candidates for the onboarding picker. Clones of one repository
+ * share a group keyed by their normalized origin URL. Repositories without an
+ * origin get a group each. Directories that are not git repositories are
+ * returned separately so the UI can fold them away by default. Groups sort by
+ * most recent activity, newest first.
+ */
+export function groupOnboardingProjects<
+  T extends Pick<
+    AgentSessionProjectCandidate,
+    "path" | "title" | "git" | "threadCount" | "lastActiveAt"
+  >,
+>(candidates: ReadonlyArray<T>) {
+  const groups = new Map<string, OnboardingProjectGroup<T> & { candidates: Array<T> }>();
+  const other: Array<T> = [];
+
+  for (const candidate of candidates) {
+    if (candidate.git === null) {
+      other.push(candidate);
+      continue;
+    }
+    const key =
+      candidate.git.remoteKey === null
+        ? `path:${candidate.path}`
+        : `remote:${candidate.git.remoteKey}`;
+    const existing = groups.get(key);
+    if (existing === undefined) {
+      groups.set(key, {
+        key,
+        label: candidate.git.repository ?? candidate.title,
+        repository: candidate.git.repository,
+        candidates: [candidate],
+        threadCount: candidate.threadCount,
+        lastActiveAt: candidate.lastActiveAt,
+      });
+      continue;
+    }
+    existing.candidates.push(candidate);
+    groups.set(key, {
+      ...existing,
+      threadCount: existing.threadCount + candidate.threadCount,
+      lastActiveAt: latestActivity(existing.lastActiveAt, candidate.lastActiveAt),
+    });
+  }
+
+  const repositories = [...groups.values()].sort((left, right) => {
+    if (left.lastActiveAt === right.lastActiveAt) return left.label.localeCompare(right.label);
+    if (left.lastActiveAt === null) return 1;
+    if (right.lastActiveAt === null) return -1;
+    return right.lastActiveAt.localeCompare(left.lastActiveAt);
+  });
+
+  return { repositories, other };
 }
 
 /** Use the server's project match before the client snapshot, which can lag behind the scan. */

--- a/docs/user/welcome-wizard.md
+++ b/docs/user/welcome-wizard.md
@@ -47,14 +47,15 @@ terminal metadata while the terminal process can use them.
 ## Import your projects
 
 T3 Code finds directories that Claude Code or Codex has used. Git repositories
-are listed first, newest activity on top, with the GitHub repository name when
-the origin is on GitHub. Clones of the same repository share one group.
-Directories that are not git repositories sit under "Other folders".
+are listed first, newest activity on top. When the remote is on GitHub, the
+group shows the repository as `owner/name`. Clones with the same remote share
+one group. Directories that are not git repositories sit under "Other folders".
 
 The default selection includes git repositories active within the last 30 days
 with at least three conversations. Use the checkboxes, or "Select all" and
 "Select none", to change the selection. Linked git worktrees, Codex scratch
-directories, Downloads, and temporary directories are not offered.
+directories under `Documents/Codex`, and anything under `Downloads` are not
+offered.
 
 A large or malformed history can reach the scan limit. T3 Code keeps the
 projects it found and warns when projects or conversations may be missing.

--- a/docs/user/welcome-wizard.md
+++ b/docs/user/welcome-wizard.md
@@ -46,9 +46,15 @@ terminal metadata while the terminal process can use them.
 
 ## Import your projects
 
-T3 Code finds directories that Claude Code or Codex has used. The default
-selection includes projects active within the last 30 days. Use the checkboxes
-to include older projects or change the selection.
+T3 Code finds directories that Claude Code or Codex has used. Git repositories
+are listed first, newest activity on top, with the GitHub repository name when
+the origin is on GitHub. Clones of the same repository share one group.
+Directories that are not git repositories sit under "Other folders".
+
+The default selection includes git repositories active within the last 30 days
+with at least three conversations. Use the checkboxes, or "Select all" and
+"Select none", to change the selection. Linked git worktrees, Codex scratch
+directories, Downloads, and temporary directories are not offered.
 
 A large or malformed history can reach the scan limit. T3 Code keeps the
 projects it found and warns when projects or conversations may be missing.

--- a/packages/contracts/src/agentSessions.ts
+++ b/packages/contracts/src/agentSessions.ts
@@ -37,6 +37,18 @@ export type AgentSessionScanInput = typeof AgentSessionScanInput.Type;
  * T3 Code project. `alreadyImported` marks candidates that already have an
  * active project rooted at the same path.
  */
+/**
+ * Git identity of a candidate directory, read from `.git/config` without
+ * spawning git. `remoteKey` is the normalized origin URL, shared by every
+ * clone of the same repository so the client can group them. `repository`
+ * is the GitHub `owner/name` when the origin is on GitHub.
+ */
+export const AgentSessionProjectGit = Schema.Struct({
+  remoteKey: Schema.NullOr(Schema.String),
+  repository: Schema.NullOr(Schema.String),
+});
+export type AgentSessionProjectGit = typeof AgentSessionProjectGit.Type;
+
 export const AgentSessionProjectCandidate = Schema.Struct({
   path: TrimmedNonEmptyString,
   title: TrimmedNonEmptyString,
@@ -45,6 +57,8 @@ export const AgentSessionProjectCandidate = Schema.Struct({
   threadCount: NonNegativeInt,
   lastActiveAt: Schema.NullOr(IsoDateTime),
   alreadyImported: Schema.Boolean,
+  /** `null` when the directory is not the root of a git repository. */
+  git: Schema.NullOr(AgentSessionProjectGit),
 });
 export type AgentSessionProjectCandidate = typeof AgentSessionProjectCandidate.Type;
 

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -68,7 +68,28 @@ describe("parseOriginUrlFromGitConfig", () => {
     expect(parseOriginUrlFromGitConfig(config)).toBe("git@github.com:pingdotgg/t3code.git");
   });
 
-  it("returns null when there is no origin section", () => {
+  it("strips inline comments and quotes from the url value", () => {
+    expect(
+      parseOriginUrlFromGitConfig(
+        '[remote "origin"]\n\turl = https://github.com/acme/repo.git # mirror\n',
+      ),
+    ).toBe("https://github.com/acme/repo.git");
+    expect(
+      parseOriginUrlFromGitConfig('[remote "origin"]\n\turl = "git@github.com:acme/repo.git"\n'),
+    ).toBe("git@github.com:acme/repo.git");
+  });
+
+  it("falls back to the first remote when there is no origin", () => {
+    const config = [
+      '[remote "upstream"]',
+      "\turl = https://github.com/acme/repo.git",
+      '[remote "fork"]',
+      "\turl = https://github.com/me/repo.git",
+    ].join("\n");
+    expect(parseOriginUrlFromGitConfig(config)).toBe("https://github.com/acme/repo.git");
+  });
+
+  it("returns null when there is no remote section", () => {
     expect(parseOriginUrlFromGitConfig("[core]\n\tbare = false\n")).toBeNull();
     expect(parseOriginUrlFromGitConfig("")).toBeNull();
   });
@@ -81,6 +102,9 @@ describe("parseGitHubRepositoryNameWithOwnerFromRemoteUrl", () => {
     ).toBe("T3Tools/T3Code");
     expect(
       parseGitHubRepositoryNameWithOwnerFromRemoteUrl("https://github.com/T3Tools/T3Code.git"),
+    ).toBe("T3Tools/T3Code");
+    expect(
+      parseGitHubRepositoryNameWithOwnerFromRemoteUrl("ssh://github.com/T3Tools/T3Code.git"),
     ).toBe("T3Tools/T3Code");
   });
 });

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -79,6 +79,20 @@ describe("parseOriginUrlFromGitConfig", () => {
     ).toBe("git@github.com:acme/repo.git");
   });
 
+  it("accepts legacy dotted headers, header comments, and line continuations", () => {
+    expect(parseOriginUrlFromGitConfig("[remote.origin]\n\turl = git@github.com:a/b.git\n")).toBe(
+      "git@github.com:a/b.git",
+    );
+    expect(
+      parseOriginUrlFromGitConfig('[remote "origin"] # primary\n\turl = git@github.com:a/b.git\n'),
+    ).toBe("git@github.com:a/b.git");
+    expect(
+      parseOriginUrlFromGitConfig(
+        '[remote "origin"]\n\turl = https://github.com/acme/\\\n\t\trepo.git\n',
+      ),
+    ).toBe("https://github.com/acme/repo.git");
+  });
+
   it("falls back to the first remote when there is no origin", () => {
     const config = [
       '[remote "upstream"]',

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -83,6 +83,15 @@ describe("parseOriginUrlFromGitConfig", () => {
     expect(parseOriginUrlFromGitConfig("[remote.origin]\n\turl = git@github.com:a/b.git\n")).toBe(
       "git@github.com:a/b.git",
     );
+    // Git folds the dotted form to lowercase but keeps quoted names as written.
+    expect(parseOriginUrlFromGitConfig("[remote.Origin]\n\turl = git@github.com:a/b.git\n")).toBe(
+      "git@github.com:a/b.git",
+    );
+    expect(
+      parseOriginUrlFromGitConfig(
+        '[remote "Origin"]\n\turl = git@github.com:x/y.git\n[remote "origin"]\n\turl = git@github.com:a/b.git\n',
+      ),
+    ).toBe("git@github.com:a/b.git");
     expect(
       parseOriginUrlFromGitConfig('[remote "origin"] # primary\n\turl = git@github.com:a/b.git\n'),
     ).toBe("git@github.com:a/b.git");

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -7,6 +7,7 @@ import {
   isTemporaryWorktreeBranch,
   normalizeGitRemoteUrl,
   parseGitHubRepositoryNameWithOwnerFromRemoteUrl,
+  parseOriginUrlFromGitConfig,
   WORKTREE_BRANCH_PREFIX,
 } from "./git.ts";
 
@@ -48,6 +49,28 @@ describe("normalizeGitRemoteUrl", () => {
     expect(normalizeGitRemoteUrl("deploy@bitbucket.org:workspace/repo.git")).toBe(
       "bitbucket.org/workspace/repo",
     );
+  });
+});
+
+describe("parseOriginUrlFromGitConfig", () => {
+  it("reads the origin url and ignores other remotes", () => {
+    const config = [
+      "[core]",
+      "\trepositoryformatversion = 0",
+      '[remote "upstream"]',
+      "\turl = https://github.com/other/repo.git",
+      '[remote "origin"]',
+      "\turl = git@github.com:pingdotgg/t3code.git",
+      "\tfetch = +refs/heads/*:refs/remotes/origin/*",
+      '[branch "main"]',
+      "\tremote = origin",
+    ].join("\n");
+    expect(parseOriginUrlFromGitConfig(config)).toBe("git@github.com:pingdotgg/t3code.git");
+  });
+
+  it("returns null when there is no origin section", () => {
+    expect(parseOriginUrlFromGitConfig("[core]\n\tbare = false\n")).toBeNull();
+    expect(parseOriginUrlFromGitConfig("")).toBeNull();
   });
 });
 

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -144,26 +144,62 @@ export function normalizeGitRemoteUrl(value: string): string {
 }
 
 /**
- * Read `remote.origin.url` from raw `.git/config` text. Avoids spawning git
- * for callers that only need the origin, such as project discovery scans.
+ * Unquote a git config value: strip an inline `#` or `;` comment outside
+ * quotes, then drop surrounding quotes and backslash escapes.
+ */
+function parseGitConfigValue(raw: string): string {
+  let out = "";
+  let quoted = false;
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw[index]!;
+    if (char === "\\" && index + 1 < raw.length) {
+      out += raw[index + 1];
+      index += 1;
+      continue;
+    }
+    if (char === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (!quoted && (char === "#" || char === ";")) break;
+    out += char;
+  }
+  return out.trim();
+}
+
+/**
+ * Read the primary remote URL from raw `.git/config` text without spawning
+ * git. Prefers `remote.origin.url` and falls back to the first remote so
+ * clones made with `git clone --origin <name>` still resolve.
  */
 export function parseOriginUrlFromGitConfig(configText: string): string | null {
-  let inOrigin = false;
+  let section: string | null = null;
+  let originUrl: string | null = null;
+  let firstRemoteUrl: string | null = null;
   for (const rawLine of configText.split(/\r?\n/)) {
     const line = rawLine.trim();
     if (line.length === 0 || line.startsWith("#") || line.startsWith(";")) continue;
-    if (line.startsWith("[")) {
-      inOrigin = /^\[\s*remote\s+"origin"\s*\]$/i.test(line);
+    const header = /^\[\s*remote\s+"([^"]+)"\s*\]$/i.exec(line);
+    if (header) {
+      section = header[1] ?? null;
       continue;
     }
-    if (!inOrigin) continue;
-    const match = /^url\s*=\s*(.+)$/i.exec(line);
-    if (match?.[1]) {
-      const url = match[1].trim();
-      return url.length > 0 ? url : null;
+    if (line.startsWith("[")) {
+      section = null;
+      continue;
+    }
+    if (section === null) continue;
+    const match = /^url\s*=\s*(.*)$/i.exec(line);
+    if (!match) continue;
+    const url = parseGitConfigValue(match[1] ?? "");
+    if (url.length === 0) continue;
+    if (section === "origin") {
+      originUrl ??= url;
+    } else {
+      firstRemoteUrl ??= url;
     }
   }
-  return null;
+  return originUrl ?? firstRemoteUrl;
 }
 
 /**
@@ -176,7 +212,7 @@ export function parseGitHubRepositoryNameWithOwnerFromRemoteUrl(url: string | nu
   }
 
   const match =
-    /^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https:\/\/github\.com\/|git:\/\/github\.com\/)([^/\s]+\/[^/\s]+?)(?:\.git)?\/?$/i.exec(
+    /^(?:git@github\.com:|ssh:\/\/(?:git@)?github\.com\/|https:\/\/github\.com\/|git:\/\/github\.com\/)([^/\s]+\/[^/\s]+?)(?:\.git)?\/?$/i.exec(
       trimmed,
     );
   const repositoryNameWithOwner = match?.[1]?.trim() ?? "";

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -144,6 +144,29 @@ export function normalizeGitRemoteUrl(value: string): string {
 }
 
 /**
+ * Read `remote.origin.url` from raw `.git/config` text. Avoids spawning git
+ * for callers that only need the origin, such as project discovery scans.
+ */
+export function parseOriginUrlFromGitConfig(configText: string): string | null {
+  let inOrigin = false;
+  for (const rawLine of configText.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("#") || line.startsWith(";")) continue;
+    if (line.startsWith("[")) {
+      inOrigin = /^\[\s*remote\s+"origin"\s*\]$/i.test(line);
+      continue;
+    }
+    if (!inOrigin) continue;
+    const match = /^url\s*=\s*(.+)$/i.exec(line);
+    if (match?.[1]) {
+      const url = match[1].trim();
+      return url.length > 0 ? url : null;
+    }
+  }
+  return null;
+}
+
+/**
  * Best-effort parse of a GitHub `owner/repo` identifier from common remote URL shapes.
  */
 export function parseGitHubRepositoryNameWithOwnerFromRemoteUrl(url: string | null): string | null {

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -176,12 +176,16 @@ export function parseOriginUrlFromGitConfig(configText: string): string | null {
   let section: string | null = null;
   let originUrl: string | null = null;
   let firstRemoteUrl: string | null = null;
-  for (const rawLine of configText.split(/\r?\n/)) {
+  // A trailing backslash continues the value on the next line.
+  const joined = configText.replace(/\\\r?\n[ \t]*/g, "");
+  for (const rawLine of joined.split(/\r?\n/)) {
     const line = rawLine.trim();
     if (line.length === 0 || line.startsWith("#") || line.startsWith(";")) continue;
-    const header = /^\[\s*remote\s+"([^"]+)"\s*\]$/i.exec(line);
+    // Both `[remote "origin"]` and the legacy `[remote.origin]` form, with an
+    // optional trailing comment.
+    const header = /^\[\s*remote(?:\s+"([^"]+)"|\.([^\]\s]+))\s*\](?:\s*[#;].*)?$/i.exec(line);
     if (header) {
-      section = header[1] ?? null;
+      section = header[1] ?? header[2] ?? null;
       continue;
     }
     if (line.startsWith("[")) {

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -182,10 +182,11 @@ export function parseOriginUrlFromGitConfig(configText: string): string | null {
     const line = rawLine.trim();
     if (line.length === 0 || line.startsWith("#") || line.startsWith(";")) continue;
     // Both `[remote "origin"]` and the legacy `[remote.origin]` form, with an
-    // optional trailing comment.
+    // optional trailing comment. Git keeps quoted subsections case-sensitive
+    // but folds the dotted form to lowercase.
     const header = /^\[\s*remote(?:\s+"([^"]+)"|\.([^\]\s]+))\s*\](?:\s*[#;].*)?$/i.exec(line);
     if (header) {
-      section = header[1] ?? header[2] ?? null;
+      section = header[1] ?? header[2]?.toLowerCase() ?? null;
       continue;
     }
     if (line.startsWith("[")) {


### PR DESCRIPTION
Onboarding listed every directory Claude Code or Codex had ever run in as one flat list of paths, with everything from the last 30 days preselected. On my machine that was 270 rows and 80 preselected. Most of them were Codex scratch folders, worktrees, and one-off questions. I wanted two or three projects and had no fast way to get there.

The scanner now reads each candidate's `.git/config` directly, so the client can group clones by origin and show the GitHub `owner/name`. Linked worktrees, Codex scratch directories under `~/Documents/Codex`, `~/Downloads`, and temp roots are no longer offered. Folders that are not git repositories collapse under "Other folders". The default selection requires a git repository with at least three threads. Select all and Select none sit above the list, and each row shows the source icons, thread count, and last activity.

On the same machine this drops the list to 162 rows and the default selection to 16.

| Before | After |
| --- | --- |
| ![Before: flat list of 270 paths, 38 preselected](https://files.tslop.org/2026/09/onboarding-import-pr-before-f6c43426.png) | ![After: grouped by repository, 16 of 162 preselected](https://files.tslop.org/2026/09/onboarding-import-pr-after-v3-cdb5d9e6.png) |

Mobile has no project import step, so there is no mobile change.

Created with Claude Fable 5.1 in Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Git identity and repo grouping to `AgentSessionScanner` scan logic
> - Adds a nullable Git identity field to scan candidates so non-repository workspaces are represented with a null value
> - Groups Codex rollouts by `cwd` across date directories and merges Claude and Codex candidates for imported projects
> - Excludes Codex scratch directories and Downloads paths from scan results, keeping only ordinary workspaces eligible
> - Skips linked git worktrees (gitdir pointer) while reporting normalized remote and GitHub repository metadata for real checkouts
> - Behavioral Change: existing test expectations now require the new Git identity field on all candidate assertions; callers consuming scan candidates must handle the added field
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 03e2e22.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding now groups cloned projects by repository and shows repository details, thread counts, activity, and selection controls.
  * Git-backed projects display normalized repository information, including GitHub owner and repository names.
  * Project selection supports selecting all or none, with grouped and collapsible project lists.

* **Bug Fixes**
  * Linked worktrees and scratch or download folders are no longer offered as projects.
  * Git repository detection now supports varied remote configuration formats and submodules.

* **Documentation**
  * Updated onboarding guidance to explain repository grouping and excluded folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->