### PR TITLE
fix(web): keep project favicon shape consistent across sizes

### DIFF
--- a/apps/web/src/components/ProjectFavicon.tsx
+++ b/apps/web/src/components/ProjectFavicon.tsx
@@ -227,7 +227,7 @@ function ProjectFaviconImage({
         <img
           src={displayedSrc}
           alt=""
-          className={cn("size-3.5 shrink-0 rounded-sm object-contain", className)}
+          className={cn("size-3.5 shrink-0 rounded-[37.5%] object-contain", className)}
           onError={() => handleLoadError(displayedSrc)}
         />
       ) : null}


### PR DESCRIPTION
## What Changed

Give project favicon images a proportional corner radius in `ProjectFavicon`: `rounded-[37.5%]` instead of `rounded-sm`. This is one line in the shared web component, with no per-caller overrides.

## Why

The default 6px radius makes a 12px favicon circular and a 14px favicon rounder than the 16px sidebar icon. The same project therefore has different icon shapes in the sidebar, thread tooltip, and chat breadcrumb.

37.5% preserves the sidebar's existing 6/16 ratio at every size. The 16px sidebar icon keeps its current shape; smaller images become less rounded, and the 24px Settings preview gets a 9px radius. This applies to web and the desktop web UI. Emoji and Lucide fallback icons are unaffected; the separate native mobile component is unchanged.

## UI Changes

Actual screenshots from an isolated local app with an Atlas demo project. Before: upstream `dc39615ae`; after: `2b484aa3b`. The following crops are enlarged **4×** so the corners are visible. The sidebar is included as an unchanged reference.

| Before | After |
| --- | --- |
| ![Before: sidebar, chat breadcrumb, and Settings at 4x](https://github.com/user-attachments/assets/e5a12c9c-2638-4340-9261-b1db4b2e6e56) | ![After: matching proportions at 4x](https://github.com/user-attachments/assets/a9d315b3-07cb-48d2-9fd1-f9ab5c727de1) |

<details>
<summary>Original screenshots</summary>

| View | Before | After |
| --- | --- | --- |
| Chat | ![Chat before](https://github.com/user-attachments/assets/1dfff60e-53b0-47c5-bc5d-71969c2df40e) | ![Chat after](https://github.com/user-attachments/assets/d57d995c-8809-4a63-868e-729808c61613) |
| Settings | ![Settings before](https://github.com/user-attachments/assets/ae57b032-fb6f-458d-aa31-9f454e0f1c13) | ![Settings after](https://github.com/user-attachments/assets/08297153-583e-4881-b958-4018f55eac6b) |

</details>

## Verification

- Existing `ProjectFavicon.test.tsx`: **6 tests passed** (`vp test run src/components/ProjectFavicon.test.tsx --project unit`, from `apps/web`). These cover component behavior, not visual appearance.
- `vp lint apps/web/src/components/ProjectFavicon.tsx` and `git diff --check` passed.
- Checked the actual browser rendering and computed radius for the 16px sidebar, 14px breadcrumb, and 24px Settings preview. Screenshots above show the visual change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] Video is not applicable: no animation or interaction changes

Made with GPT-6 via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix project favicon border-radius to 37.5% for consistent shape across sizes
> Updates `ProjectFaviconImage` to use a 37.5% border-radius instead of a small preset radius. This keeps the favicon shape consistent at different image sizes. Loading, error handling, and fallback rendering are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b484aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated project favicon images with a more rounded corner treatment for a softer appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->