### PR TITLE
fix(server): resume archived Codex sessions

### DIFF
--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -781,6 +781,97 @@ describe("isRecoverableThreadResumeError", () => {
 });
 
 describe("openCodexThread", () => {
+  it.effect("unarchives an archived session and resumes the same thread", () =>
+    Effect.gen(function* () {
+      const calls: Array<{ method: string; payload: unknown }> = [];
+      const opened = yield* openCodexThread({
+        client: {
+          request: () => Effect.die("An archived session must not start fresh"),
+          raw: {
+            request: (method, payload) =>
+              Effect.suspend(() => {
+                calls.push({ method, payload });
+                if (calls.length === 1) {
+                  return Effect.fail(
+                    new CodexErrors.CodexAppServerRequestError({
+                      code: -32600,
+                      errorMessage:
+                        "session saved-thread is archived. Run `codex unarchive saved-thread` to unarchive it first.",
+                    }),
+                  );
+                }
+                return Effect.succeed(makeThreadOpenResponse("saved-thread"));
+              }),
+          },
+        },
+        threadId: ThreadId.make("thread-1"),
+        runtimeMode: "auto",
+        cwd: "/tmp/project",
+        requestedModel: "gpt-5.3-codex",
+        serviceTier: "fast",
+        resumeThreadId: "saved-thread",
+      });
+
+      NodeAssert.equal(opened.thread.id, "saved-thread");
+      NodeAssert.deepStrictEqual(
+        calls.map((call) => call.method),
+        ["thread/resume", "thread/unarchive", "thread/resume"],
+      );
+      NodeAssert.deepStrictEqual(calls[1]?.payload, { threadId: "saved-thread" });
+      NodeAssert.deepStrictEqual(calls[2]?.payload, calls[0]?.payload);
+    }),
+  );
+
+  it.effect(
+    "propagates unarchive and retry failures without starting fresh or retrying again",
+    () =>
+      Effect.gen(function* () {
+        for (const failAt of [2, 3]) {
+          for (const errorMessage of ["thread not found", "session saved-thread is archived"]) {
+            const failure = new CodexErrors.CodexAppServerRequestError({
+              code: -32600,
+              errorMessage,
+            });
+            const calls: string[] = [];
+            const error = yield* openCodexThread({
+              client: {
+                request: () => Effect.die("An archived session must not start fresh"),
+                raw: {
+                  request: (method) =>
+                    Effect.suspend(() => {
+                      calls.push(method);
+                      if (calls.length === failAt) return Effect.fail(failure);
+                      if (calls.length === 1) {
+                        return Effect.fail(
+                          new CodexErrors.CodexAppServerRequestError({
+                            code: -32600,
+                            errorMessage:
+                              "Run `codex unarchive saved-thread` to unarchive it first.",
+                          }),
+                        );
+                      }
+                      return Effect.succeed({});
+                    }),
+                },
+              },
+              threadId: ThreadId.make("thread-1"),
+              runtimeMode: "full-access",
+              cwd: "/tmp/project",
+              requestedModel: undefined,
+              serviceTier: undefined,
+              resumeThreadId: "saved-thread",
+            }).pipe(Effect.flip);
+
+            NodeAssert.strictEqual(error, failure);
+            NodeAssert.deepStrictEqual(
+              calls,
+              ["thread/resume", "thread/unarchive", "thread/resume"].slice(0, failAt),
+            );
+          }
+        }
+      }),
+  );
+
   it.effect("resumes metadata when historical turns contain unknown error values", () =>
     Effect.gen(function* () {
       const response = makeThreadOpenResponse("saved-thread");
@@ -875,13 +966,13 @@ describe("openCodexThread", () => {
 
   it.effect("falls back to thread/start when resume fails recoverably", () =>
     Effect.gen(function* () {
-      const calls: Array<{ method: "thread/start" | "thread/resume"; payload: unknown }> = [];
+      const calls: Array<{ method: string; payload: unknown }> = [];
       const started = makeThreadOpenResponse("fresh-thread");
       const client = {
         raw: {
           request: (
-            method: "thread/resume",
-            payload: CodexRpc.ClientRequestParamsByMethod["thread/resume"],
+            method: "thread/resume" | "thread/unarchive",
+            payload: CodexRpc.ClientRequestParamsByMethod["thread/resume" | "thread/unarchive"],
           ) => {
             calls.push({ method, payload });
             return Effect.fail(

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -686,8 +686,8 @@ const decodeCodexThreadResumeMetadata = Schema.decodeUnknownEffect(CodexThreadRe
 interface CodexThreadOpenClient {
   readonly raw: {
     readonly request: (
-      method: "thread/resume",
-      payload: CodexRpc.ClientRequestParamsByMethod["thread/resume"] & {
+      method: "thread/resume" | "thread/unarchive",
+      payload: CodexRpc.ClientRequestParamsByMethod["thread/resume" | "thread/unarchive"] & {
         readonly excludeTurns?: boolean;
       },
     ) => Effect.Effect<unknown, CodexErrors.CodexAppServerError>;
@@ -725,7 +725,7 @@ export const openCodexThread = (input: {
   // Older providers may still return history despite excludeTurns. Only the
   // session metadata is needed here, so unrelated historical items cannot
   // prevent resuming a valid provider thread.
-  return input.client.raw
+  const resume = input.client.raw
     .request("thread/resume", {
       threadId: resumeThreadId,
       ...startParams,
@@ -743,16 +743,27 @@ export const openCodexThread = (input: {
           ),
         ),
       ),
-      Effect.catchIf(isRecoverableThreadResumeError, (error) =>
-        Effect.logWarning("codex app-server thread resume fell back to fresh start", {
+    );
+
+  return resume.pipe(
+    Effect.catch((error) => {
+      if (/is archived|codex unarchive/i.test(error.message)) {
+        return input.client.raw
+          .request("thread/unarchive", { threadId: resumeThreadId })
+          .pipe(Effect.andThen(resume));
+      }
+      if (isRecoverableThreadResumeError(error)) {
+        return Effect.logWarning("codex app-server thread resume fell back to fresh start", {
           threadId: input.threadId,
           requestedRuntimeMode: input.runtimeMode,
           resumeThreadId,
           recoverable: true,
           cause: error,
-        }).pipe(Effect.andThen(input.client.request("thread/start", startParams))),
-      ),
-    );
+        }).pipe(Effect.andThen(input.client.request("thread/start", startParams)));
+      }
+      return Effect.fail(error);
+    }),
+  );
 };
 
 function readNotificationThreadId(notification: CodexServerNotification): string | undefined {


### PR DESCRIPTION
Archiving a Codex conversation outside T3 makes the next session resume fail with `session … is archived`. T3 surfaces the error and cannot continue the conversation.

Unarchive the saved provider thread and retry the same resume once, keeping its history and settings. If unarchive or the retry fails, propagate that error without starting a fresh thread. Existing missing-thread recovery stays unchanged.

Reproduced before the fix with the exact reported error in a runtime regression test: 1 failed, 40 passed. After the fix, all 89 Codex runtime and adapter tests pass, including recovery failures and the one-retry limit. Server typecheck, targeted lint, formatting, and whitespace checks pass. Verification used protocol test doubles, not a live ChatGPT archive operation.

This shared server path serves web, desktop, and mobile; no client UI or wire contracts change.

Fixes #10481.

Model: GPT-6. Harness: Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `openCodexThread` to resume archived Codex sessions by unarchiving first
> - When a resume request returns an archived-session error, `openCodexThread` now sends a thread-unarchive request and retries the original resume with the same parameters.
> - Errors from the unarchive step or the retry propagate directly — no fresh thread start or additional retry occurs for those failures.
> - Recoverable non-archived resume errors still fall back to starting a fresh thread, as before.
> - Risk: the `CodexThreadOpenClient` raw-request type is expanded to accept `unarchive` method calls; any callers or mocks that assume resume-only requests need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d52466.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Archived conversation threads can now be restored and resumed automatically.
  - Improved recovery when resuming a thread fails, reducing unnecessary creation of new conversations.
  - Added safeguards to preserve existing error handling when restoration or retry attempts fail.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->