### PR TITLE
fix(cursor): enable sandbox in auto mode

### DIFF
--- a/apps/server/src/provider/acp/CursorAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.test.ts
@@ -83,10 +83,10 @@ describe("buildCursorAcpSpawnInput", () => {
     });
   });
 
-  it("uses Cursor auto-review in auto mode", () => {
+  it("uses Cursor auto-review with sandbox in auto mode", () => {
     expect(buildCursorAcpSpawnInput(undefined, "/tmp/project", undefined, "auto")).toEqual({
       command: "cursor-agent",
-      args: ["--auto-review", "acp"],
+      args: ["--auto-review", "--sandbox", "enabled", "acp"],
       cwd: "/tmp/project",
     });
   });

--- a/apps/server/src/provider/acp/CursorAcpSupport.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.ts
@@ -22,7 +22,7 @@ type CursorAcpRuntimeCursorSettings = Pick<CursorSettings, "apiEndpoint" | "bina
 function cursorAcpPermissionArgs(runtimeMode?: RuntimeMode): ReadonlyArray<string> {
   switch (runtimeMode) {
     case "auto":
-      return ["--auto-review"];
+      return ["--auto-review", "--sandbox", "enabled"];
     case "full-access":
       return ["--force"];
     default:


### PR DESCRIPTION
## What Changed

Cursor sessions in T3's Auto runtime mode now launch with both `--auto-review` and `--sandbox enabled`. This makes T3's mapping match Cursor's native **Auto-Review (with Sandbox)** mode instead of leaving the Cursor CLI sandbox disabled.

## Why

#9283 added `--auto-review`, but Cursor exposes auto-review and sandboxing as separate CLI options. Without the sandbox flag, routine commands that should run automatically inside the workspace can fall back to allowlist checks and repeatedly prompt for approval.

This preserves Cursor's normal safety boundary: operations that need to run outside the sandbox still emit an ACP permission request for the user.

## Evidence

Cursor presents the corresponding native mode as **Auto-Review (with Sandbox)**:

![Cursor's native Auto-Review with Sandbox setting](https://github.com/user-attachments/assets/138ca9ab-7681-41bd-981b-3f5b28b852c6)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI changes: not applicable
- [x] Animation/interaction changes: not applicable

## Testing

- `./node_modules/.bin/vp test run apps/server/src/provider/acp/CursorAcpSupport.test.ts` — 7 passed
- `./node_modules/.bin/vp test run apps/server/src/provider/Layers/CursorAdapter.test.ts` — 20 passed

Built by gpt-5.6-sol in the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable sandbox option for Cursor ACP auto mode
> Updates `cursorAcpPermissionArgs` in [CursorAcpSupport.ts](https://github.com/pingdotgg/t3code/pull/10510/files#diff-b1d00612dffa089ec6b38ee66ba6c910fe9c5240bc928acb859177510a99f4a4) so auto runtime-mode launches include both auto-review and the enabled sandbox flag. Full-access and default modes are unchanged. The corresponding test in [CursorAcpSupport.test.ts](https://github.com/pingdotgg/t3code/pull/10510/files#diff-544f008620c3375bb195067d942fb7d9712044e59e9c48c401370e13afeefa7e) is updated to expect the new sandbox arguments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6596d75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Automatic runtime mode now launches with sandbox protection enabled alongside automatic review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->