### PR TITLE
fix(desktop): route preview clipboard shortcuts to guest

### DIFF
--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -67,6 +67,52 @@ describe("isPreviewRefreshShortcut", () => {
   });
 });
 
+describe("previewEditingCommand", () => {
+  const input = (overrides: Partial<Electron.Input> = {}) =>
+    ({
+      type: "keyDown",
+      key: "c",
+      code: "KeyC",
+      isAutoRepeat: false,
+      isComposing: false,
+      shift: false,
+      control: false,
+      alt: false,
+      meta: true,
+      location: 0,
+      modifiers: [],
+      ...overrides,
+    }) as Electron.Input;
+
+  it.each([
+    ["c", "copy"],
+    ["x", "cut"],
+    ["v", "paste"],
+    ["a", "selectAll"],
+  ] as const)("maps Meta+%s to %s", (key, command) => {
+    expect(PreviewManager.previewEditingCommand(input({ key }))).toBe(command);
+  });
+
+  it("maps Shift+Meta+V to paste-and-match-style", () => {
+    expect(PreviewManager.previewEditingCommand(input({ key: "v", shift: true }))).toBe(
+      "pasteAndMatchStyle",
+    );
+  });
+
+  it("supports Control shortcuts and rejects non-editing variants", () => {
+    expect(
+      PreviewManager.previewEditingCommand(input({ key: "v", meta: false, control: true })),
+    ).toBe("paste");
+    expect(PreviewManager.previewEditingCommand(input({ key: "c", alt: true }))).toBeUndefined();
+    expect(
+      PreviewManager.previewEditingCommand(input({ key: "c", type: "keyUp" })),
+    ).toBeUndefined();
+    expect(
+      PreviewManager.previewEditingCommand(input({ key: "c", isComposing: true })),
+    ).toBeUndefined();
+  });
+});
+
 describe("previewWindowOpenAction", () => {
   const details = (overrides: {
     readonly url?: string;
@@ -355,6 +401,11 @@ const makeFaviconWebContents = (options?: {
       options?.rasterize ? options.rasterize(scripts[0]?.code ?? "") : TEST_FAVICON,
   );
   const reload = vi.fn();
+  const copy = vi.fn();
+  const cut = vi.fn();
+  const paste = vi.fn();
+  const pasteAndMatchStyle = vi.fn();
+  const selectAll = vi.fn();
   const loadURL = vi.fn(async (url: string) => {
     currentUrl = url;
   });
@@ -373,6 +424,11 @@ const makeFaviconWebContents = (options?: {
     setAudioMuted: vi.fn(),
     isCurrentlyAudible: () => false,
     reload,
+    copy,
+    cut,
+    paste,
+    pasteAndMatchStyle,
+    selectAll,
     reloadIgnoringCache: vi.fn(),
     loadURL,
     on: vi.fn((event: string, listener: (...args: never[]) => void) => {
@@ -497,7 +553,7 @@ describe("PreviewManager", () => {
         ).toHaveBeenCalledWith(true);
         const beforeInput = preview.listeners.get("before-input-event")!;
         for (const control of [false, true]) {
-          for (const key of ["k", ",", "w", "j", "q", "+", "a", "c", "v", "x"]) {
+          for (const key of ["k", ",", "w", "j", "q", "+"]) {
             for (const type of ["keyDown", "keyUp"]) {
               const preventDefault = vi.fn();
               beforeInput(
@@ -510,6 +566,41 @@ describe("PreviewManager", () => {
           }
         }
         expect(sendInputEvent).not.toHaveBeenCalled();
+
+        const editShortcuts = [
+          ["c", "copy"],
+          ["x", "cut"],
+          ["v", "paste"],
+          ["a", "selectAll"],
+        ] as const;
+        for (const [key, method] of editShortcuts) {
+          const preventDefault = vi.fn();
+          beforeInput(
+            { preventDefault } as never,
+            { type: "keyDown", key, meta: true, control: false, shift: false, alt: false } as never,
+          );
+          yield* Effect.yieldNow;
+          expect(preventDefault).toHaveBeenCalledOnce();
+          expect((preview.webContents as Electron.WebContents)[method]).toHaveBeenCalledOnce();
+        }
+
+        const pasteAndMatchStylePreventDefault = vi.fn();
+        beforeInput(
+          { preventDefault: pasteAndMatchStylePreventDefault } as never,
+          {
+            type: "keyDown",
+            key: "v",
+            meta: true,
+            control: false,
+            shift: true,
+            alt: false,
+          } as never,
+        );
+        yield* Effect.yieldNow;
+        expect(pasteAndMatchStylePreventDefault).toHaveBeenCalledOnce();
+        expect(
+          (preview.webContents as Electron.WebContents).pasteAndMatchStyle,
+        ).toHaveBeenCalledOnce();
 
         const preventDefault = vi.fn();
         beforeInput(

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -535,6 +535,36 @@ export const isPreviewRefreshShortcut = (input: Electron.Input): boolean =>
   !input.shift &&
   !input.alt;
 
+type PreviewEditingCommand = "copy" | "cut" | "paste" | "pasteAndMatchStyle" | "selectAll";
+
+/**
+ * Resolve native editing shortcuts before Chromium or the host menu can route
+ * them away from the embedded preview guest.
+ */
+export const previewEditingCommand = (input: Electron.Input): PreviewEditingCommand | undefined => {
+  if (
+    input.type !== "keyDown" ||
+    input.alt ||
+    (!input.meta && !input.control) ||
+    input.isComposing
+  ) {
+    return undefined;
+  }
+
+  switch (input.key.toLowerCase()) {
+    case "a":
+      return input.shift ? undefined : "selectAll";
+    case "c":
+      return input.shift ? undefined : "copy";
+    case "x":
+      return input.shift ? undefined : "cut";
+    case "v":
+      return input.shift ? "pasteAndMatchStyle" : "paste";
+    default:
+      return undefined;
+  }
+};
+
 const isPreviewInputSignal = (value: unknown): value is PreviewInputSignal => {
   if (typeof value !== "object" || value === null || !("kind" in value)) return false;
   if (value.kind === "pointer") {
@@ -1854,6 +1884,38 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         );
         return;
       }
+
+      const editingCommand = previewEditingCommand(input);
+      if (editingCommand === undefined) return;
+      event.preventDefault();
+      runFork(
+        attempt(
+          {
+            operation: `shortcut.${editingCommand}`,
+            tabId,
+            webContentsId: wc.id,
+          },
+          () => {
+            switch (editingCommand) {
+              case "copy":
+                wc.copy();
+                return;
+              case "cut":
+                wc.cut();
+                return;
+              case "paste":
+                wc.paste();
+                return;
+              case "pasteAndMatchStyle":
+                wc.pasteAndMatchStyle();
+                return;
+              case "selectAll":
+                wc.selectAll();
+                return;
+            }
+          },
+        ).pipe(Effect.ignore),
+      );
     };
     yield* Scope.addFinalizer(
       scope,


### PR DESCRIPTION
## Problem

Physical Cmd/Ctrl+C, Cmd/Ctrl+X, Cmd/Ctrl+V, and Cmd/Ctrl+A inside the desktop sidebar Browser preview could be handled by the host window instead of the embedded preview guest. The existing clipboard permission fix covers page JavaScript clipboard writes, but not native keyboard editing shortcuts.

## Fix

Intercept native editing shortcuts in the preview WebContents before host menu handling and dispatch them directly to the guest editing commands, including paste-as-plain-text.

## Verification

- `PATH=/Users/kristupas/.vite-plus/js_runtime/node/24.17.0/bin:$PATH vp test run apps/desktop/src/preview/Manager.test.ts apps/desktop/src/preview/BrowserSession.test.ts` — 99 passed
- `PATH=/Users/kristupas/.vite-plus/js_runtime/node/24.17.0/bin:$PATH vp run --filter @t3tools/desktop typecheck` — passed
- `vp fmt --check apps/desktop/src/preview/Manager.ts apps/desktop/src/preview/Manager.test.ts` — passed
- `vp run build:desktop` — passed

This is related to preview input routing, but specifically fixes physical native clipboard shortcuts rather than preview automation targeting.

Model: GPT-5.6
Harness: Codex

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route preview clipboard shortcuts (copy, cut, paste, select-all) to guest in `PreviewManager`
> - Adds `previewEditingCommand` resolver that maps Meta/Control key-down inputs (without Alt) to native editing commands: copy, cut, paste, `paste-and-match-style` (Shift+Meta+V), and select-all. Excludes composing, key-up, and Alt-modified inputs.
> - The before-input handler in `preview.makeNativeOperations` now intercepts resolved editing commands, prevents the default input event, and calls the matching `webContents` native method via the existing Effect operation pipeline.
> - Risk: `previewEditingCommand` is strict about modifier combinations — only Meta or Control without Alt qualify. Non-qualifying inputs fall through unhandled, so custom host-level key bindings that rely on Alt may no longer be shadowed by preview defaults.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 278d10f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->