### PR TITLE
fix(mobile): match Working status color to desktop

### DIFF
--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -55,7 +55,7 @@ const STATUS_LABEL_BY_STATUS: Partial<
 > = {
   approval: { label: "Approval", className: "text-warning-foreground" },
   input: { label: "Input", className: "text-foreground-secondary" },
-  working: { label: "Working", className: "text-foreground-secondary" },
+  working: { label: "Working", className: "text-adaptive-sky-600-400" },
   failed: { label: "Failed", className: "text-danger-foreground" },
 };
 

--- a/apps/mobile/src/features/threads/threadPresentation.ts
+++ b/apps/mobile/src/features/threads/threadPresentation.ts
@@ -67,7 +67,7 @@ export function resolveThreadStatus(
       kind: "working",
       label: "Working",
       pillClassName: "bg-primary/10",
-      textClassName: "text-foreground-secondary",
+      textClassName: "text-adaptive-sky-600-400",
       iconColor: "#0a84ff",
       iconBackground: "rgba(10,132,255,0.22)",
       pulse: true,


### PR DESCRIPTION
## What Changed

Use the existing adaptive sky color for the Working label in both mobile thread lists.

## Why

Working was rendered in secondary gray on mobile while the desktop sidebar uses blue. The existing token provides sky-600 in light mode and sky-400 in dark mode, including custom mobile themes.

## UI Changes

Captured on an iPhone 17 simulator (iOS 26.5) with an isolated demo environment.

| Appearance | Before | After |
| --- | --- | --- |
| Light | <img src="https://github.com/user-attachments/assets/d478e50c-0d24-4d37-b56c-07782e461c53" width="300" alt="Before: gray Working label in light mode" /> | <img src="https://github.com/user-attachments/assets/1ac2ff15-0f6b-4402-ba5e-2f25e66bb824" width="300" alt="After: blue Working label in light mode" /> |
| Dark | <img src="https://github.com/user-attachments/assets/61542b8f-c7e7-4f6f-ad2a-a0d628c65693" width="300" alt="Before: gray Working label in dark mode" /> | <img src="https://github.com/user-attachments/assets/11c99b9b-3593-427d-8012-61683b497e4d" width="300" alt="After: blue Working label in dark mode" /> |

## Validation

- iOS simulator build and visual verification in light and dark mode.
- Targeted lint: no errors; two existing dependency warnings.
- Formatting and git diff checks passed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes

Implemented with GPT-6, using the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix mobile 'Working' thread status color to match desktop
> Changes the text class for working and running thread statuses from secondary foreground to adaptive sky in [thread-list-v2-items.tsx](https://github.com/pingdotgg/t3code/pull/10515/files#diff-2cea439fc4533a1bdf479cb7688682b3833ed6dbb1ce83c425862cd1af610fb2) and [threadPresentation.ts](https://github.com/pingdotgg/t3code/pull/10515/files#diff-46bd62be665f34c9913a0c1c8a4eca6eb9542ba6a2143478080d996bb6aaa5ff). This aligns the mobile thread list colors with the desktop app.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 190211b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the “Working” status label in thread lists to use the adaptive sky color for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->