### PR TITLE
fix(web): remove inserted citations on cancel

### DIFF
--- a/apps/web/src/components/ComposerCitationNode.tsx
+++ b/apps/web/src/components/ComposerCitationNode.tsx
@@ -42,6 +42,7 @@ export type ComposerCitationCommentRequest = {
 export type ComposerCitationCommentTarget = {
   nodeKey: NodeKey;
   sourceAnchor?: AssistantCitationSourceAnchor;
+  removeOnCancel?: boolean;
 };
 
 export const ComposerCitationCommentContext = createContext<{
@@ -68,7 +69,11 @@ export function $consumeComposerCitationCommentRequest(requestRef: {
   let offset = 0;
   for (const node of paragraph.getChildren()) {
     if (offset === request.citationStart && node instanceof ComposerCitationNode) {
-      return { nodeKey: node.getKey(), sourceAnchor: request.sourceAnchor };
+      return {
+        nodeKey: node.getKey(),
+        sourceAnchor: request.sourceAnchor,
+        removeOnCancel: true,
+      };
     }
     offset += node.getTextContentSize();
   }
@@ -78,6 +83,8 @@ export function $consumeComposerCitationCommentRequest(requestRef: {
 function ComposerCitationDecorator(props: { citation: AssistantCitation; nodeKey: NodeKey }) {
   const [editor] = useLexicalComposerContext();
   const commentContext = use(ComposerCitationCommentContext);
+  const commentTarget =
+    commentContext.openComment?.nodeKey === props.nodeKey ? commentContext.openComment : null;
   const onSaveComment = (comment: string): boolean => {
     if (!editor.isEditable()) return false;
     let accepted = false;
@@ -118,15 +125,13 @@ function ComposerCitationDecorator(props: { citation: AssistantCitation; nodeKey
       <AssistantCitationChip
         citation={props.citation}
         commentEditor={{
-          open: commentContext.openComment?.nodeKey === props.nodeKey,
-          sourceAnchor:
-            commentContext.openComment?.nodeKey === props.nodeKey
-              ? commentContext.openComment.sourceAnchor
-              : undefined,
+          open: commentTarget !== null,
+          sourceAnchor: commentTarget?.sourceAnchor,
           onOpenChange: (open) => {
             if (open && !editor.isEditable()) return;
             commentContext.onOpenChange(props.nodeKey, open);
           },
+          ...(commentTarget?.removeOnCancel ? { onCancel: onRemove } : {}),
           onSave: onSaveComment,
           onSaveAndSend: (comment) => {
             if (!onSaveComment(comment)) return false;

--- a/apps/web/src/components/chat/AssistantCitationChip.tsx
+++ b/apps/web/src/components/chat/AssistantCitationChip.tsx
@@ -41,6 +41,7 @@ export function AssistantCitationChip({
     open: boolean;
     sourceAnchor?: AssistantCitationSourceAnchor | undefined;
     onOpenChange: (open: boolean) => void;
+    onCancel?: () => void;
     onSave: (comment: string) => boolean;
     onSaveAndSend?: (comment: string) => boolean;
   };
@@ -168,7 +169,13 @@ export function AssistantCitationChip({
                       },
                     }
                   : {})}
-                onCancel={() => commentEditor.onOpenChange(false)}
+                onCancel={() => {
+                  if (commentEditor.onCancel) {
+                    commentEditor.onCancel();
+                  } else {
+                    commentEditor.onOpenChange(false);
+                  }
+                }}
               />
             </PopoverPopup>
           ) : null}


### PR DESCRIPTION
Canceling the cite prompt currently leaves the citation chip that the prompt inserted in the composer.

Mark citation targets created by the cite prompt for removal on cancel. Existing citation edits still close normally, while canceling a fresh citation removes it and returns focus to the composer.

Validation: 29 focused composer tests pass, web typecheck passes, targeted lint and formatting pass. Browser verification has not been run.

Model: GPT-5.6 Sol. Harness: Codex.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove inserted citations when comment is cancelled in `ComposerCitationDecorator`
> Adds an optional `removeOnCancel` flag to the `ComposerCitationCommentTarget` type so controlled citation comment requests can signal that their matched citation node should be deleted on cancel. [ComposerCitationNode.tsx](https://github.com/pingdotgg/t3code/pull/10518/files#diff-e9adc91131ecdfb732f8646819c8425988f40fed28a36a8648a573abaee66f68) now passes the citation removal handler as the comment editor's cancel callback when that flag is set. [AssistantCitationChip.tsx](https://github.com/pingdotgg/t3code/pull/10518/files#diff-aa0f19153372ef00eb6101dc407e4a1d74ad80762ba509ae80b50eaedc9a6c9a) adds an optional `onCancel` callback to the comment editor; callers without the callback keep the existing close-only behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 843cebe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Canceling a newly inserted citation now removes it from the composer.
  - Citation cancellation consistently closes the citation editor when no removal action is needed.
- **Improvements**
  - Citation comment targets support configurable behavior when cancellation occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->