### PR TITLE
fix(mobile): allow choosing the voice input language

### DIFF
--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -19,6 +19,7 @@ import {
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
 import { AndroidScreenHeader } from "../../components/AndroidScreenHeader";
+import { ControlPillMenu } from "../../components/ControlPill";
 import { AppText as Text, AppTextInput as TextInput } from "../../components/AppText";
 import { supportsAgentAwarenessPush } from "../agent-awareness/capabilities";
 import { setLiveActivityUpdatesEnabled } from "../agent-awareness/liveActivityPreferences";
@@ -544,10 +545,59 @@ function ConfiguredSettingsRouteScreen() {
 function GeneralSettingsSection() {
   return (
     <SettingsSection title="General">
+      {Platform.OS === "ios" && Number.parseInt(Platform.Version, 10) >= 26 ? (
+        <VoiceInputLanguageRow />
+      ) : null}
       <SettingsRow icon="folder" label="Project Grouping" target="SettingsProjectGrouping" />
       <AutoSettleSettingsRows />
       <SettingsRow icon="chart.bar.xaxis" label="Usage" target="SettingsUsage" />
     </SettingsSection>
+  );
+}
+
+const VOICE_INPUT_LANGUAGES = [
+  { id: "system", title: "System" },
+  { id: "yue-CN", title: "Cantonese" },
+  { id: "zh-CN", title: "Chinese (Simplified)" },
+  { id: "zh-TW", title: "Chinese (Traditional)" },
+  { id: "en-US", title: "English" },
+  { id: "fr-FR", title: "French" },
+  { id: "de-DE", title: "German" },
+  { id: "it-IT", title: "Italian" },
+  { id: "ja-JP", title: "Japanese" },
+  { id: "ko-KR", title: "Korean" },
+  { id: "pt-BR", title: "Portuguese" },
+  { id: "es-ES", title: "Spanish" },
+];
+
+function VoiceInputLanguageRow() {
+  const preferences = useAtomValue(mobilePreferencesAtom);
+  const savePreferences = useAtomSet(updateMobilePreferencesAtom);
+  if (!AsyncResult.isSuccess(preferences)) return null;
+  const locale = preferences.value.voiceInputLocale ?? "system";
+
+  return (
+    <ControlPillMenu
+      accessible
+      accessibilityRole="button"
+      accessibilityLabel="Voice Input Language"
+      title="Voice Input Language"
+      actions={VOICE_INPUT_LANGUAGES.map((language) => ({
+        ...language,
+        state: language.id === locale ? "on" : "off",
+      }))}
+      onPressAction={({ nativeEvent }) =>
+        savePreferences({
+          voiceInputLocale: nativeEvent.event === "system" ? null : nativeEvent.event,
+        })
+      }
+    >
+      <SettingsRow
+        icon="mic"
+        label="Voice Input Language"
+        value={VOICE_INPUT_LANGUAGES.find((language) => language.id === locale)?.title}
+      />
+    </ControlPillMenu>
   );
 }
 

--- a/apps/mobile/src/features/voice-input/useVoiceInputController.ts
+++ b/apps/mobile/src/features/voice-input/useVoiceInputController.ts
@@ -1,3 +1,5 @@
+import { useAtomValue } from "@effect/atom-react";
+import { AsyncResult } from "effect/unstable/reactivity";
 import {
   RecordingPresets,
   requestRecordingPermissionsAsync,
@@ -14,6 +16,7 @@ import { useSharedValue } from "react-native-reanimated";
 
 import type { ComposerEditorSelection } from "../../components/ComposerEditor";
 import { getLocalVoiceTranscriber } from "../../native/voiceTranscription";
+import { mobilePreferencesAtom } from "../../state/preferences";
 import { getNativeShowcaseScene } from "../showcase/nativeShowcaseScene";
 import {
   VoiceInputController,
@@ -69,6 +72,10 @@ export function useVoiceInputController(input: {
   readonly onChangeDraftMessage: (value: string) => void;
   readonly onChangeSelection: (selection: ComposerEditorSelection) => void;
 }) {
+  const preferences = useAtomValue(mobilePreferencesAtom);
+  const locale = AsyncResult.isSuccess(preferences)
+    ? (preferences.value.voiceInputLocale ?? undefined)
+    : undefined;
   const [state, setState] = useState<VoiceInputState>(INITIAL_STATE);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const elapsedSecondsRef = useRef(0);
@@ -84,8 +91,8 @@ export function useVoiceInputController(input: {
     previousDraftRef.current = { ownerKey: input.ownerKey, text: input.draftMessage };
     revisionRef.current += 1;
   }
-  const latestInputRef = useRef(input);
-  latestInputRef.current = input;
+  const latestInputRef = useRef({ ...input, locale });
+  latestInputRef.current = { ...input, locale };
 
   const handleRecorderStatus = useCallback((status: RecordingStatus) => {
     controllerRef.current?.handleRecorderStatus({
@@ -100,7 +107,7 @@ export function useVoiceInputController(input: {
   if (!controllerRef.current) {
     controllerRef.current = new VoiceInputController({
       recorder,
-      getTranscriber: getLocalVoiceTranscriber,
+      getTranscriber: () => getLocalVoiceTranscriber(latestInputRef.current.locale),
       requestPermission: async () => {
         const permission = await requestRecordingPermissionsAsync();
         return { granted: permission.granted, canAskAgain: permission.canAskAgain };
@@ -206,7 +213,9 @@ export function useVoiceInputController(input: {
   return {
     // Store screenshots show the dictation button even on simulators, whose
     // on-device transcription is unavailable.
-    isAvailable: getLocalVoiceTranscriber() !== null || getNativeShowcaseScene() !== null,
+    isAvailable:
+      AsyncResult.isSuccess(preferences) &&
+      (getLocalVoiceTranscriber(locale) !== null || getNativeShowcaseScene() !== null),
     state,
     audioLevels,
     elapsedSeconds,

--- a/apps/mobile/src/native/voiceTranscription.ios.test.ts
+++ b/apps/mobile/src/native/voiceTranscription.ios.test.ts
@@ -56,6 +56,27 @@ afterEach(() => {
 });
 
 describe("getLocalVoiceTranscriber", () => {
+  it("transcribes in French when explicitly selected on an English device", async () => {
+    vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue({
+      ...Intl.DateTimeFormat().resolvedOptions(),
+      locale: "en-US",
+    });
+    mocks.prepare.mockResolvedValue("fr-FR");
+    mocks.transcribe.mockResolvedValue({
+      duration: 1,
+      segments: [{ text: "Bonjour.", startSecond: 0, endSecond: 1 }],
+    });
+    const options = { signal: new AbortController().signal };
+    const prepared = await getLocalVoiceTranscriber("fr-FR")!.prepare(options);
+
+    await expect(prepared.transcribe("file:///voice.m4a", options)).resolves.toBe("Bonjour.");
+    expect(mocks.prepare).toHaveBeenCalledWith("fr-FR");
+    expect(mocks.transcribe).toHaveBeenCalledWith(audio, "fr-FR");
+
+    await getLocalVoiceTranscriber()!.prepare(options);
+    expect(mocks.prepare).toHaveBeenLastCalledWith("en-US");
+  });
+
   it("keeps the selected language and Apple's resolved locale when the device language changes", async () => {
     const resolvedOptions = Intl.DateTimeFormat().resolvedOptions();
     const deviceLocale = vi

--- a/apps/mobile/src/native/voiceTranscription.ios.ts
+++ b/apps/mobile/src/native/voiceTranscription.ios.ts
@@ -33,8 +33,7 @@ function getNativeErrorCode(error: unknown): string | undefined {
   return typeof error.code === "string" ? error.code : undefined;
 }
 
-export function getLocalVoiceTranscriber(): VoiceTranscriber | null {
-  const locale = getDeviceLocale();
+export function getLocalVoiceTranscriber(locale = getDeviceLocale()): VoiceTranscriber | null {
   if (!AppleTranscription.isAvailable(locale)) return null;
   return { prepare: (options) => prepareVoiceTranscription(locale, options) };
 }
@@ -63,7 +62,7 @@ async function prepareVoiceTranscription(
     if (getNativeErrorCode(error) === "AppleTranscriptionUnsupportedLocale") {
       throw new VoiceTranscriptionError(
         "unsupported-locale",
-        "Voice transcription does not support this device language.",
+        "Voice transcription does not support this language.",
         { cause: error },
       );
     }

--- a/apps/mobile/src/native/voiceTranscription.ts
+++ b/apps/mobile/src/native/voiceTranscription.ts
@@ -1,5 +1,5 @@
 import type { VoiceTranscriber } from "@t3tools/client-runtime/voice-input";
 
-export function getLocalVoiceTranscriber(): VoiceTranscriber | null {
+export function getLocalVoiceTranscriber(_locale?: string): VoiceTranscriber | null {
   return null;
 }

--- a/apps/mobile/src/persistence/mobile-preferences.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.ts
@@ -17,6 +17,7 @@ const PREFERENCES_FALLBACK_KEY = "t3code.preferences.fallback";
 
 export interface Preferences {
   readonly liveActivitiesEnabled?: boolean;
+  readonly voiceInputLocale?: string | null;
   readonly themeId?: MobileThemeId;
   readonly lightThemeId?: MobileThemeId;
   readonly darkThemeId?: MobileThemeId;
@@ -86,6 +87,7 @@ export class MobilePreferencesStore extends Context.Service<
 function sanitizePreferences(parsed: Preferences): Preferences {
   const preferences: {
     liveActivitiesEnabled?: boolean;
+    voiceInputLocale?: string | null;
     themeId?: MobileThemeId;
     lightThemeId?: MobileThemeId;
     darkThemeId?: MobileThemeId;
@@ -107,6 +109,9 @@ function sanitizePreferences(parsed: Preferences): Preferences {
 
   if (typeof parsed.liveActivitiesEnabled === "boolean") {
     preferences.liveActivitiesEnabled = parsed.liveActivitiesEnabled;
+  }
+  if (typeof parsed.voiceInputLocale === "string" || parsed.voiceInputLocale === null) {
+    preferences.voiceInputLocale = parsed.voiceInputLocale;
   }
   if (
     typeof parsed.themeId === "string" &&

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -86,6 +86,9 @@ On supported iPhones with iOS 26 or later, use the composer's microphone to reco
 then confirm to transcribe. Text is inserted where your selection was when
 recording started, ready for you to review and edit before sending.
 
+Choose **Settings → General → Voice Input Language** to dictate in a different
+language. **System** follows your device's locale.
+
 The first use may download Apple's speech model and needs a network connection.
 Later transcription works offline for that language. Recordings can be up to five
 minutes long. Canceling, leaving the screen, or an audio interruption discards the


### PR DESCRIPTION
## What Changed

Add **Voice Input Language** at the top of **Settings → General** on iOS 26+. The choice uses the existing mobile preferences store and applies to the next recording. **System** preserves the current device-locale behavior.

## Why

Voice input always used the device locale, so someone speaking French on an English-configured iPhone could get an English transcription. Users can now choose the language they speak without changing their device settings.

## UI Changes

| Before | After (French selected) | Language menu |
| --- | --- | --- |
| ![Settings before the change](https://github.com/user-attachments/assets/201ca164-5be0-49b1-a381-ca06bc3ce492) | ![Voice Input Language at the top of General](https://github.com/user-attachments/assets/b015ce9b-c7ea-4fed-8ecb-325ada86d4d8) | ![Native language selection menu](https://github.com/user-attachments/assets/a2c6f198-63c9-4a88-8b02-f5c0c5ffca38) |

https://github.com/user-attachments/assets/527fbab4-e493-4d65-bb0c-958eabe266c2

## Validation

- 35 focused tests pass across the native transcriber, voice-input controller, and preferences.
- Mobile typecheck and formatting checks pass; targeted lint reports only existing warnings.
- iOS 26.5 simulator: language menu, French selection, persistence after relaunch, and resetting to System verified.
- Native iOS build passes. Speech recognition itself was not verified on a physical iPhone.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Implemented with GPT-6 via Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add selectable voice input language to mobile settings on iOS 26+
> - Adds a voice-input language row to General Settings on iOS 26 and later, backed by a new nullable `voiceInputLocale` field in mobile preferences (`System` stores null; specific locales store their identifier)
> - Passes the selected locale through `useVoiceInputController` and `getLocalVoiceTranscriber` so transcription uses it for availability checks and preparation; omitted or null locale falls back to the device default
> - Adds tests for explicit French locale on an English device and for the omitted-locale fallback path
> - Behavioral Change: `useVoiceInputController` now reports voice input as unavailable until preferences load successfully, and unsupported-locale error text refers to the requested language rather than the device language
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ec36f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Voice Input Language setting on iOS 26 and later.
  - Choose from 12 languages or **System** to follow the device locale.
  - Selected language preferences are saved and applied to voice transcription.
  - Voice input now checks availability for the selected language.

- **Documentation**
  - Updated iPhone voice input guidance with instructions for changing the transcription language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->