### PR TITLE
fix(server): prevent worktree pairing from falling back to the live install

### DIFF
--- a/apps/server/src/cli/pair.test.ts
+++ b/apps/server/src/cli/pair.test.ts
@@ -8,10 +8,12 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NetService from "@t3tools/shared/Net";
 import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
 import { assert, describe, expect, it } from "@effect/vitest";
+import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as TestConsole from "effect/testing/TestConsole";
 import { Command } from "effect/unstable/cli";
+import { vi } from "vite-plus/test";
 
 import { cli } from "../bin.ts";
 import {
@@ -144,6 +146,73 @@ const withDescriptorServer = <A, E, R>(run: (origin: string) => Effect.Effect<A,
   );
 
 describe("t3 pair", () => {
+  it.effect.each(["missing", "stale", "local", "explicit", "checkout"] as const)(
+    "isolates pairing discovery: %s",
+    (scenario) =>
+      withDescriptorServer((origin) =>
+        Effect.gen(function* () {
+          const root = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-pair-worktree-"));
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => NodeFS.rmSync(root, { recursive: true, force: true })),
+          );
+          const worktree = NodePath.join(root, "worktree");
+          const sharedHome = NodePath.join(root, "shared");
+          NodeFS.mkdirSync(worktree);
+          if (scenario === "checkout") {
+            NodeFS.mkdirSync(NodePath.join(worktree, ".git"));
+          } else {
+            NodeFS.writeFileSync(
+              NodePath.join(worktree, ".git"),
+              "gitdir: /elsewhere/.git/worktrees/pair-test\n",
+            );
+          }
+          const nested = NodePath.join(worktree, "src");
+          NodeFS.mkdirSync(nested);
+          const cwd = vi.spyOn(process, "cwd").mockReturnValue(nested);
+          yield* Effect.addFinalizer(() => Effect.sync(() => cwd.mockRestore()));
+          const state = yield* makePersistedServerRuntimeState({
+            config: { host: "127.0.0.1", devUrl: undefined },
+            port: Number(new URL(origin).port),
+          });
+          yield* persistServerRuntimeState({
+            path: NodePath.join(sharedHome, "userdata", "server-runtime.json"),
+            state,
+          });
+          if (scenario === "stale" || scenario === "local") {
+            yield* persistServerRuntimeState({
+              path: NodePath.join(worktree, ".t3", "userdata", "server-runtime.json"),
+              state: scenario === "stale" ? { ...state, pid: 4_194_305 } : state,
+            });
+          }
+
+          const outcome = yield* captureStdout(
+            runCli(scenario === "explicit" ? ["pair", "--base-dir", sharedHome] : ["pair"]),
+          ).pipe(
+            Effect.catch((error) => Effect.succeed(String(error))),
+            Effect.provide(
+              ConfigProvider.layer(ConfigProvider.fromEnv({ env: { T3CODE_HOME: sharedHome } })),
+            ),
+          );
+
+          assert.equal(
+            NodeFS.existsSync(NodePath.join(sharedHome, "userdata", "state.sqlite")),
+            scenario === "explicit" || scenario === "checkout",
+          );
+          if (scenario === "local" || scenario === "explicit" || scenario === "checkout") {
+            assert.include(outcome, `Pairing URL: ${origin}/pair#token=`);
+            return;
+          }
+          assert.include(outcome, "No running T3 Code server found.");
+          assert.include(
+            outcome,
+            NodePath.join(worktree, ".t3", "userdata", "server-runtime.json"),
+          );
+          assert.include(outcome, NodePath.join(worktree, ".t3", "dev", "server-runtime.json"));
+          assert.notInclude(outcome, sharedHome);
+        }),
+      ).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
   it.effect("mints a token and prints a QR pairing URL for a live server", () =>
     withDescriptorServer((origin) =>
       Effect.gen(function* () {

--- a/apps/server/src/cli/pair.ts
+++ b/apps/server/src/cli/pair.ts
@@ -5,7 +5,7 @@
  * Discovery reads the `server-runtime.json` a live server persists next to its
  * database, then confirms the process is actually answering by fetching its
  * public environment descriptor. Inside a linked git worktree the worktree's
- * own `.t3` is checked first (matching dev-runner precedence); otherwise the
+ * own `.t3` is checked exclusively (matching dev-runner precedence); otherwise the
  * shared T3 home. `--tailscale` publishes the server over Tailscale Serve
  * HTTPS and pairs through the tailnet URL instead.
  */
@@ -244,15 +244,15 @@ const discoverPairTarget = Effect.fn("pair.discoverPairTarget")(function* (
   if (explicitBaseDir !== undefined && explicitBaseDir.trim().length > 0) {
     bases.push(yield* resolveBaseDir(explicitBaseDir));
   } else {
-    // Same precedence as dev-runner: inside a linked worktree its own `.t3`
-    // outranks the shared home, so `t3 pair` in a worktree pairs with the dev
-    // server under test rather than the daily-driver install.
+    // Match dev-runner: a worktree must never fall back to the daily-driver
+    // install, even when its own server is stopped or has not been started.
     const worktreeHome = yield* resolveWorktreeT3Home(process.cwd());
     if (worktreeHome !== undefined) {
       bases.push(worktreeHome);
+    } else {
+      const envHome = yield* Config.string("T3CODE_HOME").pipe(Config.option);
+      bases.push(yield* resolveBaseDir(Option.getOrUndefined(envHome)));
     }
-    const envHome = yield* Config.string("T3CODE_HOME").pipe(Config.option);
-    bases.push(yield* resolveBaseDir(Option.getOrUndefined(envHome)));
   }
 
   const checkedStatePaths: Array<string> = [];


### PR DESCRIPTION
Running `t3 pair` from a linked worktree with no live local server silently selected the shared install and opened its database with the checkout's migrations. Discovery now checks only the worktree's `.t3`, matching dev-runner behavior. A missing or stale local server returns `NoRunningServerError`; an explicit `--base-dir` and discovery outside linked worktrees still work.

Reproduced before the fix through the actual CLI handler with disposable homes and a local HTTP descriptor server: both missing and stale worktree state created SQLite in the shared home. Both regressions now pass and assert that no shared database is created. All 15 pairing tests pass, including local pairing, explicit targeting, and ordinary-checkout discovery. Server typecheck, targeted lint, and formatting pass; typecheck reports existing suggestions in unrelated files. No live install was touched.

This implements the fail-closed discovery fix requested in the triage for #10516. Minting still uses `EnvironmentAuth.runtimeLayer`, so preventing checkout migrations when a database is explicitly targeted, including through `auth pairing create`, remains a follow-up. This does not repair already affected databases.

Model: GPT-6. Harness: Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix worktree pairing fallback to live T3CODE_HOME install
> Adds a parameterized discovery test in [pair.test.ts](https://github.com/pingdotgg/t3code/pull/10520/files#diff-745370d4ad2a235aefb01cc38bb4e54144f6987acd11aa7f8e720ecc4e2d9867) covering missing, stale, local, explicit-base, and regular-checkout worktree scenarios. The test creates temporary worktree and shared-home layouts, mocks the working directory, and verifies which state database and pairing output are used. Confirms that linked worktrees no longer fall back to the shared T3CODE_HOME installation, while local worktree state, explicit base directories, and regular checkouts still produce pairing URLs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c32b39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `t3 pair` discovery in linked Git worktrees.
  - Pairing now consistently uses the worktree’s local `.t3` directory and no longer falls back to the shared T3 home directory when operating there.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->