### PR TITLE
fix(server): derive imported Codex titles from user requests

### DIFF
--- a/apps/server/src/project/AgentSessionScanner.test.ts
+++ b/apps/server/src/project/AgentSessionScanner.test.ts
@@ -1470,7 +1470,7 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
           contents: [
             encodeTranscriptRecord({
               type: "session_meta",
-              payload: { id: "codex-recent", cwd: workspace },
+              payload: { id: "codex-recent", cwd: workspace, name: "Saved code review" },
             }),
             encodeTranscriptRecord({
               type: "event_msg",
@@ -1499,6 +1499,10 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
         expect(threads.map((thread) => thread.providerSessionId)).toEqual([
           "codex-recent",
           "claude-recent",
+        ]);
+        expect(threads.map((thread) => thread.title)).toEqual([
+          "Saved code review",
+          "Fix the project",
         ]);
         expect(threads.map((thread) => thread.messages.map((message) => message.text))).toEqual([
           ["Review this code", "Looks good"],
@@ -2958,7 +2962,7 @@ describe("parseAgentSessionTranscript", () => {
         }),
         encodeTranscriptRecord({
           type: "session_meta",
-          payload: { id: "parent-session" },
+          payload: { id: "parent-session", name: "Parent title" },
         }),
         encodeTranscriptRecord({
           type: "event_msg",
@@ -2972,6 +2976,7 @@ describe("parseAgentSessionTranscript", () => {
     });
 
     expect(thread?.providerSessionId).toBe("fork-session");
+    expect(thread?.title).toBe("Continue in the fork");
   });
 
   it("skips Codex transcripts without a resumable session ID", () => {
@@ -3064,6 +3069,52 @@ describe("parseAgentSessionTranscript", () => {
     ]);
   });
 
+  it.each([
+    [
+      "<recommended_plugins>\nAvailable plugins\n</recommended_plugins>Fix the import",
+      {},
+      "Fix the import",
+    ],
+    [
+      "<recommended_plugins>\nPlugins\n</recommended_plugins>\n<environment_context>\n<cwd>/tmp</cwd>\n</environment_context>\n## My request for Codex:\n\nFix the import",
+      {},
+      "Fix the import",
+    ],
+    [
+      "# AGENTS.md instructions for /tmp\n\n<INSTRUCTIONS>\nRules\n</INSTRUCTIONS>\n<user_instructions>Rules</user_instructions>\nFix the import",
+      {},
+      "Fix the import",
+    ],
+    ["<recommended_plugins>Plugins</recommended_plugins>", {}, "Imported thread"],
+    ["<recommended_plugins>Unclosed example", {}, "<recommended_plugins>Unclosed example"],
+    ["<example>Keep this XML</example>", {}, "<example>Keep this XML</example>"],
+    ["Fix the import\nMore detail", { name: " Saved title " }, "Saved title"],
+    ["Fix the import", { threadName: "Renamed thread" }, "Renamed thread"],
+    ["Fix the import", { name: " ", threadName: " " }, "Fix the import"],
+    ["Fix the import", { name: null, threadName: null }, "Fix the import"],
+    ["x".repeat(120), {}, "x".repeat(100)],
+  ])("derives a Codex title without changing prompt %s", (prompt, metadata, title) => {
+    const thread = AgentSessionScanner.parseAgentSessionTranscript({
+      contents: [
+        encodeTranscriptRecord({
+          type: "session_meta",
+          payload: { id: "codex-session", ...metadata },
+        }),
+        encodeTranscriptRecord({
+          type: "event_msg",
+          payload: { type: "user_message", message: prompt },
+        }),
+      ].join("\n"),
+      source: "codex",
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      fallbackSessionId: "fallback",
+      lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
+    });
+
+    expect(thread?.title).toBe(title);
+    expect(thread?.messages.map((message) => message.text)).toEqual([prompt]);
+  });
+
   it("preserves context markup in response-only Codex messages", () => {
     const context = "<environment_context>\n<cwd>/tmp/project</cwd>\n</environment_context>";
     const thread = AgentSessionScanner.parseAgentSessionTranscript({
@@ -3097,7 +3148,7 @@ describe("parseAgentSessionTranscript", () => {
       lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
     });
 
-    expect(thread?.title).toBe("<environment_context>");
+    expect(thread?.title).toBe("Initialize Git and add a README.");
     expect(thread?.messages.map((message) => message.text)).toEqual([
       context,
       "Initialize Git and add a README.",
@@ -3124,7 +3175,7 @@ describe("parseAgentSessionTranscript", () => {
       lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
     });
 
-    expect(thread?.title).toBe("<environment_context>");
+    expect(thread?.title).toBe("Create a useful project.");
     expect(thread?.messages.map((message) => message.text)).toEqual([prompt]);
   });
 
@@ -3147,7 +3198,7 @@ describe("parseAgentSessionTranscript", () => {
       lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
     });
 
-    expect(thread?.title).toBe("## My request for Codex:");
+    expect(thread?.title).toBe("Fix the visible bug");
     expect(thread?.messages.map((message) => message.text)).toEqual([prompt]);
   });
 

--- a/apps/server/src/project/AgentSessionScanner.ts
+++ b/apps/server/src/project/AgentSessionScanner.ts
@@ -123,6 +123,8 @@ const TranscriptRecord = Schema.Struct({
     Schema.Struct({
       id: Schema.optional(Schema.String),
       session_id: Schema.optional(Schema.String),
+      name: Schema.optional(Schema.NullOr(Schema.String)),
+      threadName: Schema.optional(Schema.NullOr(Schema.String)),
       type: Schema.optional(Schema.String),
       role: Schema.optional(Schema.String),
       message: Schema.optional(Schema.String),
@@ -303,6 +305,7 @@ function parseAgentSessionRecords(
   // timestamp text, so only transcript metadata can provide a resumable ID.
   let providerSessionId = input.source === "codex" ? "" : input.fallbackSessionId;
   let title: string | null = null;
+  let derivedTitle: string | undefined;
   let model: string | null = null;
   let hasCodexSessionId = false;
   const messages: Array<AgentSessionThreadMessage & { readonly codexResponseUser: boolean }> = [];
@@ -371,6 +374,19 @@ function parseAgentSessionRecords(
     if (firstUserMessage === undefined && message.role === "user") {
       firstUserMessage = message;
     }
+    if (derivedTitle === undefined && message.role === "user") {
+      // Strip only known leading Codex preambles, and only for the title.
+      const prompt =
+        input.source === "codex"
+          ? message.text
+              .trim()
+              .replace(
+                /^(?:(?:# AGENTS\.md instructions for [^\n]*\n\s*)?<(recommended_plugins|environment_context|user_instructions|INSTRUCTIONS)>[\s\S]*?<\/\1>\s*|## My request for Codex:\s*)+/,
+                "",
+              )
+          : message.text.trim();
+      derivedTitle = prompt.split("\n")[0]?.slice(0, 100).trim() || undefined;
+    }
     messages.push(message);
     if (messages.length > MAX_IMPORTED_MESSAGES) messages.shift();
   };
@@ -428,6 +444,7 @@ function parseAgentSessionRecords(
       if (!hasCodexSessionId && sessionId) {
         providerSessionId = sessionId;
         hasCodexSessionId = true;
+        title = record.payload?.name?.trim() || record.payload?.threadName?.trim() || null;
       }
       continue;
     }
@@ -491,13 +508,12 @@ function parseAgentSessionRecords(
   const retainedMessages = firstUserMessageRetained
     ? visibleMessages
     : [visibleFirstUserMessage, ...visibleMessages.slice(-(MAX_IMPORTED_MESSAGES - 1))];
-  const derivedTitle = visibleFirstUserMessage.text.trim().split("\n")[0]?.slice(0, 100).trim();
 
   return {
     source: input.source,
     providerInstanceId: input.providerInstanceId,
     providerSessionId,
-    title: title ?? (derivedTitle && derivedTitle.length > 0 ? derivedTitle : "Imported thread"),
+    title: title ?? derivedTitle ?? "Imported thread",
     model,
     createdAt: retainedMessages[0]?.createdAt ?? fallbackTimestamp,
     updatedAt: fallbackTimestamp,


### PR DESCRIPTION
Importing a Codex session could name the thread `<recommended_plugins>` or `<environment_context>` instead of the user's request.

Prefer `name` or `threadName` when present in the session metadata. Otherwise, skip known leading Codex context blocks and the request heading when deriving the title. Context-only messages are skipped for title selection; imported history stays unchanged. The fix lives in the shared scanner used by onboarding imports.

Reproduced before the fix with nine failing regression cases. Scanner/importer tests, server typecheck, targeted lint, and formatting pass. Coverage includes preserved message text, response-only transcripts, empty context, nullable titles, fork metadata, and streamed transcript reads. This is a server parsing change; no browser verification was performed. Existing imported threads are not renamed.

Closes #10513.

Model: GPT-6. Harness: Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `parseAgentSessionRecords` to derive imported Codex titles from user requests
> - Imported Codex transcripts now prefer a saved session name from metadata, otherwise derive a title from cleaned first-user prompt text (first line, up to 100 chars), and fall back to a generic title.
> - Title derivation strips recognized leading instruction, context, plugin, and request-heading preambles before extracting the first line; the original user prompt in the stored message list is never modified.
> - Extended `TranscriptRecord` schema with nullable optional fields for a saved session name and an alternate thread name in [AgentSessionScanner.ts](https://github.com/pingdotgg/t3code/pull/10521/files#diff-851d20dfd11e67ec3ea443c93e0dac4997fb79b8d09c75fbd4aaffb9e7459064).
> - Added parameterized and integration tests covering preamble removal, markup handling, metadata fallback, truncation, fork metadata, and response-only transcripts.
> - Behavioral Change: existing Codex imports that relied on context markers or request headings as titles now use the cleaned first-line request text instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5253a17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Imported Codex threads now use saved session names when available.
  - Thread titles are derived more accurately from the user’s request when no saved name exists.
  - Removed common prompt instructions, markup, and headings from automatically generated titles.
  - Added handling for additional session metadata title fields.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->