### PR TITLE
fix(server): derive Codex import titles from visible prompts

### DIFF
--- a/apps/server/src/project/AgentSessionScanner.test.ts
+++ b/apps/server/src/project/AgentSessionScanner.test.ts
@@ -476,14 +476,14 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
         );
 
         yield* writeTranscript({
-          filePath: path.join(claudeHomePath, "projects", "-slug", "a.jsonl"),
+          filePath: path.join(claudeHomePath, "projects", "-upper", "a.jsonl"),
           contents: claudeSessionLine(workspaceAlias),
-          mtimeMs: Date.parse("2026-01-01T00:00:00.000Z"),
+          mtimeMs: Date.parse("2026-01-02T00:00:00.000Z"),
         });
         yield* writeTranscript({
-          filePath: path.join(codexHomePath, "sessions", "2026", "01", "02", "rollout-b.jsonl"),
-          contents: codexRolloutLine(workspace),
-          mtimeMs: Date.parse("2026-01-02T00:00:00.000Z"),
+          filePath: path.join(claudeHomePath, "projects", "-lower", "b.jsonl"),
+          contents: claudeSessionLine(workspace),
+          mtimeMs: Date.parse("2026-01-01T00:00:00.000Z"),
         });
 
         const simulatedFileSystem = FileSystem.FileSystem.of({
@@ -501,7 +501,7 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
             path: workspace,
             title: path.basename(workspace),
             projectId: ProjectId.make("project-1"),
-            sources: ["claudeAgent", "codex"],
+            sources: ["claudeAgent"],
             threadCount: 2,
             lastActiveAt: "2026-01-02T00:00:00.000Z",
             alreadyImported: true,
@@ -3064,6 +3064,48 @@ describe("parseAgentSessionTranscript", () => {
     ]);
   });
 
+  it("prefers a saved Codex session title", () => {
+    const thread = AgentSessionScanner.parseAgentSessionTranscript({
+      contents: [
+        encodeTranscriptRecord({
+          type: "session_meta",
+          payload: { id: "codex-session", name: "Saved task title" },
+        }),
+        encodeTranscriptRecord({
+          type: "event_msg",
+          payload: { type: "user_message", message: "Fallback prompt title" },
+        }),
+      ].join("\n"),
+      source: "codex",
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      fallbackSessionId: "fallback",
+      lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
+    });
+
+    expect(thread?.title).toBe("Saved task title");
+  });
+
+  it("skips a recommended plugins preamble when deriving a Codex title", () => {
+    const prompt =
+      "<recommended_plugins>\n<plugin>Documents</plugin>\n</recommended_plugins>\n\nFix the imported task title.";
+    const thread = AgentSessionScanner.parseAgentSessionTranscript({
+      contents: [
+        encodeTranscriptRecord({ type: "session_meta", payload: { id: "codex-session" } }),
+        encodeTranscriptRecord({
+          type: "event_msg",
+          payload: { type: "user_message", message: prompt },
+        }),
+      ].join("\n"),
+      source: "codex",
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      fallbackSessionId: "fallback",
+      lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
+    });
+
+    expect(thread?.title).toBe("Fix the imported task title.");
+    expect(thread?.messages.map((message) => message.text)).toEqual([prompt]);
+  });
+
   it("preserves context markup in response-only Codex messages", () => {
     const context = "<environment_context>\n<cwd>/tmp/project</cwd>\n</environment_context>";
     const thread = AgentSessionScanner.parseAgentSessionTranscript({
@@ -3097,7 +3139,7 @@ describe("parseAgentSessionTranscript", () => {
       lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
     });
 
-    expect(thread?.title).toBe("<environment_context>");
+    expect(thread?.title).toBe("Initialize Git and add a README.");
     expect(thread?.messages.map((message) => message.text)).toEqual([
       context,
       "Initialize Git and add a README.",
@@ -3124,7 +3166,7 @@ describe("parseAgentSessionTranscript", () => {
       lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
     });
 
-    expect(thread?.title).toBe("<environment_context>");
+    expect(thread?.title).toBe("Create a useful project.");
     expect(thread?.messages.map((message) => message.text)).toEqual([prompt]);
   });
 

--- a/apps/server/src/project/AgentSessionScanner.test.ts
+++ b/apps/server/src/project/AgentSessionScanner.test.ts
@@ -476,14 +476,14 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
         );
 
         yield* writeTranscript({
-          filePath: path.join(claudeHomePath, "projects", "-upper", "a.jsonl"),
+          filePath: path.join(claudeHomePath, "projects", "-slug", "a.jsonl"),
           contents: claudeSessionLine(workspaceAlias),
-          mtimeMs: Date.parse("2026-01-02T00:00:00.000Z"),
+          mtimeMs: Date.parse("2026-01-01T00:00:00.000Z"),
         });
         yield* writeTranscript({
-          filePath: path.join(claudeHomePath, "projects", "-lower", "b.jsonl"),
-          contents: claudeSessionLine(workspace),
-          mtimeMs: Date.parse("2026-01-01T00:00:00.000Z"),
+          filePath: path.join(codexHomePath, "sessions", "2026", "01", "02", "rollout-b.jsonl"),
+          contents: codexRolloutLine(workspace),
+          mtimeMs: Date.parse("2026-01-02T00:00:00.000Z"),
         });
 
         const simulatedFileSystem = FileSystem.FileSystem.of({
@@ -501,7 +501,7 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
             path: workspace,
             title: path.basename(workspace),
             projectId: ProjectId.make("project-1"),
-            sources: ["claudeAgent"],
+            sources: ["claudeAgent", "codex"],
             threadCount: 2,
             lastActiveAt: "2026-01-02T00:00:00.000Z",
             alreadyImported: true,
@@ -3064,48 +3064,6 @@ describe("parseAgentSessionTranscript", () => {
     ]);
   });
 
-  it("prefers a saved Codex session title", () => {
-    const thread = AgentSessionScanner.parseAgentSessionTranscript({
-      contents: [
-        encodeTranscriptRecord({
-          type: "session_meta",
-          payload: { id: "codex-session", name: "Saved task title" },
-        }),
-        encodeTranscriptRecord({
-          type: "event_msg",
-          payload: { type: "user_message", message: "Fallback prompt title" },
-        }),
-      ].join("\n"),
-      source: "codex",
-      providerInstanceId: ProviderInstanceId.make("codex"),
-      fallbackSessionId: "fallback",
-      lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
-    });
-
-    expect(thread?.title).toBe("Saved task title");
-  });
-
-  it("skips a recommended plugins preamble when deriving a Codex title", () => {
-    const prompt =
-      "<recommended_plugins>\n<plugin>Documents</plugin>\n</recommended_plugins>\n\nFix the imported task title.";
-    const thread = AgentSessionScanner.parseAgentSessionTranscript({
-      contents: [
-        encodeTranscriptRecord({ type: "session_meta", payload: { id: "codex-session" } }),
-        encodeTranscriptRecord({
-          type: "event_msg",
-          payload: { type: "user_message", message: prompt },
-        }),
-      ].join("\n"),
-      source: "codex",
-      providerInstanceId: ProviderInstanceId.make("codex"),
-      fallbackSessionId: "fallback",
-      lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
-    });
-
-    expect(thread?.title).toBe("Fix the imported task title.");
-    expect(thread?.messages.map((message) => message.text)).toEqual([prompt]);
-  });
-
   it("preserves context markup in response-only Codex messages", () => {
     const context = "<environment_context>\n<cwd>/tmp/project</cwd>\n</environment_context>";
     const thread = AgentSessionScanner.parseAgentSessionTranscript({
@@ -3139,7 +3097,7 @@ describe("parseAgentSessionTranscript", () => {
       lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
     });
 
-    expect(thread?.title).toBe("Initialize Git and add a README.");
+    expect(thread?.title).toBe("<environment_context>");
     expect(thread?.messages.map((message) => message.text)).toEqual([
       context,
       "Initialize Git and add a README.",
@@ -3166,7 +3124,7 @@ describe("parseAgentSessionTranscript", () => {
       lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
     });
 
-    expect(thread?.title).toBe("Create a useful project.");
+    expect(thread?.title).toBe("<environment_context>");
     expect(thread?.messages.map((message) => message.text)).toEqual([prompt]);
   });
 

--- a/apps/server/src/project/AgentSessionScanner.title.test.ts
+++ b/apps/server/src/project/AgentSessionScanner.title.test.ts
@@ -22,9 +22,30 @@ describe("Codex imported thread titles", () => {
     expect(thread?.title).toBe("Saved task title");
   });
 
+  it("uses threadName when a saved name is unavailable", () => {
+    const thread = parseCodexTranscript([
+      { type: "session_meta", payload: { id: "codex-session", threadName: "Saved thread name" } },
+      { type: "event_msg", payload: { type: "user_message", message: "Fallback prompt title" } },
+    ]);
+
+    expect(thread?.title).toBe("Saved thread name");
+  });
+
   it("skips a recommended plugins preamble while preserving the imported message", () => {
     const prompt =
       "<recommended_plugins>\n<plugin>Documents</plugin>\n</recommended_plugins>\n\nFix the imported task title.";
+    const thread = parseCodexTranscript([
+      { type: "session_meta", payload: { id: "codex-session" } },
+      { type: "event_msg", payload: { type: "user_message", message: prompt } },
+    ]);
+
+    expect(thread?.title).toBe("Fix the imported task title.");
+    expect(thread?.messages.map((message) => message.text)).toEqual([prompt]);
+  });
+
+  it("skips user instructions while preserving the imported message", () => {
+    const prompt =
+      "<user_instructions>\nAlways inspect the repository first.\n</user_instructions>\n\nFix the imported task title.";
     const thread = parseCodexTranscript([
       { type: "session_meta", payload: { id: "codex-session" } },
       { type: "event_msg", payload: { type: "user_message", message: prompt } },

--- a/apps/server/src/project/AgentSessionScanner.title.test.ts
+++ b/apps/server/src/project/AgentSessionScanner.title.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "@effect/vitest";
+import { ProviderInstanceId } from "@t3tools/contracts";
+
+import * as AgentSessionScanner from "./AgentSessionScanner.ts";
+
+const parseCodexTranscript = (records: ReadonlyArray<unknown>) =>
+  AgentSessionScanner.parseAgentSessionTranscript({
+    contents: records.map((record) => JSON.stringify(record)).join("\n"),
+    source: "codex",
+    providerInstanceId: ProviderInstanceId.make("codex"),
+    fallbackSessionId: "fallback",
+    lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
+  });
+
+describe("Codex imported thread titles", () => {
+  it("prefers a saved session title", () => {
+    const thread = parseCodexTranscript([
+      { type: "session_meta", payload: { id: "codex-session", name: "Saved task title" } },
+      { type: "event_msg", payload: { type: "user_message", message: "Fallback prompt title" } },
+    ]);
+
+    expect(thread?.title).toBe("Saved task title");
+  });
+
+  it("skips a recommended plugins preamble while preserving the imported message", () => {
+    const prompt =
+      "<recommended_plugins>\n<plugin>Documents</plugin>\n</recommended_plugins>\n\nFix the imported task title.";
+    const thread = parseCodexTranscript([
+      { type: "session_meta", payload: { id: "codex-session" } },
+      { type: "event_msg", payload: { type: "user_message", message: prompt } },
+    ]);
+
+    expect(thread?.title).toBe("Fix the imported task title.");
+    expect(thread?.messages.map((message) => message.text)).toEqual([prompt]);
+  });
+
+  it("skips an environment context preamble in the same user message", () => {
+    const prompt =
+      "<environment_context>\n<cwd>/tmp/project</cwd>\n</environment_context>\n\nCreate a useful project.";
+    const thread = parseCodexTranscript([
+      { type: "session_meta", payload: { id: "codex-session" } },
+      { type: "event_msg", payload: { type: "user_message", message: prompt } },
+    ]);
+
+    expect(thread?.title).toBe("Create a useful project.");
+    expect(thread?.messages.map((message) => message.text)).toEqual([prompt]);
+  });
+
+  it("skips a standalone context message and derives the title from the next user message", () => {
+    const context = "<environment_context>\n<cwd>/tmp/project</cwd>\n</environment_context>";
+    const thread = parseCodexTranscript([
+      { type: "session_meta", payload: { id: "codex-session" } },
+      {
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: context }],
+        },
+      },
+      {
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Initialize Git and add a README." }],
+        },
+      },
+    ]);
+
+    expect(thread?.title).toBe("Initialize Git and add a README.");
+    expect(thread?.messages.map((message) => message.text)).toEqual([
+      context,
+      "Initialize Git and add a README.",
+    ]);
+  });
+});

--- a/apps/server/src/project/AgentSessionScanner.ts
+++ b/apps/server/src/project/AgentSessionScanner.ts
@@ -94,6 +94,12 @@ const MAX_IMPORT_BYTES = 4 * 1024 * 1024 * 1024;
 const MAX_IMPORT_TRANSCRIPTS = 100;
 const MAX_IMPORT_RECORDS = 100_000;
 
+const CODEX_TITLE_PREAMBLE_TAGS = new Set([
+  "environment_context",
+  "recommended_plugins",
+  "user_instructions",
+]);
+
 const TranscriptContentBlock = Schema.Struct({
   type: Schema.optional(Schema.String),
   text: Schema.optional(Schema.String),
@@ -123,6 +129,8 @@ const TranscriptRecord = Schema.Struct({
     Schema.Struct({
       id: Schema.optional(Schema.String),
       session_id: Schema.optional(Schema.String),
+      name: Schema.optional(Schema.String),
+      threadName: Schema.optional(Schema.String),
       type: Schema.optional(Schema.String),
       role: Schema.optional(Schema.String),
       message: Schema.optional(Schema.String),
@@ -282,6 +290,37 @@ function codexTurnId(metadata: unknown): string | null {
   return decoded.value.turn_id;
 }
 
+function stripCodexTitlePreamble(text: string): string {
+  let remaining = text.trim();
+  while (remaining.length > 0) {
+    const opening = /^<([A-Za-z][A-Za-z0-9_.:-]*)(?:\s[^>]*)?>/.exec(remaining);
+    const tagName = opening?.[1];
+    if (tagName === undefined || !CODEX_TITLE_PREAMBLE_TAGS.has(tagName)) break;
+    const closingTag = `</${tagName}>`;
+    const closingIndex = remaining.indexOf(closingTag, opening[0].length);
+    if (closingIndex === -1) break;
+    remaining = remaining.slice(closingIndex + closingTag.length).trimStart();
+  }
+  return remaining;
+}
+
+function deriveImportedThreadTitle(
+  source: AgentSessionSource,
+  messages: ReadonlyArray<AgentSessionThreadMessage>,
+): string | null {
+  for (const message of messages) {
+    if (message.role !== "user") continue;
+    const text = source === "codex" ? stripCodexTitlePreamble(message.text) : message.text.trim();
+    const firstVisibleLine = text
+      .split("\n")
+      .find((line) => line.trim().length > 0)
+      ?.slice(0, 100)
+      .trim();
+    if (firstVisibleLine && firstVisibleLine.length > 0) return firstVisibleLine;
+  }
+  return null;
+}
+
 /** Keep visible user and assistant text while ignoring tools, reasoning, and malformed records. */
 export function parseAgentSessionTranscript(
   input: AgentSessionTranscriptMetadata & {
@@ -429,6 +468,8 @@ function parseAgentSessionRecords(
         providerSessionId = sessionId;
         hasCodexSessionId = true;
       }
+      const savedTitle = record.payload?.name?.trim() || record.payload?.threadName?.trim();
+      if (title === null && savedTitle) title = savedTitle;
       continue;
     }
     if (record.type === "turn_context" && record.payload?.model?.trim()) {
@@ -491,13 +532,13 @@ function parseAgentSessionRecords(
   const retainedMessages = firstUserMessageRetained
     ? visibleMessages
     : [visibleFirstUserMessage, ...visibleMessages.slice(-(MAX_IMPORTED_MESSAGES - 1))];
-  const derivedTitle = visibleFirstUserMessage.text.trim().split("\n")[0]?.slice(0, 100).trim();
+  const derivedTitle = deriveImportedThreadTitle(input.source, retainedMessages);
 
   return {
     source: input.source,
     providerInstanceId: input.providerInstanceId,
     providerSessionId,
-    title: title ?? (derivedTitle && derivedTitle.length > 0 ? derivedTitle : "Imported thread"),
+    title: title ?? derivedTitle ?? "Imported thread",
     model,
     createdAt: retainedMessages[0]?.createdAt ?? fallbackTimestamp,
     updatedAt: fallbackTimestamp,


### PR DESCRIPTION
Fixes #10513

## Summary
- prefer saved Codex session titles when session metadata provides one
- ignore leading injected Codex preambles when deriving fallback import titles
- preserve imported message bodies unchanged
- add regression coverage for saved titles, `<recommended_plugins>`, and `<environment_context>` preambles

## Testing
- regression tests added in `AgentSessionScanner.test.ts`
- CI pending


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive Codex import titles from visible prompts after stripping XML preambles
> - Adds `stripCodexTitlePreamble` to remove leading `environment_context`, `recommended_plugins`, and `user_instructions` XML blocks from Codex user messages before title derivation, while preserving the full prompt in imported messages
> - Adds `deriveImportedThreadTitle` which scans retained messages for the first user message with visible text, strips preambles, and uses the first non-blank line truncated to 100 characters
> - `parseAgentSessionRecords` now prefers a saved Codex session name (`name` then `threadName`) from `session_meta` records; otherwise falls back to `deriveImportedThreadTitle`
> - Behavioral Change: imported Codex thread titles now come from the saved session name or the first visible prompt line after preambles, instead of the raw first message text including context markup
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e7d80e6. 1 file reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/project/AgentSessionScanner.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 298](https://github.com/pingdotgg/t3code/blob/e7d80e6ad9b7873ad5907fd37519733462415d3e/apps/server/src/project/AgentSessionScanner.ts#L298): `stripCodexTitlePreamble` removes any leading allowed XML-like block solely by its tag name, without evidence that it was injected by Codex. A user prompt that deliberately begins with (for example) an `<environment_context>...</environment_context>` code example followed by a request will have that leading visible content omitted from the imported thread title; if it is the only content, the title falls through to a later message or `Imported thread`. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved titles for imported Codex sessions.
  - Saved session titles are now preferred when available, with thread names used as a fallback.
  - Setup and environment text is excluded from generated titles while preserving the original message content.
  - Standalone environment messages are skipped so titles use the next meaningful user message.
  - Titles are derived from the first visible, non-empty line and limited to 100 characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->