### PR TITLE
fix(desktop): show startup failures instead of a blank window

### DIFF
--- a/apps/desktop/src/app/DesktopLifecycle.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.test.ts
@@ -91,6 +91,7 @@ function makeDesktopWindowLayer(
     showConnectingSplash: Effect.void,
     handleBackendReady: () => Effect.void,
     handleBackendNotReady: Effect.void,
+    handleBackendFailed: () => Effect.void,
     flushMainWindowBounds: input.flushMainWindowBounds ?? Effect.void,
     dispatchMenuAction: () => Effect.void,
     zoomMain: () => Effect.void,

--- a/apps/desktop/src/backend/DesktopBackendManager.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.test.ts
@@ -121,6 +121,7 @@ interface MakeInstanceInput {
   readonly backendOutputLog?: Partial<DesktopObservability.DesktopBackendOutputLogShape>;
   readonly onReady?: Effect.Effect<void>;
   readonly onShutdown?: Effect.Effect<void>;
+  readonly onFailed?: (reason: string) => Effect.Effect<void>;
   readonly onPreflightFailed?: (
     failure: DesktopBackendManager.PreflightFailure,
   ) => Effect.Effect<boolean>;
@@ -184,6 +185,7 @@ function makeTestInstance(input: MakeInstanceInput) {
     configResolve: input.configResolve ?? Effect.succeed(input.config ?? baseConfig),
     ...(input.onReady ? { onReady: () => input.onReady! } : {}),
     ...(input.onShutdown ? { onShutdown: () => input.onShutdown! } : {}),
+    ...(input.onFailed ? { onFailed: input.onFailed } : {}),
     ...(input.onPreflightFailed ? { onPreflightFailed: input.onPreflightFailed } : {}),
   });
 
@@ -191,6 +193,98 @@ function makeTestInstance(input: MakeInstanceInput) {
 }
 
 describe("DesktopBackendManager", () => {
+  for (const becomesReady of [false, true]) {
+    it.effect(`stops a primary crash loop (reaches readiness: ${becomesReady})`, () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const persisted = yield* Queue.unbounded<string>();
+          const ready = yield* Queue.unbounded<void>();
+          const failures: string[] = [];
+          let starts = 0;
+          const instance = yield* makeTestInstance({
+            spawnerLayer: Layer.succeed(
+              ChildProcessSpawner.ChildProcessSpawner,
+              ChildProcessSpawner.make(() =>
+                Effect.sync(() => {
+                  starts += 1;
+                  return makeProcess({
+                    exitCode: (becomesReady ? Queue.take(ready) : Effect.void).pipe(
+                      Effect.as(ChildProcessSpawner.ExitCode(1)),
+                    ),
+                  });
+                }),
+              ),
+            ),
+            httpClientLayer: becomesReady
+              ? healthyHttpClientLayer
+              : httpClientLayer(() => Effect.never),
+            onReady: Queue.offer(ready, undefined).pipe(Effect.asVoid),
+            backendOutputLog: {
+              persistFailure: ({ details }) => Queue.offer(persisted, details).pipe(Effect.asVoid),
+            },
+            onFailed: (reason) =>
+              Effect.sync(() => {
+                failures.push(reason);
+              }),
+          });
+          yield* instance.start;
+          yield* Queue.take(persisted);
+          for (const delay of [500, 1_000, 2_000, 4_000]) {
+            yield* TestClock.adjust(delay);
+            yield* Queue.take(persisted);
+          }
+          yield* TestClock.adjust(10_000);
+          assert.deepEqual(failures, ["code=1"]);
+          assert.equal(starts, 5);
+          assert.equal((yield* instance.snapshot).desiredRunning, false);
+          assert.equal((yield* instance.snapshot).restartScheduled, false);
+        }).pipe(Effect.provide(TestClock.layer())),
+      ),
+    );
+  }
+
+  it.effect("resets the primary crash allowance after a minute of readiness", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const ready = yield* Queue.unbounded<void>();
+        const exits = yield* Queue.unbounded<void>();
+        const persisted = yield* Queue.unbounded<void>();
+        const failures: string[] = [];
+        const instance = yield* makeTestInstance({
+          spawnerLayer: Layer.succeed(
+            ChildProcessSpawner.ChildProcessSpawner,
+            ChildProcessSpawner.make(() =>
+              Effect.succeed(
+                makeProcess({
+                  exitCode: Queue.take(exits).pipe(Effect.as(ChildProcessSpawner.ExitCode(1))),
+                }),
+              ),
+            ),
+          ),
+          onReady: Queue.offer(ready, undefined).pipe(Effect.asVoid),
+          onFailed: (reason) =>
+            Effect.sync(() => {
+              failures.push(reason);
+            }),
+          backendOutputLog: {
+            persistFailure: () => Queue.offer(persisted, undefined).pipe(Effect.asVoid),
+          },
+        });
+        yield* instance.start;
+        for (const [index, delay] of [500, 1_000, 500, 1_000, 2_000].entries()) {
+          yield* Queue.take(ready);
+          if (index === 2) yield* TestClock.adjust(60_000);
+          yield* Queue.offer(exits, undefined);
+          yield* Queue.take(persisted);
+          yield* TestClock.adjust(delay);
+        }
+        yield* Queue.take(ready);
+        assert.deepEqual(failures, []);
+        assert.equal((yield* instance.snapshot).ready, true);
+      }).pipe(Effect.provide(TestClock.layer())),
+    ),
+  );
+
   it.effect("spawns the backend with fd3 bootstrap and fd4 telemetry", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/apps/desktop/src/backend/DesktopBackendManager.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.test.ts
@@ -193,53 +193,73 @@ function makeTestInstance(input: MakeInstanceInput) {
 }
 
 describe("DesktopBackendManager", () => {
-  for (const becomesReady of [false, true]) {
-    it.effect(`stops a primary crash loop (reaches readiness: ${becomesReady})`, () =>
-      Effect.scoped(
-        Effect.gen(function* () {
-          const persisted = yield* Queue.unbounded<string>();
-          const ready = yield* Queue.unbounded<void>();
-          const failures: string[] = [];
-          let starts = 0;
-          const instance = yield* makeTestInstance({
-            spawnerLayer: Layer.succeed(
-              ChildProcessSpawner.ChildProcessSpawner,
-              ChildProcessSpawner.make(() =>
-                Effect.sync(() => {
-                  starts += 1;
-                  return makeProcess({
-                    exitCode: (becomesReady ? Queue.take(ready) : Effect.void).pipe(
-                      Effect.as(ChildProcessSpawner.ExitCode(1)),
-                    ),
-                  });
-                }),
+  for (const [becomesReady, preflightRetries] of [
+    [false, 0],
+    [true, 0],
+    [false, 4],
+    [true, 4],
+  ] as const) {
+    it.effect(
+      `stops after five crashes (ready: ${becomesReady}, preflight retries: ${preflightRetries})`,
+      () =>
+        Effect.scoped(
+          Effect.gen(function* () {
+            const persisted = yield* Queue.unbounded<string>();
+            const ready = yield* Queue.unbounded<void>();
+            const failures: string[] = [];
+            let starts = 0;
+            let resolves = 0;
+            const instance = yield* makeTestInstance({
+              configResolve: Effect.sync(() =>
+                resolves++ < preflightRetries
+                  ? {
+                      ...baseConfig,
+                      preflightFailure: Option.some({ reason: "WSL is starting", fatal: false }),
+                    }
+                  : baseConfig,
               ),
-            ),
-            httpClientLayer: becomesReady
-              ? healthyHttpClientLayer
-              : httpClientLayer(() => Effect.never),
-            onReady: Queue.offer(ready, undefined).pipe(Effect.asVoid),
-            backendOutputLog: {
-              persistFailure: ({ details }) => Queue.offer(persisted, details).pipe(Effect.asVoid),
-            },
-            onFailed: (reason) =>
-              Effect.sync(() => {
-                failures.push(reason);
-              }),
-          });
-          yield* instance.start;
-          yield* Queue.take(persisted);
-          for (const delay of [500, 1_000, 2_000, 4_000]) {
-            yield* TestClock.adjust(delay);
+              spawnerLayer: Layer.succeed(
+                ChildProcessSpawner.ChildProcessSpawner,
+                ChildProcessSpawner.make(() =>
+                  Effect.sync(() => {
+                    starts += 1;
+                    return makeProcess({
+                      exitCode: (becomesReady ? Queue.take(ready) : Effect.void).pipe(
+                        Effect.as(ChildProcessSpawner.ExitCode(1)),
+                      ),
+                    });
+                  }),
+                ),
+              ),
+              httpClientLayer: becomesReady
+                ? healthyHttpClientLayer
+                : httpClientLayer(() => Effect.never),
+              onReady: Queue.offer(ready, undefined).pipe(Effect.asVoid),
+              backendOutputLog: {
+                persistFailure: ({ details }) =>
+                  Queue.offer(persisted, details).pipe(Effect.asVoid),
+              },
+              onFailed: (reason) =>
+                Effect.sync(() => {
+                  failures.push(reason);
+                }),
+            });
+            yield* instance.start;
+            if (preflightRetries > 0) yield* TestClock.adjust(7_500);
             yield* Queue.take(persisted);
-          }
-          yield* TestClock.adjust(10_000);
-          assert.deepEqual(failures, ["code=1"]);
-          assert.equal(starts, 5);
-          assert.equal((yield* instance.snapshot).desiredRunning, false);
-          assert.equal((yield* instance.snapshot).restartScheduled, false);
-        }).pipe(Effect.provide(TestClock.layer())),
-      ),
+            yield* TestClock.adjust(0);
+            assert.deepEqual(failures, []);
+            for (const delay of [500, 1_000, 2_000, 4_000]) {
+              yield* TestClock.adjust(preflightRetries > 0 ? 10_000 : delay);
+              yield* Queue.take(persisted);
+            }
+            yield* TestClock.adjust(10_000);
+            assert.deepEqual(failures, ["code=1"]);
+            assert.equal(starts, 5);
+            assert.equal((yield* instance.snapshot).desiredRunning, false);
+            assert.equal((yield* instance.snapshot).restartScheduled, false);
+          }).pipe(Effect.provide(TestClock.layer())),
+        ),
     );
   }
 

--- a/apps/desktop/src/backend/DesktopBackendManager.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.ts
@@ -321,6 +321,7 @@ interface BackendManagerState {
   readonly config: Option.Option<DesktopBackendStartConfig>;
   readonly active: Option.Option<ActiveBackendRun>;
   readonly restartAttempt: number;
+  readonly crashAttempt: number;
   // Consecutive bounded/fatal preflight failures, reset on a clean or
   // unbounded-transient preflight. restartAttempt counts all restarts.
   readonly preflightFailureAttempt: number;
@@ -334,6 +335,7 @@ const initialState: BackendManagerState = {
   config: Option.none(),
   active: Option.none(),
   restartAttempt: 0,
+  crashAttempt: 0,
   preflightFailureAttempt: 0,
   restartFiber: Option.none(),
   nextRunId: 1,
@@ -741,6 +743,7 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
           config: Option.some(config.value),
           preflightFailureAttempt: resetFatalPreflightCounter ? 0 : latest.preflightFailureAttempt,
           restartAttempt: current.desiredRunning ? latest.restartAttempt : 0,
+          crashAttempt: current.desiredRunning ? latest.crashAttempt : 0,
         }));
 
         const preflightFailure = config.value.preflightFailure;
@@ -876,6 +879,10 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
                         readyAt !== undefined && now - readyAt >= STABLE_BACKEND_UPTIME_MS
                           ? 0
                           : latest.restartAttempt,
+                      crashAttempt:
+                        readyAt !== undefined && now - readyAt >= STABLE_BACKEND_UPTIME_MS
+                          ? 0
+                          : latest.crashAttempt,
                       active: Option.none<ActiveBackendRun>(),
                       ready: false,
                     };
@@ -1007,7 +1014,7 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
       terminalFailure &&
       current.desiredRunning &&
       spec.onFailed &&
-      current.restartAttempt >= MAX_CRASH_ATTEMPTS - 1
+      current.crashAttempt >= MAX_CRASH_ATTEMPTS - 1
     ) {
       yield* Ref.update(state, (latest) => ({ ...latest, desiredRunning: false, ready: false }));
       // The dialog can quit the app, whose shutdown acquires this instance's mutex.
@@ -1025,6 +1032,7 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
         {
           ...latest,
           restartAttempt: latest.restartAttempt + 1,
+          crashAttempt: latest.crashAttempt + (terminalFailure ? 1 : 0),
         },
       ] as const;
     });

--- a/apps/desktop/src/backend/DesktopBackendManager.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.ts
@@ -25,6 +25,7 @@
 
 import * as Brand from "effect/Brand";
 import * as Cause from "effect/Cause";
+import * as Clock from "effect/Clock";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -56,6 +57,8 @@ import * as DesktopWslEnvironment from "../wsl/DesktopWslEnvironment.ts";
 
 const INITIAL_RESTART_DELAY = Duration.millis(500);
 const MAX_RESTART_DELAY = Duration.seconds(10);
+const MAX_CRASH_ATTEMPTS = 5;
+const STABLE_BACKEND_UPTIME_MS = 60_000;
 // After this many consecutive fatal preflight failures, stop the silent
 // restart loop and surface the reason via onPreflightFailed. Transient
 // failures may instead provide their own larger retryLimit when they should
@@ -295,6 +298,8 @@ export interface BackendInstanceSpec {
   // between "fired onReady" and "currentConfig already advanced".
   readonly onReady?: (httpBaseUrl: URL) => Effect.Effect<void>;
   readonly onShutdown?: () => Effect.Effect<void>;
+  // Opts this instance into bounded crash recovery and reports the terminal failure.
+  readonly onFailed?: (reason: string) => Effect.Effect<void>;
   // Fired once when a fatal or bounded preflight failure has exhausted its
   // retries. Returns true when the callback changed configuration and the
   // manager should resolve once more; false stops the failed instance.
@@ -735,6 +740,7 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
           ready: false,
           config: Option.some(config.value),
           preflightFailureAttempt: resetFatalPreflightCounter ? 0 : latest.preflightFailureAttempt,
+          restartAttempt: current.desiredRunning ? latest.restartAttempt : 0,
         }));
 
         const preflightFailure = config.value.preflightFailure;
@@ -805,7 +811,7 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
         );
 
         if (!entryExists) {
-          yield* scheduleRestart(`missing server entry at ${config.value.entryPath}`);
+          yield* scheduleRestart(`missing server entry at ${config.value.entryPath}`, true);
           return;
         }
 
@@ -826,11 +832,13 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
           },
         ]);
 
+        let readyAt: number | undefined;
         const finalizeRun = Effect.fn("desktop.backendInstance.finalizeRun")(function* (
           reason: string,
         ) {
           yield* mutex.withPermits(1)(
             Effect.gen(function* () {
+              const now = yield* Clock.currentTimeMillis;
               const { isCurrentRun, nextState, pid, exitObserved, stopRequested, wasReady } =
                 yield* Ref.modify(
                   state,
@@ -864,6 +872,10 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
 
                     const next = {
                       ...latest,
+                      restartAttempt:
+                        readyAt !== undefined && now - readyAt >= STABLE_BACKEND_UPTIME_MS
+                          ? 0
+                          : latest.restartAttempt,
                       active: Option.none<ActiveBackendRun>(),
                       ready: false,
                     };
@@ -898,7 +910,7 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
               }
 
               if (isCurrentRun && nextState.desiredRunning) {
-                yield* scheduleRestart(reason);
+                yield* scheduleRestart(reason, true);
               }
             }),
           );
@@ -924,6 +936,7 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
               exitObserved: true,
             })),
           onReady: Effect.fn("desktop.backendInstance.onReady")(function* () {
+            readyAt = yield* Clock.currentTimeMillis;
             const isCurrentRun = yield* Ref.modify(state, (latest) => {
               const activeRun = Option.getOrUndefined(latest.active);
               if (activeRun?.id !== runId) {
@@ -934,7 +947,7 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
                 true,
                 {
                   ...latest,
-                  restartAttempt: 0,
+                  restartAttempt: spec.onFailed ? latest.restartAttempt : 0,
                   ready: true,
                 },
               ] as const;
@@ -987,7 +1000,20 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
 
   const scheduleRestart = Effect.fn("desktop.backendInstance.scheduleRestart")(function* (
     reason: string,
+    terminalFailure = false,
   ) {
+    const current = yield* Ref.get(state);
+    if (
+      terminalFailure &&
+      current.desiredRunning &&
+      spec.onFailed &&
+      current.restartAttempt >= MAX_CRASH_ATTEMPTS - 1
+    ) {
+      yield* Ref.update(state, (latest) => ({ ...latest, desiredRunning: false, ready: false }));
+      // The dialog can quit the app, whose shutdown acquires this instance's mutex.
+      yield* Effect.forkIn(spec.onFailed(reason), parentScope);
+      return;
+    }
     const scheduled = yield* Ref.modify(state, (latest) => {
       if (!latest.desiredRunning || Option.isSome(latest.restartFiber)) {
         return [Option.none<Duration.Duration>(), latest] as const;

--- a/apps/desktop/src/backend/DesktopBackendPool.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendPool.test.ts
@@ -95,6 +95,7 @@ function makePoolLayer(
           showConnectingSplash: Effect.void,
           handleBackendReady: () => Effect.void,
           handleBackendNotReady: Effect.void,
+          handleBackendFailed: () => Effect.void,
           flushMainWindowBounds: Effect.void,
           dispatchMenuAction: () => Effect.die("unexpected menu action"),
           zoomMain: () => Effect.die("unexpected zoom"),

--- a/apps/desktop/src/backend/DesktopBackendPool.ts
+++ b/apps/desktop/src/backend/DesktopBackendPool.ts
@@ -286,8 +286,7 @@ export const layer = Layer.effect(
       label: configuration.resolvePrimaryLabel,
       configResolve: configuration.resolvePrimary,
       // Window creation errors propagating out of handleBackendReady must
-      // not block the readiness callback (that would prevent restartAttempt
-      // from being reset), so we absorb them here. The window service only
+      // not block the readiness callback, so we absorb them here. The window service only
       // logs on success, so log the failure here before swallowing it —
       // otherwise a post-readiness window-open failure vanishes silently and
       // is near-impossible to diagnose in production.
@@ -300,6 +299,7 @@ export const layer = Layer.effect(
           ),
         ),
       onShutdown: () => desktopWindow.handleBackendNotReady,
+      onFailed: desktopWindow.handleBackendFailed,
       onPreflightFailed: handlePrimaryPreflightFailure,
     });
 

--- a/apps/desktop/src/electron/ElectronDialog.ts
+++ b/apps/desktop/src/electron/ElectronDialog.ts
@@ -97,6 +97,7 @@ export class ElectronDialog extends Context.Service<
     ) => Effect.Effect<readonly string[], ElectronDialogPickFilesError>;
     readonly showMessageBox: (
       options: Electron.MessageBoxOptions,
+      owner?: Electron.BrowserWindow,
     ) => Effect.Effect<Electron.MessageBoxReturnValue, ElectronDialogShowMessageBoxError>;
     readonly showErrorBox: (title: string, content: string) => Effect.Effect<void>;
   }
@@ -163,9 +164,12 @@ export const make = ElectronDialog.of({
     });
     return result.canceled ? [] : result.filePaths;
   }),
-  showMessageBox: (options) =>
+  showMessageBox: (options, owner) =>
     Effect.tryPromise({
-      try: () => Electron.dialog.showMessageBox(options),
+      try: () =>
+        owner && !owner.isDestroyed()
+          ? Electron.dialog.showMessageBox(owner, options)
+          : Electron.dialog.showMessageBox(options),
       catch: (cause) =>
         new ElectronDialogShowMessageBoxError({
           type: options.type ?? null,

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -83,6 +83,7 @@ const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
     showConnectingSplash: Effect.void,
     handleBackendReady: () => Effect.void,
     handleBackendNotReady: Effect.void,
+    handleBackendFailed: () => Effect.void,
     flushMainWindowBounds: Effect.void,
     dispatchMenuAction: (action) => Deferred.succeed(selectedAction, action).pipe(Effect.asVoid),
     zoomMain: (direction) =>

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -3,6 +3,8 @@ import { assert, describe, it } from "@effect/vitest";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
+import * as Queue from "effect/Queue";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
 import * as Option from "effect/Option";
@@ -38,6 +40,7 @@ import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopState from "../app/DesktopState.ts";
 import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 import * as DesktopClientSettings from "../settings/DesktopClientSettings.ts";
+import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronMenu from "../electron/ElectronMenu.ts";
 import * as ElectronShell from "../electron/ElectronShell.ts";
@@ -209,6 +212,12 @@ function makeTestLayer(input: {
   ) => Effect.Effect<void>;
   readonly openedExternalUrls?: unknown[];
   readonly previewZoomReapplies?: number[];
+  readonly production?: boolean;
+  readonly showMessageBox?: ElectronDialog.ElectronDialog["Service"]["showMessageBox"];
+  readonly copyText?: ElectronShell.ElectronShell["Service"]["copyText"];
+  readonly quit?: Effect.Effect<void>;
+  readonly relaunch?: ElectronApp.ElectronApp["Service"]["relaunch"];
+  readonly readLog?: Effect.Effect<string>;
 }) {
   let desktopSettings = input.desktopSettings ?? DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS;
   const desktopAppSettingsLayer = Layer.succeed(DesktopAppSettings.DesktopAppSettings, {
@@ -267,12 +276,25 @@ function makeTestLayer(input: {
     Layer.provide(
       Layer.mergeAll(
         desktopAssetsLayer,
-        desktopEnvironmentLayer,
+        Layer.effect(
+          DesktopEnvironment.DesktopEnvironment,
+          Effect.gen(function* () {
+            const environment = yield* DesktopEnvironment.DesktopEnvironment;
+            return { ...environment, isDevelopment: !input.production };
+          }),
+        ).pipe(Layer.provide(desktopEnvironmentLayer)),
         desktopAppSettingsLayer,
         desktopClientSettingsLayer,
         desktopServerExposureLayer,
         DesktopState.layer,
-        electronAppLayer,
+        Layer.mock(ElectronApp.ElectronApp)({
+          quit: input.quit ?? Effect.void,
+          ...(input.relaunch ? { relaunch: input.relaunch } : {}),
+        }),
+        FileSystem.layerNoop({ readFileString: () => input.readLog ?? Effect.succeed("") }),
+        Layer.mock(ElectronDialog.ElectronDialog)(
+          input.showMessageBox ? { showMessageBox: input.showMessageBox } : {},
+        ),
         electronMenuLayer,
         Layer.succeed(ElectronShell.ElectronShell, {
           openExternal: (url) =>
@@ -281,7 +303,7 @@ function makeTestLayer(input: {
               return true;
             }),
           openSystemSettings: () => Effect.succeed(true),
-          copyText: () => Effect.void,
+          copyText: input.copyText ?? (() => Effect.void),
         } satisfies ElectronShell.ElectronShell["Service"]),
         electronThemeLayer,
         electronWindowLayer,
@@ -378,6 +400,8 @@ const makeSplashScenario = (createOutcomes: readonly (Electron.BrowserWindow | n
           desktopClientSettingsLayer,
           desktopServerExposureLayer,
           electronAppLayer,
+          NodeServices.layer,
+          Layer.mock(ElectronDialog.ElectronDialog)({}),
           electronMenuLayer,
           Layer.succeed(ElectronShell.ElectronShell, {
             openExternal: () => Effect.succeed(true),
@@ -400,6 +424,57 @@ const makeSplashScenario = (createOutcomes: readonly (Electron.BrowserWindow | n
   });
 
 describe("DesktopWindow", () => {
+  it.effect("surfaces production load failures once and supports copying logs and retrying", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeBrowserWindow();
+      const dialogs = yield* Queue.unbounded<Electron.MessageBoxOptions>();
+      const responses = yield* Queue.unbounded<number>();
+      const copied = yield* Queue.unbounded<string>();
+      const quit = yield* Deferred.make<void>();
+      let relaunched = false;
+      const log = "Error: no such column: branch_pull_request_json";
+      const layer = makeTestLayer({
+        window: fake.window,
+        createCount: yield* Ref.make(0),
+        mainWindow: yield* Ref.make(Option.none<Electron.BrowserWindow>()),
+        production: true,
+        readLog: Effect.succeed(log),
+        showMessageBox: (options) =>
+          Queue.offer(dialogs, options).pipe(
+            Effect.andThen(Queue.take(responses)),
+            Effect.map((response) => ({ response, checkboxChecked: false })),
+          ),
+        copyText: (text) => Queue.offer(copied, text).pipe(Effect.asVoid),
+        relaunch: () =>
+          Effect.sync(() => {
+            relaunched = true;
+          }),
+        quit: Deferred.succeed(quit, undefined).pipe(Effect.asVoid),
+      });
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.createMain;
+        const fail = fake.webContentsListeners.get("did-fail-load")!;
+        fail({}, -3, "ERR_ABORTED", "t3code://app/", true);
+        fail({}, -9, "ERR_UNEXPECTED", "t3code://app/", false);
+        assert.equal(yield* Queue.size(dialogs), 0);
+        fail({}, -9, "ERR_UNEXPECTED", "t3code://app/", true);
+        const dialog = yield* Queue.take(dialogs);
+        assert.include(dialog.detail, log);
+        assert.include(dialog.detail, "ERR_UNEXPECTED (-9)");
+        assert.deepEqual(dialog.buttons, ["Retry", "Copy Logs", "Quit"]);
+        yield* desktopWindow.handleBackendFailed("code=1");
+        assert.equal(yield* Queue.size(dialogs), 0);
+        yield* Queue.offer(responses, 1);
+        assert.include(yield* Queue.take(copied), log);
+        yield* Queue.take(dialogs);
+        yield* Queue.offer(responses, 0);
+        yield* Deferred.await(quit);
+        assert.equal(relaunched, true);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
   it("leaves fullscreen before concealing a pending quit", () => {
     const fakeWindow = makeFakeBrowserWindow();
 

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -2,6 +2,7 @@ import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
@@ -14,6 +15,7 @@ import * as DesktopAssets from "../app/DesktopAssets.ts";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import { makeComponentLogger } from "../app/DesktopObservability.ts";
 import * as ElectronMenu from "../electron/ElectronMenu.ts";
+import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import { getDesktopUrl } from "../electron/ElectronProtocol.ts";
 import * as ElectronShell from "../electron/ElectronShell.ts";
 import * as ElectronTheme from "../electron/ElectronTheme.ts";
@@ -98,6 +100,7 @@ export class DesktopWindow extends Context.Service<
     // window so a "macOS dock click" while the backend is down doesn't
     // produce a stranded window pointing at nothing.
     readonly handleBackendNotReady: Effect.Effect<void>;
+    readonly handleBackendFailed: (reason: string) => Effect.Effect<void>;
     readonly flushMainWindowBounds: Effect.Effect<void>;
     readonly dispatchMenuAction: (action: string) => Effect.Effect<void, DesktopWindowError>;
     // Zooms the main window's own webContents. The Electron `zoomIn`/`zoomOut`
@@ -289,6 +292,9 @@ export const make = Effect.gen(function* () {
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
   const clientSettings = yield* DesktopClientSettings.DesktopClientSettings;
   const electronApp = yield* ElectronApp.ElectronApp;
+  const electronDialog = yield* ElectronDialog.ElectronDialog;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const failureVisible = yield* Ref.make(false);
   // Window-side latch for the primary backend's readiness. Set by
   // handleBackendReady (driven by the pool's onReady callback), cleared
   // by handleBackendNotReady (driven by onShutdown). Only consumed by
@@ -307,6 +313,45 @@ export const make = Effect.gen(function* () {
     const splash = yield* Ref.getAndSet(splashWindowRef, Option.none());
     if (Option.isSome(splash) && !splash.value.isDestroyed()) {
       splash.value.close();
+    }
+  });
+
+  const handleBackendFailed = Effect.fn("desktop.window.handleBackendFailed")(function* (
+    reason: string,
+  ) {
+    if (yield* Ref.getAndSet(failureVisible, true)) return;
+    const logPath = environment.path.join(environment.logDir, "server-child.log");
+    const logs = yield* fileSystem.readFileString(logPath).pipe(Effect.orElseSucceed(() => ""));
+    const detail = `${reason}\n\n${logs.slice(-4_000)}\n\nLogs: ${logPath}`;
+    while (true) {
+      const { response } = yield* electronDialog
+        .showMessageBox(
+          {
+            type: "error",
+            title: environment.displayName,
+            message: "T3 Code couldn't start",
+            detail,
+            buttons: ["Retry", "Copy Logs", "Quit"],
+            defaultId: 0,
+            cancelId: 2,
+            noLink: true,
+          },
+          Option.getOrUndefined(yield* electronWindow.currentMainOrFirst),
+        )
+        .pipe(
+          Effect.catch(() =>
+            electronDialog
+              .showErrorBox("T3 Code couldn't start", detail)
+              .pipe(Effect.as({ response: 2 })),
+          ),
+        );
+      if (response === 1) {
+        yield* electronShell.copyText(`${reason}\n\n${logs}\n\nLogs: ${logPath}`);
+        continue;
+      }
+      if (response === 0) yield* electronApp.relaunch({});
+      yield* electronApp.quit;
+      return;
     }
   });
 
@@ -685,6 +730,9 @@ export const make = Effect.gen(function* () {
         if (!isMainFrame) {
           return;
         }
+        if (!environment.isDevelopment && errorCode !== -3 && !window.isDestroyed()) {
+          runFork(handleBackendFailed(`${errorDescription} (${errorCode})\n${validatedURL}`));
+        }
         const retryInMs =
           environment.isDevelopment &&
           isRetryableDevelopmentRendererLoadFailure({
@@ -851,6 +899,7 @@ export const make = Effect.gen(function* () {
   );
 
   return DesktopWindow.of({
+    handleBackendFailed,
     createMain,
     ensureMain,
     revealOrCreateMain,


### PR DESCRIPTION
When the local backend repeatedly crashes or the production `t3code://app/` page fails to load, desktop can leave a blank window with no explanation. The web error boundary cannot run because the page never loads.

Show a native main-process dialog with the failure, recent child logs, Retry, Copy Logs, and Quit. The primary backend stops after five failed runs; a minute of readiness resets that allowance so ordinary later crashes still recover. Retry relaunches desktop. Secondary WSL recovery and existing preflight fallback stay unchanged.

Fixes #10517. This surfaces the failure; it does not repair the separate SQLite migration error.

Verified with 71 focused desktop tests, desktop typecheck, and targeted lint/formatting. The new crash-loop regression failed before the fix. The follow-up preflight regression reproduced the review finding: four transient preflight retries exhausted the allowance on the first crash. Crash attempts now have their own counter, independent of preflight/configuration retries used for backoff. Coverage includes crashes before readiness, repeated brief readiness, sustained recovery, duplicate failures, aborted/subframe loads, copying diagnostics, and retrying.

The screenshots were retaken on macOS 27.0 (Apple Silicon) with Electron 43.4.1. They use the real desktop window controller and production protocol in isolated Electron, with an unavailable backend and a synthetic child-error log. Before uses `8b2838e0e`; after uses PR head `ad0cda1e3`. Native Copy Logs was verified against the clipboard, and Quit was exercised. The after capture shows the native dialog after Copy Logs reopens it. No live application state was used. Windows was not exercised.

The earlier Linux recording is retained below as supplementary evidence of Copy Logs and Quit; Retry was also exercised during that earlier Linux run.

<details>
<summary>Before: blank desktop window on macOS</summary>

![Before: blank desktop window on macOS](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-10517/before-macos.png)

</details>

After: native macOS startup diagnostics.

![After: native macOS startup failure dialog](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-10517/after-macos.png)

[Earlier Linux native dialog recording](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-10517/startup-recovery-v2.mp4)

Model: GPT-6. Harness: Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show desktop startup failure dialog with bounded crash-loop recovery
> - Adds a five-attempt crash allowance and 60-second stable-readiness reset for primary backends in `DesktopBackendManager`; after exhaustion, restarts stop and the terminal reason is forwarded to `DesktopWindow.handleBackendFailed`
> - `DesktopWindow` presents a once-only production dialog with recent logs, Copy Logs, Retry (relaunch then quit), and Quit choices; production main-frame renderer load failures (non-`ERR_ABORTED`) trigger the same flow
> - `ElectronDialog.showMessageBox` accepts an optional owner `BrowserWindow`, falling back to the unowned API when the owner is missing or destroyed
> - Behavioral Change: readiness alone no longer resets the crash counter — only 60s of continuous readiness does; manual restart now resets the counter; missing server entries are treated as terminal-failure candidates
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c53a080. 4 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a production failure dialog with options to retry, copy server logs, or quit.
  * Added bounded automatic backend crash recovery, stopping after repeated terminal failures.
  * Restart tracking resets after a fresh start or 60 seconds of stable operation.
  * Error dialogs can now be associated with the relevant application window.

* **Bug Fixes**
  * Prevented duplicate failure dialogs when multiple load failures occur.
  * Improved handling of backend readiness and transient recovery failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
