### PR TITLE
fix(web): highlight only the active settings section

### DIFF
--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -45,8 +45,9 @@ import {
 import { SidebarUtilityMenu } from "../sidebar/SidebarChrome";
 import { scrollToSettingsTarget } from "./settingsLayout";
 import {
-  getVisibleSettingsSectionIds,
+  getActiveSettingsSectionId,
   observeSettingsSectionVisibility,
+  type SettingsSectionVisibilityScope,
   type SettingsSectionVisibilityState,
 } from "./settingsSectionVisibility";
 import {
@@ -154,6 +155,10 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
   const [sectionVisibility, setSectionVisibility] = useState<SettingsSectionVisibilityState | null>(
     null,
   );
+  const [preferredSection, setPreferredSection] = useState<{
+    scope: SettingsSectionVisibilityScope | null;
+    targetId: string;
+  } | null>(null);
   const searchableItems = useAvailableSettingsSearchItems();
   const results = useMemo(() => searchSettings(query, searchableItems), [query, searchableItems]);
   const isSearching = query.trim().length > 0;
@@ -169,10 +174,11 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
     const pageSections = path ? SETTINGS_PAGE_SECTIONS[path] : undefined;
     return path && pageSections ? { path, pageSections } : null;
   }, [resolvedPathname]);
-  const visiblePageSectionIds = getVisibleSettingsSectionIds({
+  const activePageSectionId = getActiveSettingsSectionId({
     activePath: activeSettingsPath,
     scope: observedVisibilityScope,
     visibility: sectionVisibility,
+    preferredSection,
   });
 
   useEffect(() => {
@@ -249,6 +255,7 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
   );
   const handlePageSectionClick = useCallback(
     (to: SettingsPath, targetId: string) => {
+      setPreferredSection({ scope: observedVisibilityScope, targetId });
       if (isMobile) {
         setOpenMobile(false);
       }
@@ -263,7 +270,7 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
         state: { settingsTargetHighlight: false },
       });
     },
-    [isMobile, navigate, pathname, setOpenMobile],
+    [isMobile, navigate, observedVisibilityScope, pathname, setOpenMobile],
   );
   const clearSearch = useCallback(() => {
     setQuery("");
@@ -435,10 +442,12 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
                               <SidebarMenuSubButton
                                 render={<button type="button" />}
                                 size="sm"
-                                data-visible={visiblePageSectionIds.has(section.targetId)}
+                                aria-current={
+                                  activePageSectionId === section.targetId ? "location" : undefined
+                                }
                                 className={cn(
                                   "w-full text-sidebar-muted-foreground/65",
-                                  visiblePageSectionIds.has(section.targetId) &&
+                                  activePageSectionId === section.targetId &&
                                     "font-medium text-sidebar-foreground",
                                 )}
                                 onClick={() => handlePageSectionClick(item.to, section.targetId)}

--- a/apps/web/src/components/settings/settingsLayout.test.tsx
+++ b/apps/web/src/components/settings/settingsLayout.test.tsx
@@ -25,7 +25,7 @@ describe("settings search targets", () => {
     expect(markup).not.toContain("settings-search-target-pulse");
   });
 
-  it("scrolls directly to a section header and restarts the destination pulse", () => {
+  it.each([true, false])("scrolls to a section header with highlight=%s", (highlight) => {
     const sectionScrollIntoView = vi.fn();
     const headerScrollIntoView = vi.fn();
     const focus = vi.fn();
@@ -48,16 +48,21 @@ describe("settings search targets", () => {
       matchMedia: vi.fn(() => ({ matches: false })),
     });
 
-    expect(scrollToSettingsTarget("providers")).toBe(true);
+    expect(scrollToSettingsTarget("providers", { highlight })).toBe(true);
     expect(headerScrollIntoView).toHaveBeenCalledWith({
       behavior: "smooth",
-      block: "center",
+      block: highlight ? "center" : "start",
     });
     expect(sectionScrollIntoView).not.toHaveBeenCalled();
     expect(focus).toHaveBeenCalledWith({ preventScroll: true });
     expect(remove).toHaveBeenCalledWith("settings-search-target-pulse");
-    expect(add).toHaveBeenCalledWith("settings-search-target-pulse");
-    expect(addEventListener).toHaveBeenCalledWith("blur", expect.any(Function), { once: true });
+    if (highlight) {
+      expect(add).toHaveBeenCalledWith("settings-search-target-pulse");
+      expect(addEventListener).toHaveBeenCalledWith("blur", expect.any(Function), { once: true });
+    } else {
+      expect(add).not.toHaveBeenCalled();
+      expect(addEventListener).not.toHaveBeenCalled();
+    }
   });
 
   it("does not animate the destination when reduced motion is requested", () => {

--- a/apps/web/src/components/settings/settingsLayout.tsx
+++ b/apps/web/src/components/settings/settingsLayout.tsx
@@ -71,7 +71,7 @@ function scrollAndFocusSettingsTarget(target: HTMLElement, highlight = true): vo
 
   scrollTarget.scrollIntoView({
     behavior: prefersReducedMotion ? "auto" : "smooth",
-    block: "center",
+    block: highlight ? "center" : "start",
   });
   target.focus({ preventScroll: true });
   target.classList.remove("settings-search-target-pulse");

--- a/apps/web/src/components/settings/settingsSectionVisibility.test.ts
+++ b/apps/web/src/components/settings/settingsSectionVisibility.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
-  getVisibleSettingsSectionIds,
+  getActiveSettingsSectionId,
   observeSettingsSectionVisibility,
   type SettingsSectionVisibilityEnvironment,
 } from "./settingsSectionVisibility";
@@ -83,28 +83,54 @@ describe("settings section visibility", () => {
     };
 
     expect(
-      getVisibleSettingsSectionIds({
+      getActiveSettingsSectionId({
         activePath: "/settings/general",
         scope: firstGeneralVisit,
         visibility: firstVisibility,
       }),
-    ).toEqual(new Set(["text-generation"]));
+    ).toBe("text-generation");
     expect(
-      getVisibleSettingsSectionIds({
+      getActiveSettingsSectionId({
         activePath: "/settings/providers",
         scope: null,
         visibility: firstVisibility,
       }),
-    ).toEqual(new Set());
+    ).toBeUndefined();
 
     const secondGeneralVisit = { path: "/settings/general" };
     expect(
-      getVisibleSettingsSectionIds({
+      getActiveSettingsSectionId({
         activePath: "/settings/general",
         scope: secondGeneralVisit,
         visibility: firstVisibility,
       }),
-    ).toEqual(new Set());
+    ).toBeUndefined();
+  });
+
+  it("selects one visible section, preferring the clicked destination within the current visit", () => {
+    const scope = { path: "/settings/general" };
+    const state = {
+      activePath: scope.path,
+      scope,
+      visibility: {
+        scope,
+        targetIds: new Set(["behavior", "projects-and-threads", "confirmations"]),
+      },
+    };
+    const preferredSection = { scope, targetId: "projects-and-threads" };
+
+    expect(getActiveSettingsSectionId(state)).toBe("behavior");
+    expect(getActiveSettingsSectionId({ ...state, preferredSection })).toBe("projects-and-threads");
+    expect(
+      getActiveSettingsSectionId({
+        ...state,
+        preferredSection: { ...preferredSection, scope: { path: scope.path } },
+      }),
+    ).toBe("behavior");
+    state.visibility.targetIds.delete("projects-and-threads");
+    expect(getActiveSettingsSectionId({ ...state, preferredSection })).toBe("behavior");
+    state.visibility.targetIds.clear();
+    expect(getActiveSettingsSectionId({ ...state, preferredSection })).toBeUndefined();
   });
 
   it("accumulates visible sections and emits them in sidebar order", () => {

--- a/apps/web/src/components/settings/settingsSectionVisibility.ts
+++ b/apps/web/src/components/settings/settingsSectionVisibility.ts
@@ -12,21 +12,27 @@ export type SettingsSectionVisibilityState = {
   readonly targetIds: ReadonlySet<string>;
 };
 
-const EMPTY_VISIBLE_SETTINGS_SECTION_IDS: ReadonlySet<string> = new Set();
-
-export function getVisibleSettingsSectionIds({
+export function getActiveSettingsSectionId({
   activePath,
   scope,
   visibility,
+  preferredSection,
 }: {
   readonly activePath: string | undefined;
   readonly scope: SettingsSectionVisibilityScope | null;
   readonly visibility: SettingsSectionVisibilityState | null;
-}): ReadonlySet<string> {
+  readonly preferredSection?: {
+    readonly scope: SettingsSectionVisibilityScope | null;
+    readonly targetId: string;
+  } | null;
+}): string | undefined {
   if (!scope || activePath !== scope.path || visibility?.scope !== scope) {
-    return EMPTY_VISIBLE_SETTINGS_SECTION_IDS;
+    return undefined;
   }
-  return visibility.targetIds;
+  if (preferredSection?.scope === scope && visibility.targetIds.has(preferredSection.targetId)) {
+    return preferredSection.targetId;
+  }
+  return visibility.targetIds.values().next().value;
 }
 
 type ElementObserver = {


### PR DESCRIPTION
Clicking a nested settings link could leave Behavior and other nearby sections highlighted. The sidebar treated every visible section as selected, and jumps centered the destination heading.

Select one visible section, preferring the clicked destination while it remains in view and falling back to the first visible section when scrolling away. Section links now align their headings at the top; search results retain centered jumps. The existing observer and route scoping stay in place, with `aria-current` identifying the active section.

Verified 13 focused tests, web typecheck, and scoped lint/formatting. The selection and alignment regressions fail against the original code. Lint retains the existing search-result effect warning.

Chromium checks covered all 15 links across General, Appearance, Connections, and Source Control; manual scrolling; sectioned/unsectioned route changes; centered search; and the sidebar at phone width. Normal and reduced motion both passed. Web and desktop share this sidebar; native Electron and React Native were not exercised. No server, provider, or connection contracts changed.

| Before: three sections highlighted | After: only the clicked section highlighted |
| --- | --- |
| ![Before clicking Projects and threads](https://github.com/Gigioxx/t3code/releases/download/evidence-settings-section-selection/before.png) | ![After clicking Projects and threads](https://github.com/Gigioxx/t3code/releases/download/evidence-settings-section-selection/after.png) |

Interaction recordings: [before](https://github.com/Gigioxx/t3code/releases/download/evidence-settings-section-selection/before.webm) · [after](https://github.com/Gigioxx/t3code/releases/download/evidence-settings-section-selection/after.webm).

Model: GPT-6. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `SettingsSidebarNav` to highlight only the active settings section
> - Replaces the visible-section-set API with a scalar active-section API in [settingsSectionVisibility.ts](https://github.com/pingdotgg/t3code/pull/10524/files#diff-f8f96cb710bc74cb096fed760ae2ea6a5e3b781335bbbf3cfd8834557528d5d3), preferring the most recently clicked visible section and falling back to the first visible target
> - Sidebar submenu buttons now use `aria-current` and active text styling for only the selected section instead of a `data-visible` attribute for every visible section
> - Non-highlighted settings targets scroll into view with start alignment instead of center alignment in [settingsLayout.tsx](https://github.com/pingdotgg/t3code/pull/10524/files#diff-b320015b8831dfe0790cf2606a38785fca21e9a39f13b7d8afefbead69523dc9); highlighted targets keep center alignment
> - Behavioral Change: `getActiveSettingsSectionId` now returns a single section ID or `undefined` instead of a set of visible section IDs; callers that depended on the set API need updating
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc3f6a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Settings navigation now clearly indicates the currently active section.
  - Selecting a settings section keeps that destination highlighted during the current visit when available.
  - Navigating to settings targets without highlighting now positions the destination at the top of the viewport, while highlighted targets remain centered.
  - Settings section selection now falls back smoothly when the preferred destination is unavailable or hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->