### PR TITLE
feat(web): show clone progress while cloning projects

### DIFF
--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -961,10 +961,16 @@ export function AddProjectDestinationScreen(props: {
         if (event.kind === "progress") setCloneProgress(event);
       },
     });
-    setCloneProgress(null);
     if (AsyncResult.isFailure(cloneResult)) {
+      setCloneProgress(null);
       setError(errorMessage(Cause.squash(cloneResult.cause)));
     } else {
+      setCloneProgress({
+        kind: "progress",
+        phase: "complete",
+        percent: 100,
+        detail: "Adding project…",
+      });
       const createResult = await createProject(cloneResult.value.cwd);
       if (createResult && AsyncResult.isFailure(createResult)) {
         setError(errorMessage(Cause.squash(createResult.cause)));
@@ -1004,7 +1010,9 @@ export function AddProjectDestinationScreen(props: {
           }
         >
           <View className="mb-2 flex-row items-center justify-between">
-            <Text className="font-t3-medium text-sm text-foreground">Cloning project</Text>
+            <Text className="font-t3-medium text-sm text-foreground">
+              {cloneProgress.phase === "complete" ? "Adding project" : "Cloning project"}
+            </Text>
             <Text className="text-xs text-foreground-muted">
               {cloneProgress.percent === null ? "" : `${cloneProgress.percent}%`}
             </Text>

--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -36,6 +36,7 @@ import {
   type EnvironmentId,
   type EnvironmentMachineKind,
   ProjectId,
+  type SourceControlCloneProgressEvent,
   resolveEnvironmentMachineKind,
 } from "@t3tools/contracts";
 import { CommonActions, StackActions, useNavigation } from "@react-navigation/native";
@@ -904,9 +905,12 @@ export function AddProjectDestinationScreen(props: {
   readonly repositoryTitle?: string | string[];
   readonly repositoryName?: string | string[];
 }) {
-  const cloneRepository = useAtomCommand(sourceControlEnvironment.cloneRepository, {
-    reportFailure: false,
-  });
+  const cloneRepositoryWithProgress = useAtomCommand(
+    sourceControlEnvironment.cloneRepositoryWithProgress,
+    {
+      reportFailure: false,
+    },
+  );
   const environment = useEnvironmentFromParam(props.environmentId);
   const createProject = useCreateProject(environment);
   const remoteUrl = stringParam(props.remoteUrl);
@@ -922,6 +926,10 @@ export function AddProjectDestinationScreen(props: {
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [cloneProgress, setCloneProgress] = useState<Extract<
+    SourceControlCloneProgressEvent,
+    { kind: "progress" }
+  > | null>(null);
 
   const submitPath = useCallback(async () => {
     if (!environment || !remoteUrl || isBrowseNavigating || isSubmitting) return;
@@ -937,13 +945,23 @@ export function AddProjectDestinationScreen(props: {
     }
 
     setIsSubmitting(true);
-    const cloneResult = await cloneRepository({
+    setCloneProgress({
+      kind: "progress",
+      phase: "preparing",
+      percent: 0,
+      detail: "Preparing clone…",
+    });
+    const cloneResult = await cloneRepositoryWithProgress({
       environmentId: environment.environmentId,
       input: {
         remoteUrl,
         destinationPath: resolved.path,
       },
+      onProgress: (event) => {
+        if (event.kind === "progress") setCloneProgress(event);
+      },
     });
+    setCloneProgress(null);
     if (AsyncResult.isFailure(cloneResult)) {
       setError(errorMessage(Cause.squash(cloneResult.cause)));
     } else {
@@ -954,7 +972,7 @@ export function AddProjectDestinationScreen(props: {
     }
     setIsSubmitting(false);
   }, [
-    cloneRepository,
+    cloneRepositoryWithProgress,
     createProject,
     environment,
     isBrowseNavigating,
@@ -974,27 +992,59 @@ export function AddProjectDestinationScreen(props: {
           </Text>
         </View>
       ) : null}
+      {isSubmitting && cloneProgress ? (
+        <View
+          className="mt-2 rounded-[18px] border border-border/60 bg-card px-4 py-3"
+          accessibilityLiveRegion="polite"
+          accessibilityRole="progressbar"
+          accessibilityValue={
+            cloneProgress.percent === null
+              ? undefined
+              : { max: 100, min: 0, now: cloneProgress.percent }
+          }
+        >
+          <View className="mb-2 flex-row items-center justify-between">
+            <Text className="font-t3-medium text-sm text-foreground">Cloning project</Text>
+            <Text className="text-xs text-foreground-muted">
+              {cloneProgress.percent === null ? "" : `${cloneProgress.percent}%`}
+            </Text>
+          </View>
+          <Text className="mb-2 text-xs text-foreground-muted">{cloneProgress.detail}</Text>
+          <View className="h-1.5 overflow-hidden rounded-full bg-muted">
+            <View
+              className="h-full rounded-full bg-accent"
+              style={
+                cloneProgress.percent === null
+                  ? { width: "35%" }
+                  : { width: `${cloneProgress.percent}%` }
+              }
+            />
+          </View>
+        </View>
+      ) : null}
       {environment ? (
-        <>
-          <ProjectPathInput
-            value={pathInput}
-            onChangeText={setPathInput}
-            onSubmit={() => void submitPath()}
-          />
-          <PrimaryActionButton
-            label="Clone project"
-            disabled={isBrowseNavigating || isSubmitting || !remoteUrl}
-            onPress={() => void submitPath()}
-            loading={isSubmitting}
-          />
-          <FolderBrowser
-            environment={environment}
-            navigateToBrowsePath={navigateToBrowsePath}
-            pathInput={pathInput}
-            setPathInput={setPathInput}
-            pinnedDirectoryName={repositoryName}
-          />
-        </>
+        isSubmitting ? null : (
+          <>
+            <ProjectPathInput
+              value={pathInput}
+              onChangeText={setPathInput}
+              onSubmit={() => void submitPath()}
+            />
+            <PrimaryActionButton
+              label="Clone project"
+              disabled={isBrowseNavigating || isSubmitting || !remoteUrl}
+              onPress={() => void submitPath()}
+              loading={isSubmitting}
+            />
+            <FolderBrowser
+              environment={environment}
+              navigateToBrowsePath={navigateToBrowsePath}
+              pathInput={pathInput}
+              setPathInput={setPathInput}
+              pinnedDirectoryName={repositoryName}
+            />
+          </>
+        )
       ) : (
         <EmptyEnvironmentState />
       )}

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -92,6 +92,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.pullRequestsSetLabels]: AuthOrchestrationOperateScope,
   [WS_METHODS.sourceControlLookupRepository]: AuthOrchestrationReadScope,
   [WS_METHODS.sourceControlCloneRepository]: AuthOrchestrationOperateScope,
+  [WS_METHODS.sourceControlCloneRepositoryWithProgress]: AuthOrchestrationOperateScope,
   [WS_METHODS.sourceControlPublishRepository]: AuthOrchestrationOperateScope,
   [WS_METHODS.projectsListEntries]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsReadFile]: AuthOrchestrationReadScope,

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -178,7 +178,7 @@ it.effect("clones a looked-up repository into the requested destination", () =>
       assert.deepStrictEqual(cloneCalls, [
         {
           cwd: parent,
-          args: ["clone", CLONE_URLS.url, "t3code"],
+          args: ["clone", "--progress", CLONE_URLS.url, "t3code"],
         },
       ]);
     }).pipe(

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -9,6 +9,7 @@ import {
   SourceControlRepositoryError,
   type SourceControlCloneRepositoryInput,
   type SourceControlCloneRepositoryResult,
+  type SourceControlCloneProgressPhase,
   type SourceControlCloneProtocol,
   type SourceControlProviderKind,
   type SourceControlPublishRepositoryInput,
@@ -32,12 +33,21 @@ export class SourceControlRepositoryService extends Context.Service<
     ) => Effect.Effect<SourceControlRepositoryInfo, SourceControlRepositoryError>;
     readonly cloneRepository: (
       input: SourceControlCloneRepositoryInput,
+      progress?: CloneRepositoryProgress,
     ) => Effect.Effect<SourceControlCloneRepositoryResult, SourceControlRepositoryError>;
     readonly publishRepository: (
       input: SourceControlPublishRepositoryInput,
     ) => Effect.Effect<SourceControlPublishRepositoryResult, SourceControlRepositoryError>;
   }
 >()("t3/sourceControl/SourceControlRepositoryService") {}
+
+export interface CloneRepositoryProgress {
+  readonly report: (input: {
+    readonly phase: SourceControlCloneProgressPhase;
+    readonly percent: number | null;
+    readonly detail: string;
+  }) => Effect.Effect<void>;
+}
 
 function mapRepositoryError(operation: string, provider: SourceControlProviderKind) {
   return Effect.mapError((cause: unknown) =>
@@ -169,6 +179,7 @@ export const make = Effect.gen(function* () {
 
   const cloneRepository = Effect.fn("SourceControlRepositoryService.cloneRepository")(function* (
     input: SourceControlCloneRepositoryInput,
+    progress?: CloneRepositoryProgress,
   ) {
     const preparedDestination = yield* prepareDestination(input.destinationPath);
     let repository: SourceControlRepositoryInfo | null = null;
@@ -193,13 +204,72 @@ export const make = Effect.gen(function* () {
       });
     }
 
+    yield* (
+      progress?.report({
+        phase: "preparing",
+        percent: 0,
+        detail: "Preparing clone…",
+      }) ?? Effect.void
+    );
+
+    const reportGitProgress = (line: string) => {
+      const match =
+        /(?:remote:\s*)?(Enumerating|Counting|Compressing|Receiving|Resolving) objects:\s+(\d+)%/i.exec(
+          line,
+        );
+      const checkoutMatch = /Checking out files:\s+(\d+)%/i.exec(line);
+      if (!match && !checkoutMatch) return Effect.void;
+      const rawPercent = Number(match?.[2] ?? checkoutMatch?.[1] ?? 0);
+      const rawPhase = match?.[1]?.toLowerCase() ?? "checking_out";
+      const phase = rawPhase;
+      const phaseByName: Record<string, SourceControlCloneProgressPhase> = {
+        enumerating: "counting",
+        counting: "counting",
+        compressing: "compressing",
+        receiving: "receiving",
+        resolving: "resolving",
+        checking_out: "checking_out",
+      };
+      const normalizedPhase = phaseByName[phase] ?? "receiving";
+      const progressRanges: Record<SourceControlCloneProgressPhase, readonly [number, number]> = {
+        preparing: [0, 0],
+        counting: [0, 15],
+        compressing: [15, 30],
+        receiving: [30, 85],
+        resolving: [85, 92],
+        checking_out: [92, 100],
+        complete: [100, 100],
+      };
+      const [start, end] = progressRanges[normalizedPhase];
+      return (
+        progress?.report({
+          phase: normalizedPhase,
+          percent: Math.round(start + ((end - start) * rawPercent) / 100),
+          detail: checkoutMatch
+            ? `Checking out files: ${rawPercent}%`
+            : `${match?.[1] ?? "Receiving"} objects: ${rawPercent}%`,
+        }) ?? Effect.void
+      );
+    };
+
     yield* git.execute({
       operation: "SourceControlRepositoryService.cloneRepository",
       cwd: preparedDestination.parentPath,
-      args: ["clone", remoteUrl, preparedDestination.directoryName],
+      args: ["clone", "--progress", remoteUrl, preparedDestination.directoryName],
       timeoutMs: 120_000,
       maxOutputBytes: 256 * 1024,
+      progress: {
+        onStderrLine: reportGitProgress,
+      },
     });
+
+    yield* (
+      progress?.report({
+        phase: "complete",
+        percent: 100,
+        detail: "Clone complete",
+      }) ?? Effect.void
+    );
 
     return {
       cwd: preparedDestination.destinationPath,
@@ -268,8 +338,8 @@ export const make = Effect.gen(function* () {
   return SourceControlRepositoryService.of({
     lookupRepository: (input) =>
       lookupRepository(input).pipe(mapRepositoryError("lookupRepository", input.provider)),
-    cloneRepository: (input) =>
-      cloneRepository(input).pipe(
+    cloneRepository: (input, progress) =>
+      cloneRepository(input, progress).pipe(
         mapRepositoryError("cloneRepository", input.provider ?? "unknown"),
       ),
     publishRepository: (input) =>

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -24,6 +24,7 @@ import { expandHomePathWith } from "../pathExpansion.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as SourceControlProviderRegistry from "./SourceControlProviderRegistry.ts";
 const isSourceControlRepositoryError = Schema.is(SourceControlRepositoryError);
+const CLONE_TIMEOUT_MS = 10 * 60_000;
 
 export class SourceControlRepositoryService extends Context.Service<
   SourceControlRepositoryService,
@@ -256,7 +257,7 @@ export const make = Effect.gen(function* () {
       operation: "SourceControlRepositoryService.cloneRepository",
       cwd: preparedDestination.parentPath,
       args: ["clone", "--progress", remoteUrl, preparedDestination.directoryName],
-      timeoutMs: 120_000,
+      timeoutMs: CLONE_TIMEOUT_MS,
       maxOutputBytes: 256 * 1024,
       progress: {
         onStderrLine: reportGitProgress,

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -88,6 +88,20 @@ function selectRemoteUrl(
   }
 }
 
+function formatCloneProgressDetail(line: string, isCheckout: boolean): string {
+  if (isCheckout) return "Checking out files";
+
+  const detail = line.replace(/^(?:remote:\s*)/i, "").trim();
+  const match =
+    /^(Enumerating|Counting|Compressing|Receiving|Resolving) objects:\s+\d+%(?:\s+\(([^)]+)\))?(?:,\s*(.*))?$/i.exec(
+      detail,
+    );
+  if (!match) return detail;
+
+  const suffix = [match[2], match[3]].filter(Boolean).join(" · ");
+  return `${match[1]} objects${suffix.length > 0 ? ` · ${suffix}` : ""}`;
+}
+
 export const make = Effect.gen(function* () {
   const config = yield* ServerConfig;
   const fileSystem = yield* FileSystem.FileSystem;
@@ -246,9 +260,7 @@ export const make = Effect.gen(function* () {
         progress?.report({
           phase: normalizedPhase,
           percent: Math.round(start + ((end - start) * rawPercent) / 100),
-          detail: checkoutMatch
-            ? `Checking out files: ${rawPercent}%`
-            : line.replace(/^(?:remote:\s*)/i, "").trim(),
+          detail: formatCloneProgressDetail(line, checkoutMatch !== null),
         }) ?? Effect.void
       );
     };

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -229,13 +229,13 @@ export const make = Effect.gen(function* () {
 
     const reportGitProgress = (line: string) => {
       const match =
-        /(?:remote:\s*)?(Enumerating|Counting|Compressing|Receiving|Resolving) objects:\s+(\d+)%/i.exec(
+        /(?:remote:\s*)?(?:(Enumerating|Counting|Compressing|Receiving) objects:\s+(\d+)%|Resolving deltas:\s+(\d+)%)/i.exec(
           line,
         );
-      const checkoutMatch = /Checking out files:\s+(\d+)%/i.exec(line);
+      const checkoutMatch = /(?:Checking out files|Updating files):\s+(\d+)%/i.exec(line);
       if (!match && !checkoutMatch) return Effect.void;
-      const rawPercent = Number(match?.[2] ?? checkoutMatch?.[1] ?? 0);
-      const rawPhase = match?.[1]?.toLowerCase() ?? "checking_out";
+      const rawPercent = Number(match?.[2] ?? match?.[3] ?? checkoutMatch?.[1] ?? 0);
+      const rawPhase = match?.[1]?.toLowerCase() ?? (match ? "resolving" : "checking_out");
       const phase = rawPhase;
       const phaseByName: Record<string, SourceControlCloneProgressPhase> = {
         enumerating: "counting",

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -248,7 +248,7 @@ export const make = Effect.gen(function* () {
           percent: Math.round(start + ((end - start) * rawPercent) / 100),
           detail: checkoutMatch
             ? `Checking out files: ${rawPercent}%`
-            : `${match?.[1] ?? "Receiving"} objects: ${rawPercent}%`,
+            : line.replace(/^(?:remote:\s*)/i, "").trim(),
         }) ?? Effect.void
       );
     };

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -655,14 +655,16 @@ const collectOutput = Effect.fnUntraced(function* (
   let truncated = false;
 
   const emitCompleteLines = Effect.fnUntraced(function* (flush: boolean) {
-    let newlineIndex = lineBuffer.indexOf("\n");
-    while (newlineIndex >= 0) {
-      const line = lineBuffer.slice(0, newlineIndex).replace(/\r$/, "");
-      lineBuffer = lineBuffer.slice(newlineIndex + 1);
+    let delimiterIndex = lineBuffer.search(/[\r\n]/);
+    while (delimiterIndex >= 0) {
+      const delimiter = lineBuffer[delimiterIndex];
+      const delimiterLength = delimiter === "\r" && lineBuffer[delimiterIndex + 1] === "\n" ? 2 : 1;
+      const line = lineBuffer.slice(0, delimiterIndex);
+      lineBuffer = lineBuffer.slice(delimiterIndex + delimiterLength);
       if (line.length > 0 && onLine) {
         yield* onLine(line);
       }
-      newlineIndex = lineBuffer.indexOf("\n");
+      delimiterIndex = lineBuffer.search(/[\r\n]/);
     }
 
     if (flush) {

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -32,6 +32,8 @@ import {
   type OrchestrationClientOrigin,
   type OrchestrationCommand,
   type GitActionProgressEvent,
+  type SourceControlCloneProgressEvent,
+  SourceControlRepositoryError,
   type GitManagerServiceError,
   OrchestrationDispatchCommandError,
   type OrchestrationEvent,
@@ -2238,6 +2240,29 @@ const makeWsRpcLayer = (
           observeRpcEffect(
             WS_METHODS.sourceControlCloneRepository,
             sourceControlRepositories.cloneRepository(input),
+            {
+              "rpc.aggregate": "source-control",
+            },
+          ),
+        [WS_METHODS.sourceControlCloneRepositoryWithProgress]: (input) =>
+          observeRpcStream(
+            WS_METHODS.sourceControlCloneRepositoryWithProgress,
+            Stream.callback<SourceControlCloneProgressEvent, SourceControlRepositoryError>(
+              (queue) =>
+                sourceControlRepositories
+                  .cloneRepository(input, {
+                    report: (progress) =>
+                      Queue.offer(queue, { kind: "progress", ...progress }).pipe(Effect.asVoid),
+                  })
+                  .pipe(
+                    Effect.flatMap((result) =>
+                      Queue.offer(queue, { kind: "finished", result }).pipe(
+                        Effect.andThen(Queue.end(queue).pipe(Effect.asVoid)),
+                      ),
+                    ),
+                    Effect.catchCause((cause) => Queue.failCause(queue, cause)),
+                  ),
+            ),
             {
               "rpc.aggregate": "source-control",
             },

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -45,6 +45,7 @@ import {
   FolderIcon,
   FolderPlusIcon,
   LinkIcon,
+  LoaderCircleIcon,
   MessageSquareIcon,
   PaletteIcon,
   SettingsIcon,
@@ -2577,9 +2578,11 @@ function OpenCommandPaletteDialog(props: {
                   hasHighlightedBrowseItem,
                 })
               : undefined,
-        wrapperClassName: isSubmenu
-          ? "[&_[data-slot=autocomplete-start-addon]]:pointer-events-auto"
-          : undefined,
+        wrapperClassName: isRemoteProjectCloning
+          ? "hidden"
+          : isSubmenu
+            ? "[&_[data-slot=autocomplete-start-addon]]:pointer-events-auto"
+            : undefined,
         ...(isSubmenu
           ? {
               startAddon: (
@@ -2609,7 +2612,7 @@ function OpenCommandPaletteDialog(props: {
       showBackHint={isSubmenu}
       value={query}
     >
-      {remoteProjectContext ? (
+      {remoteProjectContext && !isRemoteProjectCloning ? (
         <div className="p-2 pb-0">
           <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">Repository</div>
           <div className="flex min-h-8 items-center gap-2 rounded-sm px-2 py-1.5">
@@ -2624,24 +2627,41 @@ function OpenCommandPaletteDialog(props: {
         </div>
       ) : null}
       {isRemoteProjectCloning && cloneProgress ? (
-        <div
-          className="mx-2 mt-2 mb-1 rounded-md border border-border/60 bg-muted/20 px-3 py-3"
-          role="status"
-          aria-live="polite"
-        >
-          <div className="mb-2 flex items-center justify-between gap-3">
-            <span className="font-medium text-foreground text-sm">Cloning project</span>
-            <span className="text-muted-foreground text-xs tabular-nums">
-              {cloneProgress.percent === null ? "" : `${cloneProgress.percent}%`}
+        <div className="px-4 pb-4 pt-4" role="status" aria-live="polite">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex min-w-0 items-center gap-2.5">
+              <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-foreground/[0.06] text-muted-foreground">
+                {remoteProjectContext?.icon}
+              </span>
+              <span className="flex min-w-0 flex-col">
+                <span className="truncate font-medium text-foreground text-sm">
+                  {remoteProjectContext?.title ?? "Repository"}
+                </span>
+                <span className="truncate text-muted-foreground/75 text-xs">
+                  {query || "Preparing destination"}
+                </span>
+              </span>
+            </div>
+            <span className="shrink-0 rounded-full bg-foreground/[0.06] px-2 py-1 font-medium text-muted-foreground text-[11px] tabular-nums">
+              Cloning{cloneProgress.percent === null ? "" : ` ${cloneProgress.percent}%`}
             </span>
           </div>
-          <div className="mb-2 text-muted-foreground text-xs">{cloneProgress.detail}</div>
+          <div className="mt-5 flex items-center gap-2 text-xs">
+            <LoaderCircleIcon className="size-3.5 shrink-0 animate-spin text-primary motion-reduce:animate-none" />
+            <span className="min-w-0 flex-1 truncate font-medium text-foreground">
+              {cloneProgress.detail}
+            </span>
+            <span className="shrink-0 text-muted-foreground tabular-nums">
+              {cloneProgress.percent === null ? "—" : `${cloneProgress.percent}%`}
+            </span>
+          </div>
           <div
-            className="h-1.5 w-full overflow-hidden rounded-full bg-muted/60"
+            className="mt-2 h-1 w-full overflow-hidden rounded-full bg-foreground/[0.08]"
             role="progressbar"
             aria-valuemin={0}
             aria-valuemax={100}
             aria-valuenow={cloneProgress.percent ?? undefined}
+            aria-valuetext={cloneProgress.detail}
             aria-label="Clone progress"
           >
             <div
@@ -2653,6 +2673,10 @@ function OpenCommandPaletteDialog(props: {
                 cloneProgress.percent === null ? undefined : { width: `${cloneProgress.percent}%` }
               }
             />
+          </div>
+          <div className="mt-2 flex items-center justify-between gap-3 text-[11px] text-muted-foreground/65">
+            <span className="min-w-0 truncate">{remoteProjectContext?.description}</span>
+            <span className="shrink-0">{cloneProgress.phase.replace("_", " ")}</span>
           </div>
         </div>
       ) : null}

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2644,7 +2644,7 @@ function OpenCommandPaletteDialog(props: {
                   {remoteProjectContext?.title ?? "Repository"}
                 </span>
                 <span className="truncate text-muted-foreground/75 text-xs">
-                  {query || "Preparing destination"}
+                  {(remoteProjectContext?.description ?? query) || "Preparing destination"}
                 </span>
               </span>
             </div>

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2086,7 +2086,9 @@ function OpenCommandPaletteDialog(props: {
         onProgress: (event) => {
           if (event.kind !== "progress") return;
           setCloneProgress((previous) =>
-            previous?.phase === event.phase && previous.percent === event.percent
+            previous?.phase === event.phase &&
+            previous.percent === event.percent &&
+            previous.detail === event.detail
               ? previous
               : event,
           );
@@ -2669,6 +2671,7 @@ function OpenCommandPaletteDialog(props: {
               className={cn(
                 "h-full rounded-full bg-primary transition-[width] duration-500 ease-out motion-reduce:transition-none",
                 cloneProgress.percent === null && "w-1/3",
+                cloneProgress.phase === "receiving" && "animate-pulse",
               )}
               style={
                 cloneProgress.percent === null ? undefined : { width: `${cloneProgress.percent}%` }

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2596,7 +2596,10 @@ function OpenCommandPaletteDialog(props: {
                   type="button"
                   className="flex cursor-pointer items-center"
                   aria-label="Back"
-                  onClick={popView}
+                  disabled={isRemoteProjectCloning}
+                  onClick={() => {
+                    if (!isRemoteProjectCloning) popView();
+                  }}
                 >
                   <ArrowLeftIcon />
                 </button>
@@ -2650,7 +2653,7 @@ function OpenCommandPaletteDialog(props: {
             </div>
           </div>
           <div className="mt-5 flex items-center gap-2 text-xs">
-            <LoaderCircleIcon className="size-3.5 shrink-0 animate-spin text-primary motion-reduce:animate-none" />
+            <LoaderCircleIcon className="size-3.5 shrink-0 text-primary" />
             <span className="min-w-0 flex-1 truncate font-medium text-foreground">
               {cloneProgress.detail}
             </span>
@@ -2671,7 +2674,6 @@ function OpenCommandPaletteDialog(props: {
               className={cn(
                 "h-full rounded-full bg-primary transition-[width] duration-500 ease-out motion-reduce:transition-none",
                 cloneProgress.percent === null && "w-1/3",
-                cloneProgress.phase === "receiving" && "animate-pulse",
               )}
               style={
                 cloneProgress.percent === null ? undefined : { width: `${cloneProgress.percent}%` }

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -30,7 +30,6 @@ import {
   type FilesystemBrowseResult,
   type ProjectId,
   type SourceControlDiscoveryResult,
-  type SourceControlCloneProgressEvent,
   type SourceControlProviderKind,
   type SourceControlRepositoryInfo,
   PRIMARY_LOCAL_ENVIRONMENT_ID,
@@ -591,10 +590,9 @@ function OpenCommandPaletteDialog(props: {
     reportFailure: false,
     reportDefect: false,
   });
-  const cloneRepositoryWithProgress = useAtomCommand(
-    sourceControlEnvironment.cloneRepositoryWithProgress,
-    { reportFailure: false },
-  );
+  const cloneRepository = useAtomCommand(sourceControlEnvironment.cloneRepository, {
+    reportFailure: false,
+  });
   const { environments } = useEnvironments();
   const desktopLocalBootstraps = useDesktopLocalBootstraps();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
@@ -688,10 +686,6 @@ function OpenCommandPaletteDialog(props: {
   );
   const [isPickingProjectFolder, setIsPickingProjectFolder] = useState(false);
   const [addProjectCloneFlow, setAddProjectCloneFlow] = useState<AddProjectCloneFlow | null>(null);
-  const [cloneProgress, setCloneProgress] = useState<Extract<
-    SourceControlCloneProgressEvent,
-    { kind: "progress" }
-  > | null>(null);
   const [isRemoteProjectLookingUp, setIsRemoteProjectLookingUp] = useState(false);
   const [isRemoteProjectCloning, setIsRemoteProjectCloning] = useState(false);
   const projectGroupingSettings = useMemo(
@@ -2070,39 +2064,30 @@ function OpenCommandPaletteDialog(props: {
     }
 
     setIsRemoteProjectCloning(true);
-    setCloneProgress({
-      kind: "progress",
-      phase: "preparing",
-      percent: 0,
-      detail: "Preparing clone…",
-    });
-    const cloneResult = await cloneRepositoryWithProgress({
-      environmentId: addProjectCloneFlow.environmentId,
-      input: {
-        remoteUrl: addProjectCloneFlow.remoteUrl,
-        destinationPath,
-      },
-      onProgress: (event) => {
-        if (event.kind === "progress") {
-          setCloneProgress(event);
+    try {
+      const cloneResult = await cloneRepository({
+        environmentId: addProjectCloneFlow.environmentId,
+        input: {
+          remoteUrl: addProjectCloneFlow.remoteUrl,
+          destinationPath,
+        },
+      });
+      if (cloneResult._tag === "Failure") {
+        if (!isAtomCommandInterrupted(cloneResult)) {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Clone failed",
+              description: errorMessage(squashAtomCommandFailure(cloneResult)),
+            }),
+          );
         }
-      },
-    });
-    setIsRemoteProjectCloning(false);
-    setCloneProgress(null);
-    if (cloneResult._tag === "Failure") {
-      if (!isAtomCommandInterrupted(cloneResult)) {
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: "Clone failed",
-            description: errorMessage(squashAtomCommandFailure(cloneResult)),
-          }),
-        );
+        return;
       }
-      return;
+      await handleAddProject(cloneResult.value.cwd);
+    } finally {
+      setIsRemoteProjectCloning(false);
     }
-    await handleAddProject(cloneResult.value.cwd);
   }
 
   const browseTo = useCallback(
@@ -2626,7 +2611,7 @@ function OpenCommandPaletteDialog(props: {
           </div>
         </div>
       ) : null}
-      {isRemoteProjectCloning && cloneProgress ? (
+      {isRemoteProjectCloning ? (
         <div className="px-4 pb-4 pt-4" role="status" aria-live="polite">
           <div className="flex items-start justify-between gap-3">
             <div className="flex min-w-0 items-center gap-2.5">
@@ -2642,17 +2627,11 @@ function OpenCommandPaletteDialog(props: {
                 </span>
               </span>
             </div>
-            <span className="shrink-0 rounded-full bg-foreground/[0.06] px-2 py-1 font-medium text-muted-foreground text-[11px] tabular-nums">
-              Cloning{cloneProgress.percent === null ? "" : ` ${cloneProgress.percent}%`}
-            </span>
           </div>
           <div className="mt-5 flex items-center gap-2 text-xs">
             <LoaderCircleIcon className="size-3.5 shrink-0 animate-spin text-primary motion-reduce:animate-none" />
             <span className="min-w-0 flex-1 truncate font-medium text-foreground">
-              {cloneProgress.detail}
-            </span>
-            <span className="shrink-0 text-muted-foreground tabular-nums">
-              {cloneProgress.percent === null ? "—" : `${cloneProgress.percent}%`}
+              Cloning repository…
             </span>
           </div>
           <div
@@ -2660,23 +2639,13 @@ function OpenCommandPaletteDialog(props: {
             role="progressbar"
             aria-valuemin={0}
             aria-valuemax={100}
-            aria-valuenow={cloneProgress.percent ?? undefined}
-            aria-valuetext={cloneProgress.detail}
             aria-label="Clone progress"
           >
-            <div
-              className={cn(
-                "h-full rounded-full bg-primary transition-[width] duration-500 ease-out motion-reduce:transition-none",
-                cloneProgress.percent === null && "w-1/3",
-              )}
-              style={
-                cloneProgress.percent === null ? undefined : { width: `${cloneProgress.percent}%` }
-              }
-            />
+            <div className="h-full w-1/3 rounded-full bg-primary motion-safe:animate-[preview-loading-progress_1.8s_ease-in-out_infinite] motion-reduce:animate-none" />
           </div>
           <div className="mt-2 flex items-center justify-between gap-3 text-[11px] text-muted-foreground/65">
             <span className="min-w-0 truncate">{remoteProjectContext?.description}</span>
-            <span className="shrink-0">{cloneProgress.phase.replace("_", " ")}</span>
+            <span className="shrink-0">Cloning</span>
           </div>
         </div>
       ) : null}

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -30,6 +30,7 @@ import {
   type FilesystemBrowseResult,
   type ProjectId,
   type SourceControlDiscoveryResult,
+  type SourceControlCloneProgressEvent,
   type SourceControlProviderKind,
   type SourceControlRepositoryInfo,
   PRIMARY_LOCAL_ENVIRONMENT_ID,
@@ -590,9 +591,10 @@ function OpenCommandPaletteDialog(props: {
     reportFailure: false,
     reportDefect: false,
   });
-  const cloneRepository = useAtomCommand(sourceControlEnvironment.cloneRepository, {
-    reportFailure: false,
-  });
+  const cloneRepositoryWithProgress = useAtomCommand(
+    sourceControlEnvironment.cloneRepositoryWithProgress,
+    { reportFailure: false },
+  );
   const { environments } = useEnvironments();
   const desktopLocalBootstraps = useDesktopLocalBootstraps();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
@@ -686,6 +688,10 @@ function OpenCommandPaletteDialog(props: {
   );
   const [isPickingProjectFolder, setIsPickingProjectFolder] = useState(false);
   const [addProjectCloneFlow, setAddProjectCloneFlow] = useState<AddProjectCloneFlow | null>(null);
+  const [cloneProgress, setCloneProgress] = useState<Extract<
+    SourceControlCloneProgressEvent,
+    { kind: "progress" }
+  > | null>(null);
   const [isRemoteProjectLookingUp, setIsRemoteProjectLookingUp] = useState(false);
   const [isRemoteProjectCloning, setIsRemoteProjectCloning] = useState(false);
   const projectGroupingSettings = useMemo(
@@ -2065,11 +2071,25 @@ function OpenCommandPaletteDialog(props: {
 
     setIsRemoteProjectCloning(true);
     try {
-      const cloneResult = await cloneRepository({
+      setCloneProgress({
+        kind: "progress",
+        phase: "preparing",
+        percent: 0,
+        detail: "Preparing clone…",
+      });
+      const cloneResult = await cloneRepositoryWithProgress({
         environmentId: addProjectCloneFlow.environmentId,
         input: {
           remoteUrl: addProjectCloneFlow.remoteUrl,
           destinationPath,
+        },
+        onProgress: (event) => {
+          if (event.kind !== "progress") return;
+          setCloneProgress((previous) =>
+            previous?.phase === event.phase && previous.percent === event.percent
+              ? previous
+              : event,
+          );
         },
       });
       if (cloneResult._tag === "Failure") {
@@ -2087,6 +2107,7 @@ function OpenCommandPaletteDialog(props: {
       await handleAddProject(cloneResult.value.cwd);
     } finally {
       setIsRemoteProjectCloning(false);
+      setCloneProgress(null);
     }
   }
 
@@ -2563,11 +2584,9 @@ function OpenCommandPaletteDialog(props: {
                   hasHighlightedBrowseItem,
                 })
               : undefined,
-        wrapperClassName: isRemoteProjectCloning
-          ? "hidden"
-          : isSubmenu
-            ? "[&_[data-slot=autocomplete-start-addon]]:pointer-events-auto"
-            : undefined,
+        wrapperClassName: isSubmenu
+          ? "[&_[data-slot=autocomplete-start-addon]]:pointer-events-auto"
+          : undefined,
         ...(isSubmenu
           ? {
               startAddon: (
@@ -2611,7 +2630,7 @@ function OpenCommandPaletteDialog(props: {
           </div>
         </div>
       ) : null}
-      {isRemoteProjectCloning ? (
+      {isRemoteProjectCloning && cloneProgress ? (
         <div className="px-4 pb-4 pt-4" role="status" aria-live="polite">
           <div className="flex items-start justify-between gap-3">
             <div className="flex min-w-0 items-center gap-2.5">
@@ -2631,7 +2650,10 @@ function OpenCommandPaletteDialog(props: {
           <div className="mt-5 flex items-center gap-2 text-xs">
             <LoaderCircleIcon className="size-3.5 shrink-0 animate-spin text-primary motion-reduce:animate-none" />
             <span className="min-w-0 flex-1 truncate font-medium text-foreground">
-              Cloning repository…
+              {cloneProgress.detail}
+            </span>
+            <span className="shrink-0 text-muted-foreground tabular-nums">
+              {cloneProgress.percent === null ? "—" : `${cloneProgress.percent}%`}
             </span>
           </div>
           <div
@@ -2639,13 +2661,23 @@ function OpenCommandPaletteDialog(props: {
             role="progressbar"
             aria-valuemin={0}
             aria-valuemax={100}
+            aria-valuenow={cloneProgress.percent ?? undefined}
+            aria-valuetext={cloneProgress.detail}
             aria-label="Clone progress"
           >
-            <div className="h-full w-1/3 rounded-full bg-primary motion-safe:animate-[preview-loading-progress_1.8s_ease-in-out_infinite] motion-reduce:animate-none" />
+            <div
+              className={cn(
+                "h-full rounded-full bg-primary transition-[width] duration-500 ease-out motion-reduce:transition-none",
+                cloneProgress.percent === null && "w-1/3",
+              )}
+              style={
+                cloneProgress.percent === null ? undefined : { width: `${cloneProgress.percent}%` }
+              }
+            />
           </div>
           <div className="mt-2 flex items-center justify-between gap-3 text-[11px] text-muted-foreground/65">
             <span className="min-w-0 truncate">{remoteProjectContext?.description}</span>
-            <span className="shrink-0">Cloning</span>
+            <span className="shrink-0">{cloneProgress.phase.replace("_", " ")}</span>
           </div>
         </div>
       ) : null}

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2678,9 +2678,6 @@ function OpenCommandPaletteDialog(props: {
               }
             />
           </div>
-          <div className="mt-2 flex items-center justify-end gap-3 text-[11px] text-muted-foreground/65">
-            <span className="shrink-0">{cloneProgress.phase.replace("_", " ")}</span>
-          </div>
         </div>
       ) : null}
       {!isRemoteProjectCloning ? (

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2678,8 +2678,7 @@ function OpenCommandPaletteDialog(props: {
               }
             />
           </div>
-          <div className="mt-2 flex items-center justify-between gap-3 text-[11px] text-muted-foreground/65">
-            <span className="min-w-0 truncate">{remoteProjectContext?.description}</span>
+          <div className="mt-2 flex items-center justify-end gap-3 text-[11px] text-muted-foreground/65">
             <span className="shrink-0">{cloneProgress.phase.replace("_", " ")}</span>
           </div>
         </div>

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -30,6 +30,7 @@ import {
   type FilesystemBrowseResult,
   type ProjectId,
   type SourceControlDiscoveryResult,
+  type SourceControlCloneProgressEvent,
   type SourceControlProviderKind,
   type SourceControlRepositoryInfo,
   PRIMARY_LOCAL_ENVIRONMENT_ID,
@@ -589,9 +590,10 @@ function OpenCommandPaletteDialog(props: {
     reportFailure: false,
     reportDefect: false,
   });
-  const cloneRepository = useAtomCommand(sourceControlEnvironment.cloneRepository, {
-    reportFailure: false,
-  });
+  const cloneRepositoryWithProgress = useAtomCommand(
+    sourceControlEnvironment.cloneRepositoryWithProgress,
+    { reportFailure: false },
+  );
   const { environments } = useEnvironments();
   const desktopLocalBootstraps = useDesktopLocalBootstraps();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
@@ -685,6 +687,10 @@ function OpenCommandPaletteDialog(props: {
   );
   const [isPickingProjectFolder, setIsPickingProjectFolder] = useState(false);
   const [addProjectCloneFlow, setAddProjectCloneFlow] = useState<AddProjectCloneFlow | null>(null);
+  const [cloneProgress, setCloneProgress] = useState<Extract<
+    SourceControlCloneProgressEvent,
+    { kind: "progress" }
+  > | null>(null);
   const [isRemoteProjectLookingUp, setIsRemoteProjectLookingUp] = useState(false);
   const [isRemoteProjectCloning, setIsRemoteProjectCloning] = useState(false);
   const projectGroupingSettings = useMemo(
@@ -2063,14 +2069,26 @@ function OpenCommandPaletteDialog(props: {
     }
 
     setIsRemoteProjectCloning(true);
-    const cloneResult = await cloneRepository({
+    setCloneProgress({
+      kind: "progress",
+      phase: "preparing",
+      percent: 0,
+      detail: "Preparing clone…",
+    });
+    const cloneResult = await cloneRepositoryWithProgress({
       environmentId: addProjectCloneFlow.environmentId,
       input: {
         remoteUrl: addProjectCloneFlow.remoteUrl,
         destinationPath,
       },
+      onProgress: (event) => {
+        if (event.kind === "progress") {
+          setCloneProgress(event);
+        }
+      },
     });
     setIsRemoteProjectCloning(false);
+    setCloneProgress(null);
     if (cloneResult._tag === "Failure") {
       if (!isAtomCommandInterrupted(cloneResult)) {
         toastManager.add(
@@ -2544,8 +2562,8 @@ function OpenCommandPaletteDialog(props: {
       key={`${viewStack.length}-${browseGeneration}-${isBrowsing}-${addProjectCloneFlow?.step ?? "none"}`}
       aria-label="Command palette"
       autoHighlight={isBrowsing || isRemoteProjectCloneFlow ? false : "always"}
-      footerActionLabel={footerActionLabel}
-      footerTrailing={footerTrailing}
+      footerActionLabel={isRemoteProjectCloning ? undefined : footerActionLabel}
+      footerTrailing={isRemoteProjectCloning ? undefined : footerTrailing}
       inputAccessory={inputAccessory}
       inputProps={{
         // The submit button is absolutely positioned over the field, so the
@@ -2559,7 +2577,6 @@ function OpenCommandPaletteDialog(props: {
                   hasHighlightedBrowseItem,
                 })
               : undefined,
-        placeholder: inputPlaceholder,
         wrapperClassName: isSubmenu
           ? "[&_[data-slot=autocomplete-start-addon]]:pointer-events-auto"
           : undefined,
@@ -2580,6 +2597,8 @@ function OpenCommandPaletteDialog(props: {
             ? { startAddon: <FolderPlusIcon /> }
             : {}),
         onKeyDown: handleKeyDown,
+        disabled: isRemoteProjectCloning,
+        placeholder: isRemoteProjectCloning ? "Cloning project…" : inputPlaceholder,
       }}
       mode="none"
       onItemHighlighted={(value) => {
@@ -2604,31 +2623,67 @@ function OpenCommandPaletteDialog(props: {
           </div>
         </div>
       ) : null}
-      <CommandPaletteResults
-        groups={displayedGroups}
-        highlightedItemValue={highlightedItemValue}
-        isActionsOnly={isActionsOnly}
-        keybindings={keybindings}
-        onExecuteItem={executeItem}
-        {...(addProjectCloneFlow?.step === "repository"
-          ? {
-              emptyStateMessage:
-                addProjectCloneFlow.source === "url"
-                  ? "Enter a Git clone URL and press Enter to continue."
-                  : "Enter a repository path and press Enter to look it up.",
-            }
-          : addProjectCloneFlow?.step === "confirm"
-            ? { emptyStateMessage: "Choose a destination path and press Enter to clone." }
-            : relativePathNeedsActiveProject
-              ? { emptyStateMessage: "Relative paths require an active project." }
-              : willCreateProjectPath
-                ? {
-                    emptyStateMessage: "Press Enter to create this folder and add it as a project.",
-                  }
-                : threadSearch.isPending
-                  ? { emptyStateMessage: "Searching thread messages…" }
-                  : {})}
-      />
+      {isRemoteProjectCloning && cloneProgress ? (
+        <div
+          className="mx-2 mt-2 mb-1 rounded-md border border-border/60 bg-muted/20 px-3 py-3"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <span className="font-medium text-foreground text-sm">Cloning project</span>
+            <span className="text-muted-foreground text-xs tabular-nums">
+              {cloneProgress.percent === null ? "" : `${cloneProgress.percent}%`}
+            </span>
+          </div>
+          <div className="mb-2 text-muted-foreground text-xs">{cloneProgress.detail}</div>
+          <div
+            className="h-1.5 w-full overflow-hidden rounded-full bg-muted/60"
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={cloneProgress.percent ?? undefined}
+            aria-label="Clone progress"
+          >
+            <div
+              className={cn(
+                "h-full rounded-full bg-primary transition-[width] duration-500 ease-out motion-reduce:transition-none",
+                cloneProgress.percent === null && "w-1/3",
+              )}
+              style={
+                cloneProgress.percent === null ? undefined : { width: `${cloneProgress.percent}%` }
+              }
+            />
+          </div>
+        </div>
+      ) : null}
+      {!isRemoteProjectCloning ? (
+        <CommandPaletteResults
+          groups={displayedGroups}
+          highlightedItemValue={highlightedItemValue}
+          isActionsOnly={isActionsOnly}
+          keybindings={keybindings}
+          onExecuteItem={executeItem}
+          {...(addProjectCloneFlow?.step === "repository"
+            ? {
+                emptyStateMessage:
+                  addProjectCloneFlow.source === "url"
+                    ? "Enter a Git clone URL and press Enter to continue."
+                    : "Enter a repository path and press Enter to look it up.",
+              }
+            : addProjectCloneFlow?.step === "confirm"
+              ? { emptyStateMessage: "Choose a destination path and press Enter to clone." }
+              : relativePathNeedsActiveProject
+                ? { emptyStateMessage: "Relative paths require an active project." }
+                : willCreateProjectPath
+                  ? {
+                      emptyStateMessage:
+                        "Press Enter to create this folder and add it as a project.",
+                    }
+                  : threadSearch.isPending
+                    ? { emptyStateMessage: "Searching thread messages…" }
+                    : {})}
+        />
+      ) : null}
     </CommandPaletteContent>
   );
 }

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -60,7 +60,8 @@ export type EnvironmentSubscriptionRpcTag =
 export type EnvironmentStreamCommandRpcTag =
   | typeof WS_METHODS.cloudInstallRelayClient
   | typeof WS_METHODS.serverUpdateServerWithProgress
-  | typeof WS_METHODS.gitRunStackedAction;
+  | typeof WS_METHODS.gitRunStackedAction
+  | typeof WS_METHODS.sourceControlCloneRepositoryWithProgress;
 
 export type EnvironmentStreamRpcTag =
   | EnvironmentSubscriptionRpcTag

--- a/packages/client-runtime/src/state/sourceControl.ts
+++ b/packages/client-runtime/src/state/sourceControl.ts
@@ -1,15 +1,32 @@
-import { WS_METHODS } from "@t3tools/contracts";
+import {
+  type EnvironmentId as EnvironmentIdType,
+  type SourceControlCloneProgressEvent,
+  type SourceControlCloneRepositoryInput,
+  type SourceControlCloneRepositoryResult,
+  WS_METHODS,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
 import { Atom } from "effect/unstable/reactivity";
 
 import {
   createAtomCommandScheduler,
   createEnvironmentRpcCommand,
   createEnvironmentRpcQueryAtomFamily,
+  createRuntimeCommand,
+  runStreamInEnvironment,
 } from "./runtime.ts";
 import type { EnvironmentRegistry } from "../connection/registry.ts";
 import { EnvironmentCacheStore } from "../platform/persistence.ts";
+import { runStream } from "../rpc/client.ts";
 import { vcsCommandConcurrency, vcsCommandScheduler } from "./vcsCommandScheduler.ts";
 import { invalidateCachedVcsRefs } from "./vcsRefInvalidation.ts";
+
+export interface CloneRepositoryWithProgressInput {
+  readonly environmentId: EnvironmentIdType;
+  readonly input: SourceControlCloneRepositoryInput;
+  readonly onProgress?: (event: SourceControlCloneProgressEvent) => void;
+}
 
 export function createSourceControlEnvironmentAtoms<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | EnvironmentCacheStore | R, E>,
@@ -32,6 +49,38 @@ export function createSourceControlEnvironmentAtoms<R, E>(
         mode: "serial",
         key: ({ environmentId }) => environmentId,
       },
+    }),
+    cloneRepositoryWithProgress: createRuntimeCommand(runtime, {
+      label: "environment-data:source-control:clone-repository-with-progress",
+      scheduler: commandScheduler,
+      concurrency: { mode: "serial", key: (input) => input.environmentId },
+      execute: (
+        input: CloneRepositoryWithProgressInput,
+      ): Effect.Effect<
+        SourceControlCloneRepositoryResult,
+        unknown,
+        EnvironmentRegistry | EnvironmentCacheStore | R
+      > =>
+        Effect.gen(function* () {
+          let result: SourceControlCloneRepositoryResult | null = null;
+          yield* runStreamInEnvironment(
+            input.environmentId,
+            runStream(WS_METHODS.sourceControlCloneRepositoryWithProgress, input.input),
+          ).pipe(
+            Stream.runForEach((event) =>
+              Effect.sync(() => {
+                if (event.kind === "finished") {
+                  result = event.result;
+                }
+                input.onProgress?.(event);
+              }),
+            ),
+          );
+          if (result === null) {
+            throw new Error("Clone progress stream ended without a result.");
+          }
+          return result;
+        }),
     }),
     publishRepository: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:source-control:publish-repository",

--- a/packages/client-runtime/src/state/sourceControl.ts
+++ b/packages/client-runtime/src/state/sourceControl.ts
@@ -72,7 +72,12 @@ export function createSourceControlEnvironmentAtoms<R, E>(
                 if (event.kind === "finished") {
                   result = event.result;
                 }
-                input.onProgress?.(event);
+                try {
+                  input.onProgress?.(event);
+                } catch {
+                  // Progress callbacks are presentation-only and must not abort cloning.
+                  return;
+                }
               }),
             ),
           );

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -225,6 +225,7 @@ import { UsagePricing, UsageReadError, UsageSummary, UsageSummaryInput } from ".
 import { ServerSettings, ServerSettingsError, ServerSettingsPatch } from "./settings.ts";
 import {
   SourceControlCloneRepositoryInput,
+  SourceControlCloneProgressEvent,
   SourceControlCloneRepositoryResult,
   SourceControlDiscoveryResult,
   SourceControlPublishRepositoryInput,
@@ -366,6 +367,7 @@ export const WS_METHODS = {
   // Source control methods
   sourceControlLookupRepository: "sourceControl.lookupRepository",
   sourceControlCloneRepository: "sourceControl.cloneRepository",
+  sourceControlCloneRepositoryWithProgress: "sourceControl.cloneRepositoryWithProgress",
   sourceControlPublishRepository: "sourceControl.publishRepository",
 
   // Streaming subscriptions
@@ -774,6 +776,16 @@ const WsSourceControlCloneRepositoryRpc = Rpc.make(WS_METHODS.sourceControlClone
   success: SourceControlCloneRepositoryResult,
   error: Schema.Union([SourceControlRepositoryError, EnvironmentAuthorizationError]),
 });
+
+const WsSourceControlCloneRepositoryWithProgressRpc = Rpc.make(
+  WS_METHODS.sourceControlCloneRepositoryWithProgress,
+  {
+    payload: SourceControlCloneRepositoryInput,
+    success: SourceControlCloneProgressEvent,
+    error: Schema.Union([SourceControlRepositoryError, EnvironmentAuthorizationError]),
+    stream: true,
+  },
+);
 
 const WsSourceControlPublishRepositoryRpc = Rpc.make(WS_METHODS.sourceControlPublishRepository, {
   payload: SourceControlPublishRepositoryInput,
@@ -1241,6 +1253,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsPullRequestsSetLabelsRpc,
   WsSourceControlLookupRepositoryRpc,
   WsSourceControlCloneRepositoryRpc,
+  WsSourceControlCloneRepositoryWithProgressRpc,
   WsSourceControlPublishRepositoryRpc,
   WsProjectsListEntriesRpc,
   WsProjectsReadFileRpc,

--- a/packages/contracts/src/sourceControl.ts
+++ b/packages/contracts/src/sourceControl.ts
@@ -84,6 +84,35 @@ export const SourceControlCloneRepositoryResult = Schema.Struct({
 });
 export type SourceControlCloneRepositoryResult = typeof SourceControlCloneRepositoryResult.Type;
 
+export const SourceControlCloneProgressPhase = Schema.Literals([
+  "preparing",
+  "counting",
+  "compressing",
+  "receiving",
+  "resolving",
+  "checking_out",
+  "complete",
+]);
+export type SourceControlCloneProgressPhase = typeof SourceControlCloneProgressPhase.Type;
+
+const SourceControlCloneProgressBase = Schema.Struct({
+  phase: SourceControlCloneProgressPhase,
+  percent: Schema.NullOr(Schema.Number),
+  detail: TrimmedNonEmptyString,
+});
+
+export const SourceControlCloneProgressEvent = Schema.Union([
+  Schema.Struct({
+    ...SourceControlCloneProgressBase.fields,
+    kind: Schema.Literal("progress"),
+  }),
+  Schema.Struct({
+    kind: Schema.Literal("finished"),
+    result: SourceControlCloneRepositoryResult,
+  }),
+]);
+export type SourceControlCloneProgressEvent = typeof SourceControlCloneProgressEvent.Type;
+
 export const SourceControlPublishRepositoryInput = Schema.Struct({
   cwd: TrimmedNonEmptyString,
   provider: SourceControlProviderKind,


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Added clone progress feedback when adding a GitHub project.
- Ensured the command palette closes after successful project creation.
- Increased the clone timeout for slower repositories.

## Why

Cloning previously provided little feedback and could appear stuck during slow object transfers. The new progress state makes activity clearer without duplicating information or changing the existing clone flow.

The UI now shows one overall percentage while retaining useful transfer details such as object counts and download speed.

## UI Changes

Before:

<img width="632" height="459" alt="file-53a558f45b16e47f5e273701040c36d4" src="https://github.com/user-attachments/assets/16292872-e0db-4a1b-9a16-78c65d47af86" />

After: 

<img width="690" height="300" alt="dyn-9d7e34c5e4f99f21de919357070864c2" src="https://github.com/user-attachments/assets/9e451079-622c-4abb-80e4-30139fa9428c" />

<!-- Attach before/after screenshots and a short interaction video here. -->

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show clone progress in `AddProjectDestinationScreen` while cloning
> - Replaces the non-streaming clone command with the progress-capable clone RPC in the mobile add-project flow
> - Adds local state for progress events, reports an initial preparing state, and forwards progress callbacks with phase detail and percentage
> - Hides the path input, clone button, and folder browser while cloning; clears progress after the call finishes
> - Behavioral Change: `AddProjectDestinationScreen` now hides destination controls for the entire clone operation and displays an accessible progress card until cloning completes
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 46a6a39. 10 files reviewed, 3 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live progress reporting when cloning remote repositories on mobile and web.
  * Progress displays show the current phase, details, percentage, and progress bar.
  * Form controls and command palette actions are temporarily disabled during cloning.
  * Clone operations can now continue for longer while reporting updates.

* **Bug Fixes**
  * Improved handling of Git output across different line-ending formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->