### PR TITLE
fix(desktop): preserve preview viewport when app is zoomed

### DIFF
--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -217,6 +217,7 @@ type TestDisplayMediaHandler = (
 
 interface TestHostWebContents {
   readonly id: number;
+  readonly getZoomFactor: () => number;
   readonly mainFrame: { readonly frameTreeNodeId: number };
   readonly executeJavaScript: ReturnType<typeof vi.fn>;
   readonly isDestroyed: () => boolean;
@@ -234,6 +235,7 @@ const makeTestHostWebContents = (): TestHostWebContents => {
   let handler: TestDisplayMediaHandler | undefined;
   return {
     id: 7,
+    getZoomFactor: () => 1,
     mainFrame: { frameTreeNodeId: 7 },
     executeJavaScript: vi.fn(async () => true),
     isDestroyed: () => false,
@@ -481,7 +483,7 @@ describe("PreviewManager", () => {
       Effect.gen(function* () {
         const preview = makeFaviconWebContents();
         const sendInputEvent = vi.fn();
-        const hostWebContents = { sendInputEvent };
+        const hostWebContents = { sendInputEvent, getZoomFactor: () => 1 };
         Object.assign(preview.webContents, { hostWebContents });
         fromId.mockReturnValue(preview.webContents);
         yield* manager.setMainWindow({
@@ -1261,6 +1263,7 @@ describe("PreviewManager", () => {
   effectIt.effect("keeps the tab's own zoom instead of the guest's reported zoom", () =>
     withManager((manager) =>
       Effect.gen(function* () {
+        const hostWebContents = { getZoomFactor: () => 1.44 };
         let effectiveZoom = 0.9;
         let zoomReadable = true;
         let url = "https://example.com";
@@ -1268,6 +1271,7 @@ describe("PreviewManager", () => {
         const setZoomFactor = vi.fn();
         fromId.mockReturnValue({
           id: 42,
+          hostWebContents,
           isDestroyed: () => false,
           getType: () => "webview",
           getURL: () => url,
@@ -1308,7 +1312,7 @@ describe("PreviewManager", () => {
         yield* manager.registerWebview("tab_zoom", 42);
 
         expect(states.at(-1)?.zoomFactor).toBe(1);
-        expect(setZoomFactor).toHaveBeenCalledWith(1);
+        expect(setZoomFactor).toHaveBeenCalledWith(1.44);
 
         // An app zoom leaves the guest reporting the inherited level. Navigating
         // must not adopt it as the preview's zoom.
@@ -1326,7 +1330,7 @@ describe("PreviewManager", () => {
 
         // Only the preview's own zoom controls move it.
         yield* manager.zoomIn("tab_zoom");
-        expect(setZoomFactor).toHaveBeenCalledWith(1.1);
+        expect(setZoomFactor).toHaveBeenCalledWith(1.1 * 1.44);
         expect(states.at(-1)?.zoomFactor).toBe(1.1);
 
         zoomReadable = false;
@@ -1338,6 +1342,7 @@ describe("PreviewManager", () => {
         const replacementSetZoomFactor = vi.fn();
         fromId.mockReturnValue({
           id: 43,
+          hostWebContents,
           isDestroyed: () => false,
           getType: () => "webview",
           getURL: () => url,
@@ -1365,7 +1370,7 @@ describe("PreviewManager", () => {
 
         yield* manager.registerWebview("tab_zoom", 43);
 
-        expect(replacementSetZoomFactor).toHaveBeenCalledWith(1.1);
+        expect(replacementSetZoomFactor).toHaveBeenCalledWith(1.1 * 1.44);
         expect(states.at(-1)?.zoomFactor).toBe(1.1);
       }),
     ),
@@ -1376,9 +1381,11 @@ describe("PreviewManager", () => {
   effectIt.effect("re-applies each tab's own zoom when the app window zooms", () =>
     withManager((manager) =>
       Effect.gen(function* () {
+        let hostZoom = 1;
         const setZoomFactor = vi.fn();
         fromId.mockReturnValue({
           id: 42,
+          hostWebContents: { getZoomFactor: () => hostZoom },
           isDestroyed: () => false,
           getType: () => "webview",
           getURL: () => "https://example.com",
@@ -1409,10 +1416,11 @@ describe("PreviewManager", () => {
         yield* manager.zoomIn("tab_reapply");
         setZoomFactor.mockClear();
 
-        yield* manager.reapplyZoom();
-
-        expect(setZoomFactor).toHaveBeenCalledTimes(1);
-        expect(setZoomFactor).toHaveBeenCalledWith(1.1);
+        for (const zoom of [1.44, 0.8, 1]) {
+          hostZoom = zoom;
+          yield* manager.reapplyZoom();
+          expect(setZoomFactor).toHaveBeenLastCalledWith(1.1 * hostZoom);
+        }
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -923,7 +923,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     const wc = webContents.fromId(tab.webContentsId);
     if (!wc || wc.isDestroyed()) return;
     yield* attempt({ operation: "assertTabZoom", tabId, webContentsId: wc.id }, () =>
-      wc.setZoomFactor(tab.zoomFactor),
+      wc.setZoomFactor(tab.zoomFactor * (wc.hostWebContents?.getZoomFactor() ?? 1)),
     ).pipe(Effect.ignore);
   });
 
@@ -2125,12 +2125,10 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     ) {
       return yield* new PreviewTabNotFoundError({ tabId });
     }
-    // Always assert the tab's own zoom rather than reading the guest's: a guest
-    // attaching while the app UI is zoomed starts at the embedder's inherited
-    // zoom level, which is not the preview's zoom. Done before the guest is
-    // published so it never paints a frame at the inherited zoom.
+    // The webview's box is in host CSS pixels. Include host zoom so the guest's
+    // CSS viewport matches the requested size, even when the app UI is zoomed.
     yield* attempt({ operation: "registerWebview.restoreZoomFactor", tabId, webContentsId }, () =>
-      wc.setZoomFactor(currentTab.zoomFactor),
+      wc.setZoomFactor(currentTab.zoomFactor * (wc.hostWebContents?.getZoomFactor() ?? 1)),
     );
     // A replacement guest attaches unmuted, so reassert the tab's mute before it
     // is published rather than letting it emit audio the user already silenced.
@@ -2550,10 +2548,8 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   });
 
   /**
-   * Chromium hands every guest `<webview>` the embedder's zoom level, so zooming
-   * the app UI drags the previewed page along with it. The preview browser owns
-   * its own zoom factor, so re-assert it on each attached guest whenever the main
-   * window's zoom changes (see DesktopWindow.zoomMain).
+   * Re-assert each tab's zoom relative to the host after app zoom changes
+   * (see DesktopWindow.zoomMain), keeping its CSS viewport stable.
    */
   const reapplyZoom = Effect.fn("PreviewManager.reapplyZoom")(function* () {
     const tabIds = Array.from((yield* SynchronizedRef.get(tabsRef)).keys());
@@ -2572,7 +2568,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       const wc = webContents.fromId(tab.webContentsId);
       if (wc && !wc.isDestroyed()) {
         yield* attempt({ operation: "applyZoom", tabId, webContentsId: wc.id }, () =>
-          wc.setZoomFactor(next),
+          wc.setZoomFactor(next * (wc.hostWebContents?.getZoomFactor() ?? 1)),
         );
       }
     }
@@ -4507,8 +4503,7 @@ export class PreviewManager extends Context.Service<
     readonly zoomIn: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
     readonly zoomOut: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
     readonly resetZoom: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
-    // Re-applies every attached guest's own zoom factor, undoing the zoom level
-    // Chromium inherits from the embedder when the app UI zooms.
+    // Re-applies each tab's zoom relative to its host after app UI zoom changes.
     readonly reapplyZoom: () => Effect.Effect<void>;
     readonly hardReload: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
     readonly setColorScheme: (


### PR DESCRIPTION
App UI zoom enlarged the desktop preview's CSS viewport without changing the device toolbar dimensions. At 144% app zoom, a 375 × 667 preview laid out at 540 × 960 and selected desktop breakpoints.

Include the host zoom factor in the three places that apply guest zoom. The tab's saved zoom stays independent; attachment, reload, app zoom changes, and preview zoom controls use the same composition. No renderer or protocol changes.

Fixes #10525.

Verified in an isolated Electron 43.4.1 app on Linux with a local responsive page:

| Toolbar | Before, app zoom 144% | After |
| --- | --- | --- |
| 375 × 667 | 540 × 960 | 375 × 667 |
| 390 × 844 | 562 × 1215 | 390 × 844 |
| 271 × 586 | 390 × 844 | 271 × 586 |

Checked 36 combinations of these sizes, app zoom at 83%, 100%, and 144%, and preview zoom at 100%, 110%, 125%, and 150%. All 144% cases match exactly. Four zoomed-out cases differ by one CSS pixel at fractional scaling; this patch does not eliminate that rounding. Reload and device-toolbar close/reopen passed. macOS/Windows were not exercised; web and mobile do not host this Electron webview.

Two regression cases failed before the fix. All 110 preview-manager/window tests, desktop typecheck, targeted lint, and formatting pass. The Electron bundles built; the full desktop build stops at missing Linux libsecret development headers for the unrelated browser-import helper.

| Before | After |
| --- | --- |
| ![375px toolbar with a 540px CSS viewport](https://github.com/user-attachments/assets/e7afea86-bc25-4104-9105-0611d0740aa9) | ![375px toolbar with the correct 375px mobile layout](https://github.com/user-attachments/assets/45e818d5-6d05-4891-9001-e439ddde2431) |

Model: GPT-6. Harness: Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix preview viewport zoom to account for host window zoom factor
> - Preview guests now receive their tab zoom multiplied by the host webContents zoom factor (defaulting to 1), so previews stay correct when the app window is zoomed.
> - Updates `PreviewManager.assertTabZoom`, `PreviewManager.registerWebview`, and `PreviewManager.applyZoom` to scale guest zoom writes by the host factor while storing the unscaled value as the tab's logical zoom.
> - `PreviewManager.reapplyZoom` re-asserts each tab's zoom relative to the current host zoom after app UI zoom changes.
> - Behavioral Change: existing preview guests that assumed the guest zoom equals the raw tab zoom will now see the host factor applied; verify callers in [Manager.ts](https://github.com/pingdotgg/t3code/pull/10536/files#diff-089eb443c0884e11dbe412c68c0a1b7b22e3f1d0b8672c79facba02399e3dc53) and any out-of-tree consumers handle the scaled value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d99f57.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preview tab zoom now accounts for the host window’s zoom level.
  - Preview content maintains the expected relative zoom when the application UI is zoomed.
  - Zoom settings are correctly preserved when opening, replacing, or reapplying preview tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->