### PR TITLE
fix(desktop): recover failed shell environment capture

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -2,6 +2,7 @@ import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
+import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 
 import * as NetService from "@t3tools/shared/Net";
@@ -26,6 +27,7 @@ import * as DesktopShutdown from "./DesktopShutdown.ts";
 import * as DesktopServerExposure from "../backend/DesktopServerExposure.ts";
 import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 import * as DesktopShellEnvironment from "../shell/DesktopShellEnvironment.ts";
+import { recoverShellEnvironment } from "../shell/DesktopShellEnvironmentRecovery.ts";
 import * as DesktopState from "./DesktopState.ts";
 import * as DesktopRemoteUpdates from "../updates/DesktopRemoteUpdates.ts";
 import * as DesktopUpdates from "../updates/DesktopUpdates.ts";
@@ -242,7 +244,7 @@ const startup = Effect.gen(function* () {
   const updates = yield* DesktopUpdates.DesktopUpdates;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
 
-  yield* shellEnvironment.installIntoProcess;
+  const shellEnvironmentResult = yield* Effect.result(shellEnvironment.installIntoProcess);
   const hasCommandLinePasswordStore =
     preReadyElectronOptions.linuxPasswordStoreCommandLine !== null;
   const linuxElectronOptions =
@@ -287,6 +289,11 @@ const startup = Effect.gen(function* () {
     Effect.catchCause((cause) => fatalStartupCause("whenReady", cause)),
   );
   yield* logStartupInfo("app ready");
+  if (Result.isFailure(shellEnvironmentResult)) {
+    yield* recoverShellEnvironment().pipe(
+      Effect.catchCause((cause) => fatalStartupCause("shell environment recovery", cause)),
+    );
+  }
   if (environment.platform === "linux") {
     const selectedBackend = yield* safeStorage.selectedStorageBackend;
     yield* logStartupInfo("safe storage ready", {

--- a/apps/desktop/src/app/DesktopAppErrors.test.ts
+++ b/apps/desktop/src/app/DesktopAppErrors.test.ts
@@ -1,4 +1,9 @@
 import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { recoverShellEnvironment } from "../shell/DesktopShellEnvironmentRecovery.ts";
+import * as ElectronDialog from "../electron/ElectronDialog.ts";
+import * as DesktopShellEnvironment from "../shell/DesktopShellEnvironment.ts";
 
 import {
   DesktopBackendPortUnavailableError,
@@ -27,4 +32,45 @@ describe("DesktopApp errors", () => {
 
     assert.equal(error.message, "T3CODE_PORT is required in desktop development.");
   });
+});
+
+describe("shell environment recovery", () => {
+  it.effect.each([
+    { responses: [0], failures: 0, attempts: 1 },
+    { responses: [0, 0], failures: 1, attempts: 2 },
+    { responses: [1], failures: 0, attempts: 0 },
+    { responses: [0, 1], failures: 1, attempts: 1 },
+  ])("recovers or continues: %j", ({ responses, failures, attempts }) =>
+    Effect.gen(function* () {
+      let captures = 0;
+      let dialogs = 0;
+      yield* recoverShellEnvironment().pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(DesktopShellEnvironment.DesktopShellEnvironment, {
+              installIntoProcess: Effect.suspend(() => {
+                captures++;
+                return captures <= failures
+                  ? Effect.fail(new DesktopShellEnvironment.DesktopShellEnvironmentCaptureError())
+                  : Effect.void;
+              }),
+            }),
+            Layer.succeed(ElectronDialog.ElectronDialog, {
+              pickFolder: () => Effect.die("unused"),
+              pickFiles: () => Effect.die("unused"),
+              showErrorBox: () => Effect.die("unused"),
+              showMessageBox: () =>
+                Effect.sync(() => {
+                  const response = responses[dialogs++];
+                  assert.isDefined(response);
+                  return { response: response ?? 1, checkboxChecked: false };
+                }),
+            }),
+          ),
+        ),
+      );
+      assert.equal(captures, attempts);
+      assert.equal(dialogs, responses.length);
+    }),
+  );
 });

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -1,8 +1,13 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as TestClock from "effect/testing/TestClock";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
+import * as Option from "effect/Option";
+import type * as Tracer from "effect/Tracer";
 import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 import * as Sink from "effect/Sink";
@@ -67,7 +72,7 @@ function withProcessEnv<A, E, R>(
 function runShellEnvironment(input: {
   readonly env: NodeJS.ProcessEnv;
   readonly platform: NodeJS.Platform;
-  readonly handler: (command: ChildProcess.Command) => string;
+  readonly handler: (command: ChildProcess.Command) => string | Effect.Effect<string>;
   readonly failure?: PlatformError.PlatformError;
 }) {
   const environmentLayer = Layer.succeed(
@@ -79,9 +84,13 @@ function runShellEnvironment(input: {
   const spawnerLayer = Layer.succeed(
     ChildProcessSpawner.ChildProcessSpawner,
     ChildProcessSpawner.make((command) =>
-      input.failure === undefined
-        ? Effect.succeed(makeProcess(input.handler(command)))
-        : Effect.fail(input.failure),
+      Effect.suspend(() => {
+        if (input.failure !== undefined) return Effect.fail(input.failure);
+        const output = input.handler(command);
+        return (Effect.isEffect(output) ? output : Effect.succeed(output)).pipe(
+          Effect.map(makeProcess),
+        );
+      }),
     ),
   );
 
@@ -126,6 +135,75 @@ describe("DesktopShellEnvironment", () => {
       assert.equal(env.PATH, "/opt/homebrew/bin:/usr/bin:/Users/test/.local/bin");
       assert.equal(env.SSH_AUTH_SOCK, "/tmp/secretive.sock");
       assert.equal(env.HOMEBREW_PREFIX, "/opt/homebrew");
+    }),
+  );
+
+  it.effect("retries a timed-out login shell before starting with an incomplete PATH", () =>
+    Effect.gen(function* () {
+      const env = { SHELL: "/bin/zsh", PATH: "/usr/bin:/bin:/usr/sbin:/sbin" };
+      let attempts = 0;
+      const capture = yield* runShellEnvironment({
+        env,
+        platform: "darwin",
+        handler: (command) => {
+          if (command._tag !== "StandardCommand" || command.command === "/bin/launchctl") return "";
+          attempts++;
+          return attempts === 1 ? Effect.never : envOutput({ PATH: "/opt/homebrew/bin:/usr/bin" });
+        },
+      }).pipe(Effect.forkChild);
+
+      yield* TestClock.adjust("5 seconds");
+      yield* Fiber.join(capture);
+      assert.equal(attempts, 2);
+      assert.equal(env.PATH, "/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin");
+    }),
+  );
+
+  it.effect("fails capture when both login shell and launchctl provide no PATH", () =>
+    Effect.gen(function* () {
+      const env = { SHELL: "/bin/zsh", PATH: "/usr/bin" };
+      const spans = new Map<string, Tracer.Span>();
+      const result = yield* runShellEnvironment({
+        env,
+        platform: "darwin",
+        handler: () =>
+          Effect.gen(function* () {
+            let span: Tracer.AnySpan = yield* Effect.currentSpan.pipe(Effect.orDie);
+            while (span._tag === "Span") {
+              spans.set(span.name, span);
+              if (Option.isNone(span.parent)) break;
+              span = span.parent.value;
+            }
+            return "";
+          }),
+      }).pipe(Effect.exit);
+      assert.isTrue(Exit.isFailure(result));
+      for (const name of ["installPosixEnvironment", "installIntoProcess"]) {
+        const status = spans.get(`desktop.shellEnvironment.${name}`)?.status;
+        assert.equal(status?._tag, "Ended");
+        if (status?._tag === "Ended") assert.isTrue(Exit.isFailure(status.exit));
+      }
+      assert.equal(env.PATH, "/usr/bin");
+    }),
+  );
+
+  it.effect("bounds repeated timeouts and still tries launchctl", () =>
+    Effect.gen(function* () {
+      const env = { SHELL: "/bin/zsh", PATH: "/usr/bin" };
+      const commands: string[] = [];
+      const capture = yield* runShellEnvironment({
+        env,
+        platform: "darwin",
+        handler: (command) => {
+          if (command._tag !== "StandardCommand") return "";
+          commands.push(command.command);
+          return command.command === "/bin/launchctl" ? "" : Effect.never;
+        },
+      }).pipe(Effect.exit, Effect.forkChild);
+
+      yield* TestClock.adjust("10 seconds");
+      assert.isTrue(Exit.isFailure(yield* Fiber.join(capture)));
+      assert.deepEqual(commands, ["/bin/zsh", "/bin/zsh", "/bin/launchctl"]);
     }),
   );
 
@@ -294,7 +372,13 @@ describe("DesktopShellEnvironment", () => {
         },
       });
 
-      assert.deepEqual(commands, ["/opt/homebrew/bin/nu", "/bin/zsh", "/bin/launchctl"]);
+      assert.deepEqual(commands, [
+        "/opt/homebrew/bin/nu",
+        "/opt/homebrew/bin/nu",
+        "/bin/zsh",
+        "/bin/zsh",
+        "/bin/launchctl",
+      ]);
       assert.equal(env.PATH, "/opt/homebrew/bin:/usr/bin");
     }),
   );
@@ -429,12 +513,13 @@ describe("DesktopShellEnvironment", () => {
       handler: () => "",
       failure: cause,
     }).pipe(
+      Effect.exit,
       Effect.andThen(
         Effect.sync(() => {
           const errors = messages
             .flatMap((message) => (Array.isArray(message) ? message : [message]))
             .filter(isDesktopShellEnvironmentCommandError);
-          assert.lengthOf(errors, 1);
+          assert.lengthOf(errors, 2);
           assert.equal(errors[0]?.probe, "login-shell");
           assert.equal(errors[0]?.executable, "bash");
           assert.equal(errors[0]?.argumentCount, 2);

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -60,10 +60,19 @@ export class DesktopShellEnvironmentCommandTimeoutError extends Schema.TaggedErr
   }
 }
 
+export class DesktopShellEnvironmentCaptureError extends Schema.TaggedErrorClass<DesktopShellEnvironmentCaptureError>()(
+  "DesktopShellEnvironmentCaptureError",
+  {},
+) {
+  override get message(): string {
+    return "The shell environment could not be captured.";
+  }
+}
+
 export class DesktopShellEnvironment extends Context.Service<
   DesktopShellEnvironment,
   {
-    readonly installIntoProcess: Effect.Effect<void>;
+    readonly installIntoProcess: Effect.Effect<void, DesktopShellEnvironmentCaptureError>;
   }
 >()("@t3tools/desktop/shell/DesktopShellEnvironment") {}
 
@@ -342,7 +351,10 @@ const readLoginShellEnvironment = (
         command: shell,
         args: ["-ilc", capturePosixEnvironmentCommand(names)],
         timeout: LOGIN_SHELL_TIMEOUT,
-      }).pipe(Effect.map((output) => extractEnvironment(output, names)));
+      }).pipe(
+        Effect.map((output) => extractEnvironment(output, names)),
+        Effect.repeat({ times: 1, while: (environment) => !environment.PATH?.trim() }),
+      );
 
 const readLaunchctlPath = runCommandOutput({
   probe: "launchctl-path",
@@ -423,7 +435,7 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
     config: ShellEnvironmentConfig,
   ): Effect.fn.Return<
     void,
-    never,
+    DesktopShellEnvironmentCaptureError,
     ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
   > {
     const fileSystem = yield* FileSystem.FileSystem;
@@ -434,17 +446,17 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
         shellEnvironment,
         yield* readLoginShellEnvironment(shell, LOGIN_SHELL_ENV_NAMES),
       );
-      if (shellEnvironment.PATH) break;
+      if (shellEnvironment.PATH?.trim()) break;
     }
 
     const launchctlPath =
-      config.platform === "darwin" && !shellEnvironment.PATH
+      config.platform === "darwin" && !shellEnvironment.PATH?.trim()
         ? yield* readLaunchctlPath
         : Option.none<string>();
-    const mergedPath = mergePaths(config.platform, [
-      trimNonEmpty(shellEnvironment.PATH).pipe(Option.orElse(() => launchctlPath)),
-      readEnvPath(config.env),
-    ]);
+    const capturedPath = trimNonEmpty(shellEnvironment.PATH).pipe(
+      Option.orElse(() => launchctlPath),
+    );
+    const mergedPath = mergePaths(config.platform, [capturedPath, readEnvPath(config.env)]);
 
     if (Option.isSome(mergedPath)) {
       config.env.PATH = mergedPath.value;
@@ -518,12 +530,19 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
         }
       }
     }
+    if (Option.isNone(capturedPath)) {
+      return yield* new DesktopShellEnvironmentCaptureError();
+    }
   },
 );
 
 const installShellEnvironment = (
   config: ShellEnvironmentConfig,
-): Effect.Effect<void, never, ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem> => {
+): Effect.Effect<
+  void,
+  DesktopShellEnvironmentCaptureError,
+  ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+> => {
   if (config.platform === "win32") {
     return installWindowsEnvironment(config);
   }
@@ -546,6 +565,7 @@ export const make = Effect.gen(function* () {
       Effect.provideService(FileSystem.FileSystem, fileSystem),
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
       Effect.withSpan("desktop.shellEnvironment.installIntoProcess"),
+      Effect.tapError(Effect.logWarning),
     );
 
   return DesktopShellEnvironment.of({ installIntoProcess });

--- a/apps/desktop/src/shell/DesktopShellEnvironmentRecovery.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironmentRecovery.ts
@@ -1,0 +1,26 @@
+import * as Effect from "effect/Effect";
+import * as Result from "effect/Result";
+import * as ElectronDialog from "../electron/ElectronDialog.ts";
+import * as DesktopShellEnvironment from "./DesktopShellEnvironment.ts";
+
+export const recoverShellEnvironment = Effect.fn("desktop.startup.recoverShellEnvironment")(
+  function* () {
+    const shellEnvironment = yield* DesktopShellEnvironment.DesktopShellEnvironment;
+    const electronDialog = yield* ElectronDialog.ElectronDialog;
+    while (true) {
+      const { response } = yield* electronDialog.showMessageBox({
+        type: "warning",
+        title: "T3 Code",
+        message: "The shell environment could not be captured.",
+        detail:
+          "Installed agent CLIs may appear missing because T3 Code could not read your shell's PATH. Retry after checking your shell configuration, or continue and set an absolute CLI path in provider settings.",
+        buttons: ["Retry", "Continue"],
+        defaultId: 0,
+        cancelId: 1,
+      });
+      if (response !== 0) return;
+      const result = yield* Effect.result(shellEnvironment.installIntoProcess);
+      if (Result.isSuccess(result)) return;
+    }
+  },
+);


### PR DESCRIPTION
A timed-out desktop login-shell probe could leave every provider using launchd's default PATH while both install spans reported success. Retry each POSIX shell once when it returns no usable PATH, retain the launchctl fallback, and fail the install effect if neither captures PATH.

After Electron is ready, show a native warning with Retry and Continue before starting the bundled server. Retry captures the environment again in the same process, so providers inherit the recovered PATH. Continue preserves startup and explains the absolute CLI path workaround. Windows is unchanged. This handles failed startup capture; refreshing an already-running server after Continue remains the separate #9429 concern.

Fixes #10534.

Verified: 23 focused tests, desktop typecheck, scoped lint and formatting. The retry and false-success regressions fail against the original code. Tests cover the 5-second timeout, bounded retries, launchctl fallback, failed parent spans, and recovery choices. Each unsuccessful shell candidate can now take one additional 5-second attempt.

An isolated Linux Electron harness also ran real shell subprocesses: a cold probe timed out on the original code and left a fixture CLI unresolved; the patched code retried and spawned it by bare name. Native Retry recaptured PATH without restarting Electron; Escape continued with the inherited PATH. macOS itself and the full desktop client were not exercised.

Evidence below uses the production capture/recovery code with a controlled shell and fixture CLI. The surrounding diagnostics are the test harness, not the T3 client UI.

| Before: silent success with missing CLI | After: capture failure with recovery choices |
| --- | --- |
| ![Original capture result](https://github.com/Gigioxx/t3code/releases/download/evidence-10534-shell-capture/before.png) | ![Native shell recovery dialog](https://github.com/Gigioxx/t3code/releases/download/evidence-10534-shell-capture/after.png) |

[Retry recording](https://github.com/Gigioxx/t3code/releases/download/evidence-10534-shell-capture/retry.mp4) · [Recovered PATH and successful child process](https://github.com/Gigioxx/t3code/releases/download/evidence-10534-shell-capture/recovered.png)

Model: GPT-6. Harness: Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Recover from failed shell environment capture during desktop startup
> - Desktop startup previously failed when shell-environment installation threw `DesktopShellEnvironmentCaptureError`; it now captures the result and continues to the Electron-ready stage
> - After Electron is ready, the workflow invokes shell-environment recovery, converting recovery failures into fatal startup failures
> - User can retry (reinstalls the environment) or continue (proceeds without a successful capture)
> - Risk: startup now proceeds past a failed capture in [DesktopApp.ts](https://github.com/pingdotgg/t3code/pull/10537/files#diff-267cf20af5c499f356b88a4bc3d3dec61aa6c7a3398f93f8836975b3bcf764e9); consumers relying on a populated shell environment may see missing variables when the user chooses "continue"
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28b6b6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop startup reliability when the shell environment or PATH cannot be detected.
  * Shell environment detection now retries transient or empty results and uses a fallback where available.

* **New Features**
  * Added recovery prompts when shell environment detection fails, allowing you to retry or continue starting the app.
  * Startup errors are now handled more gracefully instead of interrupting the launch process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->