### PR TITLE
fix(desktop): allow PDF previews from connected environments

### DIFF
--- a/apps/desktop/src/electron/ElectronProtocol.test.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.test.ts
@@ -226,6 +226,7 @@ describe("ElectronProtocol", () => {
       "https:",
     ]);
     assert.deepEqual(directives["media-src"], ["'self'", "t3code:", "blob:", "http:", "https:"]);
+    assert.deepEqual(directives["frame-src"], ["'self'", "http:", "https:"]);
     assert.deepEqual(directives["font-src"], ["'self'", "t3code:", "data:"]);
   });
 });

--- a/apps/desktop/src/electron/ElectronProtocol.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.ts
@@ -91,7 +91,7 @@ export function makeDesktopContentSecurityPolicy(input: DesktopProtocolRegistrat
     "style-src 'self' 'unsafe-inline'",
     `font-src 'self' ${input.scheme}: data:`,
     "worker-src 'self' blob:",
-    "frame-src 'self' https://challenges.cloudflare.com",
+    "frame-src 'self' http: https:",
     "form-action 'self'",
   ].join("; ");
 }


### PR DESCRIPTION
PDF previews in the desktop sidebar showed the filename but stayed blank. The desktop CSP only allowed app-origin and Cloudflare frames, so it blocked signed document URLs from connected environments before the PDF viewer could load.

Allow HTTP and HTTPS frames, matching the existing image and video policy for user-configured environments. This is one production line and an assertion in the existing CSP test. HTML previews retain their iframe and response sandboxes; script sources stay restricted.

Verified the failure before editing in Electron 43.4.1 on Linux using the actual desktop CSP and a synthetic PDF served from a separate origin. The same fixture renders after the change. Also uploaded, sent, and opened the PDF in the isolated web app: the signed attachment response is `200 application/pdf` and the content is visible. The physical MacBook-to-WSL connection was not exercised.

Six protocol tests, desktop typecheck, targeted lint, and formatting pass. The new assertion fails on the old policy.

| Before | After |
| --- | --- |
| ![Blank PDF frame](https://github.com/Gigioxx/t3code/releases/download/evidence-pdf-preview-672cdc24/before.png) | ![Rendered PDF content](https://github.com/Gigioxx/t3code/releases/download/evidence-pdf-preview-672cdc24/after.png) |

Screenshots show the isolated Electron reproduction, not a full app window. No private documents are included.

Model: GPT-6. Harness: Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow `http:` and `https:` in desktop CSP `frame-src` for PDF previews
> Updates `makeDesktopContentSecurityPolicy` to use `'self'`, `http:`, and `https:` scheme sources instead of `'self'` plus the Cloudflare challenges host. This permits frames loaded from connected environments, enabling PDF previews. Test assertions in the Electron protocol suite updated to match.
> - Risk: broadening `frame-src` to all HTTP/HTTPS origins relaxes the desktop renderer CSP; any page that embeds untrusted frame URLs now has fewer restrictions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85dbe83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved desktop app compatibility with embedded content by allowing frames served over HTTP and HTTPS.
  - Frames loaded from the desktop application itself remain supported under the existing security policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->