### PR TITLE
fix(web): keep scroll-to-end button close to composer

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -313,7 +313,7 @@ import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
 import { MessagesTimeline } from "./chat/MessagesTimeline";
 import type { AssistantCitationRequest } from "./chat/AssistantCitationSource";
 import { resolveTimelineIsAtEnd } from "./chat/MessagesTimeline.logic";
-import { resolveComposerTimelineInset } from "./composerFooterLayout";
+import { resolveComposerTimelineInset, resolveScrollToEndClearance } from "./composerFooterLayout";
 import { ChatHeader } from "./chat/ChatHeader";
 import { PanelLayoutControls, RightPanelMaximizeControl } from "./chat/PanelLayoutControls";
 import { expandedImageKey, type ExpandedImagePreview } from "./chat/ExpandedImagePreview";
@@ -5121,27 +5121,48 @@ export default function ChatView(props: ChatViewProps) {
       ? activePlan.steps
       : null;
 
-  const publishComposerOverlayHeight = useCallback((height: number) => {
-    const nextHeight = Math.ceil(height);
-    if (nextHeight <= 0) return;
-    const previousHeight = composerOverlayHeightRef.current;
-    if (previousHeight !== nextHeight) {
-      composerOverlayHeightRef.current = nextHeight;
-      setComposerOverlayHeight(nextHeight);
-    }
-    const nextInset = resolveComposerTimelineInset({
-      currentInset: composerTimelineInsetRef.current,
-      overlayHeight: nextHeight,
-      isResting: composerRestingRef.current,
-    });
-    if (composerTimelineInsetRef.current !== nextInset) {
-      composerTimelineInsetRef.current = nextInset;
-      setComposerTimelineInset(nextInset);
-    }
-    setScrollToEndClearance((currentClearance) =>
-      currentClearance === nextHeight ? currentClearance : nextHeight,
-    );
-  }, []);
+  const publishComposerOverlayHeight = useCallback(
+    (height: number) => {
+      const nextHeight = Math.ceil(height);
+      if (nextHeight <= 0) return;
+      const previousHeight = composerOverlayHeightRef.current;
+      if (previousHeight !== nextHeight) {
+        composerOverlayHeightRef.current = nextHeight;
+        setComposerOverlayHeight(nextHeight);
+      }
+      const nextInset = resolveComposerTimelineInset({
+        currentInset: composerTimelineInsetRef.current,
+        overlayHeight: nextHeight,
+        isResting: composerRestingRef.current,
+      });
+      if (composerTimelineInsetRef.current !== nextInset) {
+        composerTimelineInsetRef.current = nextInset;
+        setComposerTimelineInset(nextInset);
+      }
+      const mainSurface = composerOverlayElement?.querySelector<HTMLElement>(
+        '[data-chat-composer-main-surface="true"]',
+      );
+      const button = composerOverlayElement?.parentElement?.querySelector<HTMLElement>(
+        'button[aria-label="Scroll to end"]',
+      );
+      const clearance =
+        composerOverlayElement && mainSurface && button
+          ? resolveScrollToEndClearance({
+              overlayHeight: nextHeight,
+              mainSurfaceTop: mainSurface.getBoundingClientRect().top,
+              button: button.getBoundingClientRect(),
+              attachments: Array.from(
+                composerOverlayElement.querySelectorAll<HTMLElement>(
+                  '[data-composer-banner-surface="attached"]',
+                ),
+                (element) => element.getBoundingClientRect(),
+              ),
+            })
+          : nextHeight;
+      setScrollToEndClearance(clearance);
+    },
+    [composerOverlayElement],
+  );
   // The composer reports its resting flag from a layout effect, which runs
   // before this component's own layout effects and before any resize
   // observation, so every measurement below sees the flag for its layout.
@@ -5174,7 +5195,7 @@ export default function ChatView(props: ChatViewProps) {
     return () => {
       resizeObserver.disconnect();
     };
-  }, [composerOverlayElement, publishComposerOverlayHeight]);
+  }, [composerOverlayElement, publishComposerOverlayHeight, showScrollToBottom]);
   const openPanelPullRequestUrl = useOpenPanelPullRequestUrl(activeThreadRef);
   const activeThreadReferenceCopyTarget = useMemo(
     () =>

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -120,6 +120,7 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
     >
       <div className={cn("relative flex flex-col-reverse", hasStack && stackExpanded && "z-50")}>
         <div
+          key={frontItem.id}
           className={cn(
             "relative z-10 transition-[translate,opacity] duration-220 ease-in",
             exitingItemId === frontItem.id
@@ -147,7 +148,7 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
         {hasStack ? (
           <div
             ref={noticesRef}
-            className={cn("relative z-20", stackExpanded && "min-h-3")}
+            className="relative z-20 min-h-3"
             onPointerEnter={(event) => {
               if (event.pointerType === "touch") return;
               if (document.activeElement === peekRef.current) {

--- a/apps/web/src/components/composerFooterLayout.test.ts
+++ b/apps/web/src/components/composerFooterLayout.test.ts
@@ -7,6 +7,7 @@ import {
   COMPOSER_RESTING_EXPANSION_MIN_PX,
   getRestingComposerImagePreviewCounts,
   resolveComposerTimelineInset,
+  resolveScrollToEndClearance,
   resolveRestingComposerControlsLayout,
   resolveRestingComposerControlsNaturalWidth,
   shouldAnimateComposerRestingTransition,
@@ -422,5 +423,29 @@ describe("resolveRestingComposerControlsLayout hysteresis", () => {
         previous: { hiddenCount: 2, visible: false },
       }),
     ).toEqual({ hiddenCount: 2, visible: true });
+  });
+});
+
+describe("resolveScrollToEndClearance", () => {
+  it("removes the side tab gap in both composer states while clearing overlapping attachments", () => {
+    for (const overlayHeight of [120, 214]) {
+      const layout = {
+        overlayHeight,
+        mainSurfaceTop: 534,
+        button: { left: 340, right: 460 },
+        attachments: [{ top: 500, left: 600, right: 700 }],
+      };
+      expect(resolveScrollToEndClearance(layout)).toBe(overlayHeight - 34);
+      expect(resolveScrollToEndClearance({ ...layout, attachments: [] })).toBe(overlayHeight);
+      expect(
+        resolveScrollToEndClearance({
+          ...layout,
+          attachments: [...layout.attachments, { top: 500, left: 100, right: 700 }],
+        }),
+      ).toBe(overlayHeight);
+      expect(resolveScrollToEndClearance({ ...layout, button: { left: 590, right: 710 } })).toBe(
+        overlayHeight,
+      );
+    }
   });
 });

--- a/apps/web/src/components/composerFooterLayout.ts
+++ b/apps/web/src/components/composerFooterLayout.ts
@@ -191,3 +191,20 @@ export function resolveRestingComposerControlsLayout(
       : minimumWidth <= hostWidth;
   return { hiddenCount, visible };
 }
+
+export function resolveScrollToEndClearance(input: {
+  overlayHeight: number;
+  mainSurfaceTop: number;
+  button: { left: number; right: number };
+  attachments: ReadonlyArray<{ top: number; left: number; right: number }>;
+}): number {
+  let contentTop = input.mainSurfaceTop;
+  let top = contentTop;
+  for (const attachment of input.attachments) {
+    contentTop = Math.min(contentTop, attachment.top);
+    if (attachment.left < input.button.right && attachment.right > input.button.left) {
+      top = Math.min(top, attachment.top);
+    }
+  }
+  return Math.ceil(input.overlayHeight - (top - contentTop));
+}


### PR DESCRIPTION
The Stash tab added 34 px of empty space between the composer and “Scroll to end” in both the collapsed and expanded states. The button now clears only attached content that overlaps its width. In the real app, the gap falls from 52 px to 18 px in both states.

The existing height measurement still drives composer transitions and timeline spacing. Full-width attachments and Stash at narrow widths keep their clearance. This changes the shared web/desktop chat view; the native mobile client is unchanged.

Verified with 35 composer layout tests, the web type check, targeted lint and formatting, and real-app checks at 1280, 600, and 375 px. Focus/scroll transitions, opening Stash, and scrolling to the end worked. Lint reports existing warnings in ChatView. Browser checks used an isolated local server with sample messages; the Electron shell was not launched.

| State | Before | After |
| --- | --- | --- |
| Collapsed | ![Collapsed before](https://github.com/user-attachments/assets/6da6a5bb-5c1d-42c5-8d49-e83e6a890770) | ![Collapsed after](https://github.com/user-attachments/assets/58615744-4c22-48e6-8c95-8bf5a780afd3) |
| Expanded | ![Expanded before](https://github.com/user-attachments/assets/2e27090d-5989-43dd-89ca-bfc0d01b2dfe) | ![Expanded after](https://github.com/user-attachments/assets/591250e2-b1ed-44f8-9656-581b11350b9d) |

Model: GPT-6. Harness: Codex.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ChatView` scroll-to-end button clearance to account for attached banners
> - Adds `resolveScrollToEndClearance` in [composerFooterLayout.ts](https://github.com/pingdotgg/t3code/pull/10543/files#diff-f2c45cfa4b4b1e011f20b2464141c82ddc1b7023b5d2707e33b4ab4504c747f8) to compute clearance from overlay height, main-surface position, button bounds, and attached-banner rectangles. Clearance is reduced only when a banner sits above the button without horizontally overlapping it.
> - `ChatView` now measures the composer, scroll-to-end button, and banner surfaces, stores the resolver's clearance, and reruns the measurement effect when scroll-to-bottom visibility changes.
> - `ComposerBannerStack` keeps the notices container at minimum height in both collapsed and expanded states, and remounts the front banner wrapper when the front item changes.
> - Risk: clearance now shrinks when a non-overlapping banner is present; callers relying on the full overlay-height clearance when banners exist should verify [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/10543/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) overlay-height fallback logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1784151.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scroll-to-end button positioning when the message composer includes attachments or banners.
  - The timeline now reserves appropriate bottom clearance based on visible composer content.
  - Positioning updates correctly when the scroll-to-bottom control appears or disappears.
  - Composer banner spacing remains consistent when banners are collapsed or displayed.

- **Tests**
  - Added coverage for scroll-to-end clearance across attachment overlap and button placement scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->