### PR TITLE
fix(claude): name the usage limit on retried turns too

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -2367,6 +2367,156 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  const USAGE_LIMIT_MESSAGE =
+    "Claude usage limit reached. Send the message again once the limit resets.";
+
+  const limitedAssistant = (uuid: string, error: string) =>
+    ({
+      type: "assistant",
+      session_id: "sdk-session-limit-retry",
+      uuid,
+      parent_tool_use_id: null,
+      error,
+      is_api_error_message: true,
+      message: {
+        id: `assistant-message-${uuid}`,
+        model: "<synthetic>",
+        content: [
+          {
+            type: "text",
+            text: "You've hit your session limit · resets 9:20pm (Europe/Vienna)",
+          },
+        ],
+      },
+    }) as unknown as SDKMessage;
+
+  const apiErrorResult = (uuid: string) =>
+    ({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      terminal_reason: "api_error",
+      errors: [],
+      session_id: "sdk-session-limit-retry",
+      uuid,
+    }) as unknown as SDKMessage;
+
+  it.effect("names the usage limit when only the assistant error reports it", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId: session.threadId, input: "hello", attachments: [] });
+
+      // No rate_limit_event: the CLI already reported this window last turn.
+      harness.query.emit(limitedAssistant("assistant-limit", "rate_limit"));
+      harness.query.emit(apiErrorResult("result-limit-retry"));
+
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      const errors = events.filter((event) => event.type === "runtime.error");
+      assert.equal(errors.length, 1);
+      assert.equal(
+        errors[0]?.type === "runtime.error" ? errors[0].payload.message : undefined,
+        USAGE_LIMIT_MESSAGE,
+      );
+      const payload = completedTurn(events);
+      assert.equal(payload.state, "failed");
+      assert.equal(payload.errorMessage, USAGE_LIMIT_MESSAGE);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("names the usage limit on a retry that repeats no rate_limit_event", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const firstTurnFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.sendTurn({ threadId: session.threadId, input: "hello", attachments: [] });
+      const nowMs = yield* Clock.currentTimeMillis;
+      harness.query.emit({
+        type: "rate_limit_event",
+        rate_limit_info: {
+          status: "rejected",
+          rateLimitType: "five_hour",
+          resetsAt: Math.floor(nowMs / 1000) + 7200,
+        },
+        session_id: "sdk-session-limit-retry",
+        uuid: "rate-limit-rejected",
+      } as unknown as SDKMessage);
+      harness.query.emit(limitedAssistant("assistant-limit-1", "rate_limit"));
+      harness.query.emit(apiErrorResult("result-limit-1"));
+      assert.equal(
+        completedTurn(Array.from(yield* Fiber.join(firstTurnFiber))).errorMessage,
+        USAGE_LIMIT_MESSAGE,
+      );
+
+      // The retry carries only the assistant error; the window did not change
+      // state, so the CLI stays silent about it.
+      const secondTurnFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.sendTurn({ threadId: session.threadId, input: "again", attachments: [] });
+      harness.query.emit(limitedAssistant("assistant-limit-2", "rate_limit"));
+      harness.query.emit(apiErrorResult("result-limit-2"));
+      const payload = completedTurn(Array.from(yield* Fiber.join(secondTurnFiber)));
+      assert.equal(payload.state, "failed");
+      assert.equal(payload.errorMessage, USAGE_LIMIT_MESSAGE);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("keeps the generic API error for a non-limit assistant error", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId: session.threadId, input: "hello", attachments: [] });
+      harness.query.emit(limitedAssistant("assistant-server-error", "server_error"));
+      harness.query.emit(apiErrorResult("result-server-error"));
+
+      const payload = completedTurn(Array.from(yield* Fiber.join(eventsFiber)));
+      assert.equal(payload.state, "failed");
+      assert.equal(payload.errorMessage, "Claude gave up after repeated API errors.");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect.each([
     {
       name: "listed error with api_error",

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -161,6 +161,7 @@ interface ClaudeTurnState {
   nextSyntheticAssistantBlockIndex: number;
   authenticationFailureMessage: string | undefined;
   rejectedRateLimitTypes: Set<string>;
+  rateLimitedAssistantMessage: boolean;
 }
 
 interface AssistantTextBlockState {
@@ -3168,6 +3169,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         nextSyntheticAssistantBlockIndex: -1,
         authenticationFailureMessage: undefined,
         rejectedRateLimitTypes: new Set(),
+        rateLimitedAssistantMessage: false,
       };
       context.session = {
         ...context.session,
@@ -3234,6 +3236,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           cwd: path.resolve(context.session.cwd ?? "."),
         });
       }
+      // Retries while still limited carry this assistant error but no
+      // rate_limit_event, which the CLI only emits when the window changes
+      // state, so the rejected set alone misses every turn after the first.
+      if (message.error === "rate_limit") {
+        context.turnState.rateLimitedAssistantMessage = true;
+      }
       context.turnState.items.push(message.message);
       if (
         normalizeClaudeActiveTokenUsage(
@@ -3263,7 +3271,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     const turn = context.turnState;
     const failureHint =
       turn?.authenticationFailureMessage ??
-      (turn && turn.rejectedRateLimitTypes.size > 0
+      (turn && (turn.rejectedRateLimitTypes.size > 0 || turn.rateLimitedAssistantMessage)
         ? "Claude usage limit reached. Send the message again once the limit resets."
         : undefined);
     const { status, errorMessage } = resultOutcome(message, failureHint);
@@ -4949,6 +4957,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         nextSyntheticAssistantBlockIndex: -1,
         authenticationFailureMessage: undefined,
         rejectedRateLimitTypes: new Set(),
+        rateLimitedAssistantMessage: false,
       };
 
       const updatedAt = yield* nowIso;


### PR DESCRIPTION
Closes #10544.

## What Changed

A Claude turn retried while the account is still limited now fails with the same sentence as the first limited turn, **"Claude usage limit reached. Send the message again once the limit resets."**, instead of falling back to "Claude gave up after repeated API errors."

The CLI sends `rate_limit_event` with `status: "rejected"` only when the limit state changes, so #10321's latch saw it on the first turn and nothing on the retries. Those turns still carry an `assistant` message with `error: "rate_limit"` (the same channel the sign-out latch already reads), so the adapter now records that too and the result names the limit. A boolean on the turn state rather than a sentinel in the rejected-window set, which recovery events add to and delete from by window id.

## Why

Three consecutive turns on one thread: the first said the limit, the next two said the provider gave up. Users read the second sentence as an outage and retry harder.

## UI Changes

None beyond the sentence: the failed turn's banner and row are the ones #10321 introduced. Before, from the report in #10544:

<img src="https://github.com/user-attachments/assets/f140d161-c6ac-4f9d-8ec5-15dc6383f534" width="900" alt="Before: the first limited turn names the limit, the two retries say Claude gave up after repeated API errors" />

## Verification

- `vp test run apps/server/src/provider/Layers/ClaudeAdapter.test.ts` — 120 tests pass, three new: a turn with only the assistant `rate_limit` error names the limit in both the runtime error and the turn's error message; two consecutive turns in one session (first with the `rate_limit_event`, second with only the assistant error) both name it; an assistant `server_error` still yields the generic message. Reverting the condition fails exactly the two new positive cases.
- Server typecheck clean on the touched file; lint and format clean.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (message-only change; before shown, after is the sentence #10321 already renders)
- [ ] I included a video for animation/interaction changes (nothing moves)

Built with Claude Fable 5.1 in Claude Code, with an Opus subagent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ClaudeAdapter` to name usage limit on retried turns with assistant-only rate-limit errors
> Adds `rateLimitedAssistantMessage` to the per-turn state in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/10546/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc), set when an assistant SDK message reports a `rate_limit` error. The adapter now includes this flag alongside `rejectedRateLimitTypes` when building the failure hint for result processing, so a failed turn is classified as a usage-limit error even when no `rate_limit_event` was emitted (e.g. on a retry).
> - Other assistant error values (e.g. `server_error`) keep the generic repeated-API-error message.
> - Adds test fixtures and cases in [ClaudeAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/10546/files#diff-1657a55ebc1e3682293aa20a7f71a55adf8de546f36af50f289dca9da45b0b6f) covering assistant-only rate limits, repeated usage limits across turns, and non-limit assistant errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a5f39d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage-limit error reporting for Claude interactions.
  * Repeated rate-limit failures now consistently display the usage-limit message instead of a generic API error.
  * Non-rate-limit errors continue to show the appropriate generic failure message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->