### PR TITLE
fix(web): tolerate servers that predate git identity in project import

### DIFF
--- a/apps/server/src/project/AgentSessionScanner.ts
+++ b/apps/server/src/project/AgentSessionScanner.ts
@@ -24,6 +24,7 @@ import {
   resolveProviderInstanceEnabled,
   type AgentSessionImportSource,
   type AgentSessionProjectCandidate,
+  type AgentSessionProjectGit,
   type AgentSessionScanResult,
   type ProviderInstanceConfig,
 } from "@t3tools/contracts";
@@ -695,7 +696,7 @@ export const make = Effect.gen(function* () {
   const readGitIdentity = Effect.fn("AgentSessionScanner.readGitIdentity")(function* (
     directory: string,
   ): Effect.fn.Return<
-    | { readonly _tag: "Repository"; readonly git: AgentSessionProjectCandidate["git"] }
+    | { readonly _tag: "Repository"; readonly git: AgentSessionProjectGit | null }
     | { readonly _tag: "Worktree" }
     | { readonly _tag: "NotGit" }
   > {
@@ -1209,11 +1210,11 @@ export const make = Effect.gen(function* () {
         sources: Array<AgentSessionSource>;
         threadCount: number;
         lastActiveAtMs: number | null;
-        git: AgentSessionProjectCandidate["git"];
+        git: AgentSessionProjectGit | null;
       }
     >();
     const directoryKeys = new Map<string, string>();
-    const gitIdentities = new Map<string, AgentSessionProjectCandidate["git"]>();
+    const gitIdentities = new Map<string, AgentSessionProjectGit | null>();
 
     for (const candidate of raw) {
       const expanded = expandHomePath(candidate.cwd.trim());

--- a/apps/web/src/onboarding/projectImport.logic.test.ts
+++ b/apps/web/src/onboarding/projectImport.logic.test.ts
@@ -74,6 +74,12 @@ describe("partitionOnboardingProjects", () => {
 
     expect(partitionOnboardingProjects([repo, folder, thin], now).recent).toEqual([repo]);
   });
+
+  it("selects candidates from servers that do not report git identity", () => {
+    const { git: _git, ...legacy } = candidate("/projects/legacy");
+
+    expect(partitionOnboardingProjects([legacy], now).recent).toEqual([legacy]);
+  });
 });
 
 describe("groupOnboardingProjects", () => {
@@ -125,6 +131,17 @@ describe("groupOnboardingProjects", () => {
         threadCount: 3,
         lastActiveAt: "2026-08-20T12:00:00.000Z",
       },
+    ]);
+  });
+
+  it("lists candidates without git identity as standalone repositories", () => {
+    const { git: _git, ...legacy } = candidate("/code/legacy", { title: "legacy" });
+
+    const grouped = groupOnboardingProjects([legacy]);
+
+    expect(grouped.other).toEqual([]);
+    expect(grouped.repositories.map((group) => [group.label, group.repository])).toEqual([
+      ["legacy", null],
     ]);
   });
 });

--- a/apps/web/src/onboarding/projectImport.logic.ts
+++ b/apps/web/src/onboarding/projectImport.logic.ts
@@ -9,6 +9,8 @@ const DEFAULT_SELECTION_MIN_THREADS = 3;
  * Existing projects still need their agent history imported, so every scan
  * candidate is offered. The default selection is narrower: git repositories
  * active in the last 30 days with enough threads to look like real work.
+ * Servers that predate the git scan omit `git`; their candidates are treated
+ * as repositories so old computers still get a useful default selection.
  */
 export function partitionOnboardingProjects<T extends AgentSessionProjectCandidate>(
   candidates: ReadonlyArray<T>,
@@ -48,9 +50,10 @@ function latestActivity(left: string | null, right: string | null): string | nul
 /**
  * Group scan candidates for the onboarding picker. Clones of one repository
  * share a group keyed by their normalized origin URL. Repositories without an
- * origin get a group each. Directories that are not git repositories are
- * returned separately so the UI can fold them away by default. Groups sort by
- * most recent activity, newest first.
+ * origin get a group each, as do candidates from servers that do not report
+ * git identity. Directories that are not git repositories are returned
+ * separately so the UI can fold them away by default. Groups sort by most
+ * recent activity, newest first.
  */
 export function groupOnboardingProjects<
   T extends Pick<
@@ -66,16 +69,14 @@ export function groupOnboardingProjects<
       other.push(candidate);
       continue;
     }
-    const key =
-      candidate.git.remoteKey === null
-        ? `path:${candidate.path}`
-        : `remote:${candidate.git.remoteKey}`;
+    const git = candidate.git ?? { remoteKey: null, repository: null };
+    const key = git.remoteKey === null ? `path:${candidate.path}` : `remote:${git.remoteKey}`;
     const existing = groups.get(key);
     if (existing === undefined) {
       groups.set(key, {
         key,
-        label: candidate.git.repository ?? candidate.title,
-        repository: candidate.git.repository,
+        label: git.repository ?? candidate.title,
+        repository: git.repository,
         candidates: [candidate],
         threadCount: candidate.threadCount,
         lastActiveAt: candidate.lastActiveAt,

--- a/packages/contracts/src/agentSessions.test.ts
+++ b/packages/contracts/src/agentSessions.test.ts
@@ -1,0 +1,36 @@
+import * as Schema from "effect/Schema";
+import { describe, expect, it } from "vite-plus/test";
+
+import { AgentSessionScanResult } from "./agentSessions.ts";
+
+const decodeScanResult = Schema.decodeUnknownSync(AgentSessionScanResult);
+
+const candidate = {
+  path: "/projects/repo",
+  title: "repo",
+  sources: ["codex"],
+  threadCount: 3,
+  lastActiveAt: "2026-08-20T12:00:00.000Z",
+  alreadyImported: false,
+} as const;
+
+describe("AgentSessionScanResult", () => {
+  it("decodes candidates from servers that predate the git scan", () => {
+    const result = decodeScanResult({
+      candidates: [candidate],
+      scannedAt: "2026-08-22T12:00:00.000Z",
+    });
+
+    expect(result.candidates[0]?.git).toBeUndefined();
+  });
+
+  it("preserves reported git identity", () => {
+    const git = { remoteKey: "github.com/pingdotgg/t3code", repository: "pingdotgg/t3code" };
+    const result = decodeScanResult({
+      candidates: [{ ...candidate, git }],
+      scannedAt: "2026-08-22T12:00:00.000Z",
+    });
+
+    expect(result.candidates[0]?.git).toEqual(git);
+  });
+});

--- a/packages/contracts/src/agentSessions.ts
+++ b/packages/contracts/src/agentSessions.ts
@@ -57,8 +57,12 @@ export const AgentSessionProjectCandidate = Schema.Struct({
   threadCount: NonNegativeInt,
   lastActiveAt: Schema.NullOr(IsoDateTime),
   alreadyImported: Schema.Boolean,
-  /** `null` when the directory is not the root of a git repository. */
-  git: Schema.NullOr(AgentSessionProjectGit),
+  /**
+   * `null` when the directory is not the root of a git repository. Missing on
+   * servers that predate the git scan, where the client cannot tell repositories
+   * from plain folders and should treat every candidate as a standalone project.
+   */
+  git: Schema.optionalKey(Schema.NullOr(AgentSessionProjectGit)),
 });
 export type AgentSessionProjectCandidate = typeof AgentSessionProjectCandidate.Type;
 


### PR DESCRIPTION
The onboarding Projects step decodes the scan result strictly, so a web client newer than the server (app.t3.codes nightly against a server still on the previous release) fails every computer with `Could not check projects. Missing key at ["value"]["candidates"][0]["git"]`, which #10493 introduced by adding a required `git` field to `AgentSessionProjectCandidate`.

`git` is now `optionalKey` on the wire. The client keeps `null` ("not a git repo") separate from `undefined` ("server did not say"): candidates without the field are listed as standalone repositories and stay in the default selection, which is how onboarding behaved before #10493, instead of being folded under "Other folders" and deselected. The server's scanner types point at `AgentSessionProjectGit | null` directly and still always send the field.

Mobile has no project import step.

## Evidence

Both captures are the web client paired to the same server built from `dc39615ae` (the commit before #10493), same viewport and data; only the client changes.

| Before (`main` client) | After (this branch) |
| --- | --- |
| ![Projects step on main showing "Could not check projects. Missing key ... git" for the computer, with Import 0 projects](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/47a0c67ea31d9211/before.png) | ![Projects step on this branch listing t3code, fleet and bubugames from the old server, 3 of 3 selected](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/c6d59c792f27d6c5/after.png) |

## Verification

- `vp test run packages/contracts/src/agentSessions.test.ts apps/web/src/onboarding/projectImport.logic.test.ts apps/server/src/project/AgentSessionScanner.test.ts` — new decode tests for the missing key, and grouping/default-selection tests for candidates without `git`.
- `tsgo --noEmit` for `packages/contracts`, `apps/web`, `apps/server`.

Created with Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tolerate missing `git` field in `AgentSessionProjectCandidate` for project import
> - Changes the `git` field on `AgentSessionProjectCandidate` from required-nullable to optional-nullable so scan results from older servers without git scanning decode correctly
> - Updates `groupOnboardingProjects` in [projectImport.logic.ts](https://github.com/pingdotgg/t3code/pull/10547/files#diff-6ea4fcf4f3f52a6b44f0530024b2b907bbbf724a61f85150766a8bfae40923dd) to treat candidates with an omitted `git` as standalone repository groups using a path-based key and the candidate title as the label, with a null repository identity
> - Candidates with explicit `git: null` continue to be placed in the non-repository collection; only omitted fields trigger the fallback
> - Adjusts `AgentSessionScanner` types in [AgentSessionScanner.ts](https://github.com/pingdotgg/t3code/pull/10547/files#diff-851d20dfd11e67ec3ea443c93e0dac4997fb79b8d09c75fbd4aaffb9e7459064) to use explicit nullable `AgentSessionProjectGit` rather than the optional property type
> - Risk: servers or clients that assumed `git` was always present on decoded candidates must now handle the field being absent; the in-tree web and server readers are updated
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf0d8de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed project onboarding for candidates without Git information.
  - Projects from servers that have not completed a Git scan are now handled safely and grouped by path.
  - Such projects remain available in recent selections and appear as standalone repositories instead of being grouped as miscellaneous items.

- **Compatibility**
  - Improved compatibility with older servers that do not provide Git metadata during project scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->