### PR TITLE
fix(desktop): extract Electron with PowerShell on Windows

### DIFF
--- a/apps/desktop/scripts/ensure-electron-runtime.mjs
+++ b/apps/desktop/scripts/ensure-electron-runtime.mjs
@@ -129,6 +129,15 @@ function installElectronRuntime(electronDir, version) {
     ]);
     if (hostPlatform === "darwin") {
       runChecked("ditto", ["-x", "-k", zipPath, NodePath.join(electronDir, "dist")]);
+    } else if (hostPlatform === "win32") {
+      // Windows includes PowerShell, but python3 may only be a Microsoft Store alias.
+      const quote = (value) => `'${value.replaceAll("'", "''")}'`;
+      runChecked("powershell.exe", [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `Expand-Archive -LiteralPath ${quote(zipPath)} -DestinationPath ${quote(NodePath.join(electronDir, "dist"))} -Force -ErrorAction Stop`,
+      ]);
     } else {
       runChecked("python3", [
         "-c",

--- a/apps/desktop/scripts/ensure-electron-runtime.mjs
+++ b/apps/desktop/scripts/ensure-electron-runtime.mjs
@@ -101,10 +101,11 @@ function invalidRuntimePaths(electronDir, platformPath) {
   ].filter((runtimePath) => NodeFS.existsSync(runtimePath) && !isMachO(runtimePath));
 }
 
-function runChecked(command, args) {
+function runChecked(command, args, env) {
   const result = NodeChildProcess.spawnSync(command, args, {
     encoding: "utf8",
     stdio: "inherit",
+    env,
   });
 
   if (result.status === 0) {
@@ -131,13 +132,21 @@ function installElectronRuntime(electronDir, version) {
       runChecked("ditto", ["-x", "-k", zipPath, NodePath.join(electronDir, "dist")]);
     } else if (hostPlatform === "win32") {
       // Windows includes PowerShell, but python3 may only be a Microsoft Store alias.
-      const quote = (value) => `'${value.replaceAll("'", "''")}'`;
-      runChecked("powershell.exe", [
-        "-NoProfile",
-        "-NonInteractive",
-        "-Command",
-        `Expand-Archive -LiteralPath ${quote(zipPath)} -DestinationPath ${quote(NodePath.join(electronDir, "dist"))} -Force -ErrorAction Stop`,
-      ]);
+      // Pass paths as data: PowerShell also treats curly apostrophes as string delimiters.
+      runChecked(
+        "powershell.exe",
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          "Expand-Archive -LiteralPath $env:T3_ELECTRON_ARCHIVE -DestinationPath $env:T3_ELECTRON_DESTINATION -Force -ErrorAction Stop",
+        ],
+        {
+          ...process.env,
+          T3_ELECTRON_ARCHIVE: zipPath,
+          T3_ELECTRON_DESTINATION: NodePath.join(electronDir, "dist"),
+        },
+      );
     } else {
       runChecked("python3", [
         "-c",


### PR DESCRIPTION
## What Changed

Use Windows' built-in PowerShell `Expand-Archive` to extract Electron runtime archives on Windows. Paths are quoted with embedded apostrophes escaped, and extraction errors fail the installer. macOS and Linux behavior is unchanged.

## Why

The Electron runtime repair script uses `python3` on non-MacOS systems to extract downloaded archives. On Windows systems where that command resolves to the Microsoft Store alias, extraction fails with exit code 9009 and prevents `pnpm dev:desktop` from starting. This is a "nice to have" fix for Windows devs, so we don't need to install another Python or get it on our PATH. (I ran into it when trying to test #10542.)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract Windows Electron runtime using PowerShell instead of `python3`
> The `installElectronRuntime` function in [ensure-electron-runtime.mjs](https://github.com/pingdotgg/t3code/pull/10551/files#diff-ffa12623c197ac91a2f9d1fa734698e3ae5f97ed3b4f614ff78be20aef1e3952) now uses PowerShell to extract the Electron archive on Windows, removing the `python3` dependency. PowerShell runs without a profile or interactive input, and paths are escaped for single-quoted literals. Other platforms remain unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36d2284.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows desktop runtime setup with a more reliable archive extraction process.
  * Preserved platform-specific runtime extraction support for macOS and other supported platforms.
  * Improved handling of archive and destination paths during Windows setup to reduce extraction failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->