### PR TITLE
fix(server): resolve SSH aliases for repository identity

### DIFF
--- a/apps/server/src/project/RepositoryIdentityResolver.test.ts
+++ b/apps/server/src/project/RepositoryIdentityResolver.test.ts
@@ -72,7 +72,8 @@ it.layer(NodeServices.layer)("RepositoryIdentityResolverLive", (it) => {
 
       expect(first?.canonicalKey).toBe("github.com/t3tools/t3code");
       expect(second).toEqual(first);
-      expect(calls).toEqual([
+      const gitCalls = calls.filter((args) => !args.includes("-G"));
+      expect(gitCalls).toEqual([
         ["-C", "/repo/packages/web", "rev-parse", "--show-toplevel"],
         ["-C", "/repo", "remote", "-v"],
       ]);
@@ -80,7 +81,7 @@ it.layer(NodeServices.layer)("RepositoryIdentityResolverLive", (it) => {
       const refreshed = yield* resolver.resolve("/repo/packages/web", { refresh: true });
       expect(refreshed?.rootPath).toBe("/repo/packages/web");
       expect(yield* resolver.resolve("/repo/packages/web")).toEqual(refreshed);
-      expect(calls.slice(2)).toEqual([
+      expect(calls.filter((args) => !args.includes("-G")).slice(2)).toEqual([
         ["-C", "/repo/packages/web", "rev-parse", "--show-toplevel"],
         ["-C", "/repo/packages/web", "remote", "-v"],
       ]);
@@ -127,6 +128,7 @@ it.layer(NodeServices.layer)("RepositoryIdentityResolverLive", (it) => {
         ["-C", "/repo/packages/web", "rev-parse", "--show-toplevel"],
         ["-C", "/repo/packages/web", "rev-parse", "--show-toplevel"],
         ["-C", "/repo", "remote", "-v"],
+        ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10", "-G", "--", "github.com"],
       ]);
     }).pipe(Effect.provide(resolverLayer));
   });
@@ -158,6 +160,75 @@ it.layer(NodeServices.layer)("RepositoryIdentityResolverLive", (it) => {
       expect(identity?.name).toBe("t3code");
     }).pipe(Effect.provide(RepositoryIdentityResolver.layer)),
   );
+
+  it.effect.each([
+    {
+      remoteUrl: "git@github.com-t3-test:example/project.git",
+      stdout: "hostname github.com\n",
+      code: 0,
+      host: "github.com",
+    },
+    {
+      remoteUrl: "ssh://git@github.com-t3-test:2222/example/project.git",
+      stdout: "hostname github.com\n",
+      code: 0,
+      host: "github.com",
+    },
+    {
+      remoteUrl: "git@github.com-t3-test:example/project.git",
+      stdout: "",
+      code: 1,
+      host: "github.com-t3-test",
+    },
+    {
+      remoteUrl: "git@github.com-t3-test:example/project.git",
+      stdout: "user git\n",
+      code: 0,
+      host: "github.com-t3-test",
+    },
+  ])("resolves repository identity without changing transport: %j", (fixture) => {
+    const calls: Array<{ readonly command: string; readonly args: ReadonlyArray<string> }> = [];
+    const processRunner = Layer.succeed(ProcessRunner.ProcessRunner, {
+      run: (input) =>
+        Effect.sync(() => {
+          calls.push({ command: input.command, args: input.args });
+          const isRootLookup = input.command === "git" && input.args.includes("rev-parse");
+          const isRemoteLookup = input.command === "git" && input.args.includes("remote");
+          const isSshLookup = input.command === "ssh" && input.args.includes("-G");
+          return {
+            stdout: isRootLookup
+              ? "/repo\n"
+              : isRemoteLookup
+                ? `origin\t${fixture.remoteUrl} (fetch)\n`
+                : isSshLookup
+                  ? fixture.stdout
+                  : "",
+            stderr: "",
+            code: ChildProcessSpawner.ExitCode(isSshLookup ? fixture.code : 0),
+            timedOut: false,
+            stdoutTruncated: false,
+            stderrTruncated: false,
+            stdoutInvalidUtf8: false,
+            stderrInvalidUtf8: false,
+          };
+        }),
+    });
+    const resolverLayer = Layer.effect(
+      RepositoryIdentityResolver.RepositoryIdentityResolver,
+      RepositoryIdentityResolver.make(),
+    ).pipe(Layer.provide(processRunner));
+
+    return Effect.gen(function* () {
+      const resolver = yield* RepositoryIdentityResolver.RepositoryIdentityResolver;
+      const identity = yield* resolver.resolve("/repo");
+
+      expect(identity?.canonicalKey).toBe(`${fixture.host}/example/project`);
+      expect(identity?.provider).toBe("github");
+      expect(identity?.displayName).toBe("example/project");
+      expect(identity?.locator.remoteUrl).toBe(fixture.remoteUrl);
+      expect(calls.some(({ command }) => command === "ssh")).toBe(true);
+    }).pipe(Effect.provide(resolverLayer));
+  });
 
   it.effect("returns the git top-level root path when resolving from a nested workspace", () =>
     Effect.gen(function* () {

--- a/apps/server/src/project/RepositoryIdentityResolver.test.ts
+++ b/apps/server/src/project/RepositoryIdentityResolver.test.ts
@@ -163,6 +163,18 @@ it.layer(NodeServices.layer)("RepositoryIdentityResolverLive", (it) => {
 
   it.effect.each([
     {
+      remoteUrl: "git@github.com:example/project.git",
+      stdout: "hostname ssh.github.com\nport 443\n",
+      code: 0,
+      host: "github.com",
+    },
+    {
+      remoteUrl: "git@github.com-t3-test:example/project.git",
+      stdout: "hostname ssh.github.com\nport 443\n",
+      code: 0,
+      host: "github.com",
+    },
+    {
       remoteUrl: "git@github.com-t3-test:example/project.git",
       stdout: "hostname github.com\n",
       code: 0,

--- a/apps/server/src/project/RepositoryIdentityResolver.ts
+++ b/apps/server/src/project/RepositoryIdentityResolver.ts
@@ -111,7 +111,10 @@ const resolveRepositoryRemoteHost = Effect.fn("RepositoryIdentityResolver.resolv
       return undefined;
     }
     const resolvedHost = parseSshResolvedHostName(resolved.value.stdout, host);
-    return resolvedHost.toLowerCase() === host.toLowerCase() ? undefined : resolvedHost;
+    // GitHub's SSH-over-443 endpoint is a transport host, not its API host.
+    const repositoryHost =
+      resolvedHost.toLowerCase() === "ssh.github.com" ? "github.com" : resolvedHost;
+    return repositoryHost.toLowerCase() === host.toLowerCase() ? undefined : repositoryHost;
   },
 );
 

--- a/apps/server/src/project/RepositoryIdentityResolver.ts
+++ b/apps/server/src/project/RepositoryIdentityResolver.ts
@@ -3,6 +3,7 @@ import {
   detectSourceControlProviderFromGitRemoteUrl,
   normalizeGitRemoteUrl,
 } from "@t3tools/shared/git";
+import { isSshRemoteUrl } from "@t3tools/shared/sourceControl";
 import * as Cache from "effect/Cache";
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
@@ -63,14 +64,71 @@ function pickPrimaryRemote(
   return remoteName && remoteUrl ? { remoteName, remoteUrl } : null;
 }
 
+function parseSshRemoteHost(remoteUrl: string): string | null {
+  const trimmed = remoteUrl.trim();
+  if (!isSshRemoteUrl(trimmed)) return null;
+
+  if (trimmed.toLowerCase().startsWith("ssh://")) {
+    try {
+      const host = new URL(trimmed).hostname.trim();
+      return host.length > 0 ? host : null;
+    } catch {
+      return null;
+    }
+  }
+
+  const match = /^[^@/\s]+@([^:/\s]+):/u.exec(trimmed);
+  const host = match?.[1]?.trim() ?? "";
+  return host.length > 0 ? host : null;
+}
+
+function parseSshResolvedHostName(stdout: string, fallback: string): string {
+  for (const line of stdout.split(/\r?\n/u)) {
+    const [key, ...rest] = line.trim().split(/\s+/u);
+    const hostname = rest.join(" ").trim();
+    if (key?.toLowerCase() === "hostname" && hostname.length > 0) {
+      return hostname;
+    }
+  }
+  return fallback;
+}
+
+const resolveRepositoryRemoteHost = Effect.fn("RepositoryIdentityResolver.resolveRemoteHost")(
+  function* (remoteUrl: string) {
+    const processRunner = yield* ProcessRunner.ProcessRunner;
+    const host = parseSshRemoteHost(remoteUrl);
+    if (host === null) return undefined;
+
+    const resolved = yield* processRunner
+      .run({
+        command: "ssh",
+        args: ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10", "-G", "--", host],
+        timeout: Duration.seconds(5),
+        timeoutBehavior: "timedOutResult",
+      })
+      .pipe(Effect.option);
+    if (resolved._tag === "None" || resolved.value.code !== 0 || resolved.value.timedOut) {
+      return undefined;
+    }
+    const resolvedHost = parseSshResolvedHostName(resolved.value.stdout, host);
+    return resolvedHost.toLowerCase() === host.toLowerCase() ? undefined : resolvedHost;
+  },
+);
+
 function buildRepositoryIdentity(input: {
   readonly remoteName: string;
   readonly remoteUrl: string;
   readonly rootPath: string;
+  readonly canonicalHost?: string;
 }): RepositoryIdentity {
-  const canonicalKey = normalizeGitRemoteUrl(input.remoteUrl);
-  const sourceControlProvider = detectSourceControlProviderFromGitRemoteUrl(input.remoteUrl);
-  const repositoryPath = canonicalKey.split("/").slice(1).join("/");
+  const remoteKey = normalizeGitRemoteUrl(input.remoteUrl);
+  const repositoryPath = remoteKey.split("/").slice(1).join("/");
+  const canonicalHost = input.canonicalHost?.trim().toLowerCase();
+  const canonicalKey =
+    canonicalHost && repositoryPath.length > 0 ? `${canonicalHost}/${repositoryPath}` : remoteKey;
+  const sourceControlProvider = detectSourceControlProviderFromGitRemoteUrl(
+    input.canonicalHost === undefined ? input.remoteUrl : `https://${canonicalKey}`,
+  );
   const repositoryPathSegments = repositoryPath.split("/").filter((segment) => segment.length > 0);
   const [owner] = repositoryPathSegments;
   const repositoryName = repositoryPathSegments.at(-1);
@@ -130,7 +188,14 @@ const resolveRepositoryIdentityFromCacheKey = Effect.fn(
   }
 
   const remote = pickPrimaryRemote(parseRemoteFetchUrls(remoteResult.value.stdout));
-  return remote ? buildRepositoryIdentity({ ...remote, rootPath: cacheKey }) : null;
+  if (remote === null) return null;
+
+  const canonicalHost = yield* resolveRepositoryRemoteHost(remote.remoteUrl);
+  return buildRepositoryIdentity({
+    ...remote,
+    rootPath: cacheKey,
+    ...(canonicalHost === undefined ? {} : { canonicalHost }),
+  });
 });
 
 export const make = Effect.fn("RepositoryIdentityResolver.make")(function* (


### PR DESCRIPTION
An SSH remote such as `git@github.com-work:owner/repo.git` currently makes the Pull Requests page use `github.com-work` as its GitHub API host, even when SSH configuration maps that alias to `github.com`. Authentication can appear healthy while the PR lookup fails.

Resolve SSH `HostName` through a bounded local `ssh -G` call when deriving repository identity. Keep the original remote URL for transport and retain existing behavior when resolution fails or does not change the hostname. Normalize GitHub's `ssh.github.com` transport endpoint to `github.com` so the documented SSH-over-443 configuration continues to work. No database migration or Git configuration changes.

Validation:
- 120 focused resolver and PullRequestService tests pass, including SCP/SSH URL aliases, failed/incomplete resolution, and SSH-over-443 cases. Regression tests failed before the respective fixes.
- Focused lint and server typecheck pass.
- A live probe using the actual resolver against an unchanged SSH-alias checkout fails before the change and successfully lists PRs after it, with the raw remote URL preserved. This is source/CLI evidence, not an installed-client UI pass.
- Independent Standards and Spec reviews accepted exact head `8a3570fc2355f6fa500b5445ff6ed30d5118d1ad`; one correction round addressed SSH-over-443.

Implemented with GPT-5.6-Luna xhigh and GPT-6-Astra medium in Codex, running from ChatGPT outside T3. Two fresh GPT-6-Astra high sessions performed the independent reviews.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve SSH aliases when identifying Git repositories
> - Adds `parseSshRemoteHost` and `parseSshResolvedHostName` helpers to parse SSH remote URLs and `ssh -G` config output in [RepositoryIdentityResolver.ts](https://github.com/pingdotgg/t3code/pull/10552/files#diff-150725a1a7c2fad32a2af878e610161760c1d30b61e1fc4e4aaba35d01587171)
> - `resolveRemoteHost` now runs `ssh -G` in batch mode with a 10s connection timeout and 5s process timeout; failed or timed-out lookups fall back to the original remote host
> - `buildRepositoryIdentity` uses the resolved canonical host (e.g. `ssh.github.com` mapped to `github.com`) for `canonicalKey` and provider detection, while keeping the original remote URL in the locator
> - `resolveRepositoryIdentityFromCacheKey` returns `null` when no primary remote exists and passes the resolved SSH host to the identity builder when available
> - Risk: SSH-config lookups add a subprocess call per repository identity resolution; callers that asserted on the exact process-call sequence in `RepositoryIdentityResolver.test.ts` are updated, but out-of-tree consumers relying on the old call order may need adjustment
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a3570f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repository identity detection for SSH remotes, including custom SSH host aliases.
  - More reliably identifies the canonical GitHub host and source control provider.
  - Preserves the original remote URL and transport details.
  - Handles SSH lookup failures and missing host information without incorrectly resolving repository identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->