### PR TITLE
feat(mcp): expose thread model selection

### DIFF
--- a/apps/server/src/mcp/toolkits/thread/handlers.ts
+++ b/apps/server/src/mcp/toolkits/thread/handlers.ts
@@ -60,6 +60,38 @@ const readQuestion = Effect.fn("mcp.readQuestion")(function* (
   return { ...context, request, item };
 });
 export const ThreadToolkitHandlersLive = ThreadToolkit.toLayer({
+  t3_thread_configuration: (input) =>
+    Effect.gen(function* () {
+      const {
+        projection: { thread },
+      } = yield* readThread(input.threadId);
+      return {
+        threadId: thread.id,
+        modelSelection: thread.modelSelection,
+        runtimeMode: thread.runtimeMode,
+        interactionMode: thread.interactionMode,
+      };
+    }),
+  t3_thread_configure: (input) =>
+    Effect.gen(function* () {
+      const {
+        threads,
+        projection: { thread },
+      } = yield* readWritableThread();
+      const type =
+        thread.modelSelection.instanceId === input.modelSelection.instanceId
+          ? "thread.model-selection.set"
+          : "provider.switch";
+      const result = yield* threads
+        .dispatch({
+          type,
+          threadId: thread.id,
+          commandId: yield* newCommandId(),
+          modelSelection: input.modelSelection,
+        })
+        .pipe(Effect.mapError(unavailable));
+      return { sequence: result.sequence };
+    }),
   t3_pending_request_list: (input) =>
     Effect.gen(function* () {
       const { projection } = yield* readThread(input.threadId);

--- a/apps/server/src/mcp/toolkits/thread/handlers.ts
+++ b/apps/server/src/mcp/toolkits/thread/handlers.ts
@@ -8,6 +8,7 @@ import {
   type OrchestrationV2Command,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import { modelSelectionCommandType } from "@t3tools/shared/model";
 
 import { newCommandId, readThread, readWritableThread, unavailable } from "../../threadAccess.ts";
 import { queuedRunsInDeliveryOrder } from "../../../orchestration-v2/QueuedRunOrder.ts";
@@ -78,10 +79,7 @@ export const ThreadToolkitHandlersLive = ThreadToolkit.toLayer({
         threads,
         projection: { thread },
       } = yield* readWritableThread();
-      const type =
-        thread.modelSelection.instanceId === input.modelSelection.instanceId
-          ? "thread.model-selection.set"
-          : "provider.switch";
+      const type = modelSelectionCommandType(thread.providerInstanceId, input.modelSelection);
       const result = yield* threads
         .dispatch({
           type,

--- a/apps/server/src/mcp/toolkits/thread/tools.ts
+++ b/apps/server/src/mcp/toolkits/thread/tools.ts
@@ -1,4 +1,7 @@
 import {
+  ModelSelection,
+  RuntimeMode,
+  ProviderInteractionMode,
   RuntimeRequestId,
   ProviderUserInputAnswers,
   IsoDateTime,
@@ -150,7 +153,30 @@ export const PendingRequestRespondTool = Tool.make("t3_pending_request_respond",
   .annotate(Tool.Destructive, true)
   .annotate(Tool.OpenWorld, true);
 
+export const ThreadConfigurationTool = Tool.make("t3_thread_configuration", {
+  ...commandTool,
+  description:
+    "Read a thread's provider/model selection and modes in the calling project. orchestrator_capabilities lists available providers and models.",
+  parameters: Schema.Struct({ threadId: Schema.optional(ThreadId) }),
+  success: Schema.Struct({
+    threadId: ThreadId,
+    modelSelection: ModelSelection,
+    runtimeMode: RuntimeMode,
+    interactionMode: ProviderInteractionMode,
+  }),
+})
+  .annotate(Tool.Readonly, true)
+  .annotate(Tool.Destructive, false);
+export const ThreadConfigureTool = Tool.make("t3_thread_configure", {
+  ...commandTool,
+  description:
+    "Set this calling thread's provider, model and options with the existing selection command. This does not change permission modes or other threads. Use orchestrator_capabilities to choose a selection.",
+  parameters: Schema.Struct({ modelSelection: ModelSelection }),
+}).annotate(Tool.Destructive, true);
+
 export const ThreadToolkit = Toolkit.make(
+  ThreadConfigurationTool,
+  ThreadConfigureTool,
   PendingRequestListTool,
   PendingRequestReadTool,
   PendingRequestRespondTool,

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
@@ -810,6 +810,7 @@ export const CLAUDE_READ_ONLY_T3_MCP_ALLOWED_TOOLS: ReadonlyArray<string> = [
   "mcp__t3-code__t3_thread_wait",
   "mcp__t3-code__t3_pending_request_list",
   "mcp__t3-code__t3_pending_request_read",
+  "mcp__t3-code__t3_thread_configuration",
   "mcp__t3-code__t3_queue_list",
   "mcp__t3-code__t3_queue_read",
 ];

--- a/packages/shared/src/t3McpToolPresentation.ts
+++ b/packages/shared/src/t3McpToolPresentation.ts
@@ -57,6 +57,8 @@ const T3_MCP_TOOLS: Record<
   t3_pending_request_list: { displayName: "List pending questions" },
   t3_pending_request_read: { displayName: "Read pending questions" },
   t3_pending_request_respond: { displayName: "Answer pending questions" },
+  t3_thread_configuration: { displayName: "Read thread configuration" },
+  t3_thread_configure: { displayName: "Set thread model" },
   t3_thread_organize: { displayName: "Organize a thread" },
   t3_thread_update: { displayName: "Update T3 thread metadata" },
   t3_thread_send: { displayName: "Send to a T3 thread", summaryAction: "thread-send" },


### PR DESCRIPTION
Part 7/16 of the [shared-core and MCP stack](https://github.com/pingdotgg/t3code/stacks/10582). Based on [#10556](https://github.com/pingdotgg/t3code/pull/10556). Next: [#10558](https://github.com/pingdotgg/t3code/pull/10558).

Read thread configuration and change the calling thread provider/model/options through existing selection and switch commands.

This intentionally limits writes to the caller. Permission-mode changes, cross-thread configuration and multi-command retry transactions are separate work. Provider/model discovery already exists in orchestrator_capabilities.

The command choice is now shared with client-runtime through modelSelectionCommandType; MCP does not maintain a separate provider comparison.

MCP-only rebuild of [#8695](https://github.com/pingdotgg/t3code/pull/8695), preserving attribution to Julius Marminge's original work. Original branches remain available for separate service follow-ups.

Validation: The composed stack passes 94 tests across 12 focused files, including shared core MCP and real MCP/V2 integration, attachment intake, project RPC/service contracts, and client model command selection. Server/contracts/shared/client-runtime typechecks and targeted format/lint/diff checks pass. New behavior coverage lives with the shared operation; no per-tool mock suite was added. Current-head CI is shown below.

Layer size: 4 files, +59/-0. No domain-service production implementation or documentation files change in this MCP layer.

Prepared with Codex in the OpenAI agent runtime.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `t3_thread_configuration` and `t3_thread_configure` MCP tools for thread model selection
> - Adds a read-only `t3_thread_configuration` tool that returns the calling thread's ID, model selection, runtime mode, and interaction mode
> - Adds a destructive `t3_thread_configure` tool that dispatches a model-selection command to the current writable thread without changing permission modes or other threads
> - Registers both tools in `ThreadToolkit`, adds `t3_thread_configuration` to the Claude read-only allowlist, and adds display-name entries in the T3 MCP presentation map
> - Risk: `t3_thread_configure` opens the current thread for writing and dispatches a command; callers that invoke it concurrently may interleave sequence numbers. Reviewers should check `ThreadToolkitHandlersLive` configure handler in [handlers.ts](https://github.com/pingdotgg/t3code/pull/10557/files#diff-c86137ad202b428627265a1cfb74fbaed2f5df4c5edd2ecc9289bf94241146bf) for dispatch and error-mapping behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b0152bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->