### PR TITLE
feat(mcp): expose the existing thread search query

### DIFF
--- a/apps/server/src/mcp/toolkits/thread/handlers.ts
+++ b/apps/server/src/mcp/toolkits/thread/handlers.ts
@@ -10,7 +10,14 @@ import {
 import * as Effect from "effect/Effect";
 import { modelSelectionCommandType } from "@t3tools/shared/model";
 
-import { newCommandId, readThread, readWritableThread, unavailable } from "../../threadAccess.ts";
+import {
+  newCommandId,
+  readCaller,
+  readThread,
+  readWritableThread,
+  unavailable,
+} from "../../threadAccess.ts";
+import * as ProjectionSnapshotQuery from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
 import { queuedRunsInDeliveryOrder } from "../../../orchestration-v2/QueuedRunOrder.ts";
 import { ThreadToolkit } from "./tools.ts";
 
@@ -61,6 +68,13 @@ const readQuestion = Effect.fn("mcp.readQuestion")(function* (
   return { ...context, request, item };
 });
 export const ThreadToolkitHandlersLive = ThreadToolkit.toLayer({
+  t3_thread_search: (input) =>
+    Effect.gen(function* () {
+      const { caller } = yield* readCaller();
+      const query = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
+      const result = yield* query.searchThreads(input).pipe(Effect.mapError(unavailable));
+      return { matches: result.matches.filter((match) => match.projectId === caller.projectId) };
+    }),
   t3_thread_fork: (input) =>
     Effect.gen(function* () {
       const { threads, projection } = yield* readWritableThread();

--- a/apps/server/src/mcp/toolkits/thread/tools.ts
+++ b/apps/server/src/mcp/toolkits/thread/tools.ts
@@ -1,4 +1,6 @@
 import {
+  OrchestrationSearchThreadsInput,
+  OrchestrationSearchThreadsResult,
   OrchestrationV2ThreadForkSourcePoint,
   OrchestrationV2ContextTransfer,
   TrimmedNonEmptyString,
@@ -18,6 +20,7 @@ import * as Crypto from "effect/Crypto";
 import * as Schema from "effect/Schema";
 import { Tool, Toolkit } from "effect/unstable/ai";
 
+import { ProjectionSnapshotQuery } from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
 import { ThreadManagementService } from "../../../orchestration-v2/ThreadManagementService.ts";
 import { McpInvocationContext } from "../../McpInvocationContext.ts";
 
@@ -216,7 +219,19 @@ export const ThreadTransfersTool = Tool.make("t3_thread_transfers", {
   .annotate(Tool.Readonly, true)
   .annotate(Tool.Destructive, false);
 
+export const ThreadSearchTool = Tool.make("t3_thread_search", {
+  ...commandTool,
+  description:
+    "Search active thread titles and content with the app's existing bounded search. Returns matches in the calling project from the global top matches; other-project matches are omitted, so this may return fewer than limit. No pagination or exhaustive-result guarantee.",
+  parameters: OrchestrationSearchThreadsInput,
+  success: OrchestrationSearchThreadsResult,
+  dependencies: [...commandTool.dependencies, ProjectionSnapshotQuery],
+})
+  .annotate(Tool.Readonly, true)
+  .annotate(Tool.Destructive, false);
+
 export const ThreadToolkit = Toolkit.make(
+  ThreadSearchTool,
   ThreadForkTool,
   ThreadMergeBackTool,
   ThreadTransfersTool,

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
@@ -812,6 +812,7 @@ export const CLAUDE_READ_ONLY_T3_MCP_ALLOWED_TOOLS: ReadonlyArray<string> = [
   "mcp__t3-code__t3_pending_request_read",
   "mcp__t3-code__t3_thread_configuration",
   "mcp__t3-code__t3_thread_transfers",
+  "mcp__t3-code__t3_thread_search",
   "mcp__t3-code__t3_preview_list",
   "mcp__t3-code__t3_environment_read",
   "mcp__t3-code__t3_queue_list",

--- a/packages/shared/src/t3McpToolPresentation.ts
+++ b/packages/shared/src/t3McpToolPresentation.ts
@@ -61,6 +61,7 @@ const T3_MCP_TOOLS: Record<
   t3_thread_configure: { displayName: "Set thread model" },
   t3_thread_fork: { displayName: "Fork this thread" },
   t3_thread_merge_back: { displayName: "Merge thread context" },
+  t3_thread_search: { displayName: "Search thread content" },
   t3_thread_transfers: { displayName: "Read thread transfers" },
   t3_thread_organize: { displayName: "Organize a thread" },
   t3_thread_update: { displayName: "Update T3 thread metadata" },


### PR DESCRIPTION
Part 11/16 of the [shared-core and MCP stack](https://github.com/pingdotgg/t3code/stacks/10582). Based on [#10560](https://github.com/pingdotgg/t3code/pull/10560). Next: [#10562](https://github.com/pingdotgg/t3code/pull/10562).

Expose the existing bounded searchThreads query and return only matches from the calling project.

This filters the global top results, so a project can underfill the requested limit. It is not exhaustive or paginated. Project-first SQL pagination and search-service correctness changes belong in a separate service PR.

MCP-only rebuild of [#8721](https://github.com/pingdotgg/t3code/pull/8721), [#8722](https://github.com/pingdotgg/t3code/pull/8722), preserving attribution to Julius Marminge's original work. Original branches remain available for separate service follow-ups.

Validation: The composed stack passes 94 tests across 12 focused files, including shared core MCP and real MCP/V2 integration, attachment intake, project RPC/service contracts, and client model command selection. Server/contracts/shared/client-runtime typechecks and targeted format/lint/diff checks pass. New behavior coverage lives with the shared operation; no per-tool mock suite was added. Current-head CI is shown below.

Layer size: 4 files, +32/-1. No domain-service production implementation or documentation files change in this MCP layer.

Prepared with Codex in the OpenAI agent runtime.
