### PR TITLE
feat(mcp): expose scheduled task run-now

### DIFF
--- a/apps/server/src/mcp/toolkits/thread/handlers.ts
+++ b/apps/server/src/mcp/toolkits/thread/handlers.ts
@@ -13,11 +13,13 @@ import { modelSelectionCommandType } from "@t3tools/shared/model";
 import {
   newCommandId,
   readCaller,
+  readMutationCaller,
   readThread,
   readWritableThread,
   unavailable,
 } from "../../threadAccess.ts";
 import * as ProjectionSnapshotQuery from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import * as ScheduledTasks from "../../../scheduledTasks/ScheduledTaskService.ts";
 import { queuedRunsInDeliveryOrder } from "../../../orchestration-v2/QueuedRunOrder.ts";
 import { ThreadToolkit } from "./tools.ts";
 
@@ -68,6 +70,36 @@ const readQuestion = Effect.fn("mcp.readQuestion")(function* (
   return { ...context, request, item };
 });
 export const ThreadToolkitHandlersLive = ThreadToolkit.toLayer({
+  run_scheduled_task_now: (input) =>
+    Effect.gen(function* () {
+      const { caller } = yield* readMutationCaller();
+      if (
+        caller.archivedAt !== null ||
+        caller.runtimeMode !== "full-access" ||
+        caller.interactionMode !== "default"
+      )
+        return yield* new OrchestratorMcpFailure({
+          code: "capability_denied",
+          message: "Running a scheduled task requires a live full-access/default thread.",
+        });
+      const scheduler = yield* ScheduledTasks.ScheduledTaskService;
+      const { tasks } = yield* scheduler.list().pipe(Effect.mapError(unavailable));
+      if (!tasks.some((task) => task.id === input.taskId && task.projectId === caller.projectId))
+        return yield* new OrchestratorMcpFailure({
+          code: "invalid_request",
+          message: "The task was not found in the calling project.",
+        });
+      const { task } = yield* scheduler
+        .runNow({ id: input.taskId })
+        .pipe(Effect.mapError(unavailable));
+      return {
+        taskId: task.id,
+        threadId: task.threadId,
+        lastRunStatus: task.lastRunStatus,
+        runCount: task.runCount,
+        nextRunAt: task.nextRunAt,
+      };
+    }),
   t3_thread_search: (input) =>
     Effect.gen(function* () {
       const { caller } = yield* readCaller();

--- a/apps/server/src/mcp/toolkits/thread/tools.ts
+++ b/apps/server/src/mcp/toolkits/thread/tools.ts
@@ -1,4 +1,6 @@
 import {
+  ScheduledTaskId,
+  ScheduledTask,
   OrchestrationSearchThreadsInput,
   OrchestrationSearchThreadsResult,
   OrchestrationV2ThreadForkSourcePoint,
@@ -21,6 +23,7 @@ import * as Schema from "effect/Schema";
 import { Tool, Toolkit } from "effect/unstable/ai";
 
 import { ProjectionSnapshotQuery } from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ScheduledTaskService } from "../../../scheduledTasks/ScheduledTaskService.ts";
 import { ThreadManagementService } from "../../../orchestration-v2/ThreadManagementService.ts";
 import { McpInvocationContext } from "../../McpInvocationContext.ts";
 
@@ -230,7 +233,25 @@ export const ThreadSearchTool = Tool.make("t3_thread_search", {
   .annotate(Tool.Readonly, true)
   .annotate(Tool.Destructive, false);
 
+export const ScheduledTaskRunTool = Tool.make("run_scheduled_task_now", {
+  ...commandTool,
+  description:
+    "Run a scheduled task in the calling project now through the existing scheduler. Requires a full-access/default caller. Each call is a new manual run; completion means dispatch/bookkeeping completed, not that the provider turn finished.",
+  parameters: Schema.Struct({ taskId: ScheduledTaskId }),
+  success: Schema.Struct({
+    taskId: ScheduledTaskId,
+    threadId: ScheduledTask.fields.threadId,
+    lastRunStatus: ScheduledTask.fields.lastRunStatus,
+    runCount: NonNegativeInt,
+    nextRunAt: ScheduledTask.fields.nextRunAt,
+  }),
+  dependencies: [...commandTool.dependencies, ScheduledTaskService],
+})
+  .annotate(Tool.Destructive, true)
+  .annotate(Tool.OpenWorld, true);
+
 export const ThreadToolkit = Toolkit.make(
+  ScheduledTaskRunTool,
   ThreadSearchTool,
   ThreadForkTool,
   ThreadMergeBackTool,

--- a/packages/shared/src/t3McpToolPresentation.ts
+++ b/packages/shared/src/t3McpToolPresentation.ts
@@ -34,6 +34,7 @@ const T3_MCP_TOOLS: Record<
   delegate_task: { displayName: "Delegate a child task", summaryAction: "delegate" },
   task_status: { displayName: "Get delegated task status", summaryAction: "task-status" },
   task_cancel: { displayName: "Cancel delegated task", summaryAction: "task-cancel" },
+  run_scheduled_task_now: { displayName: "Run scheduled task now" },
   schedule_task: { displayName: "Schedule a recurring task", summaryAction: "schedule-create" },
   list_scheduled_tasks: { displayName: "List scheduled tasks", summaryAction: "schedule-list" },
   update_scheduled_task: {


### PR DESCRIPTION
Part 12/16 of the [shared-core and MCP stack](https://github.com/pingdotgg/t3code/stacks/10582). Based on [#10561](https://github.com/pingdotgg/t3code/pull/10561). Next: [#10563](https://github.com/pingdotgg/t3code/pull/10563).

Expose ScheduledTaskService.runNow for tasks in the calling project, using the existing manual-run execution and bookkeeping.

Requires a full-access/default caller. Each call is a new manual run, not an idempotent retry. Returned bookkeeping is not provider turn completion; durable keyed retries and scheduler hardening are separate.

MCP-only rebuild of [#8731](https://github.com/pingdotgg/t3code/pull/8731), preserving attribution to Julius Marminge's original work. Original branches remain available for separate service follow-ups.

Validation: The composed stack passes 94 tests across 12 focused files, including shared core MCP and real MCP/V2 integration, attachment intake, project RPC/service contracts, and client model command selection. Server/contracts/shared/client-runtime typechecks and targeted format/lint/diff checks pass. New behavior coverage lives with the shared operation; no per-tool mock suite was added. Current-head CI is shown below.

Layer size: 3 files, +54/-0. No domain-service production implementation or documentation files change in this MCP layer.

Prepared with Codex in the OpenAI agent runtime.
