### PR TITLE
feat(mcp): expose project thread launch service

### DIFF
--- a/apps/server/src/mcp/toolkits/project/handlers.ts
+++ b/apps/server/src/mcp/toolkits/project/handlers.ts
@@ -1,7 +1,7 @@
 import { MessageId, ThreadId, OrchestratorMcpFailure, ProjectId } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
-import * as Launch from "../../../orchestration-v2/ThreadLaunchService.ts";
+import * as ThreadMessageIntake from "../../../orchestration-v2/ThreadMessageIntake.ts";
 import * as Claims from "../../../orchestration-v2/AttachmentClaims.ts";
 import * as Project from "../../../project/ProjectService.ts";
 import * as Repositories from "../../../sourceControl/SourceControlRepositoryService.ts";
@@ -45,7 +45,6 @@ export const ProjectHandlersLive = ProjectToolkit.toLayer({
           code: "capability_denied",
           message: "Project launches require a full-access/default calling thread.",
         });
-      const launch = yield* Launch.ThreadLaunchService;
       const commandId = yield* newCommandId();
       const threadId = ThreadId.make(commandId);
       const messageId = MessageId.make(commandId);
@@ -55,38 +54,33 @@ export const ProjectHandlersLive = ProjectToolkit.toLayer({
           code: "invalid_request",
           message: "A new thread accepts only pending attachment uploads.",
         });
-      const claimed = yield* Claims.claimPendingAttachments({ threadId, attachments }).pipe(
-        Effect.mapError(
-          (error) =>
-            new OrchestratorMcpFailure({
-              code: "orchestration_error",
-              message: error.message,
+      const result = yield* ThreadMessageIntake.launchThread({
+        commandId,
+        threadId,
+        projectId: input.projectId ?? caller.projectId,
+        title: input.title,
+        modelSelection: input.modelSelection ?? caller.modelSelection,
+        runtimeMode: input.runtimeMode ?? caller.runtimeMode,
+        interactionMode: input.interactionMode ?? caller.interactionMode,
+        workspaceStrategy: input.workspaceStrategy ?? { type: "root" },
+        ...(input.message === undefined && attachments.length === 0
+          ? {}
+          : {
+              initialMessage: {
+                messageId,
+                text: input.message ?? "",
+                attachments,
+              },
             }),
+        createdBy: "agent",
+        creationSource: "mcp",
+      }).pipe(
+        Effect.mapError((error) =>
+          error._tag === "AttachmentClaimError"
+            ? new OrchestratorMcpFailure({ code: "orchestration_error", message: error.message })
+            : unavailable(),
         ),
       );
-      const result = yield* launch
-        .launch({
-          commandId,
-          threadId,
-          projectId: input.projectId ?? caller.projectId,
-          title: input.title,
-          modelSelection: input.modelSelection ?? caller.modelSelection,
-          runtimeMode: input.runtimeMode ?? caller.runtimeMode,
-          interactionMode: input.interactionMode ?? caller.interactionMode,
-          workspaceStrategy: input.workspaceStrategy ?? { type: "root" },
-          ...(input.message === undefined && attachments.length === 0
-            ? {}
-            : {
-                initialMessage: {
-                  messageId,
-                  text: input.message ?? "",
-                  attachments: claimed.attachments,
-                },
-              }),
-          createdBy: "agent",
-          creationSource: "mcp",
-        })
-        .pipe(Effect.mapError(unavailable));
       const thread = result.projection.thread;
       const run = result.projection.runs.find((run) => run.userMessageId === messageId);
       return {

--- a/apps/server/src/mcp/toolkits/project/handlers.ts
+++ b/apps/server/src/mcp/toolkits/project/handlers.ts
@@ -1,6 +1,8 @@
-import { OrchestratorMcpFailure, ProjectId } from "@t3tools/contracts";
+import { MessageId, ThreadId, OrchestratorMcpFailure, ProjectId } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
+import * as Launch from "../../../orchestration-v2/ThreadLaunchService.ts";
+import * as Claims from "../../../orchestration-v2/AttachmentClaims.ts";
 import * as Project from "../../../project/ProjectService.ts";
 import * as Repositories from "../../../sourceControl/SourceControlRepositoryService.ts";
 import { newCommandId, readCaller, readMutationCaller, unavailable } from "../../threadAccess.ts";
@@ -35,6 +37,60 @@ const mutation = Effect.gen(function* () {
   return yield* Project.ProjectService;
 });
 export const ProjectHandlersLive = ProjectToolkit.toLayer({
+  t3_thread_launch: (input) =>
+    Effect.gen(function* () {
+      const { caller } = yield* readMutationCaller();
+      if (caller.runtimeMode !== "full-access" || caller.interactionMode !== "default")
+        return yield* new OrchestratorMcpFailure({
+          code: "capability_denied",
+          message: "Project launches require a full-access/default calling thread.",
+        });
+      const launch = yield* Launch.ThreadLaunchService;
+      const commandId = yield* newCommandId();
+      const threadId = ThreadId.make(commandId);
+      const messageId = MessageId.make(commandId);
+      const attachments = input.attachments ?? [];
+      if (attachments.some((attachment) => !Claims.attachmentIsPendingUpload(attachment)))
+        return yield* new OrchestratorMcpFailure({
+          code: "invalid_request",
+          message: "A new thread accepts only pending attachment uploads.",
+        });
+      const claimed = yield* Claims.claimPendingAttachments({ threadId, attachments }).pipe(
+        Effect.mapError(unavailable),
+      );
+      const result = yield* launch
+        .launch({
+          commandId,
+          threadId,
+          projectId: input.projectId ?? caller.projectId,
+          title: input.title,
+          modelSelection: input.modelSelection ?? caller.modelSelection,
+          runtimeMode: input.runtimeMode ?? caller.runtimeMode,
+          interactionMode: input.interactionMode ?? caller.interactionMode,
+          workspaceStrategy: input.workspaceStrategy ?? { type: "root" },
+          ...(input.message === undefined && attachments.length === 0
+            ? {}
+            : {
+                initialMessage: {
+                  messageId,
+                  text: input.message ?? "",
+                  attachments: claimed.attachments,
+                },
+              }),
+          createdBy: "agent",
+          creationSource: "mcp",
+        })
+        .pipe(Effect.mapError(unavailable));
+      const thread = result.projection.thread;
+      const run = result.projection.runs.find((run) => run.userMessageId === messageId);
+      return {
+        threadId: thread.id,
+        projectId: thread.projectId,
+        modelSelection: thread.modelSelection,
+        runId: run?.id ?? null,
+        status: run?.status ?? null,
+      };
+    }),
   t3_project_list: (input) =>
     Effect.gen(function* () {
       const projects = yield* access;

--- a/apps/server/src/mcp/toolkits/project/handlers.ts
+++ b/apps/server/src/mcp/toolkits/project/handlers.ts
@@ -56,7 +56,13 @@ export const ProjectHandlersLive = ProjectToolkit.toLayer({
           message: "A new thread accepts only pending attachment uploads.",
         });
       const claimed = yield* Claims.claimPendingAttachments({ threadId, attachments }).pipe(
-        Effect.mapError(unavailable),
+        Effect.mapError(
+          (error) =>
+            new OrchestratorMcpFailure({
+              code: "orchestration_error",
+              message: error.message,
+            }),
+        ),
       );
       const result = yield* launch
         .launch({

--- a/apps/server/src/mcp/toolkits/project/tools.ts
+++ b/apps/server/src/mcp/toolkits/project/tools.ts
@@ -1,5 +1,13 @@
 import {
   NonNegativeInt,
+  ThreadId,
+  RunId,
+  OrchestrationV2RunStatus,
+  OrchestrationV2ThreadLaunchWorkspaceStrategy,
+  RuntimeMode,
+  ProviderInteractionMode,
+  ChatImageAttachment,
+  ChatFileAttachment,
   Project,
   ProjectCreatePayload,
   ProjectUpdatePayload,
@@ -8,6 +16,9 @@ import {
   SourceControlCloneRepositoryInput,
   SourceControlCloneRepositoryResult,
 } from "@t3tools/contracts";
+import * as FileSystem from "effect/FileSystem";
+import { ServerConfig } from "../../../config.ts";
+import { ThreadLaunchService } from "../../../orchestration-v2/ThreadLaunchService.ts";
 import * as Crypto from "effect/Crypto";
 import * as Schema from "effect/Schema";
 import { Tool, Toolkit } from "effect/unstable/ai";
@@ -73,7 +84,38 @@ export const ProjectCloneTool = Tool.make("t3_project_clone", {
 })
   .annotate(Tool.Destructive, true)
   .annotate(Tool.OpenWorld, true);
+export const ThreadLaunchTool = Tool.make("t3_thread_launch", {
+  ...shared,
+  description:
+    "Launch a thread in a registered project using the same launch service as the app. Omit projectId/modelSelection/modes to inherit from the caller. Supports root, existing_worktree, or a new worktree. Each call is a new launch, with no retry key. Preparation can continue after acceptance; failures may leave a created thread. Attachments must be pending uploads. Requires a full-access/default caller.",
+  parameters: Schema.Struct({
+    projectId: Schema.optional(ProjectId),
+    title: TrimmedNonEmptyString,
+    modelSelection: Schema.optional(ModelSelection),
+    runtimeMode: Schema.optional(RuntimeMode),
+    interactionMode: Schema.optional(ProviderInteractionMode),
+    workspaceStrategy: Schema.optional(OrchestrationV2ThreadLaunchWorkspaceStrategy),
+    message: Schema.optional(Schema.String.check(Schema.isMaxLength(120000))),
+    attachments: Schema.optional(
+      Schema.Array(Schema.Union([ChatImageAttachment, ChatFileAttachment])).check(
+        Schema.isMaxLength(8),
+      ),
+    ),
+  }),
+  success: Schema.Struct({
+    threadId: ThreadId,
+    projectId: ProjectId,
+    modelSelection: ModelSelection,
+    runId: Schema.NullOr(RunId),
+    status: Schema.NullOr(OrchestrationV2RunStatus),
+  }),
+  dependencies: [...shared.dependencies, ThreadLaunchService, FileSystem.FileSystem, ServerConfig],
+})
+  .annotate(Tool.Destructive, true)
+  .annotate(Tool.OpenWorld, true);
+
 export const ProjectToolkit = Toolkit.make(
+  ThreadLaunchTool,
   ProjectListTool,
   ProjectReadTool,
   ProjectCreateTool,

--- a/apps/server/src/mcp/toolkits/project/tools.ts
+++ b/apps/server/src/mcp/toolkits/project/tools.ts
@@ -1,5 +1,7 @@
 import {
   NonNegativeInt,
+  ModelSelection,
+  TrimmedNonEmptyString,
   ThreadId,
   RunId,
   OrchestrationV2RunStatus,

--- a/packages/shared/src/t3McpToolPresentation.ts
+++ b/packages/shared/src/t3McpToolPresentation.ts
@@ -75,6 +75,7 @@ const T3_MCP_TOOLS: Record<
   t3_preview_close: { displayName: "Close a preview tab" },
   t3_environment_read: { displayName: "Read environment preferences" },
   t3_environment_preferences_update: { displayName: "Update environment preferences" },
+  t3_thread_launch: { displayName: "Launch a project thread" },
   t3_project_list: { displayName: "List projects" },
   t3_project_read: { displayName: "Read a project" },
   t3_project_create: { displayName: "Create a project" },


### PR DESCRIPTION
Part 15/16 of the [shared-core and MCP stack](https://github.com/pingdotgg/t3code/stacks/10582). Based on [#10564](https://github.com/pingdotgg/t3code/pull/10564). Next: [#10566](https://github.com/pingdotgg/t3code/pull/10566).

Expose ThreadLaunchService through t3_thread_launch, including a registered project selector, workspace strategy, optional message and pending attachments.

Existing create_threads/t3_thread_start are untouched. Requires a full-access/default caller. Each call is a new launch; failures can leave an accepted partial thread. Preparation and workspace behavior remain in ThreadLaunchService. No new parent-run admission or retry journal.

Attachment claiming and launch execution now go through ThreadMessageIntake, shared with RPC. MCP retains caller defaults, pending-upload policy, and response mapping.

MCP-only rebuild of [#8678](https://github.com/pingdotgg/t3code/pull/8678), preserving attribution to Julius Marminge's original work. Original branches remain available for separate service follow-ups.

Validation: The composed stack passes 94 tests across 12 focused files, including shared core MCP and real MCP/V2 integration, attachment intake, project RPC/service contracts, and client model command selection. Server/contracts/shared/client-runtime typechecks and targeted format/lint/diff checks pass. New behavior coverage lives with the shared operation; no per-tool mock suite was added. Current-head CI is shown below.

Layer size: 3 files, +102/-1. No domain-service production implementation or documentation files change in this MCP layer.

Prepared with Codex in the OpenAI agent runtime.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `t3_thread_launch` MCP tool and handler to `ProjectToolkit`
> - Adds the `t3_thread_launch` handler in `project.ProjectHandlersLive`, which validates a full-access caller, accepts pending-upload attachments, applies caller defaults for project/model/modes, and launches a thread through `ThreadMessageIntake`, returning thread ID and optional initial-run status.
> - Adds the `project.ThreadLaunchTool` schema with bounded message, up to eight attachments, and structured success/failure output; registers it as the first tool in `ProjectToolkit`.
> - Adds a display-name entry ("Launch a project thread") in `T3_MCP_TOOLS`.
> - Risk: launch preparation may continue after acceptance and can leave a created thread on failure; callers must supply only pending-upload attachments or receive an orchestration error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3492b15.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->