### PR TITLE
feat(mcp): expose branch-backed workspace discovery

### DIFF
--- a/apps/server/src/mcp/toolkits/worktree/handlers.ts
+++ b/apps/server/src/mcp/toolkits/worktree/handlers.ts
@@ -1,3 +1,8 @@
+import { OrchestratorMcpFailure } from "@t3tools/contracts";
+import * as Option from "effect/Option";
+import * as GitWorkflow from "../../../git/GitWorkflowService.ts";
+import * as Project from "../../../project/ProjectService.ts";
+import { readCaller, unavailable } from "../../threadAccess.ts";
 import * as Effect from "effect/Effect";
 
 import { McpInvocationContext } from "../../McpInvocationContext.ts";
@@ -5,6 +10,27 @@ import { WorktreeMcpService } from "../../WorktreeMcpService.ts";
 import { WorktreeToolkit } from "./tools.ts";
 
 const handlers = {
+  t3_worktree_list: (input) =>
+    Effect.gen(function* () {
+      const context = yield* McpInvocationContext;
+      if (!context.capabilities.has("worktree"))
+        return yield* new OrchestratorMcpFailure({
+          code: "capability_denied",
+          message: "This credential cannot inspect worktrees.",
+        });
+      const { caller } = yield* readCaller();
+      const projects = yield* Project.ProjectService;
+      const project = yield* projects.getById(caller.projectId).pipe(Effect.mapError(unavailable));
+      if (Option.isNone(project))
+        return yield* new OrchestratorMcpFailure({
+          code: "invalid_request",
+          message: "The project was not found.",
+        });
+      const git = yield* GitWorkflow.GitWorkflowService;
+      return yield* git
+        .listRefs({ ...input, cwd: caller.worktreePath ?? project.value.workspaceRoot })
+        .pipe(Effect.mapError(unavailable));
+    }),
   t3_worktree_handoff: (input) =>
     Effect.gen(function* () {
       const scope = yield* McpInvocationContext;

--- a/apps/server/src/mcp/toolkits/worktree/tools.ts
+++ b/apps/server/src/mcp/toolkits/worktree/tools.ts
@@ -1,9 +1,16 @@
 import {
   WorktreeMcpFailure,
+  OrchestratorMcpFailure,
+  VcsListRefsInput,
+  VcsListRefsResult,
   WorktreeMcpHandoffInput,
   WorktreeMcpHandoffResult,
   WorktreeMcpStatusResult,
 } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+import { GitWorkflowService } from "../../../git/GitWorkflowService.ts";
+import { ProjectService } from "../../../project/ProjectService.ts";
+import { ThreadManagementService } from "../../../orchestration-v2/ThreadManagementService.ts";
 import { Tool, Toolkit } from "effect/unstable/ai";
 
 import * as McpInvocationContext from "../../McpInvocationContext.ts";
@@ -44,4 +51,30 @@ export const WorktreeStatusTool = Tool.make("t3_worktree_status", {
   .annotate(Tool.Idempotent, true)
   .annotate(Tool.OpenWorld, false);
 
-export const WorktreeToolkit = Toolkit.make(WorktreeHandoffTool, WorktreeStatusTool);
+export const WorktreeListTool = Tool.make("t3_worktree_list", {
+  description:
+    "List branch refs and their associated checkout paths for this thread's workspace using the app's ref inventory. Detached worktrees without a branch are not included. Use t3_worktree_status for the thread binding and t3_worktree_handoff to create a new worktree.",
+  parameters: Schema.Struct({
+    query: VcsListRefsInput.fields.query,
+    cursor: VcsListRefsInput.fields.cursor,
+    limit: VcsListRefsInput.fields.limit,
+    refKind: VcsListRefsInput.fields.refKind,
+    includeMatchingRemoteRefs: VcsListRefsInput.fields.includeMatchingRemoteRefs,
+  }),
+  success: VcsListRefsResult,
+  failure: OrchestratorMcpFailure,
+  failureMode: "return",
+  dependencies: [
+    McpInvocationContext.McpInvocationContext,
+    ThreadManagementService,
+    ProjectService,
+    GitWorkflowService,
+  ],
+})
+  .annotate(Tool.Readonly, true)
+  .annotate(Tool.Destructive, false);
+export const WorktreeToolkit = Toolkit.make(
+  WorktreeHandoffTool,
+  WorktreeStatusTool,
+  WorktreeListTool,
+);

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.test.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.test.ts
@@ -48,6 +48,7 @@ import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import { PreviewControlsToolkit } from "../../mcp/toolkits/previewControls/tools.ts";
 import { EnvironmentToolkit } from "../../mcp/toolkits/environment/tools.ts";
 import { ProjectToolkit } from "../../mcp/toolkits/project/tools.ts";
+import { WorktreeToolkit } from "../../mcp/toolkits/worktree/tools.ts";
 import { ThreadToolkit } from "../../mcp/toolkits/thread/tools.ts";
 import { OrchestratorToolkit } from "../../mcp/toolkits/orchestrator/tools.ts";
 import type { EventNdjsonLogger } from "../../provider/Layers/EventNdjsonLogger.ts";
@@ -587,6 +588,7 @@ describe("ClaudeAdapterV2 MCP query overrides", () => {
     const readOnlyToolNames = [
       ...Object.values(OrchestratorToolkit.tools),
       ...Object.values(ThreadToolkit.tools),
+      ...Object.values(WorktreeToolkit.tools),
       ...Object.values(ProjectToolkit.tools),
       ...Object.values(EnvironmentToolkit.tools),
       ...Object.values(PreviewControlsToolkit.tools),

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
@@ -812,6 +812,8 @@ export const CLAUDE_READ_ONLY_T3_MCP_ALLOWED_TOOLS: ReadonlyArray<string> = [
   "mcp__t3-code__t3_pending_request_read",
   "mcp__t3-code__t3_thread_configuration",
   "mcp__t3-code__t3_thread_transfers",
+  "mcp__t3-code__t3_worktree_status",
+  "mcp__t3-code__t3_worktree_list",
   "mcp__t3-code__t3_project_list",
   "mcp__t3-code__t3_project_read",
   "mcp__t3-code__t3_thread_search",

--- a/packages/shared/src/t3McpToolPresentation.ts
+++ b/packages/shared/src/t3McpToolPresentation.ts
@@ -70,6 +70,7 @@ const T3_MCP_TOOLS: Record<
   t3_thread_wait: { displayName: "Wait for a T3 thread", summaryAction: "thread-wait" },
   t3_thread_interrupt: { displayName: "Interrupt a T3 thread", summaryAction: "thread-interrupt" },
   t3_worktree_handoff: { displayName: "Hand off thread to a git worktree" },
+  t3_worktree_list: { displayName: "List workspace branches" },
   t3_worktree_status: { displayName: "Get thread worktree status" },
   t3_preview_list: { displayName: "List preview tabs" },
   t3_preview_close: { displayName: "Close a preview tab" },


### PR DESCRIPTION
Part 16/16 of the [shared-core and MCP stack](https://github.com/pingdotgg/t3code/stacks/10582). Based on [#10565](https://github.com/pingdotgg/t3code/pull/10565).

Expose GitWorkflowService.listRefs for the calling thread workspace. Existing worktree handoff and status tools stay unchanged.

This discovers branch-backed refs/worktrees only. Detached unbound inventory and switching an existing checkout require a shared service operation and are intentionally not rebuilt inside MCP. The old workspace work is retained for that extraction.

MCP-only rebuild of [#8685](https://github.com/pingdotgg/t3code/pull/8685), [#8680](https://github.com/pingdotgg/t3code/pull/8680), preserving attribution to Julius Marminge's original work. Original branches remain available for separate service follow-ups.

Validation: The composed stack passes 94 tests across 12 focused files, including shared core MCP and real MCP/V2 integration, attachment intake, project RPC/service contracts, and client model command selection. Server/contracts/shared/client-runtime typechecks and targeted format/lint/diff checks pass. New behavior coverage lives with the shared operation; no per-tool mock suite was added. Current-head CI is shown below.

Layer size: 5 files, +65/-1. No domain-service production implementation or documentation files change in this MCP layer.

Prepared with Codex in the OpenAI agent runtime.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `t3_worktree_list` MCP tool for branch-backed workspace discovery
> - Adds a readonly `t3_worktree_list` tool to the worktree toolkit that lists git refs using the caller's worktree path or the project workspace root.
> - The handler checks the worktree capability and project existence, returning structured failures when either is missing; git errors map to an unavailable failure.
> - Registers the tool in `CLAUDE_READ_ONLY_T3_MCP_ALLOWED_TOOLS` and the `T3_MCP_TOOLS` presentation registry (label "List workspace branches"), and updates the Claude readonly allowlist test to cover the new tool.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1dce00c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->