### PR TITLE
fix(web): retain loaded pull request diff pages on refresh

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -256,9 +256,9 @@ function PullRequestCodeTab({
     readonly key: string;
     readonly cursor: string | null;
     readonly slices: ReadonlyArray<DiffSlice>;
-  }>({ key: "", cursor: null, slices: NO_SLICES });
+    readonly revalidating: boolean;
+  }>({ key: "", cursor: null, slices: NO_SLICES, revalidating: false });
   const parseCache = useRef(new Map<string, RenderablePatch>());
-  const revalidatingSlices = useRef(false);
   const registry = useContext(RegistryContext);
   const [viewer, setViewer] = useState<CodeViewHandle<ReviewAnnotationGroup> | null>(null);
 
@@ -270,19 +270,19 @@ function PullRequestCodeTab({
   // The panel keeps this mounted across pull requests, so an open composer would otherwise
   // survive the switch and attach its comment to whichever one is on screen when it is sent.
   useEffect(() => {
-    revalidatingSlices.current = false;
     setDraft(null);
     setSelectedLines(null);
     setToggledFiles(new Set());
     setFoldOverride(null);
     setVisibleCommitCount(COMMIT_PAGE_SIZE);
     setOrphansOpen(false);
-    setSliceState({ key: scopeKey, cursor: null, slices: NO_SLICES });
+    setSliceState({ key: scopeKey, cursor: null, slices: NO_SLICES, revalidating: false });
     parseCache.current.clear();
   }, [scopeKey]);
 
   const loadedSlices = sliceState.key === scopeKey ? sliceState.slices : NO_SLICES;
   const cursor = sliceState.key === scopeKey ? sliceState.cursor : null;
+  const revalidating = sliceState.key === scopeKey && sliceState.revalidating;
   const diffQuery = useEnvironmentQuery(
     pullRequestEnvironment.diff({
       environmentId,
@@ -308,8 +308,7 @@ function PullRequestCodeTab({
     };
     const index = slices.findIndex((slice) => slice.cursor === cursor);
     if (index === -1) {
-      revalidatingSlices.current = false;
-      setSliceState({ key: scopeKey, cursor, slices: [...slices, next] });
+      setSliceState({ key: scopeKey, cursor, slices: [...slices, next], revalidating: false });
       return;
     }
     const existing = slices[index];
@@ -329,7 +328,7 @@ function PullRequestCodeTab({
         );
       })
     ) {
-      if (revalidatingSlices.current) {
+      if (revalidating) {
         const following = slices[index + 1];
         if (following !== undefined) {
           registry.refresh(
@@ -342,23 +341,28 @@ function PullRequestCodeTab({
               },
             }),
           );
-          setSliceState({ key: scopeKey, cursor: following.cursor, slices });
+          setSliceState({ key: scopeKey, cursor: following.cursor, slices, revalidating: true });
           return;
         }
+        setSliceState({ key: scopeKey, cursor, slices, revalidating: false });
       }
-      revalidatingSlices.current = false;
       return;
     }
     // A page that came back different means the diff moved under the review. The slices
     // after it go with the replacement: their cursors were positions in the old diff.
-    revalidatingSlices.current = false;
-    setSliceState({ key: scopeKey, cursor, slices: [...slices.slice(0, index), next] });
+    setSliceState({
+      key: scopeKey,
+      cursor,
+      slices: [...slices.slice(0, index), next],
+      revalidating: false,
+    });
   }, [
     cursor,
     diffQuery.data,
     diffQuery.isPending,
     scopeKey,
     loadedSlices,
+    revalidating,
     registry,
     environmentId,
     reference,
@@ -376,11 +380,10 @@ function PullRequestCodeTab({
   useEffect(() => {
     if (appliedRefreshToken.current === refreshToken) return;
     appliedRefreshToken.current = refreshToken;
-    revalidatingSlices.current = true;
     setSliceState((previous) =>
       previous.key === scopeKey
-        ? { ...previous, cursor: null }
-        : { key: scopeKey, cursor: null, slices: NO_SLICES },
+        ? { ...previous, cursor: null, revalidating: true }
+        : { key: scopeKey, cursor: null, slices: NO_SLICES, revalidating: true },
     );
     refreshFirstDiffPage();
   }, [refreshToken, scopeKey, refreshFirstDiffPage]);
@@ -607,14 +610,19 @@ function PullRequestCodeTab({
   // A failed slice must not be asked for again on its own. The files already loaded keep the
   // sentinel on screen, so re-arming it after a failure would request the same slice forever.
   const canLoadNextSlice =
+    !revalidating &&
     nextCursor !== null &&
     nextCursor !== cursor &&
     !diffQuery.isPending &&
     diffQuery.error === null;
   const loadNextSlice = useCallback(() => {
     if (nextCursor === null) return;
-    setSliceState((previous) => ({ ...previous, cursor: nextCursor }));
-  }, [nextCursor]);
+    setSliceState((previous) =>
+      previous.revalidating || previous.key !== scopeKey
+        ? previous
+        : { ...previous, cursor: nextCursor },
+    );
+  }, [nextCursor, scopeKey]);
 
   // The sentinel is held as state rather than a ref because the viewer mounts its own footer:
   // an effect reading a ref could run before that node exists and would never arm the observer.

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -760,7 +760,7 @@ function PullRequestCodeTab({
           {diffQuery.error !== null ? (
             <>
               <span>
-                {nextCursor === null
+                {revalidating || nextCursor === null
                   ? "This diff could not be refreshed."
                   : "The rest of this diff could not be loaded."}
               </span>
@@ -778,7 +778,7 @@ function PullRequestCodeTab({
           ) : null}
         </div>
       ),
-    [nextCursor, diffQuery.error, diffQuery.isPending, diffQuery.refresh],
+    [nextCursor, revalidating, diffQuery.error, diffQuery.isPending, diffQuery.refresh],
   );
 
   const renderHeaderPrefix = useCallback(

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -297,7 +297,7 @@ function PullRequestCodeTab({
   // text would cost more with every slice, which is the wall the slicing exists to remove.
   useEffect(() => {
     const data = diffQuery.data;
-    if (data === null || diffQuery.isPending) return;
+    if (data === null || diffQuery.isPending || diffQuery.error !== null) return;
     const slices = loadedSlices;
     const next = {
       cursor,
@@ -367,6 +367,7 @@ function PullRequestCodeTab({
   }, [
     cursor,
     diffQuery.data,
+    diffQuery.error,
     diffQuery.isPending,
     scopeKey,
     loadedSlices,
@@ -750,18 +751,25 @@ function PullRequestCodeTab({
   // update), which is the jank this file is otherwise clean of.
   const renderCodeViewFooter = useCallback(
     () =>
-      // Only while something is still owed. A finished diff whose query fails on a later
-      // refresh — a reconnect re-runs every one of them — is whole on screen already, and
-      // saying otherwise sends the reader looking for files that are all there.
-      nextCursor === null ? null : (
+      // Retained pages remain readable after a failed refresh, but may now be outdated.
+      nextCursor === null && diffQuery.error === null ? null : (
         <div
           ref={setSentinel}
           className="flex items-center justify-center gap-2 py-2 text-xs text-muted-foreground"
         >
           {diffQuery.error !== null ? (
             <>
-              <span>The rest of this diff could not be loaded.</span>
-              <Button size="xs" variant="outline" onClick={() => diffQuery.refresh()}>
+              <span>
+                {nextCursor === null
+                  ? "This diff could not be refreshed."
+                  : "The rest of this diff could not be loaded."}
+              </span>
+              <Button
+                size="xs"
+                variant="outline"
+                disabled={diffQuery.isPending}
+                onClick={() => diffQuery.refresh()}
+              >
                 Retry
               </Button>
             </>
@@ -1306,17 +1314,21 @@ function PullRequestCodeTab({
             <pre className="whitespace-pre-wrap break-words font-mono text-xs">{slice.text}</pre>
           </div>
         ))}
+        {renderCodeViewFooter()}
       </div>,
     );
   }
 
   if (items.length === 0 && nextCursor === null) {
     return withReviewBar(
-      <p className="px-4 py-5 text-sm text-muted-foreground">
-        {commit === null
-          ? "This pull request has no file changes."
-          : "This commit has no file changes."}
-      </p>,
+      <>
+        <p className="px-4 py-5 text-sm text-muted-foreground">
+          {commit === null
+            ? "This pull request has no file changes."
+            : "This commit has no file changes."}
+        </p>
+        {renderCodeViewFooter()}
+      </>,
     );
   }
 

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -350,6 +350,14 @@ function PullRequestCodeTab({
     }
     // A page that came back different means the diff moved under the review. The slices
     // after it go with the replacement: their cursors were positions in the old diff.
+    for (const slice of slices.slice(index)) {
+      const patchHash = fnv1a32(slice.patch);
+      for (const theme of ["light", "dark"] as const) {
+        parseCache.current.delete(
+          `pull-request:${scopeKey}:${theme}:${slice.cursor ?? "first"}:${patchHash}`,
+        );
+      }
+    }
     setSliceState({
       key: scopeKey,
       cursor,

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -24,9 +24,17 @@ import {
   TriangleAlertIcon,
   XIcon,
 } from "lucide-react";
-import { useAtomRefresh } from "@effect/atom-react";
+import { RegistryContext, useAtomRefresh } from "@effect/atom-react";
 import * as Schema from "effect/Schema";
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 import { useLocalStorage } from "~/hooks/useLocalStorage";
 import { useClientSettings, useUpdateClientSettings } from "~/hooks/useSettings";
@@ -213,7 +221,7 @@ function PullRequestCodeTab({
   /** Absent where there is no active agent composer to receive a local comment. */
   onAddToAgentSelection?: (input: PullRequestAgentSelectionInput) => void;
   onRefresh: () => void;
-  /** Bumped by the panel's refresh button: drop the accumulated pages and re-read the diff. */
+  /** Revalidate loaded pages after a host revision change or an explicit refresh. */
   refreshToken?: number;
 }) {
   const { resolvedTheme } = useTheme();
@@ -250,6 +258,8 @@ function PullRequestCodeTab({
     readonly slices: ReadonlyArray<DiffSlice>;
   }>({ key: "", cursor: null, slices: NO_SLICES });
   const parseCache = useRef(new Map<string, RenderablePatch>());
+  const revalidatingSlices = useRef(false);
+  const registry = useContext(RegistryContext);
   const [viewer, setViewer] = useState<CodeViewHandle<ReviewAnnotationGroup> | null>(null);
 
   const referenceKey = pullRequestReviewKey(reference);
@@ -260,6 +270,7 @@ function PullRequestCodeTab({
   // The panel keeps this mounted across pull requests, so an open composer would otherwise
   // survive the switch and attach its comment to whichever one is on screen when it is sent.
   useEffect(() => {
+    revalidatingSlices.current = false;
     setDraft(null);
     setSelectedLines(null);
     setToggledFiles(new Set());
@@ -286,46 +297,75 @@ function PullRequestCodeTab({
   // text would cost more with every slice, which is the wall the slicing exists to remove.
   useEffect(() => {
     const data = diffQuery.data;
-    if (data === null) return;
-    setSliceState((previous) => {
-      const slices = previous.key === scopeKey ? previous.slices : NO_SLICES;
-      const next = {
-        cursor,
-        patch: data.patch,
-        truncated: data.truncated,
-        nextCursor: data.nextCursor,
-        omittedFileStats: data.omittedFileStats ?? [],
-      };
-      const index = slices.findIndex((slice) => slice.cursor === cursor);
-      if (index === -1) {
-        return { key: scopeKey, cursor, slices: [...slices, next] };
-      }
-      const existing = slices[index];
-      if (
-        existing !== undefined &&
-        existing.patch === next.patch &&
-        existing.truncated === next.truncated &&
-        existing.nextCursor === next.nextCursor &&
-        existing.omittedFileStats.length === next.omittedFileStats.length &&
-        existing.omittedFileStats.every((file, index) => {
-          const refreshed = next.omittedFileStats[index];
-          return (
-            refreshed !== undefined &&
-            refreshed.path === file.path &&
-            refreshed.additions === file.additions &&
-            refreshed.deletions === file.deletions
+    if (data === null || diffQuery.isPending) return;
+    const slices = loadedSlices;
+    const next = {
+      cursor,
+      patch: data.patch,
+      truncated: data.truncated,
+      nextCursor: data.nextCursor,
+      omittedFileStats: data.omittedFileStats ?? [],
+    };
+    const index = slices.findIndex((slice) => slice.cursor === cursor);
+    if (index === -1) {
+      revalidatingSlices.current = false;
+      setSliceState({ key: scopeKey, cursor, slices: [...slices, next] });
+      return;
+    }
+    const existing = slices[index];
+    if (
+      existing !== undefined &&
+      existing.patch === next.patch &&
+      existing.truncated === next.truncated &&
+      existing.nextCursor === next.nextCursor &&
+      existing.omittedFileStats.length === next.omittedFileStats.length &&
+      existing.omittedFileStats.every((file, index) => {
+        const refreshed = next.omittedFileStats[index];
+        return (
+          refreshed !== undefined &&
+          refreshed.path === file.path &&
+          refreshed.additions === file.additions &&
+          refreshed.deletions === file.deletions
+        );
+      })
+    ) {
+      if (revalidatingSlices.current) {
+        const following = slices[index + 1];
+        if (following !== undefined) {
+          registry.refresh(
+            pullRequestEnvironment.diff({
+              environmentId,
+              input: {
+                ...reference,
+                ...(following.cursor === null ? {} : { cursor: following.cursor }),
+                ...(commit === null ? {} : { commit }),
+              },
+            }),
           );
-        })
-      ) {
-        return previous;
+          setSliceState({ key: scopeKey, cursor: following.cursor, slices });
+          return;
+        }
       }
-      // A page that came back different means the diff moved under the review. The slices
-      // after it go with the replacement: their cursors were positions in the old diff.
-      return { key: scopeKey, cursor, slices: [...slices.slice(0, index), next] };
-    });
-  }, [cursor, diffQuery.data, scopeKey]);
-  // The refresh button rereads from the first page rather than the page the reader is on:
-  // pages are positions in one snapshot of the diff, and a fresh snapshot starts over.
+      revalidatingSlices.current = false;
+      return;
+    }
+    // A page that came back different means the diff moved under the review. The slices
+    // after it go with the replacement: their cursors were positions in the old diff.
+    revalidatingSlices.current = false;
+    setSliceState({ key: scopeKey, cursor, slices: [...slices.slice(0, index), next] });
+  }, [
+    cursor,
+    diffQuery.data,
+    diffQuery.isPending,
+    scopeKey,
+    loadedSlices,
+    registry,
+    environmentId,
+    reference,
+    commit,
+  ]);
+  // Keep loaded pages visible while checking them in order. Only a changed page drops the
+  // pages after it, since their cursors may no longer refer to the same files.
   const refreshFirstDiffPage = useAtomRefresh(
     pullRequestEnvironment.diff({
       environmentId,
@@ -336,7 +376,12 @@ function PullRequestCodeTab({
   useEffect(() => {
     if (appliedRefreshToken.current === refreshToken) return;
     appliedRefreshToken.current = refreshToken;
-    setSliceState({ key: scopeKey, cursor: null, slices: NO_SLICES });
+    revalidatingSlices.current = true;
+    setSliceState((previous) =>
+      previous.key === scopeKey
+        ? { ...previous, cursor: null }
+        : { key: scopeKey, cursor: null, slices: NO_SLICES },
+    );
     refreshFirstDiffPage();
   }, [refreshToken, scopeKey, refreshFirstDiffPage]);
   const reviewKey = referenceKey;

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.refresh.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.refresh.test.tsx
@@ -136,91 +136,97 @@ afterEach(async () => {
   vi.unstubAllGlobals();
 });
 
-it.effect.each(["files", "empty", "raw", "additional page", "multiple pages"] as const)(
-  "shows diff failures and supports retry for %s",
-  (kind) =>
-    Effect.gen(function* () {
-      const h = yield* makeHarness("page");
-      const initial =
-        kind === "additional page" || kind === "multiple pages"
-          ? pages[0]!
-          : {
-              ...pages[1]!,
-              patch:
-                kind === "empty"
-                  ? ""
-                  : kind === "raw"
-                    ? "Unstructured patch content"
-                    : pages[1]!.patch,
-            };
-      h.updateDiff(initial);
-      yield* Effect.promise(async () => {
-        await act(async () => {
-          renderer = create(h.panel());
-        });
-        const button = (text: string) =>
-          renderer!.root.findAllByType("button").find((node) => node.children.includes(text))!;
-        const click = {
-          nativeEvent: new Event("click"),
-          preventDefault: state.noop,
-          currentTarget: { tagName: "BUTTON" },
-        };
-        await act(async () => {
-          button("Code").props.onClick(click);
-          await import("./PullRequestCodeTab");
-        });
-        if (kind === "multiple pages") {
-          await act(async () => button("Load more files").props.onClick(click));
-        }
-        const content = () => JSON.stringify(renderer!.toJSON());
-        const retained =
-          kind === "empty"
-            ? "This pull request has no file changes."
-            : kind === "raw"
-              ? initial.patch
-              : kind === "additional page"
-                ? "first.ts"
-                : "second.ts";
-        expect(content()).toContain(retained);
-        const loadDiff = h.loadDiff.getMockImplementation()!;
-        const failure = Effect.fail(
-          new EnvironmentInternalError({
-            code: "internal_error",
-            reason: "internal_error",
-            traceId: "test-refresh-failure",
-          }),
-        );
-        h.loadDiff.mockImplementation((connection, input) =>
-          kind === "multiple pages" && input.cursor !== undefined
-            ? loadDiff(connection, input)
-            : failure,
-        );
-        h.loadDiff.mockClear();
-        await act(async () => {
-          if (kind === "additional page") button("Load more files").props.onClick(click);
-          else renderer!.update(h.panel(1));
-        });
-        const errorText =
-          kind === "additional page"
-            ? "The rest of this diff could not be loaded."
-            : "This diff could not be refreshed.";
-        expect(content()).toContain(retained);
-        expect(content()).toContain(errorText);
-        if (kind === "multiple pages") {
-          expect(h.loadDiff.mock.calls.every(([, input]) => input.cursor === undefined)).toBe(true);
-        }
-        const failedRequests = h.loadDiff.mock.calls.length;
-        h.loadDiff.mockImplementation(loadDiff);
-        if (kind === "multiple pages") h.updateSecondPage(pages[2]!);
-        else if (kind !== "additional page") h.updateDiff(pages[2]!);
-        await act(async () => button("Retry").props.onClick(click));
-        expect(h.loadDiff).toHaveBeenCalledTimes(
-          failedRequests + (kind === "multiple pages" ? 2 : 1),
-        );
-        expect(content()).not.toContain(errorText);
-        expect(content()).toContain(kind === "additional page" ? "second.ts" : "updated.ts");
+const failureKinds = [
+  "files",
+  "empty",
+  "raw",
+  "additional page",
+  "multiple pages",
+  "partial refresh",
+] as const;
+it.effect.each(failureKinds)("shows diff failures and supports retry for %s", (kind) =>
+  Effect.gen(function* () {
+    const h = yield* makeHarness("page");
+    const initial =
+      kind === "additional page" || kind === "multiple pages" || kind === "partial refresh"
+        ? pages[0]!
+        : {
+            ...pages[1]!,
+            patch:
+              kind === "empty"
+                ? ""
+                : kind === "raw"
+                  ? "Unstructured patch content"
+                  : pages[1]!.patch,
+          };
+    h.updateDiff(initial);
+    yield* Effect.promise(async () => {
+      await act(async () => {
+        renderer = create(h.panel());
       });
-    }),
+      const button = (text: string) =>
+        renderer!.root.findAllByType("button").find((node) => node.children.includes(text))!;
+      const click = {
+        nativeEvent: new Event("click"),
+        preventDefault: state.noop,
+        currentTarget: { tagName: "BUTTON" },
+      };
+      await act(async () => {
+        button("Code").props.onClick(click);
+        await import("./PullRequestCodeTab");
+      });
+      if (kind === "multiple pages") {
+        await act(async () => button("Load more files").props.onClick(click));
+      }
+      const content = () => JSON.stringify(renderer!.toJSON());
+      const retained =
+        kind === "empty"
+          ? "This pull request has no file changes."
+          : kind === "raw"
+            ? initial.patch
+            : kind === "additional page" || kind === "partial refresh"
+              ? "first.ts"
+              : "second.ts";
+      expect(content()).toContain(retained);
+      const loadDiff = h.loadDiff.getMockImplementation()!;
+      const failure = Effect.fail(
+        new EnvironmentInternalError({
+          code: "internal_error",
+          reason: "internal_error",
+          traceId: "test-refresh-failure",
+        }),
+      );
+      h.loadDiff.mockImplementation((connection, input) =>
+        kind === "multiple pages" && input.cursor !== undefined
+          ? loadDiff(connection, input)
+          : failure,
+      );
+      h.loadDiff.mockClear();
+      await act(async () => {
+        if (kind === "additional page") button("Load more files").props.onClick(click);
+        else renderer!.update(h.panel(1));
+      });
+      const errorText =
+        kind === "additional page"
+          ? "The rest of this diff could not be loaded."
+          : "This diff could not be refreshed.";
+      expect(content()).toContain(retained);
+      expect(content()).toContain(errorText);
+      if (kind === "multiple pages") {
+        expect(h.loadDiff.mock.calls.every(([, input]) => input.cursor === undefined)).toBe(true);
+      }
+      const failedRequests = h.loadDiff.mock.calls.length;
+      h.loadDiff.mockImplementation(loadDiff);
+      if (kind === "multiple pages") h.updateSecondPage(pages[2]!);
+      else if (kind !== "additional page") h.updateDiff(pages[2]!);
+      await act(async () => button("Retry").props.onClick(click));
+      expect(h.loadDiff).toHaveBeenCalledTimes(
+        failedRequests + (kind === "multiple pages" ? 2 : 1),
+      );
+      expect(content()).not.toContain(errorText);
+      expect(content()).toContain(kind === "additional page" ? "second.ts" : "updated.ts");
+    });
+  }),
 );
 
 const makeHarness = Effect.fn("PullRequestDetailPanelTest.makeHarness")(function* (

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.refresh.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.refresh.test.tsx
@@ -1,0 +1,371 @@
+import { RegistryContext } from "@effect/atom-react";
+import { it } from "@effect/vitest";
+import {
+  AVAILABLE_CONNECTION_STATE,
+  EnvironmentRegistry,
+  EnvironmentSupervisor,
+  PrimaryConnectionTarget,
+  type PreparedConnection,
+  type SupervisorConnectionState,
+} from "@t3tools/client-runtime/connection";
+import type { RpcSession, WsRpcProtocolClient } from "@t3tools/client-runtime/rpc";
+import { PullRequestDiffLoader } from "@t3tools/client-runtime/state/pull-requests";
+import { EnvironmentId, ProjectId, WS_METHODS, type PullRequestDetail } from "@t3tools/contracts";
+import type { CodeViewDiffItem } from "@pierre/diffs/react";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as PubSub from "effect/PubSub";
+import * as Stream from "effect/Stream";
+import * as SubscriptionRef from "effect/SubscriptionRef";
+import { AtomRegistry } from "effect/unstable/reactivity";
+import { act, type ReactNode } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, expect, vi } from "vite-plus/test";
+
+import { PullRequestDetailPanel } from "./PullRequestDetailPanel";
+
+const state = vi.hoisted(() => ({
+  layer: null as Layer.Layer<EnvironmentRegistry | PullRequestDiffLoader> | null,
+  registry: null as AtomRegistry.AtomRegistry | null,
+  noop: () => {},
+}));
+const reference = { projectId: ProjectId.make("project-1"), repository: "acme/web", number: 7 };
+const environmentId = EnvironmentId.make("env-1");
+
+vi.mock("../ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => children,
+  TooltipPopup: () => null,
+}));
+vi.mock("../ui/menu", () => ({
+  Menu: ({ children }: { children: ReactNode }) => children,
+  MenuTrigger: ({ children }: { children: ReactNode }) => children,
+  MenuPopup: () => null,
+  MenuItem: () => null,
+  MenuRadioGroup: () => null,
+  MenuRadioItem: () => null,
+  MenuSeparator: () => null,
+  DropdownMenu: ({ children }: { children: ReactNode }) => children,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => children,
+  DropdownMenuContent: () => null,
+  DropdownMenuItem: () => null,
+}));
+
+vi.mock("~/connection/runtime", async () => {
+  const { Atom } = await import("effect/unstable/reactivity");
+  const Layer = await import("effect/Layer");
+  return { connectionAtomRuntime: Atom.runtime(Layer.suspend(() => state.layer!)) };
+});
+vi.mock("~/rpc/atomRegistry", () => ({
+  get appAtomRegistry() {
+    return state.registry!;
+  },
+}));
+vi.mock("~/hooks/useLiveRefresh", () => ({ useLiveRefresh: () => {} }));
+vi.mock("~/hooks/useHandleNewThread", () => ({ useNewThreadHandler: () => state.noop }));
+vi.mock("~/lib/sourceControlActions", () => ({
+  usePreparePullRequestThreadAction: () => state.noop,
+}));
+vi.mock("~/state/environments", () => ({ useEnvironments: () => ({ environments: [] }) }));
+vi.mock("~/state/entities", () => ({ useProjects: () => [] }));
+vi.mock("~/hooks/useSettings", () => ({
+  useClientSettings: () => ({ diffLayout: "unified", wordWrap: false }),
+  useUpdateClientSettings: () => state.noop,
+}));
+vi.mock("~/hooks/useTheme", () => ({ useTheme: () => ({ resolvedTheme: "dark" }) }));
+vi.mock("~/hooks/useLocalStorage", () => ({ useLocalStorage: () => [true, state.noop] }));
+vi.mock("~/hooks/useCopyToClipboard", () => ({
+  useCopyToClipboard: () => ({ copyToClipboard: state.noop, isCopied: false }),
+}));
+vi.mock("./PullRequestSummaryTab", () => ({ PullRequestSummaryTab: () => null }));
+vi.mock("./PullRequestTimelineTab", () => ({ PullRequestTimelineTab: () => null }));
+vi.mock("./PullRequestMarkdown", async () => {
+  const { createContext } = await import("react");
+  return { PullRequestMarkdownContext: createContext(null) };
+});
+vi.mock("./PullRequestChecksPopover", () => ({ PullRequestChecksPopover: () => null }));
+vi.mock("./PullRequestReviewBar", () => ({ PullRequestReviewBar: () => null }));
+vi.mock("./PullRequestReviewAnnotation", () => ({
+  PendingReviewCommentCard: () => null,
+  ReviewThreadCard: () => null,
+}));
+vi.mock("../diffs/DiffFileTree", () => ({
+  DiffFileTree: ({ footer }: { footer: ReactNode }) => footer,
+}));
+vi.mock("../diffs/StyledDiffCodeView", () => ({
+  // Render parsed file names without starting the diff viewer's workers.
+  StyledDiffCodeView: ({ items }: { items: ReadonlyArray<CodeViewDiffItem> }) => (
+    <div data-testid="diff-viewer">
+      {items.map((item) => (
+        <span key={item.id}>{item.fileDiff.name}</span>
+      ))}
+    </div>
+  ),
+}));
+
+const pages = ["first.ts", "second.ts", "updated.ts", "manual.ts"].map((path, index) => ({
+  patch: `diff --git a/${path} b/${path}\n--- a/${path}\n+++ b/${path}\n@@ -1 +1 @@\n-old\n+new\n`,
+  truncated: index === 0,
+  nextCursor: index === 0 ? "page-2" : null,
+  omittedFileStats: [],
+}));
+
+let renderer: ReactTestRenderer | undefined;
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  state.registry = AtomRegistry.make();
+});
+afterEach(async () => {
+  await act(() => renderer?.unmount());
+  renderer = undefined;
+  state.registry?.dispose();
+  vi.unstubAllGlobals();
+});
+
+const makeHarness = Effect.fn("PullRequestDetailPanelTest.makeHarness")(function* (
+  context: "thread" | "page",
+) {
+  let detail: PullRequestDetail = {
+    ...reference,
+    provider: "github",
+    projectTitle: "web",
+    workspaceRoot: "/repo",
+    title: "Review changes",
+    body: "",
+    url: "https://github.com/acme/web/pull/7",
+    author: null,
+    state: "open",
+    isDraft: false,
+    mergeability: "mergeable",
+    additions: 2,
+    deletions: 2,
+    changedFiles: 2,
+    headBranch: "feature",
+    baseBranch: "main",
+    createdAt: "2026-09-07T10:00:00Z",
+    updatedAt: "2026-09-07T10:00:00Z",
+    mergedAt: null,
+    closedAt: null,
+    reviewers: [],
+    labels: [],
+    checks: [],
+    capabilities: {
+      diff: true,
+      comment: false,
+      actions: [],
+      mergeMethods: [],
+      search: false,
+      review: { inlineComment: false, reply: false, resolve: false, verdicts: [] },
+      reviewers: { request: false, listCandidates: false },
+    },
+    viewerPermissions: {
+      actions: [],
+      comment: false,
+      resolve: false,
+      verdicts: [],
+      requestReviewers: false,
+    },
+    mergeCapabilities: { merge: false, squash: false, rebase: false },
+  };
+  const refreshes = yield* PubSub.unbounded<number>({ replay: 1 });
+  yield* PubSub.publish(refreshes, 0);
+  const readDetail = vi.fn(() => Effect.sync(() => ({ ...detail })));
+  const invalidate = vi.fn(() => Effect.void);
+  let firstPage = pages[0]!;
+  let secondPage = pages[1]!;
+  let diffGate: Promise<void> = Promise.resolve();
+  const loadDiff = vi.fn<PullRequestDiffLoader["Service"]["load"]>((_connection, input) =>
+    Effect.promise(async () => {
+      await diffGate;
+      return input.cursor === undefined ? firstPage : secondPage;
+    }),
+  );
+  const client = {
+    [WS_METHODS.pullRequestsSubscribeRefreshes]: () => Stream.fromPubSub(refreshes),
+    [WS_METHODS.pullRequestsDetail]: readDetail,
+    [WS_METHODS.pullRequestsActivity]: () =>
+      Effect.succeed({
+        author: null,
+        reviewers: [],
+        comments: [],
+        commentCount: 0,
+        commentsTruncated: false,
+        reviewThreads: [],
+        commits: [],
+        reactions: [],
+      }),
+    [WS_METHODS.pullRequestsInvalidate]: invalidate,
+    [WS_METHODS.vcsListRefs]: () => Effect.succeed({ refs: [] }),
+  } as unknown as WsRpcProtocolClient;
+  const target = new PrimaryConnectionTarget({
+    environmentId,
+    label: "Test environment",
+    httpBaseUrl: "https://environment.example.test",
+    wsBaseUrl: "wss://environment.example.test",
+  });
+  const session: RpcSession = {
+    client,
+    initialConfig: Effect.never,
+    subscribeServerConfig: (input) => client.subscribeServerConfig(input),
+    ready: Effect.void,
+    probe: Effect.void,
+    closed: Effect.never,
+  };
+  const supervisor = EnvironmentSupervisor.of({
+    target,
+    state: yield* SubscriptionRef.make<SupervisorConnectionState>({
+      ...AVAILABLE_CONNECTION_STATE,
+      desired: true,
+      network: "online",
+      phase: "connected",
+      attempt: 1,
+      generation: 1,
+    }),
+    session: yield* SubscriptionRef.make(Option.some(session)),
+    prepared: yield* SubscriptionRef.make<Option.Option<PreparedConnection>>(
+      Option.some({
+        environmentId,
+        label: target.label,
+        target,
+        httpBaseUrl: target.httpBaseUrl,
+        socketUrl: target.wsBaseUrl,
+        httpAuthorization: null,
+      }),
+    ),
+    connect: Effect.void,
+    disconnect: Effect.void,
+    retryNow: Effect.void,
+  });
+  state.layer = Layer.merge(
+    Layer.succeed(
+      EnvironmentRegistry,
+      EnvironmentRegistry.of({
+        run: (_environmentId, effect) =>
+          Effect.provideService(effect, EnvironmentSupervisor, supervisor),
+        runStream: (_environmentId, stream) =>
+          Stream.provideService(stream, EnvironmentSupervisor, supervisor),
+        followStream: (_environmentId, stream) =>
+          Stream.provideService(stream, EnvironmentSupervisor, supervisor),
+      } as EnvironmentRegistry["Service"]),
+    ),
+    Layer.succeed(PullRequestDiffLoader, PullRequestDiffLoader.of({ load: loadDiff })),
+  );
+  const registry = state.registry!;
+  const panel = (refreshToken = 0) => (
+    <RegistryContext.Provider value={registry}>
+      <PullRequestDetailPanel
+        environmentId={environmentId}
+        reference={{ ...reference }}
+        context={context}
+        refreshToken={refreshToken}
+      />
+    </RegistryContext.Provider>
+  );
+  return {
+    panel,
+    refreshes,
+    readDetail,
+    invalidate,
+    loadDiff,
+    updateDetail: (updatedAt: string) => {
+      detail = { ...detail, updatedAt };
+    },
+    updateDiff: (page: (typeof pages)[number]) => {
+      firstPage = page;
+    },
+    updateSecondPage: (page: (typeof pages)[number]) => {
+      secondPage = page;
+    },
+    pauseDiff: () => {
+      let resume = state.noop;
+      diffGate = new Promise<void>((resolve) => {
+        resume = resolve;
+      });
+      return resume;
+    },
+  };
+});
+
+it.effect.each(["thread", "page"] as const)(
+  "retains loaded diff pages across unchanged turns in the %s panel and reloads a changed PR",
+  (context) =>
+    Effect.gen(function* () {
+      const h = yield* makeHarness(context);
+      yield* Effect.promise(async () => {
+        await act(async () => {
+          renderer = create(h.panel());
+        });
+        const button = (text: string) =>
+          renderer!.root.findAllByType("button").find((node) => node.children.includes(text))!;
+        const click = {
+          nativeEvent: new Event("click"),
+          preventDefault: state.noop,
+          currentTarget: { tagName: "BUTTON" },
+        };
+        await act(async () => {
+          button("Code").props.onClick(click);
+          await import("./PullRequestCodeTab");
+        });
+        await act(async () => button("Load more files").props.onClick(click));
+        const viewer = () => renderer!.root.findByProps({ "data-testid": "diff-viewer" });
+        const files = () =>
+          viewer()
+            .findAllByType("span")
+            .map((node) => node.children.join(""));
+        expect(files()).toEqual(["first.ts", "second.ts"]);
+        const originalViewer = viewer();
+        h.loadDiff.mockClear();
+        h.readDetail.mockClear();
+        await act(async () => {
+          PubSub.publishUnsafe(h.refreshes, 1);
+        });
+        expect(h.readDetail).toHaveBeenCalled();
+        expect(files()).toEqual(["first.ts", "second.ts"]);
+        expect(viewer()).toBe(originalViewer);
+        expect(h.loadDiff).not.toHaveBeenCalled();
+
+        // Host metadata can change without changing any of the loaded diff pages.
+        const resumeDiff = h.pauseDiff();
+        await act(async () => {
+          h.updateDetail("2026-09-07T10:00:30Z");
+          PubSub.publishUnsafe(h.refreshes, 2);
+        });
+        expect(h.loadDiff).toHaveBeenCalledTimes(1);
+        expect(files()).toEqual(["first.ts", "second.ts"]);
+        expect(viewer()).toBe(originalViewer);
+        await act(async () => resumeDiff());
+        expect(files()).toEqual(["first.ts", "second.ts"]);
+        expect(viewer()).toBe(originalViewer);
+        expect(h.loadDiff).toHaveBeenCalledTimes(2);
+        h.loadDiff.mockClear();
+
+        // An unchanged first page must not hide changes on a later loaded page.
+        await act(async () => {
+          h.updateDetail("2026-09-07T10:00:45Z");
+          h.updateSecondPage(pages[2]!);
+          PubSub.publishUnsafe(h.refreshes, 3);
+        });
+        expect(files()).toEqual(["first.ts", "updated.ts"]);
+        expect(h.loadDiff).toHaveBeenCalledTimes(2);
+        h.loadDiff.mockClear();
+
+        await act(async () => {
+          h.updateDetail("2026-09-07T10:01:00Z");
+          h.updateDiff(pages[2]!);
+          PubSub.publishUnsafe(h.refreshes, 4);
+        });
+        expect(files()).toEqual(["updated.ts"]);
+        expect(h.loadDiff).toHaveBeenCalledTimes(1);
+
+        // A user-requested refresh still reloads even though updatedAt has not changed.
+        await act(async () => {
+          h.updateDiff(pages[3]!);
+          renderer!.update(h.panel(1));
+        });
+        expect(files()).toEqual(["manual.ts"]);
+        expect(h.invalidate).toHaveBeenCalledTimes(1);
+        expect(h.loadDiff).toHaveBeenCalledTimes(2);
+      });
+    }),
+);

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.refresh.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.refresh.test.tsx
@@ -10,7 +10,13 @@ import {
 } from "@t3tools/client-runtime/connection";
 import type { RpcSession, WsRpcProtocolClient } from "@t3tools/client-runtime/rpc";
 import { PullRequestDiffLoader } from "@t3tools/client-runtime/state/pull-requests";
-import { EnvironmentId, ProjectId, WS_METHODS, type PullRequestDetail } from "@t3tools/contracts";
+import {
+  EnvironmentId,
+  EnvironmentInternalError,
+  ProjectId,
+  WS_METHODS,
+  type PullRequestDetail,
+} from "@t3tools/contracts";
 import type { CodeViewDiffItem } from "@pierre/diffs/react";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -95,11 +101,18 @@ vi.mock("../diffs/DiffFileTree", () => ({
 }));
 vi.mock("../diffs/StyledDiffCodeView", () => ({
   // Render parsed file names without starting the diff viewer's workers.
-  StyledDiffCodeView: ({ items }: { items: ReadonlyArray<CodeViewDiffItem> }) => (
+  StyledDiffCodeView: ({
+    items,
+    renderCodeViewFooter,
+  }: {
+    items: ReadonlyArray<CodeViewDiffItem>;
+    renderCodeViewFooter?: () => ReactNode;
+  }) => (
     <div data-testid="diff-viewer">
       {items.map((item) => (
         <span key={item.id}>{item.fileDiff.name}</span>
       ))}
+      {renderCodeViewFooter?.()}
     </div>
   ),
 }));
@@ -122,6 +135,93 @@ afterEach(async () => {
   state.registry?.dispose();
   vi.unstubAllGlobals();
 });
+
+it.effect.each(["files", "empty", "raw", "additional page", "multiple pages"] as const)(
+  "shows diff failures and supports retry for %s",
+  (kind) =>
+    Effect.gen(function* () {
+      const h = yield* makeHarness("page");
+      const initial =
+        kind === "additional page" || kind === "multiple pages"
+          ? pages[0]!
+          : {
+              ...pages[1]!,
+              patch:
+                kind === "empty"
+                  ? ""
+                  : kind === "raw"
+                    ? "Unstructured patch content"
+                    : pages[1]!.patch,
+            };
+      h.updateDiff(initial);
+      yield* Effect.promise(async () => {
+        await act(async () => {
+          renderer = create(h.panel());
+        });
+        const button = (text: string) =>
+          renderer!.root.findAllByType("button").find((node) => node.children.includes(text))!;
+        const click = {
+          nativeEvent: new Event("click"),
+          preventDefault: state.noop,
+          currentTarget: { tagName: "BUTTON" },
+        };
+        await act(async () => {
+          button("Code").props.onClick(click);
+          await import("./PullRequestCodeTab");
+        });
+        if (kind === "multiple pages") {
+          await act(async () => button("Load more files").props.onClick(click));
+        }
+        const content = () => JSON.stringify(renderer!.toJSON());
+        const retained =
+          kind === "empty"
+            ? "This pull request has no file changes."
+            : kind === "raw"
+              ? initial.patch
+              : kind === "additional page"
+                ? "first.ts"
+                : "second.ts";
+        expect(content()).toContain(retained);
+        const loadDiff = h.loadDiff.getMockImplementation()!;
+        const failure = Effect.fail(
+          new EnvironmentInternalError({
+            code: "internal_error",
+            reason: "internal_error",
+            traceId: "test-refresh-failure",
+          }),
+        );
+        h.loadDiff.mockImplementation((connection, input) =>
+          kind === "multiple pages" && input.cursor !== undefined
+            ? loadDiff(connection, input)
+            : failure,
+        );
+        h.loadDiff.mockClear();
+        await act(async () => {
+          if (kind === "additional page") button("Load more files").props.onClick(click);
+          else renderer!.update(h.panel(1));
+        });
+        const errorText =
+          kind === "additional page"
+            ? "The rest of this diff could not be loaded."
+            : "This diff could not be refreshed.";
+        expect(content()).toContain(retained);
+        expect(content()).toContain(errorText);
+        if (kind === "multiple pages") {
+          expect(h.loadDiff.mock.calls.every(([, input]) => input.cursor === undefined)).toBe(true);
+        }
+        const failedRequests = h.loadDiff.mock.calls.length;
+        h.loadDiff.mockImplementation(loadDiff);
+        if (kind === "multiple pages") h.updateSecondPage(pages[2]!);
+        else if (kind !== "additional page") h.updateDiff(pages[2]!);
+        await act(async () => button("Retry").props.onClick(click));
+        expect(h.loadDiff).toHaveBeenCalledTimes(
+          failedRequests + (kind === "multiple pages" ? 2 : 1),
+        );
+        expect(content()).not.toContain(errorText);
+        expect(content()).toContain(kind === "additional page" ? "second.ts" : "updated.ts");
+      });
+    }),
+);
 
 const makeHarness = Effect.fn("PullRequestDetailPanelTest.makeHarness")(function* (
   context: "thread" | "page",

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -70,11 +70,7 @@ import { useProjects } from "~/state/entities";
 import { useEnvironments, usePrimaryEnvironmentId } from "~/state/environments";
 import { useEnvironmentQuery } from "~/state/query";
 import { useLiveRefresh } from "~/hooks/useLiveRefresh";
-import {
-  pullRequestEnvironment,
-  usePullRequestTurnRefresh,
-  useSharedPullRequestSummary,
-} from "~/state/pullRequests";
+import { pullRequestEnvironment, useSharedPullRequestSummary } from "~/state/pullRequests";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { vcsEnvironment } from "~/state/vcs";
 import { formatRelativeTimeLabel } from "~/timestampFormat";
@@ -584,7 +580,6 @@ export function PullRequestDetailPanel({
   const activityQuery = useEnvironmentQuery(
     pullRequestEnvironment.activity({ environmentId, input: reference }),
   );
-  const turnRefresh = usePullRequestTurnRefresh(environmentId);
   const [cachedDetail, setCachedDetail] = useState(() =>
     readPullRequestDetailSnapshot(
       typeof window === "undefined" ? undefined : window.localStorage,
@@ -709,7 +704,6 @@ export function PullRequestDetailPanel({
     activityQuery.refresh();
   }, [activityQuery.refresh, detailQuery.refresh]);
   const [refreshToken, setRefreshToken] = useState(0);
-  const codeRefreshToken = refreshToken + (turnRefresh ?? 0);
   const activityRevision = useRef<{ readonly key: string; readonly updatedAt: string } | null>(
     null,
   );
@@ -2433,7 +2427,7 @@ export function PullRequestDetailPanel({
                     fixFindingLabel={handoffLabels.fixFinding}
                     onFixFinding={startFixFinding}
                     onRefresh={refreshDetail}
-                    refreshToken={codeRefreshToken}
+                    refreshToken={refreshToken}
                   />
                 </Suspense>
               </div>

--- a/apps/web/src/state/pullRequests.ts
+++ b/apps/web/src/state/pullRequests.ts
@@ -164,11 +164,6 @@ export function usePullRequestTurnRefreshes(
   ).values;
 }
 
-export function usePullRequestTurnRefresh(environmentId: EnvironmentId): number | null {
-  const result = useAtomValue(pullRequestEnvironment.refreshes({ environmentId, input: {} }));
-  return Option.getOrNull(AsyncResult.value(result));
-}
-
 export interface MergedPullRequestListView {
   readonly data: MergedPullRequestList | null;
   readonly error: string | null;


### PR DESCRIPTION
## What Changed

Keep loaded PR diff pages visible during refresh. Unchanged pages stay loaded, so agent turns no longer reset the Code tab when the PR hasn't changed.
Added tests for automatic and manual refreshes.

## Why

Every agent turn reset the PR diff, even when nothing changed. This made users reload files they'd already opened. Keeping unchanged pages loaded avoids that disruption while still picking up new changes.

## UI Changes

Before: refreshing cleared loaded diff pages, forcing users to load them again.

https://github.com/user-attachments/assets/4902152c-96af-489b-bdeb-8e7d457a59b5

After: loaded pages stay visible during refresh and remain loaded if unchanged.

https://github.com/user-attachments/assets/3cb43a69-7763-4b9b-98df-8582795b6143

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retain loaded diff pages during pull request refresh in `PullRequestCodeTab`
> - Refreshing the PR code tab now keeps loaded diff pages visible while revalidating them in cursor order instead of clearing all pages.
> - An unchanged page advances revalidation to the next loaded cursor; a changed page replaces that page and discards later slices whose cursors may be stale.
> - Removes the `usePullRequestTurnRefresh` hook and its consumption in `PullRequestDetailPanel`; the Code tab now receives the local panel refresh token directly and performs ordered revalidation itself.
> - Adds an isolated test harness with controlled refresh events and paged diff fixtures covering unchanged-turn retention, sequential revalidation, changed-page invalidation, and explicit reload.
> - Behavioral Change: `PullRequestCodeTab` no longer clears all loaded slices on refresh-token change; callers expecting a full reload on every refresh will see retained pages instead. Removed `state/pullRequests.ts` `usePullRequestTurnRefresh` hook.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 556a3d3. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull request diff refreshes by preserving unchanged pages and reloading only affected content.
  - Ensures changed pull requests and manual refreshes display the latest diff.
  - Maintains consistent behavior across threaded, paginated, raw, and empty diff views.
  - Prevents pagination conflicts during diff revalidation.
  - Keeps previously loaded content visible while refreshing.
  - Displays a clear refresh error with a Retry option when an existing diff cannot be refreshed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->