### PR TITLE
fix(web): remove excess sidebar thread spacing

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -567,7 +567,7 @@ function SidebarSectionPlaceholder(props: {
     <SortableSidebarMarker
       marker={props.marker}
       data-testid={`sidebar-${props.marker}`}
-      className="relative mx-0.5 h-0"
+      className="relative mx-0.5 -mb-px h-0"
     >
       {props.showHint ? (
         <div
@@ -597,7 +597,7 @@ function SidebarDragBoundary(props: {
     <SortableSidebarMarker
       marker={props.marker}
       data-testid={`sidebar-${props.marker}`}
-      className="pointer-events-none relative mx-0.5 h-0"
+      className="pointer-events-none relative mx-0.5 -mb-px h-0"
     >
       {props.visible ? (
         <div className="sidebar-drag-boundary-label absolute inset-x-2 top-1 flex h-4 items-center gap-2">
@@ -4607,7 +4607,7 @@ export default function Sidebar() {
                   <ul
                     ref={attachListMotionRef}
                     role="list"
-                    className="relative flex flex-col gap-px pt-2"
+                    className="relative flex flex-col gap-px"
                   >
                     {(() => {
                       const renderThreadRowInner = (


### PR DESCRIPTION
the sidebar gap below "all projects" grew to 21 css pixels after #9731 added top padding and invisible drag markers; #10464 added another marker. remove the extra padding and cancel the zero-height markers' flex gaps, restoring the original 10px spacing while keeping drag targets measurable.

verified the spacing in the real web client in dark and light themes, project filtering and reset, and pointer-event drags into pinned and back into the empty active section with persisted state checks. 203 existing sidebar logic/drag tests, web typecheck, and scoped lint pass (existing lint warnings only); this shared sidebar serves web and desktop, while mobile has a separate sidebar.

before, dark:

![before: extra gap below all projects in dark theme](https://uploads-production-47e4.up.railway.app/files/a117279b-65d4-4f89-9c57-22d90514a52d/sidebar-before-dark-crop.png)

after, dark:

![after: restored sidebar spacing in dark theme](https://uploads-production-47e4.up.railway.app/files/0917190f-d014-4b6d-9a8d-07dcb855f41e/sidebar-after-dark-crop.png)

before, light:

![before: extra gap below all projects in light theme](https://uploads-production-47e4.up.railway.app/files/ce37b2ba-cae7-4d54-953f-ab4e59933c42/sidebar-before-light-crop.png)

after, light:

![after: restored sidebar spacing in light theme](https://uploads-production-47e4.up.railway.app/files/ab5b4c39-72e9-4c45-a0d9-d8a23b7c02ec/sidebar-after-light-crop.png)

model: gpt-5.6-sol. harness: codex.
