### PR TITLE
fix(web): make settings project scopes searchable and scrollable

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -208,7 +208,7 @@ import { Input } from "./ui/input";
 import {
   Combobox,
   ComboboxEmpty,
-  ComboboxInput,
+  ComboboxSearchInput,
   ComboboxItem,
   ComboboxList,
   ComboboxPopup,
@@ -4395,48 +4395,34 @@ export default function Sidebar() {
                     align="start"
                     className="w-(--anchor-width) min-w-0 overflow-hidden"
                   >
-                    <div className="shrink-0 px-3 pt-2.5">
-                      <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">
-                        <SearchIcon
-                          aria-hidden="true"
-                          className="pointer-events-none absolute top-1.5 left-0 size-4 shrink-0 text-muted-foreground/55"
-                        />
-                        <ComboboxInput
-                          aria-label="Search projects"
-                          className="[&_input]:h-6.5 [&_input]:ps-5 [&_input]:font-sans [&_input]:leading-6.5"
-                          inputClassName="rounded-none bg-transparent text-sm"
-                          placeholder="Search projects..."
-                          showTrigger={false}
-                          size="sm"
-                          unstyled
-                          value={projectScopeMenuState.query}
-                          onKeyDown={(event) => {
-                            if (
-                              event.defaultPrevented ||
-                              event.nativeEvent.isComposing ||
-                              event.ctrlKey ||
-                              event.altKey ||
-                              event.metaKey ||
-                              (event.key !== "ContextMenu" &&
-                                !(event.shiftKey && event.key === "F10"))
-                            ) {
-                              return;
-                            }
-                            // Combobox items use virtual focus: keyboard events
-                            // stay on this input, not on the highlighted option.
-                            const scopeKey = highlightedProjectScopeKeyRef.current;
-                            const project = scopeKey ? projectGroupByScopeKey.get(scopeKey) : null;
-                            if (project) handleProjectSettings(event, project);
-                          }}
-                          onChange={(event) =>
-                            dispatchProjectScopeMenu({
-                              type: "query-changed",
-                              query: event.target.value,
-                            })
-                          }
-                        />
-                      </div>
-                    </div>
+                    <ComboboxSearchInput
+                      aria-label="Search projects"
+                      placeholder="Search projects..."
+                      value={projectScopeMenuState.query}
+                      onKeyDown={(event) => {
+                        if (
+                          event.defaultPrevented ||
+                          event.nativeEvent.isComposing ||
+                          event.ctrlKey ||
+                          event.altKey ||
+                          event.metaKey ||
+                          (event.key !== "ContextMenu" && !(event.shiftKey && event.key === "F10"))
+                        ) {
+                          return;
+                        }
+                        // Combobox items use virtual focus: keyboard events
+                        // stay on this input, not on the highlighted option.
+                        const scopeKey = highlightedProjectScopeKeyRef.current;
+                        const project = scopeKey ? projectGroupByScopeKey.get(scopeKey) : null;
+                        if (project) handleProjectSettings(event, project);
+                      }}
+                      onChange={(event) =>
+                        dispatchProjectScopeMenu({
+                          type: "query-changed",
+                          query: event.target.value,
+                        })
+                      }
+                    />
                     <ComboboxEmpty>No matching projects.</ComboboxEmpty>
                     <ComboboxList>
                       {(item: (typeof projectScopeItems)[number]) => {

--- a/apps/web/src/components/settings/ProjectsSettings.tsx
+++ b/apps/web/src/components/settings/ProjectsSettings.tsx
@@ -1,5 +1,5 @@
 import { resolveEnvironmentMachineKind } from "@t3tools/contracts";
-import { ChevronDownIcon, FolderIcon, SearchIcon } from "lucide-react";
+import { ChevronDownIcon, FolderIcon } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import { EnvironmentMachineIcon } from "../EnvironmentMachineIcon";
 import { ProjectFavicon } from "../ProjectFavicon";
@@ -9,7 +9,7 @@ import { Toggle, ToggleGroup } from "../ui/toggle-group";
 import {
   Combobox,
   ComboboxEmpty,
-  ComboboxInput,
+  ComboboxSearchInput,
   ComboboxItem,
   ComboboxList,
   ComboboxPopup,
@@ -60,15 +60,7 @@ function ScopePicker({
         <ChevronDownIcon aria-hidden className="-me-1 size-3 opacity-50" />
       </ComboboxTrigger>
       <ComboboxPopup align="start" className="w-64">
-        <div className="shrink-0 p-2">
-          <ComboboxInput
-            aria-label={`Search ${label}s`}
-            placeholder={`Search ${label}s...`}
-            startAddon={<SearchIcon />}
-            showTrigger={false}
-            size="sm"
-          />
-        </div>
+        <ComboboxSearchInput aria-label={`Search ${label}s`} placeholder={`Search ${label}s...`} />
         <ComboboxEmpty>No matching {label}s.</ComboboxEmpty>
         <ComboboxList>
           {(item: (typeof items)[number]) => (

--- a/apps/web/src/components/settings/ProjectsSettings.tsx
+++ b/apps/web/src/components/settings/ProjectsSettings.tsx
@@ -1,12 +1,22 @@
 import { resolveEnvironmentMachineKind } from "@t3tools/contracts";
-import { FolderIcon } from "lucide-react";
-import type { ReactNode } from "react";
+import { ChevronDownIcon, FolderIcon, SearchIcon } from "lucide-react";
+import { type ReactNode, useState } from "react";
 import { EnvironmentMachineIcon } from "../EnvironmentMachineIcon";
 import { ProjectFavicon } from "../ProjectFavicon";
 import { WorkspacePageContainer } from "../WorkspacePageContainer";
 import { useEnvironments } from "../../state/environments";
 import { Toggle, ToggleGroup } from "../ui/toggle-group";
-import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
+import {
+  Combobox,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxPopup,
+  ComboboxTrigger,
+} from "../ui/combobox";
+import { selectTriggerVariants } from "../ui/select";
+import { cn } from "../../lib/utils";
 import { ProjectSettingsPanel, useSettingsProjectGroups } from "./ProjectSettingsPanel";
 import { ProjectDefaultsSettings } from "./ProjectDefaultsSettings";
 
@@ -21,44 +31,67 @@ function ScopePicker({
   options: ReadonlyArray<{ value: string; label: string; icon?: ReactNode }>;
   onChange: (value: string | null) => void;
 }) {
+  const [query, setQuery] = useState("");
   const selected = options.find((option) => option.value === value);
   const allIcon =
     label === "project" ? <FolderIcon aria-hidden className="size-3.5 shrink-0" /> : null;
+  const items = [{ value: "all", label: `All ${label}s`, icon: allIcon }, ...options];
   return (
-    <Select
-      value={value ?? "all"}
+    <Combobox
+      items={items}
+      value={items.find((item) => item.value === (value ?? "all")) ?? null}
+      inputValue={query}
+      onInputValueChange={setQuery}
+      onOpenChange={() => setQuery("")}
       onValueChange={(next) => {
-        if (next) onChange(next === "all" ? null : next);
+        if (next) onChange(next.value === "all" ? null : next.value);
       }}
     >
-      <SelectTrigger
-        size="compact"
+      <ComboboxTrigger
         aria-label={`${label === "project" ? "Project" : "Machine"} scope`}
-        className="w-auto min-w-0 max-w-52"
+        className={cn(selectTriggerVariants({ size: "compact" }), "w-auto min-w-0 max-w-52")}
       >
-        <SelectValue className="flex min-w-0 items-center gap-1.5">
+        <span className="flex min-w-0 items-center gap-1.5">
           {value === null ? allIcon : selected?.icon}
           <span className="truncate">
             {value === null ? `All ${label}s` : (selected?.label ?? `Unavailable ${label}`)}
           </span>
-        </SelectValue>
-      </SelectTrigger>
-      <SelectPopup align="start" alignItemWithTrigger={false}>
-        <SelectItem value="all">
-          <span className="flex items-center gap-2">
-            {allIcon}All {label}s
-          </span>
-        </SelectItem>
-        {options.map((option) => (
-          <SelectItem key={option.value} value={option.value}>
-            <span className="flex items-center gap-2">
-              {option.icon}
-              {option.label}
-            </span>
-          </SelectItem>
-        ))}
-      </SelectPopup>
-    </Select>
+        </span>
+        <ChevronDownIcon aria-hidden className="-me-1 size-3 opacity-50" />
+      </ComboboxTrigger>
+      <ComboboxPopup align="start" className="w-64">
+        <div className="shrink-0 px-3 pt-2.5">
+          <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">
+            <SearchIcon
+              aria-hidden
+              className="pointer-events-none absolute top-1.5 left-0 size-4 shrink-0 text-muted-foreground/55"
+            />
+            <ComboboxInput
+              aria-label={`Search ${label}s`}
+              className="[&_input]:h-6.5 [&_input]:ps-5 [&_input]:font-sans [&_input]:leading-6.5"
+              inputClassName="rounded-none bg-transparent text-sm"
+              placeholder={`Search ${label}s...`}
+              showTrigger={false}
+              size="sm"
+              unstyled
+            />
+          </div>
+        </div>
+        <ComboboxEmpty>No matching {label}s.</ComboboxEmpty>
+        <ComboboxList>
+          {(item: (typeof items)[number]) => (
+            <ComboboxItem
+              key={item.value}
+              value={item}
+              contentClassName="flex min-w-0 items-center gap-2"
+            >
+              {item.icon}
+              <span className="truncate">{item.label}</span>
+            </ComboboxItem>
+          )}
+        </ComboboxList>
+      </ComboboxPopup>
+    </Combobox>
   );
 }
 

--- a/apps/web/src/components/settings/ProjectsSettings.tsx
+++ b/apps/web/src/components/settings/ProjectsSettings.tsx
@@ -60,22 +60,14 @@ function ScopePicker({
         <ChevronDownIcon aria-hidden className="-me-1 size-3 opacity-50" />
       </ComboboxTrigger>
       <ComboboxPopup align="start" className="w-64">
-        <div className="shrink-0 px-3 pt-2.5">
-          <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">
-            <SearchIcon
-              aria-hidden
-              className="pointer-events-none absolute top-1.5 left-0 size-4 shrink-0 text-muted-foreground/55"
-            />
-            <ComboboxInput
-              aria-label={`Search ${label}s`}
-              className="[&_input]:h-6.5 [&_input]:ps-5 [&_input]:font-sans [&_input]:leading-6.5"
-              inputClassName="rounded-none bg-transparent text-sm"
-              placeholder={`Search ${label}s...`}
-              showTrigger={false}
-              size="sm"
-              unstyled
-            />
-          </div>
+        <div className="shrink-0 p-2">
+          <ComboboxInput
+            aria-label={`Search ${label}s`}
+            placeholder={`Search ${label}s...`}
+            startAddon={<SearchIcon />}
+            showTrigger={false}
+            size="sm"
+          />
         </div>
         <ComboboxEmpty>No matching {label}s.</ComboboxEmpty>
         <ComboboxList>

--- a/apps/web/src/components/ui/combobox.tsx
+++ b/apps/web/src/components/ui/combobox.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Combobox as ComboboxPrimitive } from "@base-ui/react/combobox";
-import { ChevronsUpDownIcon, XIcon } from "lucide-react";
+import { ChevronsUpDownIcon, SearchIcon, XIcon } from "lucide-react";
 import * as React from "react";
 
 import { cn } from "~/lib/utils";
@@ -126,6 +126,27 @@ function ComboboxInput({
           <XIcon />
         </ComboboxClear>
       )}
+    </div>
+  );
+}
+
+function ComboboxSearchInput(props: React.ComponentProps<typeof ComboboxInput>) {
+  return (
+    <div className="shrink-0 px-3 pt-2.5">
+      <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">
+        <SearchIcon
+          aria-hidden="true"
+          className="pointer-events-none absolute top-1.5 left-0 size-4 shrink-0 text-muted-foreground/55"
+        />
+        <ComboboxInput
+          {...props}
+          className="[&_input]:h-6.5 [&_input]:ps-5 [&_input]:font-sans [&_input]:leading-6.5"
+          inputClassName="rounded-none bg-transparent text-sm"
+          showTrigger={false}
+          size="sm"
+          unstyled
+        />
+      </div>
     </div>
   );
 }
@@ -393,6 +414,7 @@ export {
   Combobox,
   ComboboxChipsInput,
   ComboboxInput,
+  ComboboxSearchInput,
   ComboboxTrigger,
   ComboboxPopup,
   ComboboxItem,


### PR DESCRIPTION
settings → projects could open a project list tall enough to cover most of the page. reuse the sidebar's exact search field for project and machine scope dropdowns, with an empty state and a scrollable list capped at 23rem. both selectors share the same component so styling stays identical; existing scope actions remain intact.

verified web typecheck, focused lint, 158 sidebar logic tests, the sidebar shift+f10 project-settings shortcut, and actual browser search, keyboard selection, query reset, empty results, scrolling to the last project, and returning to all projects. checked desktop dark and 390px light layouts; the >3-machine dropdown branch was not exercised. recording export saved on the desktop host and could not be retrieved for playback or upload, so interaction video evidence remains blocked.

![before: settings project selector with 15 projects](https://uploads-production-47e4.up.railway.app/files/c98f6583-a459-41e3-aae2-b3564fc80030/project-scope-before.png)

![after: searchable settings project selector with capped height](https://uploads-production-47e4.up.railway.app/files/a1924b44-8caf-4db8-b0dd-3dd081915e6c/project-search-restored.png)

![after: settings project selector at 390px in light theme](https://uploads-production-47e4.up.railway.app/files/61fb5413-6e35-41fc-bb1f-d41a7cc21e5c/projects-selector-shared-search-narrow-light.png)

model: gpt-5.6-sol; harness: codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated project scope search fields in Settings and the sidebar with a consistent, reusable search interface.
  * Added clearer focus styling and a built-in search icon while preserving existing filtering and keyboard interactions.
  * Maintained project scope query behavior and navigation to project settings from the sidebar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `Select`-based project scope pickers with searchable `Combobox`
> - Adds `ComboboxSearchInput` to [combobox.tsx](https://github.com/pingdotgg/t3code/pull/10570/files#diff-10ddf105a1e88483c98dd15827574c77c53320d7ae56a262c90bfad67e790ef9) as a shared wrapper around `ComboboxInput` with a search icon and standardized layout.
> - Updates [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/10570/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) to use `ComboboxSearchInput` for the project-scope search markup.
> - Replaces the `Select`-based `ScopePicker` in [ProjectsSettings.tsx](https://github.com/pingdotgg/t3code/pull/10570/files#diff-53194b756a9505aa3ac9973521a2af01d99834eb9198ecfca6d31575b55c7c1d) with a `Combobox` that supports local search query, a no-match empty state, and an all-scopes option.
> - Behavioral Change: selecting the synthetic all-scopes item still reports `null`; selecting an option reports its value, preserving the existing callback contract.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5499a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
