### PR TITLE
fix(preview): transfer recordings to the agent environment

### DIFF
--- a/apps/server/src/mcp/PreviewAutomationBroker.test.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.test.ts
@@ -404,6 +404,57 @@ it.effect("classifies a remote non-editable target without collapsing it to exec
   );
 });
 
+it.effect.each([
+  ["PreviewAutomationRecordingTransferError", "invalid-metadata"],
+  ["PreviewAutomationRecordingTransferError", "invalid-upload"],
+  ["PreviewAutomationRecordingTransferError", "size-mismatch"],
+  ["PreviewAutomationRecordingTransferError", "retain-failed"],
+  ["PreviewAutomationRecordingTransferError", "upload-failed"],
+  ["PreviewAutomationRecordingTransferError", "unknown-reason"],
+  ["PreviewAutomationRecordingDesktopUpdateRequiredError", undefined],
+  ["PreviewAutomationRecordingTooLargeError", undefined],
+  ["PreviewAutomationRecordingDeadlineExpiredError", undefined],
+] as const)("preserves recording failure %s", ([tag, reason]) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const broker = yield* makeBroker;
+      const remoteError = {
+        _tag: tag,
+        message: "remote recording details",
+        detail: { reason, threadId: "untrusted-thread" },
+      };
+      const requests = requestsFrom(yield* broker.connect(makeHost()));
+      yield* Stream.runForEach(requests, (request) =>
+        broker.respond({
+          clientId: "client-1",
+          connectionId: request.connectionId,
+          requestId: request.requestId,
+          ok: false,
+          error: remoteError,
+        }),
+      ).pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+      const error = yield* broker
+        .invoke<void>({
+          scope,
+          operation: "recordingStop",
+          input: {},
+        })
+        .pipe(Effect.flip);
+      expect(error).toMatchObject({
+        _tag: tag,
+        threadId: scope.threadId,
+        ...(reason === undefined
+          ? {}
+          : { reason: reason === "unknown-reason" ? "upload-failed" : reason }),
+      });
+      expect(error.cause).toBe(remoteError);
+      expect(error.message).toContain("remains on the desktop");
+      expect(error.message).not.toContain("remote recording details");
+    }),
+  ),
+);
+
 it.effect("distinguishes malformed remote failures", () =>
   Effect.scoped(
     Effect.gen(function* () {

--- a/apps/server/src/mcp/PreviewAutomationBroker.test.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.test.ts
@@ -405,23 +405,18 @@ it.effect("classifies a remote non-editable target without collapsing it to exec
 });
 
 it.effect.each([
-  ["PreviewAutomationRecordingTransferError", "invalid-metadata"],
-  ["PreviewAutomationRecordingTransferError", "invalid-upload"],
-  ["PreviewAutomationRecordingTransferError", "size-mismatch"],
-  ["PreviewAutomationRecordingTransferError", "retain-failed"],
-  ["PreviewAutomationRecordingTransferError", "upload-failed"],
-  ["PreviewAutomationRecordingTransferError", "unknown-reason"],
-  ["PreviewAutomationRecordingDesktopUpdateRequiredError", undefined],
-  ["PreviewAutomationRecordingTooLargeError", undefined],
-  ["PreviewAutomationRecordingDeadlineExpiredError", undefined],
-] as const)("preserves recording failure %s", ([tag, reason]) =>
+  "PreviewAutomationRecordingTransferError",
+  "PreviewAutomationRecordingDesktopUpdateRequiredError",
+  "PreviewAutomationRecordingTooLargeError",
+  "PreviewAutomationRecordingDeadlineExpiredError",
+] as const)("preserves recording failure %s", (tag) =>
   Effect.scoped(
     Effect.gen(function* () {
       const broker = yield* makeBroker;
       const remoteError = {
         _tag: tag,
         message: "remote recording details",
-        detail: { reason, threadId: "untrusted-thread" },
+        detail: { reason: "untrusted-reason", threadId: "untrusted-thread" },
       };
       const requests = requestsFrom(yield* broker.connect(makeHost()));
       yield* Stream.runForEach(requests, (request) =>
@@ -444,9 +439,6 @@ it.effect.each([
       expect(error).toMatchObject({
         _tag: tag,
         threadId: scope.threadId,
-        ...(reason === undefined
-          ? {}
-          : { reason: reason === "unknown-reason" ? "upload-failed" : reason }),
       });
       expect(error.cause).toBe(remoteError);
       expect(error.message).toContain("remains on the desktop");

--- a/apps/server/src/mcp/PreviewAutomationBroker.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.ts
@@ -7,6 +7,10 @@ import {
   PreviewAutomationMalformedResponseError,
   PreviewAutomationNoAvailableHostError,
   PreviewAutomationRemoteUnavailableError,
+  PreviewAutomationRecordingTransferError,
+  PreviewAutomationRecordingDesktopUpdateRequiredError,
+  PreviewAutomationRecordingTooLargeError,
+  PreviewAutomationRecordingDeadlineExpiredError,
   PreviewAutomationRequestQueueClosedError,
   PreviewAutomationResultTooLargeError,
   PreviewAutomationTabNotFoundError,
@@ -183,6 +187,8 @@ function remoteDetailKind(detail: unknown): RemoteDetailKind {
   }
 }
 
+const isRecordingTransferReason = Schema.is(PreviewAutomationRecordingTransferError.fields.reason);
+
 const classifyResponseError = (
   context: PreviewAutomationRequestErrorContext,
   error: NonNullable<PreviewAutomationResponse["error"]>,
@@ -194,6 +200,32 @@ const classifyResponseError = (
     cause: error,
   };
   switch (error._tag) {
+    case "PreviewAutomationRecordingDesktopUpdateRequiredError":
+      return new PreviewAutomationRecordingDesktopUpdateRequiredError({
+        threadId: context.threadId,
+        cause: error,
+      });
+    case "PreviewAutomationRecordingTooLargeError":
+      return new PreviewAutomationRecordingTooLargeError({
+        threadId: context.threadId,
+        cause: error,
+      });
+    case "PreviewAutomationRecordingDeadlineExpiredError":
+      return new PreviewAutomationRecordingDeadlineExpiredError({
+        threadId: context.threadId,
+        cause: error,
+      });
+    case "PreviewAutomationRecordingTransferError": {
+      const reason =
+        typeof error.detail === "object" && error.detail !== null && "reason" in error.detail
+          ? error.detail.reason
+          : undefined;
+      return new PreviewAutomationRecordingTransferError({
+        threadId: context.threadId,
+        reason: isRecordingTransferReason(reason) ? reason : "upload-failed",
+        cause: error,
+      });
+    }
     case "PreviewAutomationNoAvailableHostError":
       return new PreviewAutomationNoAvailableHostError({
         ...context,

--- a/apps/server/src/mcp/PreviewAutomationBroker.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.ts
@@ -187,8 +187,6 @@ function remoteDetailKind(detail: unknown): RemoteDetailKind {
   }
 }
 
-const isRecordingTransferReason = Schema.is(PreviewAutomationRecordingTransferError.fields.reason);
-
 const classifyResponseError = (
   context: PreviewAutomationRequestErrorContext,
   error: NonNullable<PreviewAutomationResponse["error"]>,
@@ -215,17 +213,11 @@ const classifyResponseError = (
         threadId: context.threadId,
         cause: error,
       });
-    case "PreviewAutomationRecordingTransferError": {
-      const reason =
-        typeof error.detail === "object" && error.detail !== null && "reason" in error.detail
-          ? error.detail.reason
-          : undefined;
+    case "PreviewAutomationRecordingTransferError":
       return new PreviewAutomationRecordingTransferError({
         threadId: context.threadId,
-        reason: isRecordingTransferReason(reason) ? reason : "upload-failed",
         cause: error,
       });
-    }
     case "PreviewAutomationNoAvailableHostError":
       return new PreviewAutomationNoAvailableHostError({
         ...context,

--- a/apps/server/src/mcp/toolkits/preview/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/preview/handlers.test.ts
@@ -118,7 +118,7 @@ describe("claimPreviewRecording", () => {
         } else {
           expect(result._tag).toBe("Failure");
           if (result._tag !== "Failure") return;
-          expect(result.failure).toMatchObject({ reason: "size-mismatch" });
+          expect(result.failure._tag).toBe("PreviewAutomationRecordingTransferError");
           expect(yield* fileSystem.exists(pendingPath)).toBe(true);
         }
       }).pipe(

--- a/apps/server/src/mcp/toolkits/preview/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/preview/handlers.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it } from "@effect/vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { ThreadId } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
 
-import { normalizePreviewOpenInput } from "./handlers.ts";
+import {
+  createPendingAttachmentId,
+  parseThreadSegmentFromAttachmentId,
+} from "../../../attachmentStore.ts";
+import * as ServerConfig from "../../../config.ts";
+import { claimPreviewRecording, normalizePreviewOpenInput } from "./handlers.ts";
 
 describe("normalizePreviewOpenInput", () => {
   it("leaves an unstated visibility for the client preference to decide", () => {
@@ -29,4 +40,71 @@ describe("normalizePreviewOpenInput", () => {
       show: true,
     });
   });
+});
+
+describe("claimPreviewRecording", () => {
+  it.effect.each([6, 5])(
+    "claims only a complete uploaded recording (reported bytes: %s)",
+    (sizeBytes) =>
+      Effect.gen(function* () {
+        const config = yield* ServerConfig.ServerConfig;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const uploadedAttachmentId = createPendingAttachmentId(".webm");
+        const pendingPath = path.join(config.attachmentsDir, `${uploadedAttachmentId}.webm`);
+        yield* fileSystem.makeDirectory(config.attachmentsDir, { recursive: true });
+        yield* fileSystem.writeFileString(pendingPath, "video!");
+        const response = {
+          id: "desktop-recording",
+          tabId: "tab-1",
+          path: "/desktop/recording.webm",
+          mimeType: "video/webm",
+          sizeBytes,
+          createdAt: "2026-09-07T00:00:00.000Z",
+          uploadedAttachmentId,
+        };
+        const result = yield* claimPreviewRecording(ThreadId.make("thread-1"), response).pipe(
+          Effect.result,
+        );
+        if (sizeBytes === 6) {
+          expect(result._tag).toBe("Success");
+          if (result._tag !== "Success") return;
+          expect(result.success.path).not.toBe(response.path);
+          expect(parseThreadSegmentFromAttachmentId(result.success.id)).toBe("thread-1");
+          expect(yield* fileSystem.readFileString(result.success.path)).toBe("video!");
+          expect(yield* fileSystem.exists(pendingPath)).toBe(false);
+        } else {
+          expect(result._tag).toBe("Failure");
+          expect(yield* fileSystem.exists(pendingPath)).toBe(true);
+        }
+      }).pipe(
+        Effect.provide(
+          ServerConfig.layerTest(process.cwd(), { prefix: "t3-preview-recording-" }).pipe(
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+      ),
+  );
+
+  it.effect("reports an older desktop without returning its inaccessible path", () =>
+    Effect.gen(function* () {
+      const result = yield* claimPreviewRecording(ThreadId.make("thread-1"), {
+        id: "desktop-recording",
+        tabId: "tab-1",
+        path: "/desktop/recording.webm",
+        mimeType: "video/webm",
+        sizeBytes: 6,
+        createdAt: "2026-09-07T00:00:00.000Z",
+      }).pipe(Effect.result);
+      expect(result._tag).toBe("Failure");
+      if (result._tag !== "Failure") return;
+      expect(result.failure.message).toContain("Update the desktop app");
+    }).pipe(
+      Effect.provide(
+        ServerConfig.layerTest(process.cwd(), { prefix: "t3-preview-recording-" }).pipe(
+          Layer.provideMerge(NodeServices.layer),
+        ),
+      ),
+    ),
+  );
 });

--- a/apps/server/src/mcp/toolkits/preview/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/preview/handlers.test.ts
@@ -75,6 +75,8 @@ describe("claimPreviewRecording", () => {
           expect(yield* fileSystem.exists(pendingPath)).toBe(false);
         } else {
           expect(result._tag).toBe("Failure");
+          if (result._tag !== "Failure") return;
+          expect(result.failure.reason).toBe("size-mismatch");
           expect(yield* fileSystem.exists(pendingPath)).toBe(true);
         }
       }).pipe(
@@ -98,6 +100,7 @@ describe("claimPreviewRecording", () => {
       }).pipe(Effect.result);
       expect(result._tag).toBe("Failure");
       if (result._tag !== "Failure") return;
+      expect(result.failure.reason).toBe("desktop-update-required");
       expect(result.failure.message).toContain("Update the desktop app");
     }).pipe(
       Effect.provide(

--- a/apps/server/src/mcp/toolkits/preview/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/preview/handlers.test.ts
@@ -43,6 +43,48 @@ describe("normalizePreviewOpenInput", () => {
 });
 
 describe("claimPreviewRecording", () => {
+  it.effect("overlapping and repeated claims return the same retained recording", () =>
+    Effect.gen(function* () {
+      const config = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const uploadedAttachmentId = createPendingAttachmentId(".webm");
+      const pendingPath = path.join(config.attachmentsDir, `${uploadedAttachmentId}.webm`);
+      yield* fileSystem.makeDirectory(config.attachmentsDir, { recursive: true });
+      yield* fileSystem.writeFileString(pendingPath, "video!");
+      const response = {
+        id: "desktop-recording",
+        tabId: "tab-1",
+        path: "/desktop/recording.webm",
+        mimeType: "video/webm",
+        sizeBytes: 6,
+        createdAt: "2026-09-07T00:00:00.000Z",
+        uploadedAttachmentId,
+      };
+      const claim = claimPreviewRecording(ThreadId.make("thread-1"), response);
+      const [first, second] = yield* Effect.all([claim, claim], { concurrency: "unbounded" });
+      expect(first).toEqual(second);
+      expect(yield* claim).toEqual(first);
+      expect(yield* fileSystem.readFileString(first.path)).toBe("video!");
+      expect(yield* fileSystem.exists(pendingPath)).toBe(false);
+      const wrongThread = yield* claimPreviewRecording(ThreadId.make("thread-2"), response).pipe(
+        Effect.result,
+      );
+      expect(wrongThread._tag).toBe("Failure");
+      const wrongPath = yield* claimPreviewRecording(ThreadId.make("thread-1"), {
+        ...response,
+        uploadedAttachmentId: `../${uploadedAttachmentId}`,
+      }).pipe(Effect.result);
+      expect(wrongPath._tag).toBe("Failure");
+    }).pipe(
+      Effect.provide(
+        ServerConfig.layerTest(process.cwd(), { prefix: "t3-preview-recording-" }).pipe(
+          Layer.provideMerge(NodeServices.layer),
+        ),
+      ),
+    ),
+  );
+
   it.effect.each([6, 5])(
     "claims only a complete uploaded recording (reported bytes: %s)",
     (sizeBytes) =>
@@ -76,7 +118,7 @@ describe("claimPreviewRecording", () => {
         } else {
           expect(result._tag).toBe("Failure");
           if (result._tag !== "Failure") return;
-          expect(result.failure.reason).toBe("size-mismatch");
+          expect(result.failure).toMatchObject({ reason: "size-mismatch" });
           expect(yield* fileSystem.exists(pendingPath)).toBe(true);
         }
       }).pipe(
@@ -100,7 +142,7 @@ describe("claimPreviewRecording", () => {
       }).pipe(Effect.result);
       expect(result._tag).toBe("Failure");
       if (result._tag !== "Failure") return;
-      expect(result.failure.reason).toBe("desktop-update-required");
+      expect(result.failure._tag).toBe("PreviewAutomationRecordingDesktopUpdateRequiredError");
       expect(result.failure.message).toContain("Update the desktop app");
     }).pipe(
       Effect.provide(

--- a/apps/server/src/mcp/toolkits/preview/handlers.ts
+++ b/apps/server/src/mcp/toolkits/preview/handlers.ts
@@ -1,16 +1,23 @@
 import * as Effect from "effect/Effect";
-import type {
-  PreviewAutomationOperation,
-  PreviewAutomationOpenInput,
+import * as FileSystem from "effect/FileSystem";
+import * as Schema from "effect/Schema";
+import {
+  PROVIDER_SEND_TURN_MAX_FILE_BYTES,
+  PreviewAutomationRecordingTransferError,
   PreviewAutomationRecordingArtifact,
-  PreviewAutomationRecordingStatus,
-  PreviewAutomationResizeResult,
-  PreviewAutomationSetColorSchemeResult,
-  PreviewAutomationSnapshot,
-  PreviewAutomationStatus,
-  PreviewTabId,
+  type ThreadId,
+  type PreviewAutomationOperation,
+  type PreviewAutomationOpenInput,
+  type PreviewAutomationRecordingStatus,
+  type PreviewAutomationResizeResult,
+  type PreviewAutomationSetColorSchemeResult,
+  type PreviewAutomationSnapshot,
+  type PreviewAutomationStatus,
+  type PreviewTabId,
 } from "@t3tools/contracts";
 
+import { planAttachmentClaim } from "../../../attachmentStore.ts";
+import * as ServerConfig from "../../../config.ts";
 import * as McpInvocationContext from "../../McpInvocationContext.ts";
 import * as PreviewAutomationBroker from "../../PreviewAutomationBroker.ts";
 import { PreviewSnapshotToolkit, PreviewStandardToolkit, PreviewToolkit } from "./tools.ts";
@@ -67,6 +74,73 @@ const invokeTargeted = <A>(
   return invoke<A>(operation, operationInput, timeoutMs, tabId);
 };
 
+const UploadedRecordingArtifact = Schema.Struct({
+  ...PreviewAutomationRecordingArtifact.fields,
+  uploadedAttachmentId: Schema.optional(Schema.String),
+});
+const decodeUploadedRecordingArtifact = Schema.decodeUnknownEffect(UploadedRecordingArtifact);
+const isRecordingTransferError = Schema.is(PreviewAutomationRecordingTransferError);
+
+export const claimPreviewRecording = Effect.fn("PreviewToolkit.claimRecording")(function* (
+  threadId: ThreadId,
+  response: unknown,
+) {
+  const artifact = yield* decodeUploadedRecordingArtifact(response).pipe(
+    Effect.mapError(
+      (cause) =>
+        new PreviewAutomationRecordingTransferError({
+          threadId,
+          detail: "The desktop returned invalid recording metadata.",
+          cause,
+        }),
+    ),
+  );
+  if (!artifact.uploadedAttachmentId) {
+    return yield* new PreviewAutomationRecordingTransferError({
+      threadId,
+      detail:
+        "Update the desktop app to transfer recordings. The recording remains on the desktop.",
+    });
+  }
+  const config = yield* ServerConfig.ServerConfig;
+  const claim = planAttachmentClaim({
+    attachmentsDir: config.attachmentsDir,
+    threadId,
+    attachmentId: artifact.uploadedAttachmentId,
+  });
+  if (!claim.ok) {
+    return yield* new PreviewAutomationRecordingTransferError({ threadId, detail: claim.reason });
+  }
+  const fileSystem = yield* FileSystem.FileSystem;
+  yield* Effect.gen(function* () {
+    const stat = yield* fileSystem.stat(claim.currentPath);
+    if (
+      stat.type !== "File" ||
+      Number(stat.size) !== artifact.sizeBytes ||
+      artifact.sizeBytes <= 0 ||
+      artifact.sizeBytes > PROVIDER_SEND_TURN_MAX_FILE_BYTES
+    ) {
+      return yield* new PreviewAutomationRecordingTransferError({
+        threadId,
+        detail: "The uploaded recording size does not match its metadata or exceeds 50 MiB.",
+      });
+    }
+    yield* fileSystem.rename(claim.currentPath, claim.finalPath);
+  }).pipe(
+    Effect.mapError((cause) =>
+      isRecordingTransferError(cause)
+        ? cause
+        : new PreviewAutomationRecordingTransferError({
+            threadId,
+            detail: "The uploaded recording could not be retained.",
+            cause,
+          }),
+    ),
+  );
+  const { uploadedAttachmentId: _uploadedAttachmentId, ...recording } = artifact;
+  return { ...recording, id: claim.finalId, path: claim.finalPath };
+});
+
 const handlers = {
   preview_status: (input) => invokeTargeted<PreviewAutomationStatus>("status", input ?? {}),
   preview_open: (input) =>
@@ -94,7 +168,15 @@ const handlers = {
   preview_recording_start: (input) =>
     invokeTargeted<PreviewAutomationRecordingStatus>("recordingStart", input ?? {}),
   preview_recording_stop: (input) =>
-    invokeTargeted<PreviewAutomationRecordingArtifact>("recordingStop", input ?? {}),
+    Effect.gen(function* () {
+      const scope = yield* McpInvocationContext.requireMcpCapability("preview");
+      const response = yield* invokeTargeted<unknown>(
+        "recordingStop",
+        { ...input, transferToEnvironment: true },
+        120_000,
+      );
+      return yield* claimPreviewRecording(scope.threadId, response);
+    }),
 } satisfies Parameters<typeof PreviewToolkit.toLayer>[0];
 
 const { preview_snapshot, ...standardHandlers } = handlers;

--- a/apps/server/src/mcp/toolkits/preview/handlers.ts
+++ b/apps/server/src/mcp/toolkits/preview/handlers.ts
@@ -3,6 +3,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Schema from "effect/Schema";
 import {
   PROVIDER_SEND_TURN_MAX_FILE_BYTES,
+  PREVIEW_RECORDING_STOP_TIMEOUT_MS,
   PreviewAutomationRecordingTransferError,
   PreviewAutomationRecordingArtifact,
   type ThreadId,
@@ -90,7 +91,7 @@ export const claimPreviewRecording = Effect.fn("PreviewToolkit.claimRecording")(
       (cause) =>
         new PreviewAutomationRecordingTransferError({
           threadId,
-          detail: "The desktop returned invalid recording metadata.",
+          reason: "invalid-metadata",
           cause,
         }),
     ),
@@ -98,8 +99,7 @@ export const claimPreviewRecording = Effect.fn("PreviewToolkit.claimRecording")(
   if (!artifact.uploadedAttachmentId) {
     return yield* new PreviewAutomationRecordingTransferError({
       threadId,
-      detail:
-        "Update the desktop app to transfer recordings. The recording remains on the desktop.",
+      reason: "desktop-update-required",
     });
   }
   const config = yield* ServerConfig.ServerConfig;
@@ -109,7 +109,10 @@ export const claimPreviewRecording = Effect.fn("PreviewToolkit.claimRecording")(
     attachmentId: artifact.uploadedAttachmentId,
   });
   if (!claim.ok) {
-    return yield* new PreviewAutomationRecordingTransferError({ threadId, detail: claim.reason });
+    return yield* new PreviewAutomationRecordingTransferError({
+      threadId,
+      reason: "invalid-upload",
+    });
   }
   const fileSystem = yield* FileSystem.FileSystem;
   yield* Effect.gen(function* () {
@@ -122,7 +125,7 @@ export const claimPreviewRecording = Effect.fn("PreviewToolkit.claimRecording")(
     ) {
       return yield* new PreviewAutomationRecordingTransferError({
         threadId,
-        detail: "The uploaded recording size does not match its metadata or exceeds 50 MiB.",
+        reason: "size-mismatch",
       });
     }
     yield* fileSystem.rename(claim.currentPath, claim.finalPath);
@@ -132,7 +135,7 @@ export const claimPreviewRecording = Effect.fn("PreviewToolkit.claimRecording")(
         ? cause
         : new PreviewAutomationRecordingTransferError({
             threadId,
-            detail: "The uploaded recording could not be retained.",
+            reason: "retain-failed",
             cause,
           }),
     ),
@@ -173,7 +176,7 @@ const handlers = {
       const response = yield* invokeTargeted<unknown>(
         "recordingStop",
         { ...input, transferToEnvironment: true },
-        120_000,
+        PREVIEW_RECORDING_STOP_TIMEOUT_MS,
       );
       return yield* claimPreviewRecording(scope.threadId, response);
     }),

--- a/apps/server/src/mcp/toolkits/preview/handlers.ts
+++ b/apps/server/src/mcp/toolkits/preview/handlers.ts
@@ -5,6 +5,7 @@ import {
   PROVIDER_SEND_TURN_MAX_FILE_BYTES,
   PREVIEW_RECORDING_STOP_TIMEOUT_MS,
   PreviewAutomationRecordingTransferError,
+  PreviewAutomationRecordingDesktopUpdateRequiredError,
   PreviewAutomationRecordingArtifact,
   type ThreadId,
   type PreviewAutomationOperation,
@@ -17,7 +18,13 @@ import {
   type PreviewTabId,
 } from "@t3tools/contracts";
 
-import { planAttachmentClaim } from "../../../attachmentStore.ts";
+import {
+  parseAttachmentUuid,
+  parseAttachmentFileExtension,
+  PENDING_ATTACHMENT_THREAD_SEGMENT,
+  toSafeThreadAttachmentSegment,
+} from "../../../attachmentStore.ts";
+import { resolveAttachmentRelativePath } from "../../../attachmentPaths.ts";
 import * as ServerConfig from "../../../config.ts";
 import * as McpInvocationContext from "../../McpInvocationContext.ts";
 import * as PreviewAutomationBroker from "../../PreviewAutomationBroker.ts";
@@ -97,38 +104,71 @@ export const claimPreviewRecording = Effect.fn("PreviewToolkit.claimRecording")(
     ),
   );
   if (!artifact.uploadedAttachmentId) {
-    return yield* new PreviewAutomationRecordingTransferError({
-      threadId,
-      reason: "desktop-update-required",
-    });
+    return yield* new PreviewAutomationRecordingDesktopUpdateRequiredError({ threadId });
   }
   const config = yield* ServerConfig.ServerConfig;
-  const claim = planAttachmentClaim({
+  const uuid = parseAttachmentUuid(artifact.uploadedAttachmentId);
+  const extension = parseAttachmentFileExtension(artifact.uploadedAttachmentId);
+  const threadSegment = toSafeThreadAttachmentSegment(threadId);
+  const pendingId = `${PENDING_ATTACHMENT_THREAD_SEGMENT}-${uuid}-${extension}`;
+  if (!uuid || !extension || !threadSegment || artifact.uploadedAttachmentId !== pendingId) {
+    return yield* new PreviewAutomationRecordingTransferError({
+      threadId,
+      reason: "invalid-upload",
+    });
+  }
+  // The same completed upload can be returned to overlapping stop requests.
+  const finalId = `${threadSegment}-${uuid}-${extension}`;
+  const currentPath = resolveAttachmentRelativePath({
     attachmentsDir: config.attachmentsDir,
-    threadId,
-    attachmentId: artifact.uploadedAttachmentId,
+    relativePath: `${pendingId}.${extension}`,
   });
-  if (!claim.ok) {
+  const finalPath = resolveAttachmentRelativePath({
+    attachmentsDir: config.attachmentsDir,
+    relativePath: `${finalId}.${extension}`,
+  });
+  if (!currentPath || !finalPath) {
     return yield* new PreviewAutomationRecordingTransferError({
       threadId,
       reason: "invalid-upload",
     });
   }
   const fileSystem = yield* FileSystem.FileSystem;
+  const matchesRecording = (stat: FileSystem.File.Info) =>
+    stat.type === "File" &&
+    Number(stat.size) === artifact.sizeBytes &&
+    artifact.sizeBytes > 0 &&
+    artifact.sizeBytes <= PROVIDER_SEND_TURN_MAX_FILE_BYTES;
   yield* Effect.gen(function* () {
-    const stat = yield* fileSystem.stat(claim.currentPath);
-    if (
-      stat.type !== "File" ||
-      Number(stat.size) !== artifact.sizeBytes ||
-      artifact.sizeBytes <= 0 ||
-      artifact.sizeBytes > PROVIDER_SEND_TURN_MAX_FILE_BYTES
-    ) {
+    const pendingStat = yield* fileSystem
+      .stat(currentPath)
+      .pipe(
+        Effect.catch((cause) =>
+          cause.reason._tag === "NotFound" ? Effect.succeed(null) : Effect.fail(cause),
+        ),
+      );
+    const stat = pendingStat ?? (yield* fileSystem.stat(finalPath));
+    if (!matchesRecording(stat)) {
       return yield* new PreviewAutomationRecordingTransferError({
         threadId,
         reason: "size-mismatch",
       });
     }
-    yield* fileSystem.rename(claim.currentPath, claim.finalPath);
+    if (pendingStat) {
+      yield* fileSystem
+        .rename(currentPath, finalPath)
+        .pipe(
+          Effect.catch((cause) =>
+            cause.reason._tag === "NotFound" ? Effect.void : Effect.fail(cause),
+          ),
+        );
+      if (!matchesRecording(yield* fileSystem.stat(finalPath))) {
+        return yield* new PreviewAutomationRecordingTransferError({
+          threadId,
+          reason: "size-mismatch",
+        });
+      }
+    }
   }).pipe(
     Effect.mapError((cause) =>
       isRecordingTransferError(cause)
@@ -141,7 +181,7 @@ export const claimPreviewRecording = Effect.fn("PreviewToolkit.claimRecording")(
     ),
   );
   const { uploadedAttachmentId: _uploadedAttachmentId, ...recording } = artifact;
-  return { ...recording, id: claim.finalId, path: claim.finalPath };
+  return { ...recording, id: finalId, path: finalPath };
 });
 
 const handlers = {

--- a/apps/server/src/mcp/toolkits/preview/handlers.ts
+++ b/apps/server/src/mcp/toolkits/preview/handlers.ts
@@ -87,7 +87,6 @@ const UploadedRecordingArtifact = Schema.Struct({
   uploadedAttachmentId: Schema.optional(Schema.String),
 });
 const decodeUploadedRecordingArtifact = Schema.decodeUnknownEffect(UploadedRecordingArtifact);
-const isRecordingTransferError = Schema.is(PreviewAutomationRecordingTransferError);
 
 export const claimPreviewRecording = Effect.fn("PreviewToolkit.claimRecording")(function* (
   threadId: ThreadId,
@@ -98,7 +97,6 @@ export const claimPreviewRecording = Effect.fn("PreviewToolkit.claimRecording")(
       (cause) =>
         new PreviewAutomationRecordingTransferError({
           threadId,
-          reason: "invalid-metadata",
           cause,
         }),
     ),
@@ -114,7 +112,6 @@ export const claimPreviewRecording = Effect.fn("PreviewToolkit.claimRecording")(
   if (!uuid || !extension || !threadSegment || artifact.uploadedAttachmentId !== pendingId) {
     return yield* new PreviewAutomationRecordingTransferError({
       threadId,
-      reason: "invalid-upload",
     });
   }
   // The same completed upload can be returned to overlapping stop requests.
@@ -128,57 +125,31 @@ export const claimPreviewRecording = Effect.fn("PreviewToolkit.claimRecording")(
     relativePath: `${finalId}.${extension}`,
   });
   if (!currentPath || !finalPath) {
-    return yield* new PreviewAutomationRecordingTransferError({
-      threadId,
-      reason: "invalid-upload",
-    });
+    return yield* new PreviewAutomationRecordingTransferError({ threadId });
   }
   const fileSystem = yield* FileSystem.FileSystem;
-  const matchesRecording = (stat: FileSystem.File.Info) =>
-    stat.type === "File" &&
-    Number(stat.size) === artifact.sizeBytes &&
-    artifact.sizeBytes > 0 &&
-    artifact.sizeBytes <= PROVIDER_SEND_TURN_MAX_FILE_BYTES;
+  const validateFile = (filePath: string) =>
+    fileSystem.stat(filePath).pipe(
+      Effect.filterOrFail(
+        (stat) =>
+          stat.type === "File" &&
+          Number(stat.size) === artifact.sizeBytes &&
+          artifact.sizeBytes > 0 &&
+          artifact.sizeBytes <= PROVIDER_SEND_TURN_MAX_FILE_BYTES,
+        () => new PreviewAutomationRecordingTransferError({ threadId }),
+      ),
+    );
   yield* Effect.gen(function* () {
-    const pendingStat = yield* fileSystem
-      .stat(currentPath)
-      .pipe(
-        Effect.catch((cause) =>
-          cause.reason._tag === "NotFound" ? Effect.succeed(null) : Effect.fail(cause),
-        ),
-      );
-    const stat = pendingStat ?? (yield* fileSystem.stat(finalPath));
-    if (!matchesRecording(stat)) {
-      return yield* new PreviewAutomationRecordingTransferError({
-        threadId,
-        reason: "size-mismatch",
-      });
-    }
-    if (pendingStat) {
-      yield* fileSystem
-        .rename(currentPath, finalPath)
-        .pipe(
-          Effect.catch((cause) =>
-            cause.reason._tag === "NotFound" ? Effect.void : Effect.fail(cause),
-          ),
-        );
-      if (!matchesRecording(yield* fileSystem.stat(finalPath))) {
-        return yield* new PreviewAutomationRecordingTransferError({
-          threadId,
-          reason: "size-mismatch",
-        });
-      }
-    }
+    yield* validateFile(currentPath);
+    yield* fileSystem.rename(currentPath, finalPath);
   }).pipe(
-    Effect.mapError((cause) =>
-      isRecordingTransferError(cause)
-        ? cause
-        : new PreviewAutomationRecordingTransferError({
-            threadId,
-            reason: "retain-failed",
-            cause,
-          }),
+    // Another stop may already have claimed this exact upload for this thread.
+    Effect.catch((cause) =>
+      cause._tag !== "PreviewAutomationRecordingTransferError" && cause.reason._tag === "NotFound"
+        ? validateFile(finalPath)
+        : Effect.fail(cause),
     ),
+    Effect.mapError((cause) => new PreviewAutomationRecordingTransferError({ threadId, cause })),
   );
   const { uploadedAttachmentId: _uploadedAttachmentId, ...recording } = artifact;
   return { ...recording, id: finalId, path: finalPath };

--- a/apps/server/src/mcp/toolkits/preview/tools.ts
+++ b/apps/server/src/mcp/toolkits/preview/tools.ts
@@ -19,10 +19,12 @@ import {
   PreviewAutomationWaitForInput,
 } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
+import * as FileSystem from "effect/FileSystem";
 import { Tool, Toolkit } from "effect/unstable/ai";
 
 import * as McpInvocationContext from "../../McpInvocationContext.ts";
 import * as PreviewAutomationBroker from "../../PreviewAutomationBroker.ts";
+import * as ServerConfig from "../../../config.ts";
 
 const dependencies = [
   McpInvocationContext.McpInvocationContext,
@@ -207,11 +209,11 @@ export const PreviewRecordingStartTool = safeBrowserTool(
 export const PreviewRecordingStopTool = safeBrowserTool(
   Tool.make("preview_recording_stop", {
     description:
-      "Stop recording the collaborative browser tab selected by tabId, or this agent session's current tab when omitted, and save it as a local evidence artifact.",
+      "Stop recording the collaborative browser tab selected by tabId, or this agent session's current tab when omitted, and transfer the compressed recording once (up to 50 MiB) to an evidence file readable in this agent's environment. Returns its environment-local path after transfer succeeds.",
     parameters: PreviewAutomationTabTargetInput,
     success: PreviewAutomationRecordingArtifact,
     failure: PreviewAutomationError,
-    dependencies,
+    dependencies: [...dependencies, FileSystem.FileSystem, ServerConfig.ServerConfig],
   }).annotate(Tool.Title, "Stop browser recording"),
 );
 

--- a/apps/web/src/browser/browserRecording.test.ts
+++ b/apps/web/src/browser/browserRecording.test.ts
@@ -180,6 +180,44 @@ describe("browser recording", () => {
     await stopBrowserRecording("automation-recording-tab");
   });
 
+  it("saves locally and releases capture before transferring the encoded recording once", async () => {
+    const stopTrack = vi.fn();
+    getDisplayMedia.mockResolvedValue({
+      getVideoTracks: () => [],
+      getTracks: () => [{ stop: stopTrack }],
+    });
+    await startBrowserRecording("transfer-tab");
+    let finishUpload!: () => void;
+    const uploaded = new Promise<void>((resolve) => {
+      finishUpload = resolve;
+    });
+    const transfer = vi.fn(async (artifact, blob: Blob) => {
+      expect(save).toHaveBeenCalledOnce();
+      expect(stopTrack).toHaveBeenCalled();
+      expect(artifact.path).toBe("/tmp/recording-test.webm");
+      expect(blob.type).toBe("video/webm;codecs=vp9");
+      await uploaded;
+    });
+    const firstStop = stopBrowserRecording("transfer-tab", transfer);
+    const secondStop = stopBrowserRecording("transfer-tab", transfer);
+    finishUpload();
+    expect(await firstStop).toEqual(await secondStop);
+    expect(transfer).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the saved desktop file and releases the recording when transfer fails", async () => {
+    await startBrowserRecording("failed-transfer-tab");
+    await expect(
+      stopBrowserRecording("failed-transfer-tab", async () => {
+        throw new Error("Connection interrupted");
+      }),
+    ).rejects.toMatchObject({ _tag: "BrowserRecordingOperationError" });
+    expect(save).toHaveBeenCalledOnce();
+    expect(readActiveBrowserRecordingTabIds().has("failed-transfer-tab")).toBe(false);
+    await startBrowserRecording("failed-transfer-tab");
+    await stopBrowserRecording("failed-transfer-tab");
+  });
+
   it("paints and holds a hidden browser surface for the recording lifetime", async () => {
     startScreencast.mockImplementationOnce(async (tabId: string) => {
       expect(animationFrameCount).toBe(2);

--- a/apps/web/src/browser/browserRecording.test.ts
+++ b/apps/web/src/browser/browserRecording.test.ts
@@ -78,6 +78,7 @@ import {
   readActiveBrowserRecordingTargets,
   startBrowserRecording,
   stopBrowserRecording,
+  stopBrowserRecordingForUpload,
 } from "./browserRecording";
 import { useBrowserSurfaceStore } from "./browserSurfaceStore";
 import { previewRuntimeTabId } from "./previewRuntimeTabId";
@@ -197,21 +198,25 @@ describe("browser recording", () => {
       expect(artifact.path).toBe("/tmp/recording-test.webm");
       expect(blob.type).toBe("video/webm;codecs=vp9");
       await uploaded;
+      return "uploaded-recording";
     });
-    const firstStop = stopBrowserRecording("transfer-tab", transfer);
-    const secondStop = stopBrowserRecording("transfer-tab", transfer);
+    const localStop = stopBrowserRecording("transfer-tab");
+    const firstStop = stopBrowserRecordingForUpload("transfer-tab", transfer);
+    const secondStop = stopBrowserRecordingForUpload("transfer-tab", transfer);
     finishUpload();
     expect(await firstStop).toEqual(await secondStop);
+    expect((await firstStop)?.uploadedAttachmentId).toBe("uploaded-recording");
+    expect((await localStop)?.path).toBe("/tmp/recording-test.webm");
     expect(transfer).toHaveBeenCalledOnce();
   });
 
   it("keeps the saved desktop file and releases the recording when transfer fails", async () => {
     await startBrowserRecording("failed-transfer-tab");
     await expect(
-      stopBrowserRecording("failed-transfer-tab", async () => {
+      stopBrowserRecordingForUpload("failed-transfer-tab", async () => {
         throw new Error("Connection interrupted");
       }),
-    ).rejects.toMatchObject({ _tag: "BrowserRecordingOperationError" });
+    ).rejects.toThrow("Connection interrupted");
     expect(save).toHaveBeenCalledOnce();
     expect(readActiveBrowserRecordingTabIds().has("failed-transfer-tab")).toBe(false);
     await startBrowserRecording("failed-transfer-tab");

--- a/apps/web/src/browser/browserRecording.ts
+++ b/apps/web/src/browser/browserRecording.ts
@@ -123,6 +123,8 @@ interface ActiveRecording {
   releaseSurfaceActivity: (() => void) | null;
   stream: MediaStream | null;
   recorder: MediaRecorder | null;
+  savedBlob?: Blob;
+  uploadPromise?: Promise<string>;
   lifecycle: BrowserRecordingLifecycle;
 }
 
@@ -661,7 +663,6 @@ export async function startBrowserRecording(
 const finalizeBrowserRecording = async (
   bridge: NonNullable<typeof previewBridge>,
   recording: ActiveRecording,
-  onSaved?: (artifact: DesktopPreviewRecordingArtifact, blob: Blob) => Promise<void>,
 ): Promise<DesktopPreviewRecordingArtifact | null> => {
   const { tabId } = recording;
   let result:
@@ -709,7 +710,7 @@ const finalizeBrowserRecording = async (
           mimeType,
           new Uint8Array(await blob.arrayBuffer()),
         );
-        await onSaved?.(artifact, blob);
+        recording.savedBlob = blob;
         result = { _tag: "Success", artifact };
       } catch (cause) {
         throw new BrowserRecordingOperationError({
@@ -794,7 +795,6 @@ const discardBrowserRecording = async (
 
 export function stopBrowserRecording(
   tabId: string,
-  onSaved?: (artifact: DesktopPreviewRecordingArtifact, blob: Blob) => Promise<void>,
 ): Promise<DesktopPreviewRecordingArtifact | null> {
   const bridge = previewBridge;
   const recording = activeRecordings.get(tabId);
@@ -803,7 +803,7 @@ export function stopBrowserRecording(
   if (recording.lifecycle.phase === "starting") recording.lifecycle.cancelBeforeGrant();
 
   const stopPromise = Promise.resolve()
-    .then(() => finalizeBrowserRecording(bridge, recording, onSaved))
+    .then(() => finalizeBrowserRecording(bridge, recording))
     .catch((error) => {
       if (isStartupWaitTimeout(error) && activeRecordings.get(recording.tabId) === recording) {
         const cleanupAfterStartup = recording.startupSettled.then(() =>
@@ -816,4 +816,17 @@ export function stopBrowserRecording(
     });
   recording.lifecycle = { phase: "stopping", stopPromise };
   return stopPromise;
+}
+
+/** Joins local stops and shares one upload among concurrent automation requests. */
+export async function stopBrowserRecordingForUpload(
+  tabId: string,
+  upload: (artifact: DesktopPreviewRecordingArtifact, blob: Blob) => Promise<string>,
+): Promise<(DesktopPreviewRecordingArtifact & { uploadedAttachmentId: string }) | null> {
+  const recording = activeRecordings.get(tabId);
+  if (!recording) return null;
+  const artifact = await stopBrowserRecording(tabId);
+  if (!artifact || !recording.savedBlob) return null;
+  recording.uploadPromise ??= upload(artifact, recording.savedBlob);
+  return { ...artifact, uploadedAttachmentId: await recording.uploadPromise };
 }

--- a/apps/web/src/browser/browserRecording.ts
+++ b/apps/web/src/browser/browserRecording.ts
@@ -661,6 +661,7 @@ export async function startBrowserRecording(
 const finalizeBrowserRecording = async (
   bridge: NonNullable<typeof previewBridge>,
   recording: ActiveRecording,
+  onSaved?: (artifact: DesktopPreviewRecordingArtifact, blob: Blob) => Promise<void>,
 ): Promise<DesktopPreviewRecordingArtifact | null> => {
   const { tabId } = recording;
   let result:
@@ -708,6 +709,7 @@ const finalizeBrowserRecording = async (
           mimeType,
           new Uint8Array(await blob.arrayBuffer()),
         );
+        await onSaved?.(artifact, blob);
         result = { _tag: "Success", artifact };
       } catch (cause) {
         throw new BrowserRecordingOperationError({
@@ -792,6 +794,7 @@ const discardBrowserRecording = async (
 
 export function stopBrowserRecording(
   tabId: string,
+  onSaved?: (artifact: DesktopPreviewRecordingArtifact, blob: Blob) => Promise<void>,
 ): Promise<DesktopPreviewRecordingArtifact | null> {
   const bridge = previewBridge;
   const recording = activeRecordings.get(tabId);
@@ -800,7 +803,7 @@ export function stopBrowserRecording(
   if (recording.lifecycle.phase === "starting") recording.lifecycle.cancelBeforeGrant();
 
   const stopPromise = Promise.resolve()
-    .then(() => finalizeBrowserRecording(bridge, recording))
+    .then(() => finalizeBrowserRecording(bridge, recording, onSaved))
     .catch((error) => {
       if (isStartupWaitTimeout(error) && activeRecordings.get(recording.tabId) === recording) {
         const cleanupAfterStartup = recording.startupSettled.then(() =>

--- a/apps/web/src/browser/browserRecordingUpload.ts
+++ b/apps/web/src/browser/browserRecordingUpload.ts
@@ -1,10 +1,16 @@
 import {
   PROVIDER_SEND_TURN_MAX_FILE_BYTES,
+  PreviewAutomationRecordingTransferError,
+  PreviewAutomationRecordingTooLargeError,
+  PreviewAutomationRecordingDeadlineExpiredError,
   type DesktopPreviewRecordingArtifact,
-  type EnvironmentId,
+  type ScopedThreadRef,
 } from "@t3tools/contracts";
 import { resolveAssetUrl } from "@t3tools/client-runtime/state/assets";
-import { runAttachmentUploadCycle } from "@t3tools/client-runtime/state/attachments";
+import {
+  deletePendingAttachmentUpload,
+  runAttachmentUploadCycle,
+} from "@t3tools/client-runtime/state/attachments";
 
 import { appAtomRegistry } from "~/rpc/atomRegistry";
 import { attachmentEnvironment } from "~/state/attachments";
@@ -12,13 +18,13 @@ import { readPreparedConnection } from "~/state/session";
 
 /** Sends the finished encoded file once; capture frames never cross the environment connection. */
 export async function uploadBrowserRecording(
-  environmentId: EnvironmentId,
+  { environmentId, threadId }: ScopedThreadRef,
   artifact: DesktopPreviewRecordingArtifact,
   blob: Blob,
   deadlineMs: number,
 ): Promise<string> {
   if (blob.size > PROVIDER_SEND_TURN_MAX_FILE_BYTES) {
-    throw new Error(`Recording exceeds the 50 MiB transfer limit. Desktop copy: ${artifact.path}`);
+    throw new PreviewAutomationRecordingTooLargeError({ threadId });
   }
   const result = await runAttachmentUploadCycle({
     registry: appAtomRegistry,
@@ -57,8 +63,22 @@ export async function uploadBrowserRecording(
     },
   });
   if (result.status !== "uploaded") {
-    throw new Error(`Recording transfer failed. Desktop copy: ${artifact.path}`, {
-      cause: result.status === "failed" ? result.error : undefined,
+    if (result.attachmentId) {
+      deletePendingAttachmentUpload({
+        registry: appAtomRegistry,
+        remove: attachmentEnvironment.remove,
+        environmentId,
+        attachmentId: result.attachmentId,
+      });
+    }
+    const cause = result.status === "failed" ? result.error : undefined;
+    if (Date.now() >= deadlineMs - 1_000) {
+      throw new PreviewAutomationRecordingDeadlineExpiredError({ threadId, cause });
+    }
+    throw new PreviewAutomationRecordingTransferError({
+      threadId,
+      reason: "upload-failed",
+      cause,
     });
   }
   return result.attachmentId;

--- a/apps/web/src/browser/browserRecordingUpload.ts
+++ b/apps/web/src/browser/browserRecordingUpload.ts
@@ -1,0 +1,58 @@
+import {
+  PROVIDER_SEND_TURN_MAX_FILE_BYTES,
+  type DesktopPreviewRecordingArtifact,
+  type EnvironmentId,
+} from "@t3tools/contracts";
+import { resolveAssetUrl } from "@t3tools/client-runtime/state/assets";
+import { runAttachmentUploadCycle } from "@t3tools/client-runtime/state/attachments";
+
+import { appAtomRegistry } from "~/rpc/atomRegistry";
+import { attachmentEnvironment } from "~/state/attachments";
+import { readPreparedConnection } from "~/state/session";
+
+/** Sends the finished encoded file once; capture frames never cross the environment connection. */
+export async function uploadBrowserRecording(
+  environmentId: EnvironmentId,
+  artifact: DesktopPreviewRecordingArtifact,
+  blob: Blob,
+): Promise<string> {
+  if (blob.size > PROVIDER_SEND_TURN_MAX_FILE_BYTES) {
+    throw new Error(`Recording exceeds the 50 MiB transfer limit. Desktop copy: ${artifact.path}`);
+  }
+  const result = await runAttachmentUploadCycle({
+    registry: appAtomRegistry,
+    createUploadUrl: attachmentEnvironment.createUploadUrl,
+    remove: attachmentEnvironment.remove,
+    environmentId,
+    upload: {
+      type: "file",
+      name: artifact.path.split(/[\\/]/).at(-1) ?? artifact.id,
+      mimeType: artifact.mimeType,
+      sizeBytes: blob.size,
+    },
+    resolveUploadUrl: (relativeUrl) => {
+      const connection = readPreparedConnection(environmentId);
+      return connection ? resolveAssetUrl(connection.httpBaseUrl, relativeUrl) : null;
+    },
+    transport: (url) => {
+      const controller = new AbortController();
+      return {
+        abort: () => controller.abort(),
+        done: fetch(url, {
+          method: "POST",
+          headers: { "Content-Type": artifact.mimeType },
+          body: blob,
+          signal: AbortSignal.any([controller.signal, AbortSignal.timeout(110_000)]),
+        }).then((response) => {
+          if (!response.ok) throw new Error(`Recording upload rejected (${response.status}).`);
+        }),
+      };
+    },
+  });
+  if (result.status !== "uploaded") {
+    throw new Error(`Recording transfer failed. Desktop copy: ${artifact.path}`, {
+      cause: result.status === "failed" ? result.error : undefined,
+    });
+  }
+  return result.attachmentId;
+}

--- a/apps/web/src/browser/browserRecordingUpload.ts
+++ b/apps/web/src/browser/browserRecordingUpload.ts
@@ -77,7 +77,6 @@ export async function uploadBrowserRecording(
     }
     throw new PreviewAutomationRecordingTransferError({
       threadId,
-      reason: "upload-failed",
       cause,
     });
   }

--- a/apps/web/src/browser/browserRecordingUpload.ts
+++ b/apps/web/src/browser/browserRecordingUpload.ts
@@ -15,6 +15,7 @@ export async function uploadBrowserRecording(
   environmentId: EnvironmentId,
   artifact: DesktopPreviewRecordingArtifact,
   blob: Blob,
+  deadlineMs: number,
 ): Promise<string> {
   if (blob.size > PROVIDER_SEND_TURN_MAX_FILE_BYTES) {
     throw new Error(`Recording exceeds the 50 MiB transfer limit. Desktop copy: ${artifact.path}`);
@@ -36,16 +37,22 @@ export async function uploadBrowserRecording(
     },
     transport: (url) => {
       const controller = new AbortController();
+      // Encoding, saving and minting consume the same request budget. Leave time to reply.
+      const remainingMs = deadlineMs - Date.now() - 1_000;
       return {
         abort: () => controller.abort(),
-        done: fetch(url, {
-          method: "POST",
-          headers: { "Content-Type": artifact.mimeType },
-          body: blob,
-          signal: AbortSignal.any([controller.signal, AbortSignal.timeout(110_000)]),
-        }).then((response) => {
-          if (!response.ok) throw new Error(`Recording upload rejected (${response.status}).`);
-        }),
+        done:
+          remainingMs <= 0
+            ? Promise.reject(new Error("Recording transfer deadline expired."))
+            : fetch(url, {
+                method: "POST",
+                headers: { "Content-Type": artifact.mimeType },
+                body: blob,
+                signal: AbortSignal.any([controller.signal, AbortSignal.timeout(remainingMs)]),
+              }).then((response) => {
+                if (!response.ok)
+                  throw new Error(`Recording upload rejected (${response.status}).`);
+              }),
       };
     },
   });

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -37,6 +37,7 @@ import {
   stopBrowserRecording,
 } from "~/browser/browserRecording";
 import { resolveBrowserRecordingStopTarget } from "~/browser/browserRecordingScope";
+import { uploadBrowserRecording } from "~/browser/browserRecordingUpload";
 import {
   acquireBrowserSurfaceActivity,
   useBrowserSurfaceStore,
@@ -716,7 +717,26 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             const stopRuntimeTabId =
               activeRecordings.find((recording) => recording.serverTabId === stopTabId)
                 ?.runtimeTabId ?? null;
-            const artifact = stopRuntimeTabId ? await stopBrowserRecording(stopRuntimeTabId) : null;
+            const transferToEnvironment =
+              typeof request.input === "object" &&
+              request.input !== null &&
+              "transferToEnvironment" in request.input &&
+              request.input.transferToEnvironment === true;
+            let uploadedAttachmentId: string | undefined;
+            const artifact = stopRuntimeTabId
+              ? await stopBrowserRecording(
+                  stopRuntimeTabId,
+                  transferToEnvironment
+                    ? async (saved, blob) => {
+                        uploadedAttachmentId = await uploadBrowserRecording(
+                          environmentId,
+                          saved,
+                          blob,
+                        );
+                      }
+                    : undefined,
+                )
+              : null;
             if (!artifact || !stopTabId) {
               return raisePreviewAutomationHostError(
                 new PreviewAutomationRecordingNotActiveError({
@@ -727,7 +747,11 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                 }),
               );
             }
-            return { ...artifact, tabId: stopTabId };
+            return {
+              ...artifact,
+              tabId: stopTabId,
+              ...(uploadedAttachmentId ? { uploadedAttachmentId } : {}),
+            };
           }
         }
       } catch (cause) {

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -35,6 +35,7 @@ import {
   readActiveBrowserRecordingTargets,
   startBrowserRecording,
   stopBrowserRecording,
+  stopBrowserRecordingForUpload,
 } from "~/browser/browserRecording";
 import { resolveBrowserRecordingStopTarget } from "~/browser/browserRecordingScope";
 import { uploadBrowserRecording } from "~/browser/browserRecordingUpload";
@@ -722,20 +723,12 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
               request.input !== null &&
               "transferToEnvironment" in request.input &&
               request.input.transferToEnvironment === true;
-            let uploadedAttachmentId: string | undefined;
             const artifact = stopRuntimeTabId
-              ? await stopBrowserRecording(
-                  stopRuntimeTabId,
-                  transferToEnvironment
-                    ? async (saved, blob) => {
-                        uploadedAttachmentId = await uploadBrowserRecording(
-                          environmentId,
-                          saved,
-                          blob,
-                        );
-                      }
-                    : undefined,
-                )
+              ? transferToEnvironment
+                ? await stopBrowserRecordingForUpload(stopRuntimeTabId, (saved, blob) =>
+                    uploadBrowserRecording(environmentId, saved, blob, hostDeadlineMs),
+                  )
+                : await stopBrowserRecording(stopRuntimeTabId)
               : null;
             if (!artifact || !stopTabId) {
               return raisePreviewAutomationHostError(
@@ -750,7 +743,6 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             return {
               ...artifact,
               tabId: stopTabId,
-              ...(uploadedAttachmentId ? { uploadedAttachmentId } : {}),
             };
           }
         }

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -726,7 +726,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             const artifact = stopRuntimeTabId
               ? transferToEnvironment
                 ? await stopBrowserRecordingForUpload(stopRuntimeTabId, (saved, blob) =>
-                    uploadBrowserRecording(environmentId, saved, blob, hostDeadlineMs),
+                    uploadBrowserRecording(threadRef, saved, blob, hostDeadlineMs),
                   )
                 : await stopBrowserRecording(stopRuntimeTabId)
               : null;

--- a/apps/web/src/components/preview/previewAutomationErrors.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.ts
@@ -2,6 +2,10 @@ import {
   EnvironmentId,
   type PreviewAutomationHost,
   PreviewAutomationOperation,
+  PreviewAutomationRecordingTransferError,
+  PreviewAutomationRecordingDesktopUpdateRequiredError,
+  PreviewAutomationRecordingTooLargeError,
+  PreviewAutomationRecordingDeadlineExpiredError,
   type PreviewAutomationRequest,
   type PreviewAutomationResponse,
   PreviewTabId,
@@ -206,6 +210,10 @@ export class PreviewAutomationOperationError extends Schema.TaggedErrorClass<Pre
 }
 
 export const PreviewAutomationHostError = Schema.Union([
+  PreviewAutomationRecordingTransferError,
+  PreviewAutomationRecordingDesktopUpdateRequiredError,
+  PreviewAutomationRecordingTooLargeError,
+  PreviewAutomationRecordingDeadlineExpiredError,
   PreviewAutomationOverlayTimeoutError,
   PreviewAutomationNavigationTimeoutError,
   PreviewAutomationViewportTimeoutError,
@@ -228,7 +236,7 @@ export function serializePreviewAutomationHostError(
     ),
   );
   return {
-    _tag: error.responseTag,
+    _tag: "responseTag" in error ? error.responseTag : error._tag,
     message: error.message,
     ...(Object.keys(detail).length === 0 ? {} : { detail }),
   };

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -862,13 +862,6 @@ export class PreviewAutomationRecordingTransferError extends Schema.TaggedErrorC
   "PreviewAutomationRecordingTransferError",
   {
     threadId: ThreadId,
-    reason: Schema.Literals([
-      "invalid-metadata",
-      "invalid-upload",
-      "size-mismatch",
-      "retain-failed",
-      "upload-failed",
-    ]),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -553,6 +553,8 @@ export const PreviewAutomationRecordingStatus = Schema.Struct({
 });
 export type PreviewAutomationRecordingStatus = typeof PreviewAutomationRecordingStatus.Type;
 
+export const PREVIEW_RECORDING_STOP_TIMEOUT_MS = 120_000;
+
 export const PreviewAutomationRecordingArtifact = Schema.Struct({
   id: Schema.String,
   tabId: PreviewTabId,
@@ -860,12 +862,26 @@ export class PreviewAutomationRecordingTransferError extends Schema.TaggedErrorC
   "PreviewAutomationRecordingTransferError",
   {
     threadId: ThreadId,
-    detail: Schema.String,
+    reason: Schema.Literals([
+      "invalid-metadata",
+      "desktop-update-required",
+      "invalid-upload",
+      "size-mismatch",
+      "retain-failed",
+    ]),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
-    return `Preview recording could not be saved to the agent environment: ${this.detail}`;
+    const detail = {
+      "invalid-metadata": "The desktop returned invalid recording metadata.",
+      "desktop-update-required":
+        "Update the desktop app to transfer recordings. The recording remains on the desktop.",
+      "invalid-upload": "The uploaded recording is missing, expired, or already claimed.",
+      "size-mismatch": "The uploaded recording size does not match its metadata or exceeds 50 MiB.",
+      "retain-failed": "The uploaded recording could not be retained.",
+    }[this.reason];
+    return `Preview recording could not be saved to the agent environment: ${detail}`;
   }
 }
 

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -856,7 +856,21 @@ export class PreviewAutomationMalformedResponseError extends Schema.TaggedErrorC
   }
 }
 
+export class PreviewAutomationRecordingTransferError extends Schema.TaggedErrorClass<PreviewAutomationRecordingTransferError>()(
+  "PreviewAutomationRecordingTransferError",
+  {
+    threadId: ThreadId,
+    detail: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return `Preview recording could not be saved to the agent environment: ${this.detail}`;
+  }
+}
+
 export const PreviewAutomationError = Schema.Union([
+  PreviewAutomationRecordingTransferError,
   PreviewAutomationUnavailableError,
   PreviewAutomationNoAvailableHostError,
   PreviewAutomationUnsupportedClientError,

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -864,29 +864,51 @@ export class PreviewAutomationRecordingTransferError extends Schema.TaggedErrorC
     threadId: ThreadId,
     reason: Schema.Literals([
       "invalid-metadata",
-      "desktop-update-required",
       "invalid-upload",
       "size-mismatch",
       "retain-failed",
+      "upload-failed",
     ]),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
-    const detail = {
-      "invalid-metadata": "The desktop returned invalid recording metadata.",
-      "desktop-update-required":
-        "Update the desktop app to transfer recordings. The recording remains on the desktop.",
-      "invalid-upload": "The uploaded recording is missing, expired, or already claimed.",
-      "size-mismatch": "The uploaded recording size does not match its metadata or exceeds 50 MiB.",
-      "retain-failed": "The uploaded recording could not be retained.",
-    }[this.reason];
-    return `Preview recording could not be saved to the agent environment: ${detail}`;
+    return "Preview recording could not be saved to the agent environment. The saved copy remains on the desktop.";
+  }
+}
+
+export class PreviewAutomationRecordingDesktopUpdateRequiredError extends Schema.TaggedErrorClass<PreviewAutomationRecordingDesktopUpdateRequiredError>()(
+  "PreviewAutomationRecordingDesktopUpdateRequiredError",
+  { threadId: ThreadId, cause: Schema.optional(Schema.Defect()) },
+) {
+  override get message(): string {
+    return "Update the desktop app to transfer recordings. The recording remains on the desktop.";
+  }
+}
+
+export class PreviewAutomationRecordingTooLargeError extends Schema.TaggedErrorClass<PreviewAutomationRecordingTooLargeError>()(
+  "PreviewAutomationRecordingTooLargeError",
+  { threadId: ThreadId, cause: Schema.optional(Schema.Defect()) },
+) {
+  override get message(): string {
+    return "The recording exceeds 50 MiB. The saved copy remains on the desktop.";
+  }
+}
+
+export class PreviewAutomationRecordingDeadlineExpiredError extends Schema.TaggedErrorClass<PreviewAutomationRecordingDeadlineExpiredError>()(
+  "PreviewAutomationRecordingDeadlineExpiredError",
+  { threadId: ThreadId, cause: Schema.optional(Schema.Defect()) },
+) {
+  override get message(): string {
+    return "The recording transfer deadline expired. The saved copy remains on the desktop.";
   }
 }
 
 export const PreviewAutomationError = Schema.Union([
   PreviewAutomationRecordingTransferError,
+  PreviewAutomationRecordingDesktopUpdateRequiredError,
+  PreviewAutomationRecordingTooLargeError,
+  PreviewAutomationRecordingDeadlineExpiredError,
   PreviewAutomationUnavailableError,
   PreviewAutomationNoAvailableHostError,
   PreviewAutomationUnsupportedClientError,


### PR DESCRIPTION
Preview recordings previously returned a desktop-local path that remote agents could not read. Agent-requested recordings now transfer the finished encoded file once through the existing signed binary upload endpoint, then return a server-local path; transfers are capped at 50 MiB and the desktop copy is retained.

Verified with real Electron recording through MCP, an authenticated connection between separate desktop/server processes and state directories on one Linux host, and matching SHA-256 hashes for the desktop and server files. The 1280×800, 17.8-second mostly static example transferred 66,086 bytes and played through without errors or dropped frames; moving content will produce larger files. Web/server typechecks and focused recording, upload, and broker tests pass. The simplified revision passed 46 focused server tests and another real MCP recording transfer: its 15,095-byte server file matched the desktop SHA-256.

![animated excerpt of the recording transferred to the agent environment](https://uploads-production-47e4.up.railway.app/files/28085bf2-a454-44cb-bd01-a2fe1bfada51/preview-recording-evidence.gif)

Written with gpt-5.6-sol in Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Transfer preview recordings from desktop to agent environment
> - Changes the preview recording-stop handler to ask the desktop to transfer the saved recording, then claims the uploaded attachment into a thread-scoped server path instead of returning the raw desktop artifact.
> - Adds `uploadBrowserRecording` in [browserRecordingUpload.ts](https://github.com/pingdotgg/t3code/pull/10572/files#diff-efd3384d9bf03cbdcec4e7936f3e78b2f558f1650fdad11ea84e621da698120b) to upload finalized browser recordings once to the environment with a bounded 120-second deadline, rejecting blobs over 50 MiB and mapping deadline/transfer failures to typed errors.
> - Adds `stopBrowserRecordingForUpload` in [browserRecording.ts](https://github.com/pingdotgg/t3code/pull/10572/files#diff-79c653393bbf38f68ecf4b38c7f60fa3a90926e6f50c2d7fcb3f1cb18e5b8135) so concurrent and repeated stop requests for one tab share a single upload promise.
> - Adds four typed error classes (`PreviewAutomationRecordingTransferError`, `PreviewAutomationRecordingDesktopUpdateRequiredError`, `PreviewAutomationRecordingTooLargeError`, `PreviewAutomationRecordingDeadlineExpiredError`) in [previewAutomation.ts](https://github.com/pingdotgg/t3code/pull/10572/files#diff-2ef56f22cedaed8aa5c26215295ac5661980479b1dced68072d9ca5bc81a9602) with fixed public messages and the remote response retained as cause.
> - Risk: recording-stop now requires the preview MCP capability and a 120-second transfer wait; older desktop clients without transfer support produce `PreviewAutomationRecordingDesktopUpdateRequiredError` instead of returning a local artifact.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized af49c30.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview recordings can be transferred to the agent environment after stopping, with the local file path returned.
  * Concurrent stop requests share a single upload.
  * Recording errors now distinguish outdated desktop clients, oversized recordings, expired transfers, and upload failures.

* **Bug Fixes**
  * Recording transfers handle completed and incomplete uploads more reliably.
  * Desktop recordings remain available when environment transfer fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->