### PR TITLE
feat(web): add keyboard revert picker

### DIFF
--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -1764,6 +1764,48 @@ describe("CheckpointReactor", () => {
     ).toBe(false);
   });
 
+  it("reverts a stopped thread using its persisted workspace", async () => {
+    const harness = await createHarness({ hasSession: false });
+    const threadId = ThreadId.make("thread-1");
+    const createdAt = "2026-01-01T00:00:00.000Z";
+
+    for (const turnCount of [1, 2]) {
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.diff.complete",
+          commandId: CommandId.make(`cmd-stopped-diff-${turnCount}`),
+          threadId,
+          turnId: asTurnId(`turn-${turnCount}`),
+          completedAt: createdAt,
+          checkpointRef: checkpointRefForThreadTurn(threadId, turnCount),
+          status: "ready",
+          files: [],
+          checkpointTurnCount: turnCount,
+          createdAt,
+        }),
+      );
+    }
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.revert",
+        commandId: CommandId.make("cmd-stopped-revert"),
+        threadId,
+        turnCount: 1,
+        createdAt,
+      }),
+    );
+    await harness.drain();
+
+    const thread = (await harness.readModel()).threads.find((entry) => entry.id === threadId);
+    expect(thread?.checkpoints).toHaveLength(1);
+    expect(harness.provider.rollbackConversation).toHaveBeenCalledWith({
+      threadId,
+      numTurns: 1,
+    });
+    expect(NodeFS.readFileSync(NodePath.join(harness.cwd, "README.md"), "utf8")).toBe("v2\n");
+  });
+
   it("executes provider revert and emits thread.reverted for claude sessions", async () => {
     const harness = await createHarness({ providerName: ProviderDriverKind.make("claudeAgent") });
     const createdAt = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -699,21 +699,18 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const sessionRuntime = yield* resolveSessionRuntimeForThread(event.payload.threadId);
-    if (Option.isNone(sessionRuntime)) {
+    const projects = yield* resolveThreadProjects(thread.projectId);
+    const checkpointCwd = yield* resolveCheckpointCwd({
+      threadId: thread.id,
+      thread,
+      projects,
+      preferSessionRuntime: true,
+    });
+    if (!checkpointCwd) {
       yield* appendRevertFailureActivity({
         threadId: event.payload.threadId,
         turnCount: event.payload.turnCount,
-        detail: "No active provider session with workspace cwd is bound to this thread.",
-        createdAt: now,
-      }).pipe(Effect.catch(() => Effect.void));
-      return;
-    }
-    if (!(yield* checkpointStore.isGitRepository(sessionRuntime.value.cwd))) {
-      yield* appendRevertFailureActivity({
-        threadId: event.payload.threadId,
-        turnCount: event.payload.turnCount,
-        detail: "Checkpoints are unavailable because this project is not a git repository.",
+        detail: "No Git workspace is available for this thread.",
         createdAt: now,
       }).pipe(Effect.catch(() => Effect.void));
       return;
@@ -754,7 +751,7 @@ const make = Effect.gen(function* () {
     yield* providerService.assertConversationRollbackSupported(event.payload.threadId);
 
     const restored = yield* checkpointStore.restoreCheckpoint({
-      cwd: sessionRuntime.value.cwd,
+      cwd: checkpointCwd,
       checkpointRef: targetCheckpointRef,
       fallbackToHead: event.payload.turnCount === 0,
     });
@@ -770,12 +767,12 @@ const make = Effect.gen(function* () {
 
     // Refresh the workspace entry index so the @-mention file picker
     // reflects the reverted filesystem state.
-    yield* workspaceEntries.refresh(sessionRuntime.value.cwd);
+    yield* workspaceEntries.refresh(checkpointCwd);
 
     const rolledBackTurns = Math.max(0, currentTurnCount - event.payload.turnCount);
     if (rolledBackTurns > 0) {
       yield* providerService.rollbackConversation({
-        threadId: sessionRuntime.value.threadId,
+        threadId: event.payload.threadId,
         numTurns: rolledBackTurns,
       });
     }
@@ -789,7 +786,7 @@ const make = Effect.gen(function* () {
 
     if (staleCheckpointRefs.length > 0) {
       yield* checkpointStore.deleteCheckpointRefs({
-        cwd: sessionRuntime.value.cwd,
+        cwd: checkpointCwd,
         checkpointRefs: staleCheckpointRefs,
       });
     }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -197,6 +197,12 @@ import {
 } from "@t3tools/client-runtime/state/subagentRuntime";
 import { BranchToolbar } from "./BranchToolbar";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
+import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
+import {
+  type ComposerRevertPicker,
+  deriveRevertPickerOptions,
+  type RevertPickerOption,
+} from "./chat/revertPicker.logic";
 import ThreadTerminalDrawer from "./ThreadTerminalDrawer";
 import {
   AlarmClockIcon,
@@ -1602,6 +1608,11 @@ export default function ChatView(props: ChatViewProps) {
   >({});
   const [isConnecting, _setIsConnecting] = useState(false);
   const [isRevertingCheckpoint, setIsRevertingCheckpoint] = useState(false);
+  const [revertPreviewMessageId, setRevertPreviewMessageId] = useState<MessageId | null>(null);
+  const onRevertPreviewHighlight = useCallback((option: RevertPickerOption | null) => {
+    setRevertPreviewMessageId(option?.messageId ?? null);
+  }, []);
+  const revertPickerRef = useRef<ComposerRevertPicker | null>(null);
   const [maximizedRightPanelThreadKey, setMaximizedRightPanelThreadKey] = useState<string | null>(
     null,
   );
@@ -6047,6 +6058,26 @@ export default function ChatView(props: ChatViewProps) {
         return;
       }
 
+      if (command === "chat.revert" || command === "chat.revertLast") {
+        const picker = revertPickerRef.current;
+        if (!picker) return;
+        event.preventDefault();
+        event.stopPropagation();
+        if (event.repeat) return;
+        if (command === "chat.revert") {
+          composerRef.current?.openRevertMenu();
+          return;
+        }
+        if (picker.blockedReason !== null) {
+          setThreadError(activeThreadId, picker.blockedReason);
+          return;
+        }
+        const latest = picker.options.find((option) => option.turnCount !== null);
+        if (latest?.turnCount === undefined || latest.turnCount === null) return;
+        picker.onRevert(latest.turnCount);
+        return;
+      }
+
       const scriptId = projectScriptIdFromCommand(command);
       if (!scriptId || !activeProject) return;
       const script = activeProjectScripts.find((entry) => entry.id === scriptId);
@@ -6080,6 +6111,7 @@ export default function ChatView(props: ChatViewProps) {
     handleUnsettleActiveThread,
     isServerThread,
     onToggleDiff,
+    setThreadError,
     pinThread,
     settleThread,
     supportsPinning,
@@ -6112,7 +6144,7 @@ export default function ChatView(props: ChatViewProps) {
   }, [activeThreadId, composerRef]);
 
   const onRevertToTurnCount = useCallback(
-    async (turnCount: number) => {
+    async (turnCount: number, options?: { skipConfirm?: boolean }) => {
       const localApi = readLocalApi();
       if (!localApi || !activeThread || isRevertingCheckpoint) return;
 
@@ -6134,16 +6166,18 @@ export default function ChatView(props: ChatViewProps) {
         setThreadError(activeThread.id, "Interrupt the current turn before reverting checkpoints.");
         return;
       }
-      const confirmed = await localApi.dialogs.confirm(
-        [
-          `Revert this thread to checkpoint ${turnCount}?`,
-          "This will discard newer messages and turn diffs in this thread.",
-          "This action cannot be undone.",
-        ].join("\n"),
-        { variant: "destructive" },
-      );
-      if (!confirmed) {
-        return;
+      if (options?.skipConfirm !== true) {
+        const confirmed = await localApi.dialogs.confirm(
+          [
+            `Revert this thread to checkpoint ${turnCount}?`,
+            "This will discard newer messages and turn diffs in this thread.",
+            "This action cannot be undone.",
+          ].join("\n"),
+          { variant: "destructive" },
+        );
+        if (!confirmed) {
+          return;
+        }
       }
 
       setIsRevertingCheckpoint(true);
@@ -7635,6 +7669,62 @@ export default function ChatView(props: ChatViewProps) {
   const onRevertTimelineTurn = useCallback((targetTurnCount: number) => {
     void onRevertToTurnCountRef.current(targetTurnCount);
   }, []);
+  const onRevertPickedTurn = useCallback((targetTurnCount: number) => {
+    void onRevertToTurnCountRef.current(targetTurnCount, { skipConfirm: true });
+  }, []);
+  const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
+    useTurnDiffSummaries(activeThread);
+  const revertPickerOptions = useMemo(
+    () =>
+      deriveRevertPickerOptions({
+        supportsConversationRollback,
+        timelineEntries,
+        turnDiffSummaries,
+        inferredCheckpointTurnCountByTurnId,
+      }),
+    [
+      inferredCheckpointTurnCountByTurnId,
+      supportsConversationRollback,
+      timelineEntries,
+      turnDiffSummaries,
+    ],
+  );
+  const revertBlockedReason = useMemo(() => {
+    if (activeEnvironmentUnavailable && activeEnvironmentUnavailableLabel) {
+      return `Reconnect ${activeEnvironmentUnavailableLabel} before reverting checkpoints.`;
+    }
+    if (isRevertingCheckpoint) return "A revert is already running in this thread.";
+    if (phase === "running" || isSendBusy || isConnecting) {
+      return "Interrupt the current turn before reverting checkpoints.";
+    }
+    return null;
+  }, [
+    activeEnvironmentUnavailable,
+    activeEnvironmentUnavailableLabel,
+    isConnecting,
+    isRevertingCheckpoint,
+    isSendBusy,
+    phase,
+  ]);
+  const revertPicker = useMemo<ComposerRevertPicker | null>(
+    () =>
+      supportsConversationRollback
+        ? {
+            options: revertPickerOptions,
+            blockedReason: revertBlockedReason,
+            onHighlight: onRevertPreviewHighlight,
+            onRevert: onRevertPickedTurn,
+          }
+        : null,
+    [
+      onRevertPickedTurn,
+      onRevertPreviewHighlight,
+      revertBlockedReason,
+      revertPickerOptions,
+      supportsConversationRollback,
+    ],
+  );
+  revertPickerRef.current = revertPicker;
 
   // Empty state: no active thread
   if (!activeThread) {
@@ -7950,6 +8040,7 @@ export default function ChatView(props: ChatViewProps) {
                 routeThreadKey={routeThreadKey}
                 onOpenTurnDiff={onOpenTurnDiff}
                 supportsConversationRollback={supportsConversationRollback}
+                revertPreviewMessageId={revertPreviewMessageId}
                 onRevertToTurnCount={onRevertTimelineTurn}
                 onUseArtifactTemplate={useArtifactTemplate}
                 isRevertingCheckpoint={isRevertingCheckpoint}
@@ -8088,6 +8179,7 @@ export default function ChatView(props: ChatViewProps) {
                                 : undefined
                             }
                             environmentUnavailable={activeEnvironmentUnavailableState}
+                            revert={revertPicker}
                             activePendingApproval={activePendingApproval}
                             pendingApprovals={pendingApprovals}
                             pendingUserInputs={pendingUserInputs}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -165,6 +165,8 @@ import {
 import { measureRestingComposerControls } from "./restingComposerControlsMeasurement";
 import { observeResponsiveBreakpointFade, usePanelAnimationSettings } from "../../panelAnimations";
 import { type ComposerPromptEditorHandle, ComposerPromptEditor } from "../ComposerPromptEditor";
+import { ComposerRevertMenu } from "./ComposerRevertMenu";
+import { type ComposerRevertPicker, type RevertPickerOption } from "./revertPicker.logic";
 import { ProviderModelPicker } from "./ProviderModelPicker";
 import { type ComposerCommandItem, ComposerCommandMenu } from "./ComposerCommandMenu";
 import { ComposerPendingApprovalActions } from "./ComposerPendingApprovalActions";
@@ -248,6 +250,7 @@ type ComposerCommandMenuPosition = {
 };
 
 const COMPOSER_SCROLL_COLLAPSE_THRESHOLD_PX = 24;
+const DOUBLE_ESCAPE_WINDOW_MS = 500;
 const COMPOSER_SCROLL_GESTURE_RESET_MS = 120;
 const COMPOSER_RESTING_TRANSITION_DURATION_MS = 280;
 const COMPOSER_RESTING_TRANSITION_CLEANUP_BUFFER_MS = 50;
@@ -1124,6 +1127,8 @@ export interface ChatComposerHandle {
   openModelPicker: () => void;
   toggleModelPicker: () => void;
   isModelPickerOpen: () => boolean;
+  openRevertMenu: () => void;
+  isRevertMenuOpen: () => boolean;
   compactContext: () => void;
   readSnapshot: () => {
     value: string;
@@ -1196,6 +1201,7 @@ export interface ChatComposerProps {
   bannerItems: readonly ComposerBannerStackItem[];
   /** Picking /usage-limits from the menu is the action itself; the draft keeps nothing of it. */
   onUsageLimitsCommand?: (() => void) | undefined;
+  revert: ComposerRevertPicker | null;
   environmentUnavailable: {
     readonly label: string;
     readonly connection: EnvironmentConnectionPresentation;
@@ -1401,6 +1407,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     setThreadError,
     onExpandImage,
     onFileOpen,
+    revert: revertPicker,
   } = props;
   const activeTasksProgress = props.threadSyncPhase === null ? props.activeTasksProgress : null;
   const activeTaskSteps = props.threadSyncPhase === null ? props.activeTaskSteps : null;
@@ -1824,6 +1831,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const hasWrappedPrompt = useComposerMultilinePrompt(composerMenuAnchor);
   const hasMultilinePrompt = prompt.includes("\n") || hasWrappedPrompt;
   const [isStashMenuOpen, setIsStashMenuOpen] = useState(false);
+  const [isRevertMenuOpen, setIsRevertMenuOpen] = useState(false);
   const [isTasksDrawerOpen, setIsTasksDrawerOpen] = useState(false);
   const [stashPulse, setStashPulse] = useState<{ key: number; active: boolean }>({
     key: 0,
@@ -3707,6 +3715,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     isTasksDrawerOpen ||
     composerMenuOpen ||
     isStashMenuOpen ||
+    isRevertMenuOpen ||
     isDragOverComposer ||
     isPreparingWorktree ||
     noProviderAvailable ||
@@ -4123,17 +4132,94 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     setIsTasksDrawerOpen(false);
   }, [activeThreadId]);
 
-  // Close the stash menu whenever the trigger-driven command menu opens so
-  // the two popovers never stack in the same layer, and when the user
-  // resumes typing (the menu is a transient picker, not a panel).
+  // Close the stash and revert menus whenever the trigger-driven command menu
+  // opens so the popovers never stack in the same layer, and when the user
+  // resumes typing (both are transient pickers, not panels).
   useEffect(() => {
     if (composerMenuOpen) {
       setIsStashMenuOpen(false);
+      setIsRevertMenuOpen(false);
     }
   }, [composerMenuOpen]);
   useEffect(() => {
     setIsStashMenuOpen(false);
+    setIsRevertMenuOpen(false);
   }, [prompt]);
+  useEffect(() => {
+    setIsRevertMenuOpen(false);
+  }, [activeThreadId]);
+
+  const openRevertMenu = useCallback(
+    (options?: { surfaceBlockedReason?: boolean }) => {
+      const revert = revertPicker;
+      if (!revert) return;
+      if (revert.blockedReason !== null) {
+        if (options?.surfaceBlockedReason) setThreadError(activeThreadId, revert.blockedReason);
+        return;
+      }
+      if (!revert.options.some((option) => option.turnCount !== null)) return;
+      setIsStashMenuOpen(false);
+      setIsRevertMenuOpen(true);
+    },
+    [activeThreadId, revertPicker, setThreadError],
+  );
+  const closeRevertMenu = useCallback(() => setIsRevertMenuOpen(false), []);
+  const revertToOption = useCallback(
+    (option: RevertPickerOption) => {
+      if (option.turnCount === null) return;
+      setIsRevertMenuOpen(false);
+      revertPicker?.onRevert(option.turnCount);
+    },
+    [revertPicker],
+  );
+
+  const lastEscapeAtRef = useRef(0);
+  useEffect(() => {
+    if (!revertPicker) return;
+    const handler = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== "Escape" || event.repeat || isRevertMenuOpen) return;
+      if (
+        composerSendState.hasSendableContent ||
+        composerMenuOpen ||
+        isStashMenuOpen ||
+        isComposerModelPickerOpen ||
+        isTasksDrawerOpen ||
+        isComposerApprovalState ||
+        hasBlockingComposerTopDrawer ||
+        revertPicker.blockedReason !== null ||
+        isCommandPaletteOpen() ||
+        getTerminalFocusOwner() !== null ||
+        !(
+          event.target instanceof Element &&
+          event.target.closest('[data-chat-composer-body="true"]')
+        )
+      ) {
+        lastEscapeAtRef.current = 0;
+        return;
+      }
+      const pressedAt = Date.now();
+      const previousPressedAt = lastEscapeAtRef.current;
+      lastEscapeAtRef.current = pressedAt;
+      if (pressedAt - previousPressedAt > DOUBLE_ESCAPE_WINDOW_MS) return;
+      lastEscapeAtRef.current = 0;
+      event.preventDefault();
+      event.stopPropagation();
+      openRevertMenu();
+    };
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, [
+    composerMenuOpen,
+    composerSendState.hasSendableContent,
+    hasBlockingComposerTopDrawer,
+    isComposerApprovalState,
+    isComposerModelPickerOpen,
+    isRevertMenuOpen,
+    isStashMenuOpen,
+    isTasksDrawerOpen,
+    openRevertMenu,
+    revertPicker,
+  ]);
 
   useEffect(() => {
     const handler = (event: globalThis.KeyboardEvent) => {
@@ -4569,6 +4655,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       },
       compactContext: compactThreadContext,
       isModelPickerOpen: () => isComposerModelPickerOpen,
+      openRevertMenu: () => openRevertMenu({ surfaceBlockedReason: true }),
+      isRevertMenuOpen: () => isRevertMenuOpen,
       readSnapshot: () => {
         return readComposerSnapshot();
       },
@@ -4695,6 +4783,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       getTimelineScrollableNode,
       isTimelineAtLogicalEnd,
       setIsComposerScrollCollapsed,
+      openRevertMenu,
+      isRevertMenuOpen,
     ],
   );
 
@@ -5025,23 +5115,40 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                 isComposerResting && "py-2 sm:py-2",
               )}
             >
-              {isStashMenuOpen && !composerMenuOpen && !isComposerApprovalState && (
-                <ComposerCommandMenuLayer anchor={composerMenuAnchor}>
-                  <ComposerStashMenu
-                    entries={stashQueue}
-                    stashShortcutLabel={shortcutLabelForCommand(keybindings, "composer.stash", {
-                      context: {
-                        terminalFocus: false,
-                        terminalOpen,
-                        modelPickerOpen: false,
-                      },
-                    })}
-                    onRestore={restoreStashEntry}
-                    onDelete={deleteStashEntry}
-                    onClose={() => setIsStashMenuOpen(false)}
-                  />
-                </ComposerCommandMenuLayer>
-              )}
+              {isRevertMenuOpen &&
+                revertPicker &&
+                !composerMenuOpen &&
+                !isComposerApprovalState && (
+                  <ComposerCommandMenuLayer anchor={composerMenuAnchor}>
+                    <ComposerRevertMenu
+                      options={revertPicker.options}
+                      onHighlight={revertPicker.onHighlight}
+                      onRevert={revertToOption}
+                      onClose={closeRevertMenu}
+                    />
+                  </ComposerCommandMenuLayer>
+                )}
+
+              {isStashMenuOpen &&
+                !isRevertMenuOpen &&
+                !composerMenuOpen &&
+                !isComposerApprovalState && (
+                  <ComposerCommandMenuLayer anchor={composerMenuAnchor}>
+                    <ComposerStashMenu
+                      entries={stashQueue}
+                      stashShortcutLabel={shortcutLabelForCommand(keybindings, "composer.stash", {
+                        context: {
+                          terminalFocus: false,
+                          terminalOpen,
+                          modelPickerOpen: false,
+                        },
+                      })}
+                      onRestore={restoreStashEntry}
+                      onDelete={deleteStashEntry}
+                      onClose={() => setIsStashMenuOpen(false)}
+                    />
+                  </ComposerCommandMenuLayer>
+                )}
 
               {composerMenuOpen && !isComposerApprovalState && (
                 <ComposerCommandMenuLayer anchor={composerMenuAnchor}>

--- a/apps/web/src/components/chat/ComposerRevertMenu.tsx
+++ b/apps/web/src/components/chat/ComposerRevertMenu.tsx
@@ -1,0 +1,196 @@
+import { HistoryIcon } from "lucide-react";
+import { memo, useEffect, useRef, useState } from "react";
+
+import { cn } from "~/lib/utils";
+import { formatRelativeTimeLabel } from "../../timestampFormat";
+import { ComposerBanner } from "./ComposerBanner";
+import { DiffStatLabel } from "./DiffStatLabel";
+import { type RevertPickerOption } from "./revertPicker.logic";
+
+function isSelectable(option: RevertPickerOption): boolean {
+  return option.turnCount !== null;
+}
+
+function nextSelectableIndex(
+  options: ReadonlyArray<RevertPickerOption>,
+  fromIndex: number,
+  offset: number,
+): number | null {
+  for (let step = 1; step <= options.length; step += 1) {
+    const index = (fromIndex + offset * step + options.length * step) % options.length;
+    const option = options[index];
+    if (option && isSelectable(option)) return index;
+  }
+  return null;
+}
+
+export const ComposerRevertMenu = memo(function ComposerRevertMenu(props: {
+  options: ReadonlyArray<RevertPickerOption>;
+  onHighlight: (option: RevertPickerOption | null) => void;
+  onRevert: (option: RevertPickerOption) => void;
+  onClose: () => void;
+}) {
+  const { options, onHighlight, onRevert, onClose } = props;
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const [highlightedId, setHighlightedId] = useState<string | null>(
+    options.find(isSelectable)?.messageId ?? null,
+  );
+
+  const highlightedOption =
+    options.find((option) => option.messageId === highlightedId) ?? options.find(isSelectable);
+
+  useEffect(() => {
+    onHighlight(highlightedOption ?? null);
+  }, [highlightedOption, onHighlight]);
+  useEffect(() => () => onHighlight(null), [onHighlight]);
+
+  useEffect(() => {
+    const closeOnOutsidePointer = (event: PointerEvent) => {
+      const drawer = drawerRef.current;
+      if (drawer && event.composedPath().includes(drawer)) return;
+      onClose();
+    };
+    document.addEventListener("pointerdown", closeOnOutsidePointer, true);
+    return () => document.removeEventListener("pointerdown", closeOnOutsidePointer, true);
+  }, [onClose]);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+        return;
+      }
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        if (options.length === 0) return;
+        event.preventDefault();
+        event.stopPropagation();
+        const currentIndex = options.findIndex(
+          (option) => option.messageId === highlightedOption?.messageId,
+        );
+        const offset = event.key === "ArrowDown" ? 1 : -1;
+        const nextIndex = nextSelectableIndex(
+          options,
+          currentIndex >= 0 ? currentIndex : offset === 1 ? -1 : 0,
+          offset,
+        );
+        if (nextIndex === null) return;
+        setHighlightedId(options[nextIndex]?.messageId ?? null);
+        const nextRow =
+          drawerRef.current?.querySelectorAll<HTMLElement>("[data-revert-option]")[nextIndex];
+        nextRow?.scrollIntoView({ block: "nearest" });
+        return;
+      }
+      if (event.key === "Enter") {
+        if (!highlightedOption || !isSelectable(highlightedOption)) return;
+        event.preventDefault();
+        event.stopPropagation();
+        onRevert(highlightedOption);
+      }
+    };
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, [highlightedOption, onClose, onRevert, options]);
+
+  return (
+    <ComposerBanner.Root ref={drawerRef} data-composer-revert-drawer="true">
+      <ComposerBanner.Row
+        render={<button type="button" />}
+        aria-label="Close revert picker"
+        aria-expanded="true"
+        onPointerDown={(event) => event.preventDefault()}
+        onClick={onClose}
+      >
+        <ComposerBanner.Icon>
+          <HistoryIcon />
+        </ComposerBanner.Icon>
+        <ComposerBanner.Content className="text-muted-foreground">Revert to</ComposerBanner.Content>
+        <ComposerBanner.Actions>
+          <ComposerBanner.ToggleIcon expanded />
+        </ComposerBanner.Actions>
+      </ComposerBanner.Row>
+      <ComposerBanner.Scroll>
+        <ComposerBanner.Children render={<ul role="list" />} aria-label="Revert targets">
+          {options.map((option) => {
+            const selectable = isSelectable(option);
+            const highlighted = highlightedOption?.messageId === option.messageId;
+            return (
+              <ComposerBanner.Row
+                render={<li />}
+                key={option.messageId}
+                data-revert-option={option.messageId}
+                data-revert-option-disabled={selectable ? undefined : "true"}
+                data-highlighted={highlighted || undefined}
+                className={cn(
+                  "relative rounded-sm",
+                  highlighted && "bg-accent text-accent-foreground",
+                )}
+                onMouseMove={() => {
+                  if (selectable && highlightedId !== option.messageId) {
+                    setHighlightedId(option.messageId);
+                  }
+                }}
+              >
+                <ComposerBanner.Icon className="justify-end pe-1 tabular-nums">
+                  {option.turnLabel ?? "·"}
+                </ComposerBanner.Icon>
+                <ComposerBanner.Content>
+                  {selectable ? (
+                    <button
+                      type="button"
+                      className="min-w-0 flex-1 cursor-pointer truncate text-left text-foreground/80 outline-none before:absolute before:inset-0 before:rounded-sm focus-visible:before:ring-2 focus-visible:before:ring-ring"
+                      aria-label={`Revert to before: ${option.snippet}`}
+                      onPointerDown={(event) => event.preventDefault()}
+                      onClick={() => onRevert(option)}
+                    >
+                      {option.snippet}
+                    </button>
+                  ) : (
+                    <span className="min-w-0 flex-1 truncate text-muted-foreground/70">
+                      {option.snippet}
+                    </span>
+                  )}
+                </ComposerBanner.Content>
+                <ComposerBanner.Actions>
+                  {!selectable ? (
+                    <span className="shrink-0 text-muted-foreground/70">
+                      {option.unavailableReason === "pending"
+                        ? "no checkpoint"
+                        : "checkpoint expired"}
+                    </span>
+                  ) : option.filesChanged === 0 ? (
+                    <span className="shrink-0 text-muted-foreground">no changes</span>
+                  ) : (
+                    <span className="flex shrink-0 items-center gap-1.5 text-muted-foreground">
+                      <span className="tabular-nums">
+                        {option.filesChanged} file{option.filesChanged === 1 ? "" : "s"}
+                      </span>
+                      <DiffStatLabel
+                        additions={option.additions}
+                        deletions={option.deletions}
+                        layout="inline"
+                      />
+                    </span>
+                  )}
+                  <time
+                    dateTime={option.createdAt}
+                    className="shrink-0 text-muted-foreground tabular-nums max-sm:hidden"
+                  >
+                    {formatRelativeTimeLabel(option.createdAt)}
+                  </time>
+                </ComposerBanner.Actions>
+              </ComposerBanner.Row>
+            );
+          })}
+        </ComposerBanner.Children>
+      </ComposerBanner.Scroll>
+      <ComposerBanner.Row>
+        <ComposerBanner.Icon />
+        <ComposerBanner.Content className="text-muted-foreground/70">
+          ↑↓ select · ⏎ revert · esc cancel
+        </ComposerBanner.Content>
+      </ComposerBanner.Row>
+    </ComposerBanner.Root>
+  );
+});

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -777,11 +777,11 @@ function attachTrailingToolGroupsToAssistant(
   return result;
 }
 
-/** Match each user message to the next assistant checkpoint. */
-function buildRevertTurnCountByUserMessageId(input: {
+export function buildRevertTurnCountByUserMessageId(input: {
   supportsConversationRollback: boolean;
   timelineEntries: ReadonlyArray<TimelineEntry>;
   turnDiffSummaryByAssistantMessageId: ReadonlyMap<MessageId, TurnDiffSummary>;
+  turnDiffSummaryByTurnId: ReadonlyMap<TurnId, TurnDiffSummary>;
   inferredCheckpointTurnCountByTurnId: Readonly<Record<string, number | undefined>>;
 }): Map<MessageId, number> {
   const byUserMessageId = new Map<MessageId, number>();
@@ -800,7 +800,11 @@ function buildRevertTurnCountByUserMessageId(input: {
       if (nextEntry.message.role === "user") {
         break;
       }
-      const summary = input.turnDiffSummaryByAssistantMessageId.get(nextEntry.message.id);
+      const summary =
+        input.turnDiffSummaryByAssistantMessageId.get(nextEntry.message.id) ??
+        (nextEntry.message.turnId === null
+          ? undefined
+          : input.turnDiffSummaryByTurnId.get(nextEntry.message.turnId));
       if (!summary) {
         continue;
       }
@@ -828,7 +832,9 @@ export function deriveMessagesTimelineRows(input: {
   supportsConversationRollback: boolean;
 }): MessagesTimelineRow[] {
   const turnDiffSummaryByAssistantMessageId = new Map<MessageId, TurnDiffSummary>();
+  const turnDiffSummaryByTurnId = new Map<TurnId, TurnDiffSummary>();
   for (const summary of input.turnDiffSummaries) {
+    turnDiffSummaryByTurnId.set(summary.turnId, summary);
     if (summary.assistantMessageId) {
       turnDiffSummaryByAssistantMessageId.set(summary.assistantMessageId, summary);
     }
@@ -837,6 +843,7 @@ export function deriveMessagesTimelineRows(input: {
     supportsConversationRollback: input.supportsConversationRollback,
     timelineEntries: input.timelineEntries,
     turnDiffSummaryByAssistantMessageId,
+    turnDiffSummaryByTurnId,
     inferredCheckpointTurnCountByTurnId: input.supportsConversationRollback
       ? inferCheckpointTurnCountByTurnId(input.turnDiffSummaries)
       : {},

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -223,6 +223,7 @@ interface TimelineRowActivityState {
   isCompacting: boolean;
   isRevertingCheckpoint: boolean;
   latestTurnId: TurnId | null;
+  revertPreviewDiscardedRowIds: ReadonlySet<string> | null;
 }
 
 const TimelineRowCtx = createContext<TimelineRowSharedState>(null!);
@@ -316,6 +317,7 @@ interface MessagesTimelineProps {
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
   supportsConversationRollback: boolean;
   onRevertToTurnCount: (targetTurnCount: number) => void;
+  revertPreviewMessageId?: MessageId | null;
   onUseArtifactTemplate?: (template: CodexArtifactTemplate) => void;
   isRevertingCheckpoint: boolean;
   onImageExpand: (preview: ExpandedImagePreview) => void;
@@ -374,6 +376,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   onOpenTurnDiff,
   supportsConversationRollback,
   onRevertToTurnCount,
+  revertPreviewMessageId = null,
   onUseArtifactTemplate = NOOP_USE_ARTIFACT_TEMPLATE,
   isRevertingCheckpoint,
   onImageExpand,
@@ -716,6 +719,28 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     };
   }, [timelineViewportElement, rows.length, reportContentOverflow]);
 
+  const revertPreview = useMemo(() => {
+    if (revertPreviewMessageId === null) return null;
+    const index = rows.findIndex(
+      (row) => row.kind === "message" && row.message.id === revertPreviewMessageId,
+    );
+    if (index === -1) return null;
+    const discardedRowIds: ReadonlySet<string> = new Set(
+      rows.slice(index + 1).map((row) => row.id),
+    );
+    return { index, discardedRowIds };
+  }, [revertPreviewMessageId, rows]);
+  const revertPreviewIndex = revertPreview?.index ?? null;
+  useEffect(() => {
+    if (revertPreviewIndex === null) return;
+    onManualNavigation();
+    void listRef.current?.scrollToIndex({
+      index: revertPreviewIndex,
+      animated: true,
+      viewOffset: 24,
+    });
+  }, [listRef, onManualNavigation, revertPreviewIndex]);
+
   const sharedState = useMemo<TimelineRowSharedState>(
     () => ({
       citationRequest: readyCitationRequest,
@@ -774,8 +799,16 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       isCompacting,
       isRevertingCheckpoint,
       latestTurnId: latestTurn?.turnId ?? null,
+      revertPreviewDiscardedRowIds: revertPreview?.discardedRowIds ?? null,
     }),
-    [isCompacting, isRevertingCheckpoint, isWorking, isPreparingWorktree, latestTurn?.turnId],
+    [
+      isCompacting,
+      isRevertingCheckpoint,
+      isWorking,
+      isPreparingWorktree,
+      latestTurn?.turnId,
+      revertPreview,
+    ],
   );
 
   // Stable renderItem — no closure deps. Row components read shared state
@@ -1173,6 +1206,7 @@ type TimelineWorkEntry = Extract<MessagesTimelineRow, { kind: "work" }>["grouped
 type TimelineRow = MessagesTimelineRow;
 
 const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: TimelineRow }) {
+  const { revertPreviewDiscardedRowIds } = use(TimelineRowActivityCtx);
   const isExpandedToolGroup = row.kind === "work" && row.isExpandedToolGroup;
   const isExpandedToolGroupHeader =
     (row.kind === "work-toggle" && row.expanded) || (row.kind === "work-live" && row.expanded);
@@ -1201,7 +1235,9 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
           row.kind === "assistant-meta"
           ? "group/assistant"
           : null,
+        revertPreviewDiscardedRowIds?.has(row.id) && "opacity-35 transition-opacity duration-100",
       )}
+      data-revert-preview-discarded={revertPreviewDiscardedRowIds?.has(row.id) || undefined}
       data-timeline-row-id={row.id}
       data-timeline-row-kind={row.kind}
       data-message-id={

--- a/apps/web/src/components/chat/revertPicker.logic.test.ts
+++ b/apps/web/src/components/chat/revertPicker.logic.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { CheckpointRef, MessageId, TurnId } from "@t3tools/contracts";
+import { type TimelineEntry } from "../../session-logic";
+import { type ChatMessage, type TurnDiffSummary } from "../../types";
+import { deriveRevertPickerOptions } from "./revertPicker.logic";
+
+const time = (seconds: number) => new Date(Date.UTC(2026, 8, 7, 12, 0, seconds)).toISOString();
+
+function message(id: string, role: "user" | "assistant", createdAt: string): ChatMessage {
+  return {
+    id: MessageId.make(id),
+    role,
+    text: id,
+    turnId: role === "assistant" ? TurnId.make(`turn-${id}`) : null,
+    streaming: false,
+    createdAt,
+    updatedAt: createdAt,
+  };
+}
+
+function entry(value: ChatMessage): TimelineEntry {
+  return {
+    id: `message:${value.id}`,
+    kind: "message",
+    createdAt: value.createdAt,
+    message: value,
+  };
+}
+
+function checkpoint(
+  assistant: ChatMessage,
+  checkpointTurnCount: number,
+  files: TurnDiffSummary["files"],
+): TurnDiffSummary {
+  return {
+    turnId: assistant.turnId!,
+    checkpointTurnCount,
+    checkpointRef: CheckpointRef.make(`refs/t3/checkpoints/${checkpointTurnCount}`),
+    status: "ready",
+    files,
+    assistantMessageId: assistant.id,
+    completedAt: assistant.createdAt,
+  };
+}
+
+describe("deriveRevertPickerOptions", () => {
+  it("returns nothing when conversation rollback is unsupported", () => {
+    expect(
+      deriveRevertPickerOptions({
+        supportsConversationRollback: false,
+        timelineEntries: [entry(message("user", "user", time(0)))],
+        turnDiffSummaries: [],
+        inferredCheckpointTurnCountByTurnId: {},
+      }),
+    ).toEqual([]);
+  });
+
+  it("lists newest messages first with cumulative discarded diffstats", () => {
+    const expired = message("expired", "user", time(0));
+    const userA = message("user-a", "user", time(1));
+    const assistantA = message("assistant-a", "assistant", time(2));
+    const userB = message("user-b", "user", time(3));
+    const assistantB = message("assistant-b", "assistant", time(4));
+    const userC = message("user-c", "user", time(5));
+    const assistantC = message("assistant-c", "assistant", time(6));
+    const pending = message("pending", "user", time(7));
+    const summaries = [
+      checkpoint(assistantA, 1, [{ path: "a.ts", kind: "modified", additions: 2, deletions: 1 }]),
+      checkpoint(assistantB, 2, [
+        { path: "shared.ts", kind: "modified", additions: 3, deletions: 2 },
+      ]),
+      checkpoint(assistantC, 3, [
+        { path: "shared.ts", kind: "modified", additions: 5, deletions: 4 },
+        { path: "c.ts", kind: "added", additions: 7, deletions: 0 },
+      ]),
+    ];
+
+    const options = deriveRevertPickerOptions({
+      supportsConversationRollback: true,
+      timelineEntries: [
+        expired,
+        userA,
+        assistantA,
+        userB,
+        assistantB,
+        userC,
+        assistantC,
+        pending,
+      ].map(entry),
+      turnDiffSummaries: summaries,
+      inferredCheckpointTurnCountByTurnId: {},
+    });
+
+    expect(options.map((option) => option.messageId)).toEqual([
+      pending.id,
+      userC.id,
+      userB.id,
+      userA.id,
+      expired.id,
+    ]);
+    expect(options[0]).toMatchObject({ turnCount: null, unavailableReason: "pending" });
+    expect(options[1]).toMatchObject({
+      turnLabel: 3,
+      turnCount: 2,
+      unavailableReason: null,
+      filesChanged: 2,
+      additions: 12,
+      deletions: 4,
+    });
+    expect(options[2]).toMatchObject({
+      turnLabel: 2,
+      turnCount: 1,
+      filesChanged: 2,
+      additions: 15,
+      deletions: 6,
+    });
+    expect(options.at(-1)).toMatchObject({ turnCount: null, unavailableReason: "expired" });
+  });
+
+  it("matches older checkpoints by turn ID when assistant message IDs are absent", () => {
+    const user = message("user", "user", time(0));
+    const assistant = message("assistant", "assistant", time(1));
+    const summary = { ...checkpoint(assistant, 1, []), assistantMessageId: null };
+
+    expect(
+      deriveRevertPickerOptions({
+        supportsConversationRollback: true,
+        timelineEntries: [entry(user), entry(assistant)],
+        turnDiffSummaries: [summary],
+        inferredCheckpointTurnCountByTurnId: { [assistant.turnId!]: 1 },
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        messageId: user.id,
+        turnCount: 0,
+        unavailableReason: null,
+      }),
+    ]);
+  });
+});

--- a/apps/web/src/components/chat/revertPicker.logic.ts
+++ b/apps/web/src/components/chat/revertPicker.logic.ts
@@ -1,0 +1,99 @@
+import { type MessageId, type TurnId } from "@t3tools/contracts";
+
+import { assistantCitationsToPlainText } from "@t3tools/shared/assistantCitations";
+import { type TimelineEntry } from "../../session-logic";
+import { type TurnDiffSummary } from "../../types";
+import { buildRevertTurnCountByUserMessageId } from "./MessagesTimeline.logic";
+
+const SNIPPET_MAX_CHARS = 72;
+
+export interface RevertPickerOption {
+  readonly messageId: MessageId;
+  readonly turnLabel: number | null;
+  readonly turnCount: number | null;
+  readonly unavailableReason: "expired" | "pending" | null;
+  readonly snippet: string;
+  readonly createdAt: string;
+  readonly filesChanged: number;
+  readonly additions: number;
+  readonly deletions: number;
+}
+
+function messageSnippet(text: string): string {
+  const trimmed = assistantCitationsToPlainText(text).trim().replace(/\s+/g, " ");
+  if (trimmed.length === 0) return "(empty message)";
+  return trimmed.length > SNIPPET_MAX_CHARS ? `${trimmed.slice(0, SNIPPET_MAX_CHARS)}…` : trimmed;
+}
+
+function discardedDiffstat(
+  turnDiffSummaries: ReadonlyArray<TurnDiffSummary>,
+  turnCount: number,
+): { filesChanged: number; additions: number; deletions: number } {
+  const paths = new Set<string>();
+  let additions = 0;
+  let deletions = 0;
+  for (const summary of turnDiffSummaries) {
+    if (summary.checkpointTurnCount <= turnCount) continue;
+    for (const file of summary.files) {
+      paths.add(file.path);
+      additions += file.additions;
+      deletions += file.deletions;
+    }
+  }
+  return { filesChanged: paths.size, additions, deletions };
+}
+
+export interface ComposerRevertPicker {
+  readonly options: ReadonlyArray<RevertPickerOption>;
+  readonly blockedReason: string | null;
+  readonly onHighlight: (option: RevertPickerOption | null) => void;
+  readonly onRevert: (turnCount: number) => void;
+}
+
+export function deriveRevertPickerOptions(input: {
+  supportsConversationRollback: boolean;
+  timelineEntries: ReadonlyArray<TimelineEntry>;
+  turnDiffSummaries: ReadonlyArray<TurnDiffSummary>;
+  inferredCheckpointTurnCountByTurnId: Readonly<Record<string, number | undefined>>;
+}): RevertPickerOption[] {
+  if (!input.supportsConversationRollback) return [];
+
+  const turnDiffSummaryByAssistantMessageId = new Map<MessageId, TurnDiffSummary>();
+  const turnDiffSummaryByTurnId = new Map<TurnId, TurnDiffSummary>();
+  for (const summary of input.turnDiffSummaries) {
+    turnDiffSummaryByTurnId.set(summary.turnId, summary);
+    if (summary.assistantMessageId) {
+      turnDiffSummaryByAssistantMessageId.set(summary.assistantMessageId, summary);
+    }
+  }
+
+  const revertTurnCountByUserMessageId = buildRevertTurnCountByUserMessageId({
+    supportsConversationRollback: true,
+    timelineEntries: input.timelineEntries,
+    turnDiffSummaryByAssistantMessageId,
+    turnDiffSummaryByTurnId,
+    inferredCheckpointTurnCountByTurnId: input.inferredCheckpointTurnCountByTurnId,
+  });
+
+  const options: RevertPickerOption[] = [];
+  let seenLiveCheckpoint = false;
+  for (const entry of input.timelineEntries) {
+    if (entry.kind !== "message" || entry.message.role !== "user") continue;
+    const turnCount = revertTurnCountByUserMessageId.get(entry.message.id) ?? null;
+    if (turnCount !== null) seenLiveCheckpoint = true;
+    const diffstat =
+      turnCount === null
+        ? { filesChanged: 0, additions: 0, deletions: 0 }
+        : discardedDiffstat(input.turnDiffSummaries, turnCount);
+    options.push({
+      messageId: entry.message.id,
+      turnLabel: turnCount === null ? null : turnCount + 1,
+      turnCount,
+      unavailableReason: turnCount !== null ? null : seenLiveCheckpoint ? "pending" : "expired",
+      snippet: messageSnippet(entry.message.text),
+      createdAt: entry.message.createdAt,
+      ...diffstat,
+    });
+  }
+  return options.toReversed();
+}

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -136,6 +136,7 @@ describe("KeybindingsSettings.logic", () => {
 
   it("formats static and project script command labels", () => {
     expect(commandLabel("commandPalette.toggle")).toBe("Command Palette: Toggle");
+    expect(commandLabel("chat.revertLast")).toBe("Chat: Revert Last");
     expect(commandLabel("themeEditor.toggle")).toBe("Theme Editor: Toggle");
     expect(commandLabel("script.setup-db.run")).toBe("Run Script: Setup Db");
   });
@@ -165,7 +166,13 @@ describe("KeybindingsSettings.logic", () => {
     ] satisfies ResolvedKeybindingsConfig);
 
     expect(options).toEqual(
-      expect.arrayContaining(["chat.new", "rightPanel.toggleMaximized", "script.setup-db.run"]),
+      expect.arrayContaining([
+        "chat.new",
+        "chat.revert",
+        "chat.revertLast",
+        "rightPanel.toggleMaximized",
+        "script.setup-db.run",
+      ]),
     );
   });
 

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -141,6 +141,7 @@ const DEFAULT_BINDINGS = compile([
   },
   { shortcut: modShortcut("o", { shiftKey: true }), command: "chat.new" },
   { shortcut: modShortcut("n", { shiftKey: true }), command: "chat.newLocal" },
+  { shortcut: modShortcut("z", { shiftKey: true }), command: "chat.revert" },
   { shortcut: modShortcut("o"), command: "editor.openFavorite" },
   { shortcut: modShortcut("[", { shiftKey: true }), command: "thread.previous" },
   { shortcut: modShortcut("]", { shiftKey: true }), command: "thread.next" },
@@ -570,6 +571,21 @@ describe("chat/editor shortcuts", () => {
         platform: "Linux",
       }),
       "chat.newLocal",
+    );
+  });
+
+  it("matches chat.revert shortcut", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "z", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+      }),
+      "chat.revert",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "z", ctrlKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux",
+      }),
+      "chat.revert",
     );
   });
 

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -90,6 +90,18 @@ it.effect("parses keybinding rules", () =>
     });
     assert.strictEqual(parsedLocal.command, "chat.newLocal");
 
+    const parsedRevert = yield* decode(KeybindingRule, {
+      key: "mod+shift+z",
+      command: "chat.revert",
+    });
+    assert.strictEqual(parsedRevert.command, "chat.revert");
+
+    const parsedRevertLast = yield* decode(KeybindingRule, {
+      key: "mod+z",
+      command: "chat.revertLast",
+    });
+    assert.strictEqual(parsedRevertLast.command, "chat.revertLast");
+
     const parsedModelPickerToggle = yield* decode(KeybindingRule, {
       key: "mod+shift+m",
       command: "modelPicker.toggle",

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -74,6 +74,8 @@ export const STATIC_KEYBINDING_COMMANDS = [
   "composer.stash",
   "chat.new",
   "chat.newLocal",
+  "chat.revert",
+  "chat.revertLast",
   "editor.openFavorite",
   ...MODEL_PICKER_KEYBINDING_COMMANDS,
   ...THREAD_KEYBINDING_COMMANDS,

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -43,6 +43,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+n", command: "chat.new", when: "!terminalFocus" },
   { key: "mod+shift+o", command: "chat.new", when: "!terminalFocus" },
   { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
+  { key: "mod+shift+z", command: "chat.revert", when: "!terminalFocus" },
   { key: "mod+shift+m", command: "modelPicker.toggle", when: "!terminalFocus" },
   { key: "mod+o", command: "editor.openFavorite" },
   { key: "mod+shift+[", command: "thread.previous" },


### PR DESCRIPTION
Adds keyboard-first checkpoint revert so users can inspect and choose a target without relying on per-message hover controls.

Adds `chat.revert` with `mod+shift+z`, an unbound `chat.revertLast` command, and double Escape from an empty idle composer. The picker previews the target in the timeline, dims discarded rows, shows cumulative diff stats, skips expired checkpoints, and commits with Enter without an extra dialog. Providers without conversation rollback leave the shortcut inactive.

Older checkpoints fall back to turn IDs when assistant message IDs are unavailable. Stopped threads resolve their persisted Git workspace and recover the provider session instead of requiring an already active process. Empty file diffs remain revertible.

Post-revert Undo is not included because provider conversation rollbacks are not generically reversible through the current adapter contract.

Tests:
- 178 focused web and contracts tests
- 3 focused checkpoint reactor tests
- Web and server typechecks
- Targeted lint completed with existing warnings only

Generated with GPT-5.6 Sol in the Codex harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a revert picker for chat conversations, allowing users to preview and return to earlier turns.
  - Revert options show message snippets, change summaries, timestamps, and availability status.
  - Added keyboard shortcuts for opening the revert menu and reverting the latest turn.
  - Added keyboard and pointer interactions for navigating, selecting, and dismissing the picker.

- **Bug Fixes**
  - Reverting now works for stopped conversations using their persisted workspace, even without an active provider session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->