### PR TITLE
fix(claude): isolate subagent tool streams

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1467,6 +1467,157 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  for (const ending of ["results", "turn-completed", "stream-failed"] as const) {
+    it.effect(`isolates parent and sibling tool streams through ${ending}`, () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+        const eventsFiber = yield* adapter.streamEvents.pipe(
+          Stream.takeUntil((event) => event.type === "turn.completed"),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+        yield* adapter.sendTurn({ threadId: THREAD_ID, input: "Delegate work", attachments: [] });
+        const stream = (owner: string | null, event: unknown) =>
+          harness.query.emit({
+            type: "stream_event",
+            session_id: "sdk-isolated",
+            uuid: "stream-isolated",
+            parent_tool_use_id: owner,
+            event,
+          } as unknown as SDKMessage);
+        const owners = [null, "task-a", "task-b"] as const;
+        stream(null, {
+          type: "content_block_start",
+          index: 1,
+          content_block: { type: "text", text: "" },
+        });
+        stream(null, {
+          type: "content_block_delta",
+          index: 1,
+          delta: { type: "text_delta", text: "Parent " },
+        });
+        for (const owner of owners) {
+          stream(owner, {
+            type: "content_block_start",
+            index: 0,
+            content_block: {
+              type: "tool_use",
+              id: `tool-${owner ?? "parent"}`,
+              name: "Read",
+              input: {},
+            },
+          });
+        }
+        for (const owner of owners) {
+          stream(owner, {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "input_json_delta", partial_json: '{"file_path":"' },
+          });
+        }
+        for (const owner of owners.toReversed()) {
+          stream(owner, {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "input_json_delta", partial_json: `${owner ?? "parent"}.ts"}` },
+          });
+          stream(owner, { type: "content_block_stop", index: 0 });
+        }
+        // A suppressed child text block must not close the parent's block at the same index.
+        stream("task-a", {
+          type: "content_block_start",
+          index: 1,
+          content_block: { type: "text", text: "" },
+        });
+        stream("task-a", { type: "content_block_stop", index: 1 });
+        stream(null, {
+          type: "content_block_delta",
+          index: 1,
+          delta: { type: "text_delta", text: "answer" },
+        });
+        stream(null, { type: "content_block_stop", index: 1 });
+        if (ending === "results") {
+          for (const owner of owners.toReversed()) {
+            harness.query.emit({
+              type: "user",
+              session_id: "sdk-isolated",
+              uuid: "result-isolated",
+              parent_tool_use_id: owner,
+              message: {
+                role: "user",
+                content: [
+                  {
+                    type: "tool_result",
+                    tool_use_id: `tool-${owner ?? "parent"}`,
+                    content: `result-${owner ?? "parent"}`,
+                    is_error: owner === "task-b",
+                  },
+                ],
+              },
+            } as unknown as SDKMessage);
+          }
+        }
+        if (ending === "stream-failed") harness.query.fail(new Error("SDK stream failed"));
+        else
+          harness.query.emit({
+            type: "result",
+            subtype: "success",
+            is_error: false,
+            errors: [],
+            session_id: "sdk-isolated",
+            uuid: "result-isolated",
+          } as unknown as SDKMessage);
+        const events = Array.from(yield* Fiber.join(eventsFiber));
+        const textDeltas = events.filter(
+          (event) =>
+            event.type === "content.delta" && event.payload.streamKind === "assistant_text",
+        );
+        assert.equal(textDeltas.length, 2);
+        assert.equal(textDeltas[0]?.itemId, textDeltas[1]?.itemId);
+        for (const owner of owners) {
+          const completed = events.filter(
+            (event) =>
+              event.type === "item.completed" && event.itemId === `tool-${owner ?? "parent"}`,
+          );
+          assert.equal(completed.length, 1);
+          const event = completed[0];
+          assert.equal(event?.type, "item.completed");
+          if (event?.type !== "item.completed") return;
+          assert.equal(event.payload.parentToolUseId, owner ?? undefined);
+          assert.equal(
+            event.payload.status,
+            ending === "stream-failed" || (ending === "results" && owner === "task-b")
+              ? "failed"
+              : "completed",
+          );
+          assert.deepEqual(event.payload.data, {
+            toolName: "Read",
+            input: { file_path: `${owner ?? "parent"}.ts` },
+            ...(ending === "results"
+              ? {
+                  result: {
+                    type: "tool_result",
+                    tool_use_id: `tool-${owner ?? "parent"}`,
+                    content: `result-${owner ?? "parent"}`,
+                    is_error: owner === "task-b",
+                  },
+                }
+              : {}),
+          });
+        }
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    });
+  }
+
   it.effect("maps Claude reasoning deltas, streamed tool inputs, and tool results", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1492,6 +1492,18 @@ describe("ClaudeAdapterLive", () => {
             event,
           } as unknown as SDKMessage);
         const owners = [null, "task-a", "task-b"] as const;
+        for (const owner of ["task-a", "task-b"]) {
+          harness.query.emit({
+            type: "system",
+            subtype: "task_started",
+            task_id: `agent-${owner}`,
+            tool_use_id: owner,
+            description: owner,
+            task_type: "local_agent",
+            session_id: "sdk-isolated",
+            uuid: `started-${owner}`,
+          } as unknown as SDKMessage);
+        }
         stream(null, {
           type: "content_block_start",
           index: 1,
@@ -1590,6 +1602,7 @@ describe("ClaudeAdapterLive", () => {
           assert.equal(event?.type, "item.completed");
           if (event?.type !== "item.completed") return;
           assert.equal(event.payload.parentToolUseId, owner ?? undefined);
+          assert.equal(event.payload.agentId, owner === null ? undefined : `agent-${owner}`);
           assert.equal(
             event.payload.status,
             ending === "stream-failed" || (ending === "results" && owner === "task-b")

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -305,7 +305,7 @@ interface ClaudeSessionContext {
     id: TurnId;
     items: Array<unknown>;
   }>;
-  readonly inFlightTools: Map<number, ToolInFlight>;
+  readonly inFlightTools: Map<string, ToolInFlight>;
   readonly claudeTasks: Map<string, ClaudeTaskState>;
   readonly taskAgents: Map<string, ClaudeTaskAgentState>;
   /**
@@ -2565,6 +2565,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           status: status === "completed" ? "completed" : "failed",
           title: tool.title,
           ...(tool.detail ? { detail: tool.detail } : {}),
+          ...(tool.agentId ? { agentId: tool.agentId } : {}),
+          ...(tool.parentToolUseId ? { parentToolUseId: tool.parentToolUseId } : {}),
           data: {
             toolName: tool.toolName,
             input: tool.input,
@@ -2746,7 +2748,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       }
 
       if (event.delta.type === "input_json_delta") {
-        const tool = context.inFlightTools.get(event.index);
+        // Every parent and subagent message numbers its own content blocks from zero.
+        const toolKey = `${streamParentToolUseId ?? ""}:${event.index}`;
+        const tool = context.inFlightTools.get(toolKey);
         if (!tool || typeof event.delta.partial_json !== "string") {
           return;
         }
@@ -2770,7 +2774,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           parsedInput && Object.keys(parsedInput).length > 0
             ? toolInputFingerprint(parsedInput)
             : undefined;
-        context.inFlightTools.set(event.index, nextTool);
+        context.inFlightTools.set(toolKey, nextTool);
 
         if (
           !parsedInput ||
@@ -2784,7 +2788,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           ...nextTool,
           lastEmittedInputFingerprint: nextFingerprint,
         };
-        context.inFlightTools.set(event.index, nextTool);
+        context.inFlightTools.set(toolKey, nextTool);
 
         const stamp = yield* makeEventStamp();
         yield* offerRuntimeEvent({
@@ -2895,7 +2899,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...(owningAgentId ? { agentId: owningAgentId } : {}),
         ...(parentToolUseId ? { parentToolUseId } : {}),
       };
-      context.inFlightTools.set(index, tool);
+      context.inFlightTools.set(`${parentToolUseId ?? ""}:${index}`, tool);
 
       const stamp = yield* makeEventStamp();
       yield* offerRuntimeEvent({
@@ -2931,6 +2935,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     if (event.type === "content_block_stop") {
+      if (streamParentToolUseId !== null && streamParentToolUseId !== undefined) return;
       const { index } = event;
       const assistantBlock = context.turnState?.assistantTextBlocks.get(index);
       if (assistantBlock) {
@@ -2939,10 +2944,6 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           rawMethod: "claude/stream_event/content_block_stop",
           rawPayload: message,
         });
-        return;
-      }
-      const tool = context.inFlightTools.get(index);
-      if (!tool) {
         return;
       }
     }
@@ -4209,7 +4210,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
       const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
       const pendingUserInputs = new Map<ApprovalRequestId, PendingUserInput>();
-      const inFlightTools = new Map<number, ToolInFlight>();
+      const inFlightTools = new Map<string, ToolInFlight>();
       const claudeTasks = new Map<string, ClaudeTaskState>();
       const taskAgents = new Map<string, ClaudeTaskAgentState>();
       const pendingTaskModels = new Map<string, string>();


### PR DESCRIPTION
## What Changed

Claude's adapter now keys in-flight tools by their parent tool-use ID and content-block index. Child block-stop events no longer close the parent's assistant text block, and interrupted tool completions retain their child-agent attribution.

## Why

Parent and subagent streams each number their content blocks from zero. Interleaved streams could overwrite another agent's tool state, mix JSON input, lose tool completions, or split the parent's narration.

Addresses the remaining stream-ownership problem reported in #5395.

## Testing

- Regression failed on upstream with a split parent assistant item and a missing parent tool completion.
- All 120 Claude adapter tests pass, including interleaved parent and sibling streams with equal indices, partial JSON, normal completion, and failure cleanup.
- Server typecheck and scoped lint and formatting pass.
- Adapter-only changes, with no client rendering changes or browser verification.

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ClaudeAdapter` subagent tool stream isolation with composite registry keys
> - Changes the in-flight tool registry key from a numeric content-block index to a composite of the stream's parent tool-use identifier and the content-block index, so parent and sibling Claude streams no longer share tool state when their indexes collide
> - Makes child-stream content-block stops return early before modifying assistant text state, preventing a sibling stop from closing a parent text block
> - Includes the owning agent identifier and parent tool-use identifier in completed tool item payloads when present
> - Adds a parameterized test in [ClaudeAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/10575/files#diff-1657a55ebc1e3682293aa20a7f71a55adf8de546f36af50f289dca9da45b0b6f) covering result delivery, turn completion, and SDK stream failure paths with parent and sibling tool streams sharing content-block indexes
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81aec3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability for conversations involving nested tools.
  * Prevented tool results from being mixed up when parent and child tool streams use the same position.
  * Corrected completion events to preserve tool ownership and associated agent details.
  * Ensured assistant text and tool completion events remain correctly separated across interleaved streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->