### PR TITLE
refactor(shared): share model-selection command choice

### DIFF
--- a/packages/client-runtime/src/operations/commands.test.ts
+++ b/packages/client-runtime/src/operations/commands.test.ts
@@ -534,10 +534,19 @@ describe("V2 environment commands", () => {
       }).pipe(Effect.provide(TEST_CRYPTO_LAYER)),
   );
 
-  it.effect("uses provider.switch when model selection changes provider instance", () =>
+  it.effect("selects a model command by provider instance, not by model name", () =>
     Effect.gen(function* () {
       const commands: OrchestrationV2Command[] = [];
       const supervisor = yield* makeSupervisor({ commands, projects: [] });
+
+      yield* updateThreadMetadata({
+        commandId: CommandId.make("same-provider"),
+        threadId: v2ThreadId,
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "another-model",
+        },
+      }).pipe(Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor));
 
       yield* updateThreadMetadata({
         commandId: CommandId.make("switch-provider"),
@@ -549,6 +558,12 @@ describe("V2 environment commands", () => {
       }).pipe(Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor));
 
       expect(commands).toEqual([
+        {
+          type: "thread.model-selection.set",
+          commandId: "same-provider",
+          threadId: v2ThreadId,
+          modelSelection: { instanceId: "codex", model: "another-model" },
+        },
         {
           type: "provider.switch",
           commandId: "switch-provider",

--- a/packages/client-runtime/src/operations/commands.ts
+++ b/packages/client-runtime/src/operations/commands.ts
@@ -25,6 +25,7 @@ import {
 } from "@t3tools/contracts";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
+import { modelSelectionCommandType } from "@t3tools/shared/model";
 
 import { request } from "../rpc/client.ts";
 
@@ -524,10 +525,10 @@ export const updateThreadMetadata = Effect.fn("EnvironmentCommands.updateThreadM
     }
     if (input.modelSelection !== undefined) {
       const projection = yield* getProjection(input.threadId);
-      const type =
-        projection.thread.providerInstanceId === input.modelSelection.instanceId
-          ? ("thread.model-selection.set" as const)
-          : ("provider.switch" as const);
+      const type = modelSelectionCommandType(
+        projection.thread.providerInstanceId,
+        input.modelSelection,
+      );
       result = yield* dispatch({
         type,
         commandId: result === null ? commandId : CommandId.make(`${commandId}:model-selection`),

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -14,6 +14,16 @@ import { copySorted } from "./Array.ts";
 
 const DEFAULT_PROVIDER_DRIVER_KIND = ProviderDriverKind.make("codex");
 
+/** Choose the command for a model change against the thread's current provider instance. */
+export function modelSelectionCommandType(
+  currentInstanceId: ProviderInstanceId,
+  selection: ModelSelection,
+) {
+  return currentInstanceId === selection.instanceId
+    ? ("thread.model-selection.set" as const)
+    : ("provider.switch" as const);
+}
+
 export interface SelectableModelOption {
   slug: string;
   name: string;


### PR DESCRIPTION
Part 1/16 of the [shared-core and MCP stack](https://github.com/pingdotgg/t3code/stacks/10582). Based on `t3code/codex-turn-mapping` at `415ed0f73b97f1655b6282492f81d0b2bba3a9cc`. Next: [#10578](https://github.com/pingdotgg/t3code/pull/10578).

The client and MCP must choose the same command when changing a thread's model. This extracts modelSelectionCommandType into the existing shared model module and makes client-runtime use it. The MCP consumer follows in its own layer.

Same provider instance uses thread.model-selection.set; a different instance uses provider.switch. The current provider instance is authoritative; changing a model name alone does not switch providers. No new provider policy or command behavior.

Validation: Existing client command and shared model suites: 25 tests passed. Client-runtime/shared typechecks passed. The client regression observes the actual command for same-provider and different-provider changes.

Layer size: 3 files, +31/-5. No MCP tools are introduced in this prerequisite.

Prepared with Codex in the OpenAI agent runtime.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract shared `modelSelectionCommandType` helper for thread model selection
> - Extracts the provider instance comparison logic from `updateThreadMetadata` into a shared `modelSelectionCommandType` helper in [model.ts](https://github.com/pingdotgg/t3code/pull/10577/files#diff-6319cd97b4ed5842958c7fbc93b4ed733efa158c2b1ad15c1d54bcddea713505)
> - The helper returns `thread.model-selection.set` when the current and selected provider instance IDs match, and `provider.switch` when they differ
> - Updates tests in [commands.test.ts](https://github.com/pingdotgg/t3code/pull/10577/files#diff-94bce5e8234367c86a477e5f8329538b8f04c90ea8ba3b0fa413c6ae8077e7c9) to verify command selection based on provider instance, adding a same-provider case
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a645d4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->