### PR TITLE
refactor(project): share create and update inputs

### DIFF
--- a/apps/server/src/project/ProjectService.ts
+++ b/apps/server/src/project/ProjectService.ts
@@ -3,10 +3,9 @@ import {
   ModelSelection,
   ProjectId,
   type Project,
-  type ProjectIconOverride,
-  type ProjectScript,
+  type ProjectCreatePayload,
+  type ProjectUpdatePayload,
   type ProjectSnapshot,
-  type ThreadEnvMode,
 } from "@t3tools/contracts";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
@@ -29,27 +28,14 @@ import * as ProjectionProjects from "../persistence/Services/ProjectionProjects.
 import { ProjectEnrichmentService, type ProjectEnrichment } from "./ProjectEnrichmentService.ts";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
 
-export interface ProjectCreateInput {
+export interface ProjectCreateInput extends ProjectCreatePayload {
   readonly commandId: CommandId;
   readonly projectId: ProjectId;
-  readonly title: string;
-  readonly workspaceRoot: string;
-  readonly createWorkspaceRootIfMissing?: boolean;
-  readonly defaultModelSelection?: ModelSelection | null;
-  readonly scripts?: ReadonlyArray<ProjectScript>;
 }
 
-export interface ProjectUpdateInput {
+export interface ProjectUpdateInput extends ProjectUpdatePayload {
   readonly commandId: CommandId;
   readonly projectId: ProjectId;
-  readonly title?: string;
-  readonly workspaceRoot?: string;
-  readonly defaultModelSelection?: ModelSelection | null;
-  readonly autoPull?: boolean;
-  readonly projectIcon?: ProjectIconOverride | null;
-  readonly faviconPath?: string | null;
-  readonly defaultThreadEnvMode?: ThreadEnvMode | null;
-  readonly scripts?: ReadonlyArray<ProjectScript>;
 }
 
 export interface ProjectBootstrapInput extends ProjectCreateInput {}

--- a/apps/server/src/project/ProjectService.ts
+++ b/apps/server/src/project/ProjectService.ts
@@ -1,6 +1,5 @@
 import {
   CommandId,
-  ModelSelection,
   ProjectId,
   type Project,
   type ProjectCreatePayload,

--- a/packages/contracts/src/project.test.ts
+++ b/packages/contracts/src/project.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   ProjectReadFileError,
+  ProjectCreatePayload,
+  ProjectUpdatePayload,
+  ProjectMutation,
   ProjectSearchContentsError,
   ProjectSearchContentsInput,
   ProjectSearchEntriesError,
@@ -105,5 +108,43 @@ describe("project RPC errors", () => {
     expect(writeError.message).toBe("Legacy project write failure.");
     expect(writeError.relativePath).toBeUndefined();
     expect(writeError.failure).toBeUndefined();
+  });
+});
+
+describe("shared project payloads", () => {
+  it("preserves omitted, false, and null values through RPC envelopes", () => {
+    const create = Schema.decodeUnknownSync(ProjectCreatePayload)({
+      title: " Example ",
+      workspaceRoot: "/workspace",
+      createWorkspaceRootIfMissing: false,
+    });
+    const update = Schema.decodeUnknownSync(ProjectUpdatePayload)({
+      autoPull: false,
+      defaultModelSelection: null,
+      faviconPath: null,
+    });
+    const envelope = { commandId: "command", projectId: "project" };
+    const decode = Schema.decodeUnknownSync(ProjectMutation);
+    expect(decode({ type: "project.create", ...envelope, ...create })).toEqual({
+      type: "project.create",
+      ...envelope,
+      title: "Example",
+      workspaceRoot: "/workspace",
+      createWorkspaceRootIfMissing: false,
+    });
+    expect(decode({ type: "project.update", ...envelope, ...update })).toEqual({
+      type: "project.update",
+      ...envelope,
+      autoPull: false,
+      defaultModelSelection: null,
+      faviconPath: null,
+    });
+    expect(Object.hasOwn(create, "scripts")).toBe(false);
+    expect(Object.hasOwn(update, "title")).toBe(false);
+    // Internal RPC callers may explicitly supply undefined, as before the extraction.
+    expect(decode({ type: "project.update", ...envelope, title: undefined })).toHaveProperty(
+      "title",
+      undefined,
+    );
   });
 });

--- a/packages/contracts/src/project.test.ts
+++ b/packages/contracts/src/project.test.ts
@@ -13,6 +13,9 @@ import {
   ProjectWriteFileError,
 } from "./project.ts";
 
+const decodeProjectCreatePayload = Schema.decodeUnknownSync(ProjectCreatePayload);
+const decodeProjectUpdatePayload = Schema.decodeUnknownSync(ProjectUpdatePayload);
+const decodeProjectMutation = Schema.decodeUnknownSync(ProjectMutation);
 const decodeSearchEntriesInput = Schema.decodeUnknownSync(ProjectSearchEntriesInput);
 const decodeSearchContentsInput = Schema.decodeUnknownSync(ProjectSearchContentsInput);
 
@@ -113,26 +116,25 @@ describe("project RPC errors", () => {
 
 describe("shared project payloads", () => {
   it("preserves omitted, false, and null values through RPC envelopes", () => {
-    const create = Schema.decodeUnknownSync(ProjectCreatePayload)({
+    const create = decodeProjectCreatePayload({
       title: " Example ",
       workspaceRoot: "/workspace",
       createWorkspaceRootIfMissing: false,
     });
-    const update = Schema.decodeUnknownSync(ProjectUpdatePayload)({
+    const update = decodeProjectUpdatePayload({
       autoPull: false,
       defaultModelSelection: null,
       faviconPath: null,
     });
     const envelope = { commandId: "command", projectId: "project" };
-    const decode = Schema.decodeUnknownSync(ProjectMutation);
-    expect(decode({ type: "project.create", ...envelope, ...create })).toEqual({
+    expect(decodeProjectMutation({ type: "project.create", ...envelope, ...create })).toEqual({
       type: "project.create",
       ...envelope,
       title: "Example",
       workspaceRoot: "/workspace",
       createWorkspaceRootIfMissing: false,
     });
-    expect(decode({ type: "project.update", ...envelope, ...update })).toEqual({
+    expect(decodeProjectMutation({ type: "project.update", ...envelope, ...update })).toEqual({
       type: "project.update",
       ...envelope,
       autoPull: false,
@@ -142,9 +144,8 @@ describe("shared project payloads", () => {
     expect(Object.hasOwn(create, "scripts")).toBe(false);
     expect(Object.hasOwn(update, "title")).toBe(false);
     // Internal RPC callers may explicitly supply undefined, as before the extraction.
-    expect(decode({ type: "project.update", ...envelope, title: undefined })).toHaveProperty(
-      "title",
-      undefined,
-    );
+    expect(
+      decodeProjectMutation({ type: "project.update", ...envelope, title: undefined }),
+    ).toHaveProperty("title", undefined);
   });
 });

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -113,29 +113,39 @@ export const ProjectChange = Schema.Union([
 ]);
 export type ProjectChange = typeof ProjectChange.Type;
 
+export const ProjectCreatePayload = Schema.Struct({
+  title: TrimmedNonEmptyString,
+  workspaceRoot: TrimmedNonEmptyString,
+  createWorkspaceRootIfMissing: Schema.optional(Schema.Boolean),
+  defaultModelSelection: Schema.optional(Schema.NullOr(ModelSelection)),
+  scripts: Schema.optional(Schema.Array(ProjectScript)),
+});
+export type ProjectCreatePayload = typeof ProjectCreatePayload.Type;
+
+export const ProjectUpdatePayload = Schema.Struct({
+  title: Schema.optional(TrimmedNonEmptyString),
+  workspaceRoot: Schema.optional(TrimmedNonEmptyString),
+  defaultModelSelection: Schema.optional(Schema.NullOr(ModelSelection)),
+  autoPull: Schema.optional(Schema.Boolean),
+  projectIcon: Schema.optional(Schema.NullOr(ProjectIconOverride)),
+  faviconPath: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
+  defaultThreadEnvMode: Schema.optional(Schema.NullOr(ThreadEnvMode)),
+  scripts: Schema.optional(Schema.Array(ProjectScript)),
+});
+export type ProjectUpdatePayload = typeof ProjectUpdatePayload.Type;
+
 export const ProjectMutation = Schema.Union([
   Schema.Struct({
     type: Schema.Literal("project.create"),
     commandId: CommandId,
     projectId: ProjectId,
-    title: TrimmedNonEmptyString,
-    workspaceRoot: TrimmedNonEmptyString,
-    createWorkspaceRootIfMissing: Schema.optional(Schema.Boolean),
-    defaultModelSelection: Schema.optional(Schema.NullOr(ModelSelection)),
-    scripts: Schema.optional(Schema.Array(ProjectScript)),
+    ...ProjectCreatePayload.fields,
   }),
   Schema.Struct({
     type: Schema.Literal("project.update"),
     commandId: CommandId,
     projectId: ProjectId,
-    title: Schema.optional(TrimmedNonEmptyString),
-    workspaceRoot: Schema.optional(TrimmedNonEmptyString),
-    defaultModelSelection: Schema.optional(Schema.NullOr(ModelSelection)),
-    autoPull: Schema.optional(Schema.Boolean),
-    projectIcon: Schema.optional(Schema.NullOr(ProjectIconOverride)),
-    faviconPath: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
-    defaultThreadEnvMode: Schema.optional(Schema.NullOr(ThreadEnvMode)),
-    scripts: Schema.optional(Schema.Array(ProjectScript)),
+    ...ProjectUpdatePayload.fields,
   }),
   Schema.Struct({
     type: Schema.Literal("project.delete"),


### PR DESCRIPTION
Part 2/16 of the [shared-core and MCP stack](https://github.com/pingdotgg/t3code/stacks/10582). Based on [#10577](https://github.com/pingdotgg/t3code/pull/10577). Next: [#10580](https://github.com/pingdotgg/t3code/pull/10580).

Project create/update fields were separately defined by the RPC contract, service input types, and MCP tools. This exports ProjectCreatePayload and ProjectUpdatePayload from contracts, composes the existing ProjectMutation envelope from them, and derives ProjectService input types from the same payloads. MCP consumes them in its own layer.

Existing RPC fields and omitted/null/false behavior are preserved, including explicit undefined for internal RPC callers. No project service execution, authorization, or deletion behavior changes.

Validation: Contracts, project service and HTTP mapping suites: 20 tests passed. Independent server/contracts typechecks passed. The contract regression covers trimmed input and omitted/null/false values through the RPC envelope.

Layer size: 3 files, +69/-32. No MCP tools are introduced in this prerequisite.

Prepared with Codex in the OpenAI agent runtime.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract `ProjectCreatePayload` and `ProjectUpdatePayload` schemas for shared project inputs
> - Splits the create and update field definitions out of the `ProjectMutation` union in [project.ts](https://github.com/pingdotgg/t3code/pull/10578/files#diff-8884ce1953b4cd4c0485483959ee19cfc087d42ff24c02d5f59af5957d80ec5f) into standalone exported `ProjectCreatePayload` and `ProjectUpdatePayload` schemas and inferred types.
> - Refactors `ProjectCreateInput` and `ProjectUpdateInput` in [ProjectService.ts](https://github.com/pingdotgg/t3code/pull/10578/files#diff-2d4902da35b90c0995e0574e3a79ff67533daf562ebe083ac15c843bd73e7a1e) to extend the shared payload contracts, keeping only `commandId` and `projectId` locally.
> - Adds tests in [project.test.ts](https://github.com/pingdotgg/t3code/pull/10578/files#diff-0c22633439ab1787d811ad232c392083a71b27b346235d2d0bb4a0ea8adee0a6) covering optional/nullable field behavior: omitted properties stay omitted, `false` and `null` are preserved, and explicitly-supplied `undefined` update properties remain present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8073615.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->