### PR TITLE
fix(server): publish complete secrets atomically

### DIFF
--- a/apps/server/src/auth/ServerSecretStore.publication.test.ts
+++ b/apps/server/src/auth/ServerSecretStore.publication.test.ts
@@ -204,4 +204,89 @@ it.layer(NodeServices.layer)("secret publication", (it) => {
       if ((yield* HostProcessPlatform) !== "win32") assert.equal(stat.mode & 0o777, 0o600);
     }).pipe(Effect.provide(configLayer())),
   );
+
+  it.effect("flushes the published directory entry before reporting success", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const config = yield* ServerConfig.ServerConfig;
+      const flushing = yield* Deferred.make<void>();
+      const resume = yield* Deferred.make<void>();
+      let complete = false;
+      const store = yield* ServerSecretStore.make.pipe(
+        Effect.provideService(FileSystem.FileSystem, {
+          ...fs,
+          open: (path, options) =>
+            fs.open(path, options).pipe(
+              Effect.map((file) =>
+                path === config.secretsDir
+                  ? {
+                      ...file,
+                      sync: Deferred.succeed(flushing, undefined).pipe(
+                        Effect.andThen(Deferred.await(resume)),
+                      ),
+                    }
+                  : file,
+              ),
+            ),
+        }),
+      );
+      const writer = yield* store.create("signing-key", new Uint8Array(32)).pipe(
+        Effect.tap(() =>
+          Effect.sync(() => {
+            complete = true;
+          }),
+        ),
+        Effect.forkChild,
+      );
+      yield* Deferred.await(flushing);
+      assert.isFalse(complete);
+      assert.lengthOf(Option.getOrThrow(yield* store.get("signing-key")), 32);
+      yield* Deferred.succeed(resume, undefined);
+      yield* Fiber.join(writer);
+      assert.isTrue(complete);
+    }).pipe(Effect.provide(configLayer())),
+  );
+
+  for (const [platform, code, succeeds] of [
+    ["win32", "EPERM", true],
+    ["linux", "EPERM", false],
+    ["win32", "EIO", false],
+    ["linux", "EIO", false],
+  ] as const) {
+    it.effect(`handles directory flush ${code} on ${platform} without losing published bytes`, () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const config = yield* ServerConfig.ServerConfig;
+        const failure = PlatformError.systemError({
+          _tag: code === "EPERM" ? "PermissionDenied" : "Unknown",
+          module: "FileSystem",
+          method: "sync",
+          pathOrDescriptor: config.secretsDir,
+          cause: Object.assign(new Error("Injected directory sync failure"), { code }),
+        });
+        const store = yield* ServerSecretStore.make.pipe(
+          Effect.provideService(HostProcessPlatform, platform),
+          Effect.provideService(FileSystem.FileSystem, {
+            ...fs,
+            open: (path, options) =>
+              fs
+                .open(path, options)
+                .pipe(
+                  Effect.map((file) =>
+                    path === config.secretsDir ? { ...file, sync: Effect.fail(failure) } : file,
+                  ),
+                ),
+          }),
+        );
+        const result = yield* store.create("signing-key", new Uint8Array(32)).pipe(Effect.result);
+        assert.equal(result._tag, succeeds ? "Success" : "Failure");
+        if (result._tag === "Failure") {
+          assert.instanceOf(result.failure, ServerSecretStore.SecretStorePersistError);
+          assert.equal(result.failure.cause, failure);
+        }
+        assert.lengthOf(Option.getOrThrow(yield* store.get("signing-key")), 32);
+        assert.deepEqual(yield* fs.readDirectory(config.secretsDir), ["signing-key.bin"]);
+      }).pipe(Effect.provide(configLayer())),
+    );
+  }
 });

--- a/apps/server/src/auth/ServerSecretStore.publication.test.ts
+++ b/apps/server/src/auth/ServerSecretStore.publication.test.ts
@@ -1,0 +1,207 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { assert, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as PlatformError from "effect/PlatformError";
+
+import * as ServerConfig from "../config.ts";
+import * as ServerSecretStore from "./ServerSecretStore.ts";
+
+const configLayer = () =>
+  ServerConfig.layerTest(process.cwd(), { prefix: "t3-secret-publication-test-" });
+
+it.layer(NodeServices.layer)("secret publication", (it) => {
+  it.effect("does not expose a secret until its complete contents are written", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const writing = yield* Deferred.make<void>();
+      const resume = yield* Deferred.make<void>();
+      const store = yield* ServerSecretStore.make.pipe(
+        Effect.provideService(FileSystem.FileSystem, {
+          ...fs,
+          open: (path, options) =>
+            fs.open(path, options).pipe(
+              Effect.map((file) => ({
+                ...file,
+                sync: file.sync,
+                writeAll: (bytes) =>
+                  Deferred.succeed(writing, undefined).pipe(
+                    Effect.andThen(Deferred.await(resume)),
+                    Effect.andThen(file.writeAll(bytes)),
+                  ),
+              })),
+            ),
+        }),
+      );
+      const value = Uint8Array.from([1, 2, 3, 4]);
+      const writer = yield* store.create("signing-key", value).pipe(Effect.forkChild);
+      yield* Deferred.await(writing);
+      const duringWrite = yield* store.get("signing-key");
+      yield* Deferred.succeed(resume, undefined);
+      yield* Fiber.join(writer);
+      assert.isTrue(Option.isNone(duringWrite));
+      assert.deepEqual(Option.getOrThrow(yield* store.get("signing-key")), value);
+    }).pipe(Effect.provide(configLayer())),
+  );
+
+  it.effect("concurrent generators both return the complete winning secret", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const writing = yield* Deferred.make<void>();
+      const resume = yield* Deferred.make<void>();
+      let firstWrite = true;
+      const store = yield* ServerSecretStore.make.pipe(
+        Effect.provideService(FileSystem.FileSystem, {
+          ...fs,
+          open: (path, options) =>
+            fs.open(path, options).pipe(
+              Effect.map((file) => ({
+                ...file,
+                sync: file.sync,
+                writeAll: Effect.fn(function* (bytes) {
+                  if (firstWrite) {
+                    firstWrite = false;
+                    yield* Deferred.succeed(writing, undefined);
+                    yield* Deferred.await(resume);
+                  }
+                  yield* file.writeAll(bytes);
+                }),
+              })),
+            ),
+        }),
+      );
+      const first = yield* store.getOrCreateRandom("signing-key", 32).pipe(Effect.forkChild);
+      yield* Deferred.await(writing);
+      const second = yield* store.getOrCreateRandom("signing-key", 32);
+      yield* Deferred.succeed(resume, undefined);
+      const firstValue = yield* Fiber.join(first);
+      assert.lengthOf(second, 32);
+      assert.deepEqual(firstValue, second);
+      assert.deepEqual(Option.getOrThrow(yield* store.get("signing-key")), second);
+    }).pipe(Effect.provide(configLayer())),
+  );
+
+  it.effect("failed partial writes leave no secret and allow a later create", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const config = yield* ServerConfig.ServerConfig;
+      let failWrite = true;
+      const store = yield* ServerSecretStore.make.pipe(
+        Effect.provideService(FileSystem.FileSystem, {
+          ...fs,
+          open: (path, options) =>
+            fs.open(path, options).pipe(
+              Effect.map((file) => ({
+                ...file,
+                sync: file.sync,
+                writeAll: Effect.fn(function* (bytes) {
+                  if (failWrite) {
+                    failWrite = false;
+                    yield* file.writeAll(bytes.subarray(0, 2));
+                    return yield* PlatformError.systemError({
+                      _tag: "Unknown",
+                      module: "FileSystem",
+                      method: "writeAll",
+                      pathOrDescriptor: path,
+                      description: "Injected write failure",
+                    });
+                  }
+                  yield* file.writeAll(bytes);
+                }),
+              })),
+            ),
+        }),
+      );
+      const value = Uint8Array.from([1, 2, 3, 4]);
+      const error = yield* store.create("signing-key", value).pipe(Effect.flip);
+      assert.instanceOf(error, ServerSecretStore.SecretStorePersistError);
+      assert.isTrue(Option.isNone(yield* store.get("signing-key")));
+      assert.deepEqual(yield* fs.readDirectory(config.secretsDir), []);
+      yield* store.create("signing-key", value);
+      assert.deepEqual(Option.getOrThrow(yield* store.get("signing-key")), value);
+    }).pipe(Effect.provide(configLayer())),
+  );
+
+  it.effect("interrupted writes do not leave a key or temporary files behind", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const config = yield* ServerConfig.ServerConfig;
+      const writing = yield* Deferred.make<void>();
+      const store = yield* ServerSecretStore.make.pipe(
+        Effect.provideService(FileSystem.FileSystem, {
+          ...fs,
+          open: (path, options) =>
+            fs.open(path, options).pipe(
+              Effect.map((file) => ({
+                ...file,
+                sync: file.sync,
+                writeAll: () =>
+                  Deferred.succeed(writing, undefined).pipe(Effect.andThen(Effect.never)),
+              })),
+            ),
+        }),
+      );
+      const writer = yield* store
+        .create("signing-key", Uint8Array.from([1, 2, 3]))
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(writing);
+      yield* Fiber.interrupt(writer);
+      assert.isTrue(Option.isNone(yield* store.get("signing-key")));
+      assert.deepEqual(yield* fs.readDirectory(config.secretsDir), []);
+    }).pipe(Effect.provide(configLayer())),
+  );
+
+  it.effect("a sync failure does not publish an unflushed secret", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const config = yield* ServerConfig.ServerConfig;
+      const store = yield* ServerSecretStore.make.pipe(
+        Effect.provideService(FileSystem.FileSystem, {
+          ...fs,
+          open: (path, options) =>
+            fs.open(path, options).pipe(
+              Effect.map((file) => ({
+                ...file,
+                writeAll: (bytes) => file.writeAll(bytes),
+                sync: Effect.fail(
+                  PlatformError.systemError({
+                    _tag: "Unknown",
+                    module: "FileSystem",
+                    method: "sync",
+                    pathOrDescriptor: path,
+                    description: "Injected sync failure",
+                  }),
+                ),
+              })),
+            ),
+        }),
+      );
+      const error = yield* store.create("signing-key", new Uint8Array(32)).pipe(Effect.flip);
+      assert.instanceOf(error, ServerSecretStore.SecretStorePersistError);
+      assert.isTrue(Option.isNone(yield* store.get("signing-key")));
+      assert.deepEqual(yield* fs.readDirectory(config.secretsDir), []);
+    }).pipe(Effect.provide(configLayer())),
+  );
+
+  it.effect("a losing creator leaves the existing key intact and removes its temporary data", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const config = yield* ServerConfig.ServerConfig;
+      const store = yield* ServerSecretStore.make;
+      const winner = Uint8Array.from([1, 2, 3, 4]);
+      yield* store.create("signing-key", winner);
+      const loser = yield* store
+        .create("signing-key", Uint8Array.from([5, 6, 7, 8]))
+        .pipe(Effect.flip);
+      assert.isTrue(ServerSecretStore.isSecretAlreadyExistsError(loser));
+      assert.deepEqual(Option.getOrThrow(yield* store.get("signing-key")), winner);
+      assert.deepEqual(yield* fs.readDirectory(config.secretsDir), ["signing-key.bin"]);
+      const stat = yield* fs.stat(`${config.secretsDir}/signing-key.bin`);
+      if ((yield* HostProcessPlatform) !== "win32") assert.equal(stat.mode & 0o777, 0o600);
+    }).pipe(Effect.provide(configLayer())),
+  );
+});

--- a/apps/server/src/auth/ServerSecretStore.ts
+++ b/apps/server/src/auth/ServerSecretStore.ts
@@ -225,13 +225,24 @@ export const make = Effect.gen(function* () {
     const secretPath = resolveSecretPath(name);
     return Effect.scoped(
       Effect.gen(function* () {
-        const file = yield* fileSystem.open(secretPath, {
-          flag: "wx",
-          mode: 0o600,
+        const temporaryDirectory = yield* fileSystem.makeTempDirectoryScoped({
+          directory: serverConfig.secretsDir,
+          prefix: ".create-",
         });
-        yield* file.writeAll(value);
-        yield* file.sync;
-        yield* fileSystem.chmod(secretPath, 0o600);
+        const temporaryPath = path.join(temporaryDirectory, "secret.bin");
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const file = yield* fileSystem.open(temporaryPath, {
+              flag: "wx",
+              mode: 0o600,
+            });
+            yield* file.writeAll(value);
+            yield* file.sync;
+            yield* fileSystem.chmod(temporaryPath, 0o600);
+          }),
+        );
+        // Publish complete bytes without replacing a concurrent creator's secret.
+        yield* fileSystem.link(temporaryPath, secretPath);
       }),
     ).pipe(
       Effect.mapError(

--- a/apps/server/src/auth/ServerSecretStore.ts
+++ b/apps/server/src/auth/ServerSecretStore.ts
@@ -8,7 +8,7 @@ import * as Path from "effect/Path";
 import * as Predicate from "effect/Predicate";
 import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
-import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as HostProcess from "@t3tools/shared/hostProcess";
 
 import * as ServerConfig from "../config.ts";
 
@@ -155,7 +155,7 @@ export const make = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const serverConfig = yield* ServerConfig.ServerConfig;
-  const platform = yield* HostProcessPlatform;
+  const platform = yield* HostProcess.HostProcessPlatform;
 
   yield* fileSystem.makeDirectory(serverConfig.secretsDir, { recursive: true });
   yield* fileSystem.chmod(serverConfig.secretsDir, 0o700).pipe(

--- a/apps/server/src/auth/ServerSecretStore.ts
+++ b/apps/server/src/auth/ServerSecretStore.ts
@@ -8,6 +8,7 @@ import * as Path from "effect/Path";
 import * as Predicate from "effect/Predicate";
 import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
 import * as ServerConfig from "../config.ts";
 
@@ -154,6 +155,7 @@ export const make = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const serverConfig = yield* ServerConfig.ServerConfig;
+  const platform = yield* HostProcessPlatform;
 
   yield* fileSystem.makeDirectory(serverConfig.secretsDir, { recursive: true });
   yield* fileSystem.chmod(serverConfig.secretsDir, 0o700).pipe(
@@ -243,6 +245,16 @@ export const make = Effect.gen(function* () {
         );
         // Publish complete bytes without replacing a concurrent creator's secret.
         yield* fileSystem.link(temporaryPath, secretPath);
+        const directory = yield* fileSystem.open(serverConfig.secretsDir, { flag: "r" });
+        yield* directory.sync.pipe(
+          Effect.catch((cause) =>
+            platform === "win32" &&
+            Predicate.hasProperty(cause.reason.cause, "code") &&
+            cause.reason.cause.code === "EPERM"
+              ? Effect.void
+              : Effect.fail(cause),
+          ),
+        );
       }),
     ).pipe(
       Effect.mapError(


### PR DESCRIPTION
## What Changed

New secrets are written, flushed, and closed in a scoped temporary directory before an atomic hard link publishes them. An existing secret still wins a concurrent creation attempt. Failed and interrupted writes clean up their temporary data without leaving a partially written final file.

## Why

Exclusive creation currently creates the final path before writing its contents. Another startup or request can read the empty file and retain a different signing key from the eventual writer. A write or flush failure leaves that incomplete key on disk for future requests.

This affects the shared store used by session signing, asset signing, environment keys, and replay markers. Existing secrets are not regenerated or migrated.

## Testing

- Five regressions fail on upstream: visible incomplete writes, an empty key returned to a concurrent generator, and leftover final files after write failure, interruption, or flush failure.
- All 73 focused tests pass across secret storage, sessions, DPoP, environment keys, attachment uploads, and asset access.
- Server typecheck, scoped lint, and formatting pass.
- Tests use disposable directories and explicit synchronization, never the live database or secrets.
- No frontend changes or browser verification. Native Windows execution was not available.

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish complete secrets atomically in `ServerSecretStore.make`
> - `create` now writes to a temporary file in a scoped directory, syncs and chmods it, then hard-links it to the final secret path without replacing an existing entry
> - Temporary resources are cleaned up through the scoped operation; partial, interrupted, or failed writes leave no published secret or leftover files
> - Directory sync is awaited before success; Windows `EPERM` from directory sync is tolerated, while other sync failures return a `SecretStorePersistError`
> - Risk: concurrent creators that lose the race no longer replace the existing secret — the non-replacing hard-link means a colliding creator receives an already-exists error and must remove its own temporary data; review the hard-link and temp-dir cleanup in [ServerSecretStore.ts](https://github.com/pingdotgg/t3code/pull/10579/files#diff-ba1dc01960ef9039f0c35daa5ed29eb4c63ae7c4202faf83b04259d422c1c557)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b3ed79.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret creation reliability by ensuring secrets are only visible after they are fully written and synchronized.
  * Prevented incomplete or interrupted writes from leaving behind exposed secrets or temporary files.
  * Preserved existing secrets when concurrent creation attempts occur.
  * Maintained secure file permissions for newly created secrets.
  * Improved handling of persistence failures without losing successfully published secret data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->