### PR TITLE
fix(git): include staged files in unborn repository reviews

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -813,6 +813,39 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
   });
 
   describe("review diff previews", () => {
+    for (const objectFormat of ["sha1", "sha256"]) {
+      it.effect(
+        `includes staged files and their current contents before the first ${objectFormat} commit`,
+        () =>
+          Effect.gen(function* () {
+            const cwd = yield* makeTmpDir();
+            const driver = yield* GitVcsDriver.GitVcsDriver;
+            yield* git(cwd, ["init", `--object-format=${objectFormat}`]);
+            yield* writeTextFile(cwd, "staged.txt", "staged version\n");
+            yield* writeTextFile(cwd, "deleted.txt", "removed after staging\n");
+            yield* git(cwd, ["add", "."]);
+            yield* writeTextFile(cwd, "staged.txt", "current version\n");
+            const fileSystem = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            yield* fileSystem.remove(path.join(cwd, "deleted.txt"));
+            yield* writeTextFile(cwd, "untracked.txt", "untracked version\n");
+
+            const preview = yield* driver.getReviewDiffPreview({ cwd, ignoreWhitespace: false });
+            const workingTree = preview.sources.find((source) => source.kind === "working-tree");
+            assert.include(workingTree?.diff, "+++ b/staged.txt");
+            assert.include(workingTree?.diff, "+current version");
+            assert.include(workingTree?.diff, "+++ b/untracked.txt");
+            assert.notInclude(workingTree?.diff, "staged version");
+            assert.notInclude(workingTree?.diff, "deleted.txt");
+            assert.equal(workingTree?.truncated, false);
+            assert.equal(
+              preview.sources.find((source) => source.kind === "branch-range")?.diff,
+              "",
+            );
+          }),
+      );
+    }
+
     it.effect("drops an unterminated path from truncated NUL-separated git output", () =>
       Effect.sync(() => {
         const paths = splitNullSeparatedGitStdoutPaths({

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -2289,26 +2289,44 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
           )
         : null);
 
-    const dirtyTrackedResult = yield* executeGit(
-      "GitVcsDriver.getReviewDiffPreview.dirtyTracked",
-      input.cwd,
-      [
-        "diff",
-        "--patch",
-        "--no-color",
-        "--no-ext-diff",
-        "--no-textconv",
-        "--minimal",
-        ...PATCH_RENDER_PREFIX_ARGS,
-        ...(input.ignoreWhitespace ? ["--ignore-all-space"] : []),
-        "HEAD",
-        "--",
-      ],
-      {
-        maxOutputBytes: REVIEW_DIFF_PATCH_MAX_OUTPUT_BYTES,
-        appendTruncationMarker: true,
-      },
-    ).pipe(
+    const readTrackedDiff = (revision: string, allowNonZeroExit = false) =>
+      executeGitWithStableDiagnostics(
+        "GitVcsDriver.getReviewDiffPreview.dirtyTracked",
+        input.cwd,
+        [
+          "diff",
+          "--patch",
+          "--no-color",
+          "--no-ext-diff",
+          "--no-textconv",
+          "--minimal",
+          ...PATCH_RENDER_PREFIX_ARGS,
+          ...(input.ignoreWhitespace ? ["--ignore-all-space"] : []),
+          revision,
+          "--",
+        ],
+        {
+          allowNonZeroExit,
+          maxOutputBytes: REVIEW_DIFF_PATCH_MAX_OUTPUT_BYTES,
+          appendTruncationMarker: true,
+        },
+      );
+    const dirtyTrackedResult = yield* readTrackedDiff("HEAD", true).pipe(
+      Effect.flatMap(
+        Effect.fn(function* (result) {
+          if (result.exitCode === 0) return result;
+          if (!isUnbornHeadStderr(result.stderr)) return { ...result, stdout: "" };
+          // An unborn branch has no HEAD, but staged files still need a combined
+          // index/worktree diff. Derive the empty tree for the repo's object format.
+          const emptyTree = yield* runGitStdoutWithOptions(
+            "GitVcsDriver.getReviewDiffPreview.emptyTree",
+            input.cwd,
+            ["hash-object", "-t", "tree", "--stdin"],
+            { stdin: "" },
+          );
+          return yield* readTrackedDiff(emptyTree.trim());
+        }),
+      ),
       Effect.orElseSucceed(() => ({
         exitCode: 0,
         stdout: "",


### PR DESCRIPTION
## What Changed

Working-tree review falls back to the repository's empty tree when `HEAD` does not exist yet. The patch includes staged files and their subsequent unstaged edits as one combined diff, while keeping untracked-file handling unchanged.

## Why

In a new repository, staged files are no longer untracked, but diffing them against `HEAD` fails because there is no first commit. The failure was swallowed and review omitted those files entirely.

## Testing

- The real-Git regression fails on upstream because the staged file is missing from the review.
- Ten focused review tests pass, including unborn SHA-1 and SHA-256 repositories, staged plus unstaged content, deleted staged files, untracked files, and whitespace handling.
- Server typecheck, scoped lint, and formatting pass.
- Backend diff generation only, with no client rendering changes or browser verification.

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `GitVcsDriver.getReviewDiffPreview` for unborn repositories
> - `getReviewDiffPreview` now detects when HEAD points to an unborn branch and retries the tracked diff against the repository's empty-tree object ID, so staged and working-tree content appears in reviews before the first commit.
> - The empty-tree ID is derived via `hash-object` and works for both SHA-1 and SHA-256 repositories.
> - Added a parameterized integration test in [GitVcsDriverCore.test.ts](https://github.com/pingdotgg/t3code/pull/10581/files#diff-ac30488287dac9aa8d4cb819c508d77d2e47267d4aae35819e6fa24b86312c26) covering staged, modified, deleted, and untracked files in unborn repos.
> - Risk: a non-unborn non-zero exit from the tracked-diff command now produces empty tracked output instead of surfacing the error; check the non-zero handling in [GitVcsDriverCore.ts](https://github.com/pingdotgg/t3code/pull/10581/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8) if diff failures were previously expected to propagate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 286901a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Review diff previews now correctly display current changes to tracked files alongside untracked files.
  - Diff previews now work reliably in repositories using either SHA-1 or SHA-256 object formats.
  - Initial repositories without an existing commit are handled correctly.
  - Unrelated deleted or previously staged content is no longer incorrectly included in the working-tree preview.
  - Empty branch-range previews are reported accurately when no applicable changes exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->